### PR TITLE
Relocate erasure coding

### DIFF
--- a/shaded/hadoop/pom.xml
+++ b/shaded/hadoop/pom.xml
@@ -161,6 +161,10 @@
                   <shadedPattern>${shading.prefix}.org.apache.curator</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>org.apache.hadoop.io.erasurecode</pattern>
+                  <shadedPattern>${shading.prefix}.org.apache.hadoop.io.erasurecode</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>org.apache.http</pattern>
                   <shadedPattern>${shading.prefix}.org.apache.http</shadedPattern>
                 </relocation>


### PR DESCRIPTION
This fixes classloading issue related to erasure coding by making sure the UFS has a private copy of the class.