### PR TITLE
Port changes of [#12135] to branch-2.2

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/FileSystemShellUtils.java
+++ b/shell/src/main/java/alluxio/cli/fs/FileSystemShellUtils.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -276,25 +275,24 @@ public final class FileSystemShellUtils {
   }
 
   /**
-   * The characters that have special regex semantics.
-   */
-  private static final Pattern SPECIAL_REGEX_CHARS = Pattern.compile("[{}()\\[\\].+*?^$\\\\|]");
-
-  /**
    * Escapes the special characters in a given string.
    *
    * @param str input string
    * @return the string with special characters escaped
    */
   private static String escape(String str) {
-    return SPECIAL_REGEX_CHARS.matcher(str).replaceAll("\\\\$0");
+    return str.replace(".", "%2E")
+        .replace("+", "%2B")
+        .replace("^", "%5E")
+        .replace("$", "%24")
+        .replace("*", "%2A");
   }
 
   /**
    * Replaces the wildcards with Java's regex semantics.
    */
   private static String replaceWildcards(String text) {
-    return escape(text).replace("\\*", ".*");
+    return escape(text).replace("%2A", ".*");
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
@@ -168,7 +168,7 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
    */
   @Test
   public void copyWildcardWithSpecialCharacters() throws Exception {
-    String testDir = FileSystemShellUtilsTest.resetFileHierarchy(sFileSystem);
+    String testDir = FileSystemShellUtilsTest.resetFileHierarchy(mFileSystem);
     char[] specialChars = new char[]{'.', '+', '^', '$'};
     for (char specialChar : specialChars) {
       copyWildcardWithSpecialChar(testDir, specialChar);
@@ -177,15 +177,15 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
 
   private void copyWildcardWithSpecialChar(String testDir, char specialChar) throws Exception {
     String specialFolderName = String.format("%s/folder%sname", testDir, specialChar);
-    sFsShell.run("mkdir", specialFolderName);
-    sFsShell.run("mkdir", "/result");
-    Assert.assertTrue(sFileSystem.exists(new AlluxioURI(specialFolderName)));
-    sFsShell.run("cp", testDir + "/foobar4", specialFolderName + "/foobar4");
-    Assert.assertTrue(sFileSystem.exists(new AlluxioURI(specialFolderName + "/foobar4")));
-    sFsShell.run("cp", specialFolderName + "/*", "/result/");
-    Assert.assertTrue(sFileSystem.exists(new AlluxioURI("/result/foobar4")));
-    sFsShell.run("rm", "/result/foobar4");
-    Assert.assertFalse(sFileSystem.exists(new AlluxioURI("/result/foobar4")));
+    mFsShell.run("mkdir", specialFolderName);
+    mFsShell.run("mkdir", "/result");
+    Assert.assertTrue(mFileSystem.exists(new AlluxioURI(specialFolderName)));
+    mFsShell.run("cp", testDir + "/foobar4", specialFolderName + "/foobar4");
+    Assert.assertTrue(mFileSystem.exists(new AlluxioURI(specialFolderName + "/foobar4")));
+    mFsShell.run("cp", specialFolderName + "/*", "/result/");
+    Assert.assertTrue(mFileSystem.exists(new AlluxioURI("/result/foobar4")));
+    mFsShell.run("rm", "/result/foobar4");
+    Assert.assertFalse(mFileSystem.exists(new AlluxioURI("/result/foobar4")));
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
@@ -163,6 +163,32 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
   }
 
   /**
+   * Tests copying a list of files with special characters in folder name
+   * specified through a wildcard expression.
+   */
+  @Test
+  public void copyWildcardWithSpecialCharacters() throws Exception {
+    String testDir = FileSystemShellUtilsTest.resetFileHierarchy(sFileSystem);
+    char[] specialChars = new char[]{'.', '+', '^', '$'};
+    for (char specialChar : specialChars) {
+      copyWildcardWithSpecialChar(testDir, specialChar);
+    }
+  }
+
+  private void copyWildcardWithSpecialChar(String testDir, char specialChar) throws Exception {
+    String specialFolderName = String.format("%s/folder%sname", testDir, specialChar);
+    sFsShell.run("mkdir", specialFolderName);
+    sFsShell.run("mkdir", "/result");
+    Assert.assertTrue(sFileSystem.exists(new AlluxioURI(specialFolderName)));
+    sFsShell.run("cp", testDir + "/foobar4", specialFolderName + "/foobar4");
+    Assert.assertTrue(sFileSystem.exists(new AlluxioURI(specialFolderName + "/foobar4")));
+    sFsShell.run("cp", specialFolderName + "/*", "/result/");
+    Assert.assertTrue(sFileSystem.exists(new AlluxioURI("/result/foobar4")));
+    sFsShell.run("rm", "/result/foobar4");
+    Assert.assertFalse(sFileSystem.exists(new AlluxioURI("/result/foobar4")));
+  }
+
+  /**
    * Tests copying a file with attributes preserved.
    */
   @Test


### PR DESCRIPTION
Previously if we try to use wildcard to copy files in path with special characters like '.', '+', '^', "$', '*', the cp will fail.
This test fix the escape function to escape special characters used in regrex pattern matching.

[This is an auto-generated PR to cherry-pick committed PR #12135 into target branch branch-2.2]