### PR TITLE
Improve robustness of LocalCacheManager

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -14,9 +14,6 @@ package alluxio.client.file.cache;
 import alluxio.conf.AlluxioConfiguration;
 
 import java.io.IOException;
-import java.nio.channels.ReadableByteChannel;
-
-import javax.annotation.Nullable;
 
 /**
  * Interface for managing cached pages.
@@ -42,25 +39,30 @@ public interface CacheManager extends AutoCloseable  {
   boolean put(PageId pageId, byte[] page);
 
   /**
-   * Wraps the page in a channel or null if the queried page is not found in the cache or otherwise
-   * unable to be read from the cache.
+   * Reads the entire page if the queried page is found in the cache, stores the result in buffer.
    *
    * @param pageId page identifier
-   * @return a channel to read the page
+   * @param bytesToRead number of bytes to read in this page
+   * @param buffer destination buffer to write
+   * @param offsetInBuffer offset in the destination buffer to write
+   * @return number of bytes read, 0 if page is not found, -1 on errors
    */
-  @Nullable
-  ReadableByteChannel get(PageId pageId);
+  default int get(PageId pageId, int bytesToRead, byte[] buffer, int offsetInBuffer) {
+    return get(pageId, 0, bytesToRead, buffer, offsetInBuffer);
+  }
 
   /**
-   * Wraps a part of the page in a channel or null if the queried page is not found in the cache or
-   * otherwise unable to be read from the cache.
+   * Reads a part of a page if the queried page is found in the cache, stores the result in
+   * buffer.
    *
    * @param pageId page identifier
    * @param pageOffset offset into the page
-   * @return a channel to read the page
+   * @param bytesToRead number of bytes to read in this page
+   * @param buffer destination buffer to write
+   * @param offsetInBuffer offset in the destination buffer to write
+   * @return number of bytes read, 0 if page is not found, -1 on errors
    */
-  @Nullable
-  ReadableByteChannel get(PageId pageId, int pageOffset);
+  int get(PageId pageId, int pageOffset, int bytesToRead, byte[] buffer, int offsetInBuffer);
 
   /**
    * Deletes a page from the cache.

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
@@ -18,10 +18,6 @@ import com.codahale.metrics.Counter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.channels.ReadableByteChannel;
-
-import javax.annotation.Nullable;
-
 /**
  * A wrapper class of CacheManager without throwing unchecked exceptions.
  */
@@ -48,27 +44,26 @@ public class NoExceptionCacheManager implements CacheManager {
     }
   }
 
-  @Nullable
   @Override
-  public ReadableByteChannel get(PageId pageId) {
+  public int get(PageId pageId, int bytesToRead, byte[] buffer, int offsetInBuffer) {
     try {
-      return mCacheManager.get(pageId);
+      return mCacheManager.get(pageId, bytesToRead, buffer, offsetInBuffer);
     } catch (Exception e) {
       LOG.error("Failed to get page {}", pageId, e);
       Metrics.GET_ERRORS.inc();
-      return null;
+      return -1;
     }
   }
 
-  @Nullable
   @Override
-  public ReadableByteChannel get(PageId pageId, int pageOffset) {
+  public int get(PageId pageId, int pageOffset, int bytesToRead, byte[] buffer,
+      int offsetInBuffer) {
     try {
-      return mCacheManager.get(pageId, pageOffset);
+      return mCacheManager.get(pageId, pageOffset,  bytesToRead, buffer, offsetInBuffer);
     } catch (Exception e) {
       LOG.error("Failed to get page {}, offset {}", pageId, pageOffset, e);
       Metrics.GET_ERRORS.inc();
-      return null;
+      return -1;
     }
   }
 

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -385,7 +385,8 @@ public class LocalCacheFileInStreamTest {
         return 0;
       }
       mPagesServed++;
-      return Arrays.copyOfRange(mPages.get(pageId), pageOffset, PAGE_SIZE).length;
+      System.arraycopy(mPages.get(pageId), pageOffset, buffer, offsetInBuffer, bytesToRead);
+      return bytesToRead;
     }
 
     @Override

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -61,8 +61,6 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -381,22 +379,13 @@ public class LocalCacheFileInStreamTest {
     }
 
     @Override
-    public ReadableByteChannel get(PageId pageId) {
+    public int get(PageId pageId, int pageOffset, int bytesToRead, byte[] buffer,
+        int offsetInBuffer) {
       if (!mPages.containsKey(pageId)) {
-        return null;
+        return 0;
       }
       mPagesServed++;
-      return Channels.newChannel(new ByteArrayInputStream(mPages.get(pageId)));
-    }
-
-    @Override
-    public ReadableByteChannel get(PageId pageId, int pageOffset) {
-      if (!mPages.containsKey(pageId)) {
-        return null;
-      }
-      mPagesServed++;
-      return Channels.newChannel(new ByteArrayInputStream(
-          Arrays.copyOfRange(mPages.get(pageId), pageOffset, PAGE_SIZE)));
+      return Arrays.copyOfRange(mPages.get(pageId), pageOffset, PAGE_SIZE).length;
     }
 
     @Override


### PR DESCRIPTION
This PR fixes a potential race condition in LocalCacheManager and improves its robustness.

Though designed to be threadsafe, `LocalCacheManager` returns a `ReadableByteChannel` to 
`LocalCacheFileInStream`, where I/O operations like reading a file is actually done at `read` or `positionedRead` at `LocalCacheFileInStream`. This leaves an opportunity to multiple threads racing on the same `file` outside threadsafe `LocalCacheManager`. E.g., a super slow reader thread may contend with a evictor thread who wants to remove the same page file per LRU policy, leaving the reader thread risk undefined behavior (up to operating system).

Invariants after this PR:

(1) operating a page files is always protected inside the page lock.
(2) given no operation on the cache `LocalCacheFileInStream` (moved to `LocalCacheManager` in this PR), if cache fails in certain unexpected way, exceptions will always be catched by the `NoExceptionCacheManager`.

This PR changes the API of `LocalCacheManager.read` from returning a channel to returning the number of bytes read but copying bytes inside, which is a bit different from what i previously discussed with @calvinjia . This will make the code much simpler. 