### PR TITLE
Upgrade jets3t to 0.9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,7 @@
       <dependency>
         <groupId>net.java.dev.jets3t</groupId>
         <artifactId>jets3t</artifactId>
-        <version>0.8.1</version>
+        <version>0.9.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Jets3t and it's dependencies changed to 0.9.4 in alluxio-underfs-gcs, alluxio-table-server-underdb-glue and alluxio-underfs-wasb
