### PR TITLE
Fix the socket timeout config processing in hms tool

### DIFF
--- a/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationTool.java
+++ b/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationTool.java
@@ -98,8 +98,15 @@ public class HmsValidationTool implements ValidationTool {
           .getOrDefault(ValidationConfig.DATABASE_CONFIG_NAME, DEFAULT_DATABASE);
       tables = (String) configMap
           .getOrDefault(ValidationConfig.TABLES_CONFIG_NAME, "");
-      socketTimeout = (int) configMap
+      Object socketTimeoutConfig = configMap
           .getOrDefault(ValidationConfig.SOCKET_TIMEOUT_CONFIG_NAME, DEFAULT_SOCKET_TIMEOUT);
+      if (socketTimeoutConfig instanceof Integer) {
+        socketTimeout = (int) socketTimeoutConfig;
+      } else if (socketTimeoutConfig instanceof String) {
+        socketTimeout = Integer.parseInt((String) socketTimeoutConfig);
+      } else {
+        LOG.error("Failed to process socket timeout config {}", socketTimeoutConfig);
+      }
     } catch (RuntimeException e) {
       // Try not to throw exception on the construction function
       // The hms validation tool itself should return failed message if the given config is invalid

--- a/shell/src/main/java/alluxio/cli/HmsTests.java
+++ b/shell/src/main/java/alluxio/cli/HmsTests.java
@@ -102,7 +102,7 @@ public class HmsTests {
     String metastoreUri = cmd.getOptionValue(METASTORE_URI_OPTION_NAME);
     String database = cmd.getOptionValue(DATABASE_OPTION_NAME, "");
     String tables = cmd.getOptionValue(TABLES_OPTION_NAME, "");
-    int socketTimeout = Integer.parseInt(cmd.getOptionValue(SOCKET_TIMEOUT_OPTION_NAME, "-1"));
+    String socketTimeout = cmd.getOptionValue(SOCKET_TIMEOUT_OPTION_NAME, "-1");
 
     ValidationToolRegistry registry
         = new ValidationToolRegistry(new InstancedConfiguration(ConfigurationUtils.defaults()));


### PR DESCRIPTION
SocketTimeoutConfig can be provided as String or integer object. 
Process both types and use default socket timeout if the object is not String or integer