### PR TITLE
Write async persistent tmp file to sub-directory of mount point

### DIFF
--- a/core/base/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/base/src/main/java/alluxio/util/io/PathUtils.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -169,6 +170,56 @@ public final class PathUtils {
       return AlluxioURI.SEPARATOR;
     }
     return parent;
+  }
+
+  /**
+   * Join two path elements for ufs, separated by {@link AlluxioURI#SEPARATOR}.
+   *
+   * For example,
+   *
+   * <pre>
+   * {@code
+   * concatUfsPath("s3://myroot/", "filename").equals("s3://myroot/filename");
+   * concatUfsPath("s3://", "filename").equals("s3://filename");
+   * }
+   * </pre>
+   *
+   * @param base base path
+   * @param path path element to concatenate
+   * @return joined path
+   */
+  public static String concatUfsPath(String base, String path) {
+    Pattern basePattern = Pattern.compile("(...)\\/\\/");
+    // use conCatPath to join path if base is not starting with //
+    if (!basePattern.matcher(base).matches()) {
+      return concatPath(base, path);
+    } else {
+      Preconditions.checkArgument(base != null, "Failed to concatPath: base is null");
+      Preconditions.checkArgument(path != null, "Failed to concatPath: a null set of paths");
+      String trimmedPath = SEPARATOR_MATCHER.trimFrom(path);
+      StringBuilder output = new StringBuilder(base.length() + trimmedPath.length());
+      output.append(base);
+      output.append(trimmedPath);
+      return output.toString();
+    }
+  }
+
+  /**
+   * Get temp path for async persistence job.
+   *
+   * "s3://"
+   *
+   * @param path ufs path
+   * @return ufs temp path
+   */
+  public static String getPersistentTmpPath(String path) {
+    String tempPath;
+    String fileName = FilenameUtils.getName(path);
+    String parentPath = path.substring(0, path.length() - fileName.length());
+    tempPath = concatUfsPath(parentPath, "alluxio_persistent_job");
+    tempPath = concatPath(tempPath, fileName);
+    tempPath = temporaryFileName(System.currentTimeMillis(), tempPath);
+    return tempPath;
   }
 
   /**

--- a/core/base/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/base/src/main/java/alluxio/util/io/PathUtils.java
@@ -174,6 +174,22 @@ public final class PathUtils {
   }
 
   /**
+   * Gets the parent of the the file at a ufs path.
+   *
+   * @param path the ufs path
+   * @return the parent path of the file; this is "/" if the given path is the root
+   */
+  public static String getUfsParent(String path) {
+    String name = FilenameUtils.getName(path);
+    String parent = path.substring(0, path.length() - name.length() - 1);
+    if (parent.isEmpty()) {
+      // The parent is the root path without any prefix.
+      return AlluxioURI.SEPARATOR;
+    }
+    return parent;
+  }
+
+  /**
    * Join two path elements for ufs, separated by {@link AlluxioURI#SEPARATOR}.
    *
    * For example,

--- a/core/base/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/base/src/main/java/alluxio/util/io/PathUtils.java
@@ -174,22 +174,6 @@ public final class PathUtils {
   }
 
   /**
-   * Gets the parent of the the file at a ufs path.
-   *
-   * @param path the ufs path
-   * @return the parent path of the file; this is "/" if the given path is the root
-   */
-  public static String getUfsParent(String path) {
-    String name = FilenameUtils.getName(path);
-    String parent = path.substring(0, path.length() - name.length() - 1);
-    if (parent.isEmpty()) {
-      // The parent is the root path without any prefix.
-      return AlluxioURI.SEPARATOR;
-    }
-    return parent;
-  }
-
-  /**
    * Join two path elements for ufs, separated by {@link AlluxioURI#SEPARATOR}.
    *
    * For example,

--- a/core/base/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/base/src/main/java/alluxio/util/io/PathUtils.java
@@ -215,11 +215,13 @@ public final class PathUtils {
     StringBuilder tempFilePath = new StringBuilder();
     StringBuilder tempFileName = new StringBuilder();
     String fileName = FilenameUtils.getName(path);
+    String timeStamp = String.valueOf(System.currentTimeMillis());
     tempFilePath.append(".alluxio_ufs_persistence/");
     String uuid = UUID.randomUUID().toString();
     tempFileName.append(fileName);
     tempFileName.append(".alluxio.");
-    tempFileName.append(uuid);
+    tempFileName.append(timeStamp);
+    tempFileName.append(String.format(".%s", uuid));
     tempFileName.append(".tmp");
     tempFilePath.append(tempFileName);
     return tempFilePath.toString();

--- a/core/base/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/base/src/main/java/alluxio/util/io/PathUtils.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -207,19 +208,21 @@ public final class PathUtils {
   /**
    * Get temp path for async persistence job.
    *
-   * "s3://"
-   *
    * @param path ufs path
-   * @return ufs temp path
+   * @return ufs temp path with UUID
    */
   public static String getPersistentTmpPath(String path) {
-    String tempPath;
+    StringBuilder tempFilePath = new StringBuilder();
+    StringBuilder tempFileName = new StringBuilder();
     String fileName = FilenameUtils.getName(path);
-    String parentPath = path.substring(0, path.length() - fileName.length());
-    tempPath = concatUfsPath(parentPath, "alluxio_persistent_job");
-    tempPath = concatPath(tempPath, fileName);
-    tempPath = temporaryFileName(System.currentTimeMillis(), tempPath);
-    return tempPath;
+    tempFilePath.append(".alluxio_ufs_persistence/");
+    String uuid = UUID.randomUUID().toString();
+    tempFileName.append(fileName);
+    tempFileName.append(".alluxio.");
+    tempFileName.append(uuid);
+    tempFileName.append(".tmp");
+    tempFilePath.append(tempFileName);
+    return tempFilePath.toString();
   }
 
   /**

--- a/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
@@ -245,19 +245,18 @@ public final class PathUtilsTest {
   public void getPersistentTmpPath() {
     // Get temporary path
     Pattern pattern = Pattern.compile(
-        "s3:\\/\\/test\\/alluxio_persistent_job\\/test\\.parquet\\.alluxio\\.\\w+\\.tmp");
+        "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\S+\\.tmp");
     String tempPersistencePath = PathUtils.getPersistentTmpPath("s3://test/test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
-    pattern = Pattern.compile(
-        "hdfs:\\/\\/localhost:9010\\/test\\/alluxio_persistent_job\\/test\\.parquet\\.alluxio\\.\\w+\\.tmp");
+    pattern = Pattern.compile("\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\S+\\.tmp");
     tempPersistencePath = PathUtils.getPersistentTmpPath("hdfs://localhost:9010/test/test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
 
     // Get temporary path with root path
-    pattern = Pattern.compile("s3:\\/\\/alluxio_persistent_job\\/test\\.parquet\\.alluxio\\.\\w+\\.tmp");
+    pattern = Pattern.compile("\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\S+\\.tmp");
     tempPersistencePath = PathUtils.getPersistentTmpPath("s3://test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
-    pattern = Pattern.compile("hdfs:\\/\\/localhost:9010\\/alluxio_persistent_job\\/test\\.parquet\\.alluxio\\.\\w+\\.tmp");
+    pattern = Pattern.compile("\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\S+\\.tmp");
     tempPersistencePath = PathUtils.getPersistentTmpPath("hdfs://localhost:9010/test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
   }

--- a/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
@@ -245,18 +245,21 @@ public final class PathUtilsTest {
   public void getPersistentTmpPath() {
     // Get temporary path
     Pattern pattern = Pattern.compile(
-        "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\S+\\.tmp");
+        "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
     String tempPersistencePath = PathUtils.getPersistentTmpPath("s3://test/test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
-    pattern = Pattern.compile("\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\S+\\.tmp");
+    pattern = Pattern.compile(
+        "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
     tempPersistencePath = PathUtils.getPersistentTmpPath("hdfs://localhost:9010/test/test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
 
     // Get temporary path with root path
-    pattern = Pattern.compile("\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\S+\\.tmp");
+    pattern = Pattern.compile(
+        "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
     tempPersistencePath = PathUtils.getPersistentTmpPath("s3://test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
-    pattern = Pattern.compile("\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\S+\\.tmp");
+    pattern = Pattern.compile(
+        "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
     tempPersistencePath = PathUtils.getPersistentTmpPath("hdfs://localhost:9010/test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
   }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3989,9 +3989,9 @@ public final class DefaultFileSystemMaster extends CoreMaster
                   Inode ancestorInode = ancestor.getSecond();
                   MkdirsOptions options = MkdirsOptions.defaults(ServerConfiguration.global())
                       .setCreateParent(false)
-                      .setOwner(inode.getOwner())
-                      .setGroup(inode.getGroup())
-                      .setMode(new Mode(inode.getMode()));
+                      .setOwner(ancestorInode.getOwner())
+                      .setGroup(ancestorInode.getGroup())
+                      .setMode(new Mode(ancestorInode.getMode()));
                   // UFS mkdirs might fail if the directory is already created.
                   // If so, skip the mkdirs and assume the directory is already prepared,
                   // regardless of permission matching.

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3971,7 +3971,9 @@ public final class DefaultFileSystemMaster extends CoreMaster
                 // check if the destination direction is valid
                 String ufsParentPath = PathUtils.getUfsParent(ufsPath);
                 if (!ufs.isExistingDirectory(ufsParentPath)) {
-                  ufs.create(ufsParentPath);
+                  LOG.info("There is not parent directory for {}. Create parent path {}.",
+                      ufsPath, tempUfsPath);
+                  ufs.mkdirs(ufsParentPath);
                 }
                 if (!ufs.renameRenamableFile(tempUfsPath, ufsPath)) {
                   throw new IOException(

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -180,7 +180,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import io.grpc.ServerInterceptors;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -3800,7 +3799,9 @@ public final class DefaultFileSystemMaster extends CoreMaster
         } else {
           // make temp path for temp file to avoid the
           // error reading (failure of temp file clean up)
-          tempUfsPath = PathUtils.getPersistentTmpPath(resolution.getUri().toString());
+          String mountPointUri = resolution.getUfsMountPointUri().toString();
+          tempUfsPath = PathUtils.concatUfsPath(mountPointUri,
+              PathUtils.getPersistentTmpPath(resolution.getUri().toString()));
           LOG.info("Temp file {} for File persistent.", tempUfsPath);
         }
       }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -180,6 +180,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import io.grpc.ServerInterceptors;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -3797,14 +3798,15 @@ public final class DefaultFileSystemMaster extends CoreMaster
             && ufsResource.get().isObjectStorage()) {
           tempUfsPath = resolution.getUri().toString();
         } else {
-          tempUfsPath = PathUtils.temporaryFileName(
-              System.currentTimeMillis(), resolution.getUri().toString());
+          // make temp path for temp file to avoid the
+          // error reading (failure of temp file clean up)
+          tempUfsPath = PathUtils.getPersistentTmpPath(resolution.getUri().toString());
+          LOG.info("Temp file {} for File persistent.", tempUfsPath);
         }
       }
 
       PersistConfig config =
           new PersistConfig(uri.getPath(), resolution.getMountId(), false, tempUfsPath);
-
       // Schedule the persist job.
       long jobId;
       JobMasterClient client = mJobMasterClientPool.acquire();

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3802,6 +3802,8 @@ public final class DefaultFileSystemMaster extends CoreMaster
           String mountPointUri = resolution.getUfsMountPointUri().toString();
           tempUfsPath = PathUtils.concatUfsPath(mountPointUri,
               PathUtils.getPersistentTmpPath(resolution.getUri().toString()));
+          LOG.debug("Generate tmp ufs path {} from ufs path {} for persistence.",
+              tempUfsPath, resolution.getUri().toString());
           LOG.info("Temp file {} for File persistent.", tempUfsPath);
         }
       }
@@ -3966,6 +3968,11 @@ public final class DefaultFileSystemMaster extends CoreMaster
                 // Make rename only when tempUfsPath is different from final ufsPath. Note that,
                 // on object store, we take the optimization to skip the rename by having
                 // tempUfsPath the same as final ufsPath.
+                // check if the destination direction is valid
+                String ufsParentPath = PathUtils.getUfsParent(ufsPath);
+                if (!ufs.isExistingDirectory(ufsParentPath)) {
+                  ufs.create(ufsParentPath);
+                }
                 if (!ufs.renameRenamableFile(tempUfsPath, ufsPath)) {
                   throw new IOException(
                       String.format("Failed to rename %s to %s.", tempUfsPath, ufsPath));

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -451,6 +451,13 @@ public final class MountTable implements DelegatingJournaled {
     }
 
     /**
+     * @return the mount uri in the ufs
+     */
+    public AlluxioURI getUfsMountPointUri() {
+      return mUfsClient.getUfsMountPointUri();
+    }
+
+    /**
      * @return the {@link UnderFileSystem} closeable resource
      */
     public CloseableResource<UnderFileSystem> acquireUfsResource() {

--- a/core/server/master/src/test/java/alluxio/master/file/PersistenceTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PersistenceTest.java
@@ -62,6 +62,7 @@ import alluxio.util.WaitForOptions;
 import alluxio.wire.FileInfo;
 import alluxio.worker.job.JobMasterClientContext;
 
+import org.apache.commons.io.FilenameUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -497,7 +498,8 @@ public final class PersistenceTest {
     PersistJob job = persistJobs.get(fileInfo.getFileId());
     Assert.assertEquals(fileInfo.getFileId(), job.getFileId());
     Assert.assertEquals(jobId, job.getId());
-    Assert.assertTrue(job.getTempUfsPath().contains(testFile.getPath()));
+    String fileName = FilenameUtils.getName(testFile.getPath());
+    Assert.assertTrue(job.getTempUfsPath().contains(fileName));
     Assert.assertEquals(
         PersistenceState.TO_BE_PERSISTED.toString(), fileInfo.getPersistenceState());
   }


### PR DESCRIPTION
Currently, Alluxio writes the temporary file of async persistence to the path, which is the same as the destination file path. The computing framework, like presto, will pick up the tmp files, which is leftover there for some reason, fail to clean up, etc.

This change writes the tmp file of async persistent to the sub dir of the mount point.