### PR TITLE
Add block lock cleaner

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2444,6 +2444,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
+  public static final PropertyKey WORKER_BLOCK_LOCK_TIMEOUT =
+      new Builder(Name.WORKER_BLOCK_LOCK_TIMEOUT)
+          .setDefaultValue("3min")
+          .setDescription("The timeout value of block locks lifetime. If a block lock "
+              + "is holding for more than the given timeout without updates, "
+              + "the lock will be invalidated to not block other block write operations.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.WORKER)
+          .build();
   public static final PropertyKey WORKER_CONTAINER_HOSTNAME =
       new Builder(Name.WORKER_CONTAINER_HOSTNAME)
           .setDescription("The container hostname if worker is running in a container.")
@@ -5187,6 +5196,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.block.heartbeat.interval";
     public static final String WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS =
         "alluxio.worker.block.heartbeat.timeout";
+    public static final String WORKER_BLOCK_LOCK_TIMEOUT =
+        "alluxio.worker.block.lock.timeout";
     public static final String WORKER_CONTAINER_HOSTNAME =
         "alluxio.worker.container.hostname";
     public static final String WORKER_DATA_FOLDER = "alluxio.worker.data.folder";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2446,7 +2446,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey WORKER_BLOCK_LOCK_TIMEOUT =
       new Builder(Name.WORKER_BLOCK_LOCK_TIMEOUT)
-          .setDefaultValue("3min")
+          .setDefaultValue("5min")
           .setDescription("The timeout value of block locks lifetime. If a block lock "
               + "is holding for more than the given timeout without updates, "
               + "the lock will be invalidated to not block other block write operations.")

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
@@ -71,7 +71,7 @@ public final class BlockLockManager {
   @GuardedBy("mSharedMapsLock")
   private final Map<Long, ClientRWLock> mLocks = new HashMap<>();
 
-  /** A map from a block id to all the locks hold by this session. */
+  /** A map from a block id to all the locks of this block. */
   @GuardedBy("mSharedMapsLock")
   private final Map<Long, Set<Long>> mBlockIdToLockIdsMap = new HashMap<>();
 
@@ -141,7 +141,8 @@ public final class BlockLockManager {
             LOG.debug("Removed outdated lock {} of block {}",
                 lockId, blockId);
           } else {
-            LOG.info("Failed to remove outdated lock {} of block {}",
+            // Should not reach here
+            LOG.warn("Record of lock {} belonging to block {} is missing.",
                 lockId, blockId);
           }
         }
@@ -365,7 +366,7 @@ public final class BlockLockManager {
   private static final class LockRecord {
     private final long mBlockId;
     private final Lock mLock;
-    private AtomicLong mLastAcessTime;
+    private AtomicLong mLastAccessTime;
 
     /** Creates a new instance of {@link LockRecord}.
      *
@@ -375,21 +376,21 @@ public final class BlockLockManager {
     LockRecord(long blockId, Lock lock) {
       mBlockId = blockId;
       mLock = lock;
-      mLastAcessTime = new AtomicLong(System.currentTimeMillis());
+      mLastAccessTime = new AtomicLong(System.currentTimeMillis());
     }
 
     /**
      * Updates the last access time to current time.
      */
     void updateLastAccessTime() {
-      mLastAcessTime.getAndSet(System.currentTimeMillis());
+      mLastAccessTime.set(System.currentTimeMillis());
     }
 
     /**
-     * @return the session id
+     * @return the last access time of this lock
      */
     long getLastAccessTime() {
-      return mLastAcessTime.get();
+      return mLastAccessTime.get();
     }
 
     /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
@@ -103,7 +103,6 @@ public final class BlockLockManager {
    * @param blockLockType {@link BlockLockType#READ} or {@link BlockLockType#WRITE}
    * @return lock id
    */
-  // TODO(lu) reconsider exception thrown
   public long lockBlock(long sessionId, long blockId, BlockLockType blockLockType) {
     ClientRWLock blockLock = getBlockLock(blockId);
     Lock lock;

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataEvictorView.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataEvictorView.java
@@ -48,7 +48,7 @@ public class BlockMetadataEvictorView extends BlockMetadataView {
   private final Set<Long> mPinnedInodes = new HashSet<>();
 
   /** Indices of locks that are being used. */
-  private final Set<Long> mInUseBlocks = new HashSet<>();
+  private final Set<Long> mInUseBlocks;
 
   /**
    * Creates a new instance of {@link BlockMetadataEvictorView}. Now we always create a new view
@@ -64,7 +64,7 @@ public class BlockMetadataEvictorView extends BlockMetadataView {
     super(manager);
     mPinnedInodes.addAll(Preconditions.checkNotNull(pinnedInodes, "pinnedInodes"));
     Preconditions.checkNotNull(lockedBlocks, "lockedBlocks");
-    mInUseBlocks.addAll(lockedBlocks);
+    mInUseBlocks = lockedBlocks;
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
@@ -64,16 +64,6 @@ public interface BlockStore extends SessionCleanable, Closeable {
   void unlockBlock(long lockId) throws BlockDoesNotExistException;
 
   /**
-   * Releases an acquired block lock based on a session id and block id.
-   * TODO(calvin): temporary, will be removed after changing client side code.
-   *
-   * @param sessionId the id of the session to lock this block
-   * @param blockId the id of the block to lock
-   * @return false if it fails to unlock due to the lock is not found
-   */
-  boolean unlockBlock(long sessionId, long blockId);
-
-  /**
    * Creates the metadata of a new block and assigns a temporary path (e.g., a subdir of the final
    * location named after session id) to store its data. The location can be a location with
    * specific tier and dir, or {@link BlockStoreLocation#anyTier()}, or

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
@@ -315,6 +315,14 @@ public interface BlockStore extends SessionCleanable, Closeable {
   boolean hasBlockMeta(long blockId);
 
   /**
+   * Handles the block lock heartbeat.
+   *
+   * @param lockId the block lock id
+   * @return true if heartbeat successfully, false if unable to find the lock id
+   */
+  boolean blockLockHeartbeat(long lockId);
+
+  /**
    * Cleans up the data associated with a specific session (typically a dead session). Clean up
    * entails unlocking the block locks of this session, reclaiming space of temp blocks created by
    * this session, and deleting the session temporary folder.

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -361,16 +361,6 @@ public interface BlockWorker extends Worker, SessionCleanable {
   void unlockBlock(long lockId) throws BlockDoesNotExistException;
 
   /**
-   * Releases the lock with the specified session and block id.
-   *
-   * @param sessionId the session id
-   * @param blockId the block id
-   * @return false if it fails to unlock due to the lock is not found
-   */
-  // TODO(calvin): Remove when lock and reads are separate operations.
-  boolean unlockBlock(long sessionId, long blockId);
-
-  /**
    * Handles the heartbeat from a client.
    *
    * @param sessionId the id of the client

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -226,6 +226,14 @@ public interface BlockWorker extends Worker, SessionCleanable {
   boolean hasBlockMeta(long blockId);
 
   /**
+   * Handles the block lock heartbeat.
+   *
+   * @param lockId the block lock id
+   * @return true if heartbeat successfully, false if unable to find the lock id
+   */
+  boolean blockLockHeartbeat(long lockId);
+
+  /**
    * Obtains a read lock the block.
    *
    * @param sessionId the id of the client

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -405,6 +405,11 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
   }
 
   @Override
+  public boolean blockLockHeartbeat(long lockId) {
+    return mBlockStore.blockLockHeartbeat(lockId);
+  }
+
+  @Override
   public long lockBlock(long sessionId, long blockId) throws BlockDoesNotExistException {
     return mBlockStore.lockBlock(sessionId, blockId);
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -489,12 +489,6 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
   }
 
   @Override
-  // TODO(calvin): Remove when lock and reads are separate operations.
-  public boolean unlockBlock(long sessionId, long blockId) {
-    return mBlockStore.unlockBlock(sessionId, blockId);
-  }
-
-  @Override
   public void sessionHeartbeat(long sessionId) {
     mSessions.sessionHeartbeat(sessionId);
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -174,12 +174,6 @@ public class TieredBlockStore implements BlockStore {
   }
 
   @Override
-  public boolean unlockBlock(long sessionId, long blockId) {
-    LOG.debug("unlockBlock: sessionId={}, blockId={}", sessionId, blockId);
-    return mLockManager.unlockBlock(sessionId, blockId);
-  }
-
-  @Override
   public BlockWriter getBlockWriter(long sessionId, long blockId)
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
       IOException {
@@ -451,8 +445,6 @@ public class TieredBlockStore implements BlockStore {
   @Override
   public void cleanupSession(long sessionId) {
     LOG.debug("cleanupSession: sessionId={}", sessionId);
-    // Release all locks the session is holding.
-    mLockManager.cleanupSession(sessionId);
 
     // Collect a list of temp blocks the given session owns and abort all of them with best effort
     List<TempBlockMeta> tempBlocksToRemove;

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -136,6 +136,14 @@ public class TieredBlockStore implements BlockStore {
   }
 
   @Override
+  public boolean blockLockHeartbeat(long lockId) {
+    LOG.debug("blockLockHeartbeat: lockId={}", lockId);
+    try (LockResource r = new LockResource(mMetadataReadLock)) {
+      return mLockManager.blockLockHeartbeat(lockId);
+    }
+  }
+
+  @Override
   public long lockBlock(long sessionId, long blockId) throws BlockDoesNotExistException {
     LOG.debug("lockBlock: sessionId={}, blockId={}", sessionId, blockId);
     long lockId = mLockManager.lockBlock(sessionId, blockId, BlockLockType.READ);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -162,7 +162,9 @@ public final class BlockReadHandler extends AbstractReadHandler<BlockReadRequest
         throws Exception {
       if (context.getBlockReader() != null) {
         if (!mWorker.blockLockHeartbeat(mLockId)) {
-          LOG.warn("Cannot find lock {} of block {}", mLockId, context.getRequest().getId());
+          LOG.warn("Lock {} of block {} cannot be found and may be deleted "
+              + "due to long unresponsive time.",
+              mLockId, context.getRequest().getId());
         }
         return;
       }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -161,6 +161,9 @@ public final class BlockReadHandler extends AbstractReadHandler<BlockReadRequest
     private void openBlock(BlockReadRequestContext context)
         throws Exception {
       if (context.getBlockReader() != null) {
+        if (!mWorker.blockLockHeartbeat(mLockId)) {
+          LOG.warn("Cannot find lock {} of block {}", mLockId, context.getRequest().getId());
+        }
         return;
       }
       BlockReadRequest request = context.getRequest();

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
@@ -140,25 +140,6 @@ public final class BlockLockManagerTest {
   }
 
   /**
-   * Tests that an exception is thrown when trying to validate a lock of a block via
-   * {@link BlockLockManager#validateLock(long, long, long)} after the session was cleaned up.
-   */
-  @Test
-  public void cleanupSession() throws Exception {
-    long sessionId1 = TEST_SESSION_ID;
-    long sessionId2 = TEST_SESSION_ID + 1;
-    long lockId1 = mLockManager.lockBlock(sessionId1, TEST_BLOCK_ID, BlockLockType.READ);
-    long lockId2 = mLockManager.lockBlock(sessionId2, TEST_BLOCK_ID, BlockLockType.READ);
-    mThrown.expect(BlockDoesNotExistException.class);
-    mThrown.expectMessage(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_LOCK_ID.getMessage(lockId2));
-    mLockManager.cleanupSession(sessionId2);
-    // Expect validating sessionId1 to get through
-    mLockManager.validateLock(sessionId1, TEST_BLOCK_ID, lockId1);
-    // Because sessionId2 has been cleaned up, expect validating sessionId2 to throw IOException
-    mLockManager.validateLock(sessionId2, TEST_BLOCK_ID, lockId2);
-  }
-
-  /**
    * Tests that up to WORKER_TIERED_STORE_BLOCK_LOCKS block locks can be grabbed simultaneously.
    */
   @Test(timeout = 10000)

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockWorkerTest.java
@@ -479,20 +479,14 @@ public class BlockWorkerTest {
   }
 
   /**
-   * Tests the {@link BlockWorker#unlockBlock(long)} and {@link BlockWorker#unlockBlock(long, long)}
+   * Tests the {@link BlockWorker#unlockBlock(long)}
    * method.
    */
   @Test
   public void unlockBlock() throws Exception {
     long lockId = mRandom.nextLong();
-    long sessionId = mRandom.nextLong();
-    long blockId = mRandom.nextLong();
-
     mBlockWorker.unlockBlock(lockId);
     verify(mBlockStore).unlockBlock(lockId);
-
-    mBlockWorker.unlockBlock(sessionId, blockId);
-    verify(mBlockStore).unlockBlock(sessionId, blockId);
   }
 
   /**


### PR DESCRIPTION
One of the potential fix/improve of #12444 and #11309 

Before Alluxio 1.5, Alluxio has a `session cleaner`, each session(client) will do session heartbeat to show session active. When a session timeout, all locks and temporary blocks holding by this session will be cleanup. After changes in #5377, session cleaner is not working anymore. #12444 and #11309  show a potential lock leak happening. When block lock leaks, we currently have no way to clean up those locks which may block our async block removers and space allocators.

This PR makes the following changes
1. Remove the `session id` concept in `BlockLockManager`. Session id concept is still useful for cleaning the temporary blocks when writing blocks, but is useless and can be removed in other places.
2. Add a `lastAccessTime` info in the block lock record. If a block lock hasn't been accessed (through `blockLockHeartbeat` or `validateLock`) for a period of time (5 min by default in my pr), it will be cleaned up when another write lock block request of the same block is coming in. In other words, when we want to write lock a block, we first clean up all the outdated locks of this block.
3. Add `blockLockHeartbeat` in the `BlockDataReader.openBlock()`. So that when a client is reading a block chunk data, it will first update the `lastAccessTime` of that lock. Making sure that we don't delete in-use locks in unexpected long block remote read process.

The potential risk of this fix:
1.  Mistakenly delete in-use locks. `ShortCircutBlockReadHandler` doesn't do `blockLockHeartbeat`. If a `ShortCircutBlockReadHandler` doesn't finish within the timeout (5min by default), it may error out because the block already been removed. If other master operations like `moveBlock, commitBlock, removeBlock` take longer than the timeout, it may also error out.

Things left for future PRs:
1. Remove the session id from places that not need it.
2. How to cleanup temporary blocks of lost sessions