### PR TITLE
Disable TRACE and OPTIONS on REST services

### DIFF
--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -42,13 +42,13 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public abstract class WebServer {
   private static final Logger LOG = LoggerFactory.getLogger(WebServer.class);
+  private static final String DISABLED_METHODS = "TRACE,OPTIONS";
 
   private final Server mServer;
   private final String mServiceName;
   private final InetSocketAddress mAddress;
   private final ServerConnector mServerConnector;
   private final ConstraintSecurityHandler mSecurityHandler;
-  private static final String DISABLED_METHODS = "TRACE,OPTIONS";
   protected final ServletContextHandler mServletContextHandler;
 
   /**
@@ -91,7 +91,8 @@ public abstract class WebServer {
     }
 
     System.setProperty("org.apache.jasper.compiler.disablejsr199", "false");
-    mServletContextHandler = new ServletContextHandler(ServletContextHandler.SECURITY);
+    mServletContextHandler = new ServletContextHandler(ServletContextHandler.SECURITY
+        | ServletContextHandler.NO_SECURITY);
     mServletContextHandler.setContextPath(AlluxioURI.SEPARATOR);
 
     // Disable specified methods on REST services

--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -96,8 +96,8 @@ public abstract class WebServer {
 
     // Disable specified methods on REST services
     mSecurityHandler = (ConstraintSecurityHandler) mServletContextHandler.getSecurityHandler();
-    for (String s :DISABLED_METHODS.split(",")) {
-      disableHandler(s);
+    for (String s : DISABLED_METHODS.split(",")) {
+      disableMethod(s);
     }
 
     HandlerList handlers = new HandlerList();
@@ -129,7 +129,7 @@ public abstract class WebServer {
   /**
    * @param method to disable
    */
-  private void disableHandler(String method) {
+  private void disableMethod(String method) {
     Constraint constraint = new Constraint();
     constraint.setAuthenticate(true);
     constraint.setName("Disable " + method);

--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -92,7 +92,7 @@ public abstract class WebServer {
 
     System.setProperty("org.apache.jasper.compiler.disablejsr199", "false");
     mServletContextHandler = new ServletContextHandler(ServletContextHandler.SECURITY
-        | ServletContextHandler.NO_SECURITY);
+        | ServletContextHandler.NO_SESSIONS);
     mServletContextHandler.setContextPath(AlluxioURI.SEPARATOR);
 
     // Disable specified methods on REST services


### PR DESCRIPTION
Disable these methods on REST services since they're not commonly used and they flag in network vulnerability scans