### PR TITLE
Remove java stack trace log to fix list miss file status perf

### DIFF
--- a/core/server/common/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/common/src/main/java/alluxio/RpcUtils.java
@@ -119,7 +119,7 @@ public final class RpcUtils {
         MetricsSystem.counter(getQualifiedFailureMetricName(methodName)).inc();
         if (!logger.isDebugEnabled()) {
           logger.warn("Exit (Error): {}: {}, Error={}", methodName,
-              String.format(description, args), e);
+              String.format(description, args), e.getMessage());
         }
       }
       throw AlluxioStatusException.fromAlluxioException(e).toGrpcStatusException();


### PR DESCRIPTION
Logging java stack trace hurt the performance of listing a large number of miss files, remove java stack trace to fix the performance issue.