### PR TITLE
Add Parquet Compression option

### DIFF
--- a/job/common/src/main/java/alluxio/job/plan/transform/CompactConfig.java
+++ b/job/common/src/main/java/alluxio/job/plan/transform/CompactConfig.java
@@ -35,11 +35,13 @@ public final class CompactConfig implements PlanConfig {
 
   private static final String NAME = "Compact";
 
-  private final PartitionInfo mPartitionInfo;
+  private final PartitionInfo mInputPartitionInfo;
   /**
    * Files directly under this directory are compacted.
    */
   private final String mInput;
+
+  private final PartitionInfo mOutputPartitionInfo;
   /**
    * Compacted files are stored under this directory.
    */
@@ -54,29 +56,39 @@ public final class CompactConfig implements PlanConfig {
   private final long mMinFileSize;
 
   /**
-   * @param partitionInfo the partition info
+   * @param inputPartitionInfo the input partition info
    * @param input the input directory
+   * @param outputPartitionInfo the output partition info
    * @param output the output directory
    * @param maxNumFiles the maximum number of files after compaction
    * @param minFileSize the minimum file size for coalescing
    */
-  public CompactConfig(@JsonProperty("partitionInfo") PartitionInfo partitionInfo,
+  public CompactConfig(@JsonProperty("inputPartitionInfo") PartitionInfo inputPartitionInfo,
                        @JsonProperty("input") String input,
+                       @JsonProperty("outputPartitionInfo") PartitionInfo outputPartitionInfo,
                        @JsonProperty("output") String output,
                        @JsonProperty("maxNumFiles") Integer maxNumFiles,
                        @JsonProperty("minFileSize") Long minFileSize) {
-    mPartitionInfo = partitionInfo;
+    mInputPartitionInfo = inputPartitionInfo;
     mInput = Preconditions.checkNotNull(input, "input");
+    mOutputPartitionInfo = outputPartitionInfo;
     mOutput = Preconditions.checkNotNull(output, "output");
     mMaxNumFiles = Preconditions.checkNotNull(maxNumFiles, "maxNumFiles");
     mMinFileSize = Preconditions.checkNotNull(minFileSize, "minFileSize");
   }
 
   /**
-   * @return the partition info
+   * @return the input partition info
    */
-  public PartitionInfo getPartitionInfo() {
-    return mPartitionInfo;
+  public PartitionInfo getInputPartitionInfo() {
+    return mInputPartitionInfo;
+  }
+
+  /**
+   * @return the output partition info
+   */
+  public PartitionInfo getOutputPartitionInfo() {
+    return mOutputPartitionInfo;
   }
 
   /**
@@ -119,7 +131,7 @@ public final class CompactConfig implements PlanConfig {
       return false;
     }
     CompactConfig that = (CompactConfig) obj;
-    return mPartitionInfo.equals(that.mPartitionInfo)
+    return mInputPartitionInfo.equals(that.mInputPartitionInfo)
         && mInput.equals(that.mInput)
         && mOutput.equals(that.mOutput)
         && mMaxNumFiles == that.mMaxNumFiles
@@ -128,7 +140,7 @@ public final class CompactConfig implements PlanConfig {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mPartitionInfo, mInput, mOutput, mMaxNumFiles, mMinFileSize);
+    return Objects.hashCode(mInputPartitionInfo, mInput, mOutput, mMaxNumFiles, mMinFileSize);
   }
 
   @Override
@@ -138,7 +150,7 @@ public final class CompactConfig implements PlanConfig {
         .add("output", mOutput)
         .add("maxNumFiles", mMaxNumFiles)
         .add("minFileSize", mMinFileSize)
-        .add("partitionInfo", mPartitionInfo)
+        .add("partitionInfo", mInputPartitionInfo)
         .toString();
   }
 

--- a/job/common/src/main/java/alluxio/job/plan/transform/CompactConfig.java
+++ b/job/common/src/main/java/alluxio/job/plan/transform/CompactConfig.java
@@ -132,6 +132,7 @@ public final class CompactConfig implements PlanConfig {
     }
     CompactConfig that = (CompactConfig) obj;
     return mInputPartitionInfo.equals(that.mInputPartitionInfo)
+        && mOutputPartitionInfo.equals(that.mOutputPartitionInfo)
         && mInput.equals(that.mInput)
         && mOutput.equals(that.mOutput)
         && mMaxNumFiles == that.mMaxNumFiles
@@ -140,7 +141,8 @@ public final class CompactConfig implements PlanConfig {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mInputPartitionInfo, mInput, mOutput, mMaxNumFiles, mMinFileSize);
+    return Objects.hashCode(mInputPartitionInfo, mOutputPartitionInfo, mInput, mOutput,
+        mMaxNumFiles, mMinFileSize);
   }
 
   @Override
@@ -150,7 +152,8 @@ public final class CompactConfig implements PlanConfig {
         .add("output", mOutput)
         .add("maxNumFiles", mMaxNumFiles)
         .add("minFileSize", mMinFileSize)
-        .add("partitionInfo", mInputPartitionInfo)
+        .add("inputPartitionInfo", mInputPartitionInfo)
+        .add("outputPartitionInfo", mOutputPartitionInfo)
         .toString();
   }
 

--- a/job/common/src/main/java/alluxio/job/plan/transform/PartitionInfo.java
+++ b/job/common/src/main/java/alluxio/job/plan/transform/PartitionInfo.java
@@ -27,6 +27,11 @@ import java.util.HashMap;
 public class PartitionInfo implements Serializable {
   private static final long serialVersionUID = 6905153658064056381L;
 
+  /**
+   * Key in Serde Properties to denote parquet compression method
+   */
+  public static final String PARQUET_COMPRESSION = "parquet.compression";
+
   private final String mSerdeClass;
   private final String mInputFormatClass;
   private final HashMap<String, String> mSerdeProperties;

--- a/job/common/src/main/java/alluxio/job/plan/transform/PartitionInfo.java
+++ b/job/common/src/main/java/alluxio/job/plan/transform/PartitionInfo.java
@@ -30,7 +30,7 @@ public class PartitionInfo implements Serializable {
   /**
    * Key in Serde Properties to denote parquet compression method.
    */
-  public static final String PARQUET_COMPRESSION = "parquet.compression";
+  public static final String PARQUET_COMPRESSION = "file.parquet.compression";
 
   private final String mSerdeClass;
   private final String mInputFormatClass;

--- a/job/common/src/main/java/alluxio/job/plan/transform/PartitionInfo.java
+++ b/job/common/src/main/java/alluxio/job/plan/transform/PartitionInfo.java
@@ -28,7 +28,7 @@ public class PartitionInfo implements Serializable {
   private static final long serialVersionUID = 6905153658064056381L;
 
   /**
-   * Key in Serde Properties to denote parquet compression method
+   * Key in Serde Properties to denote parquet compression method.
    */
   public static final String PARQUET_COMPRESSION = "parquet.compression";
 

--- a/job/common/src/test/java/alluxio/job/workflow/composite/CompositeConfigTest.java
+++ b/job/common/src/test/java/alluxio/job/workflow/composite/CompositeConfigTest.java
@@ -42,7 +42,7 @@ public final class CompositeConfigTest {
     jobs.add(new CompositeConfig(new ArrayList<>(), true));
     jobs.add(new CompositeConfig(new ArrayList<>(), false));
     jobs.add(new CompositeConfig(Lists.newArrayList(new LoadConfig("/", 1)), true));
-    jobs.add(new CompactConfig(pInfo, "/input", "/output", 100, FileUtils.ONE_GB));
+    jobs.add(new CompactConfig(pInfo, "/input", pInfo, "/output", 100, FileUtils.ONE_GB));
     CONFIG = new CompositeConfig(jobs, true);
   }
 

--- a/job/server/src/main/java/alluxio/job/plan/transform/CompactDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/CompactDefinition.java
@@ -97,10 +97,10 @@ public final class CompactDefinition
     int maxNumFiles = config.getMaxNumFiles();
     long groupMinSize = config.getMinFileSize();
 
-    if (!files.isEmpty() && config.getPartitionInfo() != null) {
+    if (!files.isEmpty() && config.getInputPartitionInfo() != null) {
       // adjust the group minimum size for source compression ratio
       groupMinSize *= COMPRESSION_RATIO.get(
-          config.getPartitionInfo().getFormat(files.get(0).getName()));
+          config.getInputPartitionInfo().getFormat(files.get(0).getName()));
     }
 
     if (totalFileSize / groupMinSize > maxNumFiles) {
@@ -182,14 +182,15 @@ public final class CompactDefinition
 
       TableSchema schema;
       try (TableReader reader = TableReader.create(new AlluxioURI(inputs.get(0)),
-          config.getPartitionInfo())) {
+          config.getInputPartitionInfo())) {
         schema = reader.getSchema();
       }
 
-      try (TableWriter writer = TableWriter.create(schema, output)) {
+      try (TableWriter writer = TableWriter.create(schema, output,
+          config.getOutputPartitionInfo())) {
         for (String input : inputs) {
           try (TableReader reader = TableReader.create(new AlluxioURI(input),
-              config.getPartitionInfo())) {
+              config.getInputPartitionInfo())) {
             for (TableRow row = reader.read(); row != null; row = reader.read()) {
               writer.write(row);
             }

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/TableWriter.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/TableWriter.java
@@ -35,7 +35,7 @@ public interface TableWriter extends Closeable {
   /**
    * @param schema the table schema
    * @param uri the URI to the output
-   * @param partitionInfo the writer for the output
+   * @param partitionInfo the partition info (default configuration is used if null)
    * @return the writer for the output
    */
   static TableWriter create(TableSchema schema, AlluxioURI uri,

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/TableWriter.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/TableWriter.java
@@ -27,16 +27,21 @@ public interface TableWriter extends Closeable {
    * @param schema the table schema
    * @param uri the URI to the output
    * @return the writer for the output
-   * @throws IOException when failed to create the writer
    */
   static TableWriter create(TableSchema schema, AlluxioURI uri) throws IOException {
     return create(schema, uri, null);
   }
 
+  /**
+   * @param schema the table schema
+   * @param uri the URI to the output
+   * @param partitionInfo the writer for the output
+   * @return the writer for the output
+   */
   static TableWriter create(TableSchema schema, AlluxioURI uri,
                             @Nullable PartitionInfo partitionInfo) throws IOException {
     ReadWriterUtils.checkUri(uri);
-    return ParquetWriter.create(schema, uri);
+    return ParquetWriter.create(schema, uri, partitionInfo);
   }
 
   /**

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/TableWriter.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/TableWriter.java
@@ -12,8 +12,10 @@
 package alluxio.job.plan.transform.format;
 
 import alluxio.AlluxioURI;
+import alluxio.job.plan.transform.PartitionInfo;
 import alluxio.job.plan.transform.format.parquet.ParquetWriter;
 
+import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 
@@ -28,6 +30,11 @@ public interface TableWriter extends Closeable {
    * @throws IOException when failed to create the writer
    */
   static TableWriter create(TableSchema schema, AlluxioURI uri) throws IOException {
+    return create(schema, uri, null);
+  }
+
+  static TableWriter create(TableSchema schema, AlluxioURI uri,
+                            @Nullable PartitionInfo partitionInfo) throws IOException {
     ReadWriterUtils.checkUri(uri);
     return ParquetWriter.create(schema, uri);
   }

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetWriter.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetWriter.java
@@ -29,6 +29,7 @@ import org.apache.parquet.hadoop.util.HadoopOutputFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 /**
@@ -68,11 +69,11 @@ public final class ParquetWriter implements TableWriter {
    *
    * @param schema the schema
    * @param uri the URI to the output
-   * @param partitionInfo the partitionInfo
+   * @param partitionInfo the partitionInfo (default configuration is used if null)
    * @return the writer
    */
   public static ParquetWriter create(TableSchema schema, AlluxioURI uri,
-                                     PartitionInfo partitionInfo) throws IOException {
+                                     @Nullable PartitionInfo partitionInfo) throws IOException {
     String compressionCodec = DEFAULT_COMPRESSION_CODEC;
     if (partitionInfo != null) {
       compressionCodec = partitionInfo.getSerdeProperties().getOrDefault(

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetWriter.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetWriter.java
@@ -12,6 +12,7 @@
 package alluxio.job.plan.transform.format.parquet;
 
 import alluxio.AlluxioURI;
+import alluxio.job.plan.transform.PartitionInfo;
 import alluxio.job.plan.transform.format.JobPath;
 import alluxio.job.plan.transform.format.ReadWriterUtils;
 import alluxio.job.plan.transform.format.TableRow;
@@ -40,6 +41,7 @@ public final class ParquetWriter implements TableWriter {
   private static final int MAX_IN_MEMORY_RECORDS = 10000;
   private static final int ROW_GROUP_SIZE =
       org.apache.parquet.hadoop.ParquetWriter.DEFAULT_BLOCK_SIZE;
+  private static final String DEFAULT_COMPRESSION_CODEC = CompressionCodecName.SNAPPY.name();
 
   private final org.apache.parquet.hadoop.ParquetWriter<Record> mWriter;
   private long mRecordSize; // bytes
@@ -55,11 +57,40 @@ public final class ParquetWriter implements TableWriter {
    * @param schema the schema
    * @param uri the URI to the output
    * @return the writer
-   * @throws IOException when failed to create the writer
    */
   public static ParquetWriter create(TableSchema schema, AlluxioURI uri)
       throws IOException {
-    return ParquetWriter.create(schema, uri, ROW_GROUP_SIZE, true);
+    return ParquetWriter.create(schema, uri, ROW_GROUP_SIZE, true, DEFAULT_COMPRESSION_CODEC);
+  }
+
+  /**
+   * Creates a parquet writer based on the partitionInfo.
+   *
+   * @param schema the schema
+   * @param uri the URI to the output
+   * @param partitionInfo the partitionInfo
+   * @return the writer
+   */
+  public static ParquetWriter create(TableSchema schema, AlluxioURI uri,
+                                     PartitionInfo partitionInfo) throws IOException {
+    final String compressionCodec = partitionInfo.getSerdeProperties().getOrDefault(
+        PartitionInfo.PARQUET_COMPRESSION, DEFAULT_COMPRESSION_CODEC);
+    return ParquetWriter.create(schema, uri, ROW_GROUP_SIZE, true, compressionCodec);
+  }
+
+  /**
+   * Creates a Parquet writer specifying a row group size and whether to have dictionary enabled.
+   *
+   * @param schema the schema
+   * @param uri the URI to the output
+   * @param rowGroupSize the row group size
+   * @param enableDictionary whether to enable dictionary
+   * @return the writer
+   */
+  public static ParquetWriter create(TableSchema schema, AlluxioURI uri, int rowGroupSize,
+                                     boolean enableDictionary) throws IOException {
+    return ParquetWriter.create(schema, uri, rowGroupSize, enableDictionary,
+        DEFAULT_COMPRESSION_CODEC);
   }
 
   /**
@@ -69,11 +100,11 @@ public final class ParquetWriter implements TableWriter {
    * @param uri the URI to the output
    * @param rowGroupSize the row group size
    * @param enableDictionary whether to enable dictionary
+   * @param compressionCodec the compression codec name
    * @return the writer
-   * @throws IOException when failed to create the writer
    */
   public static ParquetWriter create(TableSchema schema, AlluxioURI uri, int rowGroupSize,
-                                     boolean enableDictionary)
+                                     boolean enableDictionary, String compressionCodec)
       throws IOException {
     Configuration conf = ReadWriterUtils.writeThroughConf();
     ParquetSchema parquetSchema = schema.toParquet();
@@ -82,7 +113,7 @@ public final class ParquetWriter implements TableWriter {
             new JobPath(uri.getScheme(), uri.getAuthority().toString(), uri.getPath()), conf))
         .withWriterVersion(ParquetProperties.WriterVersion.PARQUET_2_0)
         .withConf(conf)
-        .withCompressionCodec(CompressionCodecName.SNAPPY)
+        .withCompressionCodec(CompressionCodecName.fromConf(compressionCodec))
         .withRowGroupSize(rowGroupSize)
         .withDictionaryPageSize(org.apache.parquet.hadoop.ParquetWriter.DEFAULT_PAGE_SIZE)
         .withDictionaryEncoding(enableDictionary)

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetWriter.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetWriter.java
@@ -73,8 +73,11 @@ public final class ParquetWriter implements TableWriter {
    */
   public static ParquetWriter create(TableSchema schema, AlluxioURI uri,
                                      PartitionInfo partitionInfo) throws IOException {
-    final String compressionCodec = partitionInfo.getSerdeProperties().getOrDefault(
-        PartitionInfo.PARQUET_COMPRESSION, DEFAULT_COMPRESSION_CODEC);
+    String compressionCodec = DEFAULT_COMPRESSION_CODEC;
+    if (partitionInfo != null) {
+      compressionCodec = partitionInfo.getSerdeProperties().getOrDefault(
+          PartitionInfo.PARQUET_COMPRESSION, DEFAULT_COMPRESSION_CODEC);
+    }
     return ParquetWriter.create(schema, uri, ROW_GROUP_SIZE, true, compressionCodec);
   }
 

--- a/job/server/src/test/java/alluxio/job/plan/transform/CompactDefinitionSelectExecutorsTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/CompactDefinitionSelectExecutorsTest.java
@@ -50,8 +50,8 @@ public class CompactDefinitionSelectExecutorsTest extends SelectExecutorsTest {
     PartitionInfo mockPartitionInfo = mock(PartitionInfo.class);
     when(mockPartitionInfo.getFormat(any())).thenReturn(Format.CSV);
 
-    CompactConfig config = new CompactConfig(mockPartitionInfo, INPUT_DIR, mockPartitionInfo, OUTPUT_DIR,
-        numCompactedFiles, 2 * FileUtils.ONE_GB);
+    CompactConfig config = new CompactConfig(mockPartitionInfo, INPUT_DIR, mockPartitionInfo,
+        OUTPUT_DIR, numCompactedFiles, 2 * FileUtils.ONE_GB);
 
     List<URIStatus> inputFiles = new ArrayList<>();
     for (int i = 0; i < totalFiles; i++) {

--- a/job/server/src/test/java/alluxio/job/plan/transform/CompactDefinitionSelectExecutorsTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/CompactDefinitionSelectExecutorsTest.java
@@ -50,7 +50,7 @@ public class CompactDefinitionSelectExecutorsTest extends SelectExecutorsTest {
     PartitionInfo mockPartitionInfo = mock(PartitionInfo.class);
     when(mockPartitionInfo.getFormat(any())).thenReturn(Format.CSV);
 
-    CompactConfig config = new CompactConfig(mockPartitionInfo, INPUT_DIR, OUTPUT_DIR,
+    CompactConfig config = new CompactConfig(mockPartitionInfo, INPUT_DIR, mockPartitionInfo, OUTPUT_DIR,
         numCompactedFiles, 2 * FileUtils.ONE_GB);
 
     List<URIStatus> inputFiles = new ArrayList<>();

--- a/job/server/src/test/java/alluxio/job/plan/transform/format/ReadWriteTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/format/ReadWriteTest.java
@@ -46,28 +46,6 @@ public final class ReadWriteTest extends BaseTransformTest {
       HiveConstants.PARQUET_INPUT_FORMAT_CLASS, new HashMap<>(), new HashMap<>(),
       new ArrayList<>());
 
-  private void createCsvFile(File file, boolean gzipped) throws IOException {
-    OutputStream outputStream = new FileOutputStream(file);
-    try {
-      if (gzipped) {
-        outputStream = new GZIPOutputStream(outputStream);
-      }
-      outputStream.write("a,b,c\n".getBytes());
-      outputStream.write("1,2,3\n".getBytes());
-    } finally {
-      outputStream.close();
-    }
-  }
-
-  private void createParquetFile(File file) throws IOException {
-    TableSchema schema = new ParquetSchema(SCHEMA);
-    TableRow row = new ParquetRow(RECORD);
-    AlluxioURI uri = new AlluxioURI("file:///" + file.getPath());
-    try (TableWriter writer = TableWriter.create(schema, uri)) {
-      writer.write(row);
-    }
-  }
-
   @Test
   public void readWrite() throws Exception {
     final File file = mTempFolder.newFile("test.parquet");
@@ -77,7 +55,7 @@ public final class ReadWriteTest extends BaseTransformTest {
     TableSchema schema = new ParquetSchema(SCHEMA);
     TableRow row = new ParquetRow(RECORD);
     AlluxioURI uri = new AlluxioURI("file:///" + file.getPath());
-    try (TableWriter writer = TableWriter.create(schema, uri)) {
+    try (TableWriter writer = TableWriter.create(schema, uri, mPartitionInfo)) {
       for (int r = 0; r < numRows; r++) {
         writer.write(row);
       }

--- a/job/server/src/test/java/alluxio/job/plan/transform/format/ReadWriteTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/format/ReadWriteTest.java
@@ -24,8 +24,6 @@ import com.google.common.collect.Lists;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -40,7 +38,6 @@ import java.util.zip.GZIPOutputStream;
 /**
  * Tests {@link TableReader} and {@link TableWriter}.
  */
-@RunWith(PowerMockRunner.class)
 public final class ReadWriteTest extends BaseTransformTest {
   @Rule
   public TemporaryFolder mTempFolder = new TemporaryFolder();

--- a/job/server/src/test/java/alluxio/job/plan/transform/format/ReadWriteTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/format/ReadWriteTest.java
@@ -12,7 +12,6 @@
 package alluxio.job.plan.transform.format;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
 
 import alluxio.AlluxioURI;
 import alluxio.job.plan.transform.BaseTransformTest;
@@ -21,14 +20,11 @@ import alluxio.job.plan.transform.PartitionInfo;
 import alluxio.job.plan.transform.format.parquet.ParquetRow;
 import alluxio.job.plan.transform.format.parquet.ParquetSchema;
 
-import alluxio.job.plan.transform.format.parquet.ParquetWriter;
 import com.google.common.collect.Lists;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;

--- a/job/server/src/test/java/alluxio/job/plan/transform/format/ReadWriteTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/format/ReadWriteTest.java
@@ -26,14 +26,10 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.zip.GZIPOutputStream;
 
 /**
  * Tests {@link TableReader} and {@link TableWriter}.

--- a/job/server/src/test/java/alluxio/job/plan/transform/format/ReadWriteTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/transform/format/ReadWriteTest.java
@@ -12,6 +12,7 @@
 package alluxio.job.plan.transform.format;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 
 import alluxio.AlluxioURI;
 import alluxio.job.plan.transform.BaseTransformTest;
@@ -20,10 +21,15 @@ import alluxio.job.plan.transform.PartitionInfo;
 import alluxio.job.plan.transform.format.parquet.ParquetRow;
 import alluxio.job.plan.transform.format.parquet.ParquetSchema;
 
+import alluxio.job.plan.transform.format.parquet.ParquetWriter;
 import com.google.common.collect.Lists;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -38,6 +44,7 @@ import java.util.zip.GZIPOutputStream;
 /**
  * Tests {@link TableReader} and {@link TableWriter}.
  */
+@RunWith(PowerMockRunner.class)
 public final class ReadWriteTest extends BaseTransformTest {
   @Rule
   public TemporaryFolder mTempFolder = new TemporaryFolder();

--- a/table/server/common/src/main/java/alluxio/table/common/layout/HiveLayout.java
+++ b/table/server/common/src/main/java/alluxio/table/common/layout/HiveLayout.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.table.ColumnStatisticsInfo;
 import alluxio.grpc.table.layout.hive.PartitionInfo;
+import alluxio.grpc.table.layout.hive.StorageFormat;
 import alluxio.job.plan.transform.HiveConstants;
 import alluxio.table.common.Layout;
 import alluxio.table.common.LayoutFactory;
@@ -24,6 +25,7 @@ import alluxio.table.common.transform.TransformPlan;
 import alluxio.util.ConfigurationUtils;
 
 import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 /**
@@ -110,15 +113,25 @@ public class HiveLayout implements Layout {
     return mPartitionStatsInfo;
   }
 
-  private HiveLayout transformLayout(AlluxioURI transformedUri) {
+  private HiveLayout transformLayout(AlluxioURI transformedUri, TransformDefinition definition) {
+    final Properties properties = definition.getProperties();
+
     // TODO(cc): assumption here is the transformed data is in Parquet format.
+    final StorageFormat.Builder storageFormatBuilder = mPartitionInfo.getStorage().getStorageFormat().toBuilder()
+        .setSerde(HiveConstants.PARQUET_SERDE_CLASS)
+        .setInputFormat(HiveConstants.PARQUET_INPUT_FORMAT_CLASS)
+        .setOutputFormat(HiveConstants.PARQUET_OUTPUT_FORMAT_CLASS);
+
+    final String compressionKey = alluxio.job.plan.transform.PartitionInfo.PARQUET_COMPRESSION;
+    final String compression = properties.getProperty(compressionKey);
+    if (!StringUtils.isEmpty(compression)) {
+      storageFormatBuilder.putSerdelibParameters(compressionKey, compression);
+    }
+
     PartitionInfo info = mPartitionInfo.toBuilder()
         .putAllParameters(mPartitionInfo.getParametersMap())
         .setStorage(mPartitionInfo.getStorage().toBuilder()
-            .setStorageFormat(mPartitionInfo.getStorage().getStorageFormat().toBuilder()
-                .setSerde(HiveConstants.PARQUET_SERDE_CLASS)
-                .setInputFormat(HiveConstants.PARQUET_INPUT_FORMAT_CLASS)
-                .setOutputFormat(HiveConstants.PARQUET_OUTPUT_FORMAT_CLASS)
+            .setStorageFormat(storageFormatBuilder
                 .build())
             .setLocation(transformedUri.toString())
             .build())
@@ -134,7 +147,7 @@ public class HiveLayout implements Layout {
     AlluxioURI outputUri = new AlluxioURI(
         ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global())
         + outputPath.getPath());
-    HiveLayout transformedLayout = transformLayout(outputUri);
+    HiveLayout transformedLayout = transformLayout(outputUri, definition);
     return new TransformPlan(this, transformedLayout, definition);
   }
 

--- a/table/server/common/src/main/java/alluxio/table/common/layout/HiveLayout.java
+++ b/table/server/common/src/main/java/alluxio/table/common/layout/HiveLayout.java
@@ -117,7 +117,8 @@ public class HiveLayout implements Layout {
     final Properties properties = definition.getProperties();
 
     // TODO(cc): assumption here is the transformed data is in Parquet format.
-    final StorageFormat.Builder storageFormatBuilder = mPartitionInfo.getStorage().getStorageFormat().toBuilder()
+    final StorageFormat.Builder storageFormatBuilder = mPartitionInfo.getStorage()
+        .getStorageFormat().toBuilder()
         .setSerde(HiveConstants.PARQUET_SERDE_CLASS)
         .setInputFormat(HiveConstants.PARQUET_INPUT_FORMAT_CLASS)
         .setOutputFormat(HiveConstants.PARQUET_OUTPUT_FORMAT_CLASS);

--- a/table/server/common/src/main/java/alluxio/table/common/transform/TransformDefinition.java
+++ b/table/server/common/src/main/java/alluxio/table/common/transform/TransformDefinition.java
@@ -26,18 +26,20 @@ import java.util.Properties;
 public class TransformDefinition {
   private final String mDefinition;
   private final List<TransformAction> mActions;
+  private final Properties mProperties;
 
   /**
    * The user-provided definition is normalized by:
    * 1. trimming whitespaces and semicolon from the beginning and end;
    * 2. normalize to lower case.
-   *
-   * @param definition the string definition
+   *  @param definition the string definition
    * @param actions the list of actions
+   * @param properties the list of properties extracted from definition
    */
-  private TransformDefinition(String definition, List<TransformAction> actions) {
+  private TransformDefinition(String definition, List<TransformAction> actions, Properties properties) {
     mDefinition = normalize(definition);
     mActions = actions;
+    mProperties = properties;
   }
 
   private String normalize(String definition) {
@@ -63,6 +65,13 @@ public class TransformDefinition {
   }
 
   /**
+   * @return the list of properties extracted from the user-provided definition
+   */
+  public Properties getProperties() {
+    return mProperties;
+  }
+
+  /**
    * @param definition the string definition
    * @return the {@link TransformDefinition} representation
    */
@@ -70,7 +79,7 @@ public class TransformDefinition {
     definition = definition.trim();
 
     if (definition.isEmpty()) {
-      return new TransformDefinition(definition, Collections.emptyList());
+      return new TransformDefinition(definition, Collections.emptyList(), new Properties());
     }
 
     // accept semicolon as new lines for inline definitions
@@ -84,11 +93,11 @@ public class TransformDefinition {
       properties.load(reader);
     } catch (IOException e) {
       // The only way this throws an IOException is if the definition is null which isn't possible.
-      return new TransformDefinition(definition, Collections.emptyList());
+      return new TransformDefinition(definition, Collections.emptyList(), properties);
     }
 
     final List<TransformAction> actions = TransformActionRegistry.create(properties);
 
-    return new TransformDefinition(definition, actions);
+    return new TransformDefinition(definition, actions, properties);
   }
 }

--- a/table/server/common/src/main/java/alluxio/table/common/transform/TransformDefinition.java
+++ b/table/server/common/src/main/java/alluxio/table/common/transform/TransformDefinition.java
@@ -32,7 +32,7 @@ public class TransformDefinition {
    * The user-provided definition is normalized by:
    * 1. trimming whitespaces and semicolon from the beginning and end;
    * 2. normalize to lower case.
-   *  @param definition the string definition
+   * @param definition the string definition
    * @param actions the list of actions
    * @param properties the list of properties extracted from definition
    */

--- a/table/server/common/src/main/java/alluxio/table/common/transform/TransformDefinition.java
+++ b/table/server/common/src/main/java/alluxio/table/common/transform/TransformDefinition.java
@@ -38,6 +38,7 @@ public class TransformDefinition {
    */
   private TransformDefinition(String definition, List<TransformAction> actions,
                               Properties properties) {
+    // TODO(bradley): derive definition string from properties or vice versa
     mDefinition = normalize(definition);
     mActions = actions;
     mProperties = properties;

--- a/table/server/common/src/main/java/alluxio/table/common/transform/TransformDefinition.java
+++ b/table/server/common/src/main/java/alluxio/table/common/transform/TransformDefinition.java
@@ -36,7 +36,8 @@ public class TransformDefinition {
    * @param actions the list of actions
    * @param properties the list of properties extracted from definition
    */
-  private TransformDefinition(String definition, List<TransformAction> actions, Properties properties) {
+  private TransformDefinition(String definition, List<TransformAction> actions,
+                              Properties properties) {
     mDefinition = normalize(definition);
     mActions = actions;
     mProperties = properties;

--- a/table/server/common/src/main/java/alluxio/table/common/transform/action/CompactAction.java
+++ b/table/server/common/src/main/java/alluxio/table/common/transform/action/CompactAction.java
@@ -91,7 +91,9 @@ public class CompactAction implements TransformAction {
   public JobConfig generateJobConfig(Layout base, Layout transformed, boolean deleteSrc) {
     alluxio.job.plan.transform.PartitionInfo basePartitionInfo =
         TransformActionUtils.generatePartitionInfo(base);
+    alluxio.job.plan.transform.PartitionInfo transformedPartitionInfo =
+        TransformActionUtils.generatePartitionInfo(transformed);
     return new CompactConfig(basePartitionInfo, base.getLocation().toString(),
-        transformed.getLocation().toString(), mNumFiles, mFileSize);
+        transformedPartitionInfo, transformed.getLocation().toString(), mNumFiles, mFileSize);
   }
 }

--- a/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
@@ -33,6 +33,7 @@ import alluxio.table.common.UdbPartition;
 import alluxio.table.common.layout.HiveLayout;
 import alluxio.table.common.transform.TransformDefinition;
 import alluxio.table.common.transform.TransformPlan;
+import alluxio.table.common.transform.action.TransformActionUtils;
 import alluxio.table.common.udb.UdbContext;
 import alluxio.table.common.udb.UdbTable;
 import alluxio.table.common.udb.UnderDatabaseRegistry;
@@ -330,6 +331,28 @@ public class AlluxioCatalogTest {
     plans = mCatalog.getTransformPlan(dbName, tableName, TRANSFORM_DEFINITION);
     assertEquals("alluxio://zk@host:1000/",
         plans.get(0).getTransformedLayout().getLocation().getRootPath());
+  }
+
+  @Test
+  public void getTransformPlanTransformedLayout() throws Exception {
+    String dbName = "testdb";
+    TestDatabase.genTable(1, 1, false);
+    mCatalog.attachDatabase(NoopJournalContext.INSTANCE,
+        TestUdbFactory.TYPE, "connect_URI", TestDatabase.TEST_UDB_NAME, dbName,
+        Collections.emptyMap(), false);
+    String tableName = TestDatabase.getTableName(0);
+
+    ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
+
+    final TransformDefinition transformDefinition =
+        TransformDefinition.parse("file.count.max=100;parquet.compression=uncompressed");
+
+    List<TransformPlan> plans = mCatalog.getTransformPlan(dbName, tableName, transformDefinition);
+    assertEquals(1, plans.size());
+    alluxio.job.plan.transform.PartitionInfo transformedPartitionInfo =
+        TransformActionUtils.generatePartitionInfo(plans.get(0).getTransformedLayout());
+    assertEquals("uncompressed",
+        transformedPartitionInfo.getSerdeProperties().get("parquet.compression"));
   }
 
   @Test

--- a/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
@@ -345,14 +345,14 @@ public class AlluxioCatalogTest {
     ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
 
     final TransformDefinition transformDefinition =
-        TransformDefinition.parse("file.count.max=100;parquet.compression=uncompressed");
+        TransformDefinition.parse("file.count.max=100;file.parquet.compression=uncompressed");
 
     List<TransformPlan> plans = mCatalog.getTransformPlan(dbName, tableName, transformDefinition);
     assertEquals(1, plans.size());
     alluxio.job.plan.transform.PartitionInfo transformedPartitionInfo =
         TransformActionUtils.generatePartitionInfo(plans.get(0).getTransformedLayout());
     assertEquals("uncompressed",
-        transformedPartitionInfo.getSerdeProperties().get("parquet.compression"));
+        transformedPartitionInfo.getSerdeProperties().get("file.parquet.compression"));
   }
 
   @Test


### PR DESCRIPTION
**Supported compressions**

parquet.compression=snappy

-rw-r--r--  ec2-user       ec2-user             176773098       PERSISTED 03-19-2020 17:02:33:446 100% /catalog/movielens/tables/ratings/_internal_/ratings/20200319-170148-870-XX8Nm/part-0.parquet

parquet.compression=gzip

-rw-r--r--  ec2-user       ec2-user             123313059       PERSISTED 03-19-2020 17:16:04:797   0% /catalog/movielens/tables/ratings/_internal_/ratings/20200319-171507-662-AnOVT/part-0.parquet

parquet.compression=uncompressed

-rw-r--r--  ec2-user       ec2-user             208935017       PERSISTED 03-19-2020 17:11:50:626   0% /catalog/movielens/tables/ratings/_internal_/ratings/20200319-171107-547-xWDJC/part-0.parquet


**Can be supported but not yet**

parquet.compression=lzo
Class com.hadoop.compression.lzo.LzoCodec not found

parquet.compression=brotli
Class rg.apache.hadoop.io.compress.BrotliCodec not found

parquet.compression=lz4
native lz4 library not available

parquet.compression=zstd
Class rg.apache.hadoop.io.compress.ZStandardCodec not found