### PR TITLE
Add more options to collectInfo command

### DIFF
--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -839,7 +839,7 @@ public final class CommonUtils {
     File[] files = dir.listFiles();
     // File#listFiles can return null when the path is invalid
     if (files == null) {
-      return Collections.EMPTY_LIST;
+      return Collections.emptyList();
     }
     List<File> result = new ArrayList<>(files.length);
     for (File f : files) {

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -830,21 +830,21 @@ public final class CommonUtils {
   }
 
   /**
-   * Recursively lists a dir and all its subdirs and return all the files.
+   * Recursively lists a local dir and all its subdirs and return all the files.
    *
    * @param dir the directory
    * @return a list of all the files
    * */
-  public static List<File> recursiveListDir(File dir) {
+  public static List<File> recursiveListLocalDir(File dir) {
     File[] files = dir.listFiles();
     // File#listFiles can return null when the path is invalid
     if (files == null) {
-      return new ArrayList<>();
+      return Collections.EMPTY_LIST;
     }
     List<File> result = new ArrayList<>(files.length);
     for (File f : files) {
       if (f.isDirectory()) {
-        result.addAll(recursiveListDir(f));
+        result.addAll(recursiveListLocalDir(f));
         continue;
       }
       result.add(f);

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -837,6 +837,10 @@ public final class CommonUtils {
    * */
   public static List<File> recursiveListDir(File dir) {
     File[] files = dir.listFiles();
+    // File#listFiles can return null when the path is invalid
+    if (files == null) {
+      return new ArrayList<>();
+    }
     List<File> result = new ArrayList<>(files.length);
     for (File f : files) {
       if (f.isDirectory()) {

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -829,6 +829,12 @@ public final class CommonUtils {
     }
   }
 
+  /**
+   * Recursively lists a dir and all its subdirs and return all the files.
+   *
+   * @param dir the directory
+   * @return a list of all the files
+   * */
   public static List<File> recursiveListDir(File dir) {
     File[] files = dir.listFiles();
     List<File> result = new ArrayList<>(files.length);

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.Constructor;
@@ -828,16 +829,18 @@ public final class CommonUtils {
     }
   }
 
-  public static final String[] VALID_DATE_FORMATS = new String[]{
-          "yyyy-mm-dd HH:mm:ss,SSS", // "2020-03-19 11:57:58,883"
-          "yyyy-MM-dd'T'HH:mm:ss.SSSXX", // 2020-06-23T23:52:23.970+0800
-          "yyyy/MM/dd HH:mm:ss",
-          "dd MMM yyyy HH:mm:ss",
-          "MM-dd-yyyy HH:mm:ss",
-          "yyyy/MM/dd",
-          "dd MMM yyyy",
-          "MM-dd-yyyy"
-  };
+  public static List<File> recursiveListDir(File dir) {
+    File[] files = dir.listFiles();
+    List<File> result = new ArrayList<>(files.length);
+    for (File f : files) {
+      if (f.isDirectory()) {
+        result.addAll(recursiveListDir(f));
+        continue;
+      }
+      result.add(f);
+    }
+    return result;
+  }
 
   private CommonUtils() {} // prevent instantiation
 }

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -828,5 +828,16 @@ public final class CommonUtils {
     }
   }
 
+  public static final String[] VALID_DATE_FORMATS = new String[]{
+          "yyyy-mm-dd HH:mm:ss,SSS", // "2020-03-19 11:57:58,883"
+          "yyyy-MM-dd'T'HH:mm:ss.SSSXX", // 2020-06-23T23:52:23.970+0800
+          "yyyy/MM/dd HH:mm:ss",
+          "dd MMM yyyy HH:mm:ss",
+          "MM-dd-yyyy HH:mm:ss",
+          "yyyy/MM/dd",
+          "dd MMM yyyy",
+          "MM-dd-yyyy"
+  };
+
   private CommonUtils() {} // prevent instantiation
 }

--- a/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
@@ -43,7 +43,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
@@ -646,7 +645,8 @@ public class CommonUtilsTest {
     assertEquals(allFiles, new HashSet<>(listedFiles));
   }
 
-  private void createFileOrDir(File dir, int index, Random rand, Set<File> files) throws IOException {
+  private void createFileOrDir(File dir, int index, Random rand, Set<File> files)
+          throws IOException {
     int childType = rand.nextInt(2);
     File child = new File(dir, index + "");
     if (childType == 1) {

--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -80,8 +80,6 @@ public class CollectInfo extends AbstractShell {
           + "collectJvmInfo:     collects jstack from the JVMs.\n"
           + "collectLog:         collects the log files under ${ALLUXIO_HOME}/logs/.\n"
           + "collectMetrics:     collects Alluxio system metrics.\n\n"
-          + "<filename-prefixes> filename prefixes, separated by comma\n"
-          + "<datetime>          a datetime string like 2020-06-27T11:58:53\n"
           + "<outputPath>        the directory you want the collected tarball to be in\n\n"
           + "WARNING: This command MAY bundle credentials. To understand the risks refer "
           + "to the docs here.\nhttps://docs.alluxio.io/os/user/edge/en/operation/"

--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -239,6 +239,22 @@ public class CollectInfo extends AbstractShell {
     System.exit(ret);
   }
 
+  // Convert the command line back to a list of arguments
+  private List<String> cmdLineToArgs(CommandLine cmd) {
+    List<String> args = new ArrayList<>();
+    for (Option opt : cmd.getOptions()) {
+      if (opt.equals(LOCAL_OPTION) || opt.equals(THREAD_NUM_OPTION)) {
+        continue;
+      }
+      args.add("--" + opt.getLongOpt());
+      if (opt.hasArg()) {
+        args.add(opt.getValue());
+      }
+    }
+    args.addAll(cmd.getArgList());
+    return args;
+  }
+
   /**
    * Finds all nodes in the cluster.
    * Then invokes collectInfo with --local option on each of them locally.
@@ -279,7 +295,9 @@ public class CollectInfo extends AbstractShell {
 
         String[] collectInfoArgs =
                 (String[]) ArrayUtils.addAll(
-                        new String[]{alluxioBinPath, "collectInfo", "--local"}, args);
+                        new String[]{alluxioBinPath, "collectInfo", "--local"},
+                        cmdLineToArgs(cmdLine).toArray(new String[0]));
+        System.out.format("Invoking command %s%n", Arrays.toString(collectInfoArgs));
         try {
           CommandReturn cr = ShellUtils.sshExecCommandWithOutput(host, collectInfoArgs);
           return cr;

--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -21,7 +21,6 @@ import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
 import alluxio.exception.AlluxioException;
 import alluxio.shell.CommandReturn;
-import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.ShellUtils;
 import alluxio.util.io.FileUtils;
@@ -44,7 +43,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -433,7 +431,8 @@ public class CollectInfo extends AbstractShell {
     return ret;
   }
 
-  private int executeAndAddFile(String[] argv, CommandLine cmdLine, List<File> filesToCollect) throws IOException, AlluxioException {
+  private int executeAndAddFile(String[] argv, CommandLine cmdLine, List<File> filesToCollect)
+          throws IOException, AlluxioException {
     // The argv length has been validated
     String subCommand = argv[0];
     String targetDirPath = argv[1];

--- a/shell/src/main/java/alluxio/cli/bundler/command/AbstractCollectInfoCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/AbstractCollectInfoCommand.java
@@ -56,12 +56,15 @@ public abstract class AbstractCollectInfoCommand implements Command {
    * */
   public String getWorkingDirectory(CommandLine cl) {
     String[] args = cl.getArgs();
-    String baseDirPath = args[0];
+    String baseDirPath = args[1];
     String workingDirPath =  Paths.get(baseDirPath, this.getCommandName()).toString();
     LOG.debug("Command %s works in %s", this.getCommandName(), workingDirPath);
     // mkdirs checks existence of the path
     File workingDir = new File(workingDirPath);
-    workingDir.mkdirs();
+    if (!workingDir.exists()) {
+      System.out.format("Working path %s does not exist. mkdir first%n", workingDirPath);
+      workingDir.mkdirs();
+    }
     return workingDirPath;
   }
 

--- a/shell/src/main/java/alluxio/cli/bundler/command/AbstractCollectInfoCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/AbstractCollectInfoCommand.java
@@ -62,7 +62,8 @@ public abstract class AbstractCollectInfoCommand implements Command {
     // mkdirs checks existence of the path
     File workingDir = new File(workingDirPath);
     if (!workingDir.exists()) {
-      System.out.format("Working path %s does not exist. mkdir first%n", workingDirPath);
+
+      System.out.format("Creating working directory: %s%n", workingDirPath);
       workingDir.mkdirs();
     }
     return workingDirPath;

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectAlluxioInfoCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectAlluxioInfoCommand.java
@@ -60,7 +60,10 @@ public class CollectAlluxioInfoCommand extends ExecuteShellCollectInfoCommand {
   @Override
   protected void registerCommands() {
     // TODO(jiacheng): a command to find lost blocks?
+    // alluxio getConf will mask the credential fields
     registerCommand("getConf",
+            new AlluxioCommand(mAlluxioPath, "getConf"), null);
+    registerCommand("getConf master",
             new AlluxioCommand(mAlluxioPath, "getConf --master --source"), null);
     registerCommand("fsadmin",
             new AlluxioCommand(mAlluxioPath, "fsadmin report"), null);
@@ -74,6 +77,10 @@ public class CollectAlluxioInfoCommand extends ExecuteShellCollectInfoCommand {
             new AlluxioCommand(mAlluxioPath, String.format("fs ls -R %s",
                     mFsContext.getClusterConf().get(PropertyKey.MASTER_JOURNAL_FOLDER))),
             getListJournalCommand());
+    registerCommand("runTests",
+            new AlluxioCommand(mAlluxioPath, "runTests"), null);
+    registerCommand("validateConf",
+            new AlluxioCommand(mAlluxioPath, "validateConf"), null);
   }
 
   /**

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectConfigCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectConfigCommand.java
@@ -11,10 +11,12 @@
 
 package alluxio.cli.bundler.command;
 
+import alluxio.Constants;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 
+import alluxio.util.CommonUtils;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -22,6 +24,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Command to collect Alluxio config files.
@@ -29,6 +35,10 @@ import java.io.IOException;
 public class CollectConfigCommand extends AbstractCollectInfoCommand {
   public static final String COMMAND_NAME = "collectConfig";
   private static final Logger LOG = LoggerFactory.getLogger(CollectConfigCommand.class);
+
+  private static final Set<String> EXCLUDED_FILES = Stream.of(
+          Constants.SITE_PROPERTIES
+  ).collect(Collectors.toSet());
 
   /**
    * Creates a new instance of {@link CollectConfigCommand}.
@@ -52,10 +62,21 @@ public class CollectConfigCommand extends AbstractCollectInfoCommand {
   @Override
   public int run(CommandLine cl) throws AlluxioException, IOException {
     mWorkingDirPath = getWorkingDirectory(cl);
-    String confDir = mFsContext.getClusterConf().get(PropertyKey.CONF_DIR);
+    String confDirPath = mFsContext.getClusterConf().get(PropertyKey.CONF_DIR);
 
-    // TODO(jiacheng): phase 2 copy intelligently, check security risks
-    FileUtils.copyDirectory(new File(confDir), new File(mWorkingDirPath), true);
+    File confDir = new File(confDirPath);
+    List<File> allFiles = CommonUtils.recursiveListDir(confDir);
+    for (File f : allFiles) {
+      String relativePath = confDir.toURI().relativize(f.toURI()).getPath();
+      // Ignore file prefixes to exclude
+      for (String prefix : EXCLUDED_FILES) {
+        if (relativePath.startsWith(prefix)) {
+          continue;
+        }
+        File targetFile = new File(mWorkingDirPath, relativePath);
+        FileUtils.copyFile(f, targetFile, true);
+      }
+    }
 
     return 0;
   }

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectConfigCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectConfigCommand.java
@@ -65,7 +65,7 @@ public class CollectConfigCommand extends AbstractCollectInfoCommand {
     String confDirPath = mFsContext.getClusterConf().get(PropertyKey.CONF_DIR);
 
     File confDir = new File(confDirPath);
-    List<File> allFiles = CommonUtils.recursiveListDir(confDir);
+    List<File> allFiles = CommonUtils.recursiveListLocalDir(confDir);
     for (File f : allFiles) {
       String relativePath = confDir.toURI().relativize(f.toURI()).getPath();
       // Ignore file prefixes to exclude

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectConfigCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectConfigCommand.java
@@ -17,6 +17,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.util.CommonUtils;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -26,8 +27,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Command to collect Alluxio config files.
@@ -36,9 +35,8 @@ public class CollectConfigCommand extends AbstractCollectInfoCommand {
   public static final String COMMAND_NAME = "collectConfig";
   private static final Logger LOG = LoggerFactory.getLogger(CollectConfigCommand.class);
 
-  private static final Set<String> EXCLUDED_FILES = Stream.of(
-          Constants.SITE_PROPERTIES
-  ).collect(Collectors.toSet());
+  private static final Set<String> EXCLUDED_FILE_PREFIXES = ImmutableSet.of(
+          Constants.SITE_PROPERTIES);
 
   /**
    * Creates a new instance of {@link CollectConfigCommand}.
@@ -67,10 +65,11 @@ public class CollectConfigCommand extends AbstractCollectInfoCommand {
     File confDir = new File(confDirPath);
     List<File> allFiles = CommonUtils.recursiveListLocalDir(confDir);
     for (File f : allFiles) {
+      String filename = f.getName();
       String relativePath = confDir.toURI().relativize(f.toURI()).getPath();
       // Ignore file prefixes to exclude
-      for (String prefix : EXCLUDED_FILES) {
-        if (relativePath.startsWith(prefix)) {
+      for (String prefix : EXCLUDED_FILE_PREFIXES) {
+        if (filename.startsWith(prefix)) {
           continue;
         }
         File targetFile = new File(mWorkingDirPath, relativePath);

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectConfigCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectConfigCommand.java
@@ -15,8 +15,8 @@ import alluxio.Constants;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
-
 import alluxio.util.CommonUtils;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectConfigCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectConfigCommand.java
@@ -68,13 +68,11 @@ public class CollectConfigCommand extends AbstractCollectInfoCommand {
       String filename = f.getName();
       String relativePath = confDir.toURI().relativize(f.toURI()).getPath();
       // Ignore file prefixes to exclude
-      for (String prefix : EXCLUDED_FILE_PREFIXES) {
-        if (filename.startsWith(prefix)) {
-          continue;
-        }
-        File targetFile = new File(mWorkingDirPath, relativePath);
-        FileUtils.copyFile(f, targetFile, true);
+      if (EXCLUDED_FILE_PREFIXES.stream().anyMatch(filename::startsWith)) {
+        continue;
       }
+      File targetFile = new File(mWorkingDirPath, relativePath);
+      FileUtils.copyFile(f, targetFile, true);
     }
 
     return 0;

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
@@ -194,7 +194,7 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
       return -1;
     }
 
-    List<File> allFiles = CommonUtils.recursiveListDir(mLogDir);
+    List<File> allFiles = CommonUtils.recursiveListLocalDir(mLogDir);
     for (File f : allFiles) {
       String relativePath = getRelativePathToLogDir(f);
       try {

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
@@ -106,25 +106,27 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
           Option.builder().required(false).argName("filename-prefixes")
                   .longOpt(INCLUDE_OPTION_NAME).hasArg(true)
                   .desc("extra log file name prefixes to include in ${ALLUXIO_HOME}/logs. "
-                          + "The files that start with the prefix will be included.").build();
+                          + "The files that start with the prefix will be included.\n"
+                          + "<filename-prefixes> filename prefixes, separated by comma").build();
   public static final String EXCLUDE_OPTION_NAME = "exclude-logs";
   private static final Option EXCLUDE_OPTION =
           Option.builder().required(false).argName("filename-prefixes")
                   .longOpt(EXCLUDE_OPTION_NAME).hasArg(true)
                   .desc("extra log file name prefixes to exclude in ${ALLUXIO_HOME}/logs. "
-                          + "The files that start with the prefix will be excluded.").build();
+                          + "The files that start with the prefix will be excluded.\n"
+                          + "<filename-prefixes> filename prefixes, separated by comma").build();
   private static final String START_OPTION_NAME = "start-time";
   private static final Option START_OPTION =
           Option.builder().required(false).argName("datetime")
                   .longOpt(START_OPTION_NAME).hasArg(true)
-                  .desc("logs that do not contain entries after this time will be ignored")
-                  .build();
+                  .desc("logs that do not contain entries after this time will be ignored\n"
+                          + "<datetime> a datetime string like 2020-06-27T11:58:53").build();
   private static final String END_OPTION_NAME = "end-time";
   private static final Option END_OPTION =
           Option.builder().required(false).argName("datetime")
                   .longOpt(END_OPTION_NAME).hasArg(true)
-                  .desc("logs that do not contain entries before this time will be ignored")
-                  .build();
+                  .desc("logs that do not contain entries before this time will be ignored\n"
+                          + "<datetime> a datetime string like 2020-06-27T11:58:53").build();
   // Class specific options are aggregated into CollectInfo with reflection
   public static final Options OPTIONS = new Options().addOption(INCLUDE_OPTION)
           .addOption(EXCLUDE_OPTION).addOption(START_OPTION).addOption(END_OPTION);

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
@@ -11,17 +11,42 @@
 
 package alluxio.cli.bundler.command;
 
+import alluxio.cli.bundler.CollectInfo;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 
+import alluxio.util.CommonUtils;
+import jline.internal.Nullable;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.time.DateUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URI;
+import java.text.ParseException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Command to collect Alluxio logs.
@@ -29,6 +54,52 @@ import java.io.IOException;
 public class CollectLogCommand  extends AbstractCollectInfoCommand {
   public static final String COMMAND_NAME = "collectLog";
   private static final Logger LOG = LoggerFactory.getLogger(CollectLogCommand.class);
+  public static final Set<String> FILE_NAMES = Stream.of(
+          "master.log",
+          "master.out",
+          "job_master.log",
+          "job_master.out",
+          "master_audit.log",
+          "worker.log",
+          "worker.out",
+          "job_worker.log",
+          "job_worker.out",
+          "proxy.log",
+          "proxy.out",
+          "task.log",
+          "task.out",
+          "user"
+  ).collect(Collectors.toSet());
+
+  private String mLogDirPath;
+  private File mLogDir;
+  private URI mLogDirUri;
+  private Set<String> mIncludedPrefix;
+  private Set<String> mExcludedPrefix;
+  private LocalDateTime mStartTime;
+  private LocalDateTime mEndTime;
+
+  // TODO(jiacheng): load these with reflection?
+  // CollectLogCommand
+  public static final String INCLUDE_OPTION_NAME = "include-logs";
+  private static final Option INCLUDE_OPTION =
+          Option.builder().required(false).argName("i").longOpt(INCLUDE_OPTION_NAME).hasArg(true)
+                  .desc("extra log file names to include in ${ALLUXIO_HOME}/logs").build();
+  public static final String EXCLUDE_OPTION_NAME = "exclude-logs";
+  private static final Option EXCLUDE_OPTION =
+          Option.builder().required(false).argName("x").longOpt(EXCLUDE_OPTION_NAME).hasArg(true)
+                  .desc("extra log file names to exclude in ${ALLUXIO_HOME}/logs").build();
+  public static final String START_OPTION_NAME = "start-time";
+  private static final Option START_OPTION =
+          Option.builder().required(false).argName("s").longOpt(START_OPTION_NAME).hasArg(true)
+                  .desc("").build();
+  public static final String END_OPTION_NAME = "end-time";
+  private static final Option END_OPTION =
+          Option.builder().required(false).argName("e").longOpt(END_OPTION_NAME).hasArg(true)
+                  .desc("").build();
+  private static final Options OPTIONS =
+          new Options().addOption(EXCLUDE_OPTION).addOption(INCLUDE_OPTION)
+                  .addOption(START_OPTION).addOption(END_OPTION);
 
   /**
    * Creates a new instance of {@link CollectLogCommand}.
@@ -37,6 +108,10 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
    * */
   public CollectLogCommand(FileSystemContext fsContext) {
     super(fsContext);
+    mLogDirPath = fsContext.getClusterConf().get(PropertyKey.LOGS_DIR);
+    System.out.println("Log dir path: " + mLogDirPath);
+    mLogDir = new File(mLogDirPath);
+    mLogDirUri = mLogDir.toURI();
   }
 
   @Override
@@ -53,13 +128,158 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
   public int run(CommandLine cl) throws AlluxioException, IOException {
     // Determine the working dir path
     mWorkingDirPath = getWorkingDirectory(cl);
-    String logDir = mFsContext.getClusterConf().get(PropertyKey.LOGS_DIR);
 
     // TODO(jiacheng): phase 2 Copy intelligently find security risks
     // TODO(jiacheng): phase 2 components option
-    FileUtils.copyDirectory(new File(logDir), new File(mWorkingDirPath), true);
+    mIncludedPrefix = new HashSet<>(FILE_NAMES);
+    // Define whitelist and blacklist
+    if (cl.hasOption(CollectInfo.INCLUDE_OPTION_NAME)) {
+      Set<String> toInclude = parseFileNames(cl.getOptionValue(CollectInfo.INCLUDE_OPTION_NAME));
+      System.out.println("Include the following filename prefixes: " + toInclude);
+      mIncludedPrefix.addAll(toInclude);
+    }
+    if (cl.hasOption(CollectInfo.EXCLUDE_OPTION_NAME)) {
+      mExcludedPrefix = parseFileNames(cl.getOptionValue(CollectInfo.EXCLUDE_OPTION_NAME));
+      System.out.println("Exclude the following filename prefixes: " + mExcludedPrefix);
+    }
+    System.out.println("Target file names: " + mIncludedPrefix);
+
+    // Check file timestamps
+    boolean checkTimeStamp = false;
+    if (cl.hasOption(CollectInfo.START_OPTION_NAME)) {
+      String startTimeStr = cl.getOptionValue(CollectInfo.START_OPTION_NAME);
+      mStartTime = parseDateTime(startTimeStr);
+      checkTimeStamp = true;
+    }
+    if (cl.hasOption(CollectInfo.END_OPTION_NAME)) {
+      String endTimeStr = cl.getOptionValue(CollectInfo.END_OPTION_NAME);
+      mEndTime = parseDateTime(endTimeStr);
+      checkTimeStamp = true;
+    }
+
+    // TODO(jiacheng): need an identical function
+//    FileUtils.copyDirectory(new File(logDir), new File(mWorkingDirPath), true);
+    if (!mLogDir.exists()) {
+      // TODO(jiacheng): Log?
+      return -1;
+    }
+
+    copyDir(mLogDir, checkTimeStamp);
 
     return 0;
+  }
+
+  private void copyDir(File sourceDir, boolean checkTimeStamp) throws IOException {
+    File[] files = sourceDir.listFiles();
+    for (File f : files) {
+      System.out.println("File " + f.getCanonicalPath());
+      if (f.isDirectory()) {
+        System.out.println("File " + f.getCanonicalPath() + " is a directory");
+        copyDir(f, checkTimeStamp);
+        continue;
+      }
+
+      // Copy file
+      String relativePath = getRelativePathToLogDir(f);
+      System.out.println("Relative path against log dir: " + relativePath);
+      if (!shouldCopy(f, relativePath, checkTimeStamp)) {
+        continue;
+      }
+      File targetFile = new File(mWorkingDirPath, relativePath);
+      FileUtils.copyFile(f, targetFile, true);
+    }
+  }
+
+  private String getRelativePathToLogDir(File f) {
+    return mLogDirUri.relativize(f.toURI()).getPath();
+  }
+
+  private boolean shouldCopy(File f, String relativePath, boolean checkTimeStamp) {
+    if (!fileNameIsWanted(relativePath)) {
+      System.out.format("File %s is not wanted.%n", relativePath);
+      return false;
+    }
+    if (checkTimeStamp) {
+      System.out.println("Filter file by timestamp");
+      if (!fileTimeStampIsWanted(f)) {
+        System.out.println("File timestamp is out of range.");
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean fileNameIsWanted(String fileName) {
+    if (mExcludedPrefix != null) {
+      for (String x : mExcludedPrefix) {
+        if (fileName.startsWith(x)) {
+          return false;
+        }
+      }
+    }
+    for (String s : mIncludedPrefix) {
+      if (fileName.startsWith(s)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean fileTimeStampIsWanted(File f) {
+    long timestamp = f.lastModified();
+    LocalDateTime fileEndTime =
+            LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.systemDefault());
+    System.out.println("File last modified time is " + fileEndTime);
+
+    LocalDateTime fileStartTime = inferFileStartTime(f);
+    if (fileStartTime == null) {
+      fileStartTime = LocalDateTime.MIN;
+    }
+    System.out.format("File has start time %s and end time %s%n", fileStartTime, fileEndTime);
+
+    // The file is earlier than the desired interval
+    if (mStartTime != null && mStartTime.isAfter(fileEndTime)) {
+      System.out.format("Wanted interval starts at %s, later than file last modified time %s%n", mStartTime, fileEndTime);
+      return false;
+    }
+    // The file is later than the desired interval
+    if (mEndTime != null && mEndTime.isBefore(fileStartTime)) {
+      System.out.format("Wanted interval ends at %s, earlier than file first entry time %s%n", mEndTime, fileStartTime);
+      return false;
+    }
+    return true;
+  }
+
+  public static LocalDateTime inferFileStartTime(File f) {
+    int r = 0;
+    try (Scanner scanner = new Scanner(f)){
+      while (scanner.hasNextLine() && r < 30) {
+        String line = scanner.nextLine();
+        LocalDateTime datetime = parseDateTime(line);
+        if (datetime != null) {
+          System.out.format("Identified datetime %s on line %s%n", datetime, r);
+          return datetime;
+        }
+        r++;
+      }
+    } catch (FileNotFoundException e) {
+      // TODO(jiacheng)
+      e.printStackTrace();
+    }
+    System.out.format("Datetime not found after %d rows.%n", r);
+    return null;
+  }
+
+  private String getLoggers() {
+    org.apache.log4j.Logger rootLogger = org.apache.log4j.Logger.getRootLogger();
+    rootLogger.getAllAppenders();
+    return "";
+  }
+
+  private Set<String> parseFileNames(String input) {
+    Set<String> names = new HashSet<>();
+    names.addAll(Stream.of(input.split(",")).map(String::trim).collect(Collectors.toList()));
+    return names;
   }
 
   @Override
@@ -70,5 +290,40 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
   @Override
   public String getDescription() {
     return "Collect Alluxio log files";
+  }
+
+
+  public static String[] formats = new String[]{
+          "yyyy-MM-dd HH:mm:ss,SSS", // "2020-05-15 09:21:52,359"
+          "yy/MM/dd HH:mm:ss", // "20/05/18 16:11:18"
+          "yyyy-MM-dd'T'HH:mm:ss.SSSXX", // "2020-05-16T00:00:01.084+0800"
+          "yyyy-MM-dd HH:mm:ss", // "2020-06-27 11:58:53"
+          "yyyy-MM-dd HH:mm",
+          "yyyy-MM-dd",
+  };
+
+  @Nullable
+  public static LocalDateTime parseDateTime(String s) {
+    for (String f : formats) {
+      DateTimeFormatter fmt = DateTimeFormatter.ofPattern(f);
+      try {
+        int len = f.length();
+        if (f.endsWith("XX")) {
+          len += 1; // "XX" in the format parses to timezone offset like "+0800"
+          System.out.format("Format %s has len %s%n", f, len);
+        }
+        if (s.length() < len) {
+          continue;
+        }
+        String datePart = s.substring(0, len);
+        LocalDateTime datetime = LocalDateTime.parse(datePart, fmt);
+        return datetime;
+      } catch (DateTimeParseException e) {
+        continue;
+      }
+    }
+    // Unknown format here
+    LOG.debug("Unknown date format in {}", s.length() > 50 ? s.substring(0, 50) : s);
+    return null;
   }
 }

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
@@ -33,7 +33,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Scanner;
@@ -95,8 +94,8 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
                           + "The files that start with the prefix will be included.").build();
   public static final String EXCLUDE_OPTION_NAME = "exclude-logs";
   private static final Option EXCLUDE_OPTION =
-          Option.builder().required(false).argName("filename-prefixes").
-                  longOpt(EXCLUDE_OPTION_NAME).hasArg(true)
+          Option.builder().required(false).argName("filename-prefixes")
+                  .longOpt(EXCLUDE_OPTION_NAME).hasArg(true)
                   .desc("extra log file name prefixes to exclude in ${ALLUXIO_HOME}/logs. "
                           + "The files that start with the prefix will be excluded.").build();
   private static final String START_OPTION_NAME = "start-time";

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
@@ -139,9 +139,8 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
     System.out.format("Found options in CollectLogCommand: %s%n", Arrays.toString(cl.getOptions()));
 
     // TODO(jiacheng): phase 2 Copy intelligently find security risks
-    // TODO(jiacheng): phase 2 components option
     mIncludedPrefix = new HashSet<>(FILE_NAMES);
-    // Define whitelist and blacklist
+    // Define include list and exclude list
     if (cl.hasOption(INCLUDE_OPTION_NAME)) {
       Set<String> toInclude = parseFileNames(cl.getOptionValue(INCLUDE_OPTION_NAME));
       System.out.println("Include the following filename prefixes: " + toInclude);

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
@@ -33,7 +33,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -72,19 +71,27 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
   private static final int TRY_PARSE_LOG_ROWS = 30;
 
   // Preserves the order of iteration, we try the longer pattern before the shorter one
-  private static final Map<String, Integer> FORMAT_TO_LEN = new LinkedHashMap<String, Integer>(){
+  private static final Map<DateTimeFormatter, Integer> FORMATTERS =
+          new LinkedHashMap<DateTimeFormatter, Integer>(){
     {
-      put("yyyy-MM-dd HH:mm:ss,SSS", 23);
-      put("yyyy-MM-dd HH:mm:ss", 19);
-      put("yyyy-MM-dd HH:mm", 16);
-      put("yy/MM/dd HH:mm:ss", 17);
-      put("yy/MM/dd HH:mm", 14);
-      put("yyyy-MM-dd'T'HH:mm:ss.SSSXX", 28);
-      put("yyyy-MM-dd'T'HH:mm:ss", 19);
-      put("yyyy-MM-dd'T'HH:mm", 16);
+      // "2020-01-03 12:10:11,874"
+      put(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS"), 23);
+      // "2020-01-03 12:10:11"
+      put(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"), 19);
+      // "2020-01-03 12:10"
+      put(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"), 16);
+      // "20/01/03 12:10:11"
+      put(DateTimeFormatter.ofPattern("yy/MM/dd HH:mm:ss"), 17);
+      // "20/01/03 12:10"
+      put(DateTimeFormatter.ofPattern("yy/MM/dd HH:mm"), 14);
+      // 2020-01-03T12:10:11.874+0800
+      put(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXX"), 28);
+      // 2020-01-03T12:10:11
+      put(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"), 19);
+      // 2020-01-03T12:10
+      put(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"), 16);
     }
   };
-  private static final Map<String, DateTimeFormatter> STRING_TO_FORMATTER = initFormatters();
 
   private String mLogDirPath;
   private File mLogDir;
@@ -121,14 +128,6 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
   // Class specific options are aggregated into CollectInfo with reflection
   public static final Options OPTIONS = new Options().addOption(INCLUDE_OPTION)
           .addOption(EXCLUDE_OPTION).addOption(START_OPTION).addOption(END_OPTION);
-
-  private static Map<String, DateTimeFormatter> initFormatters() {
-    Map<String, DateTimeFormatter> strToFormatters = new HashMap<>();
-    for (String s : FORMAT_TO_LEN.keySet()) {
-      strToFormatters.put(s, DateTimeFormatter.ofPattern(s));
-    }
-    return strToFormatters;
-  }
 
   /**
    * Creates a new instance of {@link CollectLogCommand}.
@@ -254,18 +253,13 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
     if (fileStartTime == null) {
       fileStartTime = LocalDateTime.MIN;
     }
-    System.out.format("File %s [%s, %s]%n", f.getCanonicalPath(), fileStartTime, fileEndTime);
 
     // The file is earlier than the desired interval
     if (mStartTime != null && mStartTime.isAfter(fileEndTime)) {
-      System.out.format("File %s [%s, %s] is complete before start time %s%n",
-              f.getCanonicalPath(), fileStartTime, fileEndTime, mStartTime);
       return false;
     }
     // The file is later than the desired interval
     if (mEndTime != null && mEndTime.isBefore(fileStartTime)) {
-      System.out.format("File %s [%s, %s] is created after end time %s%n",
-              f.getCanonicalPath(), fileStartTime, fileEndTime, mEndTime);
       return false;
     }
     return true;
@@ -318,10 +312,9 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
    * */
   @Nullable
   public static LocalDateTime parseDateTime(String s) {
-    for (Map.Entry<String, Integer> entry : FORMAT_TO_LEN.entrySet()) {
-      String f = entry.getKey();
+    for (Map.Entry<DateTimeFormatter, Integer> entry : FORMATTERS.entrySet()) {
+      DateTimeFormatter fmt = entry.getKey();
       int len = entry.getValue();
-      DateTimeFormatter fmt = STRING_TO_FORMATTER.get(f);
       try {
         if (s.length() < len) {
           continue;

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
@@ -68,14 +68,14 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
   // The timestamped log entries start after this general information block.
   private static final int TRY_PARSE_LOG_ROWS = 30;
 
-  public static final String[] TIME_FORMATS = new String[]{
-      "yyyy-MM-dd HH:mm:ss,SSS", // "2020-06-27 11:58:53,084"
-      "yy/MM/dd HH:mm:ss", // "20/06/27 11:58:53"
-      "yyyy-MM-dd'T'HH:mm:ss.SSSXX", // 2020-06-27T11:58:53.084+0800
-      "yyyy-MM-dd'T'HH:mm:ss", // 2020-06-27T11:58:53.084
-      "yyyy-MM-dd HH:mm:ss", // "2020-06-27 11:58:53"
-      "yyyy-MM-dd HH:mm", // "2020-06-27 11:58"
-      "yyyy-MM-dd" // // "2020-06-27"
+  static final String[] TIME_FORMATS = new String[]{
+      "yyyy-MM-dd HH:mm:ss,SSS",        // "2020-06-27 11:58:53,084"
+      "yy/MM/dd HH:mm:ss",              // "20/06/27 11:58:53"
+      "yyyy-MM-dd'T'HH:mm:ss.SSSXX",    // 2020-06-27T11:58:53.084+0800
+      "yyyy-MM-dd'T'HH:mm:ss",          // 2020-06-27T11:58:53.084
+      "yyyy-MM-dd HH:mm:ss",            // "2020-06-27 11:58:53"
+      "yyyy-MM-dd HH:mm",               // "2020-06-27 11:58"
+      "yyyy-MM-dd"                      // "2020-06-27"
   };
 
   private String mLogDirPath;
@@ -181,7 +181,7 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
         }
         File targetFile = new File(mWorkingDirPath, relativePath);
         FileUtils.copyFile(f, targetFile, true);
-      } catch (FileNotFoundException e) {
+      } catch (IOException e) {
         System.err.format("ERROR: file %s not found %s%n", f.getCanonicalPath(), e.getMessage());
       }
     }
@@ -194,7 +194,7 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
   }
 
   private boolean shouldCopy(File f, String relativePath, boolean checkTimeStamp)
-          throws FileNotFoundException {
+          throws IOException {
     if (!fileNameIsWanted(relativePath)) {
       return false;
     }
@@ -222,7 +222,7 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
     return false;
   }
 
-  private boolean fileTimeStampIsWanted(File f) throws FileNotFoundException {
+  private boolean fileTimeStampIsWanted(File f) throws IOException {
     long timestamp = f.lastModified();
     LocalDateTime fileEndTime =
             LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.systemDefault());
@@ -235,10 +235,14 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
 
     // The file is earlier than the desired interval
     if (mStartTime != null && mStartTime.isAfter(fileEndTime)) {
+      System.out.format("File %s [%s, %s] is complete before start time %s%n",
+              f.getCanonicalPath(), fileStartTime, fileEndTime, mStartTime);
       return false;
     }
     // The file is later than the desired interval
     if (mEndTime != null && mEndTime.isBefore(fileStartTime)) {
+      System.out.format("File %s [%s, %s] is created after end time %s%n",
+              f.getCanonicalPath(), fileStartTime, fileEndTime, mEndTime);
       return false;
     }
     return true;

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
@@ -69,9 +69,11 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
           "yyyy-MM-dd HH:mm:ss,SSS", // "2020-05-15 09:21:52,359"
           "yy/MM/dd HH:mm:ss", // "20/05/18 16:11:18"
           "yyyy-MM-dd'T'HH:mm:ss.SSSXX", // "2020-05-16T00:00:01.084+0800"
+          "yyyy-MM-dd'T'HH:mm:ss", // "2020-05-16T00:00:01.084
           "yyyy-MM-dd HH:mm:ss", // "2020-06-27 11:58:53"
           "yyyy-MM-dd HH:mm",
           "yyyy-MM-dd",
+          "MMM dd, yyyyy hh:mm:ss a" // "Jul 07, 2020 6:42:43 PM"
   };
 
   private String mLogDirPath;
@@ -280,16 +282,20 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
   @Nullable
   public static LocalDateTime parseDateTime(String s) {
     for (String f : TIME_FORMATS) {
+      System.out.format("Format %s%n", f);
       DateTimeFormatter fmt = DateTimeFormatter.ofPattern(f);
       try {
         int len = f.length();
         if (f.endsWith("XX")) {
-          len += 1; // "XX" in the format parses to timezone offset like "+0800"
-          System.out.format("Format %s has len %s%n", f, len);
+          len += 3; // "XX" in the format parses to timezone offset like "+0800"
+        }
+        if (f.contains("'T'")) {
+          len -= 2; // the extra two single quotes are not in the datetime string
         }
         if (s.length() < len) {
           continue;
         }
+
         String datePart = s.substring(0, len);
         LocalDateTime datetime = LocalDateTime.parse(datePart, fmt);
         return datetime;

--- a/shell/src/test/java/alluxio/cli/bundler/CollectInfoTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/CollectInfoTest.java
@@ -14,27 +14,15 @@ package alluxio.cli.bundler;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.cli.bundler.command.AbstractCollectInfoCommand;
-import alluxio.cli.bundler.command.CollectLogCommand;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.cli.Command;
-import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 
-import org.apache.commons.lang.time.DateUtils;
-import org.apache.log4j.Appender;
 import org.junit.Test;
 import org.reflections.Reflections;
 
 import java.lang.reflect.Modifier;
-import java.text.SimpleDateFormat;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collection;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.Locale;
 
 public class CollectInfoTest {
   private static InstancedConfiguration sConf =
@@ -57,71 +45,5 @@ public class CollectInfoTest {
     CollectInfo ic = new CollectInfo(sConf);
     Collection<Command> commands = ic.getCommands();
     assertEquals(getNumberOfCommands(), commands.size());
-  }
-
-  @Test
-  public void loggers() {
-    org.apache.log4j.Logger rootLogger = org.apache.log4j.Logger.getRootLogger();
-    Enumeration e = rootLogger.getAllAppenders();
-    while (e.hasMoreElements()) {
-      Appender app = (Appender) e.nextElement();
-      System.out.println(app.getName());
-      System.out.println(app);
-    }
-    System.out.println(rootLogger.getAppender("JOB_MASTER_LOGGER"));
-
-  }
-
-  @Test
-  public void getDateTime() throws Exception {
-    int len = "2020-03-19 11:57:58,883".length();
-    String content = "2020-03-19 11:57:58,883 INFO  NettyUtils - EPOLL is not available, will use NIO\n" +
-            "2020-03-19 11:57:58,963 INFO  ExtensionFactoryRegistry - Loading core jars from /Users/jiachengliu/Documents/Alluxio/alluxio-jiacheng/alluxio/lib\n" +
-            "2020-03-19 11:57:58,997 INFO  TieredIdentityFactory - Initialized tiered identity TieredIdentity(node=localhost, rack=null)\n";
-    DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS");
-    LocalDate dateTime = LocalDate.parse(content.substring(0, len), dtf);
-    System.out.println(dateTime);
-
-
-    SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS", Locale.ENGLISH);
-
-    Date date = formatter.parse(content.substring(0, len));
-    System.out.println(date);
-  }
-
-  @Test
-  public void parseGCLog() throws Exception {
-    int len = "2020-06-23T23:52:23.970+0800".length();
-    String content = "2020-05-16T00:00:01.084+0800\tINFO\tdispatcher-query-7960\tcom.bluetalon.presto.btclient.BtTcpClientPoolFactory\tAttempting to connect to PDP";
-//    Instant i = Instant.parse(content);
-//    Date d = Date.from(i);
-//    System.out.println(d);
-//    DateTimeFormatter dtf = DateTimeFormatter.ISO_DATE_TIME;
-    DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXX");
-    LocalDateTime datetime = LocalDateTime.parse(content.substring(0, len), dtf);
-    System.out.println(datetime);
-//    SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-ddTHH:mm:ssXX", Locale.ENGLISH);
-
-//    Date date = formatter.parse(content.substring(0, len));
-//    System.out.println(d.format(dtf));
-  }
-
-  @Test
-  public void parseDate() {
-    String[] contents = new String[]{
-            "2020-05-15 09:21:52,359 INFO BlockStateChange: BLOCK* addStoredBlock: blockMap updated: 10.70.22.120:1025 is added to blk_1126110055_52485351{blockUCState=UNDER_CONSTRUCTION, primaryNodeIndex=-1, replicas=[ReplicaUnderConstruction[[DISK]DS-f2c7ade9-525a-4364-84c1-1d62bd3bf2b2:NORMAL:10.70.22.120:1025|FINALIZED]]} size 0",
-            "20/05/18 16:11:18 INFO util.SignalUtils: Registered signal handler for TERM",
-            "2020-05-16T00:00:01.084+0800\tINFO\tdispatcher-query-7960\tcom.bluetalon.presto.btclient.BtTcpClientPoolFactory\tAttempting to connect to PDP",
-            "2020-05-14 21:05:53,822 WARN org.apache.zookeeper.server.NIOServerCnxn: caught end of stream exception",
-            "2020-06-27 11:58:53 INFO  SignalUtils:57 - Registered signal handler for INT",
-            "2020-06-23T23:52:23.970+0800: 1.652: [CMS-concurrent-mark-start]",
-            "2020-03-19 11:57:58,997 INFO  TieredIdentityFactory - Initialized tiered identity TieredIdentity(node=localhost, rack=null)\n"
-    };
-
-    for (int i = 0; i < contents.length; i++) {
-      String s = contents[i];
-      LocalDateTime datetime = CollectLogCommand.parseDateTime(s);
-      System.out.println(datetime);
-    }
   }
 }

--- a/shell/src/test/java/alluxio/cli/bundler/CollectInfoTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/CollectInfoTest.java
@@ -14,15 +14,27 @@ package alluxio.cli.bundler;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.cli.bundler.command.AbstractCollectInfoCommand;
+import alluxio.cli.bundler.command.CollectLogCommand;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.cli.Command;
+import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 
+import org.apache.commons.lang.time.DateUtils;
+import org.apache.log4j.Appender;
 import org.junit.Test;
 import org.reflections.Reflections;
 
 import java.lang.reflect.Modifier;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.Locale;
 
 public class CollectInfoTest {
   private static InstancedConfiguration sConf =
@@ -45,5 +57,71 @@ public class CollectInfoTest {
     CollectInfo ic = new CollectInfo(sConf);
     Collection<Command> commands = ic.getCommands();
     assertEquals(getNumberOfCommands(), commands.size());
+  }
+
+  @Test
+  public void loggers() {
+    org.apache.log4j.Logger rootLogger = org.apache.log4j.Logger.getRootLogger();
+    Enumeration e = rootLogger.getAllAppenders();
+    while (e.hasMoreElements()) {
+      Appender app = (Appender) e.nextElement();
+      System.out.println(app.getName());
+      System.out.println(app);
+    }
+    System.out.println(rootLogger.getAppender("JOB_MASTER_LOGGER"));
+
+  }
+
+  @Test
+  public void getDateTime() throws Exception {
+    int len = "2020-03-19 11:57:58,883".length();
+    String content = "2020-03-19 11:57:58,883 INFO  NettyUtils - EPOLL is not available, will use NIO\n" +
+            "2020-03-19 11:57:58,963 INFO  ExtensionFactoryRegistry - Loading core jars from /Users/jiachengliu/Documents/Alluxio/alluxio-jiacheng/alluxio/lib\n" +
+            "2020-03-19 11:57:58,997 INFO  TieredIdentityFactory - Initialized tiered identity TieredIdentity(node=localhost, rack=null)\n";
+    DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS");
+    LocalDate dateTime = LocalDate.parse(content.substring(0, len), dtf);
+    System.out.println(dateTime);
+
+
+    SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS", Locale.ENGLISH);
+
+    Date date = formatter.parse(content.substring(0, len));
+    System.out.println(date);
+  }
+
+  @Test
+  public void parseGCLog() throws Exception {
+    int len = "2020-06-23T23:52:23.970+0800".length();
+    String content = "2020-05-16T00:00:01.084+0800\tINFO\tdispatcher-query-7960\tcom.bluetalon.presto.btclient.BtTcpClientPoolFactory\tAttempting to connect to PDP";
+//    Instant i = Instant.parse(content);
+//    Date d = Date.from(i);
+//    System.out.println(d);
+//    DateTimeFormatter dtf = DateTimeFormatter.ISO_DATE_TIME;
+    DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXX");
+    LocalDateTime datetime = LocalDateTime.parse(content.substring(0, len), dtf);
+    System.out.println(datetime);
+//    SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-ddTHH:mm:ssXX", Locale.ENGLISH);
+
+//    Date date = formatter.parse(content.substring(0, len));
+//    System.out.println(d.format(dtf));
+  }
+
+  @Test
+  public void parseDate() {
+    String[] contents = new String[]{
+            "2020-05-15 09:21:52,359 INFO BlockStateChange: BLOCK* addStoredBlock: blockMap updated: 10.70.22.120:1025 is added to blk_1126110055_52485351{blockUCState=UNDER_CONSTRUCTION, primaryNodeIndex=-1, replicas=[ReplicaUnderConstruction[[DISK]DS-f2c7ade9-525a-4364-84c1-1d62bd3bf2b2:NORMAL:10.70.22.120:1025|FINALIZED]]} size 0",
+            "20/05/18 16:11:18 INFO util.SignalUtils: Registered signal handler for TERM",
+            "2020-05-16T00:00:01.084+0800\tINFO\tdispatcher-query-7960\tcom.bluetalon.presto.btclient.BtTcpClientPoolFactory\tAttempting to connect to PDP",
+            "2020-05-14 21:05:53,822 WARN org.apache.zookeeper.server.NIOServerCnxn: caught end of stream exception",
+            "2020-06-27 11:58:53 INFO  SignalUtils:57 - Registered signal handler for INT",
+            "2020-06-23T23:52:23.970+0800: 1.652: [CMS-concurrent-mark-start]",
+            "2020-03-19 11:57:58,997 INFO  TieredIdentityFactory - Initialized tiered identity TieredIdentity(node=localhost, rack=null)\n"
+    };
+
+    for (int i = 0; i < contents.length; i++) {
+      String s = contents[i];
+      LocalDateTime datetime = CollectLogCommand.parseDateTime(s);
+      System.out.println(datetime);
+    }
   }
 }

--- a/shell/src/test/java/alluxio/cli/bundler/InfoCollectorTestUtils.java
+++ b/shell/src/test/java/alluxio/cli/bundler/InfoCollectorTestUtils.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Paths;
 
@@ -37,9 +38,23 @@ public class InfoCollectorTestUtils {
   }
 
   public static File createFileInDir(File dir, String fileName) throws IOException {
-    File newFile = new File(Paths.get(dir.getAbsolutePath(), fileName).toString());
+    File newFile = new File(Paths.get(dir.getCanonicalPath(), fileName).toUri());
     newFile.createNewFile();
     return newFile;
+  }
+
+  public static File createFileInDir(File dir, String fileName, String content) throws IOException {
+    File newFile = new File(Paths.get(dir.getCanonicalPath(), fileName).toUri());
+    newFile.createNewFile();
+    FileWriter writer = new FileWriter(newFile);
+    writer.write(content);
+    return newFile;
+  }
+
+  public static File createDirInDir(File dir, String dirName) throws IOException {
+    File newDir = new File(Paths.get(dir.getCanonicalPath(), dirName).toUri());
+    newDir.mkdir();
+    return newDir;
   }
 
   public static void create() {

--- a/shell/src/test/java/alluxio/cli/bundler/InfoCollectorTestUtils.java
+++ b/shell/src/test/java/alluxio/cli/bundler/InfoCollectorTestUtils.java
@@ -11,21 +11,21 @@
 
 package alluxio.cli.bundler;
 
+import static org.junit.Assert.assertEquals;
+
 import alluxio.util.CommonUtils;
+
 import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
 
 public class InfoCollectorTestUtils {
   private static final Logger LOG = LoggerFactory.getLogger(InfoCollectorTestUtils.class);
@@ -66,7 +66,8 @@ public class InfoCollectorTestUtils {
 
   public static Set<String> getAllFileNamesRelative(File dir, File baseDir) throws IOException {
     if (!dir.isDirectory()) {
-      throw new IOException(String.format("Expected a directory but found a file at %s%n", dir.getCanonicalPath()));
+      throw new IOException(String.format("Expected a directory but found a file at %s%n",
+              dir.getCanonicalPath()));
     }
     Set<String> fileSet = new HashSet<>();
     List<File> allFiles = CommonUtils.recursiveListDir(dir);

--- a/shell/src/test/java/alluxio/cli/bundler/InfoCollectorTestUtils.java
+++ b/shell/src/test/java/alluxio/cli/bundler/InfoCollectorTestUtils.java
@@ -11,6 +11,7 @@
 
 package alluxio.cli.bundler;
 
+import alluxio.util.CommonUtils;
 import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -20,6 +21,11 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
 
 public class InfoCollectorTestUtils {
   private static final Logger LOG = LoggerFactory.getLogger(InfoCollectorTestUtils.class);
@@ -43,14 +49,6 @@ public class InfoCollectorTestUtils {
     return newFile;
   }
 
-  public static File createFileInDir(File dir, String fileName, String content) throws IOException {
-    File newFile = new File(Paths.get(dir.getCanonicalPath(), fileName).toUri());
-    newFile.createNewFile();
-    FileWriter writer = new FileWriter(newFile);
-    writer.write(content);
-    return newFile;
-  }
-
   public static File createDirInDir(File dir, String dirName) throws IOException {
     File newDir = new File(Paths.get(dir.getCanonicalPath(), dirName).toUri());
     newDir.mkdir();
@@ -59,5 +57,23 @@ public class InfoCollectorTestUtils {
 
   public static void create() {
     Files.createTempDir();
+  }
+
+  public static void verifyAllFiles(File targetDir, Set<String> expectedFiles) throws IOException {
+    Set<String> copiedFiles = getAllFileNamesRelative(targetDir, targetDir);
+    assertEquals(expectedFiles, copiedFiles);
+  }
+
+  public static Set<String> getAllFileNamesRelative(File dir, File baseDir) throws IOException {
+    if (!dir.isDirectory()) {
+      throw new IOException(String.format("Expected a directory but found a file at %s%n", dir.getCanonicalPath()));
+    }
+    Set<String> fileSet = new HashSet<>();
+    List<File> allFiles = CommonUtils.recursiveListDir(dir);
+    for (File f : allFiles) {
+      String relativePath = baseDir.toURI().relativize(f.toURI()).toString();
+      fileSet.add(relativePath);
+    }
+    return fileSet;
   }
 }

--- a/shell/src/test/java/alluxio/cli/bundler/InfoCollectorTestUtils.java
+++ b/shell/src/test/java/alluxio/cli/bundler/InfoCollectorTestUtils.java
@@ -55,10 +55,6 @@ public class InfoCollectorTestUtils {
     return newDir;
   }
 
-  public static void create() {
-    Files.createTempDir();
-  }
-
   public static void verifyAllFiles(File targetDir, Set<String> expectedFiles) throws IOException {
     Set<String> copiedFiles = getAllFileNamesRelative(targetDir, targetDir);
     assertEquals(expectedFiles, copiedFiles);
@@ -70,7 +66,7 @@ public class InfoCollectorTestUtils {
               dir.getCanonicalPath()));
     }
     Set<String> fileSet = new HashSet<>();
-    List<File> allFiles = CommonUtils.recursiveListDir(dir);
+    List<File> allFiles = CommonUtils.recursiveListLocalDir(dir);
     for (File f : allFiles) {
       String relativePath = baseDir.toURI().relativize(f.toURI()).toString();
       fileSet.add(relativePath);

--- a/shell/src/test/java/alluxio/cli/bundler/command/CollectAlluxioInfoCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/command/CollectAlluxioInfoCommandTest.java
@@ -52,7 +52,7 @@ public class CollectAlluxioInfoCommandTest {
     // Write to temp dir
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
-    String[] mockArgs = new String[]{targetDir.getAbsolutePath()};
+    String[] mockArgs = new String[]{cmd.getCommandName(), targetDir.getAbsolutePath()};
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
 
     // Replace commands to execute
@@ -91,7 +91,7 @@ public class CollectAlluxioInfoCommandTest {
     // Write to temp dir
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
-    String[] mockArgs = new String[]{targetDir.getAbsolutePath()};
+    String[] mockArgs = new String[]{cmd.getCommandName(), targetDir.getAbsolutePath()};
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
 
     // Replace commands to execute

--- a/shell/src/test/java/alluxio/cli/bundler/command/CollectConfCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/command/CollectConfCommandTest.java
@@ -85,7 +85,7 @@ public class CollectConfCommandTest {
 
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
-    String[] mockArgs = new String[]{targetDir.getAbsolutePath()};
+    String[] mockArgs = new String[]{cmd.getCommandName(), targetDir.getAbsolutePath()};
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
     int ret = cmd.run(mockCommandLine);
     Assert.assertEquals(0, ret);

--- a/shell/src/test/java/alluxio/cli/bundler/command/CollectConfCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/command/CollectConfCommandTest.java
@@ -91,12 +91,12 @@ public class CollectConfCommandTest {
     Assert.assertEquals(0, ret);
 
     // Files will be copied to sub-dir of target dir
-    File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
+    File subDir = new File(Paths.get(targetDir.getAbsolutePath(),
+            cmd.getCommandName()).toString());
 
     // alluxio-site.properties will be filtered since it contains unmasked credentials
     mExpectedFiles.remove("alluxio-site.properties");
     mExpectedFiles.remove("alluxio-site.properties.template");
     InfoCollectorTestUtils.verifyAllFiles(subDir, mExpectedFiles);
   }
-
 }

--- a/shell/src/test/java/alluxio/cli/bundler/command/CollectConfCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/command/CollectConfCommandTest.java
@@ -21,38 +21,67 @@ import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 
 import org.apache.commons.cli.CommandLine;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CollectConfCommandTest {
-  private static InstancedConfiguration sConf;
-  private static File sTestDir;
+  public static final Set<String> FILE_NAMES = Stream.of(
+          "alluxio-site.properties",
+          "alluxio-site.properties.template",
+          "alluxio-env.sh",
+          "metrics.properties",
+          "metrics.properties.template",
+          "log4j.properties",
+          "core-site.properties",
+          "core-site.properties.template",
+          "hdfs-site.properties",
+          "master",
+          "worker",
+          "start-dfs.sh" // Some startup procedure not defined in Alluxio
+  ).collect(Collectors.toSet());
+  private Set<String> mExpectedFiles;
+  private InstancedConfiguration mConf;
+  private File mTestDir;
 
-  @BeforeClass
-  public static void initConf() throws IOException {
-    sTestDir = prepareConfDir();
-    sConf = InstancedConfiguration.defaults();
-    sConf.set(PropertyKey.CONF_DIR, sTestDir.getAbsolutePath());
+  @Before
+  public void initConf() throws IOException {
+    mExpectedFiles = new HashSet<>();
+    mTestDir = prepareConfDir();
+    mConf = InstancedConfiguration.defaults();
+    mConf.set(PropertyKey.CONF_DIR, mTestDir.getAbsolutePath());
+  }
+
+  @After
+  public void emptyLogDir() {
+    mConf.unset(PropertyKey.CONF_DIR);
+    mTestDir.delete();
   }
 
   // Prepare a temp dir with some log files
-  private static File prepareConfDir() throws IOException {
+  private File prepareConfDir() throws IOException {
     // The dir path will contain randomness so will be different every time
     File testConfDir = InfoCollectorTestUtils.createTemporaryDirectory();
-    InfoCollectorTestUtils.createFileInDir(testConfDir, "alluxio-site.properties");
-    InfoCollectorTestUtils.createFileInDir(testConfDir, "alluxio-env.sh");
+
+    for (String s : FILE_NAMES) {
+      InfoCollectorTestUtils.createFileInDir(testConfDir, s);
+      mExpectedFiles.add(s);
+    }
     return testConfDir;
   }
 
   @Test
   public void confDirCopied() throws IOException, AlluxioException {
-    CollectConfigCommand cmd = new CollectConfigCommand(FileSystemContext.create(sConf));
+    CollectConfigCommand cmd = new CollectConfigCommand(FileSystemContext.create(mConf));
 
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
@@ -64,11 +93,10 @@ public class CollectConfCommandTest {
     // Files will be copied to sub-dir of target dir
     File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
 
-    // Check the dir copied
-    String[] files = subDir.list();
-    Arrays.sort(files);
-    String[] expectedFiles = sTestDir.list();
-    Arrays.sort(expectedFiles);
-    Assert.assertEquals(expectedFiles, files);
+    // alluxio-site.properties will be filtered since it contains unmasked credentials
+    mExpectedFiles.remove("alluxio-site.properties");
+    mExpectedFiles.remove("alluxio-site.properties.template");
+    InfoCollectorTestUtils.verifyAllFiles(subDir, mExpectedFiles);
   }
+
 }

--- a/shell/src/test/java/alluxio/cli/bundler/command/CollectEnvCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/command/CollectEnvCommandTest.java
@@ -52,7 +52,7 @@ public class CollectEnvCommandTest {
     // Write to temp dir
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
-    String[] mockArgs = new String[]{targetDir.getAbsolutePath()};
+    String[] mockArgs = new String[]{cmd.getCommandName(), targetDir.getAbsolutePath()};
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
 
     // Replace commands to execute
@@ -88,7 +88,7 @@ public class CollectEnvCommandTest {
     // Write to temp dir
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
-    String[] mockArgs = new String[]{targetDir.getAbsolutePath()};
+    String[] mockArgs = new String[]{cmd.getCommandName(), targetDir.getAbsolutePath()};
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
 
     // Replace commands to execute

--- a/shell/src/test/java/alluxio/cli/bundler/command/CollectLogCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/command/CollectLogCommandTest.java
@@ -68,7 +68,7 @@ public class CollectLogCommandTest {
     // The dir path will contain randomness so will be different every time
     File testLogDir = InfoCollectorTestUtils.createTemporaryDirectory();
     // Prepare the normal log files that normal users will have
-    for (String s : CollectLogCommand.FILE_NAMES) {
+    for (String s : CollectLogCommand.FILE_NAMES_PREFIXES) {
       InfoCollectorTestUtils.createFileInDir(testLogDir, s);
     }
     // Create some extra log files

--- a/shell/src/test/java/alluxio/cli/bundler/command/CollectLogCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/command/CollectLogCommandTest.java
@@ -478,6 +478,27 @@ public class CollectLogCommandTest {
             expectedDatetime, gcDatetime),
             gcDatetime,
             new DatetimeMatcher().setDatetime(expectedDatetime));
+
+
+    String proxyLog = "2020-07-23 04:22:44,573 INFO  ProcessUtils - Starting Alluxio Proxy.\n" +
+            "2020-07-23 04:22:44,586 INFO  log - Logging initialized @335ms to org.eclipse.jetty.util.log.Slf4jLog\n" +
+            "2020-07-23 04:22:44,765 INFO  TieredIdentityFactory - Initialized tiered identity TieredIdentity(node=FsmetaV2SmallFileASYNC-THROUGH-585-masters-1, rack=null)\n" +
+            "2020-07-23 04:22:44,773 INFO  WebServer - Alluxio Proxy Web service starting @ /0.0.0.0:39999\n" +
+            "2020-07-23 04:22:44,775 INFO  Server - jetty-9.4.28.v20200408; built: 2020-04-08T17:49:39.557Z; git: ab228fde9e55e9164c738d7fa121f8ac5acd51c9; jvm 1.8.0_242-b08\n" +
+            "2020-07-23 04:22:44,795 WARN  SecurityHandler - ServletContext@o.e.j.s.ServletContextHandler@448ff1a8{/,null,STARTING} has uncovered http methods for path: /\n" +
+            "2020-07-23 04:22:50,799 INFO  ContextHandler - Started o.e.j.s.ServletContextHandler@448ff1a8{/,null,AVAILABLE}\n" +
+            "2020-07-23 04:22:50,810 INFO  AbstractConnector - Started ServerConnector@2b98378d{HTTP/1.1, (http/1.1)}{0.0.0.0:39999}\n" +
+            "2020-07-23 04:22:50,811 INFO  Server - Started @6560ms\n" +
+            "2020-07-23 04:22:50,811 INFO  WebServer - Alluxio Proxy Web service started @ /0.0.0.0:39999";
+    File proxyLogFile = new File(mTestDir, "proxy.log");
+    writeToFile(proxyLogFile, proxyLog);
+    LocalDateTime proxyDatetime = CollectLogCommand.inferFileStartTime(proxyLogFile);
+    expectedDatetime = LocalDateTime.of(2020, 7, 23, 4, 22, 44,
+            573 * MILLISEC_TO_NANOSEC);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, proxyDatetime),
+            proxyDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
   }
 
   private void writeToFile(File f, String content) throws IOException {

--- a/shell/src/test/java/alluxio/cli/bundler/command/CollectLogCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/command/CollectLogCommandTest.java
@@ -195,7 +195,7 @@ public class CollectLogCommandTest {
     // Other logs all end before this issue
     LocalDateTime logEnd = issueEnd.minusHours(1);
     long logEndTimestamp = logEnd.toEpochSecond(ZoneOffset.UTC);
-    for (File f : CommonUtils.recursiveListDir(mTestDir)) {
+    for (File f : CommonUtils.recursiveListLocalDir(mTestDir)) {
       f.setLastModified(logEndTimestamp);
     }
 
@@ -263,7 +263,7 @@ public class CollectLogCommandTest {
     // Other logs all end before this issue
     LocalDateTime logEnd = issueEnd.minusHours(1);
     long logEndTimestamp = logEnd.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
-    for (File f : CommonUtils.recursiveListDir(mTestDir)) {
+    for (File f : CommonUtils.recursiveListLocalDir(mTestDir)) {
       f.setLastModified(logEndTimestamp);
     }
 

--- a/shell/src/test/java/alluxio/cli/bundler/command/CollectLogCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/command/CollectLogCommandTest.java
@@ -11,7 +11,8 @@
 
 package alluxio.cli.bundler.command;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -21,8 +22,8 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
-
 import alluxio.util.CommonUtils;
+
 import org.apache.commons.cli.CommandLine;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -33,16 +34,16 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class CollectLogCommandTest {
+  private static final int MILLISEC_TO_NANOSEC = 1_000_000;
+
   private InstancedConfiguration mConf;
   private File mTestDir;
   private Set<String> mExpectedFiles;
@@ -85,7 +86,8 @@ public class CollectLogCommandTest {
     InfoCollectorTestUtils.createFileInDir(userLogDir, "user_root.out");
 
     // Set up expectation
-    Set<String> createdFiles = InfoCollectorTestUtils.getAllFileNamesRelative(testLogDir, testLogDir);
+    Set<String> createdFiles = InfoCollectorTestUtils
+            .getAllFileNamesRelative(testLogDir, testLogDir);
     mExpectedFiles = createdFiles;
 
     return testLogDir;
@@ -103,7 +105,7 @@ public class CollectLogCommandTest {
     assertEquals(0, ret);
 
     // Files will be copied to sub-dir of target dir
-    File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
+    File subDir = new File(targetDir, cmd.getCommandName());
 
     InfoCollectorTestUtils.verifyAllFiles(subDir, mExpectedFiles);
   }
@@ -123,7 +125,7 @@ public class CollectLogCommandTest {
     assertEquals(0, ret);
 
     // Files will be copied to sub-dir of target dir
-    File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
+    File subDir = new File(targetDir, cmd.getCommandName());
 
     InfoCollectorTestUtils.verifyAllFiles(subDir, mExpectedFiles);
   }
@@ -144,7 +146,7 @@ public class CollectLogCommandTest {
     assertEquals(0, ret);
 
     // Files will be copied to sub-dir of target dir
-    File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
+    File subDir = new File(targetDir, cmd.getCommandName());
     mExpectedFiles.remove("master.log.1");
     mExpectedFiles.remove("worker.log");
     mExpectedFiles.remove("worker.out");
@@ -173,7 +175,7 @@ public class CollectLogCommandTest {
     assertEquals(0, ret);
 
     // Files will be copied to sub-dir of target dir
-    File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
+    File subDir = new File(targetDir, cmd.getCommandName());
     mExpectedFiles.add("alluxio_gc.log");
     mExpectedFiles.add("alluxio_gc.log.1");
     mExpectedFiles.add("alluxio_gc.log.2");
@@ -197,37 +199,39 @@ public class CollectLogCommandTest {
 
     // Some logs are created after this time, should be ignored
     File masterLog = new File(mTestDir, "master.log");
-    String log = "2020-07-08 18:53:45,129 INFO  CopycatServer - Server started successfully!\n" +
-            "2020-07-08 18:53:59,129 INFO  RaftJournalSystem - Started Raft Journal System in 13175ms\n" +
-            "2020-07-09 00:01:59,135 INFO  DefaultMetaMaster - Standby master with address localhost:19998 starts sending heartbeat to leader master.\n" +
-            "2020-07-09 00:03:59,135 INFO  AlluxioMasterProcess - All masters started\n" +
-            "2020-07-09 01:12:59,138 INFO  AbstractPrimarySelector - Primary selector transitioning to PRIMARY\n" +
-            "2020-07-09 01:53:59,139 INFO  AbstractMaster - TableMaster: Stopped secondary master.";
+    String log = "2020-07-08 18:53:45,129 INFO  CopycatServer - Server started successfully!\n"
+            + "2020-07-08 18:53:59,129 INFO  RaftJournalSystem - Started Raft Journal System..\n"
+            + "2020-07-09 00:01:59,135 INFO  DefaultMetaMaster - Standby master with address...\n"
+            + "2020-07-09 00:03:59,135 INFO  AlluxioMasterProcess - All masters started\n"
+            + "2020-07-09 01:12:59,138 INFO  AbstractPrimarySelector - Primary selector..\n"
+            + "2020-07-09 01:53:59,139 INFO  AbstractMaster - TableMaster: Stopped secondary..";
     writeToFile(masterLog, log);
-    masterLog.setLastModified(LocalDateTime.of(2020, 7, 9, 1, 53, 59).toEpochSecond(ZoneOffset.UTC));
+    masterLog.setLastModified(LocalDateTime.of(2020, 7, 9, 1, 53, 59)
+            .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
 
     // Some logs overlap with the end time
     File masterLog1 = new File(mTestDir, "master.log.1");
-    String log1 = "2020-07-08 16:53:44,639 INFO  BlockMasterFactory - Creating alluxio.master.block.BlockMaster \n" +
-            "2020-07-08 16:53:44,639 INFO  TableMasterFactory - Creating alluxio.master.table.TableMaster \n" +
-            "2020-07-08 17:01:44,639 INFO  MetaMasterFactory - Creating alluxio.master.meta.MetaMaster \n" +
-            "2020-07-08 17:01:45,639 INFO  FileSystemMasterFactory - Creating alluxio.master.file.FileSystemMaster \n" +
-            "2020-07-08 18:53:44,751 INFO  UnderDatabaseRegistry - Registered UDBs: hive,glue\n" +
-            "2020-07-08 18:53:44,756 INFO  LayoutRegistry - Registered Table Layouts: hive";
+    String log1 = "2020-07-08 16:53:44,639 INFO  BlockMasterFactory - Creating..\n"
+            + "2020-07-08 16:53:44,639 INFO  TableMasterFactory - Creating..\n"
+            + "2020-07-08 17:01:44,639 INFO  MetaMasterFactory - Creating..\n"
+            + "2020-07-08 17:01:45,639 INFO  FileSystemMasterFactory - Creating..\n"
+            + "2020-07-08 18:53:44,751 INFO  UnderDatabaseRegistry - Registered UDBs: hive,glue\n"
+            + "2020-07-08 18:53:44,756 INFO  LayoutRegistry - Registered Table Layouts: hive";
     writeToFile(masterLog1, log1);
-    masterLog1.setLastModified(LocalDateTime.of(2020, 7, 8, 18, 53, 45).toEpochSecond(ZoneOffset.UTC));
+    masterLog1.setLastModified(LocalDateTime.of(2020, 7, 8, 18, 53, 45)
+            .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
 
     // Some logs end before this end time
     File masterLog2 = new File(mTestDir, "master.log.2");
-    String log2 = "2020-07-08 15:40:45,656 INFO  HdfsUnderFileSystem - Successfully instantiated SupportedHdfsActiveSyncProvider\n" +
-            "2020-07-08 15:51:45,782 INFO  RocksStore - Opened rocks database under path /data/02/alluxio/metastore/inodes\n" +
-            "2020-07-08 15:53:45,862 INFO  RocksStore - Opened rocks database under path /data/02/alluxio/metastore/blocks\n" +
-            "2020-07-08 16:52:41,876 INFO  RocksStore - Opened rocks database under path /data/02/alluxio/metastore/inodes\n" +
-            "2020-07-08 16:53:43,876 INFO  JournalStateMachine - Initialized new journal state machine";
+    String log2 = "2020-07-08 15:40:45,656 INFO  HdfsUnderFileSystem - Successfully..\n"
+            + "2020-07-08 15:51:45,782 INFO  RocksStore - Opened rocks database under path..\n"
+            + "2020-07-08 15:53:45,862 INFO  RocksStore - Opened rocks database under path..\n"
+            + "2020-07-08 16:52:41,876 INFO  RocksStore - Opened rocks database under path..\n"
+            + "2020-07-08 16:53:43,876 INFO  JournalStateMachine - Initialized new journal..";
     writeToFile(masterLog2, log2);
-    masterLog1.setLastModified(LocalDateTime.of(2020, 7, 8, 16, 53, 44).toEpochSecond(ZoneOffset.UTC));
+    masterLog1.setLastModified(LocalDateTime.of(2020, 7, 8, 16, 53, 44)
+            .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
 
-    // Copy
     CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
@@ -242,15 +246,9 @@ public class CollectLogCommandTest {
     assertEquals(0, ret);
 
     // Files will be copied to sub-dir of target dir
-    File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
+    File subDir = new File(targetDir, cmd.getCommandName());
     mExpectedFiles.remove("master.log");
     InfoCollectorTestUtils.verifyAllFiles(subDir, mExpectedFiles);
-  }
-
-  private void writeToFile(File f, String content) throws IOException {
-    try (FileWriter writer = new FileWriter(f)) {
-      writer.write(content);
-    }
   }
 
   @Test
@@ -269,35 +267,38 @@ public class CollectLogCommandTest {
 
     // Some logs are created after this time, should be included
     File masterLog = new File(mTestDir, "master.log");
-    String log = "2020-07-08 18:53:45,129 INFO  CopycatServer - Server started successfully!\n" +
-            "2020-07-08 18:53:59,129 INFO  RaftJournalSystem - Started Raft Journal System in 13175ms\n" +
-            "2020-07-09 00:01:59,135 INFO  DefaultMetaMaster - Standby master with address localhost:19998 starts sending heartbeat to leader master.\n" +
-            "2020-07-09 00:03:59,135 INFO  AlluxioMasterProcess - All masters started\n" +
-            "2020-07-09 01:12:59,138 INFO  AbstractPrimarySelector - Primary selector transitioning to PRIMARY\n" +
-            "2020-07-09 01:53:59,139 INFO  AbstractMaster - TableMaster: Stopped secondary master.";
+    String log = "2020-07-08 18:53:45,129 INFO  CopycatServer - Server started successfully!\n"
+            + "2020-07-08 18:53:59,129 INFO  RaftJournalSystem - Started Raft Journal System..\n"
+            + "2020-07-09 00:01:59,135 INFO  DefaultMetaMaster - Standby master with address..\n"
+            + "2020-07-09 00:03:59,135 INFO  AlluxioMasterProcess - All masters started\n"
+            + "2020-07-09 01:12:59,138 INFO  AbstractPrimarySelector - Primary selector..\n"
+            + "2020-07-09 01:53:59,139 INFO  AbstractMaster - TableMaster: Stopped..";
     writeToFile(masterLog, log);
-    masterLog.setLastModified(LocalDateTime.of(2020, 7, 9, 1, 53, 59).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+    masterLog.setLastModified(LocalDateTime.of(2020, 7, 9, 1, 53, 59)
+            .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
 
     // Some logs overlap with the start time, should be included
     File masterLog1 = new File(mTestDir, "master.log.1");
-    String log1 = "2020-07-08 16:53:44,639 INFO  BlockMasterFactory - Creating alluxio.master.block.BlockMaster \n" +
-            "2020-07-08 16:53:44,639 INFO  TableMasterFactory - Creating alluxio.master.table.TableMaster \n" +
-            "2020-07-08 17:01:44,639 INFO  MetaMasterFactory - Creating alluxio.master.meta.MetaMaster \n" +
-            "2020-07-08 17:01:45,639 INFO  FileSystemMasterFactory - Creating alluxio.master.file.FileSystemMaster \n" +
-            "2020-07-08 18:53:44,751 INFO  UnderDatabaseRegistry - Registered UDBs: hive,glue\n" +
-            "2020-07-08 18:53:44,756 INFO  LayoutRegistry - Registered Table Layouts: hive";
+    String log1 = "2020-07-08 16:53:44,639 INFO  BlockMasterFactory - Creating..\n"
+            + "2020-07-08 16:53:44,639 INFO  TableMasterFactory - Creating..\n"
+            + "2020-07-08 17:01:44,639 INFO  MetaMasterFactory - Creating..\n"
+            + "2020-07-08 17:01:45,639 INFO  FileSystemMasterFactory - Creating..\n"
+            + "2020-07-08 18:53:44,751 INFO  UnderDatabaseRegistry - Registered UDBs: hive,glue\n"
+            + "2020-07-08 18:53:44,756 INFO  LayoutRegistry - Registered Table Layouts: hive";
     writeToFile(masterLog1, log1);
-    masterLog1.setLastModified(LocalDateTime.of(2020, 7, 8, 18, 53, 45).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+    masterLog1.setLastModified(LocalDateTime.of(2020, 7, 8, 18, 53, 45)
+            .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
 
     // Some logs end before the start time, should be ignored
     File masterLog2 = new File(mTestDir, "master.log.2");
-    String log2 = "2020-07-08 15:40:45,656 INFO  HdfsUnderFileSystem - Successfully instantiated SupportedHdfsActiveSyncProvider\n" +
-            "2020-07-08 15:51:45,782 INFO  RocksStore - Opened rocks database under path /data/02/alluxio/metastore/inodes\n" +
-            "2020-07-08 15:53:45,862 INFO  RocksStore - Opened rocks database under path /data/02/alluxio/metastore/blocks\n" +
-            "2020-07-08 16:52:41,876 INFO  RocksStore - Opened rocks database under path /data/02/alluxio/metastore/inodes\n" +
-            "2020-07-08 16:53:43,876 INFO  JournalStateMachine - Initialized new journal state machine";
+    String log2 = "2020-07-08 15:40:45,656 INFO  HdfsUnderFileSystem - Successfully..\n"
+            + "2020-07-08 15:51:45,782 INFO  RocksStore - Opened rocks database under path..\n"
+            + "2020-07-08 15:53:45,862 INFO  RocksStore - Opened rocks database under path..\n"
+            + "2020-07-08 16:52:41,876 INFO  RocksStore - Opened rocks database under path..\n"
+            + "2020-07-08 16:53:43,876 INFO  JournalStateMachine - Initialized new..";
     writeToFile(masterLog2, log2);
-    masterLog2.setLastModified(LocalDateTime.of(2020, 7, 8, 16, 53, 44).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+    masterLog2.setLastModified(LocalDateTime.of(2020, 7, 8, 16, 53, 44)
+            .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
 
     // Copy
     CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
@@ -314,24 +315,27 @@ public class CollectLogCommandTest {
     assertEquals(0, ret);
 
     // Files will be copied to sub-dir of target dir
-    File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
+    File subDir = new File(targetDir, cmd.getCommandName());
     mExpectedFiles = new HashSet<>();
     mExpectedFiles.add("master.log");
     mExpectedFiles.add("master.log.1");
     InfoCollectorTestUtils.verifyAllFiles(subDir, mExpectedFiles);
   }
 
+  /**
+   * A LocalDateTime matcher for assertThat.
+   * */
   class DatetimeMatcher extends TypeSafeMatcher<LocalDateTime> {
-    private LocalDateTime datetime;
+    private LocalDateTime mDatetime;
 
-    public DatetimeMatcher setDatetime(LocalDateTime datetime) {
-      this.datetime = datetime;
+    DatetimeMatcher setDatetime(LocalDateTime datetime) {
+      mDatetime = datetime;
       return this;
     }
 
     @Override
     protected boolean matchesSafely(LocalDateTime s) {
-      return datetime.isEqual(s);
+      return mDatetime.isEqual(s);
     }
 
     @Override
@@ -342,108 +346,143 @@ public class CollectLogCommandTest {
 
   @Test
   public void inferDateFromLog() throws Exception {
-    // Alluxio logs
-    String alluxioLog = "2020-03-19 11:58:10,104 WARN  ServerConfiguration - Reloaded properties\n" +
-            "2020-03-19 11:58:10,106 WARN  ServerConfiguration - Loaded hostname localhost\n" +
-            "2020-03-19 11:58:10,591 WARN  RetryUtils - Failed to load cluster default configuration with master (attempt 1): alluxio.exception.status.UnavailableException: Failed to handshake with master localhost:19998 to load cluster default configuration values: UNAVAILABLE: io exception";
+    // A piece of Alluxio log with default format
+    String alluxioLog = "2020-03-19 11:58:10,104 WARN  ServerConfiguration - Reloaded properties\n"
+            + "2020-03-19 11:58:10,106 WARN  ServerConfiguration - Loaded hostname localhost\n"
+            + "2020-03-19 11:58:10,591 WARN  RetryUtils - Failed to load cluster default..";
     File alluxioLogFile = new File(mTestDir, "alluxio-worker.log");
     writeToFile(alluxioLogFile, alluxioLog);
     LocalDateTime alluxioLogDatetime = CollectLogCommand.inferFileStartTime(alluxioLogFile);
-    LocalDateTime expectedDatetime = LocalDateTime.of(2020, 3, 19, 11, 58, 10, 104 * 1_000_000);
-    assertThat(String.format("Expected datetime is %s but inferred %s from file%n", expectedDatetime, alluxioLogDatetime),
-            alluxioLogDatetime, new DatetimeMatcher().setDatetime(expectedDatetime));
+    LocalDateTime expectedDatetime = LocalDateTime.of(2020, 3, 19, 11, 58, 10,
+            104 * MILLISEC_TO_NANOSEC);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, alluxioLogDatetime),
+            alluxioLogDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
 
-    // Yarn application log default format
-    String yarnAppLog = "\n" +
-            "Logged in as: user\n" +
-            "Application\n" +
-            "About\n" +
-            "Jobs\n" +
-            "Tools\n" +
-            "Log Type: container-localizer-syslog\n" +
-            "\n" +
-            "Log Upload Time: Mon May 18 16:11:22 +0800 2020\n" +
-            "\n" +
-            "Log Length: 0\n" +
-            "\n" +
-            "\n" +
-            "Log Type: stderr\n" +
-            "\n" +
-            "Log Upload Time: Mon May 18 16:11:22 +0800 2020\n" +
-            "\n" +
-            "Log Length: 3616\n" +
-            "\n" +
-            "20/05/18 16:11:18 INFO util.SignalUtils: Registered signal handler for TERM\n" +
-            "20/05/18 16:11:18 INFO util.SignalUtils: Registered signal handler for HUP\n" +
-            "20/05/18 16:11:18 INFO util.SignalUtils: Registered signal handler for INT";
+    // A piece of sample Yarn application log with default format
+    // The first >20 lines are un-timestamped information about the job
+    String yarnAppLog = "\nLogged in as: user\nApplication\nAbout\nJobs\nTools\n"
+            + "Log Type: container-localizer-syslog\n\n"
+            + "Log Upload Time: Mon May 18 16:11:22 +0800 2020\n\n"
+            + "Log Length: 0\n\n\nLog Type: stderr\n\n"
+            + "Log Upload Time: Mon May 18 16:11:22 +0800 2020\n\n"
+            + "Log Length: 3616\n\n"
+            + "20/05/18 16:11:18 INFO util.SignalUtils: Registered signal handler for TERM\n"
+            + "20/05/18 16:11:18 INFO util.SignalUtils: Registered signal handler for HUP\n"
+            + "20/05/18 16:11:18 INFO util.SignalUtils: Registered signal handler for INT";
     File yarnAppLogFile = new File(mTestDir, "yarn-application.log");
     writeToFile(yarnAppLogFile, yarnAppLog);
     LocalDateTime yarnAppDatetime = CollectLogCommand.inferFileStartTime(yarnAppLogFile);
     expectedDatetime = LocalDateTime.of(2020, 5, 18, 16, 11, 18);
-    assertThat(String.format("Expected datetime is %s but inferred %s from file%n", expectedDatetime, yarnAppDatetime),
-            yarnAppDatetime, new DatetimeMatcher().setDatetime(expectedDatetime));
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, yarnAppDatetime),
+            yarnAppDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
 
-    // Yarn log default format
-    String yarnLog = "2020-05-16 02:02:25,855 INFO org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerImpl: container_e103_1584954066020_230169_01_000004 Container Transitioned from ALLOCATED to ACQUIRED\n" +
-            "2020-05-16 02:02:25,909 INFO org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppSchedulingInfo: checking for deactivate... \n" +
-            "2020-05-16 02:02:26,006 INFO org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerImpl: container_e103_1584954066020_230168_01_000047 Container Transitioned from ALLOCATED to ACQUIRED";
+    // A piece of Yarn log with default format
+    String yarnLog = "2020-05-16 02:02:25,855 INFO org.apache.hadoop.yarn.server.resourcemanager"
+            + ".rmcontainer.RMContainerImpl: container_e103_1584954066020_230169_01_000004 "
+            + "Container Transitioned from ALLOCATED to ACQUIRED\n"
+            + "2020-05-16 02:02:25,909 INFO org.apache.hadoop.yarn.server.resourcemanager"
+            + ".scheduler.AppSchedulingInfo: checking for deactivate... \n"
+            + "2020-05-16 02:02:26,006 INFO org.apache.hadoop.yarn.server.resourcemanager"
+            + ".rmcontainer.RMContainerImpl: container_e103_1584954066020_230168_01_000047 "
+            + "Container Transitioned from ALLOCATED to ACQUIRED";
     File yarnLogFile = new File(mTestDir, "yarn-rm.log");
     writeToFile(yarnLogFile, yarnLog);
     LocalDateTime yarnDatetime = CollectLogCommand.inferFileStartTime(yarnLogFile);
-    expectedDatetime = LocalDateTime.of(2020, 5, 16, 2, 2, 25, 855 * 1_000_000);
-    assertThat(String.format("Expected datetime is %s but inferred %s from file%n", expectedDatetime, yarnDatetime),
-            yarnDatetime, new DatetimeMatcher().setDatetime(expectedDatetime));
+    expectedDatetime = LocalDateTime.of(2020, 5, 16, 2, 2, 25,
+            855 * MILLISEC_TO_NANOSEC);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, yarnDatetime),
+            yarnDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
 
-    // ZK log default format
-    String zkLog = "2020-05-14 21:05:53,822 WARN org.apache.zookeeper.server.NIOServerCnxn: caught end of stream exception\n" +
-            "EndOfStreamException: Unable to read additional data from client sessionid 0x471fa7133c193e4, likely client has closed socket\n" +
-            "\tat org.apache.zookeeper.server.NIOServerCnxn.doIO(NIOServerCnxn.java:241)\n" +
-            "\tat org.apache.zookeeper.server.NIOServerCnxnFactory.run(NIOServerCnxnFactory.java:208)\n" +
-            "\tat java.lang.Thread.run(Thread.java:748)\n" +
-            "2020-05-14 21:05:53,823 INFO org.apache.zookeeper.server.NIOServerCnxn: Closed socket connection for client /10.64.23.190:50120 which had sessionid 0x471fa7133c193e4\n" +
-            "2020-05-14 21:05:53,911 WARN org.apache.zookeeper.server.NIOServerCnxn: caught end of stream exception\n" +
-            "EndOfStreamException: Unable to read additional data from client sessionid 0x471fa7133c193e1, likely client has closed socket\n" +
-            "\tat org.apache.zookeeper.server.NIOServerCnxn.doIO(NIOServerCnxn.java:241)\n" +
-            "\tat org.apache.zookeeper.server.NIOServerCnxnFactory.run(NIOServerCnxnFactory.java:208)\n" +
-            "\tat java.lang.Thread.run(Thread.java:748)";
+    // A piece of ZK log with default format
+    String zkLog = "2020-05-14 21:05:53,822 WARN org.apache.zookeeper.server.NIOServerCnxn: "
+            + "caught end of stream exception\n"
+            + "EndOfStreamException: Unable to read additional data from client sessionid.., "
+            + "likely client has closed socket\n"
+            + "\tat org.apache.zookeeper.server.NIOServerCnxn.doIO(NIOServerCnxn.java:241)\n"
+            + "\tat org.apache.zookeeper.server.NIOServerCnxnFactory.run(NIOServerCnxnFactory..)\n"
+            + "\tat java.lang.Thread.run(Thread.java:748)\n"
+            + "2020-05-14 21:05:53,823 INFO org.apache.zookeeper.server.NIOServerCnxn: "
+            + "Closed socket connection for client /10.64.23.190:50120 which had sessionid..\n"
+            + "2020-05-14 21:05:53,911 WARN org.apache.zookeeper.server.NIOServerCnxn: "
+            + "caught end of stream exception\n"
+            + "EndOfStreamException: Unable to read additional data from client sessionid.."
+            + "likely client has closed socket\n";
     File zkLogFile = new File(mTestDir, "zk.log");
     writeToFile(zkLogFile, zkLog);
     LocalDateTime zkDatetime = CollectLogCommand.inferFileStartTime(zkLogFile);
-    expectedDatetime = LocalDateTime.of(2020, 5, 14, 21, 5, 53, 822 * 1_000_000);
-    assertThat(String.format("Expected datetime is %s but inferred %s from file%n", expectedDatetime, zkDatetime),
-            zkDatetime, new DatetimeMatcher().setDatetime(expectedDatetime));
+    expectedDatetime = LocalDateTime.of(2020, 5, 14, 21, 5, 53,
+            822 * MILLISEC_TO_NANOSEC);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, zkDatetime),
+            zkDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
 
-    // HDFS log default format
-    String hdfsLog = "2020-05-15 22:02:27,878 INFO BlockStateChange: BLOCK* addStoredBlock: blockMap updated: 10.64.23.184:1025 is added to blk_1126197354_52572663{blockUCState=UNDER_CONSTRUCTION, primaryNodeIndex=-1, replicas=[ReplicaUnderConstruction[[DISK]DS-46e3eb6e-7109-4a13-92dd-31b53658bfcf:NORMAL:10.64.23.124:1025|FINALIZED], ReplicaUnderConstruction[[DISK]DS-f2e3f3b1-73f7-4a75-b22d-e1067317469e:NORMAL:10.64.23.184:1025|FINALIZED]]} size 0\n" +
-            "2020-05-15 22:02:27,878 INFO BlockStateChange: BLOCK* addStoredBlock: blockMap updated: 10.70.22.117:1025 is added to blk_1126197354_52572663{blockUCState=UNDER_CONSTRUCTION, primaryNodeIndex=-1, replicas=[ReplicaUnderConstruction[[DISK]DS-46e3eb6e-7109-4a13-92dd-31b53658bfcf:NORMAL:10.64.23.124:1025|FINALIZED], ReplicaUnderConstruction[[DISK]DS-f2e3f3b1-73f7-4a75-b22d-e1067317469e:NORMAL:10.64.23.184:1025|FINALIZED], ReplicaUnderConstruction[[DISK]DS-2ba9205e-24e7-4730-9c6c-6777d9e4bcdd:NORMAL:10.70.22.117:1025|FINALIZED]]} size 0";
+    // A piece of sample HDFS log with default format
+    String hdfsLog = "2020-05-15 22:02:27,878 INFO BlockStateChange: BLOCK* addStoredBlock: "
+            + "blockMap updated: 10.64.23.184:1025 is added to blk_1126197354_52572663 size 0..\n"
+            + "2020-05-15 22:02:27,878 INFO BlockStateChange: BLOCK* addStoredBlock: blockMap "
+            + "updated: 10.70.22.117:1025 is added to blk_1126197354_52572663 size 0..";
     File hdfsLogFile = new File(mTestDir, "hdfs.log");
     writeToFile(hdfsLogFile, hdfsLog);
     LocalDateTime hdfsDatetime = CollectLogCommand.inferFileStartTime(hdfsLogFile);
-    expectedDatetime = LocalDateTime.of(2020, 5, 15, 22, 2, 27, 878 * 1_000_000);
-    assertThat(String.format("Expected datetime is %s but inferred %s from file%n", expectedDatetime, hdfsDatetime),
-            hdfsDatetime, new DatetimeMatcher().setDatetime(expectedDatetime));
+    expectedDatetime = LocalDateTime.of(2020, 5, 15, 22, 2, 27,
+            878 * MILLISEC_TO_NANOSEC);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, hdfsDatetime),
+            hdfsDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
 
-    // Presto log default format
-    String prestoLog = "2020-05-16T00:00:01.059+0800\tINFO\tdispatcher-query-7960\tio.prestosql.event.QueryMonitor\tTIMELINE: Query 20200515_155959_06700_6r6b4 :: Transaction:[4d30e960-c319-439c-84dd-022ddab6fa5e] :: elapsed 1208ms :: planning 0ms :: waiting 0ms :: scheduling 1208ms :: running 0ms :: finishing 1208ms :: begin 2020-05-15T23:59:59.850+08:00 :: end 2020-05-16T00:00:01.058+08:00\n" +
-            "2020-05-16T00:00:01.083+0800\tINFO\tdispatcher-query-7960\tcom.bluetalon.presto.authorization.BtStatementAccessControl\tStatementRewriteContext: FullStatementRewriteContext{queryId=20200515_160001_06701_6r6b4, principal=Optional[edsfuser@SVCS.DBS.COM], user=edsfuser, source=presto-jdbc, catalog=Optional[hive], schema=Optional[default], startTime=1589558401082, remoteUserAddress=10.70.23.171}\n" +
-            "2020-05-16T00:00:01.083+0800\tINFO\tdispatcher-query-7960\tcom.bluetalon.presto.authorization.BtStatementAccessControl\tBtStatementAccessControl.getModifiedQuery() entering: user=edsfuser,principal=Optional[edsfuser@SVCS.DBS.COM],query=CREATE OR REPLACE VIEW P_S_SG.S_ADA_CASP_DATAPOST_MCASTMT_4_view_ns AS SELECT \"businessdate\",\"camstmfl_brch\",\"camstmfl_category_ident\",\"camstmfl_ccy\",\"camstmfl_ccy_desc\",\"camstmfl_chkdgt\",\"camstmfl_conv_currency\",\"camstmfl_conv_rate\",\"camstmfl_dept\",\"camstmfl_filehdr_sysid\",\"camstmfl_product_code\",\"camstmfl_rchq_reason\",\"camstmfl_rchq_reason_desc\",\"camstmfl_request_type\",\"camstmfl_reversal_ind\",\"camstmfl_sector_code\",\"camstmfl_serial\",\"camstmfl_serial_day\",\"camstmfl_serial_month\",\"camstmfl_serial_product\",\"camstmfl_serial_ref\",\"camstmfl_stmt_code\",\"camstmfl_stmt_date\",\"camstmfl_suffix\",\"camstmfl_summary_sysid\",\"camstmfl_suppress_ind\",\"camstmfl_total_records\",\"camstmfl_trans_amount\",\"camstmfl_trans_amount_dec\",\"camstmfl_trans_amount_sign\",\"camstmfl_trans_balance\",\"camstmfl_trans_balance_dec\",\"camstmfl_trans_balance_sign\",\"camstmfl_trans_date\",\"camstmfl_trans_dd\",\"camstmfl_trans_mm\",\"camstmfl_trans_type\",\"camstmfl_trans_yy\",\"camstmfl_value_date\",\"camstmfl_value_dd\",\"camstmfl_value_mm\",\"camstmfl_value_yy\",\"rowid\",\"rowmd5\",\"rowkey\",\"business_date\" FROM S_SG.S_ADA_CASP_DATAPOST_MCASTMT_4,catalog=hive,schema=default";
+    // A piece of sample Presto log wtih default format
+    String prestoLog = "2020-05-16T00:00:01.059+0800\tINFO\tdispatcher-query-7960"
+            + "\tio.prestosql.event.QueryMonitor\tTIMELINE: Query 20200515_155959_06700_6r6b4"
+            + " :: Transaction:[4d30e960-c319-439c-84dd-022ddab6fa5e] :: elapsed 1208ms :: "
+            + "planning 0ms :: waiting 0ms :: scheduling 1208ms :: running 0ms :: finishing 1208ms"
+            + " :: begin 2020-05-15T23:59:59.850+08:00 :: end 2020-05-16T00:00:01.058+08:00\n"
+            + "2020-05-16T00:00:03.530+0800\tINFO\tdispatcher-query-7948\t"
+            + "io.prestosql.event.QueryMonitor\tTIMELINE: Query 20200515_160001_06701_6r6b4"
+            + " :: Transaction:[be9b396e-6697-4ecd-9782-2ca1174c1be1] :: elapsed 2316ms"
+            + " :: planning 0ms :: waiting 0ms :: scheduling 2316ms :: running 0ms"
+            + " :: finishing 2316ms :: begin 2020-05-16T00:00:01.212+08:00"
+            + " :: end 2020-05-16T00:00:03.528+08:00";
     File prestoLogFile = new File(mTestDir, "presto.log");
     writeToFile(prestoLogFile, prestoLog);
     LocalDateTime prestoDatetime = CollectLogCommand.inferFileStartTime(prestoLogFile);
-    expectedDatetime = LocalDateTime.of(2020, 5, 16, 0, 0, 1, 59 * 1_000_000);
-    assertThat(String.format("Expected datetime is %s but inferred %s from file%n", expectedDatetime, prestoDatetime),
-            prestoDatetime, new DatetimeMatcher().setDatetime(expectedDatetime));
+    expectedDatetime = LocalDateTime.of(2020, 5, 16, 0, 0, 1,
+            59 * MILLISEC_TO_NANOSEC);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, prestoDatetime),
+            prestoDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
 
     // ParNew/CMS GC log default format
-    String gcLog = "Java HotSpot(TM) 64-Bit Server VM (25.151-b12) for linux-amd64 JRE (1.8.0_151-b12), built on Sep  5 2017 19:20:58 by \"java_re\" with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)\n" +
-            "Memory: 4k page, physical 197920016k(194009624k free), swap 33279996k(33279996k free)\n" +
-            "CommandLine flags: -XX:CMSInitiatingOccupancyFraction=65 -XX:InitialHeapSize=154618822656 -XX:MaxDirectMemorySize=103079215104 -XX:MaxHeapSize=154618822656 -XX:MaxNewSize=32212254720 -XX:MaxTenuringThreshold=6 -XX:MetaspaceSize=536870912 -XX:NewSize=32212254720 -XX:OldPLABSize=16 -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+UseCMSInitiatingOccupancyOnly -XX:+UseConcMarkSweepGC -XX:+UseParNewGC \n" +
-            "2020-05-07T10:01:11.409+0800: 4.304: [GC (GCLocker Initiated GC) 2020-05-07T10:01:11.410+0800: 4.304: [ParNew: 25669137K->130531K(28311552K), 0.4330954 secs] 25669137K->130531K(147849216K), 0.4332463 secs] [Times: user=4.50 sys=0.08, real=0.44 secs] ";
+    String gcLog = "Java HotSpot(TM) 64-Bit Server VM (25.151-b12) for linux-amd64 JRE (1.8.0), "
+            + "built on Sep  5 2017 19:20:58 by \"java_re\" with gcc 4.3.0 20080428..\n"
+            + "Memory: 4k page, physical 1979200k(1940096k free), swap 332799k(332799k free)\n"
+            + "CommandLine flags: -XX:CMSInitiatingOccupancyFraction=65 -XX:InitialHeapSize=..\n"
+            + "2020-05-07T10:01:11.409+0800: 4.304: [GC (GCLocker Initiated GC) "
+            + "2020-05-07T10:01:11.410+0800: 4.304: [ParNew: 25669137K->130531K(28311552K), "
+            + "0.4330954 secs] 25669137K->130531K(147849216K), 0.4332463 secs] "
+            + "[Times: user=4.50 sys=0.08, real=0.44 secs] ";
     File gcLogFile = new File(mTestDir, "gc.log");
     writeToFile(gcLogFile, gcLog);
     LocalDateTime gcDatetime = CollectLogCommand.inferFileStartTime(gcLogFile);
-    expectedDatetime = LocalDateTime.of(2020, 5, 7, 10, 1, 11, 409 * 1_000_000);
-    assertThat(String.format("Expected datetime is %s but inferred %s from file%n", expectedDatetime, gcDatetime),
-            gcDatetime, new DatetimeMatcher().setDatetime(expectedDatetime));
+    expectedDatetime = LocalDateTime.of(2020, 5, 7, 10, 1, 11,
+            409 * MILLISEC_TO_NANOSEC);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, gcDatetime),
+            gcDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
+  }
+
+  private void writeToFile(File f, String content) throws IOException {
+    try (FileWriter writer = new FileWriter(f)) {
+      writer.write(content);
+    }
   }
 }

--- a/shell/src/test/java/alluxio/cli/bundler/command/CollectLogCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/command/CollectLogCommandTest.java
@@ -97,7 +97,7 @@ public class CollectLogCommandTest {
 
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
-    String[] mockArgs = new String[]{targetDir.getAbsolutePath()};
+    String[] mockArgs = new String[]{cmd.getCommandName(), targetDir.getAbsolutePath()};
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
     int ret = cmd.run(mockCommandLine);
     assertEquals(0, ret);
@@ -117,7 +117,7 @@ public class CollectLogCommandTest {
     CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
-    String[] mockArgs = new String[]{targetDir.getAbsolutePath()};
+    String[] mockArgs = new String[]{cmd.getCommandName(), targetDir.getAbsolutePath()};
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
     int ret = cmd.run(mockCommandLine);
     assertEquals(0, ret);
@@ -134,6 +134,7 @@ public class CollectLogCommandTest {
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
     String[] mockArgs = new String[]{
+            cmd.getCommandName(),
             targetDir.getAbsolutePath()
     };
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
@@ -162,6 +163,7 @@ public class CollectLogCommandTest {
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
     String[] mockArgs = new String[]{
+            cmd.getCommandName(),
             targetDir.getAbsolutePath()
     };
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
@@ -230,6 +232,7 @@ public class CollectLogCommandTest {
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
     String[] mockArgs = new String[]{
+            cmd.getCommandName(),
             targetDir.getAbsolutePath()
     };
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
@@ -301,6 +304,7 @@ public class CollectLogCommandTest {
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
     String[] mockArgs = new String[]{
+            cmd.getCommandName(),
             targetDir.getAbsolutePath()
     };
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
@@ -338,6 +342,17 @@ public class CollectLogCommandTest {
 
   @Test
   public void inferDateFromLog() throws Exception {
+    // Alluxio logs
+    String alluxioLog = "2020-03-19 11:58:10,104 WARN  ServerConfiguration - Reloaded properties\n" +
+            "2020-03-19 11:58:10,106 WARN  ServerConfiguration - Loaded hostname localhost\n" +
+            "2020-03-19 11:58:10,591 WARN  RetryUtils - Failed to load cluster default configuration with master (attempt 1): alluxio.exception.status.UnavailableException: Failed to handshake with master localhost:19998 to load cluster default configuration values: UNAVAILABLE: io exception";
+    File alluxioLogFile = new File(mTestDir, "alluxio-worker.log");
+    writeToFile(alluxioLogFile, alluxioLog);
+    LocalDateTime alluxioLogDatetime = CollectLogCommand.inferFileStartTime(alluxioLogFile);
+    LocalDateTime expectedDatetime = LocalDateTime.of(2020, 3, 19, 11, 58, 10, 104 * 1_000_000);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n", expectedDatetime, alluxioLogDatetime),
+            alluxioLogDatetime, new DatetimeMatcher().setDatetime(expectedDatetime));
+
     // Yarn application log default format
     String yarnAppLog = "\n" +
             "Logged in as: user\n" +
@@ -364,7 +379,7 @@ public class CollectLogCommandTest {
     File yarnAppLogFile = new File(mTestDir, "yarn-application.log");
     writeToFile(yarnAppLogFile, yarnAppLog);
     LocalDateTime yarnAppDatetime = CollectLogCommand.inferFileStartTime(yarnAppLogFile);
-    LocalDateTime expectedDatetime = LocalDateTime.of(2020, 5, 18, 16, 11, 18);
+    expectedDatetime = LocalDateTime.of(2020, 5, 18, 16, 11, 18);
     assertThat(String.format("Expected datetime is %s but inferred %s from file%n", expectedDatetime, yarnAppDatetime),
             yarnAppDatetime, new DatetimeMatcher().setDatetime(expectedDatetime));
 

--- a/shell/src/test/java/alluxio/cli/bundler/command/CollectLogCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/command/CollectLogCommandTest.java
@@ -11,6 +11,8 @@
 
 package alluxio.cli.bundler.command;
 
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -21,54 +23,432 @@ import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 
 import org.apache.commons.cli.CommandLine;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.cglib.core.Local;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalUnit;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class CollectLogCommandTest {
-  private static InstancedConfiguration sConf;
-  private static File sTestDir;
+  private InstancedConfiguration mConf;
+  private File mTestDir;
+  private Set<String> mExpectedFiles;
 
-  @BeforeClass
-  public static void initConf() throws IOException {
-    sTestDir = prepareLogDir("testLog");
-    sConf = InstancedConfiguration.defaults();
-    sConf.set(PropertyKey.LOGS_DIR, sTestDir.getAbsolutePath());
+  @Before
+  public void initLogDirAndConf() throws IOException {
+    mTestDir = prepareLogDir();
+    mConf = InstancedConfiguration.defaults();
+    mConf.set(PropertyKey.LOGS_DIR, mTestDir.getAbsolutePath());
+  }
+
+  @After
+  public void emptyLogDir() {
+    mConf.unset(PropertyKey.LOGS_DIR);
+    mTestDir.delete();
   }
 
   // Prepare a temp dir with some log files
-  private static File prepareLogDir(String prefix) throws IOException {
+  private File prepareLogDir() throws IOException {
     // The dir path will contain randomness so will be different every time
-    File testConfDir = InfoCollectorTestUtils.createTemporaryDirectory();
-    InfoCollectorTestUtils.createFileInDir(testConfDir, "master.log");
-    InfoCollectorTestUtils.createFileInDir(testConfDir, "worker.log");
-    return testConfDir;
+    File testLogDir = InfoCollectorTestUtils.createTemporaryDirectory();
+    // Prepare the normal log files that normal users will have
+    for (String s : CollectLogCommand.FILE_NAMES) {
+      InfoCollectorTestUtils.createFileInDir(testLogDir, s);
+    }
+    // Create some extra log files
+    InfoCollectorTestUtils.createFileInDir(testLogDir, "master.log.1");
+    InfoCollectorTestUtils.createFileInDir(testLogDir, "master.log.2");
+    InfoCollectorTestUtils.createFileInDir(testLogDir, "worker.log.backup");
+    // Remove the user file and create a directory
+    File userDir = new File(testLogDir, "user");
+    if (userDir.exists()) {
+      userDir.delete();
+    }
+    // Put logs in the user log dir
+    File userLogDir = InfoCollectorTestUtils.createDirInDir(testLogDir, "user");
+    InfoCollectorTestUtils.createFileInDir(userLogDir, "user_hadoop.log");
+    InfoCollectorTestUtils.createFileInDir(userLogDir, "user_hadoop.out");
+    InfoCollectorTestUtils.createFileInDir(userLogDir, "user_root.log");
+    InfoCollectorTestUtils.createFileInDir(userLogDir, "user_root.out");
+
+    // Set up expectation
+    Set<String> createdFiles = getAllFileNamesRelative(testLogDir, testLogDir);
+    mExpectedFiles = createdFiles;
+
+    return testLogDir;
   }
 
   @Test
-  public void logDirCopied() throws IOException, AlluxioException {
-    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(sConf));
+  public void logFilesCopied() throws IOException, AlluxioException {
+    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
 
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
     String[] mockArgs = new String[]{targetDir.getAbsolutePath()};
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
     int ret = cmd.run(mockCommandLine);
-    Assert.assertEquals(0, ret);
+    assertEquals(0, ret);
 
     // Files will be copied to sub-dir of target dir
     File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
 
-    // Check the dir copied
-    String[] files = subDir.list();
-    Arrays.sort(files);
-    String[] expectedFiles = sTestDir.list();
-    Arrays.sort(expectedFiles);
-    Assert.assertEquals(expectedFiles, files);
+    verifyAllFiles(subDir);
   }
+
+  private void verifyAllFiles(File targetDir) throws IOException {
+    Set<String> copiedFiles = getAllFileNamesRelative(targetDir, targetDir);
+
+    System.out.println("Expected");
+    System.out.println(mExpectedFiles);
+    System.out.println("Copied");
+    System.out.println(copiedFiles);
+    Set<String> missing = new HashSet<>(mExpectedFiles);
+    missing.removeAll(copiedFiles);
+    System.out.println("Missing:");
+    System.out.println(missing);
+    Set<String> extra = new HashSet<>(copiedFiles);
+    extra.removeAll(mExpectedFiles);
+    System.out.println("Extra:");
+    System.out.println(extra);
+    assertTrue(mExpectedFiles.containsAll(copiedFiles));
+    assertTrue(copiedFiles.containsAll(mExpectedFiles));
+  }
+
+  private Set<String> getAllFileNamesRelative(File dir, File baseDir) throws IOException {
+    if (!dir.isDirectory()) {
+      throw new IOException(String.format("Expected a directory but found a file at %s%n", dir.getCanonicalPath()));
+    }
+    Set<String> fileSet = new HashSet<>();
+    List<File> allFiles = recursiveListDir(dir);
+    for (File f : allFiles) {
+      String relativePath = baseDir.toURI().relativize(f.toURI()).toString();
+      fileSet.add(relativePath);
+    }
+    return fileSet;
+  }
+
+  private List<File> recursiveListDir(File dir) {
+    File[] files = dir.listFiles();
+    List<File> result = new ArrayList<>(files.length);
+    for (File f : files) {
+      if (f.isDirectory()) {
+        result.addAll(recursiveListDir(f));
+        continue;
+      }
+      result.add(f);
+    }
+    return result;
+  }
+
+
+  @Test
+  public void irrelevantFileIgnored() throws Exception {
+    // This file will not be copied
+    // Not included in the expected set
+    InfoCollectorTestUtils.createFileInDir(mTestDir, "irrelevant");
+
+    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
+    File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
+    CommandLine mockCommandLine = mock(CommandLine.class);
+    String[] mockArgs = new String[]{targetDir.getAbsolutePath()};
+    when(mockCommandLine.getArgs()).thenReturn(mockArgs);
+    int ret = cmd.run(mockCommandLine);
+    assertEquals(0, ret);
+
+    // Files will be copied to sub-dir of target dir
+    File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
+
+    verifyAllFiles(subDir);
+  }
+
+  @Test
+  public void fileNameExcluded() throws Exception {
+    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
+    File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
+    CommandLine mockCommandLine = mock(CommandLine.class);
+    String[] mockArgs = new String[]{
+            targetDir.getAbsolutePath()
+    };
+    when(mockCommandLine.getArgs()).thenReturn(mockArgs);
+    when(mockCommandLine.hasOption(eq("exclude-logs"))).thenReturn(true);
+    when(mockCommandLine.getOptionValue(eq("exclude-logs"))).thenReturn("master.log.1, worker");
+    int ret = cmd.run(mockCommandLine);
+    assertEquals(0, ret);
+
+    // Files will be copied to sub-dir of target dir
+    File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
+    mExpectedFiles.remove("master.log.1");
+    mExpectedFiles.remove("worker.log");
+    mExpectedFiles.remove("worker.out");
+    mExpectedFiles.remove("worker.log.backup");
+
+    verifyAllFiles(subDir);
+  }
+
+  @Test
+  public void fileNameIncluded() throws Exception {
+    InfoCollectorTestUtils.createFileInDir(mTestDir, "alluxio_gc.log");
+    InfoCollectorTestUtils.createFileInDir(mTestDir, "alluxio_gc.log.1");
+    InfoCollectorTestUtils.createFileInDir(mTestDir, "alluxio_gc.log.2");
+
+    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
+    File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
+    CommandLine mockCommandLine = mock(CommandLine.class);
+    String[] mockArgs = new String[]{
+            targetDir.getAbsolutePath()
+    };
+    when(mockCommandLine.getArgs()).thenReturn(mockArgs);
+    when(mockCommandLine.hasOption(eq("include-logs"))).thenReturn(true);
+    when(mockCommandLine.getOptionValue(eq("include-logs"))).thenReturn("alluxio_gc");
+    int ret = cmd.run(mockCommandLine);
+    assertEquals(0, ret);
+
+    // Files will be copied to sub-dir of target dir
+    File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
+    mExpectedFiles.add("alluxio_gc.log");
+    mExpectedFiles.add("alluxio_gc.log.1");
+    mExpectedFiles.add("alluxio_gc.log.2");
+
+    verifyAllFiles(subDir);
+  }
+
+  @Test
+  public void endTimeFilter() throws Exception {
+    // Define an issue end datetime
+    // We ignore logs that are created after this
+    LocalDateTime issueEnd = LocalDateTime.of(2020, 7, 8, 18, 0, 0);
+    DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    // Other logs all end before this issue
+    LocalDateTime logEnd = issueEnd.minusHours(1);
+    long logEndTimestamp = logEnd.toEpochSecond(ZoneOffset.UTC);
+    for (File f : recursiveListDir(mTestDir)) {
+      f.setLastModified(logEndTimestamp);
+    }
+
+    // Some logs are created after this time, should be ignored
+    File masterLog = new File(mTestDir, "master.log");
+    String log = "2020-07-08 18:53:45,129 INFO  CopycatServer - Server started successfully!\n" +
+            "2020-07-08 18:53:59,129 INFO  RaftJournalSystem - Started Raft Journal System in 13175ms\n" +
+            "2020-07-09 00:01:59,135 INFO  DefaultMetaMaster - Standby master with address localhost:19998 starts sending heartbeat to leader master.\n" +
+            "2020-07-09 00:03:59,135 INFO  AlluxioMasterProcess - All masters started\n" +
+            "2020-07-09 01:12:59,138 INFO  AbstractPrimarySelector - Primary selector transitioning to PRIMARY\n" +
+            "2020-07-09 01:53:59,139 INFO  AbstractMaster - TableMaster: Stopped secondary master.";
+    writeToFile(masterLog, log);
+    masterLog.setLastModified(LocalDateTime.of(2020, 7, 9, 1, 53, 59).toEpochSecond(ZoneOffset.UTC));
+
+    // Some logs overlap with the end time
+    File masterLog1 = new File(mTestDir, "master.log.1");
+    String log1 = "2020-07-08 16:53:44,639 INFO  BlockMasterFactory - Creating alluxio.master.block.BlockMaster \n" +
+            "2020-07-08 16:53:44,639 INFO  TableMasterFactory - Creating alluxio.master.table.TableMaster \n" +
+            "2020-07-08 17:01:44,639 INFO  MetaMasterFactory - Creating alluxio.master.meta.MetaMaster \n" +
+            "2020-07-08 17:01:45,639 INFO  FileSystemMasterFactory - Creating alluxio.master.file.FileSystemMaster \n" +
+            "2020-07-08 18:53:44,751 INFO  UnderDatabaseRegistry - Registered UDBs: hive,glue\n" +
+            "2020-07-08 18:53:44,756 INFO  LayoutRegistry - Registered Table Layouts: hive";
+    writeToFile(masterLog1, log1);
+    masterLog1.setLastModified(LocalDateTime.of(2020, 7, 8, 18, 53, 45).toEpochSecond(ZoneOffset.UTC));
+
+    // Some logs end before this end time
+    File masterLog2 = new File(mTestDir, "master.log.2");
+    String log2 = "2020-07-08 15:40:45,656 INFO  HdfsUnderFileSystem - Successfully instantiated SupportedHdfsActiveSyncProvider\n" +
+            "2020-07-08 15:51:45,782 INFO  RocksStore - Opened rocks database under path /data/02/alluxio/metastore/inodes\n" +
+            "2020-07-08 15:53:45,862 INFO  RocksStore - Opened rocks database under path /data/02/alluxio/metastore/blocks\n" +
+            "2020-07-08 16:52:41,876 INFO  RocksStore - Opened rocks database under path /data/02/alluxio/metastore/inodes\n" +
+            "2020-07-08 16:53:43,876 INFO  JournalStateMachine - Initialized new journal state machine";
+    writeToFile(masterLog2, log2);
+    masterLog1.setLastModified(LocalDateTime.of(2020, 7, 8, 16, 53, 44).toEpochSecond(ZoneOffset.UTC));
+
+    // Copy
+    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
+    File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
+    CommandLine mockCommandLine = mock(CommandLine.class);
+    String[] mockArgs = new String[]{
+            targetDir.getAbsolutePath()
+    };
+    when(mockCommandLine.getArgs()).thenReturn(mockArgs);
+    when(mockCommandLine.hasOption(eq("end-time"))).thenReturn(true);
+    when(mockCommandLine.getOptionValue(eq("end-time"))).thenReturn(issueEnd.format(fmt));
+    int ret = cmd.run(mockCommandLine);
+    assertEquals(0, ret);
+
+    // Files will be copied to sub-dir of target dir
+    File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
+    mExpectedFiles.remove("master.log");
+    verifyAllFiles(subDir);
+  }
+
+  private void writeToFile(File f, String content) throws IOException {
+    try (FileWriter writer = new FileWriter(f)) {
+      writer.write(content);
+    }
+  }
+
+  @Test
+  public void startTimeFilter() throws Exception {
+    // Define an issue start datetime
+    // We ignore logs that are done before this
+    LocalDateTime issueEnd = LocalDateTime.of(2020, 7, 8, 18, 0, 0);
+    DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    // Other logs all end before this issue
+    LocalDateTime logEnd = issueEnd.minusHours(1);
+    long logEndTimestamp = logEnd.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+    for (File f : recursiveListDir(mTestDir)) {
+      f.setLastModified(logEndTimestamp);
+    }
+
+    // Some logs are created after this time, should be included
+    File masterLog = new File(mTestDir, "master.log");
+    String log = "2020-07-08 18:53:45,129 INFO  CopycatServer - Server started successfully!\n" +
+            "2020-07-08 18:53:59,129 INFO  RaftJournalSystem - Started Raft Journal System in 13175ms\n" +
+            "2020-07-09 00:01:59,135 INFO  DefaultMetaMaster - Standby master with address localhost:19998 starts sending heartbeat to leader master.\n" +
+            "2020-07-09 00:03:59,135 INFO  AlluxioMasterProcess - All masters started\n" +
+            "2020-07-09 01:12:59,138 INFO  AbstractPrimarySelector - Primary selector transitioning to PRIMARY\n" +
+            "2020-07-09 01:53:59,139 INFO  AbstractMaster - TableMaster: Stopped secondary master.";
+    writeToFile(masterLog, log);
+    masterLog.setLastModified(LocalDateTime.of(2020, 7, 9, 1, 53, 59).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+
+    // Some logs overlap with the start time, should be included
+    File masterLog1 = new File(mTestDir, "master.log.1");
+    String log1 = "2020-07-08 16:53:44,639 INFO  BlockMasterFactory - Creating alluxio.master.block.BlockMaster \n" +
+            "2020-07-08 16:53:44,639 INFO  TableMasterFactory - Creating alluxio.master.table.TableMaster \n" +
+            "2020-07-08 17:01:44,639 INFO  MetaMasterFactory - Creating alluxio.master.meta.MetaMaster \n" +
+            "2020-07-08 17:01:45,639 INFO  FileSystemMasterFactory - Creating alluxio.master.file.FileSystemMaster \n" +
+            "2020-07-08 18:53:44,751 INFO  UnderDatabaseRegistry - Registered UDBs: hive,glue\n" +
+            "2020-07-08 18:53:44,756 INFO  LayoutRegistry - Registered Table Layouts: hive";
+    writeToFile(masterLog1, log1);
+    masterLog1.setLastModified(LocalDateTime.of(2020, 7, 8, 18, 53, 45).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+
+    // Some logs end before the start time, should be ignored
+    File masterLog2 = new File(mTestDir, "master.log.2");
+    String log2 = "2020-07-08 15:40:45,656 INFO  HdfsUnderFileSystem - Successfully instantiated SupportedHdfsActiveSyncProvider\n" +
+            "2020-07-08 15:51:45,782 INFO  RocksStore - Opened rocks database under path /data/02/alluxio/metastore/inodes\n" +
+            "2020-07-08 15:53:45,862 INFO  RocksStore - Opened rocks database under path /data/02/alluxio/metastore/blocks\n" +
+            "2020-07-08 16:52:41,876 INFO  RocksStore - Opened rocks database under path /data/02/alluxio/metastore/inodes\n" +
+            "2020-07-08 16:53:43,876 INFO  JournalStateMachine - Initialized new journal state machine";
+    writeToFile(masterLog2, log2);
+    masterLog2.setLastModified(LocalDateTime.of(2020, 7, 8, 16, 53, 44).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+
+    // Copy
+    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
+    File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
+    CommandLine mockCommandLine = mock(CommandLine.class);
+    String[] mockArgs = new String[]{
+            targetDir.getAbsolutePath()
+    };
+    when(mockCommandLine.getArgs()).thenReturn(mockArgs);
+    when(mockCommandLine.hasOption(eq("start-time"))).thenReturn(true);
+    when(mockCommandLine.getOptionValue(eq("start-time"))).thenReturn(issueEnd.format(fmt));
+    int ret = cmd.run(mockCommandLine);
+    assertEquals(0, ret);
+
+    // Files will be copied to sub-dir of target dir
+    File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
+    mExpectedFiles = new HashSet<>();
+    mExpectedFiles.add("master.log");
+    mExpectedFiles.add("master.log.1");
+    verifyAllFiles(subDir);
+  }
+
+  @Test
+  public void inferDateFromLog() throws Exception {
+
+    // TODO(jiacheng): refactor using assertThat
+    // more formats
+    String yarnAppLog = "\n" +
+            "Logged in as: user\n" +
+            "Application\n" +
+            "About\n" +
+            "Jobs\n" +
+            "Tools\n" +
+            "Log Type: container-localizer-syslog\n" +
+            "\n" +
+            "Log Upload Time: Mon May 18 16:11:22 +0800 2020\n" +
+            "\n" +
+            "Log Length: 0\n" +
+            "\n" +
+            "\n" +
+            "Log Type: stderr\n" +
+            "\n" +
+            "Log Upload Time: Mon May 18 16:11:22 +0800 2020\n" +
+            "\n" +
+            "Log Length: 3616\n" +
+            "\n" +
+            "20/05/18 16:11:18 INFO util.SignalUtils: Registered signal handler for TERM\n" +
+            "20/05/18 16:11:18 INFO util.SignalUtils: Registered signal handler for HUP\n" +
+            "20/05/18 16:11:18 INFO util.SignalUtils: Registered signal handler for INT";
+    File yarnAppLogFile = new File(mTestDir, "yarn-application.log");
+    writeToFile(yarnAppLogFile, yarnAppLog);
+    LocalDateTime yarnAppDatetime = CollectLogCommand.inferFileStartTime(yarnAppLogFile);
+    assertTrue(LocalDateTime.of(2020, 5, 18, 16, 11, 18).isEqual(yarnAppDatetime));
+
+    String yarnLog = "2020-05-16 02:02:25,855 INFO org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerImpl: container_e103_1584954066020_230169_01_000004 Container Transitioned from ALLOCATED to ACQUIRED\n" +
+            "2020-05-16 02:02:25,909 INFO org.apache.hadoop.yarn.server.resourcemanager.scheduler.AppSchedulingInfo: checking for deactivate... \n" +
+            "2020-05-16 02:02:26,006 INFO org.apache.hadoop.yarn.server.resourcemanager.rmcontainer.RMContainerImpl: container_e103_1584954066020_230168_01_000047 Container Transitioned from ALLOCATED to ACQUIRED";
+    File yarnLogFile = new File(mTestDir, "yarn-rm.log");
+    writeToFile(yarnLogFile, yarnLog);
+    LocalDateTime yarnDatetime = CollectLogCommand.inferFileStartTime(yarnLogFile);
+    System.out.println("yarn date time " + yarnDatetime);
+    System.out.println("expected datetime " + LocalDateTime.of(2020, 5, 16, 2, 2, 25, 855 * 1_000_000));
+    assertTrue(LocalDateTime.of(2020, 5, 16, 2, 2, 25, 855 * 1_000_000).isEqual(yarnDatetime));
+
+    String zkLog = "2020-05-14 21:05:53,822 WARN org.apache.zookeeper.server.NIOServerCnxn: caught end of stream exception\n" +
+            "EndOfStreamException: Unable to read additional data from client sessionid 0x471fa7133c193e4, likely client has closed socket\n" +
+            "\tat org.apache.zookeeper.server.NIOServerCnxn.doIO(NIOServerCnxn.java:241)\n" +
+            "\tat org.apache.zookeeper.server.NIOServerCnxnFactory.run(NIOServerCnxnFactory.java:208)\n" +
+            "\tat java.lang.Thread.run(Thread.java:748)\n" +
+            "2020-05-14 21:05:53,823 INFO org.apache.zookeeper.server.NIOServerCnxn: Closed socket connection for client /10.64.23.190:50120 which had sessionid 0x471fa7133c193e4\n" +
+            "2020-05-14 21:05:53,911 WARN org.apache.zookeeper.server.NIOServerCnxn: caught end of stream exception\n" +
+            "EndOfStreamException: Unable to read additional data from client sessionid 0x471fa7133c193e1, likely client has closed socket\n" +
+            "\tat org.apache.zookeeper.server.NIOServerCnxn.doIO(NIOServerCnxn.java:241)\n" +
+            "\tat org.apache.zookeeper.server.NIOServerCnxnFactory.run(NIOServerCnxnFactory.java:208)\n" +
+            "\tat java.lang.Thread.run(Thread.java:748)";
+    File zkLogFile = new File(mTestDir, "zk.log");
+    writeToFile(zkLogFile, zkLog);
+    LocalDateTime zkDatetime = CollectLogCommand.inferFileStartTime(zkLogFile);
+    assertTrue(LocalDateTime.of(2020, 5, 14, 21, 5, 53, 822 * 1_000_000).isEqual(zkDatetime));
+
+    String hdfsLog = "2020-05-15 22:02:27,878 INFO BlockStateChange: BLOCK* addStoredBlock: blockMap updated: 10.64.23.184:1025 is added to blk_1126197354_52572663{blockUCState=UNDER_CONSTRUCTION, primaryNodeIndex=-1, replicas=[ReplicaUnderConstruction[[DISK]DS-46e3eb6e-7109-4a13-92dd-31b53658bfcf:NORMAL:10.64.23.124:1025|FINALIZED], ReplicaUnderConstruction[[DISK]DS-f2e3f3b1-73f7-4a75-b22d-e1067317469e:NORMAL:10.64.23.184:1025|FINALIZED]]} size 0\n" +
+            "2020-05-15 22:02:27,878 INFO BlockStateChange: BLOCK* addStoredBlock: blockMap updated: 10.70.22.117:1025 is added to blk_1126197354_52572663{blockUCState=UNDER_CONSTRUCTION, primaryNodeIndex=-1, replicas=[ReplicaUnderConstruction[[DISK]DS-46e3eb6e-7109-4a13-92dd-31b53658bfcf:NORMAL:10.64.23.124:1025|FINALIZED], ReplicaUnderConstruction[[DISK]DS-f2e3f3b1-73f7-4a75-b22d-e1067317469e:NORMAL:10.64.23.184:1025|FINALIZED], ReplicaUnderConstruction[[DISK]DS-2ba9205e-24e7-4730-9c6c-6777d9e4bcdd:NORMAL:10.70.22.117:1025|FINALIZED]]} size 0";
+    File hdfsLogFile = new File(mTestDir, "hdfs.log");
+    writeToFile(hdfsLogFile, hdfsLog);
+    LocalDateTime hdfsDatetime = CollectLogCommand.inferFileStartTime(hdfsLogFile);
+    assertTrue(LocalDateTime.of(2020, 5, 15, 22, 2, 27, 878 * 1_000_000).isEqual(hdfsDatetime));
+
+    String prestoLog = "2020-05-16T00:00:01.059+0800\tINFO\tdispatcher-query-7960\tio.prestosql.event.QueryMonitor\tTIMELINE: Query 20200515_155959_06700_6r6b4 :: Transaction:[4d30e960-c319-439c-84dd-022ddab6fa5e] :: elapsed 1208ms :: planning 0ms :: waiting 0ms :: scheduling 1208ms :: running 0ms :: finishing 1208ms :: begin 2020-05-15T23:59:59.850+08:00 :: end 2020-05-16T00:00:01.058+08:00\n" +
+            "2020-05-16T00:00:01.083+0800\tINFO\tdispatcher-query-7960\tcom.bluetalon.presto.authorization.BtStatementAccessControl\tStatementRewriteContext: FullStatementRewriteContext{queryId=20200515_160001_06701_6r6b4, principal=Optional[edsfuser@SVCS.DBS.COM], user=edsfuser, source=presto-jdbc, catalog=Optional[hive], schema=Optional[default], startTime=1589558401082, remoteUserAddress=10.70.23.171}\n" +
+            "2020-05-16T00:00:01.083+0800\tINFO\tdispatcher-query-7960\tcom.bluetalon.presto.authorization.BtStatementAccessControl\tBtStatementAccessControl.getModifiedQuery() entering: user=edsfuser,principal=Optional[edsfuser@SVCS.DBS.COM],query=CREATE OR REPLACE VIEW P_S_SG.S_ADA_CASP_DATAPOST_MCASTMT_4_view_ns AS SELECT \"businessdate\",\"camstmfl_brch\",\"camstmfl_category_ident\",\"camstmfl_ccy\",\"camstmfl_ccy_desc\",\"camstmfl_chkdgt\",\"camstmfl_conv_currency\",\"camstmfl_conv_rate\",\"camstmfl_dept\",\"camstmfl_filehdr_sysid\",\"camstmfl_product_code\",\"camstmfl_rchq_reason\",\"camstmfl_rchq_reason_desc\",\"camstmfl_request_type\",\"camstmfl_reversal_ind\",\"camstmfl_sector_code\",\"camstmfl_serial\",\"camstmfl_serial_day\",\"camstmfl_serial_month\",\"camstmfl_serial_product\",\"camstmfl_serial_ref\",\"camstmfl_stmt_code\",\"camstmfl_stmt_date\",\"camstmfl_suffix\",\"camstmfl_summary_sysid\",\"camstmfl_suppress_ind\",\"camstmfl_total_records\",\"camstmfl_trans_amount\",\"camstmfl_trans_amount_dec\",\"camstmfl_trans_amount_sign\",\"camstmfl_trans_balance\",\"camstmfl_trans_balance_dec\",\"camstmfl_trans_balance_sign\",\"camstmfl_trans_date\",\"camstmfl_trans_dd\",\"camstmfl_trans_mm\",\"camstmfl_trans_type\",\"camstmfl_trans_yy\",\"camstmfl_value_date\",\"camstmfl_value_dd\",\"camstmfl_value_mm\",\"camstmfl_value_yy\",\"rowid\",\"rowmd5\",\"rowkey\",\"business_date\" FROM S_SG.S_ADA_CASP_DATAPOST_MCASTMT_4,catalog=hive,schema=default";
+    File prestoLogFile = new File(mTestDir, "presto.log");
+    writeToFile(prestoLogFile, prestoLog);
+    LocalDateTime prestoDatetime = CollectLogCommand.inferFileStartTime(prestoLogFile);
+    System.out.println("Expected " + LocalDateTime.of(2020, 5, 16, 0, 1, 59));
+    assertTrue(LocalDateTime.of(2020, 5, 16, 0, 0, 1, 59 * 1_000_000).isEqual(prestoDatetime));
+
+    String gcLog = "Java HotSpot(TM) 64-Bit Server VM (25.151-b12) for linux-amd64 JRE (1.8.0_151-b12), built on Sep  5 2017 19:20:58 by \"java_re\" with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)\n" +
+            "Memory: 4k page, physical 197920016k(194009624k free), swap 33279996k(33279996k free)\n" +
+            "CommandLine flags: -XX:CMSInitiatingOccupancyFraction=65 -XX:InitialHeapSize=154618822656 -XX:MaxDirectMemorySize=103079215104 -XX:MaxHeapSize=154618822656 -XX:MaxNewSize=32212254720 -XX:MaxTenuringThreshold=6 -XX:MetaspaceSize=536870912 -XX:NewSize=32212254720 -XX:OldPLABSize=16 -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+UseCMSInitiatingOccupancyOnly -XX:+UseConcMarkSweepGC -XX:+UseParNewGC \n" +
+            "2020-05-07T10:01:11.409+0800: 4.304: [GC (GCLocker Initiated GC) 2020-05-07T10:01:11.410+0800: 4.304: [ParNew: 25669137K->130531K(28311552K), 0.4330954 secs] 25669137K->130531K(147849216K), 0.4332463 secs] [Times: user=4.50 sys=0.08, real=0.44 secs] ";
+    File gcLogFile = new File(mTestDir, "gc.log");
+    writeToFile(gcLogFile, gcLog);
+    LocalDateTime gcDatetime = CollectLogCommand.inferFileStartTime(gcLogFile);
+    assertTrue(LocalDateTime.of(2020, 5, 7, 10, 1, 11, 409 * 1_000_000).isEqual(gcDatetime));
+  }
+
 }


### PR DESCRIPTION
This adds 3 features to `collectInfo`

1. With `--exclude-logs <filename-prefixes>`, `--include-logs <filename-prefixes>` and `--additional-logs` the user is able to specify log files to take or not take. By default only Alluxio-relevant files under `${ALLUXIO_HOME}/logs` are included and unrecognized files are ignored.

For example, `alluxio collectInfo --additional-logs alluxio_gc --exclude-logs master collectLog <tmp-dir>` will include all `alluxio_gc*` files (supposedly for GC logs) and exclude all `master*` files like `master.log.*` and `master.out`.

`alluxio collectInfo --include-logs master collectLog <tmp-dir>` will, however, take only the `master*` files like `master.log` and `master.out`.

2. With `--start-time <datetime>` and `--end-time <datetime>` the user can specify a certain time window to cover. This serves the need where only events in one window is of interest. The files that end before the `start time` or starts after the `end time` will be ignored. The `end time` of a file is the last modification time. The `start time` of a file is inferred by reading the first set of rows.

3. `alluxio-site.properties` will not be collected as it can contain unmasked credentials. This is replaced with doing a local `alluxio getConf`.