### PR TITLE
Reduce the number of operations on BackupRestoreTest

### DIFF
--- a/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
@@ -385,7 +385,7 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
     List<Thread> opThreads = new ArrayList<>();
     // Run background threads to perform metadata operations while the journal backups and restores
     // are happening.
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 5; i++) {
       AlluxioOperationThread thread = new AlluxioOperationThread(mCluster.getFileSystemClient());
       thread.start();
       opThreads.add(thread);


### PR DESCRIPTION
Too many threads are being created for this operation to be done well on less beefy machines.