### PR TITLE
Improve performance of sasl authentication

### DIFF
--- a/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
+++ b/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
@@ -62,6 +62,8 @@ public class DefaultAuthenticationServer
   /** Alluxio client configuration. */
   protected final AlluxioConfiguration mConfiguration;
 
+  private final ImpersonationAuthenticator mImpersonationAuthenticator;
+
   /**
    * Creates {@link DefaultAuthenticationServer} instance.
    * @param hostName host name of the server
@@ -78,6 +80,7 @@ public class DefaultAuthenticationServer
         Executors.newScheduledThreadPool(1, ThreadFactoryUtils.build("auth-cleanup", true));
     mScheduler.scheduleAtFixedRate(this::cleanupStaleClients, mCleanupIntervalMs,
         mCleanupIntervalMs, TimeUnit.MILLISECONDS);
+    mImpersonationAuthenticator = new ImpersonationAuthenticator(conf);
   }
 
   @Override
@@ -126,7 +129,7 @@ public class DefaultAuthenticationServer
     switch (authScheme) {
       case SIMPLE:
       case CUSTOM:
-        return new SaslServerHandlerPlain(mHostName, mConfiguration);
+        return new SaslServerHandlerPlain(mHostName, mConfiguration, mImpersonationAuthenticator);
       default:
         throw new StatusRuntimeException(Status.UNAUTHENTICATED.augmentDescription(
             String.format("Authentication scheme:%s is not supported", authScheme)));

--- a/core/common/src/main/java/alluxio/security/authentication/ImpersonationAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ImpersonationAuthenticator.java
@@ -50,6 +50,9 @@ public final class ImpersonationAuthenticator {
   /**
    * Constructs a new {@link ImpersonationAuthenticator}.
    *
+   * Note the constructor for this object is expensive. Take care with how many of these are
+   * instantiated.
+   *
    * @param conf conf Alluxio configuration
    */
   public ImpersonationAuthenticator(AlluxioConfiguration conf) {

--- a/core/common/src/main/java/alluxio/security/authentication/plain/PlainSaslServerCallbackHandler.java
+++ b/core/common/src/main/java/alluxio/security/authentication/plain/PlainSaslServerCallbackHandler.java
@@ -11,7 +11,6 @@
 
 package alluxio.security.authentication.plain;
 
-import alluxio.conf.AlluxioConfiguration;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.authentication.AuthenticationProvider;
 import alluxio.security.authentication.ImpersonationAuthenticator;
@@ -40,13 +39,13 @@ public final class PlainSaslServerCallbackHandler implements CallbackHandler {
    * Constructs a new callback handler.
    *
    * @param authenticationProvider the authentication provider used
-   * @param conf Alluxio configuration
+   * @param authenticator the impersonation authenticator
    */
   public PlainSaslServerCallbackHandler(AuthenticationProvider authenticationProvider,
-      AlluxioConfiguration conf) {
+      ImpersonationAuthenticator authenticator) {
     mAuthenticationProvider = Preconditions.checkNotNull(authenticationProvider,
         "authenticationProvider");
-    mImpersonationAuthenticator = new ImpersonationAuthenticator(conf);
+    mImpersonationAuthenticator = authenticator;
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/security/authentication/plain/SaslServerHandlerPlain.java
+++ b/core/common/src/main/java/alluxio/security/authentication/plain/SaslServerHandlerPlain.java
@@ -17,6 +17,7 @@ import alluxio.security.authentication.AbstractSaslServerHandler;
 import alluxio.security.authentication.AuthenticatedUserInfo;
 import alluxio.security.authentication.AuthenticationProvider;
 import alluxio.security.authentication.AuthType;
+import alluxio.security.authentication.ImpersonationAuthenticator;
 import alluxio.security.authentication.SaslServerHandler;
 
 import org.slf4j.Logger;
@@ -43,14 +44,16 @@ public class SaslServerHandlerPlain extends AbstractSaslServerHandler {
    *
    * @param serverName server name
    * @param conf Alluxio configuration
+   * @param authenticator the impersonation authenticator
    * @throws SaslException
    */
-  public SaslServerHandlerPlain(String serverName, AlluxioConfiguration conf) throws SaslException {
+  public SaslServerHandlerPlain(String serverName, AlluxioConfiguration conf,
+      ImpersonationAuthenticator authenticator) throws SaslException {
     AuthType authType =
         conf.getEnum(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.class);
     AuthenticationProvider provider = AuthenticationProvider.Factory.create(authType, conf);
     mSaslServer = Sasl.createSaslServer(PlainSaslServerProvider.MECHANISM, null, serverName,
-        new HashMap<String, String>(), new PlainSaslServerCallbackHandler(provider, conf));
+        new HashMap<String, String>(), new PlainSaslServerCallbackHandler(provider, authenticator));
   }
 
   @Override

--- a/core/common/src/test/java/alluxio/security/authentication/PlainSaslServerCallbackHandlerTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/PlainSaslServerCallbackHandlerTest.java
@@ -56,7 +56,8 @@ public final class PlainSaslServerCallbackHandlerTest {
   @Before
   public void before() throws Exception {
     mPlainServerCBHandler = new PlainSaslServerCallbackHandler(
-        AuthenticationProvider.Factory.create(AuthType.CUSTOM, mConfiguration), mConfiguration);
+        AuthenticationProvider.Factory.create(AuthType.CUSTOM, mConfiguration),
+        new ImpersonationAuthenticator(mConfiguration));
   }
 
   @After


### PR DESCRIPTION
Before this PR, the ImpersonationAuthenticator class could effectively
bottleneck the amount of concurrent channels that a worker could handle. 

The `<init>` for the ImpersonationAuthenticator class required iterating over
all keys within an Alluxio configuration, not only doing key lookups, but also
performing regex matching. For some keys this could be especially expensive
(i.e, default supplier which calls Runtime.getRuntime().availableProcessors()).
On top of that, performing regex matching is also quite expensive for a few
hundred keys.

After taking a quick peek at the code it seems that it's entirely unnecessary to
instantiate the impersonation authenticator for every new handler that we
create. Instead, it can just be a field within the DefaultAuthenticationServer.
Then, it only ever needs to be instantiated once.