### PR TITLE
Make config reinit executor static

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
@@ -48,12 +48,14 @@ public final class BlockWorkerClientPool extends DynamicResourcePool<BlockWorker
    *
    * @param userState the parent userState
    * @param address address of the worker
+   * @param minCapacity the minimum capacity of the pool
    * @param maxCapacity the maximum capacity of the pool
    * @param alluxioConf Alluxio configuration
    */
-  public BlockWorkerClientPool(UserState userState, GrpcServerAddress address, int maxCapacity,
-      AlluxioConfiguration alluxioConf) {
-    super(Options.defaultOptions().setMaxCapacity(maxCapacity).setGcExecutor(GC_EXECUTOR));
+  public BlockWorkerClientPool(UserState userState, GrpcServerAddress address, int minCapacity,
+      int maxCapacity, AlluxioConfiguration alluxioConf) {
+    super(Options.defaultOptions().setMinCapacity(minCapacity).setMaxCapacity(maxCapacity)
+        .setGcExecutor(GC_EXECUTOR));
     mUserState = userState;
     mAddress = address;
     mConf = alluxioConf;

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -514,7 +514,8 @@ public class FileSystemContext implements Closeable {
         mBlockWorkerClientPoolMap;
     return new CloseableResource<BlockWorkerClient>(poolMap.computeIfAbsent(key,
         k -> new BlockWorkerClientPool(context.getUserState(), serverAddress,
-            context.getClusterConf().getInt(PropertyKey.USER_BLOCK_WORKER_CLIENT_POOL_SIZE),
+            context.getClusterConf().getInt(PropertyKey.USER_BLOCK_WORKER_CLIENT_POOL_MIN),
+            context.getClusterConf().getInt(PropertyKey.USER_BLOCK_WORKER_CLIENT_POOL_MAX),
             context.getClusterConf()))
         .acquire()) {
       // Save the reference to the original pool map.

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContextReinitializer.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContextReinitializer.java
@@ -69,8 +69,6 @@ public final class FileSystemContextReinitializer implements Closeable {
             mExecutor.heartbeat();
           } catch (Exception e) {
             LOG.error("Uncaught exception in config hearbeat executor, shutting down", e);
-          } finally {
-            mExecutor.close();
           }
         }, 0,
         mContext.getClientContext().getClusterConf().getMs(PropertyKey.USER_CONF_SYNC_INTERVAL),
@@ -186,8 +184,10 @@ public final class FileSystemContextReinitializer implements Closeable {
    */
   public void close() {
     if (mFuture != null) {
-      mFuture.cancel(false);
+      mFuture.cancel(true);
       mFuture = null;
+
+      mExecutor.close();
     }
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContextReinitializer.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContextReinitializer.java
@@ -173,8 +173,6 @@ public final class FileSystemContextReinitializer implements Closeable {
    * If already closed, this is a noop.
    */
   public void close() {
-    if (!REINIT_EXECUTOR.isShutdown()) {
-      REINIT_EXECUTOR.shutdownNow();
-    }
+    // Do not close static executor shared across context instances
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContextReinitializer.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContextReinitializer.java
@@ -65,13 +65,12 @@ public final class FileSystemContextReinitializer implements Closeable {
     mContext = context;
     mExecutor = new ConfigHashSync(context);
     mFuture = REINIT_EXECUTOR.scheduleAtFixedRate(() -> {
-          try {
-            mExecutor.heartbeat();
-          } catch (Exception e) {
-            LOG.error("Uncaught exception in config hearbeat executor, shutting down", e);
-          }
-        }, 0,
-        mContext.getClientContext().getClusterConf().getMs(PropertyKey.USER_CONF_SYNC_INTERVAL),
+      try {
+        mExecutor.heartbeat();
+      } catch (Exception e) {
+        LOG.error("Uncaught exception in config hearbeat executor, shutting down", e);
+      }
+    }, 0, mContext.getClientContext().getClusterConf().getMs(PropertyKey.USER_CONF_SYNC_INTERVAL),
         TimeUnit.MILLISECONDS);
   }
 

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3106,6 +3106,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "client pool. For long running processes, this should be set to zero.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
+          .setIsHidden(true)
           .build();
   public static final PropertyKey USER_FILE_MASTER_CLIENT_POOL_SIZE_MAX =
       new Builder(Name.USER_FILE_MASTER_CLIENT_POOL_SIZE_MAX)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2972,7 +2972,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey USER_BLOCK_WORKER_CLIENT_POOL_MIN =
       new Builder(Name.USER_BLOCK_WORKER_CLIENT_POOL_MIN)
-          .setDefaultValue(1)
+          .setDefaultValue(0)
           .setDescription("The minimum number of block worker clients cached in the block "
               + "worker client pool.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2970,13 +2970,22 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
-  public static final PropertyKey USER_BLOCK_WORKER_CLIENT_POOL_SIZE =
-      new Builder(Name.USER_BLOCK_WORKER_CLIENT_POOL_SIZE)
+  public static final PropertyKey USER_BLOCK_WORKER_CLIENT_POOL_MIN =
+      new Builder(Name.USER_BLOCK_WORKER_CLIENT_POOL_MIN)
+          .setDefaultValue(1)
+          .setDescription("The minimum number of block worker clients cached in the block "
+              + "worker client pool.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey USER_BLOCK_WORKER_CLIENT_POOL_MAX =
+      new Builder(Name.USER_BLOCK_WORKER_CLIENT_POOL_MAX)
           .setDefaultValue(1024)
           .setDescription("The maximum number of block worker clients cached in the block "
               + "worker client pool.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
+          .setAlias(new String[] {"alluxio.user.block.worker.client.pool.size"})
           .build();
   public static final PropertyKey USER_BLOCK_WORKER_CLIENT_POOL_GC_THRESHOLD_MS =
       new Builder(Name.USER_BLOCK_WORKER_CLIENT_POOL_GC_THRESHOLD_MS)
@@ -4973,6 +4982,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.block.read.retry.max.duration";
     public static final String USER_BLOCK_WORKER_CLIENT_POOL_GC_THRESHOLD_MS =
         "alluxio.user.block.worker.client.pool.gc.threshold";
+    public static final String USER_BLOCK_WORKER_CLIENT_POOL_MIN =
+        "alluxio.user.block.worker.client.pool.min";
+    public static final String USER_BLOCK_WORKER_CLIENT_POOL_MAX =
+        "alluxio.user.block.worker.client.pool.max";
     public static final String USER_BLOCK_WORKER_CLIENT_POOL_SIZE =
         "alluxio.user.block.worker.client.pool.size";
     public static final String USER_BLOCK_WORKER_CLIENT_READ_RETRY =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2976,6 +2976,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("The minimum number of block worker clients cached in the block "
               + "worker client pool.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setIsHidden(true)
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_BLOCK_WORKER_CLIENT_POOL_MAX =
@@ -3106,7 +3107,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "client pool. For long running processes, this should be set to zero.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
-          .setIsHidden(true)
           .build();
   public static final PropertyKey USER_FILE_MASTER_CLIENT_POOL_SIZE_MAX =
       new Builder(Name.USER_FILE_MASTER_CLIENT_POOL_SIZE_MAX)

--- a/core/common/src/main/java/alluxio/heartbeat/HeartbeatContext.java
+++ b/core/common/src/main/java/alluxio/heartbeat/HeartbeatContext.java
@@ -55,7 +55,6 @@ public final class HeartbeatContext {
   public static final String MASTER_TABLE_TRANSFORMATION_MONITOR =
       "Master Table Transformation Monitor";
   public static final String META_MASTER_SYNC = "Meta Master Sync";
-  public static final String META_MASTER_CONFIG_HASH_SYNC = "Meta Master Config Hash Sync";
   public static final String WORKER_BLOCK_SYNC = "Worker Block Sync";
   public static final String WORKER_CLIENT = "Worker Client";
   public static final String WORKER_FILESYSTEM_MASTER_SYNC = "Worker FileSystemMaster Sync";
@@ -85,7 +84,6 @@ public final class HeartbeatContext {
     sTimerClasses.put(MASTER_ACTIVE_UFS_SYNC, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_TABLE_TRANSFORMATION_MONITOR, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(META_MASTER_SYNC, SLEEPING_TIMER_CLASS);
-    sTimerClasses.put(META_MASTER_CONFIG_HASH_SYNC, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(WORKER_FILESYSTEM_MASTER_SYNC, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(WORKER_BLOCK_SYNC, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(WORKER_CLIENT, SLEEPING_TIMER_CLASS);


### PR DESCRIPTION
Each FSContext instance creates a new single threaded executor pool for meta master config sync. For long running clients such as yarn RM, if the filesystem is not closed properly we would leak all non-static resources unless garbage collected. 

Fixes: https://github.com/Alluxio/alluxio/issues/11344