### PR TITLE
Fix LostStorageIntegrationTest failure on user 'root'

### DIFF
--- a/tests/src/test/java/alluxio/server/tieredstore/LostStorageIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/tieredstore/LostStorageIntegrationTest.java
@@ -78,7 +78,7 @@ public class LostStorageIntegrationTest extends BaseIntegrationTest {
     File hddDir = Files.createTempDir();
     String hddPath = hddDir.getAbsolutePath();
 
-//    // Mock no write permission so worker storage paths cannot be initialize
+    // Mock no write permission so worker storage paths cannot be initialize
     PowerMockito.mockStatic(StorageDir.class);
     Mockito.when(StorageDir.newStorageDir(any(StorageTier.class),
         anyInt(),

--- a/tests/src/test/java/alluxio/server/tieredstore/LostStorageIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/tieredstore/LostStorageIntegrationTest.java
@@ -11,10 +11,16 @@
 
 package alluxio.server.tieredstore;
 
+import static org.mockito.AdditionalMatchers.or;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.startsWith;
+
 import alluxio.ClientContext;
 import alluxio.Constants;
 import alluxio.client.block.BlockMasterClient;
-
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.StorageList;
@@ -23,12 +29,21 @@ import alluxio.master.LocalAlluxioCluster;
 import alluxio.master.MasterClientContext;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
+import alluxio.worker.block.meta.StorageDir;
+import alluxio.worker.block.meta.StorageTier;
 
 import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,6 +53,9 @@ import java.util.Map;
 /**
  * Tests for getting worker lost storage information.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({StorageDir.class})
+@PowerMockIgnore({"javax.*.*", "com.sun.*", "org.xml.*"})
 public class LostStorageIntegrationTest extends BaseIntegrationTest {
   private static final int CAPACITY_BYTES = Constants.KB;
   private static final String SSD_TIER = "SSD";
@@ -60,9 +78,21 @@ public class LostStorageIntegrationTest extends BaseIntegrationTest {
     File hddDir = Files.createTempDir();
     String hddPath = hddDir.getAbsolutePath();
 
-    // Set to read only so worker storage paths cannot be initialize
-    ssdDir.setReadOnly();
-    hddDir.setReadOnly();
+//    // Mock no write permission so worker storage paths cannot be initialize
+    PowerMockito.mockStatic(StorageDir.class);
+    Mockito.when(StorageDir.newStorageDir(any(StorageTier.class),
+        anyInt(),
+        anyLong(),
+        anyLong(),
+        anyString(),
+        anyString())).thenCallRealMethod();
+    Mockito.when(StorageDir.newStorageDir(any(StorageTier.class),
+        anyInt(),
+        anyLong(),
+        anyLong(),
+        or(startsWith(ssdPath), startsWith(hddPath)),
+        anyString())).thenThrow(
+            new IOException("mock no write permission exception"));
 
     startClusterWithWorkerStorage(ssdPath, hddPath);
     checkLostStorageResults(ssdPath, hddPath);
@@ -92,8 +122,22 @@ public class LostStorageIntegrationTest extends BaseIntegrationTest {
     File hddDir = Files.createTempDir();
     String hddPath = hddDir.getAbsolutePath();
 
-    // Set to read only so worker storage paths cannot be initialize
-    ssdDir.setReadOnly();
+    // Mock no write permission so worker storage paths cannot be initialize
+    PowerMockito.mockStatic(StorageDir.class);
+    Mockito.when(StorageDir.newStorageDir(Matchers.any(StorageTier.class),
+        Matchers.anyInt(),
+        Matchers.anyLong(),
+        Matchers.anyLong(),
+        Matchers.anyString(),
+        Matchers.anyString())).thenCallRealMethod();
+    Mockito.when(StorageDir.newStorageDir(Matchers.any(StorageTier.class),
+        Matchers.anyInt(),
+        Matchers.anyLong(),
+        Matchers.anyLong(),
+        Matchers.startsWith(ssdPath),
+        Matchers.anyString())).thenThrow(
+            new IOException("mock no write permission exception"));
+
     startClusterWithWorkerStorage(ssdPath, hddPath);
 
     FileUtils.deleteDirectory(hddDir);


### PR DESCRIPTION
Fix #12187

With this PR, root user and none-root user can pass the `LostStorageIntegrationTest` by exexuted

```bash
# mvn test -Dtest=LostStorageIntegrationTest -pl tests
```

the following is the test by root user.

```bash
[root@c2eaf3f187f2 alluxio]# /softwares/apache-maven-3.6.3/bin/mvn test -Dtest=LostStorageIntegrationTest -pl tests
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.alluxio:alluxio-shaded-hadoop:jar:3.3.0
[WARNING] 'version' contains an expression but should be a constant. @ org.alluxio:alluxio-shaded-hadoop:${ufs.hadoop.version}, /projects/github/alluxio/shaded/hadoop/pom.xml, line 23, column 12
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[INFO]
[INFO] ---------------------< org.alluxio:alluxio-tests >----------------------
[INFO] Building Alluxio Tests 2.4.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-maven) @ alluxio-tests ---
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-versions) @ alluxio-tests ---
[INFO]
[INFO] --- maven-checkstyle-plugin:2.17:check (checkstyle) @ alluxio-tests ---
[INFO] Starting audit...
Audit done.
[INFO]
[INFO] --- license-maven-plugin:4.0.rc1:check (default) @ alluxio-tests ---
[INFO] Checking licenses...
[WARNING] Unable to find a comment style definition for some files. You may want to add a custom mapping for the relevant file extensions.
[INFO]
[INFO] --- maven-resources-plugin:2.7:resources (default-resources) @ alluxio-tests ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /projects/github/alluxio/tests/src/main/resources
[INFO]
[INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ alluxio-tests ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 16 source files to /projects/github/alluxio/tests/target/classes
[INFO] /projects/github/alluxio/tests/src/main/java/alluxio/master/backcompat/BackwardsCompatibilityJournalGenerator.java: Some input files use or override a deprecated API.
[INFO] /projects/github/alluxio/tests/src/main/java/alluxio/master/backcompat/BackwardsCompatibilityJournalGenerator.java: Recompile with -Xlint:deprecation for details.
[INFO]
[INFO] >>> spotbugs-maven-plugin:4.0.4:check (default) > :spotbugs @ alluxio-tests >>>
[INFO]
[INFO] --- spotbugs-maven-plugin:4.0.4:spotbugs (spotbugs) @ alluxio-tests ---
[INFO] Fork Value is true
[INFO] Done SpotBugs Analysis....
[INFO]
[INFO] <<< spotbugs-maven-plugin:4.0.4:check (default) < :spotbugs @ alluxio-tests <<<
[INFO]
[INFO]
[INFO] --- spotbugs-maven-plugin:4.0.4:check (default) @ alluxio-tests ---
[INFO] BugInstance size is 0
[INFO] Error size is 0
[INFO] No errors/warnings found
[INFO]
[INFO] --- jcp:6.1.2:preprocessTests (preprocessSources) @ alluxio-tests ---
[INFO] Preprocess sources : /projects/github/alluxio/tests/src/test/java
[INFO] Preprocess destination : /projects/github/alluxio/tests/target/generated-test-sources/preprocessed
[INFO] -----------------------------------------------------------------
[INFO] Completed, preprocessed 209 files, copied 0 files, elapsed time 14016ms
[INFO] A Compile source root has been removed from the root list [/projects/github/alluxio/tests/src/test/java]
[INFO] The New compile source root has been added into the list [/projects/github/alluxio/tests/target/generated-test-sources/preprocessed]
[INFO]
[INFO] --- maven-resources-plugin:2.7:testResources (default-testResources) @ alluxio-tests ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 10 resources
[INFO]
[INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ alluxio-tests ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 201 source files to /projects/github/alluxio/tests/target/test-classes
[INFO] /projects/github/alluxio/tests/target/generated-test-sources/preprocessed/alluxio/client/fs/FileSystemMasterRestartIntegrationTest.java: Some input files use or override a deprecated API.
[INFO] /projects/github/alluxio/tests/target/generated-test-sources/preprocessed/alluxio/client/fs/FileSystemMasterRestartIntegrationTest.java: Recompile with -Xlint:deprecation for details.
[INFO] /projects/github/alluxio/tests/target/generated-test-sources/preprocessed/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java: Some input files use unchecked or unsafe operations.
[INFO] /projects/github/alluxio/tests/target/generated-test-sources/preprocessed/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java: Recompile with -Xlint:unchecked for details.
[INFO]
[INFO] --- maven-surefire-plugin:2.22.2:test (default-test) @ alluxio-tests ---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running alluxio.server.tieredstore.LostStorageIntegrationTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 112.123 s - in alluxio.server.tieredstore.LostStorageIntegrationTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  06:03 min
[INFO] Finished at: 2020-10-14T03:20:08Z
[INFO] ------------------------------------------------------------------------
```