### PR TITLE
Run git clean with two -f

### DIFF
--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -17,7 +17,7 @@ set -ex
 
 if [ -n "${ALLUXIO_GIT_CLEAN}" ]
 then
-  git clean -fdx
+  git clean -ffdx
 fi
 
 mvn_args=""


### PR DESCRIPTION
in order to properly clean subdirectories that are git repos
see https://stackoverflow.com/questions/9314365/git-clean-is-not-removing-a-submodule-added-to-a-branch-when-switching-branches