### PR TITLE
Add validation tool jar to tarball

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -214,6 +214,7 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 		fmt.Sprintf("lib/alluxio-table-server-underdb-glue-%v.jar", version),
 		fmt.Sprintf("lib/alluxio-table-server-underdb-hive-%v.jar", version),
 		fmt.Sprintf("lib/alluxio-integration-tools-hms-%v.jar", version),
+		fmt.Sprintf("lib/alluxio-integration-tools-validation-%v.jar", version),
 		"libexec/alluxio-config.sh",
 		"LICENSE",
 	}


### PR DESCRIPTION
The `alluxio-integration-tools-validation.jar` needs to be added to the Alluxio tarball