### PR TITLE
Downgrade hive client version in validation tools

### DIFF
--- a/integration/tools/hms/pom.xml
+++ b/integration/tools/hms/pom.xml
@@ -31,7 +31,7 @@
     <build.path>${project.parent.parent.parent.basedir}/build</build.path>
     <lib.jar.name>${project.artifactId}-${project.version}.jar</lib.jar.name>
     <failIfNoTests>false</failIfNoTests>
-    <hive-metastore.version>3.1.2</hive-metastore.version>
+    <hive-metastore.version>2.3.7</hive-metastore.version>
   </properties>
 
   <dependencies>

--- a/integration/tools/hms/pom.xml
+++ b/integration/tools/hms/pom.xml
@@ -88,6 +88,10 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
+        <exclusion>
+           <groupId>jdk.tools</groupId>
+           <artifactId>jdk.tools</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This should help with the validation tools working with older version of hive metastore. 