### PR TITLE
Format K8s Configmap helm template

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -32,15 +32,144 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   ALLUXIO_JAVA_OPTS: |-
-    {{if $isSingleMaster}}-Dalluxio.master.hostname={{ $fullName }}-{{ $defaultMasterName }}{{end}} -Dalluxio.master.journal.type={{ .Values.journal.type }} -Dalluxio.master.journal.folder={{ .Values.journal.folder }} {{if $isHaEmbedded}}-Dalluxio.master.embedded.journal.addresses={{range $i := until $masterCount}}{{ $fullName }}-master-{{$i}}:19200,{{end}}{{end}} {{ .Values.jvmOptions }} {{- range $key, $val := .Values.properties }} -D{{ $key }}={{ $val }} {{ end }}
+    {{- $alluxioJavaOpts := list }}
+
+    {{- /* Specify master hostname if single master */}}
+    {{- if $isSingleMaster }}
+      {{- $alluxioJavaOpts = printf "-Dalluxio.master.hostname=%v-%v" $fullName $defaultMasterName | append $alluxioJavaOpts }}
+    {{- end }}
+    {{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.type=%v" .Values.journal.type | append $alluxioJavaOpts }}
+    {{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.folder=%v" .Values.journal.folder | append $alluxioJavaOpts }}
+
+    {{- /* Generate HA embedded journal address for masters */}}
+    {{- if $isHaEmbedded }}
+      {{- $embeddedJournalAddresses := "-Dalluxio.master.embedded.journal.addresses=" }}
+      {{- range $i := until $masterCount }}
+        {{- $embeddedJournalAddresses = printf "%v,%v-master-%v:19200" $embeddedJournalAddresses $fullName $i }}
+      {{- end }}
+      {{- $alluxioJavaOpts = append $alluxioJavaOpts $embeddedJournalAddresses }}
+    {{- end }}
+    {{- range $key, $val := .Values.properties }}
+      {{- $alluxioJavaOpts = printf "-D%v=%v" $key $val | append $alluxioJavaOpts }}
+    {{- end }}
+    {{- if .Values.jvmOptions }}
+      {{- $alluxioJavaOpts = concat $alluxioJavaOpts .Values.jvmOptions }}
+    {{- end }}
+
+    {{- /* Format ALLUXIO_JAVA_OPTS list to one line */}}
+    {{ range $key := $alluxioJavaOpts }}{{ printf "%v " $key }}{{ end }}
   ALLUXIO_MASTER_JAVA_OPTS: |-
-    -Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME} -Dalluxio.master.web.bind.host=0.0.0.0 {{ .Values.master.jvmOptions }} {{- range $key, $val := .Values.master.properties }} -D{{ $key }}={{ $val }} {{ end }}
+    {{- $masterJavaOpts := list }}
+    {{- $masterJavaOpts = print "-Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME}" | append $masterJavaOpts }}
+    {{- $masterJavaOpts = print "-Dalluxio.master.web.bind.host=0.0.0.0" | append $masterJavaOpts }}
+    {{- range $key, $val := .Values.master.properties }}
+      {{- $masterJavaOpts = printf "-D%v=%v" $key $val | append $masterJavaOpts }}
+    {{- end }}
+    {{- if .Values.master.jvmOptions }}
+      {{- $masterJavaOpts = concat $masterJavaOpts .Values.master.jvmOptions }}
+    {{- end }}
+
+    {{- /* Format ALLUXIO_MASTER_JAVA_OPTS list to one line */}}
+    {{ range $key := $masterJavaOpts }}{{ printf "%v " $key }}{{ end }}
   ALLUXIO_JOB_MASTER_JAVA_OPTS: |-
-    -Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME} -Dalluxio.job.master.bind.host=0.0.0.0 {{ .Values.jobMaster.jvmOptions }} {{- range $key, $val := .Values.jobMaster.properties }} -D{{ $key }}={{ $val }} {{ end }}
+    {{- $jobMasterJavaOpts := list }}
+    {{- $jobMasterJavaOpts = print "-Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME}" | append $jobMasterJavaOpts }}
+    {{- $jobMasterJavaOpts = print "-Dalluxio.job.master.web.bind.host=0.0.0.0" | append $jobMasterJavaOpts }}
+    {{- range $key, $val := .Values.jobMaster.properties }}
+      {{- $jobMasterJavaOpts = printf "-D%v=%v" $key $val | append $jobMasterJavaOpts }}
+    {{- end }}
+    {{- if .Values.jobMaster.jvmOptions }}
+      {{- $jobMasterJavaOpts = concat $jobMasterJavaOpts .Values.jobMaster.jvmOptions }}
+    {{- end }}
+
+    {{- /* Format ALLUXIO_JOB_MASTER_JAVA_OPTS list to one line */}}
+    {{ range $key := $jobMasterJavaOpts }}{{ printf "%v " $key }}{{ end }}
   ALLUXIO_WORKER_JAVA_OPTS: |-
-    -Dalluxio.worker.bind.host=0.0.0.0 {{ .Values.worker.jvmOptions }} {{- if eq .Values.shortCircuit.enabled false}} -Dalluxio.user.short.circuit.enabled=false {{- end }} {{- if and .Values.shortCircuit.enabled (eq .Values.shortCircuit.policy "uuid") }} -Dalluxio.worker.data.server.domain.socket.address=/opt/domain -Dalluxio.worker.data.server.domain.socket.as.uuid=true {{- end}} {{- if .Values.worker.resources  }} {{- if .Values.worker.resources.requests }} {{- if .Values.worker.resources.requests.memory }} -Dalluxio.worker.memory.size={{ .Values.worker.resources.requests.memory }} {{- end}} {{- end}} {{- end}} -Dalluxio.worker.rpc.port={{ .Values.worker.ports.rpc }} -Dalluxio.worker.web.port={{ .Values.worker.ports.web }} {{- range $key, $val := .Values.worker.properties }} -D{{ $key }}={{ $val }} {{- end}} -Dalluxio.worker.hostname=${ALLUXIO_WORKER_HOSTNAME} {{- if not .Values.worker.hostNetwork }} -Dalluxio.worker.container.hostname=${ALLUXIO_WORKER_CONTAINER_HOSTNAME} {{- end}} {{- if .Values.tieredstore }} -Dalluxio.worker.tieredstore.levels={{ len .Values.tieredstore.levels }} {{- range .Values.tieredstore.levels }} -Dalluxio.worker.tieredstore.level{{ .level }}.dirs.mediumtype={{ .mediumtype }} {{- if .path }} -Dalluxio.worker.tieredstore.level{{ .level }}.dirs.path={{ .path }} {{- end}} {{- if .quota }} -Dalluxio.worker.tieredstore.level{{ .level }}.dirs.quota={{ .quota }} {{- end}} {{- if .high }} -Dalluxio.worker.tieredstore.level{{ .level }}.watermark.high.ratio={{ .high }} {{- end}} {{- if .low }} -Dalluxio.worker.tieredstore.level{{ .level }}.watermark.low.ratio={{ .low }} {{- end}} {{- end}} {{ end }}
+    {{- $workerJavaOpts := list }}
+    {{- $workerJavaOpts = print "-Dalluxio.worker.hostname=${ALLUXIO_WORKER_HOSTNAME}" | append $workerJavaOpts }}
+    {{- $workerJavaOpts = print "-Dalluxio.worker.bind.host=0.0.0.0" | append $workerJavaOpts }}
+    {{- $workerJavaOpts = printf "-Dalluxio.worker.rpc.port=%v" .Values.worker.ports.rpc | append $workerJavaOpts }}
+    {{- $workerJavaOpts = printf "-Dalluxio.worker.web.port=%v" .Values.worker.ports.web | append $workerJavaOpts }}
+
+    {{- /* Short circuit configuration */}}
+    {{- if eq .Values.shortCircuit.enabled false}}
+      {{- $workerJavaOpts = print "-Dalluxio.user.short.circuit.enabled=false" | append $workerJavaOpts }}
+    {{- end }}
+    {{- if and .Values.shortCircuit.enabled (eq .Values.shortCircuit.policy "uuid") }}
+      {{- $workerJavaOpts = print "-Dalluxio.worker.data.server.domain.socket.address=/opt/domain" | append $workerJavaOpts }}
+      {{- $workerJavaOpts = print "-Dalluxio.worker.data.server.domain.socket.as.uuid=true" | append $workerJavaOpts }}
+    {{- end}}
+
+    {{- /* Record container hostname if not using host network */}}
+    {{- if not .Values.worker.hostNetwork }}
+      {{- $workerJavaOpts = print "-Dalluxio.worker.container.hostname=${ALLUXIO_WORKER_CONTAINER_HOSTNAME}" | append $workerJavaOpts }}
+    {{- end}}
+
+    {{- /* Resource configuration */}}
+    {{- if .Values.worker.resources  }}
+      {{- if .Values.worker.resources.requests }}
+        {{- if .Values.worker.resources.requests.memory }}
+          {{- $workerJavaOpts = printf "-Dalluxio.worker.memory.size=%v" .Values.worker.resources.requests.memory | append $workerJavaOpts }}
+        {{- end}}
+      {{- end}}
+    {{- end}}
+
+    {{- /* Tiered store configuration */}}
+    {{- if .Values.tieredstore }}
+      {{- $workerJavaOpts = printf "-Dalluxio.worker.tieredstore.levels=%v" (len .Values.tieredstore.levels) | append $workerJavaOpts }}
+      {{- range .Values.tieredstore.levels }}
+        {{- $tierName := printf "-Dalluxio.worker.tieredstore.level%v" .level }}
+        {{- $workerJavaOpts = printf "%v.dirs.mediumtype=%v" $tierName .mediumtype | append $workerJavaOpts }}
+        {{- if .path }}
+          {{- $workerJavaOpts = printf "%v.dirs.path=%v" $tierName .path | append $workerJavaOpts }}
+        {{- end}}
+        {{- if .quota }}
+          {{- $workerJavaOpts = printf "%v.dirs.quota=%v" $tierName .quota | append $workerJavaOpts }}
+        {{- end}}
+        {{- if .high }}
+          {{- $workerJavaOpts = printf "%v.watermark.high.ratio=%v" $tierName .high | append $workerJavaOpts }}
+        {{- end}}
+        {{- if .low }}
+          {{- $workerJavaOpts = printf "%v.watermark.low.ratio=%v" $tierName .low | append $workerJavaOpts }}
+        {{- end}}
+      {{- end}}
+    {{- end }}
+
+    {{- range $key, $val := .Values.worker.properties }}
+      {{- $workerJavaOpts = printf "-D%v=%v" $key $val | append $workerJavaOpts }}
+    {{- end }}
+    {{- if .Values.worker.jvmOptions }}
+      {{- $workerJavaOpts = concat $workerJavaOpts .Values.worker.jvmOptions }}
+    {{- end }}
+
+    {{- /* Format ALLUXIO_WORKER_JAVA_OPTS list to one line */}}
+    {{ range $key := $workerJavaOpts }}{{ printf "%v " $key }}{{ end }}
   ALLUXIO_JOB_WORKER_JAVA_OPTS: |-
-    -Dalluxio.job.worker.rpc.port={{ .Values.jobWorker.ports.rpc }} {{ .Values.jobWorker.jvmOptions }} -Dalluxio.job.worker.data.port={{ .Values.jobWorker.ports.data }} -Dalluxio.job.worker.web.port={{ .Values.jobWorker.ports.web }} -Dalluxio.worker.hostname=${ALLUXIO_WORKER_HOSTNAME} 
+    {{- $jobWorkerJavaOpts := list }}
+    {{- $jobWorkerJavaOpts = print "-Dalluxio.worker.hostname=${ALLUXIO_WORKER_HOSTNAME}" | append $jobWorkerJavaOpts }}
+    {{- $jobWorkerJavaOpts = printf "-Dalluxio.job.worker.rpc.port=%v" .Values.jobWorker.ports.rpc | append $jobWorkerJavaOpts }}
+    {{- $jobWorkerJavaOpts = printf "-Dalluxio.job.worker.data.port=%v" .Values.jobWorker.ports.data | append $jobWorkerJavaOpts }}
+    {{- $jobWorkerJavaOpts = printf "-Dalluxio.job.worker.web.port=%v" .Values.jobWorker.ports.web | append $jobWorkerJavaOpts }}
+    {{- range $key, $val := .Values.jobWorker.properties }}
+      {{- $jobWorkerJavaOpts = printf "-D%v=%v" $key $val | append $jobWorkerJavaOpts }}
+    {{- end }}
+    {{- if .Values.jobWorker.jvmOptions }}
+      {{- $jobWorkerJavaOpts = concat $jobWorkerJavaOpts .Values.jobWorker.jvmOptions }}
+    {{- end }}
+
+    {{- /* Format ALLUXIO_JOB_WORKER_JAVA_OPTS list to one line */}}
+    {{ range $key := $jobWorkerJavaOpts }}{{ printf "%v " $key }}{{ end }}
   ALLUXIO_FUSE_JAVA_OPTS: |-
-    -Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME} -Dalluxio.worker.hostname=${ALLUXIO_CLIENT_HOSTNAME} {{ .Values.fuse.jvmOptions }} {{- range $key, $val := .Values.fuse.properties }} -D{{ $key }}={{ $val }} {{ end }}
+    {{- $fuseJavaOpts := list }}
+    {{- $fuseJavaOpts = print "-Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $fuseJavaOpts }}
+    {{- $fuseJavaOpts = print "-Dalluxio.worker.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $fuseJavaOpts }}
+    {{- range $key, $val := .Values.fuse.properties }}
+      {{- $fuseJavaOpts = printf "-D%v=%v" $key $val | append $fuseJavaOpts }}
+    {{- end }}
+    {{- if .Values.fuse.jvmOptions }}
+      {{- $fuseJavaOpts = concat $fuseJavaOpts .Values.fuse.jvmOptions }}
+    {{- end }}
+
+    {{- /* Format ALLUXIO_FUSE_JAVA_OPTS list to one line */}}
+    {{ range $key := $fuseJavaOpts }}{{ printf "%v " $key }}{{ end }}
   ALLUXIO_WORKER_TIEREDSTORE_LEVEL0_DIRS_PATH: /dev/shm

--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -61,7 +61,6 @@ data:
   ALLUXIO_MASTER_JAVA_OPTS: |-
     {{- $masterJavaOpts := list }}
     {{- $masterJavaOpts = print "-Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME}" | append $masterJavaOpts }}
-    {{- $masterJavaOpts = print "-Dalluxio.master.web.bind.host=0.0.0.0" | append $masterJavaOpts }}
     {{- range $key, $val := .Values.master.properties }}
       {{- $masterJavaOpts = printf "-D%v=%v" $key $val | append $masterJavaOpts }}
     {{- end }}
@@ -74,7 +73,6 @@ data:
   ALLUXIO_JOB_MASTER_JAVA_OPTS: |-
     {{- $jobMasterJavaOpts := list }}
     {{- $jobMasterJavaOpts = print "-Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME}" | append $jobMasterJavaOpts }}
-    {{- $jobMasterJavaOpts = print "-Dalluxio.job.master.web.bind.host=0.0.0.0" | append $jobMasterJavaOpts }}
     {{- range $key, $val := .Values.jobMaster.properties }}
       {{- $jobMasterJavaOpts = printf "-D%v=%v" $key $val | append $jobMasterJavaOpts }}
     {{- end }}
@@ -87,7 +85,6 @@ data:
   ALLUXIO_WORKER_JAVA_OPTS: |-
     {{- $workerJavaOpts := list }}
     {{- $workerJavaOpts = print "-Dalluxio.worker.hostname=${ALLUXIO_WORKER_HOSTNAME}" | append $workerJavaOpts }}
-    {{- $workerJavaOpts = print "-Dalluxio.worker.bind.host=0.0.0.0" | append $workerJavaOpts }}
     {{- $workerJavaOpts = printf "-Dalluxio.worker.rpc.port=%v" .Values.worker.ports.rpc | append $workerJavaOpts }}
     {{- $workerJavaOpts = printf "-Dalluxio.worker.web.port=%v" .Values.worker.ports.web | append $workerJavaOpts }}
 

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -33,10 +33,10 @@ properties:
 # Recommended JVM Heap options for running in Docker
 # Ref: https://developers.redhat.com/blog/2017/03/14/java-inside-docker/
 # These JVM options are common to all Alluxio services
-jvmOptions:
-  - "-XX:+UnlockExperimentalVMOptions"
-  - "-XX:+UseCGroupMemoryLimitForHeap"
-  - "-XX:MaxRAMFraction=2"
+# jvmOptions:
+#   - "-XX:+UnlockExperimentalVMOptions"
+#   - "-XX:+UseCGroupMemoryLimitForHeap"
+#   - "-XX:MaxRAMFraction=2"
 
 # Mount Persistent Volumes to all components
 # mounts:

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -33,7 +33,10 @@ properties:
 # Recommended JVM Heap options for running in Docker
 # Ref: https://developers.redhat.com/blog/2017/03/14/java-inside-docker/
 # These JVM options are common to all Alluxio services
-# jvmOptions: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=2 "
+jvmOptions:
+  - "-XX:+UnlockExperimentalVMOptions"
+  - "-XX:+UseCGroupMemoryLimitForHeap"
+  - "-XX:MaxRAMFraction=2"
 
 # Mount Persistent Volumes to all components
 # mounts:
@@ -68,7 +71,7 @@ master:
     rpc: 19998
     web: 19999
   # JVM options specific to the master container
-  jvmOptions: ""
+  jvmOptions:
   nodeSelector: {}
   hostNetwork: false
   dnsPolicy: ClusterFirst
@@ -97,7 +100,7 @@ jobMaster:
     rpc: 20001
     web: 20002
   # JVM options specific to the jobMaster container
-  jvmOptions: ""
+  jvmOptions:
 
 # Alluxio supports journal type of UFS and EMBEDDED
 # UFS journal with HDFS example
@@ -150,7 +153,7 @@ worker:
     rpc: 29999
     web: 30000
   # JVM options specific to the worker container
-  jvmOptions: ""
+  jvmOptions:
   nodeSelector: {}
   hostNetwork: false
   dnsPolicy: ClusterFirst
@@ -172,7 +175,7 @@ jobWorker:
     data: 30002
     web: 30003
   # JVM options specific to the jobWorker container
-  jvmOptions: ""
+  jvmOptions:
 
 # Tiered Storage
 # emptyDir example
@@ -240,7 +243,8 @@ fuse:
   properties:
   # Customize the MaxDirectMemorySize
   # These options are specific to the FUSE daemon
-  jvmOptions: " -XX:MaxDirectMemorySize=2g "
+  jvmOptions:
+    - "-XX:MaxDirectMemorySize=2g"
   hostNetwork: true
   dnsPolicy: ClusterFirstWithHostNet
   user: 0
@@ -266,3 +270,8 @@ fuse:
 #     alluxio-hdfs-config: hdfsConfig
 #   worker: # Shared by worker and jobWorker containers
 #     alluxio-hdfs-config: hdfsConfig
+
+alluxioJava: |-
+  -Dalluxio.master.journal.type={{ .Values.journal.type }}
+  -Dalluxio.master.journal.folder={{ .Values.journal.folder }}
+

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -270,8 +270,3 @@ fuse:
 #     alluxio-hdfs-config: hdfsConfig
 #   worker: # Shared by worker and jobWorker containers
 #     alluxio-hdfs-config: hdfsConfig
-
-alluxioJava: |-
-  -Dalluxio.master.journal.type={{ .Values.journal.type }}
-  -Dalluxio.master.journal.folder={{ .Values.journal.folder }}
-


### PR DESCRIPTION
This change breaks the one-liner property for each Java option into one line for each single property. This makes the helm template more manageable.

This addresses https://github.com/Alluxio/alluxio/issues/11081