### PR TITLE
Fix local cache locking

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/DefaultMetaStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/DefaultMetaStore.java
@@ -13,21 +13,36 @@ package alluxio.client.file.cache;
 
 import alluxio.exception.PageNotFoundException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+
+import javax.annotation.Nullable;
 
 /**
  * The default implementation of a metadata store for pages stored in cache. This implementation
  * is not thread safe and requires synchronizations on external callers.
  */
 public class DefaultMetaStore implements MetaStore {
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultMetaStore.class);
   /** A map from PageId to page info. */
   private final Map<PageId, PageInfo> mPageMap = new HashMap<>();
   /** The number of logical bytes used. */
   private final AtomicLong mBytes = new AtomicLong(0);
   /** The number of pages stored. */
   private final AtomicLong mPages = new AtomicLong(0);
+  /** The evictor. */
+  private final CacheEvictor mEvictor;
+
+  /**
+   * @param evictor cache evictor
+   */
+  public DefaultMetaStore(CacheEvictor evictor) {
+    mEvictor = evictor;
+  }
 
   @Override
   public boolean hasPage(PageId pageId) {
@@ -39,6 +54,7 @@ public class DefaultMetaStore implements MetaStore {
     mPageMap.put(pageId, pageInfo);
     mBytes.addAndGet(pageInfo.getPageSize());
     mPages.incrementAndGet();
+    mEvictor.updateOnPut(pageId);
   }
 
   @Override
@@ -46,6 +62,7 @@ public class DefaultMetaStore implements MetaStore {
     if (!mPageMap.containsKey(pageId)) {
       throw new PageNotFoundException(String.format("Page %s could not be found", pageId));
     }
+    mEvictor.updateOnGet(pageId);
     return mPageMap.get(pageId);
   }
 
@@ -57,6 +74,7 @@ public class DefaultMetaStore implements MetaStore {
     PageInfo pageInfo = mPageMap.remove(pageId);
     mBytes.addAndGet(-pageInfo.getPageSize());
     mPages.decrementAndGet();
+    mEvictor.updateOnDelete(pageId);
   }
 
   @Override
@@ -74,5 +92,22 @@ public class DefaultMetaStore implements MetaStore {
     mPages.set(0);
     mBytes.set(0);
     mPageMap.clear();
+    mEvictor.reset();
+  }
+
+  @Override
+  @Nullable
+  public PageInfo evict() {
+    PageId victim = mEvictor.evict();
+    if (victim == null) {
+      return null;
+    }
+    PageInfo victimInfo = mPageMap.get(victim);
+    if (victimInfo == null) {
+      LOG.error("Invalid result returned by evictor: page {} not available", victim);
+      mEvictor.updateOnDelete(victim);
+      return null;
+    }
+    return victimInfo;
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/MetaStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/MetaStore.java
@@ -19,10 +19,11 @@ import alluxio.exception.PageNotFoundException;
 public interface MetaStore {
 
   /**
+   * @param evictor cache evictor
    * @return an instance of MetaStore
    */
-  static MetaStore create() {
-    return new DefaultMetaStore();
+  static MetaStore create(CacheEvictor evictor) {
+    return new DefaultMetaStore(evictor);
   }
 
   /**
@@ -66,4 +67,9 @@ public interface MetaStore {
    * Resets the meta store.
    */
   void reset();
+
+  /**
+   * @return a page to evict
+   */
+  PageInfo evict();
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -138,11 +138,10 @@ public interface PageStore extends AutoCloseable {
    * Deletes a page from the store.
    *
    * @param pageId page identifier
-   * @param pageSize page size in bytes
    * @throws IOException when the store fails to delete this page
    * @throws PageNotFoundException when the page isn't found in the store
    */
-  void delete(PageId pageId, long pageSize) throws IOException, PageNotFoundException;
+  void delete(PageId pageId) throws IOException, PageNotFoundException;
 
   /**
    * Gets a stream of all pages from the page store. This stream needs to be closed as it may

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -120,7 +120,7 @@ public class LocalPageStore implements PageStore {
   }
 
   @Override
-  public void delete(PageId pageId, long pageSize) throws IOException, PageNotFoundException {
+  public void delete(PageId pageId) throws IOException, PageNotFoundException {
     Path p = getFilePath(pageId);
     if (!Files.exists(p)) {
       throw new PageNotFoundException(p.toString());

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
@@ -146,7 +146,7 @@ public class RocksPageStore implements PageStore {
   }
 
   @Override
-  public void delete(PageId pageId, long pageSize) throws PageNotFoundException {
+  public void delete(PageId pageId) throws PageNotFoundException {
     try {
       byte[] key = getKeyFromPageId(pageId);
       mDb.delete(key);

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/DefaultMetaStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/DefaultMetaStoreTest.java
@@ -11,6 +11,8 @@
 
 package alluxio.client.file.cache;
 
+import alluxio.ConfigurationTestUtils;
+import alluxio.conf.InstancedConfiguration;
 import alluxio.exception.PageNotFoundException;
 
 import org.junit.Assert;
@@ -28,6 +30,8 @@ public final class DefaultMetaStoreTest {
 
   private final PageId mPage = new PageId("1L", 2L);
   private final PageInfo mPageInfo = new PageInfo(mPage, 1024);
+  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+
   private DefaultMetaStore mMetaStore;
 
   /**
@@ -35,7 +39,7 @@ public final class DefaultMetaStoreTest {
    */
   @Before
   public void before() {
-    mMetaStore = new DefaultMetaStore();
+    mMetaStore = new DefaultMetaStore(CacheEvictor.create(mConf));
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -23,6 +23,7 @@ import alluxio.client.file.cache.store.PageStoreOptions;
 import alluxio.client.file.cache.store.PageStoreType;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.PageNotFoundException;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.FileUtils;
 
@@ -36,7 +37,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Paths;
 import java.util.LinkedList;
-import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -73,10 +73,10 @@ public final class LocalCacheManagerTest {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, CACHE_SIZE_BYTES);
     mConf.set(PropertyKey.USER_CLIENT_CACHE_DIR, mTemp.getRoot().getAbsolutePath());
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED, false);
-    mMetaStore = MetaStore.create();
     mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mEvictor = new FIFOEvictor(mMetaStore);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore, mEvictor);
+    mEvictor = new FIFOEvictor();
+    mMetaStore = MetaStore.create(mEvictor);
+    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
   }
 
   private byte[] page(int i, int pageLen) {
@@ -106,7 +106,7 @@ public final class LocalCacheManagerTest {
   public void putEvict() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
     mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore, mEvictor);
+    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
     assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
     assertTrue(mCacheManager.put(PAGE_ID2, PAGE2));
     assertEquals(0, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
@@ -119,7 +119,7 @@ public final class LocalCacheManagerTest {
     // Cache size is only one full page, but should be able to store multiple small pages
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
     mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore, mEvictor);
+    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
     int smallPageLen = 8;
     long numPages = mConf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE) / smallPageLen;
     for (int i = 0; i < numPages; i++) {
@@ -139,7 +139,7 @@ public final class LocalCacheManagerTest {
   public void evictSmallPageByPutSmallPage() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
     mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore, mEvictor);
+    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
     int smallPageLen = 8;
     long numPages = mConf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE) / smallPageLen;
     for (int i = 0; i < numPages; i++) {
@@ -164,7 +164,7 @@ public final class LocalCacheManagerTest {
   public void evictSmallPagesByPutPigPage() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
     mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore, mEvictor);
+    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
     int smallPageLen = 8;
     long numPages = mConf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE) / smallPageLen;
     for (int i = 0; i < numPages; i++) {
@@ -186,7 +186,7 @@ public final class LocalCacheManagerTest {
   public void evictBigPagesByPutSmallPage() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
     mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore, mEvictor);
+    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
     PageId bigPageId = pageId(-1, 0);
     assertTrue(mCacheManager.put(bigPageId, page(0, PAGE_SIZE_BYTES)));
     int smallPageLen = 8;
@@ -318,7 +318,7 @@ public final class LocalCacheManagerTest {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_THREADS, threads);
     mConf.set(PropertyKey.USER_CLIENT_CACHE_STORE_TYPE, "LOCAL");
     PutDelayedPageStore pageStore = new PutDelayedPageStore();
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore, mEvictor);
+    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore);
     for (int i = 0; i < threads; i++) {
       PageId pageId = new PageId("5", i);
       assertTrue(mCacheManager.put(pageId, page(i, PAGE_SIZE_BYTES)));
@@ -343,7 +343,7 @@ public final class LocalCacheManagerTest {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_THREADS, threads);
     mConf.set(PropertyKey.USER_CLIENT_CACHE_STORE_TYPE, "LOCAL");
     PutDelayedPageStore pageStore = new PutDelayedPageStore();
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore, mEvictor);
+    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore);
     assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
     assertFalse(mCacheManager.put(PAGE_ID1, PAGE1));
     pageStore.setHanging(false);
@@ -357,8 +357,8 @@ public final class LocalCacheManagerTest {
   @Test
   public void recoverCacheFromFailedPut() throws Exception {
     FaultyPageStore pageStore = new FaultyPageStore();
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore, mEvictor);
-    pageStore.setFaulty(true);
+    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore);
+    pageStore.setPutFaulty(true);
     // a failed put
     assertFalse(mCacheManager.put(PAGE_ID1, PAGE1));
     // no state left after previous failed put
@@ -367,7 +367,25 @@ public final class LocalCacheManagerTest {
     assertFalse(mCacheManager.put(PAGE_ID1, PAGE1));
     // still no state left
     assertEquals(0, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
-    pageStore.setFaulty(false);
+    pageStore.setPutFaulty(false);
+    assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
+    assertEquals(PAGE_SIZE_BYTES, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+    assertArrayEquals(PAGE1, mBuf);
+  }
+
+  @Test
+  public void failedPageStoreDeleteOnEviction() throws Exception {
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
+    FaultyPageStore pageStore = new FaultyPageStore();
+    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore);
+    pageStore.setDeleteFaulty(true);
+    // first put should be ok
+    assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
+    // trigger a failed eviction
+    assertFalse(mCacheManager.put(PAGE_ID2, PAGE2));
+    // restore page store to function
+    pageStore.setDeleteFaulty(false);
+    // trigger another eviction, this should work
     assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
     assertEquals(PAGE_SIZE_BYTES, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
     assertArrayEquals(PAGE1, mBuf);
@@ -381,18 +399,31 @@ public final class LocalCacheManagerTest {
       super(PageStoreOptions.create(mConf).toOptions());
     }
 
-    private AtomicBoolean mFaulty = new AtomicBoolean(false);
+    private AtomicBoolean mPutFaulty = new AtomicBoolean(false);
+    private AtomicBoolean mDeleteFaulty = new AtomicBoolean(false);
 
     @Override
     public void put(PageId pageId, byte[] page) throws IOException {
-      if (mFaulty.get()) {
+      if (mPutFaulty.get()) {
         throw new IOException("Not found");
       }
       super.put(pageId, page);
     }
 
-    void setFaulty(boolean faulty) {
-      mFaulty.set(faulty);
+    @Override
+    public void delete(PageId pageId) throws IOException, PageNotFoundException {
+      if (mDeleteFaulty.get()) {
+        throw new IOException("Not found");
+      }
+      super.delete(pageId);
+    }
+
+    void setPutFaulty(boolean faulty) {
+      mPutFaulty.set(faulty);
+    }
+
+    void setDeleteFaulty(boolean faulty) {
+      mDeleteFaulty.set(faulty);
     }
   }
 
@@ -428,12 +459,9 @@ public final class LocalCacheManagerTest {
    * Implementation of Evictor using FIFO eviction policy for the test.
    */
   class FIFOEvictor implements CacheEvictor {
-    final Queue<PageId> mQueue = new LinkedList<>();
-    final MetaStore  mMetaStore;
+    final LinkedList<PageId> mQueue = new LinkedList<>();
 
-    public FIFOEvictor(MetaStore metaStore) {
-      mMetaStore = metaStore;
-    }
+    public FIFOEvictor() {}
 
     @Override
     public void updateOnGet(PageId pageId) {
@@ -447,21 +475,13 @@ public final class LocalCacheManagerTest {
 
     @Override
     public void updateOnDelete(PageId pageId) {
-      // noop
+      mQueue.remove(mQueue.indexOf(pageId));
     }
 
     @Nullable
     @Override
     public PageId evict() {
-      PageId pageId;
-      while ((pageId = mQueue.peek()) != null) {
-        if (mMetaStore.hasPage(pageId)) {
-          return pageId;
-        }
-        // this page has been deleted
-        mQueue.poll();
-      }
-      return null;
+      return mQueue.peek();
     }
 
     @Override

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
@@ -90,7 +90,7 @@ public class PageStoreTest {
     byte[] buf = new byte[1024];
     assertEquals(msgBytes.length, mPageStore.get(id, buf));
     assertArrayEquals(msgBytes, Arrays.copyOfRange(buf, 0, msgBytes.length));
-    mPageStore.delete(id, msgBytes.length);
+    mPageStore.delete(id);
     try {
       mPageStore.get(id, buf);
       fail();

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -902,6 +902,20 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_PUT_BENIGN_RACING_ERRORS =
+      new Builder(Name.CLIENT_CACHE_PUT_BENIGN_RACING_ERRORS)
+          .setDescription("Number of failures when adding pages due to racing eviction. This error"
+              + " is benign.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_CACHE_PUT_STORE_DELETE_ERRORS =
+      new Builder(Name.CLIENT_CACHE_PUT_STORE_DELETE_ERRORS)
+          .setDescription("Number of failures when putting cached data in the client cache due to"
+              + " failed deletes in page store.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_PUT_STORE_WRITE_ERRORS =
       new Builder(Name.CLIENT_CACHE_PUT_STORE_WRITE_ERRORS)
           .setDescription("Number of failures when putting cached data in the client cache due to"
@@ -1131,6 +1145,10 @@ public final class MetricKey implements Comparable<MetricKey> {
         "Client.CachePutAsyncRejectionErrors";
     public static final String CLIENT_CACHE_PUT_EVICTION_ERRORS =
         "Client.CachePutEvictionErrors";
+    public static final String CLIENT_CACHE_PUT_BENIGN_RACING_ERRORS =
+        "Client.CachePutBenignRacingErrors";
+    public static final String CLIENT_CACHE_PUT_STORE_DELETE_ERRORS =
+        "Client.CachePutStoreDeleteErrors";
     public static final String CLIENT_CACHE_PUT_STORE_WRITE_ERRORS =
         "Client.CachePutStoreWriteErrors";
 


### PR DESCRIPTION
Fix two issues:

(1) Previously MetaStore and Evictor are both used as the state to make eviction decisions, but they are not put in the same critical section, and not coordinated to be consistent in tricky cases of failed page store deletes. This PR makes evictor a part of MetaStore so their content will always be consistent
(2) Eviction is a 2PC (phase 1 in metastore and phase 2 in pagestore), this PR fixes the undo logic when this 2PC failed in the middle.