### PR TITLE
Fix edge case for ObjectUFS when looking at root path

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -1116,14 +1116,16 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * @param path the path to strip
    * @return the path without the bucket prefix
    */
-  protected String stripPrefixIfPresent(String path) {
+  @VisibleForTesting
+  public String stripPrefixIfPresent(String path) {
+    final String normalizedPath = PathUtils.normalizePath(path, PATH_SEPARATOR);
     String stripedKey = CommonUtils.stripPrefixIfPresent(
-        PathUtils.normalizePath(path, PATH_SEPARATOR),
+        normalizedPath,
         PathUtils.normalizePath(mRootKeySupplier.get(), PATH_SEPARATOR));
-    if (!stripedKey.equals(path)) {
+    if (!stripedKey.equals(normalizedPath)) {
       return stripedKey;
     }
-    return CommonUtils.stripPrefixIfPresent(path, PATH_SEPARATOR);
+    return CommonUtils.stripPrefixIfPresent(normalizedPath, PATH_SEPARATOR);
   }
 
   /**

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -1117,7 +1117,8 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
    * @return the path without the bucket prefix
    */
   protected String stripPrefixIfPresent(String path) {
-    String stripedKey = CommonUtils.stripPrefixIfPresent(path,
+    String stripedKey = CommonUtils.stripPrefixIfPresent(
+        PathUtils.normalizePath(path, PATH_SEPARATOR),
         PathUtils.normalizePath(mRootKeySupplier.get(), PATH_SEPARATOR));
     if (!stripedKey.equals(path)) {
       return stripedKey;

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
@@ -244,6 +244,6 @@ public class S3AUnderFileSystemTest {
   public void stripPrefixIfPresent() throws Exception {
     Assert.assertEquals("", mS3UnderFileSystem.stripPrefixIfPresent("s3a://" + BUCKET_NAME));
     Assert.assertEquals("", mS3UnderFileSystem.stripPrefixIfPresent("s3a://" + BUCKET_NAME + "/"));
-    Assert.assertEquals("test", mS3UnderFileSystem.stripPrefixIfPresent("test"));
+    Assert.assertEquals("test/", mS3UnderFileSystem.stripPrefixIfPresent("test"));
   }
 }

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
@@ -239,4 +239,9 @@ public class S3AUnderFileSystemTest {
     Assert.assertEquals(UfsMode.READ_WRITE,
         mS3UnderFileSystem.getOperationMode(physicalUfsState));
   }
+
+  @Test
+  public void stripPrefixIfPresent() throws Exception {
+    Assert.assertEquals("", mS3UnderFileSystem.stripPrefixIfPresent("s3a://bucket"));
+  }
 }

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
@@ -245,5 +245,7 @@ public class S3AUnderFileSystemTest {
     Assert.assertEquals("", mS3UnderFileSystem.stripPrefixIfPresent("s3a://" + BUCKET_NAME));
     Assert.assertEquals("", mS3UnderFileSystem.stripPrefixIfPresent("s3a://" + BUCKET_NAME + "/"));
     Assert.assertEquals("test/", mS3UnderFileSystem.stripPrefixIfPresent("test"));
+    Assert.assertEquals("test/",
+        mS3UnderFileSystem.stripPrefixIfPresent("s3a://" + BUCKET_NAME + "/test/"));
   }
 }

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
@@ -242,6 +242,6 @@ public class S3AUnderFileSystemTest {
 
   @Test
   public void stripPrefixIfPresent() throws Exception {
-    Assert.assertEquals("", mS3UnderFileSystem.stripPrefixIfPresent("s3a://bucket"));
+    Assert.assertEquals("", mS3UnderFileSystem.stripPrefixIfPresent("s3a://" + BUCKET_NAME));
   }
 }

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
@@ -243,5 +243,7 @@ public class S3AUnderFileSystemTest {
   @Test
   public void stripPrefixIfPresent() throws Exception {
     Assert.assertEquals("", mS3UnderFileSystem.stripPrefixIfPresent("s3a://" + BUCKET_NAME));
+    Assert.assertEquals("", mS3UnderFileSystem.stripPrefixIfPresent("s3a://" + BUCKET_NAME + "/"));
+    Assert.assertEquals("test", mS3UnderFileSystem.stripPrefixIfPresent("test"));
   }
 }


### PR DESCRIPTION
Path of s3://<bucket_name> currently doesn't work while s3://<bucket_name>/ does because

s3://<bucket_name>/ gets currently replaced with the empty string when using it with the correct client while
s3://<bucket_name> does not get replaced with the empty string.