### PR TITLE
Enable faster PR builds via github actions

### DIFF
--- a/.github/workflows/java11_integration_tests.yml
+++ b/.github/workflows/java11_integration_tests.yml
@@ -55,7 +55,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=-webui,-shaded/client,-shaded/hadoop,-shaded/ozone,-integration/tools/hms \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms \
           ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.5-jdk11 \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60

--- a/.github/workflows/java11_integration_tests.yml
+++ b/.github/workflows/java11_integration_tests.yml
@@ -55,6 +55,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
+          ALLUXIO_DOCKER_MVN_SKIP_SLOW_COMPILE=true \
           ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.5-jdk11 \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60

--- a/.github/workflows/java11_integration_tests.yml
+++ b/.github/workflows/java11_integration_tests.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    name: "Test modules: "
+    name: "modules: "
 
     strategy:
       fail-fast: false
@@ -21,7 +21,9 @@ jobs:
           - >-
             alluxio.master.**
           - >-
-            alluxio.server.ft.**
+            alluxio.server.ft.**,!alluxio.server.ft.journal.raft.**,!alluxio.server.ft.journal.ufs.**
+          - >-
+            alluxio.server.ft.journal.raft.**,alluxio.server.ft.journal.ufs.**
           - >-
             alluxio.server.**,!alluxio.server.ft.**
           - >-
@@ -55,7 +57,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server \
           ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.5-jdk11 \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60

--- a/.github/workflows/java11_integration_tests.yml
+++ b/.github/workflows/java11_integration_tests.yml
@@ -55,7 +55,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_SKIP_SLOW_COMPILE=true \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=-webui,-shaded/client,-shaded/hadoop,-shaded/ozone,-integration/tools/hms \
           ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.5-jdk11 \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60

--- a/.github/workflows/java11_integration_tests_webui.yml
+++ b/.github/workflows/java11_integration_tests_webui.yml
@@ -1,4 +1,4 @@
-name: Java 11 Integration Tests
+name: Java 11 Integration Tests (w/ webui)
 
 on: [pull_request]
 
@@ -11,23 +11,7 @@ jobs:
       matrix:
         modules:
           - >-
-            alluxio.client.cli.**,!alluxio.client.cli.fs.**
-          - >-
-            alluxio.client.cli.fs.**
-          - >-
-            alluxio.client.fs.**,!alluxio.client.fs.concurrent.**,!alluxio.client.fs.io.**
-          - >-
-            alluxio.client.fs.concurrent.**,alluxio.client.fs.io.**
-          - >-
-            alluxio.client.**,!alluxio.client.fs.**,!alluxio.client.cli.**
-          - >-
-            alluxio.job.**,alluxio.master.**,alluxio.stress.**
-          - >-
-            alluxio.server.ft.**,!alluxio.server.ft.journal.raft.**,!alluxio.server.ft.journal.ufs.**
-          - >-
-            alluxio.server.ft.journal.raft.**,alluxio.server.ft.journal.ufs.**
-          - >-
-            alluxio.server.**,!alluxio.server.ft.**
+            alluxio.web.**
 
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.title, 'DOCFIX') &&
@@ -57,7 +41,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server,!table/server/underdb/glue,!table/server/underdb/hive,!underfs/hdfs,!underfs/ozone,!underfs/adl,!underfs/wasb,!underfs/cos,!underfs/kodo,!underfs/oss,!underfs/swift \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server \
           ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.5-jdk11 \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60

--- a/.github/workflows/java11_unit_tests.yml
+++ b/.github/workflows/java11_unit_tests.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    name: "Test modules: "
+    name: "modules: "
 
     strategy:
       fail-fast: false

--- a/.github/workflows/java11_unit_tests.yml
+++ b/.github/workflows/java11_unit_tests.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         modules:
           - >-
-            !alluxio.master.metastore.rocks.**
+            !alluxio.client.**,!alluxio.master.**
           - >-
