### PR TITLE
Add logging in FileInStream and BlockInStream

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/LoggingUtils.java
+++ b/core/client/fs/src/main/java/alluxio/client/LoggingUtils.java
@@ -1,0 +1,83 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client;
+
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.util.ConfigurationUtils;
+
+import org.slf4j.Logger;
+
+import java.io.IOException;
+
+/**
+ * Utils for client-side logging.
+ */
+public final  class LoggingUtils {
+  private static final long THRESHOLD = new InstancedConfiguration(ConfigurationUtils.defaults())
+      .getMs(PropertyKey.USER_LOGGING_THRESHOLD);
+
+  /**
+   * The method to be executed.
+   *
+   * @param <V> the return value of {@link #call()}
+   */
+  public interface Callable<V> {
+    /**
+     * Execute the task.
+     *
+     * @return result
+     * @throws IOException when any exception defined in gRPC happens
+     */
+    V call() throws IOException;
+  }
+
+  /**
+   * Execute a method and log the method in debug level.
+   *
+   * @param <V> type of return value of the RPC call
+   * @param method the method to be executed
+   * @param logger the logger to use for this call
+   * @param methodName the human readable name of the RPC call
+   * @param description the format string of the description, used for logging
+   * @param args the arguments for the description
+   * @return the return value of the RPC call
+   * @throws IOException
+   */
+  public static <V> V callAndLog(Callable<V> method, Logger logger, String methodName,
+      String description, Object... args) throws IOException {
+    String debugDesc = logger.isDebugEnabled() ? String.format(description, args) : null;
+    long startMs = System.currentTimeMillis();
+    logger.debug("Enter: {}({})", methodName, debugDesc);
+    try {
+      V ret = method.call();
+      long duration = System.currentTimeMillis() - startMs;
+      logger.debug("Exit (OK): {}({}) in {} ms", methodName, debugDesc, duration);
+      if (duration >= THRESHOLD) {
+        logger.warn("{}({}) returned {} in {} ms", methodName, String.format(description, args),
+            ret, duration);
+      }
+      return ret;
+    } catch (Exception e) {
+      long duration = System.currentTimeMillis() - startMs;
+      logger.debug("Exit (ERROR): {}({}) in {} ms: {}", methodName, debugDesc, duration,
+          e.toString());
+      if (duration >= THRESHOLD) {
+        logger.warn("{}({}) failed with exception [{}] in {} ms (>={}ms)", methodName,
+            String.format(description, args), e.toString(), duration, THRESHOLD);
+      }
+      throw e;
+    }
+  }
+
+  private LoggingUtils() {} // prevent initialization
+}

