### PR TITLE
Increase master serving timeout for slower machines

### DIFF
--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -99,7 +99,7 @@ public final class MultiProcessCluster {
   private static final Logger LOG = LoggerFactory.getLogger(MultiProcessCluster.class);
   private static final File ARTIFACTS_DIR = new File(Constants.TEST_ARTIFACTS_DIR);
   private static final File TESTS_LOG = new File(Constants.TESTS_LOG);
-  private static final int WAIT_MASTER_SERVING_TIMEOUT_MS = 10000;
+  private static final int WAIT_MASTER_SERVING_TIMEOUT_MS = 20000;
 
   private final Map<PropertyKey, String> mProperties;
   private final Map<Integer, Map<PropertyKey, String>> mMasterProperties;


### PR DESCRIPTION
When running tests on less faster machines, the timeout for master serving timeout becomes an issue.