### PR TITLE
[DOCFIX] Fix naming inconsistencies in COSN docs

### DIFF
--- a/docs/cn/ufs/COSN.md
+++ b/docs/cn/ufs/COSN.md
@@ -9,13 +9,16 @@ priority: 5
 * 内容列表
 {:toc}
 
-该指南介绍如何配置Alluxio以使用腾讯云[对象存储](https://cloud.tencent.com/product/cos)(Cloud Object Storage，简称：COS)作为底层文件系统。对象存储是腾讯云提供的面向非结构化数据，支持 HTTP/HTTPS协议访问的分布式存储服务，它能容纳海量数据并保证用户对带宽和容量扩充无感知，可以作为大数据计算与分析的数据池。
+该指南介绍如何配置Alluxio以使用腾讯云[对象存储](https://cloud.tencent.com/product/cos)(Cloud Object Storage，简称：COS)作为底层文件系统。
+对象存储是腾讯云提供的面向非结构化数据，支持 HTTP/HTTPS协议访问的分布式存储服务，它能容纳海量数据并保证用户对带宽和容量扩充无感知，可以作为大数据计算与分析的数据池。
 
 ## 初始步骤
 
-通常，Alluxio以集群模式在多个机器上运行。需要在机器上部署二进制包。你可以自己[编译Alluxio](Building-Alluxio-From-Source.html)，或者[下载二进制包](Running-Alluxio-Locally.html)。
+通常，Alluxio以集群模式在多个机器上运行。需要在机器上部署二进制包。
+你可以自己[编译Alluxio](Building-Alluxio-From-Source.html)，或者[下载二进制包](Running-Alluxio-Locally.html)。
 
-为了在COS上使用Alluxio，需要创建一个bucket（或者使用一个已有的bucket）。然后在该bucket中新建一个目录，或者使用一个存在的目录。在该指南中，COS Bucket的名称为COSN_ALLUXIO_BUCKET，在该bucket里的目录名称为COSN_DATA。还需提供一个COS的REGION，它们指定了你的bucket在哪个地域，本向导中的REGION名为COSN_REGION。
+为了在COS上使用Alluxio，需要创建一个bucket（或者使用一个已有的bucket）。然后在该bucket中新建一个目录，或者使用一个存在的目录。
+在该指南中，COS Bucket的名称为`COSN_ALLUXIO_BUCKET`，在该bucket里的目录名称为`COSN_DATA`。还需提供一个COS的REGION，它们指定了你的bucket在哪个地域，本向导中的REGION名为`COSN_REGION`。
 
 ## 安装COSN
 
@@ -23,13 +26,13 @@ Alluxio通过[统一命名空间](Unified-and-Transparent-Namespace.html)统一�
 
 ### 根目录安装
 
-若要在Alluxio中使用COSN作为底层文件系统，需修改conf/alluxio-site.properties和conf/core-site.conf配置文件。首先要指定一个已有的COS bucket和其中的目录作为底层文件系统，可以在`conf/alluxio-site.properties`中添加如下语句指定它：
+若要在Alluxio中使用COSN作为底层文件系统，需修改`conf/alluxio-site.properties`和`conf/core-site.xml`配置文件。首先要指定一个已有的COS bucket和其中的目录作为底层文件系统，可以在`conf/alluxio-site.properties`中添加如下语句指定它：
 
 ```
 alluxio.master.mount.table.root.ufs=cosn://COSN_ALLUXIO_BUCKET/COSN_DATA/
 ```
 
-接着，需要指定COS的配置信息以便访问COS，在`conf/core-site.conf`中添加：
+接着，需要指定COS的配置信息以便访问COS，在`conf/core-site.xml`中添加：
 
 ```
 <property>
@@ -87,10 +90,10 @@ $ ./bin/alluxio-start.sh local
 $ ./bin/alluxio runTests
 ```
 
-运行成功后，访问你的COS目录`COS_ALLUXIO_BUCKET/COS_DATA`，确认其中包含了由Alluxio创建的文件和目录。在该测试中，创建的文件名称应像：
+运行成功后，访问你的COS目录`COSN_ALLUXIO_BUCKET/COSN_DATA`，确认其中包含了由Alluxio创建的文件和目录。在该测试中，创建的文件名称应像：
 
 ```console
-COS_ALLUXIO_BUCKET/COS_DATA/default_tests_files/BASIC_CACHE_THROUGH
+COSN_ALLUXIO_BUCKET/COSN_DATA/default_tests_files/BASIC_CACHE_THROUGH
 ```
 
 运行以下命令停止Alluxio：

--- a/docs/en/ufs/COSN.md
+++ b/docs/en/ufs/COSN.md
@@ -9,36 +9,42 @@ priority: 5
 * Table of Contents
 {:toc}
 
-This guide describes how to configure Alluxio with Tencent [COS](https://cloud.tencent.com/product/cos)(Cloud Object Storage)as the under storage system. Object storage is provided by Tencent Cloud for unstructured data, which support HTTP/HTTPS protocol, can accommodate massive amounts of data and ensure that users are unaware of bandwidth and capacity expansion and can be used as a data pool for big data calculation and analysis.
+This guide describes how to configure Alluxio with Tencent [COS](https://cloud.tencent.com/product/cos) (Cloud Object Storage) as the under storage system.
+Tencent Cloud Object Storage (COS) is a distributed storage service offered by Tencent Cloud for unstructured data and accessible via HTTP/HTTPS protocols.
+It can store massive amounts of data and features imperceptible bandwidth and capacity expansion, making it a perfect data pool for big data computation and analytics.
 
 ## Basic Setup
 
-Usually, Alluxio runs on multiple machines in cluster mode and needs to deploy the binary package on the machines. You can either [compile Alluxio]({{ '/en/contributor/Building-Alluxio-From-Source.html' | relativize_url }}), or [download the binaries locally]({{ '/en/deploy/Running-Alluxio-Locally.html' | relativize_url }}).
+Alluxio runs on multiple machines in cluster mode so its binary package needs to be deployed on the machines.
+You can either [compile Alluxio]({{ '/en/contributor/Building-Alluxio-From-Source.html' | relativize_url }}) or [download the binaries locally]({{ '/en/deploy/Running-Alluxio-Locally.html' | relativize_url }}).
 
-In preparation for using COS with Alluxio, create a bucket (or use an existing bucket).You should also note the directory you want to use in that bucket, either by creating a new directory in the bucket, or using an existing one. For the purposes of this guide, the COS Bucket name is called COSN_ALLUXIO_BUCKET, the directory in that bucket is calledCOSN_DATA, and COS Bucket region is called COSN_REGION which specifies the region of your bucket.
+In preparation for using COS with Alluxio, create a new bucket or use an existing bucket.
+You should also note the directory you want to use in that bucket, either by creating a new directory in the bucket or using an existing one.
+For the purposes of this guide, the COS Bucket name is called `COSN_ALLUXIO_BUCKET`, the directory in that bucket is called `COSN_DATA`, and COS Bucket region is called `COSN_REGION` which specifies the region of your bucket.
 
 ## Basic Setup
 
-Alluxio unifies access to different storage systems through the [unified namespace]({{ '/en/core-services/Unified-Namespace.html' | relativize_url }}) feature. COSN UFS is used to access Tencent Cloud object storage, and an COSN location can be either mounted at the root of the Alluxio namespace or at a nested directory.
+Alluxio unifies access to different storage systems through the [unified namespace]({{ '/en/core-services/Unified-Namespace.html' | relativize_url }}) feature.
+COSN UFS is used to access Tencent Cloud object storage and a COS location can be either mounted at the root of the Alluxio namespace or as a nested directory.
 
 ### Root Mount Point
 
-Create `conf/alluxio-site.properties` and `conf/core-site/properties` if they do not exist.
+Create `conf/alluxio-site.properties` and `conf/core-site.xml` if they do not exist.
 
 ```console
 $ cp conf/alluxio-site.properties.template conf/alluxio-site.properties
-$ cp conf/core-site.properties.template conf/core-site.properties
+$ cp conf/core-site.xml.template conf/core-site.xml
 ```
 
-Configure Alluxio to use COSN as its under storage system by modifying `conf/alluxio-site.properties` and `conf/core-site/properties`.
-Specify an existing COSN bucket and directory as the under storage system by modifying
+Configure Alluxio to use COSN as its under storage system by modifying `conf/alluxio-site.properties` and `conf/core-site.xml`.
+Specify an existing COS bucket and directory as the under storage system by modifying
 `conf/alluxio-site.properties` to include:
 
 ```
 alluxio.master.mount.table.root.ufs=cosn://COSN_ALLUXIO_BUCKET/COSN_DATA/
 ```
 
-Specify COS configuration information in order to access COS by modifying `conf/core-site.conf` to include:
+Specify COS configuration information in order to access COS by modifying `conf/core-site.xml` to include:
 
 ```
 <property>
@@ -63,11 +69,13 @@ Specify COS configuration information in order to access COS by modifying `conf/
 </property>
 ```
 
-The above is the most basic configuration, For more configuration please refer to [here](https://hadoop.apache.org/docs/r3.3.0/hadoop-cos/cloud-storage/index.html). After these changes, Alluxio should be configured to work with COSN as its under storage system, and you can try [Running Alluxio Locally with COSN](#running-alluxio-locally-with-cosn).
+The above is the most basic configuration. For more configuration please refer to [here](https://hadoop.apache.org/docs/r3.3.0/hadoop-cos/cloud-storage/index.html).
+After these changes, Alluxio should be configured to work with COSN as its under storage system and you can try [Running Alluxio Locally with COSN](#running-alluxio-locally-with-cosn).
 
 ### Nested Mount
 
-An COSN location can be mounted at a nested directory in the Alluxio namespace to have unified access to multiple under storage systems. [Mount Command]({{ '/cn/operation/User-CLI.html' | relativize_url }}#mount)can be used for this purpose.
+A COS location can be mounted at a nested directory in the Alluxio namespace to have unified access to multiple under storage systems.
+The [mount command]({{ '/en/operation/User-CLI.html' | relativize_url }}#mount) can be used for this purpose.
 
 ```console
 $ ./bin/alluxio fs mount --option fs.cosn.userinfo.secretId=<COSN_SECRET_ID> \
@@ -78,8 +86,6 @@ $ ./bin/alluxio fs mount --option fs.cosn.userinfo.secretId=<COSN_SECRET_ID> \
     /cosn cosn://COSN_ALLUXIO_BUCKET/COSN_DATA/
 ```
 
-The above is the most basic configuration, For more configuration please refer to [here](https://hadoop.apache.org/docs/r3.3.0/hadoop-cos/cloud-storage/index.html).
-
 ## Running Alluxio Locally with COSN
 
 Start up Alluxio locally to see that everything works.
@@ -89,7 +95,7 @@ $ ./bin/alluxio format
 $ ./bin/alluxio-start.sh local
 ```
 
-This should start an Alluxio master and an Alluxio worker. You can see the master UI at http://localhost:19999.
+This should start an Alluxio master and an Alluxio worker. You can see the master UI at [http://localhost:19999](http://localhost:19999).
 
 Run a simple example program:
 
@@ -97,7 +103,8 @@ Run a simple example program:
 $ ./bin/alluxio runTests
 ```
 
-Visit your COS directory `COSN_ALLUXIO_BUCKET/COSN_DATA` to verify the files and directories created by Alluxio exist. For this test, you should see files named like:
+Visit your COS directory at `COSN_ALLUXIO_BUCKET/COSN_DATA` to verify the files and directories created by Alluxio exist.
+For this test, you should see files named like:
 
 ```console
 COSN_ALLUXIO_BUCKET/COSN_DATA/default_tests_files/BASIC_CACHE_THROUGH


### PR DESCRIPTION
core-site.conf and core-site/properties -> core-site.xml
COS_* -> COSN_* for bucket, data, and region placeholders