### PR TITLE
Implement concurrent ufs input stream cache

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamCache.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamCache.java
@@ -1,0 +1,321 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block;
+
+import alluxio.Constants;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.underfs.SeekableUnderFileInputStream;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.OpenOptions;
+import alluxio.util.IdUtils;
+import alluxio.util.executor.ExecutorServiceFactories;
+import alluxio.worker.block.io.BlockReader;
+
+import com.google.common.base.Preconditions;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalListeners;
+import com.google.common.cache.RemovalNotification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * This class implements a {@link BlockReader} to read a block directly from UFS, and
+ * optionally cache the block to the Alluxio worker if the whole block it is read.
+ */
+@ThreadSafe
+public final class UfsInputStreamCache {
+  private static final Logger LOG = LoggerFactory.getLogger(UfsInputStreamCache.class);
+  private static final boolean CACHE_ENABLED =
+      ServerConfiguration.getBoolean(PropertyKey.WORKER_UFS_INSTREAM_CACHE_ENABLED);
+
+  /**
+   * A map from the ufs file id to the metadata of the input streams. Synchronization on this map
+   * before access.
+   */
+  private final Map<Long, StreamIdSet> mFileIdToStreamIds;
+  /** Cache of the input streams, from the input stream id to the input stream. */
+  private final Cache<Long, CachedSeekableInputStream> mStreamCache;
+  /** Thread pool for asynchronously removing the expired input streams. */
+  private final ExecutorService mRemovalThreadPool;
+
+  public UfsInputStreamCache() {
+    mFileIdToStreamIds = new ConcurrentHashMap<>();
+    mRemovalThreadPool = ExecutorServiceFactories
+        .fixedThreadPool(Constants.UFS_INPUT_STREAM_CACHE_EXPIRATION, 2)
+        .create();
+
+    // A listener to the input stream removal.
+    RemovalListener<Long, CachedSeekableInputStream> listener =
+        (RemovalNotification<Long, CachedSeekableInputStream> removal) -> {
+          CachedSeekableInputStream inputStream = removal.getValue();
+          final long fileId = inputStream.getFileId();
+          final long resourceId = removal.getKey();
+          boolean shouldClose = false;
+
+          StreamIdSet streamIds = mFileIdToStreamIds.get(inputStream.getFileId());
+          if (streamIds == null) {
+            LOG.warn(
+                "Removed UFS input stream (fileId: {} resourceId: {}) but does not exist",
+                fileId, resourceId);
+          } else {
+            synchronized (streamIds) {
+              // remove the key
+              if (streamIds.removeInUse(resourceId)) {
+                LOG.warn("Removed in-use UFS input stream (fileId: {} resourceId: {})", fileId,
+                    resourceId);
+              }
+              if (streamIds.removeAvailable(resourceId)) {
+                // close the resource
+                LOG.debug("Removed available UFS input stream (fileId: {} resourceId: {})", fileId,
+                    resourceId);
+                shouldClose = true;
+              }
+              if (streamIds.isEmpty()) {
+                // remove the value from the mapping
+                mFileIdToStreamIds.remove(fileId);
+              }
+            }
+          }
+
+          if (shouldClose) {
+            try {
+              inputStream.close();
+            } catch (IOException e) {
+              LOG.warn("Failed to close UFS input stream resource of file {} with file id {}"
+                      + " and resource id {}", inputStream.getFilePath(), inputStream.getFileId(),
+                  resourceId);
+            }
+          }
+        };
+    mStreamCache = CacheBuilder.newBuilder()
+        .maximumSize(ServerConfiguration.getInt(PropertyKey.WORKER_UFS_INSTREAM_CACHE_MAX_SIZE))
+        .expireAfterAccess(
+            ServerConfiguration.getMs(PropertyKey.WORKER_UFS_INSTREAM_CACHE_EXPIRARTION_TIME),
+            TimeUnit.MILLISECONDS)
+        .removalListener(RemovalListeners.asynchronous(listener, mRemovalThreadPool)).build();
+  }
+
+  /**
+   * Releases an input stream. The input stream is closed if it's already expired.
+   *
+   * @param inputStream the input stream to release
+   * @throws IOException when input stream fails to close
+   */
+  public void release(InputStream inputStream) throws IOException {
+    if (!(inputStream instanceof CachedSeekableInputStream) || !CACHE_ENABLED) {
+      // for non-seekable input stream, close and return
+      inputStream.close();
+      return;
+    }
+
+    CachedSeekableInputStream cachedStream = (CachedSeekableInputStream) inputStream;
+    long fileId = cachedStream.getFileId();
+    long resourceId = cachedStream.getResourceId();
+    StreamIdSet streamIds = mFileIdToStreamIds.get(fileId);
+
+    if (streamIds == null) {
+      // the cache no longer tracks this input stream
+      LOG.debug("UFS input stream (fileId: {} resourceId: {}) is already expired", fileId,
+          resourceId);
+      inputStream.close();
+      return;
+    }
+
+    if (!streamIds.release(resourceId)) {
+      LOG.debug("Close the expired UFS input stream (fileId: {} resourceId: {})", fileId,
+          resourceId);
+      // the input stream expired, close it
+      inputStream.close();
+    }
+  }
+
+  /**
+   * Acquires an input stream. For seekable input streams, if there is an available input stream in
+   * the cache, reuse it and repositions the offset, otherwise the manager opens a new input stream.
+   *
+   * @param ufs the under file system
+   * @param path the path to the under storage file
+   * @param fileId the file id
+   * @param openOptions the open options
+   * @return the acquired input stream
+   * @throws IOException if the input stream fails to open
+   */
+  public InputStream acquire(UnderFileSystem ufs, String path, long fileId, OpenOptions openOptions)
+      throws IOException {
+    if (!ufs.isSeekable() || !CACHE_ENABLED) {
+      // only seekable UFSes are cachable/reusable, always return a new input stream
+      return ufs.openExistingFile(path, openOptions);
+    }
+
+    // explicit cache cleanup
+    mStreamCache.cleanUp();
+
+    StreamIdSet streamIds = mFileIdToStreamIds.compute(fileId, (key, value) -> {
+      if (value != null) {
+        return value;
+      }
+      return new StreamIdSet();
+    });
+
+    // Try to acquire an existing id from the stream id set.
+    // synchronized is required to be consistent between availableIds() and acquire(id).
+    CachedSeekableInputStream inputStream = null;
+    synchronized (streamIds) {
+      // find the next available input stream from the cache
+      for (long id : streamIds.availableIds()) {
+        inputStream = mStreamCache.getIfPresent(id);
+        if (inputStream != null) {
+          // acquire it now while locked, so other threads cannot take it
+          streamIds.acquire(id);
+          break;
+        }
+      }
+    }
+
+    if (inputStream != null) {
+      // for the cached ufs instream, seek (outside of critical section) to the requested position.
+      LOG.debug("Reused the under file input stream resource of {}", inputStream.getResourceId());
+      inputStream.seek(openOptions.getOffset());
+      return inputStream;
+    }
+
+    // no cached input stream is available, acquire a new id and open a new stream
+    final long newId = streamIds.acquireNewId();
+    try {
+      inputStream = mStreamCache.get(newId, () -> {
+        SeekableUnderFileInputStream ufsStream = (SeekableUnderFileInputStream) ufs
+            .openExistingFile(path,
+                OpenOptions.defaults().setPositionShort(openOptions.getPositionShort())
+                    .setOffset(openOptions.getOffset()));
+        LOG.debug("Created the under file input stream resource of {}", newId);
+        return new CachedSeekableInputStream(ufsStream, newId, fileId, path);
+      });
+    } catch (ExecutionException e) {
+      LOG.warn("Failed to create a new cached ufs instream of file id {} and path {}", fileId,
+          path, e);
+      // fall back to an uncached ufs creation.
+      return ufs.openExistingFile(path,
+          OpenOptions.defaults().setOffset(openOptions.getOffset()));
+    }
+    return inputStream;
+  }
+
+  /**
+   * The metadata of the input streams associated with an under storage file that tracks which input
+   * streams are in-use or available. Each input stream is identified by a unique id.
+   */
+  @ThreadSafe
+  private static class StreamIdSet {
+    private final Set<Long> mInUseStreamIds;
+    private final Set<Long> mAvailableStreamIds;
+
+    /**
+     * Creates a new {@link StreamIdSet}.
+     */
+    StreamIdSet() {
+      mInUseStreamIds = new HashSet<>();
+      mAvailableStreamIds = new HashSet<>();
+    }
+
+    /**
+     * @return a view of the available input stream ids
+     */
+    synchronized Set<Long> availableIds() {
+      return Collections.unmodifiableSet(mAvailableStreamIds);
+    }
+
+    /**
+     * Marks an input stream as acquired.
+     *
+     * @param id the id of the input stream
+     */
+    synchronized void acquire(long id) {
+      Preconditions.checkArgument(!mInUseStreamIds.contains(id), "%d is already in use", id);
+      mAvailableStreamIds.remove(id);
+      mInUseStreamIds.add(id);
+    }
+
+    synchronized long acquireNewId() {
+      while (true) {
+        long newId = IdUtils.getRandomNonNegativeLong();
+        if (mAvailableStreamIds.contains(newId) || mInUseStreamIds.contains(newId)) {
+          // This id already managed, try again.
+          continue;
+        }
+
+        acquire(newId);
+        return newId;
+      }
+    }
+
+    /**
+     * @return if there is any outstanding input streams of the file
+     */
+    synchronized boolean isEmpty() {
+      return mInUseStreamIds.isEmpty() && mAvailableStreamIds.isEmpty();
+    }
+
+    /**
+     * Marks an input stream as not in use.
+     * @param id the id of the input stream
+     * @return true if removed from the in-use streams
+     */
+    synchronized boolean removeInUse(long id) {
+      return mInUseStreamIds.remove(id);
+    }
+
+    /**
+     * Removes the mark of the input stream as available.
+     *
+     * @param id the id of the input stream
+     * @return <code>true</code> if the given input stream is available, <code>false</code> if the
+     *         given input stream is not among available input streams
+     */
+    synchronized boolean removeAvailable(long id) {
+      return mAvailableStreamIds.remove(id);
+    }
+
+    /**
+     * Returns an id to the input stream pool. It marks the id from in use to available. If the
+     * input stream is already removed from the cache, then do nothing.
+     *
+     * @param id id of the input stream
+     * @return true if the id is marked from in use to available; false if the id no longer used for
+     *         cache
+     */
+    synchronized boolean release(long id) {
+      Preconditions.checkArgument(!mAvailableStreamIds.contains(id));
+      if (mInUseStreamIds.contains(id)) {
+        mInUseStreamIds.remove(id);
+        mAvailableStreamIds.add(id);
+        return true;
+      }
+      return false;
+    }
+  }
+}

