### PR TITLE
Enable the JVM pause monitor by default

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4616,15 +4616,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_JVM_MONITOR_ENABLED =
       new Builder(Name.MASTER_JVM_MONITOR_ENABLED)
-          .setDefaultValue(false)
-          .setDescription("Whether to enable start JVM monitor thread on master.")
+          .setDefaultValue(true)
+          .setDescription("Whether to enable start JVM monitor thread on the master. This will "
+              + "start a thread to detect JVM-wide pauses induced by GC or other reasons.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey WORKER_JVM_MONITOR_ENABLED =
       new Builder(Name.WORKER_JVM_MONITOR_ENABLED)
-          .setDefaultValue(false)
-          .setDescription("Whether to enable start JVM monitor thread on worker.")
+          .setDefaultValue(true)
+          .setDescription("Whether to enable start JVM monitor thread on the worker. This will "
+              + "start a thread to detect JVM-wide pauses induced by GC or other reasons.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4596,14 +4596,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey JVM_MONITOR_WARN_THRESHOLD_MS =
       new Builder(Name.JVM_MONITOR_WARN_THRESHOLD_MS)
           .setDefaultValue("10sec")
-          .setDescription("Extra sleep time longer than this threshold, log WARN.")
+          .setDescription("When the JVM pauses for anything longer than this, log a WARN message.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey JVM_MONITOR_INFO_THRESHOLD_MS =
       new Builder(Name.JVM_MONITOR_INFO_THRESHOLD_MS)
           .setDefaultValue("1sec")
-          .setDescription("Extra sleep time longer than this threshold, log INFO.")
+          .setDescription("When the JVM pauses for anything longer than this, log an INFO message.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();

--- a/core/common/src/main/java/alluxio/util/JvmPauseMonitor.java
+++ b/core/common/src/main/java/alluxio/util/JvmPauseMonitor.java
@@ -54,7 +54,7 @@ public class JvmPauseMonitor {
   /** Times extra sleep time exceed INFO. */
   private final AtomicLong mInfoTimeExceeded = new AtomicLong();
   /** Total extra sleep time. */
-  private AtomicLong mTotalExtraTimeMs = new AtomicLong();
+  private final AtomicLong mTotalExtraTimeMs = new AtomicLong();
 
   private Thread mJvmMonitorThread;
 

--- a/core/common/src/main/java/alluxio/util/JvmPauseMonitor.java
+++ b/core/common/src/main/java/alluxio/util/JvmPauseMonitor.java
@@ -68,8 +68,6 @@ public class JvmPauseMonitor {
     Preconditions.checkArgument(gcSleepIntervalMs > 0, "gc sleep interval must be > 0");
     Preconditions.checkArgument(warnThresholdMs > 0, "warn threshold must be > 0");
     Preconditions.checkArgument(infoThresholdMs > 0, "info threshold must be > 0");
-    Preconditions.checkArgument(infoThresholdMs > gcSleepIntervalMs,
-        "gc info threshold must be > gc sleep interval");
     Preconditions.checkArgument(warnThresholdMs > infoThresholdMs,
         "gc warn threshold must be > gc info threshold");
     mGcSleepIntervalMs = gcSleepIntervalMs;

--- a/core/common/src/main/java/alluxio/util/JvmPauseMonitor.java
+++ b/core/common/src/main/java/alluxio/util/JvmPauseMonitor.java
@@ -11,6 +11,7 @@
 
 package alluxio.util;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Class to monitor JVM with a daemon thread, the thread sleep period of time
@@ -35,7 +37,7 @@ import java.util.concurrent.TimeUnit;
  * JVM has paused processing. Then log it into different level.
  */
 @NotThreadSafe
-public final class JvmPauseMonitor {
+public class JvmPauseMonitor {
   private static final Log LOG = LogFactory.getLog(JvmPauseMonitor.class);
 
   /** The time to sleep. */
@@ -48,11 +50,11 @@ public final class JvmPauseMonitor {
   private final long mInfoThresholdMs;
 
   /** Times extra sleep time exceed WARN. */
-  private long mWarnTimeExceeded = 0;
+  private final AtomicLong mWarnTimeExceeded = new AtomicLong();
   /** Times extra sleep time exceed INFO. */
-  private long mInfoTimeExceeded = 0;
+  private final AtomicLong mInfoTimeExceeded = new AtomicLong();
   /** Total extra sleep time. */
-  private long mTotalExtraTimeMs = 0;
+  private AtomicLong mTotalExtraTimeMs = new AtomicLong();
 
   private Thread mJvmMonitorThread;
 
@@ -63,6 +65,13 @@ public final class JvmPauseMonitor {
    * @param infoThresholdMs when gc pauses exceeds this time in milliseconds log INFO
    */
   public JvmPauseMonitor(long gcSleepIntervalMs, long warnThresholdMs, long infoThresholdMs) {
+    Preconditions.checkArgument(gcSleepIntervalMs > 0, "gc sleep interval must be > 0");
+    Preconditions.checkArgument(warnThresholdMs > 0, "warn threshold must be > 0");
+    Preconditions.checkArgument(infoThresholdMs > 0, "info threshold must be > 0");
+    Preconditions.checkArgument(infoThresholdMs > gcSleepIntervalMs,
+        "gc info threshold must be > gc sleep interval");
+    Preconditions.checkArgument(warnThresholdMs > infoThresholdMs,
+        "gc warn threshold must be > gc info threshold");
     mGcSleepIntervalMs = gcSleepIntervalMs;
     mWarnThresholdMs = warnThresholdMs;
     mInfoThresholdMs = infoThresholdMs;
@@ -89,42 +98,35 @@ public final class JvmPauseMonitor {
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     }
-    reset();
-  }
-
-  /**
-   * Resets value of mJvmMonitorThread.
-   */
-  public void reset() {
     mJvmMonitorThread = null;
   }
 
   /**
-   * @return true if thread started,false otherwise
+   * @return true if thread started, false otherwise
    */
   public boolean isStarted() {
-    return mJvmMonitorThread != null;
+    return mJvmMonitorThread != null && mJvmMonitorThread.isAlive();
   }
 
   /**
    * @return time exceeds WARN threshold in milliseconds
    */
   public long getWarnTimeExceeded() {
-    return mWarnTimeExceeded;
+    return mWarnTimeExceeded.get();
   }
 
   /**
    * @return time exceeds INFO threshold in milliseconds
    */
   public long getInfoTimeExceeded() {
-    return mInfoTimeExceeded;
+    return mInfoTimeExceeded.get();
   }
 
   /**
    * @return Total extra time in milliseconds
    */
   public long getTotalExtraTime() {
-    return mTotalExtraTimeMs;
+    return mTotalExtraTimeMs.get();
   }
 
   private String getMemoryInfo() {
@@ -172,11 +174,22 @@ public final class JvmPauseMonitor {
 
   private Map<String, GarbageCollectorMXBean> getGarbageCollectorMXBeans() {
     List<GarbageCollectorMXBean> gcBeanList = ManagementFactory.getGarbageCollectorMXBeans();
-    Map<String, GarbageCollectorMXBean> gcBeanMap = new HashMap();
+    Map<String, GarbageCollectorMXBean> gcBeanMap = new HashMap<>();
     for (GarbageCollectorMXBean gcBean : gcBeanList) {
       gcBeanMap.put(gcBean.getName(), gcBean);
     }
     return gcBeanMap;
+  }
+
+  /**
+   * Sleep this thread for the configured interval. Used indirectly in order to test
+   *
+   * @param ms time to sleep in milliseconds
+   * @throws InterruptedException when the thread's sleep is interrupted
+   */
+  @VisibleForTesting
+  void sleepMillis(long ms) throws InterruptedException {
+    Thread.sleep(ms);
   }
 
   private class GcMonitor extends Thread {
@@ -192,21 +205,21 @@ public final class JvmPauseMonitor {
       while (true) {
         sw.reset().start();
         try {
-          Thread.sleep(mGcSleepIntervalMs);
+          sleepMillis(mGcSleepIntervalMs);
         } catch (InterruptedException ie) {
-          LOG.warn(ie.getStackTrace());
+          LOG.warn("JVM pause monitor interrupted during sleep.");
           return;
         }
         long extraTime = sw.elapsed(TimeUnit.MILLISECONDS) - mGcSleepIntervalMs;
-        mTotalExtraTimeMs += extraTime;
+        mTotalExtraTimeMs.addAndGet(extraTime);
         Map<String, GarbageCollectorMXBean> gcBeanMapAfterSleep = getGarbageCollectorMXBeans();
 
         if (extraTime > mWarnThresholdMs) {
-          mInfoTimeExceeded++;
-          mWarnTimeExceeded++;
+          mInfoTimeExceeded.incrementAndGet();
+          mWarnTimeExceeded.incrementAndGet();
           LOG.warn(formatLogString(extraTime, gcBeanMapBeforeSleep, gcBeanMapAfterSleep));
         } else if (extraTime > mInfoThresholdMs) {
-          mInfoTimeExceeded++;
+          mInfoTimeExceeded.incrementAndGet();
           LOG.info(formatLogString(
               extraTime, gcBeanMapBeforeSleep, gcBeanMapAfterSleep));
         }

--- a/core/common/src/test/java/alluxio/TestLoggerRule.java
+++ b/core/common/src/test/java/alluxio/TestLoggerRule.java
@@ -12,6 +12,7 @@
 package alluxio;
 
 import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
 import org.junit.After;
@@ -50,6 +51,16 @@ public class TestLoggerRule extends AbstractResourceRule {
   }
 
   /**
+   * Determine if a specific pattern appears in log output with the specified level.
+   *
+   * @param pattern a pattern text to search for in log events
+   * @return true if a log message containing the pattern exists, false otherwise
+   */
+  public boolean wasLoggedWithLevel(String pattern, Level level) {
+    return mAppender.wasLoggedWithLevel(Pattern.compile(".*" + pattern + ".*"), level);
+  }
+
+  /**
    * Count the number of times a specific pattern appears in log messages.
    *
    * @param pattern Pattern to search for in log events
@@ -72,7 +83,7 @@ public class TestLoggerRule extends AbstractResourceRule {
 
   public class TestAppender extends AppenderSkeleton {
     @GuardedBy("this")
-    private List<LoggingEvent> mEvents = new ArrayList<>();
+    private final List<LoggingEvent> mEvents = new ArrayList<>();
 
     public void close() { }
 
@@ -82,6 +93,18 @@ public class TestLoggerRule extends AbstractResourceRule {
     public synchronized boolean wasLogged(Pattern pattern) {
       for (LoggingEvent e : mEvents) {
         if (pattern.matcher(e.getRenderedMessage()).matches()) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    /**
+     * Determines whether a message with the given pattern was logged.
+     */
+    public synchronized boolean wasLoggedWithLevel(Pattern pattern, Level level) {
+      for (LoggingEvent e : mEvents) {
+        if (e.getLevel().equals(level) && pattern.matcher(e.getRenderedMessage()).matches()) {
           return true;
         }
       }

--- a/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java
+++ b/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java
@@ -41,7 +41,6 @@ public final class JvmPauseMonitorTest {
   @Test
   public void pauseMonitorStartStopTest() {
     JvmPauseMonitor mon = new JvmPauseMonitor(100, 1000, 500);
-    int before = Thread.activeCount();
     mon.start();
     assertTrue(mon.isStarted());
     mon.stop();
@@ -90,12 +89,6 @@ public final class JvmPauseMonitorTest {
   public void testNegativeWarnThreshold() {
     mException.expect(IllegalArgumentException.class);
     new JvmPauseMonitor(100, -1, 500);
-  }
-
-  @Test
-  public void testTinyInfoThreshold() {
-    mException.expect(IllegalArgumentException.class);
-    new JvmPauseMonitor(100, 5000, 50);
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java
+++ b/core/common/src/test/java/alluxio/util/JvmPauseMonitorTest.java
@@ -11,39 +11,186 @@
 
 package alluxio.util;
 
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
 
-import alluxio.conf.InstancedConfiguration;
-import alluxio.conf.PropertyKey;
+import alluxio.TestLoggerRule;
 
-import com.google.common.collect.Lists;
-import org.junit.Ignore;
+import org.apache.log4j.Level;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
-import java.util.List;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
 
 public final class JvmPauseMonitorTest {
-  @Test
-  @Ignore("https://alluxio.atlassian.net/browse/ALLUXIO-3059")
-  public void monitorTest() {
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
-    long gcSleepInterval = conf.getMs(PropertyKey.JVM_MONITOR_SLEEP_INTERVAL_MS);
-    long warnThreshold = conf.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS);
-    long infoThreshold = conf.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS);
 
-    JvmPauseMonitor jvmPauseMonitor = new JvmPauseMonitor(gcSleepInterval, warnThreshold,
-        infoThreshold);
-    jvmPauseMonitor.start();
-    List<String> list = Lists.newArrayList();
-    int i = 0;
-    while (true) {
-      list.add(String.valueOf(i++));
-      if (jvmPauseMonitor.getWarnTimeExceeded() != 0) {
-        jvmPauseMonitor.stop();
-        break;
+  @Rule
+  public TestLoggerRule mLogRule = new TestLoggerRule();
+
+  @Rule
+  public ExpectedException mException = ExpectedException.none();
+
+  @Test
+  public void pauseMonitorStartStopTest() {
+    JvmPauseMonitor mon = new JvmPauseMonitor(100, 1000, 500);
+    int before = Thread.activeCount();
+    mon.start();
+    assertTrue(mon.isStarted());
+    mon.stop();
+    assertFalse(mon.isStarted());
+  }
+
+  @Test
+  public void interruptOnStop() throws Exception {
+    JvmPauseMonitor mon = Mockito.spy(new JvmPauseMonitor(10000, 900000, 90000));
+    CyclicBarrier barrier = new CyclicBarrier(2);
+    doAnswer((Answer<Void>) invocation -> {
+      barrier.await();
+      invocation.callRealMethod();
+      return null;
+    }).when(mon).sleepMillis(any(Long.class));
+    Thread current = Thread.currentThread();
+    Thread t1 = new Thread(() -> {
+      try {
+        barrier.await();
+        current.interrupt();
+      } catch (InterruptedException | BrokenBarrierException e) {
+        fail("Failed to await on barrier");
       }
+    });
+    t1.start();
+    mon.start();
+    barrier.await();
+    mon.stop();
+    assertTrue(Thread.currentThread().isInterrupted());
+    t1.join();
+  }
+
+  @Test
+  public void testNegativeGcSleep() {
+    mException.expect(IllegalArgumentException.class);
+    new JvmPauseMonitor(-1, 100, 500);
+  }
+
+  @Test
+  public void testNegativeInfoThreshold() {
+    mException.expect(IllegalArgumentException.class);
+    new JvmPauseMonitor(100, 500, -1);
+  }
+
+  @Test
+  public void testNegativeWarnThreshold() {
+    mException.expect(IllegalArgumentException.class);
+    new JvmPauseMonitor(100, -1, 500);
+  }
+
+  @Test
+  public void testTinyInfoThreshold() {
+    mException.expect(IllegalArgumentException.class);
+    new JvmPauseMonitor(100, 5000, 50);
+  }
+
+  @Test
+  public void testTinyWarnThreshold() {
+    mException.expect(IllegalArgumentException.class);
+    new JvmPauseMonitor(100, 50, 5000);
+  }
+
+  /**
+   * This test mocks the {@link JvmPauseMonitor#sleepMillis(long)} (long)} method to simulate a
+   * pause which logs at the INFO level.
+   */
+  @Test
+  public void testMockedInfoPause() throws Exception {
+    JvmPauseMonitor mon = Mockito.spy(new JvmPauseMonitor(100, 500, 250));
+    CyclicBarrier before = new CyclicBarrier(2);
+    doAnswer((Answer<Void>) invocation -> {
+      Thread.sleep(250);
+      invocation.callRealMethod();
+      before.await();
+      return null;
+    }).when(mon).sleepMillis(any(Long.class));
+    mon.start();
+    before.await(); // runs the monitor once
+    // wait until it reaches the barrier again
+    while (before.getNumberWaiting() < 1) {
+      Thread.sleep(20);
     }
-    assertNotEquals(jvmPauseMonitor.getWarnTimeExceeded(), 0);
-    assertNotEquals(jvmPauseMonitor.getTotalExtraTime(), 0);
+    assertEquals(1, mon.getInfoTimeExceeded());
+    assertEquals(0, mon.getWarnTimeExceeded());
+    assertEquals(250, mon.getTotalExtraTime(), 25);
+    assertTrue(mLogRule.wasLoggedWithLevel("JVM paused.*\n.*\n.*", Level.INFO));
+    assertEquals(1, mLogRule.logCount("JVM paused.*\n.*\n.*"));
+    before.await(); // runs the monitor once
+    // wait until it reaches the barrier again
+    while (before.getNumberWaiting() < 1) {
+      Thread.sleep(20);
+    }
+    assertEquals(2, mon.getInfoTimeExceeded());
+    assertEquals(0, mon.getWarnTimeExceeded());
+    assertEquals(500, mon.getTotalExtraTime(), 50);
+    assertEquals(2, mLogRule.logCount("JVM paused.*\n.*\n.*"));
+    before.await(); // runs the monitor once
+    // wait until it reaches the barrier again
+    while (before.getNumberWaiting() < 1) {
+      Thread.sleep(20);
+    }
+    assertEquals(3, mon.getInfoTimeExceeded());
+    assertEquals(0, mon.getWarnTimeExceeded());
+    assertEquals(750, mon.getTotalExtraTime(), 75);
+    assertEquals(3, mLogRule.logCount("JVM paused.*\n.*\n.*"));
+  }
+
+  /**
+   * This test mocks the {@link JvmPauseMonitor#sleepMillis(long)} (long)} method to simulate a
+   * pause which logs at the WARN level.
+   */
+  @Test
+  public void testMockedWarnPause() throws Exception {
+    JvmPauseMonitor mon = Mockito.spy(new JvmPauseMonitor(100, 200, 150));
+    CyclicBarrier before = new CyclicBarrier(2);
+    doAnswer((Answer<Void>) invocation -> {
+      Thread.sleep(250);
+      invocation.callRealMethod();
+      before.await();
+      return null;
+    }).when(mon).sleepMillis(any(Long.class));
+    mon.start();
+    before.await(); // runs the monitor once
+    // wait until it reaches the barrier again
+    while (before.getNumberWaiting() < 1) {
+      Thread.sleep(20);
+    }
+    assertEquals(1, mon.getInfoTimeExceeded());
+    assertEquals(1, mon.getWarnTimeExceeded());
+    assertEquals(250, mon.getTotalExtraTime(), 25);
+    assertTrue(mLogRule.wasLoggedWithLevel("JVM paused.*\n.*\n.*", Level.WARN));
+    assertEquals(1, mLogRule.logCount("JVM paused.*\n.*\n.*"));
+    before.await(); // runs the monitor once
+    // wait until it reaches the barrier again
+    while (before.getNumberWaiting() < 1) {
+      Thread.sleep(20);
+    }
+    assertEquals(2, mon.getInfoTimeExceeded());
+    assertEquals(2, mon.getWarnTimeExceeded());
+    assertEquals(500, mon.getTotalExtraTime(), 50);
+    assertEquals(2, mLogRule.logCount("JVM paused.*\n.*\n.*"));
+    before.await(); // runs the monitor once
+    // wait until it reaches the barrier again
+    while (before.getNumberWaiting() < 1) {
+      Thread.sleep(20);
+    }
+    assertEquals(3, mon.getInfoTimeExceeded());
+    assertEquals(3, mon.getWarnTimeExceeded());
+    assertEquals(750, mon.getTotalExtraTime(), 75);
+    assertEquals(3, mLogRule.logCount("JVM paused.*\n.*\n.*"));
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -266,8 +266,8 @@ public class AlluxioMasterProcess extends MasterProcess {
     if (ServerConfiguration.getBoolean(PropertyKey.MASTER_JVM_MONITOR_ENABLED)) {
       mJvmPauseMonitor = new JvmPauseMonitor(
           ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_SLEEP_INTERVAL_MS),
-          ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS),
-          ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS));
+          ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS),
+          ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS));
       mJvmPauseMonitor.start();
     }
   }

--- a/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
+++ b/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
@@ -14,12 +14,14 @@ package alluxio.master;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import alluxio.Constants;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.master.journal.noop.NoopJournalSystem;
 import alluxio.master.journal.raft.RaftJournalConfiguration;
 import alluxio.master.journal.raft.RaftJournalSystem;
 import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
 import alluxio.util.io.FileUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.util.network.NetworkAddressUtils;
@@ -156,7 +158,7 @@ public final class AlluxioMasterProcessTest {
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
-    });
+    }, WaitForOptions.defaults().setTimeoutMs(5 * Constants.MINUTE_MS));
   }
 
   private boolean isBound(int port) {

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -245,8 +245,8 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
       mJvmPauseMonitor =
           new JvmPauseMonitor(
               ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_SLEEP_INTERVAL_MS),
-              ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS),
-              ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS));
+              ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS),
+              ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS));
       mJvmPauseMonitor.start();
     }
 

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -245,8 +245,8 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
       mJvmPauseMonitor =
           new JvmPauseMonitor(
               ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_SLEEP_INTERVAL_MS),
-              ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS),
-              ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS));
+              ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS),
+              ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS));
       mJvmPauseMonitor.start();
     }
 


### PR DESCRIPTION
In addition to turning it on by default;
- Many new tests were added. Code coverage is 82/89 (92%)
- Minor tweaks and improvements to the class