### PR TITLE
Revert jets3t to 0.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -395,7 +395,7 @@
       <dependency>
         <groupId>net.java.dev.jets3t</groupId>
         <artifactId>jets3t</artifactId>
-        <version>0.9.4</version>
+        <version>0.8.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -282,8 +282,6 @@ public class GCSUnderFileSystem extends ObjectUnderFileSystem {
 
   @Override
   protected ObjectStatus getObjectStatus(String key) throws IOException {
-    ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
-    Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
     try {
       GSObject meta = mClient.getObjectDetails(mBucketName, key);
       if (meta == null) {
@@ -296,8 +294,6 @@ public class GCSUnderFileSystem extends ObjectUnderFileSystem {
         return null;
       }
       throw new IOException(e);
-    } finally {
-      Thread.currentThread().setContextClassLoader(previousClassLoader);
     }
   }
 


### PR DESCRIPTION
Jets3t targets AWS, changes from 0.8.1 to 0.9.4 are mostly AWS changes, not related to either GCS or Java 11.
Using 0.9.4 requires using custom classloader to run nearly all GCS APIs which is inefficient and reduce code cleanness.
Revert the version for now.