### PR TITLE
Remove synchronized in ConfigHashSync

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/ConfigHashSync.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ConfigHashSync.java
@@ -72,7 +72,7 @@ public final class ConfigHashSync implements HeartbeatExecutor {
   }
 
   @Override
-  public void heartbeat() {
+  public synchronized void heartbeat() {
     if (!mContext.getClientContext().getClusterConf().clusterDefaultsLoaded()) {
       // Wait until the initial cluster defaults are loaded.
       return;

--- a/core/client/fs/src/main/java/alluxio/client/file/ConfigHashSync.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ConfigHashSync.java
@@ -72,7 +72,7 @@ public final class ConfigHashSync implements HeartbeatExecutor {
   }
 
   @Override
-  public synchronized void heartbeat() {
+  public void heartbeat() {
     if (!mContext.getClientContext().getClusterConf().clusterDefaultsLoaded()) {
       // Wait until the initial cluster defaults are loaded.
       return;
@@ -108,7 +108,7 @@ public final class ConfigHashSync implements HeartbeatExecutor {
   }
 
   @Override
-  public synchronized void close() {
+  public void close() {
     mClient.close();
   }
 }


### PR DESCRIPTION
If the ConfigHashSync's Heartbeat thread is running, the client can't be closed. Unfortunately, the cancel on heartbeat thread that gets called can be unreliable at times and as a result, there is a possibility of a deadlock.

One Thread:
(waiting on ConfigHashSync synchronized)
at alluxio.client.file.ConfigHashSync.close(ConfigHashSync.java:112)
at alluxio.client.file.FileSystemContextReinitializer.close(FileSystemContextReinitializer.java:189)
(has FileSystemContext synchronized lock)
at alluxio.client.file.FileSystemContext.close(FileSystemContext.java:262)

HeartBeatThread:
(waiting on FileSystemContext's synchronized lock)
at alluxio.client.file.FileSystemContext.getMasterAddress(FileSystemContext.java:417)
at alluxio.client.file.FileSystemContext.reinit(FileSystemContext.java:348)
(has ConfigHashSync synchronized lock)
at alluxio.client.file.ConfigHashSync.heartbeat(ConfigHashSync.java:95)
    

Resolve this by removing synchronized on ConfigHashSync since all of its instance variables are threadsafe.
