### PR TITLE
Implement listLocatedStatus hdfs api

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -213,30 +213,8 @@ public class BaseFileSystem implements FileSystem {
       throws IOException, AlluxioException {
     List<BlockLocationInfo> blockLocations = new ArrayList<>();
     // Don't need to checkUri here because we call other client operations
-    List<FileBlockInfo> blocks = getStatus(path).getFileBlockInfos();
-    for (FileBlockInfo fileBlockInfo : blocks) {
-      // add the existing in-Alluxio block locations
-      List<WorkerNetAddress> locations = fileBlockInfo.getBlockInfo().getLocations()
-          .stream().map(BlockLocation::getWorkerAddress).collect(toList());
-      if (locations.isEmpty()) { // No in-Alluxio location
-        if (!fileBlockInfo.getUfsLocations().isEmpty()) {
-          // Case 1: Fallback to use under file system locations with co-located workers.
-          // This maps UFS locations to a worker which is co-located.
-          Map<String, WorkerNetAddress> finalWorkerHosts = getHostWorkerMap();
-          locations = fileBlockInfo.getUfsLocations().stream().map(
-              location -> finalWorkerHosts.get(HostAndPort.fromString(location).getHost()))
-              .filter(Objects::nonNull).collect(toList());
-        }
-        if (locations.isEmpty() && mFsContext.getPathConf(path)
-            .getBoolean(PropertyKey.USER_UFS_BLOCK_LOCATION_ALL_FALLBACK_ENABLED)) {
-          // Case 2: Fallback to add all workers to locations so some apps (Impala) won't panic.
-          locations.addAll(getHostWorkerMap().values());
-          Collections.shuffle(locations);
-        }
-      }
-      blockLocations.add(new BlockLocationInfo(fileBlockInfo, locations));
-    }
-    return blockLocations;
+    URIStatus status = getStatus(path);
+    return getBlockLocations(status);
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/DelegatingFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DelegatingFileSystem.java
@@ -101,6 +101,11 @@ public class DelegatingFileSystem implements FileSystem {
   }
 
   @Override
+  public List<BlockLocationInfo> getBlockLocations(URIStatus status) throws IOException {
+    return mDelegatedFileSystem.getBlockLocations(status);
+  }
+
+  @Override
   public AlluxioConfiguration getConf() {
     return mDelegatedFileSystem.getConf();
   }

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -305,6 +305,15 @@ public interface FileSystem extends Closeable {
   List<BlockLocationInfo> getBlockLocations(AlluxioURI path)
       throws FileDoesNotExistException, IOException, AlluxioException;
 
+  /**
+   * Equivalent to {@link #getBlockLocations(AlluxioURI)} but for an existing {@link URIStatus}.
+   *
+   * @param status a status to get the block locations for
+   * @return a list of blocks with the workers whose hosts have the blocks. The blocks may not
+   *         necessarily be stored in Alluxio. The blocks are returned in the order of their
+   *         sequences in file.
+   * @throws IOException
+   */
   List<BlockLocationInfo> getBlockLocations(URIStatus status) throws IOException;
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -305,6 +305,8 @@ public interface FileSystem extends Closeable {
   List<BlockLocationInfo> getBlockLocations(AlluxioURI path)
       throws FileDoesNotExistException, IOException, AlluxioException;
 
+  List<BlockLocationInfo> getBlockLocations(URIStatus status) throws IOException;
+
   /**
    * @return the configuration which the FileSystem is using to connect to Alluxio
    */

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemCache.java
@@ -270,6 +270,14 @@ public class FileSystemCache {
     }
 
     @Override
+    public List<BlockLocationInfo> getBlockLocations(URIStatus status) throws IOException {
+      if (mClosed) {
+        throw new IOException(CLOSED_FS_ERROR_MESSAGE);
+      }
+      return super.getBlockLocations(status);
+    }
+
+    @Override
     public AlluxioConfiguration getConf() {
       return super.getConf();
     }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -454,6 +454,11 @@ public class LocalCacheFileInStreamTest {
     }
 
     @Override
+    public List<BlockLocationInfo> getBlockLocations(URIStatus status) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public AlluxioConfiguration getConf() {
       return sConf;
     }

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -46,7 +46,9 @@ import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.After;
 import org.junit.Before;
@@ -357,6 +359,45 @@ public class AbstractFileSystemTest {
     FileStatus[] fileStatuses = alluxioHadoopFs.listStatus(path);
     assertFileInfoEqualsFileStatus(fileInfo1, fileStatuses[0]);
     assertFileInfoEqualsFileStatus(fileInfo2, fileStatuses[1]);
+    alluxioHadoopFs.close();
+  }
+
+  @Test
+  public void listLocatedStatus() throws Exception {
+    FileInfo fileInfo1 = new FileInfo()
+        .setLastModificationTimeMs(111L)
+        .setLastAccessTimeMs(123L)
+        .setFolder(false)
+        .setOwner("user1")
+        .setGroup("group1")
+        .setMode(00755);
+    FileInfo fileInfo2 = new FileInfo()
+        .setLastModificationTimeMs(222L)
+        .setLastAccessTimeMs(234L)
+        .setFolder(true)
+        .setOwner("user2")
+        .setGroup("group2")
+        .setMode(00644);
+
+    Path path = new Path("/dir");
+    alluxio.client.file.FileSystem alluxioFs =
+        mock(alluxio.client.file.FileSystem.class);
+    when(alluxioFs.listStatus(new AlluxioURI(HadoopUtils.getPathWithoutScheme(path))))
+        .thenReturn(Lists.newArrayList(new URIStatus(fileInfo1), new URIStatus(fileInfo2)));
+    FileSystem alluxioHadoopFs = new FileSystem(alluxioFs);
+
+    FileStatus[] fileStatuses = alluxioHadoopFs.listStatus(path);
+
+    // call listLocatedStatus and match with listStatus.
+    RemoteIterator<LocatedFileStatus> it = alluxioHadoopFs.listLocatedStatus(path);
+    List<LocatedFileStatus> locatedStatuses = new ArrayList<>();
+    while (it.hasNext()) {
+      locatedStatuses.add(it.next());
+    }
+    assertEquals(fileStatuses.length, locatedStatuses.size());
+    assertEquals(fileStatuses[0], locatedStatuses.get(0));
+    assertEquals(fileStatuses[1], locatedStatuses.get(1));
+
     alluxioHadoopFs.close();
   }
 


### PR DESCRIPTION
The default implementation of `listLocatedStatus` calls `listStatus`, then for each path, calls `getFileStatus`, and `getBlockLocations`. However, the Alluxio status includes the block locations, so this PR eliminates the 2 additional RPCs per path in the listing.