### PR TITLE
Prevent removeBlock from waiting indefinitly

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncBlockRemover.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncBlockRemover.java
@@ -12,17 +12,15 @@
 package alluxio.worker.block;
 
 import alluxio.Sessions;
-import alluxio.exception.BlockDoesNotExistException;
-import alluxio.exception.InvalidWorkerStateException;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.ThreadFactoryUtils;
 
 import com.codahale.metrics.Counter;
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -42,7 +40,6 @@ public class AsyncBlockRemover {
   private static final Logger LOG = LoggerFactory.getLogger(AsyncBlockRemover.class);
 
   private static final int DEFAULT_BLOCK_REMOVER_POOL_SIZE = 10;
-  private static final int INVALID_BLOCK_ID = -1;
 
   private final BlockWorker mBlockWorker;
   /** This list is used for queueing blocks to be removed by BlockWorker. */
@@ -52,7 +49,7 @@ public class AsyncBlockRemover {
   private final ExecutorService mRemoverPool;
   private final Counter mTakeCount;
   private final Counter mRemovedSuccessCount;
-
+  private final int mPoolSize;
   private volatile boolean mShutdown = false;
 
   /**
@@ -60,24 +57,38 @@ public class AsyncBlockRemover {
    * @param worker block worker
    */
   public AsyncBlockRemover(BlockWorker worker) {
+    this(worker, DEFAULT_BLOCK_REMOVER_POOL_SIZE, new LinkedBlockingQueue<>(),
+        Collections.newSetFromMap(new ConcurrentHashMap<>()));
+  }
+
+  /**
+   * Constructor of AsyncBlockRemover.
+   *
+   * @param worker block worker
+   * @param threads number of threads
+   * @param blocksToRemove blocks to remove
+   * @param removingBlocks blocks being removed
+   */
+  @VisibleForTesting
+  public AsyncBlockRemover(BlockWorker worker, int threads, BlockingQueue<Long> blocksToRemove,
+      Set<Long> removingBlocks) {
     mBlockWorker = worker;
-    mBlocksToRemove = new LinkedBlockingQueue<>();
-    mRemovingBlocks = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    mPoolSize = threads;
+    mBlocksToRemove = blocksToRemove;
+    mRemovingBlocks = removingBlocks;
     mTakeCount = MetricsSystem.counter(MetricKey.WORKER_BLOCK_REMOVER_TRY_REMOVE_COUNT
         .getName());
     mRemovedSuccessCount =
         MetricsSystem.counter(MetricKey.WORKER_BLOCK_REMOVER_REMOVED_COUNT
             .getName());
     MetricsSystem.registerGaugeIfAbsent(
-        MetricKey.WORKER_BLOCK_REMOVER_TRY_REMOVE_BLOCKS_SIZE.getName(),
-        () -> mBlocksToRemove.size());
+        MetricKey.WORKER_BLOCK_REMOVER_TRY_REMOVE_BLOCKS_SIZE.getName(), mBlocksToRemove::size);
     MetricsSystem.registerGaugeIfAbsent(
-        MetricKey.WORKER_BLOCK_REMOVER_REMOVING_BLOCKS_SIZE.getName(),
-        () -> mRemovingBlocks.size());
+        MetricKey.WORKER_BLOCK_REMOVER_REMOVING_BLOCKS_SIZE.getName(), mRemovingBlocks::size);
 
-    mRemoverPool = Executors.newFixedThreadPool(DEFAULT_BLOCK_REMOVER_POOL_SIZE,
+    mRemoverPool = Executors.newFixedThreadPool(mPoolSize,
         ThreadFactoryUtils.build("block-removal-service-%d", true));
-    for (int i = 0; i < DEFAULT_BLOCK_REMOVER_POOL_SIZE; i++) {
+    for (int i = 0; i < mPoolSize; i++) {
       mRemoverPool.execute(new BlockRemover());
     }
   }
@@ -111,41 +122,31 @@ public class AsyncBlockRemover {
   }
 
   private class BlockRemover implements Runnable {
-    private String mThreadName;
-
     @Override
     public void run() {
-      mThreadName = Thread.currentThread().getName();
-      long blockToBeRemoved;
+      String threadName = Thread.currentThread().getName();
       while (true) {
-        blockToBeRemoved = INVALID_BLOCK_ID;
+        Long blockToBeRemoved = null;
         try {
           blockToBeRemoved = mBlocksToRemove.take();
           mTakeCount.inc();
           mBlockWorker.removeBlock(Sessions.MASTER_COMMAND_SESSION_ID, blockToBeRemoved);
           mRemovedSuccessCount.inc();
-          LOG.debug("Block {} is removed in thread {}.", blockToBeRemoved, mThreadName);
+          LOG.debug("Block {} is removed in thread {}.", blockToBeRemoved, threadName);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           // Only log warning if interrupted not due to a shutdown.
           if (!mShutdown) {
-            LOG.warn("{} got interrupted while it was cleaning block {}.", mThreadName,
+            LOG.warn("{} got interrupted while it was cleaning block {}.", threadName,
                 blockToBeRemoved);
           }
           break;
-        } catch (IOException e) {
-          LOG.warn("IOException occurred while {} was cleaning block {}, exception is {}.",
-              mThreadName, blockToBeRemoved, e.getMessage());
-        } catch (BlockDoesNotExistException e) {
-          LOG.warn("{}: block {} may be deleted already. exception is {}.",
-              mThreadName, blockToBeRemoved, e.getMessage());
-        } catch (InvalidWorkerStateException e) {
-          LOG.warn("{}: invalid block state for block {}, exception is {}.",
-              mThreadName, blockToBeRemoved, e.getMessage());
         } catch (Exception e) {
-          LOG.warn("Unexpected exception: {}.", e.getMessage());
+          LOG.warn("Failed to remove block {} instructed by master. This is best-effort and "
+              + "will be tried later. threadName {}, error {}", blockToBeRemoved,
+              threadName, e.getMessage());
         } finally {
-          if (blockToBeRemoved != INVALID_BLOCK_ID) {
+          if (blockToBeRemoved != null) {
             mRemovingBlocks.remove(blockToBeRemoved);
           }
         }

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncBlockRemover.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncBlockRemover.java
@@ -22,7 +22,6 @@ import com.codahale.metrics.Counter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -32,6 +31,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Asynchronous block removal service.
@@ -142,7 +143,7 @@ public class AsyncBlockRemover {
           LOG.warn("{}: invalid block state for block {}, exception is {}.",
               mThreadName, blockToBeRemoved, e.getMessage());
         } catch (Exception e) {
-          LOG.warn("Unexpected exception: {}.", e);
+          LOG.warn("Unexpected exception: {}.", e.getMessage());
         } finally {
           if (blockToBeRemoved != INVALID_BLOCK_ID) {
             mRemovingBlocks.remove(blockToBeRemoved);

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -11,8 +11,8 @@
 
 package alluxio.worker.block;
 
-import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.exception.BlockAlreadyExistsException;
 import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.ExceptionMessage;
@@ -22,19 +22,19 @@ import alluxio.master.block.BlockId;
 import alluxio.resource.LockResource;
 import alluxio.util.io.FileUtils;
 import alluxio.worker.block.allocator.Allocator;
+import alluxio.worker.block.annotator.BlockIterator;
+import alluxio.worker.block.annotator.BlockOrder;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
 import alluxio.worker.block.io.StoreBlockReader;
 import alluxio.worker.block.io.StoreBlockWriter;
-import alluxio.worker.block.management.ManagementTaskCoordinator;
 import alluxio.worker.block.management.DefaultStoreLoadTracker;
+import alluxio.worker.block.management.ManagementTaskCoordinator;
 import alluxio.worker.block.meta.BlockMeta;
 import alluxio.worker.block.meta.StorageDir;
 import alluxio.worker.block.meta.StorageDirView;
 import alluxio.worker.block.meta.StorageTier;
 import alluxio.worker.block.meta.TempBlockMeta;
-import alluxio.worker.block.annotator.BlockIterator;
-import alluxio.worker.block.annotator.BlockOrder;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -51,6 +51,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -86,7 +87,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe // TODO(jiri): make thread-safe (c.f. ALLUXIO-1624)
 public class TieredBlockStore implements BlockStore {
   private static final Logger LOG = LoggerFactory.getLogger(TieredBlockStore.class);
-
+  private static final long REMOVE_BLOCK_TIMEOUT_MS = 60_000;
   private final BlockMetadataManager mMetaManager;
   private final BlockLockManager mLockManager;
   private final Allocator mAllocator;
@@ -378,8 +379,11 @@ public class TieredBlockStore implements BlockStore {
   public void removeBlock(long sessionId, long blockId, BlockStoreLocation location)
       throws InvalidWorkerStateException, BlockDoesNotExistException, IOException {
     LOG.debug("removeBlock: sessionId={}, blockId={}, location={}", sessionId, blockId, location);
-    long lockId = mLockManager.lockBlock(sessionId, blockId, BlockLockType.WRITE);
-
+    long lockId = mLockManager.tryLockBlock(sessionId, blockId, BlockLockType.WRITE,
+        REMOVE_BLOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    if (lockId == BlockLockManager.INVALID_LOCK_ID) {
+      throw new IOException(String.format("Can not acquire lock for block %d", blockId));
+    }
     BlockMeta blockMeta;
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       if (mMetaManager.hasTempBlockMeta(blockId)) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -382,7 +382,9 @@ public class TieredBlockStore implements BlockStore {
     long lockId = mLockManager.tryLockBlock(sessionId, blockId, BlockLockType.WRITE,
         REMOVE_BLOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     if (lockId == BlockLockManager.INVALID_LOCK_ID) {
-      throw new IOException(String.format("Can not acquire lock for block %d", blockId));
+      throw new IOException(
+          String.format("Can not acquire lock to remove block %d for session %d after %d ms",
+              blockId, sessionId, REMOVE_BLOCK_TIMEOUT_MS));
     }
     BlockMeta blockMeta;
     try (LockResource r = new LockResource(mMetadataReadLock)) {

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
@@ -129,6 +129,7 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
             mLockId, mRequest.getBlockId(), e.getMessage());
       }
       mWorker.cleanupSession(mSessionId);
+      mLockId = BlockLockManager.INVALID_LOCK_ID;
     }
     mResponseObserver.onError(GrpcExceptionUtils.fromThrowable(t));
   }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
@@ -129,7 +129,6 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
             mLockId, mRequest.getBlockId(), e.getMessage());
       }
       mWorker.cleanupSession(mSessionId);
-      mLockId = BlockLockManager.INVALID_LOCK_ID;
     }
     mResponseObserver.onError(GrpcExceptionUtils.fromThrowable(t));
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/AsyncBlockRemoverTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/AsyncBlockRemoverTest.java
@@ -1,0 +1,83 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+
+import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Tests for AsyncBlockRemover.
+ */
+public class AsyncBlockRemoverTest {
+  private AsyncBlockRemover mRemover;
+  private final BlockingQueue<Long> mBlocksToRemove = new LinkedBlockingQueue<>();
+  private final Set<Long> mBlocksTriedToRemoved =
+      Collections.newSetFromMap(new ConcurrentHashMap<>());
+  private final BlockWorker mMockWorker = Mockito.mock(BlockWorker.class);
+
+  @Test
+  public void blockRemove() throws Exception {
+    doAnswer(args -> {
+      // keeps track the blocks to remove
+      mBlocksTriedToRemoved.add(args.getArgument(1));
+      return null;
+    }).when(mMockWorker).removeBlock(anyLong(), anyLong());
+    mRemover = new AsyncBlockRemover(mMockWorker, 10, mBlocksToRemove,
+        Collections.newSetFromMap(new ConcurrentHashMap<>()));
+    List<Long> blocks = new ArrayList<>();
+    for (long i = 0; i < 100; i ++) {
+      blocks.add(i);
+    }
+    mRemover.addBlocksToDelete(blocks);
+    CommonUtils.waitFor("async block removal completed",
+        () -> mBlocksTriedToRemoved.size() == blocks.size(),
+        WaitForOptions.defaults().setTimeoutMs(10000));
+    assertEquals(0, mBlocksToRemove.size());
+  }
+
+  @Test
+  public void failedBlockRemove() throws Exception {
+    doAnswer(args -> {
+      // keeps track the blocks to remove
+      mBlocksTriedToRemoved.add(args.getArgument(1));
+      // throw exception
+      throw new IOException("Failed to remove block");
+    }).when(mMockWorker).removeBlock(anyLong(), anyLong());
+    mRemover = new AsyncBlockRemover(mMockWorker, 10, mBlocksToRemove,
+        Collections.newSetFromMap(new ConcurrentHashMap<>()));
+    List<Long> blocks = new ArrayList<>();
+    for (long i = 0; i < 100; i ++) {
+      blocks.add(i);
+    }
+    mRemover.addBlocksToDelete(blocks);
+    CommonUtils.waitFor("async block removal completed",
+        () -> mBlocksTriedToRemoved.size() == blocks.size(),
+        WaitForOptions.defaults().setTimeoutMs(10000));
+    assertEquals(0, mBlocksToRemove.size());
+  }
+}

--- a/core/server/worker/src/test/java/alluxio/worker/block/AsyncBlockRemoverTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/AsyncBlockRemoverTest.java
@@ -50,7 +50,7 @@ public class AsyncBlockRemoverTest {
     mRemover = new AsyncBlockRemover(mMockWorker, 10, mBlocksToRemove,
         Collections.newSetFromMap(new ConcurrentHashMap<>()));
     List<Long> blocks = new ArrayList<>();
-    for (long i = 0; i < 100; i ++) {
+    for (long i = 0; i < 100; i++) {
       blocks.add(i);
     }
     mRemover.addBlocksToDelete(blocks);
@@ -71,7 +71,7 @@ public class AsyncBlockRemoverTest {
     mRemover = new AsyncBlockRemover(mMockWorker, 10, mBlocksToRemove,
         Collections.newSetFromMap(new ConcurrentHashMap<>()));
     List<Long> blocks = new ArrayList<>();
-    for (long i = 0; i < 100; i ++) {
+    for (long i = 0; i < 100; i++) {
       blocks.add(i);
     }
     mRemover.addBlocksToDelete(blocks);

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
@@ -15,9 +15,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import alluxio.conf.ServerConfiguration;
-import alluxio.conf.PropertyKey;
 import alluxio.collections.ConcurrentHashSet;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidWorkerStateException;
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Unit tests for {@link BlockLockManager}.
@@ -82,6 +83,16 @@ public final class BlockLockManagerTest {
     // Read-lock on can both get through
     long lockId1 = mLockManager.lockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.READ);
     long lockId2 = mLockManager.lockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.READ);
+    assertNotEquals(lockId1, lockId2);
+  }
+
+  @Test
+  public void tryLockBlock() {
+    // Read-lock on can both get through
+    long lockId1 = mLockManager.tryLockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.READ,
+        1, TimeUnit.MINUTES);
+    long lockId2 = mLockManager.tryLockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.READ,
+        1, TimeUnit.MINUTES);
     assertNotEquals(lockId1, lockId2);
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.worker.block;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -30,10 +31,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,10 +41,9 @@ import java.util.concurrent.TimeUnit;
 /**
  * Unit tests for {@link BlockLockManager}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(BlockMetadataManager.class)
 public final class BlockLockManagerTest {
   private static final long TEST_SESSION_ID = 2;
+  private static final long TEST_SESSION_ID2 = 3;
   private static final long TEST_BLOCK_ID = 9;
 
   private BlockLockManager mLockManager;
@@ -64,14 +60,12 @@ public final class BlockLockManagerTest {
    * Sets up all dependencies before a test runs.
    */
   @Before
-  public void before() throws Exception {
-    BlockMetadataManager mockMetaManager = PowerMockito.mock(BlockMetadataManager.class);
-    PowerMockito.when(mockMetaManager.hasBlockMeta(TEST_BLOCK_ID)).thenReturn(true);
+  public void before() {
     mLockManager = new BlockLockManager();
   }
 
   @After
-  public void after() throws Exception {
+  public void after() {
     ServerConfiguration.reset();
   }
 
@@ -94,6 +88,37 @@ public final class BlockLockManagerTest {
     long lockId2 = mLockManager.tryLockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.READ,
         1, TimeUnit.MINUTES);
     assertNotEquals(lockId1, lockId2);
+  }
+
+  @Test
+  public void tryLockBlockWithReadLockLocked() throws Exception {
+    // Hold a read-lock on test block
+    long lockId1 = mLockManager.lockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.READ);
+    // Read-lock on the same block should get through
+    long lockId2 = mLockManager.tryLockBlock(TEST_SESSION_ID2, TEST_BLOCK_ID, BlockLockType.READ,
+        1, TimeUnit.SECONDS);
+    assertNotEquals(BlockLockManager.INVALID_LOCK_ID, lockId2);
+    mLockManager.unlockBlock(lockId2);
+    // Write-lock should fail
+    long lockId3 = mLockManager.tryLockBlock(TEST_SESSION_ID2, TEST_BLOCK_ID, BlockLockType.WRITE,
+        1, TimeUnit.SECONDS);
+    assertEquals(BlockLockManager.INVALID_LOCK_ID, lockId3);
+    mLockManager.unlockBlock(lockId1);
+  }
+
+  @Test
+  public void tryLockBlockWithWriteLockLocked() throws Exception {
+    // Hold a write-lock on test block
+    long lockId1 = mLockManager.lockBlock(TEST_SESSION_ID, TEST_BLOCK_ID, BlockLockType.WRITE);
+    // Read-lock should fail
+    long lockId2 = mLockManager.tryLockBlock(TEST_SESSION_ID2, TEST_BLOCK_ID, BlockLockType.READ,
+        1, TimeUnit.SECONDS);
+    assertEquals(BlockLockManager.INVALID_LOCK_ID, lockId2);
+    // Write-lock should fail
+    long lockId3 = mLockManager.tryLockBlock(TEST_SESSION_ID2, TEST_BLOCK_ID, BlockLockType.WRITE,
+        1, TimeUnit.SECONDS);
+    assertEquals(BlockLockManager.INVALID_LOCK_ID, lockId3);
+    mLockManager.unlockBlock(lockId1);
   }
 
   /**


### PR DESCRIPTION
aim to fix the symptom of #12444 and #11309
Use `tryLock()` instead of `lock()` when locking worker blocks to prevent forever waiting for block locks.
and replace https://github.com/Alluxio/alluxio/pull/12507/files

This PR fixes the symptom of frozen AsycBlockRemover caused by failing block lock acquisition by using tryLock.