### PR TITLE
Implement interrupt based locking protocol over state-lock

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1283,6 +1283,41 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_BACKUP_STATE_LOCK_EXCLUSIVE_DURATION =
+      new Builder(Name.MASTER_BACKUP_STATE_LOCK_EXCLUSIVE_DURATION)
+          .setDefaultValue("0ms")
+          .setDescription("Alluxio master will allow only exclusive locking of "
+              + "the state-lock for this duration. This duration starts after masters "
+              + "are started for the first time. "
+              + "User RPCs will fail to acquire state-lock during this phase and "
+              + "a backup is guaranteed take the state-lock meanwhile.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_ENABLED =
+      new Builder(Name.MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_ENABLED)
+          .setDefaultValue(true)
+          .setDescription("This controls whether RPCs that are waiting/holding state-lock "
+              + "in shared-mode will be interrupted while state-lock is taken exclusively.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_BACKUP_STATE_LOCK_FORCED_DURATION =
+      new Builder(Name.MASTER_BACKUP_STATE_LOCK_FORCED_DURATION)
+          .setDefaultValue("15min")
+          .setDescription("Exclusive locking of the state-lock will timeout after "
+              + "this duration is spent on forced phase.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_INTERVAL =
+      new Builder(Name.MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_INTERVAL)
+          .setDefaultValue("30sec")
+          .setDescription("The interval at which the RPCs that are waiting/holding state-lock "
+              + "in shared-mode will be interrupted while state-lock is taken exclusively.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_DAILY_BACKUP_ENABLED =
       new Builder(Name.MASTER_DAILY_BACKUP_ENABLED)
           .setDefaultValue(false)
@@ -1310,33 +1345,78 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
-  public static final PropertyKey MASTER_BACKUP_STATE_LOCK_TIMEOUT =
-      new Builder(Name.MASTER_BACKUP_STATE_LOCK_TIMEOUT)
+  public static final PropertyKey MASTER_SHELL_BACKUP_STATE_LOCK_GRACE_MODE =
+      new Builder(Name.MASTER_SHELL_BACKUP_STATE_LOCK_GRACE_MODE)
+          .setDefaultValue("TIMEOUT")
+          .setDescription("Grace mode helps taking the state-lock exclusively for backup "
+              + "with minimum disruption to existing RPCs. This low-impact locking phase "
+              + "is called grace-cycle. Two modes are supported: TIMEOUT/FORCED."
+              + "TIMEOUT: Means exclusive locking will timeout if it cannot acquire the lock"
+              + "with grace-cycle. "
+              + "FORCED: Means the state-lock will be taken forcefully if grace-cycle fails "
+              + "to acquire it. Forced phase might trigger interrupting of existing RPCs if "
+              + "it is enabled.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_SHELL_BACKUP_STATE_LOCK_TRY_DURATION =
+      new Builder(Name.MASTER_SHELL_BACKUP_STATE_LOCK_TRY_DURATION)
           .setDefaultValue("1m")
-          .setDescription(
-              "The max duration to try acquiring the state lock for taking backups via shell.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setDescription("The duration that controls how long the state-lock is "
+              + "tried within a single grace-cycle.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_SHELL_BACKUP_STATE_LOCK_SLEEP_DURATION =
+      new Builder(Name.MASTER_SHELL_BACKUP_STATE_LOCK_SLEEP_DURATION)
+          .setDefaultValue("0")
+          .setDescription("The duration that controls how long the lock waiter "
+              + "sleeps within a single grace-cycle.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_SHELL_BACKUP_STATE_LOCK_TIMEOUT =
+      new Builder(Name.MASTER_SHELL_BACKUP_STATE_LOCK_TIMEOUT)
+          .setDefaultValue("1m")
+          .setDescription("The max duration for a grace-cycle.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_DAILY_BACKUP_STATE_LOCK_GRACE_MODE =
+      new Builder(Name.MASTER_DAILY_BACKUP_STATE_LOCK_GRACE_MODE)
+          .setDefaultValue("FORCED")
+          .setDescription("Grace mode helps taking the state-lock exclusively for backup "
+              + "with minimum disruption to existing RPCs. This low-impact locking phase "
+              + "is called grace-cycle. Two modes are supported: TIMEOUT/FORCED."
+              + "TIMEOUT: Means exclusive locking will timeout if it cannot acquire the lock"
+              + "with grace-cycle. "
+              + "FORCED: Means the state-lock will be taken forcefully if grace-cycle fails "
+              + "to acquire it. Forced phase might trigger interrupting of existing RPCs if "
+              + "it is enabled.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_DAILY_BACKUP_STATE_LOCK_TRY_DURATION =
       new Builder(Name.MASTER_DAILY_BACKUP_STATE_LOCK_TRY_DURATION)
           .setDefaultValue("30s")
-          .setDescription("The duration to try acquiring the state lock exclusively..")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setDescription("The duration that controls how long the state-lock is "
+              + "tried within a single grace-cycle.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_DAILY_BACKUP_STATE_LOCK_SLEEP_DURATION =
       new Builder(Name.MASTER_DAILY_BACKUP_STATE_LOCK_SLEEP_DURATION)
           .setDefaultValue("10m")
-          .setDescription("The duration to sleep between trials to acquire the lock.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setDescription("The duration that controls how long the lock waiter "
+              + "sleeps within a single grace-cycle.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT =
       new Builder(Name.MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT)
           .setDefaultValue("12h")
-          .setDescription("The max duration to try acquiring the state lock.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setDescription("The max duration for a grace-cycle.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_BIND_HOST =
@@ -4615,14 +4695,30 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.backup.connect.interval.max";
     public static final String MASTER_BACKUP_ABANDON_TIMEOUT =
         "alluxio.master.backup.abandon.timeout";
-    public static final String MASTER_BACKUP_STATE_LOCK_TIMEOUT =
-        "alluxio.master.backup.state.lock.timeout";
+    public static final String MASTER_BACKUP_STATE_LOCK_EXCLUSIVE_DURATION =
+        "alluxio.master.backup.state.lock.exclusive.duration";
+    public static final String MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_ENABLED =
+        "alluxio.master.backup.state.lock.interrupt.cycle.enabled";
+    public static final String MASTER_BACKUP_STATE_LOCK_FORCED_DURATION =
+        "alluxio.master.backup.state.lock.forced.duration";
+    public static final String MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_INTERVAL =
+        "alluxio.master.backup.state.lock.interrupt.cycle.interval";
+    public static final String MASTER_SHELL_BACKUP_STATE_LOCK_GRACE_MODE =
+        "alluxio.master.shell.backup.state.lock.grace.mode";
+    public static final String MASTER_SHELL_BACKUP_STATE_LOCK_TRY_DURATION =
+        "alluxio.master.shell.backup.state.lock.try.duration";
+    public static final String MASTER_SHELL_BACKUP_STATE_LOCK_SLEEP_DURATION =
+        "alluxio.master.shell.backup.state.lock.sleep.duration";
+    public static final String MASTER_SHELL_BACKUP_STATE_LOCK_TIMEOUT =
+        "alluxio.master.shell.backup.state.lock.timeout";
     public static final String MASTER_DAILY_BACKUP_ENABLED =
         "alluxio.master.daily.backup.enabled";
     public static final String MASTER_DAILY_BACKUP_FILES_RETAINED =
         "alluxio.master.daily.backup.files.retained";
     public static final String MASTER_DAILY_BACKUP_TIME =
         "alluxio.master.daily.backup.time";
+    public static final String MASTER_DAILY_BACKUP_STATE_LOCK_GRACE_MODE =
+        "alluxio.master.daily.backup.state.lock.grace.mode";
     public static final String MASTER_DAILY_BACKUP_STATE_LOCK_TRY_DURATION =
         "alluxio.master.daily.backup.state.lock.try.duration";
     public static final String MASTER_DAILY_BACKUP_STATE_LOCK_SLEEP_DURATION =

--- a/core/common/src/main/java/alluxio/resource/RefCountLockResource.java
+++ b/core/common/src/main/java/alluxio/resource/RefCountLockResource.java
@@ -33,7 +33,7 @@ public class RefCountLockResource extends LockResource {
    * @param refCount ref count for the lock
    */
   public RefCountLockResource(Lock lock, boolean acquireLock, AtomicInteger refCount) {
-    super(lock, acquireLock);
+    super(lock, acquireLock, false);
     mRefCount = Preconditions.checkNotNull(refCount, "Reference Counter can not be null");
   }
 

--- a/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/AbstractMaster.java
@@ -17,6 +17,7 @@ import alluxio.exception.status.UnavailableException;
 import alluxio.master.journal.Journal;
 import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.StateChangeJournalContext;
+import alluxio.resource.LockResource;
 import alluxio.util.executor.ExecutorServiceFactory;
 
 import com.google.common.base.Preconditions;
@@ -135,8 +136,15 @@ public abstract class AbstractMaster implements Master {
   public JournalContext createJournalContext() throws UnavailableException {
     // Use the state change lock for the journal context, since all modifications to journaled
     // state must happen inside of a journal context.
-    return new StateChangeJournalContext(mJournal.createJournalContext(),
-        mMasterContext.stateChangeLock());
+    LockResource sharedLockResource;
+    try {
+      sharedLockResource = mMasterContext.getStateLockManager().lockShared();
+    } catch (InterruptedException e) {
+      throw new UnavailableException(
+          "Failed to acquire state-lock due to ongoing backup activity.");
+    }
+
+    return new StateChangeJournalContext(mJournal.createJournalContext(), sharedLockResource);
   }
 
   @Override

--- a/core/server/common/src/main/java/alluxio/master/StateLockManager.java
+++ b/core/server/common/src/main/java/alluxio/master/StateLockManager.java
@@ -1,0 +1,254 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master;
+
+import alluxio.collections.ConcurrentHashSet;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.exception.ExceptionMessage;
+import alluxio.resource.LockResource;
+import alluxio.util.ThreadFactoryUtils;
+
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Provides graceful and interruptable locking protocol for taking the state lock.
+ *
+ * {@link #lockShared()} will be used by user RPCs and may throw {@link InterruptedException}
+ * based on options passed to {@link #lockExclusive(StateLockOptions)}.
+ *
+ * {@link #lockExclusive(StateLockOptions)} will be used by metadata backups in order to
+ * guarantee paused state during critical tasks.
+ */
+public class StateLockManager {
+  private static final Logger LOG = LoggerFactory.getLogger(StateLockManager.class);
+
+  /** The state-lock. */
+  private ReadWriteLock mStateLock = new ReentrantReadWriteLock(true);
+
+  /** The set of threads that are waiting for or holding the state-lock in shared mode. */
+  private Set<Thread> mSharedWaitersAndHolders;
+  /** Scheduler that is used for interrupt-cycle. */
+  private ScheduledExecutorService mScheduler;
+
+  /** Whether exclusive locking will trigger interrupt-cycle. */
+  private boolean mInterruptCycleEnabled;
+  /** Interval at which threads around shared-lock will be interrupted during interrupt-cycle. */
+  private long mInterruptCycleInterval;
+  /** Used to synchronize execution/termination of interrupt-cycle. */
+  private Lock mInterruptCycleLock = new ReentrantLock(true);
+  /** How many active exclusive locking attempts. */
+  private volatile long mInterruptCycleRefCount = 0;
+  /** The future for the active interrupt cycle. */
+  private ScheduledFuture<?> mInterrupterFuture;
+
+  /** This is the deadline for forcing the lock. */
+  private long mForcedDurationMs;
+
+  // TODO(ggezer): Make it bound to a process start/stop cycle.
+  /** Shared locking requests will fail until this time. */
+  private long mExclusiveOnlyDeadlineMs = -1;
+
+  /**
+   * Creates a new state-lock manager.
+   */
+  public StateLockManager() {
+    mSharedWaitersAndHolders = new ConcurrentHashSet<>();
+    // Init members.
+    mScheduler = Executors
+        .newSingleThreadScheduledExecutor(ThreadFactoryUtils.build("state-lock-manager-%d", true));
+    // Read properties.
+    mInterruptCycleEnabled = ServerConfiguration
+        .getBoolean(PropertyKey.MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_ENABLED);
+    mInterruptCycleInterval =
+        ServerConfiguration.getMs(PropertyKey.MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_INTERVAL);
+    mForcedDurationMs =
+        ServerConfiguration.getMs(PropertyKey.MASTER_BACKUP_STATE_LOCK_FORCED_DURATION);
+    // Validate properties.
+    Preconditions.checkArgument(mInterruptCycleInterval > 0,
+        "Interrupt-cycle interval should be greater than 0.");
+  }
+
+  /**
+   * This is called by owning process in order to signal that
+   * the state is read completely and masters are started.
+   *
+   * This triggers the beginning of exclusive-only maintenance mode for the state-lock.
+   * Note: Calling it multiple times does not reset the maintenance window.
+   */
+  public void mastersStartedCallback() {
+    if (mExclusiveOnlyDeadlineMs == -1) {
+      long exclusiveOnlyDurationMs =
+          ServerConfiguration.getMs(PropertyKey.MASTER_BACKUP_STATE_LOCK_EXCLUSIVE_DURATION);
+      mExclusiveOnlyDeadlineMs = System.currentTimeMillis() + exclusiveOnlyDurationMs;
+      if (exclusiveOnlyDurationMs > 0) {
+        LOG.info("State-lock will remain in exclusive-only mode for %dms until %s",
+            exclusiveOnlyDurationMs, new Date(mExclusiveOnlyDeadlineMs).toString());
+      }
+    }
+  }
+
+  /**
+   * Locks the state shared.
+   *
+   * Calling thread might be interrupted by this manager,
+   * if it found to be waiting for the shared lock under when:
+   *  - backup is exiting grace-cycle and entering the lock permanently
+   *  - backup is in progress
+   *
+   * @return the lock resource
+   * @throws InterruptedException
+   */
+  public LockResource lockShared() throws InterruptedException {
+    // Do not allow taking shared lock during safe-mode.
+    long exclusiveOnlyRemainingMs = mExclusiveOnlyDeadlineMs - System.currentTimeMillis();
+    if (exclusiveOnlyRemainingMs > 0) {
+      String safeModeMsg = String.format(
+          "Master still in exclusive-only phase (%dms remaining) for the state-lock. "
+              + "Please see documentation for %s.",
+          exclusiveOnlyRemainingMs, PropertyKey.Name.MASTER_BACKUP_STATE_LOCK_EXCLUSIVE_DURATION);
+      throw new IllegalStateException(safeModeMsg);
+    }
+    // Register thread for interrupt cycle.
+    mSharedWaitersAndHolders.add(Thread.currentThread());
+    // Grab the lock interruptibly.
+    mStateLock.readLock().lockInterruptibly();
+    // Return the resource.
+    // Register an action to remove the thread from holders registry before releasing the lock.
+    return new LockResource(mStateLock.readLock(), false, false, () -> {
+      mSharedWaitersAndHolders.remove(Thread.currentThread());
+    });
+  }
+
+  /**
+   * Locks the state exclusively.
+   *
+   * @param lockOptions exclusive lock options
+   * @return the lock resource
+   * @throws TimeoutException if locking times out
+   * @throws InterruptedException if interrupting during locking
+   */
+  public LockResource lockExclusive(StateLockOptions lockOptions)
+      throws TimeoutException, InterruptedException {
+    // Run the grace cycle.
+    StateLockOptions.GraceMode graceMode = lockOptions.getGraceMode();
+    boolean lockAcquired = false;
+    long deadlineMs = System.currentTimeMillis() + lockOptions.getGraceCycleTimeoutMs();
+    while (System.currentTimeMillis() < deadlineMs) {
+      if (mStateLock.writeLock().tryLock(lockOptions.getGraceCycleTryMs(), TimeUnit.MILLISECONDS)) {
+        lockAcquired = true;
+        break;
+      } else {
+        long remainingWaitMs = deadlineMs - System.currentTimeMillis();
+        if (remainingWaitMs > 0) {
+          Thread.sleep(Math.min(lockOptions.getGraceCycleSleepMs(), remainingWaitMs));
+        }
+      }
+    }
+    if (lockAcquired) { // Lock was acquired within grace-cycle.
+      activateInterruptCycle();
+    } else { // Lock couldn't be acquired by grace-cycle.
+      if (graceMode == StateLockOptions.GraceMode.TIMEOUT) {
+        throw new TimeoutException(
+            ExceptionMessage.STATE_LOCK_TIMED_OUT.getMessage(lockOptions.getGraceCycleTimeoutMs()));
+      }
+      // Activate the interrupt cycle before entering the lock because it might wait in the queue.
+      activateInterruptCycle();
+      // Force the lock.
+      try {
+        if (!mStateLock.writeLock().tryLock(mForcedDurationMs, TimeUnit.MILLISECONDS)) {
+          throw new TimeoutException(ExceptionMessage.STATE_LOCK_TIMED_OUT
+              .getMessage(lockOptions.getGraceCycleTimeoutMs() + mForcedDurationMs));
+        }
+      } catch (InterruptedException e) {
+        // Deactivate interrupter if active.
+        deactivateInterruptCycle();
+        throw e;
+      }
+    }
+
+    // We have the lock, wrap it and return.
+    // Register an action for cancelling the interrupt cycle before releasing the lock.
+    return new LockResource(mStateLock.writeLock(), false, false, () -> {
+      // Before releasing the write-lock, activate interrupter if active.
+      deactivateInterruptCycle();
+    });
+  }
+
+  /**
+   * Schedules the cycle of interrupting state-lock waiters/holders.
+   * It's called when:
+   *  - Lock is acquired by grace-cycle
+   *  - Lock is being taken directly after unsuccessful grace-cycle
+   *
+   * Calling it multiple times only schedules one interrupt-cycle.
+   */
+  private void activateInterruptCycle() {
+    if (!mInterruptCycleEnabled) {
+      return;
+    }
+    try (LockResource lr = new LockResource(mInterruptCycleLock)) {
+      // Don't reschedule if it was before.
+      if (mInterruptCycleRefCount++ > 0) {
+        return;
+      }
+      // Setup the cycle.
+      mInterrupterFuture = mScheduler.scheduleAtFixedRate(this::waiterInterruptRoutine,
+          mInterruptCycleInterval, mInterruptCycleInterval, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  /**
+   * Stops the cycle of interrupting state-lock waiters/holders.
+   *
+   * Interrupt-cycle will be stopped when this method is called as much as
+   * {@link #activateInterruptCycle()}.
+   */
+  private void deactivateInterruptCycle() {
+    if (!mInterruptCycleEnabled) {
+      return;
+    }
+    try (LockResource lr = new LockResource(mInterruptCycleLock)) {
+      Preconditions.checkArgument(mInterruptCycleRefCount > 0);
+      // Don't do anything if there are exclusive lockers.
+      if (--mInterruptCycleRefCount > 0) {
+        return;
+      }
+      // Cancel the cycle.
+      mInterrupterFuture.cancel(true);
+      mInterrupterFuture = null;
+    }
+  }
+
+  /**
+   * Scheduled routine that interrupts waiters/holders of shared lock.
+   */
+  private void waiterInterruptRoutine() {
+    for (Thread th : mSharedWaitersAndHolders) {
+      th.interrupt();
+    }
+  }
+}

--- a/core/server/common/src/main/java/alluxio/master/StateLockOptions.java
+++ b/core/server/common/src/main/java/alluxio/master/StateLockOptions.java
@@ -1,0 +1,141 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master;
+
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+
+/**
+ * Used to define state-lock options for taking it exclusively.
+ * A typical framework for obtaining the state-lock exclusively is:
+ *  1- Run a grace-cycle:
+ *      cycle of {@link Lock#tryLock()} - {@link Thread#sleep(long)} calls.
+ *  2- Call {@link Lock#tryLock(long, TimeUnit)} for a long duration
+ *    a- Duration configured by {@link PropertyKey#MASTER_BACKUP_STATE_LOCK_FORCED_DURATION}.
+ *    b- Shared lock holders/waiter will regularly be interrupted if
+ *       {@link PropertyKey#MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_ENABLED} is true.
+ *       - Interrupt interval defined by
+ *         {@link PropertyKey#MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_INTERVAL}.
+ */
+public class StateLockOptions {
+  /** Whether to wait grace-cycle. */
+  private final GraceMode mGraceMode;
+
+  /** try part of grace-cycle. */
+  private final long mGraceCycleTryMs;
+  /** sleep of grace-cycle. */
+  private final long mGraceCycleSleepMs;
+  /** total duration of grace-cycle. */
+  private final long mGraceCycleTimeoutMs;
+
+  /**
+   * Creates an option class that is consulted while taking a state-lock exclusively
+   * from {@link StateLockManager}.
+   *
+   * @param graceMode the mode for grace-cycle
+   * @param graceCycleTryMs grace-cycle try duration
+   * @param graceCycleSleepMs grace-cycle sleep duration
+   * @param graceCycleTimeoutMs total grace-cycle duration
+   */
+  public StateLockOptions(GraceMode graceMode, long graceCycleTryMs, long graceCycleSleepMs,
+      long graceCycleTimeoutMs) {
+    mGraceMode = graceMode;
+    mGraceCycleTryMs = graceCycleTryMs;
+    mGraceCycleSleepMs = graceCycleSleepMs;
+    mGraceCycleTimeoutMs = graceCycleTimeoutMs;
+  }
+
+  /**
+   * @return the {@link GraceMode} of this options
+   */
+  public GraceMode getGraceMode() {
+    return mGraceMode;
+  }
+
+  /**
+   * @return try duration of grace-cycle
+   */
+  public long getGraceCycleTryMs() {
+    return mGraceCycleTryMs;
+  }
+
+  /**
+   * @return sleep duration of grace-cycle
+   */
+  public long getGraceCycleSleepMs() {
+    return mGraceCycleSleepMs;
+  }
+
+  /**
+   * @return total duration of grace-cycle
+   */
+  public long getGraceCycleTimeoutMs() {
+    return mGraceCycleTimeoutMs;
+  }
+
+  /**
+   * @return {@link StateLockOptions} default instance for shell backups
+   */
+  public static StateLockOptions defaultsForShellBackup() {
+    return new StateLockOptions(
+        ServerConfiguration.getEnum(
+            PropertyKey.MASTER_SHELL_BACKUP_STATE_LOCK_GRACE_MODE, GraceMode.class),
+        ServerConfiguration.getMs(
+            PropertyKey.MASTER_SHELL_BACKUP_STATE_LOCK_TRY_DURATION),
+        ServerConfiguration.getMs(
+            PropertyKey.MASTER_SHELL_BACKUP_STATE_LOCK_SLEEP_DURATION),
+        ServerConfiguration.getMs(
+            PropertyKey.MASTER_SHELL_BACKUP_STATE_LOCK_TIMEOUT)
+    );
+  }
+
+  /**
+   * @return {@link StateLockOptions} default instance for daily backups
+   */
+  public static StateLockOptions defaultsForDailyBackup() {
+    return new StateLockOptions(
+        ServerConfiguration.getEnum(
+            PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_GRACE_MODE, GraceMode.class),
+        ServerConfiguration.getMs(
+            PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_TRY_DURATION),
+        ServerConfiguration.getMs(
+            PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_SLEEP_DURATION),
+        ServerConfiguration.getMs(
+            PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT)
+    );
+  }
+
+  /**
+   * This default instance is effectively the same as locking on write-lock.
+   *
+   * @return {@link StateLockOptions} default
+   */
+  public static StateLockOptions defaults() {
+    return new StateLockOptions(
+        GraceMode.FORCED, // force the lock
+        0, // grace-cycle try duration ms
+        0, // grace-cycle sleep duration ms
+        0 // grace-cycle total duration ms
+    );
+  }
+
+  /**
+   * Defines the grace mode of exclusive locking of the state-lock.
+   */
+  public enum GraceMode {
+    TIMEOUT,    // Timeout if lock can't be acquired by grace-cycle.
+    FORCED,     // Force the lock if grace-cycle failed to acquire it.
+  }
+}

--- a/core/server/common/src/main/java/alluxio/master/journal/StateChangeJournalContext.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/StateChangeJournalContext.java
@@ -19,8 +19,6 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.locks.Lock;
-
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -36,12 +34,12 @@ public final class StateChangeJournalContext implements JournalContext {
    * Constructs a {@link StateChangeJournalContext}.
    *
    * @param journalContext the journal context to wrap
-   * @param stateLock the state lock to use
+   * @param stateLockResource the state lock resource to keep
    */
-  public StateChangeJournalContext(JournalContext journalContext, Lock stateLock) {
+  public StateChangeJournalContext(JournalContext journalContext, LockResource stateLockResource) {
     Preconditions.checkNotNull(journalContext, "journalContext");
     mJournalContext = journalContext;
-    mStateLockResource = new LockResource(stateLock);
+    mStateLockResource = stateLockResource;
   }
 
   @Override

--- a/core/server/common/src/test/java/alluxio/master/StateLockManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/StateLockManagerTest.java
@@ -1,0 +1,219 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master;
+
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.resource.LockResource;
+import alluxio.util.CommonUtils;
+
+import com.google.common.util.concurrent.SettableFuture;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Tests {@link StateLockManager} functionality.
+ */
+public class StateLockManagerTest {
+
+  @Rule
+  public ExpectedException mExpected = ExpectedException.none();
+
+  private void configureInterruptCycle(boolean enabled) {
+    configureInterruptCycle(enabled, 100);
+  }
+
+  private void configureInterruptCycle(boolean enabled, long intervalMs) {
+    ServerConfiguration.set(PropertyKey.MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_ENABLED, enabled);
+    ServerConfiguration.set(PropertyKey.MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_INTERVAL,
+        intervalMs);
+  }
+
+  @Test
+  public void testGraceMode_Timeout() throws Throwable {
+    configureInterruptCycle(false);
+    // The state-lock instance.
+    StateLockManager stateLockManager = new StateLockManager();
+    // Start a thread that owns the state-lock in shared mode.
+    StateLockingThread sharedHolderThread = new StateLockingThread(stateLockManager, false);
+    sharedHolderThread.start();
+    sharedHolderThread.waitUntilStateLockAcquired();
+    // Expect timeout when the lock is held in shared mode.
+    mExpected.expect(TimeoutException.class);
+    stateLockManager
+        .lockExclusive(new StateLockOptions(StateLockOptions.GraceMode.TIMEOUT, 10, 0, 100));
+    // Exit the shared holder.
+    sharedHolderThread.unlockExit();
+    sharedHolderThread.join();
+    // Create an exclusive owner of the state-lock.
+    StateLockingThread exclusiveHolderThread = new StateLockingThread(stateLockManager, true);
+    exclusiveHolderThread.start();
+    exclusiveHolderThread.waitUntilStateLockAcquired();
+    // Expect timeout when the lock is held in exclusive mode.
+    mExpected.expect(TimeoutException.class);
+    stateLockManager
+        .lockExclusive(new StateLockOptions(StateLockOptions.GraceMode.TIMEOUT, 10, 0, 100));
+    // Exit the exclusive holder.
+    exclusiveHolderThread.unlockExit();
+    exclusiveHolderThread.join();
+    // Now the lock can be acquired within the grace-cycle.
+    try (LockResource lr = stateLockManager
+        .lockExclusive(new StateLockOptions(StateLockOptions.GraceMode.TIMEOUT, 10, 0, 100))) {
+      // Acquired within the grace-cycle with no active holder.
+    }
+  }
+
+  @Test
+  public void testGraceMode_Forced() throws Throwable {
+    // Enable interrupt-cycle with 100ms interval.
+    configureInterruptCycle(true, 100);
+    // The state-lock instance.
+    StateLockManager stateLockManager = new StateLockManager();
+    // Start a thread that owns the state-lock in shared mode.
+    StateLockingThread sharedHolderThread = new StateLockingThread(stateLockManager, false);
+    sharedHolderThread.start();
+    sharedHolderThread.waitUntilStateLockAcquired();
+    // Take the state-lock exclusively with GUARANTEED grace mode.
+    try (LockResource lr = stateLockManager
+        .lockExclusive(new StateLockOptions(StateLockOptions.GraceMode.FORCED, 10, 0, 100))) {
+      // Holder should have been interrupted.
+      Assert.assertTrue(sharedHolderThread.lockInterrupted());
+      sharedHolderThread.join();
+      // Spawn a new thread that waits on the lock.
+      StateLockingThread sharedWaiterThread = new StateLockingThread(stateLockManager, false);
+      sharedWaiterThread.start();
+      // Wait until it's interrupted by the cycle too.
+      CommonUtils.waitFor("waiter interrupted", () -> sharedWaiterThread.lockInterrupted());
+      sharedWaiterThread.join();
+    }
+  }
+
+  @Test
+  public void testExclusiveOnlyMode() throws Throwable {
+    // Configure exclusive-only duration to cover the entire test execution.
+    final long exclusiveOnlyDurationMs = 30 * 1000;
+    ServerConfiguration.set(PropertyKey.MASTER_BACKUP_STATE_LOCK_EXCLUSIVE_DURATION,
+        exclusiveOnlyDurationMs);
+
+    // The state-lock instance.
+    StateLockManager stateLockManager = new StateLockManager();
+    // Simulate masters-started event to initiate the exclusive-only phase.
+    stateLockManager.mastersStartedCallback();
+
+    for (int i = 0; i < 10; i++) {
+      StateLockingThread sharedHolderThread = new StateLockingThread(stateLockManager, false);
+      sharedHolderThread.start();
+      // Shared lockers are expected to fail.
+      mExpected.expect(IllegalStateException.class);
+      sharedHolderThread.waitUntilStateLockAcquired();
+    }
+
+    // Exclusive locking should be allowed.
+    StateLockingThread exclusiveHolderThread = new StateLockingThread(stateLockManager, true);
+    exclusiveHolderThread.start();
+    // State lock should be acquired.
+    exclusiveHolderThread.waitUntilStateLockAcquired();
+    // Signal exit and wait for the exclusive locker.
+    exclusiveHolderThread.unlockExit();
+    exclusiveHolderThread.join();
+  }
+
+  /**
+   * Test thread that:
+   *  1- locks on state-lock with requested mode shared/exclusive.
+   *  2- fires that state-lock is acquired.
+   *  3- sleeps on internal lock before exiting, while holding the state-lock.
+   *  4- releases the state-lock right before exiting.
+   */
+  class StateLockingThread extends Thread {
+    private StateLockManager mStateLockManager;
+    private boolean mExclusive;
+    private Lock mExitLock = new ReentrantLock();
+    private SettableFuture<Void> mStateLockAcquired;
+    private boolean mInterrupted = false;
+
+    /**
+     * Creates a state-locking test thread.
+     *
+     * @param stateLockManager state lock manager
+     * @param exclusive whether to acquire the state-lock exclusives
+     */
+    public StateLockingThread(StateLockManager stateLockManager, boolean exclusive) {
+      mStateLockManager = stateLockManager;
+      mExclusive = exclusive;
+      mStateLockAcquired = SettableFuture.create();
+      mExitLock.lock();
+    }
+
+    @Override
+    public void run() {
+      LockResource lr = null;
+      try {
+        if (mExclusive) {
+          lr = mStateLockManager.lockExclusive(StateLockOptions.defaults());
+        } else {
+          lr = mStateLockManager.lockShared();
+        }
+        mStateLockAcquired.set(null);
+
+        mExitLock.lockInterruptibly();
+      } catch (Exception e) {
+        if (e instanceof InterruptedException) {
+          mInterrupted = true;
+        }
+        mStateLockAcquired.setException(e);
+      } finally {
+        if (lr != null) {
+          lr.close();
+        }
+      }
+    }
+
+    /**
+     * Allows thread to exit after acquiring the state-lock.
+     */
+    public void unlockExit() {
+      mExitLock.unlock();
+    }
+
+    /**
+     * Holds the caller until this thread acquires the state-lock.
+     *
+     * @throws Exception that is received while acquiring the state-lock
+     */
+    public void waitUntilStateLockAcquired() throws Throwable {
+      try {
+        mStateLockAcquired.get();
+      } catch (ExecutionException e) {
+        if (e.getCause() != null) {
+          throw e.getCause();
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    /**
+     * @return {@code true} if this thread is interrupted around locks
+     */
+    public boolean lockInterrupted() {
+      return mInterrupted;
+    }
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -211,6 +211,8 @@ public class AlluxioMasterProcess extends MasterProcess {
         startRejectingServers();
       }
       mRegistry.start(isLeader);
+      // Signal state-lock-manager that masters are ready.
+      mContext.getStateLockManager().mastersStartedCallback();
       LOG.info("All masters started");
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/core/server/master/src/main/java/alluxio/master/backup/BackupOps.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupOps.java
@@ -14,6 +14,7 @@ package alluxio.master.backup;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.BackupPRequest;
 import alluxio.grpc.BackupStatusPRequest;
+import alluxio.master.StateLockOptions;
 import alluxio.wire.BackupStatus;
 
 import java.io.IOException;
@@ -33,10 +34,12 @@ public interface BackupOps {
    * allowed by passing "AllowLeader" option in the request.
    *
    * @param request the backup request
+   * @param stateLockOptions the state lock options during the backup
    * @return the backup status response
    * @throws IOException if backup fails
    */
-  BackupStatus backup(BackupPRequest request) throws AlluxioException;
+  BackupStatus backup(BackupPRequest request, StateLockOptions stateLockOptions)
+      throws AlluxioException;
 
   /**
    * Used to query the status of a backup.

--- a/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
@@ -26,6 +26,7 @@ import alluxio.grpc.ServiceType;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.MasterClientContext;
 import alluxio.master.MasterInquireClient;
+import alluxio.master.StateLockOptions;
 import alluxio.master.journal.CatchupFuture;
 import alluxio.master.transport.GrpcMessagingClient;
 import alluxio.retry.ExponentialBackoffRetry;
@@ -143,7 +144,8 @@ public class BackupWorkerRole extends AbstractBackupRole {
   }
 
   @Override
-  public BackupStatus backup(BackupPRequest request) throws AlluxioException {
+  public BackupStatus backup(BackupPRequest request, StateLockOptions stateLockOptions)
+      throws AlluxioException {
     throw new IllegalStateException("Backup-worker role can't serve RPCs");
   }
 

--- a/core/server/master/src/main/java/alluxio/master/meta/DailyMetadataBackup.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DailyMetadataBackup.java
@@ -17,6 +17,7 @@ import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.BackupPOptions;
 import alluxio.grpc.BackupPRequest;
 import alluxio.master.BackupManager;
+import alluxio.master.StateLockOptions;
 import alluxio.resource.CloseableResource;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UfsStatus;
@@ -114,18 +115,10 @@ public final class DailyMetadataBackup {
    */
   private void dailyBackup() {
     try {
-      BackupStatus resp =
-          mMetaMaster.backup(BackupPRequest.newBuilder()
-              .setTargetDirectory(mBackupDir)
-              .setOptions(BackupPOptions.newBuilder()
-                  .setLocalFileSystem(mIsLocal)
-                  .setStateLockTryDurationMs(ServerConfiguration
-                      .getMs(PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_TRY_DURATION))
-                  .setStateLockSleepDurationMs(ServerConfiguration
-                      .getMs(PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_SLEEP_DURATION))
-                  .setStateLockTimeoutMs(ServerConfiguration
-                      .getMs(PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT)))
-              .build());
+      BackupStatus resp = mMetaMaster.backup(
+          BackupPRequest.newBuilder().setTargetDirectory(mBackupDir)
+              .setOptions(BackupPOptions.newBuilder().setLocalFileSystem(mIsLocal)).build(),
+          StateLockOptions.defaultsForDailyBackup());
       if (mIsLocal) {
         LOG.info("Successfully backed up journal to {} on master {} with {} entries.",
             resp.getBackupUri(), resp.getHostname(), resp.getEntryCount());

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -40,6 +40,7 @@ import alluxio.heartbeat.HeartbeatThread;
 import alluxio.master.CoreMaster;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.MasterClientContext;
+import alluxio.master.StateLockOptions;
 import alluxio.master.backup.BackupLeaderRole;
 import alluxio.master.backup.BackupRole;
 import alluxio.master.backup.BackupWorkerRole;
@@ -357,22 +358,9 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
   }
 
   @Override
-  public BackupStatus backup(BackupPRequest request) throws AlluxioException {
-    // Update the request based on caller.
-    // Currently daily-backup provides all required state-lock timeouts.
-    // Here the code assumes it's a shell invocation when related fields are not set.
-    if (!request.getOptions().hasStateLockTimeoutMs()) {
-      // Make shell invocations to try acquiring the lock the whole time.
-      request = request.toBuilder()
-          .setOptions(request.getOptions().toBuilder()
-              .setStateLockTimeoutMs(
-                  ServerConfiguration.getMs(PropertyKey.MASTER_BACKUP_STATE_LOCK_TIMEOUT))
-              .setStateLockTryDurationMs(
-                  ServerConfiguration.getMs(PropertyKey.MASTER_BACKUP_STATE_LOCK_TIMEOUT))
-              .setStateLockSleepDurationMs(0))
-          .build();
-    }
-    return mBackupRole.backup(request);
+  public BackupStatus backup(BackupPRequest request, StateLockOptions stateLockOptions)
+      throws AlluxioException {
+    return mBackupRole.backup(request, stateLockOptions);
   }
 
   @Override
@@ -382,11 +370,14 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
 
   @Override
   public String checkpoint() throws IOException {
-    try (LockResource lr = new LockResource(mMasterContext.pauseStateLock())) {
+    try (LockResource lr =
+        mMasterContext.getStateLockManager().lockExclusive(StateLockOptions.defaults())) {
       mJournalSystem.checkpoint();
+      return NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.MASTER_RPC,
+          ServerConfiguration.global());
+    } catch (Exception e) {
+      throw new IOException("Failed to take a checkpoint.", e);
     }
-    return NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.MASTER_RPC,
-        ServerConfiguration.global());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/meta/MetaMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/MetaMasterClientServiceHandler.java
@@ -27,6 +27,7 @@ import alluxio.grpc.GetMasterInfoPResponse;
 import alluxio.grpc.MasterInfo;
 import alluxio.grpc.MasterInfoField;
 import alluxio.grpc.MetaMasterClientServiceGrpc;
+import alluxio.master.StateLockOptions;
 import alluxio.wire.Address;
 
 import io.grpc.stub.StreamObserver;
@@ -54,7 +55,8 @@ public final class MetaMasterClientServiceHandler
 
   @Override
   public void backup(BackupPRequest request, StreamObserver<BackupPStatus> responseObserver) {
-    RpcUtils.call(LOG, () -> mMetaMaster.backup(request).toProto(),
+    RpcUtils.call(LOG,
+        () -> mMetaMaster.backup(request, StateLockOptions.defaultsForShellBackup()).toProto(),
         "backup", "request=%s", responseObserver, request);
   }
 

--- a/core/server/master/src/test/java/alluxio/master/meta/DailyMetadataBackupTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/DailyMetadataBackupTest.java
@@ -63,10 +63,11 @@ public class DailyMetadataBackupTest {
     mBackupDir = "/tmp/test/alluxio_backups";
 
     mMetaMaster = Mockito.mock(MetaMaster.class);
-    when(mMetaMaster.backup(any())).thenReturn(BackupStatus.fromProto(BackupPStatus.newBuilder()
-        .setBackupId(UUID.randomUUID().toString()).setBackupState(BackupState.Completed)
-        .setBackupUri(PathUtils.concatPath(mBackupDir, generateBackupFileName()))
-        .setBackupHost("localhost").build()));
+    when(mMetaMaster.backup(any(), any()))
+        .thenReturn(BackupStatus.fromProto(BackupPStatus.newBuilder()
+            .setBackupId(UUID.randomUUID().toString()).setBackupState(BackupState.Completed)
+            .setBackupUri(PathUtils.concatPath(mBackupDir, generateBackupFileName()))
+            .setBackupHost("localhost").build()));
 
     mUfs = Mockito.mock(UnderFileSystem.class);
     when(mUfs.getUnderFSType()).thenReturn("local");
@@ -101,19 +102,19 @@ public class DailyMetadataBackupTest {
       int backUpFileNum = 0;
       when(mUfs.listStatus(mBackupDir)).thenReturn(generateUfsStatuses(++backUpFileNum));
       mScheduler.jumpAndExecute(1, TimeUnit.DAYS);
-      verify(mMetaMaster, times(backUpFileNum)).backup(any());
+      verify(mMetaMaster, times(backUpFileNum)).backup(any(), any());
       int deleteFileNum = getNumOfDeleteFile(backUpFileNum, fileToRetain);
       verify(mUfs, times(deleteFileNum)).deleteFile(any());
 
       when(mUfs.listStatus(mBackupDir)).thenReturn(generateUfsStatuses(++backUpFileNum));
       mScheduler.jumpAndExecute(1, TimeUnit.DAYS);
-      verify(mMetaMaster, times(backUpFileNum)).backup(any());
+      verify(mMetaMaster, times(backUpFileNum)).backup(any(), any());
       deleteFileNum += getNumOfDeleteFile(backUpFileNum, fileToRetain);
       verify(mUfs, times(deleteFileNum)).deleteExistingFile(any());
 
       when(mUfs.listStatus(mBackupDir)).thenReturn(generateUfsStatuses(++backUpFileNum));
       mScheduler.jumpAndExecute(1, TimeUnit.DAYS);
-      verify(mMetaMaster, times(backUpFileNum)).backup(any());
+      verify(mMetaMaster, times(backUpFileNum)).backup(any(), any());
       deleteFileNum += getNumOfDeleteFile(backUpFileNum, fileToRetain);
       verify(mUfs, times(deleteFileNum)).deleteExistingFile(any());
     }

--- a/core/transport/src/grpc/meta_master.proto
+++ b/core/transport/src/grpc/meta_master.proto
@@ -119,9 +119,6 @@ message BackupPOptions {
     optional bool localFileSystem = 1;
     optional bool runAsync = 2;
     optional bool allowLeader = 3;
-    optional int64 stateLockTryDurationMs = 4;
-    optional int64 stateLockSleepDurationMs = 5;
-    optional int64 stateLockTimeoutMs = 6;
 }
 message BackupPStatus {
     optional string backupId = 1;

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/BackupCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/BackupCommandIntegrationTest.java
@@ -12,26 +12,19 @@
 package alluxio.client.cli.fsadmin;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 
 import alluxio.AlluxioTestDirectory;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.PropertyKey.Name;
 import alluxio.conf.ServerConfiguration;
-import alluxio.exception.ExceptionMessage;
-import alluxio.master.MasterContext;
-import alluxio.master.MasterProcess;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
 import org.junit.Test;
-import org.powermock.reflect.Whitebox;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.concurrent.locks.Lock;
 
 /**
  * Integration tests for the backup command.
@@ -61,32 +54,5 @@ public final class BackupCommandIntegrationTest extends AbstractFsAdminShellTest
     assertEquals("", mErrOutput.toString());
     assertEquals(0, errCode);
     assertEquals(1, Files.list(dir).count());
-  }
-
-  @Test
-  @LocalAlluxioClusterResource.Config(confParams = {Name.MASTER_BACKUP_DIRECTORY,
-      "${alluxio.work.dir}/backups", Name.MASTER_BACKUP_STATE_LOCK_TIMEOUT, "3s"})
-  public void timeout() throws IOException {
-    // Grab the master state-change lock via reflection.
-    MasterProcess masterProcess =
-        Whitebox.getInternalState(mLocalAlluxioCluster.getLocalAlluxioMaster(), "mMasterProcess");
-    MasterContext masterCtx = Whitebox.getInternalState(masterProcess, "mContext");
-    Lock stateLock = masterCtx.pauseStateLock();
-
-    try {
-      // Lock the state-change lock on the master before initiating the backup.
-      stateLock.lock();
-      // Prepare for a backup.
-      Path dir = Paths.get(ServerConfiguration.get(PropertyKey.MASTER_BACKUP_DIRECTORY));
-      Files.createDirectories(dir);
-      assertEquals(0, Files.list(dir).count());
-      // Initiate backup. It should fail.
-      int errCode = mFsAdminShell.run("backup");
-      assertTrue(mOutput.toString().contains(ExceptionMessage.STATE_LOCK_TIMED_OUT
-          .getMessage(3000/* matching the cluster resource configuration. */)));
-      assertNotEquals(0, errCode);
-    } finally {
-      masterCtx.pauseStateLock().unlock();
-    }
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/BackupCommandStateLockingIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/BackupCommandStateLockingIntegrationTest.java
@@ -1,0 +1,101 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.cli.fsadmin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import alluxio.AlluxioURI;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.ExceptionMessage;
+import alluxio.master.MasterContext;
+import alluxio.master.MasterProcess;
+import alluxio.master.StateLockManager;
+import alluxio.master.StateLockOptions;
+import alluxio.resource.LockResource;
+import alluxio.testutils.LocalAlluxioClusterResource;
+
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Integration tests for the backup command's interaction with the state-locking.
+ */
+public final class BackupCommandStateLockingIntegrationTest extends AbstractFsAdminShellTest {
+  @Test
+  @LocalAlluxioClusterResource.Config(confParams = {
+      PropertyKey.Name.MASTER_BACKUP_DIRECTORY, "${alluxio.work.dir}/backups",
+      PropertyKey.Name.MASTER_SHELL_BACKUP_STATE_LOCK_TRY_DURATION, "3s",
+      PropertyKey.Name.MASTER_SHELL_BACKUP_STATE_LOCK_TIMEOUT, "3s"})
+  public void timeoutWhenStateLockAcquired() throws Exception {
+    // Grab the master state-lock-manager via reflection.
+    MasterProcess masterProcess =
+        Whitebox.getInternalState(mLocalAlluxioCluster.getLocalAlluxioMaster(), "mMasterProcess");
+    MasterContext masterCtx = Whitebox.getInternalState(masterProcess, "mContext");
+    StateLockManager stateLockManager = masterCtx.getStateLockManager();
+
+    // Lock the state-change lock on the master before initiating the backup.
+    try (LockResource lr = stateLockManager.lockExclusive(StateLockOptions.defaults())) {
+      // Prepare for a backup.
+      Path dir = Paths.get(ServerConfiguration.get(PropertyKey.MASTER_BACKUP_DIRECTORY));
+      Files.createDirectories(dir);
+      assertEquals(0, Files.list(dir).count());
+      // Initiate backup. It should fail.
+      int errCode = mFsAdminShell.run("backup");
+      assertTrue(mOutput.toString().contains(ExceptionMessage.STATE_LOCK_TIMED_OUT
+          .getMessage(3000/* matching the cluster resource configuration. */)));
+      assertNotEquals(0, errCode);
+    }
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(confParams = {
+      PropertyKey.Name.MASTER_BACKUP_DIRECTORY, "${alluxio.work.dir}/backups"})
+  public void takeBackupDuringExclusiveOnlyPhase() throws Exception {
+    // Grab the master state-lock-manager via reflection.
+    MasterProcess masterProcess =
+        Whitebox.getInternalState(mLocalAlluxioCluster.getLocalAlluxioMaster(), "mMasterProcess");
+    MasterContext masterCtx = Whitebox.getInternalState(masterProcess, "mContext");
+    StateLockManager stateLockManager = masterCtx.getStateLockManager();
+
+    // Activate exclusive-only phase via reflection.
+    // Cannot make via cluster property due to lack of support from test utilities.
+    long exclusiveOnlyDurationMs = 30000;
+    Whitebox.setInternalState(stateLockManager, "mExclusiveOnlyDeadlineMs",
+        System.currentTimeMillis() + exclusiveOnlyDurationMs);
+
+    try {
+      // getStatus() should fail during exclusive-only phase.
+      mException.expect(AlluxioException.class);
+      mLocalAlluxioCluster.getClient().getStatus(new AlluxioURI("/"));
+      // Prepare for a backup.
+      Path dir = Paths.get(ServerConfiguration.get(PropertyKey.MASTER_BACKUP_DIRECTORY));
+      Files.createDirectories(dir);
+      assertEquals(0, Files.list(dir).count());
+      // Take the backup. It should be allowed.
+      int errCode = mFsAdminShell.run("backup");
+      assertEquals("", mErrOutput.toString());
+      assertEquals(0, errCode);
+      assertEquals(1, Files.list(dir).count());
+    } finally {
+      // Reset exclusive-only phase.
+      Whitebox.setInternalState(stateLockManager, "mExclusiveOnlyDeadlineMs", -1);
+    }
+  }
+}


### PR DESCRIPTION
This PR, in general, introduces a new locking framework over state-lock.
Changes can be summarized as:

- Backups take the lock exclusive with an initial grace-cycle.
Grace-cycle is defined as `tryLock-sleep` cycles until the lock is held.
3 graceful locking strategies have been implemented (TIMEOUT, FORCED)

- Immediate shared holders/waiters of state-lock may now be interrupted
as part of interrupt-cycle task, which is activated before or after
taking the lock.

- Shell/daily backups can now be configured for all grace modes via
master config change. (Defaults for Shell: TIMEOUT, Daily: FORCED)

- A new maintenance duration( exclusive-only phase) is defined for
masters, during which only exclusive locking will be allowed. This
duration is effective after the first time masters are started, after
reading the journals.

pr-link: Alluxio/alluxio#11535
change-id: cid-b0ca6b03b8b9f563ad537ebd14991ce4fe1cacf5