### PR TITLE
Add --trace to jekyll build cmd to display error

### DIFF
--- a/dev/scripts/check-docs.sh
+++ b/dev/scripts/check-docs.sh
@@ -20,5 +20,5 @@ SCRIPT_DIR=$(cd "$( dirname "$( readlink "$0" || echo "$0" )" )"; pwd)
 
 GOPATH="${SCRIPT_DIR}" go run "${SCRIPT_DIR}/src/alluxio.org/check-docs/main.go"
 
-cd "${SCRIPT_DIR}"/../../docs && jekyll build
+cd "${SCRIPT_DIR}"/../../docs && jekyll build --trace
 


### PR DESCRIPTION
@bf8086 this will display a stacktrace when `jekyll build` fails within docs check