### PR TITLE
Make Ratis client retry on catchup failures

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -519,6 +519,8 @@ public class RaftJournalSystem extends AbstractJournalSystem {
       try {
         future.get(5, TimeUnit.SECONDS);
       } catch (TimeoutException | ExecutionException e) {
+        client.getClientRpc().handleException(mPeerId,
+            e instanceof ExecutionException ? e.getCause() : e, true);
         LOG.info("Exception submitting term start entry: {}", e.toString());
         continue;
       }


### PR DESCRIPTION
Sometimes a Ratis client decides to timeout and close connection when master tries to gain primacy. This change makes the master to notify Ratis client to reconnect when an exception is throw, so we don't just keep retrying on a closed client.