### PR TITLE
Add maven plugin for proto lock

### DIFF
--- a/core/transport/pom.xml
+++ b/core/transport/pom.xml
@@ -30,7 +30,6 @@
     <!-- The shading prefix should match the artifact ID, replacing '-' with '.' -->
     <shading.prefix>alluxio.core.transport</shading.prefix>
     <skip.protoc>false</skip.protoc>
-    <proto-backwards-compatibility.version>1.0.5</proto-backwards-compatibility.version>
   </properties>
 
   <dependencies>
@@ -138,7 +137,6 @@
       <plugin>
         <groupId>com.salesforce.servicelibs</groupId>
         <artifactId>proto-backwards-compatibility</artifactId>
-        <version>${proto-backwards-compatibility.version}</version>
         <configuration>
           <protoSourceRoot>${basedir}/target/classes/</protoSourceRoot>
         </configuration>

--- a/core/transport/pom.xml
+++ b/core/transport/pom.xml
@@ -30,6 +30,7 @@
     <!-- The shading prefix should match the artifact ID, replacing '-' with '.' -->
     <shading.prefix>alluxio.core.transport</shading.prefix>
     <skip.protoc>false</skip.protoc>
+    <proto-backwards-compatibility.version>1.0.5</proto-backwards-compatibility.version>
   </properties>
 
   <dependencies>
@@ -128,6 +129,23 @@
             <goals>
               <goal>compile</goal>
               <goal>compile-custom</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Proto lock for preventing backwards compatibility issues -->
+      <plugin>
+        <groupId>com.salesforce.servicelibs</groupId>
+        <artifactId>proto-backwards-compatibility</artifactId>
+        <version>${proto-backwards-compatibility.version}</version>
+        <configuration>
+          <protoSourceRoot>${basedir}/target/classes/</protoSourceRoot>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>backwards-compatibility-check</goal>
             </goals>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -265,14 +265,14 @@
         <version>${protobuf.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.salesforce.servicelibs</groupId>
-        <artifactId>proto-backwards-compatibility</artifactId>
-        <version>1.0.5</version>
-      </dependency>
-      <dependency>
         <groupId>com.jamesmurty.utils</groupId>
         <artifactId>java-xmlbuilder</artifactId>
         <version>1.3</version>
+      </dependency>
+      <dependency>
+        <groupId>com.salesforce.servicelibs</groupId>
+        <artifactId>proto-backwards-compatibility</artifactId>
+        <version>1.0.5</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,11 @@
         <version>${protobuf.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.salesforce.servicelibs</groupId>
+        <artifactId>proto-backwards-compatibility</artifactId>
+        <version>1.0.5</version>
+      </dependency>
+      <dependency>
         <groupId>com.jamesmurty.utils</groupId>
         <artifactId>java-xmlbuilder</artifactId>
         <version>1.3</version>


### PR DESCRIPTION
#12596 
Introduce https://github.com/salesforce/proto-backwards-compat-maven-plugin to help prevent proto changes which can break backwards compatibility.
This plugin can fail the build when some field in a proto file is removed. Such as:

diff --git a/core/transport/src/main/proto/grpc/table/layout/hive/hive.proto b/core/transport/src/main/proto/grpc/table/layout/hive/hive.proto
index 538fbe02a0..829ed6f023 100644
--- a/core/transport/src/main/proto/grpc/table/layout/hive/hive.proto
+++ b/core/transport/src/main/proto/grpc/table/layout/hive/hive.proto
@@ -28,7 +28,6 @@ message SortingColumn {
ASCENDING = 0;
DESCENDING = 1;
}

required SortingOrder order = 2;
}
The plugin will trigger a build failure for notification:
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 27.064 s
[INFO] Finished at: 2020-12-22T21:45:30+08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.salesforce.servicelibs:proto-backwards-compatibility:1.0.5:backwards-compatibility-check (default) on project alluxio-core-transport: Backwards compatibility check failed! -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR] mvn -rf :alluxio-core-transport