### PR TITLE
Update oshi dependency version from 4.2.0 to 5.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <maven.version>3.3.9</maven.version>
     <metrics.version>4.1.11</metrics.version>
     <orc.version>1.6.3</orc.version>
-    <oshi.version>4.2.0</oshi.version>
+    <oshi.version>5.3.5</oshi.version>
     <powermock.version>2.0.7</powermock.version>
     <prometheus.version>0.8.0</prometheus.version>
     <guava.version>29.0-jre</guava.version>


### PR DESCRIPTION
Update oshi version from 4.2.0 to 5.3.5 to solve the jvm crash problem mentioned int #12502.

Fixes #12502