### PR TITLE
Update emr script

### DIFF
--- a/integration/emr/alluxio-emr.sh
+++ b/integration/emr/alluxio-emr.sh
@@ -101,6 +101,7 @@ get_aws_region() {
   curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/[a-z]$//'
 }
 
+
 # Puts a shutdown hook under the EMR defined /mnt/var/lib/instance-controller/public/shutdown-actions directory.
 # 
 # Args:
@@ -170,13 +171,15 @@ main() {
   print_help() {
     local -r USAGE=$(cat <<USAGE_END
 
-Usage: alluxio-emr.sh <root-ufs-uri> [-b <backup_uri>]
-                             [ -d <alluxio-download-uri>]
-                             [-f <file_uri>]
-                             [-i <journal_backup_uri>]
-                             [-n <storage percentage>]
-                             [-p <delimited_properties>]
-                             [-s <property_delimiter>]
+Usage: alluxio-emr.sh [-u <root-ufs-uri>]
+                      [-b <backup_uri>]
+                      [-d <alluxio-download-uri>]
+                      [-f <file_uri>]
+                      [-i <journal_backup_uri>]
+                      [-n <storage percentage>]
+                      [-p <delimited_properties>]
+                      [-s <property_delimiter>]
+                      [-c]
 
 alluxio-emr.sh is a script which can be used to bootstrap an AWS EMR cluster
 with Alluxio. It can download and install Alluxio as well as add properties
@@ -189,8 +192,9 @@ nothing will be installed over it, even if -d is specified.
 
 If a different Alluxio version is desired, see the -d option.
 
-  <root-ufs-uri>    (Required) The URI of the root UFS in the Alluxio
-                    namespace.
+  -u                The URI of the root UFS in the Alluxio namespace. If this 
+                    is not provided, the emr hdfs root will be used as the root
+                    UFS. 
 
   -b                An s3:// URI that the Alluxio master will write a backup
                     to upon shutdown of the EMR cluster. The backup and and
@@ -231,7 +235,8 @@ If a different Alluxio version is desired, see the -d option.
   -s                A string containing a single character representing what
                     delimiter should be used to split the Alluxio properties
                     provided in the [-p] argument.
-
+  
+  -c                Install the alluxio client jars only
 USAGE_END
 )
     echo -e "${USAGE}" >&2
@@ -244,17 +249,16 @@ USAGE_END
   local restore_from_backup_uri=""
   local files_list=""
   local nvme_capacity_usage=""
-
-  if [[ "$#" -lt "1" ]]; then
-    echo -e "No root UFS URI provided"
-    print_help 1
-  fi
-
-  local root_ufs_uri="${1}"
-  shift
-  while getopts "b:d:f:i:n:p:s:" option; do
-    OPTARG=$(echo -e "${OPTARG}" | tr -d '[:space:]')
+  local root_ufs_uri=""
+  local client_only="false"
+  while getopts ":u:b:d:f:i:n:p:s:c" option; do
+    if [[ -n "${OPTARG-}" ]]; then
+      OPTARG=$(echo -e "${OPTARG}" | tr -d '[:space:]')
+    fi
     case "${option}" in
+      u)
+        root_ufs_uri="${OPTARG}"
+        ;;
       b)
         backup_uri="${OPTARG}"
         ;;
@@ -277,6 +281,9 @@ USAGE_END
         ;;
       n)
         nvme_capacity_usage="${OPTARG}"
+        ;;
+      c)
+        client_only="true"
         ;;
       *)
         print_help 1
@@ -332,6 +339,11 @@ USAGE_END
 
   doas alluxio "echo '${master}' > ${ALLUXIO_HOME}/conf/masters"
   doas alluxio "echo '${workers}' > ${ALLUXIO_HOME}/conf/workers"
+
+  # set root ufs uri
+  if [[ -z "${root_ufs_uri}" ]]; then
+    root_ufs_uri="hdfs://${master}:8020"
+  fi
 
   # Identify master
   local -r is_master=$(jq '.isMaster' /mnt/var/lib/info/instance.json)
