### PR TITLE
Flush when written journal reach to the given batch size

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1569,15 +1569,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
-  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_FLUSH_BATCH_SIZE =
-      new Builder(Name.MASTER_EMBEDDED_JOURNAL_FLUSH_BATCH_SIZE)
-          .setDefaultValue("1MB")
-          .setDescription("Embedded journal flush journal entries in batches to improve flush performance. "
-              + "When the current journal batch size in bytes is bigger than the configured batch size, "
-              + "an auto journal flush is triggered to avoid journal batch size grows unbounded")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.MASTER)
-          .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_PORT =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_PORT)
           .setDescription("The port to use for embedded journal communication with other masters.")
@@ -5187,8 +5178,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.embedded.journal.entry.size.max";
     public static final String MASTER_EMBEDDED_JOURNAL_FLUSH_SIZE_MAX =
         "alluxio.master.embedded.journal.flush.size.max";
-    public static final String MASTER_EMBEDDED_JOURNAL_FLUSH_BATCH_SIZE =
-        "alluxio.master.embedded.journal.flush.batch.size";
     public static final String MASTER_EMBEDDED_JOURNAL_HEARTBEAT_INTERVAL =
         "alluxio.master.embedded.journal.heartbeat.interval";
     public static final String MASTER_EMBEDDED_JOURNAL_PORT =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1569,6 +1569,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_FLUSH_BATCH_SIZE =
+      new Builder(Name.MASTER_EMBEDDED_JOURNAL_FLUSH_BATCH_SIZE)
+          .setDefaultValue("1MB")
+          .setDescription("Embedded journal flush journal entries in batches to improve flush performance. "
+              + "When the current journal batch size in bytes is bigger than the configured batch size, "
+              + "an auto journal flush is triggered to avoid journal batch size grows unbounded")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_PORT =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_PORT)
           .setDescription("The port to use for embedded journal communication with other masters.")
@@ -5178,6 +5187,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.embedded.journal.entry.size.max";
     public static final String MASTER_EMBEDDED_JOURNAL_FLUSH_SIZE_MAX =
         "alluxio.master.embedded.journal.flush.size.max";
+    public static final String MASTER_EMBEDDED_JOURNAL_FLUSH_BATCH_SIZE =
+        "alluxio.master.embedded.journal.flush.batch.size";
     public static final String MASTER_EMBEDDED_JOURNAL_HEARTBEAT_INTERVAL =
         "alluxio.master.embedded.journal.heartbeat.interval";
     public static final String MASTER_EMBEDDED_JOURNAL_PORT =

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
@@ -127,7 +127,6 @@ public class RaftJournalWriter implements JournalWriter {
             mWriteTimeoutMs), e);
       }
       mJournalEntryBuilder = null;
-      mCurrentJournalEntrySize.set(0);
     }
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
@@ -16,9 +16,8 @@ import alluxio.conf.ServerConfiguration;
 import alluxio.exception.JournalClosedException;
 import alluxio.master.journal.JournalWriter;
 import alluxio.proto.journal.Journal.JournalEntry;
-
 import alluxio.util.FormatUtils;
-import alluxio.wire.Property;
+
 import com.google.common.base.Preconditions;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
@@ -74,7 +73,8 @@ public class RaftJournalWriter implements JournalWriter {
         ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_WRITE_TIMEOUT);
     // journal entry size max is the hard limit set by underlying ratis
     // use a smaller value to guarantee we don't pass the hard limit
-    mEntrySizeMax = ServerConfiguration.getBytes(PropertyKey.MASTER_EMBEDDED_JOURNAL_ENTRY_SIZE_MAX);
+    mEntrySizeMax = ServerConfiguration
+        .getBytes(PropertyKey.MASTER_EMBEDDED_JOURNAL_ENTRY_SIZE_MAX);
     mFlushBatchBytes = mEntrySizeMax / 3;
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
@@ -69,8 +69,10 @@ public class RaftJournalWriter implements JournalWriter {
     mClosed = false;
     mWriteTimeoutMs =
         ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_WRITE_TIMEOUT);
+    // journal entry size max is the hard limit set by underlying ratis
+    // use a smaller value to guarantee we don't pass the hard limit
     mFlushBatchBytes =
