### PR TITLE
Get service version out of retryRpc loop

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -123,6 +123,7 @@ public abstract class AbstractClient implements Client {
   protected abstract ServiceType getRemoteServiceType();
 
   protected long getRemoteServiceVersion() throws AlluxioStatusException {
+    // Calling directly as this method is subject to an encompassing retry loop.
     return mVersionService
         .getServiceVersion(
             GetServiceVersionPRequest.newBuilder().setServiceType(getRemoteServiceType()).build())

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -123,11 +123,10 @@ public abstract class AbstractClient implements Client {
   protected abstract ServiceType getRemoteServiceType();
 
   protected long getRemoteServiceVersion() throws AlluxioStatusException {
-    return retryRPC(() ->
-        mVersionService.getServiceVersion(
+    return mVersionService
+        .getServiceVersion(
             GetServiceVersionPRequest.newBuilder().setServiceType(getRemoteServiceType()).build())
-            .getVersion(),
-        LOG, "getRemoteServiceVersion", "");
+        .getVersion();
   }
 
   /**


### PR DESCRIPTION
`getServiceVersion()` is a simple unauthenticated code, that is called after a successful connection.
Calling it with `retryRpc` utility opens a way for some allowed exceptions to fuel an infinite loop.

Fixes #11228