### PR TITLE
Prevent format calls in UnderFileSystemWithLogging

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -87,8 +87,8 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
-      public String toString() {
-        return "Cleanup";
+      public String methodName() {
+        return "cleanup";
       }
     });
   }
@@ -103,8 +103,8 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
-      public String toString() {
-        return "Close";
+      public String methodName() {
+        return "close";
       }
     });
   }
@@ -119,8 +119,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "ConnectFromMaster";
+      }
+
+      @Override
       public String toString() {
-        return String.format("ConnectFromMaster: hostname=%s", hostname);
+        return String.format("hostname=%s", hostname);
       }
     });
   }
@@ -135,8 +140,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "ConnectFromWorker";
+      }
+
+      @Override
       public String toString() {
-        return String.format("ConnectFromWorker: hostname=%s", hostname);
+        return String.format("hostname=%s", hostname);
       }
     });
   }
@@ -150,8 +160,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "Create";
+      }
+
+      @Override
       public String toString() {
-        return String.format("Create: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -165,8 +180,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "Create";
+      }
+
+      @Override
       public String toString() {
-        return String.format("Create: path=%s, options=%s", path, options);
+        return String.format("path=%s, options=%s", path, options);
       }
     });
   }
@@ -180,8 +200,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "CreateNonexistingFile";
+      }
+
+      @Override
       public String toString() {
-        return String.format("CreateNonexistingFile: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -196,8 +221,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "CreateNonexistingFile";
+      }
+
+      @Override
       public String toString() {
-        return String.format("CreateNonexistingFile: path=%s, options=%s", path, options);
+        return String.format("path=%s, options=%s", path, options);
       }
     });
   }
@@ -211,8 +241,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "DeleteDirectory";
+      }
+
+      @Override
       public String toString() {
-        return String.format("DeleteDirectory: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -227,8 +262,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "DeleteDirectory";
+      }
+
+      @Override
       public String toString() {
-        return String.format("DeleteDirectory: path=%s, options=%s", path, options);
+        return String.format("path=%s, options=%s", path, options);
       }
     });
   }
@@ -242,8 +282,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "DeleteExistingDirectory";
+      }
+
+      @Override
       public String toString() {
-        return String.format("DeleteExistingDirectory: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -258,8 +303,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "DeleteExistingDirectory";
+      }
+
+      @Override
       public String toString() {
-        return String.format("DeleteExistingDirectory: path=%s, options=%s", path, options);
+        return String.format("path=%s, options=%s", path, options);
       }
     });
   }
@@ -273,8 +323,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "DeleteFile";
+      }
+
+      @Override
       public String toString() {
-        return String.format("DeleteFile: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -288,8 +343,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "DeleteExistingFile";
+      }
+
+      @Override
       public String toString() {
-        return String.format("DeleteExistingFile: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -303,8 +363,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "Exists";
+      }
+
+      @Override
       public String toString() {
-        return String.format("Exists: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -319,8 +384,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "GetAcl";
+      }
+
+      @Override
       public String toString() {
-        return String.format("GetAcl: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -334,8 +404,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "GetBlockSizeByte";
+      }
+
+      @Override
       public String toString() {
-        return String.format("GetBlockSizeByte: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -349,8 +424,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "GetDirectoryStatus";
+      }
+
+      @Override
       public String toString() {
-        return String.format("GetDirectoryStatus: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -364,8 +444,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "GetExistingDirectoryStatus";
+      }
+
+      @Override
       public String toString() {
-        return String.format("GetExistingDirectoryStatus: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -379,8 +464,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "GetFileLocations";
+      }
+
+      @Override
       public String toString() {
-        return String.format("GetFileLocations: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -395,8 +485,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "GetFileLocations";
+      }
+
+      @Override
       public String toString() {
-        return String.format("GetFileLocations: path=%s, options=%s", path, options);
+        return String.format("path=%s, options=%s", path, options);
       }
     });
   }
@@ -410,8 +505,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "GetFileStatus";
+      }
+
+      @Override
       public String toString() {
-        return String.format("GetFileStatus: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -425,8 +525,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "GetExistingFileStatus";
+      }
+
+      @Override
       public String toString() {
-        return String.format("GetExistingFileStatus: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -441,8 +546,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
         }
 
         @Override
+        public String methodName() {
+          return "GetFingerprint";
+        }
+
+        @Override
         public String toString() {
-          return String.format("GetFingerprint: path=%s", path);
+          return String.format("path=%s", path);
         }
       });
     } catch (IOException e) {
@@ -465,8 +575,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "GetSpace";
+      }
+
+      @Override
       public String toString() {
-        return String.format("GetSpace: path=%s, type=%s", path, type);
+        return String.format("path=%s, type=%s", path, type);
       }
     });
   }