-        ServerConfiguration.getBytes(PropertyKey.MASTER_EMBEDDED_JOURNAL_FLUSH_BATCH_SIZE);
+        ServerConfiguration.getBytes(PropertyKey.MASTER_EMBEDDED_JOURNAL_ENTRY_SIZE_MAX) / 3;
   }
 
   @Override

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalWriterTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalWriterTest.java
@@ -1,0 +1,133 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.journal.raft;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.proto.journal.File;
+import alluxio.proto.journal.Journal;
+
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.Message;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftGroupMemberId;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Unit tests for {@link RaftJournalWriter}.
+ */
+public class RaftJournalWriterTest {
+  private LocalFirstRaftClient mClient;
+  private RaftJournalWriter mRaftJournalWriter;
+
+  @After
+  public void after() throws Exception {
+    ServerConfiguration.reset();
+  }
+
+  private void setupRaftJournalWriter() throws IOException  {
+    mClient = mock(LocalFirstRaftClient.class);
+    RaftClientReply reply = new RaftClientReply(ClientId.randomId(),
+        RaftGroupMemberId.valueOf(RaftJournalUtils.getPeerId(new InetSocketAddress(1)),
+            RaftGroupId.valueOf(UUID.fromString("02511d47-d67c-49a3-9011-abb3109a44c1"))),
+        1L, true, Message.valueOf("mp"), null, 1L, null);
+
+    CompletableFuture<RaftClientReply> future = new CompletableFuture<RaftClientReply>() {
+      @Override
+      public boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+      }
+
+      @Override
+      public boolean isCancelled() {
+        return false;
+      }
+
+      @Override
+      public boolean isDone() {
+        return false;
+      }
+
+      @Override
+      public RaftClientReply get() {
+        return reply;
+      }
+
+      @Override
+      public RaftClientReply get(long timeout, TimeUnit unit) {
+        return reply;
+      }
+    };
+    when(mClient.sendAsync(any(), any())).thenReturn(future);
+
+    mRaftJournalWriter = new RaftJournalWriter(1, mClient);
+  }
+
+  @Test
+  public void writeAndFlush() throws Exception {
+    setupRaftJournalWriter();
+    for (int i = 0; i < 10; i++) {
+      String alluxioMountPoint = "/tmp/to/file" + i;
+      String ufsPath = "hdfs://location/file" + i;
+      mRaftJournalWriter.write(Journal.JournalEntry.newBuilder()
+          .setAddMountPoint(File.AddMountPointEntry.newBuilder()
+              .setAlluxioPath(alluxioMountPoint)
+              .setUfsPath(ufsPath).build()).build());
+    }
+    verify(mClient, never()).sendAsync(any(), any());
+
+    mRaftJournalWriter.flush();
+    verify(mClient, times(1)).sendAsync(any(), any());
+    mRaftJournalWriter.flush();
+    verify(mClient, times(1)).sendAsync(any(), any());
+
+    mRaftJournalWriter.write(Journal.JournalEntry.getDefaultInstance());
+    mRaftJournalWriter.flush();
+    verify(mClient, times(2)).sendAsync(any(), any());
+  }
+
+  @Test
+  public void writeTriggerFlush() throws Exception {
+    int flushBatchSize = 128;
+    ServerConfiguration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_ENTRY_SIZE_MAX, flushBatchSize * 3);
+    setupRaftJournalWriter();
+
+    int totalMessageBytes = 0;
+    for (int i = 0; i < 10; i++) {
+      String alluxioMountPoint = "/tmp/to/file" + i;
+      String ufsPath = "hdfs://location/file" + i;
+      totalMessageBytes += alluxioMountPoint.getBytes().length;
+      totalMessageBytes += ufsPath.getBytes().length;
+      mRaftJournalWriter.write(Journal.JournalEntry.newBuilder()
+          .setAddMountPoint(File.AddMountPointEntry.newBuilder()
+              .setAlluxioPath(alluxioMountPoint)
+              .setUfsPath(ufsPath).build()).build());
+    }
+    verify(mClient, atLeast(totalMessageBytes / flushBatchSize)).sendAsync(any(), any());
+  }
+}

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalWriterTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalWriterTest.java
@@ -128,6 +128,7 @@ public class RaftJournalWriterTest {
               .setAlluxioPath(alluxioMountPoint)
               .setUfsPath(ufsPath).build()).build());
     }
+    mRaftJournalWriter.write(Journal.JournalEntry.getDefaultInstance());
     verify(mClient, atLeast(totalMessageBytes / flushBatchSize)).sendAsync(any(), any());
   }
 }


### PR DESCRIPTION
There are always chances that some new big journal entries are added unexpectedly which violates the underlying assumption of the raft implementation. 
This PR reduces the possibilities of flushing a single big journal entry by introducing journal size check and flush when reach journal batch size.