### PR TITLE
Fix configuration not getting raw values

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/meta/MetaMasterConfigurationServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/MetaMasterConfigurationServiceHandler.java
@@ -67,7 +67,7 @@ public final class MetaMasterConfigurationServiceHandler
       if (!options.getIgnoreClusterConf()) {
         if (clusterConf == null
             || !clusterConf.getClusterConfigHash().equals(hash.getClusterConfigHash())) {
-          clusterConf = mMetaMaster.getConfiguration(GetConfigurationPOptions.newBuilder()
+          clusterConf = mMetaMaster.getConfiguration(options.toBuilder()
               .setIgnorePathConf(true).build()).toProto();
           mClusterConf = clusterConf;
         }
@@ -77,7 +77,7 @@ public final class MetaMasterConfigurationServiceHandler
       if (!options.getIgnorePathConf()) {
         if (pathConf == null
             || !pathConf.getPathConfigHash().equals(hash.getPathConfigHash())) {
-          pathConf = mMetaMaster.getConfiguration(GetConfigurationPOptions.newBuilder()
+          pathConf = mMetaMaster.getConfiguration(options.toBuilder()
               .setIgnoreClusterConf(true).build()).toProto();
           mPathConf = pathConf;
         }


### PR DESCRIPTION
For configuration sync we request raw values from master, however the API implementation dropped the options.