### PR TITLE
Fix block location iteration with rocksdb

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -30,6 +30,7 @@ import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
+import org.rocksdb.Slice;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -147,9 +148,12 @@ public class RocksBlockStore implements BlockStore {
 
   @Override
   public List<BlockLocation> getLocations(long id) {
+    byte[] startKey = RocksUtils.toByteArray(id, 0);
+    byte[] endKey = RocksUtils.toByteArray(id, Long.MAX_VALUE);
+
     try (RocksIterator iter = db().newIterator(mBlockLocationsColumn.get(),
-        new ReadOptions().setPrefixSameAsStart(true))) {
-      iter.seek(Longs.toByteArray(id));
+        new ReadOptions().setIterateUpperBound(new Slice(endKey)))) {
+      iter.seek(startKey);
       List<BlockLocation> locations = new ArrayList<>();
       for (; iter.isValid(); iter.next()) {
         try {

--- a/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksBlockStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksBlockStoreTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.util.Iterator;
+import java.util.List;
 
 public class RocksBlockStoreTest {
   @Rule
@@ -58,5 +59,25 @@ public class RocksBlockStoreTest {
       assertEquals(i, block.getMeta().getLength());
     }
     assertFalse(iter.hasNext());
+  }
+
+  @Test
+  public void blockLocations() throws Exception {
+    final int blockCount = 5;
+    final int workerIdStart = 100000;
+    RocksBlockStore blockStore = new RocksBlockStore(mFolder.newFolder().getAbsolutePath());
+    // create blocks and locations
+    for (int i = 0; i < blockCount; i++) {
+      blockStore.putBlock(i, Block.BlockMeta.newBuilder().setLength(i).build());
+      blockStore
+          .addLocation(i, Block.BlockLocation.newBuilder().setWorkerId(workerIdStart + i).build());
+    }
+
+    // validate locations
+    for (int i = 0; i < blockCount; i++) {
+      List<Block.BlockLocation> locations = blockStore.getLocations(i);
+      assertEquals(1, locations.size());
+      assertEquals(workerIdStart + i, locations.get(0).getWorkerId());
+    }
   }
 }


### PR DESCRIPTION
`setPrefixSameAsStart` does not work when there is a composite key, and both components need to be specified (2 longs). Therefore, use `setIterateUpperBound` instead.

Fixes #11753
