### PR TITLE
Upgrade kryo from 4.0.2 to 5.0.0-RC8

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/JournalUtils.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalUtils.java
@@ -131,7 +131,7 @@ public final class JournalUtils {
     for (Checkpointed component : components) {
       chunked.writeString(component.getCheckpointName().toString());
       component.writeToCheckpoint(chunked);
-      chunked.endChunks();
+      chunked.endChunk();
     }
     chunked.flush();
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/checkpoint/CompoundCheckpointFormat.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/checkpoint/CompoundCheckpointFormat.java
@@ -75,9 +75,9 @@ public class CompoundCheckpointFormat implements CheckpointFormat {
       if (mFirstCheckpoint) {
         mFirstCheckpoint = false;
       } else {
-        mStream.nextChunks();
+        mStream.nextChunk();
       }
-      if (mStream.eof()) {
+      if (mStream.end()) {
         return Optional.empty();
       }
       CheckpointName name = CheckpointName.valueOf(mStream.readString());

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
       <dependency>
         <groupId>com.esotericsoftware</groupId>
         <artifactId>kryo</artifactId>
-        <version>4.0.2</version>
+        <version>5.0.0-RC8</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
dependency diff
before
```
[INFO] +- com.esotericsoftware:kryo:jar:4.0.2:compile
[INFO] |  +- com.esotericsoftware:reflectasm:jar:1.11.3:compile
[INFO] |  |  \- org.ow2.asm:asm:jar:5.0.4:compile
[INFO] |  +- com.esotericsoftware:minlog:jar:1.3.0:compile
[INFO] |  \- org.objenesis:objenesis:jar:2.5.1:compile
```
after
```
[INFO] +- com.esotericsoftware:kryo:jar:5.0.0-RC8:compile
[INFO] |  +- com.esotericsoftware:reflectasm:jar:1.11.8:compile
[INFO] |  +- org.objenesis:objenesis:jar:3.0.1:compile
[INFO] |  \- com.esotericsoftware:minlog:jar:1.3.1:compile
```