### PR TITLE
Improve PR build by inspecting PR diff

### DIFF
--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -35,6 +35,9 @@ else
     if [[ ${filepath} =~ ^docs/.* ]]; then
       # if any file starts with "docs/", run doc check
       RUN_DOC_CHECK="true"
+    elif [[ ${filepath} =~ ^integration/(dataproc|docker|emr|kubernetes|vagrant)/.* ]]; then
+      # do nothing for files in integration/ that don't contain java code
+      :
     else
       # if any other files are in the diff, run maven
       RUN_MAVEN="true"

--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -27,10 +27,7 @@ if [ -z "${TARGET_BRANCH}" ]; then
   RUN_MAVEN="true"
   RUN_DOC_CHECK="true"
 else
-  if [ -z "${TARGET_REMOTE}" ]; then
-    TARGET_REMOTE="origin"
-  fi
-  git --no-pager diff "${TARGET_REMOTE}/${TARGET_BRANCH}" --name-only > prFiles.diff
+  git --no-pager diff "refs/remotes/origin/${TARGET_BRANCH}" --name-only > prFiles.diff
   echo "PR diff is:"
   cat prFiles.diff
 

--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -15,34 +15,69 @@
 #
 set -e
 
-# Set things up so that the current user has a real name and can authenticate.
-myuid=$(id -u)
-mygid=$(id -g)
-echo "$myuid:x:$myuid:$mygid:anonymous uid:/home/jenkins:/bin/false" >> /etc/passwd
-
-export MAVEN_OPTS="-Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS"
-
-if [ -z ${ALLUXIO_BUILD_FORKCOUNT} ]
-then
-  ALLUXIO_BUILD_FORKCOUNT=4
-fi
-
 if [ -n "${ALLUXIO_GIT_CLEAN}" ]
 then
   git clean -fdx
 fi
-mvn -Duser.home=/home/jenkins -T 4C clean install -Pdeveloper -Dmaven.javadoc.skip -Dsurefire.forkCount=${ALLUXIO_BUILD_FORKCOUNT} $@
 
-if [ -n "${ALLUXIO_SONAR_ARGS}" ]
-then
-  # A separate step to run jacoco report, with all the generated coverage data. This requires the
-  # previous 'install' step to generate the jacoco exec data with the 'jacoco' profile.
-  #
-  # Must exclude some of the modules that fail to run verify again without a clean step. This is ok
-  # since these modules do not contain any source code to track for code coverage.
-  mvn -T 4C -Dfindbugs.skip -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip -Dlicense.skip -PjacocoReport verify -pl '!webui,!shaded,!shaded/client,!shaded/hadoop'
-  # run sonar analysis
-  mvn $(echo "${ALLUXIO_SONAR_ARGS}") sonar:sonar
+RUN_MAVEN="false"
+RUN_DOC_CHECK="false"
+if [ -z "${TARGET_BRANCH}" ]; then
+  # if no target branch is specified, run all checks
+  RUN_MAVEN="true"
+  RUN_DOC_CHECK="true"
+else
+  if [ -z "${TARGET_REMOTE}" ]; then
+    TARGET_REMOTE="origin"
+  fi
+  git --no-pager diff "${TARGET_REMOTE}/${TARGET_BRANCH}" --name-only > prFiles.diff
+  echo "PR diff is:"
+  cat prFiles.diff
+
+  while IFS="" read -r filepath || [ -n "$filepath" ]; do
+    if [[ ${filepath} =~ ^docs/.* ]]; then
+      # if any file starts with "docs/", run doc check
+      RUN_DOC_CHECK="true"
+    else
+      # if any other files are in the diff, run maven
+      RUN_MAVEN="true"
+    fi
+  done < prFiles.diff
+  rm prFiles.diff
 fi
 
-./dev/scripts/check-docs.sh
+if [ "$RUN_MAVEN" == "true" ]; then
+  # Set things up so that the current user has a real name and can authenticate.
+  myuid=$(id -u)
+  mygid=$(id -g)
+  echo "$myuid:x:$myuid:$mygid:anonymous uid:/home/jenkins:/bin/false" >> /etc/passwd
+
+  export MAVEN_OPTS="-Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS"
+
+  if [ -z "${ALLUXIO_BUILD_FORKCOUNT}" ]
+  then
+    ALLUXIO_BUILD_FORKCOUNT=4
+  fi
+
+  mvn -Duser.home=/home/jenkins -T 4C clean install -Pdeveloper -Dmaven.javadoc.skip -Dsurefire.forkCount=${ALLUXIO_BUILD_FORKCOUNT} $@
+
+  if [ -n "${ALLUXIO_SONAR_ARGS}" ]
+  then
+    # A separate step to run jacoco report, with all the generated coverage data. This requires the
+    # previous 'install' step to generate the jacoco exec data with the 'jacoco' profile.
+    #
+    # Must exclude some of the modules that fail to run verify again without a clean step. This is ok
+    # since these modules do not contain any source code to track for code coverage.
+    mvn -T 4C -Dfindbugs.skip -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip -Dlicense.skip -PjacocoReport verify -pl '!webui,!shaded,!shaded/client,!shaded/hadoop'
+    # run sonar analysis
+    mvn $(echo "${ALLUXIO_SONAR_ARGS}") sonar:sonar
+  fi
+else
+  echo "RUN_MAVEN was not set to true, skipping maven check"
+fi
+
+if [ "${RUN_DOC_CHECK}" == "true" ]; then
+  ./dev/scripts/check-docs.sh
+else
+  echo "RUN_DOC_CHECK was not set to true, skipping doc check"
+fi

