### PR TITLE
Fix block location iteration with rocksdb

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -28,6 +28,7 @@ import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
+import org.rocksdb.Slice;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,9 +144,12 @@ public class RocksBlockStore implements BlockStore {
 
   @Override
   public List<BlockLocation> getLocations(long id) {
+    byte[] startKey = RocksUtils.toByteArray(id, 0);
+    byte[] endKey = RocksUtils.toByteArray(id, Long.MAX_VALUE);
+
     try (RocksIterator iter = db().newIterator(mBlockLocationsColumn.get(),
-        new ReadOptions().setPrefixSameAsStart(true))) {
-      iter.seek(Longs.toByteArray(id));
+        new ReadOptions().setIterateUpperBound(new Slice(endKey)))) {
+      iter.seek(startKey);
       List<BlockLocation> locations = new ArrayList<>();
       for (; iter.isValid(); iter.next()) {
         try {

--- a/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksBlockStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksBlockStoreTest.java
@@ -1,0 +1,47 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.metastore.rocks;
+
+import static org.junit.Assert.assertEquals;
+
+import alluxio.proto.meta.Block;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.List;
+
+public class RocksBlockStoreTest {
+  @Rule
+  public TemporaryFolder mFolder = new TemporaryFolder();
+
+  @Test
+  public void blockLocations() throws Exception {
+    final int blockCount = 5;
+    final int workerIdStart = 100000;
+    RocksBlockStore blockStore = new RocksBlockStore(mFolder.newFolder().getAbsolutePath());
+    // create blocks and locations
+    for (int i = 0; i < blockCount; i++) {
+      blockStore.putBlock(i, Block.BlockMeta.newBuilder().setLength(i).build());
+      blockStore
+          .addLocation(i, Block.BlockLocation.newBuilder().setWorkerId(workerIdStart + i).build());
+    }
+
+    // validate locations
+    for (int i = 0; i < blockCount; i++) {
+      List<Block.BlockLocation> locations = blockStore.getLocations(i);
+      assertEquals(1, locations.size());
+      assertEquals(workerIdStart + i, locations.get(0).getWorkerId());
+    }
+  }
+}


### PR DESCRIPTION
`setPrefixSameAsStart` does not work when there is a composite key, and
both components need to be specified (2 longs). Therefore, use
`setIterateUpperBound` instead.

Fixes #11753

pr-link: Alluxio/alluxio#11752
change-id: cid-5c7c45fa69a5c0f0aa078d86baf229c4256d6a50