### PR TITLE
Add a cache for PropertyKey.isValid

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -473,15 +473,23 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
     mStatistics = statistics;
     mUri = URI.create(mAlluxioHeader);
 
+    // take the URI properties, hadoop configuration, and given Alluxio configuration and merge
+    // all three into a single object.
     Map<String, Object> uriConfProperties = getConfigurationFromUri(uri);
-
+    Map<String, Object> hadoopConfProperties =
+        HadoopConfigurationUtils.getConfigurationFromHadoop(conf);
+    LOG.info("Creating Alluxio configuration from Hadoop configuration {}, uri configuration {}",
+        hadoopConfProperties, uriConfProperties);
     AlluxioProperties alluxioProps =
         (alluxioConfiguration != null) ? alluxioConfiguration.copyProperties()
             : ConfigurationUtils.defaults();
-    LOG.info("Creating Alluxio configuration from Hadoop configuration {}, uri configuration {}",
-        conf, uriConfProperties);
-    AlluxioConfiguration alluxioConf = mergeConfigurations(uriConfProperties, conf, alluxioProps);
-    mAlluxioConf = alluxioConf;
+    // Merge relevant Hadoop configuration into Alluxio's configuration.
+    alluxioProps.merge(hadoopConfProperties, Source.RUNTIME);
+    // Merge relevant connection details in the URI with the highest priority
+    alluxioProps.merge(uriConfProperties, Source.RUNTIME);
+    // Creating a new instanced configuration from an AlluxioProperties object isn't expensive.
+    mAlluxioConf = new InstancedConfiguration(alluxioProps);
+    mAlluxioConf.validate();
 
     if (mFileSystem != null) {
       return;
@@ -491,34 +499,14 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
     LOG.debug("Using Hadoop subject: {}", subject);
 
     LOG.info("Initializing filesystem with connect details {}",
-        Factory.getConnectDetails(alluxioConf));
+        Factory.getConnectDetails(mAlluxioConf));
 
     // Create FileSystem for accessing Alluxio.
     // Disable URI validation for non-Alluxio schemes.
     boolean disableUriValidation =
         (uri.getScheme() == null) || uri.getScheme().equals(Constants.SCHEME);
     mFileSystem = FileSystem.Factory.create(
-        ClientContext.create(subject, alluxioConf).setUriValidationEnabled(disableUriValidation));
-  }
-
-  /**
-   * Merges the URI configuration with the Hadoop and Alluxio configuration, returning an
-   * {@link AlluxioConfiguration} with all properties merged into one object.
-   *
-   * @param uriConfProperties the configuration properties from the input uri
-   * @param conf the hadoop conf
-   * @param alluxioProps Alluxio configuration properties
-   */
-  private AlluxioConfiguration mergeConfigurations(Map<String, Object> uriConfProperties,
-      org.apache.hadoop.conf.Configuration conf, AlluxioProperties alluxioProps)
-      throws IOException {
-    // take the URI properties, hadoop configuration, and given Alluxio configuration and merge
-    // all three into a single object.
-    InstancedConfiguration newConf = HadoopConfigurationUtils.mergeHadoopConfiguration(conf,
-        alluxioProps);
-    // Connection details in the URI has the highest priority
-    newConf.merge(uriConfProperties, Source.RUNTIME);
-    return newConf;
+        ClientContext.create(subject, mAlluxioConf).setUriValidationEnabled(disableUriValidation));
   }
 
   private Subject getSubjectFromUGI(UserGroupInformation ugi)

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
@@ -12,16 +12,10 @@
 package alluxio.hadoop;
 
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.AlluxioProperties;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.Source;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -30,35 +24,25 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class HadoopConfigurationUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(HadoopConfigurationUtils.class);
-
   private HadoopConfigurationUtils() {} // Prevent instantiation.
 
   /**
-   * Merges Hadoop {@link org.apache.hadoop.conf.Configuration} with Alluxio properties.
+   * Extracts relevant configuration from Hadoop {@link org.apache.hadoop.conf.Configuration}.
    *
-   * @param hadoopConf the {@link org.apache.hadoop.conf.Configuration} to merge
-   * @param alluxioProps the Alluxio properties to merge
-   * @return a configuration with properties all merged
+   * @param hadoopConf the {@link org.apache.hadoop.conf.Configuration} to extract
+   * @return all relevant properties in a Map instance
    */
