### PR TITLE
[DOCFIX] Add flink doc back

### DIFF
--- a/docs/cn/compute/Flink.md
+++ b/docs/cn/compute/Flink.md
@@ -13,9 +13,9 @@ priority: 2
 
 ## 前期准备
 
-开始之前你需要安装好Java。同时使用[本地模式]({{ '/cn/deploy/Running-Alluxio-Locally.html' | relativize_url }})或[集群模式]({{ '/cn/deploy/Running-Alluxio-on-a-Cluster.html' | relativize_url }})构建好Alluxio。
-
-请在[Apache Flink](http://flink.apache.org/)网站上阅读Flink安装说明。
+* 安装好Java 8 Update 161 (8u161+)或更新版本, 64-bit.。
+* 使用[本地模式]({{ '/cn/deploy/Running-Alluxio-Locally.html' | relativize_url }})或[集群模式]({{ '/cn/deploy/Running-Alluxio-on-a-Cluster.html' | relativize_url }})构建好Alluxio。
+* 请在[Apache Flink](http://flink.apache.org/)网站上阅读Flink安装说明。
 
 ## 配置
 

--- a/docs/cn/compute/Flink.md
+++ b/docs/cn/compute/Flink.md
@@ -1,0 +1,102 @@
+---
+layout: global
+title: 在Alluxio上运行Apache Flink
+nickname: Apache Flink
+group: Compute Integrations
+priority: 6
+---
+
+* 内容列表
+{:toc}
+
+该指南介绍如何在Alluxio上运行[Apache Flink](http://flink.apache.org/),以便你在Flink中使用Alluxio的文件。
+
+## 前期准备
+
+开始之前你需要安装好Java。同时使用[本地模式]({{ '/cn/deploy/Running-Alluxio-Locally.html' | relativize_url }})或[集群模式]({{ '/cn/deploy/Running-Alluxio-on-a-Cluster.html' | relativize_url }})构建好Alluxio。
+
+请在[Apache Flink](http://flink.apache.org/)网站上阅读Flink安装说明。
+
+## 配置
+
+Apache Flink可以通过通用文件系统包装类（可用于Hadoop文件系统）来使用Alluxio。因此，Alluxio的配置主要在Hadoop配置文件中完成。
+
+
+### 在`core-site.xml`中设置属性
+
+如果你安装Flink的同时安装了Hadoop，将如下属性加到`core-site.xml`配置文件：
+
+```xml
+<property>
+  <name>fs.alluxio.impl</name>
+  <value>alluxio.hadoop.FileSystem</value>
+</property>
+```
+
+如果你没有安装Hadoop，创建一个包含以下内容的`core-site.xml`文件
+
+```xml
+<configuration>
+  <property>
+    <name>fs.alluxio.impl</name>
+    <value>alluxio.hadoop.FileSystem</value>
+  </property>
+</configuration>
+```
+
+### 在`conf/flink-conf.yaml`中指定`core-site.xml`的路径
+
+接下来需要指定Flink中Hadoop配置的路径。打开Flink根目录下`conf/flink-conf.yaml`文件，设置`fs.hdfs.hadoopconf`的值为`core-site.xml`的**目录**（对于新的Hadoop版本，该目录通常以`etc/hadoop`结尾）。
+
+### 布置Alluxio客户端Jar包
+
+为了与Alluxio通信，需要提供带有Alluxio核心客户端Jar包的Flink程序。我们推荐您直接从[http://www.alluxio.io/download](http://www.alluxio.io/download)下载压缩包。另外，高级用户可以选择用源文件编译产生客户端Jar包。遵循以下步骤：[here](Building-Alluxio-From-Source.html#compute-framework-support),在 `{{site.ALLUXIO_CLIENT_JAR_PATH_BUILD}}`路径下可以找到客户端的Jar包。
+
+接下来需要让Alluxio `jar`文件对Flink可用，因为其中包含了配置好的`alluxio.hadoop.FileSystem`类。
+
+有以下几种方式实现：
+
+- 将`{{site.ALLUXIO_CLIENT_JAR_PATH}}`文件放在Flink的`lib`目录下（对于本地模式以及独立集群模式）。
+- 将`{{site.ALLUXIO_CLIENT_JAR_PATH}}`文件放在布置在Yarn中的Flink下的`ship`目录下。
+- 在`HADOOP_CLASSPATH`环境变量中指定该jar文件的路径（要保证该路径对集群中的所有节点都有效）。例如：
+
+```console
+$ export HADOOP_CLASSPATH={{site.ALLUXIO_CLIENT_JAR_PATH}}
+```
+
+### 将Alluxio额外属性转化为Flink属性
+
+除此以外，如果`conf/alluxio-site.properties`和客户端相关的配置文件中有任何指定的属性，请在`{FLINK_HOME}/conf/flink-conf
+.yaml`文件中将这些属性转化为`env.java.opts`，从而方便Flink使用Alluxio的配置。例如，如果你想要将CACHE_THROUGH作为Alluxio客户端的写文件方式
+，你应该在 `{FLINK_HOME}/conf/flink-conf.yaml`增加如下配置
+
+```yaml
+env.java.opts: -Dalluxio.user.file.writetype.default=CACHE_THROUGH
+```
+
+## 在Flink中使用Alluxio
+
+Flink中使用Alluxio，指定路径时使用`alluxio://`前缀。
+
+如果Alluxio是本地安装，有效路径类似于：
+`alluxio://localhost:19998/user/hduser/gutenberg`。
+
+### Wordcount示例
+
+该示例假定你已经按前文指导安装了Alluxio和Flink。
+
+将`LICENSE`文件放入Alluxio中，假定当前目录为Alluxio工程的根目录：
+
+```console
+$ ./bin/alluxio fs copyFromLocal LICENSE alluxio://localhost:19998/LICENSE
+```
+
+在Flink工程的根目录下运行以下命令：
+
+```console
+$ ./bin/flink run examples/batch/WordCount.jar \
+--input alluxio://localhost:19998/LICENSE \
+--output alluxio://localhost:19998/output
+```
+
+接着打开浏览器，进入[http://localhost:19999/browse](http://localhost:19999/browse)，其中应存在一个`output`文件，该文件即为对`LICENSE`文件进行word count的结果。

--- a/docs/cn/compute/Flink.md
+++ b/docs/cn/compute/Flink.md
@@ -3,7 +3,7 @@ layout: global
 title: 在Alluxio上运行Apache Flink
 nickname: Apache Flink
 group: Compute Integrations
-priority: 6
+priority: 2
 ---
 
 * 内容列表

--- a/docs/en/compute/Flink.md
+++ b/docs/en/compute/Flink.md
@@ -1,0 +1,121 @@
+---
+layout: global
+title: Running Apache Flink on Alluxio
+nickname: Apache Flink
+group: Frameworks
+priority: 2
+---
+
+* Table of Contents
+{:toc}
+
+This guide describes how to get Alluxio running with [Apache Flink](http://flink.apache.org/), so
+that you can easily work with files stored in Alluxio.
+
+## Prerequisites
+
+The prerequisite for this part is that you have
+[Java](Java-Setup.html). We also assume that you have set up
+Alluxio in accordance to these guides [Local Mode](Running-Alluxio-Locally.html) or
+[Cluster Mode](Running-Alluxio-on-a-Cluster.html).
+
+Please find the guides for setting up Flink on the Apache Flink [website](http://flink.apache.org/).
+
+## Configuration
+
+Apache Flink allows to use Alluxio through a generic file system wrapper for the Hadoop file system.
+Therefore, the configuration of Alluxio is done mostly in Hadoop configuration files.
+
+### Set property in `core-site.xml`
+
+If you have a Hadoop setup next to the Flink installation, add the following property to the
+`core-site.xml` configuration file:
+
+```xml
+<property>
+  <name>fs.alluxio.impl</name>
+  <value>alluxio.hadoop.FileSystem</value>
+</property>
+```
+
+In case you don't have a Hadoop setup, you have to create a file called `core-site.xml` with the
+following contents:
+
+```xml
+<configuration>
+  <property>
+    <name>fs.alluxio.impl</name>
+    <value>alluxio.hadoop.FileSystem</value>
+  </property>
+</configuration>
+```
+
+### Specify path to `core-site.xml` in `conf/flink-conf.yaml`
+
+Next, you have to specify the path to the Hadoop configuration in Flink. Open the
+`conf/flink-conf.yaml` file in the Flink root directory and set the `fs.hdfs.hadoopconf`
+configuration value to the **directory** containing the `core-site.xml`. (For newer Hadoop versions,
+the directory usually ends with `etc/hadoop`.)
+
+### Distribute the Alluxio Client Jar
+
+In order to communicate with Alluxio, we need to provide Flink programs with the Alluxio Core Client
+jar. We recommend you to download the tarball from
+Alluxio [download page](http://www.alluxio.org/download).
+Alternatively, advanced users can choose to compile this client jar from the source code
+by following Follow the instructs [here](Building-Alluxio-From-Source.html#compute-framework-support).
+The Alluxio client jar can be found at `{{site.ALLUXIO_CLIENT_JAR_PATH}}`.
+
+We need to make the Alluxio `jar` file available to Flink, because it contains the configured
+`alluxio.hadoop.FileSystem` class.
+
+There are different ways to achieve that:
+
+- Put the `{{site.ALLUXIO_CLIENT_JAR_PATH}}` file into the `lib` directory of Flink (for local and
+standalone cluster setups)
+- Put the `{{site.ALLUXIO_CLIENT_JAR_PATH}}` file into the `ship` directory for Flink on YARN.
+- Specify the location of the jar file in the `HADOOP_CLASSPATH` environment variable (make sure its
+available on all cluster nodes as well). For example like this:
+
+```bash
+$ export HADOOP_CLASSPATH={{site.ALLUXIO_CLIENT_JAR_PATH}}
+```
+
+### Translate additional Alluxio site properties to Flink
+
+In addition, if there are any client-related properties specified in `conf/alluxio-site.properties`,
+translate those to `env.java.opts` in `{FLINK_HOME}/conf/flink-conf.yaml` for Flink to pick up
+Alluxio configuration. For example, if you want to configure Alluxio client to use CACHE_THROUGH as
+the write type, you should add the following to `{FLINK_HOME}/conf/flink-conf.yaml`.
+
+```yaml
+env.java.opts: -Dalluxio.user.file.writetype.default=CACHE_THROUGH
+```
+
+## Using Alluxio with Flink
+
+To use Alluxio with Flink, just specify paths with the `alluxio://` scheme.
+
+If Alluxio is installed locally, a valid path would look like this
+`alluxio://localhost:19998/user/hduser/gutenberg`.
+
+### Wordcount Example
+
+This example assumes you have set up Alluxio and Flink as previously described.
+
+Put the file `LICENSE` into Alluxio, assuming you are in the top level Alluxio project directory:
+
+```bash
+$ bin/alluxio fs copyFromLocal LICENSE alluxio://localhost:19998/LICENSE
+```
+
+Run the following command from the top level Flink project directory:
+
+```bash
+$ bin/flink run examples/batch/WordCount.jar --input alluxio://localhost:19998/LICENSE --output alluxio://localhost:19998/output
+```
+
+Open your browser and check [http://localhost:19999/browse](http://localhost:19999/browse). There should be an output file `output` which contains the word counts of the file `LICENSE`.
+
+> Tips：The previous example is also applicable to Alluxio in fault tolerant mode with Zookeeper. 
+Please follow the instructions in [HDFS API to connect to Alluxio with high availability](Running-Alluxio-on-a-Cluster.html#hdfs-api).

--- a/docs/en/compute/Flink.md
+++ b/docs/en/compute/Flink.md
@@ -2,7 +2,7 @@
 layout: global
 title: Running Apache Flink on Alluxio
 nickname: Apache Flink
-group: Frameworks
+group: Compute Integrations
 priority: 2
 ---
 

--- a/docs/en/compute/Flink.md
+++ b/docs/en/compute/Flink.md
@@ -74,7 +74,7 @@ standalone cluster setups)
 - Specify the location of the jar file in the `HADOOP_CLASSPATH` environment variable (make sure its
 available on all cluster nodes as well). For example like this:
 
-```bash
+```console
 $ export HADOOP_CLASSPATH={{site.ALLUXIO_CLIENT_JAR_PATH}}
 ```
 

--- a/docs/en/compute/Flink.md
+++ b/docs/en/compute/Flink.md
@@ -14,12 +14,9 @@ that you can easily work with files stored in Alluxio.
 
 ## Prerequisites
 
-The prerequisite for this part is that you have
-[Java](Java-Setup.html). We also assume that you have set up
-Alluxio in accordance to these guides [Local Mode](Running-Alluxio-Locally.html) or
-[Cluster Mode](Running-Alluxio-on-a-Cluster.html).
-
-Please find the guides for setting up Flink on the Apache Flink [website](http://flink.apache.org/).
+* Setup Java for Java 8 Update 161 or higher (8u161+), 64-bit.
+* Alluxio has been set up and is running.
+* Flink has been set up and is running.
 
 ## Configuration
 
@@ -105,14 +102,16 @@ This example assumes you have set up Alluxio and Flink as previously described.
 
 Put the file `LICENSE` into Alluxio, assuming you are in the top level Alluxio project directory:
 
-```bash
+```console
 $ bin/alluxio fs copyFromLocal LICENSE alluxio://localhost:19998/LICENSE
 ```
 
 Run the following command from the top level Flink project directory:
 
-```bash
-$ bin/flink run examples/batch/WordCount.jar --input alluxio://localhost:19998/LICENSE --output alluxio://localhost:19998/output
+```console
+$ bin/flink run examples/batch/WordCount.jar \
+  --input alluxio://localhost:19998/LICENSE \
+  --output alluxio://localhost:19998/output
 ```
 
 Open your browser and check [http://localhost:19999/browse](http://localhost:19999/browse). There should be an output file `output` which contains the word counts of the file `LICENSE`.


### PR DESCRIPTION
The Flink documentation was removed a while ago

EN version was lost in https://github.com/Alluxio/alluxio/commit/7c59f07833951131fae9f5a448753c9331714b8f It was not moved to a new address, presumably lost in the doc structure refactor. The history and intention of that commit has lost track.

CN version was removed in https://github.com/Alluxio/alluxio/commit/9cb40db8171c02399fb656525b9caf13eb3f62fc#diff-4f1b02166fb51e7e45ddba897b5926d53bdc5cda08d0a76629a04e1075fdadd5 In order to keep in sync with the EN doc.

This change intends to bring the Flink doc back. Please note that this change does not attempt to keep the Flink doc up-to-date with the current Alluxio. That will be done in a separate PR.