### PR TITLE
[SMALLFIX] Improve runTests command

### DIFF
--- a/shell/src/main/java/alluxio/cli/TestRunner.java
+++ b/shell/src/main/java/alluxio/cli/TestRunner.java
@@ -128,10 +128,6 @@ public final class TestRunner {
     for (ReadType readType : readTypes) {
       for (WriteType writeType : writeTypes) {
         for (OperationType opType : operations) {
-          if (readType == ReadType.CACHE_PROMOTE && writeType == WriteType.THROUGH) {
-            System.out.println("Skip this test");
-            continue;
-          }
           System.out.println(String.format("runTest --operation %s --readType %s --writeType %s", opType, readType, writeType));
           failed += runTest(opType, readType, writeType, fsContext);
         }

--- a/shell/src/main/java/alluxio/cli/TestRunner.java
+++ b/shell/src/main/java/alluxio/cli/TestRunner.java
@@ -128,7 +128,8 @@ public final class TestRunner {
     for (ReadType readType : readTypes) {
       for (WriteType writeType : writeTypes) {
         for (OperationType opType : operations) {
-          System.out.println(String.format("runTest --operation %s --readType %s --writeType %s", opType, readType, writeType));
+          System.out.println(String.format("runTest --operation %s --readType %s --writeType %s",
+                  opType, readType, writeType));
           failed += runTest(opType, readType, writeType, fsContext);
         }
       }

--- a/shell/src/main/java/alluxio/cli/TestRunner.java
+++ b/shell/src/main/java/alluxio/cli/TestRunner.java
@@ -128,7 +128,11 @@ public final class TestRunner {
     for (ReadType readType : readTypes) {
       for (WriteType writeType : writeTypes) {
         for (OperationType opType : operations) {
-          System.out.println(String.format("runTest %s %s %s", opType, readType, writeType));
+          if (readType == ReadType.CACHE_PROMOTE && writeType == WriteType.THROUGH) {
+            System.out.println("Skip this test");
+            continue;
+          }
+          System.out.println(String.format("runTest --operation %s --readType %s --writeType %s", opType, readType, writeType));
           failed += runTest(opType, readType, writeType, fsContext);
         }
       }


### PR DESCRIPTION
A small improvement to the printout so that the printed command can be run by users.
Example:
```
$ alluxio runTests
**runTest --operation BASIC --readType NO_CACHE --writeType ASYNC_THROUGH**
2020-10-20 16:09:47,021 INFO  BasicOperations - writeFile to file /default_tests_files/BASIC_NO_CACHE_ASYNC_THROUGH took 18 ms.
2020-10-20 16:09:47,025 INFO  BasicOperations - readFile file /default_tests_files/BASIC_NO_CACHE_ASYNC_THROUGH took 4 ms.

# The printout contains a runnable command
$ alluxio runTest --operation BASIC --readType NO_CACHE --writeType ASYNC_THROUGH
```