### PR TITLE
Add nav tabs plugin to docs

### DIFF
--- a/docs/_plugins/nav-tabs.rb
+++ b/docs/_plugins/nav-tabs.rb
@@ -1,0 +1,54 @@
+require "erb"
+require "securerandom"
+
+module Jekyll
+  module NavTabs
+    class NavTabsBlock < Liquid::Block
+      def render(context)
+        environment = context.environments.first
+        environment['navtabs'] = {} # reset each time
+        super
+
+        uuid = SecureRandom.uuid
+        template = ERB.new <<-EOF
+<ul class="nav nav-tabs" id="<%= uuid %>" role="tablist">
+<% environment['navtabs'].each_with_index do |(key, _), index| %>
+  <li class="nav-item">
+    <a <%= index == 0 ? 'class="nav-link active"' : 'class="nav-link"'%> id="<%= key %>-tab" data-toggle="tab" href="#<%= key %>" role="tab" aria-controls="<%= key %>" <%= index == 0 ? 'aria-selected="true"' : 'aria-selected="false"'%>><%= key %></a>
+  </li>
+<% end %>
+</ul>
+<div class="tab-content" id="<%= uuid %>-content">
+<% environment['navtabs'].each_with_index do |(key, value), index| %>
+  <div <%= index == 0 ? 'class="tab-pane fade show active"' : 'class="tab-pane fade"'%> id="<%= key %>" role="tabpanel" aria-labelledby="<%= key %>-tab"><%= value %></div>
+<% end %>
+</div>
+        EOF
+        template.result(binding)
+      end
+    end
+
+    class NavTabBlock < Liquid::Block
+      alias_method :render_block, :render
+
+      def initialize(tag_name, markup, tokens)
+        super
+        if markup == ""
+          raise SyntaxError.new("No toggle name given in #{tag_name} tag")
+        end
+        @toggle = markup.strip
+      end
+
+      def render(context)
+        site = context.registers[:site]
+        converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+        environment = context.environments.first
+        environment['navtabs'] ||= {}
+        environment['navtabs'][@toggle] = converter.convert(render_block(context))
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag("navtab", Jekyll::NavTabs::NavTabBlock)
+Liquid::Template.register_tag("navtabs", Jekyll::NavTabs::NavTabsBlock)

--- a/docs/_plugins/nav-tabs.rb
+++ b/docs/_plugins/nav-tabs.rb
@@ -11,7 +11,7 @@ module Jekyll
 
         uuid = SecureRandom.uuid
         template = ERB.new <<-EOF
-<ul class="nav nav-tabs" id="<%= uuid %>" role="tablist">
+<ul class="nav nav-tabs nav-tab-margin" id="<%= uuid %>" role="tablist">
 <% environment['navtabs'].each_with_index do |(key, _), index| %>
   <li class="nav-item">
     <a <%= index == 0 ? 'class="nav-link active"' : 'class="nav-link"'%> id="<%= key %>-tab" data-toggle="tab" href="#<%= key %>" role="tab" aria-controls="<%= key %>" <%= index == 0 ? 'aria-selected="true"' : 'aria-selected="false"'%>><%= key %></a>

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -52,6 +52,10 @@ div.highlight > pre.highlight {
     margin-bottom: 2.5rem;
 }
 
+.nav-tab-margin {
+    margin-bottom: 1rem;
+}
+
 body #content {
     line-height: 1.6;
     /* Inspired by Github's wiki style */


### PR DESCRIPTION
enables navigational tabs to display content that achieves the same end with different methods
for example, we are able to describe how to launch EMR via the UI (what we currently have) vs using terraform (what we plan on adding) without bloating the page by placing them serially one after another

@madanadit fyi

![image](https://user-images.githubusercontent.com/5927743/79629467-ec233400-80fe-11ea-90c9-2bb79d8eb7d9.png)

sample page code:
```
---
layout: global
title: test page
group: Overview
priority: 1
---

Hello and see my nav:

{% navtabs section1 %}
{% navtab moo %}
i'm a cow!
{% endnavtab %}
{% navtab meow %}
i'm a cat!
{% endnavtab %}
{% endnavtabs %}
```

you can try playing with this locally by
- add the above content in a new file docs/en/TestPage.md
- run `jekyll serve` from docs/
- browse to http://localhost:4000/TestPage.html