### PR TITLE
Fix configuration sync with worker

### DIFF
--- a/core/common/src/main/java/alluxio/ClientContext.java
+++ b/core/common/src/main/java/alluxio/ClientContext.java
@@ -132,7 +132,7 @@ public class ClientContext {
       return;
     }
     GetConfigurationPResponse response = ConfigurationUtils.loadConfiguration(address,
-        conf, !loadClusterConf, !loadPathConf);
+        conf, !loadClusterConf, !loadPathConf, false);
     if (loadClusterConf) {
       mClusterConf = ConfigurationUtils.getClusterConf(response, conf, Scope.CLIENT);
       mClusterConfHash = response.getClusterConfigHash();

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -472,10 +472,12 @@ public final class ConfigurationUtils {
    * @param conf the existing configuration
    * @param ignoreClusterConf do not load cluster configuration related information
    * @param ignorePathConf do not load path configuration related information
+   * @param ignoreDefaultValue do not load configuration property with default value
    * @return the RPC response
    */
   public static GetConfigurationPResponse loadConfiguration(InetSocketAddress address,
-      AlluxioConfiguration conf, boolean ignoreClusterConf, boolean ignorePathConf)
+      AlluxioConfiguration conf, boolean ignoreClusterConf, boolean ignorePathConf,
+      boolean ignoreDefaultValue)
       throws AlluxioStatusException {
     GrpcChannel channel = null;
     try {
@@ -487,6 +489,7 @@ public final class ConfigurationUtils {
           MetaMasterConfigurationServiceGrpc.newBlockingStub(channel);
       GetConfigurationPResponse response = client.getConfiguration(
           GetConfigurationPOptions.newBuilder().setRawValue(true)
+              .setIgnoreDefaultValue(ignoreDefaultValue)
               .setIgnoreClusterConf(ignoreClusterConf).setIgnorePathConf(ignorePathConf).build());
       LOG.debug("Alluxio client has loaded configuration from meta master {}", address);
       return response;
@@ -552,7 +555,7 @@ public final class ConfigurationUtils {
     Properties clusterProps = filterAndLoadProperties(clusterConfig, scope, (key, value) ->
         String.format("Loading property: %s (%s) -> %s", key, key.getScope(), value));
     // Check version.
-    String clusterVersion = clusterProps.get(PropertyKey.VERSION).toString();
+    Object clusterVersion = clusterProps.get(PropertyKey.VERSION);
     if (!clientVersion.equals(clusterVersion)) {
       LOG.warn("Alluxio {} version ({}) does not match Alluxio cluster version ({})",
           scope, clientVersion, clusterVersion);

--- a/core/server/common/src/main/java/alluxio/conf/ServerConfiguration.java
+++ b/core/server/common/src/main/java/alluxio/conf/ServerConfiguration.java
@@ -351,7 +351,7 @@ public final class ServerConfiguration {
     if (sConf.getBoolean(PropertyKey.USER_CONF_CLUSTER_DEFAULT_ENABLED)
         && !sConf.clusterDefaultsLoaded()) {
       GetConfigurationPResponse response = ConfigurationUtils.loadConfiguration(address, sConf,
-          false, true);
+          false, true, true);
       AlluxioConfiguration conf = ConfigurationUtils.getClusterConf(response, sConf, Scope.WORKER);
       sConf = new InstancedConfiguration(conf.copyProperties(), conf.clusterDefaultsLoaded());
     }

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -392,6 +392,10 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
       for (PropertyKey key : ServerConfiguration.keySet()) {
         if (key.isBuiltIn()) {
           Source source = ServerConfiguration.getSource(key);
+          if (options.getIgnoreDefaultValue() && source == Source.DEFAULT
+              && !key.equals(PropertyKey.VERSION)) {
+            continue;
+          }
           String value = ServerConfiguration.getOrDefault(key, null,
               ConfigurationValueOptions.defaults().useDisplayValue(true)
                   .useRawValue(options.getRawValue()));

--- a/core/server/master/src/main/java/alluxio/master/meta/MetaMasterConfigurationServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/MetaMasterConfigurationServiceHandler.java
@@ -68,7 +68,8 @@ public final class MetaMasterConfigurationServiceHandler
         if (clusterConf == null
             || !clusterConf.getClusterConfigHash().equals(hash.getClusterConfigHash())) {
           clusterConf = mMetaMaster.getConfiguration(GetConfigurationPOptions.newBuilder()
-              .setIgnorePathConf(true).build()).toProto();
+              .setIgnorePathConf(true).setIgnoreDefaultValue(options.getIgnoreDefaultValue())
+              .build()).toProto();
           mClusterConf = clusterConf;
         }
         builder.addAllClusterConfigs(clusterConf.getClusterConfigsList());
@@ -78,7 +79,8 @@ public final class MetaMasterConfigurationServiceHandler
         if (pathConf == null
             || !pathConf.getPathConfigHash().equals(hash.getPathConfigHash())) {
           pathConf = mMetaMaster.getConfiguration(GetConfigurationPOptions.newBuilder()
-              .setIgnoreClusterConf(true).build()).toProto();
+              .setIgnoreClusterConf(true).setIgnoreDefaultValue(options.getIgnoreDefaultValue())
+              .build()).toProto();
           mPathConf = pathConf;
         }
         builder.putAllPathConfigs(pathConf.getPathConfigsMap());

--- a/core/transport/src/main/proto/grpc/meta_master.proto
+++ b/core/transport/src/main/proto/grpc/meta_master.proto
@@ -16,6 +16,7 @@ message GetConfigurationPOptions{
  optional bool rawValue = 1;
  optional bool ignoreClusterConf = 2;
  optional bool ignorePathConf = 3;
+ optional bool ignoreDefaultValue = 4;
 }
 message GetConfigurationPResponse{
   repeated ConfigProperty clusterConfigs = 1;


### PR DESCRIPTION
We recently updated the configuration sync so all master properties will get pushed to worker unless worker specify something in config file specifically. This is okay for most cases but for property that has a server specific default value, the master default value will override worker default value, making it invalid in some cases.

For example, the default value for `alluxio.underfs.hdfs.configuration` is set to base on the configuration directory. If master and worker have different Alluxio directory for example in a containerized environment, the worker will sync the default path from master which does not exist in worker, causing worker to fail to talk to HDFS.

This change modifies the configuration sync so worker only sync the properties that are not default value on master. This way we preserve the server specific default values in the workers.