### PR TITLE
[SMALLFIX] Do not trigger async caching on posRead if source is local

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -270,7 +270,9 @@ public class AlluxioFileInStream extends FileInStream {
         len -= bytesRead;
         retry = mRetryPolicySupplier.get();
         lastException = null;
-        triggerAsyncCaching(mCachedPositionedReadStream);
+        if (mCachedPositionedReadStream.getSource() != BlockInStream.BlockInStreamSource.LOCAL) {
+          triggerAsyncCaching(mCachedPositionedReadStream);
+        }
       } catch (IOException e) {
         lastException = e;
         if (mCachedPositionedReadStream != null) {


### PR DESCRIPTION
Small fix to make posRead behavior mimic normal read behavior. If the source is local, we have already cached the data. Unfortunately our testing framework is not fine grained enough to track the RPC calls (see AlluxioFileInStreamTest#L752). 
In general, our strategy of sending async cache requests has been aggressive because we believed it is cheap for the worker to filter out duplicate requests. If this is not the case, we can probably further decrease the number of async cache requests we make.