### PR TITLE
Remove authority from the uris used in speedcore

### DIFF
--- a/job/server/src/main/java/alluxio/job/plan/transform/format/ReadWriterUtils.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/ReadWriterUtils.java
@@ -12,12 +12,10 @@
 package alluxio.job.plan.transform.format;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.client.ReadType;
 import alluxio.client.WriteType;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.ExceptionMessage;
-import alluxio.uri.NoAuthority;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.conf.Configuration;
@@ -37,11 +35,6 @@ public final class ReadWriterUtils {
   public static void checkUri(AlluxioURI uri) {
     Preconditions.checkArgument(uri.getScheme() != null && !uri.getScheme().isEmpty(),
         ExceptionMessage.TRANSFORM_TABLE_URI_LACKS_SCHEME.getMessage(uri));
-    if (uri.getScheme().equals(Constants.SCHEME)) {
-      Preconditions.checkArgument(uri.getAuthority() != null
-              && !uri.getAuthority().equals(NoAuthority.INSTANCE),
-          ExceptionMessage.TRANSFORM_TABLE_URI_LACKS_AUTHORITY.getMessage(uri));
-    }
   }
 
   /**

--- a/table/server/common/src/main/java/alluxio/table/common/layout/HiveLayout.java
+++ b/table/server/common/src/main/java/alluxio/table/common/layout/HiveLayout.java
@@ -12,7 +12,7 @@
 package alluxio.table.common.layout;
 
 import alluxio.AlluxioURI;
-import alluxio.conf.ServerConfiguration;
+import alluxio.Constants;
 import alluxio.grpc.table.ColumnStatisticsInfo;
 import alluxio.grpc.table.layout.hive.PartitionInfo;
 import alluxio.job.plan.transform.HiveConstants;
@@ -21,7 +21,6 @@ import alluxio.table.common.LayoutFactory;
 import alluxio.table.common.transform.TransformContext;
 import alluxio.table.common.transform.TransformDefinition;
 import alluxio.table.common.transform.TransformPlan;
-import alluxio.util.ConfigurationUtils;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.slf4j.Logger;
@@ -132,8 +131,7 @@ public class HiveLayout implements Layout {
       TransformDefinition definition) throws IOException {
     AlluxioURI outputPath = transformContext.generateTransformedPath();
     AlluxioURI outputUri = new AlluxioURI(
-        ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global())
-        + outputPath.getPath());
+        Constants.HEADER + outputPath.getPath());
     HiveLayout transformedLayout = transformLayout(outputUri);
     return new TransformPlan(this, transformedLayout, definition);
   }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/PathTranslator.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/PathTranslator.java
@@ -11,8 +11,7 @@
 
 package alluxio.table.under.hive.util;
 
-import alluxio.conf.ServerConfiguration;
-import alluxio.util.ConfigurationUtils;
+import alluxio.Constants;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -70,9 +69,8 @@ public class PathTranslator {
       if (ufsPath.startsWith(entry.getValue())) {
         String alluxioPath = entry.getKey() + ufsPath.substring(entry.getValue().length());
         if (alluxioPath.startsWith("/")) {
-          // scheme/authority are missing, so prefix with the scheme and authority
-          alluxioPath =
-              ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global()) + alluxioPath;
+          // scheme/authority are missing, so prefix with the scheme
+          alluxioPath = Constants.HEADER + alluxioPath;
         }
         return alluxioPath;
       }

--- a/tests/src/test/java/alluxio/job/plan/transform/format/TableReaderIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/plan/transform/format/TableReaderIntegrationTest.java
@@ -44,12 +44,4 @@ public class TableReaderIntegrationTest extends JobIntegrationTest {
     mThrown.expectMessage(ExceptionMessage.TRANSFORM_TABLE_URI_LACKS_SCHEME.getMessage(uri));
     TableReader.create(uri, mPartitionInfo).close();
   }
-
-  @Test
-  public void createAlluxioReaderWithoutAuthority() throws Exception {
-    AlluxioURI uri = new AlluxioURI("alluxio", null, "/CREATE_ALLUXIO_READER_WITHOUT_AUTHORITY");
-    mThrown.expect(IllegalArgumentException.class);
-    mThrown.expectMessage(ExceptionMessage.TRANSFORM_TABLE_URI_LACKS_AUTHORITY.getMessage(uri));
-    TableReader.create(uri, mPartitionInfo).close();
-  }
 }

--- a/tests/src/test/java/alluxio/job/plan/transform/format/TableWriterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/plan/transform/format/TableWriterIntegrationTest.java
@@ -75,12 +75,4 @@ public class TableWriterIntegrationTest extends JobIntegrationTest {
     mThrown.expectMessage(ExceptionMessage.TRANSFORM_TABLE_URI_LACKS_SCHEME.getMessage(uri));
     createWriter(uri).close();
   }
-
-  @Test
-  public void createAlluxioWriterWithoutAuthority() throws Exception {
-    AlluxioURI uri = new AlluxioURI("alluxio", null, "/CREATE_ALLUXIO_WRITER_WITHOUT_AUTHORITY");
-    mThrown.expect(IllegalArgumentException.class);
-    mThrown.expectMessage(ExceptionMessage.TRANSFORM_TABLE_URI_LACKS_AUTHORITY.getMessage(uri));
-    createWriter(uri).close();
-  }
 }


### PR DESCRIPTION
This is needed because we want to support
1. HA clusters where the authority can change depending on configuration
2. Dynamic clusters where the hostname can change from one run to the next

Also note that in the extremely unlikely case that we have a table location pointing to a different Alluxio location, the authority will still be used to ensure correctness. 

