### PR TITLE
[DOCFIX] Update Tensorflow doc

### DIFF
--- a/docs/en/compute/Tensorflow.md
+++ b/docs/en/compute/Tensorflow.md
@@ -23,7 +23,7 @@ on top of Alluxio POSIX API.
 
 * Setup Java for Java 8 Update 60 or higher (8u60+), 64-bit.
 * Alluxio has been set up and is running.
-* [Tensorflow](https://www.tensorflow.org/install/pip) installed. 
+* [Tensorflow](https://www.tensorflow.org/install/pip) installed. This guide uses Tensorflow **v1.15**.
 
 ## Setting up Alluxio POSIX API
 


### PR DESCRIPTION
Added a small note for Tensorflow 1.15. Using [Tensorflow 2.1.0](https://github.com/tensorflow/tensorflow/releases/tag/v2.1.0) will cause some minor issues when trying to run `classify_image.py`. Users would have to manually tweak the py file to get it to work. 