### PR TITLE
Fix CustomAuthenticationProviderTest.classNotProvider test in Java 11

### DIFF
--- a/core/common/src/test/java/alluxio/security/authentication/CustomAuthenticationProviderTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/CustomAuthenticationProviderTest.java
@@ -52,8 +52,11 @@ public final class CustomAuthenticationProviderTest {
   public void classNotProvider() {
     String notProviderClass = CustomAuthenticationProviderTest.class.getName();
     mThrown.expect(RuntimeException.class);
+    // Java 11 will add "class" prefix before the class names
+    // the following messages support both java 8 and java 11
     mThrown.expectMessage("alluxio.security.authentication.CustomAuthenticationProviderTest "
-        + "cannot be cast to alluxio.security.authentication.AuthenticationProvider");
+        + "cannot be cast to ");
+    mThrown.expectMessage("alluxio.security.authentication.AuthenticationProvider");
     new CustomAuthenticationProvider(notProviderClass);
   }
 


### PR DESCRIPTION
classNotProvider test has different thrown messages in Java 8 and Java 11.
Java 11 prefix the detailed class name with a "class" suffix.
The new messages support both formats.