### PR TITLE
Upgrade jackson from 2.10.1 to 2.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <protobuf.version>3.11.0</protobuf.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.2</slf4j.version>
-    <jackson.version>2.10.1</jackson.version>
+    <jackson.version>2.11.1</jackson.version>
     <ozone.version>0.5.0-beta</ozone.version>
     <surefire.forkCount>2</surefire.forkCount>
     <surefire.useSystemClassLoader>true</surefire.useSystemClassLoader>


### PR DESCRIPTION
Jackson started adding CI from Java 11 on. aws-java-sdk-core seems to have a dependency on it but overall, seems safe.