### PR TITLE
Add clearer ratis flush exception logging

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
@@ -318,7 +318,7 @@ public final class AsyncJournalWriter {
       } catch (IOException | JournalClosedException exc) {
         // Add the error logging here since the actual flush error may be overwritten
         // by the future meaningless ratis.protocol.AlreadyClosedException
-        SAMPLING_LOG.warn("Failed to flush journal entry", exc);
+        SAMPLING_LOG.warn("Failed to flush journal entry: " + exc.getMessage(), exc);
         Metrics.JOURNAL_FLUSH_FAILURE.inc();
         // Release only tickets that have been flushed. Fail the rest.
         Iterator<FlushTicket> ticketIterator = mTicketSet.iterator();


### PR DESCRIPTION
Add the debug logging since the actual flush failure will be overwritten by the last meaningless failure like `ratis.protocol.AlreadyClosedException` or `NoMoreRetriesException`.

The actual flush failure will sometimes give us helpful information or annoying meaningless logs, that's why i mark it as debug for now. Will be better to have an exception duplication-checking and only log the no-duplicate exceptions. And also link the exception to meaningful configuration suggestions.