### PR TITLE
Do not fail github-actions even when archiving artifacts fails

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -36,6 +36,7 @@ jobs:
         timeout-minutes: 60
 
       - name: Archive artifacts
+        continue-on-error: true
         uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/.github/workflows/java11_integration_tests.yml
+++ b/.github/workflows/java11_integration_tests.yml
@@ -84,6 +84,7 @@ jobs:
         timeout-minutes: 60
 
       - name: Archive artifacts
+        continue-on-error: true
         uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/.github/workflows/java11_unit_tests.yml
+++ b/.github/workflows/java11_unit_tests.yml
@@ -72,6 +72,7 @@ jobs:
         timeout-minutes: 60
 
       - name: Archive artifacts
+        continue-on-error: true
         uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -81,6 +81,7 @@ jobs:
         timeout-minutes: 60
 
       - name: Archive artifacts
+        continue-on-error: true
         uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/.github/workflows/java8_unit_tests.yml
+++ b/.github/workflows/java8_unit_tests.yml
@@ -69,6 +69,7 @@ jobs:
         timeout-minutes: 60
 
       - name: Archive artifacts
+        continue-on-error: true
         uses: actions/upload-artifact@v2
         if: always()
         with:


### PR DESCRIPTION
Uploading github-actions artifacts is extremely flaky. Just look at https://github.com/actions/upload-artifact/issues/84#issuecomment-635056117 (Note the many +1 on the issue even after the issue has been closed.).

This tries to make sure that the test isn't marked as failure because archiving the artifacts failed on some files.