### PR TITLE
Upgrade commons-io from 2.6 to 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.6</version>
+        <version>2.7</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
hbase-client has a dependency to commons-io which also gets upgraded from this as a result but it seems okay.