### PR TITLE
Implement access API for Hadoop client

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -38,6 +38,7 @@ import alluxio.exception.status.NotFoundException;
 import alluxio.exception.status.UnauthenticatedException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.Bits;
+import alluxio.grpc.CheckAccessPOptions;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
@@ -126,6 +127,20 @@ public class BaseFileSystem implements FileSystem {
   public boolean isClosed() {
     // Doesn't require locking because mClosed is volatile and marked first upon close
     return mClosed;
+  }
+
+  @Override
+  public void checkAccess(AlluxioURI path, CheckAccessPOptions options)
+      throws InvalidPathException, IOException, AlluxioException {
+    checkUri(path);
+    rpc(client -> {
+      CheckAccessPOptions mergedOptions = FileSystemOptions
+          .checkAccessDefaults(mFsContext.getPathConf(path))
+          .toBuilder().mergeFrom(options).build();
+      client.checkAccess(path, mergedOptions);
+      LOG.debug("Checked access {}, options: {}", path.getPath(), mergedOptions);
+      return null;
+    });
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/DelegatingFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DelegatingFileSystem.java
@@ -20,6 +20,7 @@ import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.FileIncompleteException;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.OpenDirectoryException;
+import alluxio.grpc.CheckAccessPOptions;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
@@ -62,6 +63,12 @@ public class DelegatingFileSystem implements FileSystem {
   @Override
   public boolean isClosed() {
     return mDelegatedFileSystem.isClosed();
+  }
+
+  @Override
+  public void checkAccess(AlluxioURI path, CheckAccessPOptions options)
+      throws InvalidPathException, IOException, AlluxioException {
+    mDelegatedFileSystem.checkAccess(path, options);
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -28,6 +28,7 @@ import alluxio.exception.FileIncompleteException;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.OpenDirectoryException;
 import alluxio.exception.status.AlluxioStatusException;
+import alluxio.grpc.CheckAccessPOptions;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
@@ -166,6 +167,17 @@ public interface FileSystem extends Closeable {
    * @return whether or not this FileSystem has been closed
    */
   boolean isClosed();
+
+  /**
+   * Checks access to a path.
+   *
+   * @param path the path of the directory to create in Alluxio space
+   * @param options options to associate with this operation
+   * @throws InvalidPathException if the path is invalid
+   * @throws alluxio.exception.AccessControlException if the access is denied
+   */
+  void checkAccess(AlluxioURI path, CheckAccessPOptions options)
+      throws InvalidPathException, IOException, AlluxioException;
 
   /**
    * Convenience method for {@link #createDirectory(AlluxioURI, CreateDirectoryPOptions)} with

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
@@ -16,6 +16,7 @@ import alluxio.Client;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.AlreadyExistsException;
 import alluxio.exception.status.NotFoundException;
+import alluxio.grpc.CheckAccessPOptions;
 import alluxio.grpc.CheckConsistencyPOptions;
 import alluxio.grpc.CompleteFilePOptions;
 import alluxio.grpc.CreateDirectoryPOptions;
@@ -61,6 +62,16 @@ public interface FileSystemMasterClient extends Client {
       return new RetryHandlingFileSystemMasterClient(conf);
     }
   }
+
+  /**
+   * Check access to a path.
+   *
+   * @param path the path to check
+   * @param options method options
+   * @throws alluxio.exception.AccessControlException if the access is denied
+   */
+  void checkAccess(AlluxioURI path, CheckAccessPOptions options)
+      throws AlluxioStatusException;
 
   /**
    * Checks the consistency of Alluxio metadata against the under storage for all files and

--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -15,6 +15,8 @@ import alluxio.AbstractMasterClient;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.exception.status.AlluxioStatusException;
+import alluxio.grpc.CheckAccessPOptions;
+import alluxio.grpc.CheckAccessPRequest;
 import alluxio.grpc.CheckConsistencyPOptions;
 import alluxio.grpc.CheckConsistencyPRequest;
 import alluxio.grpc.CompleteFilePOptions;
@@ -113,6 +115,15 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
   @Override
   protected void afterConnect() {
     mClient = FileSystemMasterClientServiceGrpc.newBlockingStub(mChannel);
+  }
+
+  @Override
+  public void checkAccess(AlluxioURI path, CheckAccessPOptions options)
+      throws AlluxioStatusException {
+    retryRPC(() -> mClient.checkAccess(
+        CheckAccessPRequest.newBuilder().setPath(getTransportPath(path))
+            .setOptions(options).build()),
+        RPC_LOG, "CheckAccess", "path=%s,options=%s", path, options);
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/util/FileSystemOptions.java
+++ b/core/client/fs/src/main/java/alluxio/util/FileSystemOptions.java
@@ -14,6 +14,7 @@ package alluxio.util;
 import alluxio.client.ReadType;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.grpc.CheckAccessPOptions;
 import alluxio.grpc.CheckConsistencyPOptions;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
@@ -66,6 +67,16 @@ public class FileSystemOptions {
             conf.get(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_UMASK)).toProto())
         .setRecursive(false)
         .setWriteType(conf.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WritePType.class))
+        .build();
+  }
+
+  /**
+   * @param conf Alluxio configuration
+   * @return options based on the configuration
+   */
+  public static CheckAccessPOptions checkAccessDefaults(AlluxioConfiguration conf) {
+    return CheckAccessPOptions.newBuilder()
+        .setCommonOptions(commonDefaults(conf))
         .build();
   }
 

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -27,6 +27,7 @@ import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.FileIncompleteException;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.OpenDirectoryException;
+import alluxio.grpc.CheckAccessPOptions;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
@@ -428,6 +429,12 @@ public class LocalCacheFileInStreamTest {
 
     @Override
     public boolean isClosed() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void checkAccess(AlluxioURI path, CheckAccessPOptions options)
+        throws InvalidPathException, IOException, AlluxioException {
       throw new UnsupportedOperationException();
     }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -69,6 +69,7 @@ import alluxio.master.audit.AuditContext;
 import alluxio.master.block.BlockId;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.file.activesync.ActiveSyncManager;
+import alluxio.master.file.contexts.CheckAccessContext;
 import alluxio.master.file.contexts.CheckConsistencyContext;
 import alluxio.master.file.contexts.CompleteFileContext;
 import alluxio.master.file.contexts.CreateDirectoryContext;
@@ -1181,6 +1182,36 @@ public final class DefaultFileSystemMaster extends CoreMaster
   @Override
   public FileSystemMasterView getFileSystemMasterView() {
     return new FileSystemMasterView(this);
+  }
+
+  @Override
+  public void checkAccess(AlluxioURI path, CheckAccessContext context)
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException {
+    try (RpcContext rpcContext = createRpcContext(context);
+         FileSystemMasterAuditContext auditContext =
+             createAuditContext("checkAccess", path, null, null)) {
+      Mode.Bits bits = Mode.Bits.fromProto(context.getOptions().getBits());
+      syncMetadata(rpcContext,
+          path,
+          context.getOptions().getCommonOptions(),
+          DescendantType.NONE,
+          auditContext,
+          LockedInodePath::getInodeOrNull,
+          (inodePath, permChecker) -> permChecker.checkPermission(bits, inodePath)
+      );
+
+      LockingScheme lockingScheme =
+          createLockingScheme(path, context.getOptions().getCommonOptions(),
+              LockPattern.READ);
+      try (LockedInodePath inodePath = mInodeTree.lockInodePath(lockingScheme)) {
+        mPermissionChecker.checkPermission(bits, inodePath);
+        if (!inodePath.fullPathExists()) {
+          throw new FileDoesNotExistException(ExceptionMessage
+              .PATH_DOES_NOT_EXIST.getMessage(path));
+        }
+        auditContext.setSucceeded(true);
+      }
+    }
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -27,6 +27,7 @@ import alluxio.exception.status.InvalidArgumentException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.SetAclAction;
 import alluxio.master.Master;
+import alluxio.master.file.contexts.CheckAccessContext;
 import alluxio.master.file.contexts.CheckConsistencyContext;
 import alluxio.master.file.contexts.CompleteFileContext;
 import alluxio.master.file.contexts.CreateDirectoryContext;
@@ -164,6 +165,19 @@ public interface FileSystemMaster extends Master {
    * @return a read-only view of the file system master
    */
   FileSystemMasterView getFileSystemMasterView();
+
+  /**
+   * Checks access to path.
+   *
+   * @param path the path to check access to
+   * @param context the method context
+   *
+   * @throws FileDoesNotExistException if the file does not exist
+   * @throws AccessControlException if permission checking fails
+   * @throws InvalidPathException if the given path is invalid
+   */
+  void checkAccess(AlluxioURI path, CheckAccessContext context)
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException;
 
   /**
    * Checks the consistency of the files and directories in the subtree under the path.

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -16,6 +16,8 @@ import alluxio.RpcUtils;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.InvalidPathException;
+import alluxio.grpc.CheckAccessPRequest;
+import alluxio.grpc.CheckAccessPResponse;
 import alluxio.grpc.CheckConsistencyPOptions;
 import alluxio.grpc.CheckConsistencyPRequest;
 import alluxio.grpc.CheckConsistencyPResponse;
@@ -66,6 +68,7 @@ import alluxio.grpc.UpdateMountPRequest;
 import alluxio.grpc.UpdateMountPResponse;
 import alluxio.grpc.UpdateUfsModePRequest;
 import alluxio.grpc.UpdateUfsModePResponse;
+import alluxio.master.file.contexts.CheckAccessContext;
 import alluxio.master.file.contexts.CheckConsistencyContext;
 import alluxio.master.file.contexts.CompleteFileContext;
 import alluxio.master.file.contexts.CreateDirectoryContext;
@@ -113,6 +116,18 @@ public final class FileSystemMasterClientServiceHandler
   public FileSystemMasterClientServiceHandler(FileSystemMaster fileSystemMaster) {
     Preconditions.checkNotNull(fileSystemMaster, "fileSystemMaster");
     mFileSystemMaster = fileSystemMaster;
+  }
+
+  @Override
+  public void checkAccess(CheckAccessPRequest request,
+      StreamObserver<CheckAccessPResponse> responseObserver) {
+    RpcUtils.call(LOG,
+        () -> {
+          AlluxioURI pathUri = getAlluxioURI(request.getPath());
+          mFileSystemMaster.checkAccess(pathUri,
+              CheckAccessContext.create(request.getOptions().toBuilder()));
+          return CheckAccessPResponse.getDefaultInstance();
+        }, "CheckAccess", "request=%s", responseObserver, request);
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CheckAccessContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CheckAccessContext.java
@@ -1,0 +1,72 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file.contexts;
+
+import alluxio.conf.ServerConfiguration;
+import alluxio.grpc.CheckAccessPOptions;
+import alluxio.util.FileSystemOptions;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * Used to merge and wrap {@link CheckAccessPOptions}.
+ */
+public class CheckAccessContext
+    extends OperationContext<CheckAccessPOptions.Builder, CheckAccessContext> {
+
+  /**
+   * Creates context with given option data.
+   *
+   * @param optionsBuilder options builder
+   */
+  private CheckAccessContext(CheckAccessPOptions.Builder optionsBuilder) {
+    super(optionsBuilder);
+  }
+
+  /**
+   * @param optionsBuilder Builder for proto {@link CheckAccessPOptions}
+   * @return the instance of {@link CheckAccessContext} with given options
+   */
+  public static CheckAccessContext create(CheckAccessPOptions.Builder optionsBuilder) {
+    return new CheckAccessContext(optionsBuilder);
+  }
+
+  /**
+   * Merges and embeds the given {@link CheckAccessPOptions} with the corresponding master
+   * options.
+   *
+   * @param optionsBuilder Builder for proto {@link CheckAccessPOptions} to merge with defaults
+   * @return the instance of {@link CheckAccessContext} with default values for master
+   */
+  public static CheckAccessContext mergeFrom(CheckAccessPOptions.Builder optionsBuilder) {
+    CheckAccessPOptions masterOptions =
+        FileSystemOptions.checkAccessDefaults(ServerConfiguration.global());
+    CheckAccessPOptions.Builder mergedOptionsBuilder =
+        masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
+    return create(mergedOptionsBuilder);
+  }
+
+  /**
+   * @return the instance of {@link CheckAccessContext} with default values for master
+   */
+  public static CheckAccessContext defaults() {
+    return create(FileSystemOptions
+        .checkAccessDefaults(ServerConfiguration.global()).toBuilder());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("ProtoOptions", getOptions().build())
+        .toString();
+  }
+}

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -36,6 +36,17 @@ message FileSystemMasterCommonPOptions {
   optional grpc.TtlAction ttlAction = 3;
 }
 
+message CheckAccessPRequest {
+  optional string path = 1;
+  optional CheckAccessPOptions options = 2;
+}
+
+message CheckAccessPResponse {}
+message CheckAccessPOptions {
+  optional Bits bits = 1;
+  optional FileSystemMasterCommonPOptions commonOptions = 2;
+}
+
 message CheckConsistencyPResponse {
   repeated string inconsistentPaths = 1;
 }
@@ -467,6 +478,11 @@ message UpdateUfsModePRequest {
  * This interface contains file system master service endpoints for Alluxio clients.
  */
 service FileSystemMasterClientService {
+
+  /**
+   * Checks access to path.
+   */
+  rpc CheckAccess(CheckAccessPRequest) returns (CheckAccessPResponse);
 
   /**
    * Checks the consistency of the files and directores with the path as the root of the subtree


### PR DESCRIPTION
the Hadoop client `access` API is called by Hive to check permission for
a table storage location. The default implementation is a simplification
of the actual permission check on the Alluxio master and can be
inconsistent in many cases. This change implemented the `access` so the
same server side permission checker is used to check certain permission
regarding an Alluxio location.

pr-link: Alluxio/alluxio#12514
change-id: cid-80237493a04cd7fcf6f1bc4fe45df9cfc6559a49