### PR TITLE
Improve HdfsPositionedReadUnderFileInputStream with a heuristic

### DIFF
--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsPositionedUnderFileInputStream.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsPositionedUnderFileInputStream.java
@@ -22,11 +22,17 @@ import org.apache.hadoop.fs.Seekable;
 import java.io.IOException;
 
 /**
- * The input stream of HDFS as under filesystem. This input stream supports seeking but internally
- * uses the positionedRead {@link FSDataInputStream} API. This stream can be cached for reuse.
+ * The input stream of HDFS as under filesystem. This input stream has two mode of operations.
+ * Under sequential mode, it uses the read api and can take advantage of underlying stream's
+ * buffering. Under random read mode, it uses the positionedRead {@link FSDataInputStream} API.
+ * This stream can be cached for reuse.
  */
 public class HdfsPositionedUnderFileInputStream extends SeekableUnderFileInputStream {
+  // After this many number of sequential reads (reads without large skips), it
+  // will switch to sequential read mode.
   private static final int SEQUENTIAL_READ_LIMIT = 3;
+  // This describes the number of bytes that we can move forward in a stream without
+  // switching to random read mode.
   private static final int MOVEMENT_LIMIT = 512;
 
   private long mPos;

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsPositionedUnderFileInputStream.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsPositionedUnderFileInputStream.java
@@ -90,32 +90,29 @@ public class HdfsPositionedUnderFileInputStream extends SeekableUnderFileInputSt
     }
     if (bytesRead > 0) {
       mPos += bytesRead;
+      mSequentialReadCount++;
     }
