### PR TITLE
Use isGetFileInfo when creating sync locking scheme

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4215,13 +4215,8 @@ public final class DefaultFileSystemMaster extends CoreMaster
   }
 
   private LockingScheme createSyncLockingScheme(AlluxioURI path,
-      FileSystemMasterCommonPOptions options) {
-    return new LockingScheme(path, LockPattern.READ, options, mUfsSyncPathCache, false);
-  }
-
-  private LockingScheme createSyncLockingScheme(AlluxioURI path,
       FileSystemMasterCommonPOptions options, boolean isGetFileInfo) {
-    return new LockingScheme(path, LockPattern.READ, options, mUfsSyncPathCache, true);
+    return new LockingScheme(path, LockPattern.READ, options, mUfsSyncPathCache, isGetFileInfo);
   }
 
   boolean isAclEnabled() {


### PR DESCRIPTION
The parameter was previously unused by accident. There also an overloaded version of the method which is unused, so I removed it.