### PR TITLE
Print out PageStoreOptions correctly

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/TimeBoundPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/TimeBoundPageStore.java
@@ -68,7 +68,7 @@ public class TimeBoundPageStore implements PageStore {
       Metrics.STORE_PUT_TIMEOUT.inc();
       throw new IOException(e);
     } catch (RejectedExecutionException e) {
-      Metrics.STORE_THREAD_REJECTED.inc();
+      Metrics.STORE_THREADS_REJECTED.inc();
       throw new IOException(e);
     } catch (Throwable t) {
       Throwables.propagateIfPossible(t, IOException.class);
@@ -90,7 +90,7 @@ public class TimeBoundPageStore implements PageStore {
       Metrics.STORE_GET_TIMEOUT.inc();
       throw new IOException(e);
     } catch (RejectedExecutionException e) {
-      Metrics.STORE_THREAD_REJECTED.inc();
+      Metrics.STORE_THREADS_REJECTED.inc();
       throw new IOException(e);
     } catch (Throwable t) {
       Throwables.propagateIfPossible(t, IOException.class, PageNotFoundException.class);
@@ -113,7 +113,7 @@ public class TimeBoundPageStore implements PageStore {
       Metrics.STORE_DELETE_TIMEOUT.inc();
       throw new IOException(e);
     } catch (RejectedExecutionException e) {
-      Metrics.STORE_THREAD_REJECTED.inc();
+      Metrics.STORE_THREADS_REJECTED.inc();
       throw new IOException(e);
     } catch (Throwable t) {
       Throwables.propagateIfPossible(t, IOException.class, PageNotFoundException.class);
@@ -151,7 +151,9 @@ public class TimeBoundPageStore implements PageStore {
      * Number of rejection of I/O threads on submitting tasks to thread pool,
      * likely due to unresponsive local file system.
      **/
-    private static final Counter STORE_THREAD_REJECTED =
+    private static final Counter STORE_THREADS_REJECTED =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_STORE_THREADS_REJECTED.getName());
+
+    private Metrics() {} // prevent instantiation
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStoreOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStoreOptions.java
@@ -11,26 +11,12 @@
 
 package alluxio.client.file.cache.store;
 
-import alluxio.Constants;
-
 import com.google.common.base.MoreObjects;
 
 /**
  * Options used to instantiate the {@link LocalPageStore}.
  */
 public class LocalPageStoreOptions extends PageStoreOptions {
-
-  /**
-   * The max number of buffers used to transfer data. Total memory usage will be equivalent to
-   * {@link #mBufferPoolSize} * {@link #mBufferSize}
-   */
-  private int mBufferPoolSize;
-
-  /**
-   * The size of the buffers used to transfer data. It is recommended to set this at or near the
-   * expected max page size.
-   */
-  private int mBufferSize;
 
   /**
    * The number of file buckets. It is recommended to set this to a high value if the number of
@@ -42,41 +28,7 @@ public class LocalPageStoreOptions extends PageStoreOptions {
    * Creates a new instance of {@link LocalPageStoreOptions}.
    */
   public LocalPageStoreOptions() {
-    mBufferPoolSize = 32;
-    mBufferSize = Constants.MB;
     mFileBuckets = 1000;
-  }
-
-  /**
-   * @param bufferPoolSize sets the buffer pool size
-   * @return the updated options
-   */
-  public LocalPageStoreOptions setBufferPoolSize(int bufferPoolSize) {
-    mBufferPoolSize = bufferPoolSize;
-    return this;
-  }
-
-  /**
-   * @return the size of the buffer pool
-   */
-  public int getBufferPoolSize() {
-    return mBufferPoolSize;
-  }
-
-  /**
-   * @param bufferSize the number of buffers in the buffer pool
-   * @return the updated options
-   */
-  public LocalPageStoreOptions setBufferSize(int bufferSize) {
-    mBufferSize = bufferSize;
-    return this;
-  }
-
-  /**
-   * @return the number of items
-   */
-  public int getBufferSize() {
-    return mBufferSize;
   }
 
   /**
@@ -104,12 +56,12 @@ public class LocalPageStoreOptions extends PageStoreOptions {
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("AlluxioVersion", mAlluxioVersion)
-        .add("BufferPoolSize", mBufferPoolSize)
         .add("CacheSize", mCacheSize)
-        .add("BufferSize", mBufferSize)
         .add("FileBuckets", mFileBuckets)
         .add("PageSize", mPageSize)
         .add("RootDir", mRootDir)
+        .add("TimeoutDuration", mTimeoutDuration)
+        .add("TimeoutThreads", mTimeoutThreads)
         .toString();
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStoreOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStoreOptions.java
@@ -130,14 +130,16 @@ public class RocksPageStoreOptions extends PageStoreOptions {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("MaxPageSize", mMaxPageSize)
-        .add("WriteBufferSize", mWriteBufferSize)
-        .add("MaxBufferPoolSize", mMaxBufferPoolSize)
-        .add("CompressionType", mCompressionType)
-        .add("RootDir", mRootDir)
-        .add("PageSize", mPageSize)
-        .add("CacheSize", mCacheSize)
         .add("AlluxioVersion", mAlluxioVersion)
+        .add("CacheSize", mCacheSize)
+        .add("CompressionType", mCompressionType)
+        .add("MaxBufferPoolSize", mMaxBufferPoolSize)
+        .add("MaxPageSize", mMaxPageSize)
+        .add("PageSize", mPageSize)
+        .add("RootDir", mRootDir)
+        .add("TimeoutDuration", mTimeoutDuration)
+        .add("TimeoutThreads", mTimeoutThreads)
+        .add("WriteBufferSize", mWriteBufferSize)
         .toString();
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/LocalPageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/LocalPageStoreTest.java
@@ -46,13 +46,6 @@ public class LocalPageStoreTest {
   }
 
   @Test
-  public void testSmallBuffer() throws Exception {
-    mOptions.setBufferSize(1).setBufferPoolSize(1);
-    LocalPageStore pageStore = new LocalPageStore(mOptions);
-    helloWorldTest(pageStore);
-  }
-
-  @Test
   public void testSingleFileBucket() throws Exception {
     mOptions.setFileBuckets(1);
     LocalPageStore pageStore = new LocalPageStore(mOptions);


### PR DESCRIPTION
With this change, we can tell if `TimeBoundPageStore` is used when creation `PageStore` from logs