### PR TITLE
Increase the memory limit of fuse in kubernetes

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -117,4 +117,5 @@
 
 - Removed obsolete master journal formatting job configuration properties
 - Set hostPID default to false
+- Increase the default memory usage for Fuse
 

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.5
+version: 0.6.6
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -286,8 +286,8 @@ fuse:
       cpu: "0.5"
       memory: "1G"
     limits:
-      cpu: "1"
-      memory: "1G"
+      cpu: "4"
+      memory: "4G"
 
 
 ##  Secrets ##


### PR DESCRIPTION
Since the default direct memory is 2G, we should increase the default memory limit to 4G to make the Heap + direct memory can work.