### PR TITLE
Move raft journal to an isolated directory

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalUtils.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalUtils.java
@@ -23,6 +23,8 @@ import java.util.concurrent.CompletableFuture;
  * Helper class for raft journal operations.
  */
 public class RaftJournalUtils {
+  public static final String RAFT_DIR = "raft";
+
   private RaftJournalUtils() {
     // prevent instantiation
   }
@@ -46,6 +48,16 @@ public class RaftJournalUtils {
    */
   public static RaftPeerId getPeerId(String host, int port) {
     return RaftPeerId.getRaftPeerId(host + "_" + port);
+  }
+
+  /**
+   * Gets the raft journal dir.
+   *
+   * @param baseDir the journal base dir
+   * @return the raft peer id
+   */
+  public static File getRaftJournalDir(File baseDir) {
+    return new File(baseDir, RAFT_DIR);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
@@ -14,6 +14,7 @@ package alluxio.master.journal.tool;
 import alluxio.master.journal.JournalEntryAssociation;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.raft.RaftJournalSystem;
+import alluxio.master.journal.raft.RaftJournalUtils;
 import alluxio.proto.journal.Journal;
 import alluxio.util.io.FileUtils;
 
@@ -108,7 +109,8 @@ public class RaftJournalDumper extends AbstractJournalDumper {
   }
 
   private File getJournalDir() {
-    return new File(mInputDir, RaftJournalSystem.RAFT_GROUP_UUID.toString());
+    return new File(RaftJournalUtils.getRaftJournalDir(new File(mInputDir)),
+        RaftJournalSystem.RAFT_GROUP_UUID.toString());
   }
 
   private void readRatisSnapshotFromDir() throws IOException {

--- a/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
+++ b/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
@@ -32,6 +32,7 @@ import alluxio.master.MasterClientContext;
 import alluxio.master.SingleMasterInquireClient;
 import alluxio.master.journal.JournalType;
 import alluxio.master.journal.raft.RaftJournalSystem;
+import alluxio.master.journal.raft.RaftJournalUtils;
 import alluxio.master.journal.tool.JournalTool;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.IntegrationTestUtils;
@@ -217,7 +218,8 @@ public class JournalToolTest extends BaseIntegrationTest {
 
   private long getCurrentRatisSnapshotIndex(String journalFolder) throws Throwable {
     try (RaftStorage storage = new RaftStorage(
-        new File(journalFolder, RaftJournalSystem.RAFT_GROUP_UUID.toString()),
+        new File(RaftJournalUtils.getRaftJournalDir(new File(journalFolder)),
+            RaftJournalSystem.RAFT_GROUP_UUID.toString()),
         RaftServerConstants.StartupOption.REGULAR)) {
       SimpleStateMachineStorage stateMachineStorage = new SimpleStateMachineStorage();
       stateMachineStorage.init(storage);

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTest.java
@@ -30,6 +30,7 @@ import alluxio.grpc.QuorumServerState;
 import alluxio.master.AlluxioMasterProcess;
 import alluxio.master.journal.JournalType;
 import alluxio.master.journal.raft.RaftJournalSystem;
+import alluxio.master.journal.raft.RaftJournalUtils;
 import alluxio.multi.process.MasterNetAddress;
 import alluxio.multi.process.MultiProcessCluster;
 import alluxio.multi.process.PortCoordination;
@@ -129,7 +130,8 @@ public final class EmbeddedJournalIntegrationTest extends BaseIntegrationTest {
     }
     int primaryMasterIndex = mCluster.getPrimaryMasterIndex(5000);
     String leaderJournalPath = mCluster.getJournalDir(primaryMasterIndex);
-    File raftDir = new File(leaderJournalPath, RaftJournalSystem.RAFT_GROUP_UUID.toString());
+    File raftDir = new File(RaftJournalUtils.getRaftJournalDir(new File(leaderJournalPath)),
+        RaftJournalSystem.RAFT_GROUP_UUID.toString());
     waitForSnapshot(raftDir);
     mCluster.stopMasters();
 
@@ -168,7 +170,8 @@ public final class EmbeddedJournalIntegrationTest extends BaseIntegrationTest {
     FileUtils.deleteDirectory(catchupJournalDir);
     assertTrue(catchupJournalDir.mkdirs());
     mCluster.startMaster(catchUpMasterIndex);
-    File raftDir = new File(catchupJournalDir, RaftJournalSystem.RAFT_GROUP_UUID.toString());
+    File raftDir = new File(RaftJournalUtils.getRaftJournalDir(catchupJournalDir),
+        RaftJournalSystem.RAFT_GROUP_UUID.toString());
     waitForSnapshot(raftDir);
     mCluster.stopMaster(catchUpMasterIndex);
     SimpleStateMachineStorage storage = new SimpleStateMachineStorage();


### PR DESCRIPTION
Master log shows the following error:

```
"2020-09-14 17:19:37,127 WARN  RaftServerProxy - FaultToleranceScaleEmbeddedJournalR-masters-1_19200: Failed to initialize the group directory /tmp/alluxio/journal/JobJournal.  Ignoring it
java.lang.IllegalArgumentException: Invalid UUID string: JobJournal
        at java.util.UUID.fromString(UUID.java:194)
        at org.apache.ratis.server.impl.RaftServerProxy.lambda$null$0(RaftServerProxy.java:197)"
```

It's because Ratis scans all directories under the configured path now and calls out the ones that are not named as a raft group id. Since we have `JobJournal` as a sub directory of the master journal directory, it is detected by Ratis which will log an error. This change addresses this issue by moving Ratis journal path to be one level deeper so it does not scan the parent directory of `JobJournal` directory.