### PR TITLE
Parallelize DistributedLoadCommand client's job completion check

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -39,6 +39,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -140,7 +142,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
     }
   }
 
-  private final List<JobAttempt> mSubmittedJobAttempts;
+  private List<JobAttempt> mSubmittedJobAttempts;
   private int mActiveJobs;
 
   /**
@@ -194,38 +196,34 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
   }
 
   /**
-   * Waits one job to complete.
+   * Waits for at least one job to complete.
    */
-  private void waitJob() throws IOException {
-    boolean removed = false;
+  private void waitJob() {
+    AtomicBoolean removed = new AtomicBoolean(false);
     while (true) {
-      Iterator<JobAttempt> iterator = mSubmittedJobAttempts.iterator();
-
-      while (iterator.hasNext()) {
-        JobAttempt jobAttempt = iterator.next();
+       mSubmittedJobAttempts = mSubmittedJobAttempts.parallelStream().filter((jobAttempt) -> {
         Status check = jobAttempt.check();
-
         switch (check) {
           case CREATED:
           case RUNNING:
-            continue;
+            return true;
           case CANCELED:
           case COMPLETED:
-            removed = true;
-            jobAttempt.close();
-            iterator.remove();
-            continue;
-          case FAILED:
-            if (!jobAttempt.run()) {
-              removed = true;
-              iterator.remove();
+            removed.set(true);
+            try {
+              jobAttempt.close();
+            } catch (IOException e) {
+              LOG.warn("Unable to close job master client", e);
             }
-            continue;
+            return false;
+          case FAILED:
+            removed.set(true);
+            return false;
           default:
             throw new IllegalStateException(String.format("Unexpected Status: %s", check));
         }
-      }
-      if (removed) {
+      }).collect(Collectors.toList());
+      if (removed.get()) {
         return;
       }
     }

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -37,7 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -201,7 +200,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
   private void waitJob() {
     AtomicBoolean removed = new AtomicBoolean(false);
     while (true) {
-       mSubmittedJobAttempts = mSubmittedJobAttempts.parallelStream().filter((jobAttempt) -> {
+      mSubmittedJobAttempts = mSubmittedJobAttempts.parallelStream().filter((jobAttempt) -> {
         Status check = jobAttempt.check();
         switch (check) {
           case CREATED:


### PR DESCRIPTION
After submitting a large number of jobs to the JobService, the code previously checked if some of the jobs are complete in serial, this code changes that to be done in parallel so that new jobs can be scheduled more quickly.