--- a/core/client/fs/src/main/java/alluxio/client/LoggingUtils.java
+++ b/core/client/fs/src/main/java/alluxio/client/LoggingUtils.java
@@ -56,24 +56,25 @@ public final  class LoggingUtils {
   public static <V> V callAndLog(Callable<V> method, Logger logger, String methodName,
       String description, Object... args) throws IOException {
     String debugDesc = logger.isDebugEnabled() ? String.format(description, args) : null;
+    long tid = Thread.currentThread().getId();
     long startMs = System.currentTimeMillis();
-    logger.debug("Enter: {}({})", methodName, debugDesc);
+    logger.debug("Enter: {}({}), tid={}", methodName, debugDesc, tid);
     try {
       V ret = method.call();
       long duration = System.currentTimeMillis() - startMs;
-      logger.debug("Exit (OK): {}({}) in {} ms", methodName, debugDesc, duration);
+      logger.debug("Exit (OK): {}({}) in {} ms, tid={}", methodName, debugDesc, duration, tid);
       if (duration >= THRESHOLD) {
-        logger.warn("{}({}) returned {} in {} ms", methodName, String.format(description, args),
-            ret, duration);
+        logger.warn("{}({}) returned {} in {} ms (>={}ms), tid={}",
+            methodName, String.format(description, args), ret, duration, THRESHOLD, tid);
       }
       return ret;
     } catch (Exception e) {
       long duration = System.currentTimeMillis() - startMs;
-      logger.debug("Exit (ERROR): {}({}) in {} ms: {}", methodName, debugDesc, duration,
-          e.toString());
+      logger.debug("Exit (ERROR): {}({}) in {} ms: {}, tid={}", methodName, debugDesc, duration,
+          e.toString(), tid);
       if (duration >= THRESHOLD) {
-        logger.warn("{}({}) failed with exception [{}] in {} ms (>={}ms)", methodName,
-            String.format(description, args), e.toString(), duration, THRESHOLD);
+        logger.warn("{}({}) failed with exception [{}] in {} ms (>={}ms), tid={}", methodName,
+            String.format(description, args), e.toString(), duration, THRESHOLD, tid);
       }
       throw e;
     }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -378,6 +378,13 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
 
   @Override
   public void close() throws IOException {
+    LoggingUtils.callAndLog(() -> {
+      closeInternal();
+      return null;
+    }, LOG, "close", "id=%d", mId);
+  }
+
+  private void closeInternal() throws IOException {
     try {
       closeDataReader();
     } finally {

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -409,7 +409,10 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
     }
 
     if (mCurrentChunk != null && mCurrentChunk.readableBytes() == 0) {
-      mCurrentChunk.release();
+      LoggingUtils.callAndLog(() -> {
+        mCurrentChunk.release();
+        return null;
+      }, LOG, "mCurrentChunk.release", "");
       mCurrentChunk = null;
     }
     if (mCurrentChunk == null) {
@@ -422,11 +425,17 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
    */
   private void closeDataReader() throws IOException {
     if (mCurrentChunk != null) {
-      mCurrentChunk.release();
+      LoggingUtils.callAndLog(() -> {
+        mCurrentChunk.release();
+        return null;
+      }, LOG, "mCurrentChunk.release", "");
       mCurrentChunk = null;
     }
     if (mDataReader != null) {
-      mDataReader.close();
+      LoggingUtils.callAndLog(() -> {
+        mDataReader.close();
+        return null;
+      }, LOG, "mDataReader.release", "");
     }
     mDataReader = null;
   }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
@@ -11,6 +11,7 @@
 
 package alluxio.client.block.stream;
 
+import alluxio.client.LoggingUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
@@ -119,6 +120,11 @@ public final class GrpcDataReader implements DataReader {
 
   @Override
   public DataBuffer readChunk() throws IOException {
+    return LoggingUtils.callAndLog(() -> readChunkInternal(),
+        LOG, "readChunk", "id=%d,pos=%d", mReadRequest.getBlockId(), mPosToRead);
+  }
+
+  private DataBuffer readChunkInternal() throws IOException {
     Preconditions.checkState(!mClient.get().isShutdown(),
         "Data reader is closed while reading data chunks.");
     DataBuffer buffer = null;
@@ -199,6 +205,11 @@ public final class GrpcDataReader implements DataReader {
 
     @Override
     public DataReader create(long offset, long len) throws IOException {
+      return LoggingUtils.callAndLog(() -> createInternal(offset, len),
+          LOG, "create", "id=%d,offset=%d,len=%d", mReadRequestPartial.getBlockId(), offset, len);
+    }
+
+    private  DataReader createInternal(long offset, long len) throws IOException {
       return new GrpcDataReader(mContext, mAddress,
           mReadRequestPartial.toBuilder().setOffset(offset).setLength(len).build());
     }

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -229,6 +229,13 @@ public class AlluxioFileInStream extends FileInStream {
 
   @Override
   public void close() throws IOException {
+    LoggingUtils.callAndLog(() -> {
+      closeInternal();
+      return null;
+    }, LOG, "close", "file=%s", mPath);
+  }
+
+  private void closeInternal() throws IOException {
     closeBlockInStream(mBlockInStream);
     closeBlockInStream(mCachedPositionedReadStream);
     mCloser.close();

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -596,38 +596,41 @@ public final class AlluxioFuseFileSystem extends FuseStubFS {
     final int sz = (int) size;
     final long fd = fi.fh.get();
     OpenFileEntry oe = mOpenFiles.getFirstByField(ID_INDEX, fd);
+    LOG.debug("OpenFileEntry: id={},in={}", oe.getId(), oe.getIn());
     if (oe == null) {
       LOG.error("Cannot find fd for {} in table", path);
       return -ErrorCodes.EBADFD();
     }
 
-    int rd = 0;
-    int nread = 0;
-    if (oe.getIn() == null) {
-      LOG.error("{} was not open for reading", path);
-      return -ErrorCodes.EBADFD();
-    }
-    try {
-      oe.getIn().seek(offset);
-      final byte[] dest = new byte[sz];
-      while (rd >= 0 && nread < size) {
-        rd = oe.getIn().read(dest, nread, sz - nread);
-        if (rd >= 0) {
-          nread += rd;
+    synchronized (oe) {
+      int rd = 0;
+      int nread = 0;
+      if (oe.getIn() == null) {
+        LOG.error("{} was not open for reading", path);
+        return -ErrorCodes.EBADFD();
+      }
+      try {
+        oe.getIn().seek(offset);
+        final byte[] dest = new byte[sz];
+        while (rd >= 0 && nread < size) {
+          rd = oe.getIn().read(dest, nread, sz - nread);
+          if (rd >= 0) {
+            nread += rd;
+          }
         }
+
+        if (nread == -1) { // EOF
+          nread = 0;
+        } else if (nread > 0) {
+          buf.put(0, dest, 0, nread);
+        }
+      } catch (Throwable t) {
+        LOG.error("Failed to read file {}", path, t);
+        return AlluxioFuseUtils.getErrorCode(t);
       }
 
-      if (nread == -1) { // EOF
-        nread = 0;
-      } else if (nread > 0) {
-        buf.put(0, dest, 0, nread);
-      }
-    } catch (Throwable t) {
-      LOG.error("Failed to read file {}", path, t);
-      return AlluxioFuseUtils.getErrorCode(t);
+      return nread;
     }
-
-    return nread;
   }
 
   /**

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -240,14 +240,16 @@ public final class AlluxioFuseUtils {
   public static int call(Logger logger, FuseCallable callable, String methodName,
       String description, Object... args) {
     String debugDesc = logger.isDebugEnabled() ? String.format(description, args) : null;
-    logger.debug("Enter: {}({})", methodName, debugDesc);
+    long tid = Thread.currentThread().getId();
+    logger.debug("Enter: {}({}), tid={}", methodName, debugDesc, tid);
     long startMs = System.currentTimeMillis();
     int ret = callable.call();
     long durationMs = System.currentTimeMillis() - startMs;
-    logger.debug("Exit ({}): {}({}) in {} ms", ret, methodName, debugDesc, durationMs);
+    logger.debug("Exit ({}): {}({}) in {} ms, tid={}",
+        ret, methodName, debugDesc, durationMs, tid);
     if (durationMs >= THRESHOLD) {
-      logger.warn("{}({}) returned {} in {} ms (>={} ms)",
-          methodName, String.format(description, args), ret, durationMs, THRESHOLD);
+      logger.warn("{}({}) returned {} in {} ms (>={} ms), tid={}",
+          methodName, String.format(description, args), ret, durationMs, THRESHOLD, tid);
     }
     return ret;
   }


### PR DESCRIPTION
Add to `conf/log4j.properties`

```
log4j.logger.alluxio.client.block.stream.BlockInStream=DEBUG
log4j.logger.alluxio.client.file.AlluxioFileInStream=DEBUG
```

to enable client-side logs like:

```
2020-03-14 01:39:50,226 DEBUG AlluxioFuseFileSystem - Enter: read(path=/aaa,buf=jnr.ffi.provider.jffi.DirectMemoryIO[address=0x11e0d5000],size=65536,offset=0)
2020-03-14 01:39:50,227 DEBUG AlluxioFileInStream - Enter: read(file=/aaa,off=0,len=65536)
2020-03-14 01:39:50,261 DEBUG BlockInStream - Creating short circuit input stream for block 83886080 (/aaa) @ WorkerNetAddress{host=10.0.1.55, rpcPort=29999, dataPort=29999, webPort=30000, domainSocketPath=, tieredIdentity=TieredIdentity(node=10.0.1.55, rack=null)}
2020-03-14 01:39:50,314 DEBUG BlockInStream - Enter: seek(id=83886080,pos=0)
2020-03-14 01:39:50,314 DEBUG BlockInStream - Exit (OK): seek(id=83886080,pos=0)
2020-03-14 01:39:50,314 DEBUG BlockInStream - Enter: read(id=83886080,off=0,len=65536)
2020-03-14 01:39:50,324 DEBUG BlockInStream - Exit (6609): read(id=83886080,off=0,len=65536)
2020-03-14 01:39:50,324 DEBUG AlluxioFileInStream - Exit (6609): read(file=/aaa,off=0,len=65536)
2020-03-14 01:39:50,324 DEBUG AlluxioFuseFileSystem - Exit (6609): read(path=/aaa,buf=jnr.ffi.provider.jffi.DirectMemoryIO[address=0x11e0d5000],size=65536,offset=0) in 98 ms
```

One  can also set `alluxio.user.logging.threshold` e.g. to `10ms` to print Block / File level instream operations longer than `10ms`. Example output in logs:

```
2020-03-15 22:56:35,736 WARN  BlockInStream - seek(id=83886080,pos=0) returned null in 0 ms
2020-03-15 22:56:35,744 WARN  BlockInStream - read(id=83886080,b=[B@30d48072,off=0,len=65536) returned 6609 in 7 ms
```

