### PR TITLE
Upgrade zookeeper from 3.5.5 to 3.5.8

### DIFF
--- a/core/common/pom.xml
+++ b/core/common/pom.xml
@@ -72,6 +72,10 @@
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -574,6 +574,13 @@
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
         <version>3.6.1</version>
+        <!-- conflicts with netty-all -->
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -573,7 +573,7 @@
       <dependency>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
-        <version>3.5.5</version>
+        <version>3.6.1</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -573,7 +573,7 @@
       <dependency>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
-        <version>3.6.1</version>
+        <version>3.5.8</version>
         <!-- conflicts with netty-all -->
         <exclusions>
           <exclusion>


### PR DESCRIPTION
Note that hive has a dependency on zookeeper that is pinned to 3.4.6 at the moment

We are still waiting for hive to be java compatible and it will be dealt with then.

Otherwise, all the dependencies seems to be from alluxio itself making this minor upgrade.