### PR TITLE
Implement a local first raft client for improved journal performance

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1513,6 +1513,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_CATCHUP_RETRY_WAIT =
+      new Builder(Name.MASTER_EMBEDDED_JOURNAL_CATCHUP_RETRY_WAIT)
+          .setDefaultValue("1s")
+          .setDescription("Time for embedded journal leader to wait before retrying a catch up.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_PORT =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_PORT)
           .setDescription("The port to use for embedded journal communication with other masters.")
@@ -1536,6 +1543,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_SHUTDOWN_TIMEOUT)
           .setDefaultValue("10sec")
           .setDescription("Maximum time to wait for embedded journal to stop on shutdown.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_WRITE_LOCAL_FIRST_ENABLED =
+      new Builder(Name.MASTER_EMBEDDED_JOURNAL_WRITE_LOCAL_FIRST_ENABLED)
+          .setDefaultValue(true)
+          .setDescription("Whether the journal writer will attempt to write entry locally before "
+              + "falling back to a full remote raft client.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
@@ -4947,6 +4962,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.embedded.journal.election.timeout";
     public static final String MASTER_EMBEDDED_JOURNAL_APPENDER_BATCH_SIZE =
         "alluxio.master.embedded.journal.appender.batch.size";
+    public static final String MASTER_EMBEDDED_JOURNAL_CATCHUP_RETRY_WAIT =
+        "alluxio.master.embedded.journal.catchup.retry.wait";
     public static final String MASTER_EMBEDDED_JOURNAL_HEARTBEAT_INTERVAL =
         "alluxio.master.embedded.journal.heartbeat.interval";
     public static final String MASTER_EMBEDDED_JOURNAL_PORT =
@@ -4955,6 +4972,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.embedded.journal.storage.level";
     public static final String MASTER_EMBEDDED_JOURNAL_SHUTDOWN_TIMEOUT =
         "alluxio.master.embedded.journal.shutdown.timeout";
+    public static final String MASTER_EMBEDDED_JOURNAL_WRITE_LOCAL_FIRST_ENABLED =
+        "alluxio.master.embedded.journal.write.local.first.enabled";
     public static final String MASTER_EMBEDDED_JOURNAL_WRITE_TIMEOUT =
         "alluxio.master.embedded.journal.write.timeout";
     public static final String MASTER_EMBEDDED_JOURNAL_SNAPSHOT_REPLICATION_CHUNK_SIZE =

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
@@ -1,0 +1,128 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.journal.raft;
+
+import alluxio.util.LogUtils;
+
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.protocol.AlreadyClosedException;
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.Message;
+import org.apache.ratis.protocol.NotLeaderException;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftClientRequest;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.util.TimeDuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+/**
+ * A client to send messages to a raft server with a strategy to attempt sending them locally first.
+ */
+public class LocalFirstRaftClient implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(LocalFirstRaftClient.class);
+  private final RaftServer mServer;
+  private final Supplier<RaftClient> mClientSupplier;
+  private ClientId mClientId;
+  private volatile RaftClient mClient;
+
+  /**
+   * @param server the local raft server
+   * @param clientSupplier a function for building a remote raft client
+   * @param clientId the client id
+   */
+  public LocalFirstRaftClient(RaftServer server, Supplier<RaftClient> clientSupplier,
+      ClientId clientId) {
+    mServer = server;
+    mClientSupplier = clientSupplier;
+    mClientId = clientId;
+  }
+
+  /**
+   * Sends a request to raft server asynchronously.
+   * @param message the message to send
+   * @param timeout the time duration to wait before giving up on the request
+   * @return a future of the server reply
+   * @throws IOException if an exception occured while sending the request
+   */
+  public CompletableFuture<RaftClientReply> sendAsync(Message message,
+      TimeDuration timeout) throws IOException {
+    if (mClient == null) {
+      return sendLocalRequest(message, timeout);
+    } else {
+      return sendRemoteRequest(message);
+    }
+  }
+
+  private CompletableFuture<RaftClientReply> sendLocalRequest(Message message,
+      TimeDuration timeout) throws IOException {
+    return mServer.submitClientRequestAsync(
+        new RaftClientRequest(mClientId, null, RaftJournalSystem.RAFT_GROUP_ID,
+            RaftJournalSystem.nextCallId(), message, RaftClientRequest.writeRequestType(), null))
+        .thenApply(reply -> handleLocalException(message, reply, timeout));
+  }
+
+  private RaftClientReply handleLocalException(Message message, RaftClientReply reply,
+      TimeDuration timeout) {
+    if (reply.getException() != null) {
+      if (reply.getException() instanceof NotLeaderException) {
+        LOG.info("Local master is no longer a leader, falling back to remote client.");
+        try {
+          return sendRemoteRequest(message).get(timeout.getDuration(), timeout.getUnit());
+        } catch (InterruptedException | TimeoutException e) {
+          throw new CompletionException(e);
+        } catch (ExecutionException e) {
+          throw new CompletionException(e.getCause());
+        }
+      }
+      throw new CompletionException(reply.getException());
+    }
+    return reply;
+  }
+
+  private CompletableFuture<RaftClientReply> sendRemoteRequest(Message message) {
+    ensureClient();
+    return mClient.sendAsync(message).exceptionally(t -> {
+      if (t instanceof ExecutionException && t.getCause() instanceof AlreadyClosedException) {
+        // create a new client
+        try {
+          mClient.close();
+        } catch (IOException e) {
+          LogUtils.warnWithException(LOG, "Failed to close client: {}", e.getMessage());
+        }
+        mClient = mClientSupplier.get();
+      }
+      throw new CompletionException(t.getCause());
+    });
+  }
+
+  private void ensureClient() {
+    if (mClient == null) {
+      mClient = mClientSupplier.get();
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (mClient != null) {
+      mClient.close();
+    }
+  }
+}

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
@@ -11,6 +11,8 @@
 
 package alluxio.master.journal.raft;
 
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
 import alluxio.util.LogUtils;
 
 import org.apache.ratis.client.RaftClient;
@@ -47,12 +49,16 @@ public class LocalFirstRaftClient implements Closeable {
    * @param server the local raft server
    * @param clientSupplier a function for building a remote raft client
    * @param clientId the client id
+   * @param configuration the server configuration
    */
   public LocalFirstRaftClient(RaftServer server, Supplier<RaftClient> clientSupplier,
-      ClientId clientId) {
+      ClientId clientId, InstancedConfiguration configuration) {
     mServer = server;
     mClientSupplier = clientSupplier;
     mClientId = clientId;
+    if (!configuration.getBoolean(PropertyKey.MASTER_EMBEDDED_JOURNAL_WRITE_LOCAL_FIRST_ENABLED)) {
+      ensureClient();
+    }
   }
 
   /**

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
@@ -101,7 +101,7 @@ public class LocalFirstRaftClient implements Closeable {
     ensureClient();
     return mClient.sendAsync(message).exceptionally(t -> {
       if (t instanceof ExecutionException && t.getCause() instanceof AlreadyClosedException) {
-        // create a new client
+        // create a new client if the current client is already closed
         try {
           mClient.close();
         } catch (IOException e) {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -377,8 +377,8 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     private ClientId mClientId;
 
     RaftLocalClient(RaftServer server, ClientId clientId) {
-      this.mServer = server;
-      this.mClientId = clientId;
+      mServer = server;
+      mClientId = clientId;
     }
 
     public CompletableFuture<RaftClientReply> sendRequestAsync(

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -148,7 +148,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class RaftJournalSystem extends AbstractJournalSystem {
-  public static final UUID RAFT_GROUP_ID = UUID.fromString("02511d47-d67c-49a3-9011-abb3109a44c1");
+  public static final UUID RAFT_GROUP_UUID =
+      UUID.fromString("02511d47-d67c-49a3-9011-abb3109a44c1");
 
   private static final Logger LOG = LoggerFactory.getLogger(RaftJournalSystem.class);
 
@@ -201,7 +202,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   private final AtomicReference<AsyncJournalWriter> mAsyncJournalWriter;
   private final ClientId mClientId = ClientId.randomId();
   private RaftGroup mRaftGroup;
-  private RaftGroupId mRaftGroupId;
+  private static final RaftGroupId RAFT_GROUP_ID = RaftGroupId.valueOf(RAFT_GROUP_UUID);
   private RaftPeerId mPeerId;
 
   private static long nextCallId() {
@@ -267,8 +268,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     Set<RaftPeer> peers = addresses.stream()
         .map(addr -> new RaftPeer(RaftJournalUtils.getPeerId(addr), addr))
         .collect(Collectors.toSet());
-    mRaftGroupId = RaftGroupId.valueOf(RAFT_GROUP_ID);
-    mRaftGroup = RaftGroup.valueOf(mRaftGroupId, peers);
+    mRaftGroup = RaftGroup.valueOf(RAFT_GROUP_ID, peers);
 
     RaftProperties properties = new RaftProperties();
 
@@ -331,6 +331,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     RaftProperties properties = new RaftProperties();
     RaftClientConfigKeys.Rpc.setRequestTimeout(properties,
         TimeDuration.valueOf(15, TimeUnit.SECONDS));
+    RaftClientConfigKeys.Async.setOutstandingRequestsMax(properties, 100);
     RetryPolicy retryPolicy = ExponentialBackoffRetry.newBuilder()
         .setBaseSleepTime(TimeDuration.valueOf(100, TimeUnit.MILLISECONDS))
         .setMaxAttempts(10)
@@ -355,31 +356,38 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   @Override
   public synchronized void gainPrimacy() {
     mSnapshotAllowed.set(false);
-    RaftClient client = createClient();
-    Runnable closeClient = () -> {
-      try {
-        client.close();
-      } catch (IOException e) {
-        LOG.warn("Failed to close raft client: {}", e.toString());
-      }
-    };
-
-    try {
+    try (RaftClient client = createClient()) {
       catchUp(mStateMachine, client);
-    } catch (TimeoutException e) {
-      closeClient.run();
+    } catch (TimeoutException | IOException e) {
       throw new RuntimeException(e);
     } catch (InterruptedException e) {
-      closeClient.run();
       Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     }
     long nextSN = mStateMachine.upgrade() + 1;
 
     Preconditions.checkState(mRaftJournalWriter == null);
-    mRaftJournalWriter = new RaftJournalWriter(nextSN, client);
+    mRaftJournalWriter = new RaftJournalWriter(nextSN, new RaftLocalClient(mServer, mClientId));
     mAsyncJournalWriter
         .set(new AsyncJournalWriter(mRaftJournalWriter, () -> getJournalSinks(null)));
+  }
+
+  static class RaftLocalClient {
+    private RaftServer mServer;
+    private ClientId mClientId;
+
+    RaftLocalClient(RaftServer server, ClientId clientId) {
+      this.mServer = server;
+      this.mClientId = clientId;
+    }
+
+    public CompletableFuture<RaftClientReply> sendRequestAsync(
+        RaftPeerId server, Message message) throws IOException {
+      return mServer.submitClientRequestAsync(
+          new RaftClientRequest(mClientId, server, RAFT_GROUP_ID, nextCallId(), message,
+              RaftClientRequest.writeRequestType(), null)
+      );
+    }
   }
 
   @Override
@@ -681,7 +689,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
       RaftPeerId server, Message message) {
     RaftClient client = createClient();
     return client.getClientRpc().sendRequestAsync(
-        new RaftClientRequest(mClientId, server, mRaftGroupId, nextCallId(), message,
+        new RaftClientRequest(mClientId, server, RAFT_GROUP_ID, nextCallId(), message,
             RaftClientRequest.staleReadRequestType(0), null)
     ).whenComplete((reply, t) -> {
       try {
@@ -694,7 +702,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
 
   private GroupInfoReply getGroupInfo() throws IOException {
     GroupInfoRequest groupInfoRequest = new GroupInfoRequest(mClientId,
-        mPeerId, mRaftGroupId, nextCallId());
+        mPeerId, RAFT_GROUP_ID, nextCallId());
     return mServer.getGroupInfo(groupInfoRequest);
   }
 
@@ -748,7 +756,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     List<RaftPeer> newPeers = new ArrayList<>(peers);
     newPeers.add(newPeer);
     RaftClientReply reply = mServer.setConfiguration(
-        new SetConfigurationRequest(mClientId, mPeerId, mRaftGroupId, nextCallId(), newPeers));
+        new SetConfigurationRequest(mClientId, mPeerId, RAFT_GROUP_ID, nextCallId(), newPeers));
     if (reply.getException() != null) {
       throw reply.getException();
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
@@ -15,12 +15,12 @@ import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.JournalClosedException;
 import alluxio.master.journal.JournalWriter;
-import alluxio.proto.journal.Journal;
 import alluxio.proto.journal.Journal.JournalEntry;
 
 import com.google.common.base.Preconditions;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,7 +96,8 @@ public class RaftJournalWriter implements JournalWriter {
         // LOG.info("{} - Sending request {}", this, entry);
         Message message = RaftJournalSystem.toRaftMessage(entry);
         mLastSubmittedSequenceNumber.set(flushSN);
-        RaftClientReply reply = mClient.sendRequestAsync(message)
+        RaftClientReply reply = mClient
+            .sendRequestAsync(message, TimeDuration.valueOf(mWriteTimeoutMs, TimeUnit.MILLISECONDS))
             .get(mWriteTimeoutMs, TimeUnit.MILLISECONDS);
         mLastCommittedSequenceNumber.set(flushSN);
         if (reply.getException() != null) {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
@@ -53,11 +53,11 @@ public class RaftJournalWriter implements JournalWriter {
 
   /**
    * @param nextSequenceNumberToWrite the sequence number for the writer to begin writing at
-   * @param client client for writing entries to the journal
+   * @param client client for writing entries to the journal; the constructed journal writer owns
+   *               this client and is responsible for closing it
    */
   public RaftJournalWriter(long nextSequenceNumberToWrite,
       LocalFirstRaftClient client) {
-    // LOG.info("new journal writer {}", this);
     mNextSequenceNumberToWrite = new AtomicLong(nextSequenceNumberToWrite);
     mLastSubmittedSequenceNumber = new AtomicLong(-1);
     mLastCommittedSequenceNumber = new AtomicLong(-1);
@@ -93,7 +93,6 @@ public class RaftJournalWriter implements JournalWriter {
         // number when applying them. This could happen if submit fails and we re-submit the same
         // entry on retry.
         JournalEntry entry = mJournalEntryBuilder.build();
-        // LOG.info("{} - Sending request {}", this, entry);
         Message message = RaftJournalSystem.toRaftMessage(entry);
         mLastSubmittedSequenceNumber.set(flushSN);
         RaftClientReply reply = mClient

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
@@ -46,7 +46,7 @@ public class RaftJournalWriter implements JournalWriter {
   private final AtomicLong mLastSubmittedSequenceNumber;
   private final AtomicLong mLastCommittedSequenceNumber;
 
-  private final RaftJournalSystem.LocalFirstClient mClient;
+  private final LocalFirstRaftClient mClient;
 
   private volatile boolean mClosed;
   private JournalEntry.Builder mJournalEntryBuilder;
@@ -56,7 +56,7 @@ public class RaftJournalWriter implements JournalWriter {
    * @param client client for writing entries to the journal
    */
   public RaftJournalWriter(long nextSequenceNumberToWrite,
-      RaftJournalSystem.LocalFirstClient client) {
+      LocalFirstRaftClient client) {
     // LOG.info("new journal writer {}", this);
     mNextSequenceNumberToWrite = new AtomicLong(nextSequenceNumberToWrite);
     mLastSubmittedSequenceNumber = new AtomicLong(-1);
@@ -97,7 +97,7 @@ public class RaftJournalWriter implements JournalWriter {
         Message message = RaftJournalSystem.toRaftMessage(entry);
         mLastSubmittedSequenceNumber.set(flushSN);
         RaftClientReply reply = mClient
-            .sendRequestAsync(message, TimeDuration.valueOf(mWriteTimeoutMs, TimeUnit.MILLISECONDS))
+            .sendAsync(message, TimeDuration.valueOf(mWriteTimeoutMs, TimeUnit.MILLISECONDS))
             .get(mWriteTimeoutMs, TimeUnit.MILLISECONDS);
         mLastCommittedSequenceNumber.set(flushSN);
         if (reply.getException() != null) {

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -71,7 +71,8 @@ public class RaftJournalTest {
       mFollowerJournalSystem = journalSystems.get(0);
     }
     // Transition primary journal to primacy state.
-    // This is required because primary selector is not used in this test.
+    mFollowerJournalSystem.notifyLeadershipStateChanged(false);
+    mLeaderJournalSystem.notifyLeadershipStateChanged(true);
     mLeaderJournalSystem.gainPrimacy();
   }
 
@@ -318,6 +319,8 @@ public class RaftJournalTest {
     // Assert that no entries applied by suspended journal system.
     Assert.assertEquals(0, countingMaster.getApplyCount());
     // Gain primacy in follower journal and validate it catches up.
+    mLeaderJournalSystem.notifyLeadershipStateChanged(false);
+    mFollowerJournalSystem.notifyLeadershipStateChanged(true);
     mFollowerJournalSystem.gainPrimacy();
     CommonUtils.waitFor(
         "full state acquired after resume", () -> mFollowerJournalSystem.getCurrentSequenceNumbers()
@@ -359,6 +362,8 @@ public class RaftJournalTest {
 
     Assert.assertEquals(catchupIndex + 1, countingMaster.getApplyCount());
     // Gain primacy in follower journal and validate it catches up.
+    mLeaderJournalSystem.notifyLeadershipStateChanged(false);
+    mFollowerJournalSystem.notifyLeadershipStateChanged(true);
     mFollowerJournalSystem.gainPrimacy();
     CommonUtils.waitFor("full state acquired after resume",
         () -> countingMaster.getApplyCount() == entryCount, mWaitOptions);
@@ -408,6 +413,8 @@ public class RaftJournalTest {
         mWaitOptions);
 
     // Gain primacy in follower journal and validate it catches up.
+    mLeaderJournalSystem.notifyLeadershipStateChanged(false);
+    mFollowerJournalSystem.notifyLeadershipStateChanged(true);
     mFollowerJournalSystem.gainPrimacy();
     // Can't use countingMaster because Raft stops applying entries for primary journals.
     // Using JournalSystem#getCurrentSequences() API instead.

--- a/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
@@ -108,7 +108,7 @@ public class RaftJournalDumper extends AbstractJournalDumper {
   }
 
   private File getJournalDir() {
-    return new File(mInputDir, RaftJournalSystem.RAFT_GROUP_ID.toString());
+    return new File(mInputDir, RaftJournalSystem.RAFT_GROUP_UUID.toString());
   }
 
   private void readRatisSnapshotFromDir() throws IOException {

--- a/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
+++ b/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
@@ -217,7 +217,7 @@ public class JournalToolTest extends BaseIntegrationTest {
 
   private long getCurrentRatisSnapshotIndex(String journalFolder) throws Throwable {
     try (RaftStorage storage = new RaftStorage(
-        new File(journalFolder, RaftJournalSystem.RAFT_GROUP_ID.toString()),
+        new File(journalFolder, RaftJournalSystem.RAFT_GROUP_UUID.toString()),
         RaftServerConstants.StartupOption.REGULAR)) {
       SimpleStateMachineStorage stateMachineStorage = new SimpleStateMachineStorage();
       stateMachineStorage.init(storage);

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTest.java
@@ -129,7 +129,7 @@ public final class EmbeddedJournalIntegrationTest extends BaseIntegrationTest {
     }
     int primaryMasterIndex = mCluster.getPrimaryMasterIndex(5000);
     String leaderJournalPath = mCluster.getJournalDir(primaryMasterIndex);
-    File raftDir = new File(leaderJournalPath, RaftJournalSystem.RAFT_GROUP_ID.toString());
+    File raftDir = new File(leaderJournalPath, RaftJournalSystem.RAFT_GROUP_UUID.toString());
     waitForSnapshot(raftDir);
     mCluster.stopMasters();
 
@@ -168,7 +168,7 @@ public final class EmbeddedJournalIntegrationTest extends BaseIntegrationTest {
     FileUtils.deleteDirectory(catchupJournalDir);
     assertTrue(catchupJournalDir.mkdirs());
     mCluster.startMaster(catchUpMasterIndex);
-    File raftDir = new File(catchupJournalDir, RaftJournalSystem.RAFT_GROUP_ID.toString());
+    File raftDir = new File(catchupJournalDir, RaftJournalSystem.RAFT_GROUP_UUID.toString());
     waitForSnapshot(raftDir);
     mCluster.stopMaster(catchUpMasterIndex);
     SimpleStateMachineStorage storage = new SimpleStateMachineStorage();


### PR DESCRIPTION
Current the raft client for writing journal entries will always checking for leadership and send the request through network interface, introducing significant overhead. This change implements a raft client which attempts sending messages directly to local server first, and falls back to the default client if the local server is no longer a leader.

The client also has built-in retry function for raft client which is closed due to timeout.