### PR TITLE
Fix yarn version check in generate-tarball

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -115,11 +115,7 @@ func getCommonMvnArgs(hadoopVersion version) []string {
 }
 
 func includeYarnIntegration(hadoopVersion version) bool {
-	// include yarn if >= 2.4
-	if hadoopVersion.major != 2 {
-		return hadoopVersion.major >= 2
-	}
-	return hadoopVersion.minor >= 4
+	return hadoopVersion.compare(2, 4, 0) >= 0
 }
 
 func getVersion() (string, error) {

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -115,7 +115,11 @@ func getCommonMvnArgs(hadoopVersion version) []string {
 }
 
 func includeYarnIntegration(hadoopVersion version) bool {
-	return hadoopVersion.major >= 2 && hadoopVersion.minor >= 4
+	// include yarn if >= 2.4
+	if hadoopVersion.major != 2 {
+		return hadoopVersion.major >= 2
+	}
+	return hadoopVersion.minor >= 4
 }
 
 func getVersion() (string, error) {

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/version.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/version.go
@@ -64,3 +64,25 @@ func (v version) hadoopProfile() string {
 		panic(fmt.Sprintf("unexpected hadoop major version %v", v.major))
 	}
 }
+
+func (v version) compare(major, minor, patch int) int {
+	if v.major < major {
+		return -1
+	}
+	if v.major > major {
+		return 1
+	}
+	if v.minor < minor {
+		return -1
+	}
+	if v.minor > minor {
+		return 1
+	}
+	if v.patch < patch {
+		return -1
+	}
+	if v.patch > patch {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
version check logic was wrong (ex. if hadoop version = 3.0, comparison of "is greater than 2.4) returned was false) . added correct comparison via helper function

facepalm