### PR TITLE
Support active sync for give list in EMR bootstrap

### DIFF
--- a/integration/emr/alluxio-emr.sh
+++ b/integration/emr/alluxio-emr.sh
@@ -462,9 +462,9 @@ If a different Alluxio version is desired, see the -d option.
                     will be downloaded, and upon Alluxio startup, the Alluxio
                     master will read and restore the backup.
 
-  -l                A string containing a delimited list of relative paths under
-                    the root UFS. Active sync will be enabled for the given paths.
-                    UFS metadata will be periodically syncing to Alluxio namespace.
+  -l                A string containing a delimited list of Alluxio paths.
+                    Active sync will be enabled for the given paths. UFS metadata
+                    will be periodically synced with the Alluxio namespace.
                     The delimiter by default is a semicolon ";". If a different
                     delimiter is desired use the [-s] argument.
 


### PR DESCRIPTION
User can pass in a list of relative paths of root UFS to enable active sync on