### PR TITLE
Enable proxy service in the helm chart

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -138,3 +138,7 @@
 0.6.11
 
 - Pass alluxio.user.hostname via ALLUXIO_FUSE_JAVA_OPTS for FUSE
+
+0.6.12
+
+- Added options to set up proxy service next to workers

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.11
+version: 0.6.12
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
+++ b/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
@@ -75,6 +75,29 @@ resources:
     {{- end }}
 {{- end -}}
 
+{{- define "alluxio.proxy.resources" -}}
+resources:
+  limits:
+    {{- if .Values.proxy.resources.limits }}
+      {{- if .Values.proxy.resources.limits.cpu  }}
+    cpu: {{ .Values.proxy.resources.limits.cpu }}
+      {{- end }}
+      {{- if .Values.proxy.resources.limits.memory  }}
+    memory: {{ .Values.proxy.resources.limits.memory }}
+      {{- end }}
+    {{- end }}
+  requests:
+    {{- if .Values.proxy.resources.requests }}
+      {{- if .Values.proxy.resources.requests.cpu  }}
+    cpu: {{ .Values.proxy.resources.requests.cpu }}
+      {{- end }}
+      {{- if .Values.proxy.resources.requests.memory  }}
+    memory: {{ .Values.proxy.resources.requests.memory }}
+      {{- end }}
+    {{- end }}
+{{- end -}}
+
+
 {{- define "alluxio.master.resources" -}}
 resources:
   limits:
@@ -288,6 +311,12 @@ readinessProbe:
     port: rpc
 {{- end -}}
 
+{{- define "alluxio.proxy.readinessProbe" -}}
+readinessProbe:
+  tcpSocket:
+    port: web
+{{- end -}}
+
 {{- define "alluxio.jobWorker.readinessProbe" -}}
 readinessProbe:
   tcpSocket:
@@ -318,6 +347,16 @@ livenessProbe:
 livenessProbe:
   tcpSocket:
     port: rpc
+  initialDelaySeconds: 15
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 2
+{{- end -}}
+
+{{- define "alluxio.proxy.livenessProbe" -}}
+livenessProbe:
+  tcpSocket:
+    port: web
   initialDelaySeconds: 15
   periodSeconds: 30
   timeoutSeconds: 5

--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -155,6 +155,15 @@
 {{- if .Values.fuse.jvmOptions }}
   {{- $fuseJavaOpts = concat $fuseJavaOpts .Values.fuse.jvmOptions }}
 {{- end }}
+
+{{- /* ===================================== */}}
+{{- /*       ALLUXIO_PROXY_JAVA_OPTS        */}}
+{{- /* ===================================== */}}
+{{- $proxyJavaOpts := list }}
+{{- $proxyJavaOpts = print "-Dalluxio.master.hostname=${ALLUXIO_MASTER_HOSTNAME}" | append $proxyJavaOpts }}
+{{- $proxyJavaOpts = print "-Dalluxio.worker.hostname=${ALLUXIO_WORKER_HOSTNAME}" | append $proxyJavaOpts }}
+#      ALLUXIO_PROXY_JAVA_OPTS: "-Dalluxio.worker.memory.size=1G  -Dalluxio.master.hostname=alluxio-master  -Dalluxio.worker.hostname=alluxio-worker"
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -181,6 +190,9 @@ data:
   ALLUXIO_WORKER_JAVA_OPTS: |-
     {{- /* Format ALLUXIO_WORKER_JAVA_OPTS list to one line */}}
     {{ range $key := $workerJavaOpts }}{{ printf "%v " $key }}{{ end }}
