### PR TITLE
Support using IP as connect host

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -439,6 +439,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.ALL)
           .build();
+  public static final PropertyKey SERVICE_USE_IP =
+      new Builder(Name.SERVICE_USE_IP)
+          .setDefaultValue("false")
+          .setDescription("If true, when alluxio.<service_name>.hostname and "
+              + "alluxio.<service_name>.bind.host of a service not specified, "
+              + "use IP as the connect host of the service.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.ALL)
+          .build();
   public static final PropertyKey TEST_MODE =
       new Builder(Name.TEST_MODE)
           .setDefaultValue(false)
@@ -4770,6 +4779,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String NETWORK_HOST_RESOLUTION_TIMEOUT_MS =
         "alluxio.network.host.resolution.timeout";
     public static final String SITE_CONF_DIR = "alluxio.site.conf.dir";
+    public static final String SERVICE_USE_IP = "alluxio.service.use.ip";
     public static final String TEST_MODE = "alluxio.test.mode";
     public static final String TMP_DIRS = "alluxio.tmp.dirs";
     public static final String USER_LOGS_DIR = "alluxio.user.logs.dir";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -439,8 +439,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.ALL)
           .build();
-  public static final PropertyKey SERVICE_USE_IP =
-      new Builder(Name.SERVICE_USE_IP)
+  public static final PropertyKey NETWORK_IP_ADDRESS_USED =
+      new Builder(Name.NETWORK_IP_ADDRESS_USED)
           .setDefaultValue("false")
           .setDescription("If true, when alluxio.<service_name>.hostname and "
               + "alluxio.<service_name>.bind.host of a service not specified, "
@@ -4778,8 +4778,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.network.connection.shutdown.timeout";
     public static final String NETWORK_HOST_RESOLUTION_TIMEOUT_MS =
         "alluxio.network.host.resolution.timeout";
+    public static final String NETWORK_IP_ADDRESS_USED = "alluxio.network.ip.address.used";
     public static final String SITE_CONF_DIR = "alluxio.site.conf.dir";
-    public static final String SERVICE_USE_IP = "alluxio.service.use.ip";
     public static final String TEST_MODE = "alluxio.test.mode";
     public static final String TMP_DIRS = "alluxio.tmp.dirs";
     public static final String USER_LOGS_DIR = "alluxio.user.logs.dir";

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -253,7 +253,7 @@ public final class NetworkAddressUtils {
    * <tr>
    * <th>Specified Hostname</th>
    * <th>Specified Bind Host</th>
-   * <th>Enable Service Using IP</th>
+   * <th>Enable Network IP Address Used</th>
    * <th>Returned Connect Host</th>
    * </tr>
    * </thead>
@@ -309,7 +309,7 @@ public final class NetworkAddressUtils {
         return bindHost;
       }
     }
-    if (conf.getBoolean(PropertyKey.SERVICE_USE_IP)) {
+    if (conf.getBoolean(PropertyKey.NETWORK_IP_ADDRESS_USED)) {
       return getLocalIpAddress((int) conf.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
     }
     return getLocalHostName((int) conf.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -253,6 +253,7 @@ public final class NetworkAddressUtils {
    * <tr>
    * <th>Specified Hostname</th>
    * <th>Specified Bind Host</th>
+   * <th>Enable Service Using IP</th>
    * <th>Returned Connect Host</th>
    * </tr>
    * </thead>
@@ -260,22 +261,32 @@ public final class NetworkAddressUtils {
    * <tr>
    * <td>hostname</td>
    * <td>hostname</td>
+   * <td>true/false</td>
    * <td>hostname</td>
    * </tr>
    * <tr>
    * <td>not defined</td>
    * <td>hostname</td>
+   * <td>true/false</td>
    * <td>hostname</td>
    * </tr>
    * <tr>
    * <td>hostname</td>
    * <td>0.0.0.0 or not defined</td>
+   * <td>true/false</td>
    * <td>hostname</td>
    * </tr>
    * <tr>
    * <td>not defined</td>
    * <td>0.0.0.0 or not defined</td>
-   * <td>localhost</td>
+   * <td>false</td>
+   * <td>local hostname</td>
+   * </tr>
+   * <tr>
+   * <td>not defined</td>
+   * <td>0.0.0.0 or not defined</td>
+   * <td>true</td>
+   * <td>local IP address</td>
    * </tr>
    * </tbody>
    * </table>
@@ -297,6 +308,9 @@ public final class NetworkAddressUtils {
       if (!bindHost.isEmpty() && !bindHost.equals(WILDCARD_ADDRESS)) {
         return bindHost;
       }
+    }
+    if (conf.getBoolean(PropertyKey.SERVICE_USE_IP)) {
+      return getLocalIpAddress((int) conf.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
     }
     return getLocalHostName((int) conf.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
   }


### PR DESCRIPTION
Fix #12420 When hostname & bind.host not specified, local hostname is chosen as the connect host of the service by default, which may cause an UnknownHostException when the **LOCAL** service hostname cannot be resolved by a **REMOTE** client. This problem can be avoided by specifying alluxio.<service_name>.hostname or alluxio.<service_name>.bind.host using an IP address. But it is really troublesome when deploying lots of nodes with different IP addresses. 

Add alluxio.service.use.ip to support using ip as the connect host when enable.