### PR TITLE
Remove jetty all dependencies from hive metastore jar

### DIFF
--- a/integration/tools/pom.xml
+++ b/integration/tools/pom.xml
@@ -40,6 +40,10 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
+          <groupId>org.eclipse.jetty.aggregate</groupId>
+          <artifactId>jetty-all</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-1.2-api</artifactId>
         </exclusion>


### PR DESCRIPTION
Jetty all dependency is conflicted with the server jetty util dependency which causes the master web UI to fail to start.  
Error: Exception "java.lang.NoSuchMethodError: org.eclipse.jetty.server.Server.<init>(Lorg/eclipse/jetty/util/thread/ThreadPool;)V", Root Cause "null"
java.lang.NoSuchMethodError: org.eclipse.jetty.server.Server.<init>(Lorg/eclipse/jetty/util/thread/ThreadPool;