### PR TITLE
Add Backblaze B2 as an Under FS Storage option

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1184,6 +1184,28 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey B2_ACCESS_KEY =
+      new Builder(Name.B2_ACCESS_KEY)
+          .setDescription("The access key of B2 bucket.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .setDisplayType(DisplayType.CREDENTIALS)
+          .build();
+  public static final PropertyKey B2_SECRET_KEY =
+      new Builder(Name.B2_SECRET_KEY)
+          .setDescription("The secret key of B2 bucket.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .setDisplayType(DisplayType.CREDENTIALS)
+          .build();
+  public static final PropertyKey B2_FOLDER_INDICATOR =
+      new Builder(Name.B2_FOLDER_INDICATOR)
+          .setDescription("The file name which indicates it is a folder.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .setDisplayType(DisplayType.DEFAULT)
+          .setDefaultValue(".bzEmpty")
+          .build();
 
   //
   // Mount table related properties
@@ -4767,6 +4789,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_KODO_CONNECT_TIMEOUT =
         "alluxio.underfs.kodo.connect.timeout";
     public static final String UNDERFS_KODO_REQUESTS_MAX = "alluxio.underfs.kodo.requests.max";
+    public static final String B2_ACCESS_KEY = "alluxio.underfs.b2.access.key";
+    public static final String B2_SECRET_KEY = "alluxio.underfs.b2.secret.key";
+    public static final String B2_FOLDER_INDICATOR = "alluxio.underfs.b2.folder.indicator";
 
     //
     // UFS access control related properties

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,7 @@
     <update.check.enabled>true</update.check.enabled>
     <update.check.host>https://diagnostics.alluxio.io</update.check.host>
     <findbugs.skip>false</findbugs.skip>
+    <b2.version>4.0.0</b2.version>
   </properties>
 
   <modules>

--- a/underfs/b2/pom.xml
+++ b/underfs/b2/pom.xml
@@ -1,0 +1,82 @@
+<!--
+
+    The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+    (the "License"). You may not use this work except in compliance with the License, which is
+    available at www.apache.org/licenses/LICENSE-2.0
+
+    This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or implied, as more fully set forth in the License.
+
+    See the NOTICE file distributed with this work for information regarding copyright ownership.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.alluxio</groupId>
+        <artifactId>alluxio-underfs</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>alluxio-underfs-b2</artifactId>
+    <name>Alluxio Under File System - Backblaze B2</name>
+    <description>Under File System implementation for Backblaze B2</description>
+
+    <properties>
+        <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
+        <!-- run properly from sub-project directories -->
+        <build.path>${project.parent.parent.basedir}/build</build.path>
+    </properties>
+
+    <dependencies>
+        <!-- External dependencies -->
+        <dependency>
+            <groupId>com.backblaze.b2</groupId>
+            <artifactId>b2-sdk-core</artifactId>
+            <version>${b2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.backblaze.b2</groupId>
+            <artifactId>b2-sdk-httpclient</artifactId>
+            <version>${b2.version}</version>
+        </dependency>
+
+        <!-- Core Alluxio dependencies -->
+        <dependency>
+            <groupId>org.alluxio</groupId>
+            <artifactId>alluxio-core-common</artifactId>
+            <scope>provided</scope>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Core Alluxio test dependencies -->
+        <dependency>
+            <groupId>org.alluxio</groupId>
+            <artifactId>alluxio-core-common</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- External test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.coderplus.maven.plugins</groupId>
+                <artifactId>copy-rename-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/underfs/b2/src/main/java/alluxio/underfs/b2/B2InputStream.java
+++ b/underfs/b2/src/main/java/alluxio/underfs/b2/B2InputStream.java
@@ -1,0 +1,150 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.b2;
+
+import com.backblaze.b2.client.B2StorageClient;
+import com.backblaze.b2.client.contentHandlers.B2ContentMemoryWriter;
+import com.backblaze.b2.client.exceptions.B2Exception;
+import com.backblaze.b2.client.structures.B2DownloadByNameRequest;
+import com.backblaze.b2.util.B2ByteRange;
+import com.google.common.base.Throwables;
+import com.google.protobuf.ServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A stream for reading a file from B2.
+ */
+@NotThreadSafe
+public class B2InputStream extends InputStream {
+  private static final Logger LOG = LoggerFactory.getLogger(B2InputStream.class);
+  private final String mBucketName;
+  private final String mKey;
+  private final B2StorageClient mB2StorageClient;
+  private long mOffset;
+  private long mLength;
+  private BufferedInputStream mBufferedInputStream;
+
+  /**
+   * Constructor for an input stream of an object in B2 using the B2-sdk implementation to read
+   * data.
+   *
+   * @param bucketName the bucket the object resides in
+   * @param key the path of the object to read
+   * @param b2StorageClient the b2 client to use for operations
+   * @param length the length of the stream in bytes
+   */
+  public B2InputStream(String bucketName, String key, B2StorageClient b2StorageClient, long length)
+      throws ServiceException {
+    this(bucketName, key, b2StorageClient, 0L, length);
+  }
+
+  /**
+   * Constructor for an input stream of an object in B2 using the B2-sdk implementation to read
+   * data.
+   *
+   * @param bucketName the bucket the object resides in
+   * @param key the path of the object to read
+   * @param b2StorageClient the b2 client to use for operations
+   * @param offset the stream position to begin reading from
+   * @param length the length of the stream in bytes
+   */
+  public B2InputStream(String bucketName, String key, B2StorageClient b2StorageClient, long offset,
+      long length) throws ServiceException {
+    mBucketName = bucketName;
+    mKey = key;
+    mB2StorageClient = b2StorageClient;
+    mOffset = offset;
+    mLength = length;
+
+    try {
+      final B2ContentMemoryWriter sink = getSink();
+      if (mOffset > 0) {
+        final B2DownloadByNameRequest request = B2DownloadByNameRequest.builder(mBucketName, mKey)
+            .setRange(B2ByteRange.between(mOffset, mLength)).build();
+        mB2StorageClient.downloadByName(request, sink);
+      } else {
+        final B2DownloadByNameRequest request =
+            B2DownloadByNameRequest.builder(mBucketName, mKey).build();
+        mB2StorageClient.downloadByName(request, sink);
+      }
+      mBufferedInputStream = new BufferedInputStream(new ByteArrayInputStream(sink.getBytes()));
+    } catch (B2Exception e) {
+      LOG.error(
+          "Failed to open stream with remote storage. bucket name: [{}], key: [{}], offset: [{}]",
+          mBucketName, mKey, mOffset);
+      Throwables.propagateIfPossible(e, ServiceException.class);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    mBufferedInputStream.close();
+  }
+
+  protected B2ContentMemoryWriter getSink() {
+    return B2ContentMemoryWriter.build();
+  }
+
+  @Override
+  public int read() throws IOException {
+    int ret = mBufferedInputStream.read();
+    if (ret != -1) {
+      mOffset++;
+    }
+    return ret;
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    int ret = mBufferedInputStream.read(b, off, len);
+    if (ret != -1) {
+      mOffset += ret;
+    }
+    return ret;
+  }
+
+  /**
+   * This method leverages the ability to open a stream from B2 from a given offset. When the
+   * underlying stream has fewer bytes buffered than the skip request, the stream is closed, and
+   * a new stream is opened starting at the requested offset.
+   *
+   * @param n number of bytes to skip
+   * @return the number of bytes skipped
+   */
+  @Override
+  public long skip(long n) throws IOException {
+    if (mBufferedInputStream.available() >= n) {
+      return mBufferedInputStream.skip(n);
+    }
+    // The number of bytes to skip is possibly large, open a new stream from B2.
+    mBufferedInputStream.close();
+    mOffset += n;
+    try {
+      final B2ContentMemoryWriter sink = getSink();
+      final B2DownloadByNameRequest request = B2DownloadByNameRequest.builder(mBucketName, mKey)
+          .setRange(B2ByteRange.between(mOffset, mLength)).build();
+      mB2StorageClient.downloadByName(request, sink);
+      mBufferedInputStream = new BufferedInputStream(new ByteArrayInputStream(sink.getBytes()));
+    } catch (B2Exception e) {
+      throw new IOException(e);
+    }
+    return n;
+  }
+}

--- a/underfs/b2/src/main/java/alluxio/underfs/b2/B2OutputStream.java
+++ b/underfs/b2/src/main/java/alluxio/underfs/b2/B2OutputStream.java
@@ -1,0 +1,159 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.b2;
+
+import alluxio.util.CommonUtils;
+import alluxio.util.io.PathUtils;
+
+import com.backblaze.b2.client.B2StorageClient;
+import com.backblaze.b2.client.contentSources.B2ContentSource;
+import com.backblaze.b2.client.contentSources.B2ContentTypes;
+import com.backblaze.b2.client.contentSources.B2FileContentSource;
+import com.backblaze.b2.client.exceptions.B2Exception;
+import com.backblaze.b2.client.structures.B2UploadFileRequest;
+import com.backblaze.b2.client.structures.B2UploadListener;
+import com.google.common.base.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A stream for writing a file to B2.
+ */
+public class B2OutputStream extends OutputStream {
+  private static final Logger LOG = LoggerFactory.getLogger(B2OutputStream.class);
+
+  /**
+   * The B2 storage client for Backblaze B2 operations.
+   */
+  private final B2StorageClient mB2StorageClient;
+
+  /**
+   * Bucket id of the Alluxio B2 bucket.
+   */
+  private final String mBucketId;
+
+  /**
+   * Flag to indicate this stream has been closed, to ensure close is only done once.
+   */
+  private final AtomicBoolean mClosed = new AtomicBoolean(false);
+
+  /**
+   * The MD5 hash of the file.
+   */
+  private MessageDigest mHash;
+
+  /**
+   * Key of the file when it is uploaded to Backblaze B2.
+   */
+  private final String mKey;
+
+  /**
+   * The local file that will be uploaded when the stream is closed.
+   */
+  private final File mFile;
+
+  /**
+   * The output stream to a local file where the file will be buffered until closed.
+   */
+  private OutputStream mLocalOutputStream;
+
+  /**
+   * Constructor for an output stream to write on Backblaze B2 using the B2-sdk.
+   *
+   * @param bucketId the bucket to write datae
+   * @param key the path of the object to be written
+   * @param b2StorageClient the b2 client to use for operations
+   * @param tmpDirs the temporary directory to store the file before uploading to under fs
+   */
+  public B2OutputStream(final String bucketId, final String key,
+      final B2StorageClient b2StorageClient, final List<String> tmpDirs) throws IOException {
+    Preconditions.checkArgument(bucketId != null && !bucketId.isEmpty(),
+        "Bucket name must " + "not be null or empty.");
+
+    mBucketId = bucketId;
+    mKey = key;
+    mB2StorageClient = b2StorageClient;
+    mFile = new File(PathUtils.concatPath(CommonUtils.getTmpDir(tmpDirs), UUID.randomUUID()));
+    try {
+      mHash = MessageDigest.getInstance("MD5");
+      mLocalOutputStream =
+          new BufferedOutputStream(new DigestOutputStream(new FileOutputStream(mFile), mHash));
+    } catch (NoSuchAlgorithmException e) {
+      LOG.warn("Algorithm not available for MD5 hash.", e);
+      mHash = null;
+      mLocalOutputStream = new BufferedOutputStream(new FileOutputStream(mFile));
+    }
+  }
+
+  @Override
+  public void write(final int b) throws IOException {
+    mLocalOutputStream.write(b);
+  }
+
+  @Override
+  public void write(final byte[] b) throws IOException {
+    mLocalOutputStream.write(b, 0, b.length);
+  }
+
+  @Override
+  public void write(final byte[] b, final int off, final int len) throws IOException {
+    mLocalOutputStream.write(b, off, len);
+  }
+
+  @Override
+  public void flush() throws IOException {
+    mLocalOutputStream.flush();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (mClosed.getAndSet(true)) {
+      return;
+    }
+    mLocalOutputStream.close();
+    try {
+      final B2UploadListener uploadListener = (progress) -> {
+        final double percent = (100. * (progress.getBytesSoFar() / (double) progress.getLength()));
+        LOG.debug(String.format("  progress(%3.2f, %s)", percent, progress.toString()));
+      };
+      final B2ContentSource source = B2FileContentSource.builder(mFile).build();
+      B2UploadFileRequest request =
+          B2UploadFileRequest.builder(mBucketId, mKey, B2ContentTypes.APPLICATION_OCTET, source)
+              .setListener(uploadListener).build();
+
+      mB2StorageClient.uploadSmallFile(request);
+    } catch (B2Exception e) {
+      LOG.error("Failed to open stream with remote storage. bucket id: [{}], key: [{}]",
+          mBucketId, mKey);
+      throw new IOException(e);
+    } finally {
+      // Delete the temporary file on the local machine if the GCS client completed
+      // the upload or if the upload failed.
+      if (!mFile.delete()) {
+        LOG.error("Failed to delete temporary file @ {}", mFile.getPath());
+      }
+    }
+  }
+}

--- a/underfs/b2/src/main/java/alluxio/underfs/b2/B2UnderFileSystem.java
+++ b/underfs/b2/src/main/java/alluxio/underfs/b2/B2UnderFileSystem.java
@@ -1,0 +1,374 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.b2;
+
+import static com.backblaze.b2.client.contentSources.B2Headers.USER_AGENT;
+import static java.util.Objects.requireNonNull;
+
+import alluxio.AlluxioURI;
+import alluxio.conf.PropertyKey;
+import alluxio.retry.RetryPolicy;
+import alluxio.underfs.ObjectUnderFileSystem;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.options.OpenOptions;
+import alluxio.util.CommonUtils;
+import alluxio.util.UnderFileSystemUtils;
+import alluxio.util.io.PathUtils;
+
+import com.backblaze.b2.client.B2ListFilesIterable;
+import com.backblaze.b2.client.B2StorageClient;
+import com.backblaze.b2.client.B2StorageClientFactory;
+import com.backblaze.b2.client.contentSources.B2ContentSource;
+import com.backblaze.b2.client.contentSources.B2ContentTypes;
+import com.backblaze.b2.client.contentSources.B2FileContentSource;
+import com.backblaze.b2.client.exceptions.B2Exception;
+import com.backblaze.b2.client.structures.B2AccountAuthorization;
+import com.backblaze.b2.client.structures.B2Allowed;
+import com.backblaze.b2.client.structures.B2Bucket;
+import com.backblaze.b2.client.structures.B2CopyFileRequest;
+import com.backblaze.b2.client.structures.B2FileVersion;
+import com.backblaze.b2.client.structures.B2ListBucketsRequest;
+import com.backblaze.b2.client.structures.B2ListFileNamesRequest;
+import com.backblaze.b2.client.structures.B2ListFileVersionsRequest;
+import com.backblaze.b2.client.structures.B2UploadFileRequest;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * B2 {@link UnderFileSystem} implementation based on the b2-sdk-core library.
+ */
+@ThreadSafe
+public class B2UnderFileSystem extends ObjectUnderFileSystem {
+  private static final Logger LOG = LoggerFactory.getLogger(B2UnderFileSystem.class);
+
+  public static final String B2_SCHEME = "b2://";
+  private static final String FOLDER_SUFFIX = "/";
+
+  private final B2StorageClient mB2StorageClient;
+  private final String mAccountId;
+  private final String mBucketName;
+  private final String mBucketId;
+  private final String mFolderIndicator;
+  private final short mBucketMode;
+
+  protected B2UnderFileSystem(AlluxioURI alluxioURI, UnderFileSystemConfiguration conf,
+      B2StorageClient b2StorageClient, String bucketId, String bucketName, short bucketMode,
+      String accountId) {
+    super(alluxioURI, conf);
+    requireNonNull(alluxioURI, "alluxioURI is null");
+    requireNonNull(conf, "conf is null");
+    requireNonNull(b2StorageClient, "b2StorageClient is null");
+    requireNonNull(bucketId, "bucketId is null");
+    requireNonNull(bucketName, "bucketName is null");
+    requireNonNull(bucketMode, "bucketMode is null");
+    requireNonNull(accountId, "accountId is null");
+
+    LOG.debug("alluxioURI: {}", alluxioURI);
+    LOG.debug("buckedId: {}", bucketId);
+    LOG.debug("bucketName: {}", bucketName);
+    LOG.debug("bucketMode: {}", bucketMode);
+    LOG.debug("accountId: {}", accountId);
+
+    mB2StorageClient = b2StorageClient;
+    mBucketId = bucketId;
+    mBucketName = bucketName;
+    mBucketMode = bucketMode;
+    mAccountId = accountId;
+    mFolderIndicator = conf.get(PropertyKey.B2_FOLDER_INDICATOR);
+  }
+
+  @Override
+  protected boolean copyObject(String src, String dst) throws IOException {
+    LOG.debug("copyObject src: {}, dst: {}", src, dst);
+    // source request
+    B2ListFileVersionsRequest srcRequest =
+        B2ListFileVersionsRequest.builder(mBucketId).setStartFileName(src).setPrefix(src).build();
+    B2FileVersion srcFileVersion = null;
+    try {
+      for (B2FileVersion version : mB2StorageClient.fileVersions(srcRequest)) {
+        if (version.getFileName().equals(src)) {
+          srcFileVersion = version;
+        } else {
+          break;
+        }
+      }
+    } catch (B2Exception e) {
+      e.printStackTrace();
+    }
+    if (srcFileVersion == null) {
+      LOG.error("Source object not found: {}", src);
+      return false;
+    }
+    String sourceFileId = srcFileVersion.getFileId();
+    // destination request
+    B2ListBucketsRequest bucketsRequest =
+        B2ListBucketsRequest.builder(mAccountId).setBucketName(dst).build();
+    try {
+      mB2StorageClient.listBuckets(bucketsRequest);
+    } catch (B2Exception e) {
+      e.printStackTrace();
+    }
+    getExistingDirectoryStatus(dst);
+    B2CopyFileRequest copyFileRequest =
+        B2CopyFileRequest.builder(sourceFileId, src).setDestinationBucketId(mBucketId).build();
+    try {
+      mB2StorageClient.copySmallFile(copyFileRequest);
+    } catch (B2Exception e) {
+      e.printStackTrace();
+    }
+
+    return true;
+  }
+
+  @Override
+  public boolean createEmptyObject(String key) {
+    final File mFile = new File(PathUtils
+        .concatPath(CommonUtils.getTmpDir(mUfsConf.getList(PropertyKey.TMP_DIRS, ",")),
+            UUID.randomUUID()));
+    final B2ContentSource source = B2FileContentSource.builder(mFile).build();
+
+    B2UploadFileRequest request =
+        B2UploadFileRequest.builder(mBucketName, key, B2ContentTypes.APPLICATION_OCTET, source)
+            .build();
+
+    try {
+      mB2StorageClient.uploadSmallFile(request);
+      return true;
+    } catch (B2Exception e) {
+      LOG.error("Failed to create an empty object on B2with key:{}", key);
+      return false;
+    }
+  }
+
+  /**
+   * Constructs a new instance of {@link B2UnderFileSystem}.
+   *
+   * @param alluxioURI the {@link AlluxioURI} for this UFS
+   * @param conf       the configuration for this UFS
+   * @return the created {@link B2UnderFileSystem} instance
+   */
+  public static B2UnderFileSystem createInstance(AlluxioURI alluxioURI,
+      UnderFileSystemConfiguration conf) throws ServiceException {
+    LOG.debug("Initializing B2 Storage Client at {}", alluxioURI);
+    B2StorageClient client = B2StorageClientFactory.createDefaultFactory()
+        .create(conf.get(PropertyKey.B2_ACCESS_KEY), conf.get(PropertyKey.B2_SECRET_KEY),
+            USER_AGENT);
+
+    try {
+      B2AccountAuthorization accountAuthorization = client.getAccountAuthorization();
+      LOG.debug("B2AccountAuthorization {}", accountAuthorization);
+
+      B2Allowed allowed = accountAuthorization.getAllowed();
+      LOG.debug("B2Allowed {}", allowed);
+
+      String accountId = accountAuthorization.getAccountId();
+      List<String> capabilities = allowed.getCapabilities();
+
+      String bucketNameFromURI = UnderFileSystemUtils.getBucketName(alluxioURI);
+      LOG.debug("bucket name from uri {}", bucketNameFromURI);
+
+      String bucketId;
+      String bucketName;
+      if (allowed.getBucketId() != null) {
+        bucketId = allowed.getBucketId();
+        bucketName = allowed.getBucketName();
+      } else {
+        B2Bucket bucket = client.getBucketOrNullByName(bucketNameFromURI);
+        LOG.debug("B2Bucket {}", bucket);
+        bucketId = bucket.getBucketId();
+        bucketName = bucket.getBucketName();
+      }
+
+      short bucketMode = B2Utils.translateBucketAcl(capabilities);
+
+      return new B2UnderFileSystem(alluxioURI, conf, client, bucketId, bucketName, bucketMode,
+          accountId);
+    } catch (B2Exception | NullPointerException e) {
+      LOG.error("Failed to instantiate B2UnderFileSystem client with key:{} and URI: {}",
+          conf.get(PropertyKey.B2_ACCESS_KEY), alluxioURI);
+      Throwables.propagateIfPossible(e, ServiceException.class);
+    }
+    return null;
+  }
+
+  @Override
+  protected OutputStream createObject(String key) throws IOException {
+    return new B2OutputStream(mBucketId, key, mB2StorageClient,
+        mUfsConf.getList(PropertyKey.TMP_DIRS, ","));
+  }
+
+  @Override
+  protected boolean deleteObject(String key) throws IOException {
+    try {
+      B2ListFileVersionsRequest request =
+          B2ListFileVersionsRequest.builder(mBucketId).setStartFileName(key).setPrefix(key).build();
+      for (B2FileVersion version : mB2StorageClient.fileVersions(request)) {
+        if (version.getFileName().equals(key)) {
+          mB2StorageClient.deleteFileVersion(version);
+        } else {
+          break;
+        }
+      }
+    } catch (B2Exception e) {
+      LOG.error("Failed to delete {}", key, e);
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  protected String getFolderSuffix() {
+    LOG.debug("getFolderSuffix {}", FOLDER_SUFFIX);
+    return FOLDER_SUFFIX;
+  }
+
+  @Nullable
+  @Override
+  protected ObjectListingChunk getObjectListingChunk(String key, boolean recursive)
+      throws IOException {
+    LOG.debug("getObjectListingChunk({}, {})", key, recursive);
+    String delimiter = recursive ? null : PATH_SEPARATOR;
+    key = PathUtils.normalizePath(key, PATH_SEPARATOR);
+    // In case key is root (empty string) do not normalize prefix.
+    key = key.equals(PATH_SEPARATOR) ? "" : key;
+
+    LOG.debug("key: {}", key);
+    LOG.debug("delimiter: {}", delimiter);
+
+    final B2ListFileNamesRequest.Builder builder =
+        B2ListFileNamesRequest.builder(mBucketId).setMaxFileCount(getListingChunkLength(mUfsConf))
+            .setPrefix(key);
+
+    if (delimiter != null) {
+      builder.setDelimiter(delimiter);
+    }
+
+    final B2ListFileNamesRequest request = builder.build();
+
+    try {
+      return new B2ObjectListingChunk(mB2StorageClient.fileNames(request));
+    } catch (B2Exception e) {
+      Throwables.propagateIfPossible(e, IOException.class);
+      return null;
+    }
+  }
+
+  @Nullable
+  @Override
+  protected ObjectStatus getObjectStatus(String key) throws IOException {
+    LOG.debug("bucketName: {}, key: {}", mBucketName, key);
+    try {
+      B2FileVersion fileInfo = mB2StorageClient.getFileInfoByName(mBucketName, key);
+      return new ObjectStatus(fileInfo.getFileName(), fileInfo.getContentSha1(),
+          fileInfo.getContentLength(), fileInfo.getUploadTimestamp());
+    } catch (B2Exception e) {
+      if (e.getCode().equals("not_found")) {
+        LOG.debug("key not found {}", key);
+        return null;
+      }
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected ObjectPermissions getPermissions() {
+    return new ObjectPermissions(mAccountId, mAccountId, mBucketMode);
+  }
+
+  @Override
+  protected String getRootKey() {
+    LOG.debug("getRootKey {}{}", B2_SCHEME, mBucketName);
+    return B2_SCHEME + mBucketName;
+  }
+
+  @Override
+  public String getUnderFSType() {
+    return "b2";
+  }
+
+  @Override
+  protected InputStream openObject(String key, OpenOptions options, RetryPolicy retryPolicy)
+      throws IOException {
+    LOG.debug("key [{}]", key);
+    LOG.debug("options [{}]", options);
+    try {
+      return new B2InputStream(mBucketName, key, mB2StorageClient, options.getOffset(),
+          options.getLength());
+    } catch (ServiceException e) {
+      throw new IOException(e.getMessage());
+    }
+  }
+
+  @Override
+  public void setMode(String path, short mode) throws IOException {}
+
+  @Override
+  public void setOwner(String path, String owner, String group) throws IOException {}
+
+  private final class B2ObjectListingChunk implements ObjectListingChunk {
+
+    private final ImmutableList<B2FileVersion> mFiles;
+
+    B2ObjectListingChunk(B2ListFilesIterable iterable) throws IOException {
+      if (iterable == null) {
+        throw new IOException("B2 listing result is null");
+      }
+      ImmutableList.Builder<B2FileVersion> builder = ImmutableList.builder();
+      iterable.iterator().forEachRemaining(file -> {
+        LOG.debug("object: {}", file);
+        if (!file.getFileName().endsWith(mFolderIndicator)) {
+          LOG.debug(file.toString());
+          builder.add(file);
+        } else {
+          LOG.debug("skipped {}", file);
+        }
+      });
+      mFiles = builder.build();
+    }
+
+    @Override
+    public String[] getCommonPrefixes() {
+      return mFiles.parallelStream().map(B2FileVersion::getFileName)
+          .filter(file -> file.endsWith(PATH_SEPARATOR)).collect(Collectors.toList())
+          .toArray(new String[] {});
+    }
+
+    @Nullable
+    @Override
+    public ObjectListingChunk getNextChunk() throws IOException {
+      return null;
+    }
+
+    @Override
+    public ObjectStatus[] getObjectStatuses() {
+      return mFiles.stream().map(
+          obj -> new ObjectStatus(obj.getFileName(), obj.getContentSha1(), obj.getContentLength(),
+              obj.getUploadTimestamp())).collect(Collectors.toList())
+          .toArray(new ObjectStatus[] {});
+    }
+  }
+}

--- a/underfs/b2/src/main/java/alluxio/underfs/b2/B2UnderFileSystemFactory.java
+++ b/underfs/b2/src/main/java/alluxio/underfs/b2/B2UnderFileSystemFactory.java
@@ -1,0 +1,67 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.b2;
+
+import alluxio.AlluxioURI;
+import alluxio.conf.PropertyKey;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.UnderFileSystemFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.protobuf.ServiceException;
+
+import java.io.IOException;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Factory for creating {@link B2UnderFileSystem}.
+ */
+@ThreadSafe
+public class B2UnderFileSystemFactory implements UnderFileSystemFactory {
+
+  private void checkB2Credentials(UnderFileSystemConfiguration conf) {
+    if (!conf.keySet().contains(PropertyKey.B2_ACCESS_KEY) || !conf.keySet()
+        .contains(PropertyKey.B2_SECRET_KEY)) {
+      String err = "B2 Credentials not available, cannot create B2 Under File System. "
+          + "The following properties should be set:\n"
+          + "\t- " + PropertyKey.Name.B2_ACCESS_KEY
+          + "\t- " + PropertyKey.Name.B2_SECRET_KEY;
+      throw new RuntimeException(new IOException(err));
+    }
+  }
+
+  @Override
+  public UnderFileSystem create(String path, UnderFileSystemConfiguration conf) {
+    Preconditions.checkNotNull(path, "path is null");
+    checkB2Credentials(conf);
+    try {
+      return B2UnderFileSystem.createInstance(new AlluxioURI(path), conf);
+    } catch (ServiceException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public boolean supportsPath(String path) {
+    if (path == null) {
+      return false;
+    }
+    return path.startsWith(B2UnderFileSystem.B2_SCHEME);
+  }
+
+  @Override
+  public boolean supportsPath(String path, UnderFileSystemConfiguration conf) {
+    return supportsPath(path);
+  }
+}

--- a/underfs/b2/src/main/java/alluxio/underfs/b2/B2Utils.java
+++ b/underfs/b2/src/main/java/alluxio/underfs/b2/B2Utils.java
@@ -1,0 +1,49 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.b2;
+
+import com.backblaze.b2.client.structures.B2Capabilities;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Util functions for B2 under file system.
+ */
+public final class B2Utils {
+
+  private B2Utils() {} // Not intended for instantiation.
+
+  /**
+   * Translates B2 bucket ACL to Alluxio owner mode.
+   *
+   * @param capabilities the ACL list of B2 bucket
+   * @return the translated posix mode in short format
+   */
+  public static short translateBucketAcl(List<String> capabilities) {
+    short mode = (short) 0;
+
+    if (capabilities
+        .containsAll(Arrays.asList(B2Capabilities.READ_FILES, B2Capabilities.WRITE_FILES))) {
+      // If the user has full control to the bucket, +rwx to the owner mode.
+      mode |= (short) 0700;
+    } else if (capabilities.contains(B2Capabilities.WRITE_FILES)) {
+      // If the bucket is writable by the user, +w to the owner mode.
+      mode |= (short) 0200;
+    } else if (capabilities.contains(B2Capabilities.READ_FILES)) {
+      // If the bucket is readable by the user, add r and x to the owner mode.
+      mode |= (short) 0500;
+    }
+
+    return mode;
+  }
+}

--- a/underfs/b2/src/main/resources/META-INF/services/alluxio.underfs.UnderFileSystemFactory
+++ b/underfs/b2/src/main/resources/META-INF/services/alluxio.underfs.UnderFileSystemFactory
@@ -1,0 +1,12 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the “License”). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+alluxio.underfs.b2.B2UnderFileSystemFactory

--- a/underfs/b2/src/test/java/alluxio/underfs/b2/B2InputStreamTest.java
+++ b/underfs/b2/src/test/java/alluxio/underfs/b2/B2InputStreamTest.java
@@ -1,0 +1,109 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.b2;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.backblaze.b2.client.B2StorageClient;
+import com.backblaze.b2.client.contentHandlers.B2ContentMemoryWriter;
+import com.backblaze.b2.client.exceptions.B2Exception;
+import com.google.protobuf.ServiceException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+
+/**
+ * Unit tests for {@link B2InputStream}.
+ */
+public class B2InputStreamTest {
+
+  private static final String BUCKET_NAME = "testBucket";
+  private static final String OBJECT_KEY = "testObjectKey";
+  @Rule
+  public ExpectedException mExpectedException = ExpectedException.none();
+  @Mock
+  private B2ContentMemoryWriter mB2ContentMemoryWriter;
+  private B2InputStream mB2InputStream;
+  private B2StorageClient mB2StorageClient;
+  private byte[] mBytes;
+
+  @Before
+  public void setUp() throws ServiceException {
+    MockitoAnnotations.initMocks(this);
+
+    mBytes = new byte[] {1, 2, 3};
+    mB2StorageClient = mock(B2StorageClient.class);
+    mB2ContentMemoryWriter = mock(B2ContentMemoryWriter.class);
+
+    when(mB2ContentMemoryWriter.getBytes()).thenReturn(mBytes);
+
+    mB2InputStream = new B2InputStream(BUCKET_NAME, OBJECT_KEY, mB2StorageClient, 0L, 100L) {
+      @Override
+      protected B2ContentMemoryWriter getSink() {
+        return mB2ContentMemoryWriter;
+      }
+    };
+  }
+
+  /**
+   * Test of close method, of class B2InputStream.
+   */
+  @Test
+  public void close() throws IOException {
+    mB2InputStream.close();
+
+    mExpectedException.expect(IOException.class);
+    mExpectedException.expectMessage(is("Stream closed"));
+    mB2InputStream.read();
+  }
+
+  /**
+   * Test of read method, of class B2InputStream.
+   */
+  @Test
+  public void read() throws IOException, B2Exception, ServiceException {
+
+    assertEquals(1, mB2InputStream.read());
+    assertEquals(2, mB2InputStream.read());
+    assertEquals(3, mB2InputStream.read());
+  }
+
+  /**
+   * Test of read method, of class B2InputStream.
+   */
+  @Test
+  public void readWithArgs() throws IOException {
+    byte[] bytes = new byte[3];
+    int readCount = mB2InputStream.read(bytes, 0, 3);
+    assertEquals(3, readCount);
+    assertArrayEquals(new byte[] {1, 2, 3}, bytes);
+  }
+
+  /**
+   * Test of skip method, of class B2InputStream.
+   */
+  @Test
+  public void skip() throws IOException {
+    assertEquals(1, mB2InputStream.read());
+    mB2InputStream.skip(1);
+    assertEquals(3, mB2InputStream.read());
+  }
+}

--- a/underfs/b2/src/test/java/alluxio/underfs/b2/B2OutputStreamTest.java
+++ b/underfs/b2/src/test/java/alluxio/underfs/b2/B2OutputStreamTest.java
@@ -1,0 +1,122 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.b2;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.util.ConfigurationUtils;
+
+import com.backblaze.b2.client.B2StorageClient;
+import com.backblaze.b2.client.structures.B2FileVersion;
+import com.backblaze.b2.client.structures.B2UploadFileRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.security.DigestOutputStream;
+
+/**
+ * Unit tests for the {@link B2OutputStream}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(B2OutputStream.class)
+public class B2OutputStreamTest {
+  private static final String BUCKET_NAME = "testBucket";
+  private static final String KEY = "testKey";
+  private static AlluxioConfiguration sConf =
+      new InstancedConfiguration(ConfigurationUtils.defaults());
+
+  private File mFile;
+  private BufferedOutputStream mLocalOutputStream;
+  private B2OutputStream mStream;
+
+  /**
+   * Sets the properties and configuration before each test runs.
+   */
+  @Before
+  public void before() throws Exception {
+    mFile = Mockito.mock(File.class);
+    mLocalOutputStream = Mockito.mock(BufferedOutputStream.class);
+    B2StorageClient b2StorageClient = Mockito.mock(B2StorageClient.class);
+    B2FileVersion result = Mockito.mock(B2FileVersion.class);
+
+    Mockito.when(b2StorageClient.uploadSmallFile(Mockito.any(B2UploadFileRequest.class)))
+        .thenReturn(result);
+    PowerMockito.whenNew(BufferedOutputStream.class)
+        .withArguments(Mockito.any(DigestOutputStream.class)).thenReturn(mLocalOutputStream);
+    PowerMockito.whenNew(File.class).withArguments(Mockito.anyString()).thenReturn(mFile);
+    FileOutputStream outputStream = PowerMockito.mock(FileOutputStream.class);
+    PowerMockito.whenNew(FileOutputStream.class).withArguments(mFile).thenReturn(outputStream);
+    mStream = new B2OutputStream(BUCKET_NAME, KEY, b2StorageClient,
+        sConf.getList(PropertyKey.TMP_DIRS, ","));
+  }
+
+  /**
+   * Tests to ensure {@link B2OutputStream#write(int)} calls the underlying output stream.
+   */
+  @Test
+  public void writeByte() throws Exception {
+    mStream.write(1);
+    mStream.close();
+    Mockito.verify(mLocalOutputStream).write(1);
+  }
+
+  /**
+   * Tests to ensure {@link B2OutputStream#write(byte[])} calls the underlying output stream.
+   */
+  @Test
+  public void writeByteArray() throws Exception {
+    byte[] b = new byte[10];
+    mStream.write(b);
+    mStream.close();
+    Mockito.verify(mLocalOutputStream).write(b, 0, b.length);
+  }
+
+  /**
+   * Tests to ensure {@link B2OutputStream#write(byte[], int, int)} calls the underlying
+   * output stream.
+   */
+  @Test
+  public void writeByteArrayWithRange() throws Exception {
+    byte[] b = new byte[10];
+    mStream.write(b, 0, b.length);
+    mStream.close();
+    Mockito.verify(mLocalOutputStream).write(b, 0, b.length);
+  }
+
+  /**
+   * Tests to ensure {@link File#delete()} is called when the stream is closed.
+   */
+  @Test
+  public void close() throws Exception {
+    mStream.close();
+    Mockito.verify(mFile).delete();
+  }
+
+  /**
+   * Tests to ensure {@link B2OutputStream#flush()} calls the underlying output stream.
+   */
+  @Test
+  public void flush() throws Exception {
+    mStream.flush();
+    mStream.close();
+    Mockito.verify(mLocalOutputStream).flush();
+  }
+}

--- a/underfs/b2/src/test/java/alluxio/underfs/b2/B2UnderFileSystemFactoryTest.java
+++ b/underfs/b2/src/test/java/alluxio/underfs/b2/B2UnderFileSystemFactoryTest.java
@@ -1,0 +1,38 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.b2;
+
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.UnderFileSystemFactory;
+import alluxio.underfs.UnderFileSystemFactoryRegistry;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link B2UnderFileSystemFactory}.
+ */
+public class B2UnderFileSystemFactoryTest {
+
+  /**
+   * This test ensures the B2 UFS module correctly accepts paths that begin with b2://.
+   */
+  @Test
+  public void factory() {
+    UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry
+        .find("b2://test-bucket/path", UnderFileSystemConfiguration.defaults());
+
+    Assert
+        .assertNotNull("A UnderFileSystemFactory should exist for b2 paths when using this module",
+            factory);
+  }
+}

--- a/underfs/b2/src/test/java/alluxio/underfs/b2/B2UtilsTest.java
+++ b/underfs/b2/src/test/java/alluxio/underfs/b2/B2UtilsTest.java
@@ -1,0 +1,59 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.b2;
+
+import com.backblaze.b2.client.structures.B2Allowed;
+import com.backblaze.b2.client.structures.B2Capabilities;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+/**
+ * Tests for {@link B2Utils} methods.
+ */
+public final class B2UtilsTest {
+
+  private static final String BUCKET_ID = "123456789012";
+  private static final String BUCKET_NAME = "foo";
+
+  @Test
+  public void translateUserReadPermission() {
+    // Setup listBuckets, listFiles, readFiles, shareFiles
+    B2Allowed readAllowed = new B2Allowed(Arrays
+        .asList(B2Capabilities.LIST_BUCKETS, B2Capabilities.LIST_FILES, B2Capabilities.READ_FILES,
+            B2Capabilities.SHARE_FILES), BUCKET_ID, BUCKET_NAME, "");
+    // Assert
+    Assert.assertEquals((short) 0500, B2Utils.translateBucketAcl(readAllowed.getCapabilities()));
+  }
+
+  @Test
+  public void translateUserWritePermission() {
+    // Setup deleteFiles, listBuckets, writeFiles
+    B2Allowed writeAllowed = new B2Allowed(Arrays
+        .asList(B2Capabilities.DELETE_FILES, B2Capabilities.LIST_BUCKETS,
+            B2Capabilities.WRITE_FILES), BUCKET_ID, BUCKET_NAME, "");
+    // Assert
+    Assert.assertEquals((short) 0200, B2Utils.translateBucketAcl(writeAllowed.getCapabilities()));
+  }
+
+  @Test
+  public void translateUserFullPermission() {
+    // Setup deleteFiles, listBuckets, listFiles, readFiles, shareFiles, writeFiles
+    B2Allowed fullAllowed = new B2Allowed(Arrays
+        .asList(B2Capabilities.DELETE_FILES, B2Capabilities.LIST_BUCKETS, B2Capabilities.LIST_FILES,
+            B2Capabilities.READ_FILES, B2Capabilities.SHARE_FILES, B2Capabilities.WRITE_FILES),
+        BUCKET_ID, BUCKET_NAME, "");
+    // Assert
+    Assert.assertEquals((short) 0700, B2Utils.translateBucketAcl(fullAllowed.getCapabilities()));
+  }
+}

--- a/underfs/pom.xml
+++ b/underfs/pom.xml
@@ -23,17 +23,18 @@
   <description>Parent POM for different implementations of Alluxio under file system</description>
 
   <modules>
+    <module>b2</module>
     <module>cos</module>
     <module>gcs</module>
     <module>hdfs</module>
     <module>kodo</module>
     <module>local</module>
     <module>oss</module>
+    <module>ozone</module>
     <module>s3a</module>
     <module>swift</module>
     <module>wasb</module>
     <module>web</module>
-    <module>ozone</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
This PR resolves #11707 by providing read only capability to Backblaze B2 as a UFS.