### PR TITLE
Add ability to override S3 max error retry count

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -929,6 +929,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_S3_MAX_ERROR_RETRY =
+      new Builder(Name.UNDERFS_S3_MAX_ERROR_RETRY)
+          .setAlias("alluxio.underfs.s3a.max.error.retry")
+          .setDescription("The maximum number of retry attempts for failed retryable requests."
+              + "Setting this property will override the AWS SDK default.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_S3_REQUEST_TIMEOUT =
       new Builder(Name.UNDERFS_S3_REQUEST_TIMEOUT)
           .setAlias("alluxio.underfs.s3a.request.timeout.ms", "alluxio.underfs.s3a.request.timeout")
@@ -4255,6 +4263,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.s3.intermediate.upload.clean.age";
     public static final String UNDERFS_S3_LIST_OBJECTS_V1 =
         "alluxio.underfs.s3.list.objects.v1";
+    public static final String UNDERFS_S3_MAX_ERROR_RETRY =
+        "alluxio.underfs.s3.max.error.retry";
     public static final String UNDERFS_S3_REQUEST_TIMEOUT =
         "alluxio.underfs.s3.request.timeout";
     public static final String UNDERFS_S3_SECURE_HTTP_ENABLED =

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -146,6 +146,11 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
     // Set the client configuration based on Alluxio configuration values.
     ClientConfiguration clientConf = new ClientConfiguration();
 
+    // Max error retry
+    if (conf.isSet(PropertyKey.UNDERFS_S3_MAX_ERROR_RETRY)) {
+      clientConf.setMaxErrorRetry(conf.getInt(PropertyKey.UNDERFS_S3_MAX_ERROR_RETRY));
+    }
+
     // Socket timeout
     clientConf
         .setSocketTimeout((int) conf.getMs(PropertyKey.UNDERFS_S3_SOCKET_TIMEOUT));


### PR DESCRIPTION
The `AmazonS3Client` default retry policy retries `AmazonClientException`s caused by an `IOException` such as when the server does not respond with `NoHttpResponseException`.

This PR adds the ability to override the AWS default count for stress tests in which we observe the following error intermittently:
```
com.amazonaws.SdkClientException: Unable to execute HTTP request: The target server failed to respond
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleRetryableException(AmazonHttpClient.java:1201)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1147)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:796)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:764)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:738)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:698)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:680)
        at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:544)
        at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:524)
        at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:5054)
        at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:5000)
        at com.amazonaws.services.s3.AmazonS3Client.getObject(AmazonS3Client.java:1486)
        at alluxio.underfs.s3a.S3AInputStream.openStream(S3AInputStream.java:148)
        at alluxio.underfs.s3a.S3AInputStream.read(S3AInputStream.java:113)
        at io.netty.buffer.UnsafeByteBufUtil.setBytes(UnsafeByteBufUtil.java:454)
        at io.netty.buffer.PooledUnsafeDirectByteBuf.setBytes(PooledUnsafeDirectByteBuf.java:208)
        at io.netty.buffer.AbstractByteBuf.writeBytes(AbstractByteBuf.java:1137)
        at alluxio.worker.block.UnderFileSystemBlockReader.transferTo(UnderFileSystemBlockReader.java:229)
        at alluxio.worker.grpc.BlockReadHandler$BlockDataReader.getDataBuffer(BlockReadHandler.java:110)
        at alluxio.worker.grpc.BlockReadHandler$BlockDataReader.getDataBuffer(BlockReadHandler.java:70)
        at alluxio.worker.grpc.AbstractReadHandler$DataReader.runInternal(AbstractReadHandler.java:325)
        at alluxio.worker.grpc.AbstractReadHandler$DataReader.run(AbstractReadHandler.java:293)
        at alluxio.worker.grpc.BlockReadHandler$BlockDataReader.run(BlockReadHandler.java:70)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at alluxio.worker.grpc.GrpcExecutors$ImpersonateThreadPoolExecutor.lambda$execute$0(GrpcExecutors.java:82)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.http.NoHttpResponseException: The target server failed to respond
        at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:141)
        at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:56)
        at org.apache.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:259)
        at org.apache.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:163)
        at org.apache.http.impl.conn.CPoolProxy.receiveResponseHeader(CPoolProxy.java:165)
        at org.apache.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:273)
        at com.amazonaws.http.protocol.SdkHttpRequestExecutor.doReceiveResponse(SdkHttpRequestExecutor.java:82)
        at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:125)
        at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:272)
        at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:185)
        at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:56)
        at com.amazonaws.http.apache.client.impl.SdkHttpClient.execute(SdkHttpClient.java:72)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1323)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1139)
        ... 27 more
```