### PR TITLE
Upgrade Junit from 4.12 to 4.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <java.version>1.8</java.version>
     <jersey.version>2.29.1</jersey.version>
     <jetty.version>9.4.28.v20200408</jetty.version>
-    <junit.version>4.12</junit.version>
+    <junit.version>4.13</junit.version>
     <log4j.version>1.2.17</log4j.version>
     <maven.version>3.3.9</maven.version>
     <metrics.version>3.1.2</metrics.version>


### PR DESCRIPTION
Junit 4.13 was released with jdk11 CI.