### PR TITLE
Increase default job worker thread pool size

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3979,8 +3979,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.JOB_WORKER_THREADPOOL_SIZE)
           .setDescription("Number of threads in the thread pool for job worker. "
               + "This may be adjusted to a lower value to alleviate resource "
-              + "saturation on the job worker nodes (CPU + IO).")
-          .setDefaultValue(10)
+              + "saturation on the job worker nodes (CPU + IO + Memory).")
+          .setDefaultValue(50)
           .setScope(Scope.WORKER)
           .build();
   public static final PropertyKey JOB_WORKER_THROTTLING =


### PR DESCRIPTION
This may cause some transformations to OOM, but it will make much of the other jobs in many of the more common setups faster.