@@ -434,39 +446,39 @@ USAGE_END
   append_alluxio_property alluxio.underfs.s3.owner.id.to.username.mapping "${canonical_id}=hadoop"
   doas alluxio "echo '# END AUTO-GENERATED PROPERTIES' >> ${ALLUXIO_SITE_PROPERTIES}"
 
-  # Alluxio can't rely on SSH to start services (i.e. no alluxio-start.sh all)
-  if [[ ${is_master} = "true" ]]; then
-    local args=""
-    if [[ "${restore_from_backup_uri}" ]]; then
-      local -r backup_name="$(basename "${restore_from_backup_uri}")"
-      local -r backup_location=/tmp/alluxio_backup
-      mkdir -p "${backup_location}"
-      cd "${backup_location}"
-      download_file "${restore_from_backup_uri}"
-      chmod -R 777 "${backup_location}"
-      args="-i ${backup_location}/${backup_name}"
-    fi
-    doas alluxio "${ALLUXIO_HOME}/bin/alluxio-start.sh -a ${args} master"
-    doas alluxio "${ALLUXIO_HOME}/bin/alluxio-start.sh -a job_master"
-    doas alluxio "${ALLUXIO_HOME}/bin/alluxio-start.sh -a proxy"
+  if [  "${client_only}" != "true" ]; then 
+    # Alluxio can't rely on SSH to start services (i.e. no alluxio-start.sh all)
+    if [ "${is_master}" = "true" ]; then
+      local args=""
+      if [[ "${restore_from_backup_uri}" ]]; then
+        local -r backup_name="$(basename "${restore_from_backup_uri}")"
+        local -r backup_location=/tmp/alluxio_backup
+        mkdir -p "${backup_location}"
+        cd "${backup_location}"
+        download_file "${restore_from_backup_uri}"
+        chmod -R 777 "${backup_location}"
+        args="-i ${backup_location}/${backup_name}"
+      fi
+      doas alluxio "${ALLUXIO_HOME}/bin/alluxio-start.sh -a ${args} master"
+      doas alluxio "${ALLUXIO_HOME}/bin/alluxio-start.sh -a job_master"
+      doas alluxio "${ALLUXIO_HOME}/bin/alluxio-start.sh -a proxy"
 
-    if [[ "${backup_uri}" ]]; then
-      register_backup_on_shutdown "${backup_uri}"
+      if [[ "${backup_uri}" ]]; then
+        register_backup_on_shutdown "${backup_uri}"
+      fi
+    else
+      if [[ "${use_mem}" ]]; then
+        ${ALLUXIO_HOME}/bin/alluxio-mount.sh SudoMount local
+      fi
+      until ${ALLUXIO_HOME}/bin/alluxio fsadmin report
+      do
+        sleep 5
+      done
+      doas alluxio "${ALLUXIO_HOME}/bin/alluxio-start.sh -a worker"
+      doas alluxio "${ALLUXIO_HOME}/bin/alluxio-start.sh -a job_worker"
+      doas alluxio "${ALLUXIO_HOME}/bin/alluxio-start.sh -a proxy"
     fi
-  else
-
-    if [[ "${use_mem}" ]]; then
-      ${ALLUXIO_HOME}/bin/alluxio-mount.sh SudoMount local
-    fi
-    until ${ALLUXIO_HOME}/bin/alluxio fsadmin report
-    do
-      sleep 5
-    done
-    doas alluxio "${ALLUXIO_HOME}/bin/alluxio-start.sh -a worker"
-    doas alluxio "${ALLUXIO_HOME}/bin/alluxio-start.sh -a job_worker"
-    doas alluxio "${ALLUXIO_HOME}/bin/alluxio-start.sh -a proxy"
   fi
-
   # Compute application configs
   doas alluxio "ln -s ${ALLUXIO_HOME}/client/*client.jar ${ALLUXIO_HOME}/client/alluxio-client.jar"
   sudo mkdir -p /usr/lib/spark/jars/


### PR DESCRIPTION
allow empty ufs uri (means local hdfs mount)
-c flag which installs client jar and conf but do not start alluxio

The reason for these changes: 
1. so that we can launch an emr cluster where the hdfs of that cluster is mounted as root mount
2. so that we can load jars on to a cluster that does not need alluxio running. In this case, a hive metastore containing alluxio uris. 
