### PR TITLE
Add loadMetadata command

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -46,6 +46,7 @@ import alluxio.grpc.FreePOptions;
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.GrpcUtils;
 import alluxio.grpc.ListStatusPOptions;
+import alluxio.grpc.LoadMetadataPOptions;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.RenamePOptions;
@@ -271,6 +272,18 @@ public class BaseFileSystem implements FileSystem {
       ListStatusPOptions mergedOptions = FileSystemOptions.listStatusDefaults(
           mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
       return client.listStatus(path, mergedOptions);
+    });
+  }
+
+  @Override
+  public void loadMetadata(AlluxioURI path, final LoadMetadataPOptions options)
+      throws FileDoesNotExistException, IOException, AlluxioException {
+    checkUri(path);
+    rpc(client -> {
+      LoadMetadataPOptions mergedOptions = FileSystemOptions.loadMetadataDefaults(
+          mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
+      client.loadMetadata(path, mergedOptions);
+      return null;
     });
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/DelegatingFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DelegatingFileSystem.java
@@ -27,6 +27,7 @@ import alluxio.grpc.ExistsPOptions;
 import alluxio.grpc.FreePOptions;
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.ListStatusPOptions;
+import alluxio.grpc.LoadMetadataPOptions;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.RenamePOptions;
@@ -115,6 +116,11 @@ public class DelegatingFileSystem implements FileSystem {
   public List<URIStatus> listStatus(AlluxioURI path, ListStatusPOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException {
     return mDelegatedFileSystem.listStatus(path, options);
+  }
+
+  @Override
+  public void loadMetadata(AlluxioURI path, LoadMetadataPOptions options) throws FileDoesNotExistException, IOException, AlluxioException {
+    mDelegatedFileSystem.loadMetadata(path, options);
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/DelegatingFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DelegatingFileSystem.java
@@ -119,7 +119,8 @@ public class DelegatingFileSystem implements FileSystem {
   }
 
   @Override
-  public void loadMetadata(AlluxioURI path, LoadMetadataPOptions options) throws FileDoesNotExistException, IOException, AlluxioException {
+  public void loadMetadata(AlluxioURI path, LoadMetadataPOptions options)
+      throws FileDoesNotExistException, IOException, AlluxioException {
     mDelegatedFileSystem.loadMetadata(path, options);
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -35,6 +35,7 @@ import alluxio.grpc.ExistsPOptions;
 import alluxio.grpc.FreePOptions;
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.ListStatusPOptions;
+import alluxio.grpc.LoadMetadataPOptions;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.RenamePOptions;
@@ -360,6 +361,28 @@ public interface FileSystem extends Closeable {
    * @throws FileDoesNotExistException if the given path does not exist
    */
   List<URIStatus> listStatus(AlluxioURI path, ListStatusPOptions options)
+      throws FileDoesNotExistException, IOException, AlluxioException;
+
+  /**
+   * Convenience method for {@link #loadMetadata(AlluxioURI, LoadMetadataPOptions)} with default
+   * options.
+   *
+   * @param path the path for which to load metadata from UFS
+   * @throws FileDoesNotExistException if the given path does not exist
+   */
+  default void loadMetadata(AlluxioURI path)
+      throws FileDoesNotExistException, IOException, AlluxioException {
+    loadMetadata(path, LoadMetadataPOptions.getDefaultInstance());
+  }
+
+  /**
+   * Loads metadata about a path in the UFS to Alluxio. No data will be transferred.
+   *
+   * @param path the path for which to load metadata from UFS
+   * @param options options to associate with this operation
+   * @throws FileDoesNotExistException if the given path does not exist
+   */
+  void loadMetadata(AlluxioURI path, LoadMetadataPOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException;
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
@@ -24,6 +24,7 @@ import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.FreePOptions;
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.ListStatusPOptions;
+import alluxio.grpc.LoadMetadataPOptions;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.RenamePOptions;
 import alluxio.grpc.ScheduleAsyncPersistencePOptions;
@@ -153,6 +154,15 @@ public interface FileSystemMasterClient extends Client {
    */
   List<URIStatus> listStatus(AlluxioURI path, ListStatusPOptions options)
       throws AlluxioStatusException;
+
+  /**
+   * Loads the metadata of a file from the under file system.
+   *
+   * @param path the path of the file to load metadata for
+   * @param options method options
+   * @throws NotFoundException if the path does not exist
+   */
+   void loadMetadata(AlluxioURI path, LoadMetadataPOptions options) throws AlluxioStatusException;
 
   /**
    * Mounts the given UFS path under the given Alluxio path.

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
@@ -162,7 +162,7 @@ public interface FileSystemMasterClient extends Client {
    * @param options method options
    * @throws NotFoundException if the path does not exist
    */
-   void loadMetadata(AlluxioURI path, LoadMetadataPOptions options) throws AlluxioStatusException;
+  void loadMetadata(AlluxioURI path, LoadMetadataPOptions options) throws AlluxioStatusException;
 
   /**
    * Mounts the given UFS path under the given Alluxio path.

--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -238,7 +238,8 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
   }
 
   @Override
-  public void loadMetadata(AlluxioURI path, LoadMetadataPOptions options) throws AlluxioStatusException {
+  public void loadMetadata(AlluxioURI path, LoadMetadataPOptions options)
+      throws AlluxioStatusException {
     retryRPC(
         () -> {
           ListStatusPOptions lsOptions = ListStatusPOptions.newBuilder()

--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -26,6 +26,7 @@ import alluxio.grpc.CreateFilePRequest;
 import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.DeletePRequest;
 import alluxio.grpc.FileSystemMasterClientServiceGrpc;
+import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.FreePOptions;
 import alluxio.grpc.FreePRequest;
 import alluxio.grpc.GetFilePathPRequest;
@@ -38,6 +39,8 @@ import alluxio.grpc.GetSyncPathListPRequest;
 import alluxio.grpc.GrpcUtils;
 import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.ListStatusPRequest;
+import alluxio.grpc.LoadMetadataPOptions;
+import alluxio.grpc.LoadMetadataPType;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.MountPRequest;
 import alluxio.grpc.RenamePOptions;
@@ -232,6 +235,28 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
                   .collect(Collectors.toList())));
       return result;
     }, RPC_LOG, "ListStatus", "path=%s,options=%s", path, options);
+  }
+
+  @Override
+  public void loadMetadata(AlluxioURI path, LoadMetadataPOptions options) throws AlluxioStatusException {
+    retryRPC(
+        () -> {
+          ListStatusPOptions lsOptions = ListStatusPOptions.newBuilder()
+              .setCommonOptions(
+                  FileSystemMasterCommonPOptions.newBuilder()
+                      .setSyncIntervalMs(0)
+                      .build())
+              .setLoadMetadataType(LoadMetadataPType.ALWAYS)
+              .setRecursive(options.getRecursive())
+              .build();
+          mClient.listStatus(
+              ListStatusPRequest.newBuilder()
+                  .setPath(getTransportPath(path))
+                  .setOptions(lsOptions).build()
+          );
+          return null;
+        }, RPC_LOG, "loadMetadata", "path=%s,options=%s", path, options
+    );
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
@@ -15,7 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.client.file.DelegatingFileSystem;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
-import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.AlluxioException;

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -476,7 +476,8 @@ public class LocalCacheFileInStreamTest {
     }
 
     @Override
-    public void loadMetadata(AlluxioURI path, LoadMetadataPOptions options) throws FileDoesNotExistException, IOException, AlluxioException {
+    public void loadMetadata(AlluxioURI path, LoadMetadataPOptions options)
+        throws FileDoesNotExistException, IOException, AlluxioException {
       throw new UnsupportedOperationException();
     }
 

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -34,6 +34,7 @@ import alluxio.grpc.ExistsPOptions;
 import alluxio.grpc.FreePOptions;
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.ListStatusPOptions;
+import alluxio.grpc.LoadMetadataPOptions;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.RenamePOptions;
@@ -471,6 +472,11 @@ public class LocalCacheFileInStreamTest {
     @Override
     public List<URIStatus> listStatus(AlluxioURI path, ListStatusPOptions options)
         throws FileDoesNotExistException, IOException, AlluxioException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void loadMetadata(AlluxioURI path, LoadMetadataPOptions options) throws FileDoesNotExistException, IOException, AlluxioException {
       throw new UnsupportedOperationException();
     }
 

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsFileSystem.java
@@ -22,6 +22,8 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.AlluxioProperties;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.Source;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.FileDoesNotExistException;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
@@ -29,6 +31,7 @@ import alluxio.grpc.ExistsPOptions;
 import alluxio.grpc.FreePOptions;
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.ListStatusPOptions;
+import alluxio.grpc.LoadMetadataPOptions;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.RenamePOptions;
@@ -151,6 +154,11 @@ public class AlluxioHdfsFileSystem implements alluxio.client.file.FileSystem {
       throws IOException {
     return Arrays.stream(mFileSystem.listStatus(HadoopUtils.toPath(alluxioURI)))
         .map(AlluxioHdfsFileSystem::toAlluxioUriStatus).collect(Collectors.toList());
+  }
+
+  @Override
+  public void loadMetadata(AlluxioURI path, LoadMetadataPOptions options) throws FileDoesNotExistException, IOException, AlluxioException {
+    throw new UnsupportedOperationException("LoadMetadata is not supported.");
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/LoadMetadataCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LoadMetadataCommand.java
@@ -1,0 +1,94 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.cli.fs.command;
+
+import alluxio.AlluxioURI;
+import alluxio.cli.CommandUtils;
+import alluxio.client.file.FileSystemContext;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.status.InvalidArgumentException;
+import alluxio.grpc.LoadMetadataPOptions;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+
+import java.io.IOException;
+
+public class LoadMetadataCommand extends AbstractFileSystemCommand {
+  private static final Option RECURSIVE_OPTION =
+      Option.builder("R")
+          .required(false)
+          .hasArg(false)
+          .desc("loadMetadata subdirectories recursively")
+          .build();
+
+  /**
+   * Constructs a new instance to load metadata for the given Alluxio path from UFS.
+   *
+   * @param fsContext the filesystem of Alluxio
+   */
+  public LoadMetadataCommand(FileSystemContext fsContext) {
+    super(fsContext);
+  }
+
+  @Override
+  public String getCommandName() {
+    return "loadMetadata";
+  }
+
+  @Override
+  public Options getOptions() {
+    return new Options().addOption(RECURSIVE_OPTION);
+   }
+
+  @Override
+  protected void runPlainPath(AlluxioURI plainPath, CommandLine cl)
+      throws AlluxioException, IOException {
+    loadMetadata(plainPath, cl.hasOption(RECURSIVE_OPTION.getOpt()));
+  }
+
+  @Override
+  public int run(CommandLine cl) throws AlluxioException, IOException {
+    String[] args = cl.getArgs();
+    AlluxioURI path = new AlluxioURI(args[0]);
+    runWildCardCmd(path, cl);
+
+    return 0;
+  }
+
+  private void loadMetadata(AlluxioURI path, boolean recursive) throws IOException {
+    try {
+      LoadMetadataPOptions options = LoadMetadataPOptions.newBuilder()
+          .setRecursive(recursive)
+          .build();
+      mFileSystem.loadMetadata(path, options);
+    } catch (AlluxioException e) {
+      throw new IOException(e.getMessage());
+    }
+  }
+
+  @Override
+  public String getUsage() {
+    return "loadMetadata [-R] <path>";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Loads metadata for the given Alluxio path from the under file system.";
+  }
+
+  @Override
+  public void validateArgs(CommandLine cl) throws InvalidArgumentException {
+    CommandUtils.checkNumOfArgsNoLessThan(this, cl, 1);
+  }
+}


### PR DESCRIPTION
We used to have a command `fs loadMetadata`
This PR restores loadMetadata command, but as a client-side optimization without storing all returned `ls` results, preventing OOM for massive amount of small files.

This optimization is experimental, going to branch-2.3-fuse only for now

Fix https://github.com/Alluxio/alluxio/issues/12088