### PR TITLE
Run alluxio processes with tini in containers

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -39,7 +39,7 @@ ARG ALLUXIO_UID=1000
 ARG ALLUXIO_GID=1000
 ARG ENABLE_DYNAMIC_USER=false
 
-RUN apk --no-cache --update add bash libc6-compat shadow && \
+RUN apk --no-cache --update add bash libc6-compat shadow tini && \
     rm -rf /var/cache/apk/*
 
 # disable JVM DNS cache

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -82,7 +82,7 @@ spec:
           {{- if .Values.master.resources  }}
 {{ include "alluxio.master.resources" . | indent 10 }}
           {{- end }}
-          command: ["/entrypoint.sh"]
+          command: ["tini", "--", "/entrypoint.sh"]
           {{- if .Values.master.args }}
           args:
 {{ toYaml .Values.master.args | trim | indent 12 }}
@@ -148,7 +148,7 @@ spec:
           {{- if .Values.jobMaster.resources  }}
 {{ include "alluxio.jobMaster.resources" . | indent 10 }}
           {{- end }}
-          command: ["/entrypoint.sh"]
+          command: ["tini", "--", "/entrypoint.sh"]
           {{- if .Values.jobMaster.args }}
           args:
 {{ toYaml .Values.jobMaster.args | trim | indent 12 }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
@@ -60,7 +60,7 @@ spec:
           {{- if .Values.worker.resources  }}
 {{ include "alluxio.worker.resources" . | indent 10 }}
           {{- end }}
-          command: ["/entrypoint.sh"]
+          command: ["tini", "--", "/entrypoint.sh"]
           {{- if .Values.worker.args }}
           args:
 {{ toYaml .Values.worker.args | trim | indent 12 }}
@@ -115,7 +115,7 @@ spec:
           {{- if .Values.jobWorker.resources  }}
 {{ include "alluxio.jobWorker.resources" . | indent 10 }}
           {{- end }}
-          command: ["/entrypoint.sh"]
+          command: ["tini", "--", "/entrypoint.sh"]
           {{- if .Values.jobWorker.args }}
           args:
 {{ toYaml .Values.jobWorker.args | trim | indent 12 }}


### PR DESCRIPTION
This solves the issue related to https://github.com/docker-library/openjdk/issues/76
In a container based on java alpine, commands like `jmap`, `jstack` don't work, and the pid of alluxio processes like `AlluxioWorker` is 1. 

Before:
```
bash-4.4$ jps
1 AlluxioMaster
904 Jps
bash-4.4$ jstack 1
1: Unable to get pid of LinuxThreads manager thread
```

After:
```
bash-4.4# jps
357 Jps
6 AlluxioWorker
# And jstack will work
```
