### PR TITLE
Simplify lock list downgrades

### DIFF
--- a/core/common/src/main/java/alluxio/resource/LockResource.java
+++ b/core/common/src/main/java/alluxio/resource/LockResource.java
@@ -35,7 +35,10 @@ import java.util.concurrent.locks.LockSupport;
 // extends Closeable instead of AutoCloseable to enable usage with Guava's Closer.
 public class LockResource implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(LockResource.class);
-  private final Lock mLock;
+
+  // The lock which represents the resource. It should only be written or modified by subclasses
+  // attempting to downgrade locks (see RWLockResource).
+  Lock mLock;
 
   /**
    * Creates a new instance of {@link LockResource} using the given lock.

--- a/core/common/src/main/java/alluxio/resource/RWLockResource.java
+++ b/core/common/src/main/java/alluxio/resource/RWLockResource.java
@@ -1,0 +1,61 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.resource;
+
+import alluxio.concurrent.LockMode;
+
+import com.google.common.base.Preconditions;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * The {@link RWLockResource} is an extension of the {@link LockResource} which allows for
+ * downgrading of locks.
+ */
+public class RWLockResource extends LockResource {
+
+  private final ReentrantReadWriteLock mRwLock;
+
+  /**
+   * Creates a new instance of RW lock that will lock with the given mode.
+   *
+   * @param rwLock the read-write lock backing the resource
+   * @param mode the initial lock mode if acquiring the lock
+   * @param acquireLock whether or not to acquire the lock
+   * @param useTryLock whether or not to use {@link java.util.concurrent.locks.Lock#tryLock} when
+   *                  acquiring the resource
+   */
+  public RWLockResource(ReentrantReadWriteLock rwLock, LockMode mode, boolean acquireLock,
+      boolean useTryLock) {
+    super(mode == LockMode.READ ? rwLock.readLock() : rwLock.writeLock(), acquireLock, useTryLock);
+    mRwLock = rwLock;
+  }
+
+  /**
+   * Downgrade from a write to a read lock.
+   *
+   * @return if a successful downgrade was performed. Returns false if it was read locked
+   */
+  public boolean downgrade() {
+    if (!mRwLock.isWriteLocked()) {
+      return false;
+    }
+    Preconditions.checkState(mRwLock.isWriteLockedByCurrentThread(),
+        "Lock downgrades may only be initiated by the holding thread.");
+
+    // Downgrade by taking the read lock and then unlocking the write lock.
+    mRwLock.readLock().lock();
+    mLock.unlock();
+    mLock = mRwLock.readLock();
+    return true;
+  }
+}

--- a/core/common/src/main/java/alluxio/resource/RWLockResource.java
+++ b/core/common/src/main/java/alluxio/resource/RWLockResource.java
@@ -51,6 +51,7 @@ public class RWLockResource extends LockResource {
     }
     Preconditions.checkState(mRwLock.isWriteLockedByCurrentThread(),
         "Lock downgrades may only be initiated by the holding thread.");
+    Preconditions.checkState(mLock == mRwLock.writeLock(), "mLock must be the same as mRwLock");
 
     // Downgrade by taking the read lock and then unlocking the write lock.
     mRwLock.readLock().lock();

--- a/core/common/src/main/java/alluxio/resource/RefCountLockResource.java
+++ b/core/common/src/main/java/alluxio/resource/RefCountLockResource.java
@@ -11,17 +11,20 @@
 
 package alluxio.resource;
 
+import alluxio.concurrent.LockMode;
+
 import com.google.common.base.Preconditions;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Reference counted Lock resource, automatically unlocks and decrements the reference count.
  * It contains a lock and a reference count for that lock, and will decrement
  * the lock reference count and unlocking when the resource is closed.
  */