--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -27,12 +27,10 @@ if [ -z "${TARGET_BRANCH}" ]; then
   RUN_MAVEN="true"
   RUN_DOC_CHECK="true"
 else
-  git --no-pager diff "refs/remotes/origin/${TARGET_BRANCH}" --name-only || true # debug, see if there's any output
-  git --no-pager diff "refs/remotes/origin/${TARGET_BRANCH}" --name-only > prFiles.diff || true
+  git --no-pager diff "refs/remotes/origin/${TARGET_BRANCH}" --name-only > prFiles.diff
   echo "PR diff is:"
   cat prFiles.diff
 
-  exit 1 # debug
   while IFS="" read -r filepath || [ -n "$filepath" ]; do
     if [[ ${filepath} =~ ^docs/.* ]]; then
       # if any file starts with "docs/", run doc check

--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -27,10 +27,12 @@ if [ -z "${TARGET_BRANCH}" ]; then
   RUN_MAVEN="true"
   RUN_DOC_CHECK="true"
 else
-  git --no-pager diff "refs/remotes/origin/${TARGET_BRANCH}" --name-only > prFiles.diff
+  git --no-pager diff "refs/remotes/origin/${TARGET_BRANCH}" --name-only || true # debug, see if there's any output
+  git --no-pager diff "refs/remotes/origin/${TARGET_BRANCH}" --name-only > prFiles.diff || true
   echo "PR diff is:"
   cat prFiles.diff
 
+  exit 1 # debug
   while IFS="" read -r filepath || [ -n "$filepath" ]; do
     if [[ ${filepath} =~ ^docs/.* ]]; then
       # if any file starts with "docs/", run doc check

--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -36,7 +36,7 @@ else
       # run all checks if modifying any part of the build process
       RUN_MAVEN="true"
       RUN_DOC_CHECK="true"
-    if [[ ${filepath} =~ ^docs/.* ]]; then
+    elif [[ ${filepath} =~ ^docs/.* ]]; then
       # if any file starts with "docs/", run doc check
       RUN_DOC_CHECK="true"
     elif [[ ${filepath} =~ ^integration/(dataproc|docker|emr|kubernetes|vagrant)/.* ]]; then

--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -13,7 +13,7 @@
 #
 # This script is run from inside the Docker container
 #
-set -e
+set -ex
 
 if [ -n "${ALLUXIO_GIT_CLEAN}" ]
 then

--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -32,6 +32,10 @@ else
   cat prFiles.diff
 
   while IFS="" read -r filepath || [ -n "$filepath" ]; do
+    if [[ ${filepath} =~ ^dev/* ]]; then
+      # run all checks if modifying any part of the build process
+      RUN_MAVEN="true"
+      RUN_DOC_CHECK="true"
     if [[ ${filepath} =~ ^docs/.* ]]; then
       # if any file starts with "docs/", run doc check
       RUN_DOC_CHECK="true"

--- a/dev/jenkins/run_docker.sh
+++ b/dev/jenkins/run_docker.sh
@@ -70,13 +70,11 @@ function main {
   run_args+=" -e ALLUXIO_PORT_COORDINATION_DIR=${home}"
 
   # If target branch or remote exists, set to run relevant checks given the diff of the PR
-  if [ -n "${TARGET_BRANCH}" ]
+  if [ -n "${ghprbTargetBranch}" ]
   then
-    run_args+=" -e TARGET_BRANCH=${TARGET_BRANCH}"
-  fi
-  if [ -n "${TARGET_REMOTE}" ]
-  then
-    run_args+=" -e TARGET_REMOTE=${TARGET_REMOTE}"
+    # this env var is defined by the github pull request builder jenkins plugin
+    # see https://plugins.jenkins.io/ghprb/
+    run_args+=" -e TARGET_BRANCH=${ghprbTargetBranch}"
   fi
 
   # Use this as an entrypoint instead of image argument so that it can be interrupted by Ctrl-C

--- a/dev/jenkins/run_docker.sh
+++ b/dev/jenkins/run_docker.sh
@@ -10,7 +10,7 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
-set -e
+set -ex
 
 function main {
   if [ -z "${ALLUXIO_DOCKER_ID}" ]

--- a/dev/jenkins/run_docker.sh
+++ b/dev/jenkins/run_docker.sh
@@ -69,6 +69,16 @@ function main {
   run_args+=" -e ALLUXIO_USE_FIXED_TEST_PORTS=true"
   run_args+=" -e ALLUXIO_PORT_COORDINATION_DIR=${home}"
 
+  # If target branch or remote exists, set to run relevant checks given the diff of the PR
+  if [ -n "${TARGET_BRANCH}" ]
+  then
+    run_args+=" -e TARGET_BRANCH=${TARGET_BRANCH}"
+  fi
+  if [ -n "${TARGET_REMOTE}" ]
+  then
+    run_args+=" -e TARGET_REMOTE=${TARGET_REMOTE}"
+  fi
+
   # Use this as an entrypoint instead of image argument so that it can be interrupted by Ctrl-C
   run_args+=" --entrypoint=dev/jenkins/build.sh"
 


### PR DESCRIPTION
we currently use this jenkins plugin to run our PR build checks: https://plugins.jenkins.io/ghprb/

the plugin defines an environment variable for the target branch that the PR is going to merge into. that means we can run `git --no-pager diff origin/master --name-only` to get a list of files that were changed in the PR. note this change also required a few tweaks to the jenkins job, most importantly the addition of pulling more refs so i can reference the ref marked as origin/master
since we have two checks, one for the maven build and one for docs, i defined two booleans that get set to true if a corresponding file is found in the diff. if this target branch variable is not available, it defaults to running all checks.
if there are more files or folders that we can incorporate into the diff check, we can waste less cycles running irrelevant checks