### PR TITLE
Prevent UI from installing dependencies twice

### DIFF
--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -40,7 +40,7 @@
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
-            <phase>generate-sources</phase>
+            <phase>process-sources</phase>
             <configuration>
               <nodeVersion>v10.11.0</nodeVersion>
               <npmVersion>6.4.1</npmVersion>
@@ -51,7 +51,7 @@
             <goals>
               <goal>npm</goal>
             </goals>
-            <phase>generate-sources</phase>
+            <phase>process-sources</phase>
             <configuration>
               <arguments>install --production --no-save --no-package-lock --no-shrinkwrap</arguments>
             </configuration>
@@ -87,7 +87,7 @@
           </execution>
           <execution>
             <id>Install npm dependencies for packages</id>
-            <phase>generate-sources</phase>
+            <phase>process-sources</phase>
             <goals>
               <goal>exec</goal>
             </goals>


### PR DESCRIPTION
The maven build actually executes the generate-sources phase twice
because the maven-sources-plugin calls the generate-sources phase during
its attach-sources target. This causes the UI module to install node/npm
AND run npm install twice during the build. Moving these plugins from
generate-sources to process-sources (the next step in the maven
lifecycle) prevents the extra calls and saves time during the build.