--- a/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamCache.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamCache.java
@@ -63,6 +63,9 @@ public final class UfsInputStreamCache {
   /** Thread pool for asynchronously removing the expired input streams. */
   private final ExecutorService mRemovalThreadPool;
 
+  /**
+   * Constructs a new UFS input stream cache.
+   */
   public UfsInputStreamCache() {
     mFileIdToStreamIds = new ConcurrentHashMap<>();
     mRemovalThreadPool = ExecutorServiceFactories
@@ -77,7 +80,7 @@ public final class UfsInputStreamCache {
           final long resourceId = removal.getKey();
           boolean shouldClose = false;
 
-          StreamIdSet streamIds = mFileIdToStreamIds.get(inputStream.getFileId());
+          StreamIdSet streamIds = mFileIdToStreamIds.get(fileId);
           if (streamIds == null) {
             LOG.warn(
                 "Removed UFS input stream (fileId: {} resourceId: {}) but does not exist",

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
@@ -75,6 +75,9 @@ public final class UnderFileSystemBlockStore implements SessionCleanable {
   /** The manager for all ufs. */
   private final UfsManager mUfsManager;
 
+  /** The cache for all ufs instream. */
+  private final UfsInputStreamCache mUfsInstreamCache;
+
   /**
    * Creates an instance of {@link UnderFileSystemBlockStore}.
    *
@@ -84,6 +87,7 @@ public final class UnderFileSystemBlockStore implements SessionCleanable {
   public UnderFileSystemBlockStore(BlockStore localBlockStore, UfsManager ufsManager) {
     mLocalBlockStore = localBlockStore;
     mUfsManager = ufsManager;
+    mUfsInstreamCache = new UfsInputStreamCache();
   }
 
   /**
@@ -237,7 +241,7 @@ public final class UnderFileSystemBlockStore implements SessionCleanable {
     }
     BlockReader reader =
         UnderFileSystemBlockReader.create(blockInfo.getMeta(), offset, positionShort,
-            mLocalBlockStore, mUfsManager);
+            mLocalBlockStore, mUfsManager, mUfsInstreamCache);
     blockInfo.setBlockReader(reader);
     return reader;
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamCacheTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamCacheTest.java
@@ -1,0 +1,206 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import alluxio.ConfigurationRule;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.test.util.ConcurrencyUtils;
+import alluxio.underfs.SeekableUnderFileInputStream;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.options.OpenOptions;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.Invocation;
+
+import java.io.Closeable;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+public final class UfsInputStreamCacheTest {
+  private static final String FILE_NAME = "/test";
+  private static final long FILE_ID = 1;
+
+  private UnderFileSystem mUfs;
+  private SeekableUnderFileInputStream[] mSeekableInStreams;
+  private UfsInputStreamCache mManager;
+  private int mNumOfInputStreams = 20;
+
+  @Before
+  public void before() throws Exception {
+    mSeekableInStreams = new SeekableUnderFileInputStream[mNumOfInputStreams];
+    mUfs = mock(UnderFileSystem.class);
+    when(mUfs.isSeekable()).thenReturn(true);
+    for (int i = 0; i < mNumOfInputStreams; i++) {
+      SeekableUnderFileInputStream instream = mock(SeekableUnderFileInputStream.class);
+      mSeekableInStreams[i] = instream;
+    }
+    when(mUfs.openExistingFile(eq(FILE_NAME), any(OpenOptions.class))).thenReturn(
+        mSeekableInStreams[0], Arrays.copyOfRange(mSeekableInStreams, 1, mNumOfInputStreams));
+    mManager = new UfsInputStreamCache();
+  }
+
+  /**
+   * Test that verifies a released input stream can be reused for the next acquisition.
+   */
+  @Test
+  public void testAcquireAndRelease() throws Exception {
+    SeekableUnderFileInputStream mockedStrem = mock(SeekableUnderFileInputStream.class);
+    when(mUfs.openExistingFile(eq(FILE_NAME), any(OpenOptions.class)))
+        .thenReturn(mockedStrem).thenThrow(new IllegalStateException("Should only be called once"));
+
+    // acquire a stream
+    InputStream instream1 =
+        mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(2));
+    // release
+    mManager.release(instream1);
+    // acquire a stream again
+    InputStream instream2 =
+        mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(4));
+
+    Assert.assertEquals(instream1, instream2);
+    // ensure the second time the released instream is the same one but repositioned
+    verify(mockedStrem).seek(4);
+  }
+
+  /**
+   * Tests acquiring multiple times will open new input streams.
+   */
+  @Test
+  public void testMultipleCheckIn() throws Exception {
+    mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(2));
+    mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(4));
+    mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(6));
+    // 3 different input streams are acquired
+    verify(mUfs, times(3)).openExistingFile(eq(FILE_NAME),
+        any(OpenOptions.class));
+  }
+
+  /**
+   * Tests the input stream is closed after the resource is expired.
+   */
+  @Test
+  public void testExpire() throws Exception {
+    try (Closeable r = new ConfigurationRule(new HashMap<PropertyKey, String>() {
+      {
+        put(PropertyKey.WORKER_UFS_INSTREAM_CACHE_EXPIRARTION_TIME, "2");
+      }
+    }, ServerConfiguration.global()).toResource()) {
+      mManager = new UfsInputStreamCache();
+      // check out a stream
+      InputStream instream =
+          mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(2));
+      // check in back
+      mManager.release(instream);
+      Thread.sleep(10);
+      // check out another stream should trigger the timeout
+      mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(4));
+      verify(mSeekableInStreams[0], timeout(2000).times(1)).close();
+    }
+  }
+
+  /**
+   * Tests concurrent acquisitions without expiration do not hit deadlock.
+   */
+  @Test
+  public void testConcurrency() throws Exception {
+    try (Closeable r = new ConfigurationRule(new HashMap<PropertyKey, String>() {
+      {
+        // use very large number
+        put(PropertyKey.WORKER_UFS_INSTREAM_CACHE_EXPIRARTION_TIME, "200000");
+      }
+    }, ServerConfiguration.global()).toResource()) {
+      mManager = new UfsInputStreamCache();
+      List<Thread> threads = new ArrayList<>();
+      int numCheckOutPerThread = 10;
+      for (int i = 0; i < mNumOfInputStreams / 2; i++) {
+        Runnable runnable = () -> {
+          for (int j = 0; j < numCheckOutPerThread; j++) {
+            InputStream instream;
+            try {
+              instream =
+                  mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(j));
+              Thread.sleep(10);
+              mManager.release(instream);
+            } catch (Exception e) {
+              // the input streams created should not be more than mNumOfInputStreams
+              Assert.fail("input stream check in and out failed." + e);
+            }
+          }
+        };
+        threads.add(new Thread(runnable));
+      }
+      ConcurrencyUtils.assertConcurrent(threads, 30);
+      // Each subsequent check out per thread should be a seek operation
+      int numSeek = 0;
+      for (int i = 0; i < mNumOfInputStreams; i++) {
+        for (Invocation invocation : mockingDetails(mSeekableInStreams[i])
+            .getInvocations()) {
+          if (invocation.getMethod().getName().equals("seek")) {
+            numSeek++;
+          }
+        }
+      }
+      Assert.assertEquals(mNumOfInputStreams / 2 * (numCheckOutPerThread - 1), numSeek);
+    }
+  }
+
+  /**
+   * Tests concurrent acquisitions with expiration do not hit deadlock.
+   */
+  @Test
+  public void testConcurrencyWithExpiration() throws Exception {
+    try (Closeable r = new ConfigurationRule(new HashMap<PropertyKey, String>() {
+      {
+        put(PropertyKey.WORKER_UFS_INSTREAM_CACHE_EXPIRARTION_TIME, "20");
+      }
+    }, ServerConfiguration.global()).toResource()) {
+      mManager = new UfsInputStreamCache();
+      List<Thread> threads = new ArrayList<>();
+      int numCheckOutPerThread = 4;
+      for (int i = 0; i < mNumOfInputStreams / numCheckOutPerThread; i++) {
+        Runnable runnable = () -> {
+          for (int j = 0; j < numCheckOutPerThread; j++) {
+            InputStream instream;
+            try {
+              instream =
+                  mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(j));
+              mManager.release(instream);
+              Thread.sleep(200);
+            } catch (Exception e) {
+              // the input streams created should not be more than mNumOfInputStreams
+              Assert.fail("input stream check in and out failed." + e);
+            }
+          }
+        };
+        threads.add(new Thread(runnable));
+      }
+      ConcurrencyUtils.assertConcurrent(threads, 30);
+      // ensure at least one expired in stream is closed
+      verify(mSeekableInStreams[0], timeout(2000)).close();
+    }
+  }
+}

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
@@ -55,6 +55,7 @@ public final class UnderFileSystemBlockReaderTest {
   private BlockStore mAlluxioBlockStore;
   private UnderFileSystemBlockMeta mUnderFileSystemBlockMeta;
   private UfsManager mUfsManager;
+  private UfsInputStreamCache mUfsInstreamCache;
   private Protocol.OpenUfsBlockOptions mOpenUfsBlockOptions;
 
   /** Rule to create a new temporary folder during each test. */
@@ -85,6 +86,7 @@ public final class UnderFileSystemBlockReaderTest {
 
     mAlluxioBlockStore = new TieredBlockStore();
     mUfsManager = mock(UfsManager.class);
+    mUfsInstreamCache = new UfsInputStreamCache();
     UfsClient ufsClient = new UfsClient(
         () -> UnderFileSystem.Factory.create(testFilePath.toString(),
             UnderFileSystemConfiguration.defaults(ServerConfiguration.global())),
@@ -112,7 +114,7 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void readFullBlock() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsManager);
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
     mReader.close();
@@ -122,7 +124,7 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void readPartialBlock() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsManager);
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE - 1);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE - 1, buffer));
     mReader.close();
