### PR TITLE
Change hms validation tool to use extension class loader

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -314,7 +314,6 @@ function main {
   "runHmsTests")
     CLASS="alluxio.cli.HmsTests"
     CLASSPATH=${ALLUXIO_CLIENT_CLASSPATH}
-    ALLUXIO_SHELL_JAVA_OPTS+=" -Dalluxio.logger.type=Console"
     runJavaClass "$@"
   ;;
   "runJournalCrashTest")

--- a/core/common/src/main/java/alluxio/cli/ValidationTool.java
+++ b/core/common/src/main/java/alluxio/cli/ValidationTool.java
@@ -1,0 +1,25 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.cli;
+
+/**
+ * The validation tool interface.
+ */
+public interface ValidationTool {
+
+  /**
+   * Runs validation tests.
+   *
+   * @return a json string of the test results
+   */
+  String runTests();
+}

--- a/core/common/src/main/java/alluxio/cli/ValidationToolFactory.java
+++ b/core/common/src/main/java/alluxio/cli/ValidationToolFactory.java
@@ -1,0 +1,30 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.cli;
+
+/**
+ * The validation tool factory interface.
+ */
+public interface ValidationToolFactory {
+
+  /**
+   * Creates a new instance of an {@link ValidationTool}.
+   * Creation must not interact with external services.
+   *
+   * @param metastoreUri hive metastore uris
+   * @param database database to run tests against
+   * @param tables tables to run tests against
+   * @param socketTimeout socket time of hms operations
+   * @return a new validation tool instance
+   */
+  ValidationTool create(String metastoreUri, String database, String tables, int socketTimeout);
+}

