### PR TITLE
Force target to be java 8 even if we are using jdk 11 to compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1304,7 +1304,7 @@
         <jdk>11</jdk>
       </activation>
       <properties>
-        <java.version>8</java.version>
+        <java.version>1.8</java.version>
       </properties>
       <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1304,7 +1304,7 @@
         <jdk>11</jdk>
       </activation>
       <properties>
-        <java.version>11</java.version>
+        <java.version>8</java.version>
       </properties>
       <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
We need our final artifact to be compatible with java 8 even if we are running jdk 11 compiler.