### PR TITLE
Increase Active Jobs Size for DistributedJobCommands

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4543,7 +4543,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("The total possible number of available job statuses in the job master. "
               + "This value includes running and finished jobs which are have completed within "
               + Name.JOB_MASTER_FINISHED_JOB_RETENTION_TIME + ".")
-          .setDefaultValue(500000)
+          .setDefaultValue(100000)
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey JOB_MASTER_WORKER_HEARTBEAT_INTERVAL =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4543,7 +4543,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("The total possible number of available job statuses in the job master. "
               + "This value includes running and finished jobs which are have completed within "
               + Name.JOB_MASTER_FINISHED_JOB_RETENTION_TIME + ".")
-          .setDefaultValue(100000)
+          .setDefaultValue(500000)
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey JOB_MASTER_WORKER_HEARTBEAT_INTERVAL =

--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  * It provides handling for submitting multiple jobs and handling retries of them.
  */
 public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCommand {
-  private static final int DEFAULT_ACTIVE_JOBS = 30000;
+  private static final int DEFAULT_ACTIVE_JOBS = 3000;
 
   protected List<JobAttempt> mSubmittedJobAttempts;
   protected int mActiveJobs;

--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  * It provides handling for submitting multiple jobs and handling retries of them.
  */
 public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCommand {
-  private static final int DEFAULT_ACTIVE_JOBS = 1000;
+  private static final int DEFAULT_ACTIVE_JOBS = 10000;
 
   protected List<JobAttempt> mSubmittedJobAttempts;
   protected int mActiveJobs;

--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  * It provides handling for submitting multiple jobs and handling retries of them.
  */
 public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCommand {
-  private static final int DEFAULT_ACTIVE_JOBS = 10000;
+  private static final int DEFAULT_ACTIVE_JOBS = 30000;
 
   protected List<JobAttempt> mSubmittedJobAttempts;
   protected int mActiveJobs;


### PR DESCRIPTION
Increase default active jobs size because this increases performance for smaller file size distributedCp/Load cases without hurting the large files. (The only increased cost is increased memory usage but the memory usage here isn't large.)