### PR TITLE
collect the client-side metrics and heartbeat them to master by default

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3770,7 +3770,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey USER_METRICS_COLLECTION_ENABLED =
       new Builder(Name.USER_METRICS_COLLECTION_ENABLED)
-          .setDefaultValue(false)
+          .setDefaultValue(true)
           .setDescription("Enable collecting the client-side metrics and heartbeat them to master")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)


### PR DESCRIPTION
If the user is not set the parameter "alluxio. User. The metrics. Collections. Enabled = true", alluxio monitoring page shows short - circuit 0 b, can lead to misunderstanding: alluxio not from the local worker load data.