### PR TITLE
Add a GH action to default branch to utilize build cache

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -2,7 +2,10 @@
 
 name: Checkstyle, Findbugs, Doc Check, etc.
 
-on: [pull_request]
+on:
+  pull_request:
+  schedule:
+    - cron: 0 0 * * *
 
 jobs:
   build:


### PR DESCRIPTION
Currently, all newly created PRs that run GH actions jobs will download all of the maven dependencies for the first run of GH actions. This leads to unnecessary network bandwidth usage and slows down each job by 2-3 minutes. This only affects the _first_ GH action run of each PR though. Subsequent actions will be able to utilize that PR branch's cache.

In order for the first GH actions PR run to utilize a cache _on the first run_, there needs to be a cache created from the default branch of the repo[[1]]. By running this small checkstyle and findbugs once a day, it will force any new dependencies to be added to the cache that all new PRs would then be able to utilize.

[1]: https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache