### PR TITLE
Upgrade cos_api to 5.6.28

### DIFF
--- a/underfs/cos/pom.xml
+++ b/underfs/cos/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>com.qcloud</groupId>
       <artifactId>cos_api</artifactId>
-      <version>5.4.0</version>
+      <version>5.6.28</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>


### PR DESCRIPTION
```
5294c5294
< [INFO]    com.qcloud:cos_api:jar:5.4.0:compile
---
> [INFO]    com.qcloud:cos_api:jar:5.6.28:compile
5298c5298
< [INFO]    joda-time:joda-time:jar:2.9.6:compile
---
> [INFO]    joda-time:joda-time:jar:2.9.9:compile
5301a5302
> [INFO]    org.bouncycastle:bcprov-jdk15on:jar:1.64:compile
```