### PR TITLE
fix bug in meta cache in MetadataCachingBaseFileSystem

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
@@ -19,6 +19,7 @@ import com.google.common.cache.CacheBuilder;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Callable;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -29,28 +30,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class MetadataCache {
   private class CachedItem {
-    private final URIStatus mStatus;
-    private final List<URIStatus> mDirStatuses;
-
-    /**
-     * Cache metadata for a path.
-     *
-     * @param status the metadata
-     */
-    public CachedItem(URIStatus status) {
-      mStatus = status;
-      mDirStatuses = null;
-    }
-
-    /**
-     * Cache metadata of paths directly under a directory.
-     *
-     * @param statuses the metadata list
-     */
-    public CachedItem(List<URIStatus> statuses) {
-      mStatus = null;
-      mDirStatuses = statuses;
-    }
+    private URIStatus mStatus = null;
+    private List<URIStatus> mDirStatuses = null;
 
     /**
      * @return the metadata of the path
@@ -66,6 +47,24 @@ public final class MetadataCache {
     @Nullable
     public List<URIStatus> getDirStatuses() {
       return mDirStatuses;
+    }
+
+    /**
+     *  put the status into cache
+     *
+     *  @param status the metadata of the path
+     */
+    public void setStatus(URIStatus status) {
+      mStatus = status;
+    }
+
+    /**
+     *  put the directory status into cache
+     *
+     *  @param statuses the metadata list
+     */
+    public void setDirStatuses(List<URIStatus> statuses) {
+      mDirStatuses = statuses;
     }
   }
 
@@ -100,7 +99,7 @@ public final class MetadataCache {
    * @param status the status to be cached
    */
   public void put(AlluxioURI path, URIStatus status) {
-    mCache.put(path.getPath(), new CachedItem(status));
+    put(path.getPath(), status);
   }
 
   /**
@@ -108,7 +107,17 @@ public final class MetadataCache {
    * @param status the status to be cached
    */
   public void put(String path, URIStatus status) {
-    mCache.put(path, new CachedItem(status));
+    try {
+      CachedItem item = mCache.get(path, new Callable<CachedItem>() {
+        @Override
+        public CachedItem call() throws Exception {
+          return new CachedItem();
+        }
+      });
+      item.setStatus(status);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
   }
 
   /**
@@ -118,9 +127,19 @@ public final class MetadataCache {
    * @param statuses the list status results
    */
   public void put(AlluxioURI dir, List<URIStatus> statuses) {
-    mCache.put(dir.getPath(), new CachedItem(statuses));
-    for (URIStatus status : statuses) {
-      mCache.put(status.getPath(), new CachedItem(status));
+    try {
+      CachedItem item = mCache.get(dir.getPath(), new Callable<CachedItem>() {
+        @Override
+        public CachedItem call() throws Exception {
+          return new CachedItem();
+        }
+      });
+      item.setDirStatuses(statuses);
+      for (URIStatus status : statuses) {
+        put(status.getPath(), status);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
     }
   }
 


### PR DESCRIPTION
Description:
meta data may be deleted in client cache although it is very hot. 
Now MetadataCache holds mStatus which stores the current file/dir status and mDirStatuses which stores the children status.
```
  private class CachedItem {
    private final URIStatus mStatus;
    private final List<URIStatus> mDirStatuses;
```
1. For example, There is a path '/A/B/C'.
2. We run the listStatus request on the directory '/A/B'. After receiving result from alluxio master, it caches 'A/B' into the cache map which stores the children status for the path '/A/B' as mDirStatuses and its children '/A/B/C' into the cach map which stores the file/dir status as mStatus. 
3. Then we run the listStatus request on the directory '/A'. After receiving result from alluxio master, it caches '/A' into the cache map which stores the children status for the path '/A' as mDirStatuses  and its children '/A/B' into the cach map which stores the file/dir status as mStatus. It replaces the previous content with a new CachedItem for '/A/B'.
```
public void put(AlluxioURI dir, List<URIStatus> statuses) {
    mCache.put(dir.getPath(), new CachedItem(statuses));
    for (URIStatus status : statuses) {
      mCache.put(status.getPath(), new CachedItem(status));
    }
```
4. If you rerrun the listStatus request on the directory '/A/B', you could not get the result. Because although the path '/A/B' is in the cache, it holds the content with mStatus. And the CachedItem with mDirStatuses has been replaced in the step 3. 