### PR TITLE
Upgrade java-xmlbuilder from 0.4 to 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
       <dependency>
         <groupId>com.jamesmurty.utils</groupId>
         <artifactId>java-xmlbuilder</artifactId>
-        <version>0.4</version>
+        <version>1.3</version>
       </dependency>
       <dependency>
         <groupId>commons-cli</groupId>


### PR DESCRIPTION
dependency diff

```
< [INFO] |  |  |  |  \- com.jamesmurty.utils:java-xmlbuilder:jar:0.4:compile
---
> [INFO] |  |  |  |  \- com.jamesmurty.utils:java-xmlbuilder:jar:1.3:compile
> [INFO] |  |  |  |     \- net.iharder:base64:jar:2.3.8:compile
```