### PR TITLE
Use a compatibility layer to handle older hive metastore

### DIFF
--- a/table/server/underdb/glue/pom.xml
+++ b/table/server/underdb/glue/pom.xml
@@ -31,7 +31,7 @@
         <build.path>${project.parent.parent.parent.parent.basedir}/build</build.path>
         <glue.version>1.11.820</glue.version>
         <aws.java.jdk.version>1.11.820</aws.java.jdk.version>
-        <hive-metastore.version>2.2.0</hive-metastore.version>
+        <hive-metastore.version>2.3.7</hive-metastore.version>
     </properties>
 
     <dependencies>

--- a/table/server/underdb/hive/pom.xml
+++ b/table/server/underdb/hive/pom.xml
@@ -26,8 +26,8 @@
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.parent.parent.basedir}/build</build.path>
-    <!-- 2.2.0 client works with a wide range of HMS, from 1.0 to 3.1 -->
-    <hive-metastore.version>2.2.0</hive-metastore.version>
+    <!-- use 2.3.7 to work with java 11 and match the version used in hcommon-hive-metastore library -->
+    <hive-metastore.version>2.3.7</hive-metastore.version>
   </properties>
 
   <dependencies>
@@ -36,6 +36,11 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.hotels</groupId>
+      <artifactId>hcommon-hive-metastore</artifactId>
+      <version>1.4.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveClientPool.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveClientPool.java
@@ -36,7 +36,8 @@ public final class HiveClientPool extends DynamicResourcePool<IMetaStoreClient> 
   private static final ScheduledExecutorService GC_EXECUTOR =
       new ScheduledThreadPoolExecutor(1, ThreadFactoryUtils.build("HiveClientPool-GC-%d", true));
 
-  private final CloseableMetaStoreClientFactory factory = new CloseableMetaStoreClientFactory();
+  private final CloseableMetaStoreClientFactory mClientFactory =
+      new CloseableMetaStoreClientFactory();
 
   private final long mGcThresholdMs;
   private final String mConnectionUri;
@@ -76,7 +77,7 @@ public final class HiveClientPool extends DynamicResourcePool<IMetaStoreClient> 
       HiveConf conf = new HiveConf();
       conf.verifyAndSet("hive.metastore.uris", mConnectionUri);
 
-      IMetaStoreClient client = factory.newInstance(conf, "hms");
+      IMetaStoreClient client = mClientFactory.newInstance(conf, "hms");
       if (!mDbExists) {
         synchronized (this) {
           // serialize the querying of the hive db


### PR DESCRIPTION
Version 2.2.0 of hive metastore client worked with a wide range of server versions, but we have to upgrade it for java 11 support. Hence we use this compatibility library which wraps the HMS client and replaces certain calls to be compatible with older versions.

https://github.com/HotelsDotCom/hcommon-hive-metastore