### PR TITLE
Improve UfsIOBench and HdfsValidationTool

### DIFF
--- a/core/common/src/main/java/alluxio/cli/ValidationUtils.java
+++ b/core/common/src/main/java/alluxio/cli/ValidationUtils.java
@@ -42,6 +42,7 @@ public final class ValidationUtils {
 
     State mState = State.OK;
     String mName = "";
+    String mDesc = "";
     // Output stores stdout if test passed or stderr if error thrown
     String mOutput = "";
     String mAdvice = "";
@@ -57,6 +58,23 @@ public final class ValidationUtils {
     public TaskResult(State state, String name, String output, String advice) {
       mState = state;
       mName = name;
+      mOutput = output;
+      mAdvice = advice;
+    }
+
+    /**
+     * Creates a new {@link TaskResult}.
+     *
+     * @param state task state
+     * @param name task name
+     * @param desc task description
+     * @param output task output
+     * @param advice task advice
+     */
+    public TaskResult(State state, String name, String desc, String output, String advice) {
+      mState = state;
+      mName = name;
+      mDesc = desc;
       mOutput = output;
       mAdvice = advice;
     }
@@ -85,6 +103,17 @@ public final class ValidationUtils {
      */
     public TaskResult setName(String name) {
       mName = name;
+      return this;
+    }
+
+    /**
+     * Sets task name.
+     *
+     * @param desc description to set
+     * @return the task result
+     */
+    public TaskResult setDesc(String desc) {
+      mDesc = desc;
       return this;
     }
 
@@ -122,6 +151,13 @@ public final class ValidationUtils {
      */
     public String getName() {
       return mName;
+    }
+
+    /**
+     * @return task description
+     */
+    public String getDesc() {
+      return mDesc;
     }
 
     /**

--- a/integration/tools/validation/src/main/java/alluxio/cli/ValidateEnv.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/ValidateEnv.java
@@ -105,16 +105,19 @@ public final class ValidateEnv {
     mConf = conf;
 
     // HDFS configuration validations
-    registerTask("ufs.hdfs.config.correctness", "validate HDFS configuration files",
+    registerTask("ufs.hdfs.config.correctness",
+            "This validates HDFS configuration files like core-site.xml and hdfs-site.xml.",
             new HdfsConfValidationTask(mPath, mConf), mCommonTasks);
     registerTask("ufs.hdfs.config.parity",
-            "validate HDFS-related configurations",
+            "If the Hadoop config directory is specified, this validates if that is "
+                    + "consistent with the HDFS configuration given to Alluxio.",
             new HdfsConfParityValidationTask(mPath, mConf), mCommonTasks);
     registerTask("ufs.hdfs.config.proxyuser",
-            "validate proxyuser configuration in hdfs for alluxio",
+            "This validate proxy user configuration in HDFS for Alluxio. "
+                    + "This is needed to enable impersonation for Alluxio.",
             new HdfsProxyUserValidationTask(mPath, mConf), mCommonTasks);
     registerTask("ufs.hdfs.config.version",
-            "validate version compatibility between alluxio and hdfs",
+            "This validates version compatibility between Alluxio and HDFS.",
             new HdfsVersionValidationTask(mConf), mCommonTasks);
 
     // port availability validations
@@ -140,12 +143,12 @@ public final class ValidateEnv {
             mCommonTasks);
 
     // security configuration validations
-    registerTask("master.ufs.hdfs.security.kerberos",
-            "validate kerberos security configurations for masters",
-            new SecureHdfsValidationTask("master", mPath, mConf), mMasterTasks);
-    registerTask("worker.ufs.hdfs.security.kerberos",
-            "validate kerberos security configurations for workers",
-            new SecureHdfsValidationTask("worker", mPath, mConf), mWorkerTasks);
+     registerTask("master.ufs.hdfs.security.kerberos",
+             "This validates kerberos security configurations for Alluxio masters.",
+             new SecureHdfsValidationTask("master", mPath, mConf), mMasterTasks);
+     registerTask("worker.ufs.hdfs.security.kerberos",
+             "This validates kerberos security configurations for Alluxio workers.",
+             new SecureHdfsValidationTask("worker", mPath, mConf), mWorkerTasks);
 
     // ssh validations
     registerTask("ssh.nodes.reachable",
@@ -154,10 +157,10 @@ public final class ValidateEnv {
 
     // UFS validations
     registerTask("ufs.path.accessible",
-            "validate the under file system location is accessible",
+            "This validates the under file system location is accessible to Alluxio.",
             new UfsDirectoryValidationTask(mPath, mConf), mCommonTasks);
     registerTask("ufs.path.superuser",
-            "validate Alluxio has super user privilege on the under file system",
+            "This validates Alluxio has super user privilege on the under file system.",
             new UfsSuperUserValidationTask(mPath, mConf), mCommonTasks);
 
     // RAM disk validations
@@ -182,7 +185,9 @@ public final class ValidateEnv {
             new ClusterConfConsistencyValidationTask(mConf), mClusterTasks);
 
     // java option validations
-    registerTask("java.native.libs", "validate java native lib paths",
+    registerTask("java.native.libs",
+            String.format("This validates if java native libraries defined at %s all exist.",
+                    NativeLibValidationTask.NATIVE_LIB_PATH),
             new NativeLibValidationTask(), mCommonTasks);
 
     mTargetTasks = initializeTargetTasks();
@@ -220,6 +225,15 @@ public final class ValidateEnv {
    * */
   public Map<ValidationTask, String> getTasks() {
     return Collections.unmodifiableMap(mTasks);
+  }
+
+  /**
+   * Gets the task descriptions.
+   *
+   * @return a map of task names mapping to their descriptions
+   * */
+  public Map<String, String> getDescription() {
+    return Collections.unmodifiableMap(mTaskDescriptions);
   }
 
   private boolean validateRemote(Collection<String> nodes, String target,

--- a/integration/tools/validation/src/main/java/alluxio/cli/ValidateEnv.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/ValidateEnv.java
@@ -143,12 +143,12 @@ public final class ValidateEnv {
             mCommonTasks);
 
     // security configuration validations
-     registerTask("master.ufs.hdfs.security.kerberos",
+    registerTask("master.ufs.hdfs.security.kerberos",
              "This validates kerberos security configurations for Alluxio masters.",
-             new SecureHdfsValidationTask("master", mPath, mConf), mMasterTasks);
-     registerTask("worker.ufs.hdfs.security.kerberos",
+            new SecureHdfsValidationTask("master", mPath, mConf), mMasterTasks);
+    registerTask("worker.ufs.hdfs.security.kerberos",
              "This validates kerberos security configurations for Alluxio workers.",
-             new SecureHdfsValidationTask("worker", mPath, mConf), mWorkerTasks);
+            new SecureHdfsValidationTask("worker", mPath, mConf), mWorkerTasks);
 
     // ssh validations
     registerTask("ssh.nodes.reachable",

--- a/integration/tools/validation/src/main/java/alluxio/cli/ValidateEnv.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/ValidateEnv.java
@@ -109,11 +109,12 @@ public final class ValidateEnv {
             "This validates HDFS configuration files like core-site.xml and hdfs-site.xml.",
             new HdfsConfValidationTask(mPath, mConf), mCommonTasks);
     registerTask("ufs.hdfs.config.parity",
-            "If the Hadoop config directory is specified, this validates if that is "
-                    + "consistent with the HDFS configuration given to Alluxio.",
+            "If a Hadoop config directory is specified, this compares the Hadoop config "
+                    + "directory with the HDFS configuration paths given to Alluxio, "
+                    + "and see if they are consistent.",
             new HdfsConfParityValidationTask(mPath, mConf), mCommonTasks);
     registerTask("ufs.hdfs.config.proxyuser",
-            "This validate proxy user configuration in HDFS for Alluxio. "
+            "This validates proxy user configuration in HDFS for Alluxio. "
                     + "This is needed to enable impersonation for Alluxio.",
             new HdfsProxyUserValidationTask(mPath, mConf), mCommonTasks);
     registerTask("ufs.hdfs.config.version",

--- a/stress/shell/src/main/java/alluxio/stress/cli/UfsIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/UfsIOBench.java
@@ -77,7 +77,7 @@ public class UfsIOBench extends Benchmark<IOTaskResult> {
       }
       return result;
     } finally {
-      if (pool != null){
+      if (pool != null) {
         pool.shutdownNow();
         pool.awaitTermination(30, TimeUnit.SECONDS);
       }

--- a/stress/shell/src/main/java/alluxio/stress/cli/UfsIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/UfsIOBench.java
@@ -11,6 +11,7 @@
 
 package alluxio.stress.cli;
 
+import alluxio.cli.ValidationUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.stress.worker.IOTaskResult;
 import alluxio.stress.worker.UfsIOParameters;
@@ -51,26 +52,40 @@ public class UfsIOBench extends Benchmark<IOTaskResult> {
 
   @Override
   public IOTaskResult runLocal() throws Exception {
+    // UfsIOBench is invoked from the job worker then runs in a standalone process
+    // The process type should be set to keep consistent
+    alluxio.util.CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.JOB_WORKER);
+
     LOG.debug("Running locally with {} threads", mParameters.mThreads);
-    ExecutorService pool =
-            ExecutorServiceFactories.fixedThreadPool("bench-io-thread", mParameters.mThreads)
-                    .create();
+    ExecutorService pool = null;
+    IOTaskResult result = null;
+    try {
+      pool = ExecutorServiceFactories.fixedThreadPool("bench-io-thread", mParameters.mThreads)
+                      .create();
 
-    IOTaskResult result = runIOBench(pool);
-    LOG.debug("IO benchmark finished with result: {}", result);
-
-    pool.shutdownNow();
-    pool.awaitTermination(30, TimeUnit.SECONDS);
-
-    // Aggregate the task results
-    return result;
+      result = runIOBench(pool);
+      LOG.debug("IO benchmark finished with result: {}", result);
+      // Aggregate the task results
+      return result;
+    } catch (Exception e) {
+      if (result == null) {
+        LOG.error("Failed run UFS IO benchmark on path {}", mParameters.mPath, e);
+        result = new IOTaskResult();
+        result.setParameters(mParameters);
+        result.setBaseParameters(mBaseParameters);
+        result.addError(ValidationUtils.getErrorInfo(e));
+      }
+      return result;
+    } finally {
+      if (pool != null){
+        pool.shutdownNow();
+        pool.awaitTermination(30, TimeUnit.SECONDS);
+      }
+    }
   }
 
   @Override
-  public void prepare() {
-    // Parse the IO size, an IllegalArgumentException will be thrown if the size is not parsable
-    FormatUtils.parseSpaceSize(mParameters.mDataSize);
-  }
+  public void prepare() {}
 
   /**
    * @param args command-line arguments
@@ -105,16 +120,18 @@ public class UfsIOBench extends Benchmark<IOTaskResult> {
   }
 
   private IOTaskResult read(ExecutorService pool)
-          throws IOException, InterruptedException, ExecutionException {
-    // Use multiple threads to saturate the bandwidth of this worker
-    int numThreads = mParameters.mThreads;
-    // This parse is guarded in prepare()
-    long ioSizeBytes = FormatUtils.parseSpaceSize(mParameters.mDataSize);
-
-    UnderFileSystemConfiguration ufsConf = UnderFileSystemConfiguration.defaults(mConf)
-            .createMountSpecificConf(mHdfsConf);
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(mParameters.mPath, ufsConf);
+          throws InterruptedException, ExecutionException {
+    UnderFileSystemConfiguration ufsConf;
+    UnderFileSystem ufs;
+    int numThreads;
+    long ioSizeBytes;
     try {
+      // Use multiple threads to saturate the bandwidth of this worker
+      numThreads = mParameters.mThreads;
+      ioSizeBytes = FormatUtils.parseSpaceSize(mParameters.mDataSize);
+      ufsConf = UnderFileSystemConfiguration.defaults(mConf)
+              .createMountSpecificConf(mHdfsConf);
+      ufs = UnderFileSystem.Factory.create(mParameters.mPath, ufsConf);
       if (!ufs.exists(mParameters.mPath)) {
         // If the directory does not exist, there's no point proceeding
         throw new IOException(String.format("The target directory %s does not exist!",
@@ -126,7 +143,7 @@ public class UfsIOBench extends Benchmark<IOTaskResult> {
       IOTaskResult result = new IOTaskResult();
       result.setParameters(mParameters);
       result.setBaseParameters(mBaseParameters);
-      result.addError(e.getMessage());
+      result.addError(ValidationUtils.getErrorInfo(e));
       return result;
     }
 
@@ -160,7 +177,7 @@ public class UfsIOBench extends Benchmark<IOTaskResult> {
           LOG.debug("Read task finished {}", p);
         } catch (Exception e) {
           LOG.error("Failed to read {}", filePath, e);
-          result.addError(e.getMessage());
+          result.addError(ValidationUtils.getErrorInfo(e));
         } finally {
           if (inStream != null) {
             try {
@@ -189,16 +206,18 @@ public class UfsIOBench extends Benchmark<IOTaskResult> {
   }
 
   private IOTaskResult write(ExecutorService pool)
-          throws IOException, InterruptedException, ExecutionException {
-    // Use multiple threads to saturate the bandwidth of this worker
-    int numThreads = mParameters.mThreads;
-    // This parse is guarded in prepare()
-    long ioSizeBytes = FormatUtils.parseSpaceSize(mParameters.mDataSize);
-
-    UnderFileSystemConfiguration ufsConf = UnderFileSystemConfiguration.defaults(mConf)
-            .createMountSpecificConf(mHdfsConf);
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(mParameters.mPath, ufsConf);
+          throws InterruptedException, ExecutionException {
+    UnderFileSystemConfiguration ufsConf;
+    UnderFileSystem ufs;
+    int numThreads;
+    long ioSizeBytes;
     try {
+      // Use multiple threads to saturate the bandwidth of this worker
+      numThreads = mParameters.mThreads;
+      ioSizeBytes = FormatUtils.parseSpaceSize(mParameters.mDataSize);
+      ufsConf = UnderFileSystemConfiguration.defaults(mConf)
+              .createMountSpecificConf(mHdfsConf);
+      ufs = UnderFileSystem.Factory.create(mParameters.mPath, ufsConf);
       if (!ufs.exists(mParameters.mPath)) {
         LOG.debug("Prepare directory {}", mParameters.mPath);
         ufs.mkdirs(mParameters.mPath);
@@ -209,7 +228,7 @@ public class UfsIOBench extends Benchmark<IOTaskResult> {
       IOTaskResult result = new IOTaskResult();
       result.setParameters(mParameters);
       result.setBaseParameters(mBaseParameters);
-      result.addError(e.getMessage());
+      result.addError(ValidationUtils.getErrorInfo(e));
       return result;
     }
 


### PR DESCRIPTION
This PR contains a few improvements to the HDFS tools:
1. Set process type of `UfsIOBench` as JOB_WORKER as it always runs in a job, invoked by a job worker.
1. Added description to each of the `TaskResult` from `HdfsValidationTool`. Each description corresponds to what the validation task did.
1. Removed `UfsContractTest` from `HdfsValidationTool`, as we only care about the accessibility of the UFS path, not all possible UFS operations.
1. Catch more exceptions now in the tools.