### PR TITLE
Add worker master periodical connections timeout

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/meta/RetryHandlingMetaMasterConfigClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/meta/RetryHandlingMetaMasterConfigClient.java
@@ -79,7 +79,7 @@ public class RetryHandlingMetaMasterConfigClient extends AbstractMasterClient
   @Override
   public Configuration getConfiguration(GetConfigurationPOptions options) throws IOException {
     return Configuration.fromProto(retryRPC(() -> mClient.withDeadlineAfter(
-        mContext.getClusterConf().getMs(PropertyKey.WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT),
+        mContext.getClusterConf().getMs(PropertyKey.WORKER_MASTER_PERIODICAL_RPC_TIMEOUT),
         TimeUnit.MILLISECONDS).getConfiguration(options),
         RPC_LOG, "GetConfiguration", "options=%s", options));
   }
@@ -87,7 +87,7 @@ public class RetryHandlingMetaMasterConfigClient extends AbstractMasterClient
   @Override
   public ConfigHash getConfigHash() throws IOException {
     return ConfigHash.fromProto(retryRPC(() -> mClient.withDeadlineAfter(
-        mContext.getClusterConf().getMs(PropertyKey.WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT),
+        mContext.getClusterConf().getMs(PropertyKey.WORKER_MASTER_PERIODICAL_RPC_TIMEOUT),
         TimeUnit.MILLISECONDS).getConfigHash(GetConfigHashPOptions.getDefaultInstance()),
         RPC_LOG, "GetConfigHash", ""));
   }

