### PR TITLE
Fix HDFSProxyUserValidationTaskTest

### DIFF
--- a/integration/tools/validation/src/test/java/alluxio/cli/ValidationTestUtils.java
+++ b/integration/tools/validation/src/test/java/alluxio/cli/ValidationTestUtils.java
@@ -73,6 +73,7 @@ public class ValidationTestUtils {
       StreamResult sResult = new StreamResult(f);
       transformer.transform(source, sResult);
     } catch (Exception e) {
+      // TODO (bradyoo): Swallowing all exceptions and merely printing is not okay!
       e.printStackTrace();
     }
   }

--- a/integration/tools/validation/src/test/java/alluxio/cli/ValidationTestUtils.java
+++ b/integration/tools/validation/src/test/java/alluxio/cli/ValidationTestUtils.java
@@ -73,7 +73,7 @@ public class ValidationTestUtils {
       StreamResult sResult = new StreamResult(f);
       transformer.transform(source, sResult);
     } catch (Exception e) {
-      // TODO (bradyoo): Swallowing all exceptions and merely printing is not okay!
+      // TODO(bradyoo): Swallowing all exceptions and merely printing is not okay!
       e.printStackTrace();
     }
   }

--- a/integration/tools/validation/src/test/java/alluxio/cli/hdfs/HdfsProxyUserValidationTaskTest.java
+++ b/integration/tools/validation/src/test/java/alluxio/cli/hdfs/HdfsProxyUserValidationTaskTest.java
@@ -20,15 +20,11 @@ import alluxio.cli.ValidationTestUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.security.authentication.AuthType;
-import alluxio.util.network.NetworkAddressUtils;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.IOException;

--- a/integration/tools/validation/src/test/java/alluxio/cli/hdfs/HdfsProxyUserValidationTaskTest.java
+++ b/integration/tools/validation/src/test/java/alluxio/cli/hdfs/HdfsProxyUserValidationTaskTest.java
@@ -35,8 +35,6 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(NetworkAddressUtils.class)
 public class HdfsProxyUserValidationTaskTest {
   private static File sTestDir;
   private InstancedConfiguration mConf;


### PR DESCRIPTION
Using Powermock makes it now such that you can no longer fetch the resource after Java 9 because (See https://stackoverflow.com/questions/54021754/why-does-the-getresource-method-return-null-in-jdk-11 UPDATE in the chosen answer)