### PR TITLE
Use local raft api for journal writer

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -371,8 +371,8 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     private ClientId mClientId;
 
     RaftLocalClient(RaftServer server, ClientId clientId) {
-      this.mServer = server;
-      this.mClientId = clientId;
+      mServer = server;
+      mClientId = clientId;
     }
 
     public CompletableFuture<RaftClientReply> sendRequestAsync(

--- a/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
@@ -108,7 +108,7 @@ public class RaftJournalDumper extends AbstractJournalDumper {
   }
 
   private File getJournalDir() {
-    return new File(mInputDir, RaftJournalSystem.RAFT_GROUP_ID.toString());
+    return new File(mInputDir, RaftJournalSystem.RAFT_GROUP_UUID.toString());
   }
 
   private void readRatisSnapshotFromDir() throws IOException {

--- a/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
+++ b/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
@@ -217,7 +217,7 @@ public class JournalToolTest extends BaseIntegrationTest {
 
   private long getCurrentRatisSnapshotIndex(String journalFolder) throws Throwable {
     try (RaftStorage storage = new RaftStorage(
-        new File(journalFolder, RaftJournalSystem.RAFT_GROUP_ID.toString()),
+        new File(journalFolder, RaftJournalSystem.RAFT_GROUP_UUID.toString()),
         RaftServerConstants.StartupOption.REGULAR)) {
       SimpleStateMachineStorage stateMachineStorage = new SimpleStateMachineStorage();
       stateMachineStorage.init(storage);

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTest.java
@@ -129,7 +129,7 @@ public final class EmbeddedJournalIntegrationTest extends BaseIntegrationTest {
     }
     int primaryMasterIndex = mCluster.getPrimaryMasterIndex(5000);
     String leaderJournalPath = mCluster.getJournalDir(primaryMasterIndex);
-    File raftDir = new File(leaderJournalPath, RaftJournalSystem.RAFT_GROUP_ID.toString());
+    File raftDir = new File(leaderJournalPath, RaftJournalSystem.RAFT_GROUP_UUID.toString());
     waitForSnapshot(raftDir);
     mCluster.stopMasters();
 
@@ -168,7 +168,7 @@ public final class EmbeddedJournalIntegrationTest extends BaseIntegrationTest {
     FileUtils.deleteDirectory(catchupJournalDir);
     assertTrue(catchupJournalDir.mkdirs());
     mCluster.startMaster(catchUpMasterIndex);
-    File raftDir = new File(catchupJournalDir, RaftJournalSystem.RAFT_GROUP_ID.toString());
+    File raftDir = new File(catchupJournalDir, RaftJournalSystem.RAFT_GROUP_UUID.toString());
     waitForSnapshot(raftDir);
     mCluster.stopMaster(catchUpMasterIndex);
     SimpleStateMachineStorage storage = new SimpleStateMachineStorage();


### PR DESCRIPTION
This change may improve flushing performance by removing additional network layer from journal flushing.