-            alluxio.master.metastore.rocks.**
+            alluxio.client.**,alluxio.master.**
 
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.title, 'DOCFIX') &&
@@ -43,6 +43,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!assembly/client,!assembly/server \
           ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.5-jdk11 \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl '!tests'
         timeout-minutes: 60

--- a/.github/workflows/java11_unit_tests.yml
+++ b/.github/workflows/java11_unit_tests.yml
@@ -45,7 +45,7 @@ jobs:
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
           ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!assembly/client,!assembly/server \
           ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.5-jdk11 \
-          dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl '!tests'
+          dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl '!tests,!webui'
         timeout-minutes: 60
 
       - name: Archive artifacts

--- a/.github/workflows/java11_unit_tests_webui.yml
+++ b/.github/workflows/java11_unit_tests_webui.yml
@@ -1,4 +1,4 @@
-name: Java 11 Integration Tests
+name: Java 11 Unit Tests (w/ webui)
 
 on: [pull_request]
 
@@ -11,23 +11,7 @@ jobs:
       matrix:
         modules:
           - >-
-            alluxio.client.cli.**,!alluxio.client.cli.fs.**
-          - >-
-            alluxio.client.cli.fs.**
-          - >-
-            alluxio.client.fs.**,!alluxio.client.fs.concurrent.**,!alluxio.client.fs.io.**
-          - >-
-            alluxio.client.fs.concurrent.**,alluxio.client.fs.io.**
-          - >-
-            alluxio.client.**,!alluxio.client.fs.**,!alluxio.client.cli.**
-          - >-
-            alluxio.job.**,alluxio.master.**,alluxio.stress.**
-          - >-
-            alluxio.server.ft.**,!alluxio.server.ft.journal.raft.**,!alluxio.server.ft.journal.ufs.**
-          - >-
-            alluxio.server.ft.journal.raft.**,alluxio.server.ft.journal.ufs.**
-          - >-
-            alluxio.server.**,!alluxio.server.ft.**
+            **
 
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.title, 'DOCFIX') &&
@@ -57,9 +41,9 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server,!table/server/underdb/glue,!table/server/underdb/hive,!underfs/hdfs,!underfs/ozone,!underfs/adl,!underfs/wasb,!underfs/cos,!underfs/kodo,!underfs/oss,!underfs/swift \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!shaded/client,!shaded/hadoop,!shaded/ozone,!assembly/client,!assembly/server \
           ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.5-jdk11 \
-          dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
+          dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl '!tests'
         timeout-minutes: 60
 
       - name: Archive artifacts

--- a/.github/workflows/java11_unit_tests_webui.yml
+++ b/.github/workflows/java11_unit_tests_webui.yml
@@ -43,7 +43,7 @@ jobs:
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
           ALLUXIO_DOCKER_MVN_PROJECT_LIST=!shaded/client,!shaded/hadoop,!shaded/ozone,!assembly/client,!assembly/server \
           ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.5-jdk11 \
-          dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl '!tests'
+          dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl 'webui'
         timeout-minutes: 60
 
       - name: Archive artifacts

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -55,6 +55,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
+          ALLUXIO_DOCKER_MVN_SKIP_SLOW_COMPILE=true \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60
 

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -53,7 +53,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=-webui,-shaded/client,-shaded/hadoop,-shaded/ozone,-integration/tools/hms \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60
 

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -11,7 +11,9 @@ jobs:
       matrix:
         modules:
           - >-
-            alluxio.client.cli.**
+            alluxio.client.cli.**,!alluxio.client.cli.fs.**
+          - >-
+            alluxio.client.cli.fs.**
           - >-
             alluxio.client.fs.**
           - >-

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -55,7 +55,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server,!table/server/underdb/glue,!table/server/underdb/hive,!underfs/hdfs,!underfs/ozone,!underfs/adl,!underfs/wasb,!underfs/cos \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server,!table/server/underdb/glue,!table/server/underdb/hive,!underfs/hdfs,!underfs/ozone,!underfs/adl,!underfs/wasb,!underfs/cos,!underfs/kodo,!underfs/oss,!underfs/swift \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60
 

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    name: "Test modules: "
+    name: "modules: "
 
     strategy:
       fail-fast: false
