### PR TITLE
[WIP] Implement worker read keepalive

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcBlockingStream.java
@@ -27,8 +27,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -77,7 +77,9 @@ public class GrpcBlockingStream<ReqT, ResT> {
   public GrpcBlockingStream(Function<StreamObserver<ResT>, StreamObserver<ReqT>> rpcFunc,
       int bufferSize, String description) {
     LOG.debug("Opening stream ({})", description);
-    mResponses = new ArrayBlockingQueue<>(bufferSize);
+    // Use an unlimited queue to avoid blocking the network threads. Depend on custom flow
+    // control to limit the size of buffer.
+    mResponses = new LinkedBlockingQueue<>();
     mResponseObserver = new ResponseStreamObserver();
     mRequestObserver = (ClientCallStreamObserver) rpcFunc.apply(mResponseObserver);
     mDescription = description;

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
@@ -150,12 +150,15 @@ public final class GrpcDataReader implements DataReader {
       return null;
     }
     mPosToRead += buffer.readableBytes();
-    try {
-      mStream.send(mReadRequest.toBuilder().setOffsetReceived(mPosToRead).build());
-    } catch (Exception e) {
-      // nothing is done as the receipt is sent at best effort
-      LOG.debug("Failed to send receipt of data to worker {} for request {}: {}.", mAddress,
-          mReadRequest, e.getMessage());
+    if (buffer.readableBytes() > 0) {
+      // Only send the offset received ack for non-empty chunks
+      try {
+        mStream.send(mReadRequest.toBuilder().setOffsetReceived(mPosToRead).build());
+      } catch (Exception e) {
+        // nothing is done as the receipt is sent at best effort
+        LOG.debug("Failed to send receipt of data to worker {} for request {}: {}.", mAddress,
+            mReadRequest, e.getMessage());
+      }
     }
     Preconditions.checkState(mPosToRead - mReadRequest.getOffset() <= mReadRequest.getLength());
     return buffer;

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataReaderTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataReaderTest.java
@@ -258,10 +258,20 @@ public final class GrpcDataReaderTest {
     while (remaining > 0) {
       int bytesToSend = (int) Math.min(remaining, CHUNK_SIZE);
       byte[] data = new byte[bytesToSend];
+
+      // add an empty buffer message
+      responses.add(
+          ReadResponse.newBuilder().setChunk(Chunk.newBuilder().setData(ByteString.EMPTY)).build());
+
+      // add the real buffer
       RANDOM.nextBytes(data);
       responses.add(ReadResponse.newBuilder()
           .setChunk(Chunk.newBuilder().setData(ByteString.copyFrom(data))).build());
       remaining -= bytesToSend;
+
+      // add an empty buffer message
+      responses.add(
+          ReadResponse.newBuilder().setChunk(Chunk.newBuilder().setData(ByteString.EMPTY)).build());
 
       for (int i = 0; i < data.length; i++) {
         if (pos >= start && pos <= end) {

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2857,6 +2857,19 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
+  public static final PropertyKey WORKER_READ_KEEPALIVE_INTERVAL =
+      new Builder(Name.WORKER_READ_KEEPALIVE_INTERVAL)
+          .setDefaultValue("15s")
+          .setDescription(String.format(
+              "The interval of time that the worker will send back empty messages to the client "
+                  + "during remote reads, to keep the channel alive. -1 will disable the keepalive "
+                  + "functionality. If this is too short, the too many packets will be sent by "
+                  + "the worker, and if this is too long, read timeouts may occur. To avoid "
+                  + "unnecessary read timeouts, this should be set to a value less than %s.",
+              Name.USER_STREAMING_DATA_TIMEOUT))
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.WORKER)
+          .build();
   public static final PropertyKey WORKER_REMOTE_IO_SLOW_THRESHOLD =
       new Builder(Name.WORKER_REMOTE_IO_SLOW_THRESHOLD)
           .setDefaultValue("10s")
@@ -5261,6 +5274,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.network.shutdown.timeout";
     public static final String WORKER_NETWORK_ZEROCOPY_ENABLED =
         "alluxio.worker.network.zerocopy.enabled";
+    public static final String WORKER_READ_KEEPALIVE_INTERVAL =
+        "alluxio.worker.read.keepalive.interval";
     public static final String WORKER_REMOTE_IO_SLOW_THRESHOLD =
         "alluxio.worker.remote.io.slow.threshold";
     public static final String WORKER_BLOCK_MASTER_CLIENT_POOL_SIZE =


### PR DESCRIPTION
There are scenarios when the worker is not able to read fast enough from local storage or UFS. This can happen if the UFS is slow, or even when the file does not exist on UFS (s3 UFS will retry several times).

Therefore, it is always possible that the worker takes a long time to send back a chunk to the client. Therefore, we implement a periodic keepalive chunk that is sent to the client to prevent the client from timing out.