### PR TITLE
Upgrade httpclient to 4.5.6 and upgrade httpcore to 4.4.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,12 +521,12 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.3</version>
+        <version>4.5.12</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>4.4.6</version>
+        <version>4.4.13</version>
       </dependency>
       <dependency>
         <groupId>org.apache.orc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -521,7 +521,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.12</version>
+        <version>4.5.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
httpclient has dependency on httpcore and most others that depend on httpclient also depend on httpcore. Note also that httpclient 4.5.11 upgraded httpcore dependency to 4.4.13 accoridng to the changelogs. Here are the list of other dependencies with a dependency on httpclient/httpcore. 

libthrift
aws-java-sdk-core
cos_api
hadoop-auth
aliyun-sdk-oss
joss
hadoop-azure
hadoop-ozone-filesystem
hadoop-auth