### PR TITLE
Port [#11783] to branch-2.3

### DIFF
--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.Constructor;
@@ -826,6 +827,29 @@ public final class CommonUtils {
     } catch (IOException e) {
       return false;
     }
+  }
+
+  /**
+   * Recursively lists a local dir and all its subdirs and return all the files.
+   *
+   * @param dir the directory
+   * @return a list of all the files
+   * */
+  public static List<File> recursiveListLocalDir(File dir) {
+    File[] files = dir.listFiles();
+    // File#listFiles can return null when the path is invalid
+    if (files == null) {
+      return Collections.emptyList();
+    }
+    List<File> result = new ArrayList<>(files.length);
+    for (File f : files) {
+      if (f.isDirectory()) {
+        result.addAll(recursiveListLocalDir(f));
+        continue;
+      }
+      result.add(f);
+    }
+    return result;
   }
 
   private CommonUtils() {} // prevent instantiation

--- a/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
@@ -25,6 +25,7 @@ import alluxio.security.group.CachedGroupMapping;
 import alluxio.security.group.GroupMappingService;
 
 import com.google.common.collect.Lists;
+import com.google.common.io.Files;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,12 +34,14 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
@@ -624,6 +627,36 @@ public class CommonUtilsTest {
           WaitForOptions.defaults().setInterval(10).setTimeoutMs(1000));
     } finally {
       service.shutdownNow();
+    }
+  }
+
+  @Test
+  public void recursiveList() throws Exception {
+    File tmpDirFile = Files.createTempDir();
+    tmpDirFile.deleteOnExit();
+
+    Set<File> allFiles = new HashSet<>();
+    // Create 10 files at randomly deep level in the directory
+    for (int i = 0; i < 10; i++) {
+      createFileOrDir(tmpDirFile, i, new Random(), allFiles);
+    }
+
+    List<File> listedFiles = CommonUtils.recursiveListLocalDir(tmpDirFile);
+    assertEquals(allFiles, new HashSet<>(listedFiles));
+  }
+
+  private void createFileOrDir(File dir, int index, Random rand, Set<File> files)
+          throws IOException {
+    int childType = rand.nextInt(2);
+    File child = new File(dir, index + "");
+    if (childType == 1) {
+      // The child is a directory, go deeper into it
+      child.mkdir();
+      createFileOrDir(child, index, rand, files);
+    } else {
+      // The child is a file
+      child.createNewFile();
+      files.add(child);
     }
   }
 }

--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -19,6 +19,7 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
+import alluxio.exception.AlluxioException;
 import alluxio.shell.CommandReturn;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.ShellUtils;
