### PR TITLE
Add thread-factory for fork-join-pool threads

### DIFF
--- a/core/common/src/main/java/alluxio/concurrent/jsr/ForkJoinPool.java
+++ b/core/common/src/main/java/alluxio/concurrent/jsr/ForkJoinPool.java
@@ -26,6 +26,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Predicate;
 
@@ -2490,6 +2491,45 @@ public class ForkJoinPool extends AbstractExecutorService {
       return AccessController.doPrivileged(new PrivilegedAction<ForkJoinWorkerThread>() {
         public ForkJoinWorkerThread run() {
           return new ForkJoinWorkerThread(pool, ClassLoader.getSystemClassLoader());
+        }
+      }, ACC);
+    }
+  }
+
+  /**
+   * Default ForkJoinWorkerThreadFactory implementation; creates a new ForkJoinWorkerThread using
+   * the system class loader as the thread context class loader.
+   */
+  public static final class AlluxioForkJoinWorkerThreadFactory
+          implements ForkJoinWorkerThreadFactory {
+    private static final AccessControlContext ACC = contextWithPermissions(
+            // new RuntimePermission("setContextClassLoader"), // java9-concurrent-backport changed
+            new RuntimePermission("getClassLoader"));
+    // Thread id counter.
+    private static final AtomicLong sThreadId = new AtomicLong(0);
+    // Thread properties.
+    private final String mNameFormat;
+    private final boolean mIsDaemon;
+
+    /**
+     * Creates a new thread-factory for {@link ForkJoinPool}.
+     *
+     * @param threadNameFormat thread name format
+     * @param isDaemon is daemon
+     */
+    public AlluxioForkJoinWorkerThreadFactory(String threadNameFormat, boolean isDaemon){
+      mNameFormat = threadNameFormat;
+      mIsDaemon = isDaemon;
+    }
+
+    public final ForkJoinWorkerThread newThread(ForkJoinPool pool) {
+      return AccessController.doPrivileged(new PrivilegedAction<ForkJoinWorkerThread>() {
+        public ForkJoinWorkerThread run() {
+          ForkJoinWorkerThread th =
+              new ForkJoinWorkerThread(pool, ClassLoader.getSystemClassLoader());
+          th.setName(String.format(mNameFormat, sThreadId.getAndIncrement()));
+          th.setDaemon(mIsDaemon);
+          return th;
         }
       }, ACC);
     }

--- a/core/common/src/main/java/alluxio/concurrent/jsr/ForkJoinPool.java
+++ b/core/common/src/main/java/alluxio/concurrent/jsr/ForkJoinPool.java
@@ -2505,8 +2505,8 @@ public class ForkJoinPool extends AbstractExecutorService {
     private static final AccessControlContext ACC = contextWithPermissions(
             // new RuntimePermission("setContextClassLoader"), // java9-concurrent-backport changed
             new RuntimePermission("getClassLoader"));
-    // Thread id counter.
-    private static final AtomicLong sThreadId = new AtomicLong(0);
+    // ForkJoinWorkerThread index counter.
+    private static final AtomicLong sThreadIndex = new AtomicLong(0);
     // Thread properties.
     private final String mNameFormat;
     private final boolean mIsDaemon;
@@ -2527,7 +2527,7 @@ public class ForkJoinPool extends AbstractExecutorService {
         public ForkJoinWorkerThread run() {
           ForkJoinWorkerThread th =
               new ForkJoinWorkerThread(pool, ClassLoader.getSystemClassLoader());
-          th.setName(String.format(mNameFormat, sThreadId.getAndIncrement()));
+          th.setName(String.format(mNameFormat, sThreadIndex.getAndIncrement()));
           th.setDaemon(mIsDaemon);
           return th;
         }

--- a/core/common/src/main/java/alluxio/util/ThreadFactoryUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadFactoryUtils.java
@@ -11,6 +11,8 @@
 
 package alluxio.util;
 
+import alluxio.concurrent.jsr.ForkJoinPool;
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import java.util.concurrent.ThreadFactory;
@@ -35,5 +37,20 @@ public final class ThreadFactoryUtils {
    */
   public static ThreadFactory build(final String nameFormat, boolean isDaemon) {
     return new ThreadFactoryBuilder().setDaemon(isDaemon).setNameFormat(nameFormat).build();
+  }
+
+  /**
+   * Creates a {@link ForkJoinPool.ForkJoinWorkerThreadFactory} that spawns off threads
+   * for {@link ForkJoinPool}.
+   *
+   * @param nameFormat name pattern for each thread. should contain '%d' to distinguish between
+   *                   threads.
+   * @param isDaemon if true, the {@link java.util.concurrent.ThreadFactory} will create
+   *                 daemon threads.
+   * @return the created factory
+   */
+  public static ForkJoinPool.ForkJoinWorkerThreadFactory buildFjp(final String nameFormat,
+      boolean isDaemon) {
+    return new ForkJoinPool.AlluxioForkJoinWorkerThreadFactory(nameFormat, isDaemon);
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -37,6 +37,7 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.util.CommonUtils.ProcessType;
 import alluxio.util.JvmPauseMonitor;
+import alluxio.util.ThreadFactoryUtils;
 import alluxio.util.URIUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.web.MasterWebServer;
@@ -306,7 +307,7 @@ public class AlluxioMasterProcess extends MasterProcess {
 
       mRPCExecutor = new ForkJoinPool(
           ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM),
-          ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+          ThreadFactoryUtils.buildFjp("master-rpc-pool-thread-%d", true),
           null,
           true,
           ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_CORE_POOL_SIZE),


### PR DESCRIPTION
This PR introduces a thread-factory implementation for use by `ForkJoinPool` in order to provide a custom name for worker threads.