### PR TITLE
Enable ufsIOtest to retrieve configuration from a mount point

### DIFF
--- a/core/base/src/main/java/alluxio/wire/MountPointInfo.java
+++ b/core/base/src/main/java/alluxio/wire/MountPointInfo.java
@@ -192,8 +192,8 @@ public class MountPointInfo implements Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mMountId, mUfsUri, mUfsType, mUfsCapacityBytes, mUfsUsedBytes, mReadOnly,
-        mProperties, mShared);
+    return Objects.hashCode(mMountId, mUfsUri, mUfsType, mUfsCapacityBytes,
+        mUfsUsedBytes, mReadOnly, mProperties, mShared);
   }
 
   @Override

--- a/core/base/src/main/java/alluxio/wire/MountPointInfo.java
+++ b/core/base/src/main/java/alluxio/wire/MountPointInfo.java
@@ -35,6 +35,7 @@ public class MountPointInfo implements Serializable {
 
   private String mUfsUri = "";
   private String mUfsType = "";
+  private long mMountId = 0;
   private long mUfsCapacityBytes = UNKNOWN_CAPACITY_BYTES;
   private long mUfsUsedBytes = UNKNOWN_USED_BYTES;
   private boolean mReadOnly;
@@ -45,6 +46,13 @@ public class MountPointInfo implements Serializable {
    * Creates a new instance of {@link MountPointInfo}.
    */
   public MountPointInfo() {}
+
+  /**
+   * @return the mount id
+   */
+  public long getMountId() {
+    return mMountId;
+  }
 
   /**
    * @return the uri of the under filesystem
@@ -93,6 +101,15 @@ public class MountPointInfo implements Serializable {
    */
   public boolean getShared() {
     return mShared;
+  }
+
+  /**
+   * @param mountId set mountId
+   * @return the mount point information
+   */
+  public MountPointInfo setMountId(long mountId) {
+    mMountId = mountId;
+    return this;
   }
 
   /**
@@ -170,18 +187,19 @@ public class MountPointInfo implements Serializable {
     return mUfsUri.equals(that.mUfsUri) && mUfsType.equals(that.mUfsType)
         && mUfsCapacityBytes == that.mUfsCapacityBytes && mUfsUsedBytes == that.mUfsUsedBytes
         && mReadOnly == that.mReadOnly && mProperties.equals(that.mProperties)
-        && mShared == that.mShared;
+        && mShared == that.mShared && mMountId == that.mMountId;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mUfsUri, mUfsType, mUfsCapacityBytes, mUfsUsedBytes, mReadOnly,
+    return Objects.hashCode(mMountId, mUfsUri, mUfsType, mUfsCapacityBytes, mUfsUsedBytes, mReadOnly,
         mProperties, mShared);
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("ufsUrl", mUfsUri).add("ufsType", mUfsType)
+    return MoreObjects.toStringHelper(this).add("mountId", mMountId)
+        .add("ufsUrl", mUfsUri).add("ufsType", mUfsType)
         .add("ufsCapacityBytes", mUfsCapacityBytes).add("ufsUsedBytes", mUfsUsedBytes)
         .add("readOnly", mReadOnly).add("properties", mProperties)
         .add("shared", mShared).toString();

--- a/core/common/src/main/java/alluxio/concurrent/ManagedBlockingUfsForwarder.java
+++ b/core/common/src/main/java/alluxio/concurrent/ManagedBlockingUfsForwarder.java
@@ -208,7 +208,7 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
 
   @Override
   public AlluxioConfiguration getConfiguration() throws IOException {
-    return new ManagedBlockingUfsMethod<AlluxioConfiguration> () {
+    return new ManagedBlockingUfsMethod<AlluxioConfiguration>() {
       @Override
       public AlluxioConfiguration execute() throws IOException {
         return mUfs.getConfiguration();

--- a/core/common/src/main/java/alluxio/concurrent/ManagedBlockingUfsForwarder.java
+++ b/core/common/src/main/java/alluxio/concurrent/ManagedBlockingUfsForwarder.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.SyncInfo;
 import alluxio.collections.Pair;
 import alluxio.concurrent.jsr.ForkJoinPool;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.security.authorization.AccessControlList;
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
@@ -201,6 +202,16 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
       @Override
       public Long execute() throws IOException {
         return mUfs.getBlockSizeByte(path);
+      }
+    }.get();
+  }
+
+  @Override
+  public AlluxioConfiguration getConfiguration() throws IOException {
+    return new ManagedBlockingUfsMethod<AlluxioConfiguration> () {
+      @Override
+      public AlluxioConfiguration execute() throws IOException {
+        return mUfs.getConfiguration();
       }
     }.get();
   }

--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -43,6 +43,9 @@ import javax.annotation.Nonnull;
 public class InstancedConfiguration implements AlluxioConfiguration {
   private static final Logger LOG = LoggerFactory.getLogger(InstancedConfiguration.class);
 
+  public static final AlluxioConfiguration EMPTY_CONFIGURATION
+      = new InstancedConfiguration(new AlluxioProperties());
+
   /** Regex string to find "${key}" for variable substitution. */
   private static final String REGEX_STRING = "(\\$\\{([^{}]*)\\})";
   /** Regex to find ${key} for variable substitution. */

--- a/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
@@ -303,7 +303,9 @@ public final class GrpcUtils {
         .setUfsCapacityBytes(mountPointPInfo.getUfsCapacityBytes())
         .setUfsUsedBytes(mountPointPInfo.getUfsUsedBytes())
         .setReadOnly(mountPointPInfo.getReadOnly())
-        .setProperties(mountPointPInfo.getPropertiesMap()).setShared(mountPointPInfo.getShared());
+        .setProperties(mountPointPInfo.getPropertiesMap())
+        .setMountId(mountPointPInfo.getMountId())
+        .setShared(mountPointPInfo.getShared());
   }
 
   /**
@@ -562,7 +564,9 @@ public final class GrpcUtils {
     return alluxio.grpc.MountPointInfo.newBuilder().setUfsUri(info.getUfsUri())
         .setUfsType(info.getUfsType()).setUfsCapacityBytes(info.getUfsCapacityBytes())
         .setReadOnly(info.getReadOnly()).putAllProperties(info.getProperties())
-        .setShared(info.getShared()).build();
+        .setShared(info.getShared())
+        .setMountId(info.getMountId())
+        .build();
   }
 
   /**

--- a/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
@@ -566,6 +566,7 @@ public final class GrpcUtils {
         .setReadOnly(info.getReadOnly()).putAllProperties(info.getProperties())
         .setShared(info.getShared())
         .setMountId(info.getMountId())
+        .setUfsUsedBytes(info.getUfsUsedBytes())
         .build();
   }
 

--- a/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.SyncInfo;
 import alluxio.collections.Pair;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.security.authorization.AccessControlList;
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
@@ -90,6 +91,11 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
   @Override
   public void setAclEntries(String path, List<AclEntry> aclEntries) throws IOException {
     // Noop here by default
+  }
+
+  @Override
+  public AlluxioConfiguration getConfiguration() {
+    return mUfsConf;
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -57,7 +57,6 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 // TODO(adit); API calls should use a URI instead of a String wherever appropriate
 public interface UnderFileSystem extends Closeable {
-
   /**
    * The factory for the {@link UnderFileSystem}.
    */
@@ -339,6 +338,13 @@ public interface UnderFileSystem extends Closeable {
   long getBlockSizeByte(String path) throws IOException;
 
   /**
+   * Gets the under file system configuration.
+   *
+   * @return the configuration
+   */
+  AlluxioConfiguration getConfiguration() throws IOException;
+
+  /**
    * Gets the directory status. The caller must already know the path is a directory. This method
    * will throw an exception if the path exists, but is a file.
    *
@@ -595,7 +601,7 @@ public interface UnderFileSystem extends Closeable {
   /**
    * Opens an {@link InputStream} for a file in under filesystem at the indicated path.
    *
-   * Similar to {@link #open(fString)} but
+   * Similar to {@link #open(String)} but
    * deals with the write-then-read eventual consistency issue.
    *
    * @param path the file name

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -13,6 +13,7 @@ package alluxio.underfs;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.annotation.PublicApi;
 import alluxio.SyncInfo;
@@ -342,7 +343,9 @@ public interface UnderFileSystem extends Closeable {
    *
    * @return the configuration
    */
-  AlluxioConfiguration getConfiguration() throws IOException;
+  default AlluxioConfiguration getConfiguration() {
+    return InstancedConfiguration.EMPTY_CONFIGURATION;
+  }
 
   /**
    * Gets the directory status. The caller must already know the path is a directory. This method

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -343,7 +343,7 @@ public interface UnderFileSystem extends Closeable {
    *
    * @return the configuration
    */
-  default AlluxioConfiguration getConfiguration() {
+  default AlluxioConfiguration getConfiguration() throws IOException {
     return InstancedConfiguration.EMPTY_CONFIGURATION;
   }
 

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.SyncInfo;
 import alluxio.collections.Pair;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.status.UnimplementedException;
 import alluxio.security.authorization.AccessControlList;
 import alluxio.metrics.Metric;
@@ -411,6 +412,26 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
       @Override
       public String toString() {
         return String.format("path=%s", path);
+      }
+    });
+  }
+
+  @Override
+  public AlluxioConfiguration getConfiguration() throws IOException {
+    return call(new UfsCallable<AlluxioConfiguration>() {
+      @Override
+      public AlluxioConfiguration call() throws IOException {
+        return mUnderFileSystem.getConfiguration();
+      }
+
+      @Override
+      public String methodName() {
+        return "GetConfiguration";
+      }
+
+      @Override
+      public String toString() {
+        return "";
       }
     });
   }

--- a/core/common/src/test/java/alluxio/wire/MountPointInfoTest.java
+++ b/core/common/src/test/java/alluxio/wire/MountPointInfoTest.java
@@ -39,11 +39,6 @@ public class MountPointInfoTest {
     checkEquality(mountPointInfo, other);
   }
 
-  @Test
-  public void equality() {
-
-  }
-
   public void checkEquality(MountPointInfo a, MountPointInfo b) {
     Assert.assertEquals(a.getUfsUri(), b.getUfsUri());
     Assert.assertEquals(a.getUfsType(), b.getUfsType());

--- a/core/common/src/test/java/alluxio/wire/MountPointInfoTest.java
+++ b/core/common/src/test/java/alluxio/wire/MountPointInfoTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.wire;
 
+import alluxio.grpc.GrpcUtils;
 import alluxio.util.CommonUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,6 +32,18 @@ public class MountPointInfoTest {
     checkEquality(mountPointInfo, other);
   }
 
+  @Test
+  public void proto() {
+    MountPointInfo mountPointInfo = createRandom();
+    MountPointInfo other = GrpcUtils.fromProto(GrpcUtils.toProto(mountPointInfo));
+    checkEquality(mountPointInfo, other);
+  }
+
+  @Test
+  public void equality() {
+
+  }
+
   public void checkEquality(MountPointInfo a, MountPointInfo b) {
     Assert.assertEquals(a.getUfsUri(), b.getUfsUri());
     Assert.assertEquals(a.getUfsType(), b.getUfsType());
@@ -48,6 +61,7 @@ public class MountPointInfoTest {
     String ufsType = CommonUtils.randomAlphaNumString(random.nextInt(10));
     long ufsCapacityBytes = random.nextLong();
     long ufsUsedBytes = random.nextLong();
+    long mountId = random.nextLong();
     boolean readOnly = random.nextBoolean();
     Map<String, String> properties = new HashMap<>();
     for (int i = 0, n = random.nextInt(10) + 1; i < n; i++) {
@@ -62,6 +76,7 @@ public class MountPointInfoTest {
     result.setUfsUsedBytes(ufsUsedBytes);
     result.setReadOnly(readOnly);
     result.setProperties(properties);
+    result.setMountId(mountId);
 
     return result;
   }

--- a/core/common/src/test/java/alluxio/wire/MountPointInfoTest.java
+++ b/core/common/src/test/java/alluxio/wire/MountPointInfoTest.java
@@ -38,6 +38,7 @@ public class MountPointInfoTest {
     Assert.assertEquals(a.getUfsUsedBytes(), b.getUfsUsedBytes());
     Assert.assertEquals(a.getReadOnly(), b.getReadOnly());
     Assert.assertEquals(a.getProperties(), b.getProperties());
+    Assert.assertEquals(a.getMountId(), b.getMountId());
     Assert.assertEquals(a, b);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/options/MountInfo.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/options/MountInfo.java
@@ -88,6 +88,7 @@ public class MountInfo {
     info.setReadOnly(mOptions.getReadOnly());
     info.setProperties(mOptions.getProperties());
     info.setShared(mOptions.getShared());
+    info.setMountId(mMountId);
     return info;
   }
 

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -311,6 +311,7 @@ message MountPointInfo {
   optional bool readOnly = 5;
   map<string, string> properties = 6;
   optional bool shared = 7;
+  optional int64 mountId = 8;
 }
 
 message FileSystemCommandOptions {

--- a/job/server/src/main/java/alluxio/job/plan/stress/StressBenchDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/stress/StressBenchDefinition.java
@@ -128,11 +128,11 @@ public final class StressBenchDefinition
         .collect(Collectors.toList());
 
     if (commandArgs.stream().anyMatch(
-        (s) -> s.equalsIgnoreCase(UfsIOParameters.USE_UFS_CONF))) {
+        (s) -> s.equalsIgnoreCase(UfsIOParameters.USE_MOUNT_CONF))) {
       // get ufs Uri from --path=blah://blah
       String ufsUri = commandArgs.stream().filter(s -> !s.startsWith(UfsIOParameters.PATH))
           .findFirst().map(param -> param.substring("--path".length())).orElse("");
-      commandArgs = commandArgs.stream().filter((s) -> !UfsIOParameters.USE_UFS_CONF.equals(s)
+      commandArgs = commandArgs.stream().filter((s) -> !UfsIOParameters.USE_MOUNT_CONF.equals(s)
               && !s.startsWith(UfsIOParameters.CONF)).collect(Collectors.toList());
 
       List<String> properties = getUfsConf(ufsUri, runTaskContext).entrySet().stream()

--- a/stress/common/src/main/java/alluxio/stress/worker/UfsIOParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/worker/UfsIOParameters.java
@@ -23,7 +23,7 @@ import java.util.Map;
  * Parameters used in the UFS I/O throughput test.
  * */
 public class UfsIOParameters extends Parameters {
-  public static final String USE_UFS_CONF = "--use-ufs-conf";
+  public static final String USE_MOUNT_CONF = "--use-mount-conf";
   public static final String CONF = "--conf";
   public static final String PATH = "--path";
 
@@ -39,9 +39,10 @@ public class UfsIOParameters extends Parameters {
           required = true)
   public String mPath;
 
-  @Parameter(names = {USE_UFS_CONF},
+  @Parameter(names = {USE_MOUNT_CONF},
       description = "If true, attempt to load the ufs configuration from an existing mount point "
-          + "to read/write to the base path")
+          + "to read/write to the base path, it will override the configuration specified through "
+          + "--conf parameter")
   public boolean mUseUfsConf = false;
 
   @DynamicParameter(names = CONF,

--- a/stress/common/src/main/java/alluxio/stress/worker/UfsIOParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/worker/UfsIOParameters.java
@@ -34,18 +34,17 @@ public class UfsIOParameters extends Parameters {
           description = "size of data to write and then read for each thread")
   public String mDataSize = "4G";
 
-  @Parameter(names = {"--path"},
+  @Parameter(names = {PATH},
           description = "the Ufs Path to write temporary data in",
           required = true)
   public String mPath;
 
-  @Parameter(names = {"--use-ufs-conf"},
-      description = "If true, use the existing ufs configuration to read/write to the base path")
-  @Parameters.BooleanDescription(trueDescription = "UseUFSConf",
-      falseDescription = "UseExternalConf")
+  @Parameter(names = {USE_UFS_CONF},
+      description = "If true, attempt to load the ufs configuration from an existing mount point "
+          + "to read/write to the base path")
   public boolean mUseUfsConf = false;
 
-  @DynamicParameter(names = "--conf",
+  @DynamicParameter(names = CONF,
       description = "Any HDFS client configuration key=value. Can repeat to provide multiple "
           + "configuration values.")
   public Map<String, String> mConf = new HashMap<>();

--- a/stress/common/src/main/java/alluxio/stress/worker/UfsIOParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/worker/UfsIOParameters.java
@@ -23,6 +23,10 @@ import java.util.Map;
  * Parameters used in the UFS I/O throughput test.
  * */
 public class UfsIOParameters extends Parameters {
+  public static final String USE_UFS_CONF = "--use-ufs-conf";
+  public static final String CONF = "--conf";
+  public static final String PATH = "--path";
+
   @Parameter(names = {"--threads"}, description = "the number of threads to use")
   public int mThreads = 4;
 
@@ -31,9 +35,15 @@ public class UfsIOParameters extends Parameters {
   public String mDataSize = "4G";
 
   @Parameter(names = {"--path"},
-          description = "the Alluxio directory to write temporary data in",
+          description = "the Ufs Path to write temporary data in",
           required = true)
   public String mPath;
+
+  @Parameter(names = {"--use-ufs-conf"},
+      description = "If true, use the existing ufs configuration to read/write to the base path")
+  @Parameters.BooleanDescription(trueDescription = "UseUFSConf",
+      falseDescription = "UseExternalConf")
+  public boolean mUseUfsConf = false;
 
   @DynamicParameter(names = "--conf",
       description = "Any HDFS client configuration key=value. Can repeat to provide multiple "

--- a/stress/shell/src/main/java/alluxio/stress/cli/UfsIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/UfsIOBench.java
@@ -91,7 +91,13 @@ public class UfsIOBench extends Benchmark<IOTaskResult> {
   }
 
   @Override
-  public void prepare() {}
+  public void prepare() {
+    if (mParameters.mUseUfsConf && !mBaseParameters.mCluster) {
+      throw new IllegalArgumentException(String.format(
+          "%s can not use the ufs conf if it is not running in cluster mode",
+          getClass().getName()));
+    }
+  }
 
   /**
    * @param args command-line arguments

--- a/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
+++ b/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
@@ -14,6 +14,7 @@ package alluxio.testutils.underfs.delegating;
 import alluxio.AlluxioURI;
 import alluxio.SyncInfo;
 import alluxio.collections.Pair;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.security.authorization.AccessControlList;
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
@@ -132,6 +133,11 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   @Override
   public long getBlockSizeByte(String path) throws IOException {
     return mUfs.getBlockSizeByte(path);
+  }
+
+  @Override
+  public AlluxioConfiguration getConfiguration() throws IOException {
+    return mUfs.getConfiguration();
   }
 
   @Override


### PR DESCRIPTION
Previously any ufs with credentials would need the credentials resupplied when running speed test.
This change removes that hassle for the user.