### PR TITLE
Fix creating UFS file without a parent directory

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFileWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFileWriteHandler.java
@@ -157,6 +157,7 @@ public final class UfsFileWriteHandler extends AbstractWriteHandler<UfsFileWrite
     context.setUfsResource(ufsResource);
     UnderFileSystem ufs = ufsResource.get();
     CreateOptions createOptions = CreateOptions.defaults(ServerConfiguration.global())
+        .setCreateParent(true)
         .setOwner(createUfsFileOptions.getOwner()).setGroup(createUfsFileOptions.getGroup())
         .setMode(new Mode((short) createUfsFileOptions.getMode()));
     if (createUfsFileOptions.hasAcl()) {


### PR DESCRIPTION
We have been using default `CreateOptions` when creating a UFS file.
This can fail in some configuration when a file is written to an Alluxio
directory not backed by a UFS one. This change adds the option when UFS
file writer creates the UFS file so the directory is created
automatically.

cherry-pick committed PR Alluxio/alluxio#12618