### PR TITLE
Improve entrypoint.sh to better support dynamic non-root user

### DIFF
--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -162,9 +162,9 @@ function setup_for_dynamic_non_root {
       # Chmod the dirs of tiered stores for alluxio worker
       # to ensure write permission for non-root user.
       if [[ "$1" == "worker" || "$1" == "worker-only" ]]; then
-        "${ALLUXIO_HOME}/bin/alluxio" getConf | \
+        echo "$ALLUXIO_JAVA_OPTS" | tr ' ' '\n' | \
           grep "alluxio.worker.tieredstore.level[0-9].dirs.path" | \
-          awk -F '=' '{print $2}' | \
+          cut -d '=' -f 2 | \
           grep -Ev "^$" | \
           xargs -I {} chmod -R 777 {}
       fi

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -163,7 +163,8 @@ function setup_for_dynamic_non_root {
       # to ensure write permission for non-root user.
       chmod -R 777 ${ALLUXIO_RAM_FOLDER}
       if [[ "$1" == "worker" || "$1" == "worker-only" ]]; then
-        echo "${ALLUXIO_JAVA_OPTS} ${ALLUXIO_WORKER_JAVA_OPTS}" | tr ' ' '\n' | \
+        echo "${ALLUXIO_JAVA_OPTS} ${ALLUXIO_WORKER_JAVA_OPTS}" | \
+          tr ' ' '\n' | \
           grep "alluxio.worker.tieredstore.level[0-9].dirs.path" | \
           cut -d '=' -f 2 | \
           tr ',' '\n' | \

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -161,10 +161,12 @@ function setup_for_dynamic_non_root {
       chmod -R g=u /opt/* /journal
       # Chmod the dirs of tiered stores for alluxio worker
       # to ensure write permission for non-root user.
+      chmod -R 777 ${ALLUXIO_RAM_FOLDER}
       if [[ "$1" == "worker" || "$1" == "worker-only" ]]; then
-        echo "$ALLUXIO_JAVA_OPTS" | tr ' ' '\n' | \
+        echo "${ALLUXIO_JAVA_OPTS} ${ALLUXIO_WORKER_JAVA_OPTS}" | tr ' ' '\n' | \
           grep "alluxio.worker.tieredstore.level[0-9].dirs.path" | \
           cut -d '=' -f 2 | \
+          tr ',' '\n' | \
           grep -Ev "^$" | \
           xargs -I {} chmod -R 777 {}
       fi


### PR DESCRIPTION
When running with non-root user in alluxio-worker container, non-root user may not have the write permission to the tiered store directories. This PR fixed this issue by changing the permission of tiered store dirs to 777.