### PR TITLE
Improve UriCheck validation tasks

### DIFF
--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -829,10 +830,12 @@ public final class CommonUtils {
    *
    * @param hostname host name of the network address
    * @param port port of the network address
+   * @param timeoutMs duration to attempt connection before returning false
    * @return whether the network address is reachable
    */
-  public static boolean isAddressReachable(String hostname, int port) {
-    try (Socket socket = new Socket(hostname, port)) {
+  public static boolean isAddressReachable(String hostname, int port, int timeoutMs) {
+    try (Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress(hostname, port), timeoutMs);
       return true;
     } catch (IOException e) {
       return false;

--- a/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationTool.java
+++ b/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationTool.java
@@ -56,7 +56,7 @@ public class HmsValidationTool implements ValidationTool {
     mTables = tables;
     mSocketTimeout = socketTimeout > 0 ? socketTimeout : DEFAULT_SOCKET_TIMEOUT;
     mTasks = new HashMap<>();
-    UriCheckTask uriCheck = new UriCheckTask(mMetastoreUri);
+    UriCheckTask uriCheck = new UriCheckTask(mMetastoreUri, mSocketTimeout);
     CreateHmsClientValidationTask clientTask =
         new CreateHmsClientValidationTask(mSocketTimeout, uriCheck);
     DatabaseValidationTask dbTask = new DatabaseValidationTask(mDatabase, clientTask);

--- a/integration/tools/hms/src/main/java/alluxio/cli/hms/UriCheckTask.java
+++ b/integration/tools/hms/src/main/java/alluxio/cli/hms/UriCheckTask.java
@@ -29,15 +29,18 @@ import java.util.List;
 public class UriCheckTask extends MetastoreValidationTask<Void, String> {
 
   private final String mUris;
+  private final int mTimeoutMs;
 
   /**
    * Creates a new {@link UriCheckTask}.
    *
    * @param inputUri the input URI(s) to check
+   * @param timeoutMs the duration to attempt to connect to the URI before failing
    */
-  public UriCheckTask(String inputUri) {
+  public UriCheckTask(String inputUri, int timeoutMs) {
     super(null);
     mUris = inputUri;
+    mTimeoutMs = timeoutMs;
   }
 
   @Override
@@ -78,10 +81,11 @@ public class UriCheckTask extends MetastoreValidationTask<Void, String> {
             "Please make sure the hostname in given hive metastore uri(s) is resolvable"), null);
       }
 
-      if (!CommonUtils.isAddressReachable(uri.getHost(), uri.getPort())) {
+      if (!CommonUtils.isAddressReachable(uri.getHost(), uri.getPort(), mTimeoutMs)) {
         String errorMessage = "Hive metastore uris are unreachable";
         return new Pair<>(new ValidationTaskResult(ValidationUtils.State.FAILED, getName(),
-            errorMessage, "Please make sure the given hive metastore uris are reachable"), null);
+            errorMessage, "Please make sure the given hive metastore uris are reachable. Check"
+            + " that both the host and port are correct."), null);
       }
     }
 

--- a/integration/tools/validation/src/main/java/alluxio/cli/SshValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/SshValidationTask.java
@@ -11,6 +11,7 @@
 
 package alluxio.cli;
 
+import alluxio.Constants;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.CommonUtils;
@@ -55,7 +56,7 @@ public final class SshValidationTask extends AbstractValidationTask {
 
     ValidationUtils.State state = ValidationUtils.State.OK;
     for (String nodeName : nodes) {
-      if (!CommonUtils.isAddressReachable(nodeName, 22)) {
+      if (!CommonUtils.isAddressReachable(nodeName, 22, 30 * Constants.SECOND_MS)) {
         msg.append(String.format("Unable to reach ssh port 22 on node %s.%n", nodeName));
         advice.append(String.format("Please configure password-less ssh to node %s.%n", nodeName));
         state = ValidationUtils.State.FAILED;

--- a/integration/tools/validation/src/main/java/alluxio/cli/ValidateEnv.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/ValidateEnv.java
@@ -245,7 +245,7 @@ public final class ValidateEnv {
   private boolean validateRemote(String node, String target, String name,
                                  CommandLine cmd) throws InterruptedException {
     System.out.format("Validating %s environment on %s...%n", target, node);
-    if (!CommonUtils.isAddressReachable(node, 22)) {
+    if (!CommonUtils.isAddressReachable(node, 22, 30 * Constants.SECOND_MS)) {
       System.err.format("Unable to reach ssh port 22 on node %s.%n", node);
       return false;
     }


### PR DESCRIPTION
Add a timeout value to this task so it doesn't hang for long periods of time (2min+ in my tests) when connecting to bad / unreachable URIs. Also improved the error message to be somewhat more helpful.