### PR TITLE
Apply K8s label matching to worker domain socket PVC

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -70,3 +70,4 @@
 - Changed worker domain socket volume from hostPath to PVC
 - Changed hostNetwork to false
 - Added alluxio.worker.container.hostname property to use podIP
+- Added selector labels to worker domain socket PVC

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/domain-socket-pvc.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/domain-socket-pvc.yaml
@@ -30,4 +30,10 @@ spec:
   storageClassName: {{ .Values.shortCircuit.pvcStorageClass }}
   accessModes:
 {{ toYaml .Values.shortCircuit.pvcAccessModes | trim | indent 4 -}}
+  selector:
+    matchLabels:
+      app: {{ template "alluxio.name" . }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      role: alluxio-worker
 {{- end -}}

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/domain-socket-pvc.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/domain-socket-pvc.yaml
@@ -29,7 +29,7 @@ spec:
       storage: {{ .Values.shortCircuit.pvcSize }}
   storageClassName: {{ .Values.shortCircuit.pvcStorageClass }}
   accessModes:
-{{ toYaml .Values.shortCircuit.pvcAccessModes | trim | indent 4 -}}
+{{ toYaml .Values.shortCircuit.pvcAccessModes | trim | indent 4 }}
   selector:
     matchLabels:
       app: {{ template "alluxio.name" . }}

--- a/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-pvc.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-pvc.yaml.template
@@ -28,4 +28,9 @@ spec:
       storage: 1Mi
   storageClassName: standard
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteOnceselector:
+    matchLabels:
+      app: alluxio
+      release: alluxio
+      heritage: Tiller
+      role: alluxio-worker

--- a/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-pvc.yaml.template
+++ b/integration/kubernetes/multiMaster-embeddedJournal/worker/alluxio-worker-pvc.yaml.template
@@ -28,7 +28,8 @@ spec:
       storage: 1Mi
   storageClassName: standard
   accessModes:
-    - ReadWriteOnceselector:
+    - ReadWriteOnce
+  selector:
     matchLabels:
       app: alluxio
       release: alluxio

--- a/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-pvc.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-pvc.yaml.template
@@ -28,4 +28,9 @@ spec:
       storage: 1Mi
   storageClassName: standard
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteOnceselector:
+    matchLabels:
+      app: alluxio
+      release: alluxio
+      heritage: Tiller
+      role: alluxio-worker

--- a/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-pvc.yaml.template
+++ b/integration/kubernetes/singleMaster-hdfsJournal/worker/alluxio-worker-pvc.yaml.template
@@ -28,7 +28,8 @@ spec:
       storage: 1Mi
   storageClassName: standard
   accessModes:
-    - ReadWriteOnceselector:
+    - ReadWriteOnce
+  selector:
     matchLabels:
       app: alluxio
       release: alluxio

--- a/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-pvc.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-pvc.yaml.template
@@ -28,4 +28,9 @@ spec:
       storage: 1Mi
   storageClassName: standard
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteOnceselector:
+    matchLabels:
+      app: alluxio
+      release: alluxio
+      heritage: Tiller
+      role: alluxio-worker

--- a/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-pvc.yaml.template
+++ b/integration/kubernetes/singleMaster-localJournal/worker/alluxio-worker-pvc.yaml.template
@@ -28,7 +28,8 @@ spec:
       storage: 1Mi
   storageClassName: standard
   accessModes:
-    - ReadWriteOnceselector:
+    - ReadWriteOnce
+  selector:
     matchLabels:
       app: alluxio
       release: alluxio


### PR DESCRIPTION
This change adds label selector to worker domain socket PVCs so that they only select volumes with alluxio and worker specific PVs. 

This setup should help if the users are provisioning `local` PVs which essentially constraint Pods to go to specific nodes. If there's no selector on the PVC, the worker Pods may claim volumes intended for other Pods and go to unintended nodes.