### PR TITLE
Fix Fuse crash in kubernetes in helmchart

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -101,4 +101,4 @@
 - Added inferring dnsPolicy from hostNetwork
 - Fixed one typo in ALLUXIO_CLIENT_JAVA_OPTS for FUSE
 - Fixed Fuse crash issue
-- Fixed the pod can't access itself through service
+- Change master service to headless from NodePort

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -101,4 +101,6 @@
 - Added inferring dnsPolicy from hostNetwork
 - Fixed one typo in ALLUXIO_CLIENT_JAVA_OPTS for FUSE
 - Fixed Fuse crash issue
-- Change master service to headless from NodePort
+- Changed master service to headless from NodePort
+- 
+

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -100,7 +100,9 @@
 - Removed inferring hostNetwork, dnsPolicy and domain socket from whether user is root
 - Added inferring dnsPolicy from hostNetwork
 - Fixed one typo in ALLUXIO_CLIENT_JAVA_OPTS for FUSE
+
+0.6.4
+
 - Fixed Fuse crash issue
 - Changed master service to headless from NodePort
-- 
-
+- Made the single master access itself without service

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -99,4 +99,6 @@
 - Moved metastore configuration properties to the root level, to be the same as journal
 - Removed inferring hostNetwork, dnsPolicy and domain socket from whether user is root
 - Added inferring dnsPolicy from hostNetwork
-- Fixed one typo in ALLUXIO_CLIENT_JAVA_OPTS for FUSE   
+- Fixed one typo in ALLUXIO_CLIENT_JAVA_OPTS for FUSE
+- Fixed Fuse crash issue
+- Fixed the pod can't access itself through service

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.2
+version: 0.6.3
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.3
+version: 0.6.4
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -26,6 +26,10 @@
 {{- if $isSingleMaster }}
   {{- $alluxioJavaOpts = printf "-Dalluxio.master.hostname=%v-%v" $fullName $defaultMasterName | append $alluxioJavaOpts }}
 {{- end }}
+{{ if .Values.fuse.enabled -}}
+{{- $alluxioJavaOpts = print "-Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $alluxioJavaOpts }}
+{{- $alluxioJavaOpts = printf "-Dalluxio.worker.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $alluxioJavaOpts }}
+{{- end }}
 {{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.type=%v" .Values.journal.type | append $alluxioJavaOpts }}
 {{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.folder=%v" .Values.journal.folder | append $alluxioJavaOpts }}
 
@@ -148,10 +152,8 @@
 {{- /*        ALLUXIO_FUSE_JAVA_OPTS         */}}
 {{- /* ===================================== */}}
 {{- $fuseJavaOpts := list }}
-{{- $fuseJavaOpts = print "-Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $fuseJavaOpts }}
-  {{- $fuseJavaOpts = print "-Dalluxio.worker.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $fuseJavaOpts }}
-  {{- range $key, $val := .Values.fuse.properties }}
-    {{- $fuseJavaOpts = printf "-D%v=%v" $key $val | append $fuseJavaOpts }}
+{{- range $key, $val := .Values.fuse.properties }}
+  {{- $fuseJavaOpts = printf "-D%v=%v" $key $val | append $fuseJavaOpts }}
 {{- end }}
 {{- if .Values.fuse.jvmOptions }}
   {{- $fuseJavaOpts = concat $fuseJavaOpts .Values.fuse.jvmOptions }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -27,8 +27,8 @@
   {{- $alluxioJavaOpts = printf "-Dalluxio.master.hostname=%v-%v" $fullName $defaultMasterName | append $alluxioJavaOpts }}
 {{- end }}
 {{ if .Values.fuse.enabled -}}
-{{- $alluxioJavaOpts = print "-Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $alluxioJavaOpts }}
-{{- $alluxioJavaOpts = printf "-Dalluxio.worker.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $alluxioJavaOpts }}
+  {{- $alluxioJavaOpts = print "-Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $alluxioJavaOpts }}
+  {{- $alluxioJavaOpts = printf "-Dalluxio.worker.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $alluxioJavaOpts }}
 {{- end }}
 {{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.type=%v" .Values.journal.type | append $alluxioJavaOpts }}
 {{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.folder=%v" .Values.journal.folder | append $alluxioJavaOpts }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/service.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/service.yaml
@@ -41,7 +41,7 @@ spec:
       name: embedded
     - port: 20003
       name: job-embedded
-  type: NodePort
+  clusterIP: None
   selector:
     role: alluxio-master
     app: {{ $name }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -92,6 +92,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          {{- else if $isSingleMaster }}
+          env:
+          - name: ALLUXIO_MASTER_HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           {{- end }}
           envFrom:
           - configMapRef:
@@ -147,6 +153,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          {{- else if $isSingleMaster }}
+          env:
+          - name: ALLUXIO_MASTER_HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           {{- end }}
           envFrom:
           - configMapRef:


### PR DESCRIPTION

1. Fix fuse crash issue. It's because the ALLUXIO_FUSE_OPTS are not in /opt/alluxio/conf/alluxio_env.sh, so it translates to ALLUXIO_FUSE_OPTS=" '-Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME}' "
![image](https://user-images.githubusercontent.com/3724388/84997640-6ca6f500-b181-11ea-915e-652dc4fbace5.png)

2. Make pod can access itself through service
3. Update change log


