### PR TITLE
Improve hdfs tools to return error on invalid paths

### DIFF
--- a/core/common/src/main/java/alluxio/cli/ValidationUtils.java
+++ b/core/common/src/main/java/alluxio/cli/ValidationUtils.java
@@ -11,6 +11,8 @@
 
 package alluxio.cli;
 
+import alluxio.AlluxioURI;
+
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.io.StringWriter;
@@ -152,5 +154,19 @@ public final class ValidationUtils {
     StringWriter errors = new StringWriter();
     t.printStackTrace(new PrintWriter(errors));
     return errors.toString();
+  }
+
+  /**
+   * Checks if a path is HDFS.
+   *
+   * @param path the UFS path
+   * @return true if the path is HDFS
+   * */
+  public static boolean isHdfsScheme(String path) {
+    String scheme = new AlluxioURI(path).getScheme();
+    if (scheme == null || !scheme.startsWith("hdfs")) {
+      return false;
+    }
+    return true;
   }
 }

--- a/integration/tools/validation/src/main/java/alluxio/cli/UfsSuperUserValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/UfsSuperUserValidationTask.java
@@ -27,7 +27,7 @@ import java.util.Map;
  */
 @ApplicableUfsType(ApplicableUfsType.Type.HDFS)
 public final class UfsSuperUserValidationTask extends AbstractValidationTask {
-  private final UnderFileSystem mUfs;
+  private final AlluxioConfiguration mConf;
   private final String mPath;
 
   /**
@@ -39,7 +39,7 @@ public final class UfsSuperUserValidationTask extends AbstractValidationTask {
    */
   public UfsSuperUserValidationTask(String path, AlluxioConfiguration conf) {
     mPath = path;
-    mUfs = UnderFileSystem.Factory.create(mPath, conf);
+    mConf = conf;
   }
 
   @Override
@@ -52,15 +52,17 @@ public final class UfsSuperUserValidationTask extends AbstractValidationTask {
     StringBuilder msg = new StringBuilder();
     StringBuilder advice = new StringBuilder();
 
-    if (!UnderFileSystemUtils.isHdfs(mUfs)) {
+    if (!ValidationUtils.isHdfsScheme(mPath)) {
       // only support check on HDFS for now
       msg.append(String.format("Under file system is not HDFS. Skip validation. "));
       return new ValidationUtils.TaskResult(ValidationUtils.State.SKIPPED, getName(),
               msg.toString(), advice.toString());
     }
     UfsStatus status;
+    UnderFileSystem ufs;
     try {
-      status = mUfs.getStatus(mPath);
+      ufs = UnderFileSystem.Factory.create(mPath, mConf);
+      status = ufs.getStatus(mPath);
       if (status == null) {
         msg.append(String.format("Unable to get status for under file system path %s. ", mPath));
         advice.append(String.format("Please check your path %s. ", mPath));
@@ -73,7 +75,7 @@ public final class UfsSuperUserValidationTask extends AbstractValidationTask {
         return new ValidationUtils.TaskResult(ValidationUtils.State.WARNING, getName(),
                 msg.toString(), advice.toString());
       }
-    } catch (IOException e) {
+    } catch (Exception e) {
       msg.append(String.format("Unable to access under file system path %s: %s.", mPath,
           e.getMessage()));
       msg.append(ValidationUtils.getErrorInfo(e));
@@ -81,7 +83,7 @@ public final class UfsSuperUserValidationTask extends AbstractValidationTask {
               msg.toString(), advice.toString());
     }
     try {
-      mUfs.setOwner(mPath, status.getOwner(), status.getGroup());
+      ufs.setOwner(mPath, status.getOwner(), status.getGroup());
       msg.append(String.format("User has superuser privilege to path %s.%n", mPath));
       return new ValidationUtils.TaskResult(ValidationUtils.State.OK, getName(),
               msg.toString(), advice.toString());

--- a/integration/tools/validation/src/main/java/alluxio/cli/UfsSuperUserValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/UfsSuperUserValidationTask.java
@@ -11,11 +11,9 @@
 
 package alluxio.cli;
 
-import alluxio.cli.ValidationUtils;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UnderFileSystem;
-import alluxio.util.UnderFileSystemUtils;
 
 import com.google.common.base.Strings;
 

--- a/integration/tools/validation/src/main/java/alluxio/cli/hdfs/HdfsConfParityValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/hdfs/HdfsConfParityValidationTask.java
@@ -51,7 +51,7 @@ public class HdfsConfParityValidationTask extends HdfsConfValidationTask {
 
   @Override
   public ValidationUtils.TaskResult validate(Map<String, String> optionsMap) {
-    if (!isHdfsScheme(mPath)) {
+    if (!ValidationUtils.isHdfsScheme(mPath)) {
       mMsg.append(String.format("UFS path %s is not HDFS. "
               + "Skipping validation for HDFS properties.%n", mPath));
       return new ValidationUtils.TaskResult(ValidationUtils.State.SKIPPED, getName(),

--- a/integration/tools/validation/src/main/java/alluxio/cli/hdfs/HdfsConfValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/hdfs/HdfsConfValidationTask.java
@@ -60,14 +60,6 @@ public class HdfsConfValidationTask extends AbstractValidationTask {
     return "ValidateHdfsConf";
   }
 
-  protected static boolean isHdfsScheme(String path) {
-    String scheme = new AlluxioURI(path).getScheme();
-    if (scheme == null || !scheme.startsWith("hdfs")) {
-      return false;
-    }
-    return true;
-  }
-
   protected ValidationUtils.TaskResult loadHdfsConfig() {
     Pair<String, String> clientConfFiles = getHdfsConfPaths();
     String coreConfPath = clientConfFiles.getFirst();
@@ -99,7 +91,7 @@ public class HdfsConfValidationTask extends AbstractValidationTask {
 
   @Override
   public ValidationUtils.TaskResult validate(Map<String, String> optionsMap) {
-    if (!isHdfsScheme(mPath)) {
+    if (!ValidationUtils.isHdfsScheme(mPath)) {
       mMsg.append(String.format(
               "UFS path %s is not HDFS. Skipping validation for HDFS properties.%n", mPath));
       return new ValidationUtils.TaskResult(ValidationUtils.State.SKIPPED, getName(),

--- a/integration/tools/validation/src/main/java/alluxio/cli/hdfs/HdfsConfValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/hdfs/HdfsConfValidationTask.java
@@ -11,7 +11,6 @@
 
 package alluxio.cli.hdfs;
 
-import alluxio.AlluxioURI;
 import alluxio.cli.AbstractValidationTask;
 import alluxio.cli.ValidationUtils;
 import alluxio.cli.ApplicableUfsType;

--- a/integration/tools/validation/src/main/java/alluxio/cli/hdfs/SecureHdfsValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/hdfs/SecureHdfsValidationTask.java
@@ -91,7 +91,7 @@ public final class SecureHdfsValidationTask extends HdfsConfValidationTask {
 
   @Override
   public ValidationUtils.TaskResult validate(Map<String, String> optionsMap) {
-    if (!HdfsConfValidationTask.isHdfsScheme(mPath)) {
+    if (!ValidationUtils.isHdfsScheme(mPath)) {
       mMsg.append("Skip this check as the UFS is not HDFS.\n");
       return new ValidationUtils.TaskResult(ValidationUtils.State.SKIPPED, getName(),
               mMsg.toString(), mAdvice.toString());


### PR DESCRIPTION
The hdfs mount validation tool and IO speed test tool will throw uncaught exceptions instead of returning a parsable JSON string, if the given path is not accessible. 
This change enables them to return parsable JSON results enclosing the invalid path exceptions, to whatever is consuming the results.