### PR TITLE
Bump hadoop-azure pkg version to 2.10.0

### DIFF
--- a/underfs/adl/pom.xml
+++ b/underfs/adl/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <!-- The hadoop client version adl-hadoop depends on -->
-    <adl.hadoop.version>2.9.1</adl.hadoop.version>
+    <adl.hadoop.version>2.10.0</adl.hadoop.version>
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>

--- a/underfs/wasb/pom.xml
+++ b/underfs/wasb/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <!-- The hadoop client version wasb-hadoop depends on -->
-    <wasb.hadoop.version>2.7.3.2.6.1.0-129</wasb.hadoop.version>
+    <wasb.hadoop.version>2.10.0</wasb.hadoop.version>
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>


### PR DESCRIPTION
Hadoop-azure 2.10.0 contains an important performance fix for listing flat directory with large numbers of files. Alluxio currently uses 2.7.3. With this fix, listing a dir with 8m files takes 20 min, down from hours.

Ref: https://issues.apache.org/jira/browse/HADOOP-15547