### PR TITLE
Fix flaky server start

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -201,7 +201,15 @@ public class RaftJournalSystem extends AbstractJournalSystem {
    * mode.
    */
   private final AtomicReference<AsyncJournalWriter> mAsyncJournalWriter;
+  /**
+   * The id for submitting a normal raft client request.
+   **/
   private final ClientId mClientId = ClientId.randomId();
+  /**
+   * The id for submitting a raw raft client request.
+   * Should be used for any raft API call that requires a callId.
+   **/
+  private final ClientId mRawClientId = ClientId.randomId();
   private RaftGroup mRaftGroup;
   private RaftPeerId mPeerId;
 
@@ -373,8 +381,8 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   @Override
   public synchronized void gainPrimacy() {
     mSnapshotAllowed.set(false);
-    LocalFirstRaftClient client = new LocalFirstRaftClient(mServer, this::createClient, mClientId,
-        ServerConfiguration.global());
+    LocalFirstRaftClient client = new LocalFirstRaftClient(mServer, this::createClient,
+        mRawClientId, ServerConfiguration.global());
 
     Runnable closeClient = () -> {
       try {
@@ -498,7 +506,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     // TODO(feng): consider removing this once we can automatically propagate
     //             snapshots from secondary master
     try (LocalFirstRaftClient client = new LocalFirstRaftClient(mServer, this::createClient,
-        mClientId, ServerConfiguration.global())) {
+        mRawClientId, ServerConfiguration.global())) {
       mSnapshotAllowed.set(true);
       catchUp(mStateMachine, client);
       mStateMachine.takeLocalSnapshot();
@@ -720,7 +728,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
       RaftPeerId server, Message message) {
     RaftClient client = createClient();
     return client.getClientRpc().sendRequestAsync(
-        new RaftClientRequest(mClientId, server, RAFT_GROUP_ID, nextCallId(), message,
+        new RaftClientRequest(mRawClientId, server, RAFT_GROUP_ID, nextCallId(), message,
             RaftClientRequest.staleReadRequestType(0), null)
     ).whenComplete((reply, t) -> {
       try {
@@ -732,8 +740,8 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   }
 
   private GroupInfoReply getGroupInfo() throws IOException {
-    GroupInfoRequest groupInfoRequest = new GroupInfoRequest(mClientId,
-        mPeerId, RAFT_GROUP_ID, nextCallId());
+    GroupInfoRequest groupInfoRequest = new GroupInfoRequest(mRawClientId, mPeerId, RAFT_GROUP_ID,
+        nextCallId());
     return mServer.getGroupInfo(groupInfoRequest);
   }
 
@@ -787,7 +795,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     List<RaftPeer> newPeers = new ArrayList<>(peers);
     newPeers.add(newPeer);
     RaftClientReply reply = mServer.setConfiguration(
-        new SetConfigurationRequest(mClientId, mPeerId, RAFT_GROUP_ID, nextCallId(), newPeers));
+        new SetConfigurationRequest(mRawClientId, mPeerId, RAFT_GROUP_ID, nextCallId(), newPeers));
     if (reply.getException() != null) {
       throw reply.getException();
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
@@ -58,6 +58,7 @@ public class RaftJournalWriter implements JournalWriter {
    */
   public RaftJournalWriter(long nextSequenceNumberToWrite,
       LocalFirstRaftClient client) {
+    LOG.debug("Journal writer created starting at SN#{}", nextSequenceNumberToWrite);
     mNextSequenceNumberToWrite = new AtomicLong(nextSequenceNumberToWrite);
     mLastSubmittedSequenceNumber = new AtomicLong(-1);
     mLastCommittedSequenceNumber = new AtomicLong(-1);
@@ -77,6 +78,7 @@ public class RaftJournalWriter implements JournalWriter {
     if (mJournalEntryBuilder == null) {
       mJournalEntryBuilder = JournalEntry.newBuilder();
     }
+    LOG.trace("Writing entry {}: {}", mNextSequenceNumberToWrite, entry);
     mJournalEntryBuilder.addJournalEntries(entry.toBuilder()
         .setSequenceNumber(mNextSequenceNumberToWrite.getAndIncrement()).build());
   }
@@ -95,6 +97,7 @@ public class RaftJournalWriter implements JournalWriter {
         JournalEntry entry = mJournalEntryBuilder.build();
         Message message = RaftJournalSystem.toRaftMessage(entry);
         mLastSubmittedSequenceNumber.set(flushSN);
+        LOG.trace("Flushing entry {} ({})", entry, message);
         RaftClientReply reply = mClient
             .sendAsync(message, TimeDuration.valueOf(mWriteTimeoutMs, TimeUnit.MILLISECONDS))
             .get(mWriteTimeoutMs, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Fixed two flaky issues related to server start:

- Using same clientId for normal APIs and raw APIs can cause collision in message caching.
- Sometimes server failed to retry on AlreadyClosedException because it is wrapped in a different class.