### PR TITLE
Revert rocksdb version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
     <grpc.version>1.31.0</grpc.version>
     <netty.version>4.1.48.Final</netty.version>
-    <rocksdb.version>6.11.4</rocksdb.version>
+    <rocksdb.version>5.15.10</rocksdb.version>
     <hadoop.version>3.3.0</hadoop.version>
     <jacoco.version>0.8.5</jacoco.version>
     <java.version>1.8</java.version>


### PR DESCRIPTION
rockdsdb version upgrading to  6.11.4 cause the create file and delete file performance downgrade a lot when the alluxio system has a lot of files. Revert it back to previous version until we are clear about the downgradation reason