### PR TITLE
Make reserved space on directories only when required

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2375,8 +2375,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
-  public static final PropertyKey WORKER_MANAGEMENT_RESERVED_SPACE_BYTES =
-      new Builder(Name.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES)
+  public static final PropertyKey WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES =
+      new Builder(Name.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES)
           .setDefaultValue("1GB")
           .setDescription("The amount of space that is reserved from each storage directory "
               + "for internal management tasks.")
@@ -4988,8 +4988,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.block.annotator.lrfu.attenuation.factor";
     public static final String WORKER_BLOCK_ANNOTATOR_LRFU_STEP_FACTOR =
         "alluxio.worker.block.annotator.lrfu.step.factor";
-    public static final String WORKER_MANAGEMENT_RESERVED_SPACE_BYTES =
-        "alluxio.worker.management.reserved.space.bytes";
+    public static final String WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES =
+        "alluxio.worker.management.tier.align.reserved.bytes";
     public static final String WORKER_MANAGEMENT_BACKOFF_STRATEGY =
         "alluxio.worker.management.backoff.strategy";
     public static final String WORKER_MANAGEMENT_LOAD_DETECTION_COOL_DOWN_TIME =

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
@@ -75,7 +75,8 @@ public final class BlockMetadataManager {
       mAliasToTiers = new HashMap<>(mStorageTierAssoc.size());
       mTiers = new ArrayList<>(mStorageTierAssoc.size());
       for (int tierOrdinal = 0; tierOrdinal < mStorageTierAssoc.size(); tierOrdinal++) {
-        StorageTier tier = StorageTier.newStorageTier(mStorageTierAssoc.getAlias(tierOrdinal));
+        StorageTier tier = StorageTier.newStorageTier(mStorageTierAssoc.getAlias(tierOrdinal),
+            mStorageTierAssoc.size() > 1);
         mTiers.add(tier);
         mAliasToTiers.put(tier.getTierAlias(), tier);
       }

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageDir.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageDir.java
@@ -72,10 +72,6 @@ public final class StorageDir {
     mTier = Preconditions.checkNotNull(tier, "tier");
     mDirIndex = dirIndex;
     mCapacityBytes = capacityBytes;
-    if (capacityBytes < reservedBytes) {
-      /** Reserve %5 of the capacity at the least. */
-      reservedBytes = capacityBytes / 20;
-    }
     mReservedBytes = new AtomicLong(reservedBytes);
     mAvailableBytes = new AtomicLong(capacityBytes - reservedBytes);
     mCommittedBytes = new AtomicLong(0);

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTier.java
@@ -63,7 +63,7 @@ public final class StorageTier {
     mTierOrdinal = new WorkerStorageTierAssoc().getOrdinal(tierAlias);
   }
 
-  private void initStorageTier()
+  private void initStorageTier(boolean isMultiTier)
       throws BlockAlreadyExistsException, IOException, WorkerOutOfSpaceException {
     String tmpDir = ServerConfiguration.get(PropertyKey.WORKER_DATA_TMP_FOLDER);
     PropertyKey tierDirPathConf =
@@ -87,8 +87,13 @@ public final class StorageTier {
         "Tier medium type configuration should not be blank");
     String[] dirMedium = rawDirMedium.split(",");
 
-    long reservedSpaceBytes =
-        ServerConfiguration.getBytes(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES);
+    // Set reserved bytes on directories if tier aligning is enabled.
+    long reservedBytes = 0;
+    if (isMultiTier
+        && ServerConfiguration.getBoolean(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED)) {
+      reservedBytes =
+          ServerConfiguration.getBytes(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES);
+    }
 
     mDirs = new HashMap<>(dirPaths.length);
     mLostStorage = new ArrayList<>();
@@ -99,7 +104,7 @@ public final class StorageTier {
       int mediumTypeindex = i >= dirMedium.length ? dirMedium.length - 1 : i;
       long capacity = FormatUtils.parseSpaceSize(dirQuotas[index]);
       try {
-        StorageDir dir = StorageDir.newStorageDir(this, i, capacity, reservedSpaceBytes,
+        StorageDir dir = StorageDir.newStorageDir(this, i, capacity, reservedBytes,
             dirPaths[i], dirMedium[mediumTypeindex]);
         totalCapacity += capacity;
         mDirs.put(i, dir);
@@ -184,14 +189,15 @@ public final class StorageTier {
    * Factory method to create {@link StorageTier}.
    *
    * @param tierAlias the tier alias
+   * @param isMultiTier whether this tier is part of a multi-tier setup
    * @return a new storage tier
    * @throws BlockAlreadyExistsException if the tier already exists
    * @throws WorkerOutOfSpaceException if there is not enough space available
    */
-  public static StorageTier newStorageTier(String tierAlias)
+  public static StorageTier newStorageTier(String tierAlias, boolean isMultiTier)
       throws BlockAlreadyExistsException, IOException, WorkerOutOfSpaceException {
     StorageTier ret = new StorageTier(tierAlias);
-    ret.initStorageTier();
+    ret.initStorageTier(isMultiTier);
     return ret;
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockMetadataManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockMetadataManagerTest.java
@@ -71,7 +71,8 @@ public final class BlockMetadataManagerTest {
   @Before
   public void before() throws Exception {
     String baseDir = mFolder.newFolder().getAbsolutePath();
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, 0);
+    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, "false");
+    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, "false");
     TieredBlockStoreTestUtils.setupConfWithMultiTier(baseDir, TIER_ORDINAL, TIER_ALIAS,
         TIER_PATH, TIER_CAPACITY_BYTES, TIER_MEDIA_TYPE, null);
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockStoreMetaTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockStoreMetaTest.java
@@ -53,7 +53,8 @@ public final class BlockStoreMetaTest {
   @Before
   public void before() throws Exception {
     String alluxioHome = mTestFolder.newFolder().getAbsolutePath();
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, 0);
+    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, "false");
+    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, "false");
     mMetadataManager = TieredBlockStoreTestUtils.defaultMetadataManager(alluxioHome);
 
     // Add and commit COMMITTED_BLOCKS_NUM temp blocks repeatedly

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -94,7 +94,7 @@ public final class TieredBlockStoreTest {
 
   private void init(long reservedBytes) throws Exception {
     // No reserved space for tests that are not swap related.
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, reservedBytes);
+    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES, reservedBytes);
 
     File tempFolder = mTestFolder.newFolder();
     TieredBlockStoreTestUtils.setupDefaultConf(tempFolder.getAbsolutePath());

--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorTestBase.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorTestBase.java
@@ -85,7 +85,8 @@ public class AllocatorTestBase {
    */
   protected void resetManagerView() throws Exception {
     String alluxioHome = mTestFolder.newFolder().getAbsolutePath();
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, 0);
+    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, "false");
+    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, "false");
     TieredBlockStoreTestUtils.setupConfWithMultiTier(alluxioHome, TIER_LEVEL, TIER_ALIAS,
         TIER_PATH, TIER_CAPACITY_BYTES, TIER_MEDIA_TYPE, null);
     mManager = BlockMetadataManager.createBlockMetadataManager();

--- a/core/server/worker/src/test/java/alluxio/worker/block/annotator/EmulatingBlockIteratorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/annotator/EmulatingBlockIteratorTest.java
@@ -54,7 +54,8 @@ public class EmulatingBlockIteratorTest {
     // Set an evictor class in order to activate emulation.
     ServerConfiguration.set(PropertyKey.WORKER_EVICTOR_CLASS, LRUEvictor.class.getName());
     // No reserved bytes for precise capacity planning.
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0");
+    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, "false");
+    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, "false");
 
     File tempFolder = mTestFolder.newFolder();
     mMetaManager = TieredBlockStoreTestUtils.defaultMetadataManager(tempFolder.getAbsolutePath());

--- a/core/server/worker/src/test/java/alluxio/worker/block/management/tier/AlignTaskTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/management/tier/AlignTaskTest.java
@@ -36,7 +36,8 @@ public class AlignTaskTest extends BaseTierManagementTaskTest {
   public void before() throws Exception {
     ServerConfiguration.reset();
     // Current tier layout could end up swapping 2 blocks concurrently.
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, 2 * BLOCK_SIZE);
+    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES,
+        2 * BLOCK_SIZE);
     // Disable promotions to avoid interference.
     ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, false);
     // Initialize the tier layout.

--- a/core/server/worker/src/test/java/alluxio/worker/block/management/tier/PromoteTaskTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/management/tier/PromoteTaskTest.java
@@ -32,8 +32,6 @@ public class PromoteTaskTest extends BaseTierManagementTaskTest {
     ServerConfiguration.reset();
     // Disable tier alignment to avoid interference.
     ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, false);
-    // Disable reserved space for easy measurement.
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, 0);
     // Set promotion quota percentage.
     ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_QUOTA_PERCENT,
         MOVE_QUOTA_PERCENT);

--- a/core/server/worker/src/test/java/alluxio/worker/block/management/tier/SwapRestoreTaskTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/management/tier/SwapRestoreTaskTest.java
@@ -38,7 +38,7 @@ public class SwapRestoreTaskTest extends BaseTierManagementTaskTest {
     // Disable move task to avoid interference.
     ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, false);
     // Current tier layout could end up swapping 1 big block.
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, BLOCK_SIZE);
+    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES, BLOCK_SIZE);
     // Initialize the tier layout.
     init();
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/meta/AbstractBlockMetaTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/meta/AbstractBlockMetaTest.java
@@ -65,7 +65,7 @@ public class AbstractBlockMetaTest {
         TEST_TIER_ALIAS, new String[] {testDirPath}, TEST_TIER_CAPACITY_BYTES,
         TEST_TIER_MEDIUM_TYPES, null);
 
