### PR TITLE
Add flag to disable conf sync

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -18,7 +18,6 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
-import alluxio.client.file.FileSystemContextReinitializer.ReinitBlockerResource;
 import alluxio.client.file.options.InStreamOptions;
 import alluxio.client.file.options.OutStreamOptions;
 import alluxio.conf.AlluxioConfiguration;
@@ -72,6 +71,7 @@ import com.google.common.net.HostAndPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -511,7 +511,7 @@ public class BaseFileSystem implements FileSystem {
    */
   private <R> R rpc(RpcCallable<FileSystemMasterClient, R> fn)
       throws IOException, AlluxioException {
-    try (ReinitBlockerResource r = mFsContext.blockReinit();
+    try (Closeable r = mFsContext.blockReinit();
          CloseableResource<FileSystemMasterClient> client =
              mFsContext.acquireMasterClientResource()) {
       // Explicitly connect to trigger loading configuration from meta master.

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -20,7 +20,6 @@ import alluxio.client.block.BlockMasterClientPool;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.client.block.stream.BlockWorkerClientPool;
-import alluxio.client.file.FileSystemContextReinitializer.ReinitBlockerResource;
 import alluxio.client.metrics.MetricsHeartbeatContext;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -267,7 +267,9 @@ public class FileSystemContext implements Closeable {
    * the {@link FileSystem} associated with this {@link FileSystemContext}.
    */
   public synchronized void close() throws IOException {
-    mReinitializer.close();
+    if (mReinitializer != null) {
+      mReinitializer.close();
+    }
     closeContext();
   }
 

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -54,6 +54,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -88,7 +89,7 @@ public final class BaseFileSystemTest {
    * Sets up the file system and the context before a test runs.
    */
   @Before
-  public void before() {
+  public void before() throws IOException {
     mClientContext = ClientContext.create(mConf);
     mFileContext = PowerMockito.mock(FileSystemContext.class);
     mFileSystemMasterClient = PowerMockito.mock(FileSystemMasterClient.class);
@@ -114,7 +115,7 @@ public final class BaseFileSystemTest {
   /**
    * Verifies and releases the master client after a test with a filesystem operation.
    */
-  public void verifyFilesystemContextAcquiredAndReleased() {
+  public void verifyFilesystemContextAcquiredAndReleased() throws IOException {
     verify(mFileContext).acquireMasterClientResource();
   }
 
@@ -651,7 +652,7 @@ public final class BaseFileSystemTest {
     return mTestLogger.wasLogged("The URI scheme .* is ignored");
   }
 
-  private void configureZk(String addrs) {
+  private void configureZk(String addrs) throws IOException {
     mConf.set(PropertyKey.ZOOKEEPER_ENABLED, true);
     mConf.set(PropertyKey.ZOOKEEPER_ADDRESS, addrs);
     before(); // Resets the filesystem and contexts to use proper configuration

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
@@ -24,6 +24,8 @@ import com.google.common.io.Closer;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 /**
  * Tests {@link FileSystemContext}.
  */
@@ -87,8 +89,10 @@ public final class FileSystemContextTest {
 
     @Override
     public void run() {
-      CloseableResource<FileSystemMasterClient> client = mFsCtx.acquireMasterClientResource();
-      client.close();
+      try (CloseableResource<FileSystemMasterClient> client = mFsCtx.acquireMasterClientResource()) {
+      } catch (IOException e) {
+        fail(e.getMessage());
+      }
     }
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
@@ -90,6 +90,7 @@ public final class FileSystemContextTest {
     @Override
     public void run() {
       try (CloseableResource<FileSystemMasterClient> c = mFsCtx.acquireMasterClientResource()) {
+        // Do nothing
       } catch (IOException e) {
         fail(e.getMessage());
       }

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
@@ -89,8 +89,8 @@ public final class FileSystemContextTest {
 
     @Override
     public void run() {
-      try (CloseableResource<FileSystemMasterClient> c = mFsCtx.acquireMasterClientResource()) {
-        // Do nothing
+      try {
+        CloseableResource<FileSystemMasterClient> c = mFsCtx.acquireMasterClientResource();
       } catch (IOException e) {
         fail(e.getMessage());
       }

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
@@ -89,7 +89,7 @@ public final class FileSystemContextTest {
 
     @Override
     public void run() {
-      try (CloseableResource<FileSystemMasterClient> client = mFsCtx.acquireMasterClientResource()) {
+      try (CloseableResource<FileSystemMasterClient> c = mFsCtx.acquireMasterClientResource()) {
       } catch (IOException e) {
         fail(e.getMessage());
       }

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2996,6 +2996,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_CONF_SYNC_ENABLED =
+      new Builder(Name.USER_CONF_SYNC_ENABLED)
+          .setDefaultValue("true")
+          .setDescription("Whether to enable the client-master heartbeat to "
+              + "update the configuration if necessary from meta master.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_CONF_SYNC_INTERVAL =
       new Builder(Name.USER_CONF_SYNC_INTERVAL)
           .setDefaultValue("1min")
@@ -4757,6 +4765,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.client.cache.store.type";
     public static final String USER_CONF_CLUSTER_DEFAULT_ENABLED =
         "alluxio.user.conf.cluster.default.enabled";
+    public static final String USER_CONF_SYNC_ENABLED = "alluxio.user.conf.sync.enabled";
     public static final String USER_CONF_SYNC_INTERVAL = "alluxio.user.conf.sync.interval";
     public static final String USER_DATE_FORMAT_PATTERN = "alluxio.user.date.format.pattern";
     public static final String USER_FILE_BUFFER_BYTES = "alluxio.user.file.buffer.bytes";

--- a/shell/src/main/java/alluxio/cli/fs/command/LeaderCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LeaderCommand.java
@@ -24,6 +24,7 @@ import alluxio.retry.ExponentialBackoffRetry;
 
 import org.apache.commons.cli.CommandLine;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.List;
@@ -54,7 +55,7 @@ public final class LeaderCommand extends AbstractFileSystemCommand {
   }
 
   @Override
-  public int run(CommandLine cl) {
+  public int run(CommandLine cl) throws IOException {
     try (CloseableResource<FileSystemMasterClient> client =
         mFsContext.acquireMasterClientResource()) {
       try {


### PR DESCRIPTION
Set `alluxio.user.conf.sync.enabled=false` to disable syncing of configuration with the master in a hearbeat thread. As a consequence, long running clients such as Presto, Hive or Yarn RM need to be restarted to pick up server side configuration updates.