### PR TITLE
Simplify UfsStatus handling in loadMetadata

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -625,6 +625,9 @@ public class InodeSyncStream {
       FileAlreadyCompletedException, InvalidFileSizeException, BlockInfoException {
 
     UfsStatus status = mStatusCache.fetchStatusIfAbsent(inodePath.getUri(), mMountTable);
+    if (status == null) {
+      return;
+    }
     LoadMetadataContext ctx = LoadMetadataContext.mergeFrom(
         LoadMetadataPOptions.newBuilder()
             .setCommonOptions(NO_TTL_OPTION)

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -635,8 +635,8 @@ public class InodeSyncStream {
   }
 
   /**
-  * This method creates inodes containing the metadata from the UFS. The {@link UfsStatus} object must be
-  * set in the {@link LoadMetadataContext} in order to successfully create the inodes.
+  * This method creates inodes containing the metadata from the UFS. The {@link UfsStatus} object
+  * must be set in the {@link LoadMetadataContext} in order to successfully create the inodes.
   */
   private void loadMetadata(LockedInodePath inodePath, LoadMetadataContext context)
       throws AccessControlException, BlockInfoException, FileAlreadyCompletedException,

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -634,6 +634,10 @@ public class InodeSyncStream {
     loadMetadata(inodePath, ctx);
   }
 
+  /**
+  * This method creates inodes containing the metadata from the UFS. The {@link UfsStatus} object must be
+  * set in the {@link LoadMetadataContext} in order to successfully create the inodes.
+  */
   private void loadMetadata(LockedInodePath inodePath, LoadMetadataContext context)
       throws AccessControlException, BlockInfoException, FileAlreadyCompletedException,
       FileDoesNotExistException, InvalidFileSizeException, InvalidPathException, IOException {

--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -138,10 +137,11 @@ public class UfsStatusCache {
    *
    * @param path the path the retrieve
    * @param mountTable the Alluxio mount table
-   * @return The corresponding {@link UfsStatus}, or null if it couldn't be fetched
+   * @return The corresponding {@link UfsStatus} or {@code null} if there is none stored
    */
+  @Nullable
   public UfsStatus fetchStatusIfAbsent(AlluxioURI path, MountTable mountTable)
-      throws InvalidPathException, FileNotFoundException {
+      throws InvalidPathException {
     UfsStatus status = mStatuses.get(path);
     if (status != null) {
       return status;
@@ -152,7 +152,7 @@ public class UfsStatusCache {
       UnderFileSystem ufs = ufsResource.get();
       UfsStatus ufsStatus = ufs.getStatus(ufsUri.toString());
       if (ufsStatus == null) {
-        throw new FileNotFoundException("fetched status is null for: " + ufsUri);
+        return null;
       }
       ufsStatus.setName(path.getName());
       addStatus(path, ufsStatus);

--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -138,8 +138,7 @@ public class UfsStatusCache {
    *
    * @param path the path the retrieve
    * @param mountTable the Alluxio mount table
-   * @return The corresponding {@link UfsStatus}
-   * @throws java.io.FileNotFoundException if the status can't be retrieved from the UFS
+   * @return The corresponding {@link UfsStatus}, or null if it couldn't be fetched
    */
   public UfsStatus fetchStatusIfAbsent(AlluxioURI path, MountTable mountTable)
       throws InvalidPathException, FileNotFoundException {
@@ -161,7 +160,7 @@ public class UfsStatusCache {
     } catch (IllegalArgumentException | IOException e) {
       LogUtils.warnWithException(LOG, "Failed to fetch status for {}", path, e);
     }
-    throw new FileNotFoundException("Failed to fetch status of " + ufsUri);
+    return null;
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/underfs/UfsStatusCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/underfs/UfsStatusCacheTest.java
@@ -43,7 +43,6 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -372,12 +371,7 @@ public class UfsStatusCacheTest {
   @Test
   public void testFetchSingleStatusNonExistingPath() throws Exception {
     spyUfs();
-    try {
-      UfsStatus fetched = mCache.fetchStatusIfAbsent(new AlluxioURI("/testFile"), mMountTable);
-      fail("Should have thrown FileNotFoundException");
-    } catch (FileNotFoundException e) {
-      // ignored
-    }
+    assertNull(mCache.fetchStatusIfAbsent(new AlluxioURI("/testFile"), mMountTable));
     Mockito.verify(mUfs, times(1)).getStatus(any(String.class));
   }
 
@@ -385,12 +379,7 @@ public class UfsStatusCacheTest {
   public void testFetchSingleStatusThrowsException() throws Exception {
     spyUfs();
     doThrow(new IOException("test exception")).when(mUfs).getStatus(any(String.class));
-    try {
-      UfsStatus fetched = mCache.fetchStatusIfAbsent(new AlluxioURI("/testFile"), mMountTable);
-      fail("Should have thrown FileNotFoundException");
-    } catch (FileNotFoundException e) {
-      // ignored
-    }
+    assertNull(mCache.fetchStatusIfAbsent(new AlluxioURI("/testFile"), mMountTable));
     Mockito.verify(mUfs, times(1)).getStatus(any(String.class));
   }
 


### PR DESCRIPTION
This reverts a change from #11704 while also removing redundant UFS calls. The `ufs.exists` in `loadMetadata` is no longer necessary because every call to `loadMetadata` goes through call site place which will always set the `UfsStatus` in the `LoadMetadataContext`. The attempt to retrieve the `UfsStatus` from the `UfsStatusCache` will always pull the status from the internal map, or reach out to the UFS. If the status couldn't be retrieved on the call to `fetchStatusIfAbsent` then it does not exist in the UFS.