### PR TITLE
[DOCFIX] Fix error default security type in chinese

### DIFF
--- a/docs/_data/table/cn/security-configuration.yml
+++ b/docs/_data/table/cn/security-configuration.yml
@@ -1,6 +1,6 @@
 alluxio.security.authentication.type:
   安全认证模式。目前支持三种模式：NOSASL、SIMPLE和CUSTOM。
-  默认为NOSASL，即不启用安全认证功能。
+  默认为SIMPLE，即不启用安全认证功能。
 alluxio.security.authentication.custom.provider.class:
   当alluxio.security.authentication.type被设为CUSTOM时，实现安全认证功能的类。
   该类必须实现'alluxio.security.authentication.AuthenticationProvider'接口。


### PR DESCRIPTION
The default security type in English doc is SIMPLE, but in Chinese is NOSASL.

The authentication mode. Currently three modes are supported: NOSASL, SIMPLE, CUSTOM. The default value SIMPLE indicates that a simple authentication is enabled. Server trusts whoever the client claims to be

The default type is also SIMPLE in code

```
public static final PropertyKey SECURITY_AUTHENTICATION_TYPE =
      new Builder(Name.SECURITY_AUTHENTICATION_TYPE)
          .setDefaultValue("SIMPLE")
          .setDescription("The authentication mode. Currently three modes are supported: "
              + "NOSASL, SIMPLE, CUSTOM. The default value SIMPLE indicates that a simple "
              + "authentication is enabled. Server trusts whoever the client claims to be.")
          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
          .setScope(Scope.ALL)
          .build();
```