### PR TITLE
Downgrade grpc to 1.28.1 and upgrade netty to 4.1.51.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,8 +129,8 @@
     <build.path>build</build.path>
     <copycat.version>1.2.15</copycat.version>
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
-    <grpc.version>1.31.0</grpc.version>
-    <netty.version>4.1.48.Final</netty.version>
+    <grpc.version>1.28.1</grpc.version>
+    <netty.version>4.1.51.Final</netty.version>
     <rocksdb.version>5.15.10</rocksdb.version>
     <hadoop.version>3.3.0</hadoop.version>
     <jacoco.version>0.8.5</jacoco.version>


### PR DESCRIPTION
GRPC upgrade  beyond 1.29 (included) introduces significant perf regression in alluxio metadata operations. 
We downgrade it to 1.28.1 but upgrade the problematic netty package to fix CVE. 

This addresses perf regression introduced in #11955 . 