@@ -480,8 +595,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "GetStatus";
+      }
+
+      @Override
       public String toString() {
-        return String.format("GetStatus: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -495,8 +615,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "GetExistingStatus";
+      }
+
+      @Override
       public String toString() {
-        return String.format("GetExistingStatus: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -515,8 +640,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "IsDirectory";
+      }
+
+      @Override
       public String toString() {
-        return String.format("IsDirectory: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -530,8 +660,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "IsExistingDirectory";
+      }
+
+      @Override
       public String toString() {
-        return String.format("IsExistingDirectory: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -545,8 +680,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "IsFile";
+      }
+
+      @Override
       public String toString() {
-        return String.format("IsFile: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -570,8 +710,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "ListStatus";
+      }
+
+      @Override
       public String toString() {
-        return String.format("ListStatus: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -586,8 +731,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "ListStatus";
+      }
+
+      @Override
       public String toString() {
-        return String.format("ListStatus: path=%s, options=%s", path, options);
+        return String.format("path=%s, options=%s", path, options);
       }
     });
   }
@@ -629,8 +779,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "Mkdirs";
+      }
+
+      @Override
       public String toString() {
-        return String.format("Mkdirs: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -644,8 +799,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "Mkdirs";
+      }
+
+      @Override
       public String toString() {
-        return String.format("Mkdirs: path=%s, options=%s", path, options);
+        return String.format("path=%s, options=%s", path, options);
       }
     });
   }
@@ -659,8 +819,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "Open";
+      }
+
+      @Override
       public String toString() {
-        return String.format("Open: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -674,8 +839,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "Open";
+      }
+
+      @Override
       public String toString() {
-        return String.format("Open: path=%s, options=%s", path, options);
+        return String.format("path=%s, options=%s", path, options);
       }
     });
   }
@@ -689,8 +859,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "OpenExistingFile";
+      }
+
+      @Override
       public String toString() {
-        return String.format("OpenExistingFile: path=%s", path);
+        return String.format("path=%s", path);
       }
     });
   }
@@ -705,8 +880,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "OpenExistingFile";
+      }
+
+      @Override
       public String toString() {
-        return String.format("OpenExistingFile: path=%s, options=%s", path, options);
+        return String.format("path=%s, options=%s", path, options);
       }
     });
   }
@@ -720,8 +900,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "RenameDirectory";
+      }
+
+      @Override
       public String toString() {
-        return String.format("RenameDirectory: src=%s, dst=%s", src, dst);
+        return String.format("src=%s, dst=%s", src, dst);
       }
     });
   }
@@ -735,8 +920,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "RenameRenableDirectory";
+      }
+
+      @Override
       public String toString() {
-        return String.format("RenameRenamableDirectory: src=%s, dst=%s", src, dst);
+        return String.format("src=%s, dst=%s", src, dst);
       }
     });
   }
@@ -750,8 +940,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "RenameFile";
+      }
+
+      @Override
       public String toString() {
-        return String.format("RenameFile: src=%s, dst=%s", src, dst);
+        return String.format("src=%s, dst=%s", src, dst);
       }
     });
   }
@@ -765,8 +960,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "RenameRenamableFile";
+      }
+
+      @Override
       public String toString() {
-        return String.format("RenameRenamableFile: src=%s, dst=%s", src, dst);
+        return String.format("src=%s, dst=%s", src, dst);
       }
     });
   }
