### PR TITLE
Avoid printing long proto lines in messages and exception descriptions

### DIFF
--- a/core/common/src/main/java/alluxio/util/LogUtils.java
+++ b/core/common/src/main/java/alluxio/util/LogUtils.java
@@ -143,8 +143,8 @@ public final class LogUtils {
    * @param message the message to truncate the lines for
    * @return the message, with lines truncated to length {@link #MAX_TRUNCATED_LENGTH}
    */
-  public static String truncateMessageLines(Object message) {
-    return truncateMessageLines(message, MAX_TRUNCATED_LENGTH);
+  public static String truncateMessageLineLength(Object message) {
+    return truncateMessageLineLength(message, MAX_TRUNCATED_LENGTH);
   }
 
   /**
@@ -154,7 +154,7 @@ public final class LogUtils {
    * @param maxLineLength the maximum length of a message line
    * @return the message, with lines truncated to the specified length
    */
-  public static String truncateMessageLines(Object message, int maxLineLength) {
+  public static String truncateMessageLineLength(Object message, int maxLineLength) {
     if (message == null) {
       return "null";
     }

--- a/core/common/src/main/java/alluxio/util/LogUtils.java
+++ b/core/common/src/main/java/alluxio/util/LogUtils.java
@@ -25,6 +25,8 @@ import org.slf4j.impl.Log4jLoggerAdapter;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -33,6 +35,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class LogUtils {
+  /** The truncated length for a message line. */
+  public static final int MAX_TRUNCATED_LENGTH = 300;
 
   private LogUtils() {} // prevent instantiation
 
@@ -131,5 +135,39 @@ public final class LogUtils {
       }
       logger.warn(message + ": {}", args);
     }
+  }
+
+  /**
+   * Truncates each line of a message to a certain length.
+   *
+   * @param message the message to truncate the lines for
+   * @return the message, with lines truncated to length {@link #MAX_TRUNCATED_LENGTH}
+   */
+  public static String truncateMessageLines(Object message) {
+    return truncateMessageLines(message, MAX_TRUNCATED_LENGTH);
+  }
+
+  /**
+   * Truncates each line of a message to a certain length.
+   *
+   * @param message the message to truncate the lines for
+   * @param maxLineLength the maximum length of a message line
+   * @return the message, with lines truncated to the specified length
+   */
+  public static String truncateMessageLines(Object message, int maxLineLength) {
+    if (message == null) {
+      return "null";
+    }
+    String strMessage = message.toString();
+    if (strMessage.length() <= maxLineLength) {
+      return strMessage;
+    }
+    return Arrays.stream(strMessage.split("\n")).map(line -> {
+      if (line.length() > maxLineLength) {
+        return String.format("%s ... <truncated %d characters>", line.substring(0, maxLineLength),
+            line.length() - maxLineLength);
+      }
+      return line;
+    }).collect(Collectors.joining("\n"));
   }
 }

--- a/core/common/src/test/java/alluxio/util/LogUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/LogUtilsTest.java
@@ -25,16 +25,16 @@ public final class LogUtilsTest {
   @Test
   public void truncateShort() throws Exception {
     String s;
-    assertEquals("null", LogUtils.truncateMessageLines(null));
+    assertEquals("null", LogUtils.truncateMessageLineLength(null));
     s = CommonUtils.randomAlphaNumString(1);
-    assertEquals(s, LogUtils.truncateMessageLines(s));
+    assertEquals(s, LogUtils.truncateMessageLineLength(s));
     s = CommonUtils.randomAlphaNumString(LogUtils.MAX_TRUNCATED_LENGTH);
-    assertEquals(s, LogUtils.truncateMessageLines(s));
+    assertEquals(s, LogUtils.truncateMessageLineLength(s));
 
     for (int i = 0; i < 20; i++) {
       s = CommonUtils.randomAlphaNumString(
           ThreadLocalRandom.current().nextInt(2, LogUtils.MAX_TRUNCATED_LENGTH));
-      assertEquals(s, LogUtils.truncateMessageLines(s));
+      assertEquals(s, LogUtils.truncateMessageLineLength(s));
     }
   }
 
@@ -47,7 +47,7 @@ public final class LogUtilsTest {
         s += CommonUtils.randomAlphaNumString(
             ThreadLocalRandom.current().nextInt(1, LogUtils.MAX_TRUNCATED_LENGTH + 1));
       }
-      assertEquals(s, LogUtils.truncateMessageLines(s));
+      assertEquals(s, LogUtils.truncateMessageLineLength(s));
     }
   }
 
@@ -58,7 +58,7 @@ public final class LogUtilsTest {
     for (int i = 0; i < 20; i++) {
       s = CommonUtils.randomAlphaNumString(ThreadLocalRandom.current()
           .nextInt(LogUtils.MAX_TRUNCATED_LENGTH + 1, 2 + LogUtils.MAX_TRUNCATED_LENGTH));
-      String truncated = LogUtils.truncateMessageLines(s);
+      String truncated = LogUtils.truncateMessageLineLength(s);
       assertTrue(truncated.startsWith(s.substring(0, LogUtils.MAX_TRUNCATED_LENGTH) + " ..."));
     }
   }
@@ -80,7 +80,7 @@ public final class LogUtilsTest {
         }
       }
 
-      String truncated = LogUtils.truncateMessageLines(s);
+      String truncated = LogUtils.truncateMessageLineLength(s);
 
       String[] expectedLines = s.split("\n");
       String[] actualLines = truncated.split("\n");
@@ -103,7 +103,7 @@ public final class LogUtilsTest {
     String s = CommonUtils.randomAlphaNumString(LogUtils.MAX_TRUNCATED_LENGTH);
 
     for (int length = 1; length < LogUtils.MAX_TRUNCATED_LENGTH; length++) {
-      String truncated = LogUtils.truncateMessageLines(s, length);
+      String truncated = LogUtils.truncateMessageLineLength(s, length);
       assertTrue(truncated.startsWith(s.substring(0, length) + " ..."));
     }
   }

--- a/core/common/src/test/java/alluxio/util/LogUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/LogUtilsTest.java
@@ -1,0 +1,110 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Tests {@link LogUtils}.
+ */
+public final class LogUtilsTest {
+  @Test
+  public void truncateShort() throws Exception {
+    String s;
+    assertEquals("null", LogUtils.truncateMessageLines(null));
+    s = CommonUtils.randomAlphaNumString(1);
+    assertEquals(s, LogUtils.truncateMessageLines(s));
+    s = CommonUtils.randomAlphaNumString(LogUtils.MAX_TRUNCATED_LENGTH);
+    assertEquals(s, LogUtils.truncateMessageLines(s));
+
+    for (int i = 0; i < 20; i++) {
+      s = CommonUtils.randomAlphaNumString(
+          ThreadLocalRandom.current().nextInt(2, LogUtils.MAX_TRUNCATED_LENGTH));
+      assertEquals(s, LogUtils.truncateMessageLines(s));
+    }
+  }
+
+  @Test
+  public void truncateShortLines() throws Exception {
+    for (int i = 0; i < 20; i++) {
+      String s = "";
+      for (int lines = 0; lines < ThreadLocalRandom.current().nextInt(5, 10); lines++) {
+        s += "\n";
+        s += CommonUtils.randomAlphaNumString(
+            ThreadLocalRandom.current().nextInt(1, LogUtils.MAX_TRUNCATED_LENGTH + 1));
+      }
+      assertEquals(s, LogUtils.truncateMessageLines(s));
+    }
+  }
+
+  @Test
+  public void truncateLong() throws Exception {
+    String s;
+
+    for (int i = 0; i < 20; i++) {
+      s = CommonUtils.randomAlphaNumString(ThreadLocalRandom.current()
+          .nextInt(LogUtils.MAX_TRUNCATED_LENGTH + 1, 2 + LogUtils.MAX_TRUNCATED_LENGTH));
+      String truncated = LogUtils.truncateMessageLines(s);
+      assertTrue(truncated.startsWith(s.substring(0, LogUtils.MAX_TRUNCATED_LENGTH) + " ..."));
+    }
+  }
+
+  @Test
+  public void truncateLongLines() throws Exception {
+    for (int i = 0; i < 20; i++) {
+      String s = "";
+      // generate lines both short and long
+      int lines = ThreadLocalRandom.current().nextInt(5, 10);
+      for (int j = 0; j < lines; j++) {
+        s += "\n";
+        if (j % 2 == 0) {
+          s += CommonUtils.randomAlphaNumString(
+              ThreadLocalRandom.current().nextInt(1, LogUtils.MAX_TRUNCATED_LENGTH + 1));
+        } else {
+          s = CommonUtils.randomAlphaNumString(ThreadLocalRandom.current()
+              .nextInt(LogUtils.MAX_TRUNCATED_LENGTH + 1, 2 + LogUtils.MAX_TRUNCATED_LENGTH));
+        }
+      }
+
+      String truncated = LogUtils.truncateMessageLines(s);
+
+      String[] expectedLines = s.split("\n");
+      String[] actualLines = truncated.split("\n");
+      assertEquals(expectedLines.length, actualLines.length);
+
+      // check each line
+      for (int j = 0; j < expectedLines.length; j++) {
+        if (expectedLines[j].length() <= LogUtils.MAX_TRUNCATED_LENGTH) {
+          assertEquals(expectedLines[j], actualLines[j]);
+        } else {
+          assertTrue(actualLines[j]
+              .startsWith(expectedLines[j].substring(0, LogUtils.MAX_TRUNCATED_LENGTH) + " ..."));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void truncateSpecificLength() throws Exception {
+    String s = CommonUtils.randomAlphaNumString(LogUtils.MAX_TRUNCATED_LENGTH);
+
+    for (int length = 1; length < LogUtils.MAX_TRUNCATED_LENGTH; length++) {
+      String truncated = LogUtils.truncateMessageLines(s, length);
+      assertTrue(truncated.startsWith(s.substring(0, length) + " ..."));
+    }
+  }
+}


### PR DESCRIPTION
When printing a request proto as a log message or exception message, some requests contain large payloads. Those large payloads make it difficult to inspect the message. This change truncates individual lines of message.