### PR TITLE
Make parallel sync threads configurable

### DIFF
--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -1149,6 +1149,9 @@ Here are the additional properties possible for the `-o` options:
     * `<UFS_PREFIX>`: the UFS path prefix that the mount properties are for
     * `<MOUNT_PROPERTY>`: an Alluxio mount property
   * `catalog.db.ignore.udb.tables`: comma-separated list of table names to ignore from the UDB
+  * `catalog.db.sync.threads`: number of parallel threads to use to sync with the UDB. If too large,
+  the sync may overload the UDB, and if set too low, syncing a database with many tables make take
+  a long time. The default is `4`.
 
 For the `hive` udb type, during the attach process, the Alluxio catalog will auto-mount all the
 table/partition locations in the specified database, to Alluxio. You can supply the mount options

--- a/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
+++ b/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
@@ -46,9 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -67,20 +65,16 @@ public class AlluxioCatalog implements Journaled {
   private final UnderDatabaseRegistry mUdbRegistry;
   private final LayoutRegistry mLayoutRegistry;
   private final FileSystem mFileSystem;
-  private final Supplier<ExecutorService> mExecutorServiceSupplier;
 
   /**
    * Creates an instance.
-   *
-   * @param executorServiceSupplier a supplier of an {@link ExecutorService}
    */
-  public AlluxioCatalog(Supplier<ExecutorService> executorServiceSupplier) {
+  public AlluxioCatalog() {
     mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
     mUdbRegistry = new UnderDatabaseRegistry();
     mUdbRegistry.refresh();
     mLayoutRegistry = new LayoutRegistry();
     mLayoutRegistry.refresh();
-    mExecutorServiceSupplier = executorServiceSupplier;
   }
 
   private LockResource getDbLock(String dbName) {

--- a/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
+++ b/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
@@ -129,8 +129,7 @@ public class AlluxioCatalog implements Journaled {
 
       boolean syncError = false;
       try {
-        SyncStatus status =
-            mDBs.get(dbName).sync(journalContext, mExecutorServiceSupplier.get());
+        SyncStatus status = mDBs.get(dbName).sync(journalContext);
         syncError = status.getTablesErrorsCount() > 0;
         return status;
       } catch (Exception e) {
@@ -159,7 +158,7 @@ public class AlluxioCatalog implements Journaled {
   public SyncStatus syncDatabase(JournalContext journalContext, String dbName) throws IOException {
     try (LockResource l = getDbLock(dbName)) {
       Database db = getDatabaseByName(dbName);
-      return db.sync(journalContext, mExecutorServiceSupplier.get());
+      return db.sync(journalContext);
     }
   }
 

--- a/table/server/master/src/main/java/alluxio/master/table/CatalogProperty.java
+++ b/table/server/master/src/main/java/alluxio/master/table/CatalogProperty.java
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory;
 public class CatalogProperty extends BaseProperty {
   private static final Logger LOG = LoggerFactory.getLogger(CatalogProperty.class);
 
+  public static final int DEFAULT_DB_SYNC_THREADS = 4;
+
   private CatalogProperty(String name, String description, String defaultValue) {
     super(name, description, defaultValue);
   }
@@ -29,4 +31,11 @@ public class CatalogProperty extends BaseProperty {
   public static final CatalogProperty DB_IGNORE_TABLES =
       new CatalogProperty("catalog.db.ignore.udb.tables",
           "The comma-separated list of table names to ignore from the UDB.", "");
+  public static final CatalogProperty DB_SYNC_THREADS =
+      new CatalogProperty("catalog.db.sync.threads",
+          "The maximum number of threads to use when parallel syncing all the tables from the "
+              + "under database (UDB) to the catalog. If this is set too large, the threads may "
+              + "overload the UDB, and if set too low, syncing a database with many tables may "
+              + "take a long time.",
+          Integer.toString(DEFAULT_DB_SYNC_THREADS));
 }

--- a/table/server/master/src/main/java/alluxio/master/table/DefaultTableMaster.java
+++ b/table/server/master/src/main/java/alluxio/master/table/DefaultTableMaster.java
@@ -71,7 +71,7 @@ public class DefaultTableMaster extends CoreMaster
   public DefaultTableMaster(CoreMasterContext context, JobMasterClient jobMasterClient) {
     super(context, new SystemClock(),
         ExecutorServiceFactories.cachedThreadPool(Constants.TABLE_MASTER_NAME));
-    mCatalog = new AlluxioCatalog(this::getExecutorService);
+    mCatalog = new AlluxioCatalog();
     mTransformManager = new TransformManager(this::createJournalContext, mCatalog, jobMasterClient);
     mJournaledComponents = new JournaledGroup(Lists.newArrayList(mCatalog, mTransformManager),
         CheckpointName.TABLE_MASTER);

--- a/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
@@ -36,12 +36,10 @@ import alluxio.table.common.transform.TransformPlan;
 import alluxio.table.common.udb.UdbContext;
 import alluxio.table.common.udb.UdbTable;
 import alluxio.table.common.udb.UnderDatabaseRegistry;
-import alluxio.util.executor.ExecutorServiceFactories;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,7 +55,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
@@ -65,22 +62,14 @@ public class AlluxioCatalogTest {
   private static final TransformDefinition TRANSFORM_DEFINITION =
       TransformDefinition.parse("write(hive).option(hive.file.count.max, 100);");
 
-  private static ExecutorService sService =
-      ExecutorServiceFactories.cachedThreadPool("AlluxioCatalogTest").create();
-
   private AlluxioCatalog mCatalog;
 
   @Rule
   public ExpectedException mException = ExpectedException.none();
 
-  @AfterClass
-  public static void afterClass() {
-    sService.shutdownNow();
-  }
-
   @Before
   public void before() {
-    mCatalog = new AlluxioCatalog(() -> sService);
+    mCatalog = new AlluxioCatalog();
     TestDatabase.reset();
   }
 


### PR DESCRIPTION
This adds a configuration parameter to specify the number of threads to use for syncing a database.

Fixes #11160 