### PR TITLE
Support dynamic user to run alluxio

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -18,6 +18,7 @@
 FROM alpine:3.10.2 AS extractor
 # Note that downloads for *-SNAPSHOT tarballs are not available
 ARG ALLUXIO_TARBALL=http://downloads.alluxio.io/downloads/files/2.4.0-SNAPSHOT/alluxio-2.4.0-SNAPSHOT-bin.tar.gz
+# (Alert):It's not recommended to set this Argument to true, unless you know exactly what you are doing 
 ARG ENABLE_DYANMIC_USER=false
 
 ADD ${ALLUXIO_TARBALL} /opt/
@@ -66,6 +67,7 @@ RUN if [ ${ALLUXIO_USERNAME} != "root" ] \
 COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} --from=extractor /opt/ /opt/
 COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} conf /opt/alluxio/conf/
 COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} entrypoint.sh /
+
 
 RUN if [ ${ENABLE_DYANMIC_USER} = "true" ] ; then \
        chmod -R 777 /journal; \

--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -18,6 +18,7 @@
 FROM alpine:3.10.2 AS extractor
 # Note that downloads for *-SNAPSHOT tarballs are not available
 ARG ALLUXIO_TARBALL=http://downloads.alluxio.io/downloads/files/2.4.0-SNAPSHOT/alluxio-2.4.0-SNAPSHOT-bin.tar.gz
+ARG ENABLE_DYANMIC_USER=false
 
 ADD ${ALLUXIO_TARBALL} /opt/
 # if the tarball was remote, it needs to be untarred
@@ -26,11 +27,16 @@ RUN cd /opt && \
     (if ls | grep -q ".tar.gz"; then tar -xzf *.tar.gz && rm *.tar.gz; fi) && \
     ln -s alluxio-* alluxio
 
+RUN if [ ${ENABLE_DYANMIC_USER} = "true" ] ; then \
+       chmod -R 777 /opt/* ; \
+    fi
+
 FROM openjdk:8-jdk-alpine
 ARG ALLUXIO_USERNAME=alluxio
 ARG ALLUXIO_GROUP=alluxio
 ARG ALLUXIO_UID=1000
 ARG ALLUXIO_GID=1000
+ARG ENABLE_DYANMIC_USER=false
 
 RUN apk --no-cache --update add bash libc6-compat shadow && \
     rm -rf /var/cache/apk/*
@@ -60,6 +66,10 @@ RUN if [ ${ALLUXIO_USERNAME} != "root" ] \
 COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} --from=extractor /opt/ /opt/
 COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} conf /opt/alluxio/conf/
 COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} entrypoint.sh /
+
+RUN if [ ${ENABLE_DYANMIC_USER} = "true" ] ; then \
+       chmod -R 777 /journal; \
+    fi
 
 USER ${ALLUXIO_UID}
 


### PR DESCRIPTION
The issue is that alluxio docker image only supports two users: alluxio and root, but in the customer env, they have more users and the data of each user are isolated. So we need to make alluxio docker image can support run container by specifying during running time. 

This feature by default is disabled.