### PR TITLE
Fix parllel UfsIO test

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/UfsIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/UfsIOBench.java
@@ -43,12 +43,13 @@ import java.util.stream.Collectors;
 public class UfsIOBench extends Benchmark<IOTaskResult> {
   private static final Logger LOG = LoggerFactory.getLogger(UfsIOBench.class);
   private static final int BUFFER_SIZE = 1024 * 1024;
-  private static final UUID TASK_NAME = UUID.randomUUID();
 
   @ParametersDelegate
   private UfsIOParameters mParameters = new UfsIOParameters();
 
   private final InstancedConfiguration mConf = InstancedConfiguration.defaults();
+
+  private final UUID mTaskId = UUID.randomUUID();
 
   @Override
   public IOTaskResult runLocal() throws Exception {
@@ -100,7 +101,7 @@ public class UfsIOBench extends Benchmark<IOTaskResult> {
   }
 
   private String getFilePathStr(int idx) {
-    return mParameters.mPath + String.format("io-benchmark-%s-%d", TASK_NAME.toString(), idx);
+    return mParameters.mPath + String.format("io-benchmark-%s-%d", mTaskId.toString(), idx);
   }
 
   private IOTaskResult runIOBench(ExecutorService pool) throws Exception {

--- a/stress/shell/src/main/java/alluxio/stress/cli/UfsIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/UfsIOBench.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -42,6 +43,7 @@ import java.util.stream.Collectors;
 public class UfsIOBench extends Benchmark<IOTaskResult> {
   private static final Logger LOG = LoggerFactory.getLogger(UfsIOBench.class);
   private static final int BUFFER_SIZE = 1024 * 1024;
+  private static final UUID TASK_NAME = UUID.randomUUID();
 
   @ParametersDelegate
   private UfsIOParameters mParameters = new UfsIOParameters();
@@ -98,7 +100,7 @@ public class UfsIOBench extends Benchmark<IOTaskResult> {
   }
 
   private String getFilePathStr(int idx) {
-    return mParameters.mPath + String.format("io-benchmark-%d", idx);
+    return mParameters.mPath + String.format("io-benchmark-%s-%d", TASK_NAME.toString(), idx);
   }
 
   private IOTaskResult runIOBench(ExecutorService pool) throws Exception {


### PR DESCRIPTION
Parallel task were writing to the same file, and thus failing because of that. 
Introduces a class level unique id to prevent that. 