### PR TITLE
Fix backup coordination and error handling

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/JournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalSystem.java
@@ -144,8 +144,9 @@ public interface JournalSystem {
   /**
    * Suspends applying for all journals.
    *
+   * @param interruptCallback the callback function to be invoked when the suspension is interrupted
    */
-  void suspend() throws IOException;
+  void suspend(Runnable interruptCallback) throws IOException;
 
   /**
    * Resumes applying for all journals.

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalSystem.java
@@ -144,6 +144,12 @@ public interface JournalSystem {
   /**
    * Suspends applying for all journals.
    *
+   * When using suspend, the caller needs to provide a callback method as parameter. This callback
+   * is invoked when the journal needs to reload and thus cannot suspend the state changes any
+   * more. The callback should cancel any tasks that access the master states. After the callback
+   * returns, the journal assumes that the states is no longer being accessed and will reload
+   * immediately.
+   *
    * @param interruptCallback the callback function to be invoked when the suspension is interrupted
    */
   void suspend(Runnable interruptCallback) throws IOException;

--- a/core/server/common/src/main/java/alluxio/master/journal/noop/NoopJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/noop/NoopJournalSystem.java
@@ -20,7 +20,6 @@ import alluxio.master.journal.sink.JournalSink;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
 

--- a/core/server/common/src/main/java/alluxio/master/journal/noop/NoopJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/noop/NoopJournalSystem.java
@@ -20,6 +20,7 @@ import alluxio.master.journal.sink.JournalSink;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
 
@@ -48,7 +49,7 @@ public final class NoopJournalSystem implements JournalSystem {
   }
 
   @Override
-  public void suspend() {
+  public void suspend(Runnable interruptCallback) {
     return;
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -295,7 +295,7 @@ public class JournalStateMachine extends BaseStateMachine {
    * Unpause the StateMachine. This should be done after uploading new state to the StateMachine.
    */
   public synchronized void unpause() {
-    LOG.info("Unpausiing raft state machine.");
+    LOG.info("Unpausing raft state machine.");
     getLifeCycle().startAndTransition(() -> {
       if (mJournalApplier.isSuspended()) {
         LOG.warn("Journal should not be suspended while state machine is paused.");
@@ -515,12 +515,8 @@ public class JournalStateMachine extends BaseStateMachine {
   public synchronized void resume() throws IOException {
     LOG.info("Resuming raft state machine");
     mInterruptCallback = null;
-    if (mJournalApplier.isSuspended()) {
-      mJournalApplier.resume();
-      LOG.info("Raft state machine resumed");
-    } else {
-      LOG.warn("Raft state machine is already resumed");
-    }
+    mJournalApplier.resume();
+    LOG.info("Raft state machine resumed");
   }
 
   /**

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -448,8 +448,11 @@ public class RaftJournalSystem extends AbstractJournalSystem {
 
   @Override
   public synchronized void resume() throws IOException {
-    mStateMachine.resume();
-    mSnapshotAllowed.set(true);
+    try {
+      mStateMachine.resume();
+    } finally {
+      mSnapshotAllowed.set(true);
+    }
   }
 
   @Override

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -441,9 +441,9 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   }
 
   @Override
-  public synchronized void suspend() throws IOException {
+  public synchronized void suspend(Runnable interruptCallback) throws IOException {
     mSnapshotAllowed.set(false);
-    mStateMachine.suspend();
+    mStateMachine.suspend(interruptCallback);
   }
 
   @Override

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
@@ -33,6 +33,7 @@ import alluxio.grpc.UploadSnapshotPResponse;
 import alluxio.master.MasterClientContext;
 import alluxio.security.authentication.ClientIpAddressInjector;
 import alluxio.util.CommonUtils;
+import alluxio.util.LogUtils;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -484,7 +485,7 @@ public class SnapshotReplicationManager {
         throw new UnavailableException("No recent snapshot found from followers");
       }
     } catch (Exception e) {
-      LOG.error("Failed to request snapshot info from followers", e);
+      LogUtils.warnWithException(LOG, "Failed to request snapshot info from followers", e);
       transitionState(DownloadState.REQUEST_INFO, DownloadState.IDLE);
       return;
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -111,7 +112,7 @@ public class UfsJournalSystem extends AbstractJournalSystem {
   }
 
   @Override
-  public void suspend() throws IOException {
+  public void suspend(Runnable interruptCallback) throws IOException {
     for (Map.Entry<String, UfsJournal> journalEntry : mJournals.entrySet()) {
       LOG.info("Suspending journal: {}", journalEntry.getKey());
       journalEntry.getValue().suspend();

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -122,9 +122,9 @@ public class RaftJournalTest {
     mFollowerJournalSystem.createJournal(countingMaster);
 
     // Suspend follower journal system.
-    mFollowerJournalSystem.suspend();
+    mFollowerJournalSystem.suspend(null);
     try {
-      mFollowerJournalSystem.suspend();
+      mFollowerJournalSystem.suspend(null);
       Assert.fail("Suspend succeeded for already suspended journal.");
     } catch (Exception e) {
       // Expected to fail when suspending a suspended journal.
@@ -190,7 +190,7 @@ public class RaftJournalTest {
     }
 
     // Suspend follower journal system.
-    mFollowerJournalSystem.suspend();
+    mFollowerJournalSystem.suspend(null);
 
     // Write more entries which are not applied due to suspension.
     try (JournalContext journalContext =
@@ -226,7 +226,7 @@ public class RaftJournalTest {
     mFollowerJournalSystem.createJournal(countingMaster);
 
     // Suspend follower journal system.
-    mFollowerJournalSystem.suspend();
+    mFollowerJournalSystem.suspend(null);
 
     final int entryBatchCount = 5;
     // Create batch of entries on the leader journal context.
@@ -270,7 +270,7 @@ public class RaftJournalTest {
     mFollowerJournalSystem.createJournal(countingMaster);
 
     // Suspend follower journal system.
-    mFollowerJournalSystem.suspend();
+    mFollowerJournalSystem.suspend(null);
 
     final int entryBatchCount = 5;
     // Create 2 batches of entries on the leader journal context.
@@ -303,7 +303,7 @@ public class RaftJournalTest {
     mFollowerJournalSystem.createJournal(countingMaster);
 
     // Suspend follower journal system.
-    mFollowerJournalSystem.suspend();
+    mFollowerJournalSystem.suspend(null);
 
     // Create entries on the leader journal context.
     // These will be replicated to follower journal context.
@@ -338,7 +338,7 @@ public class RaftJournalTest {
     mFollowerJournalSystem.createJournal(countingMaster);
 
     // Suspend follower journal system.
-    mFollowerJournalSystem.suspend();
+    mFollowerJournalSystem.suspend(null);
     // Catch up follower journal system to target-index:5.
     final long catchupIndex = 5;
     Map<String, Long> backupSequences = new HashMap<>();
@@ -383,7 +383,7 @@ public class RaftJournalTest {
     final int entryCount = 100000;
 
     // Suspend follower journal system.
-    mFollowerJournalSystem.suspend();
+    mFollowerJournalSystem.suspend(null);
     // Catch up follower journal to a large index to be able to transition while in progress.
     final long catchupIndex = entryCount - 5;
     Map<String, Long> backupSequences = new HashMap<>();

--- a/core/server/master/src/main/java/alluxio/master/backup/AbstractBackupRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/AbstractBackupRole.java
@@ -186,6 +186,8 @@ public abstract class AbstractBackupRole implements BackupRole {
           // Create the backup from master state.
           mBackupManager.backup(ufsStream, entryCounter);
         }
+        // Add a marker file indicating the file is completed.
+        ufs.create(backupFilePath + ".complete").close();
       } catch (IOException e) {
         try {
           ufs.deleteExistingFile(backupFilePath);

--- a/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
@@ -182,12 +182,25 @@ public class BackupWorkerRole extends AbstractBackupRole {
   }
 
   private void interruptBackup() {
-    LOG.warn("interrupting backup");
+    LOG.info("Interrupting ongoing backup.");
     if (mBackupFuture != null && !mBackupFuture.isDone()) {
-      LOG.warn("attempt to cancel backup task");
+      LOG.info("Attempt to cancel backup task.");
       mBackupFuture.cancel(true);
     }
-    LOG.warn("backup interrupted");
+    boolean shouldResume = true;
+    if (mBackupTimeoutTask != null) {
+      LOG.info("Attempt to cancel backup timeout task.");
+      shouldResume = mBackupTimeoutTask.cancel(true);
+    }
+    if (shouldResume) {
+      try {
+        LOG.info("Attempt to resume journal application.");
+        mJournalSystem.resume();
+      } catch (Exception e) {
+        LOG.warn("Failed to resume journal application: {}", e.getMessage());
+      }
+    }
+    LOG.warn("Backup interrupted successfully.");
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
@@ -49,7 +49,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Implementation of {@link BackupRole} for secondary mode.

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/BackupCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/BackupCommandIntegrationTest.java
@@ -43,7 +43,7 @@ public final class BackupCommandIntegrationTest extends AbstractFsAdminShellTest
     int errCode = mFsAdminShell.run("backup");
     assertEquals("", mErrOutput.toString());
     assertEquals(0, errCode);
-    assertEquals(1, Files.list(dir).count());
+    assertEquals(2, Files.list(dir).count());
   }
 
   @Test
@@ -54,6 +54,6 @@ public final class BackupCommandIntegrationTest extends AbstractFsAdminShellTest
     int errCode = mFsAdminShell.run("backup", dir.toAbsolutePath().toString());
     assertEquals("", mErrOutput.toString());
     assertEquals(0, errCode);
-    assertEquals(1, Files.list(dir).count());
+    assertEquals(2, Files.list(dir).count());
   }
 }


### PR DESCRIPTION
This change fixed a few issues related to backup:

- Make backup interrupt correctly when raft journal needs to reload from a snapshot. Currently if backup occurs right before a journal reload it can buffer up some entries and then corrupt journal by resuming after the reload is completed. This change added an interrupt callback to make sure backup is correctly canceled and journal is resumed before a reload happens.

- Block backup when journal is being reloaded. When a raft journal is being reloaded, the backup should not happen because it will capture inconsistent state while the master metadata is re-applied from snapshot.

- Cancel backup sub-tasks properly. Currently when a backup is cancelled due to error or interruption, the sub-tasks do not explicitly respond to interrupt signals, leaving them running in background while opening backup service for more requests. This causes increased memory consumption when multiple backup tasks are running concurrently.

- Incomplete backups. There is currently no way to tell if a backup file is incomplete before restoring it to the cluster. This change added a marker file after the backup is done to indicate the completeness.