### PR TITLE
Merge system properties in a thread-safe manner

### DIFF
--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -413,7 +413,12 @@ public final class ConfigurationUtils {
       // property file.
       AlluxioProperties properties = new AlluxioProperties();
       InstancedConfiguration conf = new InstancedConfiguration(properties);
-      properties.merge(System.getProperties(), Source.SYSTEM_PROPERTY);
+      // Can't directly pass System.getProperties() because it is not thread-safe
+      // This can cause a ConcurrentModificationException when merging.
+      Properties sysProps = new Properties();
+      System.getProperties().stringPropertyNames()
+          .forEach(key -> sysProps.setProperty(key, System.getProperty(key)));
+      properties.merge(sysProps, Source.SYSTEM_PROPERTY);
 
       // Step2: Load site specific properties file if not in test mode. Note that we decide
       // whether in test mode by default properties and system properties (via getBoolean).


### PR DESCRIPTION
I noticed after an upgrade to OpenJDK 8u252 I started getting exceptions thrown when starting the Alluxio services. Alluxio `getConf` was throwing a `ConcurrentModificationException` when trying to load the site properties. I'm not sure exactly who was modifying the properties concurrently, but it is not safe to iterate over `System.getProperties().entrySet()`, so we make a copy of the properties first now before merging.

```
Exception in thread "main" java.util.ConcurrentModificationException
        at java.util.Hashtable$Enumerator.next(Hashtable.java:1387)
        at alluxio.conf.AlluxioProperties.merge(AlluxioProperties.java:139)
        at alluxio.util.ConfigurationUtils.reloadProperties(ConfigurationUtils.java:416)
        at alluxio.util.ConfigurationUtils.defaults(ConfigurationUtils.java:399)
        at alluxio.cli.GetConf.main(GetConf.java:275)
```

The impact of this change is low because `reloadProperties` is mainly called during testing and when processes first start up; not during normal Alluxio usage.