-public class RefCountLockResource extends LockResource {
+public class RefCountLockResource extends RWLockResource {
   private final AtomicInteger mRefCount;
 
   /**
@@ -29,14 +32,15 @@ public class RefCountLockResource extends LockResource {
    * reference counter should have been initialized and incremented outside of this class.
    *
    * @param lock the lock to acquire
+   * @param mode the mode to acquire the lock in
    * @param acquireLock whether to lock the lock
    * @param refCount ref count for the lock
    * @param useTryLock applicable only if acquireLock is true. Determines whether or not to use
    *                   {@link Lock#tryLock()} or {@link Lock#lock()} to acquire the lock
    */
-  public RefCountLockResource(Lock lock, boolean acquireLock, AtomicInteger refCount,
-      boolean useTryLock) {
-    super(lock, acquireLock, useTryLock);
+  public RefCountLockResource(ReentrantReadWriteLock lock, LockMode mode, boolean acquireLock,
+      AtomicInteger refCount, boolean useTryLock) {
+    super(lock, mode, acquireLock, useTryLock);
     mRefCount = Preconditions.checkNotNull(refCount, "Reference Counter can not be null");
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -271,7 +271,7 @@ public class InodeSyncStream {
       mStatusCache.remove(mRootPath.getUri());
       // downgrade so that if operations are parallelized, the lock on the root doesn't restrict
       // concurrent operations
-      mRootPath.downgradeToPattern(LockPattern.READ);
+      mRootPath.downgradeToRead();
     }
 
     // Process any children after the root.

--- a/core/server/master/src/main/java/alluxio/master/file/meta/CompositeInodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/CompositeInodeLockList.java
@@ -87,10 +87,9 @@ public class CompositeInodeLockList implements InodeLockList {
   }
 
   @Override
-  public void downgradeLastInode() {
-    if (canDowngradeLast()) {
-      mSubLockList.downgradeLastInode();
-    }
+  public void downgradeToReadLocks() {
+    mBaseLockList.downgradeToReadLocks();
+    mSubLockList.downgradeToReadLocks();
   }
 
   @Override
@@ -109,16 +108,6 @@ public class CompositeInodeLockList implements InodeLockList {
     // Can't downgrade, just acquire new locks instead.
     mSubLockList.lockInode(inode, LockMode.WRITE);
     mSubLockList.lockEdge(inode, childName, LockMode.WRITE);
-  }
-
-  @Override
-  public void downgradeEdgeToInode(Inode inode, LockMode mode) {
-    if (canDowngradeLast()) {
-      mSubLockList.downgradeEdgeToInode(inode, mode);
-      return;
-    }
-    // Can't downgrade, just acquire new locks instead.
-    mSubLockList.lockInode(inode, LockMode.WRITE);
   }
 
   private boolean canDowngradeLast() {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/CompositeInodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/CompositeInodeLockList.java
@@ -88,8 +88,9 @@ public class CompositeInodeLockList implements InodeLockList {
 
   @Override
   public void downgradeToReadLocks() {
-    mBaseLockList.downgradeToReadLocks();
-    mSubLockList.downgradeToReadLocks();
+    if (canDowngradeLast()) {
+      mSubLockList.downgradeToReadLocks();
+    }
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockList.java
@@ -104,7 +104,7 @@ public interface InodeLockList extends AutoCloseable {
   void unlockLastEdge();
 
   /**
-   * Downgrades all inodes in the current lock list to read locks.
+   * Downgrades all locks in the current lock list to read locks.
    */
   void downgradeToReadLocks();
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockList.java
@@ -104,17 +104,9 @@ public interface InodeLockList extends AutoCloseable {
   void unlockLastEdge();
 
   /**
-   * Downgrades the last inode from a write lock to a read lock. The read lock is acquired before
-   * releasing the write lock.
-   *
-   * Example
-   * Starting from [a, a->b, b*]
-   *
-   * downgradeLastInode() results in [a, a->b, b]
-   *
-   * If the last inode is not the only write-locked inode, no downgrade occurs.
+   * Downgrades all inodes in the current lock list to read locks.
    */
-  void downgradeLastInode();
+  void downgradeToReadLocks();
 
   /**
    * Downgrades the last edge lock in the lock list from WRITE lock to READ lock.
@@ -144,24 +136,6 @@ public interface InodeLockList extends AutoCloseable {
    * @param childName the child name for the edge to add to the lock list
    */
   void pushWriteLockedEdge(Inode inode, String childName);
-
-  /**
-   * Downgrades from edge write-locking to inode write-locking. This reduces the scope of the write
-   * lock by pushing it forward one entry.
-   *
-   * Example
-   * Starting from [a, a->b*]
-   *
-   * downgradeEdgeToInode(b, LockMode.READ) results in [a, a->b, b]
-   * downgradeEdgeToInode(b, LockMode.WRITE) results in [a, a->b, b*]
-   *
-   * The read lock on a->b is acquired before releasing the write lock. This ensures that no other
-   * thread can take the write lock before the read lock is acquired.
-   *
-   * @param inode the next inode in the lock list
-   * @param mode the mode to downgrade to
-   */
-  void downgradeEdgeToInode(Inode inode, LockMode mode);
 
   /**
    * @return {@link LockMode#WRITE} if the last entry in the list is write-locked, otherwise

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
@@ -16,6 +16,7 @@ import alluxio.concurrent.LockMode;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.resource.LockResource;
+import alluxio.resource.RWLockResource;
 import alluxio.util.interfaces.Scoped;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -150,7 +151,7 @@ public class InodeLockManager implements Closeable {
    * @return a lock resource which must be closed to release the lock
    * @see #tryLockInode(Long, LockMode)
    */
-  public LockResource lockInode(InodeView inode, LockMode mode, boolean useTryLock) {
+  public RWLockResource lockInode(InodeView inode, LockMode mode, boolean useTryLock) {
     return mInodeLocks.get(inode.getId(), mode, useTryLock);
   }
 
@@ -161,7 +162,7 @@ public class InodeLockManager implements Closeable {
    * @param mode the mode to lock in
    * @return either an empty optional, or a lock resource which must be closed to release the lock
    */
-  public Optional<LockResource> tryLockInode(Long inodeId, LockMode mode) {
+  public Optional<RWLockResource> tryLockInode(Long inodeId, LockMode mode) {
     return mInodeLocks.tryGet(inodeId, mode);
   }
 
@@ -176,7 +177,7 @@ public class InodeLockManager implements Closeable {
    * @return a lock resource which must be closed to release the lock
    * @see #tryLockEdge(Edge, LockMode)
    */
-  public LockResource lockEdge(Edge edge, LockMode mode, boolean useTryLock) {
+  public RWLockResource lockEdge(Edge edge, LockMode mode, boolean useTryLock) {
     return mEdgeLocks.get(edge, mode, useTryLock);
   }
 
@@ -187,7 +188,7 @@ public class InodeLockManager implements Closeable {
    * @param mode the mode to lock in
    * @return either an empty optional, or a lock resource which must be closed to release the lock
    */
-  public Optional<LockResource> tryLockEdge(Edge edge, LockMode mode) {
+  public Optional<RWLockResource> tryLockEdge(Edge edge, LockMode mode) {
     return mEdgeLocks.tryGet(edge, mode);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -272,43 +272,11 @@ public class LockedInodePath implements Closeable {
   }
 
   /**
-   * Downgrades from the current locking scheme to the desired locking scheme.
-   *
-   * @param desiredLockPattern the pattern to downgrade to
+   * Downgrades all locks in this list to read locks.
    */
-  public void downgradeToPattern(LockPattern desiredLockPattern) {
-    switch (desiredLockPattern) {
-      case READ:
-        if (mLockPattern == LockPattern.WRITE_INODE) {
-          mLockList.downgradeLastInode();
-        } else if (mLockPattern == LockPattern.WRITE_EDGE) {
-          downgradeEdgeToInode(LockMode.READ);
-        }
-        break;
-      case WRITE_INODE:
-        if (mLockPattern == LockPattern.WRITE_EDGE) {
-          downgradeEdgeToInode(LockMode.WRITE);
-        } else {
-          Preconditions.checkState(mLockPattern == LockPattern.WRITE_INODE);
-        }
-        break;
-      case WRITE_EDGE:
-        Preconditions.checkState(mLockPattern == LockPattern.WRITE_EDGE);
-        break; // Nothing to do
-      default:
-        throw new IllegalStateException("Unknown lock pattern: " + desiredLockPattern);
-    }
-    mLockPattern = desiredLockPattern;
-  }
-
-  private void downgradeEdgeToInode(LockMode lockMode) {
-    if (fullPathExists()) {
-      Inode lastInode = mLockList.get(mLockList.numInodes() - 1);
-      mLockList.unlockLastInode();
-      mLockList.downgradeEdgeToInode(lastInode, lockMode);
-    } else {
-      mLockList.unlockLastEdge();
-    }
+  public void downgradeToRead() {
+    mLockList.downgradeToReadLocks();
+    mLockPattern = LockPattern.READ;
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
@@ -32,6 +32,7 @@ import alluxio.master.metastore.heap.HeapInodeStore;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.resource.LockResource;
+import alluxio.resource.RWLockResource;
 import alluxio.util.ConfigurationUtils;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -299,7 +300,7 @@ public final class CachingInodeStore implements InodeStore, Closeable {
       try (WriteBatch batch = useBatch ? mBackingStore.createWriteBatch() : null) {
         for (Entry entry : entries) {
           Long inodeId = entry.mKey;
-          Optional<LockResource> lockOpt = mLockManager.tryLockInode(inodeId, LockMode.WRITE);
+          Optional<RWLockResource> lockOpt = mLockManager.tryLockInode(inodeId, LockMode.WRITE);
           if (!lockOpt.isPresent()) {
             continue;
           }
@@ -435,7 +436,7 @@ public final class CachingInodeStore implements InodeStore, Closeable {
       try (WriteBatch batch = useBatch ? mBackingStore.createWriteBatch() : null) {
         for (Entry entry : entries) {
           Edge edge = entry.mKey;
-          Optional<LockResource> lockOpt = mLockManager.tryLockEdge(edge, LockMode.WRITE);
+          Optional<RWLockResource> lockOpt = mLockManager.tryLockEdge(edge, LockMode.WRITE);
           if (!lockOpt.isPresent()) {
             continue;
           }

--- a/core/server/master/src/test/java/alluxio/master/file/meta/LockedInodePathTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/LockedInodePathTest.java
@@ -344,7 +344,7 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
   public void downgradeWriteEdgeToRead() throws Exception {
     mPath = create("/a/b/c", LockPattern.WRITE_EDGE);
 
-    mPath.downgradeToPattern(LockPattern.READ);
+    mPath.downgradeToRead();
     assertTrue(mPath.fullPathExists());
     assertEquals(Arrays.asList(mRootDir, mDirA, mDirB, mFileC), mPath.getInodeList());
     assertEquals(LockPattern.READ, mPath.getLockPattern());
@@ -356,25 +356,10 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
   }
 
   @Test
-  public void downgradeWriteEdgeToWriteInode() throws Exception {
-    mPath = create("/a/b/c", LockPattern.WRITE_EDGE);
-
-    mPath.downgradeToPattern(LockPattern.WRITE_INODE);
-    assertTrue(mPath.fullPathExists());
-    assertEquals(Arrays.asList(mRootDir, mDirA, mDirB, mFileC), mPath.getInodeList());
-    assertEquals(LockPattern.WRITE_INODE, mPath.getLockPattern());
-
-    checkOnlyNodesReadLocked(mRootDir, mDirA, mDirB);
-    checkOnlyNodesWriteLocked(mFileC);
-    checkOnlyIncomingEdgesReadLocked(mRootDir, mDirA, mDirB, mFileC);
-    checkOnlyIncomingEdgesWriteLocked();
-  }
-
-  @Test
   public void downgradeWriteInodeToReadInode() throws Exception {
     mPath = create("/a/b/c", LockPattern.WRITE_INODE);
 
-    mPath.downgradeToPattern(LockPattern.READ);
+    mPath.downgradeToRead();
     assertTrue(mPath.fullPathExists());
     assertEquals(Arrays.asList(mRootDir, mDirA, mDirB, mFileC), mPath.getInodeList());
     assertEquals(LockPattern.READ, mPath.getLockPattern());

--- a/core/server/master/src/test/java/alluxio/master/file/meta/SimpleInodeLockListTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/SimpleInodeLockListTest.java
@@ -135,32 +135,10 @@ public class SimpleInodeLockListTest extends BaseInodeLockingTest {
   }
 
   @Test
-  public void downgradeLastInode() {
-    mLockList.lockRootEdge(LockMode.READ);
-    mLockList.lockInode(mRootDir, LockMode.READ);
-    mLockList.lockEdge(mRootDir, mDirA.getName(), LockMode.READ);
-    mLockList.lockInode(mDirA, LockMode.WRITE);
-
-    mLockList.downgradeLastInode();
-    assertEquals(LockMode.READ, mLockList.getLockMode());
-    assertEquals(Arrays.asList(mRootDir, mDirA), mLockList.getLockedInodes());
-
-    mLockList.unlockLastInode();
-    mLockList.lockInode(mDirA, LockMode.WRITE);
-    assertEquals(LockMode.WRITE, mLockList.getLockMode());
-    assertEquals(Arrays.asList(mRootDir, mDirA), mLockList.getLockedInodes());
-
-    checkOnlyNodesReadLocked(mRootDir);
-    checkOnlyNodesWriteLocked(mDirA);
-    checkOnlyIncomingEdgesReadLocked(mRootDir, mDirA);
-    checkOnlyIncomingEdgesWriteLocked();
-  }
-
-  @Test
   public void downgradeLastInodeRoot() {
     mLockList.lockRootEdge(LockMode.READ);
     mLockList.lockInode(mRootDir, LockMode.WRITE);
-    mLockList.downgradeLastInode();
+    mLockList.downgradeToReadLocks();
     assertEquals(LockMode.READ, mLockList.getLockMode());
     assertEquals(Arrays.asList(mRootDir), mLockList.getLockedInodes());
 
@@ -183,24 +161,6 @@ public class SimpleInodeLockListTest extends BaseInodeLockingTest {
 
     checkOnlyNodesReadLocked(mRootDir);
     checkOnlyNodesWriteLocked();
-    checkOnlyIncomingEdgesReadLocked(mRootDir, mDirA);
-    checkOnlyIncomingEdgesWriteLocked();
-  }
-
-  @Test
-  public void downgradeEdgeToInode() {
-    mLockList.lockRootEdge(LockMode.WRITE);
-    mLockList.downgradeEdgeToInode(mRootDir, LockMode.READ);
-    assertEquals(Arrays.asList(mRootDir), mLockList.getLockedInodes());
-    assertEquals(LockMode.READ, mLockList.getLockMode());
-
-    mLockList.lockEdge(mRootDir, mDirA.getName(), LockMode.WRITE);
-    mLockList.downgradeEdgeToInode(mDirA, LockMode.WRITE);
-    assertEquals(Arrays.asList(mRootDir, mDirA), mLockList.getLockedInodes());
-    assertEquals(LockMode.WRITE, mLockList.getLockMode());
-
-    checkOnlyNodesReadLocked(mRootDir);
-    checkOnlyNodesWriteLocked(mDirA);
     checkOnlyIncomingEdgesReadLocked(mRootDir, mDirA);
     checkOnlyIncomingEdgesWriteLocked();
   }


### PR DESCRIPTION
Before this change lock downgrades did NOT work if the end
of the lock list had more than one write locked inode. This
hasn't burned us until now because the new syncing changes
assumed all inodes in the locklist would be downgraded when
calling LockedInodePath#downgradeToPattern(LockPattern).
This was not the case, which ended up causing a deadlock
when the lock list contained many write-locked entries

One common case where this can occur is when a user is
loading a deeply nested file or directory via some getStatus or
listStatus call which syncs metadata and in-turn, will create
the paths as it discovers them. In doing so, the lock list is
initially populated with write locks. We require them to all
be downgraded to read locks for the metadata sync to be
performed properly.

The new syncing design also now only requires downgrades
to read locks which simplifies a lot of logic which existed
to support downgrades from WRITE_EDGE to
WRITE_INODE. These changes removes a good chunk of
that complicated code in favor of a simpler approach
which simply performs the lock downgrade for all inodes
in the list.

A new integration test case was added for this regression.