### PR TITLE
Fix fetching partition for Glue UDB

### DIFF
--- a/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/GlueDatabase.java
+++ b/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/GlueDatabase.java
@@ -391,7 +391,7 @@ public class GlueDatabase implements UnderDatabase {
                 .withMaxResults(mGlueConfiguration.getInt(Property.MAX_GLUE_FETCH_PARTITIONS))
                 .withNextToken(nextToken);
         GetPartitionsResult getPartitionsResult = glueClient.getPartitions(getPartitionsRequest);
-        getPartitionsResult.getPartitions().forEach(partition -> partitions.add(partition));
+        partitions.addAll(getPartitionsResult.getPartitions());
         nextToken = getPartitionsResult.getNextToken();
         LOG.debug("Glue table {}.{} added {} partitions.",
             mGlueDbName, tableName, partitions.size());

--- a/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/GlueDatabase.java
+++ b/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/GlueDatabase.java
@@ -393,8 +393,8 @@ public class GlueDatabase implements UnderDatabase {
         GetPartitionsResult getPartitionsResult = glueClient.getPartitions(getPartitionsRequest);
         partitions.addAll(getPartitionsResult.getPartitions());
         nextToken = getPartitionsResult.getNextToken();
-        LOG.debug("Glue table {}.{} added {} partitions.",
-            mGlueDbName, tableName, partitions.size());
+        LOG.debug("Glue table {}.{} adding {} batch partitions with total {} partitions.",
+            mGlueDbName, tableName, getPartitionsResult.getPartitions().size(), partitions.size());
       } while (nextToken != null);
 
       if (partitions != null) {

--- a/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/Property.java
+++ b/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/Property.java
@@ -142,11 +142,17 @@ public class Property extends UdbProperty {
           .setDescription("The maximum number of connection to glue metastore.")
           .build();
 
+  public static final Property MAX_GLUE_FETCH_PARTITIONS =
+      new Builder(Name.MAX_GLUE_FETCH_PARTITIONS)
+          .setDefaultValue("256")
+          .setDescription("The maximum number of partitions are fetched with getPartitions.")
+          .build();
+
   public static final Property GLUE_REGION =
       new Builder(Name.GLUE_REGION)
-        .setDefaultValue("")
-        .setDescription("The regional endpoint for client service calls.")
-        .build();
+          .setDefaultValue("")
+          .setDescription("The regional endpoint for client service calls.")
+          .build();
 
   // TODO(shouwei): check the necessity of catalogid
   public static final Property CATALOG_ID =
@@ -157,15 +163,15 @@ public class Property extends UdbProperty {
 
   public static final Property AWS_GLUE_ACCESS_KEY =
       new Builder(Name.AWS_GLUE_ACCESS_KEY)
-        .setDefaultValue("")
-        .setDescription("The access key to access the aws glue.")
-        .build();
+          .setDefaultValue("")
+          .setDescription("The access key to access the aws glue.")
+          .build();
 
   public static final Property AWS_GLUE_SECRET_KEY =
       new Builder(Name.AWS_GLUE_SECRET_KEY)
-        .setDefaultValue("")
-        .setDescription("The secret key to access the aws glue.")
-        .build();
+          .setDefaultValue("")
+          .setDescription("The secret key to access the aws glue.")
+          .build();
 
   /**
    * @return the name of alluxio.table.under.glue.Property
@@ -197,6 +203,7 @@ public class Property extends UdbProperty {
   public static final class Name {
     // AWS Glue related properties
     public static final String MAX_GLUE_CONNECTION = "max.connection";
+    public static final String MAX_GLUE_FETCH_PARTITIONS = "max.partitions";
     public static final String GLUE_REGION = "aws.region";
     public static final String CATALOG_ID = "aws.catalog.id";
     public static final String AWS_GLUE_ACCESS_KEY = "aws.accesskey";

--- a/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/Property.java
+++ b/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/Property.java
@@ -145,7 +145,7 @@ public class Property extends UdbProperty {
   public static final Property MAX_GLUE_FETCH_PARTITIONS =
       new Builder(Name.MAX_GLUE_FETCH_PARTITIONS)
           .setDefaultValue("256")
-          .setDescription("The maximum number of partitions are fetched with getPartitions.")
+          .setDescription("The maximum number of partitions to return in a single response.")
           .build();
 
   public static final Property GLUE_REGION =
@@ -203,7 +203,7 @@ public class Property extends UdbProperty {
   public static final class Name {
     // AWS Glue related properties
     public static final String MAX_GLUE_CONNECTION = "max.connection";
-    public static final String MAX_GLUE_FETCH_PARTITIONS = "max.partitions";
+    public static final String MAX_GLUE_FETCH_PARTITIONS = "partitions.fetch.max";
     public static final String GLUE_REGION = "aws.region";
     public static final String CATALOG_ID = "aws.catalog.id";
     public static final String AWS_GLUE_ACCESS_KEY = "aws.accesskey";

--- a/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/Property.java
+++ b/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/Property.java
@@ -144,7 +144,7 @@ public class Property extends UdbProperty {
 
   public static final Property MAX_GLUE_FETCH_PARTITIONS =
       new Builder(Name.MAX_GLUE_FETCH_PARTITIONS)
-          .setDefaultValue("256")
+          .setDefaultValue("512")
           .setDescription("The maximum number of partitions to return in a single response.")
           .build();
 


### PR DESCRIPTION
Glue `getPartions` fetches a random number of partition from glue service without setting the `MaxResults` and `NextToken`. Add the `withMaxResults` and `withNextToken` to fix the partition fetching for Glue UDB.