### PR TITLE
Undo upgrade of maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -954,7 +954,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>2.22.2</version>
           <configuration>
             <argLine>@{argLine} -Djava.net.preferIPv4Stack=true</argLine>
             <excludesFile>${build.path}/surefire/${surefire.excludesFile}</excludesFile>


### PR DESCRIPTION
maven-surefire-plugin occasionally crashes with 

pure virtual method called
terminate called without an active exception