### PR TITLE
Fix Fuse YAML to use ALLUXIO_USER_JAVA_OPTS

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -127,3 +127,6 @@
 
 - Fixed parsing issue with multiple medium types for tiered storage #11778
 
+0.6.9
+
+- Pass alluxio.user.hostname via ALLUXIO_USER_JAVA_OPTS for FUSE

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.8
+version: 0.6.9
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -26,9 +26,6 @@
 {{- if $isSingleMaster }}
   {{- $alluxioJavaOpts = printf "-Dalluxio.master.hostname=%v-%v" $fullName $defaultMasterName | append $alluxioJavaOpts }}
 {{- end }}
-{{ if .Values.fuse.enabled -}}
-  {{- $alluxioJavaOpts = print "-Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $alluxioJavaOpts }}
-{{- end }}
 {{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.type=%v" .Values.journal.type | append $alluxioJavaOpts }}
 {{- $alluxioJavaOpts = printf "-Dalluxio.master.journal.folder=%v" .Values.journal.folder | append $alluxioJavaOpts }}
 

--- a/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
@@ -94,7 +94,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          - name: ALLUXIO_CLIENT_JAVA_OPTS
+          - name: ALLUXIO_USER_JAVA_OPTS
             value: " -Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME} "
           {{- range $key, $value := .Values.fuse.env }}
           - name: "{{ $key }}"


### PR DESCRIPTION
Fuse YAML template uses `ALLUXIO_CLIENT_JAVA_OPTS`, whereas the correct env variable should be `ALLUXIO_USER_JAVA_OPTS`.