### PR TITLE
Avoid logging log info from ratis

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -183,3 +183,4 @@ log4j.logger.io.grpc.netty.NettyServerHandler=OFF
 # Disable noisy INFO logs from ratis
 log4j.logger.org.apache.ratis.grpc.server.GrpcServerProtocolService=WARN
 log4j.logger.org.apache.ratis.server.impl.RaftServerImpl=WARN
+log4j.logger.org.apache.ratis.server.impl.FollowerInfo=WARN

--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -179,3 +179,7 @@ log4j.appender.FUSE_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%
 
 # Disable noisy DEBUG logs
 log4j.logger.io.grpc.netty.NettyServerHandler=OFF
+
+# Disable noisy INFO logs from ratis
+log4j.logger.org.apache.ratis.grpc.server.GrpcServerProtocolService=WARN
+log4j.logger.org.apache.ratis.server.impl.RaftServerImpl=WARN


### PR DESCRIPTION
There are a large number of logs from Ratis with info level. Change the log level to WARN to avoid it.