### PR TITLE
Fix NPE associated with s3 account owner

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -841,7 +841,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "static mapping, in the format \"id1=user1;id2=user2\". The AWS S3 canonical "
               + "ID can be found at the console address "
               + "https://console.aws.amazon.com/iam/home?#security_credential . Please expand "
-              + "the \"Account Identifiers\" tab and refer to \"Canonical User ID\".")
+              + "the \"Account Identifiers\" tab and refer to \"Canonical User ID\". "
+              + "Unspecified owner id will map to a default empty username")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -62,6 +62,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -454,6 +455,7 @@ public final class CommonUtils {
    * @param key the key to query
    * @return the mapped value if the key exists, otherwise returns null
    */
+  @Nullable
   public static String getValueFromStaticMapping(String mapping, String key) {
     Map<String, String> m = Splitter.on(";")
         .omitEmptyStrings()

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -452,7 +452,7 @@ public final class CommonUtils {
    *
    * @param mapping the "key=value" mapping in string format separated by ";"
    * @param key the key to query
-   * @return the mapped value if the key exists, otherwise returns ""
+   * @return the mapped value if the key exists, otherwise returns null
    */
   public static String getValueFromStaticMapping(String mapping, String key) {
     Map<String, String> m = Splitter.on(";")

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -554,9 +554,11 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
 
         bucketMode = S3AUtils.translateBucketAcl(acl, owner.getId());
         if (mUfsConf.isSet(PropertyKey.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING)) {
+          // Here accountOwner can be null if there is no mapping set for this owner id
           accountOwner = CommonUtils.getValueFromStaticMapping(
               mUfsConf.get(PropertyKey.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING), owner.getId());
-        } else {
+        }
+        if (accountOwner == null || accountOwner.equals(DEFAULT_OWNER)) {
           // If there is no user-defined mapping, use display name or id.
           accountOwner = owner.getDisplayName() != null ? owner.getDisplayName() : owner.getId();
         }


### PR DESCRIPTION
Fixes mount failure and NPE when a user tries to mount S3 bucket with a userid to username mapping configured. 
This addresses the NPE in #11509. 