@@ -19,7 +19,9 @@ jobs:
           - >-
             alluxio.job.**,alluxio.master.**,alluxio.stress.**
           - >-
-            alluxio.server.ft.**
+            alluxio.server.ft.**,!alluxio.server.ft.journal.raft.**,!alluxio.server.ft.journal.ufs.**
+          - >-
+            alluxio.server.ft.journal.raft.**,alluxio.server.ft.journal.ufs.**
           - >-
             alluxio.server.**,!alluxio.server.ft.**
 
@@ -51,7 +53,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms,!assembly/client,!assembly/server \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60
 

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -55,7 +55,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server,table/server/underdb/glue,!table/server/underdb/hive,!underfs/hdfs,!underfs/ozone,!underfs/adl,!underfs/wasb,!underfs/cos \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60
 

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -15,7 +15,9 @@ jobs:
           - >-
             alluxio.client.cli.fs.**
           - >-
-            alluxio.client.fs.**
+            alluxio.client.fs.**,!alluxio.client.fs.concurrent.**,!alluxio.client.fs.io.**
+          - >-
+            alluxio.client.fs.concurrent.**,alluxio.client.fs.io.**
           - >-
             alluxio.client.**,!alluxio.client.fs.**,!alluxio.client.cli.**
           - >-

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -17,9 +17,7 @@ jobs:
           - >-
             alluxio.client.**,!alluxio.client.fs.**,!alluxio.client.cli.**
           - >-
-            alluxio.job.**
-          - >-
-            alluxio.master.**,alluxio.stress.**
+            alluxio.job.**,alluxio.master.**,alluxio.stress.**
           - >-
             alluxio.server.ft.**
           - >-
@@ -53,7 +51,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms,!assembly/client,!assembly/server \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60
 

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -55,7 +55,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server,table/server/underdb/glue,!table/server/underdb/hive,!underfs/hdfs,!underfs/ozone,!underfs/adl,!underfs/wasb,!underfs/cos \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server,!table/server/underdb/glue,!table/server/underdb/hive,!underfs/hdfs,!underfs/ozone,!underfs/adl,!underfs/wasb,!underfs/cos \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60
 

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -55,7 +55,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_SKIP_SLOW_COMPILE=true \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=-webui,-shaded/client,-shaded/hadoop,-shaded/ozone,-integration/tools/hms \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60
 

--- a/.github/workflows/java8_integration_tests_webui.yml
+++ b/.github/workflows/java8_integration_tests_webui.yml
@@ -41,7 +41,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=-shaded/client,-shaded/hadoop,-shaded/ozone,-integration/tools/hms \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60
 

--- a/.github/workflows/java8_integration_tests_webui.yml
+++ b/.github/workflows/java8_integration_tests_webui.yml
@@ -1,4 +1,4 @@
-name: Java 8 Integration Tests
+name: Java 8 Integration Tests (w/ webui)
 
 on: [pull_request]
 
@@ -11,19 +11,7 @@ jobs:
       matrix:
         modules:
           - >-
-            alluxio.client.cli.**
-          - >-
-            alluxio.client.fs.**
-          - >-
-            alluxio.client.**,!alluxio.client.fs.**,!alluxio.client.cli.**
-          - >-
-            alluxio.job.**
-          - >-
-            alluxio.master.**,alluxio.stress.**
-          - >-
-            alluxio.server.ft.**
-          - >-
-            alluxio.server.**,!alluxio.server.ft.**
+            alluxio.web.**
 
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.title, 'DOCFIX') &&
@@ -53,7 +41,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=-webui,-shaded/client,-shaded/hadoop,-shaded/ozone,-integration/tools/hms \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=-shaded/client,-shaded/hadoop,-shaded/ozone,-integration/tools/hms \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60
 

--- a/.github/workflows/java8_integration_tests_webui.yml
+++ b/.github/workflows/java8_integration_tests_webui.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    name: "Test modules: "
+    name: "modules: "
 
     strategy:
       fail-fast: false
