### PR TITLE
Reduce logging on FileSystem instantiation

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -97,6 +97,7 @@ public class LocalCacheManager implements CacheManager {
    */
   private static boolean restore(PageStore pageStore, PageStoreOptions options, MetaStore metaStore,
       CacheEvictor evictor) {
+    LOG.info("Attempt to restore PageStore with {}", options);
     Path rootDir = Paths.get(options.getRootDir());
     if (!Files.exists(rootDir)) {
       LOG.error("Failed to restore PageStore: Directory {} does not exist", rootDir);

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -97,10 +97,9 @@ public class LocalCacheManager implements CacheManager {
    */
   private static boolean restore(PageStore pageStore, PageStoreOptions options, MetaStore metaStore,
       CacheEvictor evictor) {
-    LOG.info("Restore PageStore with {}", options);
     Path rootDir = Paths.get(options.getRootDir());
     if (!Files.exists(rootDir)) {
-      LOG.error("Directory {} does not exist", rootDir);
+      LOG.error("Failed to restore PageStore: Directory {} does not exist", rootDir);
       return false;
     }
     try (Stream<PageInfo> stream = pageStore.getPages()) {

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -45,7 +45,7 @@ public interface PageStore extends AutoCloseable {
    * @throws IOException if I/O error happens
    */
   static PageStore create(PageStoreOptions options, boolean init) throws IOException {
-    LOG.info("Create PageStore option={}", options.toString());
+    LOG.info("Creating PageStore with option={}, init={}", options.toString(), init);
     if (init) {
       initialize(options);
     }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -478,8 +478,8 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
     AlluxioProperties alluxioProps =
         (alluxioConfiguration != null) ? alluxioConfiguration.copyProperties()
             : ConfigurationUtils.defaults();
-    LOG.info("Creating Alluxio configuration from Hadoop configuration {}, uri configuration {}, "
-        + "Alluxio configuration {}", conf, uriConfProperties, alluxioProps);
+    LOG.info("Creating Alluxio configuration from Hadoop configuration {}, uri configuration {}",
+        conf, uriConfProperties);
     AlluxioConfiguration alluxioConf = mergeConfigurations(uriConfProperties, conf, alluxioProps);
     mAlluxioConf = alluxioConf;
 

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -40,6 +40,7 @@ import alluxio.wire.BlockLocationInfo;
 import alluxio.wire.FileBlockInfo;
 import alluxio.wire.WorkerNetAddress;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.HostAndPort;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -453,6 +454,7 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
    * @param alluxioConfiguration [optional] alluxio configuration
    * @throws IOException
    */
+  @VisibleForTesting
   public synchronized void initialize(URI uri, org.apache.hadoop.conf.Configuration conf,
       @Nullable AlluxioConfiguration alluxioConfiguration)
       throws IOException {
@@ -476,6 +478,8 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
     AlluxioProperties alluxioProps =
         (alluxioConfiguration != null) ? alluxioConfiguration.copyProperties()
             : ConfigurationUtils.defaults();
+    LOG.info("Creating Alluxio configuration from Hadoop configuration {}, uri configuration {}, "
+        + "Alluxio configuration {}", conf, uriConfProperties, alluxioProps);
     AlluxioConfiguration alluxioConf = mergeConfigurations(uriConfProperties, conf, alluxioProps);
     mAlluxioConf = alluxioConf;
 

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
@@ -53,9 +53,7 @@ public final class HadoopConfigurationUtils {
         alluxioConfProperties.put(propertyName, entry.getValue());
       }
     }
-    LOG.info("Loading Alluxio properties from Hadoop configuration: {}", alluxioConfProperties);
     // Merge the relevant Hadoop configuration into Alluxio's configuration.
-
     alluxioProps.merge(alluxioConfProperties, Source.RUNTIME);
     // Creting a new instanced configuration from an AlluxioProperties object isn't expensive.
     InstancedConfiguration mergedConf = new InstancedConfiguration(alluxioProps);

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -160,7 +160,7 @@ public final class MetricsSystem {
   public static void startSinks(String metricsConfFile) {
     synchronized (MetricsSystem.class) {
       if (sSinks != null) {
-        LOG.info("Sinks have already been started.");
+        LOG.debug("Sinks have already been started.");
         return;
       }
     }
@@ -208,7 +208,7 @@ public final class MetricsSystem {
    */
   public static synchronized void startSinksFromConfig(MetricsConfig config) {
     if (sSinks != null) {
-      LOG.info("Sinks have already been started.");
+      LOG.debug("Sinks have already been started.");
       return;
     }
     LOG.info("Starting sinks with config: {}.", config);


### PR DESCRIPTION
Motivated by  issue https://github.com/Alluxio/alluxio/issues/11404, this PR updates logging level for certain logging messages 

After this PR, each query only introduced two info logging like the following;

```
2020-05-22T13:58:05.120-0700	INFO	hive-hive-6	alluxio.hadoop.AbstractFileSystem	Creating Alluxio configuration from Hadoop configuration Configuration: , uri configuration {}
2020-05-22T13:58:05.174-0700	INFO	20200522_205804_00001_nzuct.1.0.0-0-104	alluxio.hadoop.AbstractFileSystem	Creating Alluxio configuration from Hadoop configuration Configuration: , uri configuration {}
```

These two are required as currently each Presto query triggers a new Alluxio FileSystem to be created.