### PR TITLE
Create a compatibility layer to handle older hive metastores

### DIFF
--- a/table/server/underdb/glue/pom.xml
+++ b/table/server/underdb/glue/pom.xml
@@ -31,7 +31,7 @@
         <build.path>${project.parent.parent.parent.parent.basedir}/build</build.path>
         <glue.version>1.11.820</glue.version>
         <aws.java.jdk.version>1.11.820</aws.java.jdk.version>
-        <hive-metastore.version>2.2.0</hive-metastore.version>
+        <hive-metastore.version>2.3.7</hive-metastore.version>
     </properties>
 
     <dependencies>

--- a/table/server/underdb/hive/pom.xml
+++ b/table/server/underdb/hive/pom.xml
@@ -26,8 +26,8 @@
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.parent.parent.basedir}/build</build.path>
-    <!-- 2.2.0 client works with a wide range of HMS, from 1.0 to 3.1 -->
-    <hive-metastore.version>2.2.0</hive-metastore.version>
+    <!-- 2.3.7 client needs a compatibility layer to work with lower versions -->
+    <hive-metastore.version>2.3.7</hive-metastore.version>
   </properties>
 
   <dependencies>

--- a/table/server/underdb/hive/pom.xml
+++ b/table/server/underdb/hive/pom.xml
@@ -26,7 +26,7 @@
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.parent.parent.basedir}/build</build.path>
-    <!-- 2.3.7 client needs a compatibility layer to work with lower versions -->
+    <!-- 2.3.7 client needs a compatibility layer to work with versions <= 2.2.x -->
     <hive-metastore.version>2.3.7</hive-metastore.version>
   </properties>
 

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/CompatibleMetastoreClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/CompatibleMetastoreClient.java
@@ -42,7 +42,8 @@ class CompatibleMetastoreClient implements InvocationHandler {
         if (mCompat != null
             && delegateException.getCause().getClass()
             .isAssignableFrom(TApplicationException.class)) {
-          LOG.debug("Attempting to call hive metastore with compatibility client");
+          LOG.debug("Attempting to call hive metastore with compatibility class {}",
+              mCompat.getClass().getName());
           return invokeCompatibility(method, args);
         }
       } catch (InvocationTargetException compatibilityException) {

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/CompatibleMetastoreClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/CompatibleMetastoreClient.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.table.under.hive.util;
 
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/CompatibleMetastoreClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/CompatibleMetastoreClient.java
@@ -42,7 +42,7 @@ class CompatibleMetastoreClient implements InvocationHandler {
         if (mCompat != null
             && delegateException.getCause().getClass()
             .isAssignableFrom(TApplicationException.class)) {
-          LOG.debug("Attempting to call hive metastore with {}", mCompat.getClass().getName());
+          LOG.debug("Attempting to call hive metastore with compatibility client");
           return invokeCompatibility(method, args);
         }
       } catch (InvocationTargetException compatibilityException) {

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/CompatibleMetastoreClient.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/CompatibleMetastoreClient.java
@@ -1,0 +1,68 @@
+package alluxio.table.under.hive.util;
+
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.thrift.TApplicationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+class CompatibleMetastoreClient implements InvocationHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(CompatibleMetastoreClient.class);
+
+  private final IMetaStoreClient mDelegate;
+  private final HMSShim mCompat;
+
+  CompatibleMetastoreClient(IMetaStoreClient delegate, HMSShim compatibility) {
+    mDelegate = delegate;
+    mCompat = compatibility;
+  }
+
+  @Override
+  public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    try {
+      return method.invoke(mDelegate, args);
+    } catch (InvocationTargetException delegateException) {
+      try {
+        LOG.info("Couldn't invoke method {}", method.toGenericString());
+        if (mCompat != null
+            && delegateException.getCause().getClass()
+            .isAssignableFrom(TApplicationException.class)) {
+          LOG.info("Attempting to invoke with {}", mCompat.getClass().getName());
+          return invokeCompatibility(method, args);
+        }
+      } catch (InvocationTargetException compatibilityException) {
+        if (compatibilityException.getCause().getClass()
+            .isAssignableFrom(TApplicationException.class)) {
+          LOG.warn("Invocation of compatibility for metastore client method {} failed.",
+                  method.getName(), compatibilityException);
+        } else {
+          // compatibility worked but threw non TApplicationException, re-throwing cause.
+          throw compatibilityException.getCause();
+        }
+      } catch (Throwable t) {
+        LOG.warn(
+                "Unable to invoke compatibility for metastore client method {}.",
+                method.getName(), t);
+      }
+      throw delegateException.getCause();
+    }
+  }
+
+  private Object invokeCompatibility(Method method, Object[] args) throws Throwable {
+    Class<?>[] argTypes = getTypes(args);
+    Method compatibilityMethod = mCompat.getClass().getMethod(method.getName(), argTypes);
+    return compatibilityMethod.invoke(mCompat, args);
+  }
+
+  private static Class<?>[] getTypes(Object[] args) {
+    Class<?>[] argTypes = new Class<?>[args.length];
+    for (int i = 0; i < args.length; ++i) {
+      argTypes[i] = args[i].getClass();
+    }
+    return argTypes;
+  }
+}
+

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HMSClientFactory.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HMSClientFactory.java
@@ -17,6 +17,8 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Proxy;
 
