### PR TITLE
Fix ClosedByInterruptException issue in local cache

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -29,8 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -445,25 +443,16 @@ public class LocalCacheManager implements CacheManager {
     return true;
   }
 
-  private int getPage(PageId pageId, int offset, int bytesToRead, byte[] buffer,
-      int offsetInBuffer) {
-    try (ReadableByteChannel chan = mPageStore.get(pageId, offset)) {
-      // wrap return byte array in a bytebuffer and set the pos/limit for the page read
-      ByteBuffer buf = ByteBuffer.wrap(buffer);
-      buf.position(offsetInBuffer);
-      buf.limit(offsetInBuffer + bytesToRead);
-      // read data from cache
-      while (buf.position() != buf.limit()) {
-        if (chan.read(buf) == -1) {
-          break;
-        }
-      }
-      if (buf.position() != buf.limit()) {
+  private int getPage(PageId pageId, int pageOffset, int bytesToRead, byte[] buffer,
+      int bufferOffset) {
+    try {
+      int ret = mPageStore.get(pageId, pageOffset, buffer, bufferOffset);
+      if (ret != bytesToRead) {
         // data read from page store is inconsistent from the metastore
         Metrics.GET_ERRORS_FAILED_READ.inc();
         throw new IOException(String.format(
-            "Failed to read page {}: supposed to read {} bytes, {} bytes actually read",
-            pageId, bytesToRead, buf.position() - offsetInBuffer));
+            "Failed to read page %s: supposed to read %s bytes, %s bytes actually read",
+            pageId, bytesToRead, ret));
       }
     } catch (IOException | PageNotFoundException e) {
       LOG.error("Failed to get existing page {}: {}", pageId, e);

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -22,7 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -108,28 +107,32 @@ public interface PageStore extends AutoCloseable {
   void put(PageId pageId, byte[] page) throws IOException;
 
   /**
-   * Wraps a page from the store as a channel to read.
+   * Gets a page from the store to the destination buffer.
    *
    * @param pageId page identifier
+   * @param buffer destination buffer
    * @return the channel to read this page
    * @throws IOException when the store fails to read this page
    * @throws PageNotFoundException when the page isn't found in the store
    */
-  default ReadableByteChannel get(PageId pageId) throws IOException, PageNotFoundException {
-    return get(pageId, 0);
+  default int get(PageId pageId, byte[] buffer) throws IOException, PageNotFoundException {
+    return get(pageId, 0, buffer, 0);
   }
 
   /**
-   * Gets part of a page from the store to the destination channel.
+   * Gets part of a page from the store to the destination buffer.
    *
    * @param pageId page identifier
    * @param pageOffset offset within page
+   * @param buffer destination buffer
+   * @param bufferOffset offset in buffer
    * @return the number of bytes read
    * @throws IOException when the store fails to read this page
    * @throws PageNotFoundException when the page isn't found in the store
    * @throws IllegalArgumentException when the page offset exceeds the page size
    */
-  ReadableByteChannel get(PageId pageId, int pageOffset) throws IOException, PageNotFoundException;
+  int get(PageId pageId, int pageOffset, byte[] buffer, int bufferOffset) throws IOException,
+      PageNotFoundException;
 
   /**
    * Deletes a page from the store.

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/LocalPageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/LocalPageStoreTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.client.file.cache.store;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.client.file.cache.PageId;
@@ -21,11 +22,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.ByteArrayOutputStream;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 
 public class LocalPageStoreTest {
 
@@ -84,11 +83,8 @@ public class LocalPageStoreTest {
     String msg = "Hello, World!";
     PageId id = new PageId("0", 0);
     store.put(id, msg.getBytes());
-    ByteArrayOutputStream bos = new ByteArrayOutputStream(1024);
-    ByteBuffer buf = ByteBuffer.allocate(1024);
-    store.get(id).read(buf);
-    buf.flip();
-    String read = StandardCharsets.UTF_8.decode(buf).toString();
-    assertEquals(msg, read);
+    byte[] buf = new byte[1024];
+    assertEquals(msg.getBytes().length, store.get(id, buf));
+    assertArrayEquals(msg.getBytes(), Arrays.copyOfRange(buf, 0, msg.getBytes().length));
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
@@ -11,8 +11,8 @@
 
 package alluxio.client.file.cache.store;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import alluxio.Constants;
@@ -34,9 +34,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.ByteBuffer;
-import java.nio.channels.ReadableByteChannel;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -90,15 +87,12 @@ public class PageStoreTest {
     byte[] msgBytes = msg.getBytes();
     PageId id = new PageId("0", 0);
     mPageStore.put(id, msgBytes);
-    ByteBuffer buf = ByteBuffer.allocate(1024);
-    mPageStore.get(id).read(buf);
-    buf.flip();
-    String read = StandardCharsets.UTF_8.decode(buf).toString();
-    assertEquals(msg, read);
+    byte[] buf = new byte[1024];
+    assertEquals(msgBytes.length, mPageStore.get(id, buf));
+    assertArrayEquals(msgBytes, Arrays.copyOfRange(buf, 0, msgBytes.length));
     mPageStore.delete(id, msgBytes.length);
     try {
-      buf.clear();
-      mPageStore.get(id).read(buf);
+      mPageStore.get(id, buf);
       fail();
     } catch (PageNotFoundException e) {
       // Test completed successfully;
@@ -111,12 +105,11 @@ public class PageStoreTest {
     int offset = 3;
     PageId id = new PageId("0", 0);
     mPageStore.put(id, BufferUtils.getIncreasingByteArray(len));
-    ByteBuffer buf = ByteBuffer.allocate(1024);
-    try (ReadableByteChannel channel = mPageStore.get(id, offset)) {
-      channel.read(buf);
-    }
-    buf.flip();
-    assertTrue(BufferUtils.equalIncreasingByteBuffer(offset, len - offset, buf));
+    byte[] buf = new byte[len];
+    int bytesRead = mPageStore.get(id, offset, buf, 0);
+    assertEquals(len - offset, bytesRead);
+    assertArrayEquals(BufferUtils.getIncreasingByteArray(offset, len - offset),
+        Arrays.copyOfRange(buf, 0, bytesRead));
   }
 
   @Test
@@ -125,11 +118,9 @@ public class PageStoreTest {
     int offset = 36;
     PageId id = new PageId("0", 0);
     mPageStore.put(id, BufferUtils.getIncreasingByteArray(len));
-    ByteBuffer buf = ByteBuffer.allocate(1024);
+    byte[] buf = new byte[1024];
     mThrown.expect(IllegalArgumentException.class);
-    try (ReadableByteChannel channel = mPageStore.get(id, offset)) {
-      channel.read(buf);
-    }
+    mPageStore.get(id, offset, buf, 0);
   }
 
   @Test
@@ -184,14 +175,13 @@ public class PageStoreTest {
 
     ByteArrayOutputStream bos = new ByteArrayOutputStream(Constants.MB);
     ArrayList<Long> times = new ArrayList<>();
+    byte[] buf = new byte[Constants.MB];
     for (int i = 0; i < numTrials; i++) {
       Collections.shuffle(pages);
       long start = System.nanoTime();
       bos.reset();
-      ByteBuffer buf = ByteBuffer.allocate(Constants.MB);
-      for (Integer pageIndex  : pages) {
-        buf.clear();
-        store.get(new PageId("0", pageIndex)).read(buf);
+      for (Integer pageIndex : pages) {
+        store.get(new PageId("0", pageIndex), buf);
       }
       long end = System.nanoTime();
       times.add(end - start);


### PR DESCRIPTION
This patch aims to fix periodic `ClosedByInterruptException` thrown to local cache. 

```
2020-08-12T15:06:00.020-0700    ERROR   20200812_220058_08274_gyew8.1.0.9-586-95713     alluxio.client.file.cache.LocalCacheManager     Failed to get existing page PageId{FileId=47a1abdb3874925210b14e81720f4e8f, PageIndex=181}: {}
java.nio.channels.ClosedByInterruptException
        at java.base/java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:199)
        at java.base/sun.nio.ch.FileChannelImpl.read(FileChannelImpl.java:228)
        at alluxio.client.file.cache.LocalCacheManager.getPage(LocalCacheManager.java:457)
        at alluxio.client.file.cache.LocalCacheManager.get(LocalCacheManager.java:362)
        at alluxio.client.file.cache.NoExceptionCacheManager.get(NoExceptionCacheManager.java:62)
        at alluxio.client.file.cache.LocalCacheFileInStream.positionedRead(LocalCacheFileInStream.java:216)
        at com.facebook.presto.cache.alluxio.AlluxioCachingHdfsFileInputStream.read(AlluxioCachingHdfsFileInputStream.java:69)
        at com.facebook.presto.cache.alluxio.AlluxioCachingHdfsFileInputStream.readFully(AlluxioCachingHdfsFileInputStream.java:86)
```

Reason of seeing this exception is due to the use of `FileChannel` when reading a page from local disk.
A `FileChanel` is Interruptible based on its [javadoc](https://docs.oracle.com/javase/7/docs/api/java/nio/channels/FileChannel.html)
On read, it will throw a `ClosedByInterruptException` If another thread interrupts the current thread while the read operation is in progress, thereby closing the channel and setting the current thread's interrupt status. And there is very little we can do to prevent or recover from channel close. 

Therefore in this patch, we replace `Filechannel` with `FileInputStream`