### PR TITLE
Improve how tests handle restarting workers

### DIFF
--- a/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
@@ -118,7 +118,6 @@ public final class ConfigurationTestUtils {
     conf.put(PropertyKey.WORKER_MEMORY_SIZE, "100MB");
     conf.put(PropertyKey.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL, "15ms");
     conf.put(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "15ms");
-    conf.put(PropertyKey.MASTER_WORKER_TIMEOUT_MS, "500ms");
     conf.put(PropertyKey.WORKER_NETWORK_NETTY_WORKER_THREADS, "2");
 
     // Shutdown data server quickly. Graceful shutdown is unnecessarily slow.

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -259,9 +259,12 @@ public abstract class AbstractLocalAlluxioCluster {
     mWorkerThreads.clear();
 
     // forget all the workers in the master
-    DefaultBlockMaster bm = (DefaultBlockMaster) getLocalAlluxioMaster().getMasterProcess()
-        .getMaster(BlockMaster.class);
-    bm.forgetAllWorkers();
+    LocalAlluxioMaster master = getLocalAlluxioMaster();
+    if (master != null) {
+      DefaultBlockMaster bm =
+          (DefaultBlockMaster) master.getMasterProcess().getMaster(BlockMaster.class);
+      bm.forgetAllWorkers();
+    }
   }
 
   /**

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -22,6 +22,8 @@ import alluxio.client.util.ClientTestUtils;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.status.UnavailableException;
+import alluxio.master.block.BlockMaster;
+import alluxio.master.block.DefaultBlockMaster;
 import alluxio.proxy.ProxyProcess;
 import alluxio.security.GroupMappingServiceTestUtils;
 import alluxio.underfs.UnderFileSystem;
@@ -255,6 +257,11 @@ public abstract class AbstractLocalAlluxioCluster {
       }
     }
     mWorkerThreads.clear();
+
+    // forget all the workers in the master
+    DefaultBlockMaster bm = (DefaultBlockMaster) getLocalAlluxioMaster().getMasterProcess()
+        .getMaster(BlockMaster.class);
+    bm.forgetAllWorkers();
   }
 
   /**

--- a/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
+++ b/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
@@ -17,16 +17,13 @@ import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.DeletePOptions;
 import alluxio.master.LocalAlluxioCluster;
-import alluxio.master.block.BlockMaster;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.contexts.DeleteContext;
 import alluxio.master.file.contexts.ListStatusContext;
 import alluxio.metrics.MetricsSystem;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.underfs.UfsMode;
-import alluxio.util.CommonUtils;
 import alluxio.util.SecurityUtils;
-import alluxio.util.WaitForOptions;
 import alluxio.wire.FileInfo;
 
 import org.junit.rules.TestRule;
@@ -313,17 +310,6 @@ public final class LocalAlluxioClusterResource implements TestRule {
             .getMaster(FileSystemMaster.class);
       }
       if (!mCluster.get().isStartedWorkers()) {
-        // Wait for the workers to be considered "lost"
-        BlockMaster bm =
-            mCluster.get().getLocalAlluxioMaster().getMasterProcess().getMaster(BlockMaster.class);
-        CommonUtils.waitFor("all workers to be considered lost by the master", () -> {
-          try {
-            return bm.getWorkerInfoList().isEmpty();
-          } catch (Exception e) {
-            return false;
-          }
-        }, WaitForOptions.defaults().setInterval(10).setTimeoutMs(1000));
-
         // Start the new workers
         mCluster.get().startWorkers();
       }


### PR DESCRIPTION
Instead of relying on waiting for lost worker detection, force the workers to be lost.