### PR TITLE
Use profile properties for shaded hadoop version

### DIFF
--- a/integration/tools/pom.xml
+++ b/integration/tools/pom.xml
@@ -26,6 +26,7 @@
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>
+    <ufs.hadoop.version>3.3.0</ufs.hadoop.version>
     <failIfNoTests>false</failIfNoTests>
   </properties>
 
@@ -43,11 +44,63 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-shaded-hadoop</artifactId>
-      <version>${hadoop.version}</version>
-    </dependency>
   </dependencies>
 
+  <profiles>
+    <!-- Profile to build this UFS module connecting to hdfs 1 -->
+    <profile>
+      <!-- Decouple hadoop profiles: hadoop-1 to indicate north bound and ufs-hadoop-1 to indicate the south bound -->
+      <id>ufs-hadoop-1</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.alluxio</groupId>
+          <artifactId>alluxio-shaded-hadoop</artifactId>
+          <version>${ufs.hadoop.version}</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.igormaznitsa</groupId>
+            <artifactId>jcp</artifactId>
+            <configuration>
+              <globalVars>
+                <property>
+                  <name>HADOOP1</name>
+                </property>
+              </globalVars>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- Profile to build this UFS module connecting to hdfs 2 -->
+    <profile>
+      <!-- Decouple hadoop profiles: hadoop-2 to indicate north bound and ufs-hadoop-2 to indicate the south bound -->
+      <id>ufs-hadoop-2</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.alluxio</groupId>
+          <artifactId>alluxio-shaded-hadoop</artifactId>
+          <version>${ufs.hadoop.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <!-- Profile to build this UFS module connecting to hdfs 3, this is the default profile -->
+    <profile>
+      <id>ufs-hadoop-3</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.alluxio</groupId>
+          <artifactId>alluxio-shaded-hadoop</artifactId>
+          <version>${ufs.hadoop.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Fix the maven release issue introduced by #12452 
`maven release:prepare` showing the following error when directly using `${hadoop.version}` for `alluxio-shaded-hadoop`
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.1:prepare (default-cli) on project alluxio-parent: The version could not be updated: ${hadoop.version}
```
This PR change to use ufs-hadoop profiles to get the shaded hadoop version