### PR TITLE
Add support for handling 'remove_table' journal entry

### DIFF
--- a/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
+++ b/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
@@ -397,6 +397,9 @@ public class AlluxioCatalog implements Journaled {
     } else if (entry.hasAddTable()) {
       Database db = mDBs.get(entry.getAddTable().getDbName());
       return db.processJournalEntry(entry);
+    } else if (entry.hasRemoveTable()) {
+      Database db = mDBs.get(entry.getRemoveTable().getDbName());
+      return db.processJournalEntry(entry);
     } else if (entry.hasDetachDb()) {
       apply(entry.getDetachDb());
       return true;

--- a/tests/src/test/java/alluxio/server/ft/journal/TableMasterJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/TableMasterJournalIntegrationTest.java
@@ -109,6 +109,11 @@ public class TableMasterJournalIntegrationTest {
     tableMaster.syncDatabase(DB_NAME);
     checkTable(tableMaster, DB_NAME, 2, 3);
 
+    // Drop a table to create a 'remove_table' entry
+    genTable(1, 3, true);
+    tableMaster.syncDatabase(DB_NAME);
+    checkTable(tableMaster, DB_NAME, 1, 3);
+
     restartMaster();
 
     TableMaster tableMasterRestart =
@@ -117,7 +122,7 @@ public class TableMasterJournalIntegrationTest {
     checkDb(tableMasterRestart, DB_NAME, oldInfo);
     tableMasterRestart.syncDatabase(DB_NAME);
     checkDb(tableMasterRestart, DB_NAME, newInfo);
-    checkTable(tableMasterRestart, DB_NAME, 2, 3);
+    checkTable(tableMasterRestart, DB_NAME, 1, 3);
   }
 
   private void checkDb(TableMaster tableMaster, String dbName, DatabaseInfo dbInfo)


### PR DESCRIPTION
The PR aims to fix the bug that when Alluxio master is restarted, it fails to recognize the `remove_table` journal entry during journal replaying, and stuck there forever.

Fixes #12627 