### PR TITLE
Disable hostPID by default

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -112,5 +112,9 @@
 - Removed alluxio.worker.hostname from ALLUXIO_JAVA_OPTS for Fuse
 - Increase the default memory limit to match the default xmx
 - Added hostPID for using Java profile
+
+0.6.6
+
+- Removed obsolete master journal formatting job configuration properties
 - Set hostPID default to false
 

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -111,9 +111,6 @@
 
 - Removed alluxio.worker.hostname from ALLUXIO_JAVA_OPTS for Fuse
 - Increase the default memory limit to match the default xmx
-- Added HostPID for using Java profile
-
-0.6.6
-
-- Removed obsolete master journal formatting job configuration properties
+- Added hostPID for using Java profile
+- Set hostPID default to false
 

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -159,6 +159,7 @@ worker:
   ports:
     rpc: 29999
     web: 30000
+  # hostPID requires escalated privileges
   hostPID: false
   hostNetwork: false
   # dnsPolicy will be ClusterFirstWithHostNet if hostNetwork: true
@@ -269,6 +270,7 @@ fuse:
   jvmOptions:
     - "-XX:MaxDirectMemorySize=2g"
   hostNetwork: true
+  # hostPID requires escalated privileges
   hostPID: true
   dnsPolicy: ClusterFirstWithHostNet
   user: 0

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -71,7 +71,7 @@ master:
     embedded: 19200
     rpc: 19998
     web: 19999
-  hostPID: true
+  hostPID: false
   hostNetwork: false
   # dnsPolicy will be ClusterFirstWithHostNet if hostNetwork: true
   # and ClusterFirst if hostNetwork: false
@@ -159,7 +159,7 @@ worker:
   ports:
     rpc: 29999
     web: 30000
-  hostPID: true
+  hostPID: false
   hostNetwork: false
   # dnsPolicy will be ClusterFirstWithHostNet if hostNetwork: true
   # and ClusterFirst if hostNetwork: false


### PR DESCRIPTION
`hostPID` is disabled by recommended `PodSecurityPolicy`. This change disables `hostPID` as default so our default setting works with the `PodSecurityPolicy` setup. 

The `hostPID` switch was added in https://github.com/Alluxio/alluxio/pull/11610 