### PR TITLE
Fix deadlock of racing worker client acquisition and file completion

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -147,6 +147,10 @@ public class AlluxioFileInStream extends FileInStream {
         if (result != -1) {
           mPosition++;
         }
+        if (mBlockInStream.remaining() == 0) {
+          closeBlockInStream(mBlockInStream);
+          mBlockInStream = null;
+        }
         return result;
       } catch (IOException e) {
         lastException = e;
@@ -191,6 +195,10 @@ public class AlluxioFileInStream extends FileInStream {
         }
         retry = mRetryPolicySupplier.get();
         lastException = null;
+        if (mBlockInStream.remaining() == 0) {
+          closeBlockInStream(mBlockInStream);
+          mBlockInStream = null;
+        }
       } catch (IOException e) {
         lastException = e;
         if (mBlockInStream != null) {

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -279,6 +279,10 @@ public class AlluxioFileInStream extends FileInStream {
         if (mCachedPositionedReadStream.getSource() != BlockInStream.BlockInStreamSource.LOCAL) {
           triggerAsyncCaching(mCachedPositionedReadStream);
         }
+        if (bytesRead == mBlockSize - offset) {
+          mCachedPositionedReadStream.close();
+          mCachedPositionedReadStream = null;
+        }
       } catch (IOException e) {
         lastException = e;
         if (mCachedPositionedReadStream != null) {

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -149,7 +149,6 @@ public class AlluxioFileInStream extends FileInStream {
         }
         if (mBlockInStream.remaining() == 0) {
           closeBlockInStream(mBlockInStream);
-          mBlockInStream = null;
         }
         return result;
       } catch (IOException e) {
@@ -197,7 +196,6 @@ public class AlluxioFileInStream extends FileInStream {
         lastException = null;
         if (mBlockInStream.remaining() == 0) {
           closeBlockInStream(mBlockInStream);
-          mBlockInStream = null;
         }
       } catch (IOException e) {
         lastException = e;

--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -209,7 +209,13 @@ public final class AlluxioFileInStreamTest {
    */
   @Test
   public void readBlock() throws Exception {
-    testReadBuffer((int) BLOCK_LENGTH);
+    int dataRead = (int) BLOCK_LENGTH;
+    byte[] buffer = new byte[dataRead];
+    mTestStream.read(buffer);
+    assertEquals(true, mInStreams.get(0).isClosed());
+    mTestStream.close();
+
+    assertArrayEquals(BufferUtils.getIncreasingByteArray(dataRead), buffer);
   }
 
   /**
@@ -217,7 +223,16 @@ public final class AlluxioFileInStreamTest {
    */
   @Test
   public void readFile() throws Exception {
-    testReadBuffer((int) FILE_LENGTH);
+    int dataRead = (int) FILE_LENGTH;
+    byte[] buffer = new byte[dataRead];
+    mTestStream.read(buffer);
+
+    for (int i = 0; i < NUM_STREAMS; i++) {
+      assertEquals(true, mInStreams.get(i).isClosed());
+    }
+    mTestStream.close();
+
+    assertArrayEquals(BufferUtils.getIncreasingByteArray(dataRead), buffer);
   }
 
   /**

--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -647,6 +647,7 @@ public final class AlluxioFileInStreamTest {
   public void positionedRead() throws IOException {
     byte[] b = new byte[(int) BLOCK_LENGTH];
     mTestStream.positionedRead(BLOCK_LENGTH, b, 0, b.length);
+    assertEquals(true, mInStreams.get(1).isClosed());
     assertArrayEquals(BufferUtils.getIncreasingByteArray((int) BLOCK_LENGTH, (int)
         BLOCK_LENGTH), b);
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -209,6 +209,14 @@ public final class AlluxioFileInStreamTest {
    */
   @Test
   public void readBlock() throws Exception {
+    testReadBuffer((int) BLOCK_LENGTH);
+  }
+
+  /**
+   * Tests that reading the complete block works and the BlockInStream is closed.
+   */
+  @Test
+  public void readBlockStreamCloseOnEnd() throws Exception {
     int dataRead = (int) BLOCK_LENGTH;
     byte[] buffer = new byte[dataRead];
     mTestStream.read(buffer);
@@ -223,6 +231,14 @@ public final class AlluxioFileInStreamTest {
    */
   @Test
   public void readFile() throws Exception {
+    testReadBuffer((int) FILE_LENGTH);
+  }
+
+  /**
+   * Tests that reading the complete file works and all streams are closed when to the end of file.
+   */
+  @Test
+  public void readFileStreamCloseOnEnd() throws Exception {
     int dataRead = (int) FILE_LENGTH;
     byte[] buffer = new byte[dataRead];
     mTestStream.read(buffer);
@@ -647,8 +663,19 @@ public final class AlluxioFileInStreamTest {
   public void positionedRead() throws IOException {
     byte[] b = new byte[(int) BLOCK_LENGTH];
     mTestStream.positionedRead(BLOCK_LENGTH, b, 0, b.length);
-    assertEquals(true, mInStreams.get(1).isClosed());
     assertArrayEquals(BufferUtils.getIncreasingByteArray((int) BLOCK_LENGTH, (int)
+        BLOCK_LENGTH), b);
+  }
+
+  /**
+   * Tests the BlockInStream is closed when reading to the end of the block.
+   */
+  @Test
+  public void positionedReadStreamCloseOnEnd() throws IOException {
+    byte[] b = new byte[(int) BLOCK_LENGTH];
+    mTestStream.positionedRead(0, b, 0, b.length);
+    assertEquals(true, mInStreams.get(0).isClosed());
+    assertArrayEquals(BufferUtils.getIncreasingByteArray((int) 0, (int)
         BLOCK_LENGTH), b);
   }
 


### PR DESCRIPTION
Fix bug: fuse pod hang forever if open&read many files without close  the files

Root cause:
      `mBlockInStream` in `AlluxioFileInStream` won't be released even reading to end of the block.
      In this case, `BlockWorkerClient` will be held in `BlockInStream`. Given many files opened, `BlockWorkerClient` in the pool will be exhausted and the following operations will be blocked.
Fix:
      Release `mBlockInStream` after reading to end of the block.