### PR TITLE
Complete Job Workflows without any children

### DIFF
--- a/job/server/src/main/java/alluxio/master/job/workflow/WorkflowTracker.java
+++ b/job/server/src/main/java/alluxio/master/job/workflow/WorkflowTracker.java
@@ -218,6 +218,7 @@ public class WorkflowTracker {
 
   private synchronized void next(long jobId) {
     WorkflowExecution workflowExecution = mWorkflows.get(jobId);
+    mChildren.putIfAbsent(jobId, new ConcurrentHashSet<>());
 
     Set<JobConfig> childJobConfigs = workflowExecution.next();
 
@@ -232,8 +233,6 @@ public class WorkflowTracker {
     }
 
     mWaitingOn.put(jobId, childJobIds);
-
-    mChildren.putIfAbsent(jobId, new ConcurrentHashSet<>());
     mChildren.get(jobId).addAll(childJobIds);
 
     for (Long childJobId : childJobIds) {

--- a/job/server/src/test/java/alluxio/master/job/workflow/WorkflowTrackerTest.java
+++ b/job/server/src/test/java/alluxio/master/job/workflow/WorkflowTrackerTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import alluxio.exception.JobDoesNotExistException;
 import alluxio.exception.status.ResourceExhaustedException;
 import alluxio.job.JobConfig;
 import alluxio.job.JobServerContext;

--- a/job/server/src/test/java/alluxio/master/job/workflow/WorkflowTrackerTest.java
+++ b/job/server/src/test/java/alluxio/master/job/workflow/WorkflowTrackerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import alluxio.exception.JobDoesNotExistException;
 import alluxio.exception.status.ResourceExhaustedException;
 import alluxio.job.JobConfig;
 import alluxio.job.JobServerContext;
@@ -70,6 +71,16 @@ public class WorkflowTrackerTest {
     mWorkers = Lists.newArrayList(new WorkerInfo());
     mCommandManager = new CommandManager();
     mMockJobServerContext = mock(JobServerContext.class);
+  }
+
+  @Test
+  public void testEmpty() throws Exception {
+    ArrayList<JobConfig> jobs = Lists.newArrayList();
+    CompositeConfig config = new CompositeConfig(jobs, true);
+    mWorkflowTracker.run(config, 0);
+    WorkflowInfo info = mWorkflowTracker.getStatus(0, true);
+
+    assertEquals(Status.COMPLETED, info.getStatus());
   }
 
   @Test


### PR DESCRIPTION
Resolves #11118 

getStatus of a workflow job that contains no children crashed because it was expecting the list of children to be non-null. This fixes resolves it by making sure that the list is an empty list instead of null.