### PR TITLE
Fix inconsistent persistence status after setOwner failed

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4149,6 +4149,8 @@ public final class DefaultFileSystemMaster extends CoreMaster
             try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
               UnderFileSystem ufs = ufsResource.get();
               String ufsPath = resolution.getUri().toString();
+              ufs.setOwner(tempUfsPath, inode.getOwner(), inode.getGroup());
+              ufs.setMode(tempUfsPath, inode.getMode());
               if (!ufsPath.equals(tempUfsPath)) {
                 // Make rename only when tempUfsPath is different from final ufsPath. Note that,
                 // on object store, we take the optimization to skip the rename by having
@@ -4158,8 +4160,6 @@ public final class DefaultFileSystemMaster extends CoreMaster
                       String.format("Failed to rename %s to %s.", tempUfsPath, ufsPath));
                 }
               }
-              ufs.setOwner(ufsPath, inode.getOwner(), inode.getGroup());
-              ufs.setMode(ufsPath, inode.getMode());
               builder.setUfsFingerprint(ufs.getFingerprint(ufsPath));
             }
 

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -640,7 +640,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
       LOG.warn("Failed to set owner for {} with user: {}, group: {}", path, user, group);
       LOG.debug("Exception : ", e);
       LOG.warn("In order for Alluxio to modify ownership of local files, "
-          + "Alluxio should be the local file system superuser.");
+          + "Alluxio should be running as an HDFS superuser.");
       if (!Boolean.valueOf(mUfsConf.get(PropertyKey.UNDERFS_ALLOW_SET_OWNER_FAILURE))) {
         throw e;
       } else {


### PR DESCRIPTION
When Alluxio mounts an HDFS UFS as a non superuser, any file persist action would fail because it does not have permission to set owner on HDFS. However, user would see the file is already persisted on HDFS but yet Alluxio still show the file as TO_BE_PERSISTED. Further attempt to persist the file would end up timeout with misleading error message "Failed to rename x.0x000001724B700242.tmp to x".

This problem occurs because the `setOwner` operation is done after the `rename` operation on UFS, so when `setOwner` fails it leaves the persisted file in UFS but keeps the Alluxio persistence state as "TO_BE_PERSISTED". Further persist attempts would then fails due to file already exist and thus keeps on retrying and failing. 

This PR moves the setOwner call to be before rename happens, so when it fails the temporary files got removed correctly and the error in master log will state it is a permission issue instead of a renaming issue.