### PR TITLE
[DOCFIX] Fix broken link in Tiered Locality

### DIFF
--- a/dev/scripts/src/alluxio.org/check-docs/main.go
+++ b/dev/scripts/src/alluxio.org/check-docs/main.go
@@ -172,7 +172,7 @@ func parseCategoryNames(configPath string) (StringSet, error) {
 
 var (
 	// general format of a relative link, where the link will be computed by a jekyll function encapsulated in {{ }}
-	relativeLinkRe = regexp.MustCompile(`\[.+\]\({{.*}}\)`)
+	relativeLinkRe = regexp.MustCompile(`\[.+\]\({{.*}}(#.+)?\)`)
 	// path encapsulated in ' ' could have an optional search query "?q=queryStr" and/or an optional anchor reference "#anchor"
 	relativeLinkPagePathRe = regexp.MustCompile(`\[.+\]\({{ '(?P<path>[\w-./]+)(\?q=\w+)?(#.+)?' | relativize_url }}\)`)
 )
@@ -201,8 +201,8 @@ func checkFile(mdFile string, ctx *checkContext) error {
 		}
 		if relativeLinkRe.MatchString(l) {
 			for _, lineMatches := range relativeLinkRe.FindAllStringSubmatch(l, -1) {
-				if len(lineMatches) != 1 {
-					return fmt.Errorf("expected to find exactly one string submatch but found %d in line %v", len(lineMatches), l)
+				if len(lineMatches) < 1 {
+					return fmt.Errorf("expected to find at least one string submatch but found %d in line %v in file %v", len(lineMatches), l, mdFile)
 				}
 				relativeLinkStr := lineMatches[0]
 				if !relativeLinkPagePathRe.MatchString(relativeLinkStr) {

--- a/docs/en/operation/Tiered-Locality.md
+++ b/docs/en/operation/Tiered-Locality.md
@@ -61,7 +61,7 @@ alluxio.locality.rack=rack2
 This will assign this worker a tiered identity of `(node=host1, rack=rack2)`.
 
 To verify that the configuration is working, check the
-[master, worker, and application logs]({{ '/en/operation//Server-Logging.html' | relativize_url }}#log-location).
+[master, worker, and application logs]({{ '/en/operation/Basic-Logging.html' | relativize_url }}#log-location).
 A log entry should appear of the format:
 
 ```log


### PR DESCRIPTION
also update regex to catch links with anchor tags outside jekyll templating