### PR TITLE
Update grpc and netty to resolve CVEs

### DIFF
--- a/integration/tools/validation/pom.xml
+++ b/integration/tools/validation/pom.xml
@@ -48,6 +48,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
 
     <!-- Internal dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <build.path>build</build.path>
     <copycat.version>1.2.15</copycat.version>
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
-    <grpc.version>1.31.0</grpc.version>
+    <grpc.version>1.29.0</grpc.version>
     <netty.version>4.1.48.Final</netty.version>
     <rocksdb.version>6.11.4</rocksdb.version>
     <hadoop.version>3.3.0</hadoop.version>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <build.path>build</build.path>
     <copycat.version>1.2.15</copycat.version>
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
-    <grpc.version>1.29.0</grpc.version>
+    <grpc.version>1.31.0</grpc.version>
     <netty.version>4.1.48.Final</netty.version>
     <rocksdb.version>6.11.4</rocksdb.version>
     <hadoop.version>3.3.0</hadoop.version>
@@ -233,6 +233,11 @@
         <groupId>com.github.serceman</groupId>
         <artifactId>jnr-fuse</artifactId>
         <version>0.5.3</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.8.6</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,8 +129,8 @@
     <build.path>build</build.path>
     <copycat.version>1.2.15</copycat.version>
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
-    <grpc.version>1.28.1</grpc.version>
-    <netty.version>4.1.45.Final</netty.version>
+    <grpc.version>1.31.0</grpc.version>
+    <netty.version>4.1.48.Final</netty.version>
     <rocksdb.version>6.11.4</rocksdb.version>
     <hadoop.version>3.3.0</hadoop.version>
     <jacoco.version>0.8.5</jacoco.version>


### PR DESCRIPTION
Updates for netty 4.1.48.Final and grpc 1.29.0 as outlined in #11923

grpc 1.31.0 had some changes that broke the build so I stopped at 1.29.0 since it had the needed Netty updates to resolve the CVE