### PR TITLE
Throw exception when fail to create local cache

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -146,7 +146,11 @@ public interface FileSystem extends Closeable {
       // Enable local cache only for clients which have the property set.
       if (conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_ENABLED)
           && CommonUtils.PROCESS_TYPE.get().equals(CommonUtils.ProcessType.CLIENT)) {
-        return new LocalCacheFileSystem(fs, conf);
+        try {
+          return new LocalCacheFileSystem(fs, conf);
+        } catch (IOException e) {
+          LOG.error("Fallback without client caching: ", e);
+        }
       }
       return fs;
     }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
@@ -38,6 +38,7 @@ public class LocalCacheFileSystem extends DelegatingFileSystem {
 
   private final AlluxioConfiguration mConf;
 
+  // TODO(binfan): Remove the IOException throwing or make this into a factory method
   /**
    * @param fs a FileSystem instance to query on local cache miss
    * @param conf the configuration, only respected for the first call

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -283,6 +283,7 @@ public class LocalCacheManager implements CacheManager {
             mMetaStore.removePage(pageId);
           } catch (PageNotFoundException e) {
             // best effort to remove this page from meta store and ignore the exception
+            Metrics.PUT_FAILED_WRITE_ERRORS.inc();
           }
         }
         LOG.debug("Add page ({},{} bytes) without eviction: {}", pageId, page.length, ret);
@@ -326,6 +327,7 @@ public class LocalCacheManager implements CacheManager {
             mMetaStore.removePage(pageId);
           } catch (PageNotFoundException e) {
             // best effort to remove this page from meta store and ignore the exception
+            Metrics.PUT_FAILED_WRITE_ERRORS.inc();
           }
         }
         LOG.debug("Add page ({},{} bytes) after evicting ({}), success: {}", pageId, page.length,
@@ -365,6 +367,7 @@ public class LocalCacheManager implements CacheManager {
           mMetaStore.removePage(pageId);
         } catch (PageNotFoundException e) {
           // best effort to remove this page from meta store and ignore the exception
+          Metrics.GET_ERRORS_FAILED_READ.inc();
         }
       }
       LOG.debug("get({},pageOffset={}) exits", pageId, pageOffset);
@@ -472,9 +475,15 @@ public class LocalCacheManager implements CacheManager {
     /** Errors when getting pages. */
     private static final Counter GET_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_GET_ERRORS.getName());
+    /** Errors when getting pages due to failed reads from cache storage. */
+    private static final Counter GET_ERRORS_FAILED_READ =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_GET_FAILED_READ_ERRORS.getName());
     /** Errors when adding pages. */
     private static final Counter PUT_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_ERRORS.getName());
