### PR TITLE
Implement non-intrusive locking for backups

### DIFF
--- a/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -34,6 +34,7 @@ public enum ExceptionMessage {
   PATH_MUST_BE_DIRECTORY("Path \"{0}\" must be a directory."),
   PATH_MUST_BE_MOUNT_POINT("Path \"{0}\" must be a mount point."),
   PATH_INVALID("Path \"{0}\" is invalid."),
+  STATE_LOCK_TIMED_OUT("Failed to acquire the lock after {0}ms"),
 
   // general block
   BLOCK_UNAVAILABLE("Block {0} is unavailable in both Alluxio and UFS."),

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1322,6 +1322,35 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_BACKUP_STATE_LOCK_TIMEOUT =
+      new Builder(Name.MASTER_BACKUP_STATE_LOCK_TIMEOUT)
+          .setDefaultValue("1m")
+          .setDescription(
+              "The max duration to try acquiring the state lock for taking backups via shell.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_DAILY_BACKUP_STATE_LOCK_TRY_DURATION =
+      new Builder(Name.MASTER_DAILY_BACKUP_STATE_LOCK_TRY_DURATION)
+          .setDefaultValue("30s")
+          .setDescription("The duration to try acquiring the state lock exclusively..")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_DAILY_BACKUP_STATE_LOCK_SLEEP_DURATION =
+      new Builder(Name.MASTER_DAILY_BACKUP_STATE_LOCK_SLEEP_DURATION)
+          .setDefaultValue("10m")
+          .setDescription("The duration to sleep between trials to acquire the lock.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT =
+      new Builder(Name.MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT)
+          .setDefaultValue("12h")
+          .setDescription("The max duration to try acquiring the state lock.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_BIND_HOST =
       new Builder(Name.MASTER_BIND_HOST)
           .setDefaultValue("0.0.0.0")
@@ -4776,12 +4805,20 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.backup.connect.interval.max";
     public static final String MASTER_BACKUP_ABANDON_TIMEOUT =
         "alluxio.master.backup.abandon.timeout";
+    public static final String MASTER_BACKUP_STATE_LOCK_TIMEOUT =
+        "alluxio.master.backup.state.lock.timeout";
     public static final String MASTER_DAILY_BACKUP_ENABLED =
         "alluxio.master.daily.backup.enabled";
     public static final String MASTER_DAILY_BACKUP_FILES_RETAINED =
         "alluxio.master.daily.backup.files.retained";
     public static final String MASTER_DAILY_BACKUP_TIME =
         "alluxio.master.daily.backup.time";
+    public static final String MASTER_DAILY_BACKUP_STATE_LOCK_TRY_DURATION =
+        "alluxio.master.daily.backup.state.lock.try.duration";
+    public static final String MASTER_DAILY_BACKUP_STATE_LOCK_SLEEP_DURATION =
+        "alluxio.master.daily.backup.state.lock.sleep.duration";
+    public static final String MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT =
+        "alluxio.master.daily.backup.state.lock.timeout";
     public static final String MASTER_BIND_HOST = "alluxio.master.bind.host";
     public static final String MASTER_CLUSTER_METRICS_UPDATE_INTERVAL =
         "alluxio.master.cluster.metrics.update.interval";

--- a/core/common/src/main/java/alluxio/resource/LockResource.java
+++ b/core/common/src/main/java/alluxio/resource/LockResource.java
@@ -11,6 +11,8 @@
 
 package alluxio.resource;
 
+import alluxio.exception.ExceptionMessage;
+
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,8 +104,7 @@ public class LockResource implements Closeable {
       }
     }
     if (!lockAcquired) {
-      throw new TimeoutException(
-          String.format("Failed to acquire the lock:%s, after %dms", mLock, timeoutMs));
+      throw new TimeoutException(ExceptionMessage.STATE_LOCK_TIMED_OUT.getMessage(timeoutMs));
     }
   }
 

--- a/core/common/src/main/java/alluxio/resource/LockResource.java
+++ b/core/common/src/main/java/alluxio/resource/LockResource.java
@@ -97,7 +97,7 @@ public class LockResource implements Closeable {
         lockAcquired = true;
         break;
       } else {
-        long remainingWaitMs = deadlineMs = System.currentTimeMillis();
+        long remainingWaitMs = deadlineMs - System.currentTimeMillis();
         if (remainingWaitMs > 0) {
           Thread.sleep(Math.min(sleepMs, remainingWaitMs));
         }

--- a/core/common/src/main/java/alluxio/resource/LockResource.java
+++ b/core/common/src/main/java/alluxio/resource/LockResource.java
@@ -16,6 +16,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.LockSupport;
 
@@ -67,6 +69,41 @@ public class LockResource implements Closeable {
       } else {
         mLock.lock();
       }
+    }
+  }
+
+  /**
+   * Creates a new instance of {@link LockResource} using the given lock.
+   *
+   * This method will use the {@link Lock#tryLock(long, TimeUnit)} internally in a loop
+   * for trying to grab the lock without causing total blockage of other waiters of the lock.
+   *
+   * @param lock  the lock to acquire
+   * @param tryMs the duration to attempt acquiring the lock
+   * @param sleepMs the wait duration after failed attempt to acquire the lock
+   * @param timeoutMs the total duration to try acquiring the lock in a loop
+   * @throws InterruptedException if interrupted while acquiring the lock
+   * @throws TimeoutException if the lock was not acquired after given timeout
+   */
+  public LockResource(Lock lock, long tryMs, long sleepMs, long timeoutMs)
+      throws InterruptedException, TimeoutException {
+    mLock = lock;
+    long deadlineMs = System.currentTimeMillis() + timeoutMs;
+    boolean lockAcquired = false;
+    while (System.currentTimeMillis() < deadlineMs) {
+      if (mLock.tryLock(tryMs, TimeUnit.MILLISECONDS)) {
+        lockAcquired = true;
+        break;
+      } else {
+        long remainingWaitMs = deadlineMs = System.currentTimeMillis();
+        if (remainingWaitMs > 0) {
+          Thread.sleep(Math.min(sleepMs, remainingWaitMs));
+        }
+      }
+    }
+    if (!lockAcquired) {
+      throw new TimeoutException(
+          String.format("Failed to acquire the lock:%s, after %dms", mLock, timeoutMs));
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -79,6 +79,9 @@ public class AlluxioMasterProcess extends MasterProcess {
   /** The manager of safe mode state. */
   protected final SafeModeManager mSafeModeManager;
 
+  /** Master context. */
+  protected final MasterContext mContext;
+
   /** The manager for creating and restoring backups. */
   private final BackupManager mBackupManager;
 
@@ -105,7 +108,7 @@ public class AlluxioMasterProcess extends MasterProcess {
       mBackupManager = new BackupManager(mRegistry);
       String baseDir = ServerConfiguration.get(PropertyKey.MASTER_METASTORE_DIR);
       mUfsManager = new MasterUfsManager();
-      MasterContext context = CoreMasterContext.newBuilder()
+      mContext = CoreMasterContext.newBuilder()
           .setJournalSystem(mJournalSystem)
           .setSafeModeManager(mSafeModeManager)
           .setBackupManager(mBackupManager)
@@ -116,7 +119,7 @@ public class AlluxioMasterProcess extends MasterProcess {
               .getPort(ServiceType.MASTER_RPC, ServerConfiguration.global()))
           .setUfsManager(mUfsManager)
           .build();
-      MasterUtils.createMasters(mRegistry, context);
+      MasterUtils.createMasters(mRegistry, mContext);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/core/server/master/src/main/java/alluxio/master/backup/BackupLeaderRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupLeaderRole.java
@@ -254,7 +254,9 @@ public class BackupLeaderRole extends AbstractBackupRole {
   private void scheduleLocalBackup(BackupPRequest request) {
     mLocalBackupFuture = mExecutorService.submit(() -> {
       try (LockResource stateLockResource =
-          new LockResource(mStatePauseLock, mStateLockTimeout, TimeUnit.MILLISECONDS)) {
+          new LockResource(mStatePauseLock, request.getOptions().getStateLockTryDurationMs(),
+              request.getOptions().getStateLockSleepDurationMs(),
+              request.getOptions().getStateLockTimeoutMs())) {
         mBackupTracker.updateState(BackupState.Running);
         AlluxioURI backupUri = takeBackup(request, mBackupTracker.getEntryCounter());
         mBackupTracker.updateBackupUri(backupUri);
@@ -285,7 +287,9 @@ public class BackupLeaderRole extends AbstractBackupRole {
         // Get consistent journal sequences.
         Map<String, Long> journalSequences;
         try (LockResource stateLockResource =
-            new LockResource(mStatePauseLock, mStateLockTimeout, TimeUnit.MILLISECONDS)) {
+            new LockResource(mStatePauseLock, request.getOptions().getStateLockTryDurationMs(),
+                request.getOptions().getStateLockSleepDurationMs(),
+                request.getOptions().getStateLockTimeoutMs())) {
           journalSequences = mJournalSystem.getCurrentSequenceNumbers();
         }
         // Send backup request along with consistent journal sequences.

--- a/core/server/master/src/main/java/alluxio/master/meta/DailyMetadataBackup.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DailyMetadataBackup.java
@@ -115,8 +115,17 @@ public final class DailyMetadataBackup {
   private void dailyBackup() {
     try {
       BackupStatus resp =
-          mMetaMaster.backup(BackupPRequest.newBuilder().setTargetDirectory(mBackupDir)
-              .setOptions(BackupPOptions.newBuilder().setLocalFileSystem(mIsLocal)).build());
+          mMetaMaster.backup(BackupPRequest.newBuilder()
+              .setTargetDirectory(mBackupDir)
+              .setOptions(BackupPOptions.newBuilder()
+                  .setLocalFileSystem(mIsLocal)
+                  .setStateLockTryDurationMs(ServerConfiguration
+                      .getMs(PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_TRY_DURATION))
+                  .setStateLockSleepDurationMs(ServerConfiguration
+                      .getMs(PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_SLEEP_DURATION))
+                  .setStateLockTimeoutMs(ServerConfiguration
+                      .getMs(PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT)))
+              .build());
       if (mIsLocal) {
         LOG.info("Successfully backed up journal to {} on master {} with {} entries.",
             resp.getBackupUri(), resp.getHostname(), resp.getEntryCount());

--- a/core/transport/src/main/proto/grpc/meta_master.proto
+++ b/core/transport/src/main/proto/grpc/meta_master.proto
@@ -119,6 +119,9 @@ message BackupPOptions {
     optional bool localFileSystem = 1;
     optional bool runAsync = 2;
     optional bool allowLeader = 3;
+    optional int64 stateLockTryDurationMs = 4;
+    optional int64 stateLockSleepDurationMs = 5;
+    optional int64 stateLockTimeoutMs = 6;
 }
 message BackupPStatus {
     optional string backupId = 1;

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/BackupCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/BackupCommandIntegrationTest.java
@@ -12,25 +12,34 @@
 package alluxio.client.cli.fsadmin;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import alluxio.AlluxioTestDirectory;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.PropertyKey.Name;
 import alluxio.conf.ServerConfiguration;
+import alluxio.exception.ExceptionMessage;
+import alluxio.master.MasterContext;
+import alluxio.master.MasterProcess;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.locks.Lock;
 
 /**
  * Integration tests for the backup command.
  */
 @LocalAlluxioClusterResource.ServerConfig(
-    confParams = {Name.MASTER_BACKUP_DIRECTORY, "${alluxio.work.dir}/backups"})
+    confParams = {
+        Name.MASTER_BACKUP_DIRECTORY, "${alluxio.work.dir}/backups",
+        Name.MASTER_BACKUP_STATE_LOCK_TIMEOUT, "3s"})
 public final class BackupCommandIntegrationTest extends AbstractFsAdminShellTest {
   @Test
   public void defaultDirectory() throws IOException {
@@ -52,5 +61,30 @@ public final class BackupCommandIntegrationTest extends AbstractFsAdminShellTest
     assertEquals("", mErrOutput.toString());
     assertEquals(0, errCode);
     assertEquals(1, Files.list(dir).count());
+  }
+
+  @Test
+  public void timeout() throws IOException {
+    // Grab the master state-change lock via reflection.
+    MasterProcess masterProcess =
+        Whitebox.getInternalState(mLocalAlluxioCluster.getLocalAlluxioMaster(), "mMasterProcess");
+    MasterContext masterCtx = Whitebox.getInternalState(masterProcess, "mContext");
+    Lock stateLock = masterCtx.pauseStateLock();
+
+    try {
+      // Lock the state-change lock on the master before initiating the backup.
+      stateLock.lock();
+      // Prepare for a backup.
+      Path dir = Paths.get(ServerConfiguration.get(PropertyKey.MASTER_BACKUP_DIRECTORY));
+      Files.createDirectories(dir);
+      assertEquals(0, Files.list(dir).count());
+      // Initiate backup. It should fail.
+      int errCode = mFsAdminShell.run("backup");
+      assertTrue(mOutput.toString().contains(ExceptionMessage.STATE_LOCK_TIMED_OUT
+          .getMessage(3000/* matching the cluster resource configuration. */)));
+      assertNotEquals(0, errCode);
+    } finally {
+      masterCtx.pauseStateLock().unlock();
+    }
   }
 }


### PR DESCRIPTION
This is to eliminate the impact of backups when the leader has hung RPCs.
Backup not backing off from an exclusive lock acquisition was causing a pile of shared acquisition attempts. 