@@ -133,7 +135,7 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void offset() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsManager);
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache);
     ByteBuffer buffer = mReader.read(2, TEST_BLOCK_SIZE - 2);
     assertTrue(BufferUtils
         .equalIncreasingByteBuffer(2, (int) TEST_BLOCK_SIZE - 2, buffer));
@@ -145,7 +147,7 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void readOverlap() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 2, false,
-        mAlluxioBlockStore, mUfsManager);
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache);
     ByteBuffer buffer = mReader.read(2, TEST_BLOCK_SIZE - 2);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(2, (int) TEST_BLOCK_SIZE - 2, buffer));
     buffer = mReader.read(0, TEST_BLOCK_SIZE - 2);
@@ -162,7 +164,7 @@ public final class UnderFileSystemBlockReaderTest {
     mUnderFileSystemBlockMeta = new UnderFileSystemBlockMeta(SESSION_ID, BLOCK_ID,
         mOpenUfsBlockOptions.toBuilder().setNoCache(true).build());
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsManager);
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     // read should succeed even if error is thrown when caching
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
@@ -177,7 +179,7 @@ public final class UnderFileSystemBlockReaderTest {
         .when(errorThrowingBlockStore)
         .requestSpace(anyLong(), anyLong(), anyLong());
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        errorThrowingBlockStore, mUfsManager);
+        errorThrowingBlockStore, mUfsManager, mUfsInstreamCache);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
     mReader.close();
