### PR TITLE
Add a state-lock call-tracker for detecting interrupt-cycles

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -26,6 +26,7 @@ import alluxio.exception.UnexpectedAlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.SetAclAction;
+import alluxio.master.file.contexts.CallTracker;
 import alluxio.master.Master;
 import alluxio.master.file.contexts.CheckConsistencyContext;
 import alluxio.master.file.contexts.CompleteFileContext;
@@ -584,4 +585,12 @@ public interface FileSystemMaster extends Master {
    * @return the owner of the root inode, null if the inode tree is not initialized
    */
   String getRootInodeOwner();
+
+  /**
+   * Composes an FSM call-tracker over given transport tracker.
+   *
+   * @param transportTracker the transport level call-tracker
+   * @return a composed call-tracker
+   */
+  CallTracker composeCallTracker(CallTracker transportTracker);
 }

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -221,8 +221,10 @@ public final class FileSystemMasterClientServiceHandler
     try {
       RpcUtils.callAndReturn(LOG, () -> {
         AlluxioURI pathUri = getAlluxioURI(request.getPath());
-        mFileSystemMaster.listStatus(pathUri, ListStatusContext.create(
-            request.getOptions().toBuilder(), new GrpcCallTracker(responseObserver)), resultStream);
+        mFileSystemMaster.listStatus(pathUri,
+            ListStatusContext.create(request.getOptions().toBuilder(),
+                mFileSystemMaster.composeCallTracker(new GrpcCallTracker(responseObserver))),
+            resultStream);
         // Return just something.
         return null;
       }, "ListStatus", false, "request: %s", request);
@@ -281,7 +283,8 @@ public final class FileSystemMasterClientServiceHandler
   public void remove(DeletePRequest request, StreamObserver<DeletePResponse> responseObserver) {
     RpcUtils.call(LOG, () -> {
       AlluxioURI pathUri = getAlluxioURI(request.getPath());
-      mFileSystemMaster.delete(pathUri, DeleteContext.create(request.getOptions().toBuilder()));
+      mFileSystemMaster.delete(pathUri, DeleteContext.create(request.getOptions().toBuilder(),
+          mFileSystemMaster.composeCallTracker(new GrpcCallTracker(responseObserver))));
       return DeletePResponse.newBuilder().build();
     }, "Remove", "request=%s", responseObserver, request);
   }
@@ -322,8 +325,9 @@ public final class FileSystemMasterClientServiceHandler
       StreamObserver<SetAttributePResponse> responseObserver) {
     RpcUtils.call(LOG, () -> {
       AlluxioURI pathUri = getAlluxioURI(request.getPath());
-      mFileSystemMaster.setAttribute(pathUri, SetAttributeContext
-          .create(request.getOptions().toBuilder(), new GrpcCallTracker(responseObserver)));
+      mFileSystemMaster.setAttribute(pathUri,
+          SetAttributeContext.create(request.getOptions().toBuilder(),
+              mFileSystemMaster.composeCallTracker(new GrpcCallTracker(responseObserver))));
       return SetAttributePResponse.newBuilder().build();
     }, "SetAttribute", "request=%s", responseObserver, request);
   }
@@ -382,7 +386,7 @@ public final class FileSystemMasterClientServiceHandler
       mFileSystemMaster.setAcl(pathUri, request.getAction(),
           request.getEntriesList().stream().map(GrpcUtils::fromProto).collect(Collectors.toList()),
           SetAclContext.create(request.getOptions().toBuilder(),
-              new GrpcCallTracker(responseObserver)));
+              mFileSystemMaster.composeCallTracker(new GrpcCallTracker(responseObserver))));
       return SetAclPResponse.newBuilder().build();
     }, "setAcl", "request=%s", responseObserver, request);
   }

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CallTracker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CallTracker.java
@@ -21,18 +21,6 @@ public interface CallTracker {
   boolean isCancelled();
 
   /**
-   * Used when call tracking should not be enabled.
-   * Invoking it will throw a runtime exception.
-   *
-   * This tracker will be used as default for service implementations that are not modified
-   * for tracking. That way using the tracking functionality without making proper
-   * modifications will throw exceptions.
-   */
-  CallTracker DISABLED_TRACKER = () -> {
-    throw new IllegalStateException("Call tracking is not supported.");
-  };
-
-  /**
    * Used when call tracking is not desired.
    * It will always return @{code false}.
    *

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CompositeCallTracker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CompositeCallTracker.java
@@ -1,0 +1,42 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file.contexts;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A call-tracker that is composed of other call-trackers.
+ */
+public class CompositeCallTracker implements CallTracker {
+  /** Call trackers. */
+  private final List<CallTracker> mCallTrackers;
+
+  /**
+   * A new composite call-tracker that combines many call-trackers.
+   *
+   * @param callTrackers array of call-trackers
+   */
+  public CompositeCallTracker(CallTracker... callTrackers) {
+    mCallTrackers = Arrays.asList(callTrackers);
+  }
+
+  @Override
+  public boolean isCancelled() {
+    for (CallTracker callTracker : mCallTrackers) {
+      if (callTracker.isCancelled()) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/DeleteContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/DeleteContext.java
@@ -27,8 +27,8 @@ public class DeleteContext extends OperationContext<DeletePOptions.Builder> {
    *
    * @param optionsBuilder options builder
    */
-  private DeleteContext(DeletePOptions.Builder optionsBuilder) {
-    super(optionsBuilder);
+  private DeleteContext(DeletePOptions.Builder optionsBuilder, CallTracker callTracker) {
+    super(optionsBuilder, callTracker);
   }
 
   /**
@@ -36,7 +36,17 @@ public class DeleteContext extends OperationContext<DeletePOptions.Builder> {
    * @return the instance of {@link DeleteContext} with given options
    */
   public static DeleteContext create(DeletePOptions.Builder optionsBuilder) {
-    return new DeleteContext(optionsBuilder);
+    return new DeleteContext(optionsBuilder, CallTracker.NOOP_TRACKER);
+  }
+
+  /**
+   * @param optionsBuilder Builder for proto {@link DeletePOptions}
+   * @param callTracker the call tracker
+   * @return the instance of {@link DeleteContext} with given options
+   */
+  public static DeleteContext create(DeletePOptions.Builder optionsBuilder,
+      CallTracker callTracker) {
+    return new DeleteContext(optionsBuilder, callTracker);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/OperationContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/OperationContext.java
@@ -33,7 +33,7 @@ public class OperationContext<T extends com.google.protobuf.GeneratedMessageV3.B
   public OperationContext(T optionsBuilder) {
     this(optionsBuilder, null);
     mOptionsBuilder = optionsBuilder;
-    mCallTracker = CallTracker.DISABLED_TRACKER;
+    mCallTracker = CallTracker.NOOP_TRACKER;
   }
 
   /**
@@ -55,6 +55,7 @@ public class OperationContext<T extends com.google.protobuf.GeneratedMessageV3.B
   }
 
   /**
+   * TODO(ggezer): Make the call-tracker infra note the source of cancellation.
    * @return {@code true} if the call is cancelled by the client
    */
   public boolean isCancelled() {


### PR DESCRIPTION
This change introduces a new FSM call-tracker that is attached to select
recursive APIs (`list`/`setAttributes`/`setAcl`) in order for them to
respect a pending backup and bail.

pr-link: Alluxio/alluxio#11592
change-id: cid-4a140127d2f37aa1bca4d1283ad035371abdaab0