### PR TITLE
[SMALLFIX] Remove collectInfo redundant printout

### DIFF
--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -66,7 +66,8 @@ public class CollectInfo extends AbstractShell {
   private static final String USAGE =
       "collectInfo [--max-threads <threadNum>] [--local] [--help] "
           + "[--exclude-logs <filename-prefixes>] [--include-logs <filename-prefixes>] "
-          + "[--start-time <datetime>] [--end-time <datetime>] COMMAND <outputPath>\n\n"
+          + "[--additional-logs <filename-prefixes>] [--start-time <datetime>] "
+          + "[--end-time <datetime>] COMMAND <outputPath>\n\n"
           + "collectInfo runs a set of sub-commands which collect information "
           + "about your Alluxio cluster.\nIn the end of the run, "
           + "the collected information will be written to files and bundled into one tarball.\n"

--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -64,7 +64,7 @@ import java.util.stream.Collectors;
 public class CollectInfo extends AbstractShell {
   private static final Logger LOG = LoggerFactory.getLogger(CollectInfo.class);
   private static final String USAGE =
-      "USAGE: collectInfo [--max-threads <threadNum>] [--local] [--help] "
+      "collectInfo [--max-threads <threadNum>] [--local] [--help] "
           + "[--exclude-logs <filename-prefixes>] [--include-logs <filename-prefixes>] "
           + "[--start-time <datetime>] [--end-time <datetime>] COMMAND <outputPath>\n\n"
           + "collectInfo runs a set of sub-commands which collect information "


### PR DESCRIPTION
When `collectInfo` is printing the help message in `printHelp()` the output already starts with "usage:". The extra "USAGE:" string is redundant.

Also add one missing option into the message.