### PR TITLE
Add <parent> declaration to webui pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -912,6 +912,11 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.0.0-M1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>3.0.0-M3</version>
         </plugin>

--- a/webui/common/.eslintrc.js
+++ b/webui/common/.eslintrc.js
@@ -1,3 +1,13 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
 module.exports = {
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   "env": {

--- a/webui/common/.prettierrc.js
+++ b/webui/common/.prettierrc.js
@@ -1,3 +1,13 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
 module.exports =  {
     semi:  true,
     trailingComma:  'all',

--- a/webui/common/src/components/LineGraph/LineGraph.scss
+++ b/webui/common/src/components/LineGraph/LineGraph.scss
@@ -1,3 +1,13 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
 .lineGraph {
   height: 25em;
 }

--- a/webui/common/src/utilities/nivo/transformToNivoFormat.tsx
+++ b/webui/common/src/utilities/nivo/transformToNivoFormat.tsx
@@ -1,3 +1,13 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
 export interface TranformableData {
   [key: string]: string | number;
 }

--- a/webui/master/.eslintrc.js
+++ b/webui/master/.eslintrc.js
@@ -1,3 +1,13 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
 module.exports = {
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   "env": {

--- a/webui/master/.prettierrc.js
+++ b/webui/master/.prettierrc.js
@@ -1,3 +1,13 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
 module.exports =  {
     semi:  true,
     trailingComma:  'all',

--- a/webui/master/src/store/init/reducer.tsx
+++ b/webui/master/src/store/init/reducer.tsx
@@ -3,12 +3,11 @@
  * (the "License"). You may not use this work except in compliance with the License, which is
  * available at www.apache.org/licenses/LICENSE-2.0
  *
- * This software is distributed on an 'AS IS' basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied, as more fully set forth in the License.
  *
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
-
 import { Reducer } from 'redux';
 
 import { IInitState, InitActionTypes } from './types';

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -163,6 +163,9 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
+          <mapping>
+            <ts>PHP_STYLE</ts>
+          </mapping>
           <excludes>
             <exclude>**/node_modules/**</exclude>
             <exclude>node/**</exclude>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -12,12 +12,20 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.alluxio</groupId>
+  <parent>
+    <groupId>org.alluxio</groupId>
+    <artifactId>alluxio-parent</artifactId>
+    <version>2.4.0-SNAPSHOT</version>
+  </parent>
   <artifactId>alluxio-webui</artifactId>
   <version>2.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Alluxio UI</name>
   <description>Alluxio web UI pom</description>
+
+  <properties>
+    <build.path>${project.parent.basedir}/build</build.path>
+  </properties>
   <build>
     <plugins>
       <plugin>
@@ -149,6 +157,19 @@
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>
           <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/node_modules/**</exclude>
+            <exclude>node/**</exclude>
+            <exclude>**/build/**</exclude>
+            <!-- auto-generated css -->
+            <exclude>**/*.css</exclude>
+          </excludes>
         </configuration>
       </plugin>
     </plugins>

--- a/webui/worker/.eslintrc.js
+++ b/webui/worker/.eslintrc.js
@@ -1,3 +1,13 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
 module.exports = {
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   "env": {

--- a/webui/worker/.prettierrc.js
+++ b/webui/worker/.prettierrc.js
@@ -1,3 +1,13 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
 module.exports =  {
     semi:  true,
     trailingComma:  'all',


### PR DESCRIPTION
License check hasn't been properly working for a while on this. Adding the parent declaration will fix this. It will also allow us to run `mvn license:check` from the root of the repo. Before, `license:check` would fail on the webui because it would attempt to use a different plugin.