@@ -190,7 +192,7 @@ public final class UnderFileSystemBlockReaderTest {
     doThrow(new WorkerOutOfSpaceException("Ignored")).when(errorThrowingBlockStore)
         .createBlock(anyLong(), anyLong(), any(AllocateOptions.class));
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        errorThrowingBlockStore, mUfsManager);
+        errorThrowingBlockStore, mUfsManager, mUfsInstreamCache);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
     mReader.close();
@@ -200,7 +202,7 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void transferFullBlock() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsManager);
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache);
     ByteBuf buf =
         PooledByteBufAllocator.DEFAULT.buffer((int) TEST_BLOCK_SIZE * 2, (int) TEST_BLOCK_SIZE * 2);
     try {
@@ -218,7 +220,7 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void transferPartialBlock() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsManager);
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache);
     ByteBuf buf =
         PooledByteBufAllocator.DEFAULT.buffer((int) TEST_BLOCK_SIZE / 2, (int) TEST_BLOCK_SIZE / 2);
     try {
@@ -237,7 +239,7 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void getLocation() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsManager);
+        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache);
     assertTrue(mReader.getLocation().startsWith(mOpenUfsBlockOptions.getUfsPath()));
   }
 }


### PR DESCRIPTION
Re-introduce the stream cache, removed in https://github.com/Alluxio/alluxio/commit/9fc3a7dac72be6909cf0286527f1e34645999a22.

This version is very similar to the previous one, but is more concurrent, without global locks.