### PR TITLE
Port changes of [#11257] to branch-1.8

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/Fingerprint.java
+++ b/core/common/src/main/java/alluxio/underfs/Fingerprint.java
@@ -38,7 +38,7 @@ public final class Fingerprint {
   private static final Tag[] CONTENT_TAGS = {Tag.TYPE, Tag.UFS, Tag.CONTENT_HASH};
 
   private static final Pattern SANITIZE_REGEX = Pattern.compile("[ :]");
-  private static final String UNDERSCORE = "_";
+  public static final String UNDERSCORE = "_";
 
   private final Map<Tag, String> mValues;
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3508,11 +3508,19 @@ public final class DefaultFileSystemMaster extends AbstractMaster implements Fil
         // It works by calling SetAttributeInternal on the inodePath.
         if (ufsFpParsed.isValid()) {
           short mode = Short.parseShort(ufsFpParsed.getTag(Tag.MODE));
-          SetAttributeOptions options =
-              SetAttributeOptions.defaults().setOwner(ufsFpParsed.getTag(Tag.OWNER))
-                  .setGroup(ufsFpParsed.getTag(Tag.GROUP))
-                  .setMode(mode)
-                  .setUfsFingerprint(ufsFingerprint);
+          SetAttributeOptions options = SetAttributeOptions.defaults()
+              .setMode(mode)
+              .setUfsFingerprint(ufsFingerprint);
+          String owner = ufsFpParsed.getTag(Tag.OWNER);
+          if (!owner.equals(Fingerprint.UNDERSCORE)) {
+            // Only set owner if not empty
+            options.setOwner(owner);
+          }
+          String group = ufsFpParsed.getTag(Tag.GROUP);
+          if (!group.equals(Fingerprint.UNDERSCORE)) {
+            // Only set group if not empty
+            options.setGroup(group);
+          }
           long opTimeMs = System.currentTimeMillis();
           // use replayed, since updating UFS is not desired.
           setAttributeInternal(inodePath, true, opTimeMs, options);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
@@ -233,7 +233,9 @@ public abstract class Inode<T> implements JournalEntryRepresentable {
    * @return the updated object
    */
   public T setGroup(String group) {
-    mGroup = group;
+    if (!group.isEmpty()) {
+      mGroup = group;
+    }
     return getThis();
   }
 
@@ -322,7 +324,9 @@ public abstract class Inode<T> implements JournalEntryRepresentable {
    * @return the updated object
    */
   public T setOwner(String owner) {
-    mOwner = owner;
+    if (!owner.isEmpty()) {
+      mOwner = owner;
+    }
     return getThis();
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -615,11 +615,12 @@ public class InodeTree implements JournalEntryIterable {
           try {
             // Successfully added the child, while holding the write lock.
             dir.setPinned(currentInodeDirectory.isPinned());
-            inheritOwnerAndGroupIfEmpty(dir, currentInodeDirectory);
             if (options.isPersisted()) {
               // Do not journal the persist entry, since a creation entry will be journaled instead.
               syncPersistDirectory(RpcContext.NOOP, dir);
             }
+            // Do NOT call setOwner/Group after inheriting from parent if empty
+            inheritOwnerAndGroupIfEmpty(dir, currentInodeDirectory);
           } catch (Throwable e) {
             // The inode was temporarily in the child list of its parent, so another thread could
             // have access to the inode. We must mark it as deleted so that the other thread knows
@@ -722,6 +723,7 @@ public class InodeTree implements JournalEntryIterable {
           }
         }
         lastInode.setPinned(currentInodeDirectory.isPinned());
+        // Do NOT call setOwner/Group after inheriting from parent if empty
         inheritOwnerAndGroupIfEmpty(lastInode, currentInodeDirectory);
 
         // Update state while holding the write lock.

--- a/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -96,7 +96,6 @@ public final class InodeTreeTest {
       new ConfigurationRule(new ImmutableMap.Builder<PropertyKey, String>()
           .put(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true")
           .put(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test-supergroup")
-          .put(PropertyKey.MASTER_METASTORE_INODE_INHERIT_OWNER_AND_GROUP, "false")
           .build());
 
   /**
@@ -638,11 +637,10 @@ public final class InodeTreeTest {
   }
 
   /**
-   * Tests if mode is set correctly in the {@link InodeTree#addInodeFileFromJournal} and
-   * {@link InodeTree#addInodeDirectoryFromJournal} methods for empty owner/group.
+   * Tests if mode is set correctly in the {@link InodeTree#addInodeFileFromJournal}.
    */
   @Test
-  public void addInodeModeFromJournalWithEmptyOwnership() throws Exception {
+  public void addInodeModeFromJournal() throws Exception {
     createPath(mTree, NESTED_FILE_URI, sNestedFileOptions);
     InodeDirectory root = mTree.getRoot();
     InodeDirectory nested = (InodeDirectory) root.getChild("nested");
@@ -650,8 +648,6 @@ public final class InodeTreeTest {
     Inode<?> file = test.getChild("file");
     Inode[] inodeChildren = {nested, test, file};
     for (Inode child : inodeChildren) {
-      child.setOwner("");
-      child.setGroup("");
       child.setMode((short) 0600);
     }
 
@@ -677,8 +673,6 @@ public final class InodeTreeTest {
         for (LockedInodePath childPath : descendants.getInodePathList()) {
           Inode<?> child = childPath.getInodeOrNull();
           Assert.assertNotNull(child);
-          Assert.assertEquals("", child.getOwner());
-          Assert.assertEquals("", child.getGroup());
           Assert.assertEquals((short) 0600, child.getMode());
         }
       }

--- a/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -96,6 +96,7 @@ public final class InodeTreeTest {
       new ConfigurationRule(new ImmutableMap.Builder<PropertyKey, String>()
           .put(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "true")
           .put(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test-supergroup")
+          .put(PropertyKey.MASTER_METASTORE_INODE_INHERIT_OWNER_AND_GROUP, "false")
           .build());
 
   /**


### PR DESCRIPTION
This PR includes 2 changes:

For S3, when inherit_acl=false any inodes created during loadmetadata should inherit owner/group from the parent directory in alluxio instead of being empty. This was broken because setOwner was called after inheritOwnerAndGroupIfEmpty in InodeTree::createPath
When syncing metadata with s3, an updateMetadata sync plan could lead to setting the owner and group to _ in DefaultFileSystemMaster::setAttributeSingleFile. The fix is to not set the options in SetAttributePOptions to avoid setting to an empty string or _.
This can be reproduced when a directory is created in alluxio only, the same directory is then later created in the ufs and then synced. Steps to reproduce:

$ aws s3 ls s3://adit-bucket-west/
                           PRE /
$ afs mkdir /adit
Successfully created directory /adit
$ afs mount /adit/s3a s3a://adit-bucket-west/
Mounted s3a://adit-bucket-west/ at /adit/s3a
$ afs mkdir /adit/s3a/nested
Successfully created directory /adit/s3a/nested
$ aws s3 cp world s3://adit-bucket-west/nested/file
upload: ./world to s3://adit-bucket-west/nested/file
$ afs ls -Dalluxio.user.file.metadata.sync.interval=0 /adit/s3a/nested
-rwx------  _              _                            6       PERSISTED 04-09-2020 22:22:18:000   0% /adit/s3a/nested/file
$ afs ls /adit/s3a/
drwx------  _              _                            1       PERSISTED 04-09-2020 22:22:18:000  DIR /adit/s3a/nested
Fixes: #11265, #11266

[This is a manual PR to cherry-pick committed PR #11257 into target branch branch-2.8]