@@ -786,8 +986,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "SetAclEntries";
+      }
+
+      @Override
       public String toString() {
-        return String.format("SetAcl: path=%s, ACLEntries=%s", path, aclEntries);
+        return String.format("path=%s, ACLEntries=%s", path, aclEntries);
       }
     });
   }
@@ -803,8 +1008,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "SetOwner";
+      }
+
+      @Override
       public String toString() {
-        return String.format("SetOwner: path=%s, owner=%s, group=%s", path, owner, group);
+        return String.format("path=%s, owner=%s, group=%s", path, owner, group);
       }
     });
   }
@@ -819,8 +1029,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "SetMode";
+      }
+
+      @Override
       public String toString() {
-        return String.format("SetMode: path=%s, mode=%s", path, mode);
+        return String.format("path=%s, mode=%s", path, mode);
       }
     });
   }
@@ -844,8 +1059,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "StartActiveSyncPolling";
+      }
+
+      @Override
       public String toString() {
-        return String.format("Start ActiveSync Polling with %d", txId);
+        return String.format("txId=%d", txId);
       }
     });
   }
@@ -859,8 +1079,8 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
-      public String toString() {
-        return String.format("Stop ActiveSync Polling");
+      public String methodName() {
+        return "StopActiveSyncPolling";
       }
     });
   }
@@ -874,8 +1094,8 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
-      public String toString() {
-        return String.format("getActiveSyncInfo");
+      public String methodName() {
+        return "GetActiveSyncInfo";
       }
     });
   }
@@ -890,8 +1110,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "StartSync";
+      }
+
+      @Override
       public String toString() {
-        return String.format("startSync %s", uri.toString());
+        return String.format("uri=%s", uri.toString());
       }
     });
   }
@@ -906,8 +1131,13 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       }
 
       @Override
+      public String methodName() {
+        return "StopSync";
+      }
+
+      @Override
       public String toString() {
-        return String.format("stopSync %s", uri.toString());
+        return String.format("uri=%s", uri.toString());
       }
     });
   }
@@ -927,13 +1157,20 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
    *
    * @param <T> the return type of the callable
    */
-  public interface UfsCallable<T> {
+  public abstract static class UfsCallable<T> {
     /**
      * Executes the call.
      *
      * @return the result of the call
      */
-    T call() throws IOException;
+    abstract T call() throws IOException;
+
+    abstract String methodName();
+
+    @Override
+    public String toString() {
+      return "";
+    }
   }
 
   /**
@@ -944,15 +1181,15 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
    * @return the result of the callable
    */
   private <T> T call(UfsCallable<T> callable) throws IOException {
-    LOG.debug("Enter: {}", callable);
-    String methodName = callable.toString().split(NAME_SEPARATOR)[0];
+    String methodName = callable.methodName();
+    LOG.debug("Enter: {}: {}", methodName, callable);
     try (Timer.Context ctx = MetricsSystem.timer(getQualifiedMetricName(methodName)).time()) {
       T ret = callable.call();
-      LOG.debug("Exit (OK): {}", callable);
+      LOG.debug("Exit (OK): {}: {}", methodName, callable);
       return ret;
     } catch (IOException e) {
       MetricsSystem.counter(getQualifiedFailureMetricName(methodName)).inc();
-      LOG.debug("Exit (Error): {}, Error={}", callable, e.getMessage());
+      LOG.debug("Exit (Error): {}: {}, Error={}", methodName, callable, e.getMessage());
       throw e;
     }
   }
@@ -978,10 +1215,6 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
     return Metric.getMetricNameWithTags(metricName, MetricInfo.TAG_UFS,
         mEscapedPath, MetricInfo.TAG_UFS_TYPE,
         mUnderFileSystem.getUnderFSType());
-  }
-
-  private String escapePath() {
-    return MetricsSystem.escape(new AlluxioURI(mPath));
   }
 
   // TODO(calvin): This should not be in this class


### PR DESCRIPTION
Previously, every single call to the UFS would perform a String.format and then String.split call to extract the method name. This is inefficient. Now, it will simply pull the method name from the callable object. After this, String.format is only called if the log statement is enabled.

Fixes #11237 