### PR TITLE
Add alluxio.hadoop.LocalCacheFileSystem.java

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -14,6 +14,7 @@ package alluxio.client.file;
 import alluxio.AlluxioURI;
 import alluxio.ClientContext;
 import alluxio.annotation.PublicApi;
+import alluxio.client.file.cache.CacheManager;
 import alluxio.client.file.cache.LocalCacheFileSystem;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
@@ -147,7 +148,8 @@ public interface FileSystem extends Closeable {
       if (conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_ENABLED)
           && CommonUtils.PROCESS_TYPE.get().equals(CommonUtils.ProcessType.CLIENT)) {
         try {
-          return new LocalCacheFileSystem(fs, conf);
+          CacheManager cacheManager = CacheManager.Factory.get(conf);
+          return new LocalCacheFileSystem(cacheManager, fs, conf);
         } catch (IOException e) {
           LOG.error("Fallback without client caching: ", e);
         }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -12,20 +12,71 @@
 package alluxio.client.file.cache;
 
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
+
+import com.codahale.metrics.Counter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
 
 /**
  * Interface for managing cached pages.
  */
 public interface CacheManager extends AutoCloseable  {
+
   /**
-   * @param conf the Alluxio configuration
-   * @return an instance of {@link CacheManager}
+   * Factory class to get or create a CacheManager.
    */
-  static CacheManager create(AlluxioConfiguration conf) throws IOException {
-    // TODO(feng): make cache manager type configurable when we introduce more implementations.
-    return new NoExceptionCacheManager(LocalCacheManager.create(conf));
+  class Factory {
+    private static final Logger LOG = LoggerFactory.getLogger(Factory.class);
+    private static Optional<CacheManager> sCacheManager = null;
+
+    /**
+     * @param conf the Alluxio configuration
+     * @return current CacheManager, creating a new one if it doesn't yet exist
+     */
+    @Nullable
+    public static synchronized CacheManager get(AlluxioConfiguration conf) throws IOException {
+      // TODO(feng): support multiple cache managers
+      if (sCacheManager == null) {
+        try {
+          sCacheManager = Optional.of(create(conf));
+        } catch (IOException e) {
+          sCacheManager = Optional.empty();
+          throw e;
+        }
+      }
+      return sCacheManager.orElse(null);
+    }
+
+    /**
+     * @param conf the Alluxio configuration
+     * @return an instance of {@link CacheManager}
+     */
+    static CacheManager create(AlluxioConfiguration conf) throws IOException {
+      try {
+        return new NoExceptionCacheManager(LocalCacheManager.create(conf));
+      } catch (IOException e) {
+        Metrics.CREATE_ERRORS.inc();
+        LOG.error("Failed to create CacheManager", e);
+        throw e;
+      }
+    }
+
+    private Factory() {} // prevent instantiation
+
+    private static final class Metrics {
+      /** Errors when creating cache. */
+      private static final Counter CREATE_ERRORS =
+          MetricsSystem.counter(MetricKey.CLIENT_CACHE_CREATE_ERRORS.getName());
+
+      private Metrics() {} // prevent instantiation
+    }
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -20,38 +20,28 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Optional;
-
-import javax.annotation.Nullable;
 
 /**
  * Interface for managing cached pages.
  */
 public interface CacheManager extends AutoCloseable  {
-
   /**
    * Factory class to get or create a CacheManager.
    */
   class Factory {
     private static final Logger LOG = LoggerFactory.getLogger(Factory.class);
-    private static Optional<CacheManager> sCacheManager = null;
+    private static CacheManager sCacheManager = null;
 
     /**
      * @param conf the Alluxio configuration
      * @return current CacheManager, creating a new one if it doesn't yet exist
      */
-    @Nullable
     public static synchronized CacheManager get(AlluxioConfiguration conf) throws IOException {
       // TODO(feng): support multiple cache managers
       if (sCacheManager == null) {
-        try {
-          sCacheManager = Optional.of(create(conf));
-        } catch (IOException e) {
-          sCacheManager = Optional.empty();
-          throw e;
-        }
+        sCacheManager = create(conf);
       }
-      return sCacheManager.orElse(null);
+      return sCacheManager;
     }
 
     /**

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
@@ -53,18 +53,12 @@ public class LocalCacheFileSystem extends DelegatingFileSystem {
   @Override
   public FileInStream openFile(AlluxioURI path, OpenFilePOptions options)
       throws IOException, AlluxioException {
-    if (mCacheManager == null) {
-      return mDelegatedFileSystem.openFile(path, options);
-    }
     return new LocalCacheFileInStream(path, options, mDelegatedFileSystem, mCacheManager);
   }
 
   @Override
   public FileInStream openFile(URIStatus status, OpenFilePOptions options)
       throws IOException, AlluxioException {
-    if (mCacheManager == null) {
-      return mDelegatedFileSystem.openFile(status, options);
-    }
     return new LocalCacheFileInStream(status, options, mDelegatedFileSystem, mCacheManager);
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
@@ -19,49 +19,30 @@ import alluxio.client.file.URIStatus;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.OpenFilePOptions;
-import alluxio.metrics.MetricKey;
-import alluxio.metrics.MetricsSystem;
 
-import com.codahale.metrics.Counter;
+import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Optional;
 
 /**
  * A FileSystem implementation with a local cache.
  */
 public class LocalCacheFileSystem extends DelegatingFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(LocalCacheFileSystem.class);
-  private static Optional<CacheManager> sCacheManager;
-
+  private final CacheManager mCacheManager;
   private final AlluxioConfiguration mConf;
 
-  // TODO(binfan): Remove the IOException throwing or make this into a factory method
   /**
+   * @param cacheManage cache manager
    * @param fs a FileSystem instance to query on local cache miss
    * @param conf the configuration, only respected for the first call
    */
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
-      justification = "write to static is made threadsafe")
-  public LocalCacheFileSystem(FileSystem fs, AlluxioConfiguration conf) throws IOException {
+  public LocalCacheFileSystem(CacheManager cacheManage, FileSystem fs, AlluxioConfiguration conf) {
     super(fs);
-    // TODO(feng): support multiple cache managers
-    if (sCacheManager == null) {
-      synchronized (LocalCacheFileSystem.class) {
-        if (sCacheManager == null) {
-          try {
-            sCacheManager = Optional.of(CacheManager.create(conf));
-          } catch (IOException e) {
-            Metrics.CREATE_ERRORS.inc();
-            throw new IOException("Failed to create CacheManager", e);
-          }
-        }
-      }
-    }
-    mConf = conf;
+    mCacheManager = Preconditions.checkNotNull(cacheManage, "cacheManager");
+    mConf = Preconditions.checkNotNull(conf, "conf");
   }
 
   @Override
@@ -72,26 +53,18 @@ public class LocalCacheFileSystem extends DelegatingFileSystem {
   @Override
   public FileInStream openFile(AlluxioURI path, OpenFilePOptions options)
       throws IOException, AlluxioException {
-    if (sCacheManager == null || !sCacheManager.isPresent()) {
+    if (mCacheManager == null) {
       return mDelegatedFileSystem.openFile(path, options);
     }
-    return new LocalCacheFileInStream(path, options, mDelegatedFileSystem, sCacheManager.get());
+    return new LocalCacheFileInStream(path, options, mDelegatedFileSystem, mCacheManager);
   }
 
   @Override
   public FileInStream openFile(URIStatus status, OpenFilePOptions options)
       throws IOException, AlluxioException {
-    if (sCacheManager == null || !sCacheManager.isPresent()) {
+    if (mCacheManager == null) {
       return mDelegatedFileSystem.openFile(status, options);
     }
-    return new LocalCacheFileInStream(status, options, mDelegatedFileSystem, sCacheManager.get());
-  }
-
-  private static final class Metrics {
-    /** Errors when creating cache. */
-    private static final Counter CREATE_ERRORS =
-        MetricsSystem.counter(MetricKey.CLIENT_CACHE_CREATE_ERRORS.getName());
-
-    private Metrics() {} // prevent instantiation
+    return new LocalCacheFileInStream(status, options, mDelegatedFileSystem, mCacheManager);
   }
 }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsFileSystem.java
@@ -107,8 +107,8 @@ public class AlluxioHdfsFileSystem implements alluxio.client.file.FileSystem {
   @Override
   public List<URIStatus> listStatus(AlluxioURI alluxioURI, ListStatusPOptions options)
       throws IOException {
-    return Arrays.stream(mFileSystem.listStatus(HadoopUtils.toPath(alluxioURI))).map(HadoopUtils::toUriStatus)
-        .collect(Collectors.toList());
+    return Arrays.stream(mFileSystem.listStatus(HadoopUtils.toPath(alluxioURI)))
+        .map(HadoopUtils::toUriStatus).collect(Collectors.toList());
   }
 
   @Override

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsFileSystem.java
@@ -1,0 +1,219 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.hadoop;
+
+import static com.google.common.hash.Hashing.md5;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.URIStatus;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.grpc.CreateDirectoryPOptions;
+import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.DeletePOptions;
+import alluxio.grpc.ExistsPOptions;
+import alluxio.grpc.FreePOptions;
+import alluxio.grpc.GetStatusPOptions;
+import alluxio.grpc.ListStatusPOptions;
+import alluxio.grpc.MountPOptions;
+import alluxio.grpc.OpenFilePOptions;
+import alluxio.grpc.RenamePOptions;
+import alluxio.grpc.ScheduleAsyncPersistencePOptions;
+import alluxio.grpc.SetAclAction;
+import alluxio.grpc.SetAclPOptions;
+import alluxio.grpc.SetAttributePOptions;
+import alluxio.grpc.UnmountPOptions;
+import alluxio.security.authorization.AclEntry;
+import alluxio.security.authorization.Mode;
+import alluxio.wire.BlockLocationInfo;
+import alluxio.wire.FileInfo;
+import alluxio.wire.MountPointInfo;
+import alluxio.wire.SyncPointInfo;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * A wrapper class to translate Hadoop FileSystem to Alluxio FileSystem.
+ */
+public class AlluxioHdfsFileSystem implements alluxio.client.file.FileSystem {
+  private final AlluxioConfiguration mAlluxioConfiguration;
+  private final org.apache.hadoop.fs.FileSystem mFileSystem;
+
+  /**
+   * @param fileSystem file system
+   * @param alluxioConfiguration configuration
+   */
+  public AlluxioHdfsFileSystem(org.apache.hadoop.fs.FileSystem fileSystem,
+                               AlluxioConfiguration alluxioConfiguration) {
+    mFileSystem = Preconditions.checkNotNull(fileSystem, "fileSystem");
+    mAlluxioConfiguration =
+        Preconditions.checkNotNull(alluxioConfiguration, "alluxioConfiguration");
+  }
+
+  @Override
+  public void createDirectory(AlluxioURI alluxioURI, CreateDirectoryPOptions options)
+      throws IOException {
+    FsPermission permission = new FsPermission(Mode.fromProto(options.getMode()).toShort());
+    mFileSystem.mkdirs(toPath(alluxioURI), permission);
+  }
+
+  @Override
+  public FileInStream openFile(AlluxioURI alluxioURI, OpenFilePOptions options) throws IOException {
+    return new AlluxioHdfsInputStream(mFileSystem.open(toPath(alluxioURI)));
+  }
+
+  @Override
+  public FileInStream openFile(URIStatus uriStatus, OpenFilePOptions options) throws IOException {
+    return new AlluxioHdfsInputStream(mFileSystem.open(new Path(uriStatus.getPath())));
+  }
+
+  @Override
+  public FileOutStream createFile(AlluxioURI alluxioURI, CreateFilePOptions options) {
+    throw new UnsupportedOperationException("CreateFile operation is not supported");
+  }
+
+  @Override
+  public void delete(AlluxioURI alluxioURI, DeletePOptions options) {
+    throw new UnsupportedOperationException("Delete operation is not supported");
+  }
+
+  @Override
+  public boolean exists(AlluxioURI alluxioURI, ExistsPOptions options) {
+    throw new UnsupportedOperationException("Exists operation is not supported");
+  }
+
+  @Override
+  public AlluxioConfiguration getConf() {
+    return mAlluxioConfiguration;
+  }
+
+  @Override
+  public URIStatus getStatus(AlluxioURI alluxioURI, GetStatusPOptions options) throws IOException {
+    return toUriStatus(mFileSystem.getFileStatus(toPath(alluxioURI)));
+  }
+
+  @Override
+  public List<URIStatus> listStatus(AlluxioURI alluxioURI, ListStatusPOptions options)
+      throws IOException {
+    return Arrays.stream(mFileSystem.listStatus(toPath(alluxioURI))).map(this::toUriStatus)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean isClosed() {
+    throw new UnsupportedOperationException("isClosed is not supported");
+  }
+
+  @Override
+  public void free(AlluxioURI alluxioURI, FreePOptions options) {
+    throw new UnsupportedOperationException("Free is not supported.");
+  }
+
+  @Override
+  public List<BlockLocationInfo> getBlockLocations(AlluxioURI alluxioURI) {
+    throw new UnsupportedOperationException("GetBlockLocations is not supported.");
+  }
+
+  @Override
+  public void mount(AlluxioURI alluxioURI1, AlluxioURI alluxioURI2, MountPOptions options) {
+    throw new UnsupportedOperationException("Mount is not supported.");
+  }
+
+  @Override
+  public void updateMount(AlluxioURI alluxioURI, MountPOptions options) {
+    throw new UnsupportedOperationException("UpdateMount is not supported.");
+  }
+
+  @Override
+  public Map<String, MountPointInfo> getMountTable() {
+    throw new UnsupportedOperationException("GetMountTable is not supported.");
+  }
+
+  @Override
+  public List<SyncPointInfo> getSyncPathList() {
+    throw new UnsupportedOperationException("GetSyncPathList is not supported.");
+  }
+
+  @Override
+  public void persist(AlluxioURI alluxioURI, ScheduleAsyncPersistencePOptions options) {
+    throw new UnsupportedOperationException("Persist is not supported.");
+  }
+
+  @Override
+  public void rename(AlluxioURI source, AlluxioURI destination, RenamePOptions options) {
+    throw new UnsupportedOperationException("ReverseResolve is not supported.");
+  }
+
+  @Override
+  public AlluxioURI reverseResolve(AlluxioURI alluxioURI) {
+    throw new UnsupportedOperationException("ReverseResolve is not supported.");
+  }
+
+  @Override
+  public void setAcl(AlluxioURI alluxioURI, SetAclAction action, List<AclEntry> entries,
+      SetAclPOptions options) {
+    throw new UnsupportedOperationException("SetAcl is not supported.");
+  }
+
+  @Override
+  public void startSync(AlluxioURI alluxioURI) {
+    throw new UnsupportedOperationException("StartSync is not supported.");
+  }
+
+  @Override
+  public void stopSync(AlluxioURI alluxioURI) {
+    throw new UnsupportedOperationException("StopSync is not supported.");
+  }
+
+  @Override
+  public void setAttribute(AlluxioURI alluxioURI, SetAttributePOptions options) {
+    throw new UnsupportedOperationException("SetAttribute is not supported.");
+  }
+
+  @Override
+  public void unmount(AlluxioURI alluxioURI, UnmountPOptions options) {
+    throw new UnsupportedOperationException("unmount is not supported.");
+  }
+
+  @Override
+  public void close() throws IOException {
+    mFileSystem.close();
+  }
+
+  private Path toPath(AlluxioURI alluxioURI) {
+    return new Path(alluxioURI.toString());
+  }
+
+  private URIStatus toUriStatus(FileStatus status) {
+    // FilePath is a unique identifier for a file, however it can be a long string
+    // hence using md5 hash of the file path as the identifier in the cache.
+    FileInfo info = new FileInfo();
+    info.setFileIdentifier(md5().hashString(status.getPath().toString(), UTF_8).toString());
+    info.setLength(status.getLen()).setPath(status.getPath().toString());
+    info.setFolder(status.isDirectory()).setBlockSizeBytes(status.getBlockSize());
+    info.setLastModificationTimeMs(status.getModificationTime())
+        .setLastAccessTimeMs(status.getAccessTime());
+    info.setOwner(status.getOwner()).setGroup(status.getGroup());
+    return new URIStatus(info);
+  }
+}

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsInputStream.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsInputStream.java
@@ -1,0 +1,100 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.hadoop;
+
+import alluxio.client.file.FileInStream;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.IOException;
+
+/**
+ * A wrapper class to translate Hadoop FileSystem FSDataInputStream to Alluxio FileSystem
+ * FileInStream.
+ */
+public class AlluxioHdfsInputStream extends FileInStream {
+  private final FSDataInputStream mInput;
+
+  /**
+   * @param input Hadoop FileSystem FSDataInputStream
+   */
+  public AlluxioHdfsInputStream(FSDataInputStream input) {
+    mInput = Preconditions.checkNotNull(input, "null");
+  }
+
+  @Override
+  public int read(byte[] bytes) throws IOException {
+    return mInput.read(bytes);
+  }
+
+  @Override
+  public int read(byte[] bytes, int offset, int length) throws IOException {
+    return mInput.read(bytes, offset, length);
+  }
+
+  @Override
+  public int read() throws IOException {
+    return mInput.read();
+  }
+
+  @Override
+  public long skip(long length) throws IOException {
+    return mInput.skip(length);
+  }
+
+  @Override
+  public int available() throws IOException {
+    return mInput.available();
+  }
+
+  @Override
+  public void close() throws IOException {
+    mInput.close();
+  }
+
+  @Override
+  public synchronized void mark(int limit) {
+    mInput.mark(limit);
+  }
+
+  @Override
+  public synchronized void reset() throws IOException {
+    mInput.reset();
+  }
+
+  @Override
+  public boolean markSupported() {
+    return mInput.markSupported();
+  }
+
+  @Override
+  public void seek(long position) throws IOException {
+    mInput.seek(position);
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return mInput.getPos();
+  }
+
+  @Override
+  public long remaining() {
+    throw new UnsupportedOperationException("Remaining is not supported");
+  }
+
+  @Override
+  public int positionedRead(long position, byte[] buffer, int offset, int length)
+      throws IOException {
+    return mInput.read(position, buffer, offset, length);
+  }
+}

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsInputStream.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsInputStream.java
@@ -87,6 +87,7 @@ public class AlluxioHdfsInputStream extends FileInStream {
     return mInput.getPos();
   }
 
+  // TODO(binfan): implement this method
   @Override
   public long remaining() {
     throw new UnsupportedOperationException("Remaining is not supported");

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopConfigurationUtils.java
@@ -12,17 +12,13 @@
 package alluxio.hadoop;
 
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.AlluxioProperties;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.Source;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -34,34 +30,6 @@ public final class HadoopConfigurationUtils {
   private static final Logger LOG = LoggerFactory.getLogger(HadoopConfigurationUtils.class);
 
   private HadoopConfigurationUtils() {} // Prevent instantiation.
-
-  /**
-   * Merges Hadoop {@link org.apache.hadoop.conf.Configuration} with Alluxio properties.
-   *
-   * @param hadoopConf the {@link org.apache.hadoop.conf.Configuration} to merge
-   * @param alluxioProps the Alluxio properties to merge
-   * @return a configuration with properties all merged
-   */
-  //TODO(binfan): remove this method after Presto code updated
-  public static InstancedConfiguration mergeHadoopConfiguration(
-      org.apache.hadoop.conf.Configuration hadoopConf, AlluxioProperties alluxioProps) {
-    // Load Alluxio configuration if any and merge to the one in Alluxio file system
-    // Push Alluxio configuration to the Job configuration
-    Properties alluxioConfProperties = new Properties();
-    // Load any Alluxio configuration parameters existing in the Hadoop configuration.
-    for (Map.Entry<String, String> entry : hadoopConf) {
-      String propertyName = entry.getKey();
-      if (PropertyKey.isValid(propertyName)) {
-        alluxioConfProperties.put(propertyName, entry.getValue());
-      }
-    }
-    // Merge the relevant Hadoop configuration into Alluxio's configuration.
-    alluxioProps.merge(alluxioConfProperties, Source.RUNTIME);
-    // Creting a new instanced configuration from an AlluxioProperties object isn't expensive.
-    InstancedConfiguration mergedConf = new InstancedConfiguration(alluxioProps);
-    mergedConf.validate();
-    return mergedConf;
-  }
 
   /**
    * Extracts relevant configuration from Hadoop {@link org.apache.hadoop.conf.Configuration}.

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopUtils.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopUtils.java
@@ -11,13 +11,8 @@
 
 package alluxio.hadoop;
 
-import static com.google.common.hash.Hashing.md5;
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import alluxio.AlluxioURI;
-import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.wire.FileInfo;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -195,23 +190,6 @@ public final class HadoopUtils {
    */
   public static Path toPath(AlluxioURI alluxioURI) {
     return new Path(alluxioURI.toString());
-  }
-
-  /**
-   * @param status Hadoop file status
-   * @return corresponding Alluxio uri status instance
-   */
-  public static URIStatus toUriStatus(FileStatus status) {
-    // FilePath is a unique identifier for a file, however it can be a long string
-    // hence using md5 hash of the file path as the identifier in the cache.
-    FileInfo info = new FileInfo();
-    info.setFileIdentifier(md5().hashString(status.getPath().toString(), UTF_8).toString());
-    info.setLength(status.getLen()).setPath(status.getPath().toString());
-    info.setFolder(status.isDirectory()).setBlockSizeBytes(status.getBlockSize());
-    info.setLastModificationTimeMs(status.getModificationTime())
-        .setLastAccessTimeMs(status.getAccessTime());
-    info.setOwner(status.getOwner()).setGroup(status.getGroup());
-    return new URIStatus(info);
   }
 
   private HadoopUtils() {} // prevent instantiation

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
@@ -66,6 +66,17 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
     }
   }
 
+  /**
+   * Constructs a new stream for reading a file from HDFS.
+   *
+   * @param inputStream the input stream
+   * @param stats filesystem statistics
+   */
+  public HdfsFileInputStream(FileInStream inputStream, Statistics stats) {
+    mInputStream = inputStream;
+    mStatistics = stats;
+  }
+
   @Override
   public int available() throws IOException {
     if (mClosed) {

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/LocalCachingFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/LocalCachingFileSystem.java
@@ -1,0 +1,173 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.hadoop;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.cache.CacheManager;
+import alluxio.client.file.cache.LocalCacheFileInStream;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.AlluxioProperties;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Source;
+import alluxio.grpc.OpenFilePOptions;
+import alluxio.metrics.MetricsConfig;
+import alluxio.metrics.MetricsSystem;
+import alluxio.util.ConfigurationUtils;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.util.Progressable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * An Alluxio client compatible with Apache Hadoop {@link org.apache.hadoop.fs.FileSystem}
+ * interface, using Alluxio local cache. On cache miss,
+ */
+public class LocalCachingFileSystem extends org.apache.hadoop.fs.FileSystem {
+  private static final Logger LOG = LoggerFactory.getLogger(LocalCachingFileSystem.class);
+  // The filesystem to query on cache miss
+  private final org.apache.hadoop.fs.FileSystem mExternalFileSystem;
+  private CacheManager mCacheManager;
+  private org.apache.hadoop.conf.Configuration mHadoopConf;
+  private AlluxioConfiguration mAlluxioConf;
+
+  /**
+   * @param fileSystem File System instance
+   */
+  LocalCachingFileSystem(org.apache.hadoop.fs.FileSystem fileSystem) {
+    mExternalFileSystem = Preconditions.checkNotNull(fileSystem, "filesystem");
+  }
+
+  @Override
+  public synchronized void initialize(URI uri, org.apache.hadoop.conf.Configuration conf)
+      throws IOException {
+    super.initialize(uri, conf);
+    mHadoopConf = conf;
+
+    // Set statistics
+    setConf(conf);
+
+    // Take hadoop configuration to merge to Alluxio configuration
+    Map<String, Object> hadoopConfProperties =
+        HadoopConfigurationUtils.getConfigurationFromHadoop(conf);
+    LOG.info("Creating Alluxio configuration from Hadoop configuration {}", hadoopConfProperties);
+    AlluxioProperties alluxioProps = ConfigurationUtils.defaults();
+    // Merge relevant Hadoop configuration into Alluxio's configuration.
+    alluxioProps.merge(hadoopConfProperties, Source.RUNTIME);
+    // Creating a new instanced configuration from an AlluxioProperties object isn't expensive.
+    mAlluxioConf = new InstancedConfiguration(alluxioProps);
+
+    // Handle metrics
+    Properties metricsProperties = new Properties();
+    for (Map.Entry<String, String> entry : conf) {
+      metricsProperties.setProperty(entry.getKey(), entry.getValue());
+    }
+    MetricsSystem.startSinksFromConfig(new MetricsConfig(metricsProperties));
+
+    mCacheManager = CacheManager.Factory.get(mAlluxioConf);
+  }
+
+  @Override
+  public void close() throws IOException {
+    // super.close should be called first before releasing the resources in this instance, as the
+    // super class may invoke other methods in this class. For example,
+    // org.apache.hadoop.fs.FileSystem.close may check the existence of certain temp files before
+    // closing
+    super.close();
+    mExternalFileSystem.close();
+  }
+
+  /**
+   * @return scheme
+   */
+  // @Override This doesn't exist in Hadoop 1.x, so cannot put {@literal @Override}.
+  public String getScheme() {
+    return mExternalFileSystem.getScheme();
+  }
+
+  @Override
+  public FSDataInputStream open(Path path, int bufferSize) throws IOException {
+    if (mCacheManager == null) {
+      return mExternalFileSystem.open(path, bufferSize);
+    }
+    return new FSDataInputStream(new HdfsFileInputStream(
+        new LocalCacheFileInStream(
+            new AlluxioURI(path.toString()),
+            OpenFilePOptions.getDefaultInstance(),
+            new AlluxioHdfsFileSystem(mExternalFileSystem, mAlluxioConf), mCacheManager),
+        statistics));
+  }
+
+  @Override
+  public URI getUri() {
+    return mExternalFileSystem.getUri();
+  }
+
+  @Override
+  public FSDataOutputStream create(Path f, FsPermission permission, boolean overwrite,
+      int bufferSize, short replication, long blockSize, Progressable progress) throws IOException {
+    return mExternalFileSystem.create(f, permission, overwrite, bufferSize, replication, blockSize,
+        progress);
+  }
+
+  @Override
+  public FSDataOutputStream append(Path f, int bufferSize, Progressable progress)
+      throws IOException {
+    return mExternalFileSystem.append(f, bufferSize, progress);
+  }
+
+  @Override
+  public boolean rename(Path src, Path dst) throws IOException {
+    return mExternalFileSystem.rename(src, dst);
+  }
+
+  @Override
+  public boolean delete(Path f, boolean recursive) throws IOException {
+    return mExternalFileSystem.delete(f, recursive);
+  }
+
+  @Override
+  public FileStatus[] listStatus(Path f) throws FileNotFoundException, IOException {
+    return mExternalFileSystem.listStatus(f);
+  }
+
+  @Override
+  public void setWorkingDirectory(Path new_dir) {
+    mExternalFileSystem.setWorkingDirectory(new_dir);
+  }
+
+  @Override
+  public Path getWorkingDirectory() {
+    return mExternalFileSystem.getWorkingDirectory();
+  }
+
+  @Override
+  public boolean mkdirs(Path f, FsPermission permission) throws IOException {
+    return mExternalFileSystem.mkdirs(f, permission);
+  }
+
+  @Override
+  public FileStatus getFileStatus(Path f) throws IOException {
+    return mExternalFileSystem.getFileStatus(f);
+  }
+}


### PR DESCRIPTION
- move `CacheManager` singleton to `CacheManager.Factory`, so multiple different classes can access this singleton.
- Change `LocalCachingFileSystem` from inheriting `AbstractFileSystem` to Hadoop Filesystem,  to reduce the complexity & reduce # of calls of merge hadoop conf (to 1 per LocalCachingFileSystem)