### PR TITLE
Disable authority check

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -533,11 +533,12 @@ public class BaseFileSystem implements FileSystem {
          */
         Authority configured =
                 MasterInquireClient.Factory
-                        .create(mFsContext.getClusterConf(), mFsContext.getClientContext().getUserState())
+                        .create(mFsContext.getClusterConf(),
+                                mFsContext.getClientContext().getUserState())
                         .getConnectDetails().toAuthority();
         if (!configured.equals(uri.getAuthority())) {
           throw new IllegalArgumentException(
-                  String.format("The URI authority %s does not match the configured " + "value of %s.",
+                  String.format("The URI authority %s does not match the configured value of %s.",
                           uri.getAuthority(), configured));
         }
       }

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -523,17 +523,23 @@ public class BaseFileSystem implements FileSystem {
     if (uri.hasAuthority()) {
       LOG.warn("The URI authority (hostname and port) is ignored and not required in URIs passed "
           + "to the Alluxio Filesystem client.");
-      /* Even if we choose to log the warning, check if the Configuration host matches what the
-       * user passes. If not, throw an exception letting the user know they don't match.
-       */
-      Authority configured =
-          MasterInquireClient.Factory
-              .create(mFsContext.getClusterConf(), mFsContext.getClientContext().getUserState())
-              .getConnectDetails().toAuthority();
-      if (!configured.equals(uri.getAuthority())) {
-        throw new IllegalArgumentException(
-            String.format("The URI authority %s does not match the configured " + "value of %s.",
-                uri.getAuthority(), configured));
+
+      AlluxioConfiguration conf = mFsContext.getClusterConf();
+      boolean skipAuthorityCheck = conf.isSet(PropertyKey.USER_SKIP_AUTHORITY_CHECK)
+              && conf.getBoolean(PropertyKey.USER_SKIP_AUTHORITY_CHECK);
+      if (!skipAuthorityCheck) {
+        /* Even if we choose to log the warning, check if the Configuration host matches what the
+         * user passes. If not, throw an exception letting the user know they don't match.
+         */
+        Authority configured =
+                MasterInquireClient.Factory
+                        .create(mFsContext.getClusterConf(), mFsContext.getClientContext().getUserState())
+                        .getConnectDetails().toAuthority();
+        if (!configured.equals(uri.getAuthority())) {
+          throw new IllegalArgumentException(
+                  String.format("The URI authority %s does not match the configured " + "value of %s.",
+                          uri.getAuthority(), configured));
+        }
       }
     }
   }

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3922,6 +3922,21 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "aggregated, so different applications must set their own ids or leave this value "
               + "unset to use a randomly generated id.")
           .build();
+  public static final PropertyKey USER_SKIP_AUTHORITY_CHECK =
+      new Builder(Name.USER_SKIP_AUTHORITY_CHECK)
+          .setScope(Scope.CLIENT)
+          .setDefaultValue(false)
+          .setIsHidden(true)
+          .setDescription("By default, Alluxio will validate the AlluxioURI. If the authority part "
+              + "contradicts with the configuration (e.g. You specified master1,master2,master3 "
+              + "for high availability masters but the AlluxioURI is alluxio://master1:<port>/), "
+              + "Alluxio client will throw an exception. If this option is turned on, Alluxio "
+              + "client will ignore the wrong authority passed in by the AlluxioURI and use the "
+              + "configured value. This property is useful for the legacy client code, where the "
+              + "cluster setup has changed but the client code has hard-coded stale address. "
+              + "The admin can turn on this property and control where the clients connect in "
+              + "the configuration.")
+          .build();
   public static final PropertyKey USER_STREAMING_DATA_TIMEOUT =
       new Builder(Name.USER_STREAMING_DATA_TIMEOUT)
           .setAlias("alluxio.user.network.data.timeout.ms", Name.USER_NETWORK_DATA_TIMEOUT)
@@ -5627,6 +5642,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.network.writer.flush.timeout";
     public static final String USER_NETWORK_ZEROCOPY_ENABLED =
         "alluxio.user.network.zerocopy.enabled";
+    public static final String USER_SKIP_AUTHORITY_CHECK =
+        "alluxio.user.skip.authority.check";
     public static final String USER_STREAMING_DATA_TIMEOUT =
         "alluxio.user.streaming.data.timeout";
     public static final String USER_STREAMING_READER_BUFFER_SIZE_MESSAGES =


### PR DESCRIPTION
This change offers an option to make the Alluxio client NOT throw an exception when the given AlluxioURI is incorrect. Rather, it finds the correct cluster address from the configuration and connects correctly.

Some client has some stale code invoking Alluxio like this:
```
// The cluster just gone through an upgrade, the master address changed
// master1:19998 -> master1:19998,master2:19998,master3:19998
FileSystem fs = FileSystem.Factory.get();
// This path is hard coded in the code
AlluxioURI path = new AlluxioURI("alluxio://master1:19998/path");
// This fails because of BaseFileSystem.checkUri()
fs.listStatus(path);
```

It's very hard to dig all the client code and update them one by one. In the upgrade, the design intention is, the admin configures this `alluxio.user.skip.authority.check=true` on all nodes in the cluster, then the client code will not throw an error.

**This property enables users to do below:**
```
# The admin updates the configuration
$ cat /opt/alluxio/conf/alluxio-site.properties
alluxio.master.rpc.addresses=masters-1:19998,masters-2:19998,masters-3:19998
alluxio.user.skip.authority.check=true

# The user runs legacy code, the stale URL is ignored without throwing exception, connecting to the real cluster address
scala> import alluxio.client._
import alluxio.client._
scala> val fs = alluxio.client.file.FileSystem.Factory.get()
fs: alluxio.client.file.FileSystem = alluxio.client.file.FileSystemCache$InstanceCachingFileSystem@653a5a
scala> import alluxio.AlluxioURI
import alluxio.AlluxioURI
// wrong_address:1234 is ignored
scala> val uri = new alluxio.AlluxioURI(“alluxio://wrong_address:1234/default_tests_files”)
uri: alluxio.AlluxioURI = alluxio://zk:19998/default_tests_files
scala> fs.listStatus(uri)
res0: java.util.List[alluxio.client.file.URIStatus] = [FileInfo{fileId=16995319807, fileIdentifier=null, name=BASIC_NON_BYTE_BUFFER_CACHE_CACHE_THROUGH, path=/default_tests_files/BASIC_NON_BYTE_BUFFER_CACHE_CACHE_THROUGH, ufsPath=/tmp/alluxioB/underFSStorage/default_tests_files/BASIC_NON_BYTE_BUFFER_CACHE_CACHE_THROUGH, length=84, blockSizeBytes=67108864, creationTimeMs=1608692450270, completed=true, folder=false, pinned=false, pinnedlocation=[], cacheable=true, persisted=true, blockIds=[16978542592], inMemoryPercentage=100, lastModificationTimesMs=1608692450291, ttl=-1, lastAccessTimesMs=1608692450291, ttlAction=DELETE, owner=ec2-user, group=ec2-user, mode=420, persistenceState=PERSISTED, mountPoint=false, replicationMax=-1, replicationMin=0, fileBlockInfos=[FileBlockInfo{blockInfo=Blo...
```