### PR TITLE
Fix table mount option description in docs to "mount.option."

### DIFF
--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -1287,7 +1287,7 @@ Here are the attach command options:
   * `-o|--option <key=value>`: (multiple) additional properties associated with the attached db and UDB
 
 Here are the additional properties possible for the `-o` options:
-  * `udb-<UDB_TYPE>.mount-option.{<UFS_PREFIX>}.<MOUNT_PROPERTY>`: specify a mount option for a
+  * `udb-<UDB_TYPE>.mount.option.{<UFS_PREFIX>}.<MOUNT_PROPERTY>`: specify a mount option for a
   particular UFS path
     * `<UDB_TYPE>`: the UDB type
     * `<UFS_PREFIX>`: the UFS path prefix that the mount properties are for
@@ -1302,12 +1302,12 @@ Here are the additional properties possible for the `-o` options:
 For the `hive` udb type, during the attach process, the Alluxio catalog will auto-mount all the
 table/partition locations in the specified database, to Alluxio. You can supply the mount options
 for the possible table locations with the
-option `-o udb-hive.mount-option.{scheme/authority}.key=value`.
+option `-o udb-hive.mount.option.{scheme/authority}.key=value`.
 
 ```console
 $ ./bin/alluxio table attachdb hive thrift://HOSTNAME:9083 hive_db_name --db=alluxio_db_name  \
-  -o udb-hive.mount-option.{s3a://bucket1}.aws.accessKeyId=abc \
-  -o udb-hive.mount-option.{s3a://bucket2}.aws.accessKeyId=123
+  -o udb-hive.mount.option.{s3a://bucket1}.aws.accessKeyId=abc \
+  -o udb-hive.mount.option.{s3a://bucket2}.aws.accessKeyId=123
 ```
 
 This command will attach the database `hive_db_name` (of type `hive`) from the URI

--- a/table/server/common/src/main/java/alluxio/table/common/ConfigurationUtils.java
+++ b/table/server/common/src/main/java/alluxio/table/common/ConfigurationUtils.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  * A set of utility methods for configuration.
  */
 public class ConfigurationUtils {
-  public static final String MOUNT_PREFIX = "mount.option.";
+  public static final String MOUNT_PREFIX = "mount-option.";
   private static final Logger LOG = LoggerFactory.getLogger(ConfigurationUtils.class);
 
   private ConfigurationUtils() {} // prevent instantiation

--- a/table/server/common/src/main/java/alluxio/table/common/ConfigurationUtils.java
+++ b/table/server/common/src/main/java/alluxio/table/common/ConfigurationUtils.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  * A set of utility methods for configuration.
  */
 public class ConfigurationUtils {
-  public static final String MOUNT_PREFIX = "mount-option.";
+  public static final String MOUNT_PREFIX = "mount.option.";
   private static final Logger LOG = LoggerFactory.getLogger(ConfigurationUtils.class);
 
   private ConfigurationUtils() {} // prevent instantiation


### PR DESCRIPTION
Fix: #12675
The mount option of attachdb differs from docs and code.