### PR TITLE
Format only the local master to avoid wiping the whole cluster

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -218,7 +218,7 @@ start_master() {
     if [ -f "${JOURNAL_DIR}" ]; then
       echo "Journal location ${JOURNAL_DIR} is a file not a directory. Please remove the file before retrying."
     elif [ ! -e "${JOURNAL_DIR}" ]; then
-      ${LAUNCHER} ${BIN}/alluxio format
+      ${LAUNCHER} ${BIN}/alluxio formatMaster
     fi
   fi
 


### PR DESCRIPTION
This prevents the start command from formatting an entire cluster if the journal directory doesn't exist. Original behavior was built to ensure that the journal folder existed in EMBEDDED mode. However, if a user accidentally removes the directory (e.g. during an upgrade), then we want to ensure that not all nodes are formatted.