### PR TITLE
Avoid reloading old snapshots

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -244,6 +244,7 @@ public class JournalStateMachine extends BaseStateMachine {
       throw new IllegalStateException("Cannot obtain raft log index", e);
     }
   }
+
   @Override
   public CompletableFuture<TermIndex> notifyInstallSnapshotFromLeader(
       RaftProtos.RoleInfoProto roleInfoProto, TermIndex firstTermIndexInLog) {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -257,7 +257,7 @@ public class JournalStateMachine extends BaseStateMachine {
       long latestJournalIndex = getNextIndex() - 1;
       if (latestJournalIndex >= snapshotIndex.getIndex()) {
         // do not reload the state machine if the downloaded snapshot is older than the latest entry
-        // do it after installation so the leader will stop sending the same request
+        // fail the request after installation so the leader will stop sending the same request
         throw new IllegalArgumentException(
             String.format("Downloaded snapshot index %d is older than the latest entry index %d",
                 getNextIndex(), firstTermIndexInLog.getIndex()));


### PR DESCRIPTION
Ratis leader sometimes send a request to a follower to install a snapshot that is older than the follower's log. This change implements a check to avoid reloading the state machine after such snapshots are downloaded to prevent some accounting issue.