-  public static InstancedConfiguration mergeHadoopConfiguration(
-      org.apache.hadoop.conf.Configuration hadoopConf, AlluxioProperties alluxioProps) {
-    // Load Alluxio configuration if any and merge to the one in Alluxio file system
-    // Push Alluxio configuration to the Job configuration
-    Properties alluxioConfProperties = new Properties();
-    // Load any Alluxio configuration parameters existing in the Hadoop configuration.
+  public static Map<String, Object> getConfigurationFromHadoop(
+      org.apache.hadoop.conf.Configuration hadoopConf) {
+    Map<String, Object> alluxioConfProperties = new HashMap<>();
+    // Load any Alluxio configuration parameters in the Hadoop configuration.
     for (Map.Entry<String, String> entry : hadoopConf) {
       String propertyName = entry.getKey();
       if (PropertyKey.isValid(propertyName)) {
         alluxioConfProperties.put(propertyName, entry.getValue());
       }
     }
-    // Merge the relevant Hadoop configuration into Alluxio's configuration.
-    alluxioProps.merge(alluxioConfProperties, Source.RUNTIME);
-    // Creting a new instanced configuration from an AlluxioProperties object isn't expensive.
-    InstancedConfiguration mergedConf = new InstancedConfiguration(alluxioProps);
-    mergedConf.validate();
-    return mergedConf;
+    return alluxioConfProperties;
   }
 
   /**

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
@@ -12,10 +12,17 @@
 package alluxio.hadoop;
 
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.AlluxioProperties;
+import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.conf.Source;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -24,7 +31,37 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class HadoopConfigurationUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(HadoopConfigurationUtils.class);
+
   private HadoopConfigurationUtils() {} // Prevent instantiation.
+
+  /**
+   * Merges Hadoop {@link org.apache.hadoop.conf.Configuration} with Alluxio properties.
+   *
+   * @param hadoopConf the {@link org.apache.hadoop.conf.Configuration} to merge
+   * @param alluxioProps the Alluxio properties to merge
+   * @return a configuration with properties all merged
+   */
+  //TODO(binfan): remove this method after Presto code updated
+  public static InstancedConfiguration mergeHadoopConfiguration(
+      org.apache.hadoop.conf.Configuration hadoopConf, AlluxioProperties alluxioProps) {
+    // Load Alluxio configuration if any and merge to the one in Alluxio file system
+    // Push Alluxio configuration to the Job configuration
+    Properties alluxioConfProperties = new Properties();
+    // Load any Alluxio configuration parameters existing in the Hadoop configuration.
+    for (Map.Entry<String, String> entry : hadoopConf) {
+      String propertyName = entry.getKey();
+      if (PropertyKey.isValid(propertyName)) {
+        alluxioConfProperties.put(propertyName, entry.getValue());
+      }
+    }
+    // Merge the relevant Hadoop configuration into Alluxio's configuration.
+    alluxioProps.merge(alluxioConfProperties, Source.RUNTIME);
+    // Creting a new instanced configuration from an AlluxioProperties object isn't expensive.
+    InstancedConfiguration mergedConf = new InstancedConfiguration(alluxioProps);
+    mergedConf.validate();
+    return mergedConf;
+  }
 
   /**
    * Extracts relevant configuration from Hadoop {@link org.apache.hadoop.conf.Configuration}.

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
@@ -20,7 +20,6 @@ import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
 
-import org.junit.After;
 import org.junit.Test;
 
 /**
@@ -33,27 +32,20 @@ public final class HadoopConfigurationUtilsTest {
   private static final String TEST_ALLUXIO_VALUE = "alluxio.unsupported.value";
   private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
 
-  @After
-  public void after() {
-    mConf = ConfigurationTestUtils.defaults();
-  }
-
   /**
-   * Test for the {@link HadoopConfigurationUtils#mergeHadoopConfiguration} method for an empty
+   * Test for the {@link HadoopConfigurationUtils#getConfigurationFromHadoop} method for an empty
    * configuration.
    */
   @Test
   public void mergeEmptyHadoopConfiguration() {
     org.apache.hadoop.conf.Configuration hadoopConfig = new org.apache.hadoop.conf.Configuration();
-    long beforeSize = mConf.toMap().size();
-    mConf = HadoopConfigurationUtils.mergeHadoopConfiguration(hadoopConfig, mConf.copyProperties());
-    long afterSize = mConf.toMap().size();
-    assertEquals(beforeSize, afterSize);
+    mConf.merge(
+        HadoopConfigurationUtils.getConfigurationFromHadoop(hadoopConfig), Source.RUNTIME);
     assertFalse(mConf.getBoolean(PropertyKey.ZOOKEEPER_ENABLED));
   }
 
   /**
-   * Test for the {@link HadoopConfigurationUtils#mergeHadoopConfiguration} method.
+   * Test for the {@link HadoopConfigurationUtils#getConfigurationFromHadoop} method.
    */
   @Test
   public void mergeHadoopConfiguration() {
@@ -67,7 +59,8 @@ public final class HadoopConfigurationUtilsTest {
 
     // This hadoop config will not be loaded into Alluxio configuration.
     hadoopConfig.set("hadoop.config.parameter", "hadoop config value");
-    mConf = HadoopConfigurationUtils.mergeHadoopConfiguration(hadoopConfig, mConf.copyProperties());
+    mConf.merge(
+        HadoopConfigurationUtils.getConfigurationFromHadoop(hadoopConfig), Source.RUNTIME);
     assertEquals(TEST_S3_ACCCES_KEY, mConf.get(PropertyKey.S3A_ACCESS_KEY));
     assertEquals(TEST_S3_SECRET_KEY, mConf.get(PropertyKey.S3A_SECRET_KEY));
     assertEquals(Source.RUNTIME, mConf.getSource(PropertyKey.S3A_ACCESS_KEY));

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -27,6 +27,8 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Sets;
 import com.sun.management.OperatingSystemMXBean;
 import org.slf4j.Logger;
@@ -58,7 +60,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   private static final Map<String, PropertyKey> DEFAULT_KEYS_MAP = new ConcurrentHashMap<>();
   /** A map from default property key's alias to the key. */
   private static final Map<String, PropertyKey> DEFAULT_ALIAS_MAP = new ConcurrentHashMap<>();
-
+  /** A cache storing result for isValid calls. */
+  private static final Cache<String, Boolean> VALID_CACHE = CacheBuilder.newBuilder()
+      .maximumSize(1024)
+      .build();
   /**
    * The consistency check level to apply to a certain property key.
    * User can run "alluxio validateEnv all cluster.conf.consistent" to validate the consistency of
@@ -5709,6 +5714,16 @@ public final class PropertyKey implements Comparable<PropertyKey> {
    * @return whether the input is a valid property name
    */
   public static boolean isValid(String input) {
+    Boolean result = VALID_CACHE.getIfPresent(input);
+    if (result != null) {
+      return result;
+    }
+    result = isValidInternal(input);
+    VALID_CACHE.put(input, result);
+    return result;
+  }
+
+  private static boolean isValidInternal(String input) {
     // Check if input matches any default keys or aliases
     if (DEFAULT_KEYS_MAP.containsKey(input) || DEFAULT_ALIAS_MAP.containsKey(input)) {
       return true;


### PR DESCRIPTION
In certain applications like Presto, frequently initializing FileSystem instance may be costly in CPU overhead. Further analysis shows when Hadoop configuration is large, regexp used in Alluxio to check whether an given configuration property from Hadoop can be recognized by Alluxio property template contributed a lot to the CPU overhead.

This PR aims to remove this cost. My initial attempt was to introduce extra logic to avoid  `PropertyKey.isValid`. However, this approach has a fairly large footprint in multiple most basic and important classes in Alluxio codebase, and increases complexity. I am concerned with the potential risk to reason and maintain the code after a patch like this.

Later I decided to instead  add a cache inside `PropertyKey.isValid`, given the inquiries are likely to be repeated. This approach has much less footprint to the codebase. In this PR I also cleaned up `AbstractFileSystem.initialize` in terms of configuration init.