### PR TITLE
Stop tracking connections in copycat client/server

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/transport/GrpcMessagingClient.java
+++ b/core/server/common/src/main/java/alluxio/master/transport/GrpcMessagingClient.java
@@ -26,10 +26,6 @@ import io.atomix.catalyst.transport.Connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
@@ -46,9 +42,6 @@ public class GrpcMessagingClient implements Client {
   private final AlluxioConfiguration mConf;
   /** Authentication user. */
   private final UserState mUserState;
-
-  /** Created connections. */
-  private final List<Connection> mConnections;
 
   /** Executor for building client connections. */
   private final ExecutorService mExecutor;
@@ -70,7 +63,6 @@ public class GrpcMessagingClient implements Client {
     mUserState = userState;
     mExecutor = executor;
     mClientType = clientType;
-    mConnections = Collections.synchronizedList(new LinkedList<>());
   }
 
   @Override
@@ -99,7 +91,6 @@ public class GrpcMessagingClient implements Client {
         clientConnection.setTargetObserver(messageClientStub.connect(clientConnection));
 
         LOG.debug("Created a messaging client connection: {}", clientConnection);
-        mConnections.add(clientConnection);
         return clientConnection;
       } catch (Throwable e) {
         throw new RuntimeException(e);
@@ -121,13 +112,8 @@ public class GrpcMessagingClient implements Client {
 
   @Override
   public CompletableFuture<Void> close() {
-    LOG.debug("Closing messaging client with {} connections.", mConnections.size());
-    // Close created connections.
-    List<CompletableFuture<Void>> connectionCloseFutures = new ArrayList<>(mConnections.size());
-    for (Connection connection : mConnections) {
-      connectionCloseFutures.add(connection.close());
-    }
-    mConnections.clear();
-    return CompletableFuture.allOf(connectionCloseFutures.toArray(new CompletableFuture[0]));
+    LOG.debug("Closing messaging client; {}", this);
+    // Nothing to clean up
+    return CompletableFuture.completedFuture(null);
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/transport/GrpcMessagingServer.java
+++ b/core/server/common/src/main/java/alluxio/master/transport/GrpcMessagingServer.java
@@ -29,10 +29,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
@@ -56,9 +52,6 @@ public class GrpcMessagingServer implements Server {
   /** Listen future. */
   private CompletableFuture<Void> mListenFuture;
 
-  /** List of all connections created by this server. */
-  private final List<Connection> mConnections;
-
   /** Executor for building server listener. */
   private final ExecutorService mExecutor;
 
@@ -79,7 +72,6 @@ public class GrpcMessagingServer implements Server {
     mUserState = userState;
     mExecutor = executor;
     mProxy = proxy;
-    mConnections = Collections.synchronizedList(new LinkedList<>());
   }
 
   @Override
@@ -94,11 +86,6 @@ public class GrpcMessagingServer implements Server {
 
     final ThreadContext threadContext = ThreadContext.currentContextOrThrow();
     mListenFuture = CompletableFuture.runAsync(() -> {
-      // Listener that notifies both this server instance and given listener.
-      Consumer<Connection> forkListener = (connection) -> {
-        addNewConnection(connection);
-        listener.accept(connection);
-      };
 
       Address bindAddress = address;
       if (mProxy.hasProxyFor(address)) {
@@ -114,7 +101,7 @@ public class GrpcMessagingServer implements Server {
           .maxInboundMessageSize((int) mConf.getBytes(
               PropertyKey.MASTER_EMBEDDED_JOURNAL_TRANSPORT_MAX_INBOUND_MESSAGE_SIZE))
           .addService(new GrpcService(ServerInterceptors.intercept(
-              new GrpcMessagingServiceClientHandler(address, forkListener, threadContext,
+              new GrpcMessagingServiceClientHandler(address, listener::accept, threadContext,
                   mExecutor, mConf.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_ELECTION_TIMEOUT)),
               new ClientIpAddressInjector())))
           .build();
@@ -140,40 +127,16 @@ public class GrpcMessagingServer implements Server {
     }
 
     LOG.debug("Closing messaging server: {}", mGrpcServer);
-    // Close created connections.
-    List<CompletableFuture<Void>> connectionCloseFutures = new ArrayList<>(mConnections.size());
-    for (Connection connection : mConnections) {
-      connectionCloseFutures.add(connection.close());
-    }
-    mConnections.clear();
 
-    CompletableFuture<Void> future = new CompletableFuture<>();
-    CompletableFuture.allOf(connectionCloseFutures.toArray(new CompletableFuture[0]))
-        .whenComplete((result, error) -> {
-          // Shut down gRPC server once all connections are closed.
-          try {
-            mGrpcServer.shutdown();
-          } catch (Exception e) {
-            LOG.warn("Failed to close messaging gRPC server: {}", mGrpcServer);
-          } finally {
-            mGrpcServer = null;
-          }
-          // Complete the future with result from connection shut downs.
-          if (error == null) {
-            future.complete(result);
-          } else {
-            future.completeExceptionally(error);
-          }
-        });
-    return future;
-  }
-
-  /**
-   * Used to keep track of all connections created by this server instance.
-   *
-   * @param serverConnection new client connection
-   */
-  private synchronized void addNewConnection(Connection serverConnection) {
-    mConnections.add(serverConnection);
+    return CompletableFuture.runAsync(() -> {
+      // Shut down gRPC server once all connections are closed.
+      try {
+        mGrpcServer.shutdown();
+      } catch (Exception e) {
+        LOG.warn("Failed to close messaging gRPC server: {}", mGrpcServer);
+      } finally {
+        mGrpcServer = null;
+      }
+    });
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/transport/GrpcMessagingServer.java
+++ b/core/server/common/src/main/java/alluxio/master/transport/GrpcMessagingServer.java
@@ -129,7 +129,6 @@ public class GrpcMessagingServer implements Server {
     LOG.debug("Closing messaging server: {}", mGrpcServer);
 
     return CompletableFuture.runAsync(() -> {
-      // Shut down gRPC server once all connections are closed.
       try {
         mGrpcServer.shutdown();
       } catch (Exception e) {

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <apache.curator.version>4.2.0</apache.curator.version>
     <aws.amazonaws.version>1.11.215</aws.amazonaws.version>
     <build.path>build</build.path>
-    <copycat.version>1.2.14</copycat.version>
+    <copycat.version>1.2.15</copycat.version>
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
     <grpc.version>1.28.1</grpc.version>
     <netty.version>4.1.45.Final</netty.version>


### PR DESCRIPTION
Many connections can be created by the transport layer, but it is rare for copycat to close the client. Tracking the created connections is unnecessary because copycat closes them before closing the clients anyways. This prevents us from holding on to the connection references for extended periods of time, which then causes behavior resembling a memory leak.

Additionally we bump the copycat version to 1.2.15 to avoid cycling connections. 1.2.15 introduces a changes to the KeepAliveResponse serde to respect unresolved addresses.

Fixes #11355 