### PR TITLE
Change worker lockBlock to tryLockBlock

### DIFF
--- a/core/base/src/main/java/alluxio/exception/FailedToLockBlockException.java
+++ b/core/base/src/main/java/alluxio/exception/FailedToLockBlockException.java
@@ -1,0 +1,60 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.exception;
+
+/**
+ * The exception thrown when a block does not exist in Alluxio.
+ */
+public class FailedToLockBlockException extends AlluxioException {
+  private static final long serialVersionUID = -2313208021235706634L;
+
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message
+   */
+  public FailedToLockBlockException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new exception with the specified detail message and cause.
+   *
+   * @param message the detail message
+   * @param cause the cause
+   */
+  public FailedToLockBlockException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Constructs a new exception with the specified exception message and multiple parameters.
+   *
+   * @param message the exception message
+   * @param params the parameters
+   */
+  public FailedToLockBlockException(ExceptionMessage message, Object... params) {
+    this(message.getMessage(params));
+  }
+
+  /**
+   * Constructs a new exception with the specified exception message, the cause and multiple
+   * parameters.
+   *
+   * @param message the exception message
+   * @param cause the cause
+   * @param params the parameters
+   */
+  public FailedToLockBlockException(ExceptionMessage message, Throwable cause, Object... params) {
+    this(message.getMessage(params), cause);
+  }
+}

