### PR TITLE
Fix shaded client duplicate jackson.core.ObjectCodec entry

### DIFF
--- a/shaded/client/pom.xml
+++ b/shaded/client/pom.xml
@@ -100,6 +100,12 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client</artifactId>
           <scope>compile</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-core</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
Solve Error creating shaded jar: duplicate entry: META-INF/services/alluxio.shaded.client.com.fasterxml.jackson.core.ObjectCodec