### PR TITLE
Create new client pool map during context reinit

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
@@ -49,7 +49,7 @@ public interface BlockWorkerClient extends Closeable {
     /**
      * Creates a new block worker client.
      *
-     * @param subject the user subject
+     * @param userState the user subject
      * @param address the address of the worker
      * @return a new {@link BlockWorkerClient}
      */

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
@@ -66,7 +66,7 @@ public final class BlockWorkerClientPool extends DynamicResourcePool<BlockWorker
 
   @Override
   protected void closeResource(BlockWorkerClient client) throws IOException {
-    LOG.info("Block worker client for {} closed.", mAddress);
+    LOG.debug("Block worker client for {} closed.", mAddress);
     client.close();
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/ConfigHashSync.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ConfigHashSync.java
@@ -92,8 +92,7 @@ public final class ConfigHashSync implements HeartbeatExecutor {
         mContext.getClientContext().getPathConfHash());
     if (isClusterConfUpdated || isPathConfUpdated) {
       try {
-        LOG.debug("Reinitializing FileSystemContext: Cluster conf updated: {}, path conf updated:"
-            + " {}", isClusterConfUpdated, isPathConfUpdated);
+
         mContext.reinit(isClusterConfUpdated, isPathConfUpdated);
         mException = null;
       } catch (UnavailableException e) {

--- a/core/client/fs/src/main/java/alluxio/client/file/ConfigHashSync.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ConfigHashSync.java
@@ -92,7 +92,6 @@ public final class ConfigHashSync implements HeartbeatExecutor {
         mContext.getClientContext().getPathConfHash());
     if (isClusterConfUpdated || isPathConfUpdated) {
       try {
-
         mContext.reinit(isClusterConfUpdated, isPathConfUpdated);
         mException = null;
       } catch (UnavailableException e) {

--- a/core/client/fs/src/main/java/alluxio/client/file/ConfigHashSync.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ConfigHashSync.java
@@ -92,6 +92,8 @@ public final class ConfigHashSync implements HeartbeatExecutor {
         mContext.getClientContext().getPathConfHash());
     if (isClusterConfUpdated || isPathConfUpdated) {
       try {
+        LOG.debug("Reinitializing FileSystemContext: Cluster conf updated: {}, path conf updated:"
+            + " {}", isClusterConfUpdated, isPathConfUpdated);
         mContext.reinit(isClusterConfUpdated, isPathConfUpdated);
         mException = null;
       } catch (UnavailableException e) {

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -289,6 +289,7 @@ public class FileSystemContext implements Closeable {
       // Close worker group after block master clients in order to allow
       // clean termination for open streams.
       mWorkerGroup.shutdownGracefully(1L, 10L, TimeUnit.SECONDS);
+      mBlockWorkerClientPoolMap.clear();
       mBlockWorkerClientPoolMap = null;
       mLocalWorkerInitialized = false;
       mLocalWorker = null;

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -289,7 +289,6 @@ public class FileSystemContext implements Closeable {
       // Close worker group after block master clients in order to allow
       // clean termination for open streams.
       mWorkerGroup.shutdownGracefully(1L, 10L, TimeUnit.SECONDS);
-      mBlockWorkerClientPoolMap.clear();
       mBlockWorkerClientPoolMap = null;
       mLocalWorkerInitialized = false;
       mLocalWorker = null;
@@ -360,7 +359,8 @@ public class FileSystemContext implements Closeable {
         throw new UnavailableException(String.format("Failed to load configuration from "
             + "meta master (%s) during reinitialization", masterAddr), e);
       }
-      LOG.debug("Closing FileSystem context for reinitialization");
+      LOG.debug("Reinitializing FileSystemContext: update cluster conf: {}, update path conf:"
+          + " {}", updateClusterConf, updateClusterConf);
       closeContext();
       initContext(getClientContext(), MasterInquireClient.Factory.create(getClusterConf(),
           getClientContext().getUserState()));

--- a/tests/src/test/java/alluxio/client/fs/FileSystemContextReinitIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemContextReinitIntegrationTest.java
@@ -13,6 +13,7 @@ package alluxio.client.fs;
 
 import alluxio.AlluxioURI;
 import alluxio.client.ReadType;
+import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
@@ -26,6 +27,7 @@ import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.heartbeat.HeartbeatThread;
 import alluxio.heartbeat.ManuallyScheduleHeartbeat;
 import alluxio.master.MasterClientContext;
+import alluxio.resource.CloseableResource;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
@@ -112,6 +114,17 @@ public final class FileSystemContextReinitIntegrationTest extends BaseIntegratio
     updateHash();
     triggerAndWaitSync();
     checkHash(false, false);
+  }
+
+  @Test
+  public void blockWorkerClientReinit() throws Exception {
+    FileSystemContext fsContext = FileSystemContext.create(ServerConfiguration.global());
+    try (CloseableResource<BlockWorkerClient> client =
+        fsContext.acquireBlockWorkerClient(mLocalAlluxioClusterResource.get().getWorkerAddress())) {
+      fsContext.reinit(true, true);
+      fsContext.acquireBlockWorkerClient(mLocalAlluxioClusterResource.get().getWorkerAddress())
+          .close();
+    }
   }
 
   @Test


### PR DESCRIPTION
When a FileSystemContext is re-initialized, any acquired clients are expected to be released back into the same pool.

Before this change, it's possible for the following scenario to occur:
- A thread would acquire a block worker client from the pool map with key `A`.
- The context is re-initialized. All pools in the map are closed, the pool map is cleared
- Another thread acquires a block worker client with key `A` as well. This creates a new pool map entry with the same key `A`.
- The original thread tries to release the client it acquired before, and it releases back into the new blockworker client pool. The pool is not the same as before, and an exception is thrown.


Fixes #11221

                                     