### PR TITLE
Improve hdfs validation task error messages

### DIFF
--- a/integration/tools/pom.xml
+++ b/integration/tools/pom.xml
@@ -42,6 +42,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-shaded-hadoop</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/integration/tools/validation/src/main/java/alluxio/cli/UfsDirectoryValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/UfsDirectoryValidationTask.java
@@ -22,8 +22,8 @@ import java.util.Map;
  */
 @ApplicableUfsType(ApplicableUfsType.Type.ALL)
 public final class UfsDirectoryValidationTask extends AbstractValidationTask {
-  private final UnderFileSystem mUfs;
   private final String mPath;
+  private final AlluxioConfiguration mConf;
 
   /**
    * Creates a new instance of {@link UfsDirectoryValidationTask}
@@ -34,7 +34,7 @@ public final class UfsDirectoryValidationTask extends AbstractValidationTask {
    */
   public UfsDirectoryValidationTask(String path, AlluxioConfiguration conf) {
     mPath = path;
-    mUfs = UnderFileSystem.Factory.create(mPath, conf);
+    mConf = conf;
   }
 
   @Override
@@ -47,7 +47,8 @@ public final class UfsDirectoryValidationTask extends AbstractValidationTask {
     StringBuilder msg = new StringBuilder();
     StringBuilder advice = new StringBuilder();
     try {
-      UfsStatus[] listStatus = mUfs.listStatus(mPath);
+      UnderFileSystem ufs = UnderFileSystem.Factory.create(mPath, mConf);
+      UfsStatus[] listStatus = ufs.listStatus(mPath);
       if (listStatus == null) {
         msg.append(String.format("Unable to list under file system path %s. ", mPath));
         advice.append(String.format("Please check if path %s denotes a directory. ", mPath));

--- a/integration/tools/validation/src/main/java/alluxio/cli/hdfs/HdfsConfValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/hdfs/HdfsConfValidationTask.java
@@ -21,9 +21,6 @@ import alluxio.conf.PropertyKey;
 import alluxio.exception.InvalidPathException;
 import alluxio.util.io.PathUtils;
 
-import org.xml.sax.SAXException;
-
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -232,23 +229,17 @@ public class HdfsConfValidationTask extends AbstractValidationTask {
     try {
       properties = parser.parseXmlConfiguration(path);
       mMsg.append(String.format("Successfully loaded %s. %n", path));
-    } catch (ParserConfigurationException e) {
-      mState = ValidationUtils.State.FAILED;
-      mMsg.append(String.format("Failed to create instance of DocumentBuilder for file: %s. %s.%n",
-              path, e.getMessage()));
-      mMsg.append(ValidationUtils.getErrorInfo(e));
-      mAdvice.append("Please check your configuration for javax.xml.parsers.DocumentBuilder.%n");
     } catch (IOException e) {
       mState = ValidationUtils.State.FAILED;
       mMsg.append(String.format("Failed to read %s. %s.%n", path, e.getMessage()));
       mMsg.append(ValidationUtils.getErrorInfo(e));
       mAdvice.append(String.format("Please check your %s.%n", path));
-    } catch (SAXException e) {
+    } catch (RuntimeException e) {
       mState = ValidationUtils.State.FAILED;
       mMsg.append(String.format("Failed to parse %s. %s.%n", path, e.getMessage()));
       mMsg.append(ValidationUtils.getErrorInfo(e));
       mAdvice.append(String.format("Failed to parse %s as valid XML. Please check that the file "
-          + "path is correct.%n", path));
+          + "path is correct and the content is valid XML.%n", path));
     }
     return properties;
   }

--- a/integration/tools/validation/src/main/java/alluxio/cli/hdfs/HdfsConfValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/hdfs/HdfsConfValidationTask.java
@@ -25,9 +25,14 @@ import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -77,8 +82,12 @@ public class HdfsConfValidationTask extends AbstractValidationTask {
   protected Pair<String, String> getHdfsConfPaths() {
     // If ServerConfiguration does not contain the key, then a {@link RuntimeException} will be
     // thrown before calling the {@link String#split} method.
-    String[] clientHadoopConfFilePaths =
-            mConf.get(PropertyKey.UNDERFS_HDFS_CONFIGURATION).split(SEPARATOR);
+    String confVal = mConf.get(PropertyKey.UNDERFS_HDFS_CONFIGURATION);
+    String[] clientHadoopConfFilePaths = confVal.split(SEPARATOR);
+    mMsg.append(String.format(
+        "%d file path(s) detected in for HDFS configuration files for \"%s\"%n",
+        clientHadoopConfFilePaths.length, confVal));
+
     String clientCoreSiteFilePath = null;
     String clientHdfsSiteFilePath = null;
     for (String path : clientHadoopConfFilePaths) {
@@ -87,6 +96,13 @@ public class HdfsConfValidationTask extends AbstractValidationTask {
       } else if (path.contains("hdfs-site.xml")) {
         clientHdfsSiteFilePath = path;
       }
+    }
+    if (clientHadoopConfFilePaths.length < 2 || clientCoreSiteFilePath == null
+        || clientHdfsSiteFilePath == null) {
+      mAdvice.append(String.format("Additional HDFS configuration can be specified with your"
+          + " Alluxio mount point by configuring the property %s. The value for this property "
+          + "should be in the format \"{core-site.xml path}:{hdfs-site.xml path}\"%n",
+          PropertyKey.UNDERFS_HDFS_CONFIGURATION.getName()));
     }
     return new Pair<>(clientCoreSiteFilePath, clientHdfsSiteFilePath);
   }
@@ -107,7 +123,47 @@ public class HdfsConfValidationTask extends AbstractValidationTask {
     }
 
     // no conflicts between these two
-    return checkConflicts();
+    ValidationTaskResult last = checkConflicts();
+    if (last.getState() == ValidationUtils.State.OK) {
+      last = checkNameservice();
+    }
+
+    return last;
+  }
+
+  protected ValidationTaskResult checkNameservice() {
+    ValidationUtils.State state;
+    String nsKey = "dfs.nameservices";
+    String nameservices = mCoreConf.get(nsKey);
+    if (nameservices == null) {
+      nameservices = mHdfsConf.get(nsKey);
+    }
+    if (nameservices == null) {
+      return new ValidationTaskResult(ValidationUtils.State.OK, getName(), "No nameservice "
+          + "detected", "");
+    }
+    List<String> nsList =
+        Arrays.stream(nameservices.split(",")).map(String::trim).collect(Collectors.toList());
+
+    try {
+      URI u = URI.create(mPath);
+      String uriHost = u.getHost().toLowerCase();
+      long nsCount = nsList.stream().filter(s -> uriHost.equals(s.toLowerCase())).count();
+      state = ValidationUtils.State.OK;
+      if (nsCount < 1) {
+        state = ValidationUtils.State.FAILED;
+        mAdvice.append(String.format("One or more nameservices (%s) were detected in the HDFS "
+            + "configuration, but not used in the URI to connect to HDFS.", nameservices));
+        mMsg.append(String.format("Could not find any of the configured nameservices (%s) in the "
+            + "given HDFS connection URI (%s)", nameservices, u));
+      }
+    } catch (IllegalArgumentException e) {
+      state = ValidationUtils.State.FAILED;
+      mMsg.append("HDFS path not parsable as a URI.");
+      mMsg.append(ValidationUtils.getErrorInfo(e));
+      mAdvice.append("Make sure the HDFS URI is in a valid format.");
+    }
+    return new ValidationTaskResult(state, getName(), mMsg.toString(), mAdvice.toString());
   }
 
   // Verify core-site.xml and hdfs.site.xml has no conflicts
@@ -139,8 +195,6 @@ public class HdfsConfValidationTask extends AbstractValidationTask {
     if (path == null || path.isEmpty()) {
       mMsg.append(String.format("%s is not configured in Alluxio property %s%n", configName,
               PropertyKey.UNDERFS_HDFS_CONFIGURATION));
-      mAdvice.append(String.format("Please configure %s in %s%n", configName,
-              PropertyKey.UNDERFS_HDFS_CONFIGURATION));
       mState = ValidationUtils.State.SKIPPED;
       return null;
     }
@@ -155,12 +209,22 @@ public class HdfsConfValidationTask extends AbstractValidationTask {
               PropertyKey.UNDERFS_HDFS_CONFIGURATION));
       return null;
     }
-    if (!Files.isReadable(Paths.get(path))) {
+    Path confPath = Paths.get(path);
+    if (!Files.exists(confPath)) {
       mState = ValidationUtils.State.WARNING;
       mMsg.append(String.format("File does not exist at %s in Alluxio property %s.%n", path,
           PropertyKey.UNDERFS_HDFS_CONFIGURATION));
-      mAdvice.append(String.format("Please correct the path for %s in %s%n", configName,
-          PropertyKey.UNDERFS_HDFS_CONFIGURATION));
+      mAdvice.append(String.format("Could not file file at \"%s\". Correct the path in %s%n",
+          configName, PropertyKey.UNDERFS_HDFS_CONFIGURATION));
+      return null;
+    }
+    if (!Files.isReadable(Paths.get(path))) {
+      mState = ValidationUtils.State.WARNING;
+      mMsg.append(String.format("\"%s\" is not readable from Alluxio property %s.%n",
+          path, PropertyKey.UNDERFS_HDFS_CONFIGURATION));
+      mAdvice.append(String.format("Grant more accessible permissions on the file"
+              + " %s from %s%n",
+          configName, PropertyKey.UNDERFS_HDFS_CONFIGURATION));
       return null;
     }
     HadoopConfigurationFileParser parser = new HadoopConfigurationFileParser();
@@ -183,7 +247,8 @@ public class HdfsConfValidationTask extends AbstractValidationTask {
       mState = ValidationUtils.State.FAILED;
       mMsg.append(String.format("Failed to parse %s. %s.%n", path, e.getMessage()));
       mMsg.append(ValidationUtils.getErrorInfo(e));
-      mAdvice.append(String.format("Please check your %s.%n", path));
+      mAdvice.append(String.format("Failed to parse %s as valid XML. Please check that the file "
+          + "path is correct.%n", path));
     }
     return properties;
   }

--- a/integration/tools/validation/src/main/java/alluxio/cli/hdfs/HdfsProxyUserValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/hdfs/HdfsProxyUserValidationTask.java
@@ -98,7 +98,9 @@ public class HdfsProxyUserValidationTask extends HdfsConfValidationTask {
 
     ValidationTaskResult loadConfig = loadHdfsConfig();
     if (loadConfig.getState() != ValidationUtils.State.OK) {
-      return loadConfig;
+      mAdvice.insert(0, "Validating the proxy user requires additional HDFS "
+          + "configuration. ");
+      return loadConfig.setAdvice(mAdvice.toString());
     }
 
     // TODO(jiacheng): validate proxyuser.hosts for the cluster

--- a/integration/tools/validation/src/main/java/alluxio/cli/hdfs/SecureHdfsValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/hdfs/SecureHdfsValidationTask.java
@@ -98,9 +98,12 @@ public final class SecureHdfsValidationTask extends HdfsConfValidationTask {
               mMsg.toString(), mAdvice.toString());
     }
 
+    // superclass which uses its own msg and advice objects
     ValidationTaskResult loadConfig = loadHdfsConfig();
     if (loadConfig.getState() != ValidationUtils.State.OK) {
-      return loadConfig;
+      String extraAdvice = "Validating a secure HDFS connection requires specifying additional "
+          + "HDFS configuration files. ";
+      return loadConfig.setAdvice(extraAdvice + loadConfig.getAdvice());
     }
 
     // The state is OK when the HDFS is secured

--- a/integration/tools/validation/src/test/java/alluxio/cli/hdfs/HdfsConfValidationTaskTest.java
+++ b/integration/tools/validation/src/test/java/alluxio/cli/hdfs/HdfsConfValidationTaskTest.java
@@ -118,8 +118,8 @@ public class HdfsConfValidationTaskTest {
     assertEquals(ValidationUtils.State.FAILED, result.getState());
     assertThat(result.getResult(), containsString(String.format("Failed to parse %s", hdfsSite)));
     assertThat(result.getResult(), containsString(String.format("Failed to parse %s", coreSite)));
-    assertThat(result.getAdvice(), containsString(String.format("Please check your %s", hdfsSite)));
-    assertThat(result.getAdvice(), containsString(String.format("Please check your %s", coreSite)));
+    assertThat(result.getAdvice(), containsString(String.format("Failed to parse %s", hdfsSite)));
+    assertThat(result.getAdvice(), containsString(String.format("Failed to parse %s", coreSite)));
   }
 
   @Test

--- a/integration/tools/validation/src/test/java/alluxio/cli/hdfs/HdfsConfValidationTaskTest.java
+++ b/integration/tools/validation/src/test/java/alluxio/cli/hdfs/HdfsConfValidationTaskTest.java
@@ -11,9 +11,9 @@
 
 package alluxio.cli.hdfs;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import alluxio.cli.ValidationTaskResult;
 import alluxio.cli.ValidationUtils;
@@ -116,7 +116,8 @@ public class HdfsConfValidationTaskTest {
             new HdfsConfValidationTask("hdfs://namenode:9000/alluxio", sConf);
     ValidationTaskResult result = task.loadHdfsConfig();
     assertEquals(ValidationUtils.State.FAILED, result.getState());
-    assertThat(result.getResult(), containsString(String.format("Failed to parse %s", hdfsSite)));
+    assertThat(result.getResult(),
+        containsString(String.format("Failed to parse %s", hdfsSite)));
     assertThat(result.getResult(), containsString(String.format("Failed to parse %s", coreSite)));
     assertThat(result.getAdvice(), containsString(String.format("Failed to parse %s", hdfsSite)));
     assertThat(result.getAdvice(), containsString(String.format("Failed to parse %s", coreSite)));


### PR DESCRIPTION
Improvements now provide more context for a few cases
- insufficient permissions to access
- HA configured but not used (nameservices)
- more info about checks which require additional configuration
- advice about XML parsing