### PR TITLE
Remove worker hostname from ALLUXIO_JAVA_OPTS in helmchart

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -110,3 +110,7 @@
 0.6.5
 
 - Removed alluxio worker hostname from ALLUXIO_JAVA_OPTS
+- Increase the default memory limit to match the default xmx
+- Added HostPID for using Java profile
+
+

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -106,3 +106,7 @@
 - Fixed Fuse crash issue
 - Changed master service to headless from NodePort
 - Made the single master access itself without service
+
+0.6.5
+
+- Removed alluxio worker hostname from ALLUXIO_JAVA_OPTS

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -109,7 +109,7 @@
 
 0.6.5
 
-- Removed alluxio worker hostname from ALLUXIO_JAVA_OPTS
+- Removed alluxio.worker.hostname from ALLUXIO_JAVA_OPTS for Fuse
 - Increase the default memory limit to match the default xmx
 - Added HostPID for using Java profile
 

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.4
+version: 0.6.5
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -28,7 +28,6 @@
 {{- end }}
 {{ if .Values.fuse.enabled -}}
   {{- $alluxioJavaOpts = print "-Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $alluxioJavaOpts }}
-  {{- $alluxioJavaOpts = printf "-Dalluxio.worker.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $alluxioJavaOpts }}
 {{- end }}
 {{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.type=%v" .Values.journal.type | append $alluxioJavaOpts }}
 {{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.folder=%v" .Values.journal.folder | append $alluxioJavaOpts }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
@@ -41,6 +41,7 @@ spec:
         role: alluxio-fuse
     spec:
       hostNetwork: {{ .Values.fuse.hostNetwork }}
+      hostPID: {{ .Values.fuse.hostPID }}
       dnsPolicy: {{ .Values.fuse.dnsPolicy }}
       nodeSelector:
       {{- if .Values.fuse.nodeSelector }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -16,6 +16,7 @@
 {{- $isUfsLocal := and (eq .Values.journal.type "UFS") (eq .Values.journal.ufsType "local") }}
 {{- $needJournalVolume := or $isEmbedded $isUfsLocal }}
 {{- $hostNetwork := .Values.master.hostNetwork }}
+{{- $hostPID := .Values.master.hostPID }}
 {{- $name := include "alluxio.name" . }}
 {{- $fullName := include "alluxio.fullname" . }}
 {{- $chart := include "alluxio.chart" . }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
@@ -12,6 +12,7 @@
 {{- $shortCircuitEnabled := .Values.shortCircuit.enabled }}
 {{- $needDomainSocketVolume := and $shortCircuitEnabled (eq .Values.shortCircuit.policy "uuid") }}
 {{- $hostNetwork := .Values.worker.hostNetwork }}
+{{- $hostPID := .Values.worker.hostPID }}
 
 apiVersion: apps/v1
 kind: DaemonSet
@@ -39,6 +40,7 @@ spec:
         role: alluxio-worker
     spec:
       hostNetwork: {{ $hostNetwork }}
+      hostPID: {{ $hostPID }}
       dnsPolicy: {{ .Values.worker.dnsPolicy | default ($hostNetwork | ternary "ClusterFirstWithHostNet" "ClusterFirst") }}
       securityContext:
         fsGroup: {{ .Values.fsGroup }}

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -60,9 +60,10 @@ master:
     # alluxio.master.metastore: ROCKS
     # alluxio.master.metastore.dir: /metastore
   resources:
+    # The default xmx is 8G
     limits:
-      cpu: "1"
-      memory: "1G"
+      cpu: "4"
+      memory: "8G"
     requests:
       cpu: "1"
       memory: "1G"
@@ -70,6 +71,7 @@ master:
     embedded: 19200
     rpc: 19998
     web: 19999
+  hostPID: true
   hostNetwork: false
   # dnsPolicy will be ClusterFirstWithHostNet if hostNetwork: true
   # and ClusterFirst if hostNetwork: false
@@ -86,8 +88,8 @@ jobMaster:
   properties:
   resources:
     limits:
-      cpu: "1"
-      memory: "1G"
+      cpu: "4"
+      memory: "8G"
     requests:
       cpu: "1"
       memory: "1G"
@@ -159,14 +161,15 @@ worker:
   properties:
   resources:
     limits:
-      cpu: "1"
-      memory: "2G"
+      cpu: "4"
+      memory: "4G"
     requests:
       cpu: "1"
       memory: "2G"
   ports:
     rpc: 29999
     web: 30000
+  hostPID: true
   hostNetwork: false
   # dnsPolicy will be ClusterFirstWithHostNet if hostNetwork: true
   # and ClusterFirst if hostNetwork: false
@@ -183,8 +186,8 @@ jobWorker:
   properties:
   resources:
     limits:
-      cpu: "1"
-      memory: "1G"
+      cpu: "4"
+      memory: "4G"
     requests:
       cpu: "1"
       memory: "1G"
@@ -276,6 +279,7 @@ fuse:
   jvmOptions:
     - "-XX:MaxDirectMemorySize=2g"
   hostNetwork: true
+  hostPID: true
   dnsPolicy: ClusterFirstWithHostNet
   user: 0
   group: 0


### PR DESCRIPTION
We need remove alluxio worker hostname from ALLUXIO_JAVA_OPTS  to avoid that it overrides the alluxio.worker.hostname in ALLUXIO_WORKER_JAVA_OPTS.

Without this change, the alluxio.worker.hostname is not ip address:

```
bash-4.4# alluxio fsadmin report capacity
Capacity information for all workers:
    Total Capacity: 12.00GB
        Tier: MEM  Size: 2048.00MB
        Tier: SSD  Size: 10.00GB
    Used Capacity: 2048.00MB
        Tier: MEM  Size: 1024.00MB
        Tier: SSD  Size: 1024.00MB
    Used Percentage: 16%
    Free Percentage: 84%

Worker Name                  Last Heartbeat   Storage       Total            MEM           SSD
iZj6c7rzs9xaeczn47omzcZ      0                capacity      12.00GB          2048.00MB     10.00GB
                                              used          2048.00MB (16%)  1024.00MB     1024.00MB
```

