### PR TITLE
Fix custom ufs module doest not affect issue

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -49,8 +49,9 @@ func Single(args []string) error {
 	singleCmd.Parse(args[2:]) // error handling by flag.ExitOnError
 
 	if customUfsModuleFlag != "" {
-		customUfsModuleFlagArray := strings.Split(customUfsModuleFlag, ",")
+		customUfsModuleFlagArray := strings.Split(customUfsModuleFlag, "|")
 		if len(customUfsModuleFlagArray) == 2 {
+			customUfsModuleFlagArray[1] = strings.ReplaceAll(customUfsModuleFlagArray[1], ",", " ")
 			ufsModules["ufs-"+customUfsModuleFlagArray[0]] = module{customUfsModuleFlagArray[0], true, customUfsModuleFlagArray[1]}
 		} else {
 			fmt.Fprintf(os.Stderr, "customUfsModuleFlag specified, but invalid: %s\n", customUfsModuleFlag)
@@ -62,6 +63,17 @@ func Single(args []string) error {
 	}
 	if err := checkRootFlags(); err != nil {
 		return err
+	}
+	if debugFlag {
+		fmt.Fprintf(os.Stdout, "hadoopDistributionFlag=: %s\n", hadoopDistributionFlag)
+		fmt.Fprintf(os.Stdout, "customUfsModuleFlag=: %s\n", customUfsModuleFlag)
+		fmt.Fprintf(os.Stdout, "mvnArgsFlag=: %s\n", mvnArgsFlag)
+		fmt.Fprintf(os.Stdout, "targetFlag=: %s\n", targetFlag)
+		fmt.Fprintf(os.Stdout, "ufs-modules=: %s\n", ufsModulesFlag)
+
+		for _, ufsModule := range ufsModules {
+			fmt.Fprintf(os.Stdout, "ufsModule=: %s\n", ufsModule)
+		}
 	}
 	if err := generateTarball([]string{}, skipUIFlag, skipHelmFlag); err != nil {
 		return err

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/root.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/root.go
@@ -42,7 +42,7 @@ func checkRootFlags() error {
 // common flags that are used regardless of subcommand type
 // these flags provide additional settings unrelated to tarball generation
 func additionalFlags(cmd *flag.FlagSet) {
-	cmd.StringVar(&customUfsModuleFlag, "custom-ufs-module", "", "a comma-separated pair of the module name and its maven arguments. ex. hadoop-x.y,-pl underfs/hdfs -Pufs-hadoop-X -Dufs.hadoop.version=x.y.z")
+	cmd.StringVar(&customUfsModuleFlag, "custom-ufs-module", "", "a pipe-separated pair of the module name and its comma-separated maven arguments. ex. hadoop-x.y|-pl,underfs/hdfs,-Pufs-hadoop-X,-Dufs.hadoop.version=x.y.z")
 	cmd.BoolVar(&debugFlag, "debug", false, "whether to run this tool in debug mode to generate additional console output")
 	cmd.StringVar(&ufsModulesFlag, "ufs-modules", strings.Join(defaultModules(ufsModules), ","),
 		fmt.Sprintf("a comma-separated list of ufs modules to compile into the distribution tarball(s). Specify 'all' to build all ufs modules. Supported ufs modules: [%v]", strings.Join(validModules(ufsModules), ",")))


### PR DESCRIPTION
#12491

In last PR, I'm sorry that, I tested it in intellij go build debug launcher, so it can works, like the following

```bash
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/mbl/projects/github/alluxio-2/dev/scripts #gosetup
/usr/local/go/bin/go build -o /private/var/folders/hj/jty18sr93t3_cbkb01szbv3w0000gn/T/___go_build_main_go -gcflags "all=-N -l" /Users/mbl/projects/github/alluxio-2/dev/scripts/src/alluxio.org/build-distribution/main.go #gosetup
"/Users/mbl/Library/Application Support/JetBrains/IntelliJIdea2020.1/plugins/intellij-go/lib/dlv/mac/dlv" --listen=localhost:63311 --headless=true --api-version=2 --check-go-version=false --only-same-user=false exec /private/var/folders/hj/jty18sr93t3_cbkb01szbv3w0000gn/T/___go_build_main_go -- single -skip-ui -debug -target=alluxio-${VERSION}-mbl-bin.tar.gz -mvn-args --offline,-s,/Users/mbl/Downloads/settings-tq.xml "-custom-ufs-module=hadoop-2.8.5-tq-0.1.5,-pl underfs/hdfs -Pufs-hadoop-2 -Dufs.hadoop.version=2.8.5-tq-0.1.5" -ufs-modules=ufs-hadoop-2.8.5-tq-0.1.5 #gosetup

```

But I just tested it on command line, it does't works, because the `flag` module cannot accept an option value with space, so I have to use `,` as separator instead of space, now I test it can works in command line.

```bash

dev/scripts/generate-tarballs  single -skip-ui  -target="alluxio-\${VERSION}-mbl-bin.tar.gz" -mvn-args "--offline,-s,/Users/mbl/Downloads/settings-tq.xml" -custom-ufs-module="hadoop-2.8.5-internal-0.1.5|-pl,underfs/hdfs,-Pufs-hadoop-2,-Dufs.hadoop.version=2.8.5-internal-0.1.5" -ufs-modules="ufs-hadoop-2.8.5-internal-0.1.5"
``` 