### PR TITLE
Fix memory leak in inode tree iterator

### DIFF
--- a/core/common/src/main/java/alluxio/resource/CloseableIterator.java
+++ b/core/common/src/main/java/alluxio/resource/CloseableIterator.java
@@ -1,0 +1,90 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.resource;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.io.Closer;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A {@code CloseableIterator<T>} is an iterator which requires cleanup when it is no longer in use.
+ *
+ * @param <T> the type of elements returned by the iterator
+ */
+public abstract class CloseableIterator<T> extends CloseableResource<Iterator<T>> {
+  /**
+   * Creates a {@link CloseableIterator} wrapper around the given iterator. This iterator will
+   * be returned by the {@link CloseableIterator#get()} method.
+   *
+   * @param iterator the resource to wrap
+   */
+  public CloseableIterator(Iterator<T> iterator) {
+    super(iterator);
+  }
+
+  /**
+   * Wrap around an iterator with no resource to close.
+   *
+   * @param iterator the iterator to wrap around
+   * @param <T> the type of the iterable
+   * @return the closeable iterator
+   */
+  public static <T> CloseableIterator<T> noopCloseable(Iterator<? extends T> iterator) {
+    return new CloseableIterator(iterator) {
+      @Override
+      public void close() {
+        // no-op
+      }
+    };
+  }
+
+  /**
+   * Combines two iterators into a single iterator.
+   *
+   * @param a an iterator
+   * @param b another iterator
+   * @param <T> type of iterator
+   * @return the concatenated iterator
+   */
+  public static <T> CloseableIterator<T> concat(CloseableIterator<T> a, CloseableIterator<T> b) {
+    return concat(Lists.newArrayList(a, b));
+  }
+
+  /**
+   * Concatenate iterators.
+   *
+   * @param iterators a list of iterators
+   * @param <T> type of iterator
+   * @return a concatenated iterator that iterate over all elements from each of the child iterators
+   */
+  public static <T> CloseableIterator<T> concat(
+      List<CloseableIterator<T>> iterators) {
+    Iterator<? extends T> it = Iterators.concat(iterators.stream().map(CloseableIterator::get)
+        .iterator());
+    return new CloseableIterator<T>(Iterators.concat(it)) {
+      @Override
+      public void close() {
+        Closer c = Closer.create();
+        iterators.forEach(c::register);
+        try {
+          c.close();
+        } catch (IOException e) {
+          throw new RuntimeException("Failed to close iterator", e);
+        }
+      }
+    };
+  }
+}

--- a/core/common/src/test/java/alluxio/resource/CloseableIteratorTest.java
+++ b/core/common/src/test/java/alluxio/resource/CloseableIteratorTest.java
@@ -1,0 +1,82 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.resource;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Tests for {@link CloseableIterator} functions.
+ */
+public final class CloseableIteratorTest {
+  @Test
+  public void concatTwo() {
+    ArrayList<Integer> list1 = Lists.newArrayList(1, 2);
+    ArrayList<Integer> list2 = Lists.newArrayList(3, 4, 5);
+    TestIterator iterator1 = new TestIterator(list1);
+    TestIterator iterator2 = new TestIterator(list2);
+    CloseableIterator<Integer> iterator3 = CloseableIterator.concat(iterator1, iterator2);
+    Iterators.elementsEqual(Iterators.concat(list1.iterator(), list2.iterator()), iterator3.get());
+    iterator3.close();
+    Assert.assertTrue(iterator1.isClosed());
+    Assert.assertTrue(iterator2.isClosed());
+  }
+
+  @Test
+  public void concatList() {
+    ArrayList<Integer> list1 = Lists.newArrayList(1, 2);
+    ArrayList<Integer> list2 = Lists.newArrayList(3, 4, 5);
+    ArrayList<Integer> list3 = Lists.newArrayList(0);
+    TestIterator iterator1 = new TestIterator(list1);
+    TestIterator iterator2 = new TestIterator(list2);
+    TestIterator iterator3 = new TestIterator(list3);
+    CloseableIterator<Integer> iterator4 = CloseableIterator.concat(
+        Lists.newArrayList(iterator1, iterator2, iterator3));
+    Iterators.elementsEqual(Iterators.concat(list1.iterator(), list2.iterator(), list3.iterator()),
+        iterator4.get());
+    iterator4.close();
+    Assert.assertTrue(iterator1.isClosed());
+    Assert.assertTrue(iterator2.isClosed());
+    Assert.assertTrue(iterator3.isClosed());
+  }
+
+  @Test
+  public void noopCloseable() {
+    Iterator<Integer> iterator = Lists.newArrayList(1, 2).iterator();
+    CloseableIterator<Integer> closeable = CloseableIterator
+        .noopCloseable(Lists.newArrayList(1, 2).iterator());
+    Iterators.elementsEqual(iterator, closeable.get());
+  }
+
+  static class TestIterator extends CloseableIterator<Integer> {
+    private boolean mClosed;
+
+    public TestIterator(List<Integer> list) {
+      super(list.iterator());
+    }
+
+    @Override
+    public void close() {
+      mClosed = true;
+    }
+
+    public boolean isClosed() {
+      return mClosed;
+    }
+  }
+}

