### PR TITLE
Increase timeout for second startMasters in MultiProcessCheckpointTest

### DIFF
--- a/tests/src/test/java/alluxio/server/ft/journal/MultiProcessCheckpointTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/MultiProcessCheckpointTest.java
@@ -60,7 +60,7 @@ public class MultiProcessCheckpointTest {
           new URI(journal));
       cluster.stopMasters();
       cluster.startMasters();
-      cluster.waitForAllNodesRegistered(20 * Constants.SECOND_MS);
+      cluster.waitForAllNodesRegistered(40 * Constants.SECOND_MS);
       fs = cluster.getFileSystemClient();
       assertEquals(numFiles, fs.listStatus(new AlluxioURI("/")).size());
       assertEquals(numFiles + 1, (long) metricsClient.getMetrics()


### PR DESCRIPTION
The second startMasters take a significantly longer time than the first one which causes it to timeout in smaller machines.