### PR TITLE
Fix bug in meta cache in MetadataCachingBaseFileSystem

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
@@ -133,7 +133,7 @@ public final class MetadataCache {
         put(status.getPath(), status);
       }
     } catch (ExecutionException e) {
-        LOG.error("Failed to put meta into client cache for " + dir.getPath(),
+        LOG.error("Failed to put meta into client cache for dir " + dir.getPath(),
                 e);
     }
   }

--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
@@ -112,7 +112,7 @@ public final class MetadataCache {
    */
   public void put(String path, URIStatus status) {
     try {
-      CachedItem item = mCache.get(path, ()-> new CachedItem());
+      CachedItem item = mCache.get(path, () -> new CachedItem());
       item.setStatus(status);
     } catch (ExecutionException e) {
         LOG.error("Failed to put meta into client cache for " + path, e);

--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
@@ -115,7 +115,7 @@ public final class MetadataCache {
       CachedItem item = mCache.get(path, () -> new CachedItem());
       item.setStatus(status);
     } catch (ExecutionException e) {
-        LOG.error("Failed to put meta into client cache for " + path, e);
+      LOG.error("Failed to put meta into client cache for file {}", path, e);
     }
   }
 
@@ -133,8 +133,7 @@ public final class MetadataCache {
         put(status.getPath(), status);
       }
     } catch (ExecutionException e) {
-        LOG.error("Failed to put meta into client cache for dir " + dir.getPath(),
-                e);
+      LOG.error("Failed to put meta into client cache for dir {}", dir.getPath(),  e);
     }
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 import javax.annotation.Nullable;
@@ -33,6 +32,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class MetadataCache {
   private static final Logger LOG = LoggerFactory.getLogger(MetadataCache.class);
+  
   private class CachedItem {
     private URIStatus mStatus = null;
     private List<URIStatus> mDirStatuses = null;
@@ -54,7 +54,7 @@ public final class MetadataCache {
     }
 
     /**
-     *  Puts the status into cache
+     *  Puts the status into cache.
      *
      *  @param status the metadata of the path
      */
@@ -63,7 +63,7 @@ public final class MetadataCache {
     }
 
     /**
-     *  Puts the directory status into cache
+     *  Puts the directory status into cache.
      *
      *  @param statuses the metadata list
      */

--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class MetadataCache {
   private static final Logger LOG = LoggerFactory.getLogger(MetadataCache.class);
-  
+
   private class CachedItem {
     private URIStatus mStatus = null;
     private List<URIStatus> mDirStatuses = null;

--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
@@ -115,7 +115,7 @@ public final class MetadataCache {
       CachedItem item = mCache.get(path, () -> new CachedItem());
       item.setStatus(status);
     } catch (ExecutionException e) {
-      LOG.error("Failed to put meta into client cache for file {}", path, e);
+      LOG.warn("Failed to cache meta data for path {}", path);
     }
   }
 
@@ -133,7 +133,7 @@ public final class MetadataCache {
         put(status.getPath(), status);
       }
     } catch (ExecutionException e) {
-      LOG.error("Failed to put meta into client cache for dir {}", dir.getPath(),  e);
+      LOG.warn("Failed to cache metadata for dir {}", dir.getPath());
     }
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
@@ -127,7 +127,7 @@ public final class MetadataCache {
    */
   public void put(AlluxioURI dir, List<URIStatus> statuses) {
     try {
-      CachedItem item = mCache.get(dir.getPath(),()-> new CachedItem());
+      CachedItem item = mCache.get(dir.getPath(), () -> new CachedItem());
       item.setDirStatuses(statuses);
       for (URIStatus status : statuses) {
         put(status.getPath(), status);


### PR DESCRIPTION
Fix #11765

Description:
meta data may be deleted in client cache although it is very hot. 
Now MetadataCache holds mStatus which stores the current file/dir status and mDirStatuses which stores the children status.
```
  private class CachedItem {
    private final URIStatus mStatus;
    private final List<URIStatus> mDirStatuses;
```
1. For example, There is a path '/A/B/C'.
2. We run the listStatus request on the directory '/A/B'. After receiving result from alluxio master, it caches 'A/B' into the cache map which stores the children status for the path '/A/B' as mDirStatuses and its children '/A/B/C' into the cach map which stores the file/dir status as mStatus. 
3. Then we run the listStatus request on the directory '/A'. After receiving result from alluxio master, it caches '/A' into the cache map which stores the children status for the path '/A' as mDirStatuses  and its children '/A/B' into the cach map which stores the file/dir status as mStatus. It replaces the previous content with a new CachedItem for '/A/B'.
```
public void put(AlluxioURI dir, List<URIStatus> statuses) {
    mCache.put(dir.getPath(), new CachedItem(statuses));
    for (URIStatus status : statuses) {
      mCache.put(status.getPath(), new CachedItem(status));
    }
```
4. If you rerrun the listStatus request on the directory '/A/B', you could not get the result. Because although the path '/A/B' is in the cache, it holds the content with mStatus. And the CachedItem with mDirStatuses has been replaced in the step 3. 

Fixes #11765