### PR TITLE
Simplify MigrateDefinition

### DIFF
--- a/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/base/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -285,7 +285,7 @@ public enum ExceptionMessage {
 
   // migrate job (either move or copy)
   MIGRATE_CANNOT_BE_TO_SUBDIRECTORY("Cannot migrate because {0} is a prefix of {1}"),
-  MIGRATE_DIRECTORY_TO_FILE("Cannot migrate a directory ({0}) to a file ({1})"),
+  MIGRATE_DIRECTORY("Cannot migrate directory"),
   MIGRATE_FILE_TO_DIRECTORY("Cannot migrate a file ({0}) to a directory ({1})"),
   MIGRATE_NEED_OVERWRITE("Cannot migrate to {0} because it exists and overwrite is set to false"),
   MIGRATE_OVERWRITE_DIRECTORY(

--- a/job/common/src/main/java/alluxio/job/plan/migrate/MigrateConfig.java
+++ b/job/common/src/main/java/alluxio/job/plan/migrate/MigrateConfig.java
@@ -35,7 +35,6 @@ public class MigrateConfig implements PlanConfig {
   private final String mDestination;
   private final String mWriteType;
   private final boolean mOverwrite;
-  private final boolean mDeleteSource;
 
   /**
    * @param source the source path
@@ -99,12 +98,12 @@ public class MigrateConfig implements PlanConfig {
     return Objects.equal(mSource, that.mSource)
         && Objects.equal(mDestination, that.mDestination)
         && Objects.equal(mWriteType, that.mWriteType)
-        && Objects.equal(mOverwrite, that.mOverwrite)
+        && Objects.equal(mOverwrite, that.mOverwrite);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mSource, mDestination, mWriteType, mOverwrite, mDeleteSource);
+    return Objects.hashCode(mSource, mDestination, mWriteType, mOverwrite);
   }
 
   @Override

--- a/job/common/src/main/java/alluxio/job/plan/migrate/MigrateConfig.java
+++ b/job/common/src/main/java/alluxio/job/plan/migrate/MigrateConfig.java
@@ -45,18 +45,15 @@ public class MigrateConfig implements PlanConfig {
    * @param overwrite whether an existing file should be overwritten; if the source and destination
    *        are directories, the contents of the directories will be merged with common files
    *        overwritten by the source
-   * @param deleteSource whether to delete the source path after migration
    */
   public MigrateConfig(@JsonProperty("source") String source,
                        @JsonProperty("destination") String dst,
                        @JsonProperty("writeType") String writeType,
-                       @JsonProperty("overwrite") boolean overwrite,
-                       @JsonProperty("deleteSource") boolean deleteSource) {
+                       @JsonProperty("overwrite") boolean overwrite) {
     mSource = Preconditions.checkNotNull(source, "source must be set");
     mDestination = Preconditions.checkNotNull(dst, "destination must be set");
     mWriteType = writeType;
     mOverwrite = overwrite;
-    mDeleteSource = deleteSource;
   }
 
   /**
@@ -87,13 +84,6 @@ public class MigrateConfig implements PlanConfig {
     return mOverwrite;
   }
 
-  /**
-   * @return whether to delete the source path after migration
-   */
-  public boolean isDeleteSource() {
-    return mDeleteSource;
-  }
-
   @Override
   public boolean equals(Object obj) {
     if (obj == null) {
@@ -110,7 +100,6 @@ public class MigrateConfig implements PlanConfig {
         && Objects.equal(mDestination, that.mDestination)
         && Objects.equal(mWriteType, that.mWriteType)
         && Objects.equal(mOverwrite, that.mOverwrite)
-        && Objects.equal(mDeleteSource, that.mDeleteSource);
   }
 
   @Override
@@ -125,7 +114,6 @@ public class MigrateConfig implements PlanConfig {
         .add("destination", mDestination)
         .add("writeType", mWriteType)
         .add("overwrite", mOverwrite)
-        .add("deleteSource", mDeleteSource)
         .toString();
   }
 

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -23,9 +23,7 @@ import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.ExceptionMessage;
-import alluxio.exception.FileDoesNotExistException;
 import alluxio.grpc.CreateFilePOptions;
-import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
 import alluxio.grpc.WritePType;
@@ -34,77 +32,28 @@ import alluxio.job.RunTaskContext;
 import alluxio.job.SelectExecutorsContext;
 import alluxio.job.util.JobUtils;
 import alluxio.job.util.SerializableVoid;
-import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.wire.WorkerInfo;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.Stack;
 import java.util.concurrent.ConcurrentMap;
 
 /**
- * A job that migrates a source path to a destination path.
+ * A job that migrates a single file from source path to a destination path.
  * The source and the destination can be across mount points.
- *
- * If the destination exists, the source and destination must either both be files or both be
- * directories, and the overwrite configuration option must be set. If the destination does not
- * exist, its parent must be a directory and the destination will be created by the migrate command.
- *
- * If migrating a directory to an existing directory causes files to conflict, the migrated files
- * will replace the existing files.
- *
- * Unlike Unix {@code mv} or {@code cp}, the source will not be nested inside the destination when
- * the destination is a directory. This makes it so that the migrate job is idempotent when the
- * overwrite flag is set.
- *
- * Suppose we have this directory structure, where a to e are directories and f1 to f3 are files:
- *
- * ├── a
- * │   ├── e
- * │   │   └── f2
- * │   └── f1
- * └── b
- *     └── d
- *     └── e
- *         └── f3
- *
- * Migrating a to b with source deleted ({@code mv}) will result in
- *
- * ├── b
- *     ├── d
- *     ├── e
- *     │   └── f2
- *     │   └── f3
- *     └── f1
- *
- * Migrating a to b with source kept ({@code cp}) will result in
- *
- * ├── a
- * │   ├── e
- * │   │   └── f2
- * │   └── f1
- * └── b
- *     ├── d
- *     ├── e
- *     │   └── f2
- *     │   └── f3
- *     └── f1
  */
 public final class MigrateDefinition
-    extends AbstractVoidPlanDefinition<MigrateConfig, ArrayList<MigrateCommand>> {
+    extends AbstractVoidPlanDefinition<MigrateConfig, MigrateCommand> {
   private static final Logger LOG = LoggerFactory.getLogger(MigrateDefinition.class);
 
   private static final int JOBS_PER_WORKER = 10;
@@ -136,7 +85,7 @@ public final class MigrateDefinition
    * @return
    */
   @Override
-  public Set<Pair<WorkerInfo, ArrayList<MigrateCommand>>> selectExecutors(MigrateConfig config,
+  public Set<Pair<WorkerInfo, MigrateCommand>> selectExecutors(MigrateConfig config,
       List<WorkerInfo> jobWorkerInfoList, SelectExecutorsContext context) throws Exception {
     AlluxioURI source = new AlluxioURI(config.getSource());
     AlluxioURI destination = new AlluxioURI(config.getDestination());
@@ -146,43 +95,22 @@ public final class MigrateDefinition
     checkMigrateValid(config, context.getFileSystem());
     Preconditions.checkState(!jobWorkerInfoList.isEmpty(), "No workers are available");
 
-    List<URIStatus> allPathStatuses = getPathStatuses(source, context.getFileSystem());
-    ConcurrentMap<WorkerInfo, ArrayList<MigrateCommand>> assignments = Maps.newConcurrentMap();
+    URIStatus status = context.getFileSystem().getStatus(source);
     ConcurrentMap<String, WorkerInfo> hostnameToWorker = Maps.newConcurrentMap();
     for (WorkerInfo workerInfo : jobWorkerInfoList) {
       hostnameToWorker.put(workerInfo.getAddress().getHost(), workerInfo);
     }
     List<BlockWorkerInfo> alluxioWorkerInfoList = context.getFsContext().getCachedWorkers();
-    // Assign each file to the worker with the most block locality.
-    for (URIStatus status : allPathStatuses) {
-      if (status.isFolder()) {
-        migrateDirectory(status.getPath(), source.getPath(), destination.getPath(),
-            context.getFileSystem());
-      } else {
-        WorkerInfo bestJobWorker =
-            getBestJobWorker(status, alluxioWorkerInfoList, jobWorkerInfoList, hostnameToWorker);
-        String destinationPath =
-            computeTargetPath(status.getPath(), source.getPath(), destination.getPath());
-        assignments.putIfAbsent(bestJobWorker, Lists.newArrayList());
-        assignments.get(bestJobWorker).add(new MigrateCommand(status.getPath(), destinationPath));
-      }
+    if (status.isFolder()) {
+      throw new RuntimeException(ExceptionMessage.MIGRATE_DIRECTORY.getMessage());
+    } else {
+      WorkerInfo bestJobWorker =
+          getBestJobWorker(status, alluxioWorkerInfoList, jobWorkerInfoList, hostnameToWorker);
+      Set<Pair<WorkerInfo, MigrateCommand>> result = Sets.newHashSet();
+      result.add(new Pair<>(bestJobWorker,
+          new MigrateCommand(status.getPath(), destination.getPath())));
+      return result;
     }
-
-    Set<Pair<WorkerInfo, ArrayList<MigrateCommand>>> result = Sets.newHashSet();
-
-    for (Map.Entry<WorkerInfo, ArrayList<MigrateCommand>> assignment : assignments.entrySet()) {
-      ArrayList<MigrateCommand> migrateCommands = assignment.getValue();
-      List<List<MigrateCommand>> partitionedCommands =
-          CommonUtils.partition(migrateCommands, JOBS_PER_WORKER);
-
-      for (List<MigrateCommand> commands : partitionedCommands) {
-        if (!commands.isEmpty()) {
-          result.add(new Pair<>(assignment.getKey(), Lists.newArrayList(commands)));
-        }
-      }
-    }
-
-    return result;
   }
 
   private WorkerInfo getBestJobWorker(URIStatus status, List<BlockWorkerInfo> alluxioWorkerInfoList,
@@ -202,115 +130,30 @@ public final class MigrateDefinition
   }
 
   /**
-   * Computes the path that the given path should end up at when source is migrated to destination.
-   *
-   * @param path a path to migrate which must be a descendent path of the source path,
-   *        e.g. /src/file
-   * @param source the base source path being migrated, e.g. /src
-   * @param destination the path to migrate to, e.g. /dst/src
-   * @return the path which file should be migrated to, e.g. /dst/src/file
-   */
-  private static String computeTargetPath(String path, String source, String destination)
-      throws Exception {
-    String relativePath = PathUtils.subtractPaths(path, source);
-    return PathUtils.concatPath(destination, relativePath);
-  }
-
-  /**
-   * @param path the path of the directory to migrate; it must be a subpath of source
-   * @param source the base source path being migrated
-   * @param destination the destination path
-   */
-  private void migrateDirectory(String path, String source, String destination, FileSystem fs)
-      throws Exception {
-    String newDir = computeTargetPath(path, source, destination);
-    fs.createDirectory(new AlluxioURI(newDir));
-  }
-
-  /**
-   * Returns {@link URIStatus} for all paths under the specified path, including the path itself.
-   *
-   * The statuses will be listed in the order they are visited by depth-first search.
-   *
-   * @param path the target path
-   * @return a list of the {@link URIStatus} for all paths under the given path
-   * @throws Exception if an exception occurs
-   */
-  private List<URIStatus> getPathStatuses(AlluxioURI path, FileSystem fs) throws Exception {
-    // Depth-first search to to find all files under path.
-    Stack<AlluxioURI> pathsToConsider = new Stack<>();
-    pathsToConsider.add(path);
-    List<URIStatus> allStatuses = Lists.newArrayList();
-    while (!pathsToConsider.isEmpty()) {
-      AlluxioURI nextPath = pathsToConsider.pop();
-      URIStatus status = fs.getStatus(nextPath);
-      allStatuses.add(status);
-      if (status.isFolder()) {
-        List<URIStatus> childStatuses = fs.listStatus(nextPath);
-        for (URIStatus childStatus : childStatuses) {
-          if (childStatus.isFolder()) {
-            pathsToConsider.push(new AlluxioURI(childStatus.getPath()));
-          } else {
-            allStatuses.add(childStatus);
-          }
-        }
-      }
-    }
-    return ImmutableList.copyOf(allStatuses);
-  }
-
-  /**
    * {@inheritDoc}
    *
    * Migrates the file specified in the config to the configured path. If the destination path is a
    * directory, the file is migrated inside that directory.
    */
   @Override
-  public SerializableVoid runTask(MigrateConfig config, ArrayList<MigrateCommand> commands,
+  public SerializableVoid runTask(MigrateConfig config, MigrateCommand command,
       RunTaskContext context) throws Exception {
     WriteType writeType = config.getWriteType() == null
         ? ServerConfiguration.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class)
         : WriteType.valueOf(config.getWriteType());
-    for (MigrateCommand command : commands) {
-      migrate(command, writeType.toProto(), config.isDeleteSource(),
-          context.getFileSystem());
-    }
-    // Try to delete the source directory if it is empty.
-    if (config.isDeleteSource() && !hasFiles(new AlluxioURI(config.getSource()),
-        context.getFileSystem())) {
-      try {
-        // ## MigrateDeleteUnchecked
-        // Delete the source unchecked because there is no guarantee that the source
-        // has been fulled persisted yet if the source was written using ASYNC_THROUGH
-        LOG.debug("Deleting {}", config.getSource());
-        context.getFileSystem().delete(new AlluxioURI(config.getSource()),
-            DeletePOptions.newBuilder().setUnchecked(true).setRecursive(true).build());
-      } catch (FileDoesNotExistException e) {
-        // It's already deleted, possibly by another worker.
-      }
-    }
-    return null;
+    migrate(command, writeType.toProto(), context.getFileSystem());
   }
 
   /**
    * @param command the migrate command to execute
    * @param writeType the write type to use for the moved file
-   * @param deleteSource whether to delete source
    * @param fileSystem the Alluxio file system
    */
-  private static void migrate(MigrateCommand command, WritePType writeType, boolean deleteSource,
-      FileSystem fileSystem) throws Exception {
+  private static void migrate(MigrateCommand command, WritePType writeType, FileSystem fileSystem)
+      throws Exception {
     String source = command.getSource();
     String destination = command.getDestination();
     LOG.debug("Migrating {} to {}", source, destination);
-
-    // If the write type is async through and the source is being deleted but source is persisted,
-    // keep the destination to be persisted by changing its write type
-    if (deleteSource && writeType.equals(WritePType.ASYNC_THROUGH)) {
-      if (fileSystem.getStatus(new AlluxioURI(source)).isPersisted()) {
-        writeType = WritePType.CACHE_THROUGH;
-      }
-    }
 
     CreateFilePOptions createOptions =
         CreateFilePOptions.newBuilder().setWriteType(writeType).build();
@@ -329,38 +172,6 @@ public final class MigrateDefinition
         throw t;
       }
     }
-    if (deleteSource) {
-      // ## MigrateDeleteUnchecked
-      // Delete the source unchecked because there is no guarantee that the source
-      // has been fulled persisted yet if the source was written using ASYNC_THROUGH
-      fileSystem.delete(new AlluxioURI(source),
-          DeletePOptions.newBuilder().setUnchecked(true).build());
-    }
-  }
-
-  /**
-   * @param source an Alluxio URI
-   * @param fileSystem the Alluxio file system
-   * @return whether the URI is a file or a directory which contains files (including recursively)
-   * @throws Exception if an unexpected exception occurs
-   */
-  private static boolean hasFiles(AlluxioURI source, FileSystem fileSystem) throws Exception {
-    Stack<AlluxioURI> dirsToCheck = new Stack<>();
-    dirsToCheck.add(source);
-    while (!dirsToCheck.isEmpty()) {
-      try {
-        for (URIStatus status : fileSystem.listStatus(dirsToCheck.pop())) {
-          if (!status.isFolder()) {
-            return true;
-          }
-          dirsToCheck.push(new AlluxioURI(status.getPath()));
-        }
-      } catch (FileDoesNotExistException e) {
-        // This probably means another worker has deleted the directory already, so we can probably
-        // return false here. To be safe though, we will fall through and complete the search.
-      }
-    }
-    return false;
   }
 
   @Override

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -142,6 +142,7 @@ public final class MigrateDefinition
         ? ServerConfiguration.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class)
         : WriteType.valueOf(config.getWriteType());
     migrate(command, writeType.toProto(), context.getFileSystem());
+    return null;
   }
 
   /**

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
@@ -42,17 +42,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.modules.junit4.PowerMockRunnerDelegate;
-
-import java.util.Arrays;
-import java.util.Collection;
 
 /**
  * Unit tests for {@link MigrateDefinition#runTask(MigrateConfig, MigrateCommand, RunTaskContext)}.

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
@@ -58,7 +58,6 @@ import java.util.Collection;
  * Unit tests for {@link MigrateDefinition#runTask(MigrateConfig, MigrateCommand, RunTaskContext)}.
  */
 @RunWith(PowerMockRunner.class)
-@PowerMockRunnerDelegate(Parameterized.class)
 @PrepareForTest({FileSystemContext.class})
 public final class MigrateDefinitionRunTaskTest {
   private static final String TEST_DIR = "/DIR";
@@ -71,11 +70,6 @@ public final class MigrateDefinitionRunTaskTest {
   private MockFileInStream mMockInStream;
   private MockFileOutStream mMockOutStream;
   private UfsManager mMockUfsManager;
-
-  @Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] { {true}, {false} });
-  }
 
   @Before
   public void before() throws Exception {

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
@@ -41,7 +41,6 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionSelectExecutorsTest.java
@@ -83,8 +83,8 @@ public final class MigrateDefinitionSelectExecutorsTest extends SelectExecutorsT
   public void assignToLocalWorker() throws Exception {
     createFileWithBlocksOnWorkers("/src", 0);
     setPathToNotExist("/dst");
-    Set<Pair<WorkerInfo, List<MigrateCommand>>> expected = ImmutableSet.of(new Pair<>(
-        JOB_WORKERS.get(0), Collections.singletonList(new MigrateCommand("/src", "/dst"))));
+    Set<Pair<WorkerInfo, MigrateCommand>> expected = ImmutableSet.of(new Pair<>(
+        JOB_WORKERS.get(0), new MigrateCommand("/src", "/dst")));
     Assert.assertEquals(expected, assignMigrates("/src", "/dst"));
   }
 
@@ -92,8 +92,8 @@ public final class MigrateDefinitionSelectExecutorsTest extends SelectExecutorsT
   public void assignToWorkerWithMostBlocks() throws Exception {
     createFileWithBlocksOnWorkers("/src", 3, 1, 1, 3, 1);
     setPathToNotExist("/dst");
-    Set<Pair<WorkerInfo, List<MigrateCommand>>> expected = ImmutableSet.of(new Pair<>(
-        JOB_WORKERS.get(1), Collections.singletonList(new MigrateCommand("/src", "/dst"))));
+    Set<Pair<WorkerInfo, MigrateCommand>> expected = ImmutableSet.of(new Pair<>(
+        JOB_WORKERS.get(1), new MigrateCommand("/src", "/dst")));
     Assert.assertEquals(expected, assignMigrates("/src", "/dst"));
   }
 

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
@@ -83,7 +83,7 @@ public class DistributedCpCommand extends AbstractDistributedJobCommand {
 
   private CopyJobAttempt newJob(String srcPath, String dstPath) {
     CopyJobAttempt jobAttempt = new CopyJobAttempt(mClient,
-        new MigrateConfig(srcPath, dstPath, mWriteType, true, false),
+        new MigrateConfig(srcPath, dstPath, mWriteType, true),
         new CountingRetry(3));
 
     jobAttempt.run();

--- a/tests/src/test/java/alluxio/job/plan/migrate/MigrateIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/plan/migrate/MigrateIntegrationTest.java
@@ -25,25 +25,14 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.Collection;
 
 /**
  * Integration test for the migrate job.
  */
-@RunWith(Parameterized.class)
 public final class MigrateIntegrationTest extends JobIntegrationTest {
   private static final byte[] TEST_BYTES = "hello".getBytes();
-
-  @Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] { {true}, {false} });
-  }
 
   @Rule
   public TemporaryFolder mFolder = new TemporaryFolder();
@@ -80,12 +69,7 @@ public final class MigrateIntegrationTest extends JobIntegrationTest {
     createFileWithTestBytes("/mount1/source/baz/bat");
     long jobId = mJobMaster.run(new MigrateConfig("/mount1/source", "/mount2/destination",
         WriteType.CACHE_THROUGH.toString(), true));
-    waitForJobToFinish(jobId);
-    Assert.assertTrue(mFileSystem.exists(new AlluxioURI("/mount1/source")));
-    Assert.assertTrue(mFileSystem.exists(new AlluxioURI("/mount2/destination")));
-    checkFileContainsTestBytes("/mount2/destination/foo");
-    checkFileContainsTestBytes("/mount2/destination/bar");
-    checkFileContainsTestBytes("/mount2/destination/baz/bat");
+    waitForJobFailure(jobId);
   }
 
   /**

--- a/tests/src/test/java/alluxio/job/plan/migrate/MigrateIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/plan/migrate/MigrateIntegrationTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.io.File;
@@ -46,9 +45,6 @@ public final class MigrateIntegrationTest extends JobIntegrationTest {
     return Arrays.asList(new Object[][] { {true}, {false} });
   }
 
-  @Parameter
-  public boolean mDeleteSource;
-
   @Rule
   public TemporaryFolder mFolder = new TemporaryFolder();
 
@@ -62,14 +58,9 @@ public final class MigrateIntegrationTest extends JobIntegrationTest {
     String destination = "/mount2/destination";
     createFileWithTestBytes(source);
     long jobId = mJobMaster
-        .run(new MigrateConfig(source, destination, WriteType.CACHE_THROUGH.toString(), true,
-            mDeleteSource));
+        .run(new MigrateConfig(source, destination, WriteType.CACHE_THROUGH.toString(), true));
     JobInfo info = waitForJobToFinish(jobId);
-    if (mDeleteSource) {
-      Assert.assertFalse(mFileSystem.exists(new AlluxioURI(source)));
-    } else {
-      Assert.assertTrue(mFileSystem.exists(new AlluxioURI(source)));
-    }
+    Assert.assertTrue(mFileSystem.exists(new AlluxioURI(source)));
     Assert.assertTrue(mFileSystem.exists(new AlluxioURI(destination)));
     checkFileContainsTestBytes(destination);
     // One worker task is needed when moving within the same mount point.
@@ -88,13 +79,9 @@ public final class MigrateIntegrationTest extends JobIntegrationTest {
     mFileSystem.createDirectory(new AlluxioURI("/mount1/source/baz"));
     createFileWithTestBytes("/mount1/source/baz/bat");
     long jobId = mJobMaster.run(new MigrateConfig("/mount1/source", "/mount2/destination",
-        WriteType.CACHE_THROUGH.toString(), true, mDeleteSource));
+        WriteType.CACHE_THROUGH.toString(), true));
     waitForJobToFinish(jobId);
-    if (mDeleteSource) {
-      Assert.assertFalse(mFileSystem.exists(new AlluxioURI("/mount1/source")));
-    } else {
-      Assert.assertTrue(mFileSystem.exists(new AlluxioURI("/mount1/source")));
-    }
+    Assert.assertTrue(mFileSystem.exists(new AlluxioURI("/mount1/source")));
     Assert.assertTrue(mFileSystem.exists(new AlluxioURI("/mount2/destination")));
     checkFileContainsTestBytes("/mount2/destination/foo");
     checkFileContainsTestBytes("/mount2/destination/bar");


### PR DESCRIPTION
DistributedCp and DistributedMv now no longer needs the complicated folder to folder operation and now only handles file to file. Removing a bunch of code that does folder to folder work.