### PR TITLE
Trim java opts when applying them in the command line

### DIFF
--- a/job/server/src/main/java/alluxio/job/plan/stress/StressBenchDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/stress/StressBenchDefinition.java
@@ -109,7 +109,6 @@ public final class StressBenchDefinition
     }
 
     command.addAll(args);
-
     LOG.info("running command: " + String.join(" ", command));
     String output = ShellUtils.execCommand(command.toArray(new String[0]));
     return output;

--- a/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
@@ -87,12 +87,13 @@ public abstract class Benchmark<T extends TaskResult> {
    * @return the JobConfig
    * */
   public PlanConfig generateJobConfig(String[] args) {
-    // remove the cluster flag
-    List<String> commandArgs =
-            Arrays.stream(args).filter((s) -> !BaseParameters.CLUSTER_FLAG.equals(s))
-                    .filter((s) -> !s.isEmpty()).collect(Collectors.toList());
+    // remove the cluster flag and java opts
+    List<String> commandArgs = Arrays.stream(args).filter((s) ->
+        !BaseParameters.CLUSTER_FLAG.equals(s) && !s.isEmpty())
+        .collect(Collectors.toList());
 
-    commandArgs.addAll(mBaseParameters.mJavaOpts);
+    commandArgs.addAll(mBaseParameters.mJavaOpts.stream().map(String::trim)
+        .collect(Collectors.toList()));
     String className = this.getClass().getCanonicalName();
     return new StressBenchConfig(className, commandArgs, 10000, mBaseParameters.mClusterLimit);
   }


### PR DESCRIPTION
This affects running benchmarks because job master and command line processes spaces differently.
It can cause benchmark jobs to fail. 