+import javax.annotation.Nullable;
+
 class HMSClientFactory {
   private static final Logger LOG = LoggerFactory.getLogger(HMSClientFactory.class);
 
@@ -30,7 +32,7 @@ class HMSClientFactory {
     return newInstance(delegate, compatibility);
   }
 
-  static IMetaStoreClient newInstance(IMetaStoreClient delegate, HMSShim compatibility) {
+  private static IMetaStoreClient newInstance(IMetaStoreClient delegate, @Nullable HMSShim compatibility) {
     ClassLoader classLoader = IMetaStoreClient.class.getClassLoader();
     Class<?>[] interfaces = new Class<?>[] { IMetaStoreClient.class };
     CompatibleMetastoreClient handler = new CompatibleMetastoreClient(delegate,

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HMSClientFactory.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HMSClientFactory.java
@@ -1,0 +1,40 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.table.under.hive.util;
+
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Proxy;
+
+class HMSClientFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(HMSClientFactory.class);
+
+  static IMetaStoreClient newInstance(IMetaStoreClient delegate) {
+    HMSShim compatibility = null;
+    try {
+      compatibility = new HMSShim(delegate);
+    } catch (Throwable t) {
+      LOG.warn("Unable to initialize hive metastore compatibility client", t);
+    }
+    return newInstance(delegate, compatibility);
+  }
+
+  static IMetaStoreClient newInstance(IMetaStoreClient delegate, HMSShim compatibility) {
+    ClassLoader classLoader = IMetaStoreClient.class.getClassLoader();
+    Class<?>[] interfaces = new Class<?>[] { IMetaStoreClient.class };
+    CompatibleMetastoreClient handler = new CompatibleMetastoreClient(delegate,
+        compatibility);
+    return (IMetaStoreClient) Proxy.newProxyInstance(classLoader, interfaces, handler);
+  }
+}

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HMSClientFactory.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HMSClientFactory.java
@@ -32,7 +32,8 @@ class HMSClientFactory {
     return newInstance(delegate, compatibility);
   }
 
-  private static IMetaStoreClient newInstance(IMetaStoreClient delegate, @Nullable HMSShim compatibility) {
+  private static IMetaStoreClient newInstance(IMetaStoreClient delegate,
+      @Nullable HMSShim compatibility) {
     ClassLoader classLoader = IMetaStoreClient.class.getClassLoader();
     Class<?>[] interfaces = new Class<?>[] { IMetaStoreClient.class };
     CompatibleMetastoreClient handler = new CompatibleMetastoreClient(delegate,

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HMSShim.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HMSShim.java
@@ -67,7 +67,7 @@ public class HMSShim implements HiveCompatibility {
       return result;
     } catch (SecurityException | NoSuchFieldException
         | IllegalArgumentException | IllegalAccessException e) {
-      throw new RuntimeException("Unable to access the client through reflection", e);
+      throw new RuntimeException("Unable to access field " + fieldName + " through reflection", e);
     }
   }
 
@@ -81,10 +81,9 @@ public class HMSShim implements HiveCompatibility {
           "sendBase", String.class, TBase.class);
       sendBase.setAccessible(true);
       sendBase.invoke(mClient, methodName, args);
-      sendBase.setAccessible(false);
     } catch (NoSuchMethodException | SecurityException
         | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-      throw new RuntimeException("Unable to hack sendBase", e);
+      throw new RuntimeException("Unable to invoke sendBase", e);
     }
   }
 
@@ -98,7 +97,7 @@ public class HMSShim implements HiveCompatibility {
     } catch (NoSuchMethodException | SecurityException
         | IllegalAccessException | IllegalArgumentException
         | InvocationTargetException e) {
-      throw new RuntimeException("Unable to hack receiveBase", e);
+      throw new RuntimeException("Unable to invoke receiveBase", e);
     }
   }
 

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HMSShim.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HMSShim.java
@@ -1,0 +1,171 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.table.under.hive.util;
+
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore;
+import org.apache.thrift.TApplicationException;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+import org.apache.thrift.TServiceClient;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+/**
+ * Implements a shim layer for hive metastore client.
+ **/
+public class HMSShim implements HiveCompatibility {
+  private final TServiceClient mClient;
+
+  /**
+   * Constructor for HMSShim.
+   *
+   * @param client another client as delegate
+   */
+  public HMSShim(IMetaStoreClient client) {
+    while (Proxy.isProxyClass(client.getClass())) {
+      InvocationHandler handler = Proxy.getInvocationHandler(client);
+      if (handler.getClass().isAssignableFrom(RetryingMetaStoreClient.class)) {
+        client = getField(handler, "base");
+        continue;
+      }
+      // Other handlers can be added here
+      throw new RuntimeException("Unknown InvocationHandler " + handler.getClass());
+    }
+    mClient = getField(client, "client");
+  }
+
+  private static <T> T getField(Object object, String fieldName) {
+    try {
+      Field field = object.getClass().getDeclaredField(fieldName);
+      T result = null;
+      if (field.isAccessible()) {
+        result = (T) field.get(object);
+      } else {
+        field.setAccessible(true);
+        result = (T) field.get(object);
+        field.setAccessible(false);
+      }
+      return result;
+    } catch (SecurityException | NoSuchFieldException
+        | IllegalArgumentException | IllegalAccessException e) {
+      throw new RuntimeException("Unable to hack client", e);
+    }
+  }
+
+  private static Table deepCopy(Table table) {
+    return table.deepCopy();
+  }
+
+  private void sendBase(String methodName, TBase<?, ?> args) throws TException {
+    try {
+      Method sendBase = TServiceClient.class.getDeclaredMethod(
+          "sendBase", String.class, TBase.class);
+      sendBase.setAccessible(true);
+      sendBase.invoke(mClient, methodName, args);
+      sendBase.setAccessible(false);
+    } catch (NoSuchMethodException | SecurityException
+        | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+      throw new RuntimeException("Unable to hack sendBase", e);
+    }
+  }
+
+  private void receiveBase(TBase<?, ?> result, String methodName) throws TException {
+    try {
+      Method receiveBase = TServiceClient.class.getDeclaredMethod(
+          "receiveBase", TBase.class, String.class);
+      receiveBase.setAccessible(true);
+      receiveBase.invoke(mClient, result, methodName);
+      receiveBase.setAccessible(false);
+    } catch (NoSuchMethodException | SecurityException
+        | IllegalAccessException | IllegalArgumentException
+        | InvocationTargetException e) {
+      throw new RuntimeException("Unable to hack receiveBase", e);
+    }
+  }
+
+  /*
+   * Based on https://github.com/apache/hive/blob/release-1.2.1/metastore/src
+   * /java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java#L1206
+   */
+  @Override
+  public Table getTable(String dbname, String name)
+      throws MetaException, TException, NoSuchObjectException {
+    return deepCopy(get_table(dbname, name));
+  }
+
+  @Override
+  public boolean tableExists(String dbname, String name)
+      throws MetaException, TException, NoSuchObjectException {
+    try {
+      get_table(dbname, name);
+    } catch (NoSuchObjectException e) {
+      return false;
+    }
+    return true;
+  }
+
+  /*
+   * Copied from Hive 1.2.1 ThriftHiveMetastore.Client#get_table(String,String) - see
+   * https://raw.githubusercontent.com/apache/hive/release-1.2.1
+   * /metastore/src/gen/thrift/gen-javabean/org/apache/hadoop
+   * /hive/metastore/metastore/ThriftHiveMetastore.java
+   */
+  private Table get_table(String dbname, String tbl_name)
+      throws MetaException, NoSuchObjectException, TException {
+    send_get_table(dbname, tbl_name);
+    return recv_get_table();
+  }
+
+  /*
+   * Copied from Hive 1.2.1 ThriftHiveMetastore.Client#send_get_table(String,String) - see
+   * https://raw.githubusercontent.com/apache/hive/release-1.2.1
+   * /metastore/src/gen/thrift/gen-javabean/org/apache/hadoop
+   * /hive/metastore/metastore/ThriftHiveMetastore.java
+   */
+  private void send_get_table(String dbname, String tbl_name) throws TException {
+    ThriftHiveMetastore.get_table_args args = new ThriftHiveMetastore.get_table_args();
+    args.setDbname(dbname);
+    args.setTbl_name(tbl_name);
+    sendBase("get_table", args);
+  }
+
+  /*
+   * Based on Hive 1.2.1 ThriftHiveMetastore.Client#recv_get_table() - see
+   * https://raw.githubusercontent.com/apache/hive/release-1.2.1
+   * /metastore/src/gen/thrift/gen-javabean/org/apache/hadoop
+   * /hive/metastore/metastore/ThriftHiveMetastore.java
+   */
+  private Table recv_get_table()
+      throws MetaException, NoSuchObjectException, TException {
+    ThriftHiveMetastore.get_table_result result = new ThriftHiveMetastore.get_table_result();
+    receiveBase(result, "get_table");
+    if (result.isSetSuccess()) {
+      return result.getSuccess();
+    }
+    if (result.getO1() != null) {
+      throw result.getO1();
+    }
+    if (result.getO2() != null) {
+      throw result.getO2();
+    }
+    throw new TApplicationException(5, "get_table failed: unknown result");
+  }
+}

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HMSShim.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HMSShim.java
@@ -40,6 +40,7 @@ public class HMSShim implements HiveCompatibility {
    * @param client another client as delegate
    */
   public HMSShim(IMetaStoreClient client) {
+    // Because RetryingMetaStoreClient is itself a proxy, we need to get to the base class
     while (Proxy.isProxyClass(client.getClass())) {
       InvocationHandler handler = Proxy.getInvocationHandler(client);
       if (handler.getClass().isAssignableFrom(RetryingMetaStoreClient.class)) {
@@ -47,7 +48,7 @@ public class HMSShim implements HiveCompatibility {
         continue;
       }
       // Other handlers can be added here
-      throw new RuntimeException("Unknown InvocationHandler " + handler.getClass());
+      throw new RuntimeException("Unknown proxy handler for IMetaStoreClient");
     }
     mClient = getField(client, "client");
   }
@@ -66,7 +67,7 @@ public class HMSShim implements HiveCompatibility {
       return result;
     } catch (SecurityException | NoSuchFieldException
         | IllegalArgumentException | IllegalAccessException e) {
-      throw new RuntimeException("Unable to hack client", e);
+      throw new RuntimeException("Unable to access the client through reflection", e);
     }
   }
 

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveClientPool.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveClientPool.java
@@ -77,8 +77,8 @@ public final class HiveClientPool extends DynamicResourcePool<IMetaStoreClient> 
       HiveConf conf = new HiveConf();
       conf.verifyAndSet("hive.metastore.uris", mConnectionUri);
 
-      IMetaStoreClient client =
-          RetryingMetaStoreClient.getProxy(conf, NOOP_HOOK, HiveMetaStoreClient.class.getName());
+      IMetaStoreClient client = HMSClientFactory.newInstance(
+          RetryingMetaStoreClient.getProxy(conf, NOOP_HOOK, HiveMetaStoreClient.class.getName()));
       if (!mDbExists) {
         synchronized (this) {
           // serialize the querying of the hive db

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveCompatibility.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveCompatibility.java
@@ -1,0 +1,29 @@
+package alluxio.table.under.hive.util;
+
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.thrift.TException;
+
+/**
+ * Hive compatibility.
+ */
+public interface HiveCompatibility {
+  /**
+   * Get table operation.
+   * @param dbname database name
+   * @param name table name
+   * @return Table object
+   */
+  Table getTable(String dbname, String name)
+      throws MetaException, TException, NoSuchObjectException;
+
+  /**
+   * Test if a table exists.
+   * @param dbname database name
+   * @param name table name
+   * @return true if the table exists
+   */
+  boolean tableExists(String dbname, String name)
+      throws MetaException, TException, NoSuchObjectException;
+}

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveCompatibility.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveCompatibility.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.table.under.hive.util;
 
 import org.apache.hadoop.hive.metastore.api.MetaException;


### PR DESCRIPTION
Version 2.2.0 of hive metastore client worked with a wide range of server versions, but we have to upgrade it for java 11 support. Hence we add a compatibility library which proxies a number of calls to achieve compatibility with older versions. 