### PR TITLE
Use exec in runJavaClass

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -154,7 +154,7 @@ function runJavaClass {
               CLASS_ARGS+=("${arg}")
       esac
   done
-  "${JAVA}" -cp ${CLASSPATH} ${ALLUXIO_USER_JAVA_OPTS} ${ALLUXIO_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} "${CLASS_ARGS[@]}"
+  exec "${JAVA}" -cp ${CLASSPATH} ${ALLUXIO_USER_JAVA_OPTS} ${ALLUXIO_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} "${CLASS_ARGS[@]}"
 }
 
 function formatJournal {


### PR DESCRIPTION
Using `exec` on the `runJavaClass` function is a better practice to ensure that signals like `ctrl-c` and `ctrl-z` get sent to the actual java process running and not the bash shell which launched the process. 