@@ -41,7 +41,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!shaded/client,!shaded/hadoop,!shaded/ozone,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60
 

--- a/.github/workflows/java8_unit_tests.yml
+++ b/.github/workflows/java8_unit_tests.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         modules:
           - >-
-            !alluxio.master.metastore.rocks.**
+            !alluxio.client.**,!alluxio.master.**
           - >-
-            alluxio.master.metastore.rocks.**
+            alluxio.client.**,alluxio.master.**
 
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.title, 'DOCFIX') &&

--- a/.github/workflows/java8_unit_tests.yml
+++ b/.github/workflows/java8_unit_tests.yml
@@ -43,7 +43,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!shaded/hadoop,!shaded/ozone,!assembly/client,!assembly/server \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl '!tests,!webui'
         timeout-minutes: 60
 

--- a/.github/workflows/java8_unit_tests.yml
+++ b/.github/workflows/java8_unit_tests.yml
@@ -43,6 +43,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl '!tests,!webui'
         timeout-minutes: 60
 

--- a/.github/workflows/java8_unit_tests.yml
+++ b/.github/workflows/java8_unit_tests.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    name: "Test modules: "
+    name: "modules: "
 
     strategy:
       fail-fast: false

--- a/.github/workflows/java8_unit_tests_webui.yml
+++ b/.github/workflows/java8_unit_tests_webui.yml
@@ -11,9 +11,7 @@ jobs:
       matrix:
         modules:
           - >-
-            !alluxio.client.**,!alluxio.master.**
-          - >-
-            alluxio.client.**,alluxio.master.**
+            **
 
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.title, 'DOCFIX') &&

--- a/.github/workflows/java8_unit_tests_webui.yml
+++ b/.github/workflows/java8_unit_tests_webui.yml
@@ -41,6 +41,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!shaded/client,!shaded/hadoop,!shaded/ozone,!assembly/client,!assembly/server \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl 'webui'
         timeout-minutes: 60
 

--- a/.github/workflows/java8_unit_tests_webui.yml
+++ b/.github/workflows/java8_unit_tests_webui.yml
@@ -1,4 +1,4 @@
-name: Java 8 Unit Tests
+name: Java 8 Unit Tests (w/ webui)
 
 on: [pull_request]
 
@@ -43,7 +43,7 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl '!tests,!webui'
+          dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl 'webui'
         timeout-minutes: 60
 
       - name: Archive artifacts

