### PR TITLE
Add lock pool metrics

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -407,6 +407,16 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("Total number of Unmount operations")
           .setMetricType(MetricType.COUNTER)
           .build();
+  public static final MetricKey MASTER_INODE_LOCK_POOL_SIZE =
+      new Builder(Name.MASTER_INODE_LOCK_POOL_SIZE)
+          .setDescription("The size of master inode lock pool")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_EDGE_LOCK_POOL_SIZE =
+      new Builder(Name.MASTER_EDGE_LOCK_POOL_SIZE)
+          .setDescription("The size of master edge lock pool")
+          .setMetricType(MetricType.GAUGE)
+          .build();
   // Journal metrics
   public static final MetricKey MASTER_JOURNAL_FLUSH_FAILURE =
       new Builder(Name.MASTER_JOURNAL_FLUSH_FAILURE)
@@ -1123,6 +1133,8 @@ public final class MetricKey implements Comparable<MetricKey> {
     public static final String MASTER_SET_ACL_OPS = "Master.SetAclOps";
     public static final String MASTER_SET_ATTRIBUTE_OPS = "Master.SetAttributeOps";
     public static final String MASTER_UNMOUNT_OPS = "Master.UnmountOps";
+    public static final String MASTER_INODE_LOCK_POOL_SIZE = "Master.InodeLockPoolSize";
+    public static final String MASTER_EDGE_LOCK_POOL_SIZE = "Master.EdgeLockPoolSize";
 
     // metrics names for journal
     public static final String MASTER_JOURNAL_FLUSH_FAILURE = "Master.JournalFlushFailure";

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
@@ -15,6 +15,8 @@ import alluxio.collections.LockPool;
 import alluxio.concurrent.LockMode;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.resource.LockResource;
 import alluxio.resource.RWLockResource;
 import alluxio.util.interfaces.Scoped;
@@ -96,6 +98,15 @@ public class InodeLockManager implements Closeable {
               return new AtomicBoolean();
             }
           });
+
+  public InodeLockManager() {
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_INODE_LOCK_POOL_SIZE.getName(),
+        () -> mInodeLocks.size());
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_EDGE_LOCK_POOL_SIZE.getName(),
+        () -> mEdgeLocks.size());
+  }
 
   @VisibleForTesting
   boolean inodeReadLockedByCurrentThread(long inodeId) {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
@@ -99,6 +99,9 @@ public class InodeLockManager implements Closeable {
             }
           });
 
+  /**
+   * Creates a new instance of {@link InodeLockManager}.
+   */
   public InodeLockManager() {
     MetricsSystem.registerGaugeIfAbsent(
         MetricKey.MASTER_INODE_LOCK_POOL_SIZE.getName(),


### PR DESCRIPTION
Add Inode lockPool size and edge lockPool size metrics, so that we can monitor the lock pool size.

![image](https://user-images.githubusercontent.com/17329931/100265525-5c464200-2f8b-11eb-99cb-b73193f992f7.png)

![image](https://user-images.githubusercontent.com/17329931/100265546-6405e680-2f8b-11eb-9585-27753379b419.png)
