### PR TITLE
Add debug logging facilities for fuse

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -209,4 +209,37 @@ public final class AlluxioFuseUtils {
       return -ErrorCodes.EBADMSG();
     }
   }
+
+  /**
+   * An interface representing a callable for FUSE APIs.
+   */
+  public interface FuseCallable {
+    /**
+     * The RPC implementation.
+     *
+     * @return the return value from the RPC
+     */
+    int call();
+  }
+
+  /**
+   * Calls the given {@link FuseCallable} and returns its result.
+   *
+   * @param logger the logger to use for this call
+   * @param callable the callable to call
+   * @param methodName the name of the method, used for metrics
+   * @param description the format string of the description, used for logging
+   * @param args the arguments for the description
+   * @return the result
+   */
+  public static int call(Logger logger, FuseCallable callable, String methodName,
+      String description, Object... args) {
+    String debugDesc = logger.isDebugEnabled() ? String.format(description, args) : null;
+    logger.debug("Enter: {}({})", methodName, debugDesc);
+    long ts1 = System.currentTimeMillis();
+    int ret = callable.call();
+    long ts2 = System.currentTimeMillis();
+    logger.debug("Exit ({}): {}({}) in {} ms", ret, methodName, debugDesc, ts2 - ts1);
+    return ret;
+  }
 }


### PR DESCRIPTION
With this PR, after setting `log4j.logger.alluxio.fuse.AlluxioFuseFileSystem=DEBUG` in `conf/log4j.properties`, one can find debug logs on FUSE operation in `logs/fuse.log`:

```
2020-03-03 14:33:35,129 DEBUG AlluxioFuseFileSystem - Enter: chmod(path=/aaa,mode=100644)
2020-03-03 14:33:35,131 DEBUG AlluxioFuseFileSystem - Exit (0): chmod(path=/aaa,mode=100644) in 2 ms
2020-03-03 14:33:35,132 DEBUG AlluxioFuseFileSystem - Enter: getattr(path=/aaa)
2020-03-03 14:33:35,135 DEBUG AlluxioFuseFileSystem - Exit (0): getattr(path=/aaa) in 3 ms
2020-03-03 14:33:35,135 DEBUG AlluxioFuseFileSystem - Enter: getattr(path=/._aaa)
2020-03-03 14:33:35,136 DEBUG AlluxioFuseFileSystem - Failed to get info of /._aaa, path does not exist or is invalid
2020-03-03 14:33:35,136 DEBUG AlluxioFuseFileSystem - Exit (-2): getattr(path=/._aaa) in 1 ms
2020-03-03 14:33:35,137 DEBUG AlluxioFuseFileSystem - Enter: getattr(path=/._aaa)
2020-03-03 14:33:35,138 DEBUG AlluxioFuseFileSystem - Failed to get info of /._aaa, path does not exist or is invalid
2020-03-03 14:33:35,138 DEBUG AlluxioFuseFileSystem - Exit (-2): getattr(path=/._aaa) in 1 ms
2020-03-03 14:33:35,138 DEBUG AlluxioFuseFileSystem - Enter: getattr(path=/._aaa)
2020-03-03 14:33:35,140 DEBUG AlluxioFuseFileSystem - Failed to get info of /._aaa, path does not exist or is invalid
2020-03-03 14:33:35,140 DEBUG AlluxioFuseFileSystem - Exit (-2): getattr(path=/._aaa) in 2 ms
2020-03-03 14:33:35,140 DEBUG AlluxioFuseFileSystem - Enter: create(path=/._aaa,mode=100644)
2020-03-03 14:33:35,143 DEBUG AlluxioFuseFileSystem - Exit (0): create(path=/._aaa,mode=100644) in 3 ms
2020-03-03 14:33:35,144 DEBUG AlluxioFuseFileSystem - Enter: getattr(path=/._aaa)
2020-03-03 14:33:35,147 DEBUG AlluxioFuseFileSystem - Exit (0): getattr(path=/._aaa) in 3 ms
2020-03-03 14:33:35,147 DEBUG AlluxioFuseFileSystem - Enter: write(path=/._aaa,buf=jnr.ffi.provider.jffi.DirectMemoryIO[address=0x126223050],size=4096,offset=0)
2020-03-03 14:33:35,166 DEBUG AlluxioFuseFileSystem - Exit (4096): write(path=/._aaa,buf=jnr.ffi.provider.jffi.DirectMemoryIO[address=0x126223050],size=4096,offset=0) in 19 ms
```