### PR TITLE
Fix docs check script and fix links

### DIFF
--- a/dev/scripts/check-docs.sh
+++ b/dev/scripts/check-docs.sh
@@ -14,6 +14,8 @@
 # This script validates headers and relative links in documentation markdown files
 # and verifies markdown is buildable by jekyll
 
+set -eux
+
 SCRIPT_DIR=$(cd "$( dirname "$( readlink "$0" || echo "$0" )" )"; pwd)
 
 GOPATH="${SCRIPT_DIR}" go run "${SCRIPT_DIR}/src/alluxio.org/check-docs/main.go"

--- a/docs/en/deploy/Requirements.md
+++ b/docs/en/deploy/Requirements.md
@@ -15,7 +15,7 @@ Listed below are the generic requirements to run Alluxio in local or cluster mod
 
 For large scale deployments and tuning suggestions, see
 [Scalability Tuning]({{ '/en/operation/Scalability-Tuning.html' | relativize_url }})
-and [Performance Tuning]({{ '/en/operation/Performance-Tuning' | relativize_url }}).
+and [Performance Tuning]({{ '/en/operation/Performance-Tuning.html' | relativize_url }}).
 
 * Cluster nodes should be running one of the following supported operating systems:
   * MacOS 10.10 or later

--- a/docs/en/operation/Scalability-Tuning.md
+++ b/docs/en/operation/Scalability-Tuning.md
@@ -31,7 +31,7 @@ The number of files in Alluxio impacts the following:
 * Size of heap required by the master - Each file takes approximately 1 - 2 kb. If RocksDB is used,
 most file metadata is stored off-heap, and the size of the heap impacts how many files’ metadata can
 be cached on heap. See the
-[RocksDB section]({{ 'en/operation/Metastore.html#rocksdb-metastore' | relativize_url }}) for more
+[RocksDB section]({{ '/en/operation/Metastore.html#rocksdb-metastore' | relativize_url }}) for more
 information.
 * Size of disk required for journal storage - Each file takes approximately 1 - 2 kb on disk.
 * Latency of journal replay - The journal replay, which is the majority of the cold startup time for


### PR DESCRIPTION
docs check script was broken since the jekyll command was added since it ignored the exit code of the link check script. fixed by adding `set -eux`

fixes for changes introduced in https://github.com/Alluxio/alluxio/pull/11958