### PR TITLE
Fix flaky AlluxioFileInStreamTest

### DIFF
--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -123,8 +123,8 @@ public final class AlluxioFileInStreamTest {
 
     ClientTestUtils.setSmallBufferSizes(sConf);
     sConf.set(PropertyKey.USER_BLOCK_READ_RETRY_SLEEP_MIN, "1ms");
-    sConf.set(PropertyKey.USER_BLOCK_READ_RETRY_SLEEP_MIN, "5ms");
-    sConf.set(PropertyKey.USER_BLOCK_READ_RETRY_MAX_DURATION, "10ms");
+    sConf.set(PropertyKey.USER_BLOCK_READ_RETRY_SLEEP_MAX, "5ms");
+    sConf.set(PropertyKey.USER_BLOCK_READ_RETRY_MAX_DURATION, "1s");
 
     mContext = PowerMockito.mock(FileSystemContext.class);
     when(mContext.getClientContext()).thenReturn(ClientContext.create(sConf));


### PR DESCRIPTION
The max retry duration should be a bit longer to support slower test machines. The retry duration needs to be long enough for there to be at least 2 tries for some of the test cases.