### PR TITLE
Bump commons-compress from 1.16.1 to 1.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.19.0</version>
+        <version>1.19</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.16.1</version>
+        <version>1.19.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Bump to address vulnerability:
https://github.com/advisories/GHSA-53x6-4x5p-rrvv