### PR TITLE
Fix backup heartbeat termination

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
@@ -266,7 +266,8 @@ public class BackupWorkerRole extends AbstractBackupRole {
     mBackupProgressFuture = mExecutorService.submit(() -> {
       while (true) {
         // No need to check result because heartbeat will be sent regardless.
-        mBackupTracker.waitUntilFinished(mBackupHeartbeatIntervalMs, TimeUnit.MILLISECONDS);
+        boolean finished =
+            mBackupTracker.waitUntilFinished(mBackupHeartbeatIntervalMs, TimeUnit.MILLISECONDS);
         try {
           sendMessageBlocking(mLeaderConnection,
               new BackupHeartbeatMessage(mBackupTracker.getCurrentStatus()));
@@ -274,8 +275,8 @@ public class BackupWorkerRole extends AbstractBackupRole {
           LOG.warn("Failed to send heartbeat to backup-leader: {}. Error: {}", mLeaderConnection,
               e);
         }
-        // Stop heartbeats if backup finished.
-        if (!mBackupTracker.inProgress()) {
+        // Stop sending heartbeats if the latest backup has been finished.
+        if (finished) {
           break;
         }
       }


### PR DESCRIPTION
Without this fix, a backup on the backup-worker could have finished without sending the last heart-beat, causing the leader to abort after a timeout.