-    mSequentialReadCount++;
     return bytesRead;
   }
 
   @Override
   public void seek(long position) throws IOException {
-    if (Math.abs(position - mPos) > MOVEMENT_LIMIT) {
+    if (position < mPos || position - mPos > MOVEMENT_LIMIT) {
       mSequentialReadCount = 0;
-    } else {
-      ((FSDataInputStream) in).seek(position);
     }
     mPos = position;
   }
 
   @Override
   public long skip(long n) throws IOException {
+    if (n <= 0) {
+      return 0;
+    }
     if (n > MOVEMENT_LIMIT) {
       mSequentialReadCount = 0;
-      mPos += n;
-      return n;
-    } else {
-      long skipped = ((FSDataInputStream) in).skip(n);
-      mPos += skipped;
-      return skipped;
     }
+    mPos += n;
+    return n;
   }
 
   @Override

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsPositionedUnderFileInputStream.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsPositionedUnderFileInputStream.java
@@ -28,6 +28,7 @@ import java.io.IOException;
  * This stream can be cached for reuse.
  */
 public class HdfsPositionedUnderFileInputStream extends SeekableUnderFileInputStream {
+  // TODO(david): make these parameters configurations and add diagnostic metrics.
   // After this many number of sequential reads (reads without large skips), it
   // will switch to sequential read mode.
   private static final int SEQUENTIAL_READ_LIMIT = 3;

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -570,7 +570,9 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
       }
 
       LOG.info("test2" + blockLocations.length);
+
       for (BlockLocation loc : blockLocations) {
+        LOG.info("localHost: " + localHost + " block hosts" + Arrays.toString(loc.getHosts()));
         if (Arrays.stream(loc.getHosts()).noneMatch(localHost::equals)) {
           // Some blocks are remote only, use pread api to HDFS
           return false;

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -596,7 +596,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
     LOG.info("one");
     boolean remote = options.getPositionShort()
         || mUfsConf.getBoolean(PropertyKey.UNDERFS_HDFS_REMOTE)
-        || isReadLocal(hdfs, filePath, options);
+        || !isReadLocal(hdfs, filePath, options);
     LOG.info("two " + remote);
     while (retryPolicy.attempt()) {
       try {

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -556,8 +556,6 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
   private boolean isReadLocal(FileSystem fs, Path filePath, OpenOptions options) {
     String localHost = NetworkAddressUtils.getLocalHostName((int) mUfsConf
         .getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
-    // Heuristic to determine whether to use positionedRead on hdfs ufs
-    // If any block is not found on the same host, we use pread api
     BlockLocation[] blockLocations;
     try {
       blockLocations = fs.getFileBlockLocations(filePath,
@@ -569,7 +567,6 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
 
       for (BlockLocation loc : blockLocations) {
         if (Arrays.stream(loc.getHosts()).noneMatch(localHost::equals)) {
-          // Some blocks are remote only, use pread api to HDFS
           return false;
         }
       }

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -554,7 +554,6 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
   }
 
   private boolean isReadLocal(FileSystem fs, Path filePath, OpenOptions options) {
-    LOG.info("test1");
     String localHost = NetworkAddressUtils.getLocalHostName((int) mUfsConf
         .getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
     // Heuristic to determine whether to use positionedRead on hdfs ufs
@@ -563,22 +562,17 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
     try {
       blockLocations = fs.getFileBlockLocations(filePath,
           options.getOffset(), options.getLength());
-      LOG.info("returned");
       if (blockLocations == null) {
         // no blocks exist
         return true;
       }
 
-      LOG.info("test2" + blockLocations.length);
-
       for (BlockLocation loc : blockLocations) {
-        LOG.info("localHost: " + localHost + " block hosts" + Arrays.toString(loc.getHosts()));
         if (Arrays.stream(loc.getHosts()).noneMatch(localHost::equals)) {
           // Some blocks are remote only, use pread api to HDFS
           return false;
         }
       }
-      LOG.info("test3");
     } catch (IOException e) {
       return true;
     }
@@ -595,11 +589,9 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
       dfs = (DistributedFileSystem) hdfs;
     }
     Path filePath = new Path(path);
-    LOG.info("one");
     boolean remote = options.getPositionShort()
         || mUfsConf.getBoolean(PropertyKey.UNDERFS_HDFS_REMOTE)
         || !isReadLocal(hdfs, filePath, options);
-    LOG.info("two " + remote);
     while (retryPolicy.attempt()) {
       try {
         FSDataInputStream inputStream = hdfs.open(filePath);

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -553,19 +553,27 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
     throw te;
   }
 
-  private boolean isReadLocal(FileSystem fs, Path filePath, OpenOptions options)
-      throws IOException {
+  private boolean isReadLocal(FileSystem fs, Path filePath, OpenOptions options) {
     String localHost = NetworkAddressUtils.getLocalHostName((int) mUfsConf
         .getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
     // Heuristic to determine whether to use positionedRead on hdfs ufs
     // If any block is not found on the same host, we use pread api
-    BlockLocation[] blockLocations = fs.getFileBlockLocations(filePath,
-        options.getOffset(), options.getLength());
-    for (BlockLocation loc : blockLocations) {
-      if (Arrays.stream(loc.getHosts()).noneMatch(localHost::equals)) {
-        // Some blocks are remote only, use pread api to HDFS
-        return false;
+    BlockLocation[] blockLocations;
+    try {
+      blockLocations = fs.getFileBlockLocations(filePath,
+          options.getOffset(), options.getLength());
+      if (blockLocations == null) {
+        // no blocks exist
+        return true;
       }
+      for (BlockLocation loc : blockLocations) {
+        if (Arrays.stream(loc.getHosts()).noneMatch(localHost::equals)) {
+          // Some blocks are remote only, use pread api to HDFS
+          return false;
+        }
+      }
+    } catch (IOException e) {
+      return true;
     }
     return true;
   }

--- a/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemTest.java
+++ b/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemTest.java
@@ -11,16 +11,37 @@
 
 package alluxio.underfs.hdfs;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import alluxio.AlluxioURI;
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.options.OpenOptions;
+import alluxio.util.CommonUtils;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.PositionedReadable;
+import org.apache.hadoop.fs.Seekable;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.powermock.reflect.Whitebox;
+
+import java.io.File;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Tests {@link HdfsUnderFileSystem}.
@@ -30,6 +51,9 @@ public final class HdfsUnderFileSystemTest {
   private HdfsUnderFileSystem mHdfsUnderFileSystem;
   private final AlluxioConfiguration mAlluxioConf = ConfigurationTestUtils.defaults();
 
+  @Rule
+  public TemporaryFolder mTemporaryFolder = new TemporaryFolder();
+
   @Before
   public final void before() throws Exception {
     UnderFileSystemConfiguration conf =
@@ -37,8 +61,8 @@ public final class HdfsUnderFileSystemTest {
             .createMountSpecificConf(ImmutableMap.of("hadoop.security.group.mapping",
                 "org.apache.hadoop.security.ShellBasedUnixGroupsMapping", "fs.hdfs.impl",
             PropertyKey.UNDERFS_HDFS_IMPL.getDefaultValue()));
-    mHdfsUnderFileSystem = HdfsUnderFileSystem.createInstance(new AlluxioURI("file:///"),
-        conf);
+    mHdfsUnderFileSystem = HdfsUnderFileSystem.createInstance(
+        new AlluxioURI(mTemporaryFolder.getRoot().getAbsolutePath()), conf);
   }
 
   /**
@@ -62,5 +86,86 @@ public final class HdfsUnderFileSystemTest {
     org.apache.hadoop.conf.Configuration conf = HdfsUnderFileSystem.createConfiguration(ufsConf);
     Assert.assertEquals(ufsConf.get(PropertyKey.UNDERFS_HDFS_IMPL), conf.get("fs.hdfs.impl"));
     Assert.assertTrue(conf.getBoolean("fs.hdfs.impl.disable.cache", false));
+  }
+
+  class PreadSeekableStream extends FilterInputStream implements Seekable, PositionedReadable {
+
+    /**
+     * Creates a <code>FilterInputStream</code>
+     * by assigning the  argument <code>in</code>
+     * to the field <code>this.in</code> so as
+     * to remember it for later use.
+     *
+     * @param in the underlying input stream, or <code>null</code> if
+     *           this instance is to be created without an underlying stream.
+     */
+    protected PreadSeekableStream(InputStream in) {
+      super(in);
+    }
+
+    @Override
+    public int read(long l, byte[] bytes, int i, int i1) throws IOException {
+      return ((FSDataInputStream) in).read(l, bytes, i, i1);
+    }
+
+    @Override
+    public void readFully(long l, byte[] bytes, int i, int i1) throws IOException {
+      ((FSDataInputStream) in).readFully(l, bytes, i, i1);
+    }
+
+    @Override
+    public void readFully(long l, byte[] bytes) throws IOException {
+      ((FSDataInputStream) in).readFully(l, bytes);
+    }
+
+    @Override
+    public void seek(long l) throws IOException {
+      ((FSDataInputStream) in).seek(l);
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      return ((FSDataInputStream) in).getPos();
+    }
+
+    @Override
+    public boolean seekToNewSource(long l) throws IOException {
+      return ((FSDataInputStream) in).seekToNewSource(l);
+    }
+  }
+  /**
+   * Tests the dynamic switching between pread and read calls to underlying stream.
+   */
+  @Test
+  public void verifyPread() throws Exception {
+    File file = mTemporaryFolder.newFile("test.txt");
+    FileUtils.writeByteArrayToFile(file, CommonUtils.randomBytes(4096));
+    FilterInputStream in = (FilterInputStream) mHdfsUnderFileSystem.open(file.getAbsolutePath(),
+        OpenOptions.defaults().setPositionShort(true));
+    FSDataInputStream dataInput = Whitebox.getInternalState(in, "in");
+    PreadSeekableStream stream = new PreadSeekableStream(dataInput);
+    PreadSeekableStream spyStream = spy(stream);
+    Whitebox.setInternalState(in, "in", spyStream);
+    in.read();
+    in.read();
+    in.read();
+    in.read();
+    in.skip(2);
+    in.skip(2);
+    in.read();
+    in.skip(2);
+    in.read();
+    verify(spyStream, never()).read(anyInt(), any(byte[].class), anyInt(), anyInt());
+    verify(spyStream, times(6)).read(any(byte[].class), anyInt(), anyInt());
+    in.skip(1000);
+    in.read();
+    in.read();
+    in.read();
+    verify(spyStream, times(3)).read(anyInt(), any(byte[].class), anyInt(), anyInt());
+    verify(spyStream, times(6)).read(any(byte[].class), anyInt(), anyInt());
+    in.read();
+    verify(spyStream, times(3)).read(anyInt(), any(byte[].class), anyInt(), anyInt());
+    verify(spyStream, times(7)).read(any(byte[].class), anyInt(), anyInt());
+    in.close();
   }
 }

--- a/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/PreadSeekableStream.java
+++ b/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/PreadSeekableStream.java
@@ -1,7 +1,7 @@
 /*
- * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0 (the
- * "License"). You may not use this work except in compliance with the License, which is available
- * at www.apache.org/licenses/LICENSE-2.0
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
  *
  * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied, as more fully set forth in the License.

--- a/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/PreadSeekableStream.java
+++ b/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/PreadSeekableStream.java
@@ -19,7 +19,7 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-class PreadSeekableStream extends FilterInputStream implements Seekable, PositionedReadable {
+public class PreadSeekableStream extends FilterInputStream implements Seekable, PositionedReadable {
   protected PreadSeekableStream(InputStream in) {
     super(in);
   }

--- a/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/PreadSeekableStream.java
+++ b/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/PreadSeekableStream.java
@@ -1,0 +1,56 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0 (the
+ * "License"). You may not use this work except in compliance with the License, which is available
+ * at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.hdfs;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.PositionedReadable;
+import org.apache.hadoop.fs.Seekable;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+class PreadSeekableStream extends FilterInputStream implements Seekable, PositionedReadable {
+  protected PreadSeekableStream(InputStream in) {
+    super(in);
+  }
+
+  @Override
+  public int read(long position, byte[] bytes, int offset, int length) throws IOException {
+    return ((FSDataInputStream) in).read(position, bytes, offset, length);
+  }
+
+  @Override
+  public void readFully(long position, byte[] bytes, int offset, int length) throws IOException {
+    ((FSDataInputStream) in).readFully(position, bytes, offset, length);
+  }
+
+  @Override
+  public void readFully(long position, byte[] bytes) throws IOException {
+    ((FSDataInputStream) in).readFully(position, bytes);
+  }
+
+  @Override
+  public void seek(long position) throws IOException {
+    ((FSDataInputStream) in).seek(position);
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return ((FSDataInputStream) in).getPos();
+  }
+
+  @Override
+  public boolean seekToNewSource(long position) throws IOException {
+    return ((FSDataInputStream) in).seekToNewSource(position);
+  }
+}


### PR DESCRIPTION
The heuristic works as follows :
1. it starts with a pread, because a lot of times the client only does a single large read, and we want to benefit from pread in that case. 
2. if there are certain number of sequential reads in a row, we switch to buffered read mode. In this mode, preads are serviced via pread calls, and read calls are services by read calls. A sequential read is defined as a read that is within a movement limit of the previous read. This is to guard against workloads such as read, skip(2), read, skip(3) etc.
3. any non-sequential read, we change back to pread mode.