### PR TITLE
[SMALLFIX] Improve block location naming

### DIFF
--- a/core/common/src/main/java/alluxio/worker/block/BlockStoreLocation.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockStoreLocation.java
@@ -72,7 +72,7 @@ public final class BlockStoreLocation {
    * @param mediumType mediumType this returned block store location will represent
    * @return a BlockStoreLocation of any dir in any tier with a specific medium
    */
-  public static BlockStoreLocation anyDirInTierWithMedium(String mediumType) {
+  public static BlockStoreLocation anyDirInAnyTierWithMedium(String mediumType) {
     return new BlockStoreLocation(ANY_TIER, ANY_DIR, mediumType);
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -325,7 +325,7 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
     if (medium.isEmpty()) {
       loc = BlockStoreLocation.anyDirInTier(tierAlias);
     } else {
-      loc = BlockStoreLocation.anyDirInTierWithMedium(medium);
+      loc = BlockStoreLocation.anyDirInAnyTierWithMedium(medium);
     }
     TempBlockMeta createdBlock;
     try {
@@ -353,7 +353,7 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
     if (medium.isEmpty()) {
       loc = BlockStoreLocation.anyDirInTier(tierAlias);
     } else {
-      loc = BlockStoreLocation.anyDirInTierWithMedium(medium);
+      loc = BlockStoreLocation.anyDirInAnyTierWithMedium(medium);
     }
     mBlockStore.createBlock(sessionId, blockId, AllocateOptions.forCreate(initialBytes, loc));
   }
@@ -438,7 +438,7 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
   public void moveBlockToMedium(long sessionId, long blockId, String mediumType)
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
       WorkerOutOfSpaceException, IOException {
-    BlockStoreLocation dst = BlockStoreLocation.anyDirInTierWithMedium(mediumType);
+    BlockStoreLocation dst = BlockStoreLocation.anyDirInAnyTierWithMedium(mediumType);
     long lockId = mBlockStore.lockBlock(sessionId, blockId);
     try {
       BlockMeta meta = mBlockStore.getBlockMeta(sessionId, blockId, lockId);

--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/GreedyAllocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/GreedyAllocator.java
@@ -74,7 +74,7 @@ public final class GreedyAllocator implements Allocator {
 
     String mediumType = location.mediumType();
     if (!mediumType.equals(BlockStoreLocation.ANY_MEDIUM)
-        && location.equals(BlockStoreLocation.anyDirInTierWithMedium(mediumType))) {
+        && location.equals(BlockStoreLocation.anyDirInAnyTierWithMedium(mediumType))) {
       for (StorageTierView tierView : mMetadataView.getTierViews()) {
         for (StorageDirView dirView : tierView.getDirViews()) {
           if (dirView.getMediumType().equals(mediumType)

--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/MaxFreeAllocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/MaxFreeAllocator.java
@@ -70,7 +70,8 @@ public final class MaxFreeAllocator implements Allocator {
     } else if (location.equals(BlockStoreLocation.anyDirInTier(location.tierAlias()))) {
       StorageTierView tierView = mMetadataView.getTierView(location.tierAlias());
       candidateDirView = getCandidateDirInTier(tierView, blockSize, BlockStoreLocation.ANY_MEDIUM);
-    } else if (location.equals(BlockStoreLocation.anyDirInTierWithMedium(location.mediumType()))) {
+    } else if (location.equals(BlockStoreLocation.anyDirInAnyTierWithMedium(
+            location.mediumType()))) {
       for (StorageTierView tierView : mMetadataView.getTierViews()) {
         candidateDirView = getCandidateDirInTier(tierView, blockSize, location.mediumType());
         if (candidateDirView != null) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/RoundRobinAllocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/RoundRobinAllocator.java
@@ -92,7 +92,8 @@ public final class RoundRobinAllocator implements Allocator {
         mTierAliasToLastDirMap.put(tierView.getTierViewAlias(), dirViewIndex);
         return tierView.getDirView(dirViewIndex);
       }
-    } else if (location.equals(BlockStoreLocation.anyDirInTierWithMedium(location.mediumType()))) {
+    } else if (location.equals(BlockStoreLocation.anyDirInAnyTierWithMedium(
+            location.mediumType()))) {
       String medium = location.mediumType();
       int tierIndex = 0; // always starting from the first tier
       for (int i = 0; i < mMetadataView.getTierViews().size(); i++) {

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockStoreLocationTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockStoreLocationTest.java
@@ -52,7 +52,7 @@ public final class BlockStoreLocationTest {
     BlockStoreLocation dirInMEM = new BlockStoreLocation("MEM", 1);
     BlockStoreLocation dirInHDD = new BlockStoreLocation("HDD", 2);
     BlockStoreLocation dirWithMediumType = new BlockStoreLocation("MEM", 1, "MEM");
-    BlockStoreLocation anyTierWithMEM = BlockStoreLocation.anyDirInTierWithMedium("MEM");
+    BlockStoreLocation anyTierWithMEM = BlockStoreLocation.anyDirInAnyTierWithMedium("MEM");
 
     assertTrue(anyTier.belongsTo(anyTier));
     assertFalse(anyTier.belongsTo(anyDirInTierMEM));

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -420,13 +420,13 @@ public final class TieredBlockStoreTest {
 
   @Test
   public void createBlockMetaWithMediumType() throws Exception {
-    BlockStoreLocation loc = BlockStoreLocation.anyDirInTierWithMedium("MEM");
+    BlockStoreLocation loc = BlockStoreLocation.anyDirInAnyTierWithMedium("MEM");
     TempBlockMeta tempBlockMeta = mBlockStore.createBlock(SESSION_ID1, TEMP_BLOCK_ID,
         AllocateOptions.forCreate(1, loc));
     assertEquals(1, tempBlockMeta.getBlockSize());
     assertEquals(mTestDir2, tempBlockMeta.getParentDir());
 
-    BlockStoreLocation loc2 = BlockStoreLocation.anyDirInTierWithMedium("SSD");
+    BlockStoreLocation loc2 = BlockStoreLocation.anyDirInAnyTierWithMedium("SSD");
     TempBlockMeta tempBlockMeta2 = mBlockStore.createBlock(SESSION_ID1, TEMP_BLOCK_ID2,
         AllocateOptions.forCreate(1, loc2));
     assertEquals(1, tempBlockMeta2.getBlockSize());


### PR DESCRIPTION
This changes `BlockStoreLocation.anyDirInTierWithMedium` to `anyDirInAnyTierWithMedium`. The new name should be easier to understand.

The explanation for method `anyDirInTierWithMedium` is: 
```
  /**
   * Convenience method to return the block store location representing any dir in any tier
   * with specific medium.
   *
   * @param mediumType mediumType this returned block store location will represent
   * @return a BlockStoreLocation of any dir in any tier with a specific medium
   */
```

The new name is more precise. The old name `anyDirInTierWithMedium` makes me think it's one of the directories in a specific tier, that has the specific medium. Rather, it means a directory in ANY tier, with the specific medium.