+    /** Errors when adding pages due to failed writes to cache storage. */
+    private static final Counter PUT_FAILED_WRITE_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_FAILED_WRITE_ERRORS.getName());
 
     private static void registerGauges(long cacheSize, MetaStore metaStore) {
       MetricsSystem.registerGaugeIfAbsent(

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -22,12 +22,13 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.concurrent.ThreadSafe;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Metric keys. This class provides a set of pre-defined Alluxio metric keys.
@@ -831,6 +832,12 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.GAUGE)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_CREATE_ERRORS =
+      new Builder(Name.CLIENT_CACHE_CREATE_ERRORS)
+          .setDescription("Number of failures when creating a cache in the client cache.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_DELETE_ERRORS =
       new Builder(Name.CLIENT_CACHE_DELETE_ERRORS)
           .setDescription("Number of failures when deleting cached data in the client cache.")
@@ -843,9 +850,23 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_GET_FAILED_READ_ERRORS =
+      new Builder(Name.CLIENT_CACHE_GET_FAILED_READ_ERRORS)
+          .setDescription("Number of failures when getting cached data in the client cache due to"
+              + " read failures from local storage.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_PUT_ERRORS =
       new Builder(Name.CLIENT_CACHE_PUT_ERRORS)
           .setDescription("Number of failures when putting cached data in the client cache.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_CACHE_PUT_FAILED_WRITE_ERRORS =
+      new Builder(Name.CLIENT_CACHE_PUT_FAILED_WRITE_ERRORS)
+          .setDescription("Number of failures when putting cached data in the client cache due to"
+              + " write failures to local storage.")
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
@@ -1053,9 +1074,14 @@ public final class MetricKey implements Comparable<MetricKey> {
     public static final String CLIENT_CACHE_HIT_RATE = "Client.CacheHitRate";
     public static final String CLIENT_CACHE_SPACE_AVAILABLE = "Client.CacheSpaceAvailable";
     public static final String CLIENT_CACHE_SPACE_USED = "Client.CacheSpaceUsed";
+    public static final String CLIENT_CACHE_CREATE_ERRORS = "Client.CacheCreateErrors";
+    public static final String CLIENT_CACHE_PUT_ERRORS = "Client.CachePutErrors";
+    public static final String CLIENT_CACHE_PUT_FAILED_WRITE_ERRORS =
+        "Client.CachePutFailedWriteErrors";
     public static final String CLIENT_CACHE_DELETE_ERRORS = "Client.CacheDeleteErrors";
     public static final String CLIENT_CACHE_GET_ERRORS = "Client.CacheGetErrors";
-    public static final String CLIENT_CACHE_PUT_ERRORS = "Client.CachePutErrors";
+    public static final String CLIENT_CACHE_GET_FAILED_READ_ERRORS =
+        "Client.CacheGetFailedReadErrors";
 
     private Name() {} // prevent instantiation
   }


### PR DESCRIPTION

With this PR, a Presto query will fail with following error message when the cache is unable to create:

```
Query 20200522_072107_00001_4hg9d failed: cannot create caching file system
com.facebook.presto.spi.PrestoException: cannot create caching file system
	at com.facebook.presto.hive.cache.HiveCachingHdfsConfiguration.lambda$getConfiguration$0(HiveCachingHdfsConfiguration.java:80)
	at com.facebook.presto.hive.cache.HiveCachingHdfsConfiguration$CachingJobConf.createFileSystem(HiveCachingHdfsConfiguration.java:104)
	at org.apache.hadoop.fs.PrestoFileSystemCache.get(PrestoFileSystemCache.java:56)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:373)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:295)
	at com.facebook.presto.hive.HdfsEnvironment.lambda$getFileSystem$0(HdfsEnvironment.java:71)
	at com.facebook.presto.hive.authentication.NoHdfsAuthentication.doAs(NoHdfsAuthentication.java:23)
	at com.facebook.presto.hive.HdfsEnvironment.getFileSystem(HdfsEnvironment.java:70)
	at com.facebook.presto.hive.HdfsEnvironment.getFileSystem(HdfsEnvironment.java:64)
	at com.facebook.presto.hive.BackgroundHiveSplitLoader.loadPartition(BackgroundHiveSplitLoader.java:297)
	at com.facebook.presto.hive.BackgroundHiveSplitLoader.loadSplits(BackgroundHiveSplitLoader.java:269)
	at com.facebook.presto.hive.BackgroundHiveSplitLoader.access$300(BackgroundHiveSplitLoader.java:99)
	at com.facebook.presto.hive.BackgroundHiveSplitLoader$HiveSplitLoaderTask.process(BackgroundHiveSplitLoader.java:198)
	at com.facebook.presto.hive.util.ResumableTasks.safeProcessTask(ResumableTasks.java:47)
	at com.facebook.presto.hive.util.ResumableTasks.access$000(ResumableTasks.java:20)
	at com.facebook.presto.hive.util.ResumableTasks$1.run(ResumableTasks.java:35)
	at com.facebook.airlift.concurrent.BoundedExecutor.drainQueue(BoundedExecutor.java:78)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.IOException: Failed to create CacheManager
	at alluxio.client.file.cache.LocalCacheFileSystem.<init>(LocalCacheFileSystem.java:58)
	at com.facebook.presto.cache.alluxio.AlluxioCachingFileSystem$AlluxioCachingFileSystemInternal.initialize(AlluxioCachingFileSystem.java:109)
	at com.facebook.presto.cache.alluxio.AlluxioCachingFileSystem.initialize(AlluxioCachingFileSystem.java:60)
	at com.facebook.presto.cache.CacheFactory.createCachingFileSystem(CacheFactory.java:47)
	at com.facebook.presto.hive.cache.HiveCachingHdfsConfiguration.lambda$getConfiguration$0(HiveCachingHdfsConfiguration.java:70)
	... 19 more
Caused by: java.nio.file.AccessDeniedException: /Users/binfan/tmp/test/LOCAL
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:84)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
	at sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:384)
	at java.nio.file.Files.createDirectory(Files.java:674)
	at java.nio.file.Files.createAndCheckIsDirectory(Files.java:781)
	at java.nio.file.Files.createDirectories(Files.java:767)
	at alluxio.client.file.cache.PageStore.initialize(PageStore.java:89)
	at alluxio.client.file.cache.PageStore.create(PageStore.java:50)
	at alluxio.client.file.cache.LocalCacheManager.create(LocalCacheManager.java:156)
	at alluxio.client.file.cache.CacheManager.create(CacheManager.java:31)
	at alluxio.client.file.cache.LocalCacheFileSystem.<init>(LocalCacheFileSystem.java:55)
	... 23 more
```