### PR TITLE
Port changes of [#11537] to branch-2.2

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
@@ -20,6 +20,7 @@ import alluxio.conf.Source;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -41,6 +42,7 @@ public final class HadoopConfigurationUtils {
    * @param alluxioProps the Alluxio properties to merge
    * @return a configuration with properties all merged
    */
+  //TODO(binfan): remove this method after Presto code updated
   public static InstancedConfiguration mergeHadoopConfiguration(
       org.apache.hadoop.conf.Configuration hadoopConf, AlluxioProperties alluxioProps) {
     // Load Alluxio configuration if any and merge to the one in Alluxio file system
@@ -61,6 +63,25 @@ public final class HadoopConfigurationUtils {
     InstancedConfiguration mergedConf = new InstancedConfiguration(alluxioProps);
     mergedConf.validate();
     return mergedConf;
+  }
+
+  /**
+   * Extracts relevant configuration from Hadoop {@link org.apache.hadoop.conf.Configuration}.
+   *
+   * @param hadoopConf the {@link org.apache.hadoop.conf.Configuration} to extract
+   * @return all relevant properties in a Map instance
+   */
+  public static Map<String, Object> getConfigurationFromHadoop(
+      org.apache.hadoop.conf.Configuration hadoopConf) {
+    Map<String, Object> alluxioConfProperties = new HashMap<>();
+    // Load any Alluxio configuration parameters in the Hadoop configuration.
+    for (Map.Entry<String, String> entry : hadoopConf) {
+      String propertyName = entry.getKey();
+      if (PropertyKey.isValid(propertyName)) {
+        alluxioConfProperties.put(propertyName, entry.getValue());
+      }
+    }
+    return alluxioConfProperties;
   }
 
   /**

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
@@ -20,7 +20,6 @@ import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
 
-import org.junit.After;
 import org.junit.Test;
 
 /**
@@ -33,27 +32,20 @@ public final class HadoopConfigurationUtilsTest {
   private static final String TEST_ALLUXIO_VALUE = "alluxio.unsupported.value";
   private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
 
-  @After
-  public void after() {
-    mConf = ConfigurationTestUtils.defaults();
-  }
-
   /**
-   * Test for the {@link HadoopConfigurationUtils#mergeHadoopConfiguration} method for an empty
+   * Test for the {@link HadoopConfigurationUtils#getConfigurationFromHadoop} method for an empty
    * configuration.
    */
   @Test
   public void mergeEmptyHadoopConfiguration() {
     org.apache.hadoop.conf.Configuration hadoopConfig = new org.apache.hadoop.conf.Configuration();
-    long beforeSize = mConf.toMap().size();
-    mConf = HadoopConfigurationUtils.mergeHadoopConfiguration(hadoopConfig, mConf.copyProperties());
-    long afterSize = mConf.toMap().size();
-    assertEquals(beforeSize, afterSize);
+    mConf.merge(
+        HadoopConfigurationUtils.getConfigurationFromHadoop(hadoopConfig), Source.RUNTIME);
     assertFalse(mConf.getBoolean(PropertyKey.ZOOKEEPER_ENABLED));
   }
 
   /**
-   * Test for the {@link HadoopConfigurationUtils#mergeHadoopConfiguration} method.
+   * Test for the {@link HadoopConfigurationUtils#getConfigurationFromHadoop} method.
    */
   @Test
   public void mergeHadoopConfiguration() {
@@ -67,7 +59,8 @@ public final class HadoopConfigurationUtilsTest {
 
     // This hadoop config will not be loaded into Alluxio configuration.
     hadoopConfig.set("hadoop.config.parameter", "hadoop config value");
-    mConf = HadoopConfigurationUtils.mergeHadoopConfiguration(hadoopConfig, mConf.copyProperties());
+    mConf.merge(
+        HadoopConfigurationUtils.getConfigurationFromHadoop(hadoopConfig), Source.RUNTIME);
     assertEquals(TEST_S3_ACCCES_KEY, mConf.get(PropertyKey.S3A_ACCESS_KEY));
     assertEquals(TEST_S3_SECRET_KEY, mConf.get(PropertyKey.S3A_SECRET_KEY));
     assertEquals(Source.RUNTIME, mConf.getSource(PropertyKey.S3A_ACCESS_KEY));

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -27,6 +27,8 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Sets;
 import com.sun.management.OperatingSystemMXBean;
 import org.slf4j.Logger;
@@ -58,7 +60,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   private static final Map<String, PropertyKey> DEFAULT_KEYS_MAP = new ConcurrentHashMap<>();
   /** A map from default property key's alias to the key. */
   private static final Map<String, PropertyKey> DEFAULT_ALIAS_MAP = new ConcurrentHashMap<>();
-
+  /** A cache storing result for template regexp matching results. */
+  private static final Cache<String, Boolean> REGEXP_CACHE = CacheBuilder.newBuilder()
+      .maximumSize(1024)
+      .build();
   /**
    * The consistency check level to apply to a certain property key.
    * User can run "alluxio validateEnv all cluster.conf.consistent" to validate the consistency of
@@ -5465,13 +5470,22 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     if (DEFAULT_KEYS_MAP.containsKey(input) || DEFAULT_ALIAS_MAP.containsKey(input)) {
       return true;
     }
+    // Regex matching for templates can be expensive when checking properties frequently.
+    // Use a cache to store regexp matching results to reduce CPU overhead.
+    Boolean result = REGEXP_CACHE.getIfPresent(input);
+    if (result != null) {
+      return result;
+    }
     // Check if input matches any parameterized keys
+    result = false;
     for (Template template : Template.values()) {
       if (template.matches(input)) {
-        return true;
+        result = true;
+        break;
       }
     }
-    return false;
+    REGEXP_CACHE.put(input, result);
+    return result;
   }
 
   /**


### PR DESCRIPTION
Cherry-pick https://github.com/Alluxio/alluxio/pull/11537 to branch-2.2

In certain applications like Presto, frequently initializing FileSystem
instance may be costly in CPU overhead. Further analysis shows when
Hadoop configuration is large, regexp used in Alluxio to check whether
an given configuration property from Hadoop can be recognized by Alluxio
property template contributed a lot to the CPU overhead.

This PR aims to remove this cost. My initial attempt was to introduce
extra logic to avoid `PropertyKey.isValid`. However, this approach has a
fairly large footprint in multiple most basic and important classes in
Alluxio codebase, and increases complexity. I am concerned with the
potential risk to reason and maintain the code after a patch like this.

Later I decided to instead add a cache inside `PropertyKey.isValid`,
given the inquiries are likely to be repeated. This approach has much
less footprint to the codebase. In this PR I also cleaned up
`AbstractFileSystem.initialize` in terms of configuration init.

pr-link: Alluxio/alluxio#11537
change-id: cid-f096b0232adb48c53a3a735c14ed69c0cb0b5f93