### PR TITLE
Improve Helm configmap template format

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -17,6 +17,142 @@
 {{- $name := include "alluxio.name" . }}
 {{- $fullName := include "alluxio.fullname" . }}
 {{- $chart := include "alluxio.chart" . }}
+
+{{- /* ===================================== */}}
+{{- /*         ALLUXIO_JAVA_OPTS             */}}
+{{- /* ===================================== */}}
+{{- $alluxioJavaOpts := list }}
+{{- /* Specify master hostname if single master */}}
+{{- if $isSingleMaster }}
+  {{- $alluxioJavaOpts = printf "-Dalluxio.master.hostname=%v-%v" $fullName $defaultMasterName | append $alluxioJavaOpts }}
+{{- end }}
+{{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.type=%v" .Values.journal.type | append $alluxioJavaOpts }}
+{{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.folder=%v" .Values.journal.folder | append $alluxioJavaOpts }}
+
+{{- /* Generate HA embedded journal address for masters */}}
+{{- if $isHaEmbedded }}
+  {{- $embeddedJournalAddresses := "-Dalluxio.master.embedded.journal.addresses=" }}
+  {{- range $i := until $masterCount }}
+  {{- $embeddedJournalAddresses = printf "%v,%v-master-%v:19200" $embeddedJournalAddresses $fullName $i }}
+  {{- end }}
+  {{- $alluxioJavaOpts = append $alluxioJavaOpts $embeddedJournalAddresses }}
+{{- end }}
+{{- range $key, $val := .Values.properties }}
+{{- $alluxioJavaOpts = printf "-D%v=%v" $key $val | append $alluxioJavaOpts }}
+{{- end }}
+{{- if .Values.jvmOptions }}
+{{- $alluxioJavaOpts = concat $alluxioJavaOpts .Values.jvmOptions }}
+{{- end }}
+
+{{- /* ===================================== */}}
+{{- /*       ALLUXIO_MASTER_JAVA_OPTS        */}}
+{{- /* ===================================== */}}
+{{- $masterJavaOpts := list }}
+{{- $masterJavaOpts = print "-Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME}" | append $masterJavaOpts }}
+{{- range $key, $val := .Values.master.properties }}
+  {{- $masterJavaOpts = printf "-D%v=%v" $key $val | append $masterJavaOpts }}
+{{- end }}
+{{- if .Values.master.jvmOptions }}
+  {{- $masterJavaOpts = concat $masterJavaOpts .Values.master.jvmOptions }}
+{{- end }}
+
+{{- /* ===================================== */}}
+{{- /*     ALLUXIO_JOB_MASTER_JAVA_OPTS      */}}
+{{- /* ===================================== */}}
+{{- $jobMasterJavaOpts := list }}
+{{- $jobMasterJavaOpts = print "-Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME}" | append $jobMasterJavaOpts }}
+{{- range $key, $val := .Values.jobMaster.properties }}
+  {{- $jobMasterJavaOpts = printf "-D%v=%v" $key $val | append $jobMasterJavaOpts }}
+{{- end }}
+{{- if .Values.jobMaster.jvmOptions }}
+  {{- $jobMasterJavaOpts = concat $jobMasterJavaOpts .Values.jobMaster.jvmOptions }}
+{{- end }}
+
+{{- /* ===================================== */}}
+{{- /*       ALLUXIO_WORKER_JAVA_OPTS        */}}
+{{- /* ===================================== */}}
+{{- $workerJavaOpts := list }}
+{{- $workerJavaOpts = print "-Dalluxio.worker.hostname=${ALLUXIO_WORKER_HOSTNAME}" | append $workerJavaOpts }}
+{{- $workerJavaOpts = printf "-Dalluxio.worker.rpc.port=%v" .Values.worker.ports.rpc | append $workerJavaOpts }}
+{{- $workerJavaOpts = printf "-Dalluxio.worker.web.port=%v" .Values.worker.ports.web | append $workerJavaOpts }}
+
+{{- /* Short circuit configuration */}}
+{{- if eq .Values.shortCircuit.enabled false}}
+  {{- $workerJavaOpts = print "-Dalluxio.user.short.circuit.enabled=false" | append $workerJavaOpts }}
+{{- end }}
+{{- if and .Values.shortCircuit.enabled (eq .Values.shortCircuit.policy "uuid") }}
+  {{- $workerJavaOpts = print "-Dalluxio.worker.data.server.domain.socket.address=/opt/domain" | append $workerJavaOpts }}
+  {{- $workerJavaOpts = print "-Dalluxio.worker.data.server.domain.socket.as.uuid=true" | append $workerJavaOpts }}
+{{- end}}
+{{- /* Record container hostname if not using host network */}}
+{{- if not .Values.worker.hostNetwork }}
+  {{- $workerJavaOpts = print "-Dalluxio.worker.container.hostname=${ALLUXIO_WORKER_CONTAINER_HOSTNAME}" | append $workerJavaOpts }}
+{{- end}}
+
+{{- /* Resource configuration */}}
+{{- if .Values.worker.resources  }}
+  {{- if .Values.worker.resources.requests }}
+    {{- if .Values.worker.resources.requests.memory }}
+          {{- $workerJavaOpts = printf "-Dalluxio.worker.memory.size=%v" .Values.worker.resources.requests.memory | append $workerJavaOpts }}
+    {{- end}}
+  {{- end}}
+{{- end}}
+
+{{- /* Tiered store configuration */}}
+{{- if .Values.tieredstore }}
+  {{- $workerJavaOpts = printf "-Dalluxio.worker.tieredstore.levels=%v" (len .Values.tieredstore.levels) | append $workerJavaOpts }}
+  {{- range .Values.tieredstore.levels }}
+    {{- $tierName := printf "-Dalluxio.worker.tieredstore.level%v" .level }}
+    {{- $workerJavaOpts = printf "%v.dirs.mediumtype=%v" $tierName .mediumtype | append $workerJavaOpts }}
+    {{- if .path }}
+      {{- $workerJavaOpts = printf "%v.dirs.path=%v" $tierName .path | append $workerJavaOpts }}
+    {{- end}}
+    {{- if .quota }}
+      {{- $workerJavaOpts = printf "%v.dirs.quota=%v" $tierName .quota | append $workerJavaOpts }}
+    {{- end}}
+    {{- if .high }}
+      {{- $workerJavaOpts = printf "%v.watermark.high.ratio=%v" $tierName .high | append $workerJavaOpts }}
+    {{- end}}
+    {{- if .low }}
+      {{- $workerJavaOpts = printf "%v.watermark.low.ratio=%v" $tierName .low | append $workerJavaOpts }}
+    {{- end}}
+  {{- end}}
+{{- end }}
+
+{{- range $key, $val := .Values.worker.properties }}
+  {{- $workerJavaOpts = printf "-D%v=%v" $key $val | append $workerJavaOpts }}
+{{- end }}
+{{- if .Values.worker.jvmOptions }}
+  {{- $workerJavaOpts = concat $workerJavaOpts .Values.worker.jvmOptions }}
+{{- end }}
+
+{{- /* ===================================== */}}
+{{- /*     ALLUXIO_JOB_WORKER_JAVA_OPTS      */}}
+{{- /* ===================================== */}}
+{{- $jobWorkerJavaOpts := list }}
+{{- $jobWorkerJavaOpts = print "-Dalluxio.worker.hostname=${ALLUXIO_WORKER_HOSTNAME}" | append $jobWorkerJavaOpts }}
+{{- $jobWorkerJavaOpts = printf "-Dalluxio.job.worker.rpc.port=%v" .Values.jobWorker.ports.rpc | append $jobWorkerJavaOpts }}
+{{- $jobWorkerJavaOpts = printf "-Dalluxio.job.worker.data.port=%v" .Values.jobWorker.ports.data | append $jobWorkerJavaOpts }}
+{{- $jobWorkerJavaOpts = printf "-Dalluxio.job.worker.web.port=%v" .Values.jobWorker.ports.web | append $jobWorkerJavaOpts }}
+{{- range $key, $val := .Values.jobWorker.properties }}
+  {{- $jobWorkerJavaOpts = printf "-D%v=%v" $key $val | append $jobWorkerJavaOpts }}
+{{- end }}
+{{- if .Values.jobWorker.jvmOptions }}
+  {{- $jobWorkerJavaOpts = concat $jobWorkerJavaOpts .Values.jobWorker.jvmOptions }}
+{{- end }}
+
+{{- /* ===================================== */}}
+{{- /*        ALLUXIO_FUSE_JAVA_OPTS         */}}
+{{- /* ===================================== */}}
+{{- $fuseJavaOpts := list }}
+{{- $fuseJavaOpts = print "-Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $fuseJavaOpts }}
+  {{- $fuseJavaOpts = print "-Dalluxio.worker.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $fuseJavaOpts }}
+  {{- range $key, $val := .Values.fuse.properties }}
+    {{- $fuseJavaOpts = printf "-D%v=%v" $key $val | append $fuseJavaOpts }}
+{{- end }}
+{{- if .Values.fuse.jvmOptions }}
+  {{- $fuseJavaOpts = concat $fuseJavaOpts .Values.fuse.jvmOptions }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -32,141 +168,21 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   ALLUXIO_JAVA_OPTS: |-
-    {{- $alluxioJavaOpts := list }}
-
-    {{- /* Specify master hostname if single master */}}
-    {{- if $isSingleMaster }}
-      {{- $alluxioJavaOpts = printf "-Dalluxio.master.hostname=%v-%v" $fullName $defaultMasterName | append $alluxioJavaOpts }}
-    {{- end }}
-    {{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.type=%v" .Values.journal.type | append $alluxioJavaOpts }}
-    {{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.folder=%v" .Values.journal.folder | append $alluxioJavaOpts }}
-
-    {{- /* Generate HA embedded journal address for masters */}}
-    {{- if $isHaEmbedded }}
-      {{- $embeddedJournalAddresses := "-Dalluxio.master.embedded.journal.addresses=" }}
-      {{- range $i := until $masterCount }}
-        {{- $embeddedJournalAddresses = printf "%v,%v-master-%v:19200" $embeddedJournalAddresses $fullName $i }}
-      {{- end }}
-      {{- $alluxioJavaOpts = append $alluxioJavaOpts $embeddedJournalAddresses }}
-    {{- end }}
-    {{- range $key, $val := .Values.properties }}
-      {{- $alluxioJavaOpts = printf "-D%v=%v" $key $val | append $alluxioJavaOpts }}
-    {{- end }}
-    {{- if .Values.jvmOptions }}
-      {{- $alluxioJavaOpts = concat $alluxioJavaOpts .Values.jvmOptions }}
-    {{- end }}
-
     {{- /* Format ALLUXIO_JAVA_OPTS list to one line */}}
     {{ range $key := $alluxioJavaOpts }}{{ printf "%v " $key }}{{ end }}
   ALLUXIO_MASTER_JAVA_OPTS: |-
-    {{- $masterJavaOpts := list }}
-    {{- $masterJavaOpts = print "-Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME}" | append $masterJavaOpts }}
-    {{- range $key, $val := .Values.master.properties }}
-      {{- $masterJavaOpts = printf "-D%v=%v" $key $val | append $masterJavaOpts }}
-    {{- end }}
-    {{- if .Values.master.jvmOptions }}
-      {{- $masterJavaOpts = concat $masterJavaOpts .Values.master.jvmOptions }}
-    {{- end }}
-
     {{- /* Format ALLUXIO_MASTER_JAVA_OPTS list to one line */}}
     {{ range $key := $masterJavaOpts }}{{ printf "%v " $key }}{{ end }}
   ALLUXIO_JOB_MASTER_JAVA_OPTS: |-
-    {{- $jobMasterJavaOpts := list }}
-    {{- $jobMasterJavaOpts = print "-Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME}" | append $jobMasterJavaOpts }}
-    {{- range $key, $val := .Values.jobMaster.properties }}
-      {{- $jobMasterJavaOpts = printf "-D%v=%v" $key $val | append $jobMasterJavaOpts }}
-    {{- end }}
-    {{- if .Values.jobMaster.jvmOptions }}
-      {{- $jobMasterJavaOpts = concat $jobMasterJavaOpts .Values.jobMaster.jvmOptions }}
-    {{- end }}
-
     {{- /* Format ALLUXIO_JOB_MASTER_JAVA_OPTS list to one line */}}
     {{ range $key := $jobMasterJavaOpts }}{{ printf "%v " $key }}{{ end }}
   ALLUXIO_WORKER_JAVA_OPTS: |-
-    {{- $workerJavaOpts := list }}
-    {{- $workerJavaOpts = print "-Dalluxio.worker.hostname=${ALLUXIO_WORKER_HOSTNAME}" | append $workerJavaOpts }}
-    {{- $workerJavaOpts = printf "-Dalluxio.worker.rpc.port=%v" .Values.worker.ports.rpc | append $workerJavaOpts }}
-    {{- $workerJavaOpts = printf "-Dalluxio.worker.web.port=%v" .Values.worker.ports.web | append $workerJavaOpts }}
-
-    {{- /* Short circuit configuration */}}
-    {{- if eq .Values.shortCircuit.enabled false}}
-      {{- $workerJavaOpts = print "-Dalluxio.user.short.circuit.enabled=false" | append $workerJavaOpts }}
-    {{- end }}
-    {{- if and .Values.shortCircuit.enabled (eq .Values.shortCircuit.policy "uuid") }}
-      {{- $workerJavaOpts = print "-Dalluxio.worker.data.server.domain.socket.address=/opt/domain" | append $workerJavaOpts }}
-      {{- $workerJavaOpts = print "-Dalluxio.worker.data.server.domain.socket.as.uuid=true" | append $workerJavaOpts }}
-    {{- end}}
-
-    {{- /* Record container hostname if not using host network */}}
-    {{- if not .Values.worker.hostNetwork }}
-      {{- $workerJavaOpts = print "-Dalluxio.worker.container.hostname=${ALLUXIO_WORKER_CONTAINER_HOSTNAME}" | append $workerJavaOpts }}
-    {{- end}}
-
-    {{- /* Resource configuration */}}
-    {{- if .Values.worker.resources  }}
-      {{- if .Values.worker.resources.requests }}
-        {{- if .Values.worker.resources.requests.memory }}
-          {{- $workerJavaOpts = printf "-Dalluxio.worker.memory.size=%v" .Values.worker.resources.requests.memory | append $workerJavaOpts }}
-        {{- end}}
-      {{- end}}
-    {{- end}}
-
-    {{- /* Tiered store configuration */}}
-    {{- if .Values.tieredstore }}
-      {{- $workerJavaOpts = printf "-Dalluxio.worker.tieredstore.levels=%v" (len .Values.tieredstore.levels) | append $workerJavaOpts }}
-      {{- range .Values.tieredstore.levels }}
-        {{- $tierName := printf "-Dalluxio.worker.tieredstore.level%v" .level }}
-        {{- $workerJavaOpts = printf "%v.dirs.mediumtype=%v" $tierName .mediumtype | append $workerJavaOpts }}
-        {{- if .path }}
-          {{- $workerJavaOpts = printf "%v.dirs.path=%v" $tierName .path | append $workerJavaOpts }}
-        {{- end}}
-        {{- if .quota }}
-          {{- $workerJavaOpts = printf "%v.dirs.quota=%v" $tierName .quota | append $workerJavaOpts }}
-        {{- end}}
-        {{- if .high }}
-          {{- $workerJavaOpts = printf "%v.watermark.high.ratio=%v" $tierName .high | append $workerJavaOpts }}
-        {{- end}}
-        {{- if .low }}
-          {{- $workerJavaOpts = printf "%v.watermark.low.ratio=%v" $tierName .low | append $workerJavaOpts }}
-        {{- end}}
-      {{- end}}
-    {{- end }}
-
-    {{- range $key, $val := .Values.worker.properties }}
-      {{- $workerJavaOpts = printf "-D%v=%v" $key $val | append $workerJavaOpts }}
-    {{- end }}
-    {{- if .Values.worker.jvmOptions }}
-      {{- $workerJavaOpts = concat $workerJavaOpts .Values.worker.jvmOptions }}
-    {{- end }}
-
     {{- /* Format ALLUXIO_WORKER_JAVA_OPTS list to one line */}}
     {{ range $key := $workerJavaOpts }}{{ printf "%v " $key }}{{ end }}
   ALLUXIO_JOB_WORKER_JAVA_OPTS: |-
-    {{- $jobWorkerJavaOpts := list }}
-    {{- $jobWorkerJavaOpts = print "-Dalluxio.worker.hostname=${ALLUXIO_WORKER_HOSTNAME}" | append $jobWorkerJavaOpts }}
-    {{- $jobWorkerJavaOpts = printf "-Dalluxio.job.worker.rpc.port=%v" .Values.jobWorker.ports.rpc | append $jobWorkerJavaOpts }}
-    {{- $jobWorkerJavaOpts = printf "-Dalluxio.job.worker.data.port=%v" .Values.jobWorker.ports.data | append $jobWorkerJavaOpts }}
-    {{- $jobWorkerJavaOpts = printf "-Dalluxio.job.worker.web.port=%v" .Values.jobWorker.ports.web | append $jobWorkerJavaOpts }}
-    {{- range $key, $val := .Values.jobWorker.properties }}
-      {{- $jobWorkerJavaOpts = printf "-D%v=%v" $key $val | append $jobWorkerJavaOpts }}
-    {{- end }}
-    {{- if .Values.jobWorker.jvmOptions }}
-      {{- $jobWorkerJavaOpts = concat $jobWorkerJavaOpts .Values.jobWorker.jvmOptions }}
-    {{- end }}
-
     {{- /* Format ALLUXIO_JOB_WORKER_JAVA_OPTS list to one line */}}
     {{ range $key := $jobWorkerJavaOpts }}{{ printf "%v " $key }}{{ end }}
   ALLUXIO_FUSE_JAVA_OPTS: |-
-    {{- $fuseJavaOpts := list }}
-    {{- $fuseJavaOpts = print "-Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $fuseJavaOpts }}
-    {{- $fuseJavaOpts = print "-Dalluxio.worker.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $fuseJavaOpts }}
-    {{- range $key, $val := .Values.fuse.properties }}
-      {{- $fuseJavaOpts = printf "-D%v=%v" $key $val | append $fuseJavaOpts }}
-    {{- end }}
-    {{- if .Values.fuse.jvmOptions }}
-      {{- $fuseJavaOpts = concat $fuseJavaOpts .Values.fuse.jvmOptions }}
-    {{- end }}
-
     {{- /* Format ALLUXIO_FUSE_JAVA_OPTS list to one line */}}
     {{ range $key := $fuseJavaOpts }}{{ printf "%v " $key }}{{ end }}
   ALLUXIO_WORKER_TIEREDSTORE_LEVEL0_DIRS_PATH: /dev/shm

--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -10,7 +10,7 @@
 #
 
 {{ $masterCount := int .Values.master.count }}
-{{ $defaultMasterName := "master-0" }}
+{{- $defaultMasterName := "master-0" }}
 {{- $isSingleMaster := eq $masterCount 1 }}
 {{- $isHaEmbedded := and (eq .Values.journal.type "EMBEDDED") (gt $masterCount 1) }}
 {{- $release := .Release }}
@@ -38,10 +38,10 @@
   {{- $alluxioJavaOpts = append $alluxioJavaOpts $embeddedJournalAddresses }}
 {{- end }}
 {{- range $key, $val := .Values.properties }}
-{{- $alluxioJavaOpts = printf "-D%v=%v" $key $val | append $alluxioJavaOpts }}
+  {{- $alluxioJavaOpts = printf "-D%v=%v" $key $val | append $alluxioJavaOpts }}
 {{- end }}
 {{- if .Values.jvmOptions }}
-{{- $alluxioJavaOpts = concat $alluxioJavaOpts .Values.jvmOptions }}
+  {{- $alluxioJavaOpts = concat $alluxioJavaOpts .Values.jvmOptions }}
 {{- end }}
 
 {{- /* ===================================== */}}


### PR DESCRIPTION
This moves JavaOpts generation out of the multi-line properties, and puts them into the head section.

The reason for doing this is we cannot insert hashtag comments in a multi-line section like below. So if someone wants to generate comments in the helm code, that breaks the helm template.
```
ALLUXIO_MASTER_JAVA_OPTS: |-
  # This will propagate to the generated YAML, but not allowed in a multi-line property
  {{- /* This will not appear in the generated YAML */}}
  {{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.type=%v" .Values.journal.type | append $alluxioJavaOpts }}
  ...omitted...
```