### PR TITLE
Limit printing too many blocks for MasterWorkerInfo toString()

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
+++ b/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -375,9 +376,13 @@ public final class MasterWorkerInfo {
 
   @Override
   public String toString() {
+    int blockSizeLimit = 100;
     return MoreObjects.toStringHelper(this).add("id", mId).add("workerAddress", mWorkerAddress)
         .add("capacityBytes", mCapacityBytes).add("usedBytes", mUsedBytes)
-        .add("lastUpdatedTimeMs", mLastUpdatedTimeMs).add("blocks", mBlocks)
+        .add("lastUpdatedTimeMs", mLastUpdatedTimeMs)
+        .add("blocks",
+              (mBlocks.size() < blockSizeLimit) ? mBlocks :
+                mBlocks.stream().limit(blockSizeLimit).collect(Collectors.toList()))
         .add("lostStorage", mLostStorage).toString();
   }
 

--- a/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
+++ b/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
@@ -380,6 +380,7 @@ public final class MasterWorkerInfo {
     return MoreObjects.toStringHelper(this).add("id", mId).add("workerAddress", mWorkerAddress)
         .add("capacityBytes", mCapacityBytes).add("usedBytes", mUsedBytes)
         .add("lastUpdatedTimeMs", mLastUpdatedTimeMs)
+        .add("blockCount", mBlocks.size())
         .add("blocks",
               (mBlocks.size() < blockSizeLimit) ? mBlocks :
                 mBlocks.stream().limit(blockSizeLimit).collect(Collectors.toList()))

--- a/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
+++ b/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -377,13 +378,17 @@ public final class MasterWorkerInfo {
   @Override
   public String toString() {
     int blockSizeLimit = 100;
+    Collection<Long> blocks = mBlocks;
+    // We truncate the list of block IDs to print, unless it is for DEBUG logs
+    if (!LOG.isDebugEnabled()) {
+      blocks = (mBlocks.size() < blockSizeLimit) ? mBlocks :
+              mBlocks.stream().limit(blockSizeLimit).collect(Collectors.toList());
+    }
     return MoreObjects.toStringHelper(this).add("id", mId).add("workerAddress", mWorkerAddress)
         .add("capacityBytes", mCapacityBytes).add("usedBytes", mUsedBytes)
         .add("lastUpdatedTimeMs", mLastUpdatedTimeMs)
         .add("blockCount", mBlocks.size())
-        .add("blocks",
-              (mBlocks.size() < blockSizeLimit) ? mBlocks :
-                mBlocks.stream().limit(blockSizeLimit).collect(Collectors.toList()))
+        .add("blocks", blocks)
         .add("lostStorage", mLostStorage).toString();
   }
 


### PR DESCRIPTION
This makes `MasterWorkerInfo` only prints no more than 99 blocks instead of the whole list. The whole list can be incredibly long like thousands of blocks.