--- a/core/base/src/main/java/alluxio/exception/FailedToLockBlockException.java
+++ b/core/base/src/main/java/alluxio/exception/FailedToLockBlockException.java
@@ -12,7 +12,7 @@
 package alluxio.exception;
 
 /**
- * The exception thrown when a block does not exist in Alluxio.
+ * The exception thrown when fails to lock a block during a certain timeframe.
  */
 public class FailedToLockBlockException extends AlluxioException {
   private static final long serialVersionUID = -2313208021235706634L;

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2444,6 +2444,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
+  public static final PropertyKey WORKER_BLOCK_TRY_LOCK_TIMEOUT =
+      new Builder(Name.WORKER_BLOCK_TRY_LOCK_TIMEOUT)
+          .setDefaultValue("5min")
+          .setDescription("The timeout for block operations to try locking a block.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.WORKER)
+          .build();
   public static final PropertyKey WORKER_CONTAINER_HOSTNAME =
       new Builder(Name.WORKER_CONTAINER_HOSTNAME)
           .setDescription("The container hostname if worker is running in a container.")
@@ -5187,6 +5194,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.block.heartbeat.interval";
     public static final String WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS =
         "alluxio.worker.block.heartbeat.timeout";
+    public static final String WORKER_BLOCK_TRY_LOCK_TIMEOUT =
+        "alluxio.worker.block.try.lock.timeout";
     public static final String WORKER_CONTAINER_HOSTNAME =
         "alluxio.worker.container.hostname";
     public static final String WORKER_DATA_FOLDER = "alluxio.worker.data.folder";

--- a/core/common/src/main/java/alluxio/retry/RetryUtils.java
+++ b/core/common/src/main/java/alluxio/retry/RetryUtils.java
@@ -125,19 +125,6 @@ public final class RetryUtils {
   }
 
   /**
-   * @param activeUfsPollTimeoutMs the max time in milliseconds to wait for active ufs sync retries
-   * @return the default active sync retry behavior
-   */
-  public static RetryPolicy defaultLockBlockRetry(long activeUfsPollTimeoutMs) {
-    return ExponentialTimeBoundedRetry.builder()
-        .withMaxDuration(Duration
-            .ofMillis(activeUfsPollTimeoutMs))
-        .withInitialSleep(Duration.ofMillis(100))
-        .withMaxSleep(Duration.ofSeconds(60))
-        .build();
-  }
-
-  /**
    * Interface for methods which return nothing and may throw IOException.
    */
   @FunctionalInterface

--- a/core/common/src/main/java/alluxio/retry/RetryUtils.java
+++ b/core/common/src/main/java/alluxio/retry/RetryUtils.java
@@ -125,6 +125,19 @@ public final class RetryUtils {
   }
 
   /**
+   * @param activeUfsPollTimeoutMs the max time in milliseconds to wait for active ufs sync retries
+   * @return the default active sync retry behavior
+   */
+  public static RetryPolicy defaultLockBlockRetry(long activeUfsPollTimeoutMs) {
+    return ExponentialTimeBoundedRetry.builder()
+        .withMaxDuration(Duration
+            .ofMillis(activeUfsPollTimeoutMs))
+        .withInitialSleep(Duration.ofMillis(100))
+        .withMaxSleep(Duration.ofSeconds(60))
+        .build();
+  }
+
+  /**
    * Interface for methods which return nothing and may throw IOException.
    */
   @FunctionalInterface

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
@@ -103,7 +103,7 @@ public class AsyncCacheRequestManager {
               : Sessions.ASYNC_CACHE_WORKER_SESSION_ID;
           // Check if the block has already been cached on this worker
           long lockId =
-              mBlockWorker.lockBlockNoException(sessionId, blockId);
+              mBlockWorker.tryLockBlockNoException(sessionId, blockId);
           if (lockId != BlockLockManager.INVALID_LOCK_ID) {
             try {
               mBlockWorker.unlockBlock(lockId);

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
@@ -36,27 +36,6 @@ import javax.annotation.Nullable;
 public interface BlockStore extends SessionCleanable, Closeable {
 
   /**
-   * Locks an existing block and guards subsequent reads on this block.
-   *
-   * @param sessionId the id of the session to lock this block
-   * @param blockId the id of the block to lock
-   * @return the lock id (non-negative) if the lock is acquired successfully
-   * @throws BlockDoesNotExistException if block id can not be found, for example, evicted already
-   */
-  long lockBlock(long sessionId, long blockId) throws BlockDoesNotExistException;
-
-  /**
-   * Locks an existing block and guards subsequent reads on this block. If the lock fails, return
-   * {@link BlockLockManager#INVALID_LOCK_ID}.
-   *
-   * @param sessionId the id of the session to lock this block
-   * @param blockId the id of the block to lock
-   * @return the lock id (non-negative) that uniquely identifies the lock obtained or
-   *         {@link BlockLockManager#INVALID_LOCK_ID} if it failed to lock
-   */
-  long lockBlockNoException(long sessionId, long blockId);
-
-  /**
    * Tries to lock an existing block and guards subsequent reads on this block.
    *
    * @param sessionId the id of the session to lock this block
@@ -79,9 +58,10 @@ public interface BlockStore extends SessionCleanable, Closeable {
   long tryLockBlockNoException(long sessionId, long blockId);
 
   /**
-   * Releases an acquired block lock based on a lockId (returned by {@link #lockBlock(long, long)}.
+   * Releases an acquired block lock based on a lockId
+   * (returned by {@link #tryLockBlock(long, long)}.
    *
-   * @param lockId the id of the lock returned by {@link #lockBlock(long, long)}
+   * @param lockId the id of the lock returned by {@link #tryLockBlock(long, long)}
    * @throws BlockDoesNotExistException if lockId can not be found
    */
   void unlockBlock(long lockId) throws BlockDoesNotExistException;
@@ -133,7 +113,7 @@ public interface BlockStore extends SessionCleanable, Closeable {
    * Gets the metadata of a specific block from local storage.
    * <p>
    * This method requires the lock id returned by a previously acquired
-   * {@link #lockBlock(long, long)}.
+   * {@link #tryLockBlock(long, long)}.
    *
    * @param sessionId the id of the session to get this file
    * @param blockId the id of the block
@@ -238,11 +218,11 @@ public interface BlockStore extends SessionCleanable, Closeable {
    * Creates a reader of an existing block to read data from this block.
    * <p>
    * This operation requires the lock id returned by a previously acquired
-   * {@link #lockBlock(long, long)}.
+   * {@link #tryLockBlock(long, long)}.
    *
    * @param sessionId the id of the session to get the reader
    * @param blockId the id of an existing block
-   * @param lockId the id of the lock returned by {@link #lockBlock(long, long)}
+   * @param lockId the id of the lock returned by {@link #tryLockBlock(long, long)}
    * @return a {@link BlockReader} instance on this block
    * @throws BlockDoesNotExistException if lockId is not found
    * @throws InvalidWorkerStateException if session id or block id is not the same as that in the

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
@@ -42,6 +42,7 @@ public interface BlockStore extends SessionCleanable, Closeable {
    * @param blockId the id of the block to lock
    * @return the lock id (non-negative) if the lock is acquired successfully
    * @throws BlockDoesNotExistException if block id can not be found, for example, evicted already
+   * @throws FailedToLockBlockException if fails to lock the given block
    */
   long tryLockBlock(long sessionId, long blockId)
       throws BlockDoesNotExistException, FailedToLockBlockException;
@@ -147,12 +148,13 @@ public interface BlockStore extends SessionCleanable, Closeable {
    * @param pinOnCreate whether to pin block on create
    * @throws BlockAlreadyExistsException if block id already exists in committed blocks
    * @throws BlockDoesNotExistException if the temporary block can not be found
+   * @throws FailedToLockBlockException if fails to lock the given block
    * @throws InvalidWorkerStateException if block id does not belong to session id
    * @throws WorkerOutOfSpaceException if there is no more space left to hold the block
    */
   void commitBlock(long sessionId, long blockId, boolean pinOnCreate)
-      throws BlockAlreadyExistsException, BlockDoesNotExistException, InvalidWorkerStateException,
-      IOException, WorkerOutOfSpaceException, FailedToLockBlockException;
+      throws BlockAlreadyExistsException, BlockDoesNotExistException, FailedToLockBlockException,
+      InvalidWorkerStateException, IOException, WorkerOutOfSpaceException;
 
   /**
    * Similar to {@link #commitBlock(long, long, boolean)}. It returns the block locked,
@@ -164,6 +166,7 @@ public interface BlockStore extends SessionCleanable, Closeable {
    * @return the lock id
    * @throws BlockAlreadyExistsException if block id already exists in committed blocks
    * @throws BlockDoesNotExistException if the temporary block can not be found
+   * @throws FailedToLockBlockException if fails to lock the given block
    * @throws InvalidWorkerStateException if block id does not belong to session id
    * @throws WorkerOutOfSpaceException if there is no more space left to hold the block
    */
@@ -241,6 +244,7 @@ public interface BlockStore extends SessionCleanable, Closeable {
    * @throws BlockDoesNotExistException if block id can not be found
    * @throws BlockAlreadyExistsException if block id already exists in committed blocks of the
    *         newLocation
+   * @throws FailedToLockBlockException if fails to lock the given block
    * @throws InvalidWorkerStateException if block id has not been committed
    * @throws WorkerOutOfSpaceException if newLocation does not have enough extra space to hold the
    *         block
@@ -260,6 +264,7 @@ public interface BlockStore extends SessionCleanable, Closeable {
    * @throws BlockDoesNotExistException if block id can not be found
    * @throws BlockAlreadyExistsException if block id already exists in committed blocks of the
    *         newLocation
+   * @throws FailedToLockBlockException if fails to lock the given block
    * @throws InvalidWorkerStateException if block id has not been committed
    * @throws WorkerOutOfSpaceException if newLocation does not have enough extra space to hold the
    *         block
@@ -276,6 +281,7 @@ public interface BlockStore extends SessionCleanable, Closeable {
    * @param blockId the id of an existing block
    * @throws InvalidWorkerStateException if block id has not been committed
    * @throws BlockDoesNotExistException if block can not be found
+   * @throws FailedToLockBlockException if fails to lock the given block
    */
   void removeBlock(long sessionId, long blockId) throws InvalidWorkerStateException,
       BlockDoesNotExistException, FailedToLockBlockException, IOException;
@@ -288,6 +294,7 @@ public interface BlockStore extends SessionCleanable, Closeable {
    * @param location the location of the block
    * @throws InvalidWorkerStateException if block id has not been committed
    * @throws BlockDoesNotExistException if block can not be found
+   * @throws FailedToLockBlockException if fails to lock the given block
    */
   void removeBlock(long sessionId, long blockId, BlockStoreLocation location)
       throws InvalidWorkerStateException, BlockDoesNotExistException,

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -204,7 +204,7 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * Gets the metadata of a specific block from local storage.
    * <p>
    * Unlike {@link #getVolatileBlockMeta(long)}, this method requires the lock id returned by a
-   * previously acquired {@link #lockBlock(long, long)}.
+   * previously acquired {@link #tryLockBlock(long, long)}.
    *
    * @param sessionId the id of the session to get this file
    * @param blockId the id of the block
@@ -225,27 +225,6 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @return true if the block is contained, false otherwise
    */
   boolean hasBlockMeta(long blockId);
-
-  /**
-   * Obtains a read lock the block.
-   *
-   * @param sessionId the id of the client
-   * @param blockId the id of the block to be locked
-   * @return the lock id that uniquely identifies the lock obtained
-   * @throws BlockDoesNotExistException if blockId cannot be found, for example, evicted already
-   */
-  long lockBlock(long sessionId, long blockId) throws BlockDoesNotExistException;
-
-  /**
-   * Obtains a read lock the block without throwing an exception. If the lock fails, return
-   * {@link BlockLockManager#INVALID_LOCK_ID}.
-   *
-   * @param sessionId the id of the client
-   * @param blockId the id of the block to be locked
-   * @return the lock id that uniquely identifies the lock obtained or
-   *         {@link BlockLockManager#INVALID_LOCK_ID} if it failed to lock
-   */
-  long lockBlockNoException(long sessionId, long blockId);
 
   /**
    * Tries to obtain a read lock the block.

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -278,6 +278,7 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @throws BlockDoesNotExistException if blockId cannot be found
    * @throws BlockAlreadyExistsException if blockId already exists in committed blocks of the
    *         newLocation
+   * @throws FailedToLockBlockException if fails to lock the given block
    * @throws InvalidWorkerStateException if blockId has not been committed
    * @throws WorkerOutOfSpaceException if newLocation does not have enough extra space to hold the
    *         block
@@ -336,6 +337,7 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @param blockId the id of the block to be freed
    * @throws InvalidWorkerStateException if blockId has not been committed
    * @throws BlockDoesNotExistException if block cannot be found
+   * @throws FailedToLockBlockException if fails to lock the given block
    */
   void removeBlock(long sessionId, long blockId) throws InvalidWorkerStateException,
       BlockDoesNotExistException, FailedToLockBlockException, IOException;
@@ -419,6 +421,7 @@ public interface BlockWorker extends Worker, SessionCleanable {
    *         because the block exists in the Alluxio block store
    * @throws BlockDoesNotExistException if the UFS block does not exist in the
    *         {@link UnderFileSystemBlockStore}
+   * @throws FailedToLockBlockException if fails to lock the given block
    * @throws WorkerOutOfSpaceException the the worker does not have enough space to commit the block
    */
   void closeUfsBlock(long sessionId, long blockId)

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -282,7 +282,8 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
       LOG.debug("Block {} has been in block store, this could be a retry due to master-side RPC "
           + "failure, therefore ignore the exception", blockId, e);
     } catch (FailedToLockBlockException e) {
-      LOG.debug("Failed to lock block {}", blockId, e);
+      LOG.debug("Failed to lock block when committing block {} of session {}",
+          blockId, sessionId, e);
     }
 
     // TODO(calvin): Reconsider how to do this without heavy locking.

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -408,16 +408,6 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
   }
 
   @Override
-  public long lockBlock(long sessionId, long blockId) throws BlockDoesNotExistException {
-    return mBlockStore.lockBlock(sessionId, blockId);
-  }
-
-  @Override
-  public long lockBlockNoException(long sessionId, long blockId) {
-    return mBlockStore.lockBlockNoException(sessionId, blockId);
-  }
-
-  @Override
   public long tryLockBlock(long sessionId, long blockId)
       throws BlockDoesNotExistException, FailedToLockBlockException {
     return mBlockStore.tryLockBlock(sessionId, blockId);

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -137,38 +137,6 @@ public class TieredBlockStore implements BlockStore {
   }
 
   @Override
-  public long lockBlock(long sessionId, long blockId) throws BlockDoesNotExistException {
-    LOG.debug("lockBlock: sessionId={}, blockId={}", sessionId, blockId);
-    long lockId = mLockManager.lockBlock(sessionId, blockId, BlockLockType.READ);
-    boolean hasBlock;
-    try (LockResource r = new LockResource(mMetadataReadLock)) {
-      hasBlock = mMetaManager.hasBlockMeta(blockId);
-    }
-    if (hasBlock) {
-      return lockId;
-    }
-
-    mLockManager.unlockBlock(lockId);
-    throw new BlockDoesNotExistException(ExceptionMessage.NO_BLOCK_ID_FOUND, blockId);
-  }
-
-  @Override
-  public long lockBlockNoException(long sessionId, long blockId) {
-    LOG.debug("lockBlockNoException: sessionId={}, blockId={}", sessionId, blockId);
-    long lockId = mLockManager.lockBlock(sessionId, blockId, BlockLockType.READ);
-    boolean hasBlock;
-    try (LockResource r = new LockResource(mMetadataReadLock)) {
-      hasBlock = mMetaManager.hasBlockMeta(blockId);
-    }
-    if (hasBlock) {
-      return lockId;
-    }
-
-    mLockManager.unlockBlockNoException(lockId);
-    return BlockLockManager.INVALID_LOCK_ID;
-  }
-
-  @Override
   public long tryLockBlock(long sessionId, long blockId)
       throws BlockDoesNotExistException, FailedToLockBlockException {
     LOG.debug("tryLockBlock: sessionId={}, blockId={}", sessionId, blockId);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -181,9 +181,9 @@ public final class BlockReadHandler extends AbstractReadHandler<BlockReadRequest
         if (request.isPersisted() || (request.getOpenUfsBlockOptions() != null && request
             .getOpenUfsBlockOptions().hasBlockInUfsTier() && request.getOpenUfsBlockOptions()
             .getBlockInUfsTier())) {
-          lockId = mWorker.lockBlockNoException(request.getSessionId(), request.getId());
+          lockId = mWorker.tryLockBlockNoException(request.getSessionId(), request.getId());
         } else {
-          lockId = mWorker.lockBlock(request.getSessionId(), request.getId());
+          lockId = mWorker.tryLockBlock(request.getSessionId(), request.getId());
         }
         if (lockId != BlockLockManager.INVALID_LOCK_ID) {
           try {

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
@@ -88,7 +88,7 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
               LOG.warn("Failed to promote block {}: {}", mRequest.getBlockId(), e.getMessage());
             }
           }
-          mLockId = mWorker.lockBlock(mSessionId, mRequest.getBlockId());
+          mLockId = mWorker.tryLockBlock(mSessionId, mRequest.getBlockId());
           mWorker.accessBlock(mSessionId, mRequest.getBlockId());
         } else {
           LOG.warn("Lock block {} without releasing previous block lock {}.",

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
@@ -78,10 +78,10 @@ public final class BlockLockManagerTest {
    * Tests the {@link BlockLockManager#lockBlock(long, long, BlockLockType)} method.
    */
   @Test
-  public void lockBlock() {
+  public void lockBlock() throws Exception {
     // Read-lock on can both get through
-    long lockId1 = mLockManager.lockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.READ);
-    long lockId2 = mLockManager.lockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.READ);
+    long lockId1 = mLockManager.tryLockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.READ);
+    long lockId2 = mLockManager.tryLockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.READ);
     assertNotEquals(lockId1, lockId2);
   }
 
@@ -115,7 +115,7 @@ public final class BlockLockManagerTest {
    */
   @Test
   public void validateLockIdWithWrongSessionId() throws Exception {
-    long lockId = mLockManager.lockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.READ);
+    long lockId = mLockManager.tryLockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.READ);
     long wrongSessionId = TEST_SESSION_ID + 1;
     mThrown.expect(InvalidWorkerStateException.class);
     mThrown.expectMessage(ExceptionMessage.LOCK_ID_FOR_DIFFERENT_SESSION.getMessage(lockId,
@@ -130,7 +130,7 @@ public final class BlockLockManagerTest {
    */
   @Test
   public void validateLockIdWithWrongBlockId() throws Exception {
-    long lockId = mLockManager.lockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.READ);
+    long lockId = mLockManager.tryLockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.READ);
     long wrongBlockId = TEST_BLOCK_ID + 1;
     mThrown.expect(InvalidWorkerStateException.class);
     mThrown.expectMessage(ExceptionMessage.LOCK_ID_FOR_DIFFERENT_BLOCK.getMessage(lockId,
@@ -147,8 +147,8 @@ public final class BlockLockManagerTest {
   public void cleanupSession() throws Exception {
     long sessionId1 = TEST_SESSION_ID;
     long sessionId2 = TEST_SESSION_ID + 1;
-    long lockId1 = mLockManager.lockBlock(sessionId1, TEST_BLOCK_ID, BlockLockType.READ);
-    long lockId2 = mLockManager.lockBlock(sessionId2, TEST_BLOCK_ID, BlockLockType.READ);
+    long lockId1 = mLockManager.tryLockBlock(sessionId1, TEST_BLOCK_ID, BlockLockType.READ);
+    long lockId2 = mLockManager.tryLockBlock(sessionId2, TEST_BLOCK_ID, BlockLockType.READ);
     mThrown.expect(BlockDoesNotExistException.class);
     mThrown.expectMessage(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_LOCK_ID.getMessage(lockId2));
     mLockManager.cleanupSession(sessionId2);

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockWorkerTest.java
@@ -178,7 +178,7 @@ public class BlockWorkerTest {
     BlockStoreLocation blockStoreLocation = PowerMockito.mock(BlockStoreLocation.class);
     BlockStoreMeta blockStoreMeta = mock(BlockStoreMeta.class);
 
-    when(mBlockStore.lockBlock(sessionId, blockId)).thenReturn(lockId);
+    when(mBlockStore.tryLockBlock(sessionId, blockId)).thenReturn(lockId);
     when(mBlockStore.getBlockMeta(eq(sessionId), eq(blockId), anyLong())).thenReturn(blockMeta);
     when(mBlockStore.getBlockStoreMeta()).thenReturn(blockStoreMeta);
     when(mBlockStore.getBlockStoreMetaFull()).thenReturn(blockStoreMeta);
@@ -212,7 +212,7 @@ public class BlockWorkerTest {
     BlockStoreLocation blockStoreLocation = PowerMockito.mock(BlockStoreLocation.class);
     BlockStoreMeta blockStoreMeta = mock(BlockStoreMeta.class);
 
-    when(mBlockStore.lockBlock(sessionId, blockId)).thenReturn(lockId);
+    when(mBlockStore.tryLockBlock(sessionId, blockId)).thenReturn(lockId);
     when(mBlockStore.getBlockMeta(eq(sessionId), eq(blockId), anyLong())).thenReturn(blockMeta);
     when(mBlockStore.getBlockStoreMeta()).thenReturn(blockStoreMeta);
     when(blockMeta.getBlockLocation()).thenReturn(blockStoreLocation);
@@ -371,14 +371,14 @@ public class BlockWorkerTest {
   }
 
   /**
-   * Tests the {@link BlockWorker#lockBlock(long, long)} method.
+   * Tests the {@link BlockWorker#tryLockBlock(long, long)} method.
    */
   @Test
-  public void lockBlock() throws Exception {
+  public void tryLockBlock() throws Exception {
     long blockId = mRandom.nextLong();
     long sessionId = mRandom.nextLong();
-    mBlockWorker.lockBlock(sessionId, blockId);
-    verify(mBlockStore).lockBlock(sessionId, blockId);
+    mBlockWorker.tryLockBlock(sessionId, blockId);
+    verify(mBlockStore).tryLockBlock(sessionId, blockId);
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -125,11 +125,11 @@ public final class TieredBlockStoreTest {
     TieredBlockStoreTestUtils.cache2(SESSION_ID2, BLOCK_ID2, BLOCK_SIZE, mTestDir2, mMetaManager,
         mBlockIterator);
 
-    long lockId1 = mBlockStore.lockBlock(SESSION_ID1, BLOCK_ID1);
+    long lockId1 = mBlockStore.tryLockBlock(SESSION_ID1, BLOCK_ID1);
     assertTrue(
         Sets.difference(mLockManager.getLockedBlocks(), Sets.newHashSet(BLOCK_ID1)).isEmpty());
 
-    long lockId2 = mBlockStore.lockBlock(SESSION_ID2, BLOCK_ID2);
+    long lockId2 = mBlockStore.tryLockBlock(SESSION_ID2, BLOCK_ID2);
     assertNotEquals(lockId1, lockId2);
     assertTrue(
         Sets.difference(mLockManager.getLockedBlocks(), Sets.newHashSet(BLOCK_ID1, BLOCK_ID2))
@@ -153,11 +153,11 @@ public final class TieredBlockStoreTest {
     TieredBlockStoreTestUtils.cache2(SESSION_ID1, BLOCK_ID2, BLOCK_SIZE, mTestDir2, mMetaManager,
         mBlockIterator);
 
-    long lockId1 = mBlockStore.lockBlock(SESSION_ID1, BLOCK_ID1);
+    long lockId1 = mBlockStore.tryLockBlock(SESSION_ID1, BLOCK_ID1);
     assertTrue(
         Sets.difference(mLockManager.getLockedBlocks(), Sets.newHashSet(BLOCK_ID1)).isEmpty());
 
-    long lockId2 = mBlockStore.lockBlock(SESSION_ID1, BLOCK_ID2);
+    long lockId2 = mBlockStore.tryLockBlock(SESSION_ID1, BLOCK_ID2);
     assertNotEquals(lockId1, lockId2);
   }
 
@@ -169,7 +169,7 @@ public final class TieredBlockStoreTest {
     mThrown.expect(BlockDoesNotExistException.class);
     mThrown.expectMessage(ExceptionMessage.NO_BLOCK_ID_FOUND.getMessage(BLOCK_ID1));
 
-    mBlockStore.lockBlock(SESSION_ID1, BLOCK_ID1);
+    mBlockStore.tryLockBlock(SESSION_ID1, BLOCK_ID1);
   }
 
   /**
@@ -443,7 +443,7 @@ public final class TieredBlockStoreTest {
         mBlockIterator);
 
     // session1 locks a block first
-    long lockId = mBlockStore.lockBlock(SESSION_ID1, BLOCK_ID1);
+    long lockId = mBlockStore.tryLockBlock(SESSION_ID1, BLOCK_ID1);
 
     // Create file that in dir1 that won't fit.
     TieredBlockStoreTestUtils.cache(SESSION_ID2, TEMP_BLOCK_ID, mTestDir1.getCapacityBytes(),
@@ -505,7 +505,7 @@ public final class TieredBlockStoreTest {
         mTestDir2, mMetaManager, mBlockIterator);
 
     // session1 locks block2 first
-    long lockId = mBlockStore.lockBlock(SESSION_ID1, BLOCK_ID2);
+    long lockId = mBlockStore.tryLockBlock(SESSION_ID1, BLOCK_ID2);
 
     // Expect an exception because no eviction plan is feasible
     mThrown.expect(WorkerOutOfSpaceException.class);
@@ -571,7 +571,7 @@ public final class TieredBlockStoreTest {
         mBlockIterator);
 
     // session1 locks a block first
-    long lockId = mBlockStore.lockBlock(SESSION_ID1, BLOCK_ID1);
+    long lockId = mBlockStore.tryLockBlock(SESSION_ID1, BLOCK_ID1);
 
     // Expect an empty eviction plan is feasible
     mThrown.expect(WorkerOutOfSpaceException.class);

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
@@ -101,7 +101,7 @@ public final class UnderFileSystemBlockReaderTest {
   private void checkTempBlock(long start, long length) throws Exception {
     Assert.assertNotNull(mAlluxioBlockStore.getTempBlockMeta(SESSION_ID, BLOCK_ID));
     mAlluxioBlockStore.commitBlock(SESSION_ID, BLOCK_ID, false);
-    long lockId = mAlluxioBlockStore.lockBlock(SESSION_ID, BLOCK_ID);
+    long lockId = mAlluxioBlockStore.tryLockBlock(SESSION_ID, BLOCK_ID);
     BlockReader reader = mAlluxioBlockStore.getBlockReader(SESSION_ID, BLOCK_ID, lockId);
     Assert.assertEquals(length, reader.getLength());
     ByteBuffer buffer = reader.read(0, length);


### PR DESCRIPTION
One of the potential fix/improve of #12444  and #11309 
Use tryLock() instead of lock() when locking worker blocks to prevent forever waiting for block locks.
When tryLock() failed (5 minutes by default), tryLock() is log a warning message and throw FailedToLockBlockException.
