### PR TITLE
Use headless service for master pods in K8s

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/templates/master/service.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/service.yaml
@@ -41,7 +41,7 @@ spec:
       name: embedded
     - port: 20003
       name: job-embedded
-  type: NodePort
+  clusterIP: None
   selector:
     role: alluxio-master
     app: {{ $name }}


### PR DESCRIPTION
This fixes https://github.com/Alluxio/alluxio/issues/11562