### PR TITLE
Reduce number of clients in DistributedLoadCommand

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -137,7 +137,7 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
 
   private List<JobAttempt> mSubmittedJobAttempts;
   private int mActiveJobs;
-  private final JobMasterClient mClient;
+  private JobMasterClient mClient;
 
   /**
    * Constructs a new instance to load a file or directory in Alluxio space.
@@ -147,11 +147,6 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
   public DistributedLoadCommand(FileSystemContext fsContext) {
     super(fsContext);
     mSubmittedJobAttempts = Lists.newArrayList();
-
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
-    final ClientContext clientContext = ClientContext.create(conf);
-    mClient = JobMasterClient.Factory.create(
-        JobMasterClientContext.newBuilder(clientContext).build());
   }
 
   @Override
@@ -254,6 +249,9 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
    */
   private void distributedLoad(AlluxioURI filePath, int replication)
       throws AlluxioException, IOException {
+    final ClientContext clientContext = ClientContext.create(mFsContext.getPathConf(filePath));
+    mClient = JobMasterClient.Factory.create(
+        JobMasterClientContext.newBuilder(clientContext).build());
     load(filePath, replication);
     // Wait remaining jobs to complete.
     while (!mSubmittedJobAttempts.isEmpty()) {

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -147,6 +147,9 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
   public DistributedLoadCommand(FileSystemContext fsContext) {
     super(fsContext);
     mSubmittedJobAttempts = Lists.newArrayList();
+    final ClientContext clientContext = mFsContext.getClientContext();
+    mClient = JobMasterClient.Factory.create(
+        JobMasterClientContext.newBuilder(clientContext).build());
   }
 
   @Override
@@ -249,9 +252,6 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
    */
   private void distributedLoad(AlluxioURI filePath, int replication)
       throws AlluxioException, IOException {
-    final ClientContext clientContext = ClientContext.create(mFsContext.getPathConf(filePath));
-    mClient = JobMasterClient.Factory.create(
-        JobMasterClientContext.newBuilder(clientContext).build());
     load(filePath, replication);
     // Wait remaining jobs to complete.
     while (!mSubmittedJobAttempts.isEmpty()) {

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -19,7 +19,6 @@ import alluxio.cli.fs.FileSystemShellUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.client.job.JobMasterClient;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.job.plan.load.LoadConfig;
@@ -28,7 +27,6 @@ import alluxio.job.wire.JobInfo;
 import alluxio.job.wire.Status;
 import alluxio.retry.CountingRetry;
 import alluxio.retry.RetryPolicy;
-import alluxio.util.ConfigurationUtils;
 import alluxio.worker.job.JobMasterClientContext;
 
 import com.google.common.collect.Lists;

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -179,6 +179,11 @@ public final class DistributedLoadCommand extends AbstractFileSystemCommand {
     return 0;
   }
 
+  @Override
+  public void close() throws IOException {
+    mClient.close();
+  }
+
   /**
    * Creates a new job to load a file in Alluxio space, makes it resident in memory.
    *

--- a/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
@@ -39,14 +39,14 @@ public final class DistributedLoadCommandTest extends AbstractFileSystemShellTes
 
     URIStatus statusA = sFileSystem.getStatus(uriA);
     URIStatus statusB = sFileSystem.getStatus(uriB);
-    Assert.assertFalse(statusA.getInMemoryPercentage() == 100);
-    Assert.assertTrue(statusB.getInMemoryPercentage() == 100);
+    Assert.assertNotEquals(100, statusA.getInMemoryPercentage());
+    Assert.assertEquals(100, statusB.getInMemoryPercentage());
     // Testing loading of a directory
     sFsShell.run("distributedLoad", "/testRoot");
     statusA = sFileSystem.getStatus(uriA);
     statusB = sFileSystem.getStatus(uriB);
-    Assert.assertTrue(statusA.getInMemoryPercentage() == 100);
-    Assert.assertTrue(statusB.getInMemoryPercentage() == 100);
+    Assert.assertEquals(100, statusA.getInMemoryPercentage());
+    Assert.assertEquals(100, statusB.getInMemoryPercentage());
   }
 
   @Test
@@ -54,10 +54,10 @@ public final class DistributedLoadCommandTest extends AbstractFileSystemShellTes
     FileSystemTestUtils.createByteFile(sFileSystem, "/testFile", WritePType.THROUGH, 10);
     AlluxioURI uri = new AlluxioURI("/testFile");
     URIStatus status = sFileSystem.getStatus(uri);
-    Assert.assertFalse(status.getInMemoryPercentage() == 100);
+    Assert.assertNotEquals(100, status.getInMemoryPercentage());
     // Testing loading of a single file
     sFsShell.run("distributedLoad", "/testFile");
     status = sFileSystem.getStatus(uri);
-    Assert.assertTrue(status.getInMemoryPercentage() == 100);
+    Assert.assertEquals(100, status.getInMemoryPercentage());
   }
 }


### PR DESCRIPTION
Creating many clients in DistributedLoadCommand creates an issue in certain environments. Reduce the number of clients and also remove the parallelism around it to prevent race conditions when using the same client.