### PR TITLE
Remove assert in JVM Pause Monitor stop

### DIFF
--- a/core/common/src/main/java/alluxio/util/JvmPauseMonitor.java
+++ b/core/common/src/main/java/alluxio/util/JvmPauseMonitor.java
@@ -88,8 +88,9 @@ public class JvmPauseMonitor {
    * Stops jvm monitor.
    */
   public void stop() {
-    Preconditions.checkState(mJvmMonitorThread != null,
-        "JVM monitor thread does not start");
+    if (mJvmMonitorThread == null) {
+      return;
+    }
     mJvmMonitorThread.interrupt();
     try {
       mJvmMonitorThread.join();


### PR DESCRIPTION
This assert came up a lot when running integration tests in smaller machine.