### PR TITLE
Fix active sync manager error on secondary master

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -23,6 +23,7 @@ import alluxio.heartbeat.HeartbeatThread;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.RpcContext;
 import alluxio.master.file.meta.MountTable;
+import alluxio.master.file.meta.options.MountInfo;
 import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.Journaled;
@@ -98,6 +99,7 @@ public class ActiveSyncManager implements Journaled {
   private final FileSystemMaster mFileSystemMaster;
   // a local executor service used to launch polling threads
   private final ThreadPoolExecutor mExecutorService;
+  private boolean mStarted;
 
   /**
    * Constructs a Active Sync Manager.
@@ -164,6 +166,7 @@ public class ActiveSyncManager implements Journaled {
    * Start the polling threads.
    */
   public void start() throws IOException {
+    mStarted = true;
     // Initialize UFS states
     for (AlluxioURI syncPoint : mSyncPathList) {
       MountTable.Resolution resolution;
@@ -428,8 +431,9 @@ public class ActiveSyncManager implements Journaled {
         while (mountId == -1) {
           try {
             syncPointPath = mEntry.getPath();
-            MountTable.Resolution resolution = mMountTable.resolve(mEntry);
-            mountId = resolution.getMountId();
+            String mountPoint = mMountTable.getMountPoint(mEntry);
+            MountInfo mountInfo = mMountTable.getMountTable().get(mountPoint);
+            mountId = mountInfo.getMountId();
           } catch (InvalidPathException e) {
             LOG.info("Path resolution failed for {}, exception {}", syncPointPath, e);
             mEntry = null;
@@ -650,6 +654,9 @@ public class ActiveSyncManager implements Journaled {
    * 4. Stop the thread that is polling HDFS for events
    */
   public void stop() {
+    if (!mStarted) {
+      return;
+    }
     for (AlluxioURI syncPoint : mSyncPathList) {
       try {
         stopSyncInternal(syncPoint);

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -657,6 +657,7 @@ public class ActiveSyncManager implements Journaled {
     if (!mStarted) {
       return;
     }
+    mStarted = false;
     for (AlluxioURI syncPoint : mSyncPathList) {
       try {
         stopSyncInternal(syncPoint);


### PR DESCRIPTION
There has been errors when an active sync enabled secondary master get promoted to primary. It is caused by active sync manager trying to access UFS when master is in secondary mode. UFS client are not initialized for mount points on secondary master so error occurs when active sync manager accesses it during snapshotting and server stopping process.

This fix updated active sync manager to avoid unnecessary access to UFS client on a secondary master.