### PR TITLE
Remove properties for journal formatting job in helm chart

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -113,4 +113,7 @@
 - Increase the default memory limit to match the default xmx
 - Added HostPID for using Java profile
 
+0.6.6
+
+- Removed obsolete master journal formatting job configuration properties
 

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -126,16 +126,6 @@ journal:
   # Configuration for journal formatting job
   format:
     runFormat: false # Change to true to format journal
-    job:
-      activeDeadlineSeconds: 30
-      ttlSecondsAfterFinished: 10
-    resources:
-      limits:
-        cpu: "1"
-        memory: "1G"
-      requests:
-        cpu: "1"
-        memory: "1G"
 
 
 # You can enable metastore to use ROCKS DB instead of Heap


### PR DESCRIPTION
The journal formatting job has been removed from the helm chart. This removes its configuration properties.