--- a/core/common/src/main/java/alluxio/cli/ValidationToolFactory.java
+++ b/core/common/src/main/java/alluxio/cli/ValidationToolFactory.java
@@ -17,7 +17,7 @@ package alluxio.cli;
 public interface ValidationToolFactory {
 
   /**
-   * Creates a new instance of an {@link ValidationTool}.
+   * Creates a new instance of {@link ValidationTool}.
    * Creation must not interact with external services.
    *
    * @param metastoreUri hive metastore uris

--- a/core/common/src/main/java/alluxio/cli/ValidationToolRegistry.java
+++ b/core/common/src/main/java/alluxio/cli/ValidationToolRegistry.java
@@ -102,7 +102,7 @@ public class ValidationToolRegistry {
   }
 
   /**
-   * Creates a new instance of an {@link ValidationTool}.
+   * Creates a new instance of {@link ValidationTool}.
    *
    * @param metastoreUri hive metastore uris
    * @param database database to run tests against

--- a/core/common/src/main/java/alluxio/cli/ValidationToolRegistry.java
+++ b/core/common/src/main/java/alluxio/cli/ValidationToolRegistry.java
@@ -1,0 +1,133 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.cli;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.extensions.ExtensionsClassLoader;
+import alluxio.util.io.PathUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+/**
+ * The registry of validation tool implementations.
+ */
+public class ValidationToolRegistry {
+  private static final Logger LOG = LoggerFactory.getLogger(ValidationToolRegistry.class);
+  private static final String HMS_TOOL_PATTERN = "alluxio-integration-tools-hms-*.jar";
+
+  private AlluxioConfiguration mConf;
+  private ValidationToolFactory mFactory = null;
+
+  /**
+   * Creates a new instance of an {@link ValidationToolRegistry}.
+   *
+   * @param conf the Alluxio configuration
+   */
+  public ValidationToolRegistry(AlluxioConfiguration conf) {
+    mConf = conf;
+  }
+
+  /**
+   * Refreshes the registry by service loading classes.
+   */
+  public void refresh() {
+    String libDir = PathUtils.concatPath(mConf.get(PropertyKey.HOME), "lib");
+    LOG.info("Loading hive metastore validation tool jar from {}", libDir);
+    List<File> files = new ArrayList<>();
+    try (DirectoryStream<Path> stream = Files
+        .newDirectoryStream(Paths.get(libDir), HMS_TOOL_PATTERN)) {
+      for (Path entry : stream) {
+        LOG.info(entry.getFileName().toString());
+        if (entry.toFile().isFile()) {
+          files.add(entry.toFile());
+        }
+      }
+    } catch (IOException e) {
+      LOG.warn("Failed to load hive metastore validation tool lib from {}. error: {}",
+          libDir, e.toString());
+    }
+
+    // Load the validation tool factory from libraries
+    for (File jar : files) {
+      try {
+        URL extensionURL = jar.toURI().toURL();
+        ClassLoader extensionsClassLoader = new ExtensionsClassLoader(new URL[] {extensionURL},
+            ClassLoader.getSystemClassLoader());
+        for (ValidationToolFactory factory : ServiceLoader
+            .load(ValidationToolFactory.class, extensionsClassLoader)) {
+          if (mFactory != null) {
+            LOG.warn(
+                "Ignoring duplicate hms validation tool factory found in {}. Existing factory: {}",
+                factory.getClass(), mFactory.getClass());
+          }
+          mFactory = factory;
+        }
+      } catch (Throwable t) {
+        LOG.warn("Failed to load hms validation tool jar {}", jar, t);
+      }
+    }
+
+    // Load the hive metastore validation tool from the default classloader
+    for (ValidationToolFactory factory : ServiceLoader
+        .load(ValidationToolFactory.class, ValidationToolRegistry.class.getClassLoader())) {
+      if (mFactory != null) {
+        LOG.warn("Ignoring duplicate hms validation tool factory found in {}. Existing factory: {}",
+            factory.getClass(), mFactory.getClass());
+      }
+      mFactory = factory;
+    }
+
+    LOG.info("Registered hms validation tool factory: " + mFactory);
+  }
+
+  /**
+   * Creates a new instance of an {@link ValidationTool}.
+   *
+   * @param metastoreUri hive metastore uris
+   * @param database database to run tests against
+   * @param tables tables to run tests against
+   * @param socketTimeout socket time of hms operations
+   * @return a new validation tool instance
+   */
+  public ValidationTool create(String metastoreUri, String database, String tables,
+      int socketTimeout) {
+    if (mFactory == null) {
+      throw new IllegalArgumentException("HmsValidationToolFactory does not exist.");
+    }
+
+    ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      // Use the extension class loader of the factory.
+      Thread.currentThread().setContextClassLoader(mFactory.getClass().getClassLoader());
+      return mFactory.create(metastoreUri, database, tables, socketTimeout);
+    } catch (Throwable e) {
+      // Catching Throwable rather than Exception to catch service loading errors
+      throw new IllegalStateException(
+          String.format("Failed to create HmsValidationTool by factory %s", mFactory), e);
+    } finally {
+      Thread.currentThread().setContextClassLoader(previousClassLoader);
+    }
+  }
+}

