### PR TITLE
Propagate RuntimeExceptions in UfsJournalCheckpointThread

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
@@ -328,7 +328,8 @@ public final class UfsJournalCheckpointThread extends Thread {
     }
   }
 
-  private void cancelCheckpoint(UfsJournalCheckpointWriter journalWriter, long nextSequenceNumber) {
+  private void cancelCheckpoint(UfsJournalCheckpointWriter journalWriter, long nextSequenceNumber)
+      throws IOException {
     journalWriter.cancel();
     LOG.info("{}: Cancelled checkpoint [sequence number {}].", mMaster.getName(),
         nextSequenceNumber);


### PR DESCRIPTION
Partial revert of https://github.com/Alluxio/alluxio/pull/8517/files#diff-5e678cb4bd385e5896b4bd970c8ed5eaR261

Occasionally writing to checkpoint fails because of some bad state. When this happens, it is very likely that repeating the reading of journals back from the beginning won't help while crashing an restarting the process may. This is an attempt at that. 