### PR TITLE
Fix slow and contented local cache restart

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -27,11 +27,15 @@ public interface CacheManager extends AutoCloseable {
     /**
      * this cache is read only.
      */
-    READ_ONLY(0),
+    NOT_IN_USE(0),
+    /**
+     * this cache is read only.
+     */
+    READ_ONLY(1),
     /**
      * this cache can both read and write.
      */
-    READ_WRITE(1);
+    READ_WRITE(2);
 
     private final int mValue;
 

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -18,7 +18,35 @@ import java.io.IOException;
 /**
  * Interface for managing cached pages.
  */
-public interface CacheManager extends AutoCloseable  {
+public interface CacheManager extends AutoCloseable {
+
+  /**
+   * State of a cache.
+   */
+  enum State {
+    /**
+     * this cache is read only
+     */
+    READ_ONLY(0),
+    /**
+     * this cache can both read and write
+     */
+    READ_WRITE(1);
+
+    private final int mValue;
+
+    State(int value) {
+      mValue = value;
+    }
+
+    /**
+     * @return the value of the state
+     */
+    public int getValue() {
+      return mValue;
+    }
+  }
+
   /**
    * @param conf the Alluxio configuration
    * @return an instance of {@link CacheManager}
@@ -71,4 +99,9 @@ public interface CacheManager extends AutoCloseable  {
    * @return true if the page is successfully deleted, false otherwise
    */
   boolean delete(PageId pageId);
+
+  /**
+   * @return state of this cache.
+   */
+  State state();
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -25,11 +25,11 @@ public interface CacheManager extends AutoCloseable {
    */
   enum State {
     /**
-     * this cache is read only
+     * this cache is read only.
      */
     READ_ONLY(0),
     /**
-     * this cache can both read and write
+     * this cache can both read and write.
      */
     READ_WRITE(1);
 
@@ -101,7 +101,7 @@ public interface CacheManager extends AutoCloseable {
   boolean delete(PageId pageId);
 
   /**
-   * @return state of this cache.
+   * @return state of this cache
    */
   State state();
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -25,7 +25,7 @@ public interface CacheManager extends AutoCloseable {
    */
   enum State {
     /**
-     * this cache is read only.
+     * this cache is not in use.
      */
     NOT_IN_USE(0),
     /**

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
@@ -27,14 +27,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * A FileSystem implementation with a local cache.
  */
 public class LocalCacheFileSystem extends DelegatingFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(LocalCacheFileSystem.class);
-  private static Optional<CacheManager> sCacheManager;
+  private static final Lock CACHE_INIT_LOCK = new ReentrantLock();
+  @GuardedBy("CACHE_INIT_LOCK")
+  private static final AtomicReference<CacheManager> CACHE_MANAGER = new AtomicReference<>();
 
   private final AlluxioConfiguration mConf;
 
@@ -43,21 +49,20 @@ public class LocalCacheFileSystem extends DelegatingFileSystem {
    * @param fs a FileSystem instance to query on local cache miss
    * @param conf the configuration, only respected for the first call
    */
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
-      justification = "write to static is made threadsafe")
   public LocalCacheFileSystem(FileSystem fs, AlluxioConfiguration conf) throws IOException {
     super(fs);
     // TODO(feng): support multiple cache managers
-    if (sCacheManager == null) {
-      synchronized (LocalCacheFileSystem.class) {
-        if (sCacheManager == null) {
-          try {
-            sCacheManager = Optional.of(CacheManager.create(conf));
-          } catch (IOException e) {
-            Metrics.CREATE_ERRORS.inc();
-            throw new IOException("Failed to create CacheManager", e);
+    if (CACHE_MANAGER.get() == null) {
+      if (CACHE_INIT_LOCK.tryLock()) {
+        try {
+          if (CACHE_MANAGER.get() == null) {
+            CACHE_MANAGER.set(CacheManager.create(conf));
           }
+        } catch (IOException e) {
+          Metrics.CREATE_ERRORS.inc();
+          throw new IOException("Failed to create CacheManager", e);
+        } finally {
+          CACHE_INIT_LOCK.unlock();
         }
       }
     }
@@ -72,21 +77,21 @@ public class LocalCacheFileSystem extends DelegatingFileSystem {
   @Override
   public FileInStream openFile(AlluxioURI path, OpenFilePOptions options)
       throws IOException, AlluxioException {
-    if (sCacheManager == null || !sCacheManager.isPresent()
-        || sCacheManager.get().state() == CacheManager.State.NOT_IN_USE) {
+    if (CACHE_MANAGER.get() == null
+        || CACHE_MANAGER.get().state() == CacheManager.State.NOT_IN_USE) {
       return mDelegatedFileSystem.openFile(path, options);
     }
-    return new LocalCacheFileInStream(path, options, mDelegatedFileSystem, sCacheManager.get());
+    return new LocalCacheFileInStream(path, options, mDelegatedFileSystem, CACHE_MANAGER.get());
   }
 
   @Override
   public FileInStream openFile(URIStatus status, OpenFilePOptions options)
       throws IOException, AlluxioException {
-    if (sCacheManager == null || !sCacheManager.isPresent()
-        || sCacheManager.get().state() == CacheManager.State.NOT_IN_USE) {
+    if (CACHE_MANAGER.get() == null
+        || CACHE_MANAGER.get().state() == CacheManager.State.NOT_IN_USE) {
       return mDelegatedFileSystem.openFile(status, options);
     }
-    return new LocalCacheFileInStream(status, options, mDelegatedFileSystem, sCacheManager.get());
+    return new LocalCacheFileInStream(status, options, mDelegatedFileSystem, CACHE_MANAGER.get());
   }
 
   private static final class Metrics {

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
@@ -72,7 +72,8 @@ public class LocalCacheFileSystem extends DelegatingFileSystem {
   @Override
   public FileInStream openFile(AlluxioURI path, OpenFilePOptions options)
       throws IOException, AlluxioException {
-    if (sCacheManager == null || !sCacheManager.isPresent()) {
+    if (sCacheManager == null || !sCacheManager.isPresent()
+        || sCacheManager.get().state() == CacheManager.State.NOT_IN_USE) {
       return mDelegatedFileSystem.openFile(path, options);
     }
     return new LocalCacheFileInStream(path, options, mDelegatedFileSystem, sCacheManager.get());
@@ -81,7 +82,8 @@ public class LocalCacheFileSystem extends DelegatingFileSystem {
   @Override
   public FileInStream openFile(URIStatus status, OpenFilePOptions options)
       throws IOException, AlluxioException {
-    if (sCacheManager == null || !sCacheManager.isPresent()) {
+    if (sCacheManager == null || !sCacheManager.isPresent()
+        || sCacheManager.get().state() == CacheManager.State.NOT_IN_USE) {
       return mDelegatedFileSystem.openFile(status, options);
     }
     return new LocalCacheFileInStream(status, options, mDelegatedFileSystem, sCacheManager.get());

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
@@ -27,14 +27,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * A FileSystem implementation with a local cache.
  */
 public class LocalCacheFileSystem extends DelegatingFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(LocalCacheFileSystem.class);
-  private static Optional<CacheManager> sCacheManager;
+  private static final Lock LOCK = new ReentrantLock();
+  @GuardedBy("LOCK")
+  private static final AtomicReference<CacheManager> CACHE_MANAGER = new AtomicReference<>();
 
   private final AlluxioConfiguration mConf;
 
@@ -43,21 +49,20 @@ public class LocalCacheFileSystem extends DelegatingFileSystem {
    * @param fs a FileSystem instance to query on local cache miss
    * @param conf the configuration, only respected for the first call
    */
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
-      justification = "write to static is made threadsafe")
   public LocalCacheFileSystem(FileSystem fs, AlluxioConfiguration conf) throws IOException {
     super(fs);
     // TODO(feng): support multiple cache managers
-    if (sCacheManager == null) {
-      synchronized (LocalCacheFileSystem.class) {
-        if (sCacheManager == null) {
-          try {
-            sCacheManager = Optional.of(CacheManager.create(conf));
-          } catch (IOException e) {
-            Metrics.CREATE_ERRORS.inc();
-            throw new IOException("Failed to create CacheManager", e);
+    if (CACHE_MANAGER.get() == null) {
+      if (LOCK.tryLock()) {
+        try {
+          if (CACHE_MANAGER.get() == null) {
+            CACHE_MANAGER.set(CacheManager.create(conf));
           }
+        } catch (IOException e) {
+          Metrics.CREATE_ERRORS.inc();
+          throw new IOException("Failed to create CacheManager", e);
+        } finally {
+          LOCK.unlock();
         }
       }
     }
@@ -72,19 +77,19 @@ public class LocalCacheFileSystem extends DelegatingFileSystem {
   @Override
   public FileInStream openFile(AlluxioURI path, OpenFilePOptions options)
       throws IOException, AlluxioException {
-    if (sCacheManager == null || !sCacheManager.isPresent()) {
+    if (CACHE_MANAGER.get() == null) {
       return mDelegatedFileSystem.openFile(path, options);
     }
-    return new LocalCacheFileInStream(path, options, mDelegatedFileSystem, sCacheManager.get());
+    return new LocalCacheFileInStream(path, options, mDelegatedFileSystem, CACHE_MANAGER.get());
   }
 
   @Override
   public FileInStream openFile(URIStatus status, OpenFilePOptions options)
       throws IOException, AlluxioException {
-    if (sCacheManager == null || !sCacheManager.isPresent()) {
+    if (CACHE_MANAGER.get() == null) {
       return mDelegatedFileSystem.openFile(status, options);
     }
-    return new LocalCacheFileInStream(status, options, mDelegatedFileSystem, sCacheManager.get());
+    return new LocalCacheFileInStream(status, options, mDelegatedFileSystem, CACHE_MANAGER.get());
   }
 
   private static final class Metrics {

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -11,6 +11,9 @@
 
 package alluxio.client.file.cache;
 
+import static alluxio.client.file.cache.CacheManager.State.READ_ONLY;
+import static alluxio.client.file.cache.CacheManager.State.READ_WRITE;
+
 import alluxio.client.file.cache.store.PageStoreOptions;
 import alluxio.collections.ConcurrentHashSet;
 import alluxio.collections.Pair;
@@ -34,10 +37,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Stream;
@@ -69,63 +74,25 @@ public class LocalCacheManager implements CacheManager {
   private static final Logger LOG = LoggerFactory.getLogger(LocalCacheManager.class);
 
   private static final int LOCK_SIZE = 1024;
+
   private final long mPageSize;
   private final long mCacheSize;
   private final boolean mAsyncWrite;
+  private final boolean mAsyncRestore;
   /** A readwrite lock pool to guard individual pages based on striping. */
   private final ReadWriteLock[] mPageLocks = new ReentrantReadWriteLock[LOCK_SIZE];
-  private final PageStore mPageStore;
+  private PageStore mPageStore;
   /** A readwrite lock to guard metadata operations. */
   private final ReadWriteLock mMetaLock = new ReentrantReadWriteLock();
   @GuardedBy("mMetaLock")
   private final MetaStore mMetaStore;
+  /** Executor service for execute the init tasks. */
+  private final ExecutorService mInitService;
   /** Executor service for execute the async cache tasks. */
   private final ExecutorService mAsyncCacheExecutor;
   private final ConcurrentHashSet<PageId> mPendingRequests;
-
-  /**
-   * Restores a page store a the configured location, updating meta store and evictor.
-   *
-   * @param pageStore page store
-   * @param options page store options
-   * @param metaStore meta store
-   * @return whether the restore succeeds or not
-   */
-  private static boolean restore(
-      PageStore pageStore, PageStoreOptions options, MetaStore metaStore) {
-    LOG.info("Attempt to restore PageStore with {}", options);
-    Path rootDir = Paths.get(options.getRootDir());
-    if (!Files.exists(rootDir)) {
-      LOG.error("Failed to restore PageStore: Directory {} does not exist", rootDir);
-      return false;
-    }
-    long discardedPages = 0;
-    long discardedBytes = 0;
-    try (Stream<PageInfo> stream = pageStore.getPages()) {
-      Iterator<PageInfo> iterator = stream.iterator();
-      while (iterator.hasNext()) {
-        PageInfo pageInfo = iterator.next();
-        if (pageInfo == null) {
-          LOG.error("Invalid page info");
-          return false;
-        }
-        PageId pageId = pageInfo.getPageId();
-        if (metaStore.bytes() + pageInfo.getPageSize() <= pageStore.getCacheSize()) {
-          metaStore.addPage(pageId, pageInfo);
-        } else {
-          pageStore.delete(pageId);
-          discardedPages++;
-          discardedBytes += pageInfo.getPageSize();
-        }
-      }
-    } catch (Exception e) {
-      LOG.error("Failed to restore PageStore", e);
-      return false;
-    }
-    LOG.info("Restored PageStore with {} pages ({} bytes), discarded {} pages ({} bytes)",
-        metaStore.pages(), metaStore.bytes(), discardedPages, discardedBytes);
-    return true;
-  }
+  /** State of this cache. */
+  private final AtomicReference<CacheManager.State> mState = new AtomicReference<>(READ_ONLY);
 
   /**
    * @param conf the Alluxio configuration
@@ -134,26 +101,27 @@ public class LocalCacheManager implements CacheManager {
   public static LocalCacheManager create(AlluxioConfiguration conf) throws IOException {
     MetaStore metaStore = MetaStore.create(CacheEvictor.create(conf));
     PageStoreOptions options = PageStoreOptions.create(conf);
-    PageStore pageStore = null;
-    boolean restored = false;
-    try {
-      pageStore = PageStore.create(options, false);
-      restored = restore(pageStore, options, metaStore);
-    } catch (Exception e) {
-      LOG.error("Failed to restore PageStore", e);
+    PageStore pageStore = PageStore.create(options);
+    return create(conf, metaStore, pageStore, options);
+  }
+
+  /**
+   * @param conf the Alluxio configuration
+   * @param metaStore the meta store manages the metadata
+   * @param pageStore the page store manages the cache data
+   * @param options page store options
+   * @return an instance of {@link LocalCacheManager}
+   */
+  @VisibleForTesting
+  static LocalCacheManager create(AlluxioConfiguration conf, MetaStore metaStore,
+      PageStore pageStore, PageStoreOptions options) {
+    LocalCacheManager manager = new LocalCacheManager(conf, metaStore, pageStore);
+    if (conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED)) {
+      manager.mInitService.submit(() -> manager.restoreOrInit(options));
+    } else {
+      manager.restoreOrInit(options);
     }
-    if (!restored) {
-      if (pageStore != null) {
-        try {
-          pageStore.close();
-        } catch (Exception e) {
-          LOG.error("Failed to close PageStore", e);
-        }
-      }
-      metaStore.reset();
-      pageStore = PageStore.create(options, true);
-    }
-    return new LocalCacheManager(conf, metaStore, pageStore);
+    return manager;
   }
 
   /**
@@ -161,12 +129,12 @@ public class LocalCacheManager implements CacheManager {
    * @param metaStore the meta store manages the metadata
    * @param pageStore the page store manages the cache data
    */
-  @VisibleForTesting
-  LocalCacheManager(AlluxioConfiguration conf, MetaStore metaStore, PageStore pageStore) {
+  private LocalCacheManager(AlluxioConfiguration conf, MetaStore metaStore, PageStore pageStore) {
     mMetaStore = metaStore;
     mPageStore = pageStore;
     mPageSize = conf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE);
     mAsyncWrite = conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED);
+    mAsyncRestore = conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED);
     mCacheSize = pageStore.getCacheSize();
     for (int i = 0; i < LOCK_SIZE; i++) {
       mPageLocks[i] = new ReentrantReadWriteLock(true /* fair ordering */);
@@ -178,6 +146,7 @@ public class LocalCacheManager implements CacheManager {
                 conf.getInt(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_THREADS), 60,
                 TimeUnit.SECONDS, new SynchronousQueue<>())
             : null;
+    mInitService = mAsyncRestore ? Executors.newSingleThreadExecutor() : null;
     Metrics.registerGauges(mCacheSize, mMetaStore);
   }
 
@@ -221,6 +190,11 @@ public class LocalCacheManager implements CacheManager {
   @Override
   public boolean put(PageId pageId, byte[] page) {
     LOG.debug("put({},{} bytes) enters", pageId, page.length);
+    if (mState.get() != READ_WRITE) {
+      Metrics.PUT_NOT_READY_ERRORS.inc();
+      Metrics.PUT_ERRORS.inc();
+      return false;
+    }
     if (!mAsyncWrite) {
       boolean ok = putInternal(pageId, page);
       LOG.debug("put({},{} bytes) exits: {}", pageId, page.length, ok);
@@ -407,6 +381,11 @@ public class LocalCacheManager implements CacheManager {
   @Override
   public boolean delete(PageId pageId) {
     LOG.debug("delete({}) enters", pageId);
+    if (mState.get() != READ_WRITE) {
+      Metrics.DELETE_NOT_READY_ERRORS.inc();
+      Metrics.DELETE_ERRORS.inc();
+      return false;
+    }
     ReadWriteLock pageLock = getPageLock(pageId);
     try (LockResource r = new LockResource(pageLock.writeLock())) {
       try (LockResource r1 = new LockResource(mMetaLock.writeLock())) {
@@ -430,8 +409,86 @@ public class LocalCacheManager implements CacheManager {
   }
 
   @Override
+  public State state() {
+    return mState.get();
+  }
+
+  /**
+   * Restores a page store a the configured location, updating meta store.
+   */
+  private void restoreOrInit(PageStoreOptions options) {
+    Preconditions.checkState(mState.get() == READ_ONLY);
+    if (!restore(options)) {
+      try {
+        mPageStore.close();
+        try (LockResource r = new LockResource(mMetaLock.writeLock())) {
+          mMetaStore.reset();
+        }
+        PageStore.initialize(options);
+        mPageStore = PageStore.create(options);
+      } catch (Exception e) {
+        LOG.error("Failed to clean up PageStore", e);
+        return;
+      }
+    }
+    mState.set(READ_WRITE);
+    Metrics.STATE.inc();
+  }
+
+  private boolean restore(PageStoreOptions options) {
+    LOG.info("Attempt to restore PageStore with {}", options);
+    Path rootDir = Paths.get(options.getRootDir());
+    if (!Files.exists(rootDir)) {
+      LOG.error("Failed to restore PageStore: Directory {} does not exist", rootDir);
+      return false;
+    }
+    long discardedPages = 0;
+    long discardedBytes = 0;
+    try (Stream<PageInfo> stream = mPageStore.getPages()) {
+      Iterator<PageInfo> iterator = stream.iterator();
+      while (iterator.hasNext()) {
+        PageInfo pageInfo = iterator.next();
+        if (pageInfo == null) {
+          LOG.error("Invalid page info");
+          return false;
+        }
+        PageId pageId = pageInfo.getPageId();
+        ReadWriteLock pageLock = getPageLock(pageId);
+        try (LockResource r = new LockResource(pageLock.readLock())) {
+          boolean enoughSpace;
+          try (LockResource r2 = new LockResource(mMetaLock.writeLock())) {
+            enoughSpace =
+                mMetaStore.bytes() + pageInfo.getPageSize() <= mPageStore.getCacheSize();
+            if (enoughSpace) {
+              mMetaStore.addPage(pageId, pageInfo);
+            }
+          }
+          if (!enoughSpace) {
+            mPageStore.delete(pageId);
+            discardedPages++;
+            discardedBytes += pageInfo.getPageSize();
+          }
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to restore PageStore", e);
+      return false;
+    }
+    LOG.info("Complete Restored PageStore with {} pages ({} bytes), discarded {} pages ({} bytes)",
+        mMetaStore.pages(), mMetaStore.bytes(), discardedPages, discardedBytes);
+    return true;
+  }
+
+  @Override
   public void close() throws Exception {
     mPageStore.close();
+    mMetaStore.reset();
+    if (mInitService != null) {
+      mInitService.shutdownNow();
+    }
+    if (mAsyncCacheExecutor != null) {
+      mAsyncCacheExecutor.shutdownNow();
+    }
   }
 
   /**
@@ -484,6 +541,9 @@ public class LocalCacheManager implements CacheManager {
     /** Errors when deleting pages due to absence. */
     private static final Counter DELETE_NON_EXISTING_PAGE_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_DELETE_NON_EXISTING_PAGE_ERRORS.getName());
+    /** Errors when cache is not ready to delete pages. */
+    private static final Counter DELETE_NOT_READY_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_DELETE_NOT_READY_ERRORS.getName());
     /** Errors when deleting pages due to failed delete in page stores. */
     private static final Counter DELETE_STORE_DELETE_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_DELETE_STORE_DELETE_ERRORS.getName());
@@ -511,12 +571,18 @@ public class LocalCacheManager implements CacheManager {
     /** Errors when adding pages due to benign racing eviction. */
     private static final Counter PUT_BENIGN_RACING_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_BENIGN_RACING_ERRORS.getName());
+    /** Errors when cache is not ready to add pages. */
+    private static final Counter PUT_NOT_READY_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_NOT_READY_ERRORS.getName());
     /** Errors when adding pages due to failed deletes in page store. */
     private static final Counter PUT_STORE_DELETE_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_STORE_DELETE_ERRORS.getName());
     /** Errors when adding pages due to failed writes to page store. */
     private static final Counter PUT_STORE_WRITE_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_STORE_WRITE_ERRORS.getName());
+    /** State of the cache. */
+    private static final Counter STATE =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_STATE.getName());
 
     private static void registerGauges(long cacheSize, MetaStore metaStore) {
       MetricsSystem.registerGaugeIfAbsent(

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -361,7 +361,7 @@ public class LocalCacheManager implements CacheManager {
     if (mState.get() == NOT_IN_USE) {
       Metrics.GET_NOT_READY_ERRORS.inc();
       Metrics.GET_ERRORS.inc();
-      return 0;
+      return -1;
     }
     boolean hasPage;
     ReadWriteLock pageLock = getPageLock(pageId);
@@ -571,7 +571,7 @@ public class LocalCacheManager implements CacheManager {
     /** Errors when getting pages. */
     private static final Counter GET_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_GET_ERRORS.getName());
-    /** Errors when getting pages. */
+    /** Errors when cache is not ready to get pages. */
     private static final Counter GET_NOT_READY_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_GET_NOT_READY_ERRORS.getName());
     /** Errors when getting pages due to failed read from page stores. */

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
@@ -79,6 +79,11 @@ public class NoExceptionCacheManager implements CacheManager {
   }
 
   @Override
+  public State state() {
+    return mCacheManager.state();
+  }
+
+  @Override
   public void close() throws Exception {
     try {
       mCacheManager.close();

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -35,14 +35,25 @@ public interface PageStore extends AutoCloseable {
   Logger LOG = LoggerFactory.getLogger(PageStore.class);
 
   /**
-   * Creates a {@link PageStore}. When init is false, restore from previous state; clean up the
-   * cache dir otherwise.
+   * Creates a new {@link PageStore}. Previous state in the samme cache dir will be overwritten.
    *
    * @param options the options to instantiate the page store
    * @return a PageStore instance
    * @throws IOException if I/O error happens
    */
   static PageStore create(PageStoreOptions options) throws IOException {
+    initialize(options);
+    return open(options);
+  }
+
+  /**
+   * Opens an existing {@link PageStore}.
+   *
+   * @param options the options to instantiate the page store
+   * @return a PageStore instance
+   * @throws IOException if I/O error happens
+   */
+  static PageStore open(PageStoreOptions options) throws IOException {
     LOG.info("Creating PageStore with option={}", options.toString());
     final PageStore pageStore;
     switch (options.getType()) {
@@ -50,7 +61,7 @@ public interface PageStore extends AutoCloseable {
         pageStore = new LocalPageStore(options.toOptions());
         break;
       case ROCKS:
-        pageStore = RocksPageStore.create(options.toOptions());
+        pageStore = RocksPageStore.open(options.toOptions());
         break;
       default:
         throw new IllegalArgumentException(

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -39,15 +39,11 @@ public interface PageStore extends AutoCloseable {
    * cache dir otherwise.
    *
    * @param options the options to instantiate the page store
-   * @param init whether to init the cache dir
    * @return a PageStore instance
    * @throws IOException if I/O error happens
    */
-  static PageStore create(PageStoreOptions options, boolean init) throws IOException {
-    LOG.info("Creating PageStore with option={}, init={}", options.toString(), init);
-    if (init) {
-      initialize(options);
-    }
+  static PageStore create(PageStoreOptions options) throws IOException {
+    LOG.info("Creating PageStore with option={}", options.toString());
     final PageStore pageStore;
     switch (options.getType()) {
       case LOCAL:

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
@@ -59,7 +59,7 @@ public class RocksPageStore implements PageStore {
    * @return a new instance of {@link PageStore} backed by RocksDB
    * @throws IOException if I/O error happens
    */
-  public static RocksPageStore create(RocksPageStoreOptions options) throws IOException {
+  public static RocksPageStore open(RocksPageStoreOptions options) throws IOException {
     Preconditions.checkArgument(options.getMaxPageSize() > 0);
     RocksDB.loadLibrary();
     Options rocksOptions = new Options();

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -395,6 +395,11 @@ public class LocalCacheFileInStreamTest {
     }
 
     @Override
+    public State state() {
+      return State.READ_WRITE;
+    }
+
+    @Override
     public void close() throws Exception {
       // no-op
     }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -24,9 +24,12 @@ import alluxio.client.file.cache.store.PageStoreType;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.PageNotFoundException;
+import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.FileUtils;
 
+import com.google.common.collect.Streams;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,10 +39,12 @@ import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Paths;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -59,6 +64,7 @@ public final class LocalCacheManagerTest {
   private MetaStore mMetaStore;
   private PageStore mPageStore;
   private CacheEvictor mEvictor;
+  private PageStoreOptions mPageStoreOptions;
   private byte[] mBuf = new byte[PAGE_SIZE_BYTES];
 
   @Rule
@@ -73,10 +79,12 @@ public final class LocalCacheManagerTest {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, CACHE_SIZE_BYTES);
     mConf.set(PropertyKey.USER_CLIENT_CACHE_DIR, mTemp.getRoot().getAbsolutePath());
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED, false);
-    mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED, false);
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.create(mPageStoreOptions);
     mEvictor = new FIFOEvictor();
     mMetaStore = MetaStore.create(mEvictor);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
   }
 
   private byte[] page(int i, int pageLen) {
@@ -105,8 +113,9 @@ public final class LocalCacheManagerTest {
   @Test
   public void putEvict() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
-    mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.create(mPageStoreOptions);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
     assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
     assertTrue(mCacheManager.put(PAGE_ID2, PAGE2));
     assertEquals(0, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
@@ -118,8 +127,9 @@ public final class LocalCacheManagerTest {
   public void putSmallPages() throws Exception {
     // Cache size is only one full page, but should be able to store multiple small pages
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
-    mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.create(mPageStoreOptions);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
     int smallPageLen = 8;
     long numPages = mConf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE) / smallPageLen;
     for (int i = 0; i < numPages; i++) {
@@ -138,8 +148,9 @@ public final class LocalCacheManagerTest {
   @Test
   public void evictSmallPageByPutSmallPage() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
-    mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.create(mPageStoreOptions);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
     int smallPageLen = 8;
     long numPages = mConf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE) / smallPageLen;
     for (int i = 0; i < numPages; i++) {
@@ -163,8 +174,9 @@ public final class LocalCacheManagerTest {
   @Test
   public void evictSmallPagesByPutPigPage() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
-    mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.create(mPageStoreOptions);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
     int smallPageLen = 8;
     long numPages = mConf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE) / smallPageLen;
     for (int i = 0; i < numPages; i++) {
@@ -185,8 +197,9 @@ public final class LocalCacheManagerTest {
   @Test
   public void evictBigPagesByPutSmallPage() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
-    mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.create(mPageStoreOptions);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
     PageId bigPageId = pageId(-1, 0);
     assertTrue(mCacheManager.put(bigPageId, page(0, PAGE_SIZE_BYTES)));
     int smallPageLen = 8;
@@ -285,12 +298,12 @@ public final class LocalCacheManagerTest {
   }
 
   @Test
-  public void restore() throws Exception {
-    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
-    mCacheManager.put(PAGE_ID1, PAGE1);
-    mCacheManager.put(pageUuid, PAGE2);
+  public void syncRestore() throws Exception {
     mCacheManager.close();
-    mCacheManager = LocalCacheManager.create(mConf);
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    mPageStore.put(PAGE_ID1, PAGE1);
+    mPageStore.put(pageUuid, PAGE2);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
     assertEquals(PAGE1.length, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
     assertArrayEquals(PAGE1, mBuf);
     assertEquals(PAGE2.length, mCacheManager.get(pageUuid, PAGE1.length, mBuf, 0));
@@ -298,29 +311,121 @@ public final class LocalCacheManagerTest {
   }
 
   @Test
-  public void restoreFailed() throws Exception {
-    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
-    mCacheManager.put(PAGE_ID1, PAGE1);
-    mCacheManager.put(pageUuid, PAGE2);
+  public void asyncRestore() throws Exception {
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED, true);
     mCacheManager.close();
+    mPageStore.put(PAGE_ID1, PAGE1);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
+    CommonUtils.waitFor("async restore completed",
+        () ->  mCacheManager.state() == CacheManager.State.READ_WRITE,
+        WaitForOptions.defaults().setTimeoutMs(10000));
+    assertTrue(mCacheManager.put(PAGE_ID2, PAGE2));
+    assertEquals(PAGE1.length, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+    assertArrayEquals(PAGE1, mBuf);
+    assertEquals(PAGE2.length, mCacheManager.get(PAGE_ID2, PAGE2.length, mBuf, 0));
+    assertArrayEquals(PAGE2, mBuf);
+  }
+
+  @Test
+  public void asyncRestoreReadOnly() throws Exception {
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED, true);
+    mCacheManager.close();
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    SlowGetPageStore slowGetPageStore = new SlowGetPageStore();
+    slowGetPageStore.put(PAGE_ID1, PAGE1);
+    slowGetPageStore.put(pageUuid, PAGE2);
+    mCacheManager = LocalCacheManager.create(
+        mConf, mMetaStore, slowGetPageStore, mPageStoreOptions);
+    assertEquals(CacheManager.State.READ_ONLY, mCacheManager.state());
+    Thread.sleep(1000); // some buffer to restore page1
+    // In READ_ONLY mode we still get previously added page
+    assertEquals(PAGE1.length, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+    assertArrayEquals(PAGE1, mBuf);
+    assertEquals(PAGE2.length, mCacheManager.get(pageUuid, PAGE2.length, mBuf, 0));
+    assertArrayEquals(PAGE2, mBuf);
+    // In READ_ONLY mode we cannot put
+    assertFalse(mCacheManager.put(PAGE_ID2, PAGE2));
+    // In READ_ONLY mode we cannot delete
+    assertFalse(mCacheManager.delete(PAGE_ID1));
+    // stop the "fake scan"
+    slowGetPageStore.mScanComplete.set(true);
+    CommonUtils.waitFor("async restore completed",
+        () ->  mCacheManager.state() == CacheManager.State.READ_WRITE,
+        WaitForOptions.defaults().setTimeoutMs(10000));
+    // Put get back to normal
+    assertTrue(mCacheManager.put(PAGE_ID2, PAGE2));
+    assertEquals(PAGE2.length, mCacheManager.get(PAGE_ID2, PAGE2.length, mBuf, 0));
+    assertArrayEquals(PAGE2, mBuf);
+    assertTrue(mCacheManager.delete(PAGE_ID2));
+  }
+
+  @Test
+  public void syncRestoreUnknownFile() throws Exception {
+    mCacheManager.close();
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    mPageStore.put(PAGE_ID1, PAGE1);
+    mPageStore.put(pageUuid, PAGE2);
     String rootDir = PageStore.getStorePath(PageStoreType.LOCAL,
         mConf.get(PropertyKey.USER_CLIENT_CACHE_DIR)).toString();
     FileUtils.createFile(Paths.get(rootDir, "invalidPageFile").toString());
-    mCacheManager = LocalCacheManager.create(mConf);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
     assertEquals(0, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
     assertEquals(0, mCacheManager.get(pageUuid, PAGE2.length, mBuf, 0));
   }
 
   @Test
-  public void restoreWithMorePagesThanCapacity() throws Exception {
-    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
-    mCacheManager.put(PAGE_ID1, PAGE1);
-    mCacheManager.put(PAGE_ID2, PAGE2);
-    mCacheManager.put(pageUuid, BufferUtils.getIncreasingByteArray(
-        PAGE1.length + PAGE2.length + 1));
+  public void asyncRestoreUnknownFile() throws Exception {
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED, true);
     mCacheManager.close();
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    mPageStore.put(PAGE_ID1, PAGE1);
+    mPageStore.put(pageUuid, PAGE2);
+    String rootDir = PageStore.getStorePath(PageStoreType.LOCAL,
+        mConf.get(PropertyKey.USER_CLIENT_CACHE_DIR)).toString();
+    FileUtils.createFile(Paths.get(rootDir, "invalidPageFile").toString());
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
+    CommonUtils.waitFor("async restore completed",
+        () ->  mCacheManager.state() == CacheManager.State.READ_WRITE,
+        WaitForOptions.defaults().setTimeoutMs(10000));
+    assertEquals(0, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+    assertEquals(0, mCacheManager.get(pageUuid, PAGE2.length, mBuf, 0));
+  }
+
+  @Test
+  public void syncRestoreWithMorePagesThanCapacity() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE1.length + PAGE2.length);
-    mCacheManager = LocalCacheManager.create(mConf);
+    mCacheManager.close();
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    mPageStore.put(PAGE_ID1, PAGE1);
+    mPageStore.put(PAGE_ID2, PAGE2);
+    mPageStore.put(pageUuid, BufferUtils.getIncreasingByteArray(
+        PAGE1.length + PAGE2.length + 1));
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.create(mPageStoreOptions);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
+    assertEquals(PAGE1.length, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+    assertArrayEquals(PAGE1, mBuf);
+    assertEquals(PAGE2.length, mCacheManager.get(PAGE_ID2, PAGE2.length, mBuf, 0));
+    assertArrayEquals(PAGE2, mBuf);
+    assertEquals(0, mCacheManager.get(pageUuid, PAGE2.length, mBuf, 0));
+  }
+
+  @Test
+  public void asyncRestoreWithMorePagesThanCapacity() throws Exception {
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED, true);
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE1.length + PAGE2.length);
+    mCacheManager.close();
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    mPageStore.put(PAGE_ID1, PAGE1);
+    mPageStore.put(PAGE_ID2, PAGE2);
+    mPageStore.put(pageUuid, BufferUtils.getIncreasingByteArray(
+        PAGE1.length + PAGE2.length + 1));
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.create(mPageStoreOptions);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
+    CommonUtils.waitFor("async restore completed",
+        () ->  mCacheManager.state() == CacheManager.State.READ_WRITE,
+        WaitForOptions.defaults().setTimeoutMs(1000000));
     assertEquals(PAGE1.length, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
     assertArrayEquals(PAGE1, mBuf);
     assertEquals(PAGE2.length, mCacheManager.get(PAGE_ID2, PAGE2.length, mBuf, 0));
@@ -335,7 +440,7 @@ public final class LocalCacheManagerTest {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_THREADS, threads);
     mConf.set(PropertyKey.USER_CLIENT_CACHE_STORE_TYPE, "LOCAL");
     PutDelayedPageStore pageStore = new PutDelayedPageStore();
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, pageStore, mPageStoreOptions);
     for (int i = 0; i < threads; i++) {
       PageId pageId = new PageId("5", i);
       assertTrue(mCacheManager.put(pageId, page(i, PAGE_SIZE_BYTES)));
@@ -360,7 +465,7 @@ public final class LocalCacheManagerTest {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_THREADS, threads);
     mConf.set(PropertyKey.USER_CLIENT_CACHE_STORE_TYPE, "LOCAL");
     PutDelayedPageStore pageStore = new PutDelayedPageStore();
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, pageStore, mPageStoreOptions);
     assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
     assertFalse(mCacheManager.put(PAGE_ID1, PAGE1));
     pageStore.setHanging(false);
@@ -374,7 +479,7 @@ public final class LocalCacheManagerTest {
   @Test
   public void recoverCacheFromFailedPut() throws Exception {
     FaultyPageStore pageStore = new FaultyPageStore();
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, pageStore, mPageStoreOptions);
     pageStore.setPutFaulty(true);
     // a failed put
     assertFalse(mCacheManager.put(PAGE_ID1, PAGE1));
@@ -394,7 +499,7 @@ public final class LocalCacheManagerTest {
   public void failedPageStoreDeleteOnEviction() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
     FaultyPageStore pageStore = new FaultyPageStore();
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, pageStore, mPageStoreOptions);
     pageStore.setDeleteFaulty(true);
     // first put should be ok
     assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
@@ -409,7 +514,7 @@ public final class LocalCacheManagerTest {
   }
 
   /**
-   * A PageStore where put can throw IOException on put.
+   * A PageStore where put can throw IOException on put or delete.
    */
   private class FaultyPageStore extends LocalPageStore {
     public FaultyPageStore() {
@@ -469,6 +574,41 @@ public final class LocalCacheManagerTest {
 
     int getPuts() {
       return mPut.get();
+    }
+  }
+
+  /**
+   * A PageStore with slow scan.
+   */
+  private class SlowGetPageStore extends LocalPageStore {
+    private class NonStoppingSlowPageIterator implements Iterator<PageInfo> {
+      @Override
+      public boolean hasNext() {
+        return !mScanComplete.get();
+      }
+
+      @Override
+      public PageInfo next() {
+        try {
+          Thread.sleep(1000);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+        PageId id = new PageId(String.valueOf(mPageId.getAndIncrement()), 0L);
+        return new PageInfo(id, 1L);
+      }
+    }
+
+    private AtomicInteger mPageId = new AtomicInteger(100);
+    private AtomicBoolean mScanComplete = new AtomicBoolean(false);
+
+    public SlowGetPageStore() {
+      super(PageStoreOptions.create(mConf).toOptions());
+    }
+
+    @Override
+    public Stream<PageInfo> getPages() throws IOException {
+      return Stream.concat(super.getPages(), Streams.stream(new NonStoppingSlowPageIterator()));
     }
   }
 

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -312,6 +312,23 @@ public final class LocalCacheManagerTest {
   }
 
   @Test
+  public void restoreWithMorePagesThanCapacity() throws Exception {
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    mCacheManager.put(PAGE_ID1, PAGE1);
+    mCacheManager.put(PAGE_ID2, PAGE2);
+    mCacheManager.put(pageUuid, BufferUtils.getIncreasingByteArray(
+        PAGE1.length + PAGE2.length + 1));
+    mCacheManager.close();
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE1.length + PAGE2.length);
+    mCacheManager = LocalCacheManager.create(mConf);
+    assertEquals(PAGE1.length, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+    assertArrayEquals(PAGE1, mBuf);
+    assertEquals(PAGE2.length, mCacheManager.get(PAGE_ID2, PAGE2.length, mBuf, 0));
+    assertArrayEquals(PAGE2, mBuf);
+    assertEquals(0, mCacheManager.get(pageUuid, PAGE2.length, mBuf, 0));
+  }
+
+  @Test
   public void asyncCache() throws Exception {
     final int threads = 16;
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED, true);

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -406,8 +406,9 @@ public final class LocalCacheManagerTest {
     try {
       mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
       assertEquals(CacheManager.State.NOT_IN_USE, mCacheManager.state());
-      assertEquals(0, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
-      assertEquals(0, mCacheManager.get(pageUuid, PAGE2.length, mBuf, 0));
+      assertEquals(-1, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+      assertEquals(false, mCacheManager.put(PAGE_ID2, PAGE2));
+      assertEquals(false, mCacheManager.delete(PAGE_ID1));
     } finally {
       root.setWritable(true);
     }
@@ -430,8 +431,9 @@ public final class LocalCacheManagerTest {
       CommonUtils.waitFor("async restore completed",
           () -> mCacheManager.state() == CacheManager.State.NOT_IN_USE,
           WaitForOptions.defaults().setTimeoutMs(10000));
-      assertEquals(0, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
-      assertEquals(0, mCacheManager.get(pageUuid, PAGE2.length, mBuf, 0));
+      assertEquals(-1, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+      assertEquals(false, mCacheManager.put(PAGE_ID2, PAGE2));
+      assertEquals(false, mCacheManager.delete(PAGE_ID1));
     } finally {
       root.setWritable(true);
     }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -447,7 +447,7 @@ public final class LocalCacheManagerTest {
     mPageStore.put(pageUuid, BufferUtils.getIncreasingByteArray(
         PAGE1.length + PAGE2.length + 1));
     mPageStoreOptions = PageStoreOptions.create(mConf);
-    mPageStore = PageStore.create(mPageStoreOptions);
+    mPageStore = PageStore.open(mPageStoreOptions);
     mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
     assertEquals(PAGE1.length, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
     assertArrayEquals(PAGE1, mBuf);
@@ -467,7 +467,7 @@ public final class LocalCacheManagerTest {
     mPageStore.put(pageUuid, BufferUtils.getIncreasingByteArray(
         PAGE1.length + PAGE2.length + 1));
     mPageStoreOptions = PageStoreOptions.create(mConf);
-    mPageStore = PageStore.create(mPageStoreOptions);
+    mPageStore = PageStore.open(mPageStoreOptions);
     mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
     CommonUtils.waitFor("async restore completed",
         () ->  mCacheManager.state() == CacheManager.State.READ_WRITE,

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
@@ -73,7 +73,7 @@ public class PageStoreTest {
     mOptions.setCacheSize(65536);
     mOptions.setAlluxioVersion(ProjectConstants.VERSION);
     mOptions.setRootDir(mTemp.getRoot().getAbsolutePath());
-    mPageStore = PageStore.create(mOptions, true);
+    mPageStore = PageStore.create(mOptions);
   }
 
   @After

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3345,6 +3345,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED =
+      new Builder(Name.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED)
+          .setDefaultValue(true)
+          .setDescription("If this is enabled, cache restore state asynchronously.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED =
       new Builder(Name.USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED)
           .setDefaultValue(true)
@@ -5084,6 +5091,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.block.worker.client.read.retry";
     public static final String USER_BLOCK_WRITE_LOCATION_POLICY =
         "alluxio.user.block.write.location.policy.class";
+    public static final String USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED =
+        "alluxio.user.client.cache.async.restore.enabled";
     public static final String USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED =
         "alluxio.user.client.cache.async.write.enabled";
     public static final String USER_CLIENT_CACHE_ASYNC_WRITE_THREADS =

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -884,6 +884,12 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_GET_NOT_READY_ERRORS =
+      new Builder(Name.CLIENT_CACHE_GET_NOT_READY_ERRORS)
+          .setDescription("Number of failures when cache is not ready to get pages.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_GET_STORE_READ_ERRORS =
       new Builder(Name.CLIENT_CACHE_GET_STORE_READ_ERRORS)
           .setDescription("Number of failures when getting cached data in the client cache due to "
@@ -952,7 +958,7 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey CLIENT_CACHE_STATE =
       new Builder(Name.CLIENT_CACHE_STATE)
-          .setDescription("State of the cache: 0 (READ_ONLY) and 1 (READ_WRITE)")
+          .setDescription("State of the cache: 0 (NOT_IN_USE), 1 (READ_ONLY) and 2 (READ_WRITE)")
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
@@ -1175,6 +1181,7 @@ public final class MetricKey implements Comparable<MetricKey> {
     public static final String CLIENT_CACHE_DELETE_STORE_DELETE_ERRORS =
         "Client.CacheDeleteStoreDeleteErrors";
     public static final String CLIENT_CACHE_GET_ERRORS = "Client.CacheGetErrors";
+    public static final String CLIENT_CACHE_GET_NOT_READY_ERRORS = "Client.CacheGetNotReadyErrors";
     public static final String CLIENT_CACHE_GET_STORE_READ_ERRORS =
         "Client.CacheGetStoreReadErrors";
     public static final String CLIENT_CACHE_PUT_ERRORS = "Client.CachePutErrors";

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -952,7 +952,7 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey CLIENT_CACHE_STATE =
       new Builder(Name.CLIENT_CACHE_STATE)
-          .setDescription("State of the cache: 0 (NOT_READY), 1 (READ_ONLY) and 2 (READ_WRITE)")
+          .setDescription("State of the cache: 0 (READ_ONLY) and 1 (READ_WRITE)")
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -865,6 +865,12 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_DELETE_NOT_READY_ERRORS =
+      new Builder(Name.CLIENT_CACHE_DELETE_NOT_READY_ERRORS)
+          .setDescription("Number of failures when  when cache is not ready to delete pages.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_DELETE_STORE_DELETE_ERRORS =
       new Builder(Name.CLIENT_CACHE_DELETE_STORE_DELETE_ERRORS)
           .setDescription("Number of failures when deleting pages due to failed delete in page "
@@ -924,6 +930,12 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_PUT_NOT_READY_ERRORS =
+      new Builder(Name.CLIENT_CACHE_PUT_NOT_READY_ERRORS)
+          .setDescription("Number of failures when cache is not ready to add pages.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_PUT_STORE_DELETE_ERRORS =
       new Builder(Name.CLIENT_CACHE_PUT_STORE_DELETE_ERRORS)
           .setDescription("Number of failures when putting cached data in the client cache due to"
@@ -935,6 +947,12 @@ public final class MetricKey implements Comparable<MetricKey> {
       new Builder(Name.CLIENT_CACHE_PUT_STORE_WRITE_ERRORS)
           .setDescription("Number of failures when putting cached data in the client cache due to"
               + " failed writes to page store.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_CACHE_STATE =
+      new Builder(Name.CLIENT_CACHE_STATE)
+          .setDescription("State of the cache: 0 (NOT_READY), 1 (READ_ONLY) and 2 (READ_WRITE)")
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
@@ -1152,6 +1170,8 @@ public final class MetricKey implements Comparable<MetricKey> {
     public static final String CLIENT_CACHE_DELETE_ERRORS = "Client.CacheDeleteErrors";
     public static final String CLIENT_CACHE_DELETE_NON_EXISTING_PAGE_ERRORS =
         "Client.CacheDeleteNonExistingPageErrors";
+    public static final String CLIENT_CACHE_DELETE_NOT_READY_ERRORS =
+        "Client.CacheDeleteNotReadyErrors";
     public static final String CLIENT_CACHE_DELETE_STORE_DELETE_ERRORS =
         "Client.CacheDeleteStoreDeleteErrors";
     public static final String CLIENT_CACHE_GET_ERRORS = "Client.CacheGetErrors";
@@ -1164,10 +1184,13 @@ public final class MetricKey implements Comparable<MetricKey> {
         "Client.CachePutEvictionErrors";
     public static final String CLIENT_CACHE_PUT_BENIGN_RACING_ERRORS =
         "Client.CachePutBenignRacingErrors";
+    public static final String CLIENT_CACHE_PUT_NOT_READY_ERRORS =
+        "Client.CachePutNotReadyErrors";
     public static final String CLIENT_CACHE_PUT_STORE_DELETE_ERRORS =
         "Client.CachePutStoreDeleteErrors";
     public static final String CLIENT_CACHE_PUT_STORE_WRITE_ERRORS =
         "Client.CachePutStoreWriteErrors";
+    public static final String CLIENT_CACHE_STATE = "Client.CacheState";
 
     private Name() {} // prevent instantiation
   }

--- a/tests/src/test/java/alluxio/client/fs/LocalCacheManagerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LocalCacheManagerIntegrationTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.Constants;
+import alluxio.client.file.cache.CacheManager;
 import alluxio.client.file.cache.LocalCacheManager;
 import alluxio.client.file.cache.PageId;
 import alluxio.client.file.cache.PageStore;
@@ -23,6 +24,8 @@ import alluxio.conf.AlluxioProperties;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.testutils.BaseIntegrationTest;
+import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.FileUtils;
 
@@ -35,6 +38,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.nio.file.Paths;
 
+// TODO(binfan): this is not a real integration test, should be consolidated with UT
 public final class LocalCacheManagerIntegrationTest extends BaseIntegrationTest {
   private static final int PAGE_SIZE_BYTES = Constants.KB;
   private static final int PAGE_COUNT = 32;
@@ -183,6 +187,9 @@ public final class LocalCacheManagerIntegrationTest extends BaseIntegrationTest 
     // creates with different configuration
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, CACHE_SIZE_BYTES / 2);
     mCacheManager = LocalCacheManager.create(mConf);
+    CommonUtils.waitFor("async restore completed",
+        () ->  mCacheManager.state() == CacheManager.State.READ_WRITE,
+        WaitForOptions.defaults().setTimeoutMs(10000));
     assertEquals(PAGE_SIZE_BYTES, mCacheManager.get(PAGE_ID, PAGE_SIZE_BYTES, mBuffer, 0));
   }
 

--- a/tests/src/test/java/alluxio/client/fs/LocalCacheManagerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LocalCacheManagerIntegrationTest.java
@@ -182,7 +182,7 @@ public final class LocalCacheManagerIntegrationTest extends BaseIntegrationTest 
     // creates with different configuration
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, CACHE_SIZE_BYTES / 2);
     mCacheManager = LocalCacheManager.create(mConf);
-    assertEquals(0, mCacheManager.get(PAGE_ID, PAGE_SIZE_BYTES, mBuffer, 0));
+    assertEquals(PAGE_SIZE_BYTES, mCacheManager.get(PAGE_ID, PAGE_SIZE_BYTES, mBuffer, 0));
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/fs/LocalCacheManagerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LocalCacheManagerIntegrationTest.java
@@ -60,6 +60,7 @@ public final class LocalCacheManagerIntegrationTest extends BaseIntegrationTest 
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ENABLED, true);
     mConf.set(PropertyKey.USER_CLIENT_CACHE_DIR, mTemp.getRoot().getPath());
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED, false);
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED, false);
   }
 
   @After


### PR DESCRIPTION
- remove restore logic to a separate background thread meanwhile open the cache manager in a "readonly" mode to other query threads. in this way, early queries will suffer from low hit ratio but hopefully they will catch up.
- handle capacity exceeding gracefully: instead of failing the restore and delete all pages on disk, just remove the excessive pages