### PR TITLE
Upgrade parquet libraries version from 1.10.0 to 1.11.0

### DIFF
--- a/job/server/src/main/java/alluxio/job/plan/transform/CompactDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/CompactDefinition.java
@@ -25,8 +25,8 @@ import alluxio.job.util.SerializableVoid;
 import alluxio.util.CommonUtils;
 import alluxio.wire.WorkerInfo;
 
-import avro.shaded.com.google.common.collect.ImmutableMap;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <powermock.version>1.6.2</powermock.version>
     <prometheus.version>0.8.0</prometheus.version>
     <guava.version>27.0.1-jre</guava.version>
-    <parquet.version>1.10.0</parquet.version>
+    <parquet.version>1.11.0</parquet.version>
     <protobuf.version>3.11.0</protobuf.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.2</slf4j.version>


### PR DESCRIPTION
Parquet libraries started having Java 11 CI from 1.11.0.