### PR TITLE
Fix the bug that invalid field appears in alluxio helm chart

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -85,3 +85,7 @@
 0.6.1
 
 - Infer hostNetwork, dnsPolicy and domain socket volume type based on the user
+
+0.6.2
+
+- Fix alluxio chart failed to deploy with helm when "fuse.enabled" is true in values.yaml(issue: #11542)

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.1
+version: 0.6.2
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
@@ -52,7 +52,7 @@ spec:
         fsGroup: {{ .Values.fuse.fsGroup }}
       affinity:
         podAffinity:
-          RequiredDuringSchedulingIgnoredDuringExecution:
+          requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
               - key: app
@@ -63,6 +63,7 @@ spec:
                 operator: In
                 values:
                 - alluxio-worker
+            topologyKey: kubernetes.io/hostname
       containers:
         - name: alluxio-fuse
           image: {{ .Values.fuse.image }}:{{ .Values.fuse.imageTag }}


### PR DESCRIPTION
1."RequiredDuringSchedulingIgnoredDuringExecution" is an invalid field in integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml and change it to "requiredDuringSchedulingIgnoredDuringExecution"

2."topologyKey" is required in podAffinity,but it is missing in integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml

3.change chart version to 0.6.2

Fixes https://github.com/Alluxio/alluxio/issues/11542