### PR TITLE
Avoid RuntimeException for unresolved hostname during metrics reporting

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -196,15 +196,20 @@ public final class MetricsSystem {
       default:
         break;
     }
+    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    if (sourceKey != null && conf.isSet(sourceKey)) {
+      return conf.get(sourceKey);
+    }
     String hostName;
+    // Avoid throwing RuntimeException when hostname
+    // is not resolved on metrics reporting
     try {
       hostName = NetworkAddressUtils.getLocalHostMetricName(sResolveTimeout);
     } catch (RuntimeException e) {
-      hostName = "unhnown";
-      LOG.error("Can't find local host name", e.getMessage());
+      hostName = "unknown";
+      LOG.error("Can't find local host name", e);
     }
-    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
-    return sourceKey != null && conf.isSet(sourceKey) ? conf.get(sourceKey) : hostName;
+    return hostName;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -196,9 +196,15 @@ public final class MetricsSystem {
       default:
         break;
     }
+    String hostName;
+    try {
+      hostName = NetworkAddressUtils.getLocalHostMetricName(sResolveTimeout);
+    } catch (RuntimeException e) {
+      hostName = "unhnown";
+      LOG.error("Can't find local host name", e.getMessage());
+    }
     AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
-    return sourceKey != null && conf.isSet(sourceKey)
-        ? conf.get(sourceKey) : NetworkAddressUtils.getLocalHostMetricName(sResolveTimeout);
+    return sourceKey != null && conf.isSet(sourceKey) ? conf.get(sourceKey) : hostName;
   }
 
   /**


### PR DESCRIPTION
Avoid throwing RuntimeException when hostname is not resolved on metrics reporting
Fix: https://github.com/Alluxio/alluxio/issues/12672