### PR TITLE
Add getWorkerAddresses and invalidate cache when registering worker

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -78,6 +78,11 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
   List<WorkerInfo> getLostWorkersInfoList() throws UnavailableException;
 
   /**
+   * @return a set of live worker addresses
+   */
+  Set<WorkerNetAddress> getWorkerAddresses() throws UnavailableException;
+
+  /**
    * Gets the worker information list for report CLI.
    *
    * @param options the GetWorkerReportOptions defines the info range

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -468,7 +468,7 @@ public final class DefaultBlockMaster extends CoreMaster implements BlockMaster 
     if (mSafeModeManager.isInSafeMode()) {
       throw new UnavailableException(ExceptionMessage.MASTER_IN_SAFEMODE.getMessage());
     }
-    Set<WorkerNetAddress> workerAddresses = new HashSet<>();
+    Set<WorkerNetAddress> workerAddresses = new HashSet<>(mWorkers.size());
     for (MasterWorkerInfo worker : mWorkers) {
       // worker net address is unmodifiable after initialization, no locking is needed
       workerAddresses.add(worker.getWorkerAddress());

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -464,6 +464,19 @@ public final class DefaultBlockMaster extends CoreMaster implements BlockMaster 
   }
 
   @Override
+  public Set<WorkerNetAddress> getWorkerAddresses() throws UnavailableException {
+    if (mSafeModeManager.isInSafeMode()) {
+      throw new UnavailableException(ExceptionMessage.MASTER_IN_SAFEMODE.getMessage());
+    }
+    Set<WorkerNetAddress> workerAddresses = new HashSet<>();
+    for (MasterWorkerInfo worker : mWorkers) {
+      // worker net address is unmodifiable after initialization, no locking is needed
+      workerAddresses.add(worker.getWorkerAddress());
+    }
+    return workerAddresses;
+  }
+
+  @Override
   public List<WorkerInfo> getWorkerReport(GetWorkerReportOptions options)
       throws UnavailableException, InvalidArgumentException {
     if (mSafeModeManager.isInSafeMode()) {
@@ -891,7 +904,8 @@ public final class DefaultBlockMaster extends CoreMaster implements BlockMaster 
     }
 
     registerWorkerInternal(workerId);
-
+    // Invalidate cache to trigger new build of worker info list
+    mWorkerInfoCache.invalidate(WORKER_INFO_CACHE_KEY);
     LOG.info("registerWorker(): {}", worker);
   }
 


### PR DESCRIPTION
A loading cache is used for caching worker info list results. In this way, the overhead to construct worker info list is reduced but the worker info list result is not up to date. 

Add a getWorkerAddresses() method which returns the most up-to-date live worker addresses.
Add an invalidate cache in registering worker to make sure getWorkerInfoList() call catchs up with the worker changes.