-    mTier = StorageTier.newStorageTier(TEST_TIER_ALIAS);
+    mTier = StorageTier.newStorageTier(TEST_TIER_ALIAS, false);
     mDir = mTier.getDir(0);
     mBlockMeta = new AbstractBlockMetaForTest(TEST_BLOCK_ID, mDir);
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/meta/BlockMetaTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/meta/BlockMetaTest.java
@@ -56,7 +56,7 @@ public class BlockMetaTest {
         TEST_TIER_MEDIUM_TYPES, TEST_WORKER_DIR);
 
     mTestBlockDirPath = PathUtils.concatPath(mTestDirPath, TEST_WORKER_DIR);
-    StorageTier tier = StorageTier.newStorageTier(TEST_TIER_ALIAS);
+    StorageTier tier = StorageTier.newStorageTier(TEST_TIER_ALIAS, false);
     StorageDir dir = tier.getDir(0);
     mTempBlockMeta = new TempBlockMeta(TEST_SESSION_ID, TEST_BLOCK_ID, TEST_BLOCK_SIZE, dir);
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/meta/StorageDirTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/meta/StorageDirTest.java
@@ -80,7 +80,7 @@ public final class StorageDirTest {
     TieredBlockStoreTestUtils.setupConfWithSingleTier(null, TEST_TIER_ORDINAL, "MEM",
         testDirPaths, testDirCapacity, testDirMediumType, null);
 
-    mTier = StorageTier.newStorageTier("MEM");
+    mTier = StorageTier.newStorageTier("MEM", false);
     mDir = StorageDir.newStorageDir(
         mTier, TEST_DIR_INDEX, TEST_DIR_CAPACITY, 0, mTestDirPath, "MEM");
     mBlockMeta = new BlockMeta(TEST_BLOCK_ID, TEST_BLOCK_SIZE, mDir);

--- a/core/server/worker/src/test/java/alluxio/worker/block/meta/StorageTierTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/meta/StorageTierTest.java
@@ -71,7 +71,7 @@ public class StorageTierTest {
 
     mTestBlockDirPath1 = PathUtils.concatPath(mTestDirPath1,  TEST_WORKER_DATA_DIR);
     mTestBlockDirPath2 = PathUtils.concatPath(mTestDirPath2,  TEST_WORKER_DATA_DIR);
-    mTier = StorageTier.newStorageTier("MEM");
+    mTier = StorageTier.newStorageTier("MEM", false);
     mDir1 = mTier.getDir(0);
     mTempBlockMeta = new TempBlockMeta(TEST_SESSION_ID, TEST_TEMP_BLOCK_ID, TEST_BLOCK_SIZE, mDir1);
   }
@@ -109,12 +109,12 @@ public class StorageTierTest {
    */
   @Test
   public void getAvailableBytes() throws Exception {
-    // When reserved space that is configured is less than capacity %5 of the capacity is reserved.
-    long capacityBytesWithoutReserved = (long) ((TEST_DIR1_CAPACITY + TEST_DIR2_CAPACITY) * 0.95);
-    Assert.assertEquals(capacityBytesWithoutReserved, mTier.getAvailableBytes());
+    Assert.assertEquals(TEST_DIR1_CAPACITY + TEST_DIR2_CAPACITY, mTier.getAvailableBytes());
+
     // Capacity should subtract block size after adding block to a dir.
     mDir1.addTempBlockMeta(mTempBlockMeta);
-    Assert.assertEquals(capacityBytesWithoutReserved - TEST_BLOCK_SIZE, mTier.getAvailableBytes());
+    Assert.assertEquals(TEST_DIR1_CAPACITY + TEST_DIR2_CAPACITY - TEST_BLOCK_SIZE,
+        mTier.getAvailableBytes());
   }
 
   /**
@@ -146,7 +146,7 @@ public class StorageTierTest {
     PropertyKey tierDirPathConf =
         PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(0);
     ServerConfiguration.set(tierDirPathConf, "/dev/null/invalid," + mTestDirPath1);
-    mTier = StorageTier.newStorageTier("MEM");
+    mTier = StorageTier.newStorageTier("MEM", false);
     List<StorageDir> dirs = mTier.getStorageDirs();
     Assert.assertEquals(1, dirs.size());
     Assert.assertEquals(mTestBlockDirPath1, dirs.get(0).getDirPath());
@@ -160,7 +160,7 @@ public class StorageTierTest {
     ServerConfiguration
         .set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA.format(0),
             2000);
-    mTier = StorageTier.newStorageTier("MEM");
+    mTier = StorageTier.newStorageTier("MEM", false);
     List<StorageDir> dirs = mTier.getStorageDirs();
     Assert.assertEquals(2, dirs.size());
     Assert.assertEquals(mTestBlockDirPath1, dirs.get(0).getDirPath());

--- a/core/server/worker/src/test/java/alluxio/worker/block/meta/TempBlockMetaTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/meta/TempBlockMetaTest.java
@@ -51,7 +51,7 @@ public class TempBlockMetaTest {
         TEST_TIER_ALIAS, new String[] {mTestDirPath}, TEST_TIER_CAPACITY_BYTES,
         TEST_TIER_MEDIUM_TYPES, TEST_WORKER_DATA_FOLDER);
 
-    StorageTier tier = StorageTier.newStorageTier(TEST_TIER_ALIAS);
+    StorageTier tier = StorageTier.newStorageTier(TEST_TIER_ALIAS, false);
     StorageDir dir = tier.getDir(0);
     // Append the worker data folder to the expected path.
     mTestBlockDirPath = PathUtils.concatPath(mTestDirPath, TEST_WORKER_DATA_FOLDER);

--- a/tests/src/test/java/alluxio/client/cli/fs/AbstractShellIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/AbstractShellIntegrationTest.java
@@ -38,7 +38,6 @@ public abstract class AbstractShellIntegrationTest extends BaseIntegrationTest {
           .setProperty(PropertyKey.MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS, "10ms")
           .setProperty(PropertyKey.JOB_MASTER_WORKER_HEARTBEAT_INTERVAL, "200ms")
           .setProperty(PropertyKey.WORKER_MEMORY_SIZE, SIZE_BYTES)
-          .setProperty(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0")
           .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, SIZE_BYTES)
           .setProperty(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS, Integer.MAX_VALUE)
           .setProperty(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "CACHE_THROUGH")

--- a/tests/src/test/java/alluxio/client/cli/fs/command/PinCommandMultipleMediaIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/PinCommandMultipleMediaIntegrationTest.java
@@ -46,7 +46,7 @@ public final class PinCommandMultipleMediaIntegrationTest extends BaseIntegratio
           .setProperty(PropertyKey.MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS, "10ms")
           .setProperty(PropertyKey.JOB_MASTER_WORKER_HEARTBEAT_INTERVAL, "200ms")
           .setProperty(PropertyKey.WORKER_MEMORY_SIZE, SIZE_BYTES)
-          .setProperty(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0")
+          .setProperty(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, "false")
           .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, SIZE_BYTES)
           .setProperty(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS, Integer.MAX_VALUE)
           .setProperty(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "CACHE_THROUGH")

--- a/tests/src/test/java/alluxio/client/fs/AbstractFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/AbstractFileOutStreamIntegrationTest.java
@@ -72,8 +72,7 @@ public abstract class AbstractFileOutStreamIntegrationTest extends BaseIntegrati
   protected void customizeClusterResource(LocalAlluxioClusterResource.Builder resource) {
     resource.setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, BUFFER_BYTES)
         .setProperty(PropertyKey.USER_FILE_REPLICATION_DURABLE, 1)
-        .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE_BYTES)
-        .setProperty(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0");
+        .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE_BYTES);
   }
 
   private LocalAlluxioClusterResource buildLocalAlluxioClusterResource() {

--- a/tests/src/test/java/alluxio/client/fs/FileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileInStreamIntegrationTest.java
@@ -59,8 +59,7 @@ public final class FileInStreamIntegrationTest extends BaseIntegrationTest {
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource.Builder()
-          .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE)
-          .setProperty(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0").build();
+          .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE).build();
   private FileSystem mFileSystem;
   private CreateFilePOptions mWriteBoth;
   private CreateFilePOptions mWriteAlluxio;

--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
@@ -131,7 +131,6 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
           .setProperty(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS,
               String.valueOf(TTL_CHECKER_INTERVAL_MS))
           .setProperty(PropertyKey.WORKER_MEMORY_SIZE, "10mb")
-          .setProperty(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0")
           .setProperty(PropertyKey.MASTER_FILE_ACCESS_TIME_UPDATE_PRECISION, 0)
           .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, "1kb")
           .setProperty(PropertyKey.SECURITY_LOGIN_USERNAME, TEST_USER).build();

--- a/tests/src/test/java/alluxio/client/fs/LocalFirstPolicyIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LocalFirstPolicyIntegrationTest.java
@@ -58,7 +58,6 @@ public class LocalFirstPolicyIntegrationTest extends BaseIntegrationTest {
         AlluxioTestDirectory.createTemporaryDirectory("tiered_identity_test").getAbsolutePath());
     map.put(PropertyKey.WORKER_RPC_PORT, "0");
     map.put(PropertyKey.WORKER_WEB_PORT, "0");
-    map.put(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0");
 
     return map;
   }

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -95,8 +95,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
-      new LocalAlluxioClusterResource.Builder()
-          .setProperty(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0").build();
+      new LocalAlluxioClusterResource.Builder().build();
 
   @After
   public void after() throws Exception {

--- a/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
@@ -63,8 +63,7 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
   public static LocalAlluxioClusterResource sResource = new LocalAlluxioClusterResource.Builder()
       .setProperty(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false")
       .setProperty(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName())
-      .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, "1KB")
-      .setProperty(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0").build();
+      .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, "1KB").build();
 
   @Rule
   public TestRule mResetRule = sResource.getResetResource();

--- a/tests/src/test/java/alluxio/client/rest/AlluxioWorkerRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/AlluxioWorkerRestApiTest.java
@@ -44,8 +44,7 @@ public final class AlluxioWorkerRestApiTest extends RestApiTest {
   public static LocalAlluxioClusterResource sResource = new LocalAlluxioClusterResource.Builder()
       .setProperty(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, "false")
       .setProperty(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL.getAuthName())
-      .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, "1KB")
-      .setProperty(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0").build();
+      .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, "1KB").build();
 
   @Rule
   public TestRule mResetRule = sResource.getResetResource();

--- a/tests/src/test/java/alluxio/job/JobIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/JobIntegrationTest.java
@@ -53,7 +53,6 @@ public abstract class JobIntegrationTest extends BaseIntegrationTest {
         .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, String.valueOf(BUFFER_BYTES))
         .setProperty(PropertyKey.USER_STREAMING_READER_CHUNK_SIZE_BYTES, "64KB")
         .setProperty(PropertyKey.MASTER_FILE_ACCESS_TIME_UPDATE_PRECISION, "0")
-        .setProperty(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0")
         .setProperty(PropertyKey.WORKER_MEMORY_SIZE, WORKER_CAPACITY_BYTES);
     return resource.build();
   }

--- a/tests/src/test/java/alluxio/server/ft/FlakyUfsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/FlakyUfsIntegrationTest.java
@@ -79,8 +79,7 @@ public final class FlakyUfsIntegrationTest extends BaseIntegrationTest {
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource.Builder()
           .setProperty(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS,
-              DelegatingUnderFileSystemFactory.DELEGATING_SCHEME + "://" + LOCAL_UFS_PATH)
-          .setProperty(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0").build();
+              DelegatingUnderFileSystemFactory.DELEGATING_SCHEME + "://" + LOCAL_UFS_PATH).build();
   private FileSystem mFs;
 
   @Before

--- a/tests/src/test/java/alluxio/server/ft/MultiWorkerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MultiWorkerIntegrationTest.java
@@ -81,7 +81,6 @@ public final class MultiWorkerIntegrationTest extends BaseIntegrationTest {
           .setProperty(PropertyKey.WORKER_MEMORY_SIZE, WORKER_MEMORY_SIZE_BYTES)
           .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE_BYTES)
           .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, BLOCK_SIZE_BYTES)
-          .setProperty(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0")
           .setNumWorkers(NUM_WORKERS)
           .build();
 

--- a/tests/src/test/java/alluxio/server/tieredstore/SpecificTierWriteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/tieredstore/SpecificTierWriteIntegrationTest.java
@@ -58,7 +58,6 @@ public class SpecificTierWriteIntegrationTest extends BaseIntegrationTest {
           .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE_BYTES)
           .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, BLOCK_SIZE_BYTES)
           .setProperty(PropertyKey.WORKER_MEMORY_SIZE, CAPACITY_BYTES)
-          .setProperty(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0")
           .setProperty(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, "false")
           .setProperty(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, "false")
           .setProperty(PropertyKey.WORKER_TIERED_STORE_LEVELS, "3")

--- a/tests/src/test/java/alluxio/server/tieredstore/TierPromoteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/tieredstore/TierPromoteIntegrationTest.java
@@ -80,7 +80,7 @@ public class TierPromoteIntegrationTest extends BaseIntegrationTest {
         .setProperty(PropertyKey.WORKER_TIERED_STORE_LEVELS, "2")
         .setProperty(PropertyKey.WORKER_MANAGEMENT_LOAD_DETECTION_COOL_DOWN_TIME, "2s")
         .setProperty(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, "false")
-        .setProperty(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, BLOCK_SIZE_BYTES)
+        .setProperty(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES, BLOCK_SIZE_BYTES)
         .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(1), "SSD")
         .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(0),
             Files.createTempDir().getAbsolutePath())
@@ -149,8 +149,7 @@ public class TierPromoteIntegrationTest extends BaseIntegrationTest {
       confParams = {
           PropertyKey.Name.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, "false",
           PropertyKey.Name.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, "false",
-          PropertyKey.Name.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE",
-          PropertyKey.Name.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, "0"})
+          PropertyKey.Name.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE"})
   @Test
   public void promoteByRead() throws Exception {
     final int size = (int) CAPACITY_BYTES / 2;

--- a/tests/src/test/java/alluxio/server/tieredstore/TieredStoreIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/tieredstore/TieredStoreIntegrationTest.java
@@ -60,7 +60,7 @@ public class TieredStoreIntegrationTest extends BaseIntegrationTest {
           .setProperty(PropertyKey.WORKER_FILE_BUFFER_SIZE, String.valueOf(100))
           .setProperty(PropertyKey.WORKER_TIERED_STORE_LEVEL0_HIGH_WATERMARK_RATIO, 0.8)
           .setProperty(PropertyKey.USER_FILE_RESERVED_BYTES, String.valueOf(100))
-          .setProperty(PropertyKey.WORKER_MANAGEMENT_RESERVED_SPACE_BYTES, String.valueOf(0))
+          .setProperty(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, String.valueOf(false))
           .build();
 
   @Before


### PR DESCRIPTION
This is to improve the compatibility of multi-tier management for configurations that don't need the functionality.

For when the reserved space is required by a later configuration change, the `swap-restore` task will make sure reserved space will be carved out if necessary.