### PR TITLE
Return MetaMaster from MetaMasterFactory

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/meta/MetaMasterFactory.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/MetaMasterFactory.java
@@ -13,7 +13,6 @@ package alluxio.master.meta;
 
 import alluxio.Constants;
 import alluxio.master.CoreMasterContext;
-import alluxio.master.Master;
 import alluxio.master.MasterFactory;
 import alluxio.master.MasterRegistry;
 import alluxio.master.block.BlockMaster;
@@ -46,7 +45,7 @@ public final class MetaMasterFactory implements MasterFactory<CoreMasterContext>
   }
 
   @Override
-  public Master create(MasterRegistry registry, CoreMasterContext context) {
+  public MetaMaster create(MasterRegistry registry, CoreMasterContext context) {
     LOG.info("Creating {} ", MetaMaster.class.getName());
     MetaMaster metaMaster = new DefaultMetaMaster(registry.get(BlockMaster.class), context);
     registry.add(MetaMaster.class, metaMaster);


### PR DESCRIPTION
All master factories currently return their respective implementations
of the Master interface. MetaMasterFactory only returns a Master.
This is a small PR to update the class to be the same as the other
implementations