### PR TITLE
Fix permission denied while creating a directory

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -497,7 +497,7 @@ public final class AlluxioFuseFileSystem extends FuseStubFS {
           LOG.error("Failed to get user name from uid {}", uid);
           return -ErrorCodes.EFAULT();
         }
-        attributeOptionsBuilder.setGroup(userName);
+        attributeOptionsBuilder.setOwner(userName);
       }
       SetAttributePOptions setAttributePOptions = attributeOptionsBuilder.build();
       mFileSystem.createDirectory(turi,

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -476,28 +476,38 @@ public final class AlluxioFuseFileSystem extends FuseStubFS {
           path, MAX_NAME_LENGTH);
       return -ErrorCodes.ENAMETOOLONG();
     }
+    SetAttributePOptions.Builder attributeOptionsBuilder = SetAttributePOptions.newBuilder();
     FuseContext fc = getContext();
     long uid = fc.uid.get();
     long gid = fc.gid.get();
     try {
-      String groupName = AlluxioFuseUtils.getGroupName(gid);
-      if (groupName.isEmpty()) {
-        // This should never be reached since input gid is always valid
-        LOG.error("Failed to get group name from gid {}.", gid);
-        return -ErrorCodes.EFAULT();
+      if (gid != GID) {
+        String groupName = AlluxioFuseUtils.getGroupName(gid);
+        if (groupName.isEmpty()) {
+          // This should never be reached since input gid is always valid
+          LOG.error("Failed to get group name from gid {}.", gid);
+          return -ErrorCodes.EFAULT();
+        }
+        attributeOptionsBuilder.setGroup(groupName);
       }
-      String userName = AlluxioFuseUtils.getUserName(uid);
-      if (userName.isEmpty()) {
-        // This should never be reached since input uid is always valid
-        LOG.error("Failed to get user name from uid {}", uid);
-        return -ErrorCodes.EFAULT();
+      if (uid != UID) {
+        String userName = AlluxioFuseUtils.getUserName(uid);
+        if (userName.isEmpty()) {
+          // This should never be reached since input uid is always valid
+          LOG.error("Failed to get user name from uid {}", uid);
+          return -ErrorCodes.EFAULT();
+        }
+        attributeOptionsBuilder.setGroup(userName);
       }
+      SetAttributePOptions setAttributePOptions = attributeOptionsBuilder.build();
       mFileSystem.createDirectory(turi,
           CreateDirectoryPOptions.newBuilder()
               .setMode(new alluxio.security.authorization.Mode((short) mode).toProto())
               .build());
-      mFileSystem.setAttribute(turi, SetAttributePOptions.newBuilder()
-          .setOwner(userName).setGroup(groupName).build());
+      if (gid != GID || uid != UID) {
+        LOG.debug("Set attributes of path {} to {}", path, setAttributePOptions);
+        mFileSystem.setAttribute(turi, setAttributePOptions);
+      }
     } catch (FileAlreadyExistsException e) {
       LOG.debug("Failed to create directory {}, directory already exists", path);
       return -ErrorCodes.EEXIST();


### PR DESCRIPTION
**Use-case:**

Alluxio superuser:

```
./bin/alluxio fs mkdir /tmp/
./bin/alluxio fs chown userA:userA /tmp/
```

UserA:

```
mkdir ./tmp
./integration/fuse/bin/alluxio-fuse mount ./tmp /tmp
mkdir ./tmp/d1
mkdir: ./tmp/d1: Permission denied
```

master.log

```
WARN  FileSystemMasterClientServiceHandler - Exit (Error): SetAttribute: request=path: "/tmp/d1"
options {
  owner: "UserA"
  group: "UserA"
  commonOptions {
    syncIntervalMs: -1
  }
}
, Error=alluxio.exception.AccessControlException: Permission denied: UserA is not a super user or in super group
```