### PR TITLE
Fix slow and contented local cache restart

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -20,28 +20,81 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * Interface for managing cached pages.
  */
-public interface CacheManager extends AutoCloseable  {
+public interface CacheManager extends AutoCloseable {
+
+  /**
+   * State of a cache.
+   */
+  enum State {
+    /**
+     * this cache is not in use.
+     */
+    NOT_IN_USE(0),
+    /**
+     * this cache is read only.
+     */
+    READ_ONLY(1),
+    /**
+     * this cache can both read and write.
+     */
+    READ_WRITE(2);
+
+    private final int mValue;
+
+    State(int value) {
+      mValue = value;
+    }
+
+    /**
+     * @return the value of the state
+     */
+    public int getValue() {
+      return mValue;
+    }
+  }
+
   /**
    * Factory class to get or create a CacheManager.
    */
   class Factory {
     private static final Logger LOG = LoggerFactory.getLogger(Factory.class);
-    private static CacheManager sCacheManager = null;
+    private static final Lock CACHE_INIT_LOCK = new ReentrantLock();
+    @GuardedBy("CACHE_INIT_LOCK")
+    private static final AtomicReference<CacheManager> CACHE_MANAGER = new AtomicReference<>();
 
     /**
      * @param conf the Alluxio configuration
-     * @return current CacheManager, creating a new one if it doesn't yet exist
+     * @return current CacheManager handle, creating a new one if it doesn't yet exist or null in
+     *         case creation takes a long time by other threads.
      */
-    public static synchronized CacheManager get(AlluxioConfiguration conf) throws IOException {
+    @Nullable
+    public static CacheManager get(AlluxioConfiguration conf) throws IOException {
       // TODO(feng): support multiple cache managers
-      if (sCacheManager == null) {
-        sCacheManager = create(conf);
+      if (CACHE_MANAGER.get() == null) {
+        if (CACHE_INIT_LOCK.tryLock()) {
+          try {
+            if (CACHE_MANAGER.get() == null) {
+              CACHE_MANAGER.set(create(conf));
+            }
+          } catch (IOException e) {
+            Metrics.CREATE_ERRORS.inc();
+            throw new IOException("Failed to create CacheManager", e);
+          } finally {
+            CACHE_INIT_LOCK.unlock();
+          }
+        }
       }
-      return sCacheManager;
+      return CACHE_MANAGER.get();
     }
 
     /**
@@ -112,4 +165,9 @@ public interface CacheManager extends AutoCloseable  {
    * @return true if the page is successfully deleted, false otherwise
    */
   boolean delete(PageId pageId);
+
+  /**
+   * @return state of this cache
+   */
+  State state();
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileSystem.java
@@ -53,12 +53,18 @@ public class LocalCacheFileSystem extends DelegatingFileSystem {
   @Override
   public FileInStream openFile(AlluxioURI path, OpenFilePOptions options)
       throws IOException, AlluxioException {
+    if (mCacheManager == null || mCacheManager.state() == CacheManager.State.NOT_IN_USE) {
+      return mDelegatedFileSystem.openFile(path, options);
+    }
     return new LocalCacheFileInStream(path, options, mDelegatedFileSystem, mCacheManager);
   }
 
   @Override
   public FileInStream openFile(URIStatus status, OpenFilePOptions options)
       throws IOException, AlluxioException {
+    if (mCacheManager == null || mCacheManager.state() == CacheManager.State.NOT_IN_USE) {
+      return mDelegatedFileSystem.openFile(status, options);
+    }
     return new LocalCacheFileInStream(status, options, mDelegatedFileSystem, mCacheManager);
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -11,6 +11,10 @@
 
 package alluxio.client.file.cache;
 
+import static alluxio.client.file.cache.CacheManager.State.NOT_IN_USE;
+import static alluxio.client.file.cache.CacheManager.State.READ_ONLY;
+import static alluxio.client.file.cache.CacheManager.State.READ_WRITE;
+
 import alluxio.client.file.cache.store.PageStoreOptions;
 import alluxio.collections.ConcurrentHashSet;
 import alluxio.collections.Pair;
@@ -25,6 +29,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,10 +39,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Stream;
@@ -72,83 +79,62 @@ public class LocalCacheManager implements CacheManager {
   private final long mPageSize;
   private final long mCacheSize;
   private final boolean mAsyncWrite;
+  private final boolean mAsyncRestore;
   /** A readwrite lock pool to guard individual pages based on striping. */
   private final ReadWriteLock[] mPageLocks = new ReentrantReadWriteLock[LOCK_SIZE];
-  private final PageStore mPageStore;
+  private PageStore mPageStore;
   /** A readwrite lock to guard metadata operations. */
   private final ReadWriteLock mMetaLock = new ReentrantReadWriteLock();
   @GuardedBy("mMetaLock")
   private final MetaStore mMetaStore;
+  /** Executor service for execute the init tasks. */
+  private final ExecutorService mInitService;
   /** Executor service for execute the async cache tasks. */
   private final ExecutorService mAsyncCacheExecutor;
   private final ConcurrentHashSet<PageId> mPendingRequests;
-
-  /**
-   * Restores a page store a the configured location, updating meta store and evictor.
-   *
-   * @param pageStore page store
-   * @param options page store options
-   * @param metaStore meta store
-   * @return whether the restore succeeds or not
-   */
-  private static boolean restore(
-      PageStore pageStore, PageStoreOptions options, MetaStore metaStore) {
-    LOG.info("Attempt to restore PageStore with {}", options);
-    Path rootDir = Paths.get(options.getRootDir());
-    if (!Files.exists(rootDir)) {
-      LOG.error("Failed to restore PageStore: Directory {} does not exist", rootDir);
-      return false;
-    }
-    try (Stream<PageInfo> stream = pageStore.getPages()) {
-      Iterator<PageInfo> iterator = stream.iterator();
-      while (iterator.hasNext()) {
-        PageInfo pageInfo = iterator.next();
-        if (pageInfo == null) {
-          LOG.error("Invalid page info");
-          return false;
-        }
-        metaStore.addPage(pageInfo.getPageId(), pageInfo);
-        if (metaStore.bytes() > pageStore.getCacheSize()) {
-          LOG.error("Loaded pages exceed cache capacity ({} bytes)", pageStore.getCacheSize());
-          return false;
-        }
-      }
-    } catch (Exception e) {
-      LOG.error("Failed to restore PageStore", e);
-      return false;
-    }
-    LOG.info("Restored PageStore with {} existing pages and {} bytes", metaStore.pages(),
-        metaStore.bytes());
-    return true;
-  }
+  /** State of this cache. */
+  private final AtomicReference<CacheManager.State> mState = new AtomicReference<>();
 
   /**
    * @param conf the Alluxio configuration
    * @return an instance of {@link LocalCacheManager}
    */
-  public static LocalCacheManager create(AlluxioConfiguration conf) throws IOException {
+  public static LocalCacheManager create(AlluxioConfiguration conf)
+      throws IOException {
     MetaStore metaStore = MetaStore.create(CacheEvictor.create(conf));
     PageStoreOptions options = PageStoreOptions.create(conf);
-    PageStore pageStore = null;
-    boolean restored = false;
+    PageStore pageStore;
     try {
-      pageStore = PageStore.create(options, false);
-      restored = restore(pageStore, options, metaStore);
-    } catch (Exception e) {
-      LOG.error("Failed to restore PageStore", e);
+      pageStore = PageStore.open(options);
+    } catch (IOException e) {
+      pageStore = PageStore.create(options);
     }
-    if (!restored) {
-      if (pageStore != null) {
+    return create(conf, metaStore, pageStore, options);
+  }
+
+  /**
+   * @param conf the Alluxio configuration
+   * @param metaStore the meta store manages the metadata
+   * @param pageStore the page store manages the cache data
+   * @param options page store options
+   * @return an instance of {@link LocalCacheManager}
+   */
+  @VisibleForTesting
+  static LocalCacheManager create(AlluxioConfiguration conf, MetaStore metaStore,
+      PageStore pageStore, PageStoreOptions options) throws IOException {
+    LocalCacheManager manager = new LocalCacheManager(conf, metaStore, pageStore);
+    if (conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED)) {
+      manager.mInitService.submit(() -> {
         try {
-          pageStore.close();
-        } catch (Exception e) {
-          LOG.error("Failed to close PageStore", e);
+          manager.restoreOrInit(options);
+        } catch (IOException e) {
+          LOG.error("Failed to restore LocalCacheManager: ", e);
         }
-      }
-      metaStore.reset();
-      pageStore = PageStore.create(options, true);
+      });
+    } else {
+      manager.restoreOrInit(options);
     }
-    return new LocalCacheManager(conf, metaStore, pageStore);
+    return manager;
   }
 
   /**
@@ -156,12 +142,12 @@ public class LocalCacheManager implements CacheManager {
    * @param metaStore the meta store manages the metadata
    * @param pageStore the page store manages the cache data
    */
-  @VisibleForTesting
-  LocalCacheManager(AlluxioConfiguration conf, MetaStore metaStore, PageStore pageStore) {
+  private LocalCacheManager(AlluxioConfiguration conf, MetaStore metaStore, PageStore pageStore) {
     mMetaStore = metaStore;
     mPageStore = pageStore;
     mPageSize = conf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE);
     mAsyncWrite = conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED);
+    mAsyncRestore = conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED);
     mCacheSize = pageStore.getCacheSize();
     for (int i = 0; i < LOCK_SIZE; i++) {
       mPageLocks[i] = new ReentrantReadWriteLock(true /* fair ordering */);
@@ -173,7 +159,10 @@ public class LocalCacheManager implements CacheManager {
                 conf.getInt(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_THREADS), 60,
                 TimeUnit.SECONDS, new SynchronousQueue<>())
             : null;
+    mInitService = mAsyncRestore ? Executors.newSingleThreadExecutor() : null;
     Metrics.registerGauges(mCacheSize, mMetaStore);
+    mState.set(READ_ONLY);
+    Metrics.STATE.inc();
   }
 
   /**
@@ -216,6 +205,11 @@ public class LocalCacheManager implements CacheManager {
   @Override
   public boolean put(PageId pageId, byte[] page) {
     LOG.debug("put({},{} bytes) enters", pageId, page.length);
+    if (mState.get() != READ_WRITE) {
+      Metrics.PUT_NOT_READY_ERRORS.inc();
+      Metrics.PUT_ERRORS.inc();
+      return false;
+    }
     if (!mAsyncWrite) {
       boolean ok = putInternal(pageId, page);
       LOG.debug("put({},{} bytes) exits: {}", pageId, page.length, ok);
@@ -371,6 +365,11 @@ public class LocalCacheManager implements CacheManager {
         "buffer does not have enough space: bufferLength=%s offsetInBuffer=%s bytesToRead=%s",
         buffer.length, offsetInBuffer, bytesToRead);
     LOG.debug("get({},pageOffset={}) enters", pageId, pageOffset);
+    if (mState.get() == NOT_IN_USE) {
+      Metrics.GET_NOT_READY_ERRORS.inc();
+      Metrics.GET_ERRORS.inc();
+      return -1;
+    }
     boolean hasPage;
     ReadWriteLock pageLock = getPageLock(pageId);
     try (LockResource r = new LockResource(pageLock.readLock())) {
@@ -402,6 +401,11 @@ public class LocalCacheManager implements CacheManager {
   @Override
   public boolean delete(PageId pageId) {
     LOG.debug("delete({}) enters", pageId);
+    if (mState.get() != READ_WRITE) {
+      Metrics.DELETE_NOT_READY_ERRORS.inc();
+      Metrics.DELETE_ERRORS.inc();
+      return false;
+    }
     ReadWriteLock pageLock = getPageLock(pageId);
     try (LockResource r = new LockResource(pageLock.writeLock())) {
       try (LockResource r1 = new LockResource(mMetaLock.writeLock())) {
@@ -425,8 +429,95 @@ public class LocalCacheManager implements CacheManager {
   }
 
   @Override
+  public State state() {
+    return mState.get();
+  }
+
+  /**
+   * Restores a page store at the configured location, updating meta store accordingly.
+   * If restore process fails, cleanup the location and create a new page store.
+   * This method is synchronized to ensure only one thread can enter and operate.
+   */
+  private void restoreOrInit(PageStoreOptions options) throws IOException {
+    synchronized (LocalCacheManager.class) {
+      Preconditions.checkState(mState.get() == READ_ONLY);
+      if (!restore(options)) {
+        try (LockResource r = new LockResource(mMetaLock.writeLock())) {
+          mMetaStore.reset();
+        }
+        try {
+          mPageStore.close();
+          // when cache is large, e.g. millions of pages, initialize may take a while on deletion
+          mPageStore = PageStore.create(options);
+        } catch (Exception e) {
+          LOG.error("Cache is in NOT_IN_USE.");
+          mState.set(NOT_IN_USE);
+          Metrics.STATE.dec();
+          Throwables.propagateIfPossible(e, IOException.class);
+          throw new IOException(e);
+        }
+      }
+      LOG.info("Cache is in READ_WRITE.");
+      mState.set(READ_WRITE);
+      Metrics.STATE.inc();
+    }
+  }
+
+  private boolean restore(PageStoreOptions options) {
+    LOG.info("Attempt to restore PageStore with {}", options);
+    Path rootDir = Paths.get(options.getRootDir());
+    if (!Files.exists(rootDir)) {
+      LOG.error("Failed to restore PageStore: Directory {} does not exist", rootDir);
+      return false;
+    }
+    long discardedPages = 0;
+    long discardedBytes = 0;
+    try (Stream<PageInfo> stream = mPageStore.getPages()) {
+      Iterator<PageInfo> iterator = stream.iterator();
+      while (iterator.hasNext()) {
+        PageInfo pageInfo = iterator.next();
+        if (pageInfo == null) {
+          LOG.error("Failed to restore PageStore: Invalid page info");
+          return false;
+        }
+        PageId pageId = pageInfo.getPageId();
+        ReadWriteLock pageLock = getPageLock(pageId);
+        try (LockResource r = new LockResource(pageLock.writeLock())) {
+          boolean enoughSpace;
+          try (LockResource r2 = new LockResource(mMetaLock.writeLock())) {
+            enoughSpace =
+                mMetaStore.bytes() + pageInfo.getPageSize() <= mPageStore.getCacheSize();
+            if (enoughSpace) {
+              mMetaStore.addPage(pageId, pageInfo);
+            }
+          }
+          if (!enoughSpace) {
+            mPageStore.delete(pageId);
+            discardedPages++;
+            discardedBytes += pageInfo.getPageSize();
+          }
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to restore PageStore: ", e);
+      return false;
+    }
+    LOG.info("Successfully restored PageStore with {} pages ({} bytes), "
+            + "discarded {} pages ({} bytes)",
+        mMetaStore.pages(), mMetaStore.bytes(), discardedPages, discardedBytes);
+    return true;
+  }
+
+  @Override
   public void close() throws Exception {
     mPageStore.close();
+    mMetaStore.reset();
+    if (mInitService != null) {
+      mInitService.shutdownNow();
+    }
+    if (mAsyncCacheExecutor != null) {
+      mAsyncCacheExecutor.shutdownNow();
+    }
   }
 
   /**
@@ -464,36 +555,42 @@ public class LocalCacheManager implements CacheManager {
   }
 
   private static final class Metrics {
-    /** Bytes written to the cache. */
-    private static final Meter BYTES_WRITTEN_CACHE =
-        MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_WRITTEN_CACHE.getName());
     /** Bytes evicted from the cache. */
     private static final Meter BYTES_EVICTED_CACHE =
         MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_EVICTED.getName());
-    /** Pages evicted from the cache. */
-    private static final Meter PAGES_EVICTED_CACHE =
-        MetricsSystem.meter(MetricKey.CLIENT_CACHE_PAGES_EVICTED.getName());
-    /** Errors when deleting pages. */
-    private static final Counter DELETE_ERRORS =
-        MetricsSystem.counter(MetricKey.CLIENT_CACHE_DELETE_ERRORS.getName());
-    /** Errors when deleting pages due to absence. */
-    private static final Counter DELETE_NON_EXISTING_PAGE_ERRORS =
-        MetricsSystem.counter(MetricKey.CLIENT_CACHE_DELETE_NON_EXISTING_PAGE_ERRORS.getName());
-    /** Errors when deleting pages due to failed delete in page stores. */
-    private static final Counter DELETE_STORE_DELETE_ERRORS =
-        MetricsSystem.counter(MetricKey.CLIENT_CACHE_DELETE_STORE_DELETE_ERRORS.getName());
-    /** Errors when getting pages. */
-    private static final Counter GET_ERRORS =
-        MetricsSystem.counter(MetricKey.CLIENT_CACHE_GET_ERRORS.getName());
-    /** Errors when getting pages due to failed read from page stores. */
-    private static final Counter GET_STORE_READ_ERRORS =
-        MetricsSystem.counter(MetricKey.CLIENT_CACHE_GET_STORE_READ_ERRORS.getName());
+    /** Bytes written to the cache. */
+    private static final Meter BYTES_WRITTEN_CACHE =
+        MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_WRITTEN_CACHE.getName());
     /** Errors when cleaning up a failed get operation. */
     private static final Counter CLEANUP_GET_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_CLEANUP_GET_ERRORS.getName());
     /** Errors when cleaning up a failed put operation. */
     private static final Counter CLEANUP_PUT_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_CLEANUP_PUT_ERRORS.getName());
+    /** Errors when deleting pages. */
+    private static final Counter DELETE_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_DELETE_ERRORS.getName());
+    /** Errors when deleting pages due to absence. */
+    private static final Counter DELETE_NON_EXISTING_PAGE_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_DELETE_NON_EXISTING_PAGE_ERRORS.getName());
+    /** Errors when cache is not ready to delete pages. */
+    private static final Counter DELETE_NOT_READY_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_DELETE_NOT_READY_ERRORS.getName());
+    /** Errors when deleting pages due to failed delete in page stores. */
+    private static final Counter DELETE_STORE_DELETE_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_DELETE_STORE_DELETE_ERRORS.getName());
+    /** Errors when getting pages. */
+    private static final Counter GET_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_GET_ERRORS.getName());
+    /** Errors when cache is not ready to get pages. */
+    private static final Counter GET_NOT_READY_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_GET_NOT_READY_ERRORS.getName());
+    /** Errors when getting pages due to failed read from page stores. */
+    private static final Counter GET_STORE_READ_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_GET_STORE_READ_ERRORS.getName());
+    /** Pages evicted from the cache. */
+    private static final Meter PAGES_EVICTED_CACHE =
+        MetricsSystem.meter(MetricKey.CLIENT_CACHE_PAGES_EVICTED.getName());
     /** Errors when adding pages. */
     private static final Counter PUT_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_ERRORS.getName());
