### PR TITLE
Change back the S3 client build way

### DIFF
--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -198,8 +198,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
       clientConf.setSignerOverride(conf.get(PropertyKey.UNDERFS_S3_SIGNER_ALGORITHM));
     }
 
-    AmazonS3Client amazonS3Client = (AmazonS3Client) AmazonS3Client.builder()
-            .withClientConfiguration(clientConf).withCredentials(credentials).build();
+    AmazonS3Client amazonS3Client = new AmazonS3Client(credentials, clientConf);
 
     // Set a custom endpoint.
     if (conf.isSet(PropertyKey.UNDERFS_S3_ENDPOINT)) {


### PR DESCRIPTION
Revert the S3 client build way in https://github.com/Alluxio/alluxio/pull/12261/files
This is because the new builder will cause ceph failed to run with Alluxio S3 client.
The error message is 
Caused by: java.lang.IllegalArgumentException: Unable to create an UnderFileSystem instance for path: s3a://alluxios3a
Suppressed: java.lang.UnsupportedOperationException: Client is immutable when created with the builder.
        at com.amazonaws.AmazonWebServiceClient.checkMutability(AmazonWebServiceClient.java:920)
                at com.amazonaws.AmazonWebServiceClient.setEndpoint(AmazonWebServiceClient.java:226)