### PR TITLE
Add a releaseProfile to generate dependency reduced pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1489,7 +1489,7 @@
       </build>
     </profile>
     <profile>
-      <id>release-profile</id>
+      <id>release</id>
       <properties>
         <!--
             The maven shade plugin has a bug where enabling the `createDependencyReducedPom`

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,7 @@
     <update.check.enabled>true</update.check.enabled>
     <update.check.host>https://diagnostics.alluxio.io</update.check.host>
     <findbugs.skip>false</findbugs.skip>
+    <create.dependency.reduced.pom>false</create.dependency.reduced.pom>
   </properties>
 
   <modules>
@@ -1486,6 +1487,20 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>release-profile</id>
+      <properties>
+        <!--
+            The maven shade plugin has a bug where enabling the `createDependencyReducedPom`
+            property causes maven to go into an infinite loop (MSHADE-148). This is only an
+            issue for the Alluxio build if the maven version is 3.3.x or newer.
+            However, since disabling this property has the side effect of not resolving
+            variables in the released pom files, we need to enable this during
+            releases.
+        -->
+        <create.dependency.reduced.pom>true</create.dependency.reduced.pom>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/shaded/client/pom.xml
+++ b/shaded/client/pom.xml
@@ -172,6 +172,7 @@
             <configuration>
               <createSourcesJar>true</createSourcesJar>
               <shadeSourcesContent>true</shadeSourcesContent>
+              <createDependencyReducedPom>${create.dependency.reduced.pom}</createDependencyReducedPom>
               <artifactSet>
                 <excludes>
                   <!-- Leave slf4j unshaded so downstream users can configure logging -->

--- a/shaded/hadoop/pom.xml
+++ b/shaded/hadoop/pom.xml
@@ -138,6 +138,7 @@
             <configuration>
               <!-- Since we don't shade all artifacts, we need to promote the transitive dependencies -->
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <createDependencyReducedPom>${create.dependency.reduced.pom}</createDependencyReducedPom>
               <relocations>
                 <relocation>
                   <pattern>com.google</pattern>


### PR DESCRIPTION
#12338

This is a workaround for MSHADE-148, which leads to an infinite loop when building Alluxio.

There are two scenarios.
- Releasing Alluxio
Maven build with `-Prelease`. 
  - If using newer than `3.3.x` version of maven, you also have to use sequential build, Like `mvn clean install -Prelease xxxx`.
  - If using lower version maven before `3.3.x`, you can use parallel build, e.g. `mvn clean install -T 4 -Prelease xxxx`
- Not Releasing Alluxio
If you are not releasing Alluxio, you can build Alluxio like before, please don't add the `-Prelease` into you build command line. e.g. `mvn clean install -T 4 xxxx`

This patch adds a -Prelease. If present, it will set createDependencyReducedPom true. The consequences are:

If you are releasing Alluxio with this profile, you are fine as long as before.
If you are releasing Alluxio without this profile, the `alluxio-shaded-xxx-yyy.pom` will be the same as the pom.xml under the module directory.
If you are not releasing Alluxio but you are using this profile, you may run into #12338
If you are not releasing Alluxio and you did not include this profile, you are fine.
This is all documented in pom.xml and tested locally with maven 3.6.3.