### PR TITLE
Fix deadlock issue on metadata sync

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -737,18 +737,48 @@ public final class DefaultFileSystemMaster extends CoreMaster
 
   private long getFileIdInternal(AlluxioURI path, boolean checkPermission)
       throws AccessControlException, UnavailableException {
-    try (RpcContext rpcContext = createRpcContext();
-         LockedInodePath inodePath = mInodeTree.lockInodePath(path, LockPattern.READ)) {
-      if (checkPermission) {
-        mPermissionChecker.checkPermission(Mode.Bits.READ, inodePath);
+    try (RpcContext rpcContext = createRpcContext()) {
+      /*
+      In order to prevent locking twice on RPCs where metadata does _not_ need to be loaded, we use
+      a two-phase scheme as an optimization to prevent the extra lock. loadMetadataIfNotExists
+      requires a lock on the tree to determine if the path should be loaded before executing. To
+      prevent the extra lock, we execute the RPC as normal and use a conditional check in the
+      main body of the function to determine whether control flow should be shifted out of the
+      RPC logic and back to the loadMetadataIfNotExists function.
+
+      If loadMetadataIfNotExists runs, then the next pass into the main logic body should
+      continue as normal. This may present a slight decrease in performance for newly-loaded
+      metadata, but it is better than affecting the most common case where metadata is not being
+      loaded.
+       */
+      LoadMetadataContext lmCtx = LoadMetadataContext.mergeFrom(
+          LoadMetadataPOptions.newBuilder().setCreateAncestors(true));
+      boolean run = true;
+      boolean loadMetadata = false;
+      while (run) {
+        run = false;
+        if (loadMetadata) {
+          loadMetadataIfNotExist(rpcContext, path, lmCtx, false);
+        }
+        try (LockedInodePath inodePath = mInodeTree.lockInodePath(path, LockPattern.READ)) {
+          if (checkPermission) {
+            mPermissionChecker.checkPermission(Mode.Bits.READ, inodePath);
+          }
+          if (!loadMetadata && shouldLoadMetadataIfNotExists(inodePath, lmCtx)) {
+            loadMetadata = true;
+            run = true;
+            continue;
+          }
+          mInodeTree.ensureFullInodePath(inodePath);
+          return inodePath.getInode().getId();
+        } catch (InvalidPathException | FileDoesNotExistException e) {
+          return IdUtils.INVALID_FILE_ID;
+        }
       }
-      loadMetadataIfNotExist(rpcContext, inodePath, LoadMetadataContext
-          .mergeFrom(LoadMetadataPOptions.newBuilder().setCreateAncestors(true)), false);
-      mInodeTree.ensureFullInodePath(inodePath);
-      return inodePath.getInode().getId();
-    } catch (InvalidPathException | FileDoesNotExistException e) {
+    } catch (InvalidPathException e) {
       return IdUtils.INVALID_FILE_ID;
     }
+    return IdUtils.INVALID_FILE_ID;
   }
 
   @Override
@@ -769,49 +799,72 @@ public final class DefaultFileSystemMaster extends CoreMaster
         FileSystemMasterAuditContext auditContext =
             createAuditContext("getFileInfo", path, null, null)) {
 
-      if (syncMetadata(rpcContext,
-          path,
-          context.getOptions().getCommonOptions(),
-          DescendantType.ONE,
-          auditContext,
-          LockedInodePath::getInodeOrNull,
+      if (syncMetadata(rpcContext, path, context.getOptions().getCommonOptions(),
+          DescendantType.ONE, auditContext, LockedInodePath::getInodeOrNull,
           (inodePath, permChecker) -> permChecker.checkPermission(Mode.Bits.READ, inodePath),
           true)) {
         // If synced, do not load metadata.
         context.getOptions().setLoadMetadataType(LoadMetadataPType.NEVER);
       }
+      LoadMetadataContext lmCtx = LoadMetadataContext.mergeFrom(
+          LoadMetadataPOptions.newBuilder().setCreateAncestors(true).setCommonOptions(
+              FileSystemMasterCommonPOptions.newBuilder()
+                  .setTtl(context.getOptions().getCommonOptions().getTtl())
+                  .setTtlAction(context.getOptions().getCommonOptions().getTtlAction())));
+      /*
+      In order to prevent locking twice on RPCs where metadata does _not_ need to be loaded, we use
+      a two-phase scheme as an optimization to prevent the extra lock. loadMetadataIfNotExists
+      requires a lock on the tree to determine if the path should be loaded before executing. To
+      prevent the extra lock, we execute the RPC as normal and use a conditional check in the
+      main body of the function to determine whether control flow should be shifted out of the
+      RPC logic and back to the loadMetadataIfNotExists function.
 
-      LockingScheme lockingScheme = new LockingScheme(path, LockPattern.READ, false);
-      try (LockedInodePath inodePath = mInodeTree.lockInodePath(lockingScheme)) {
-        auditContext.setSrcInode(inodePath.getInodeOrNull());
-        try {
-          mPermissionChecker.checkPermission(Mode.Bits.READ, inodePath);
-        } catch (AccessControlException e) {
-          auditContext.setAllowed(false);
-          throw e;
+      If loadMetadataIfNotExists runs, then the next pass into the main logic body should
+      continue as normal. This may present a slight decrease in performance for newly-loaded
+      metadata, but it is better than affecting the most common case where metadata is not being
+      loaded.
+       */
+      boolean run = true;
+      boolean loadMetadata = false;
+      FileInfo ret = null;
+      while (run) {
+        run = false;
+        if (loadMetadata) {
+          checkLoadMetadataOptions(context.getOptions().getLoadMetadataType(), path);
+          loadMetadataIfNotExist(rpcContext, path, lmCtx, true);
         }
-        // If the file already exists, then metadata does not need to be loaded,
-        // otherwise load metadata.
-        if (!inodePath.fullPathExists()) {
-          checkLoadMetadataOptions(context.getOptions().getLoadMetadataType(), inodePath.getUri());
-          loadMetadataIfNotExist(rpcContext, inodePath, LoadMetadataContext.mergeFrom(
-              LoadMetadataPOptions.newBuilder().setCreateAncestors(true).setCommonOptions(
-                  FileSystemMasterCommonPOptions.newBuilder()
-                      .setTtl(context.getOptions().getCommonOptions().getTtl())
-                      .setTtlAction(context.getOptions().getCommonOptions().getTtlAction()))),
-              true);
+
+        LockingScheme lockingScheme = new LockingScheme(path, LockPattern.READ, false);
+        try (LockedInodePath inodePath = mInodeTree.lockInodePath(lockingScheme)) {
+          auditContext.setSrcInode(inodePath.getInodeOrNull());
+          try {
+            mPermissionChecker.checkPermission(Mode.Bits.READ, inodePath);
+          } catch (AccessControlException e) {
+            auditContext.setAllowed(false);
+            throw e;
+          }
+
+          if (!loadMetadata && shouldLoadMetadataIfNotExists(inodePath, lmCtx)) {
+            loadMetadata = true;
+            run = true;
+            continue;
+          }
+
           ensureFullPathAndUpdateCache(inodePath);
+
+          FileInfo fileInfo = getFileInfoInternal(inodePath);
+          Mode.Bits accessMode = Mode.Bits.fromProto(context.getOptions().getAccessMode());
+          if (context.getOptions().getUpdateTimestamps() && context.getOptions().hasAccessMode()
+              && (accessMode.imply(Mode.Bits.READ) || accessMode.imply(Mode.Bits.WRITE))) {
+            mAccessTimeUpdater.updateAccessTime(rpcContext.getJournalContext(),
+                inodePath.getInode(), opTimeMs);
+          }
+          auditContext.setSrcInode(inodePath.getInode()).setSucceeded(true);
+          ret = fileInfo;
         }
-        FileInfo fileInfo = getFileInfoInternal(inodePath);
-        Mode.Bits accessMode = Mode.Bits.fromProto(context.getOptions().getAccessMode());
-        if (context.getOptions().getUpdateTimestamps() && context.getOptions().hasAccessMode() && (
-            accessMode.imply(Mode.Bits.READ) || accessMode.imply(Mode.Bits.WRITE))) {
-          mAccessTimeUpdater
-              .updateAccessTime(rpcContext.getJournalContext(), inodePath.getInode(), opTimeMs);
-        }
-        auditContext.setSrcInode(inodePath.getInode()).setSucceeded(true);
-        return fileInfo;
       }
+      return Preconditions.checkNotNull(ret,
+          "fileInfo returned should not be null. This is a bug.");
     }
   }
 
@@ -883,80 +936,101 @@ public final class DefaultFileSystemMaster extends CoreMaster
       ResultStream<FileInfo> resultStream)
       throws AccessControlException, FileDoesNotExistException, InvalidPathException, IOException {
     Metrics.GET_FILE_INFO_OPS.inc();
+    LockingScheme lockingScheme = new LockingScheme(path, LockPattern.READ, false);
     try (RpcContext rpcContext = createRpcContext();
         FileSystemMasterAuditContext auditContext =
             createAuditContext("listStatus", path, null, null)) {
 
       DescendantType descendantType =
           context.getOptions().getRecursive() ? DescendantType.ALL : DescendantType.ONE;
-      if (syncMetadata(rpcContext,
-          path,
-          context.getOptions().getCommonOptions(),
-          descendantType,
-          auditContext,
-          LockedInodePath::getInodeOrNull,
+      if (syncMetadata(rpcContext, path, context.getOptions().getCommonOptions(), descendantType,
+          auditContext, LockedInodePath::getInodeOrNull,
           (inodePath, permChecker) -> permChecker.checkPermission(Mode.Bits.READ, inodePath))) {
         // If synced, do not load metadata.
         context.getOptions().setLoadMetadataType(LoadMetadataPType.NEVER);
       }
+      /*
+      In order to prevent locking twice on RPCs where metadata does _not_ need to be loaded, we use
+      a two-phase scheme as an optimization to prevent the extra lock. loadMetadataIfNotExists
+      requires a lock on the tree to determine if the path should be loaded before executing. To
+      prevent the extra lock, we execute the RPC as normal and use a conditional check in the
+      main body of the function to determine whether control flow should be shifted out of the
+      RPC logic and back to the loadMetadataIfNotExists function.
 
-      // We just synced; the new lock pattern should not sync.
-      LockingScheme lockingScheme = new LockingScheme(path, LockPattern.READ, false);
-      try (LockedInodePath inodePath = mInodeTree.lockInodePath(lockingScheme)) {
-        auditContext.setSrcInode(inodePath.getInodeOrNull());
-        try {
-          mPermissionChecker.checkPermission(Mode.Bits.READ, inodePath);
-        } catch (AccessControlException e) {
-          auditContext.setAllowed(false);
-          throw e;
+      If loadMetadataIfNotExists runs, then the next pass into the main logic body should
+      continue as normal. This may present a slight decrease in performance for newly-loaded
+      metadata, but it is better than affecting the most common case where metadata is not being
+      loaded.
+       */
+      DescendantType loadDescendantType;
+      if (context.getOptions().getLoadMetadataType() == LoadMetadataPType.NEVER) {
+        loadDescendantType = DescendantType.NONE;
+      } else if (context.getOptions().getRecursive()) {
+        loadDescendantType = DescendantType.ALL;
+      } else {
+        loadDescendantType = DescendantType.ONE;
+      }
+      // load metadata for 1 level of descendants, or all descendants if recursive
+      LoadMetadataContext loadMetadataContext = LoadMetadataContext.mergeFrom(
+          LoadMetadataPOptions.newBuilder().setCreateAncestors(true)
+              .setLoadDescendantType(GrpcUtils.toProto(loadDescendantType)).setCommonOptions(
+              FileSystemMasterCommonPOptions.newBuilder()
+                  .setTtl(context.getOptions().getCommonOptions().getTtl())
+                  .setTtlAction(context.getOptions().getCommonOptions().getTtlAction())));
+      boolean loadMetadata = false;
+      boolean run = true;
+      while (run) {
+        run = false;
+        if (loadMetadata) {
+          loadMetadataIfNotExist(rpcContext, path, loadMetadataContext, false);
         }
 
-        DescendantType loadDescendantType;
-        if (context.getOptions().getLoadMetadataType() == LoadMetadataPType.NEVER) {
-          loadDescendantType = DescendantType.NONE;
-        } else if (context.getOptions().getRecursive()) {
-          loadDescendantType = DescendantType.ALL;
-        } else {
-          loadDescendantType = DescendantType.ONE;
-        }
-        // load metadata for 1 level of descendants, or all descendants if recursive
-        LoadMetadataContext loadMetadataContext = LoadMetadataContext.mergeFrom(
-            LoadMetadataPOptions.newBuilder()
-                .setCreateAncestors(true)
-                .setLoadDescendantType(GrpcUtils.toProto(loadDescendantType))
-                .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
-                    .setTtl(context.getOptions().getCommonOptions().getTtl())
-                    .setTtlAction(context.getOptions().getCommonOptions().getTtlAction())));
-        Inode inode;
-        if (inodePath.fullPathExists()) {
-          inode = inodePath.getInode();
-          if (inode.isDirectory()
-              && context.getOptions().getLoadMetadataType() != LoadMetadataPType.ALWAYS) {
-            InodeDirectory inodeDirectory = inode.asDirectory();
-
-            boolean isLoaded = inodeDirectory.isDirectChildrenLoaded();
-            if (context.getOptions().getRecursive()) {
-              isLoaded = areDescendantsLoaded(inodeDirectory);
+        // We just synced; the new lock pattern should not sync.
+        try (LockedInodePath inodePath = mInodeTree.lockInodePath(lockingScheme)) {
+          auditContext.setSrcInode(inodePath.getInodeOrNull());
+          try {
+            mPermissionChecker.checkPermission(Mode.Bits.READ, inodePath);
+          } catch (AccessControlException e) {
+            auditContext.setAllowed(false);
+            throw e;
+          }
+          if (!loadMetadata) {
+            Inode inode;
+            boolean isLoaded = true;
+            if (inodePath.fullPathExists()) {
+              inode = inodePath.getInode();
+              if (inode.isDirectory()
+                  && context.getOptions().getLoadMetadataType() != LoadMetadataPType.ALWAYS) {
+                InodeDirectory inodeDirectory = inode.asDirectory();
+                isLoaded = inodeDirectory.isDirectChildrenLoaded();
+                if (context.getOptions().getRecursive()) {
+                  isLoaded = areDescendantsLoaded(inodeDirectory);
+                }
+                if (isLoaded) {
+                  // no need to load again.
+                  loadMetadataContext.getOptions().setLoadDescendantType(LoadDescendantPType.NONE);
+                }
+              }
+            } else {
+              checkLoadMetadataOptions(context.getOptions().getLoadMetadataType(),
+                  inodePath.getUri());
             }
-            if (isLoaded) {
-              // no need to load again.
-              loadMetadataContext.getOptions().setLoadDescendantType(LoadDescendantPType.NONE);
+            if (shouldLoadMetadataIfNotExists(inodePath, loadMetadataContext)) {
+              loadMetadata = true;
+              run = true;
+              continue;
             }
           }
-        } else {
-          checkLoadMetadataOptions(context.getOptions().getLoadMetadataType(), inodePath.getUri());
-        }
+          ensureFullPathAndUpdateCache(inodePath);
 
-        loadMetadataIfNotExist(rpcContext, inodePath, loadMetadataContext, false);
-        ensureFullPathAndUpdateCache(inodePath);
-        inode = inodePath.getInode();
-        auditContext.setSrcInode(inode);
-        DescendantType descendantTypeForListStatus =
-            (context.getOptions().getRecursive()) ? DescendantType.ALL : DescendantType.ONE;
-        listStatusInternal(context, rpcContext, inodePath, auditContext,
-            descendantTypeForListStatus, resultStream, 0);
-        auditContext.setSucceeded(true);
-        Metrics.FILE_INFOS_GOT.inc();
+          auditContext.setSrcInode(inodePath.getInode());
+          DescendantType descendantTypeForListStatus =
+              (context.getOptions().getRecursive()) ? DescendantType.ALL : DescendantType.ONE;
+          listStatusInternal(context, rpcContext, inodePath, auditContext,
+              descendantTypeForListStatus, resultStream, 0);
+          auditContext.setSucceeded(true);
+          Metrics.FILE_INFOS_GOT.inc();
+        }
       }
     }
   }
@@ -1460,7 +1534,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
   }
 
   @Override
-  public Map<String, MountPointInfo> getMountTable() {
+  public Map<String, MountPointInfo> getMountInfo() {
     SortedMap<String, MountPointInfo> mountPoints = new TreeMap<>();
     for (Map.Entry<String, MountInfo> mountPoint : mMountTable.getMountTable().entrySet()) {
       mountPoints.put(mountPoint.getKey(), getDisplayMountPointInfo(mountPoint.getValue()));
@@ -2518,12 +2592,32 @@ public final class DefaultFileSystemMaster extends CoreMaster
    * Loads metadata for the path if it is (non-existing || load direct children is set).
    *
    * @param rpcContext the rpc context
-   * @param inodePath the {@link LockedInodePath} to load the metadata for
    * @param context the load metadata context
    */
-  private void loadMetadataIfNotExist(RpcContext rpcContext, LockedInodePath inodePath,
-      LoadMetadataContext context, boolean isGetFileInfo) {
-    Preconditions.checkState(inodePath.getLockPattern() == LockPattern.READ);
+  private void loadMetadataIfNotExist(RpcContext rpcContext, AlluxioURI path,
+      LoadMetadataContext context, boolean isGetFileInfo)
+      throws InvalidPathException, AccessControlException {
+    LockingScheme scheme = new LockingScheme(path, LockPattern.READ, false);
+    boolean lm;
+    try (LockedInodePath inodePath = mInodeTree.lockInodePath(scheme)) {
+      lm = shouldLoadMetadataIfNotExists(inodePath, context);
+    }
+
+    if (lm) {
+      DescendantType syncDescendantType =
+          GrpcUtils.fromProto(context.getOptions().getLoadDescendantType());
+      FileSystemMasterCommonPOptions commonOptions =
+          context.getOptions().getCommonOptions();
+      // load metadata only and force sync
+      InodeSyncStream sync = new InodeSyncStream(new LockingScheme(path, LockPattern.READ, false),
+          this, rpcContext, syncDescendantType, commonOptions, isGetFileInfo, true, true);
+      if (!sync.sync()) {
+        LOG.debug("Failed to load metadata for path from UFS: {}", path);
+      }
+    }
+  }
+
+  boolean shouldLoadMetadataIfNotExists(LockedInodePath inodePath, LoadMetadataContext context) {
     boolean inodeExists = inodePath.fullPathExists();
     boolean loadDirectChildren = false;
     if (inodeExists) {
@@ -2536,19 +2630,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
         throw new RuntimeException(e);
       }
     }
-    if (!inodeExists || loadDirectChildren) {
-      DescendantType syncDescendantType =
-          GrpcUtils.fromProto(context.getOptions().getLoadDescendantType());
-      FileSystemMasterCommonPOptions commonOptions =
-          context.getOptions().getCommonOptions();
-      // load metadata only and force sync
-      InodeSyncStream sync = new InodeSyncStream(inodePath, mSyncMetadataExecutor,
-          this, mInodeTree, mInodeStore, mInodeLockManager, mMountTable, rpcContext,
-          syncDescendantType, mUfsSyncPathCache, commonOptions, isGetFileInfo, true, true);
-      if (!sync.sync()) {
-        LOG.debug("Failed to load metadata for path from UFS: {}", inodePath.getUri());
-      }
-    }
+    return !inodeExists || loadDirectChildren;
   }
 
   private void prepareForMount(AlluxioURI ufsPath, long mountId, MountContext context)
@@ -3158,13 +3240,10 @@ public final class DefaultFileSystemMaster extends CoreMaster
         FileSystemMasterCommonPOptions options =
             FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(0).build();
         LockingScheme scheme = createSyncLockingScheme(path, options, false);
-        try (LockedInodePath inodePath = mInodeTree.lockInodePath(scheme)) {
-          InodeSyncStream sync = new InodeSyncStream(inodePath, mActiveSyncMetadataExecutor, this,
-              mInodeTree, mInodeStore, mInodeLockManager, mMountTable, rpcContext,
-              DescendantType.ALL, mUfsSyncPathCache, options, false, false, false);
-          if (!sync.sync()) {
-            LOG.debug("Active full sync on {} didn't sync any paths.", path);
-          }
+        InodeSyncStream sync = new InodeSyncStream(scheme, this, rpcContext,
+            DescendantType.ALL, options, false, false, false);
+        if (!sync.sync()) {
+          LOG.debug("Active full sync on {} didn't sync any paths.", path);
         }
         long end = System.currentTimeMillis();
         LOG.info("Ended an active full sync of {} in {}ms", path.toString(), end - start);
@@ -3178,29 +3257,24 @@ public final class DefaultFileSystemMaster extends CoreMaster
             FileSystemMasterCommonPOptions options =
                 FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(0).build();
             LockingScheme scheme = createSyncLockingScheme(changedFile, options, false);
-            try (LockedInodePath inodePath = mInodeTree.lockInodePath(scheme)) {
-              InodeSyncStream sync = new InodeSyncStream(inodePath, mActiveSyncMetadataExecutor,
-                  this, mInodeTree, mInodeStore, mInodeLockManager, mMountTable, rpcContext,
-                  DescendantType.ONE, mUfsSyncPathCache, options, false, false, false);
-              if (!sync.sync()) {
-                // Use debug because this can be a noisy log
-                LOG.debug("Incremental sync on {} didn't sync any paths.", path);
-              }
-            } catch (InvalidPathException e) {
-              LogUtils.warnWithException(LOG,
-                  "incremental active sync processed an invalid path {}", changedFile.getPath(), e);
+            InodeSyncStream sync = new InodeSyncStream(scheme,
+                this, rpcContext,
+                DescendantType.ONE, options, false, false, false);
+            if (!sync.sync()) {
+              // Use debug because this can be a noisy log
+              LOG.debug("Incremental sync on {} didn't sync any paths.", path);
             }
             return null;
           });
         }
         executorService.invokeAll(callables);
       }
-    } catch (InvalidPathException e) {
-      LOG.warn("InvalidPathException during active sync: {}", e.toString());
     } catch (InterruptedException e) {
       LOG.warn("InterruptedException during active sync: {}", e.toString());
       Thread.currentThread().interrupt();
       return;
+    } catch (InvalidPathException | AccessControlException e) {
+      LogUtils.warnWithException(LOG, "Failed to active sync on path {}", path, e);
     }
     if (changedFiles != null) {
       long end = System.currentTimeMillis();
@@ -3262,36 +3336,20 @@ public final class DefaultFileSystemMaster extends CoreMaster
       @Nullable FileSystemMasterAuditContext auditContext,
       @Nullable Function<LockedInodePath, Inode> auditContextSrcInodeFunc,
       @Nullable PermissionCheckFunction permissionCheckOperation,
-      boolean isGetFileInfo) throws InvalidPathException, AccessControlException {
+      boolean isGetFileInfo) throws AccessControlException, InvalidPathException {
     LockingScheme syncScheme = createSyncLockingScheme(path, options, isGetFileInfo);
 
     if (!syncScheme.shouldSync()) {
       return false;
     }
-
-    try (LockedInodePath inodePath = mInodeTree.lockInodePath(syncScheme)) {
-      if (auditContext != null && auditContextSrcInodeFunc != null) {
-        auditContext.setSrcInode(auditContextSrcInodeFunc.apply(inodePath));
-      }
-      try {
-        if (permissionCheckOperation != null) {
-          permissionCheckOperation.accept(inodePath, mPermissionChecker);
-        }
-      } catch (AccessControlException e) {
-        if (auditContext != null) {
-          auditContext.setAllowed(false);
-        }
-        throw e;
-      }
-      InodeSyncStream sync = new InodeSyncStream(inodePath, mSyncMetadataExecutor, this, mInodeTree,
-          mInodeStore, mInodeLockManager, mMountTable, rpcContext, syncDescendantType,
-          mUfsSyncPathCache, options, isGetFileInfo, false, false);
-      return sync.sync();
-    }
+    InodeSyncStream sync = new InodeSyncStream(syncScheme, this, rpcContext, syncDescendantType,
+        options, auditContext, auditContextSrcInodeFunc, permissionCheckOperation, isGetFileInfo,
+        false, false);
+    return sync.sync();
   }
 
   @FunctionalInterface
-  private interface PermissionCheckFunction {
+  interface PermissionCheckFunction {
 
     /**
      * Performs this operation on the given arguments.
@@ -3303,9 +3361,28 @@ public final class DefaultFileSystemMaster extends CoreMaster
         InvalidPathException;
   }
 
-  @VisibleForTesting
   ReadOnlyInodeStore getInodeStore() {
     return mInodeStore;
+  }
+
+  InodeTree getInodeTree() {
+    return mInodeTree;
+  }
+
+  InodeLockManager getInodeLockManager() {
+    return mInodeLockManager;
+  }
+
+  MountTable getMountTable() {
+    return mMountTable;
+  }
+
+  UfsSyncPathCache getSyncPathCache() {
+    return mUfsSyncPathCache;
+  }
+
+  PermissionChecker getPermissionChecker() {
+    return mPermissionChecker;
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -234,7 +234,7 @@ public interface FileSystemMaster extends Master {
   /**
    * @return a copy of the current mount table
    */
-  Map<String, MountPointInfo>  getMountTable();
+  Map<String, MountPointInfo>  getMountInfo();
 
   /**
    * Gets the mount point information of an Alluxio path for display purpose.

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -232,9 +232,9 @@ public interface FileSystemMaster extends Master {
       AccessControlException, UnavailableException;
 
   /**
-   * @return a copy of the current mount table
+   * @return a snapshot of the mount table as a mapping of Alluxio path to {@link MountPointInfo}
    */
-  Map<String, MountPointInfo>  getMountInfo();
+  Map<String, MountPointInfo> getMountPointInfoSummary();
 
   /**
    * Gets the mount point information of an Alluxio path for display purpose.

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -257,7 +257,7 @@ public final class FileSystemMasterClientServiceHandler
   public void getMountTable(GetMountTablePRequest request,
       StreamObserver<GetMountTablePResponse> responseObserver) {
     RpcUtils.call(LOG, () -> {
-      Map<String, MountPointInfo> mountTableWire = mFileSystemMaster.getMountInfo();
+      Map<String, MountPointInfo> mountTableWire = mFileSystemMaster.getMountPointInfoSummary();
       Map<String, alluxio.grpc.MountPointInfo> mountTableProto = new HashMap<>();
       for (Map.Entry<String, MountPointInfo> entry : mountTableWire.entrySet()) {
         mountTableProto.put(entry.getKey(), GrpcUtils.toProto(entry.getValue()));

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -257,7 +257,7 @@ public final class FileSystemMasterClientServiceHandler
   public void getMountTable(GetMountTablePRequest request,
       StreamObserver<GetMountTablePResponse> responseObserver) {
     RpcUtils.call(LOG, () -> {
-      Map<String, MountPointInfo> mountTableWire = mFileSystemMaster.getMountTable();
+      Map<String, MountPointInfo> mountTableWire = mFileSystemMaster.getMountInfo();
       Map<String, alluxio.grpc.MountPointInfo> mountTableProto = new HashMap<>();
       for (Map.Entry<String, MountPointInfo> entry : mountTableWire.entrySet()) {
         mountTableProto.put(entry.getKey(), GrpcUtils.toProto(entry.getValue()));

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -67,6 +67,7 @@ import com.google.common.base.MoreObjects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collection;
@@ -80,6 +81,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.function.Function;
 
 /**
  * This class is responsible for maintaining the logic which surrounds syncing metadata between
@@ -105,7 +107,7 @@ import java.util.concurrent.Future;
  * that mean the caller of this class must not hold a write while calling {@link #sync()}.
  *
  * A user of this class is expected to create a new instance for each path that they would like
- * to process. This is because the Lock on the {@link #mRootPath} may be changed after calling
+ * to process. This is because the Lock on the {@link #mRootScheme} may be changed after calling
  * {@link #sync()}.
  *
  */
@@ -118,7 +120,7 @@ public class InodeSyncStream {
           .build();
 
   /** The root path. Should be locked with a write lock. */
-  private final LockedInodePath mRootPath;
+  private final LockingScheme mRootScheme;
 
   /** A {@link UfsSyncPathCache} maintained from the {@link DefaultFileSystemMaster}. */
   private final UfsSyncPathCache mUfsSyncPathCache;
@@ -175,6 +177,10 @@ public class InodeSyncStream {
   private final int mConcurrencyLevel =
       ServerConfiguration.getInt(PropertyKey.MASTER_METADATA_SYNC_CONCURRENCY_LEVEL);
 
+  private final FileSystemMasterAuditContext mAuditContext;
+  private final Function<LockedInodePath, Inode> mAuditContextSrcInodeFunc;
+  private final DefaultFileSystemMaster.PermissionCheckFunction mPermissionCheckOperation;
+
   /**
    * Create a new instance of {@link InodeSyncStream}.
    *
@@ -186,51 +192,69 @@ public class InodeSyncStream {
    * If loadOnly is set to {@code true}, then the the root path may have a read lock.
    *
    * @param rootPath The root path to begin syncing
-   * @param concurrencyService executor used to process paths concurrently
    * @param fsMaster the {@link FileSystemMaster} calling this method
-   * @param inodeTree the {@link InodeTree}
-   * @param inodeStore the {@link alluxio.master.metastore.InodeStore}
-   * @param inodeLockManager the {@link InodeLockManager}
-   * @param mountTable the master's {@link MountTable}
    * @param rpcContext the caller's {@link RpcContext}
    * @param descendantType determines the number of descendant inodes to sync
-   * @param ufsSyncPathCache the sync path cache to determine when inodes should be synced
+   * @param options the RPC's {@link FileSystemMasterCommonPOptions}
+   * @param auditContext the audit context to use when loading
+   * @param auditContextSrcInodeFunc the inode to set as the audit context source
+   * @param permissionCheckOperation the operation to use to check permissions
+   * @param isGetFileInfo whether the caller is {@link FileSystemMaster#getFileInfo}
+   * @param forceSync whether to sync inode metadata no matter what
+   * @param loadOnly whether to only load new metadata, rather than update existing metadata
+   */
+  public InodeSyncStream(LockingScheme rootPath, DefaultFileSystemMaster fsMaster,
+      RpcContext rpcContext, DescendantType descendantType, FileSystemMasterCommonPOptions options,
+      @Nullable FileSystemMasterAuditContext auditContext,
+      @Nullable Function<LockedInodePath, Inode> auditContextSrcInodeFunc,
+      @Nullable DefaultFileSystemMaster.PermissionCheckFunction permissionCheckOperation,
+      boolean isGetFileInfo, boolean forceSync, boolean loadOnly) {
+    mPendingPaths = new ConcurrentLinkedQueue<>();
+    mDescendantType = descendantType;
+    mRpcContext = rpcContext;
+    mStatusCache = new UfsStatusCache(fsMaster.mSyncPrefetchExecutor);
+    mMetadataSyncService = fsMaster.mSyncMetadataExecutor;
+    mForceSync = forceSync;
+    mRootScheme = rootPath;
+    mSyncOptions = options;
+    mIsGetFileInfo = isGetFileInfo;
+    mLoadOnly = loadOnly;
+    mSyncPathJobs = new LinkedList<>();
+    mFsMaster = fsMaster;
+    mInodeLockManager = fsMaster.getInodeLockManager();
+    mInodeStore = fsMaster.getInodeStore();
+    mInodeTree = fsMaster.getInodeTree();
+    mMountTable = fsMaster.getMountTable();
+    mUfsSyncPathCache = fsMaster.getSyncPathCache();
+    mAuditContext = auditContext;
+    mAuditContextSrcInodeFunc = auditContextSrcInodeFunc;
+    mPermissionCheckOperation = permissionCheckOperation;
+  }
+
+  /**
+   * Create a new instance of {@link InodeSyncStream} without any audit or permission checks.
+   *
+   * @param rootScheme The root path to begin syncing
+   * @param fsMaster the {@link FileSystemMaster} calling this method
+   * @param rpcContext the caller's {@link RpcContext}
+   * @param descendantType determines the number of descendant inodes to sync
    * @param options the RPC's {@link FileSystemMasterCommonPOptions}
    * @param isGetFileInfo whether the caller is {@link FileSystemMaster#getFileInfo}
    * @param forceSync whether to sync inode metadata no matter what
    * @param loadOnly whether to only load new metadata, rather than update existing metadata
    */
-  public InodeSyncStream(LockedInodePath rootPath, ExecutorService concurrencyService,
-      DefaultFileSystemMaster fsMaster, InodeTree inodeTree, ReadOnlyInodeStore inodeStore,
-      InodeLockManager inodeLockManager, MountTable mountTable, RpcContext rpcContext,
-      DescendantType descendantType, UfsSyncPathCache ufsSyncPathCache,
-      FileSystemMasterCommonPOptions options, boolean isGetFileInfo, boolean forceSync,
-      boolean loadOnly) {
-    mDescendantType = descendantType;
-    mFsMaster = fsMaster;
-    mPendingPaths = new ConcurrentLinkedQueue<>();
-    mInodeLockManager = inodeLockManager;
-    mInodeStore = inodeStore;
-    mInodeTree = inodeTree;
-    mMountTable = mountTable;
-    mRpcContext = rpcContext;
-    mStatusCache = new UfsStatusCache(fsMaster.mSyncPrefetchExecutor);
-    mUfsSyncPathCache = ufsSyncPathCache;
-    mForceSync = forceSync;
-    mRootPath = rootPath;
-    mSyncOptions = options;
-    mIsGetFileInfo = isGetFileInfo;
-    mLoadOnly = loadOnly;
-    mSyncPathJobs = new LinkedList<>();
-    mMetadataSyncService = concurrencyService;
+  public InodeSyncStream(LockingScheme rootScheme, DefaultFileSystemMaster fsMaster,
+      RpcContext rpcContext, DescendantType descendantType, FileSystemMasterCommonPOptions options,
+      boolean isGetFileInfo, boolean forceSync, boolean loadOnly) {
+    this(rootScheme, fsMaster, rpcContext, descendantType, options, null, null, null,
+        isGetFileInfo, forceSync, loadOnly);
   }
-
   /**
    * Sync the metadata according the the root path the stream was created with.
    *
    * @return true if at least one path was synced
    */
-  public boolean sync() {
+  public boolean sync() throws AccessControlException, InvalidPathException {
     // The high-level process for the syncing is:
     // 1. Given an Alluxio path, determine if it is not consistent with the corresponding UFS path.
     //     this means the UFS path does not exist, or has metadata which differs from Alluxio
@@ -245,9 +269,21 @@ public class InodeSyncStream {
     if (LOG.isDebugEnabled()) {
       start = System.currentTimeMillis();
     }
-
-    try {
-      syncInodeMetadata(mRootPath);
+    try (LockedInodePath path = mInodeTree.lockInodePath(mRootScheme)) {
+      if (mAuditContext != null && mAuditContextSrcInodeFunc != null) {
+        mAuditContext.setSrcInode(mAuditContextSrcInodeFunc.apply(path));
+      }
+      try {
+        if (mPermissionCheckOperation != null) {
+          mPermissionCheckOperation.accept(path, mFsMaster.getPermissionChecker());
+        }
+      } catch (AccessControlException e) {
+        if (mAuditContext != null) {
+          mAuditContext.setAllowed(false);
+        }
+        throw e;
+      }
+      syncInodeMetadata(path);
       syncPathCount++;
       if (mDescendantType == DescendantType.ONE) {
         // If descendantType is ONE, then we shouldn't process any more paths except for those
@@ -257,21 +293,18 @@ public class InodeSyncStream {
 
       // process the sync result for the original path
       try {
-        mRootPath.traverse();
+        path.traverse();
       } catch (InvalidPathException e) {
         throw new RuntimeException(e);
       }
-    } catch (AccessControlException | BlockInfoException | FileAlreadyCompletedException
+    } catch (BlockInfoException | FileAlreadyCompletedException
         | FileDoesNotExistException | InterruptedException | InvalidFileSizeException
-        | InvalidPathException | IOException e) {
+        | IOException e) {
       LogUtils.warnWithException(LOG, "Failed to sync metadata on root path {}",
           toString(), e);
     } finally {
       // regardless of the outcome, remove the UfsStatus for this path from the cache
-      mStatusCache.remove(mRootPath.getUri());
-      // downgrade so that if operations are parallelized, the lock on the root doesn't restrict
-      // concurrent operations
-      mRootPath.downgradeToRead();
+      mStatusCache.remove(mRootScheme.getPath());
     }
 
     // Process any children after the root.
@@ -348,7 +381,7 @@ public class InodeSyncStream {
       long end = System.currentTimeMillis();
       LOG.debug("synced {} paths ({} success, {} failed) in {} ms on {}",
           syncPathCount + failedSyncPathCount, syncPathCount, failedSyncPathCount, end - start,
-          mRootPath);
+          mRootScheme);
     }
     mStatusCache.cancelAllPrefetch();
     mSyncPathJobs.forEach(f -> f.cancel(true));
@@ -847,7 +880,7 @@ public class InodeSyncStream {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("rootPath", mRootPath)
+        .add("rootPath", mRootScheme)
         .add("descendantType", mDescendantType)
         .add("commonOptions", mSyncOptions)
         .add("forceSync", mForceSync)

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockingScheme.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockingScheme.java
@@ -18,6 +18,8 @@ import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.master.file.contexts.GetStatusContext;
 import alluxio.master.file.meta.InodeTree.LockPattern;
 
+import com.google.common.base.MoreObjects;
+
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -95,5 +97,14 @@ public final class LockingScheme {
    */
   public boolean shouldSync() {
     return mShouldSync;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("path", mPath)
+        .add("desiredLockPattern", mDesiredLockPattern)
+        .add("shouldSync", mShouldSync)
+        .toString();
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -809,7 +809,7 @@ public final class AlluxioMasterRestServiceHandler {
   @VisibleForTesting
   boolean isMounted(String ufs) {
     ufs = PathUtils.normalizePath(ufs, AlluxioURI.SEPARATOR);
-    for (Map.Entry<String, MountPointInfo> entry : mFileSystemMaster.getMountTable().entrySet()) {
+    for (Map.Entry<String, MountPointInfo> entry : mFileSystemMaster.getMountInfo().entrySet()) {
       String escaped = MetricsSystem.escape(new AlluxioURI(entry.getValue().getUfsUri()));
       escaped = PathUtils.normalizePath(escaped, AlluxioURI.SEPARATOR);
       if (escaped.equals(ufs)) {
@@ -1043,7 +1043,7 @@ public final class AlluxioMasterRestServiceHandler {
   }
 
   private Map<String, MountPointInfo> getMountPointsInternal() {
-    return mFileSystemMaster.getMountTable();
+    return mFileSystemMaster.getMountInfo();
   }
 
   private Map<String, Capacity> getTierCapacityInternal() {
@@ -1059,7 +1059,7 @@ public final class AlluxioMasterRestServiceHandler {
   }
 
   private Capacity getUfsCapacityInternal() {
-    MountPointInfo mountInfo = mFileSystemMaster.getMountTable().get(MountTable.ROOT);
+    MountPointInfo mountInfo = mFileSystemMaster.getMountInfo().get(MountTable.ROOT);
     if (mountInfo == null) {
       return new Capacity().setTotal(-1).setUsed(-1);
     }

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -809,7 +809,8 @@ public final class AlluxioMasterRestServiceHandler {
   @VisibleForTesting
   boolean isMounted(String ufs) {
     ufs = PathUtils.normalizePath(ufs, AlluxioURI.SEPARATOR);
-    for (Map.Entry<String, MountPointInfo> entry : mFileSystemMaster.getMountInfo().entrySet()) {
+    for (Map.Entry<String, MountPointInfo> entry :
+        mFileSystemMaster.getMountPointInfoSummary().entrySet()) {
       String escaped = MetricsSystem.escape(new AlluxioURI(entry.getValue().getUfsUri()));
       escaped = PathUtils.normalizePath(escaped, AlluxioURI.SEPARATOR);
       if (escaped.equals(ufs)) {
@@ -1043,7 +1044,7 @@ public final class AlluxioMasterRestServiceHandler {
   }
 
   private Map<String, MountPointInfo> getMountPointsInternal() {
-    return mFileSystemMaster.getMountInfo();
+    return mFileSystemMaster.getMountPointInfoSummary();
   }
 
   private Map<String, Capacity> getTierCapacityInternal() {
@@ -1059,7 +1060,7 @@ public final class AlluxioMasterRestServiceHandler {
   }
 
   private Capacity getUfsCapacityInternal() {
-    MountPointInfo mountInfo = mFileSystemMaster.getMountInfo().get(MountTable.ROOT);
+    MountPointInfo mountInfo = mFileSystemMaster.getMountPointInfoSummary().get(MountTable.ROOT);
     if (mountInfo == null) {
       return new Capacity().setTotal(-1).setUsed(-1);
     }

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -228,6 +228,7 @@ public final class FileSystemMasterTest {
   @After
   public void after() throws Exception {
     stopServices();
+    ServerConfiguration.reset();
   }
 
   @Test
@@ -2672,6 +2673,46 @@ public final class FileSystemMasterTest {
             GetStatusContext.defaults()).getPersistenceState());
   }
 
+//  @Test
+//  public void testConflictingListStatuses() throws Exception {
+//    stopServices();
+//    ServerConfiguration.set(PropertyKey.MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE, "1");
+//    ServerConfiguration.set(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL, "0");
+//    AuthenticatedClientUser.set("test");
+//    startServices();
+//    String longPath = "/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z/a";
+//    ExecutorService svc = Executors.newSingleThreadExecutor();
+//    mFileSystemMaster.createDirectory(new AlluxioURI(longPath), CreateDirectoryContext
+//        .mergeFrom(
+//            CreateDirectoryPOptions.newBuilder()
+//                .setCommonOptions(FileSystemMasterCommonPOptions
+//                  .newBuilder().setSyncIntervalMs(0))
+//                .setRecursive(true)
+//            .setWriteType(WritePType.CACHE_THROUGH)
+//        ));
+//    Future<?> f = svc.submit(() -> {
+//      AuthenticatedClientUser.set("test");
+//      try {
+//        mFileSystemMaster.listStatus(new AlluxioURI("/a"),
+//            ListStatusContext.mergeFrom(ListStatusPOptions.newBuilder()
+//                .setCommonOptions(FileSystemMasterCommonPOptions
+                    // .newBuilder().setSyncIntervalMs(0))
+//                .setRecursive(true)));
+//      } catch (AccessControlException e) {
+//        e.printStackTrace();
+//      } catch (FileDoesNotExistException e) {
+//        e.printStackTrace();
+//      } catch (InvalidPathException e) {
+//        e.printStackTrace();
+//      } catch (IOException e) {
+//        e.printStackTrace();
+//      }
+//    });
+// //    Thread.sleep(250);
+//    mFileSystemMaster.listStatus(new AlluxioURI("/a/b"),
+//        ListStatusContext.mergeFrom(ListStatusPOptions.newBuilder().setRecursive(true)));
+//  }
+
   private long createFileWithSingleBlock(AlluxioURI uri) throws Exception {
     mFileSystemMaster.createFile(uri, mNestedFileContext);
     long blockId = mFileSystemMaster.getNewBlockIdForFile(uri);
@@ -2691,8 +2732,8 @@ public final class FileSystemMasterTest {
     mRegistry.add(MetricsMaster.class, mMetricsMaster);
     mMetrics = Lists.newArrayList();
     mBlockMaster = new BlockMasterFactory().create(mRegistry, masterContext);
-    mExecutorService = Executors.newFixedThreadPool(4,
-        ThreadFactoryUtils.build("DefaultFileSystemMasterTest-%d", true));
+    mExecutorService = Executors
+        .newFixedThreadPool(4, ThreadFactoryUtils.build("DefaultFileSystemMasterTest-%d", true));
     mFileSystemMaster = new DefaultFileSystemMaster(mBlockMaster, masterContext,
         ExecutorServiceFactories.constantExecutorServiceFactory(mExecutorService));
     mInodeStore = mFileSystemMaster.getInodeStore();
@@ -2706,16 +2747,14 @@ public final class FileSystemMasterTest {
         new WorkerNetAddress().setHost("localhost").setRpcPort(80).setDataPort(81).setWebPort(82));
     mBlockMaster.workerRegister(mWorkerId1, Arrays.asList("MEM", "SSD"),
         ImmutableMap.of("MEM", (long) Constants.MB, "SSD", (long) Constants.MB),
-        ImmutableMap.of("MEM", (long) Constants.KB, "SSD", (long) Constants.KB),
-        ImmutableMap.of(), new HashMap<String, StorageList>(),
-        RegisterWorkerPOptions.getDefaultInstance());
+        ImmutableMap.of("MEM", (long) Constants.KB, "SSD", (long) Constants.KB), ImmutableMap.of(),
+        new HashMap<String, StorageList>(), RegisterWorkerPOptions.getDefaultInstance());
     mWorkerId2 = mBlockMaster.getWorkerId(
         new WorkerNetAddress().setHost("remote").setRpcPort(80).setDataPort(81).setWebPort(82));
     mBlockMaster.workerRegister(mWorkerId2, Arrays.asList("MEM", "SSD"),
         ImmutableMap.of("MEM", (long) Constants.MB, "SSD", (long) Constants.MB),
-        ImmutableMap.of("MEM", (long) Constants.KB, "SSD", (long) Constants.KB),
-        ImmutableMap.of(), new HashMap<String, StorageList>(),
-        RegisterWorkerPOptions.getDefaultInstance());
+        ImmutableMap.of("MEM", (long) Constants.KB, "SSD", (long) Constants.KB), ImmutableMap.of(),
+        new HashMap<String, StorageList>(), RegisterWorkerPOptions.getDefaultInstance());
   }
 
   private void stopServices() throws Exception {

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -2673,46 +2673,6 @@ public final class FileSystemMasterTest {
             GetStatusContext.defaults()).getPersistenceState());
   }
 
-//  @Test
-//  public void testConflictingListStatuses() throws Exception {
-//    stopServices();
-//    ServerConfiguration.set(PropertyKey.MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE, "1");
-//    ServerConfiguration.set(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL, "0");
-//    AuthenticatedClientUser.set("test");
-//    startServices();
-//    String longPath = "/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z/a";
-//    ExecutorService svc = Executors.newSingleThreadExecutor();
-//    mFileSystemMaster.createDirectory(new AlluxioURI(longPath), CreateDirectoryContext
-//        .mergeFrom(
-//            CreateDirectoryPOptions.newBuilder()
-//                .setCommonOptions(FileSystemMasterCommonPOptions
-//                  .newBuilder().setSyncIntervalMs(0))
-//                .setRecursive(true)
-//            .setWriteType(WritePType.CACHE_THROUGH)
-//        ));
-//    Future<?> f = svc.submit(() -> {
-//      AuthenticatedClientUser.set("test");
-//      try {
-//        mFileSystemMaster.listStatus(new AlluxioURI("/a"),
-//            ListStatusContext.mergeFrom(ListStatusPOptions.newBuilder()
-//                .setCommonOptions(FileSystemMasterCommonPOptions
-                    // .newBuilder().setSyncIntervalMs(0))
-//                .setRecursive(true)));
-//      } catch (AccessControlException e) {
-//        e.printStackTrace();
-//      } catch (FileDoesNotExistException e) {
-//        e.printStackTrace();
-//      } catch (InvalidPathException e) {
-//        e.printStackTrace();
-//      } catch (IOException e) {
-//        e.printStackTrace();
-//      }
-//    });
-// //    Thread.sleep(250);
-//    mFileSystemMaster.listStatus(new AlluxioURI("/a/b"),
-//        ListStatusContext.mergeFrom(ListStatusPOptions.newBuilder().setRecursive(true)));
-//  }
-
   private long createFileWithSingleBlock(AlluxioURI uri) throws Exception {
     mFileSystemMaster.createFile(uri, mNestedFileContext);
     long blockId = mFileSystemMaster.getNewBlockIdForFile(uri);

--- a/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
@@ -268,7 +268,7 @@ public final class AlluxioMasterRestServiceHandlerTest {
     Map<String, MountPointInfo> mountTable = new HashMap<>();
     mountTable.put("/s3", new MountPointInfo().setUfsUri(s3Uri));
     FileSystemMaster mockMaster = mock(FileSystemMaster.class);
-    when(mockMaster.getMountTable()).thenReturn(mountTable);
+    when(mockMaster.getMountInfo()).thenReturn(mountTable);
 
     AlluxioMasterProcess masterProcess = mock(AlluxioMasterProcess.class);
     when(masterProcess.getMaster(FileSystemMaster.class)).thenReturn(mockMaster);

--- a/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
@@ -268,7 +268,7 @@ public final class AlluxioMasterRestServiceHandlerTest {
     Map<String, MountPointInfo> mountTable = new HashMap<>();
     mountTable.put("/s3", new MountPointInfo().setUfsUri(s3Uri));
     FileSystemMaster mockMaster = mock(FileSystemMaster.class);
-    when(mockMaster.getMountInfo()).thenReturn(mountTable);
+    when(mockMaster.getMountPointInfoSummary()).thenReturn(mountTable);
 
     AlluxioMasterProcess masterProcess = mock(AlluxioMasterProcess.class);
     when(masterProcess.getMaster(FileSystemMaster.class)).thenReturn(mockMaster);

--- a/tests/src/test/java/alluxio/client/fs/MultiUfsMountIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/MultiUfsMountIntegrationTest.java
@@ -250,7 +250,7 @@ public final class MultiUfsMountIntegrationTest extends BaseIntegrationTest {
     try (FsMasterResource masterResource = MasterTestUtils
         .createLeaderFileSystemMasterFromJournal()) {
       FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
-      Map<String, MountPointInfo> mountTable = fsMaster.getMountInfo();
+      Map<String, MountPointInfo> mountTable = fsMaster.getMountPointInfoSummary();
       Assert.assertTrue(mountTable.containsKey(MOUNT_POINT1));
       Assert.assertTrue(mountTable.containsKey(MOUNT_POINT2));
       MountPointInfo mountPointInfo1 = mountTable.get(MOUNT_POINT1);
@@ -289,7 +289,7 @@ public final class MultiUfsMountIntegrationTest extends BaseIntegrationTest {
     try (FsMasterResource masterResource = MasterTestUtils
         .createLeaderFileSystemMasterFromJournal()) {
       FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
-      Map<String, MountPointInfo> mountTable = fsMaster.getMountInfo();
+      Map<String, MountPointInfo> mountTable = fsMaster.getMountPointInfoSummary();
       Assert.assertTrue(mountTable.containsKey(MOUNT_POINT3));
       MountPointInfo mountPointInfo3 = mountTable.get(MOUNT_POINT3);
       Assert.assertEquals(mUfsUri3, mountPointInfo3.getUfsUri());

--- a/tests/src/test/java/alluxio/client/fs/MultiUfsMountIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/MultiUfsMountIntegrationTest.java
@@ -250,7 +250,7 @@ public final class MultiUfsMountIntegrationTest extends BaseIntegrationTest {
     try (FsMasterResource masterResource = MasterTestUtils
         .createLeaderFileSystemMasterFromJournal()) {
       FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
-      Map<String, MountPointInfo> mountTable = fsMaster.getMountTable();
+      Map<String, MountPointInfo> mountTable = fsMaster.getMountInfo();
       Assert.assertTrue(mountTable.containsKey(MOUNT_POINT1));
       Assert.assertTrue(mountTable.containsKey(MOUNT_POINT2));
       MountPointInfo mountPointInfo1 = mountTable.get(MOUNT_POINT1);
@@ -289,7 +289,7 @@ public final class MultiUfsMountIntegrationTest extends BaseIntegrationTest {
     try (FsMasterResource masterResource = MasterTestUtils
         .createLeaderFileSystemMasterFromJournal()) {
       FileSystemMaster fsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
-      Map<String, MountPointInfo> mountTable = fsMaster.getMountTable();
+      Map<String, MountPointInfo> mountTable = fsMaster.getMountInfo();
       Assert.assertTrue(mountTable.containsKey(MOUNT_POINT3));
       MountPointInfo mountPointInfo3 = mountTable.get(MOUNT_POINT3);
       Assert.assertEquals(mUfsUri3, mountPointInfo3.getUfsUri());

--- a/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
@@ -168,7 +168,7 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
 
   @Test
   public void getMountPoints() throws Exception {
-    Map<String, MountPointInfo> mountTable = mFileSystemMaster.getMountTable();
+    Map<String, MountPointInfo> mountTable = mFileSystemMaster.getMountInfo();
     Map<String, MountPointInfo> mountPoints = getInfo(NO_PARAMS).getMountPoints();
     assertEquals(mountTable.size(), mountPoints.size());
     for (Map.Entry<String, MountPointInfo> mountPoint : mountTable.entrySet()) {

--- a/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
@@ -168,7 +168,7 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
 
   @Test
   public void getMountPoints() throws Exception {
-    Map<String, MountPointInfo> mountTable = mFileSystemMaster.getMountInfo();
+    Map<String, MountPointInfo> mountTable = mFileSystemMaster.getMountPointInfoSummary();
     Map<String, MountPointInfo> mountPoints = getInfo(NO_PARAMS).getMountPoints();
     assertEquals(mountTable.size(), mountPoints.size());
     for (Map.Entry<String, MountPointInfo> mountPoint : mountTable.entrySet()) {


### PR DESCRIPTION
This deadlock occurs when concurrent clients submit requests to
paths where one is the parent of another. It is most likely to
occur one path is a direct parent of another. There needs to be
less threads in the executor than there are paths to sync.
When the deadlock occurs it is because the child path holds a read
lock on a path the parent may be attempting to sync. This prevents
the parent path from continuing to sync. The child path though may
keep queuing sync jobs which can prevent the child from completing
its sync and thus causing deadlock because the parent can never
finish.

In order to fix this there were two major issues to be solved:

1. Unlock the root path so the ancestry of one sync does not block
another. After internal discussion, we decided that because we
don't hold the lock for any children for the duration of the sync
that it is unnecessary to hold the parent lock for the entire
duration as well.

2. Because the inode sync stream has to lock and unlock the root
path while syncing, the function loadMetadataIfNotExists needed
to be modified so that the path is unlocked before loading the
metadata. The major issue is that checking whether we need to
load metadata on a path is expensive because it requires a lock.
In order to maintain high RPC throughput for GetFileInfo and
ListStatus (the users of loadMetadataIfNotExist) this PR
introduces a two-step scheme for locking on those RPCs. The
general approach is to lock and then check if metadata needs to
be loaded, in which case we unlock and go back to the beginning
of the RPCs main logic with an extra flag set to load metdata.
In the case where the path already exists and does not need to be
loaded, then the RPC continues as normal.

There will be a slight overhead in occasions where we are loading
metadata for paths that don't yet exist, but that is not the
common case, so I am slightly less concerned about the performance
there. There will be no more locks taken there than there would be
in a normal metadata sync, so the runtimes should be comparable
anyway.