### PR TITLE
Ignore RelativePath tests in Java 11

### DIFF
--- a/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
@@ -32,6 +32,7 @@ import alluxio.util.io.BufferUtils;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -305,6 +306,7 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
   }
 
   @Test
+  @Ignore("Breaks on Java 11 because of https://bugs.openjdk.java.net/browse/JDK-8202127")
   public void copyFromLocalRelativePath() throws Exception {
     HashMap<String, String> sysProps = new HashMap<>();
     sysProps.put("user.dir", mTestFolder.getRoot().getAbsolutePath());
@@ -312,7 +314,7 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
       File localDir = mTestFolder.newFolder("testDir");
       generateRelativeFileContent(localDir.getPath() + "/testFile",
               BufferUtils.getIncreasingByteArray(10));
-      int ret = sFsShell.run("copyFromLocal", "testDir/testFile", "/testFile");
+      int ret = sFsShell.runThrowException("copyFromLocal", "testDir/testFile", "/testFile");
       Assert.assertEquals(0, ret);
       Assert.assertTrue(fileExists(new AlluxioURI(("/testFile"))));
     }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
@@ -306,8 +306,13 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
   }
 
   @Test
-  @Ignore("Breaks on Java 11 because of https://bugs.openjdk.java.net/browse/JDK-8202127")
   public void copyFromLocalRelativePath() throws Exception {
+    String version = System.getProperty("java.version");
+    if (version.startsWith("11")) {
+      // Breaks on Java 11+ because of https://bugs.openjdk.java.net/browse/JDK-8202127
+      return;
+    }
+
     HashMap<String, String> sysProps = new HashMap<>();
     sysProps.put("user.dir", mTestFolder.getRoot().getAbsolutePath());
     try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
@@ -314,7 +314,7 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
       File localDir = mTestFolder.newFolder("testDir");
       generateRelativeFileContent(localDir.getPath() + "/testFile",
               BufferUtils.getIncreasingByteArray(10));
-      int ret = sFsShell.runThrowException("copyFromLocal", "testDir/testFile", "/testFile");
+      int ret = sFsShell.run("copyFromLocal", "testDir/testFile", "/testFile");
       Assert.assertEquals(0, ret);
       Assert.assertTrue(fileExists(new AlluxioURI(("/testFile"))));
     }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
@@ -32,7 +32,6 @@ import alluxio.util.io.BufferUtils;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CopyToLocalCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CopyToLocalCommandIntegrationTest.java
@@ -48,6 +48,12 @@ public final class CopyToLocalCommandIntegrationTest extends AbstractFileSystemS
 
   @Test
   public void copyToLocalRelativePathDir() throws Exception {
+    String version = System.getProperty("java.version");
+    if (version.startsWith("11")) {
+      // Breaks on Java 11+ because of https://bugs.openjdk.java.net/browse/JDK-8202127
+      return;
+    }
+
     FileSystemTestUtils.createByteFile(sFileSystem, "/testFile", WritePType.MUST_CACHE, 10);
     HashMap<String, String> sysProps = new HashMap<>();
     sysProps.put("user.dir", mTestFolder.getRoot().getAbsolutePath());
@@ -121,6 +127,12 @@ public final class CopyToLocalCommandIntegrationTest extends AbstractFileSystemS
 
   @Test
   public void copyToLocalRelativePath() throws Exception {
+    String version = System.getProperty("java.version");
+    if (version.startsWith("11")) {
+      // Breaks on Java 11+ because of https://bugs.openjdk.java.net/browse/JDK-8202127
+      return;
+    }
+
     HashMap<String, String> sysProps = new HashMap<>();
     sysProps.put("user.dir", mTestFolder.getRoot().getAbsolutePath());
     try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {


### PR DESCRIPTION
Setting user.dir to test relative path no longer works as of Java 11 (See https://bugs.openjdk.java.net/browse/JDK-8202127)
There is not much value to this test because this ultimately just tests that new File(Relative Path) is a working behavior.