### PR TITLE
Ignore worker response when closing gRPC data reader

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
@@ -168,7 +168,6 @@ public final class GrpcDataReader implements DataReader {
         return;
       }
       mStream.close();
-      mStream.waitForComplete(mDataTimeoutMs);
     } finally {
       mMarshaller.close();
       mClient.close();


### PR DESCRIPTION
It has been observed many times that a worker might get busy/hung after a read is served and closing gRPC stream times out.
After the content is read and the underlying stream is closed, there is no need to wait for worker to acknowledge.