### PR TITLE
Update sync status after processing the entire sync

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -387,9 +387,15 @@ public class InodeSyncStream {
           syncPathCount + failedSyncPathCount, syncPathCount, failedSyncPathCount, end - start,
           mRootScheme);
     }
+    boolean success = syncPathCount > 0;
+    if (success) {
+      // update the sync path cache for the root of the sync
+      // TODO(gpang): Do we need special handling for failures and thread interrupts?
+      mUfsSyncPathCache.notifySyncedPath(mRootScheme.getPath().getPath(), mDescendantType);
+    }
     mStatusCache.cancelAllPrefetch();
     mSyncPathJobs.forEach(f -> f.cancel(true));
-    return syncPathCount > 0;
+    return success;
   }
 
   /**
@@ -598,7 +604,6 @@ public class InodeSyncStream {
     if (loadMetadata) {
       loadMetadataForPath(inodePath);
     }
-    mUfsSyncPathCache.notifySyncedPath(inodePath.getUri().getPath(), DescendantType.ONE);
 
     if (syncChildren) {
       // Iterate over Alluxio children and process persisted children.

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -711,6 +711,38 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
     Assert.assertEquals(4, paths.size());
   }
 
+  @Test
+  public void deleteUfsFileGetStatus() throws Exception {
+    new File(ufsPath("/delete")).mkdirs();
+    writeUfsFile(ufsPath("/delete/file"), 10);
+
+    List<URIStatus> paths = mFileSystem.listStatus(new AlluxioURI(alluxioPath("/delete")),
+        ListStatusPOptions.newBuilder().setRecursive(false).setCommonOptions(PSYNC_ALWAYS).build());
+
+    Assert.assertEquals(1, paths.size());
+    Assert.assertEquals("file", paths.get(0).getName());
+
+    // delete the file and wait a bit
+    new File(ufsPath("/delete/file")).delete();
+    CommonUtils.sleepMs(2000);
+
+    // getStatus (not listStatus) on the root, with a shorter interval than the sleep.
+    // This will sync that directory. The sync interval has to be long enough for the internal
+    // syncing process to finish within that time.
+    mFileSystem.getStatus(new AlluxioURI(alluxioPath("/delete")), GetStatusPOptions.newBuilder()
+        .setCommonOptions(
+            FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(1000).build()).build());
+
+    // verify that the file is deleted, without syncing
+    try {
+      mFileSystem.getStatus(new AlluxioURI(alluxioPath("/delete/file")),
+          GetStatusPOptions.newBuilder().setCommonOptions(PSYNC_NEVER).build());
+      Assert.fail("the ufs deleted file is not expected to exist after sync via getStatus");
+    } catch (FileDoesNotExistException e) {
+      // expected
+    }
+  }
+
   private String ufsPath(String path) {
     return mLocalUfsPath + path;
   }


### PR DESCRIPTION
Marking paths as sync during the sync is inaccurate, because the syncs for descendants are run in a separate thread pool. Therefore, only mark the root path as synced after everything is finished. This also reduces the number of entries in the sync cache, instead of marking each path in the tree.

Fixes #12106