### PR TITLE
Implement non-intrusive locking for backups

### DIFF
--- a/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -34,6 +34,7 @@ public enum ExceptionMessage {
   PATH_MUST_BE_DIRECTORY("Path \"{0}\" must be a directory."),
   PATH_MUST_BE_MOUNT_POINT("Path \"{0}\" must be a mount point."),
   PATH_INVALID("Path \"{0}\" is invalid."),
+  STATE_LOCK_TIMED_OUT("Failed to acquire the lock after {0}ms"),
 
   // general block
   BLOCK_UNAVAILABLE("Block {0} is unavailable in both Alluxio and UFS."),

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1304,6 +1304,35 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_BACKUP_STATE_LOCK_TIMEOUT =
+      new Builder(Name.MASTER_BACKUP_STATE_LOCK_TIMEOUT)
+          .setDefaultValue("1m")
+          .setDescription(
+              "The max duration to try acquiring the state lock for taking backups via shell.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_DAILY_BACKUP_STATE_LOCK_TRY_DURATION =
+      new Builder(Name.MASTER_DAILY_BACKUP_STATE_LOCK_TRY_DURATION)
+          .setDefaultValue("30s")
+          .setDescription("The duration to try acquiring the state lock exclusively..")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_DAILY_BACKUP_STATE_LOCK_SLEEP_DURATION =
+      new Builder(Name.MASTER_DAILY_BACKUP_STATE_LOCK_SLEEP_DURATION)
+          .setDefaultValue("10m")
+          .setDescription("The duration to sleep between trials to acquire the lock.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT =
+      new Builder(Name.MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT)
+          .setDefaultValue("12h")
+          .setDescription("The max duration to try acquiring the state lock.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_BIND_HOST =
       new Builder(Name.MASTER_BIND_HOST)
           .setDefaultValue("0.0.0.0")
@@ -4580,12 +4609,20 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.backup.connect.interval.max";
     public static final String MASTER_BACKUP_ABANDON_TIMEOUT =
         "alluxio.master.backup.abandon.timeout";
+    public static final String MASTER_BACKUP_STATE_LOCK_TIMEOUT =
+        "alluxio.master.backup.state.lock.timeout";
     public static final String MASTER_DAILY_BACKUP_ENABLED =
         "alluxio.master.daily.backup.enabled";
     public static final String MASTER_DAILY_BACKUP_FILES_RETAINED =
         "alluxio.master.daily.backup.files.retained";
     public static final String MASTER_DAILY_BACKUP_TIME =
         "alluxio.master.daily.backup.time";
+    public static final String MASTER_DAILY_BACKUP_STATE_LOCK_TRY_DURATION =
+        "alluxio.master.daily.backup.state.lock.try.duration";
+    public static final String MASTER_DAILY_BACKUP_STATE_LOCK_SLEEP_DURATION =
+        "alluxio.master.daily.backup.state.lock.sleep.duration";
+    public static final String MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT =
+        "alluxio.master.daily.backup.state.lock.timeout";
     public static final String MASTER_BIND_HOST = "alluxio.master.bind.host";
     public static final String MASTER_CLUSTER_METRICS_UPDATE_INTERVAL =
         "alluxio.master.cluster.metrics.update.interval";

--- a/core/common/src/main/java/alluxio/resource/LockResource.java
+++ b/core/common/src/main/java/alluxio/resource/LockResource.java
@@ -11,9 +11,13 @@
 
 package alluxio.resource;
 
+import alluxio.exception.ExceptionMessage;
+
 import com.google.common.annotations.VisibleForTesting;
 
 import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 
 /**
@@ -52,7 +56,41 @@ public class LockResource implements Closeable {
   }
 
   /**
-   * Returns true if the other lockresource contains the same lock.
+   * Creates a new instance of {@link LockResource} using the given lock.
+   *
+   * This method will use the {@link Lock#tryLock(long, TimeUnit)} internally in a loop
+   * for trying to grab the lock without causing total blockage of other waiters of the lock.
+   *
+   * @param lock  the lock to acquire
+   * @param tryMs the duration to attempt acquiring the lock
+   * @param sleepMs the wait duration after failed attempt to acquire the lock
+   * @param timeoutMs the total duration to try acquiring the lock in a loop
+   * @throws InterruptedException if interrupted while acquiring the lock
+   * @throws TimeoutException if the lock was not acquired after given timeout
+   */
+  public LockResource(Lock lock, long tryMs, long sleepMs, long timeoutMs)
+      throws InterruptedException, TimeoutException {
+    mLock = lock;
+    long deadlineMs = System.currentTimeMillis() + timeoutMs;
+    boolean lockAcquired = false;
+    while (System.currentTimeMillis() < deadlineMs) {
+      if (mLock.tryLock(tryMs, TimeUnit.MILLISECONDS)) {
+        lockAcquired = true;
+        break;
+      } else {
+        long remainingWaitMs = deadlineMs - System.currentTimeMillis();
+        if (remainingWaitMs > 0) {
+          Thread.sleep(Math.min(sleepMs, remainingWaitMs));
+        }
+      }
+    }
+    if (!lockAcquired) {
+      throw new TimeoutException(ExceptionMessage.STATE_LOCK_TIMED_OUT.getMessage(timeoutMs));
+    }
+  }
+
+  /**
+   * Returns true if the other {@link LockResource} contains the same lock.
    *
    * @param other other LockResource
    * @return true if the other lockResource has the same lock

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -79,6 +79,9 @@ public class AlluxioMasterProcess extends MasterProcess {
   /** The manager of safe mode state. */
   protected final SafeModeManager mSafeModeManager;
 
+  /** Master context. */
+  protected final MasterContext mContext;
+
   /** The manager for creating and restoring backups. */
   private final BackupManager mBackupManager;
 
@@ -105,7 +108,7 @@ public class AlluxioMasterProcess extends MasterProcess {
       mBackupManager = new BackupManager(mRegistry);
       String baseDir = ServerConfiguration.get(PropertyKey.MASTER_METASTORE_DIR);
       mUfsManager = new MasterUfsManager();
-      MasterContext context = CoreMasterContext.newBuilder()
+      mContext = CoreMasterContext.newBuilder()
           .setJournalSystem(mJournalSystem)
           .setSafeModeManager(mSafeModeManager)
           .setBackupManager(mBackupManager)
@@ -116,7 +119,7 @@ public class AlluxioMasterProcess extends MasterProcess {
               .getPort(ServiceType.MASTER_RPC, ServerConfiguration.global()))
           .setUfsManager(mUfsManager)
           .build();
-      MasterUtils.createMasters(mRegistry, context);
+      MasterUtils.createMasters(mRegistry, mContext);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/core/server/master/src/main/java/alluxio/master/backup/BackupLeaderRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupLeaderRole.java
@@ -67,6 +67,9 @@ public class BackupLeaderRole extends AbstractBackupRole {
   /** Metadata state pause lock. */
   private Lock mStatePauseLock;
 
+  /** Duration to try on locking the state-lock. */
+  private final long mStateLockTimeout;
+
   /** Scheduled future to time-put backups on leader. */
   private ScheduledFuture<?> mTimeoutBackupFuture;
   /** Time at which the last heart-beat was received by leader. */
@@ -98,8 +101,8 @@ public class BackupLeaderRole extends AbstractBackupRole {
     // Store state lock for pausing state change when necessary.
     mStatePauseLock = masterContext.pauseStateLock();
     // Read properties.
-    mBackupAbandonTimeout =
-        ServerConfiguration.getMs(PropertyKey.MASTER_BACKUP_ABANDON_TIMEOUT);
+    mStateLockTimeout = ServerConfiguration.getMs(PropertyKey.MASTER_BACKUP_STATE_LOCK_TIMEOUT);
+    mBackupAbandonTimeout = ServerConfiguration.getMs(PropertyKey.MASTER_BACKUP_ABANDON_TIMEOUT);
   }
 
   @Override
@@ -250,16 +253,17 @@ public class BackupLeaderRole extends AbstractBackupRole {
    */
   private void scheduleLocalBackup(BackupPRequest request) {
     mLocalBackupFuture = mExecutorService.submit(() -> {
-      try (LockResource lr = new LockResource(mStatePauseLock)) {
-        try {
-          mBackupTracker.updateState(BackupState.Running);
-          AlluxioURI backupUri = takeBackup(request, mBackupTracker.getEntryCounter());
-          mBackupTracker.updateBackupUri(backupUri);
-          mBackupTracker.updateState(BackupState.Completed);
-        } catch (IOException e) {
-          mBackupTracker.updateError(
-              new BackupException(String.format("Local backup failed: %s", e.getMessage()), e));
-        }
+      try (LockResource stateLockResource =
+          new LockResource(mStatePauseLock, request.getOptions().getStateLockTryDurationMs(),
+              request.getOptions().getStateLockSleepDurationMs(),
+              request.getOptions().getStateLockTimeoutMs())) {
+        mBackupTracker.updateState(BackupState.Running);
+        AlluxioURI backupUri = takeBackup(request, mBackupTracker.getEntryCounter());
+        mBackupTracker.updateBackupUri(backupUri);
+        mBackupTracker.updateState(BackupState.Completed);
+      } catch (Exception e) {
+        mBackupTracker.updateError(
+            new BackupException(String.format("Local backup failed: %s", e.getMessage()), e));
       }
     });
   }
@@ -282,7 +286,10 @@ public class BackupLeaderRole extends AbstractBackupRole {
         sendMessageBlocking(workerEntry.getKey(), new BackupSuspendMessage());
         // Get consistent journal sequences.
         Map<String, Long> journalSequences;
-        try (LockResource stateLock = new LockResource(mStatePauseLock)) {
+        try (LockResource stateLockResource =
+            new LockResource(mStatePauseLock, request.getOptions().getStateLockTryDurationMs(),
+                request.getOptions().getStateLockSleepDurationMs(),
+                request.getOptions().getStateLockTimeoutMs())) {
           journalSequences = mJournalSystem.getCurrentSequenceNumbers();
         }
         // Send backup request along with consistent journal sequences.

--- a/core/server/master/src/main/java/alluxio/master/meta/DailyMetadataBackup.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DailyMetadataBackup.java
@@ -115,8 +115,17 @@ public final class DailyMetadataBackup {
   private void dailyBackup() {
     try {
       BackupStatus resp =
-          mMetaMaster.backup(BackupPRequest.newBuilder().setTargetDirectory(mBackupDir)
-              .setOptions(BackupPOptions.newBuilder().setLocalFileSystem(mIsLocal)).build());
+          mMetaMaster.backup(BackupPRequest.newBuilder()
+              .setTargetDirectory(mBackupDir)
+              .setOptions(BackupPOptions.newBuilder()
+                  .setLocalFileSystem(mIsLocal)
+                  .setStateLockTryDurationMs(ServerConfiguration
+                      .getMs(PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_TRY_DURATION))
+                  .setStateLockSleepDurationMs(ServerConfiguration
+                      .getMs(PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_SLEEP_DURATION))
+                  .setStateLockTimeoutMs(ServerConfiguration
+                      .getMs(PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT)))
+              .build());
       if (mIsLocal) {
         LOG.info("Successfully backed up journal to {} on master {} with {} entries.",
             resp.getBackupUri(), resp.getHostname(), resp.getEntryCount());

--- a/core/transport/src/grpc/meta_master.proto
+++ b/core/transport/src/grpc/meta_master.proto
@@ -119,6 +119,9 @@ message BackupPOptions {
     optional bool localFileSystem = 1;
     optional bool runAsync = 2;
     optional bool allowLeader = 3;
+    optional int64 stateLockTryDurationMs = 4;
+    optional int64 stateLockSleepDurationMs = 5;
+    optional int64 stateLockTimeoutMs = 6;
 }
 message BackupPStatus {
     optional string backupId = 1;

--- a/core/transport/src/main/java/alluxio/grpc/BackupPOptions.java
+++ b/core/transport/src/main/java/alluxio/grpc/BackupPOptions.java
@@ -64,6 +64,21 @@ private static final long serialVersionUID = 0L;
             allowLeader_ = input.readBool();
             break;
           }
+          case 32: {
+            bitField0_ |= 0x00000008;
+            stateLockTryDurationMs_ = input.readInt64();
+            break;
+          }
+          case 40: {
+            bitField0_ |= 0x00000010;
+            stateLockSleepDurationMs_ = input.readInt64();
+            break;
+          }
+          case 48: {
+            bitField0_ |= 0x00000020;
+            stateLockTimeoutMs_ = input.readInt64();
+            break;
+          }
           default: {
             if (!parseUnknownField(
                 input, unknownFields, extensionRegistry, tag)) {
@@ -148,6 +163,57 @@ private static final long serialVersionUID = 0L;
     return allowLeader_;
   }
 
+  public static final int STATELOCKTRYDURATIONMS_FIELD_NUMBER = 4;
+  private long stateLockTryDurationMs_;
+  /**
+   * <code>optional int64 stateLockTryDurationMs = 4;</code>
+   * @return Whether the stateLockTryDurationMs field is set.
+   */
+  public boolean hasStateLockTryDurationMs() {
+    return ((bitField0_ & 0x00000008) != 0);
+  }
+  /**
+   * <code>optional int64 stateLockTryDurationMs = 4;</code>
+   * @return The stateLockTryDurationMs.
+   */
+  public long getStateLockTryDurationMs() {
+    return stateLockTryDurationMs_;
+  }
+
+  public static final int STATELOCKSLEEPDURATIONMS_FIELD_NUMBER = 5;
+  private long stateLockSleepDurationMs_;
+  /**
+   * <code>optional int64 stateLockSleepDurationMs = 5;</code>
+   * @return Whether the stateLockSleepDurationMs field is set.
+   */
+  public boolean hasStateLockSleepDurationMs() {
+    return ((bitField0_ & 0x00000010) != 0);
+  }
+  /**
+   * <code>optional int64 stateLockSleepDurationMs = 5;</code>
+   * @return The stateLockSleepDurationMs.
+   */
+  public long getStateLockSleepDurationMs() {
+    return stateLockSleepDurationMs_;
+  }
+
+  public static final int STATELOCKTIMEOUTMS_FIELD_NUMBER = 6;
+  private long stateLockTimeoutMs_;
+  /**
+   * <code>optional int64 stateLockTimeoutMs = 6;</code>
+   * @return Whether the stateLockTimeoutMs field is set.
+   */
+  public boolean hasStateLockTimeoutMs() {
+    return ((bitField0_ & 0x00000020) != 0);
+  }
+  /**
+   * <code>optional int64 stateLockTimeoutMs = 6;</code>
+   * @return The stateLockTimeoutMs.
+   */
+  public long getStateLockTimeoutMs() {
+    return stateLockTimeoutMs_;
+  }
+
   private byte memoizedIsInitialized = -1;
   @java.lang.Override
   public final boolean isInitialized() {
@@ -171,6 +237,15 @@ private static final long serialVersionUID = 0L;
     if (((bitField0_ & 0x00000004) != 0)) {
       output.writeBool(3, allowLeader_);
     }
+    if (((bitField0_ & 0x00000008) != 0)) {
+      output.writeInt64(4, stateLockTryDurationMs_);
+    }
+    if (((bitField0_ & 0x00000010) != 0)) {
+      output.writeInt64(5, stateLockSleepDurationMs_);
+    }
+    if (((bitField0_ & 0x00000020) != 0)) {
+      output.writeInt64(6, stateLockTimeoutMs_);
+    }
     unknownFields.writeTo(output);
   }
 
@@ -191,6 +266,18 @@ private static final long serialVersionUID = 0L;
     if (((bitField0_ & 0x00000004) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeBoolSize(3, allowLeader_);
+    }
+    if (((bitField0_ & 0x00000008) != 0)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeInt64Size(4, stateLockTryDurationMs_);
+    }
+    if (((bitField0_ & 0x00000010) != 0)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeInt64Size(5, stateLockSleepDurationMs_);
+    }
+    if (((bitField0_ & 0x00000020) != 0)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeInt64Size(6, stateLockTimeoutMs_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -222,6 +309,21 @@ private static final long serialVersionUID = 0L;
       if (getAllowLeader()
           != other.getAllowLeader()) return false;
     }
+    if (hasStateLockTryDurationMs() != other.hasStateLockTryDurationMs()) return false;
+    if (hasStateLockTryDurationMs()) {
+      if (getStateLockTryDurationMs()
+          != other.getStateLockTryDurationMs()) return false;
+    }
+    if (hasStateLockSleepDurationMs() != other.hasStateLockSleepDurationMs()) return false;
+    if (hasStateLockSleepDurationMs()) {
+      if (getStateLockSleepDurationMs()
+          != other.getStateLockSleepDurationMs()) return false;
+    }
+    if (hasStateLockTimeoutMs() != other.hasStateLockTimeoutMs()) return false;
+    if (hasStateLockTimeoutMs()) {
+      if (getStateLockTimeoutMs()
+          != other.getStateLockTimeoutMs()) return false;
+    }
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -247,6 +349,21 @@ private static final long serialVersionUID = 0L;
       hash = (37 * hash) + ALLOWLEADER_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
           getAllowLeader());
+    }
+    if (hasStateLockTryDurationMs()) {
+      hash = (37 * hash) + STATELOCKTRYDURATIONMS_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getStateLockTryDurationMs());
+    }
+    if (hasStateLockSleepDurationMs()) {
+      hash = (37 * hash) + STATELOCKSLEEPDURATIONMS_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getStateLockSleepDurationMs());
+    }
+    if (hasStateLockTimeoutMs()) {
+      hash = (37 * hash) + STATELOCKTIMEOUTMS_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getStateLockTimeoutMs());
     }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
@@ -387,6 +504,12 @@ private static final long serialVersionUID = 0L;
       bitField0_ = (bitField0_ & ~0x00000002);
       allowLeader_ = false;
       bitField0_ = (bitField0_ & ~0x00000004);
+      stateLockTryDurationMs_ = 0L;
+      bitField0_ = (bitField0_ & ~0x00000008);
+      stateLockSleepDurationMs_ = 0L;
+      bitField0_ = (bitField0_ & ~0x00000010);
+      stateLockTimeoutMs_ = 0L;
+      bitField0_ = (bitField0_ & ~0x00000020);
       return this;
     }
 
@@ -426,6 +549,18 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000004) != 0)) {
         result.allowLeader_ = allowLeader_;
         to_bitField0_ |= 0x00000004;
+      }
+      if (((from_bitField0_ & 0x00000008) != 0)) {
+        result.stateLockTryDurationMs_ = stateLockTryDurationMs_;
+        to_bitField0_ |= 0x00000008;
+      }
+      if (((from_bitField0_ & 0x00000010) != 0)) {
+        result.stateLockSleepDurationMs_ = stateLockSleepDurationMs_;
+        to_bitField0_ |= 0x00000010;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        result.stateLockTimeoutMs_ = stateLockTimeoutMs_;
+        to_bitField0_ |= 0x00000020;
       }
       result.bitField0_ = to_bitField0_;
       onBuilt();
@@ -484,6 +619,15 @@ private static final long serialVersionUID = 0L;
       }
       if (other.hasAllowLeader()) {
         setAllowLeader(other.getAllowLeader());
+      }
+      if (other.hasStateLockTryDurationMs()) {
+        setStateLockTryDurationMs(other.getStateLockTryDurationMs());
+      }
+      if (other.hasStateLockSleepDurationMs()) {
+        setStateLockSleepDurationMs(other.getStateLockSleepDurationMs());
+      }
+      if (other.hasStateLockTimeoutMs()) {
+        setStateLockTimeoutMs(other.getStateLockTimeoutMs());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -622,6 +766,117 @@ private static final long serialVersionUID = 0L;
     public Builder clearAllowLeader() {
       bitField0_ = (bitField0_ & ~0x00000004);
       allowLeader_ = false;
+      onChanged();
+      return this;
+    }
+
+    private long stateLockTryDurationMs_ ;
+    /**
+     * <code>optional int64 stateLockTryDurationMs = 4;</code>
+     * @return Whether the stateLockTryDurationMs field is set.
+     */
+    public boolean hasStateLockTryDurationMs() {
+      return ((bitField0_ & 0x00000008) != 0);
+    }
+    /**
+     * <code>optional int64 stateLockTryDurationMs = 4;</code>
+     * @return The stateLockTryDurationMs.
+     */
+    public long getStateLockTryDurationMs() {
+      return stateLockTryDurationMs_;
+    }
+    /**
+     * <code>optional int64 stateLockTryDurationMs = 4;</code>
+     * @param value The stateLockTryDurationMs to set.
+     * @return This builder for chaining.
+     */
+    public Builder setStateLockTryDurationMs(long value) {
+      bitField0_ |= 0x00000008;
+      stateLockTryDurationMs_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional int64 stateLockTryDurationMs = 4;</code>
+     * @return This builder for chaining.
+     */
+    public Builder clearStateLockTryDurationMs() {
+      bitField0_ = (bitField0_ & ~0x00000008);
+      stateLockTryDurationMs_ = 0L;
+      onChanged();
+      return this;
+    }
+
+    private long stateLockSleepDurationMs_ ;
+    /**
+     * <code>optional int64 stateLockSleepDurationMs = 5;</code>
+     * @return Whether the stateLockSleepDurationMs field is set.
+     */
+    public boolean hasStateLockSleepDurationMs() {
+      return ((bitField0_ & 0x00000010) != 0);
+    }
+    /**
+     * <code>optional int64 stateLockSleepDurationMs = 5;</code>
+     * @return The stateLockSleepDurationMs.
+     */
+    public long getStateLockSleepDurationMs() {
+      return stateLockSleepDurationMs_;
+    }
+    /**
+     * <code>optional int64 stateLockSleepDurationMs = 5;</code>
+     * @param value The stateLockSleepDurationMs to set.
+     * @return This builder for chaining.
+     */
+    public Builder setStateLockSleepDurationMs(long value) {
+      bitField0_ |= 0x00000010;
+      stateLockSleepDurationMs_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional int64 stateLockSleepDurationMs = 5;</code>
+     * @return This builder for chaining.
+     */
+    public Builder clearStateLockSleepDurationMs() {
+      bitField0_ = (bitField0_ & ~0x00000010);
+      stateLockSleepDurationMs_ = 0L;
+      onChanged();
+      return this;
+    }
+
+    private long stateLockTimeoutMs_ ;
+    /**
+     * <code>optional int64 stateLockTimeoutMs = 6;</code>
+     * @return Whether the stateLockTimeoutMs field is set.
+     */
+    public boolean hasStateLockTimeoutMs() {
+      return ((bitField0_ & 0x00000020) != 0);
+    }
+    /**
+     * <code>optional int64 stateLockTimeoutMs = 6;</code>
+     * @return The stateLockTimeoutMs.
+     */
+    public long getStateLockTimeoutMs() {
+      return stateLockTimeoutMs_;
+    }
+    /**
+     * <code>optional int64 stateLockTimeoutMs = 6;</code>
+     * @param value The stateLockTimeoutMs to set.
+     * @return This builder for chaining.
+     */
+    public Builder setStateLockTimeoutMs(long value) {
+      bitField0_ |= 0x00000020;
+      stateLockTimeoutMs_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional int64 stateLockTimeoutMs = 6;</code>
+     * @return This builder for chaining.
+     */
+    public Builder clearStateLockTimeoutMs() {
+      bitField0_ = (bitField0_ & ~0x00000020);
+      stateLockTimeoutMs_ = 0L;
       onChanged();
       return this;
     }

--- a/core/transport/src/main/java/alluxio/grpc/BackupPOptionsOrBuilder.java
+++ b/core/transport/src/main/java/alluxio/grpc/BackupPOptionsOrBuilder.java
@@ -39,4 +39,37 @@ public interface BackupPOptionsOrBuilder extends
    * @return The allowLeader.
    */
   boolean getAllowLeader();
+
+  /**
+   * <code>optional int64 stateLockTryDurationMs = 4;</code>
+   * @return Whether the stateLockTryDurationMs field is set.
+   */
+  boolean hasStateLockTryDurationMs();
+  /**
+   * <code>optional int64 stateLockTryDurationMs = 4;</code>
+   * @return The stateLockTryDurationMs.
+   */
+  long getStateLockTryDurationMs();
+
+  /**
+   * <code>optional int64 stateLockSleepDurationMs = 5;</code>
+   * @return Whether the stateLockSleepDurationMs field is set.
+   */
+  boolean hasStateLockSleepDurationMs();
+  /**
+   * <code>optional int64 stateLockSleepDurationMs = 5;</code>
+   * @return The stateLockSleepDurationMs.
+   */
+  long getStateLockSleepDurationMs();
+
+  /**
+   * <code>optional int64 stateLockTimeoutMs = 6;</code>
+   * @return Whether the stateLockTimeoutMs field is set.
+   */
+  boolean hasStateLockTimeoutMs();
+  /**
+   * <code>optional int64 stateLockTimeoutMs = 6;</code>
+   * @return The stateLockTimeoutMs.
+   */
+  long getStateLockTimeoutMs();
 }

--- a/core/transport/src/main/java/alluxio/grpc/MetaMasterProto.java
+++ b/core/transport/src/main/java/alluxio/grpc/MetaMasterProto.java
@@ -272,92 +272,95 @@ public final class MetaMasterProto {
       "se\022\026\n\016masterHostname\030\001 \001(\t\"]\n\016BackupPReq" +
       "uest\0222\n\007options\030\001 \001(\0132!.alluxio.grpc.met" +
       "a.BackupPOptions\022\027\n\017targetDirectory\030\002 \001(" +
-      "\t\"P\n\016BackupPOptions\022\027\n\017localFileSystem\030\001" +
-      " \001(\010\022\020\n\010runAsync\030\002 \001(\010\022\023\n\013allowLeader\030\003 " +
-      "\001(\010\"\246\001\n\rBackupPStatus\022\020\n\010backupId\030\001 \001(\t\022" +
-      "3\n\013backupState\030\002 \001(\0162\036.alluxio.grpc.meta" +
-      ".BackupState\022\022\n\nbackupHost\030\003 \001(\t\022\021\n\tback" +
-      "upUri\030\004 \001(\t\022\022\n\nentryCount\030\005 \001(\003\022\023\n\013backu" +
-      "pError\030\006 \001(\014\"(\n\024BackupStatusPRequest\022\020\n\010" +
-      "backupId\030\001 \001(\t\"\036\n\034SetPathConfigurationPO" +
-      "ptions\"\366\001\n\034SetPathConfigurationPRequest\022" +
-      "\014\n\004path\030\001 \001(\t\022S\n\nproperties\030\002 \003(\0132?.allu" +
-      "xio.grpc.meta.SetPathConfigurationPReque" +
-      "st.PropertiesEntry\022@\n\007options\030\003 \001(\0132/.al" +
-      "luxio.grpc.meta.SetPathConfigurationPOpt" +
-      "ions\0321\n\017PropertiesEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005" +
-      "value\030\002 \001(\t:\0028\001\"\037\n\035SetPathConfigurationP" +
-      "Response\"!\n\037RemovePathConfigurationPOpti" +
-      "ons\"\202\001\n\037RemovePathConfigurationPRequest\022" +
-      "\014\n\004path\030\001 \001(\t\022\014\n\004keys\030\002 \003(\t\022C\n\007options\030\003" +
-      " \001(\01322.alluxio.grpc.meta.RemovePathConfi" +
-      "gurationPOptions\"\"\n RemovePathConfigurat" +
-      "ionPResponse\"\027\n\025GetConfigHashPOptions\"K\n" +
-      "\026GetConfigHashPResponse\022\031\n\021clusterConfig" +
-      "Hash\030\001 \001(\t\022\026\n\016pathConfigHash\030\002 \001(\t\"\025\n\023Ge" +
-      "tMasterIdPOptions\"\177\n\023GetMasterIdPRequest" +
-      "\022/\n\rmasterAddress\030\001 \001(\0132\030.alluxio.grpc.N" +
-      "etAddress\0227\n\007options\030\002 \001(\0132&.alluxio.grp" +
-      "c.meta.GetMasterIdPOptions\"(\n\024GetMasterI" +
-      "dPResponse\022\020\n\010masterId\030\001 \001(\003\"G\n\026Register" +
-      "MasterPOptions\022-\n\007configs\030\001 \003(\0132\034.alluxi" +
-      "o.grpc.ConfigProperty\"f\n\026RegisterMasterP" +
-      "Request\022\020\n\010masterId\030\001 \001(\003\022:\n\007options\030\002 \001" +
-      "(\0132).alluxio.grpc.meta.RegisterMasterPOp" +
-      "tions\"\031\n\027RegisterMasterPResponse\"\031\n\027Mast" +
-      "erHeartbeatPOptions\"h\n\027MasterHeartbeatPR" +
-      "equest\022\020\n\010masterId\030\001 \001(\003\022;\n\007options\030\002 \001(" +
-      "\0132*.alluxio.grpc.meta.MasterHeartbeatPOp" +
-      "tions\"K\n\030MasterHeartbeatPResponse\022/\n\007com" +
-      "mand\030\001 \001(\0162\036.alluxio.grpc.meta.MetaComma" +
-      "nd*0\n\014ConfigStatus\022\n\n\006PASSED\020\001\022\010\n\004WARN\020\002" +
-      "\022\n\n\006FAILED\020\003*J\n\005Scope\022\n\n\006MASTER\020\001\022\n\n\006WOR" +
-      "KER\020\002\022\n\n\006CLIENT\020\004\022\n\n\006SERVER\020\003\022\007\n\003ALL\020\007\022\010" +
-      "\n\004NONE\020\000*\314\001\n\017MasterInfoField\022\031\n\025LEADER_M" +
-      "ASTER_ADDRESS\020\000\022\024\n\020MASTER_ADDRESSES\020\001\022\014\n" +
-      "\010RPC_PORT\020\002\022\r\n\tSAFE_MODE\020\003\022\021\n\rSTART_TIME" +
-      "_MS\020\004\022\016\n\nUP_TIME_MS\020\005\022\013\n\007VERSION\020\006\022\014\n\010WE" +
-      "B_PORT\020\007\022\024\n\020WORKER_ADDRESSES\020\010\022\027\n\023ZOOKEE" +
-      "PER_ADDRESSES\020\t*b\n\013BackupState\022\010\n\004None\020\001" +
-      "\022\016\n\nInitiating\020\002\022\021\n\rTransitioning\020\003\022\013\n\007R" +
-      "unning\020\004\022\r\n\tCompleted\020\005\022\n\n\006Failed\020\006*Y\n\013M" +
-      "etaCommand\022\027\n\023MetaCommand_Unknown\020\000\022\027\n\023M" +
-      "etaCommand_Nothing\020\001\022\030\n\024MetaCommand_Regi" +
-      "ster\020\0022\365\003\n\027MetaMasterClientService\022M\n\006Ba" +
-      "ckup\022!.alluxio.grpc.meta.BackupPRequest\032" +
-      " .alluxio.grpc.meta.BackupPStatus\022\\\n\017Get" +
-      "BackupStatus\022\'.alluxio.grpc.meta.BackupS" +
-      "tatusPRequest\032 .alluxio.grpc.meta.Backup" +
-      "PStatus\022j\n\017GetConfigReport\022*.alluxio.grp" +
-      "c.meta.GetConfigReportPOptions\032+.alluxio" +
-      ".grpc.meta.GetConfigReportPResponse\022d\n\rG" +
-      "etMasterInfo\022(.alluxio.grpc.meta.GetMast" +
-      "erInfoPOptions\032).alluxio.grpc.meta.GetMa" +
-      "sterInfoPResponse\022[\n\nCheckpoint\022%.alluxi" +
-      "o.grpc.meta.CheckpointPOptions\032&.alluxio" +
-      ".grpc.meta.CheckpointPResponse2\365\003\n\036MetaM" +
-      "asterConfigurationService\022m\n\020GetConfigur" +
-      "ation\022+.alluxio.grpc.meta.GetConfigurati" +
-      "onPOptions\032,.alluxio.grpc.meta.GetConfig" +
-      "urationPResponse\022y\n\024SetPathConfiguration" +
-      "\022/.alluxio.grpc.meta.SetPathConfiguratio" +
-      "nPRequest\0320.alluxio.grpc.meta.SetPathCon" +
-      "figurationPResponse\022\202\001\n\027RemovePathConfig" +
-      "uration\0222.alluxio.grpc.meta.RemovePathCo" +
-      "nfigurationPRequest\0323.alluxio.grpc.meta." +
-      "RemovePathConfigurationPResponse\022d\n\rGetC" +
-      "onfigHash\022(.alluxio.grpc.meta.GetConfigH" +
-      "ashPOptions\032).alluxio.grpc.meta.GetConfi" +
-      "gHashPResponse2\316\002\n\027MetaMasterMasterServi" +
-      "ce\022^\n\013GetMasterId\022&.alluxio.grpc.meta.Ge" +
-      "tMasterIdPRequest\032\'.alluxio.grpc.meta.Ge" +
-      "tMasterIdPResponse\022g\n\016RegisterMaster\022).a" +
-      "lluxio.grpc.meta.RegisterMasterPRequest\032" +
-      "*.alluxio.grpc.meta.RegisterMasterPRespo" +
-      "nse\022j\n\017MasterHeartbeat\022*.alluxio.grpc.me" +
-      "ta.MasterHeartbeatPRequest\032+.alluxio.grp" +
-      "c.meta.MasterHeartbeatPResponseB!\n\014allux" +
-      "io.grpcB\017MetaMasterProtoP\001"
+      "\t\"\256\001\n\016BackupPOptions\022\027\n\017localFileSystem\030" +
+      "\001 \001(\010\022\020\n\010runAsync\030\002 \001(\010\022\023\n\013allowLeader\030\003" +
+      " \001(\010\022\036\n\026stateLockTryDurationMs\030\004 \001(\003\022 \n\030" +
+      "stateLockSleepDurationMs\030\005 \001(\003\022\032\n\022stateL" +
+      "ockTimeoutMs\030\006 \001(\003\"\246\001\n\rBackupPStatus\022\020\n\010" +
+      "backupId\030\001 \001(\t\0223\n\013backupState\030\002 \001(\0162\036.al" +
+      "luxio.grpc.meta.BackupState\022\022\n\nbackupHos" +
+      "t\030\003 \001(\t\022\021\n\tbackupUri\030\004 \001(\t\022\022\n\nentryCount" +
+      "\030\005 \001(\003\022\023\n\013backupError\030\006 \001(\014\"(\n\024BackupSta" +
+      "tusPRequest\022\020\n\010backupId\030\001 \001(\t\"\036\n\034SetPath" +
+      "ConfigurationPOptions\"\366\001\n\034SetPathConfigu" +
+      "rationPRequest\022\014\n\004path\030\001 \001(\t\022S\n\nproperti" +
+      "es\030\002 \003(\0132?.alluxio.grpc.meta.SetPathConf" +
+      "igurationPRequest.PropertiesEntry\022@\n\007opt" +
+      "ions\030\003 \001(\0132/.alluxio.grpc.meta.SetPathCo" +
+      "nfigurationPOptions\0321\n\017PropertiesEntry\022\013" +
+      "\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\037\n\035SetPat" +
+      "hConfigurationPResponse\"!\n\037RemovePathCon" +
+      "figurationPOptions\"\202\001\n\037RemovePathConfigu" +
+      "rationPRequest\022\014\n\004path\030\001 \001(\t\022\014\n\004keys\030\002 \003" +
+      "(\t\022C\n\007options\030\003 \001(\01322.alluxio.grpc.meta." +
+      "RemovePathConfigurationPOptions\"\"\n Remov" +
+      "ePathConfigurationPResponse\"\027\n\025GetConfig" +
+      "HashPOptions\"K\n\026GetConfigHashPResponse\022\031" +
+      "\n\021clusterConfigHash\030\001 \001(\t\022\026\n\016pathConfigH" +
+      "ash\030\002 \001(\t\"\025\n\023GetMasterIdPOptions\"\177\n\023GetM" +
+      "asterIdPRequest\022/\n\rmasterAddress\030\001 \001(\0132\030" +
+      ".alluxio.grpc.NetAddress\0227\n\007options\030\002 \001(" +
+      "\0132&.alluxio.grpc.meta.GetMasterIdPOption" +
+      "s\"(\n\024GetMasterIdPResponse\022\020\n\010masterId\030\001 " +
+      "\001(\003\"G\n\026RegisterMasterPOptions\022-\n\007configs" +
+      "\030\001 \003(\0132\034.alluxio.grpc.ConfigProperty\"f\n\026" +
+      "RegisterMasterPRequest\022\020\n\010masterId\030\001 \001(\003" +
+      "\022:\n\007options\030\002 \001(\0132).alluxio.grpc.meta.Re" +
+      "gisterMasterPOptions\"\031\n\027RegisterMasterPR" +
+      "esponse\"\031\n\027MasterHeartbeatPOptions\"h\n\027Ma" +
+      "sterHeartbeatPRequest\022\020\n\010masterId\030\001 \001(\003\022" +
+      ";\n\007options\030\002 \001(\0132*.alluxio.grpc.meta.Mas" +
+      "terHeartbeatPOptions\"K\n\030MasterHeartbeatP" +
+      "Response\022/\n\007command\030\001 \001(\0162\036.alluxio.grpc" +
+      ".meta.MetaCommand*0\n\014ConfigStatus\022\n\n\006PAS" +
+      "SED\020\001\022\010\n\004WARN\020\002\022\n\n\006FAILED\020\003*J\n\005Scope\022\n\n\006" +
+      "MASTER\020\001\022\n\n\006WORKER\020\002\022\n\n\006CLIENT\020\004\022\n\n\006SERV" +
+      "ER\020\003\022\007\n\003ALL\020\007\022\010\n\004NONE\020\000*\314\001\n\017MasterInfoFi" +
+      "eld\022\031\n\025LEADER_MASTER_ADDRESS\020\000\022\024\n\020MASTER" +
+      "_ADDRESSES\020\001\022\014\n\010RPC_PORT\020\002\022\r\n\tSAFE_MODE\020" +
+      "\003\022\021\n\rSTART_TIME_MS\020\004\022\016\n\nUP_TIME_MS\020\005\022\013\n\007" +
+      "VERSION\020\006\022\014\n\010WEB_PORT\020\007\022\024\n\020WORKER_ADDRES" +
+      "SES\020\010\022\027\n\023ZOOKEEPER_ADDRESSES\020\t*b\n\013Backup" +
+      "State\022\010\n\004None\020\001\022\016\n\nInitiating\020\002\022\021\n\rTrans" +
+      "itioning\020\003\022\013\n\007Running\020\004\022\r\n\tCompleted\020\005\022\n" +
+      "\n\006Failed\020\006*Y\n\013MetaCommand\022\027\n\023MetaCommand" +
+      "_Unknown\020\000\022\027\n\023MetaCommand_Nothing\020\001\022\030\n\024M" +
+      "etaCommand_Register\020\0022\365\003\n\027MetaMasterClie" +
+      "ntService\022M\n\006Backup\022!.alluxio.grpc.meta." +
+      "BackupPRequest\032 .alluxio.grpc.meta.Backu" +
+      "pPStatus\022\\\n\017GetBackupStatus\022\'.alluxio.gr" +
+      "pc.meta.BackupStatusPRequest\032 .alluxio.g" +
+      "rpc.meta.BackupPStatus\022j\n\017GetConfigRepor" +
+      "t\022*.alluxio.grpc.meta.GetConfigReportPOp" +
+      "tions\032+.alluxio.grpc.meta.GetConfigRepor" +
+      "tPResponse\022d\n\rGetMasterInfo\022(.alluxio.gr" +
+      "pc.meta.GetMasterInfoPOptions\032).alluxio." +
+      "grpc.meta.GetMasterInfoPResponse\022[\n\nChec" +
+      "kpoint\022%.alluxio.grpc.meta.CheckpointPOp" +
+      "tions\032&.alluxio.grpc.meta.CheckpointPRes" +
+      "ponse2\365\003\n\036MetaMasterConfigurationService" +
+      "\022m\n\020GetConfiguration\022+.alluxio.grpc.meta" +
+      ".GetConfigurationPOptions\032,.alluxio.grpc" +
+      ".meta.GetConfigurationPResponse\022y\n\024SetPa" +
+      "thConfiguration\022/.alluxio.grpc.meta.SetP" +
+      "athConfigurationPRequest\0320.alluxio.grpc." +
+      "meta.SetPathConfigurationPResponse\022\202\001\n\027R" +
+      "emovePathConfiguration\0222.alluxio.grpc.me" +
+      "ta.RemovePathConfigurationPRequest\0323.all" +
+      "uxio.grpc.meta.RemovePathConfigurationPR" +
+      "esponse\022d\n\rGetConfigHash\022(.alluxio.grpc." +
+      "meta.GetConfigHashPOptions\032).alluxio.grp" +
+      "c.meta.GetConfigHashPResponse2\316\002\n\027MetaMa" +
+      "sterMasterService\022^\n\013GetMasterId\022&.allux" +
+      "io.grpc.meta.GetMasterIdPRequest\032\'.allux" +
+      "io.grpc.meta.GetMasterIdPResponse\022g\n\016Reg" +
+      "isterMaster\022).alluxio.grpc.meta.Register" +
+      "MasterPRequest\032*.alluxio.grpc.meta.Regis" +
+      "terMasterPResponse\022j\n\017MasterHeartbeat\022*." +
+      "alluxio.grpc.meta.MasterHeartbeatPReques" +
+      "t\032+.alluxio.grpc.meta.MasterHeartbeatPRe" +
+      "sponseB!\n\014alluxio.grpcB\017MetaMasterProtoP" +
+      "\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -483,7 +486,7 @@ public final class MetaMasterProto {
     internal_static_alluxio_grpc_meta_BackupPOptions_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_alluxio_grpc_meta_BackupPOptions_descriptor,
-        new java.lang.String[] { "LocalFileSystem", "RunAsync", "AllowLeader", });
+        new java.lang.String[] { "LocalFileSystem", "RunAsync", "AllowLeader", "StateLockTryDurationMs", "StateLockSleepDurationMs", "StateLockTimeoutMs", });
     internal_static_alluxio_grpc_meta_BackupPStatus_descriptor =
       getDescriptor().getMessageTypes().get(16);
     internal_static_alluxio_grpc_meta_BackupPStatus_fieldAccessorTable = new

--- a/core/transport/src/main/java/alluxio/proto/client/Cache.java
+++ b/core/transport/src/main/java/alluxio/proto/client/Cache.java
@@ -20,32 +20,39 @@ public final class Cache {
 
     /**
      * <code>optional int64 pageSize = 1;</code>
+     * @return Whether the pageSize field is set.
      */
     boolean hasPageSize();
     /**
      * <code>optional int64 pageSize = 1;</code>
+     * @return The pageSize.
      */
     long getPageSize();
 
     /**
      * <code>optional int64 cacheSize = 2;</code>
+     * @return Whether the cacheSize field is set.
      */
     boolean hasCacheSize();
     /**
      * <code>optional int64 cacheSize = 2;</code>
+     * @return The cacheSize.
      */
     long getCacheSize();
 
     /**
      * <code>optional string alluxioVersion = 3;</code>
+     * @return Whether the alluxioVersion field is set.
      */
     boolean hasAlluxioVersion();
     /**
      * <code>optional string alluxioVersion = 3;</code>
+     * @return The alluxioVersion.
      */
     java.lang.String getAlluxioVersion();
     /**
      * <code>optional string alluxioVersion = 3;</code>
+     * @return The bytes for alluxioVersion.
      */
     com.google.protobuf.ByteString
         getAlluxioVersionBytes();
@@ -63,9 +70,14 @@ public final class Cache {
       super(builder);
     }
     private PPageStoreCommonOptions() {
-      pageSize_ = 0L;
-      cacheSize_ = 0L;
       alluxioVersion_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new PPageStoreCommonOptions();
     }
 
     @java.lang.Override
@@ -92,13 +104,6 @@ public final class Cache {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 8: {
               bitField0_ |= 0x00000001;
               pageSize_ = input.readInt64();
@@ -113,6 +118,13 @@ public final class Cache {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000004;
               alluxioVersion_ = bs;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
               break;
             }
           }
@@ -132,6 +144,7 @@ public final class Cache {
       return alluxio.proto.client.Cache.internal_static_alluxio_proto_client_PPageStoreCommonOptions_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return alluxio.proto.client.Cache.internal_static_alluxio_proto_client_PPageStoreCommonOptions_fieldAccessorTable
@@ -144,12 +157,14 @@ public final class Cache {
     private long pageSize_;
     /**
      * <code>optional int64 pageSize = 1;</code>
+     * @return Whether the pageSize field is set.
      */
     public boolean hasPageSize() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>optional int64 pageSize = 1;</code>
+     * @return The pageSize.
      */
     public long getPageSize() {
       return pageSize_;
@@ -159,12 +174,14 @@ public final class Cache {
     private long cacheSize_;
     /**
      * <code>optional int64 cacheSize = 2;</code>
+     * @return Whether the cacheSize field is set.
      */
     public boolean hasCacheSize() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>optional int64 cacheSize = 2;</code>
+     * @return The cacheSize.
      */
     public long getCacheSize() {
       return cacheSize_;
@@ -174,12 +191,14 @@ public final class Cache {
     private volatile java.lang.Object alluxioVersion_;
     /**
      * <code>optional string alluxioVersion = 3;</code>
+     * @return Whether the alluxioVersion field is set.
      */
     public boolean hasAlluxioVersion() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>optional string alluxioVersion = 3;</code>
+     * @return The alluxioVersion.
      */
     public java.lang.String getAlluxioVersion() {
       java.lang.Object ref = alluxioVersion_;
@@ -197,6 +216,7 @@ public final class Cache {
     }
     /**
      * <code>optional string alluxioVersion = 3;</code>
+     * @return The bytes for alluxioVersion.
      */
     public com.google.protobuf.ByteString
         getAlluxioVersionBytes() {
@@ -213,6 +233,7 @@ public final class Cache {
     }
 
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -222,34 +243,36 @@ public final class Cache {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeInt64(1, pageSize_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeInt64(2, cacheSize_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, alluxioVersion_);
       }
       unknownFields.writeTo(output);
     }
 
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(1, pageSize_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(2, cacheSize_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, alluxioVersion_);
       }
       size += unknownFields.getSerializedSize();
@@ -267,24 +290,23 @@ public final class Cache {
       }
       alluxio.proto.client.Cache.PPageStoreCommonOptions other = (alluxio.proto.client.Cache.PPageStoreCommonOptions) obj;
 
-      boolean result = true;
-      result = result && (hasPageSize() == other.hasPageSize());
+      if (hasPageSize() != other.hasPageSize()) return false;
       if (hasPageSize()) {
-        result = result && (getPageSize()
-            == other.getPageSize());
+        if (getPageSize()
+            != other.getPageSize()) return false;
       }
-      result = result && (hasCacheSize() == other.hasCacheSize());
+      if (hasCacheSize() != other.hasCacheSize()) return false;
       if (hasCacheSize()) {
-        result = result && (getCacheSize()
-            == other.getCacheSize());
+        if (getCacheSize()
+            != other.getCacheSize()) return false;
       }
-      result = result && (hasAlluxioVersion() == other.hasAlluxioVersion());
+      if (hasAlluxioVersion() != other.hasAlluxioVersion()) return false;
       if (hasAlluxioVersion()) {
-        result = result && getAlluxioVersion()
-            .equals(other.getAlluxioVersion());
+        if (!getAlluxioVersion()
+            .equals(other.getAlluxioVersion())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -383,6 +405,7 @@ public final class Cache {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -390,6 +413,7 @@ public final class Cache {
     public static Builder newBuilder(alluxio.proto.client.Cache.PPageStoreCommonOptions prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -413,6 +437,7 @@ public final class Cache {
         return alluxio.proto.client.Cache.internal_static_alluxio_proto_client_PPageStoreCommonOptions_descriptor;
       }
 
+      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return alluxio.proto.client.Cache.internal_static_alluxio_proto_client_PPageStoreCommonOptions_fieldAccessorTable
@@ -435,6 +460,7 @@ public final class Cache {
                 .alwaysUseFieldBuilders) {
         }
       }
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         pageSize_ = 0L;
@@ -446,15 +472,18 @@ public final class Cache {
         return this;
       }
 
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return alluxio.proto.client.Cache.internal_static_alluxio_proto_client_PPageStoreCommonOptions_descriptor;
       }
 
+      @java.lang.Override
       public alluxio.proto.client.Cache.PPageStoreCommonOptions getDefaultInstanceForType() {
         return alluxio.proto.client.Cache.PPageStoreCommonOptions.getDefaultInstance();
       }
 
+      @java.lang.Override
       public alluxio.proto.client.Cache.PPageStoreCommonOptions build() {
         alluxio.proto.client.Cache.PPageStoreCommonOptions result = buildPartial();
         if (!result.isInitialized()) {
@@ -463,19 +492,20 @@ public final class Cache {
         return result;
       }
 
+      @java.lang.Override
       public alluxio.proto.client.Cache.PPageStoreCommonOptions buildPartial() {
         alluxio.proto.client.Cache.PPageStoreCommonOptions result = new alluxio.proto.client.Cache.PPageStoreCommonOptions(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.pageSize_ = pageSize_;
           to_bitField0_ |= 0x00000001;
         }
-        result.pageSize_ = pageSize_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.cacheSize_ = cacheSize_;
           to_bitField0_ |= 0x00000002;
         }
-        result.cacheSize_ = cacheSize_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.alluxioVersion_ = alluxioVersion_;
@@ -484,32 +514,39 @@ public final class Cache {
         return result;
       }
 
+      @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof alluxio.proto.client.Cache.PPageStoreCommonOptions) {
           return mergeFrom((alluxio.proto.client.Cache.PPageStoreCommonOptions)other);
@@ -537,10 +574,12 @@ public final class Cache {
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -563,18 +602,22 @@ public final class Cache {
       private long pageSize_ ;
       /**
        * <code>optional int64 pageSize = 1;</code>
+       * @return Whether the pageSize field is set.
        */
       public boolean hasPageSize() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>optional int64 pageSize = 1;</code>
+       * @return The pageSize.
        */
       public long getPageSize() {
         return pageSize_;
       }
       /**
        * <code>optional int64 pageSize = 1;</code>
+       * @param value The pageSize to set.
+       * @return This builder for chaining.
        */
       public Builder setPageSize(long value) {
         bitField0_ |= 0x00000001;
@@ -584,6 +627,7 @@ public final class Cache {
       }
       /**
        * <code>optional int64 pageSize = 1;</code>
+       * @return This builder for chaining.
        */
       public Builder clearPageSize() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -595,18 +639,22 @@ public final class Cache {
       private long cacheSize_ ;
       /**
        * <code>optional int64 cacheSize = 2;</code>
+       * @return Whether the cacheSize field is set.
        */
       public boolean hasCacheSize() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>optional int64 cacheSize = 2;</code>
+       * @return The cacheSize.
        */
       public long getCacheSize() {
         return cacheSize_;
       }
       /**
        * <code>optional int64 cacheSize = 2;</code>
+       * @param value The cacheSize to set.
+       * @return This builder for chaining.
        */
       public Builder setCacheSize(long value) {
         bitField0_ |= 0x00000002;
@@ -616,6 +664,7 @@ public final class Cache {
       }
       /**
        * <code>optional int64 cacheSize = 2;</code>
+       * @return This builder for chaining.
        */
       public Builder clearCacheSize() {
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -627,12 +676,14 @@ public final class Cache {
       private java.lang.Object alluxioVersion_ = "";
       /**
        * <code>optional string alluxioVersion = 3;</code>
+       * @return Whether the alluxioVersion field is set.
        */
       public boolean hasAlluxioVersion() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>optional string alluxioVersion = 3;</code>
+       * @return The alluxioVersion.
        */
       public java.lang.String getAlluxioVersion() {
         java.lang.Object ref = alluxioVersion_;
@@ -650,6 +701,7 @@ public final class Cache {
       }
       /**
        * <code>optional string alluxioVersion = 3;</code>
+       * @return The bytes for alluxioVersion.
        */
       public com.google.protobuf.ByteString
           getAlluxioVersionBytes() {
@@ -666,6 +718,8 @@ public final class Cache {
       }
       /**
        * <code>optional string alluxioVersion = 3;</code>
+       * @param value The alluxioVersion to set.
+       * @return This builder for chaining.
        */
       public Builder setAlluxioVersion(
           java.lang.String value) {
@@ -679,6 +733,7 @@ public final class Cache {
       }
       /**
        * <code>optional string alluxioVersion = 3;</code>
+       * @return This builder for chaining.
        */
       public Builder clearAlluxioVersion() {
         bitField0_ = (bitField0_ & ~0x00000004);
@@ -688,6 +743,8 @@ public final class Cache {
       }
       /**
        * <code>optional string alluxioVersion = 3;</code>
+       * @param value The bytes for alluxioVersion to set.
+       * @return This builder for chaining.
        */
       public Builder setAlluxioVersionBytes(
           com.google.protobuf.ByteString value) {
@@ -699,11 +756,13 @@ public final class Cache {
         onChanged();
         return this;
       }
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -725,6 +784,7 @@ public final class Cache {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<PPageStoreCommonOptions>
         PARSER = new com.google.protobuf.AbstractParser<PPageStoreCommonOptions>() {
+      @java.lang.Override
       public PPageStoreCommonOptions parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -742,6 +802,7 @@ public final class Cache {
       return PARSER;
     }
 
+    @java.lang.Override
     public alluxio.proto.client.Cache.PPageStoreCommonOptions getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -754,10 +815,12 @@ public final class Cache {
 
     /**
      * <code>optional .alluxio.proto.client.PPageStoreCommonOptions commonOptions = 1;</code>
+     * @return Whether the commonOptions field is set.
      */
     boolean hasCommonOptions();
     /**
      * <code>optional .alluxio.proto.client.PPageStoreCommonOptions commonOptions = 1;</code>
+     * @return The commonOptions.
      */
     alluxio.proto.client.Cache.PPageStoreCommonOptions getCommonOptions();
     /**
@@ -778,6 +841,13 @@ public final class Cache {
       super(builder);
     }
     private PRocksPageStoreOptions() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new PRocksPageStoreOptions();
     }
 
     @java.lang.Override
@@ -804,16 +874,9 @@ public final class Cache {
             case 0:
               done = true;
               break;
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
             case 10: {
               alluxio.proto.client.Cache.PPageStoreCommonOptions.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = commonOptions_.toBuilder();
               }
               commonOptions_ = input.readMessage(alluxio.proto.client.Cache.PPageStoreCommonOptions.PARSER, extensionRegistry);
@@ -822,6 +885,13 @@ public final class Cache {
                 commonOptions_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000001;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
               break;
             }
           }
@@ -841,6 +911,7 @@ public final class Cache {
       return alluxio.proto.client.Cache.internal_static_alluxio_proto_client_PRocksPageStoreOptions_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return alluxio.proto.client.Cache.internal_static_alluxio_proto_client_PRocksPageStoreOptions_fieldAccessorTable
@@ -853,12 +924,14 @@ public final class Cache {
     private alluxio.proto.client.Cache.PPageStoreCommonOptions commonOptions_;
     /**
      * <code>optional .alluxio.proto.client.PPageStoreCommonOptions commonOptions = 1;</code>
+     * @return Whether the commonOptions field is set.
      */
     public boolean hasCommonOptions() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>optional .alluxio.proto.client.PPageStoreCommonOptions commonOptions = 1;</code>
+     * @return The commonOptions.
      */
     public alluxio.proto.client.Cache.PPageStoreCommonOptions getCommonOptions() {
       return commonOptions_ == null ? alluxio.proto.client.Cache.PPageStoreCommonOptions.getDefaultInstance() : commonOptions_;
@@ -871,6 +944,7 @@ public final class Cache {
     }
 
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -880,20 +954,22 @@ public final class Cache {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getCommonOptions());
       }
       unknownFields.writeTo(output);
     }
 
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getCommonOptions());
       }
@@ -912,14 +988,13 @@ public final class Cache {
       }
       alluxio.proto.client.Cache.PRocksPageStoreOptions other = (alluxio.proto.client.Cache.PRocksPageStoreOptions) obj;
 
-      boolean result = true;
-      result = result && (hasCommonOptions() == other.hasCommonOptions());
+      if (hasCommonOptions() != other.hasCommonOptions()) return false;
       if (hasCommonOptions()) {
-        result = result && getCommonOptions()
-            .equals(other.getCommonOptions());
+        if (!getCommonOptions()
+            .equals(other.getCommonOptions())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -1008,6 +1083,7 @@ public final class Cache {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -1015,6 +1091,7 @@ public final class Cache {
     public static Builder newBuilder(alluxio.proto.client.Cache.PRocksPageStoreOptions prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -1038,6 +1115,7 @@ public final class Cache {
         return alluxio.proto.client.Cache.internal_static_alluxio_proto_client_PRocksPageStoreOptions_descriptor;
       }
 
+      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return alluxio.proto.client.Cache.internal_static_alluxio_proto_client_PRocksPageStoreOptions_fieldAccessorTable
@@ -1061,6 +1139,7 @@ public final class Cache {
           getCommonOptionsFieldBuilder();
         }
       }
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (commonOptionsBuilder_ == null) {
@@ -1072,15 +1151,18 @@ public final class Cache {
         return this;
       }
 
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return alluxio.proto.client.Cache.internal_static_alluxio_proto_client_PRocksPageStoreOptions_descriptor;
       }
 
+      @java.lang.Override
       public alluxio.proto.client.Cache.PRocksPageStoreOptions getDefaultInstanceForType() {
         return alluxio.proto.client.Cache.PRocksPageStoreOptions.getDefaultInstance();
       }
 
+      @java.lang.Override
       public alluxio.proto.client.Cache.PRocksPageStoreOptions build() {
         alluxio.proto.client.Cache.PRocksPageStoreOptions result = buildPartial();
         if (!result.isInitialized()) {
@@ -1089,49 +1171,57 @@ public final class Cache {
         return result;
       }
 
+      @java.lang.Override
       public alluxio.proto.client.Cache.PRocksPageStoreOptions buildPartial() {
         alluxio.proto.client.Cache.PRocksPageStoreOptions result = new alluxio.proto.client.Cache.PRocksPageStoreOptions(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (commonOptionsBuilder_ == null) {
+            result.commonOptions_ = commonOptions_;
+          } else {
+            result.commonOptions_ = commonOptionsBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
-        }
-        if (commonOptionsBuilder_ == null) {
-          result.commonOptions_ = commonOptions_;
-        } else {
-          result.commonOptions_ = commonOptionsBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
 
+      @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof alluxio.proto.client.Cache.PRocksPageStoreOptions) {
           return mergeFrom((alluxio.proto.client.Cache.PRocksPageStoreOptions)other);
@@ -1151,10 +1241,12 @@ public final class Cache {
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1174,17 +1266,19 @@ public final class Cache {
       }
       private int bitField0_;
 
-      private alluxio.proto.client.Cache.PPageStoreCommonOptions commonOptions_ = null;
+      private alluxio.proto.client.Cache.PPageStoreCommonOptions commonOptions_;
       private com.google.protobuf.SingleFieldBuilderV3<
           alluxio.proto.client.Cache.PPageStoreCommonOptions, alluxio.proto.client.Cache.PPageStoreCommonOptions.Builder, alluxio.proto.client.Cache.PPageStoreCommonOptionsOrBuilder> commonOptionsBuilder_;
       /**
        * <code>optional .alluxio.proto.client.PPageStoreCommonOptions commonOptions = 1;</code>
+       * @return Whether the commonOptions field is set.
        */
       public boolean hasCommonOptions() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>optional .alluxio.proto.client.PPageStoreCommonOptions commonOptions = 1;</code>
+       * @return The commonOptions.
        */
       public alluxio.proto.client.Cache.PPageStoreCommonOptions getCommonOptions() {
         if (commonOptionsBuilder_ == null) {
@@ -1228,7 +1322,7 @@ public final class Cache {
        */
       public Builder mergeCommonOptions(alluxio.proto.client.Cache.PPageStoreCommonOptions value) {
         if (commonOptionsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               commonOptions_ != null &&
               commonOptions_ != alluxio.proto.client.Cache.PPageStoreCommonOptions.getDefaultInstance()) {
             commonOptions_ =
@@ -1291,11 +1385,13 @@ public final class Cache {
         }
         return commonOptionsBuilder_;
       }
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -1317,6 +1413,7 @@ public final class Cache {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<PRocksPageStoreOptions>
         PARSER = new com.google.protobuf.AbstractParser<PRocksPageStoreOptions>() {
+      @java.lang.Override
       public PRocksPageStoreOptions parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1334,6 +1431,7 @@ public final class Cache {
       return PARSER;
     }
 
+    @java.lang.Override
     public alluxio.proto.client.Cache.PRocksPageStoreOptions getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -1366,18 +1464,10 @@ public final class Cache {
       "ns\022D\n\rcommonOptions\030\001 \001(\0132-.alluxio.prot" +
       "o.client.PPageStoreCommonOptions"
     };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
+    descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
-        }, assigner);
+        });
     internal_static_alluxio_proto_client_PPageStoreCommonOptions_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_alluxio_proto_client_PPageStoreCommonOptions_fieldAccessorTable = new


### PR DESCRIPTION
This is to eliminate the impact of backups when the leader has hung
RPCs.
Backup not backing off from an exclusive lock acquisition was causing a
pile of shared acquisition attempts.

pr-link: Alluxio/alluxio#11478
change-id: cid-780e620bf903dcb69a3e375c6bbd937b6dfb43db