### PR TITLE
Use longs for file offsets in stress client io

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
@@ -285,8 +285,8 @@ public class StressClientIOBench extends Benchmark<ClientIOTaskResult> {
     private final byte[] mBuffer;
     private final ByteBuffer mByteBuffer;
     private final int mThreadId;
-    private final int mFileSize;
-    private final int mMaxOffset;
+    private final long mFileSize;
+    private final long mMaxOffset;
     private final Random mRandom = new Random();
     private final long mBlockSize;
 
@@ -295,7 +295,7 @@ public class StressClientIOBench extends Benchmark<ClientIOTaskResult> {
 
     private FSDataInputStream mInStream = null;
     private FSDataOutputStream mOutStream = null;
-    private int mCurrentOffset;
+    private long mCurrentOffset;
 
     private BenchThread(BenchContext context, FileSystem fs, int threadId) {
       mContext = context;
@@ -314,7 +314,7 @@ public class StressClientIOBench extends Benchmark<ClientIOTaskResult> {
       Arrays.fill(mBuffer, (byte) 'A');
       mByteBuffer = ByteBuffer.wrap(mBuffer);
 
-      mFileSize = (int) FormatUtils.parseSpaceSize(mParameters.mFileSize);
+      mFileSize = FormatUtils.parseSpaceSize(mParameters.mFileSize);
       mCurrentOffset = mFileSize;
       mMaxOffset = mFileSize - mBuffer.length;
       mBlockSize = FormatUtils.parseSpaceSize(mParameters.mBlockSize);
@@ -377,7 +377,7 @@ public class StressClientIOBench extends Benchmark<ClientIOTaskResult> {
           mInStream = mFs.open(mFilePath);
         }
         if (mParameters.mReadRandom) {
-          mCurrentOffset = mRandom.nextInt(mMaxOffset);
+          mCurrentOffset = mRandom.nextLong() % mMaxOffset;
           if (!ClientIOOperation.isPosRead(mParameters.mOperation)) {
             // must seek if not a positioned read
             mInStream.seek(mCurrentOffset);

--- a/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -287,7 +288,7 @@ public class StressClientIOBench extends Benchmark<ClientIOTaskResult> {
     private final int mThreadId;
     private final long mFileSize;
     private final long mMaxOffset;
-    private final Random mRandom = new Random();
+    private final Iterator<Long> mLongs;
     private final long mBlockSize;
 
     private final ClientIOTaskResult.ThreadCountResult mThreadCountResult =
@@ -318,6 +319,8 @@ public class StressClientIOBench extends Benchmark<ClientIOTaskResult> {
       mCurrentOffset = mFileSize;
       mMaxOffset = mFileSize - mBuffer.length;
       mBlockSize = FormatUtils.parseSpaceSize(mParameters.mBlockSize);
+
+      mLongs = new Random().longs(0, mMaxOffset).iterator();
     }
 
     @Override
@@ -377,7 +380,7 @@ public class StressClientIOBench extends Benchmark<ClientIOTaskResult> {
           mInStream = mFs.open(mFilePath);
         }
         if (mParameters.mReadRandom) {
-          mCurrentOffset = Math.abs(mRandom.nextLong()) % mMaxOffset;
+          mCurrentOffset = mLongs.next();
           if (!ClientIOOperation.isPosRead(mParameters.mOperation)) {
             // must seek if not a positioned read
             mInStream.seek(mCurrentOffset);

--- a/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
@@ -377,7 +377,7 @@ public class StressClientIOBench extends Benchmark<ClientIOTaskResult> {
           mInStream = mFs.open(mFilePath);
         }
         if (mParameters.mReadRandom) {
-          mCurrentOffset = mRandom.nextLong() % mMaxOffset;
+          mCurrentOffset = Math.abs(mRandom.nextLong()) % mMaxOffset;
           if (!ClientIOOperation.isPosRead(mParameters.mOperation)) {
             // must seek if not a positioned read
             mInStream.seek(mCurrentOffset);


### PR DESCRIPTION
Using longs supports larger file sizes.