### PR TITLE
Make DistributedCp/Mv not retry

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
@@ -65,7 +65,7 @@ public final class DistributedCpCommand extends AbstractFileSystemCommand {
       AlluxioConfiguration conf = mFsContext.getPathConf(dstPath);
       JobGrpcClientUtils.run(new MigrateConfig(srcPath.getPath(), dstPath.getPath(),
           conf.get(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT), true,
-          false), 3, mFsContext.getPathConf(dstPath));
+          false), 1, mFsContext.getPathConf(dstPath));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       return -1;

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedMvCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedMvCommand.java
@@ -67,7 +67,7 @@ public final class DistributedMvCommand extends AbstractFileSystemCommand {
       AlluxioConfiguration conf = mFsContext.getPathConf(dstPath);
       JobGrpcClientUtils.run(new MigrateConfig(srcPath.getPath(), dstPath.getPath(),
           conf.get(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT), true,
-          true), 3, mFsContext.getPathConf(dstPath));
+          true), 1, mFsContext.getPathConf(dstPath));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       return -1;


### PR DESCRIPTION
Reason: overwrite has been broken. Overwrite hasn't appeared to have
worked since at least 2.0 or perhaps further back.

Both the createDirectory and createFile calls in MigrateDefinition is
not overwriting version.

Thus, retrying is pointless because retries will always fail with the
message of being unable to overwrite.

pr-link: Alluxio/alluxio#10665
change-id: cid-5d9b1144501a4aba5256a6fb2ec6f1686d20c43a