### PR TITLE
Rename native flag for fuse to fuse-native

### DIFF
--- a/integration/fuse/pom.xml
+++ b/integration/fuse/pom.xml
@@ -65,7 +65,7 @@
   </dependencies>
   <profiles>
     <profile>
-      <id>native</id>
+      <id>fuse-native</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>

--- a/integration/fuse/pom.xml
+++ b/integration/fuse/pom.xml
@@ -65,7 +65,7 @@
   </dependencies>
   <profiles>
     <profile>
-      <id>fuse-native</id>
+      <id>fuseNative</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>


### PR DESCRIPTION
other integrations may also have a similar `native` profile. renaming to `fuse-native` to distinguish