### PR TITLE
Disable default jni fuse

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4392,7 +4392,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey FUSE_JNIFUSE_ENABLED =
       new Builder(Name.FUSE_JNIFUSE_ENABLED)
-          .setDefaultValue(true)
+          .setDefaultValue(false)
           .setDescription("Use experimental JNIFUSE library for better performance.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)


### PR DESCRIPTION
Disable the default jnifuse property to avoid the following exception when mounting alluxio-fuse
Exception in thread "main" java.lang.UnsatisfiedLinkError: no jnifuse in java.library.path
        at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1860)
        at java.lang.Runtime.loadLibrary0(Runtime.java:870)
        at java.lang.System.loadLibrary(System.java:1124)
        at alluxio.jnifuse.AbstractFuseFileSystem.<clinit>(AbstractFuseFileSystem.java:38)
        at alluxio.fuse.AlluxioFuse.main(AlluxioFuse.java:119)