### PR TITLE
Add configuration for Ratis retry cache expiry time

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1530,6 +1530,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue(19200)
           .setScope(Scope.ALL)
           .build();
+  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_RETRY_CACHE_EXPIRY_TIME =
+      new Builder(Name.MASTER_EMBEDDED_JOURNAL_RETRY_CACHE_EXPIRY_TIME)
+          .setDefaultValue("60s")
+          .setDescription("The time for embedded journal server retry cache to expire. Setting a "
+              + "bigger value allows embedded journal server to cache the responses for a longer "
+              + "time in case of journal writer retries, but will take up more memory in master.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   /**
    * @deprecated storage level is used by copycat dependency which is removed
    */
@@ -5020,6 +5029,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.embedded.journal.heartbeat.interval";
     public static final String MASTER_EMBEDDED_JOURNAL_PORT =
         "alluxio.master.embedded.journal.port";
+    public static final String MASTER_EMBEDDED_JOURNAL_RETRY_CACHE_EXPIRY_TIME =
+        "alluxio.master.embedded.journal.retry.cache.expiry.time";
     public static final String MASTER_EMBEDDED_JOURNAL_STORAGE_LEVEL =
         "alluxio.master.embedded.journal.storage.level";
     public static final String MASTER_EMBEDDED_JOURNAL_SHUTDOWN_TIMEOUT =

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -324,6 +324,12 @@ public class RaftJournalSystem extends AbstractJournalSystem {
                 .getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_TRANSPORT_REQUEST_TIMEOUT_MS),
             TimeUnit.MILLISECONDS));
 
+    RaftServerConfigKeys.RetryCache.setExpiryTime(properties,
+        TimeDuration.valueOf(
+            ServerConfiguration.global()
+                .getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RETRY_CACHE_EXPIRY_TIME),
+            TimeUnit.MILLISECONDS));
+
     // snapshot retention
     RaftServerConfigKeys.Snapshot.setRetentionFileNum(properties, 3);
 

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -326,7 +326,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
 
     RaftServerConfigKeys.RetryCache.setExpiryTime(properties,
         TimeDuration.valueOf(
-            ServerConfiguration.global()
+            ServerConfiguration
                 .getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RETRY_CACHE_EXPIRY_TIME),
             TimeUnit.MILLISECONDS));
 


### PR DESCRIPTION
Add a configuration for Ratis retry cache expiry time. This affects the size of the Ratis server retry cache, which can consume a lot of memory if there is a high volume of journal writes in a short period of time.