### PR TITLE
Display PropertyKeys containing keywords as credentials

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5609,8 +5609,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
    * should have a {@link DisplayType} of CREDENTIALS.
    */
   private static final String[] CUSTOM_CREDENTIAL_NAME_SUBSTR = new String[]{
-    Name.S3A_ACCESS_KEY,
-    Name.S3A_SECRET_KEY
+      "accessKeyId",
+      "secretKey"
   };
 
   /**

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5605,6 +5605,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   }
 
   /**
+   * list of substrings of a name where any custom PropertyKey with a name that contains it
+   * should have a {@link DisplayType} of CREDENTIALS.
+   */
+  private static final String[] CUSTOM_CREDENTIAL_NAME_SUBSTR = new String[]{
+    Name.S3A_ACCESS_KEY,
+    Name.S3A_SECRET_KEY
+  };
+
+  /**
    * A set of templates to generate the names of parameterized properties given
    * different parameters. E.g., * {@code Template.MASTER_TIERED_STORE_GLOBAL_LEVEL_ALIAS.format(0)}
    */
@@ -5987,7 +5996,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
    */
   public static PropertyKey getOrBuildCustom(String name) {
     return DEFAULT_KEYS_MAP.computeIfAbsent(name,
-        (key) -> new Builder(key).setIsBuiltIn(false).buildUnregistered());
+        (key) -> {
+          final Builder propertyKeyBuilder = new Builder(key).setIsBuiltIn(false);
+          for (String customCredentialName : CUSTOM_CREDENTIAL_NAME_SUBSTR) {
+            if (name.contains(customCredentialName)) {
+              propertyKeyBuilder.setDisplayType(DisplayType.CREDENTIALS);
+            }
+          }
+          return propertyKeyBuilder.buildUnregistered();
+        });
   }
 
   @Override

--- a/core/common/src/test/java/alluxio/conf/PropertyKeyTest.java
+++ b/core/common/src/test/java/alluxio/conf/PropertyKeyTest.java
@@ -301,16 +301,16 @@ public final class PropertyKeyTest {
     assertTrue(PropertyKey.isDeprecated(Template.TEST_DEPRECATED_TEMPLATE.format("removed")));
     assertTrue(PropertyKey.isRemoved(RemovedKey.Name.TEST_REMOVED_KEY));
   }
-  
+
   @Test
   public void testGetOrBuildCustom() throws Exception {
-    final PropertyKey workerHostName = PropertyKey.getOrBuildCustom(PropertyKey.Name.WORKER_HOSTNAME);
-    
+    final PropertyKey workerHostName =
+        PropertyKey.getOrBuildCustom(PropertyKey.Name.WORKER_HOSTNAME);
+
     // check reference equality
     assertTrue(PropertyKey.WORKER_HOSTNAME == workerHostName);
 
     final PropertyKey test = PropertyKey.getOrBuildCustom("test");
-    
     assertEquals(PropertyKey.DisplayType.DEFAULT, test.getDisplayType());
     assertEquals("test", test.getName());
     assertTrue(test == PropertyKey.getOrBuildCustom("test"));

--- a/core/common/src/test/java/alluxio/conf/PropertyKeyTest.java
+++ b/core/common/src/test/java/alluxio/conf/PropertyKeyTest.java
@@ -301,4 +301,21 @@ public final class PropertyKeyTest {
     assertTrue(PropertyKey.isDeprecated(Template.TEST_DEPRECATED_TEMPLATE.format("removed")));
     assertTrue(PropertyKey.isRemoved(RemovedKey.Name.TEST_REMOVED_KEY));
   }
+  
+  @Test
+  public void testGetOrBuildCustom() throws Exception {
+    final PropertyKey workerHostName = PropertyKey.getOrBuildCustom(PropertyKey.Name.WORKER_HOSTNAME);
+    
+    // check reference equality
+    assertTrue(PropertyKey.WORKER_HOSTNAME == workerHostName);
+
+    final PropertyKey test = PropertyKey.getOrBuildCustom("test");
+    
+    assertEquals(PropertyKey.DisplayType.DEFAULT, test.getDisplayType());
+    assertEquals("test", test.getName());
+    assertTrue(test == PropertyKey.getOrBuildCustom("test"));
+
+    final PropertyKey accessKey = PropertyKey.getOrBuildCustom("test.accessKeyId");
+    assertEquals(PropertyKey.DisplayType.CREDENTIALS, accessKey.getDisplayType());
+  }
 }


### PR DESCRIPTION
We occasionally create custom property keys containing strings like "accessKeyId" or "secretKey" (or other combinations) that should be treated as displayType credentials and thus not be sent back to the client. 