### PR TITLE
Fix passing of parameters to benchmarks

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
@@ -157,7 +157,8 @@ public abstract class Benchmark<T extends TaskResult> {
       command.add(className);
       command.addAll(Arrays.asList(args));
       command.add(BaseParameters.IN_PROCESS_FLAG);
-      command.addAll(mBaseParameters.mJavaOpts);
+      command.addAll(mBaseParameters.mJavaOpts.stream().map(String::trim)
+          .collect(Collectors.toList()));
 
       LOG.info("running command: " + String.join(" ", command));
       return ShellUtils.execCommand(command.toArray(new String[0]));


### PR DESCRIPTION
We fixed passing of parameters for clustered benchmarks before, but did not fix it for non clustered benchmark