### PR TITLE
Make validation tool general

### DIFF
--- a/core/common/src/main/java/alluxio/cli/ValidationConfig.java
+++ b/core/common/src/main/java/alluxio/cli/ValidationConfig.java
@@ -11,24 +11,14 @@
 
 package alluxio.cli;
 
-import java.util.Map;
-
 /**
- * The validation tool factory interface.
+ * Configuration settings for the validation tools.
  */
-public interface ValidationToolFactory {
-
-  /**
-   * @return the type of validation tool for the factory
-   */
-  String getType();
-
-  /**
-   * Creates a new instance of {@link ValidationTool}.
-   * Creation must not interact with external services.
-   *
-   * @param configMap a map from config key to config value
-   * @return a new validation tool instance
-   */
-  ValidationTool create(Map<Object, Object> configMap);
+public class ValidationConfig {
+  // Hms validation tool config
+  public static final String HMS_TOOL_TYPE = "hms";
+  public static final String METASTORE_URI_CONFIG_NAME = "metastore_uri";
+  public static final String DATABASE_CONFIG_NAME = "database";
+  public static final String TABLES_CONFIG_NAME = "tables";
+  public static final String SOCKET_TIMEOUT_CONFIG_NAME = "socket_timeout";
 }

--- a/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationToolFactory.java
+++ b/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationToolFactory.java
@@ -11,14 +11,19 @@
 
 package alluxio.cli;
 
+import java.util.Map;
+
 /**
  * Factory to create hive metastore validation tool implementation.
  */
 public class HmsValidationToolFactory implements ValidationToolFactory {
+  @Override
+  public String getType() {
+    return ValidationConfig.HMS_TOOL_TYPE;
+  }
 
   @Override
-  public ValidationTool create(String metastoreUri, String database,
-      String tables, int socketTimeout) {
-    return HmsValidationTool.create(metastoreUri, database, tables, socketTimeout);
+  public ValidationTool create(Map<Object, Object> configMap) {
+    return HmsValidationTool.create(configMap);
   }
 }

--- a/shell/src/main/java/alluxio/cli/HmsTests.java
+++ b/shell/src/main/java/alluxio/cli/HmsTests.java
@@ -22,6 +22,9 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Class for running tests against an existing hive metastore.
  */
@@ -106,7 +109,13 @@ public class HmsTests {
     // Load hms validation tool from alluxio lib directory
     registry.refresh();
 
-    ValidationTool tests = registry.create(metastoreUri, database, tables, socketTimeout);
+    Map<Object, Object> configMap = new HashMap<>();
+    configMap.put(ValidationConfig.METASTORE_URI_CONFIG_NAME, metastoreUri);
+    configMap.put(ValidationConfig.DATABASE_CONFIG_NAME, database);
+    configMap.put(ValidationConfig.TABLES_CONFIG_NAME, tables);
+    configMap.put(ValidationConfig.SOCKET_TIMEOUT_CONFIG_NAME, socketTimeout);
+
+    ValidationTool tests = registry.create(ValidationConfig.HMS_TOOL_TYPE, configMap);
     String result = tests.runTests();
     System.out.println(result);
     if (result.contains(ValidationUtils.State.FAILED.toString())) {


### PR DESCRIPTION
Previously validation tool is hardcoded for hms validation tool. Since it may also be used for other tools, this PR makes the ValidationToolRegistry and Factory more generalize.