### PR TITLE
Fix config check with default values

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -690,7 +690,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey UNDERFS_WEB_TITLES =
       new Builder(Name.UNDERFS_WEB_TITLES)
-          .setDefaultValue("Index of ,Directory listing for ")
+          .setDefaultValue("Index of,Directory listing for")
           .setDescription("The title of the content for a http url.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -356,7 +356,7 @@ public final class ConfigurationUtils {
    */
   public static List<ConfigProperty> getConfiguration(AlluxioConfiguration conf, Scope scope) {
     ConfigurationValueOptions useRawDisplayValue =
-        ConfigurationValueOptions.defaults().useDisplayValue(true).useRawValue(true);
+        ConfigurationValueOptions.defaults().useDisplayValue(true);
 
     List<ConfigProperty> configs = new ArrayList<>();
     List<PropertyKey> selectedKeys =

--- a/tests/src/test/java/alluxio/server/configuration/ConfigCheckerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/configuration/ConfigCheckerIntegrationTest.java
@@ -114,7 +114,7 @@ public class ConfigCheckerIntegrationTest extends BaseIntegrationTest {
     mCluster.start();
     ConfigCheckReport report = getReport();
     // The workers values of many directory related properties are different
-    assertEquals(ConfigStatus.FAILED, report.getConfigStatus());
+    assertEquals(ConfigStatus.WARN, report.getConfigStatus());
     assertThat(report.getConfigWarns().toString(), CoreMatchers.containsString(key.getName()));
     mCluster.notifySuccess();
   }


### PR DESCRIPTION
This PR aims to fix the configuration check in the Alluxio UI when running locally and all values are not configured except for `alluxio.master.hostname` set to `localhost`

By default this should be passing, or else the user may think they have configured something incorrectly.

There are two main changes.

1. Fix a failing check from a PK with `ConsistencyCheckLevel.ENFORCE` that gets it's trailing spaces trimmed when the pk is sent over the wire. I just removed the extra trailing spaces as the usage didn't seem to require it.

2. Use the resolved value for the PK rather than the raw value. There are many PKs with "warnings" because the check on the master uses the resolved value rather than the raw value sent from the other masters/workers. I don't really see a good use for using the raw value directly, so all config values sent over the wire are resolved if they use something like `${pk.name}` on the remote process.