### PR TITLE
Deflake MultiWorkerIntegrationTest.positionReadRecoverFromLostWorker

### DIFF
--- a/tests/src/test/java/alluxio/server/ft/MultiWorkerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MultiWorkerIntegrationTest.java
@@ -172,6 +172,7 @@ public final class MultiWorkerIntegrationTest extends BaseIntegrationTest {
       byte[] buf = new byte[length];
       replicateFileBlocks(filePath);
       mResource.get().getWorkerProcess().stop();
+      Thread.sleep(500);
       int size = in.positionedRead(offset, buf, 0, length);
 
       Assert.assertEquals(length, size);


### PR DESCRIPTION
This seems to flake in about one in every 10 PR runs. So it's going to require quite a bit of runs to be reasonably confident that this did anything.