### PR TITLE
Support alluxio.tar.gz in alluxio-emr.sh emr bootstrap

### DIFF
--- a/integration/emr/alluxio-emr.sh
+++ b/integration/emr/alluxio-emr.sh
@@ -143,9 +143,12 @@ emr_install_alluxio() {
   download_file "${alluxio_tarball}"
 
   release=$(basename "${alluxio_tarball}")
-  local release_unzip
-  release_unzip="${release%%-*}" # trims everything after the first '-', ex. alluxio-foo-bar-whatever -> alluxio
-
+  local release_prefix
+  if [[ "${release}" == *-* ]]; then
+    release_unzip="${release%%-*}" # trims everything after the first '-', ex. alluxio-foo-bar-whatever -> alluxio
+  else
+    release_unzip="${release%%.tar*}" # trims everything after the '.tar', ex. alluxio.tar.gz -> alluxio
+  fi
   # Unpack and inflate the release tar
   # TODO logic for different compression formats, s3 URIs, git URIs, etc.
   sudo cp "${release}" /opt/

--- a/integration/emr/alluxio-emr.sh
+++ b/integration/emr/alluxio-emr.sh
@@ -143,7 +143,7 @@ emr_install_alluxio() {
   download_file "${alluxio_tarball}"
 
   release=$(basename "${alluxio_tarball}")
-  local release_prefix
+  local release_unzip
   if [[ "${release}" == *-* ]]; then
     release_unzip="${release%%-*}" # trims everything after the first '-', ex. alluxio-foo-bar-whatever -> alluxio
   else


### PR DESCRIPTION
Support users providing tarball with name `alluxio.tar.gz` for alluxio-emr.sh