### PR TITLE
Cancel in-progress checkpoints when thread is shutdown

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
@@ -286,6 +286,9 @@ public final class UfsJournalCheckpointThread extends Thread {
       try {
         synchronized (mCheckpointingLock) {
           if (mShutdownInitiated) {
+            // This checkpoint thread is signaled to shutdown, so any checkpoint in progress must be
+            // canceled/invalidated.
+            journalWriter.cancel();
             return;
           }
           mCheckpointing = true;


### PR DESCRIPTION
This fixes a bug when the checkpoint thread is shutdown, but there was a checkpoint in progress. Sometimes, the shutdown request can occur after the checkpoint output stream is created, but before anything is written to it. So, checkpoint stream is closed, which makes the checkpoint complete, but empty (which is incorrect).

This PR fixes the issue by canceling the stream when the thread is shutdown, instead of closing it. By canceling the stream, the checkpoint is not considered complete, but is removed. Therefore, the potentially empty file is not considered a valid checkpoint, and that file is removed.

Unfortunately, this is difficult to unittest because it depends heavily on timing. However, I ran a flaky test 500 times, and before this change it failed 14 / 500 times. With this change, it failed 0 / 500 times.