### PR TITLE
Update Web UI slack button position css to stay in place

### DIFF
--- a/webui/common/src/components/SlackButton/SlackButton.scss
+++ b/webui/common/src/components/SlackButton/SlackButton.scss
@@ -14,7 +14,7 @@
 .absolute-bottom-right {
   bottom: 0px;
   margin: 15px;
-  position: absolute;
+  position: fixed;
   right: 0px;
 }
 


### PR DESCRIPTION
fixed position will keep the button in the bottom right of the screen regardless of scrolling