--- a/dev/github/run_docker.sh
+++ b/dev/github/run_docker.sh
@@ -43,6 +43,11 @@ function main {
     run_args+=" -e ALLUXIO_MVN_RUNTOEND=true"
   fi
 
+  if [ -n "${ALLUXIO_DOCKER_MVN_SKIP_SLOW_COMPILE}" ]
+  then
+    run_args+=" -e ALLUXIO_MVN_SKIP_SLOW_COMPILE=true"
+  fi
+
   if [ -n "${ALLUXIO_SONAR_ARGS}" ]
   then
     # write out to a file, in case there are spaces in the args

--- a/dev/github/run_docker.sh
+++ b/dev/github/run_docker.sh
@@ -43,9 +43,9 @@ function main {
     run_args+=" -e ALLUXIO_MVN_RUNTOEND=true"
   fi
 
-  if [ -n "${ALLUXIO_DOCKER_MVN_SKIP_SLOW_COMPILE}" ]
+  if [ -n "${ALLUXIO_DOCKER_MVN_PROJECT_LIST}" ]
   then
-    run_args+=" -e ALLUXIO_MVN_SKIP_SLOW_COMPILE=true"
+    run_args+=" -e ALLUXIO_MVN_PROJECT_LIST=${ALLUXIO_DOCKER_MVN_PROJECT_LIST}"
   fi
 
   if [ -n "${ALLUXIO_SONAR_ARGS}" ]

--- a/dev/github/run_tests.sh
+++ b/dev/github/run_tests.sh
@@ -26,10 +26,10 @@ then
   mvn_args+=" -fn -DfailIfNoTests=false --fail-at-end"
 fi
 
-mvn_compile_args=""
-if [ -n "${ALLUXIO_MVN_SKIP_SLOW_COMPILE}" ]
+mvn_project_list=""
+if [ -n "${ALLUXIO_MVN_PROJECT_LIST}" ]
 then
-  mvn_compile_args+=" -pl !webui,!shaded/client,!shaded/hadoop"
+  mvn_project_list+=" -pl ${ALLUXIO_MVN_PROJECT_LIST}"
 fi
 
 export MAVEN_OPTS="-Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS"
@@ -40,7 +40,7 @@ PATH_BACKUP=${PATH}
 JAVA_HOME=/usr/local/openjdk-8
 PATH=$JAVA_HOME/bin:$PATH
 mvn -Duser.home=/home/jenkins -T 4C clean install -Pdeveloper -Dfindbugs.skip -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip \
--Dlicense.skip -Dsurefire.forkCount=2 ${mvn_args} ${mvn_compile_args}
+-Dlicense.skip -Dsurefire.forkCount=2 ${mvn_args} ${mvn_project_list}
 
 # Set things up so that the current user has a real name and can authenticate.
 myuid=$(id -u)

--- a/dev/github/run_tests.sh
+++ b/dev/github/run_tests.sh
@@ -26,6 +26,12 @@ then
   mvn_args+=" -fn -DfailIfNoTests=false --fail-at-end"
 fi
 
+mvn_compile_args=""
+if [ -n "${ALLUXIO_MVN_SKIP_SLOW_COMPILE}" ]
+then
+  mvn_compile_args+=" -pl \!webui,\!shaded/client,\!shaded/hadoop"
+fi
+
 export MAVEN_OPTS="-Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS"
 
 # Always use java 8 to compile the source code
@@ -34,7 +40,7 @@ PATH_BACKUP=${PATH}
 JAVA_HOME=/usr/local/openjdk-8
 PATH=$JAVA_HOME/bin:$PATH
 mvn -Duser.home=/home/jenkins -T 4C clean install -Pdeveloper -Dfindbugs.skip -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip \
--Dlicense.skip -Dsurefire.forkCount=2 ${mvn_args}
+-Dlicense.skip -Dsurefire.forkCount=2 ${mvn_args} ${mvn_compile_args}
 
 # Set things up so that the current user has a real name and can authenticate.
 myuid=$(id -u)

--- a/dev/github/run_tests.sh
+++ b/dev/github/run_tests.sh
@@ -29,7 +29,7 @@ fi
 mvn_compile_args=""
 if [ -n "${ALLUXIO_MVN_SKIP_SLOW_COMPILE}" ]
 then
-  mvn_compile_args+=" -pl \!webui,\!shaded/client,\!shaded/hadoop"
+  mvn_compile_args+=" -pl !webui,!shaded/client,!shaded/hadoop"
 fi
 
 export MAVEN_OPTS="-Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS"

--- a/tests/src/test/java/alluxio/client/fs/PersistMultipleMountsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PersistMultipleMountsIntegrationTest.java
@@ -12,6 +12,7 @@
 package alluxio.client.fs;
 
 import alluxio.AlluxioURI;
+import alluxio.client.fs.io.AbstractFileOutStreamIntegrationTest;
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.client.file.FileOutStream;

--- a/tests/src/test/java/alluxio/client/fs/PersistPermissionIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PersistPermissionIntegrationTest.java
@@ -12,6 +12,7 @@
 package alluxio.client.fs;
 
 import alluxio.AlluxioURI;
+import alluxio.client.fs.io.AbstractFileOutStreamIntegrationTest;
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.client.file.FileOutStream;

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentDeleteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentDeleteIntegrationTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.concurrent;
 
 import alluxio.AlluxioURI;
 import alluxio.AuthenticatedUserRule;

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterCreateTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterCreateTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.concurrent;
 
 import alluxio.AlluxioURI;
 import alluxio.AuthenticatedUserRule;

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterLoadMetadataTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterLoadMetadataTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.concurrent;
 
 import static org.junit.Assert.assertEquals;
 

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.concurrent;
 
 import alluxio.AlluxioURI;
 import alluxio.AuthenticatedUserRule;

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterUtils.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterUtils.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.concurrent;
 
 import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentRecursiveCreateTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentRecursiveCreateTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.concurrent;
 
 import static junit.framework.TestCase.assertTrue;
 

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentRenameIntegrationTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.concurrent;
 
 import alluxio.AlluxioURI;
 import alluxio.AuthenticatedUserRule;

--- a/tests/src/test/java/alluxio/client/fs/concurrent/FileInStreamConcurrencyIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/FileInStreamConcurrencyIntegrationTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.concurrent;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.ServerConfiguration;

--- a/tests/src/test/java/alluxio/client/fs/concurrent/FileSystemConcurrencyTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/FileSystemConcurrencyTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.concurrent;
 
 import static org.junit.Assert.assertThat;
 

--- a/tests/src/test/java/alluxio/client/fs/io/AbstractFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/AbstractFileOutStreamIntegrationTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.io;
 
 import alluxio.AlluxioURI;
 import alluxio.client.file.FileInStream;

--- a/tests/src/test/java/alluxio/client/fs/io/BufferedBlockInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/BufferedBlockInStreamIntegrationTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.io;
 
 import alluxio.AlluxioURI;
 import alluxio.client.block.stream.BlockInStream;

--- a/tests/src/test/java/alluxio/client/fs/io/FileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileInStreamIntegrationTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.io;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;

--- a/tests/src/test/java/alluxio/client/fs/io/FileInStreamRehydrationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileInStreamRehydrationIntegrationTest.java
@@ -9,11 +9,12 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.io;
 
 import alluxio.AlluxioURI;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
+import alluxio.client.fs.io.AbstractFileOutStreamIntegrationTest;
 import alluxio.conf.PropertyKey;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.URIStatus;

--- a/tests/src/test/java/alluxio/client/fs/io/FileOutStreamAsyncWriteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileOutStreamAsyncWriteIntegrationTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.io;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -22,6 +22,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.FileSystemUtils;
 import alluxio.client.file.URIStatus;
+import alluxio.client.fs.io.AbstractFileOutStreamIntegrationTest;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.status.UnavailableException;

--- a/tests/src/test/java/alluxio/client/fs/io/FileOutStreamAsyncWriteJobIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileOutStreamAsyncWriteJobIntegrationTest.java
@@ -9,12 +9,13 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.io;
 
 import alluxio.AlluxioURI;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.URIStatus;
+import alluxio.client.fs.io.AbstractFileOutStreamIntegrationTest;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;

--- a/tests/src/test/java/alluxio/client/fs/io/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileOutStreamIntegrationTest.java
@@ -9,10 +9,11 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.io;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
+import alluxio.client.fs.io.AbstractFileOutStreamIntegrationTest;
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.client.WriteType;

--- a/tests/src/test/java/alluxio/client/fs/io/LocalBlockInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/LocalBlockInStreamIntegrationTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.io;
 
 import alluxio.AlluxioURI;
 import alluxio.client.file.FileInStream;

--- a/tests/src/test/java/alluxio/client/fs/io/LocalCacheFileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/LocalCacheFileInStreamIntegrationTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.io;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/tests/src/test/java/alluxio/client/fs/io/UfsFallbackFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/UfsFallbackFileOutStreamIntegrationTest.java
@@ -9,11 +9,12 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.client.fs;
+package alluxio.client.fs.io;
 
 import alluxio.AlluxioURI;
 import alluxio.ConfigurationRule;
 import alluxio.client.file.FileSystem;
+import alluxio.client.fs.io.AbstractFileOutStreamIntegrationTest;
 import alluxio.conf.PropertyKey;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.URIStatus;


### PR DESCRIPTION
Split up some more of the tests for more even runtimes, and avoided building the webui module for most jobs, since that alone takes almost 5 minutes for each job.