### PR TITLE
Add UFS version validation task

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactoryRegistry.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactoryRegistry.java
@@ -12,6 +12,7 @@
 package alluxio.underfs;
 
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.extensions.ExtensionFactoryRegistry;
 
@@ -20,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
 
@@ -109,16 +111,7 @@ public final class UnderFileSystemFactoryRegistry {
     List<UnderFileSystemFactory> eligibleFactories = sRegistryInstance.findAll(path, ufsConf);
     if (eligibleFactories.isEmpty() && ufsConf.isSet(PropertyKey.UNDERFS_VERSION)) {
       String configuredVersion = ufsConf.get(PropertyKey.UNDERFS_VERSION);
-      // Versioned factories ignore version if not set
-      ufsConf.unset(PropertyKey.UNDERFS_VERSION);
-      // Check if any versioned factory supports the default configuration
-      List<UnderFileSystemFactory> factories = sRegistryInstance.findAll(path, ufsConf);
-      List<String> supportedVersions = new java.util.ArrayList<>();
-      for (UnderFileSystemFactory factory : factories) {
-        if (!factory.getVersion().isEmpty()) {
-          supportedVersions.add(factory.getVersion());
-        }
-      }
+      List<String> supportedVersions = getSupportedVersions(path, ufsConf);
       if (!supportedVersions.isEmpty()) {
         LOG.warn("Versions [{}] are supported for path {} but you have configured version: {}",
             StringUtils.join(supportedVersions, ","), path,
@@ -127,6 +120,32 @@ public final class UnderFileSystemFactoryRegistry {
       ufsConf.set(PropertyKey.UNDERFS_VERSION, configuredVersion);
     }
     return eligibleFactories;
+  }
+
+  /**
+   * Get a list of supported versions for a particular UFS path.
+   *
+   * @param path the UFS URI to test
+   * @param ufsConf the UFS configuration for the mount
+   * @return a list of supported versions. The list will be empty if the particular UFS type does
+   *         not support setting a version on the mount.
+   */
+  public static List<String> getSupportedVersions(String path,
+      UnderFileSystemConfiguration ufsConf) {
+    // copy properties to not modify the original conf.
+    UnderFileSystemConfiguration ufsConfCopy = UnderFileSystemConfiguration
+        .defaults(new InstancedConfiguration(ufsConf.copyProperties()));
+    // unset the configuration to make sure any supported factories for the path are returned.
+    ufsConfCopy.unset(PropertyKey.UNDERFS_VERSION);
+    // Check if any versioned factory supports the default configuration
+    List<UnderFileSystemFactory> factories = sRegistryInstance.findAll(path, ufsConfCopy);
+    List<String> supportedVersions = new ArrayList<>();
+    for (UnderFileSystemFactory factory : factories) {
+      if (!factory.getVersion().isEmpty()) {
+        supportedVersions.add(factory.getVersion());
+      }
+    }
+    return supportedVersions;
   }
 
   private static synchronized void init() {

--- a/integration/tools/validation/src/main/java/alluxio/cli/UfsVersionValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/UfsVersionValidationTask.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.cli;
 
 import alluxio.conf.AlluxioConfiguration;

--- a/integration/tools/validation/src/main/java/alluxio/cli/UfsVersionValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/UfsVersionValidationTask.java
@@ -1,0 +1,74 @@
+package alluxio.cli;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.UnderFileSystemFactoryRegistry;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This validates the UFS configuration for a users configured UFS path. It ensures that the
+ * version of the UFS library is available (if configured).
+ */
+@ApplicableUfsType(ApplicableUfsType.Type.ALL)
+public class UfsVersionValidationTask extends AbstractValidationTask {
+
+  private final String mUfsPath;
+  private final AlluxioConfiguration mConf;
+
+    /**
+     * Create a new instance of {@link UfsVersionValidationTask}.
+     *
+     * @param ufsPath the UFS URI to test
+     * @param ufsConf the configuration for the UFS URI
+     */
+  public UfsVersionValidationTask(String ufsPath, AlluxioConfiguration ufsConf) {
+    mUfsPath = ufsPath;
+    mConf = ufsConf;
+  }
+
+  @Override
+  protected ValidationTaskResult validateImpl(Map<String, String> optionMap) {
+    UnderFileSystemConfiguration ufsConf =
+          UnderFileSystemConfiguration.defaults(mConf).createMountSpecificConf(optionMap);
+    String configuredVersion = mConf.get(PropertyKey.UNDERFS_VERSION);
+    List<String> availableVersions =
+        UnderFileSystemFactoryRegistry.getSupportedVersions(mUfsPath, ufsConf);
+    ValidationTaskResult result = new ValidationTaskResult();
+    result.setName(getName());
+    result.setDesc("Validates that the configured UFS version exists as a library on the "
+        + "system.");
+
+    if (!mConf.isSetByUser(PropertyKey.UNDERFS_VERSION)) {
+      result.setState(ValidationUtils.State.SKIPPED);
+      result.setOutput("The UFS version was not configured by the user.");
+    } else if (availableVersions.contains(configuredVersion)) {
+      result.setState(ValidationUtils.State.OK);
+      result.setOutput(String.format("The UFS path %s with configured version %s is "
+          + "supported by the current installation", mUfsPath, configuredVersion));
+    } else {
+      result.setState(ValidationUtils.State.FAILED);
+
+      if (availableVersions.size() > 0) {
+        result.setOutput(String.format("UFS path %s was configured with version %s. The "
+                + "supported versions on this system are: %s",
+            mUfsPath, configuredVersion, availableVersions.toString()));
+      } else {
+        result.setOutput(String.format("UFS path %s was configured with version %s. This "
+                + "path does not support UFS version configuration.",
+            mUfsPath, configuredVersion));
+      }
+      result.setAdvice(String.format("Configured UFS version %s not available. Check that "
+              + "the version is correct. Otherwise, consider using a different version.",
+          configuredVersion));
+    }
+    return result;
+  }
+
+  @Override
+  public String getName() {
+    return "UfsVersionValidationTask";
+  }
+}

--- a/integration/tools/validation/src/main/java/alluxio/cli/ValidateEnv.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/ValidateEnv.java
@@ -147,6 +147,9 @@ public final class ValidateEnv {
             new SshValidationTask(mConf), mCommonTasks);
 
     // UFS validations
+    registerTask("ufs.version",
+        "This validates the a configured UFS library version is available on the system.",
+        new UfsVersionValidationTask(mPath, mConf), mCommonTasks);
     registerTask("ufs.path.accessible",
             "This validates the under file system location is accessible to Alluxio.",
             new UfsDirectoryValidationTask(mPath, mConf), mCommonTasks);


### PR DESCRIPTION
This new task helps expose some more information about available UFS versions to users. The cases for configuration and corresponding outputs are defined below.

- UFS version not configured: skip validation
- UFS version configured, but doesn't exist in list of valid versions: error with info and list of available versions
- UFS version configured, but list of versions empty: this indicates the UFS doesn't support versioning (i.e. non-HDFS), and directs the user to change configuration
- UFS version configured and exists in available version list: success

