### PR TITLE
Add minor RPC optimizations

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -80,6 +80,8 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   protected final Supplier<String> mRootKeySupplier =
       CommonUtils.memoize(this::getRootKey);
 
+  private final boolean mBreadcrumbsEnabled;
+
   /**
    * Constructs an {@link ObjectUnderFileSystem}.
    *
@@ -91,6 +93,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     int numThreads = mUfsConf.getInt(PropertyKey.UNDERFS_OBJECT_STORE_SERVICE_THREADS);
     mExecutorService = ExecutorServiceFactories.fixedThreadPool(
         "alluxio-underfs-object-service-worker", numThreads).create();
+    mBreadcrumbsEnabled = mUfsConf.getBoolean(PropertyKey.UNDERFS_OBJECT_STORE_BREADCRUMBS_ENABLED);
   }
 
   /**
@@ -940,8 +943,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     if (objs != null && ((objs.getObjectStatuses() != null && objs.getObjectStatuses().length > 0)
         || (objs.getCommonPrefixes() != null && objs.getCommonPrefixes().length > 0))) {
       // If the breadcrumb exists, this is a no-op
-      if (!mUfsConf.isReadOnly()
-          && mUfsConf.getBoolean(PropertyKey.UNDERFS_OBJECT_STORE_BREADCRUMBS_ENABLED)) {
+      if (!mUfsConf.isReadOnly() && mBreadcrumbsEnabled) {
         mkdirsInternal(dir);
       }
       return objs;

--- a/core/server/common/src/main/java/alluxio/master/StateLockManager.java
+++ b/core/server/common/src/main/java/alluxio/master/StateLockManager.java
@@ -130,7 +130,9 @@ public class StateLockManager {
    * @throws InterruptedException
    */
   public LockResource lockShared() throws InterruptedException {
-    LOG.debug("Thread-{} entered lockShared().", ThreadUtils.getCurrentThreadIdentifier());
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Thread-{} entered lockShared().", ThreadUtils.getCurrentThreadIdentifier());
+    }
     // Do not allow taking shared lock during safe-mode.
     long exclusiveOnlyRemainingMs = mExclusiveOnlyDeadlineMs - System.currentTimeMillis();
     if (exclusiveOnlyRemainingMs > 0) {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultBlockDeletionContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultBlockDeletionContext.java
@@ -32,7 +32,7 @@ public final class DefaultBlockDeletionContext implements BlockDeletionContext {
    */
   public DefaultBlockDeletionContext(BlockDeletionListener... listeners) {
     mListeners = Arrays.asList(listeners);
-    mBlocks = new ArrayList<>();
+    mBlocks = new ArrayList<>(0);
   }
 
   @Override


### PR DESCRIPTION
Based on my testing on a local machine these sites accounted for anywhere between 1% and 3% of the CPU time when processing the RPC.

- When calling getObjectListing on the ObjectUnderFileSystem, we should store the value of the breadcrumbs enabled as a boolean rather than always parsing from the config
- When calling `lockShared()` in the state lock manager, prevent a String.format call by wrapping with a conditional statement.
- When creating the DefaultBlockDeletionContext, initialize the array list with a size of 0 to prevent unnecessarily allocating small arrays over and over again with the default ArrayList constructor, when most times we won't even add to this ArrayList.