### PR TITLE
Add details for block worker client errors

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
@@ -55,7 +55,12 @@ public interface BlockWorkerClient extends Closeable {
     public static BlockWorkerClient create(UserState userState, GrpcServerAddress address,
         AlluxioConfiguration alluxioConf)
         throws IOException {
-      return new DefaultBlockWorkerClient(userState, address, alluxioConf);
+      try {
+        return new DefaultBlockWorkerClient(userState, address, alluxioConf);
+      } catch (Exception e) {
+        throw new IOException(
+            String.format("Failed to connect to remote block worker: %s", address), e);
+      }
     }
   }
 

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -136,12 +136,14 @@ public final class GrpcChannelBuilder {
       try {
         connection.close();
       } catch (Exception e) {
-        throw new RuntimeException("Failed release the connection.", e);
+        throw new RuntimeException(
+            "Failed to release the connection. " + mChannelKey.toStringShort(), e);
       }
       // Pretty print unavailable cases.
       if (t instanceof UnavailableException) {
-        throw new UnavailableException(
-            String.format("Target Unavailable. %s", mChannelKey.toStringShort()), t.getCause());
+        throw new UnavailableException(String.format("Failed to connect to remote server %s. %s",
+            mChannelKey.getServerAddress(), mChannelKey.toStringShort()),
+            t.getCause());
       }
       throw AlluxioStatusException.fromThrowable(t);
     }

--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractFileSystemCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractFileSystemCommand.java
@@ -22,11 +22,14 @@ import alluxio.util.ConfigurationUtils;
 
 import com.google.common.base.Joiner;
 import org.apache.commons.cli.CommandLine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -36,6 +39,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public abstract class AbstractFileSystemCommand implements Command {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractFileSystemCommand.class);
 
   protected FileSystem mFileSystem;
   protected FileSystemContext mFsContext;
@@ -91,6 +95,7 @@ public abstract class AbstractFileSystemCommand implements Command {
       try {
         runPlainPath(path, cl);
       } catch (AlluxioException | IOException e) {
+        LOG.error(String.format("error processing path: %s", path), e);
         errorMessages.add(e.getMessage() != null ? e.getMessage() : e.toString());
       }
     }


### PR DESCRIPTION
Add more obvious messaging for the previous "target unavailable" errors.