--- a/core/common/src/main/java/alluxio/cli/ValidationToolRegistry.java
+++ b/core/common/src/main/java/alluxio/cli/ValidationToolRegistry.java
@@ -59,7 +59,6 @@ public class ValidationToolRegistry {
     try (DirectoryStream<Path> stream = Files
         .newDirectoryStream(Paths.get(libDir), HMS_TOOL_PATTERN)) {
       for (Path entry : stream) {
-        LOG.info(entry.getFileName().toString());
         if (entry.toFile().isFile()) {
           files.add(entry.toFile());
         }

--- a/core/common/src/main/java/alluxio/cli/ValidationUtils.java
+++ b/core/common/src/main/java/alluxio/cli/ValidationUtils.java
@@ -11,18 +11,14 @@
 
 package alluxio.cli;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.Serializable;
 
 /**
  * Utilities to run the validation tests.
  */
-public final class ValidateUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(ValidateUtils.class);
+public final class ValidationUtils {
 
-  private ValidateUtils() {} // prevent instantiation
+  private ValidationUtils() {} // prevent instantiation
 
   /**
    * Task State.
@@ -54,7 +50,7 @@ public final class ValidateUtils {
      * @param output task output
      * @param advice task advice
      */
-    TaskResult(State state, String name, String output, String advice) {
+    public TaskResult(State state, String name, String output, String advice) {
       mState = state;
       mName = name;
       mOutput = output;
@@ -64,7 +60,7 @@ public final class ValidateUtils {
     /**
      * Creates a new {@link TaskResult}.
      */
-    TaskResult() {}
+    public TaskResult() {}
 
     /**
      * Sets task state.

--- a/core/server/master/pom.xml
+++ b/core/server/master/pom.xml
@@ -105,11 +105,6 @@
       <artifactId>alluxio-job-client</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-integration-tools</artifactId>
-      <version>${project.version}</version>
-    </dependency>
 
     <!-- External test dependencies -->
     <dependency>

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -212,6 +212,7 @@ public final class AlluxioMasterRestServiceHandler {
   public Response getWebUIInit() {
     return RestUtils.call(() -> {
       MasterWebUIInit response = new MasterWebUIInit();
+
       String proxyHostname = NetworkAddressUtils
           .getConnectHost(NetworkAddressUtils.ServiceType.PROXY_WEB, ServerConfiguration.global());
       int proxyPort = ServerConfiguration.getInt(PropertyKey.PROXY_WEB_PORT);

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -212,7 +212,6 @@ public final class AlluxioMasterRestServiceHandler {
   public Response getWebUIInit() {
     return RestUtils.call(() -> {
       MasterWebUIInit response = new MasterWebUIInit();
-
       String proxyHostname = NetworkAddressUtils
           .getConnectHost(NetworkAddressUtils.ServiceType.PROXY_WEB, ServerConfiguration.global());
       int proxyPort = ServerConfiguration.getInt(PropertyKey.PROXY_WEB_PORT);

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -213,6 +213,7 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 		fmt.Sprintf("lib/alluxio-underfs-web-%v.jar", version),
 		fmt.Sprintf("lib/alluxio-table-server-underdb-glue-%v.jar", version),
 		fmt.Sprintf("lib/alluxio-table-server-underdb-hive-%v.jar", version),
+		fmt.Sprintf("lib/alluxio-integration-tools-hms-%v.jar", version),
 		"libexec/alluxio-config.sh",
 		"LICENSE",
 	}

--- a/integration/tools/hms/pom.xml
+++ b/integration/tools/hms/pom.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+    (the "License"). You may not use this work except in compliance with the License, which is
+    available at www.apache.org/licenses/LICENSE-2.0
+
+    This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or implied, as more fully set forth in the License.
+
+    See the NOTICE file distributed with this work for information regarding copyright ownership.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>alluxio-integration-tools</artifactId>
+    <groupId>org.alluxio</groupId>
+    <version>2.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>alluxio-integration-tools-hms</artifactId>
+  <packaging>jar</packaging>
+  <name>Alluxio Integration - Tools - HMS</name>
+  <description>Alluxio integration tools for hive metastore</description>
+
+
+  <properties>
+    <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
+    <!-- run properly from sub-project directories -->
+    <build.path>${project.parent.parent.parent.basedir}/build</build.path>
+    <lib.jar.name>${project.artifactId}-${project.version}.jar</lib.jar.name>
+    <failIfNoTests>false</failIfNoTests>
+    <hive-metastore.version>2.3.6</hive-metastore.version>
+  </properties>
+
+  <dependencies>
+    <!-- External dependencies -->
+    <dependency>
+      <groupId>com.beust</groupId>
+      <artifactId>jcommander</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-metastore</artifactId>
+      <version>${hive-metastore.version}</version>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-1.2-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-web</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty.aggregate</groupId>
+          <artifactId>jetty-all</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>shade</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>LICENSE</exclude>
+                    <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-and-rename-file</id>
+            <phase>install</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${basedir}/target/${project.artifactId}-${project.version}-jar-with-dependencies.jar</sourceFile>
+              <destinationFile>${project.parent.parent.parent.basedir}/lib/${lib.jar.name}</destinationFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${basedir}/../../../lib</directory>
+              <includes>
+                <include>**/${project.artifactId}-*.jar</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/integration/tools/hms/pom.xml
+++ b/integration/tools/hms/pom.xml
@@ -46,13 +46,19 @@
       <version>${hive-metastore.version}</version>
       <scope>compile</scope>
       <exclusions>
+        <!-- Remove dependencies Alluxio has already -->
         <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
+          <groupId>org.eclipse.jetty.aggregate</groupId>
+          <artifactId>jetty-all</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <!-- Remove logging dependencies -->
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
         </exclusion>
         <exclusion>
           <groupId>log4j</groupId>
@@ -73,10 +79,6 @@
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-web</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.eclipse.jetty.aggregate</groupId>
-          <artifactId>jetty-all</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationTool.java
+++ b/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationTool.java
@@ -11,8 +11,8 @@
 
 package alluxio.cli;
 
-import alluxio.cli.ValidateUtils.State;
-import alluxio.cli.ValidateUtils.TaskResult;
+import alluxio.cli.ValidationUtils.State;
+import alluxio.cli.ValidationUtils.TaskResult;
 import alluxio.util.CommonUtils;
 
 import com.google.gson.Gson;
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
 /**
  * Run tests against an existing hive metastore.
  */
-public class ValidateHms {
+public class HmsValidationTool implements ValidationTool {
   // The maximum number of table objects that this test will get.
   // Used to avoid issuing too many calls to the hive metastore
   // which may need a long time based on network conditions
@@ -64,14 +64,14 @@ public class ValidateHms {
   private Map<State, List<TaskResult>> mResults = new HashMap<>();
 
   /**
-   * Constructs a new {@link ValidateHms}.
+   * Constructs a new {@link HmsValidationTool}.
    *
    * @param metastoreUri hive metastore uris
    * @param database database to run tests against
    * @param tables tables to run tests against
    * @param socketTimeout socket time of hms operations
    */
-  public ValidateHms(String metastoreUri, String database, String tables,
+  private HmsValidationTool(String metastoreUri, String database, String tables,
       int socketTimeout) {
     mMetastoreUri = metastoreUri;
     mDatabase = database == null || database.isEmpty() ? DEFAULT_DATABASE : database;
@@ -80,16 +80,24 @@ public class ValidateHms {
   }
 
   /**
-   * Runs tests against an existing hive metastore.
-   * If an error occur, all the following tests will be skipped.
+   * Create an instance of the {@link HmsValidationTool}.
    *
-   * @return a json string of the test results
+   * @param metastoreUri hive metastore uris
+   * @param database database to run tests against
+   * @param tables tables to run tests against
+   * @param socketTimeout socket time of hms operations
+   * @return the new instance
    */
+  public static HmsValidationTool create(String metastoreUri, String database,
+      String tables, int socketTimeout) {
+    return new HmsValidationTool(metastoreUri, database, tables, socketTimeout);
+  }
+
+  @Override
   public String runTests() {
     try {
       checkConfiguration();
-      HiveConf hiveConf = setHiveConf();
-      mClient = createHiveMetastoreClient(hiveConf);
+      mClient = createHiveMetastoreClient();
       try {
         getDatabaseTest();
         if (mTables != null && !mTables.isEmpty()) {
@@ -107,7 +115,7 @@ public class ValidateHms {
   }
 
   /**
-   * Check if the given configuration is valid.
+   * Checks if the given configuration is valid.
    *
    * @throws Exception if any of the given configuration is invalid
    */
@@ -195,17 +203,23 @@ public class ValidateHms {
   /**
    * Create hive metastore client.
    *
-   * @param hiveConf the hive configuration for this client
    * @return the created hive metastore client
    * @throws Exception if failed to create hive metastore client
    */
-  private IMetaStoreClient createHiveMetastoreClient(HiveConf hiveConf) throws Exception {
+  private IMetaStoreClient createHiveMetastoreClient() throws Exception {
     ConnectHmsAction action;
     String testName = "CreateHmsClientTest";
     try {
-      action = new ConnectHmsAction(hiveConf);
-      UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
-      ugi.doAs(action);
+      ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+      try {
+        // use the extension class loader
+        Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+        action = new ConnectHmsAction(mMetastoreUri, mSocketTimeout);
+        UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+        ugi.doAs(action);
+      } finally {
+        Thread.currentThread().setContextClassLoader(currentClassLoader);
+      }
     } catch (UndeclaredThrowableException e) {
       if (e.getUndeclaredThrowable() instanceof IMetaStoreClient.IncompatibleMetastoreException) {
         mResults.computeIfAbsent(State.FAILED, k -> new ArrayList<>()).add(
@@ -358,10 +372,12 @@ public class ValidateHms {
    */
   static class ConnectHmsAction implements java.security.PrivilegedExceptionAction<Void> {
     private IMetaStoreClient mConnection;
-    private HiveConf mHiveConf;
+    private String mMetastoreUri;
+    private int mSocketTimeout;
 
-    public ConnectHmsAction(HiveConf conf) {
-      mHiveConf = conf;
+    public ConnectHmsAction(String metastoreUri, int socketTimeout) {
+      mMetastoreUri = metastoreUri;
+      mSocketTimeout = socketTimeout;
     }
 
     public IMetaStoreClient getConnection() {
@@ -370,9 +386,11 @@ public class ValidateHms {
 
     @Override
     public Void run() throws MetaException {
-      IMetaStoreClient client = RetryingMetaStoreClient
-          .getProxy(mHiveConf, table -> null, HiveMetaStoreClient.class.getName());
-      mConnection = client;
+      HiveConf conf = new HiveConf();
+      conf.setVar(HiveConf.ConfVars.METASTOREURIS, mMetastoreUri);
+      conf.setIntVar(HiveConf.ConfVars.METASTORE_CLIENT_SOCKET_TIMEOUT, mSocketTimeout);
+      mConnection = RetryingMetaStoreClient
+          .getProxy(conf, table -> null, HiveMetaStoreClient.class.getName());
       return null;
     }
   }

--- a/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationTool.java
+++ b/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationTool.java
@@ -80,7 +80,7 @@ public class HmsValidationTool implements ValidationTool {
   }
 
   /**
-   * Create an instance of the {@link HmsValidationTool}.
+   * Creates an instance of {@link HmsValidationTool}.
    *
    * @param metastoreUri hive metastore uris
    * @param database database to run tests against
@@ -189,18 +189,6 @@ public class HmsValidationTool implements ValidationTool {
   }
 
   /**
-   * Sets hive configuration based on input parameters.
-   *
-   * @return the hive configuration
-   */
-  private HiveConf setHiveConf() {
-    HiveConf conf = new HiveConf();
-    conf.setVar(HiveConf.ConfVars.METASTOREURIS, mMetastoreUri);
-    conf.setIntVar(HiveConf.ConfVars.METASTORE_CLIENT_SOCKET_TIMEOUT, mSocketTimeout);
-    return conf;
-  }
-
-  /**
    * Create hive metastore client.
    *
    * @return the created hive metastore client
@@ -212,7 +200,7 @@ public class HmsValidationTool implements ValidationTool {
     try {
       ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
       try {
-        // use the extension class loader
+        // Use the extension class loader
         Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
         HiveConf conf = setHiveConf();
         action = new ConnectHmsAction(conf);
@@ -256,6 +244,18 @@ public class HmsValidationTool implements ValidationTool {
       throw t;
     }
     return action.getConnection();
+  }
+
+  /**
+   * Sets hive configuration based on input parameters.
+   *
+   * @return the hive configuration
+   */
+  private HiveConf setHiveConf() {
+    HiveConf conf = new HiveConf();
+    conf.setVar(HiveConf.ConfVars.METASTOREURIS, mMetastoreUri);
+    conf.setIntVar(HiveConf.ConfVars.METASTORE_CLIENT_SOCKET_TIMEOUT, mSocketTimeout);
+    return conf;
   }
 
   private void getDatabaseTest() throws Exception {

--- a/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationToolFactory.java
+++ b/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationToolFactory.java
@@ -1,0 +1,24 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.cli;
+
+/**
+ * Factory to create hive metastore validation tool implementation.
+ */
+public class HmsValidationToolFactory implements ValidationToolFactory {
+
+  @Override
+  public ValidationTool create(String metastoreUri, String database,
+      String tables, int socketTimeout) {
+    return HmsValidationTool.create(metastoreUri, database, tables, socketTimeout);
+  }
+}

--- a/integration/tools/hms/src/main/resources/META-INF/services/alluxio.cli.ValidationToolFactory
+++ b/integration/tools/hms/src/main/resources/META-INF/services/alluxio.cli.ValidationToolFactory
@@ -1,0 +1,12 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the “License”). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+alluxio.cli.HmsValidationToolFactory

--- a/integration/tools/pom.xml
+++ b/integration/tools/pom.xml
@@ -26,6 +26,7 @@
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>
     <failIfNoTests>false</failIfNoTests>
+    <hive-metastore.version>2.3.6</hive-metastore.version>
   </properties>
 
   <dependencies>
@@ -37,6 +38,7 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-metastore</artifactId>
+      <version>${hive-metastore.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/integration/tools/pom.xml
+++ b/integration/tools/pom.xml
@@ -18,6 +18,7 @@
     <groupId>org.alluxio</groupId>
     <version>2.3.0-SNAPSHOT</version>
   </parent>
+  <packaging>pom</packaging>
   <name>Alluxio Integration - Tools</name>
   <artifactId>alluxio-integration-tools</artifactId>
 
@@ -26,54 +27,20 @@
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>
     <failIfNoTests>false</failIfNoTests>
-    <hive-metastore.version>2.3.6</hive-metastore.version>
   </properties>
 
-  <dependencies>
-    <!-- External dependencies -->
-    <dependency>
-      <groupId>com.beust</groupId>
-      <artifactId>jcommander</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-metastore</artifactId>
-      <version>${hive-metastore.version}</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.jetty.aggregate</groupId>
-          <artifactId>jetty-all</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-1.2-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-slf4j-impl</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+  <modules>
+    <module>hms</module>
+  </modules>
 
+  <dependencies>
     <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>
       <version>${project.version}</version>
-    </dependency>
-
-    <!-- Internal test dependencies -->
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-common</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,6 @@
     <netty.version>4.1.45.Final</netty.version>
     <rocksdb.version>5.15.10</rocksdb.version>
     <hadoop.version>2.7.3</hadoop.version>
-    <hive-metastore.version>2.2.0</hive-metastore.version>
     <jacoco.version>0.8.5</jacoco.version>
     <java.version>1.8</java.version>
     <jersey.version>2.29.1</jersey.version>
@@ -516,11 +515,6 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-ozone-filesystem</artifactId>
         <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.hive</groupId>
-        <artifactId>hive-metastore</artifactId>
-        <version>${hive-metastore.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -67,11 +67,6 @@
     <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-integration-tools</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
       <artifactId>alluxio-table-client</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/shell/src/main/java/alluxio/cli/HmsTests.java
+++ b/shell/src/main/java/alluxio/cli/HmsTests.java
@@ -103,7 +103,7 @@ public class HmsTests {
 
     ValidationToolRegistry registry
         = new ValidationToolRegistry(new InstancedConfiguration(ConfigurationUtils.defaults()));
-    // load hms validation tool from alluxio lib directory
+    // Load hms validation tool from alluxio lib directory
     registry.refresh();
 
     ValidationTool tests = registry.create(metastoreUri, database, tables, socketTimeout);


### PR DESCRIPTION
Hms validation tool depends on hive metastore jar which internally has many dependencies that are conflicts with alluxio dependencies. 
Shade the whole hms validation tool and put it in alluxio/lib directory.
Load the hms validation tool when running hms tests.