--- a/core/client/fs/src/main/java/alluxio/client/meta/RetryHandlingMetaMasterConfigClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/meta/RetryHandlingMetaMasterConfigClient.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -77,14 +78,18 @@ public class RetryHandlingMetaMasterConfigClient extends AbstractMasterClient
 
   @Override
   public Configuration getConfiguration(GetConfigurationPOptions options) throws IOException {
-    return Configuration.fromProto(retryRPC(() ->
-        mClient.getConfiguration(options), RPC_LOG, "GetConfiguration", "options=%s", options));
+    return Configuration.fromProto(retryRPC(() -> mClient.withDeadlineAfter(
+        mContext.getClusterConf().getMs(PropertyKey.WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT),
+        TimeUnit.MILLISECONDS).getConfiguration(options),
+        RPC_LOG, "GetConfiguration", "options=%s", options));
   }
 
   @Override
   public ConfigHash getConfigHash() throws IOException {
-    return ConfigHash.fromProto(retryRPC(() -> mClient.getConfigHash(
-        GetConfigHashPOptions.getDefaultInstance()), RPC_LOG, "GetConfigHash", ""));
+    return ConfigHash.fromProto(retryRPC(() -> mClient.withDeadlineAfter(
+        mContext.getClusterConf().getMs(PropertyKey.WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT),
+        TimeUnit.MILLISECONDS).getConfigHash(GetConfigHashPOptions.getDefaultInstance()),
+        RPC_LOG, "GetConfigHash", ""));
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2659,7 +2659,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey WORKER_MASTER_PERIODICAL_RPC_TIMEOUT =
       new Builder(Name.WORKER_MASTER_PERIODICAL_RPC_TIMEOUT)
-          .setDefaultValue("1min")
+          .setDefaultValue("5min")
           .setDescription("Timeout for periodical RPC between workers "
               + "and the leading master. This property is added to prevent workers "
               + "from hanging in periodical RPCs with previous leading master "

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2651,6 +2651,16 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
       .setScope(Scope.WORKER)
       .build();
+  public static final PropertyKey WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT =
+      new Builder(Name.WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT)
+          .setDefaultValue("1min")
+          .setDescription("Timeout for periodical connections between workers "
+              + "and the leading master. Periodical connections between workers "
+              + "and previous leading master may hang which prevents workers "
+              + "from registering with the new leading master "
+              + "during flaky network situations.")
+          .setScope(Scope.WORKER)
+          .build();
   public static final PropertyKey WORKER_MASTER_CONNECT_RETRY_TIMEOUT =
       new Builder(Name.WORKER_MASTER_CONNECT_RETRY_TIMEOUT)
           .setDescription("Retry period before workers give up on connecting to master and exit.")
@@ -5149,6 +5159,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String WORKER_FREE_SPACE_TIMEOUT = "alluxio.worker.free.space.timeout";
     public static final String WORKER_HOSTNAME = "alluxio.worker.hostname";
     public static final String WORKER_KEYTAB_FILE = "alluxio.worker.keytab.file";
+    public static final String WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT =
+        "alluxio.worker.master.periodical.connect.timeout";
     public static final String WORKER_MASTER_CONNECT_RETRY_TIMEOUT =
         "alluxio.worker.master.connect.retry.timeout";
     public static final String WORKER_MEMORY_SIZE = "alluxio.worker.memory.size";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2653,7 +2653,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       .build();
   public static final PropertyKey WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT =
       new Builder(Name.WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT)
-          .setDefaultValue("1min")
+          .setDefaultValue("5min")
           .setDescription("Timeout for periodical connections between workers "
               + "and the leading master. Periodical connections between workers "
               + "and previous leading master may hang which prevents workers "

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2651,20 +2651,22 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
       .setScope(Scope.WORKER)
       .build();
-  public static final PropertyKey WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT =
-      new Builder(Name.WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT)
-          .setDefaultValue("5min")
-          .setDescription("Timeout for periodical connections between workers "
-              + "and the leading master. Periodical connections between workers "
-              + "and previous leading master may hang which prevents workers "
-              + "from registering with the new leading master "
-              + "during flaky network situations.")
-          .setScope(Scope.WORKER)
-          .build();
   public static final PropertyKey WORKER_MASTER_CONNECT_RETRY_TIMEOUT =
       new Builder(Name.WORKER_MASTER_CONNECT_RETRY_TIMEOUT)
           .setDescription("Retry period before workers give up on connecting to master and exit.")
           .setDefaultValue("1hour")
+          .setScope(Scope.WORKER)
+          .build();
+  public static final PropertyKey WORKER_MASTER_PERIODICAL_RPC_TIMEOUT =
+      new Builder(Name.WORKER_MASTER_PERIODICAL_RPC_TIMEOUT)
+          .setDefaultValue("5min")
+          .setDescription("Timeout for periodical RPC between workers "
+              + "and the leading master. This property is added to prevent workers "
+              + "from hanging in periodical RPCs with previous leading master "
+              + "during flaky network situations. If the timeout is too short, "
+              + "periodical RPCs may not have enough time to get response "
+              + "from the leading master during heavy cluster load "
+              + "and high network latency.")
           .setScope(Scope.WORKER)
           .build();
   public static final PropertyKey WORKER_RAMDISK_SIZE =
@@ -5159,10 +5161,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String WORKER_FREE_SPACE_TIMEOUT = "alluxio.worker.free.space.timeout";
     public static final String WORKER_HOSTNAME = "alluxio.worker.hostname";
     public static final String WORKER_KEYTAB_FILE = "alluxio.worker.keytab.file";
-    public static final String WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT =
-        "alluxio.worker.master.periodical.connect.timeout";
     public static final String WORKER_MASTER_CONNECT_RETRY_TIMEOUT =
         "alluxio.worker.master.connect.retry.timeout";
+    public static final String WORKER_MASTER_PERIODICAL_RPC_TIMEOUT =
+        "alluxio.worker.master.periodical.rpc.timeout";
     public static final String WORKER_MEMORY_SIZE = "alluxio.worker.memory.size";
     public static final String WORKER_NETWORK_ASYNC_CACHE_MANAGER_THREADS_MAX =
         "alluxio.worker.network.async.cache.manager.threads.max";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2659,7 +2659,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey WORKER_MASTER_PERIODICAL_RPC_TIMEOUT =
       new Builder(Name.WORKER_MASTER_PERIODICAL_RPC_TIMEOUT)
-          .setDefaultValue("5min")
+          .setDefaultValue("1min")
           .setDescription("Timeout for periodical RPC between workers "
               + "and the leading master. This property is added to prevent workers "
               + "from hanging in periodical RPCs with previous leading master "

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -42,6 +42,7 @@ import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -670,7 +671,9 @@ public final class NetworkAddressUtils {
         .build();
     try {
       ServiceVersionClientServiceGrpc.ServiceVersionClientServiceBlockingStub versionClient =
-          ServiceVersionClientServiceGrpc.newBlockingStub(channel);
+          ServiceVersionClientServiceGrpc.newBlockingStub(channel)
+              .withDeadlineAfter(conf.getMs(PropertyKey.WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT),
+                  TimeUnit.MILLISECONDS);
       versionClient.getServiceVersion(
           GetServiceVersionPRequest.newBuilder().setServiceType(serviceType).build());
     } catch (Throwable t) {

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -672,7 +672,7 @@ public final class NetworkAddressUtils {
     try {
       ServiceVersionClientServiceGrpc.ServiceVersionClientServiceBlockingStub versionClient =
           ServiceVersionClientServiceGrpc.newBlockingStub(channel)
-              .withDeadlineAfter(conf.getMs(PropertyKey.WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT),
+              .withDeadlineAfter(conf.getMs(PropertyKey.USER_MASTER_POLLING_TIMEOUT),
                   TimeUnit.MILLISECONDS);
       versionClient.getServiceVersion(
           GetServiceVersionPRequest.newBuilder().setServiceType(serviceType).build());

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
@@ -190,7 +190,7 @@ public final class BlockMasterClient extends AbstractMasterClient {
         .putAllLostStorage(lostStorageMap).build();
 
     return retryRPC(() -> mClient.withDeadlineAfter(mContext.getClusterConf()
-        .getMs(PropertyKey.WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT), TimeUnit.MILLISECONDS)
+        .getMs(PropertyKey.WORKER_MASTER_PERIODICAL_RPC_TIMEOUT), TimeUnit.MILLISECONDS)
         .blockHeartbeat(request).getCommand(), LOG, "Heartbeat", "workerId=%d", workerId);
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
@@ -13,6 +13,7 @@ package alluxio.worker.block;
 
 import alluxio.AbstractMasterClient;
 import alluxio.Constants;
+import alluxio.conf.PropertyKey;
 import alluxio.grpc.BlockHeartbeatPOptions;
 import alluxio.grpc.BlockHeartbeatPRequest;
 import alluxio.grpc.BlockIdList;
@@ -40,6 +41,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -187,8 +189,9 @@ public final class BlockMasterClient extends AbstractMasterClient {
         .addAllAddedBlocks(entryList).setOptions(options)
         .putAllLostStorage(lostStorageMap).build();
 
-    return retryRPC(() -> mClient.blockHeartbeat(request).getCommand(),
-        LOG, "Heartbeat", "workerId=%d", workerId);
+    return retryRPC(() -> mClient.withDeadlineAfter(mContext.getClusterConf()
+        .getMs(PropertyKey.WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT), TimeUnit.MILLISECONDS)
+        .blockHeartbeat(request).getCommand(), LOG, "Heartbeat", "workerId=%d", workerId);
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/file/FileSystemMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/FileSystemMasterClient.java
@@ -87,7 +87,7 @@ public final class FileSystemMasterClient extends AbstractMasterClient {
    */
   public Set<Long> getPinList() throws IOException {
     return retryRPC(() -> new HashSet<>(mClient.withDeadlineAfter(mContext.getClusterConf()
-            .getMs(PropertyKey.WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT), TimeUnit.MILLISECONDS)
+            .getMs(PropertyKey.WORKER_MASTER_PERIODICAL_RPC_TIMEOUT), TimeUnit.MILLISECONDS)
             .getPinnedFileIds(GetPinnedFileIdsPRequest.newBuilder().build())
             .getPinnedFileIdsList()),
         LOG, "GetPinList", "");

--- a/core/server/worker/src/main/java/alluxio/worker/file/FileSystemMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/file/FileSystemMasterClient.java
@@ -13,6 +13,7 @@ package alluxio.worker.file;
 
 import alluxio.AbstractMasterClient;
 import alluxio.Constants;
+import alluxio.conf.PropertyKey;
 import alluxio.grpc.FileSystemMasterWorkerServiceGrpc;
 import alluxio.grpc.GetFileInfoPRequest;
 import alluxio.grpc.GetPinnedFileIdsPRequest;
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -84,8 +86,10 @@ public final class FileSystemMasterClient extends AbstractMasterClient {
    * @return the set of pinned file ids
    */
   public Set<Long> getPinList() throws IOException {
-    return retryRPC(() -> new HashSet<>(mClient
-        .getPinnedFileIds(GetPinnedFileIdsPRequest.newBuilder().build()).getPinnedFileIdsList()),
+    return retryRPC(() -> new HashSet<>(mClient.withDeadlineAfter(mContext.getClusterConf()
+            .getMs(PropertyKey.WORKER_MASTER_PERIODICAL_CONNECT_TIMEOUT), TimeUnit.MILLISECONDS)
+            .getPinnedFileIds(GetPinnedFileIdsPRequest.newBuilder().build())
+            .getPinnedFileIdsList()),
         LOG, "GetPinList", "");
   }
 


### PR DESCRIPTION
In a cluster with multiple masters using embedded journal, when network partitioned the original leading master, leadership changes to a new leading master. The workers hang in GRPC connections with the previous leading master and don't register with the new leading master.

This PR adds the timeout to periodical connections (operations) between workers and leading masters to prevent workers from hanging forever.