### PR TITLE
Fix underfs.version property in emr and dataproc scripts

### DIFF
--- a/integration/dataproc/alluxio-dataproc.sh
+++ b/integration/dataproc/alluxio-dataproc.sh
@@ -214,7 +214,7 @@ configure_alluxio_root_mount() {
   if [[ "${root_ufs_uri}" = hdfs://* ]]; then
     local -r hdfs_version=$(/usr/share/google/get_metadata_value attributes/alluxio_hdfs_version || true)
     if [[ "${hdfs_version}" ]]; then
-      append_alluxio_property alluxio.master.mount.table.root.option.alluxio.underfs.hdfs.version "${hdfs_version}"
+      append_alluxio_property alluxio.master.mount.table.root.option.alluxio.underfs.version "${hdfs_version}"
     fi
     # core-site.xml and hdfs-site.xml downloaded from the file list will override the default one
     core_site_location="/etc/hadoop/conf/core-site.xml"

--- a/integration/emr/alluxio-emr.sh
+++ b/integration/emr/alluxio-emr.sh
@@ -384,7 +384,7 @@ configure_alluxio_hdfs_root_mount() {
       exit 2
     fi
     hdfs_version=$2
-    set_alluxio_property alluxio.master.mount.table.root.option.alluxio.underfs.hdfs.version "${hdfs_version}"
+    set_alluxio_property alluxio.master.mount.table.root.option.alluxio.underfs.version "${hdfs_version}"
     # core-site.xml and hdfs-site.xml downloaded from the file list will override the default one
     core_site_location="${HADOOP_CONF}/core-site.xml"
     hdfs_site_location="${HADOOP_CONF}/hdfs-site.xml"


### PR DESCRIPTION
both scripts were incorrectly setting the property key "alluxio.underfs.hdfs.version"

this previously worked because alluxio defaulted to using 2.7,
but once this was updated to use 3.3.0 to be compatible for java 11,
the fallback default no longer worked
