### PR TITLE
Fix backup worker crashing master on interruption

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -537,8 +537,12 @@ public class JournalStateMachine extends BaseStateMachine {
   public synchronized void resume() throws IOException {
     LOG.info("Resuming raft state machine");
     mInterruptCallback = null;
-    mJournalApplier.resume();
-    LOG.info("Raft state machine resumed");
+    if (mJournalApplier.isSuspended()) {
+      mJournalApplier.resume();
+      LOG.info("Raft state machine resumed");
+    } else {
+      LOG.info("Raft state machine is already resumed");
+    }
   }
 
   /**

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -631,4 +631,11 @@ public class JournalStateMachine extends BaseStateMachine {
   public SnapshotReplicationManager getSnapshotReplicationManager() {
     return mSnapshotManager;
   }
+
+  /**
+   * @return whether the journal is suspended
+   */
+  public synchronized boolean isSuspended() {
+    return mJournalApplier.isSuspended();
+  }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -472,6 +472,13 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     }
   }
 
+  /**
+   * @return whether the journal is suspended
+   */
+  public synchronized boolean isSuspended() {
+    return mStateMachine.isSuspended();
+  }
+
   @Override
   public synchronized CatchupFuture catchup(Map<String, Long> journalSequenceNumbers) {
     // Given sequences should be the same for each master for embedded journal.

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -326,9 +326,8 @@ public class RaftJournalTest {
         "full state acquired after resume", () -> mFollowerJournalSystem.getCurrentSequenceNumbers()
             .values().stream().distinct().collect(Collectors.toList()).get(0) == entryCount - 1,
         mWaitOptions);
-    // Resuming should fail after becoming primary.
-    mThrown.expect(IllegalStateException.class);
-    mFollowerJournalSystem.resume();
+    // Follower should no longer be suspended after becoming primary.
+    Assert.assertFalse(mFollowerJournalSystem.isSuspended());
   }
 
   @Test
@@ -368,9 +367,8 @@ public class RaftJournalTest {
     CommonUtils.waitFor("full state acquired after resume",
         () -> countingMaster.getApplyCount() == entryCount, mWaitOptions);
 
-    // Resuming should fail after becoming primary.
-    mThrown.expect(IllegalStateException.class);
-    mFollowerJournalSystem.resume();
+    // Follower should no longer be suspended after becoming primary.
+    Assert.assertFalse(mFollowerJournalSystem.isSuspended());
   }
 
   @Test
@@ -423,9 +421,8 @@ public class RaftJournalTest {
             .values().stream().distinct().collect(Collectors.toList()).get(0) == entryCount - 1,
         mWaitOptions);
 
-    // Resuming should fail after becoming primary.
-    mThrown.expect(IllegalStateException.class);
-    mFollowerJournalSystem.resume();
+    // Follower should no longer be suspended after becoming primary.
+    Assert.assertFalse(mFollowerJournalSystem.isSuspended());
   }
 
   /**


### PR DESCRIPTION
When a backup is interrupted, there is a chance that the resume callback cannot be canceled and thus happens after the server is already resumed by the journal reload process. While it makes sense for backup to crash the master if resume fails to complete and master cannot accept new journal entries, it is completely fine for master to continue if backup tries to resume an already resumed journal. This change updates the journal to not throw if someone attempts to resume after the journal is already resumed.