### PR TITLE
Add logging when RPC or Fuse calls too long

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -369,8 +369,8 @@ public abstract class AbstractClient implements Client {
       long duration = System.currentTimeMillis() - startMs;
       logger.debug("Exit (OK): {}({}) in {} ms", rpcName, debugDesc, duration);
       if (duration >= mRpcThreshold) {
-        logger.warn("{}({}) returned {} in {} ms",
-            rpcName, String.format(description, args), ret, duration);
+        logger.warn("{}({}) returned {} in {} ms (>={} ms)",
+            rpcName, String.format(description, args), ret, duration, mRpcThreshold);
       }
       return ret;
     } catch (Exception e) {

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3303,6 +3303,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_LOGGING_THRESHOLD =
+      new Builder(Name.USER_LOGGING_THRESHOLD)
+          .setDefaultValue("10s")
+          .setDescription("Logging a client RPC when it takes more time than the threshold.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_METADATA_CACHE_ENABLED =
       new Builder(Name.USER_METADATA_CACHE_ENABLED)
           .setDefaultValue(false)
@@ -3578,6 +3585,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.FUSE_FS_NAME)
           .setDefaultValue("alluxio-fuse")
           .setDescription("The FUSE file system name.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey FUSE_LOGGING_THRESHOLD =
+      new Builder(Name.FUSE_LOGGING_THRESHOLD)
+          .setDefaultValue("10s")
+          .setDescription("Logging a FUSE API call when it takes more time than the threshold.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)
           .build();
@@ -4714,6 +4728,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.local.reader.chunk.size.bytes";
     public static final String USER_LOCAL_WRITER_CHUNK_SIZE_BYTES =
         "alluxio.user.local.writer.chunk.size.bytes";
+    public static final String USER_LOGGING_THRESHOLD = "alluxio.user.logging.threshold";
     public static final String USER_METADATA_CACHE_ENABLED =
         "alluxio.user.metadata.cache.enabled";
     public static final String USER_METADATA_CACHE_MAX_SIZE =
@@ -4777,6 +4792,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String FUSE_CACHED_PATHS_MAX = "alluxio.fuse.cached.paths.max";
     public static final String FUSE_DEBUG_ENABLED = "alluxio.fuse.debug.enabled";
     public static final String FUSE_FS_NAME = "alluxio.fuse.fs.name";
+    public static final String FUSE_LOGGING_THRESHOLD = "alluxio.fuse.logging.threshold";
     public static final String FUSE_MAXWRITE_BYTES = "alluxio.fuse.maxwrite.bytes";
     public static final String FUSE_USER_GROUP_TRANSLATION_ENABLED =
         "alluxio.fuse.user.group.translation.enabled";

--- a/core/common/src/test/java/alluxio/AbstractClientTest.java
+++ b/core/common/src/test/java/alluxio/AbstractClientTest.java
@@ -127,6 +127,8 @@ public final class AbstractClientTest {
   @Test
   public void confAddress() throws Exception {
     ClientContext context = Mockito.mock(ClientContext.class);
+    Mockito.when(context.getClusterConf()).thenReturn(
+        new InstancedConfiguration(ConfigurationUtils.defaults()));
 
     InetSocketAddress baseAddress = new InetSocketAddress("0.0.0.0", 2000);
     InetSocketAddress confAddress = new InetSocketAddress("0.0.0.0", 2001);

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -71,6 +71,8 @@ public final class AlluxioFuse {
     try {
       fs.mount(Paths.get(opts.getMountPoint()), true, opts.isDebug(),
           fuseOpts.toArray(new String[0]));
+      LOG.info("Mounted Alluxio: mount point=\"{}\", opts=\"{}\"",
+          opts.getMountPoint(), fuseOpts.toArray(new String[0]));
     } catch (FuseException e) {
       LOG.error("Failed to mount {}", opts.getMountPoint(), e);
       // only try to umount file system when exception occurred.
@@ -80,6 +82,7 @@ public final class AlluxioFuse {
     } finally {
       try {
         tfs.close();
+        LOG.info("Closed Alluxio file system.");
       } catch (Exception e) {
         LOG.error("Failed to close Alluxio file system", e);
       }

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -246,7 +246,7 @@ public final class AlluxioFuseUtils {
     long durationMs = System.currentTimeMillis() - startMs;
     logger.debug("Exit ({}): {}({}) in {} ms", ret, methodName, debugDesc, durationMs);
     if (durationMs >= THRESHOLD) {
-      logger.warn("{}({}) returned {} in {} ms (>={}ms)",
+      logger.warn("{}({}) returned {} in {} ms (>={} ms)",
           methodName, String.format(description, args), ret, durationMs, THRESHOLD);
     }
     return ret;


### PR DESCRIPTION
by setting two new properties
```
alluxio.user.logging.threshold=2ms
alluxio.fuse.logging.threshold=2ms
```

Fuse or client-side RPC calls taking too long will be logged in WARN level like the following:
```
2020-03-08 23:40:44,374 WARN  BlockMasterClient - GetBlockMasterInfo(fields=[USED_BYTES, FREE_BYTES, CAPACITY_BYTES]) returned BlockMasterInfo{capacityBytes=11453246122, capacityBytesOnTiers={}, freeBytes=11453237930, liveWorkerNum=0, lostWorkerNum=0, usedBytes=8192, usedBytesOnTiers={}} in 6 ms
2020-03-08 23:40:44,374 WARN  AlluxioFuseFileSystem - statfs(path=/) returned 0 in 6 ms
2020-03-08 23:40:44,381 WARN  BlockMasterClient - GetBlockMasterInfo(fields=[USED_BYTES, FREE_BYTES, CAPACITY_BYTES]) returned BlockMasterInfo{capacityBytes=11453246122, capacityBytesOnTiers={}, freeBytes=11453237930, liveWorkerNum=0, lostWorkerNum=0, usedBytes=8192, usedBytesOnTiers={}} in 6 ms
2020-03-08 23:40:44,381 WARN  AlluxioFuseFileSystem - statfs(path=/) returned 0 in 6 ms
```