### PR TITLE
Do not configure alluxio catalog for older versions of presto in emr

### DIFF
--- a/integration/emr/alluxio-emr.sh
+++ b/integration/emr/alluxio-emr.sh
@@ -662,19 +662,26 @@ IN
   # set user provided properties
   set_custom_alluxio_properties "${delimited_properties}"
 
-  # Create a symbolic link in presto plugin directory pointing to our connector if alluxio version is above 2.2
-  for plugindir in "${ALLUXIO_HOME}"/client/presto/plugins/prestodb*; do
-    # guard against using an older version by checking for alluxio connector's existence
-    if [ -d "$plugindir" ]; then
-      doas alluxio "ln -s $plugindir ${ALLUXIO_HOME}/client/presto/plugins/prestodb_connector"
-      sudo ln -s "${ALLUXIO_HOME}/client/presto/plugins/prestodb_connector" /usr/lib/presto/plugin/hive-alluxio
-      sudo mkdir -p /etc/presto/conf/catalog
-      echo "connector.name=hive-alluxio" | sudo tee -a /etc/presto/conf/catalog/catalog_alluxio.properties
-      echo "hive.metastore=alluxio" | sudo tee -a /etc/presto/conf/catalog/catalog_alluxio.properties
-      echo "hive.metastore.alluxio.master.address=${master}:19998" | sudo tee -a /etc/presto/conf/catalog/catalog_alluxio.properties
-      break
-    fi
-  done
+  # Create a symbolic link in presto plugin directory pointing to our connector if:
+  # - emr version is >= 5.28 -> prestodb >= 0.227
+  # - alluxio version is above 2.2
+  local -r emr_version=$(jq ".releaseLabel" /mnt/var/lib/info/extraInstanceData.json  | sed -e 's/^"emr-//' -e 's/"$//')
+  local -r emr_major=$(echo "${emr_version}" | sed -s 's/\([[:digit:]]\+\)\.\([[:digit:]]\+\)\.[[:digit:]]\+/\1/')
+  local -r emr_minor=$(echo "${emr_version}" | sed -s 's/\([[:digit:]]\+\)\.\([[:digit:]]\+\)\.[[:digit:]]\+/\2/')
+  if [ "${emr_major}" -gt 5 ] || [[ "${emr_major}" -eq 5 && "${emr_minor}" -ge 28 ]]; then
+    for plugindir in "${ALLUXIO_HOME}"/client/presto/plugins/prestodb*; do
+      # guard against using an older version by checking for alluxio connector's existence
+      if [ -d "$plugindir" ]; then
+        doas alluxio "ln -s $plugindir ${ALLUXIO_HOME}/client/presto/plugins/prestodb_connector"
+        sudo ln -s "${ALLUXIO_HOME}/client/presto/plugins/prestodb_connector" /usr/lib/presto/plugin/hive-alluxio
+        sudo mkdir -p /etc/presto/conf/catalog
+        echo "connector.name=hive-alluxio" | sudo tee -a /etc/presto/conf/catalog/catalog_alluxio.properties
+        echo "hive.metastore=alluxio" | sudo tee -a /etc/presto/conf/catalog/catalog_alluxio.properties
+        echo "hive.metastore.alluxio.master.address=${master}:19998" | sudo tee -a /etc/presto/conf/catalog/catalog_alluxio.properties
+        break
+      fi
+    done
+  fi
 
   # start Alluxio cluster
   if [[ "${client_only}" != "true" ]]; then


### PR DESCRIPTION
in emr 5.25, which we refer to in our docs, the presto version is 0.220. the connector we bundle with the tarball only works with 0.227+. if we configure the alluxio catalog that uses our bundled connector and the presto version is incompatible, presto will fail to start.

this change checks for the emr version and ensures that it is >= 5.28, which is the first version that uses presto 0.227. here we are assuming that presto will be backwards compatible

i have tested this with both emr 5.25 and 5.28 to ensure the catalog is configured as described