+  ALLUXIO_PROXY_JAVA_OPTS: |-
+    {{- /* Format ALLUXIO_PROXY_JAVA_OPTS list to one line */}}
+    {{ range $key := $proxyJavaOpts }}{{ printf "%v " $key }}{{ end }}
   ALLUXIO_JOB_WORKER_JAVA_OPTS: |-
     {{- /* Format ALLUXIO_JOB_WORKER_JAVA_OPTS list to one line */}}
     {{ range $key := $jobWorkerJavaOpts }}{{ printf "%v " $key }}{{ end }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/proxy/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/proxy/daemonset.yaml
@@ -1,0 +1,83 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+{{- $hostNetwork := .Values.proxy.hostNetwork }}
+{{- $hostPID := .Values.proxy.hostPID }}
+{{ if .Values.proxy.enabled -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "alluxio.fullname" . }}-proxy
+  labels:
+    app: {{ template "alluxio.name" . }}
+    chart: {{ template "alluxio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    role: alluxio-proxy
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "alluxio.name" . }}
+      release: {{ .Release.Name }}
+      role: alluxio-proxy
+  template:
+    metadata:
+      labels:
+        app: {{ template "alluxio.name" . }}
+        chart: {{ template "alluxio.chart" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+        role: alluxio-proxy
+    spec:
+      hostNetwork: {{ $hostNetwork }}
+      hostPID: {{ $hostPID }}
+      dnsPolicy: {{ .Values.proxy.dnsPolicy | default ($hostNetwork | ternary "ClusterFirstWithHostNet" "ClusterFirst") }}
+      securityContext:
+        fsGroup: {{ .Values.fsGroup }}
+      nodeSelector:
+      {{- if .Values.proxy.nodeSelector }}
+{{ toYaml .Values.proxy.nodeSelector | trim | indent 8  }}
+      {{- else if .Values.nodeSelector }}
+{{ toYaml .Values.nodeSelector | trim | indent 8  }}
+      {{- end }}
+      containers:
+        - name: alluxio-proxy
+          image: {{ .Values.image }}:{{ .Values.imageTag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            runAsUser: {{ .Values.user }}
+            runAsGroup: {{ .Values.group }}
+          {{- if .Values.proxy.resources  }}
+{{ include "alluxio.proxy.resources" . | indent 10 }}
+          {{- end }}
+          command: ["/entrypoint.sh"]
+          {{- if .Values.proxy.args }}
+          args:
+{{ toYaml .Values.proxy.args | trim | indent 12 }}
+          {{- end }}
+          env:
+          - name: ALLUXIO_WORKER_HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          {{- range $key, $value := .Values.proxy.env }}
+          - name: "{{ $key }}"
+            value: "{{ $value }}"
+          {{- end }}
+          envFrom:
+          - configMapRef:
+              name: {{ template "alluxio.fullname" . }}-config
+{{ include "alluxio.proxy.readinessProbe" . | indent 10 }}
+{{ include "alluxio.proxy.livenessProbe" . | indent 10 }}
+          ports:
+          - containerPort: {{ .Values.proxy.ports.web }}
+            name: web
+{{- end }} # proxy enabled

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -197,6 +197,38 @@ jobWorker:
   # JVM options specific to the jobWorker container
   jvmOptions:
 
+
+## Proxy ##
+proxy:
+  enabled: false # Enable this to enable the proxy for REST API
+  env:
+    # Extra environment variables for the worker pod
+    # Example:
+    # JAVA_HOME: /opt/java
+  args:
+    - proxy
+  # Properties for the proxy component
+  properties:
+  resources:
+    limits:
+      cpu: "4"
+      memory: "4G"
+    requests:
+      cpu: "1"
+      memory: "2G"
+  ports:
+    web: 39999
+  # hostPID requires escalated privileges
+  hostPID: false
+  hostNetwork: false
+  # dnsPolicy will be ClusterFirstWithHostNet if hostNetwork: true
+  # and ClusterFirst if hostNetwork: false
+  # You can specify dnsPolicy here to override this inference
+  # dnsPolicy: ClusterFirst
+  # JVM options specific to the worker container
+  jvmOptions:
+  nodeSelector: {}
+
 # Tiered Storage
 # emptyDir example
 #  - level: 0


### PR DESCRIPTION
Hi,

I had a requirement to have the proxy service enabled via the helm chart, and so based off the worker configuration I've updated the template. I've tested this on my own deployment and it worked for my purposes. It could use a review in the required java environment variables for the proxy as I wasn't 100% sure of the proxy requirements, however I assumed master from the template, and the worker on the same host as the proxy.