@@ -506,12 +603,18 @@ public class LocalCacheManager implements CacheManager {
     /** Errors when adding pages due to benign racing eviction. */
     private static final Counter PUT_BENIGN_RACING_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_BENIGN_RACING_ERRORS.getName());
+    /** Errors when cache is not ready to add pages. */
+    private static final Counter PUT_NOT_READY_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_NOT_READY_ERRORS.getName());
     /** Errors when adding pages due to failed deletes in page store. */
     private static final Counter PUT_STORE_DELETE_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_STORE_DELETE_ERRORS.getName());
     /** Errors when adding pages due to failed writes to page store. */
     private static final Counter PUT_STORE_WRITE_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_STORE_WRITE_ERRORS.getName());
+    /** State of the cache. */
+    private static final Counter STATE =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_STATE.getName());
 
     private static void registerGauges(long cacheSize, MetaStore metaStore) {
       MetricsSystem.registerGaugeIfAbsent(

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
@@ -79,6 +79,11 @@ public class NoExceptionCacheManager implements CacheManager {
   }
 
   @Override
+  public State state() {
+    return mCacheManager.state();
+  }
+
+  @Override
   public void close() throws Exception {
     try {
       mCacheManager.close();

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -16,8 +16,11 @@ import alluxio.client.file.cache.store.PageStoreOptions;
 import alluxio.client.file.cache.store.PageStoreType;
 import alluxio.client.file.cache.store.RocksPageStore;
 import alluxio.exception.PageNotFoundException;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.util.io.FileUtils;
 
+import com.codahale.metrics.Counter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,26 +38,33 @@ public interface PageStore extends AutoCloseable {
   Logger LOG = LoggerFactory.getLogger(PageStore.class);
 
   /**
-   * Creates a {@link PageStore}. When init is false, restore from previous state; clean up the
-   * cache dir otherwise.
+   * Creates a new {@link PageStore}. Previous state in the samme cache dir will be overwritten.
    *
    * @param options the options to instantiate the page store
-   * @param init whether to init the cache dir
    * @return a PageStore instance
    * @throws IOException if I/O error happens
    */
-  static PageStore create(PageStoreOptions options, boolean init) throws IOException {
-    LOG.info("Creating PageStore with option={}, init={}", options.toString(), init);
-    if (init) {
-      initialize(options);
-    }
+  static PageStore create(PageStoreOptions options) throws IOException {
+    initialize(options);
+    return open(options);
+  }
+
+  /**
+   * Opens an existing {@link PageStore}.
+   *
+   * @param options the options to instantiate the page store
+   * @return a PageStore instance
+   * @throws IOException if I/O error happens
+   */
+  static PageStore open(PageStoreOptions options) throws IOException {
+    LOG.info("Creating PageStore with option={}", options.toString());
     final PageStore pageStore;
     switch (options.getType()) {
       case LOCAL:
         pageStore = new LocalPageStore(options.toOptions());
         break;
       case ROCKS:
-        pageStore = RocksPageStore.create(options.toOptions());
+        pageStore = RocksPageStore.open(options.toOptions());
         break;
       default:
         throw new IllegalArgumentException(
@@ -83,15 +93,14 @@ public interface PageStore extends AutoCloseable {
    */
   static void initialize(PageStoreOptions options) throws IOException {
     String rootPath = options.getRootDir();
-    PageStoreType storeType = options.getType();
-    Path storePath = getStorePath(storeType, rootPath);
-    Files.createDirectories(storePath);
+    Files.createDirectories(Paths.get(rootPath));
     LOG.debug("Clean cache directory {}", rootPath);
     try (Stream<Path> stream = Files.list(Paths.get(rootPath))) {
       stream.forEach(path -> {
         try {
           FileUtils.deletePathRecursively(path.toString());
         } catch (IOException e) {
+          Metrics.UNREMOVABLE_FILES.inc();
           LOG.warn("failed to delete {} in cache directory: {}", path, e.toString());
         }
       });
@@ -156,4 +165,13 @@ public interface PageStore extends AutoCloseable {
    * @return an estimated cache size in bytes
    */
   long getCacheSize();
+
+  /**
+   * Metrics.
+   */
+  final class Metrics {
+    /** Number of unremovable files in the cache. */
+    private static final Counter UNREMOVABLE_FILES =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_UNREMOVABLE_FILES.getName());
+  }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
@@ -59,7 +59,7 @@ public class RocksPageStore implements PageStore {
    * @return a new instance of {@link PageStore} backed by RocksDB
    * @throws IOException if I/O error happens
    */
-  public static RocksPageStore create(RocksPageStoreOptions options) throws IOException {
+  public static RocksPageStore open(RocksPageStoreOptions options) throws IOException {
     Preconditions.checkArgument(options.getMaxPageSize() > 0);
     RocksDB.loadLibrary();
     Options rocksOptions = new Options();

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -395,6 +395,11 @@ public class LocalCacheFileInStreamTest {
     }
 
     @Override
+    public State state() {
+      return State.READ_WRITE;
+    }
+
+    @Override
     public void close() throws Exception {
       // no-op
     }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -14,32 +14,41 @@ package alluxio.client.file.cache;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.file.cache.store.LocalPageStore;
 import alluxio.client.file.cache.store.PageStoreOptions;
-import alluxio.client.file.cache.store.PageStoreType;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.PageNotFoundException;
+import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.FileUtils;
+import alluxio.util.io.PathUtils;
 
+import com.google.common.collect.Streams;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -59,6 +68,7 @@ public final class LocalCacheManagerTest {
   private MetaStore mMetaStore;
   private PageStore mPageStore;
   private CacheEvictor mEvictor;
+  private PageStoreOptions mPageStoreOptions;
   private byte[] mBuf = new byte[PAGE_SIZE_BYTES];
 
   @Rule
@@ -73,10 +83,12 @@ public final class LocalCacheManagerTest {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, CACHE_SIZE_BYTES);
     mConf.set(PropertyKey.USER_CLIENT_CACHE_DIR, mTemp.getRoot().getAbsolutePath());
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED, false);
-    mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED, false);
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.create(mPageStoreOptions);
     mEvictor = new FIFOEvictor();
     mMetaStore = MetaStore.create(mEvictor);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
   }
 
   private byte[] page(int i, int pageLen) {
@@ -85,6 +97,58 @@ public final class LocalCacheManagerTest {
 
   private PageId pageId(long i, int pageIndex) {
     return new PageId(Long.toString(i), pageIndex);
+  }
+
+  @Test
+  public void createNonexistentRootDir() throws Exception {
+    mCacheManager.close();
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_DIR,
+        PathUtils.concatPath(mTemp.getRoot().getAbsolutePath(), UUID.randomUUID().toString()));
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mCacheManager = LocalCacheManager.create(mConf);
+    assertNotNull(mCacheManager);
+    assertEquals(CacheManager.State.READ_WRITE, mCacheManager.state());
+  }
+
+  @Test
+  public void createUnwriableRootDirSyncRestore() throws Exception {
+    mCacheManager.close();
+    String rootDir =
+        PathUtils.concatPath(mTemp.getRoot().getAbsolutePath(), UUID.randomUUID().toString());
+    Files.createDirectories(Paths.get(rootDir));
+    File root = new File(rootDir);
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_DIR, rootDir);
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    try {
+      root.setWritable(false);
+      LocalCacheManager.create(mConf);
+      fail();
+    } catch (Exception e) {
+      // expected
+    } finally {
+      root.setWritable(true);
+    }
+  }
+
+  @Test
+  public void createUnwriableRootDirAsyncRestore() throws Exception {
+    mCacheManager.close();
+    String rootDir =
+        PathUtils.concatPath(mTemp.getRoot().getAbsolutePath(), UUID.randomUUID().toString());
+    Files.createDirectories(Paths.get(rootDir));
+    File root = new File(rootDir);
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED, true);
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_DIR, rootDir);
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    try {
+      root.setWritable(false);
+      mCacheManager = LocalCacheManager.create(mConf);
+      CommonUtils.waitFor("async restore completed",
+          () ->  mCacheManager.state() == CacheManager.State.NOT_IN_USE,
+          WaitForOptions.defaults().setTimeoutMs(10000));
+    } finally {
+      root.setWritable(true);
+    }
   }
 
   @Test
@@ -105,8 +169,9 @@ public final class LocalCacheManagerTest {
   @Test
   public void putEvict() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
-    mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.create(mPageStoreOptions);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
     assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
     assertTrue(mCacheManager.put(PAGE_ID2, PAGE2));
     assertEquals(0, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
@@ -118,8 +183,9 @@ public final class LocalCacheManagerTest {
   public void putSmallPages() throws Exception {
     // Cache size is only one full page, but should be able to store multiple small pages
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
-    mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.create(mPageStoreOptions);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
     int smallPageLen = 8;
     long numPages = mConf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE) / smallPageLen;
     for (int i = 0; i < numPages; i++) {
@@ -138,8 +204,9 @@ public final class LocalCacheManagerTest {
   @Test
   public void evictSmallPageByPutSmallPage() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
-    mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.create(mPageStoreOptions);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
     int smallPageLen = 8;
     long numPages = mConf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE) / smallPageLen;
     for (int i = 0; i < numPages; i++) {
@@ -163,8 +230,9 @@ public final class LocalCacheManagerTest {
   @Test
   public void evictSmallPagesByPutPigPage() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
-    mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.create(mPageStoreOptions);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
     int smallPageLen = 8;
     long numPages = mConf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE) / smallPageLen;
     for (int i = 0; i < numPages; i++) {
@@ -185,8 +253,9 @@ public final class LocalCacheManagerTest {
   @Test
   public void evictBigPagesByPutSmallPage() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
-    mPageStore = PageStore.create(PageStoreOptions.create(mConf), true);
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, mPageStore);
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.create(mPageStoreOptions);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
     PageId bigPageId = pageId(-1, 0);
     assertTrue(mCacheManager.put(bigPageId, page(0, PAGE_SIZE_BYTES)));
     int smallPageLen = 8;
@@ -285,12 +354,13 @@ public final class LocalCacheManagerTest {
   }
 
   @Test
-  public void restore() throws Exception {
-    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
-    mCacheManager.put(PAGE_ID1, PAGE1);
-    mCacheManager.put(pageUuid, PAGE2);
+  public void syncRestore() throws Exception {
     mCacheManager.close();
-    mCacheManager = LocalCacheManager.create(mConf);
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    mPageStore.put(PAGE_ID1, PAGE1);
+    mPageStore.put(pageUuid, PAGE2);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
+    assertEquals(CacheManager.State.READ_WRITE, mCacheManager.state());
     assertEquals(PAGE1.length, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
     assertArrayEquals(PAGE1, mBuf);
     assertEquals(PAGE2.length, mCacheManager.get(pageUuid, PAGE1.length, mBuf, 0));
@@ -298,16 +368,167 @@ public final class LocalCacheManagerTest {
   }
 
   @Test
-  public void restoreFailed() throws Exception {
-    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
-    mCacheManager.put(PAGE_ID1, PAGE1);
-    mCacheManager.put(pageUuid, PAGE2);
+  public void asyncRestore() throws Exception {
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED, true);
     mCacheManager.close();
-    String rootDir = PageStore.getStorePath(PageStoreType.LOCAL,
-        mConf.get(PropertyKey.USER_CLIENT_CACHE_DIR)).toString();
+    mPageStore.put(PAGE_ID1, PAGE1);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
+    CommonUtils.waitFor("async restore completed",
+        () ->  mCacheManager.state() == CacheManager.State.READ_WRITE,
+        WaitForOptions.defaults().setTimeoutMs(10000));
+    assertTrue(mCacheManager.put(PAGE_ID2, PAGE2));
+    assertEquals(PAGE1.length, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+    assertArrayEquals(PAGE1, mBuf);
+    assertEquals(PAGE2.length, mCacheManager.get(PAGE_ID2, PAGE2.length, mBuf, 0));
+    assertArrayEquals(PAGE2, mBuf);
+  }
+
+  @Test
+  public void asyncRestoreReadOnly() throws Exception {
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED, true);
+    mCacheManager.close();
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    SlowGetPageStore slowGetPageStore = new SlowGetPageStore();
+    slowGetPageStore.put(PAGE_ID1, PAGE1);
+    slowGetPageStore.put(pageUuid, PAGE2);
+    mCacheManager = LocalCacheManager.create(
+        mConf, mMetaStore, slowGetPageStore, mPageStoreOptions);
+    assertEquals(CacheManager.State.READ_ONLY, mCacheManager.state());
+    Thread.sleep(1000); // some buffer to restore page1
+    // In READ_ONLY mode we still get previously added page
+    assertEquals(PAGE1.length, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+    assertArrayEquals(PAGE1, mBuf);
+    assertEquals(PAGE2.length, mCacheManager.get(pageUuid, PAGE2.length, mBuf, 0));
+    assertArrayEquals(PAGE2, mBuf);
+    // In READ_ONLY mode we cannot put
+    assertFalse(mCacheManager.put(PAGE_ID2, PAGE2));
+    // In READ_ONLY mode we cannot delete
+    assertFalse(mCacheManager.delete(PAGE_ID1));
+    // stop the "fake scan"
+    slowGetPageStore.mScanComplete.set(true);
+    CommonUtils.waitFor("async restore completed",
+        () ->  mCacheManager.state() == CacheManager.State.READ_WRITE,
+        WaitForOptions.defaults().setTimeoutMs(10000));
+    // Put get back to normal
+    assertTrue(mCacheManager.put(PAGE_ID2, PAGE2));
+    assertEquals(PAGE2.length, mCacheManager.get(PAGE_ID2, PAGE2.length, mBuf, 0));
+    assertArrayEquals(PAGE2, mBuf);
+    assertTrue(mCacheManager.delete(PAGE_ID2));
+  }
+
+  @Test
+  public void syncRestoreUnknownFile() throws Exception {
+    mCacheManager.close();
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    mPageStore.put(PAGE_ID1, PAGE1);
+    mPageStore.put(pageUuid, PAGE2);
+    String rootDir = mPageStoreOptions.getRootDir();
     FileUtils.createFile(Paths.get(rootDir, "invalidPageFile").toString());
-    mCacheManager = LocalCacheManager.create(mConf);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
+    assertEquals(CacheManager.State.READ_WRITE, mCacheManager.state());
     assertEquals(0, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+    assertEquals(0, mCacheManager.get(pageUuid, PAGE2.length, mBuf, 0));
+  }
+
+  @Test
+  public void asyncRestoreUnknownFile() throws Exception {
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED, true);
+    mCacheManager.close();
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    mPageStore.put(PAGE_ID1, PAGE1);
+    mPageStore.put(pageUuid, PAGE2);
+    String rootDir = mPageStoreOptions.getRootDir();
+    FileUtils.createFile(Paths.get(rootDir, "invalidPageFile").toString());
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
+    CommonUtils.waitFor("async restore completed",
+        () ->  mCacheManager.state() == CacheManager.State.READ_WRITE,
+        WaitForOptions.defaults().setTimeoutMs(10000));
+    assertEquals(0, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+    assertEquals(0, mCacheManager.get(pageUuid, PAGE2.length, mBuf, 0));
+  }
+
+  @Test
+  public void syncRestoreUnwritableRootDir() throws Exception {
+    mCacheManager.close();
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    mPageStore.put(PAGE_ID1, PAGE1);
+    mPageStore.put(pageUuid, PAGE2);
+    String rootDir = mPageStoreOptions.getRootDir();
+    FileUtils.deletePathRecursively(rootDir);
+    File rootParent = new File(rootDir).getParentFile();
+    try {
+      rootParent.setWritable(false);
+      LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
+    } catch (Exception e) {
+      // expected case
+    } finally {
+      rootParent.setWritable(true);
+    }
+  }
+
+  @Test
+  public void asyncRestoreUnwritableRootDir() throws Exception {
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED, true);
+    mCacheManager.close();
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    mPageStore.put(PAGE_ID1, PAGE1);
+    mPageStore.put(pageUuid, PAGE2);
+    String rootDir = mPageStoreOptions.getRootDir();
+    FileUtils.deletePathRecursively(rootDir);
+    File rootParent = new File(rootDir).getParentFile();
+    rootParent.setWritable(false);
+    try {
+      mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
+      CommonUtils.waitFor("async restore completed",
+          () -> mCacheManager.state() == CacheManager.State.NOT_IN_USE,
+          WaitForOptions.defaults().setTimeoutMs(10000));
+      assertEquals(-1, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+      assertEquals(false, mCacheManager.put(PAGE_ID2, PAGE2));
+      assertEquals(false, mCacheManager.delete(PAGE_ID1));
+    } finally {
+      rootParent.setWritable(true);
+    }
+  }
+
+  @Test
+  public void syncRestoreWithMorePagesThanCapacity() throws Exception {
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE1.length + PAGE2.length);
+    mCacheManager.close();
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    mPageStore.put(PAGE_ID1, PAGE1);
+    mPageStore.put(PAGE_ID2, PAGE2);
+    mPageStore.put(pageUuid, BufferUtils.getIncreasingByteArray(
+        PAGE1.length + PAGE2.length + 1));
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.open(mPageStoreOptions);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
+    assertEquals(PAGE1.length, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+    assertArrayEquals(PAGE1, mBuf);
+    assertEquals(PAGE2.length, mCacheManager.get(PAGE_ID2, PAGE2.length, mBuf, 0));
+    assertArrayEquals(PAGE2, mBuf);
+    assertEquals(0, mCacheManager.get(pageUuid, PAGE2.length, mBuf, 0));
+  }
+
+  @Test
+  public void asyncRestoreWithMorePagesThanCapacity() throws Exception {
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED, true);
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE1.length + PAGE2.length);
+    mCacheManager.close();
+    PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
+    mPageStore.put(PAGE_ID1, PAGE1);
+    mPageStore.put(PAGE_ID2, PAGE2);
+    mPageStore.put(pageUuid, BufferUtils.getIncreasingByteArray(
+        PAGE1.length + PAGE2.length + 1));
+    mPageStoreOptions = PageStoreOptions.create(mConf);
+    mPageStore = PageStore.open(mPageStoreOptions);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore, mPageStoreOptions);
+    CommonUtils.waitFor("async restore completed",
+        () ->  mCacheManager.state() == CacheManager.State.READ_WRITE,
+        WaitForOptions.defaults().setTimeoutMs(1000000));
+    assertEquals(PAGE1.length, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+    assertArrayEquals(PAGE1, mBuf);
+    assertEquals(PAGE2.length, mCacheManager.get(PAGE_ID2, PAGE2.length, mBuf, 0));
+    assertArrayEquals(PAGE2, mBuf);
     assertEquals(0, mCacheManager.get(pageUuid, PAGE2.length, mBuf, 0));
   }
 
@@ -318,7 +539,7 @@ public final class LocalCacheManagerTest {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_THREADS, threads);
     mConf.set(PropertyKey.USER_CLIENT_CACHE_STORE_TYPE, "LOCAL");
     PutDelayedPageStore pageStore = new PutDelayedPageStore();
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, pageStore, mPageStoreOptions);
     for (int i = 0; i < threads; i++) {
       PageId pageId = new PageId("5", i);
       assertTrue(mCacheManager.put(pageId, page(i, PAGE_SIZE_BYTES)));
@@ -343,7 +564,7 @@ public final class LocalCacheManagerTest {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_THREADS, threads);
     mConf.set(PropertyKey.USER_CLIENT_CACHE_STORE_TYPE, "LOCAL");
     PutDelayedPageStore pageStore = new PutDelayedPageStore();
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, pageStore, mPageStoreOptions);
     assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
     assertFalse(mCacheManager.put(PAGE_ID1, PAGE1));
     pageStore.setHanging(false);
@@ -357,7 +578,7 @@ public final class LocalCacheManagerTest {
   @Test
   public void recoverCacheFromFailedPut() throws Exception {
     FaultyPageStore pageStore = new FaultyPageStore();
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, pageStore, mPageStoreOptions);
     pageStore.setPutFaulty(true);
     // a failed put
     assertFalse(mCacheManager.put(PAGE_ID1, PAGE1));
@@ -377,7 +598,7 @@ public final class LocalCacheManagerTest {
   public void failedPageStoreDeleteOnEviction() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
     FaultyPageStore pageStore = new FaultyPageStore();
-    mCacheManager = new LocalCacheManager(mConf, mMetaStore, pageStore);
+    mCacheManager = LocalCacheManager.create(mConf, mMetaStore, pageStore, mPageStoreOptions);
     pageStore.setDeleteFaulty(true);
     // first put should be ok
     assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
@@ -392,7 +613,7 @@ public final class LocalCacheManagerTest {
   }
 
   /**
-   * A PageStore where put can throw IOException on put.
+   * A PageStore where put can throw IOException on put or delete.
    */
   private class FaultyPageStore extends LocalPageStore {
     public FaultyPageStore() {
@@ -452,6 +673,41 @@ public final class LocalCacheManagerTest {
 
     int getPuts() {
       return mPut.get();
+    }
+  }
+
+  /**
+   * A PageStore with slow scan.
+   */
+  private class SlowGetPageStore extends LocalPageStore {
+    private class NonStoppingSlowPageIterator implements Iterator<PageInfo> {
+      @Override
+      public boolean hasNext() {
+        return !mScanComplete.get();
+      }
+
+      @Override
+      public PageInfo next() {
+        try {
+          Thread.sleep(1000);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+        PageId id = new PageId(String.valueOf(mPageId.getAndIncrement()), 0L);
+        return new PageInfo(id, 1L);
+      }
+    }
+
+    private AtomicInteger mPageId = new AtomicInteger(100);
+    private AtomicBoolean mScanComplete = new AtomicBoolean(false);
+
+    public SlowGetPageStore() {
+      super(PageStoreOptions.create(mConf).toOptions());
+    }
+
+    @Override
+    public Stream<PageInfo> getPages() throws IOException {
+      return Stream.concat(super.getPages(), Streams.stream(new NonStoppingSlowPageIterator()));
     }
   }
 

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
@@ -73,7 +73,7 @@ public class PageStoreTest {
     mOptions.setCacheSize(65536);
     mOptions.setAlluxioVersion(ProjectConstants.VERSION);
     mOptions.setRootDir(mTemp.getRoot().getAbsolutePath());
-    mPageStore = PageStore.create(mOptions, true);
+    mPageStore = PageStore.create(mOptions);
   }
 
   @After

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3539,6 +3539,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED =
+      new Builder(Name.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED)
+          .setDefaultValue(true)
+          .setDescription("If this is enabled, cache restore state asynchronously.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED =
       new Builder(Name.USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED)
           .setDefaultValue(true)
@@ -5242,6 +5249,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.block.worker.client.read.retry";
     public static final String USER_BLOCK_WRITE_LOCATION_POLICY =
         "alluxio.user.block.write.location.policy.class";
+    public static final String USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED =
+        "alluxio.user.client.cache.async.restore.enabled";
     public static final String USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED =
         "alluxio.user.client.cache.async.write.enabled";
     public static final String USER_CLIENT_CACHE_ASYNC_WRITE_THREADS =

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -846,6 +846,12 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_UNREMOVABLE_FILES =
+      new Builder(Name.CLIENT_CACHE_UNREMOVABLE_FILES)
+          .setDescription("Amount of bytes unusable managed by the client cache.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
 
   public static final MetricKey CLIENT_CACHE_CREATE_ERRORS =
       new Builder(Name.CLIENT_CACHE_CREATE_ERRORS)
@@ -865,6 +871,12 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_DELETE_NOT_READY_ERRORS =
+      new Builder(Name.CLIENT_CACHE_DELETE_NOT_READY_ERRORS)
+          .setDescription("Number of failures when  when cache is not ready to delete pages.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_DELETE_STORE_DELETE_ERRORS =
       new Builder(Name.CLIENT_CACHE_DELETE_STORE_DELETE_ERRORS)
           .setDescription("Number of failures when deleting pages due to failed delete in page "
@@ -875,6 +887,12 @@ public final class MetricKey implements Comparable<MetricKey> {
   public static final MetricKey CLIENT_CACHE_GET_ERRORS =
       new Builder(Name.CLIENT_CACHE_GET_ERRORS)
           .setDescription("Number of failures when getting cached data in the client cache.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_CACHE_GET_NOT_READY_ERRORS =
+      new Builder(Name.CLIENT_CACHE_GET_NOT_READY_ERRORS)
+          .setDescription("Number of failures when cache is not ready to get pages.")
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
@@ -924,6 +942,12 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_PUT_NOT_READY_ERRORS =
+      new Builder(Name.CLIENT_CACHE_PUT_NOT_READY_ERRORS)
+          .setDescription("Number of failures when cache is not ready to add pages.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_PUT_STORE_DELETE_ERRORS =
       new Builder(Name.CLIENT_CACHE_PUT_STORE_DELETE_ERRORS)
           .setDescription("Number of failures when putting cached data in the client cache due to"
@@ -935,6 +959,12 @@ public final class MetricKey implements Comparable<MetricKey> {
       new Builder(Name.CLIENT_CACHE_PUT_STORE_WRITE_ERRORS)
           .setDescription("Number of failures when putting cached data in the client cache due to"
               + " failed writes to page store.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_CACHE_STATE =
+      new Builder(Name.CLIENT_CACHE_STATE)
+          .setDescription("State of the cache: 0 (NOT_IN_USE), 1 (READ_ONLY) and 2 (READ_WRITE)")
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
@@ -1152,9 +1182,12 @@ public final class MetricKey implements Comparable<MetricKey> {
     public static final String CLIENT_CACHE_DELETE_ERRORS = "Client.CacheDeleteErrors";
     public static final String CLIENT_CACHE_DELETE_NON_EXISTING_PAGE_ERRORS =
         "Client.CacheDeleteNonExistingPageErrors";
+    public static final String CLIENT_CACHE_DELETE_NOT_READY_ERRORS =
+        "Client.CacheDeleteNotReadyErrors";
     public static final String CLIENT_CACHE_DELETE_STORE_DELETE_ERRORS =
         "Client.CacheDeleteStoreDeleteErrors";
     public static final String CLIENT_CACHE_GET_ERRORS = "Client.CacheGetErrors";
+    public static final String CLIENT_CACHE_GET_NOT_READY_ERRORS = "Client.CacheGetNotReadyErrors";
     public static final String CLIENT_CACHE_GET_STORE_READ_ERRORS =
         "Client.CacheGetStoreReadErrors";
     public static final String CLIENT_CACHE_PUT_ERRORS = "Client.CachePutErrors";
@@ -1164,10 +1197,14 @@ public final class MetricKey implements Comparable<MetricKey> {
         "Client.CachePutEvictionErrors";
     public static final String CLIENT_CACHE_PUT_BENIGN_RACING_ERRORS =
         "Client.CachePutBenignRacingErrors";
+    public static final String CLIENT_CACHE_PUT_NOT_READY_ERRORS =
+        "Client.CachePutNotReadyErrors";
     public static final String CLIENT_CACHE_PUT_STORE_DELETE_ERRORS =
         "Client.CachePutStoreDeleteErrors";
     public static final String CLIENT_CACHE_PUT_STORE_WRITE_ERRORS =
         "Client.CachePutStoreWriteErrors";
+    public static final String CLIENT_CACHE_STATE = "Client.CacheState";
+    public static final String CLIENT_CACHE_UNREMOVABLE_FILES = "Client.CacheUnremovableFiles";
 
     private Name() {} // prevent instantiation
   }


### PR DESCRIPTION
Cherry-pick a6201053036ea2cb32adf30acf77f677d9f4cb09

- remove restore logic to a separate background thread meanwhile open
the cache manager in a "readonly" mode to other query threads. in this
way, early queries will suffer from low hit ratio but hopefully they
will catch up.
- handle capacity exceeding gracefully: instead of failing the restore
and delete all pages on disk, just remove the excessive pages

pr-link: Alluxio/alluxio#12087
change-id: cid-6f041d173c7cb7adf11ed241b7350f30bdb4a1c7