### PR TITLE
Test skip compile

### DIFF
--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -79,7 +79,7 @@ if [ "$RUN_MAVEN" == "true" ]; then
   # Revert back to the image default java version to run the test
   JAVA_HOME=${JAVA_HOME_BACKUP}
   PATH=${PATH_BACKUP}
-  mvn -Duser.home=/home/jenkins -T 4C test -Pdeveloper -Dskip.protoc=true  -Dmaven.javadoc.skip -Dlicense.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Dsurefire.forkCount=${ALLUXIO_BUILD_FORKCOUNT} ${mvn_args} $@
+  mvn -Duser.home=/home/jenkins -T 4C test -Pdeveloper -Dmaven.main.skip -Dskip.protoc=true  -Dmaven.javadoc.skip -Dlicense.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Dsurefire.forkCount=${ALLUXIO_BUILD_FORKCOUNT} ${mvn_args} $@
 
   if [ -n "${ALLUXIO_SONAR_ARGS}" ]
   then


### PR DESCRIPTION
Since  we compile everything with java 8, we want to force java 11 to use our java 8 compilation result. So we skip compilation stage for the java 11 maven invocation. This also reduces testing time from 28 mins to 18 mins. 