### PR TITLE
Improve logging for tier mgmt task

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -363,7 +363,7 @@ public class TieredBlockStore implements BlockStore {
       return;
     }
     throw new WorkerOutOfSpaceException(ExceptionMessage.NO_SPACE_FOR_BLOCK_MOVE,
-            moveOptions.getLocation(), blockId);
+        moveOptions.getLocation(), blockId);
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -362,10 +362,8 @@ public class TieredBlockStore implements BlockStore {
       }
       return;
     }
-    // TODO(bin): We are probably seeing a rare transient failure, maybe define and throw some
-    // other types of exception to indicate this case.
     throw new WorkerOutOfSpaceException(ExceptionMessage.NO_SPACE_FOR_BLOCK_MOVE,
-        moveOptions.getLocation(), blockId);
+            moveOptions.getLocation(), blockId);
   }
 
   @Override
@@ -655,7 +653,9 @@ public class TieredBlockStore implements BlockStore {
             return null;
           }
         } else {
-          LOG.error("Target tier: {} has no available space to store {} bytes for session: {}",
+          // We are not evicting in the target tier so having no available space just
+          // means the tier is currently full.
+          LOG.warn("Target tier: {} has no available space to store {} bytes for session: {}",
               options.getLocation(), options.getSize(), sessionId);
           return null;
         }


### PR DESCRIPTION
This change does 2 things:
1. When a tier mgmt task fails because the destination dir is full, it logs a warning instead of error
2. Adds a unit test that verifies a failed tier move issued by a tier mgmt task fail consistently