### PR TITLE
Increase timeout for MultiProcessCluster

### DIFF
--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -99,7 +99,7 @@ public final class MultiProcessCluster {
   private static final Logger LOG = LoggerFactory.getLogger(MultiProcessCluster.class);
   private static final File ARTIFACTS_DIR = new File(Constants.TEST_ARTIFACTS_DIR);
   private static final File TESTS_LOG = new File(Constants.TESTS_LOG);
-  private static final int WAIT_MASTER_SERVING_TIMEOUT_MS = 20000;
+  private static final int WAIT_MASTER_SERVING_TIMEOUT_MS = 30000;
 
   private final Map<PropertyKey, String> mProperties;
   private final Map<Integer, Map<PropertyKey, String>> mMasterProperties;


### PR DESCRIPTION
Some tests are still a bit flaky after having moved to github-actions and increasing this a little more seems to help.