@@ -34,12 +35,14 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -61,7 +64,9 @@ import java.util.stream.Collectors;
 public class CollectInfo extends AbstractShell {
   private static final Logger LOG = LoggerFactory.getLogger(CollectInfo.class);
   private static final String USAGE =
-      "USAGE: collectInfo [--max-threads <threadNum>] [--local] [--help] COMMAND <outputPath>\n\n"
+      "USAGE: collectInfo [--max-threads <threadNum>] [--local] [--help] "
+          + "[--exclude-logs <filename-prefixes>] [--include-logs <filename-prefixes>] "
+          + "[--start-time <datetime>] [--end-time <datetime>] COMMAND <outputPath>\n\n"
           + "collectInfo runs a set of sub-commands which collect information "
           + "about your Alluxio cluster.\nIn the end of the run, "
           + "the collected information will be written to files and bundled into one tarball.\n"
@@ -87,9 +92,10 @@ public class CollectInfo extends AbstractShell {
   // CMD_ALIAS map.
   private static final Set<String> UNSTABLE_ALIAS = ImmutableSet.of();
 
+  private static final String TARBALL_NAME = "alluxio-info.tar.gz";
+  private ExecutorService mExecutor;
+
   private static final String MAX_THREAD_OPTION_NAME = "max-threads";
-  private static final String LOCAL_OPTION_NAME = "local";
-  private static final String HELP_OPTION_NAME = "help";
   private static final Option THREAD_NUM_OPTION =
           Option.builder().required(false).longOpt(MAX_THREAD_OPTION_NAME).hasArg(true)
                   .desc("the number of threads this command uses\n"
@@ -97,22 +103,45 @@ public class CollectInfo extends AbstractShell {
                           + "Use a smaller number to constrain the network IO when "
                           + "transmitting tarballs.")
                   .build();
+  private static final String LOCAL_OPTION_NAME = "local";
   private static final Option LOCAL_OPTION =
           Option.builder().required(false).longOpt(LOCAL_OPTION_NAME).hasArg(false)
                   .desc("specifies this command should only collect information "
                           + "about the localhost")
                   .build();
+  private static final String HELP_OPTION_NAME = "help";
   private static final Option HELP_OPTION =
           Option.builder().required(false).longOpt(HELP_OPTION_NAME).hasArg(false)
                   .desc("shows the help message").build();
-  private static final Options OPTIONS = new Options()
+  // Build the options for collectInfo, then aggregate local options for each sub-command
+  private static final Options OPTIONS = loadOptions(new Options()
           .addOption(THREAD_NUM_OPTION)
           .addOption(LOCAL_OPTION)
-          .addOption(HELP_OPTION);
+          .addOption(HELP_OPTION));
 
-  private static final String TARBALL_NAME = "alluxio-info.tar.gz";
-
-  private ExecutorService mExecutor;
+  // Load the options defined in each sub-command class
+  private static Options loadOptions(Options options) {
+    Reflections reflections = new Reflections(Command.class.getPackage().getName());
+    for (Class<? extends Command> cls : reflections.getSubTypesOf(Command.class)) {
+      try {
+        for (Field f : cls.getDeclaredFields()) {
+          if (f.getName().equals("OPTIONS")) {
+            Options clsOptions = ((Options) f.get(null));
+            if (clsOptions == null) {
+              continue;
+            }
+            for (Option o : clsOptions.getOptions()) {
+              options.addOption(o);
+            }
+          }
+        }
+      } catch (IllegalAccessException e) {
+        LOG.warn("Failed to load OPTIONS from class {}: {}",
+                cls.getCanonicalName(), e.getMessage());
+      }
+    }
+    return options;
+  }
 
   /**
    * Creates a new instance of {@link CollectInfo}.
@@ -208,6 +237,22 @@ public class CollectInfo extends AbstractShell {
     System.exit(ret);
   }
 
+  // Convert the command line back to a list of arguments
+  private List<String> cmdLineToArgs(CommandLine cmd) {
+    List<String> args = new ArrayList<>();
+    for (Option opt : cmd.getOptions()) {
+      if (opt.equals(LOCAL_OPTION) || opt.equals(THREAD_NUM_OPTION)) {
+        continue;
+      }
+      args.add("--" + opt.getLongOpt());
+      if (opt.hasArg()) {
+        args.add(opt.getValue());
+      }
+    }
+    args.addAll(cmd.getArgList());
+    return args;
+  }
+
   /**
    * Finds all nodes in the cluster.
    * Then invokes collectInfo with --local option on each of them locally.
@@ -248,7 +293,9 @@ public class CollectInfo extends AbstractShell {
 
         String[] collectInfoArgs =
                 (String[]) ArrayUtils.addAll(
-                        new String[]{alluxioBinPath, "collectInfo", "--local"}, args);
+                        new String[]{alluxioBinPath, "collectInfo", "--local"},
+                        cmdLineToArgs(cmdLine).toArray(new String[0]));
+        System.out.format("Invoking command %s%n", Arrays.toString(collectInfoArgs));
         try {
           CommandReturn cr = ShellUtils.sshExecCommandWithOutput(host, collectInfoArgs);
           return cr;
@@ -288,7 +335,7 @@ public class CollectInfo extends AbstractShell {
         String fromPath = Paths.get(targetDir, CollectInfo.TARBALL_NAME)
                 .toAbsolutePath().toString();
         String toPath = tarballFromHost.getAbsolutePath();
-        LOG.debug("Copying %s:%s to %s", host, fromPath, toPath);
+        LOG.debug("Copying {}:{} to {}", host, fromPath, toPath);
 
         try {
           CommandReturn cr =
@@ -296,7 +343,7 @@ public class CollectInfo extends AbstractShell {
           return cr;
         } catch (IOException e) {
           // An unexpected error occurred that caused this IOException
-          LOG.error("Execution failed %s", e);
+          LOG.error("Execution failed on {}", e);
           return new CommandReturn(1, e.toString());
         }
       }, mExecutor);
@@ -358,27 +405,38 @@ public class CollectInfo extends AbstractShell {
       for (Command cmd : getCommands()) {
         System.out.format("Executing %s%n", cmd.getCommandName());
 
-        // TODO(jiacheng): phase 2 handle argv difference?
         // Replace the action with the command to execute
         childArgs[0] = cmd.getCommandName();
-        int childRet = executeAndAddFile(childArgs, filesToCollect);
-
-        // If any of the commands failed, treat as failed
-        if (ret == 0 && childRet != 0) {
-          System.err.format("Command %s failed%n", cmd.getCommandName());
-          ret = childRet;
+        // Do the best effort to finish all other commands if one fails
+        try {
+          int childRet = executeAndAddFile(childArgs, cmdLine, filesToCollect);
+          // If any of the commands failed, treat as failed
+          if (ret == 0 && childRet != 0) {
+            System.err.format("Command %s failed%n", cmd.getCommandName());
+            ret = childRet;
+          }
+        } catch (AlluxioException e) {
+          System.err.format("Command %s failed with exception:%n", cmd.getCommandName());
+          e.printStackTrace(System.err);
         }
       }
     } else {
       // Case 2. Execute a single command
-      int childRet = executeAndAddFile(args, filesToCollect);
-      if (ret == 0 && childRet != 0) {
-        ret = childRet;
+      try {
+        int childRet = executeAndAddFile(args, cmdLine, filesToCollect);
+        if (childRet != 0) {
+          ret = childRet;
+        }
+      } catch (AlluxioException e) {
+        System.err.format("Command failed with exception:%n");
+        e.printStackTrace(System.err);
+        return 1;
       }
     }
 
     // TODO(jiacheng): phase 2 add an option to disable bundle
     // Generate bundle
+    System.out.format("Files to collect: %s%n", filesToCollect);
     System.out.format("Archiving dir %s%n", targetDirPath);
 
     String tarballPath = Paths.get(targetDirPath, TARBALL_NAME).toAbsolutePath().toString();
@@ -392,10 +450,12 @@ public class CollectInfo extends AbstractShell {
     return ret;
   }
 
-  private int executeAndAddFile(String[] argv, List<File> filesToCollect) throws IOException {
+  private int executeAndAddFile(String[] argv, CommandLine cmdLine, List<File> filesToCollect)
+          throws IOException, AlluxioException {
     // The argv length has been validated
     String subCommand = argv[0];
     String targetDirPath = argv[1];
+    System.out.format("subcommand %s targetDir %s%n", subCommand, targetDirPath);
 
     AbstractCollectInfoCommand cmd = this.findCommand(subCommand);
 
@@ -404,7 +464,7 @@ public class CollectInfo extends AbstractShell {
       printHelp(String.format("%s is an unknown command.%n", subCommand));
       return 1;
     }
-    int ret = run(argv);
+    int ret = cmd.run(cmdLine);
 
     // File to collect
     File infoCmdOutputFile = cmd.generateOutputFile(targetDirPath,
@@ -492,11 +552,10 @@ public class CollectInfo extends AbstractShell {
   @Override
   protected Map<String, Command> loadCommands() {
     // Give each command the configuration
-    Map<String, Command> commands = CommandUtils.loadCommands(
+    return CommandUtils.loadCommands(
             CollectInfo.class.getPackage().getName(),
             new Class[] {FileSystemContext.class},
             new Object[] {FileSystemContext.create(mConfiguration)});
-    return commands;
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/bundler/command/AbstractCollectInfoCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/AbstractCollectInfoCommand.java
@@ -56,12 +56,16 @@ public abstract class AbstractCollectInfoCommand implements Command {
    * */
   public String getWorkingDirectory(CommandLine cl) {
     String[] args = cl.getArgs();
-    String baseDirPath = args[0];
+    String baseDirPath = args[1];
     String workingDirPath =  Paths.get(baseDirPath, this.getCommandName()).toString();
     LOG.debug("Command %s works in %s", this.getCommandName(), workingDirPath);
     // mkdirs checks existence of the path
     File workingDir = new File(workingDirPath);
-    workingDir.mkdirs();
+    if (!workingDir.exists()) {
+
+      System.out.format("Creating working directory: %s%n", workingDirPath);
+      workingDir.mkdirs();
+    }
     return workingDirPath;
   }
 

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectAlluxioInfoCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectAlluxioInfoCommand.java
@@ -60,7 +60,10 @@ public class CollectAlluxioInfoCommand extends ExecuteShellCollectInfoCommand {
   @Override
   protected void registerCommands() {
     // TODO(jiacheng): a command to find lost blocks?
+    // alluxio getConf will mask the credential fields
     registerCommand("getConf",
+            new AlluxioCommand(mAlluxioPath, "getConf"), null);
+    registerCommand("getConf master",
             new AlluxioCommand(mAlluxioPath, "getConf --master --source"), null);
     registerCommand("fsadmin",
             new AlluxioCommand(mAlluxioPath, "fsadmin report"), null);
@@ -74,6 +77,10 @@ public class CollectAlluxioInfoCommand extends ExecuteShellCollectInfoCommand {
             new AlluxioCommand(mAlluxioPath, String.format("fs ls -R %s",
                     mFsContext.getClusterConf().get(PropertyKey.MASTER_JOURNAL_FOLDER))),
             getListJournalCommand());
+    registerCommand("runTests",
+            new AlluxioCommand(mAlluxioPath, "runTests"), null);
+    registerCommand("validateConf",
+            new AlluxioCommand(mAlluxioPath, "validateConf"), null);
   }
 
   /**

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
@@ -14,14 +14,33 @@ package alluxio.cli.bundler.command;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
+import alluxio.util.CommonUtils;
 
+import jline.internal.Nullable;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Command to collect Alluxio logs.
@@ -29,6 +48,114 @@ import java.io.IOException;
 public class CollectLogCommand  extends AbstractCollectInfoCommand {
   public static final String COMMAND_NAME = "collectLog";
   private static final Logger LOG = LoggerFactory.getLogger(CollectLogCommand.class);
+  public static final Set<String> FILE_NAMES_PREFIXES = Stream.of(
+      "master.log",
+      "master.out",
+      "job_master.log",
+      "job_master.out",
+      "master_audit.log",
+      "worker.log",
+      "worker.out",
+      "job_worker.log",
+      "job_worker.out",
+      "proxy.log",
+      "proxy.out",
+      "task.log",
+      "task.out",
+      "user"
+  ).collect(Collectors.toSet());
+  // We tolerate the beginning of a log file to contain some rows that are not timestamped.
+  // A YARN application log can have >20 rows in the beginning for
+  // general information about a job.
+  // The timestamped log entries start after this general information block.
+  private static final int TRY_PARSE_LOG_ROWS = 100;
+
+  // Preserves the order of iteration, we try the longer pattern before the shorter one.
+  // The 1st field is the DateTimeFormatter of a specific pattern.
+  // The 2nd field is the length to take from the beginning of the log entry.
+  // The length of the format string can be different from the datetime string it parses to.
+  // For example, "yyyy-MM-dd'T'HH:mm:ss.SSSXX" has length of 27 but parses to
+  // "2020-10-12T12:11:10.055+0800".
+  // Note that the single quotes around 'T' are not in the real string,
+  // and "XX" parses to the timezone, which is "+0800".
+  // The datetime parsing works only when the string matches exactly to the format.
+  private static final Map<DateTimeFormatter, Integer> FORMATTERS =
+          new LinkedHashMap<DateTimeFormatter, Integer>(){
+    {
+      // "2020-01-03 12:10:11,874"
+      put(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS"), 23);
+      // "2020-01-03 12:10:11"
+      put(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"), 19);
+      // "2020-01-03 12:10"
+      put(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"), 16);
+      // "20/01/03 12:10:11"
+      put(DateTimeFormatter.ofPattern("yy/MM/dd HH:mm:ss"), 17);
+      // "20/01/03 12:10"
+      put(DateTimeFormatter.ofPattern("yy/MM/dd HH:mm"), 14);
+      // 2020-01-03T12:10:11.874+0800
+      put(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXX"), 28);
+      // 2020-01-03T12:10:11
+      put(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"), 19);
+      // 2020-01-03T12:10
+      put(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"), 16);
+    }
+  };
+
+  private String mLogDirPath;
+  private File mLogDir;
+  private URI mLogDirUri;
+  private Set<String> mIncludedPrefix;
+  private Set<String> mExcludedPrefix;
+  private LocalDateTime mStartTime;
+  private LocalDateTime mEndTime;
+
+  public static final String INCLUDE_OPTION_NAME = "include-logs";
+  public static final String EXCLUDE_OPTION_NAME = "exclude-logs";
+  public static final String ADDITIONAL_OPTION_NAME = "additional-logs";
+  private static final Option INCLUDE_OPTION =
+          Option.builder().required(false).argName("filename-prefixes")
+                  .longOpt(INCLUDE_OPTION_NAME).hasArg(true)
+                  .desc(String.format("extra log file name prefixes to include in "
+                          + "${ALLUXIO_HOME}/logs. "
+                          + "Only the files that start with the prefix will be included.%n"
+                          + "This option should not be given in combination with --%s or --%s.%n"
+                          + "<filename-prefixes> filename prefixes, separated by comma",
+                          EXCLUDE_OPTION_NAME, ADDITIONAL_OPTION_NAME)).build();
+  private static final Option EXCLUDE_OPTION =
+          Option.builder().required(false).argName("filename-prefixes")
+                  .longOpt(EXCLUDE_OPTION_NAME).hasArg(true)
+                  .desc(String.format("log file name prefixes to exclude in ${ALLUXIO_HOME}/logs. "
+                          + "The files that start with the prefix will be excluded.%n"
+                          + "This will be checked before the additions defined in --%s.%n"
+                          + "<filename-prefixes> filename prefixes, separated by comma",
+                          ADDITIONAL_OPTION_NAME)).build();
+  private static final Option ADDITIONAL_OPTION =
+          Option.builder().required(false).argName("filename-prefixes")
+                  .longOpt(ADDITIONAL_OPTION_NAME).hasArg(true)
+                  .desc(String.format("extra log file name prefixes to include in "
+                          + "${ALLUXIO_HOME}/logs. "
+                          + "The files that start with the prefix will be included, "
+                          + "in addition to the rest of regular logs like master.log.%n"
+                          + "This will be checked after the exclusions defined in --%s.%n"
+                          + "<filename-prefixes> filename prefixes, separated by comma",
+                          EXCLUDE_OPTION_NAME)).build();
+  private static final String START_OPTION_NAME = "start-time";
+  private static final Option START_OPTION =
+          Option.builder().required(false).argName("datetime")
+                  .longOpt(START_OPTION_NAME).hasArg(true)
+                  .desc("logs that do not contain entries after this time will be ignored\n"
+                          + "<datetime> a datetime string like 2020-06-27T11:58:53 or "
+                          + "\"2020-06-27 11:58:53\"").build();
+  private static final String END_OPTION_NAME = "end-time";
+  private static final Option END_OPTION =
+          Option.builder().required(false).argName("datetime")
+                  .longOpt(END_OPTION_NAME).hasArg(true)
+                  .desc("logs that do not contain entries before this time will be ignored\n"
+                          + "<datetime> a datetime string like 2020-06-27T11:58:53").build();
+  // Class specific options are aggregated into CollectInfo with reflection
+  public static final Options OPTIONS = new Options().addOption(INCLUDE_OPTION)
+          .addOption(EXCLUDE_OPTION).addOption(ADDITIONAL_OPTION)
+          .addOption(START_OPTION).addOption(END_OPTION);
 
   /**
    * Creates a new instance of {@link CollectLogCommand}.
@@ -37,6 +164,9 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
    * */
   public CollectLogCommand(FileSystemContext fsContext) {
     super(fsContext);
+    mLogDirPath = fsContext.getClusterConf().get(PropertyKey.LOGS_DIR);
+    mLogDir = new File(mLogDirPath);
+    mLogDirUri = mLogDir.toURI();
   }
 
   @Override
@@ -53,13 +183,170 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
   public int run(CommandLine cl) throws AlluxioException, IOException {
     // Determine the working dir path
     mWorkingDirPath = getWorkingDirectory(cl);
-    String logDir = mFsContext.getClusterConf().get(PropertyKey.LOGS_DIR);
 
     // TODO(jiacheng): phase 2 Copy intelligently find security risks
-    // TODO(jiacheng): phase 2 components option
-    FileUtils.copyDirectory(new File(logDir), new File(mWorkingDirPath), true);
+    mIncludedPrefix = new HashSet<>(FILE_NAMES_PREFIXES);
+    boolean listReplaced = false;
+    // Update the list according to the options
+    if (cl.hasOption(INCLUDE_OPTION_NAME)) {
+      Set<String> toInclude = parseFileNames(cl.getOptionValue(INCLUDE_OPTION_NAME));
+      System.out.format("Only include the following filename prefixes: %s%n", toInclude);
+      mIncludedPrefix = toInclude;
+      listReplaced = true;
+    }
+    if (cl.hasOption(EXCLUDE_OPTION_NAME)) {
+      if (listReplaced) {
+        System.err.format("ERROR: Please do not use --%s when --%s is specified.%n",
+                EXCLUDE_OPTION_NAME, INCLUDE_OPTION_NAME);
+        return -1;
+      }
+      mExcludedPrefix = parseFileNames(cl.getOptionValue(EXCLUDE_OPTION_NAME));
+      System.out.format("Exclude the following filename prefixes: %s%n", mExcludedPrefix);
+    }
+    if (cl.hasOption(ADDITIONAL_OPTION_NAME)) {
+      if (listReplaced) {
+        System.err.format("ERROR: Please do not use --%s when --%s is specified.%n",
+                ADDITIONAL_OPTION_NAME, INCLUDE_OPTION_NAME);
+        return -1;
+      }
+      Set<String> toInclude = parseFileNames(cl.getOptionValue(ADDITIONAL_OPTION_NAME));
+      System.out.format("Additionally, include the following filename prefixes: %s%n", toInclude);
+      mIncludedPrefix.addAll(toInclude);
+    }
+
+    // Check file timestamps
+    boolean checkTimeStamp = false;
+    if (cl.hasOption(START_OPTION_NAME)) {
+      String startTimeStr = cl.getOptionValue(START_OPTION_NAME);
+      mStartTime = parseDateTime(startTimeStr);
+      System.out.format("Time window start: %s%n", mStartTime);
+      checkTimeStamp = true;
+    }
+    if (cl.hasOption(END_OPTION_NAME)) {
+      String endTimeStr = cl.getOptionValue(END_OPTION_NAME);
+      mEndTime = parseDateTime(endTimeStr);
+      System.out.format("Time window end: %s%n", mEndTime);
+      checkTimeStamp = true;
+    }
+    if (mStartTime != null && mEndTime != null && mStartTime.isAfter(mEndTime)) {
+      System.err.format("ERROR: Start time %s is later than end time %s!%n",
+              mStartTime, mEndTime);
+    }
+
+    if (!mLogDir.exists()) {
+      System.err.format("ERROR: Alluxio log directory %s does not exist!%n", mLogDirPath);
+      return -1;
+    }
+
+    List<File> allFiles = CommonUtils.recursiveListLocalDir(mLogDir);
+    for (File f : allFiles) {
+      String relativePath = getRelativePathToLogDir(f);
+      try {
+        if (!shouldCopy(f, relativePath, checkTimeStamp)) {
+          continue;
+        }
+        File targetFile = new File(mWorkingDirPath, relativePath);
+        FileUtils.copyFile(f, targetFile, true);
+      } catch (IOException e) {
+        System.err.format("ERROR: file %s not found %s%n", f.getCanonicalPath(), e.getMessage());
+      }
+    }
 
     return 0;
+  }
+
+  private String getRelativePathToLogDir(File f) {
+    return mLogDirUri.relativize(f.toURI()).getPath();
+  }
+
+  private boolean shouldCopy(File f, String relativePath, boolean checkTimeStamp)
+          throws IOException {
+    if (!fileNameIsWanted(relativePath)) {
+      return false;
+    }
+    if (checkTimeStamp) {
+      if (!fileTimeStampIsWanted(f)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean fileNameIsWanted(String fileName) {
+    if (mExcludedPrefix != null) {
+      for (String x : mExcludedPrefix) {
+        if (fileName.startsWith(x)) {
+          return false;
+        }
+      }
+    }
+    for (String s : mIncludedPrefix) {
+      if (fileName.startsWith(s)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Check if the file is wanted, based on the time window specified and the time of this file.
+   * We assume we want the file unless we know the file is not wanted, based on the
+   * specified time window.
+   * We infer the end time from its last modified time, assuming that is the last log entry.
+   * We infer the start time by parsing the first number of log entries, trying to identify
+   * the timestamp on the log entry.
+   * If we are not able to infer the start time, we assume it is LocalDateTime.MIN.
+   * */
+  private boolean fileTimeStampIsWanted(File f) throws IOException {
+    if (mStartTime != null) {
+      long timestamp = f.lastModified();
+      LocalDateTime fileEndTime =
+              LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.systemDefault());
+      // The file is earlier than the desired interval
+      if (mStartTime.isAfter(fileEndTime)) {
+        return false;
+      }
+    }
+    if (mEndTime != null) {
+      // Infer file start time by parsing the first bunch of rows
+      LocalDateTime fileStartTime = inferFileStartTime(f);
+      if (fileStartTime == null) {
+        fileStartTime = LocalDateTime.MIN;
+      }
+      // The file is later than the desired interval
+      if (mEndTime.isBefore(fileStartTime)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Infer the starting time of a log file by parsing the log entries from the beginning.
+   * It will try the first certain lines with various known datetime patterns.
+   *
+   * @param f log file
+   * @return the parsed datetime
+   * */
+  public static LocalDateTime inferFileStartTime(File f) throws FileNotFoundException {
+    int r = 0;
+    try (Scanner scanner = new Scanner(f)) {
+      while (scanner.hasNextLine() && r < TRY_PARSE_LOG_ROWS) {
+        String line = scanner.nextLine();
+        LocalDateTime datetime = parseDateTime(line);
+        if (datetime != null) {
+          return datetime;
+        }
+        r++;
+      }
+    }
+    return null;
+  }
+
+  private static Set<String> parseFileNames(String input) {
+    Set<String> names = new HashSet<>();
+    names.addAll(Stream.of(input.split(",")).map(String::trim).collect(Collectors.toList()));
+    return names;
   }
 
   @Override
@@ -70,5 +357,34 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
   @Override
   public String getDescription() {
     return "Collect Alluxio log files";
+  }
+
+  /**
+   * Identifies the datetime from a certain piece of log by trying various known patterns.
+   * Returns null if unable to identify a datetime.
+   *
+   * @param s a log entry
+   * @return identified datetime
+   * */
+  @Nullable
+  public static LocalDateTime parseDateTime(String s) {
+    for (Map.Entry<DateTimeFormatter, Integer> entry : FORMATTERS.entrySet()) {
+      DateTimeFormatter fmt = entry.getKey();
+      int len = entry.getValue();
+      try {
+        if (s.length() < len) {
+          continue;
+        }
+        String datePart = s.substring(0, len);
+        LocalDateTime datetime = LocalDateTime.parse(datePart, fmt);
+        return datetime;
+      } catch (DateTimeParseException e) {
+        // It just means the string is not in this format
+        continue;
+      }
+    }
+    // Unknown format here
+    LOG.warn("Unknown date format in {}", s.length() > 50 ? s.substring(0, 50) : s);
+    return null;
   }
 }

--- a/shell/src/test/java/alluxio/cli/bundler/InfoCollectorTestUtils.java
+++ b/shell/src/test/java/alluxio/cli/bundler/InfoCollectorTestUtils.java
@@ -11,6 +11,10 @@
 
 package alluxio.cli.bundler;
 
+import static org.junit.Assert.assertEquals;
+
+import alluxio.util.CommonUtils;
+
 import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -19,6 +23,9 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class InfoCollectorTestUtils {
   private static final Logger LOG = LoggerFactory.getLogger(InfoCollectorTestUtils.class);
@@ -37,12 +44,33 @@ public class InfoCollectorTestUtils {
   }
 
   public static File createFileInDir(File dir, String fileName) throws IOException {
-    File newFile = new File(Paths.get(dir.getAbsolutePath(), fileName).toString());
+    File newFile = new File(Paths.get(dir.getCanonicalPath(), fileName).toUri());
     newFile.createNewFile();
     return newFile;
   }
 
-  public static void create() {
-    Files.createTempDir();
+  public static File createDirInDir(File dir, String dirName) throws IOException {
+    File newDir = new File(Paths.get(dir.getCanonicalPath(), dirName).toUri());
+    newDir.mkdir();
+    return newDir;
+  }
+
+  public static void verifyAllFiles(File targetDir, Set<String> expectedFiles) throws IOException {
+    Set<String> copiedFiles = getAllFileNamesRelative(targetDir, targetDir);
+    assertEquals(expectedFiles, copiedFiles);
+  }
+
+  public static Set<String> getAllFileNamesRelative(File dir, File baseDir) throws IOException {
+    if (!dir.isDirectory()) {
+      throw new IOException(String.format("Expected a directory but found a file at %s%n",
+              dir.getCanonicalPath()));
+    }
+    Set<String> fileSet = new HashSet<>();
+    List<File> allFiles = CommonUtils.recursiveListLocalDir(dir);
+    for (File f : allFiles) {
+      String relativePath = baseDir.toURI().relativize(f.toURI()).toString();
+      fileSet.add(relativePath);
+    }
+    return fileSet;
   }
 }

--- a/shell/src/test/java/alluxio/cli/bundler/command/CollectAlluxioInfoCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/command/CollectAlluxioInfoCommandTest.java
@@ -52,7 +52,7 @@ public class CollectAlluxioInfoCommandTest {
     // Write to temp dir
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
-    String[] mockArgs = new String[]{targetDir.getAbsolutePath()};
+    String[] mockArgs = new String[]{cmd.getCommandName(), targetDir.getAbsolutePath()};
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
 
     // Replace commands to execute
@@ -91,7 +91,7 @@ public class CollectAlluxioInfoCommandTest {
     // Write to temp dir
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
-    String[] mockArgs = new String[]{targetDir.getAbsolutePath()};
+    String[] mockArgs = new String[]{cmd.getCommandName(), targetDir.getAbsolutePath()};
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
 
     // Replace commands to execute

--- a/shell/src/test/java/alluxio/cli/bundler/command/CollectEnvCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/command/CollectEnvCommandTest.java
@@ -52,7 +52,7 @@ public class CollectEnvCommandTest {
     // Write to temp dir
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
-    String[] mockArgs = new String[]{targetDir.getAbsolutePath()};
+    String[] mockArgs = new String[]{cmd.getCommandName(), targetDir.getAbsolutePath()};
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
 
     // Replace commands to execute
@@ -88,7 +88,7 @@ public class CollectEnvCommandTest {
     // Write to temp dir
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
-    String[] mockArgs = new String[]{targetDir.getAbsolutePath()};
+    String[] mockArgs = new String[]{cmd.getCommandName(), targetDir.getAbsolutePath()};
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
 
     // Replace commands to execute

--- a/shell/src/test/java/alluxio/cli/bundler/command/CollectLogCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/command/CollectLogCommandTest.java
@@ -11,6 +11,10 @@
 
 package alluxio.cli.bundler.command;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -19,56 +23,564 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
+import alluxio.util.CommonUtils;
 
 import org.apache.commons.cli.CommandLine;
-import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.Arrays;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class CollectLogCommandTest {
-  private static InstancedConfiguration sConf;
-  private static File sTestDir;
+  private static final int MILLISEC_TO_NANOSEC = 1_000_000;
 
-  @BeforeClass
-  public static void initConf() throws IOException {
-    sTestDir = prepareLogDir("testLog");
-    sConf = InstancedConfiguration.defaults();
-    sConf.set(PropertyKey.LOGS_DIR, sTestDir.getAbsolutePath());
+  private InstancedConfiguration mConf;
+  private File mTestDir;
+  private Set<String> mExpectedFiles;
+
+  @Before
+  public void initLogDirAndConf() throws IOException {
+    mTestDir = prepareLogDir();
+    mConf = InstancedConfiguration.defaults();
+    mConf.set(PropertyKey.LOGS_DIR, mTestDir.getAbsolutePath());
+  }
+
+  @After
+  public void emptyLogDir() {
+    mConf.unset(PropertyKey.LOGS_DIR);
+    mTestDir.delete();
   }
 
   // Prepare a temp dir with some log files
-  private static File prepareLogDir(String prefix) throws IOException {
+  private File prepareLogDir() throws IOException {
     // The dir path will contain randomness so will be different every time
-    File testConfDir = InfoCollectorTestUtils.createTemporaryDirectory();
-    InfoCollectorTestUtils.createFileInDir(testConfDir, "master.log");
-    InfoCollectorTestUtils.createFileInDir(testConfDir, "worker.log");
-    return testConfDir;
+    File testLogDir = InfoCollectorTestUtils.createTemporaryDirectory();
+    // Prepare the normal log files that normal users will have
+    for (String s : CollectLogCommand.FILE_NAMES_PREFIXES) {
+      InfoCollectorTestUtils.createFileInDir(testLogDir, s);
+    }
+    // Create some extra log files
+    InfoCollectorTestUtils.createFileInDir(testLogDir, "master.log.1");
+    InfoCollectorTestUtils.createFileInDir(testLogDir, "master.log.2");
+    InfoCollectorTestUtils.createFileInDir(testLogDir, "worker.log.backup");
+    // Remove the user file and create a directory
+    File userDir = new File(testLogDir, "user");
+    if (userDir.exists()) {
+      userDir.delete();
+    }
+    // Put logs in the user log dir
+    File userLogDir = InfoCollectorTestUtils.createDirInDir(testLogDir, "user");
+    InfoCollectorTestUtils.createFileInDir(userLogDir, "user_hadoop.log");
+    InfoCollectorTestUtils.createFileInDir(userLogDir, "user_hadoop.out");
+    InfoCollectorTestUtils.createFileInDir(userLogDir, "user_root.log");
+    InfoCollectorTestUtils.createFileInDir(userLogDir, "user_root.out");
+
+    // Set up expectation
+    Set<String> createdFiles = InfoCollectorTestUtils
+            .getAllFileNamesRelative(testLogDir, testLogDir);
+    mExpectedFiles = createdFiles;
+
+    return testLogDir;
   }
 
   @Test
-  public void logDirCopied() throws IOException, AlluxioException {
-    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(sConf));
+  public void logFilesCopied() throws IOException, AlluxioException {
+    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
 
     File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
     CommandLine mockCommandLine = mock(CommandLine.class);
-    String[] mockArgs = new String[]{targetDir.getAbsolutePath()};
+    String[] mockArgs = new String[]{cmd.getCommandName(), targetDir.getAbsolutePath()};
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
     int ret = cmd.run(mockCommandLine);
-    Assert.assertEquals(0, ret);
+    assertEquals(0, ret);
 
     // Files will be copied to sub-dir of target dir
-    File subDir = new File(Paths.get(targetDir.getAbsolutePath(), cmd.getCommandName()).toString());
+    File subDir = new File(targetDir, cmd.getCommandName());
 
-    // Check the dir copied
-    String[] files = subDir.list();
-    Arrays.sort(files);
-    String[] expectedFiles = sTestDir.list();
-    Arrays.sort(expectedFiles);
-    Assert.assertEquals(expectedFiles, files);
+    InfoCollectorTestUtils.verifyAllFiles(subDir, mExpectedFiles);
+  }
+
+  @Test
+  public void irrelevantFileIgnored() throws Exception {
+    // This file will not be copied
+    // Not included in the expected set
+    InfoCollectorTestUtils.createFileInDir(mTestDir, "irrelevant");
+
+    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
+    File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
+    CommandLine mockCommandLine = mock(CommandLine.class);
+    String[] mockArgs = new String[]{cmd.getCommandName(), targetDir.getAbsolutePath()};
+    when(mockCommandLine.getArgs()).thenReturn(mockArgs);
+    int ret = cmd.run(mockCommandLine);
+    assertEquals(0, ret);
+
+    // Files will be copied to sub-dir of target dir
+    File subDir = new File(targetDir, cmd.getCommandName());
+
+    InfoCollectorTestUtils.verifyAllFiles(subDir, mExpectedFiles);
+  }
+
+  @Test
+  public void fileNameExcluded() throws Exception {
+    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
+    File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
+    CommandLine mockCommandLine = mock(CommandLine.class);
+    String[] mockArgs = new String[]{
+            cmd.getCommandName(),
+            targetDir.getAbsolutePath()
+    };
+    when(mockCommandLine.getArgs()).thenReturn(mockArgs);
+    when(mockCommandLine.hasOption(eq("exclude-logs"))).thenReturn(true);
+    when(mockCommandLine.getOptionValue(eq("exclude-logs"))).thenReturn("master.log.1, worker");
+    int ret = cmd.run(mockCommandLine);
+    assertEquals(0, ret);
+
+    // Files will be copied to sub-dir of target dir
+    File subDir = new File(targetDir, cmd.getCommandName());
+    mExpectedFiles.remove("master.log.1");
+    mExpectedFiles.remove("worker.log");
+    mExpectedFiles.remove("worker.out");
+    mExpectedFiles.remove("worker.log.backup");
+
+    InfoCollectorTestUtils.verifyAllFiles(subDir, mExpectedFiles);
+  }
+
+  @Test
+  public void fileNameAdded() throws Exception {
+    InfoCollectorTestUtils.createFileInDir(mTestDir, "alluxio_gc.log");
+    InfoCollectorTestUtils.createFileInDir(mTestDir, "alluxio_gc.log.1");
+    InfoCollectorTestUtils.createFileInDir(mTestDir, "alluxio_gc.log.2");
+
+    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
+    File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
+    CommandLine mockCommandLine = mock(CommandLine.class);
+    String[] mockArgs = new String[]{
+            cmd.getCommandName(),
+            targetDir.getAbsolutePath()
+    };
+    when(mockCommandLine.getArgs()).thenReturn(mockArgs);
+    when(mockCommandLine.hasOption(eq("additional-logs"))).thenReturn(true);
+    when(mockCommandLine.getOptionValue(eq("additional-logs"))).thenReturn("alluxio_gc");
+    int ret = cmd.run(mockCommandLine);
+    assertEquals(0, ret);
+
+    // Files will be copied to sub-dir of target dir
+    File subDir = new File(targetDir, cmd.getCommandName());
+    mExpectedFiles.add("alluxio_gc.log");
+    mExpectedFiles.add("alluxio_gc.log.1");
+    mExpectedFiles.add("alluxio_gc.log.2");
+
+    InfoCollectorTestUtils.verifyAllFiles(subDir, mExpectedFiles);
+  }
+
+  @Test
+  public void fileNameReplaced() throws Exception {
+    InfoCollectorTestUtils.createFileInDir(mTestDir, "alluxio_gc.log");
+    InfoCollectorTestUtils.createFileInDir(mTestDir, "alluxio_gc.log.1");
+    InfoCollectorTestUtils.createFileInDir(mTestDir, "alluxio_gc.log.2");
+
+    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
+    File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
+    CommandLine mockCommandLine = mock(CommandLine.class);
+    String[] mockArgs = new String[]{
+            cmd.getCommandName(),
+            targetDir.getAbsolutePath()
+    };
+    when(mockCommandLine.getArgs()).thenReturn(mockArgs);
+    when(mockCommandLine.hasOption(eq("include-logs"))).thenReturn(true);
+    when(mockCommandLine.getOptionValue(eq("include-logs"))).thenReturn("alluxio_gc, master");
+    int ret = cmd.run(mockCommandLine);
+    assertEquals(0, ret);
+
+    // Files will be copied to sub-dir of target dir
+    File subDir = new File(targetDir, cmd.getCommandName());
+    mExpectedFiles = new HashSet<>();
+    mExpectedFiles.add("alluxio_gc.log");
+    mExpectedFiles.add("alluxio_gc.log.1");
+    mExpectedFiles.add("alluxio_gc.log.2");
+    mExpectedFiles.add("master.log");
+    mExpectedFiles.add("master.log.1");
+    mExpectedFiles.add("master.log.2");
+    mExpectedFiles.add("master.out");
+    mExpectedFiles.add("master_audit.log");
+
+    InfoCollectorTestUtils.verifyAllFiles(subDir, mExpectedFiles);
+  }
+
+  @Test
+  public void illegalSelectorCombinations() throws Exception {
+    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
+    File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
+    String[] mockArgs = new String[]{
+            cmd.getCommandName(),
+            targetDir.getAbsolutePath()
+    };
+
+    // --include-logs will replace the wanted list
+    // It is ambiguous to use it with --exclude-logs
+    CommandLine includeExclude = mock(CommandLine.class);
+    when(includeExclude.getArgs()).thenReturn(mockArgs);
+    when(includeExclude.hasOption(eq("include-logs"))).thenReturn(true);
+    when(includeExclude.getOptionValue(eq("include-logs"))).thenReturn("alluxio_gc, master");
+    when(includeExclude.hasOption(eq("exclude-logs"))).thenReturn(true);
+    when(includeExclude.getOptionValue(eq("exclude-logs"))).thenReturn("master");
+    assertNotEquals(0, cmd.run(includeExclude));
+
+    // --include-logs will replace the wanted list
+    // It is ambiguous to use it with --additional-logs
+    CommandLine includeAddition = mock(CommandLine.class);
+    when(includeAddition.getArgs()).thenReturn(mockArgs);
+    when(includeAddition.hasOption(eq("include-logs"))).thenReturn(true);
+    when(includeAddition.getOptionValue(eq("include-logs"))).thenReturn("alluxio_gc, master");
+    when(includeAddition.hasOption(eq("additional-logs"))).thenReturn(true);
+    when(includeAddition.getOptionValue(eq("additional-logs"))).thenReturn("worker");
+    assertNotEquals(0, cmd.run(includeExclude));
+  }
+
+  @Test
+  public void endTimeFilter() throws Exception {
+    // Define an issue end datetime
+    // We ignore logs that are created after this
+    LocalDateTime issueEnd = LocalDateTime.of(2020, 7, 8, 18, 0, 0);
+    DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    // Other logs all end before this issue
+    LocalDateTime logEnd = issueEnd.minusHours(1);
+    long logEndTimestamp = logEnd.toEpochSecond(ZoneOffset.UTC);
+    for (File f : CommonUtils.recursiveListLocalDir(mTestDir)) {
+      f.setLastModified(logEndTimestamp);
+    }
+
+    // Some logs are created after this time, should be ignored
+    File masterLog = new File(mTestDir, "master.log");
+    String log = "2020-07-08 18:53:45,129 INFO  CopycatServer - Server started successfully!\n"
+            + "2020-07-08 18:53:59,129 INFO  RaftJournalSystem - Started Raft Journal System..\n"
+            + "2020-07-09 00:01:59,135 INFO  DefaultMetaMaster - Standby master with address...\n"
+            + "2020-07-09 00:03:59,135 INFO  AlluxioMasterProcess - All masters started\n"
+            + "2020-07-09 01:12:59,138 INFO  AbstractPrimarySelector - Primary selector..\n"
+            + "2020-07-09 01:53:59,139 INFO  AbstractMaster - TableMaster: Stopped secondary..";
+    writeToFile(masterLog, log);
+    masterLog.setLastModified(LocalDateTime.of(2020, 7, 9, 1, 53, 59)
+            .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+
+    // Some logs overlap with the end time
+    File masterLog1 = new File(mTestDir, "master.log.1");
+    String log1 = "2020-07-08 16:53:44,639 INFO  BlockMasterFactory - Creating..\n"
+            + "2020-07-08 16:53:44,639 INFO  TableMasterFactory - Creating..\n"
+            + "2020-07-08 17:01:44,639 INFO  MetaMasterFactory - Creating..\n"
+            + "2020-07-08 17:01:45,639 INFO  FileSystemMasterFactory - Creating..\n"
+            + "2020-07-08 18:53:44,751 INFO  UnderDatabaseRegistry - Registered UDBs: hive,glue\n"
+            + "2020-07-08 18:53:44,756 INFO  LayoutRegistry - Registered Table Layouts: hive";
+    writeToFile(masterLog1, log1);
+    masterLog1.setLastModified(LocalDateTime.of(2020, 7, 8, 18, 53, 45)
+            .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+
+    // Some logs end before this end time
+    File masterLog2 = new File(mTestDir, "master.log.2");
+    String log2 = "2020-07-08 15:40:45,656 INFO  HdfsUnderFileSystem - Successfully..\n"
+            + "2020-07-08 15:51:45,782 INFO  RocksStore - Opened rocks database under path..\n"
+            + "2020-07-08 15:53:45,862 INFO  RocksStore - Opened rocks database under path..\n"
+            + "2020-07-08 16:52:41,876 INFO  RocksStore - Opened rocks database under path..\n"
+            + "2020-07-08 16:53:43,876 INFO  JournalStateMachine - Initialized new journal..";
+    writeToFile(masterLog2, log2);
+    masterLog1.setLastModified(LocalDateTime.of(2020, 7, 8, 16, 53, 44)
+            .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+
+    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
+    File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
+    CommandLine mockCommandLine = mock(CommandLine.class);
+    String[] mockArgs = new String[]{
+            cmd.getCommandName(),
+            targetDir.getAbsolutePath()
+    };
+    when(mockCommandLine.getArgs()).thenReturn(mockArgs);
+    when(mockCommandLine.hasOption(eq("end-time"))).thenReturn(true);
+    when(mockCommandLine.getOptionValue(eq("end-time"))).thenReturn(issueEnd.format(fmt));
+    int ret = cmd.run(mockCommandLine);
+    assertEquals(0, ret);
+
+    // Files will be copied to sub-dir of target dir
+    File subDir = new File(targetDir, cmd.getCommandName());
+    mExpectedFiles.remove("master.log");
+    InfoCollectorTestUtils.verifyAllFiles(subDir, mExpectedFiles);
+  }
+
+  @Test
+  public void startTimeFilter() throws Exception {
+    // Define an issue start datetime
+    // We ignore logs that are done before this
+    LocalDateTime issueEnd = LocalDateTime.of(2020, 7, 8, 18, 0, 0);
+    DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    // Other logs all end before this issue
+    LocalDateTime logEnd = issueEnd.minusHours(1);
+    long logEndTimestamp = logEnd.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+    for (File f : CommonUtils.recursiveListLocalDir(mTestDir)) {
+      f.setLastModified(logEndTimestamp);
+    }
+
+    // Some logs are created after this time, should be included
+    File masterLog = new File(mTestDir, "master.log");
+    String log = "2020-07-08 18:53:45,129 INFO  CopycatServer - Server started successfully!\n"
+            + "2020-07-08 18:53:59,129 INFO  RaftJournalSystem - Started Raft Journal System..\n"
+            + "2020-07-09 00:01:59,135 INFO  DefaultMetaMaster - Standby master with address..\n"
+            + "2020-07-09 00:03:59,135 INFO  AlluxioMasterProcess - All masters started\n"
+            + "2020-07-09 01:12:59,138 INFO  AbstractPrimarySelector - Primary selector..\n"
+            + "2020-07-09 01:53:59,139 INFO  AbstractMaster - TableMaster: Stopped..";
+    writeToFile(masterLog, log);
+    masterLog.setLastModified(LocalDateTime.of(2020, 7, 9, 1, 53, 59)
+            .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+
+    // Some logs overlap with the start time, should be included
+    File masterLog1 = new File(mTestDir, "master.log.1");
+    String log1 = "2020-07-08 16:53:44,639 INFO  BlockMasterFactory - Creating..\n"
+            + "2020-07-08 16:53:44,639 INFO  TableMasterFactory - Creating..\n"
+            + "2020-07-08 17:01:44,639 INFO  MetaMasterFactory - Creating..\n"
+            + "2020-07-08 17:01:45,639 INFO  FileSystemMasterFactory - Creating..\n"
+            + "2020-07-08 18:53:44,751 INFO  UnderDatabaseRegistry - Registered UDBs: hive,glue\n"
+            + "2020-07-08 18:53:44,756 INFO  LayoutRegistry - Registered Table Layouts: hive";
+    writeToFile(masterLog1, log1);
+    masterLog1.setLastModified(LocalDateTime.of(2020, 7, 8, 18, 53, 45)
+            .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+
+    // Some logs end before the start time, should be ignored
+    File masterLog2 = new File(mTestDir, "master.log.2");
+    String log2 = "2020-07-08 15:40:45,656 INFO  HdfsUnderFileSystem - Successfully..\n"
+            + "2020-07-08 15:51:45,782 INFO  RocksStore - Opened rocks database under path..\n"
+            + "2020-07-08 15:53:45,862 INFO  RocksStore - Opened rocks database under path..\n"
+            + "2020-07-08 16:52:41,876 INFO  RocksStore - Opened rocks database under path..\n"
+            + "2020-07-08 16:53:43,876 INFO  JournalStateMachine - Initialized new..";
+    writeToFile(masterLog2, log2);
+    masterLog2.setLastModified(LocalDateTime.of(2020, 7, 8, 16, 53, 44)
+            .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+
+    // Copy
+    CollectLogCommand cmd = new CollectLogCommand(FileSystemContext.create(mConf));
+    File targetDir = InfoCollectorTestUtils.createTemporaryDirectory();
+    CommandLine mockCommandLine = mock(CommandLine.class);
+    String[] mockArgs = new String[]{
+            cmd.getCommandName(),
+            targetDir.getAbsolutePath()
+    };
+    when(mockCommandLine.getArgs()).thenReturn(mockArgs);
+    when(mockCommandLine.hasOption(eq("start-time"))).thenReturn(true);
+    when(mockCommandLine.getOptionValue(eq("start-time"))).thenReturn(issueEnd.format(fmt));
+    int ret = cmd.run(mockCommandLine);
+    assertEquals(0, ret);
+
+    // Files will be copied to sub-dir of target dir
+    File subDir = new File(targetDir, cmd.getCommandName());
+    mExpectedFiles = new HashSet<>();
+    mExpectedFiles.add("master.log");
+    mExpectedFiles.add("master.log.1");
+    InfoCollectorTestUtils.verifyAllFiles(subDir, mExpectedFiles);
+  }
+
+  /**
+   * A LocalDateTime matcher for assertThat.
+   * */
+  class DatetimeMatcher extends TypeSafeMatcher<LocalDateTime> {
+    private LocalDateTime mDatetime;
+
+    DatetimeMatcher setDatetime(LocalDateTime datetime) {
+      mDatetime = datetime;
+      return this;
+    }
+
+    @Override
+    protected boolean matchesSafely(LocalDateTime s) {
+      return mDatetime.isEqual(s);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("only digits");
+    }
+  }
+
+  @Test
+  public void inferDateFromLog() throws Exception {
+    // A piece of Alluxio log with default format
+    String alluxioLog = "2020-03-19 11:58:10,104 WARN  ServerConfiguration - Reloaded properties\n"
+            + "2020-03-19 11:58:10,106 WARN  ServerConfiguration - Loaded hostname localhost\n"
+            + "2020-03-19 11:58:10,591 WARN  RetryUtils - Failed to load cluster default..";
+    File alluxioLogFile = new File(mTestDir, "alluxio-worker.log");
+    writeToFile(alluxioLogFile, alluxioLog);
+    LocalDateTime alluxioLogDatetime = CollectLogCommand.inferFileStartTime(alluxioLogFile);
+    LocalDateTime expectedDatetime = LocalDateTime.of(2020, 3, 19, 11, 58, 10,
+            104 * MILLISEC_TO_NANOSEC);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, alluxioLogDatetime),
+            alluxioLogDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
+
+    // A piece of sample Yarn application log with default format
+    // The first >20 lines are un-timestamped information about the job
+    String yarnAppLog = "\nLogged in as: user\nApplication\nAbout\nJobs\nTools\n"
+            + "Log Type: container-localizer-syslog\n\n"
+            + "Log Upload Time: Mon May 18 16:11:22 +0800 2020\n\n"
+            + "Log Length: 0\n\n\nLog Type: stderr\n\n"
+            + "Log Upload Time: Mon May 18 16:11:22 +0800 2020\n\n"
+            + "Log Length: 3616\n\n"
+            + "20/05/18 16:11:18 INFO util.SignalUtils: Registered signal handler for TERM\n"
+            + "20/05/18 16:11:18 INFO util.SignalUtils: Registered signal handler for HUP\n"
+            + "20/05/18 16:11:18 INFO util.SignalUtils: Registered signal handler for INT";
+    File yarnAppLogFile = new File(mTestDir, "yarn-application.log");
+    writeToFile(yarnAppLogFile, yarnAppLog);
+    LocalDateTime yarnAppDatetime = CollectLogCommand.inferFileStartTime(yarnAppLogFile);
+    expectedDatetime = LocalDateTime.of(2020, 5, 18, 16, 11, 18);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, yarnAppDatetime),
+            yarnAppDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
+
+    // A piece of Yarn log with default format
+    String yarnLog = "2020-05-16 02:02:25,855 INFO org.apache.hadoop.yarn.server.resourcemanager"
+            + ".rmcontainer.RMContainerImpl: container_e103_1584954066020_230169_01_000004 "
+            + "Container Transitioned from ALLOCATED to ACQUIRED\n"
+            + "2020-05-16 02:02:25,909 INFO org.apache.hadoop.yarn.server.resourcemanager"
+            + ".scheduler.AppSchedulingInfo: checking for deactivate... \n"
+            + "2020-05-16 02:02:26,006 INFO org.apache.hadoop.yarn.server.resourcemanager"
+            + ".rmcontainer.RMContainerImpl: container_e103_1584954066020_230168_01_000047 "
+            + "Container Transitioned from ALLOCATED to ACQUIRED";
+    File yarnLogFile = new File(mTestDir, "yarn-rm.log");
+    writeToFile(yarnLogFile, yarnLog);
+    LocalDateTime yarnDatetime = CollectLogCommand.inferFileStartTime(yarnLogFile);
+    expectedDatetime = LocalDateTime.of(2020, 5, 16, 2, 2, 25,
+            855 * MILLISEC_TO_NANOSEC);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, yarnDatetime),
+            yarnDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
+
+    // A piece of ZK log with default format
+    String zkLog = "2020-05-14 21:05:53,822 WARN org.apache.zookeeper.server.NIOServerCnxn: "
+            + "caught end of stream exception\n"
+            + "EndOfStreamException: Unable to read additional data from client sessionid.., "
+            + "likely client has closed socket\n"
+            + "\tat org.apache.zookeeper.server.NIOServerCnxn.doIO(NIOServerCnxn.java:241)\n"
+            + "\tat org.apache.zookeeper.server.NIOServerCnxnFactory.run(NIOServerCnxnFactory..)\n"
+            + "\tat java.lang.Thread.run(Thread.java:748)\n"
+            + "2020-05-14 21:05:53,823 INFO org.apache.zookeeper.server.NIOServerCnxn: "
+            + "Closed socket connection for client /10.64.23.190:50120 which had sessionid..\n"
+            + "2020-05-14 21:05:53,911 WARN org.apache.zookeeper.server.NIOServerCnxn: "
+            + "caught end of stream exception\n"
+            + "EndOfStreamException: Unable to read additional data from client sessionid.."
+            + "likely client has closed socket\n";
+    File zkLogFile = new File(mTestDir, "zk.log");
+    writeToFile(zkLogFile, zkLog);
+    LocalDateTime zkDatetime = CollectLogCommand.inferFileStartTime(zkLogFile);
+    expectedDatetime = LocalDateTime.of(2020, 5, 14, 21, 5, 53,
+            822 * MILLISEC_TO_NANOSEC);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, zkDatetime),
+            zkDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
+
+    // A piece of sample HDFS log with default format
+    String hdfsLog = "2020-05-15 22:02:27,878 INFO BlockStateChange: BLOCK* addStoredBlock: "
+            + "blockMap updated: 10.64.23.184:1025 is added to blk_1126197354_52572663 size 0..\n"
+            + "2020-05-15 22:02:27,878 INFO BlockStateChange: BLOCK* addStoredBlock: blockMap "
+            + "updated: 10.70.22.117:1025 is added to blk_1126197354_52572663 size 0..";
+    File hdfsLogFile = new File(mTestDir, "hdfs.log");
+    writeToFile(hdfsLogFile, hdfsLog);
+    LocalDateTime hdfsDatetime = CollectLogCommand.inferFileStartTime(hdfsLogFile);
+    expectedDatetime = LocalDateTime.of(2020, 5, 15, 22, 2, 27,
+            878 * MILLISEC_TO_NANOSEC);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, hdfsDatetime),
+            hdfsDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
+
+    // A piece of sample Presto log wtih default format
+    String prestoLog = "2020-05-16T00:00:01.059+0800\tINFO\tdispatcher-query-7960"
+            + "\tio.prestosql.event.QueryMonitor\tTIMELINE: Query 20200515_155959_06700_6r6b4"
+            + " :: Transaction:[4d30e960-c319-439c-84dd-022ddab6fa5e] :: elapsed 1208ms :: "
+            + "planning 0ms :: waiting 0ms :: scheduling 1208ms :: running 0ms :: finishing 1208ms"
+            + " :: begin 2020-05-15T23:59:59.850+08:00 :: end 2020-05-16T00:00:01.058+08:00\n"
+            + "2020-05-16T00:00:03.530+0800\tINFO\tdispatcher-query-7948\t"
+            + "io.prestosql.event.QueryMonitor\tTIMELINE: Query 20200515_160001_06701_6r6b4"
+            + " :: Transaction:[be9b396e-6697-4ecd-9782-2ca1174c1be1] :: elapsed 2316ms"
+            + " :: planning 0ms :: waiting 0ms :: scheduling 2316ms :: running 0ms"
+            + " :: finishing 2316ms :: begin 2020-05-16T00:00:01.212+08:00"
+            + " :: end 2020-05-16T00:00:03.528+08:00";
+    File prestoLogFile = new File(mTestDir, "presto.log");
+    writeToFile(prestoLogFile, prestoLog);
+    LocalDateTime prestoDatetime = CollectLogCommand.inferFileStartTime(prestoLogFile);
+    expectedDatetime = LocalDateTime.of(2020, 5, 16, 0, 0, 1,
+            59 * MILLISEC_TO_NANOSEC);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, prestoDatetime),
+            prestoDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
+
+    // ParNew/CMS GC log default format
+    String gcLog = "Java HotSpot(TM) 64-Bit Server VM (25.151-b12) for linux-amd64 JRE (1.8.0), "
+            + "built on Sep  5 2017 19:20:58 by \"java_re\" with gcc 4.3.0 20080428..\n"
+            + "Memory: 4k page, physical 1979200k(1940096k free), swap 332799k(332799k free)\n"
+            + "CommandLine flags: -XX:CMSInitiatingOccupancyFraction=65 -XX:InitialHeapSize=..\n"
+            + "2020-05-07T10:01:11.409+0800: 4.304: [GC (GCLocker Initiated GC) "
+            + "2020-05-07T10:01:11.410+0800: 4.304: [ParNew: 25669137K->130531K(28311552K), "
+            + "0.4330954 secs] 25669137K->130531K(147849216K), 0.4332463 secs] "
+            + "[Times: user=4.50 sys=0.08, real=0.44 secs] ";
+    File gcLogFile = new File(mTestDir, "gc.log");
+    writeToFile(gcLogFile, gcLog);
+    LocalDateTime gcDatetime = CollectLogCommand.inferFileStartTime(gcLogFile);
+    expectedDatetime = LocalDateTime.of(2020, 5, 7, 10, 1, 11,
+            409 * MILLISEC_TO_NANOSEC);
+    assertThat(String.format("Expected datetime is %s but inferred %s from file%n",
+            expectedDatetime, gcDatetime),
+            gcDatetime,
+            new DatetimeMatcher().setDatetime(expectedDatetime));
+  }
+
+  @Test
+  public void commandLineDatetime() throws Exception {
+    Map<String, LocalDateTime> stringToDatetime = new HashMap<>();
+    stringToDatetime.put("2020-06-27 11:58:53,084",
+            LocalDateTime.of(2020, 6, 27, 11, 58, 53, 84 * MILLISEC_TO_NANOSEC));
+    stringToDatetime.put("2020-06-27 11:58:53",
+            LocalDateTime.of(2020, 6, 27, 11, 58, 53));
+    stringToDatetime.put("2020-06-27 11:58",
+            LocalDateTime.of(2020, 6, 27, 11, 58));
+    stringToDatetime.put("20/06/27 11:58:53",
+            LocalDateTime.of(2020, 6, 27, 11, 58, 53));
+    stringToDatetime.put("20/06/27 11:58",
+            LocalDateTime.of(2020, 6, 27, 11, 58));
+    stringToDatetime.put("2020-06-27T11:58:53.084+0800",
+            LocalDateTime.of(2020, 6, 27, 11, 58, 53, 84 * MILLISEC_TO_NANOSEC));
+    stringToDatetime.put("2020-06-27T11:58:53",
+            LocalDateTime.of(2020, 6, 27, 11, 58, 53));
+    stringToDatetime.put("2020-06-27T11:58",
+            LocalDateTime.of(2020, 6, 27, 11, 58));
+
+    for (Map.Entry<String, LocalDateTime> entry : stringToDatetime.entrySet()) {
+      String key = entry.getKey();
+      LocalDateTime expectedDatetime = entry.getValue();
+      LocalDateTime parsedDatetime = CollectLogCommand.parseDateTime(key);
+      assertThat(String.format("Expected datetime is %s but parsed %s from string %s%n",
+              expectedDatetime, parsedDatetime, key),
+              parsedDatetime,
+              new DatetimeMatcher().setDatetime(expectedDatetime));
+    }
+  }
+
+  private void writeToFile(File f, String content) throws IOException {
+    try (FileWriter writer = new FileWriter(f)) {
+      writer.write(content);
+    }
   }
 }


### PR DESCRIPTION
Manually cherry-picking as [#9940 ] is not in 2.3.

This adds 3 features to `collectInfo`

1. With `--exclude-logs <filename-prefixes>`, `--include-logs
<filename-prefixes>` and `--additional-logs` the user is able to specify
log files to take or not take. By default only Alluxio-relevant files
under `${ALLUXIO_HOME}/logs` are included and unrecognized files are
ignored.

For example, `alluxio collectInfo --additional-logs alluxio_gc
--exclude-logs master collectLog <tmp-dir>` will include all
`alluxio_gc*` files (supposedly for GC logs) and exclude all `master*`
files like `master.log.*` and `master.out`.

`alluxio collectInfo --include-logs master collectLog <tmp-dir>` will,
however, take only the `master*` files like `master.log` and
`master.out`.

2. With `--start-time <datetime>` and `--end-time <datetime>` the user
can specify a certain time window to cover. This serves the need where
only events in one window is of interest. The files that end before the
`start time` or starts after the `end time` will be ignored. The `end
time` of a file is the last modification time. The `start time` of a
file is inferred by reading the first set of rows.

3. `alluxio-site.properties` will not be collected as it can contain
unmasked credentials. This is replaced with doing a local `alluxio
getConf`.

pr-link: Alluxio/alluxio#11783
change-id: cid-00209ff5c54a6d6891e8691bdbda35c53c997388