### PR TITLE
Change the output of validation tools to an object

### DIFF
--- a/core/common/src/main/java/alluxio/cli/ValidationResults.java
+++ b/core/common/src/main/java/alluxio/cli/ValidationResults.java
@@ -1,0 +1,40 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.cli;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A container class for the validation results.
+ */
+public class ValidationResults {
+  private Map<ValidationUtils.State, List<ValidationTaskResult>> mResult;
+
+  /**
+   * Set validation results.
+   *
+   * @param result validation result
+   */
+  public void setResult(Map<ValidationUtils.State, List<ValidationTaskResult>> result) {
+    mResult = result;
+  }
+
+  /**
+   * Get Validation Result.
+   *
+   * @return validation result
+   */
+  public Map<ValidationUtils.State, List<ValidationTaskResult>> getResult() {
+    return mResult;
+  }
+}

--- a/core/common/src/main/java/alluxio/cli/ValidationTool.java
+++ b/core/common/src/main/java/alluxio/cli/ValidationTool.java
@@ -43,12 +43,14 @@ public interface ValidationTool {
    * @param results a result from a validation tool
    * @return a map representing the result input
    */
-  static Map<ValidationUtils.State, List<ValidationTaskResult>> convertResults(
+  static ValidationResults convertResults(
       List<ValidationTaskResult> results) {
     // group by state
     Map<ValidationUtils.State, List<ValidationTaskResult>> map = new HashMap<>();
     results.forEach(r -> map.computeIfAbsent(r.getState(), k -> new ArrayList<>()).add(r));
-    return map;
+    ValidationResults finalResults = new ValidationResults();
+    finalResults.setResult(map);
+    return finalResults;
   }
 
   /**
@@ -57,7 +59,7 @@ public interface ValidationTool {
    * @param map result stored in a map
    * @return a string containing json representation of the result
    */
-  static String toJson(Map<ValidationUtils.State, List<ValidationTaskResult>> map) {
+  static String toJson(ValidationResults map) {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
     return gson.toJson(map);
   }

--- a/core/common/src/main/java/alluxio/cli/ValidationUtils.java
+++ b/core/common/src/main/java/alluxio/cli/ValidationUtils.java
@@ -53,9 +53,6 @@ public final class ValidationUtils {
    * */
   public static boolean isHdfsScheme(String path) {
     String scheme = new AlluxioURI(path).getScheme();
-    if (scheme == null || !scheme.startsWith("hdfs")) {
-      return false;
-    }
-    return true;
+    return scheme != null && scheme.startsWith("hdfs");
   }
 }

--- a/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationTool.java
+++ b/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationTool.java
@@ -85,8 +85,8 @@ public class HmsValidationTool implements ValidationTool {
           .getOrDefault(ValidationConfig.DATABASE_CONFIG_NAME, DEFAULT_DATABASE);
       tables = (String) configMap
           .getOrDefault(ValidationConfig.TABLES_CONFIG_NAME, "");
-      socketTimeout = (int) configMap
-          .getOrDefault(ValidationConfig.SOCKET_TIMEOUT_CONFIG_NAME, DEFAULT_SOCKET_TIMEOUT);
+      socketTimeout = Integer.parseInt(configMap
+          .getOrDefault(ValidationConfig.SOCKET_TIMEOUT_CONFIG_NAME, DEFAULT_SOCKET_TIMEOUT).toString());
     } catch (RuntimeException e) {
       // Try not to throw exception on the construction function
       // The hms validation tool itself should return failed message if the given config is invalid

--- a/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationTool.java
+++ b/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationTool.java
@@ -86,7 +86,8 @@ public class HmsValidationTool implements ValidationTool {
       tables = (String) configMap
           .getOrDefault(ValidationConfig.TABLES_CONFIG_NAME, "");
       socketTimeout = Integer.parseInt(configMap
-          .getOrDefault(ValidationConfig.SOCKET_TIMEOUT_CONFIG_NAME, DEFAULT_SOCKET_TIMEOUT).toString());
+          .getOrDefault(ValidationConfig.SOCKET_TIMEOUT_CONFIG_NAME, DEFAULT_SOCKET_TIMEOUT)
+          .toString());
     } catch (RuntimeException e) {
       // Try not to throw exception on the construction function
       // The hms validation tool itself should return failed message if the given config is invalid


### PR DESCRIPTION
Change the output to a validation object so that Json serialization can handle it better.