--- a/core/server/common/src/main/java/alluxio/master/journal/DelegatingJournaled.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/DelegatingJournaled.java
@@ -13,12 +13,11 @@ package alluxio.master.journal;
 
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.CheckpointName;
-import alluxio.proto.journal.Journal;
 import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.resource.CloseableIterator;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Iterator;
 import java.util.function.Supplier;
 
 /**
@@ -57,7 +56,7 @@ public interface DelegatingJournaled extends Journaled {
   }
 
   @Override
-  default Iterator<Journal.JournalEntry> getJournalEntryIterator() {
+  default CloseableIterator<JournalEntry> getJournalEntryIterator() {
     return getDelegate().getJournalEntryIterator();
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalEntryIterable.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalEntryIterable.java
@@ -12,15 +12,14 @@
 package alluxio.master.journal;
 
 import alluxio.proto.journal.Journal;
-
-import java.util.Iterator;
+import alluxio.resource.CloseableIterator;
 
 /**
  * Interface to get an iterator of {@link alluxio.proto.journal.Journal.JournalEntry}s.
  */
 public interface JournalEntryIterable {
   /**
-   * @return an {@link Iterator} that iterates all the journal entries
+   * @return an {@link CloseableIterator} that iterates all the journal entries
    */
-  Iterator<Journal.JournalEntry> getJournalEntryIterator();
+  CloseableIterator<Journal.JournalEntry> getJournalEntryIterator();
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/JournaledGroup.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournaledGroup.java
@@ -14,14 +14,13 @@ package alluxio.master.journal;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.resource.CloseableIterator;
 import alluxio.util.StreamUtils;
 
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -82,9 +81,9 @@ public class JournaledGroup implements Journaled {
   }
 
   @Override
-  public Iterator<JournalEntry> getJournalEntryIterator() {
-    List<Iterator<JournalEntry>> componentIters = StreamUtils
+  public CloseableIterator<JournalEntry> getJournalEntryIterator() {
+    List<CloseableIterator<JournalEntry>> componentIters = StreamUtils
         .map(JournalEntryIterable::getJournalEntryIterator, mJournaled);
-    return Iterators.concat(componentIters.iterator());
+    return CloseableIterator.concat(componentIters);
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/NoopJournaled.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/NoopJournaled.java
@@ -16,11 +16,11 @@ import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.master.journal.checkpoint.CheckpointOutputStream;
 import alluxio.master.journal.checkpoint.CheckpointType;
 import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.resource.CloseableIterator;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collections;
-import java.util.Iterator;
 
 /**
  * Interface providing default implementations which do nothing.
@@ -52,7 +52,7 @@ public interface NoopJournaled extends Journaled {
   }
 
   @Override
-  default Iterator<JournalEntry> getJournalEntryIterator() {
-    return Collections.emptyIterator();
+  default CloseableIterator<JournalEntry> getJournalEntryIterator() {
+    return CloseableIterator.noopCloseable(Collections.emptyIterator());
   }
 }

--- a/core/server/common/src/test/java/alluxio/master/journal/JournalUtilsTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/JournalUtilsTest.java
@@ -19,6 +19,7 @@ import alluxio.master.journal.checkpoint.CheckpointOutputStream;
 import alluxio.master.journal.checkpoint.CheckpointType;
 import alluxio.proto.journal.File.AddMountPointEntry;
 import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.resource.CloseableIterator;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,7 +30,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -98,9 +98,9 @@ public final class JournalUtilsTest {
     }
 
     @Override
-    public Iterator<JournalEntry> getJournalEntryIterator() {
-      return Arrays.asList(JournalEntry.newBuilder()
-          .setAddMountPoint(AddMountPointEntry.getDefaultInstance()).build()).iterator();
+    public CloseableIterator<JournalEntry> getJournalEntryIterator() {
+      return CloseableIterator.noopCloseable(Arrays.asList(JournalEntry.newBuilder()
+          .setAddMountPoint(AddMountPointEntry.getDefaultInstance()).build()).iterator());
     }
 
     @Override

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -58,6 +58,7 @@ import alluxio.proto.journal.Block.DeleteBlockEntry;
 import alluxio.proto.journal.Journal.JournalEntry;
 import alluxio.proto.meta.Block.BlockLocation;
 import alluxio.proto.meta.Block.BlockMeta;
+import alluxio.resource.CloseableIterator;
 import alluxio.resource.LockResource;
 import alluxio.util.CommonUtils;
 import alluxio.util.IdUtils;
@@ -337,7 +338,7 @@ public final class DefaultBlockMaster extends CoreMaster implements BlockMaster 
   }
 
   @Override
-  public Iterator<JournalEntry> getJournalEntryIterator() {
+  public CloseableIterator<JournalEntry> getJournalEntryIterator() {
     Iterator<Block> it = mBlockStore.iterator();
     Iterator<JournalEntry> blockIterator = new Iterator<JournalEntry>() {
       @Override
@@ -363,8 +364,8 @@ public final class DefaultBlockMaster extends CoreMaster implements BlockMaster 
       }
     };
 
-    return Iterators
-        .concat(CommonUtils.singleElementIterator(getContainerIdJournalEntry()), blockIterator);
+    return CloseableIterator.noopCloseable(Iterators
+        .concat(CommonUtils.singleElementIterator(getContainerIdJournalEntry()), blockIterator));
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -32,6 +32,7 @@ import alluxio.proto.journal.File.AddSyncPointEntry;
 import alluxio.proto.journal.File.RemoveSyncPointEntry;
 import alluxio.proto.journal.Journal;
 import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.resource.CloseableIterator;
 import alluxio.resource.CloseableResource;
 import alluxio.resource.LockResource;
 import alluxio.retry.RetryUtils;
@@ -752,7 +753,8 @@ public class ActiveSyncManager implements Journaled {
   }
 
   @Override
-  public Iterator<JournalEntry> getJournalEntryIterator() {
-    return Iterators.concat(getSyncPathIterator(), getTxIdIterator());
+  public CloseableIterator<JournalEntry> getJournalEntryIterator() {
+    return CloseableIterator.noopCloseable(
+        Iterators.concat(getSyncPathIterator(), getTxIdIterator()));
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectoryIdGenerator.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectoryIdGenerator.java
@@ -20,11 +20,10 @@ import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.Journaled;
 import alluxio.proto.journal.File.InodeDirectoryIdGeneratorEntry;
 import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.resource.CloseableIterator;
 import alluxio.util.CommonUtils;
 
 import com.google.common.base.Preconditions;
-
-import java.util.Iterator;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -108,12 +107,13 @@ public class InodeDirectoryIdGenerator implements Journaled {
   }
 
   @Override
-  public Iterator<JournalEntry> getJournalEntryIterator() {
-    return CommonUtils.singleElementIterator(JournalEntry.newBuilder()
-        .setInodeDirectoryIdGenerator(InodeDirectoryIdGeneratorEntry.newBuilder()
-            .setContainerId(mNextDirectoryId.getContainerId())
-            .setSequenceNumber(mNextDirectoryId.getSequenceNumber()))
-        .build());
+  public CloseableIterator<JournalEntry> getJournalEntryIterator() {
+    return CloseableIterator.noopCloseable(CommonUtils.singleElementIterator(
+        JournalEntry.newBuilder()
+            .setInodeDirectoryIdGenerator(InodeDirectoryIdGeneratorEntry.newBuilder()
+                .setContainerId(mNextDirectoryId.getContainerId())
+                .setSequenceNumber(mNextDirectoryId.getSequenceNumber()))
+        .build()));
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreeBufferedIterator.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreeBufferedIterator.java
@@ -15,11 +15,13 @@ import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.master.metastore.InodeStore;
 import alluxio.proto.journal.Journal;
+import alluxio.resource.CloseableIterator;
 import alluxio.util.ThreadFactoryUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -44,12 +46,13 @@ import java.util.concurrent.atomic.AtomicReference;
  * makes applying those entries later more efficient by guaranteeing that a parent of an inode is
  * iterated before it.
  */
-public class InodeTreeBufferedIterator implements Iterator<Journal.JournalEntry> {
+public class InodeTreeBufferedIterator implements Iterator<Journal.JournalEntry>, Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(InodeTreeBufferedIterator.class);
 
   // Used to signal end of iteration.
   private static final long TERMINATION_SEQ = -1;
   private static final long FAILURE_SEQ = -2;
+  private final ExecutorService mThreadPool;
   /** Underlying inode store. */
   InodeStore mInodeStore;
   /** Root inode for enumeration. */
@@ -72,12 +75,24 @@ public class InodeTreeBufferedIterator implements Iterator<Journal.JournalEntry>
   private AtomicReference<Throwable> mBufferingFailure;
 
   /**
-   * Creates buffered iterator.
+   * Creates buffered iterator with closeable interface.
    *
    * @param inodeStore the inode store
    * @param rootInode root inode
+   * @return the buffered iterator
    */
-  public InodeTreeBufferedIterator(InodeStore inodeStore, InodeDirectory rootInode) {
+  public static CloseableIterator<Journal.JournalEntry> create(InodeStore inodeStore,
+      InodeDirectory rootInode) {
+    InodeTreeBufferedIterator iterator = new InodeTreeBufferedIterator(inodeStore, rootInode);
+    return new CloseableIterator<Journal.JournalEntry>(iterator) {
+      @Override
+      public void close() {
+        iterator.close();
+      }
+    };
+  }
+
+  private InodeTreeBufferedIterator(InodeStore inodeStore, InodeDirectory rootInode) {
     mInodeStore = inodeStore;
     mRootInode = rootInode;
     // Initialize configuration values.
@@ -89,9 +104,10 @@ public class InodeTreeBufferedIterator implements Iterator<Journal.JournalEntry>
     // Create executors.
     mCoordinatorExecutor = Executors.newSingleThreadExecutor(
         ThreadFactoryUtils.build("inode-tree-crawler-coordinator-%d", true));
+    mThreadPool = Executors.newFixedThreadPool(iteratorThreadCount,
+        ThreadFactoryUtils.build("inode-tree-crawler-%d", true));
     mCrawlerCompletionService =
-        new ExecutorCompletionService(Executors.newFixedThreadPool(iteratorThreadCount,
-            ThreadFactoryUtils.build("inode-tree-crawler-%d", true)));
+        new ExecutorCompletionService(mThreadPool);
     // Used to keep futures of active crawlers.
     mActiveCrawlers = new HashSet<>();
 
@@ -266,6 +282,7 @@ public class InodeTreeBufferedIterator implements Iterator<Journal.JournalEntry>
           return mNextElements.size() > 0;
         }
       } catch (InterruptedException ie) {
+        mActiveCrawlers.forEach((future) -> future.cancel(true));
         // Continue interrupt chain.
         Thread.currentThread().interrupt();
         throw new RuntimeException("Thread interrupted while taking an entry from buffer.");
@@ -301,5 +318,12 @@ public class InodeTreeBufferedIterator implements Iterator<Journal.JournalEntry>
   @Override
   public void remove() {
     throw new UnsupportedOperationException("remove is not supported in inode tree iterator");
+  }
+
+  @Override
+  public void close() {
+    LOG.debug("Closing {} inode tree iterators", mActiveCrawlers.size());
+    mCoordinatorExecutor.shutdownNow();
+    mThreadPool.shutdownNow();
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreePersistentState.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreePersistentState.java
@@ -36,6 +36,7 @@ import alluxio.proto.journal.File.UpdateInodeEntry;
 import alluxio.proto.journal.File.UpdateInodeEntry.Builder;
 import alluxio.proto.journal.File.UpdateInodeFileEntry;
 import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.resource.CloseableIterator;
 import alluxio.resource.LockResource;
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
@@ -54,7 +55,6 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
@@ -732,8 +732,8 @@ public class InodeTreePersistentState implements Journaled {
   }
 
   @Override
-  public Iterator<JournalEntry> getJournalEntryIterator() {
-    return new InodeTreeBufferedIterator(mInodeStore, getRoot());
+  public CloseableIterator<JournalEntry> getJournalEntryIterator() {
+    return InodeTreeBufferedIterator.create(mInodeStore, getRoot());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -31,6 +31,7 @@ import alluxio.proto.journal.File.DeleteMountPointEntry;
 import alluxio.proto.journal.File.StringPairEntry;
 import alluxio.proto.journal.Journal;
 import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.resource.CloseableIterator;
 import alluxio.resource.CloseableResource;
 import alluxio.resource.LockResource;
 import alluxio.underfs.UfsManager;
@@ -573,9 +574,9 @@ public final class MountTable implements DelegatingJournaled {
     }
 
     @Override
-    public Iterator<Journal.JournalEntry> getJournalEntryIterator() {
+    public CloseableIterator<JournalEntry> getJournalEntryIterator() {
       final Iterator<Map.Entry<String, MountInfo>> it = mMountTable.entrySet().iterator();
-      return new Iterator<Journal.JournalEntry>() {
+      return CloseableIterator.noopCloseable(new Iterator<Journal.JournalEntry>() {
         /** mEntry is always set to the next non-root mount point if exists. */
         private Map.Entry<String, MountInfo> mEntry = null;
 
@@ -627,7 +628,7 @@ public final class MountTable implements DelegatingJournaled {
         public void remove() {
           throw new UnsupportedOperationException("Mountable#Iterator#remove is not supported.");
         }
-      };
+      });
     }
 
     @Override

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -50,6 +50,7 @@ import alluxio.master.meta.checkconf.ServerConfigurationChecker;
 import alluxio.master.meta.checkconf.ServerConfigurationStore;
 import alluxio.proto.journal.Journal;
 import alluxio.proto.journal.Meta;
+import alluxio.resource.CloseableIterator;
 import alluxio.resource.LockResource;
 import alluxio.underfs.UfsManager;
 import alluxio.util.ConfigurationUtils;
@@ -73,7 +74,6 @@ import java.net.InetSocketAddress;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -206,13 +206,13 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
     }
 
     @Override
-    public Iterator<Journal.JournalEntry> getJournalEntryIterator() {
+    public CloseableIterator<Journal.JournalEntry> getJournalEntryIterator() {
       if (mClusterID.equals(INVALID_CLUSTER_ID)) {
-        return Collections.emptyIterator();
+        return CloseableIterator.noopCloseable(Collections.emptyIterator());
       }
-      return Collections.singleton(Journal.JournalEntry.newBuilder()
+      return CloseableIterator.noopCloseable(Collections.singleton(Journal.JournalEntry.newBuilder()
           .setClusterInfo(Meta.ClusterInfoEntry.newBuilder().setClusterId(mClusterID).build())
-          .build()).iterator();
+          .build()).iterator());
     }
   }
 
@@ -566,8 +566,8 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
   }
 
   @Override
-  public Iterator<Journal.JournalEntry> getJournalEntryIterator() {
-    return com.google.common.collect.Iterators.concat(mPathProperties.getJournalEntryIterator(),
+  public CloseableIterator<Journal.JournalEntry> getJournalEntryIterator() {
+    return CloseableIterator.concat(mPathProperties.getJournalEntryIterator(),
         mState.getJournalEntryIterator());
   }
 

--- a/core/server/master/src/main/java/alluxio/master/meta/PathProperties.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/PathProperties.java
@@ -21,12 +21,12 @@ import alluxio.proto.journal.Journal;
 import alluxio.proto.journal.Journal.JournalEntry;
 import alluxio.proto.journal.Meta.PathPropertiesEntry;
 import alluxio.proto.journal.Meta.RemovePathPropertiesEntry;
+import alluxio.resource.CloseableIterator;
 import alluxio.resource.LockResource;
 
 import com.google.common.collect.Iterators;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -241,13 +241,14 @@ public final class PathProperties implements DelegatingJournaled {
     }
 
     @Override
-    public Iterator<Journal.JournalEntry> getJournalEntryIterator() {
-      return Iterators.transform(mProperties.entrySet().iterator(), entry -> {
-        String path = entry.getKey();
-        Map<String, String> properties = entry.getValue();
-        return Journal.JournalEntry.newBuilder().setPathProperties(PathPropertiesEntry.newBuilder()
-            .setPath(path).putAllProperties(properties).build()).build();
-      });
+    public CloseableIterator<JournalEntry> getJournalEntryIterator() {
+      return CloseableIterator.noopCloseable(
+          Iterators.transform(mProperties.entrySet().iterator(), entry -> {
+            String path = entry.getKey();
+            Map<String, String> properties = entry.getValue();
+            return Journal.JournalEntry.newBuilder().setPathProperties(PathPropertiesEntry
+                .newBuilder().setPath(path).putAllProperties(properties).build()).build();
+          }));
     }
   }
 }

--- a/core/server/master/src/main/java/alluxio/underfs/MasterUfsManager.java
+++ b/core/server/master/src/main/java/alluxio/underfs/MasterUfsManager.java
@@ -21,6 +21,7 @@ import alluxio.master.journal.Journaled;
 import alluxio.proto.journal.File;
 import alluxio.proto.journal.File.UpdateUfsModeEntry;
 import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.resource.CloseableIterator;
 import alluxio.util.network.NetworkAddressUtils;
 
 import org.slf4j.Logger;
@@ -29,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -129,7 +129,7 @@ public final class MasterUfsManager extends AbstractUfsManager implements Delega
   }
 
   @Override
-  public Iterator<JournalEntry> getJournalEntryIterator() {
+  public CloseableIterator<JournalEntry> getJournalEntryIterator() {
     return mState.getJournalEntryIterator();
   }
 
@@ -174,13 +174,13 @@ public final class MasterUfsManager extends AbstractUfsManager implements Delega
     }
 
     @Override
-    public Iterator<JournalEntry> getJournalEntryIterator() {
-      return mUfsModes.entrySet().stream()
+    public CloseableIterator<JournalEntry> getJournalEntryIterator() {
+      return CloseableIterator.noopCloseable(mUfsModes.entrySet().stream()
           .map(e -> JournalEntry.newBuilder().setUpdateUfsMode(UpdateUfsModeEntry.newBuilder()
               .setUfsPath(e.getKey())
               .setUfsMode(File.UfsMode.valueOf(e.getValue().name())))
               .build())
-          .iterator();
+          .iterator());
     }
 
     @Override

--- a/core/server/master/src/test/java/alluxio/master/MockMaster.java
+++ b/core/server/master/src/test/java/alluxio/master/MockMaster.java
@@ -18,9 +18,9 @@ import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.master.journal.JournalContext;
 import alluxio.proto.journal.Journal;
 import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.resource.CloseableIterator;
 
 import java.util.ArrayDeque;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -73,8 +73,8 @@ public final class MockMaster implements Master {
   public void resetState() {}
 
   @Override
-  public Iterator<Journal.JournalEntry> getJournalEntryIterator() {
-    return mEntries.iterator();
+  public CloseableIterator<JournalEntry> getJournalEntryIterator() {
+    return CloseableIterator.noopCloseable(mEntries.iterator());
   }
 
   @Override

--- a/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -46,6 +46,7 @@ import alluxio.master.metastore.InodeStore;
 import alluxio.master.metrics.MetricsMaster;
 import alluxio.master.metrics.MetricsMasterFactory;
 import alluxio.proto.journal.Journal;
+import alluxio.resource.CloseableIterator;
 import alluxio.security.authorization.Mode;
 import alluxio.underfs.UfsManager;
 import alluxio.util.CommonUtils;
@@ -65,7 +66,6 @@ import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -750,16 +750,17 @@ public final class InodeTreeTest {
 
   // helper for verifying that correct objects were journaled to the output stream
   private static void verifyJournal(InodeTree root, List<MutableInode<?>> journaled) {
-    Iterator<alluxio.proto.journal.Journal.JournalEntry> it = root.getJournalEntryIterator();
-    // Read entries from InodeTree.
-    List<Journal.JournalEntry> treeEntries = new LinkedList<>();
-    while (it.hasNext()) {
-      treeEntries.add(it.next());
-    }
+    try (CloseableIterator<Journal.JournalEntry> it = root.getJournalEntryIterator()) {
+      // Read entries from InodeTree.
+      List<Journal.JournalEntry> treeEntries = new LinkedList<>();
+      while (it.get().hasNext()) {
+        treeEntries.add(it.get().next());
+      }
 
-    // Validate InodeTree entries match given entries.
-    for (MutableInode<?> node : journaled) {
-      assertTrue(treeEntries.contains(node.toJournalEntry()));
+      // Validate InodeTree entries match given entries.
+      for (MutableInode<?> node : journaled) {
+        assertTrue(treeEntries.contains(node.toJournalEntry()));
+      }
     }
   }
 

--- a/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalCheckpointThreadTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalCheckpointThreadTest.java
@@ -16,6 +16,7 @@ import alluxio.conf.ServerConfiguration;
 import alluxio.master.MockMaster;
 import alluxio.master.NoopMaster;
 import alluxio.proto.journal.Journal;
+import alluxio.resource.CloseableIterator;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.CommonUtils;
 import alluxio.util.URIUtils;
@@ -33,7 +34,6 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
-import java.util.Iterator;
 
 /**
  * Unit tests for {@link alluxio.master.journal.ufs.UfsJournalCheckpointThread}.
@@ -109,8 +109,8 @@ public final class UfsJournalCheckpointThreadTest {
 
     // Make sure all the journal entries have been processed. Note that it is not necessary that
     // the they are checkpointed.
-    Iterator<Journal.JournalEntry> it = mockMaster.getJournalEntryIterator();
-    Assert.assertEquals(10, Iterators.size(it));
+    CloseableIterator<Journal.JournalEntry> it = mockMaster.getJournalEntryIterator();
+    Assert.assertEquals(10, Iterators.size(it.get()));
   }
 
   /**

--- a/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
+++ b/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
@@ -25,6 +25,7 @@ import alluxio.master.journal.JournalEntryIterable;
 import alluxio.master.journal.Journaled;
 import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.proto.journal.Journal;
+import alluxio.resource.CloseableIterator;
 import alluxio.resource.LockResource;
 import alluxio.table.common.Layout;
 import alluxio.table.common.LayoutRegistry;
@@ -34,7 +35,6 @@ import alluxio.table.common.udb.UdbContext;
 import alluxio.table.common.udb.UnderDatabaseRegistry;
 import alluxio.util.StreamUtils;
 
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -457,11 +457,12 @@ public class AlluxioCatalog implements Journaled {
   }
 
   @Override
-  public Iterator<Journal.JournalEntry> getJournalEntryIterator() {
-    List<Iterator<Journal.JournalEntry>> componentIters = StreamUtils
+  public CloseableIterator<Journal.JournalEntry> getJournalEntryIterator() {
+    List<CloseableIterator<Journal.JournalEntry>> componentIters = StreamUtils
         .map(JournalEntryIterable::getJournalEntryIterator, mDBs.values());
 
-    return Iterators.concat(getDbIterator(), Iterators.concat(componentIters.iterator()));
+    return CloseableIterator.concat(
+        CloseableIterator.noopCloseable(getDbIterator()), CloseableIterator.concat(componentIters));
   }
 
   @Override

--- a/table/server/master/src/main/java/alluxio/master/table/Database.java
+++ b/table/server/master/src/main/java/alluxio/master/table/Database.java
@@ -22,6 +22,7 @@ import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.Journaled;
 import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.proto.journal.Journal;
+import alluxio.resource.CloseableIterator;
 import alluxio.table.common.udb.UdbContext;
 import alluxio.table.common.udb.UdbTable;
 import alluxio.table.common.udb.UnderDatabase;
@@ -479,10 +480,11 @@ public class Database implements Journaled {
   }
 
   @Override
-  public Iterator<Journal.JournalEntry> getJournalEntryIterator() {
+  public CloseableIterator<Journal.JournalEntry> getJournalEntryIterator() {
     Journal.JournalEntry entry = Journal.JournalEntry.newBuilder().setUpdateDatabaseInfo(
         toJournalProto(getDatabaseInfo(), mName)).build();
-    return Iterators.concat(Iterators.singletonIterator(entry), getTableIterator());
+    return CloseableIterator.noopCloseable(
+        Iterators.concat(Iterators.singletonIterator(entry), getTableIterator()));
   }
 
   @Override


### PR DESCRIPTION
Currently when a user iterate through the inode tree journal entries, a few threads are created to iterate through different directories. The threads will be closed when the iteration completes, but if an iteration is not fully completed, then the threads are leaked and never get properly shutdown.

This change modifies the `JournalEntryIterable` interface to return a closeable iterator of the journal entries, so the user of the iterator can explicitly shutdown the threads by calling the `close()` method or using the `try-with-resource` pattern.

The majority of the logic are in `InodeTreeBufferedIterator` class and `CloseableIterator` class.