### PR TITLE
Add alias option for tieredstore levels

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -103,6 +103,9 @@
   {{- $workerJavaOpts = printf "-Dalluxio.worker.tieredstore.levels=%v" (len .Values.tieredstore.levels) | append $workerJavaOpts }}
   {{- range .Values.tieredstore.levels }}
     {{- $tierName := printf "-Dalluxio.worker.tieredstore.level%v" .level }}
+    {{- if .alias }}
+    {{- $workerJavaOpts = printf "%v.alias=%v" $tierName .alias | append $workerJavaOpts }}
+    {{- end}}
     {{- $workerJavaOpts = printf "%v.dirs.mediumtype=%v" $tierName .mediumtype | append $workerJavaOpts }}
     {{- if .path }}
       {{- $workerJavaOpts = printf "%v.dirs.path=%v" $tierName .path | append $workerJavaOpts }}

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -180,6 +180,7 @@ jobWorker:
 # Tiered Storage
 # emptyDir example
 #  - level: 0
+#    alias: MEM
 #    mediumtype: MEM
 #    path: /dev/shm
 #    type: emptyDir
@@ -187,6 +188,7 @@ jobWorker:
 #
 # hostPath example
 #  - level: 0
+#    alias: MEM
 #    mediumtype: MEM
 #    path: /dev/shm
 #    type: hostPath
@@ -194,6 +196,7 @@ jobWorker:
 #
 # persistentVolumeClaim example
 #  - level: 1
+#    alias: SSD
 #    mediumtype: SSD
 #    type: persistentVolumeClaim
 #    name: alluxio-ssd
@@ -202,6 +205,7 @@ jobWorker:
 #
 # multi-part mediumtype example
 #  - level: 1
+#    alias: SSD,HDD
 #    mediumtype: SSD,HDD
 #    type: persistentVolumeClaim
 #    name: alluxio-ssd,alluxio-hdd
@@ -210,6 +214,7 @@ jobWorker:
 tieredstore:
   levels:
   - level: 0
+    alias: MEM
     mediumtype: MEM
     path: /dev/shm
     type: emptyDir


### PR DESCRIPTION
Alluxio worker container generated exception when it wont find alias option in configuration. Currently null value is passed to alluxio worker container and it generated exception. I have added the alias value for levels in tieredstore.