### PR TITLE
Get service version out of retryRpc loop

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -117,13 +117,11 @@ public abstract class AbstractClient implements Client {
   protected abstract ServiceType getRemoteServiceType();
 
   protected long getRemoteServiceVersion() throws AlluxioStatusException {
-    return retryRPC(new RpcCallable<Long>() {
-      public Long call() {
-        return mVersionService.getServiceVersion(
+    // Calling directly as this method is subject to an encompassing retry loop.
+    return mVersionService
+        .getServiceVersion(
             GetServiceVersionPRequest.newBuilder().setServiceType(getRemoteServiceType()).build())
-            .getVersion();
-      }
-    });
+        .getVersion();
   }
 
   /**


### PR DESCRIPTION
`getServiceVersion()` is a simple unauthenticated code, that is called
after a successful connection.
Calling it with `retryRpc` utility opens a way for some allowed
exceptions to fuel an infinite loop.

Fixes #11228

pr-link: Alluxio/alluxio#11226
change-id: cid-3c38f3ed0d8f7f033baf565e927e265b24cd18d5