### PR TITLE
Change Alluxio master in K8s to use PVC for RocksDB

### DIFF
--- a/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
+++ b/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
@@ -211,8 +211,8 @@ secrets:
 
 ***Example: Off-heap Metastore Management***
 
-The following configuration provisions an `emptyDir` volume with the specified configuration and
-configures the Alluxio master to use the mounted directory for an on-disk RocksDB-based metastore.
+The following configuration creates a `PersistentVolumeClaim` for each Alluxio master Pod with the specified 
+configuration and configures the Pod to use the volume for an on-disk RocksDB-based metastore.
 ```properties
 properties:
   alluxio.master.metastore: ROCKS
@@ -220,12 +220,12 @@ properties:
 
 master:
   metastore:
-    medium: ""
     size: 1Gi
     mountPath: /metastore
+    storageClass: "standard"
+    accessModes:
+      - ReadWriteOnce
 ```
-
-> Limitation: Limits for the disk usage are not configurable as of now.
 
 ***Example: Multiple Secrets***
 

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -173,12 +173,6 @@ spec:
           {{- end }}
       restartPolicy: Always
       volumes:
-        {{- if .Values.master.metastore }}
-        - name: alluxio-metastore
-          emptyDir:
-            medium: {{ .Values.master.metastore.medium }}
-            sizeLimit: {{ .Values.master.metastore.size | quote }}
-        {{- end }}
         {{- if .Values.secrets }}
           {{- if .Values.secrets.master }}
             {{- range $key, $val := .Values.secrets.master }}
@@ -196,8 +190,8 @@ spec:
             claimName: "{{ .name }}"
           {{- end }}
         {{- end }}
-  {{- if $needJournalVolume }}
   volumeClaimTemplates:
+  {{- if $needJournalVolume }}
     - metadata:
         name: alluxio-journal
       spec:
@@ -207,4 +201,15 @@ spec:
         resources:
           requests:
             storage: {{ .Values.journal.size }}
+  {{- end }}
+  {{- if .Values.master.metastore }}
+    - metadata:
+        name: alluxio-metastore
+      spec:
+        storageClassName: {{ .Values.master.metastore.storageClass }}
+        accessModes:
+{{ toYaml .Values.master.metastore.accessModes | indent 8 -}}
+        resources:
+          requests:
+            storage: {{ .Values.master.metastore.size }}
   {{- end }}

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -72,10 +72,14 @@ master:
   nodeSelector: {}
   hostNetwork: false
   dnsPolicy: ClusterFirst
+  # Example: use ROCKS DB instead of Heap
   # metastore:
-  #   medium: ""
   #   size: 1Gi
   #   mountPath: /metastore
+  #   storageClass: "standard"
+  #   accessModes:
+  #     - ReadWriteOnce
+
 
 jobMaster:
   args:

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -80,7 +80,6 @@ master:
   #   accessModes:
   #     - ReadWriteOnce
 
-
 jobMaster:
   args:
     - job-master

--- a/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-statefulset.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/master/alluxio-master-statefulset.yaml.template
@@ -109,4 +109,5 @@ spec:
           secret:
             secretName: alluxio-hdfs-config
             defaultMode: 256
+  volumeClaimTemplates:
 


### PR DESCRIPTION
This resolves point 3 in https://github.com/Alluxio/alluxio/issues/10253

Alluxio master Pods now use PVC for RocksDB as metastore instead of `emptyDir`.