### PR TITLE
Upgrade commons-lang3 from 3.4 to 3.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -410,7 +410,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.4</version>
+        <version>3.11</version>
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>


### PR DESCRIPTION
hive-metastore has a dependency to commons-lang3 as well which will also get upgraded from 3.4 to 3.11.