### PR TITLE
Fix ufs journal dumper input directory

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/journal/tool/JournalTool.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/JournalTool.java
@@ -44,19 +44,26 @@ public final class JournalTool {
   private static final Logger LOG = LoggerFactory.getLogger(JournalTool.class);
   private static final int EXIT_FAILED = -1;
   private static final int EXIT_SUCCEEDED = 0;
+  private static final String HELP_OPTION_NAME = "help";
+  private static final String MASTER_OPTION_NAME = "master";
+  private static final String START_OPTION_NAME = "start";
+  private static final String END_OPTION_NAME = "end";
+  private static final String INPUT_DIR_OPTION_NAME = "inputDir";
+  private static final String OUTPUT_DIR_OPTION_NAME = "outputDir";
+
   private static final Options OPTIONS = new Options()
-      .addOption("help", false, "Show help for this command.")
-      .addOption("master", true,
+      .addOption(HELP_OPTION_NAME, false, "Show help for this command.")
+      .addOption(MASTER_OPTION_NAME, true,
           "The name of the master (e.g. FileSystemMaster, BlockMaster). "
               + "Set to FileSystemMaster by default.")
-      .addOption("start", true,
+      .addOption(START_OPTION_NAME, true,
           "The start log sequence number (inclusive). Set to 0 by default.")
-      .addOption("end", true,
+      .addOption(END_OPTION_NAME, true,
           "The end log sequence number (exclusive). Set to +inf by default.")
-      .addOption("inputDir", true,
+      .addOption(INPUT_DIR_OPTION_NAME, true,
           "The input directory on-disk to read journal content from. "
               + "(Default: Read from system configuration.)")
-      .addOption("outputDir", true,
+      .addOption(OUTPUT_DIR_OPTION_NAME, true,
           "The output directory to write journal content to. "
           + "(Default: journal_dump-${timestamp})");
 
@@ -130,15 +137,17 @@ public final class JournalTool {
       System.out.println("Failed to parse input args: " + e);
       return false;
     }
-    sHelp = cmd.hasOption("help");
-    sMaster = cmd.getOptionValue("master", "FileSystemMaster");
-    sStart = Long.decode(cmd.getOptionValue("start", "0"));
-    sEnd = Long.decode(cmd.getOptionValue("end", Long.valueOf(Long.MAX_VALUE).toString()));
-    sInputDir = new File(
-        cmd.getOptionValue("inputDir", ServerConfiguration.get(PropertyKey.MASTER_JOURNAL_FOLDER)))
-            .getAbsolutePath();
+    sHelp = cmd.hasOption(HELP_OPTION_NAME);
+    sMaster = cmd.getOptionValue(MASTER_OPTION_NAME, "FileSystemMaster");
+    sStart = Long.decode(cmd.getOptionValue(START_OPTION_NAME, "0"));
+    sEnd = Long.decode(cmd.getOptionValue(END_OPTION_NAME, Long.valueOf(Long.MAX_VALUE).toString()));
+    if (cmd.hasOption(INPUT_DIR_OPTION_NAME)) {
+      sInputDir = new File(cmd.getOptionValue(INPUT_DIR_OPTION_NAME)).getAbsolutePath();
+    } else {
+      sInputDir = ServerConfiguration.get(PropertyKey.MASTER_JOURNAL_FOLDER);
+    }
     sOutputDir =
-        new File(cmd.getOptionValue("outputDir", "journal_dump-" + System.currentTimeMillis()))
+        new File(cmd.getOptionValue(OUTPUT_DIR_OPTION_NAME, "journal_dump-" + System.currentTimeMillis()))
             .getAbsolutePath();
     return true;
   }

--- a/core/server/master/src/main/java/alluxio/master/journal/tool/JournalTool.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/JournalTool.java
@@ -140,15 +140,15 @@ public final class JournalTool {
     sHelp = cmd.hasOption(HELP_OPTION_NAME);
     sMaster = cmd.getOptionValue(MASTER_OPTION_NAME, "FileSystemMaster");
     sStart = Long.decode(cmd.getOptionValue(START_OPTION_NAME, "0"));
-    sEnd = Long.decode(cmd.getOptionValue(END_OPTION_NAME, Long.valueOf(Long.MAX_VALUE).toString()));
+    sEnd = Long.decode(cmd.getOptionValue(END_OPTION_NAME, Long.valueOf(Long.MAX_VALUE)
+        .toString()));
     if (cmd.hasOption(INPUT_DIR_OPTION_NAME)) {
       sInputDir = new File(cmd.getOptionValue(INPUT_DIR_OPTION_NAME)).getAbsolutePath();
     } else {
       sInputDir = ServerConfiguration.get(PropertyKey.MASTER_JOURNAL_FOLDER);
     }
-    sOutputDir =
-        new File(cmd.getOptionValue(OUTPUT_DIR_OPTION_NAME, "journal_dump-" + System.currentTimeMillis()))
-            .getAbsolutePath();
+    sOutputDir = new File(cmd.getOptionValue(OUTPUT_DIR_OPTION_NAME,
+        "journal_dump-" + System.currentTimeMillis())).getAbsolutePath();
     return true;
   }
 

--- a/core/server/master/src/test/java/alluxio/master/journal/tool/JournalToolTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/tool/JournalToolTest.java
@@ -1,0 +1,81 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.journal.tool;
+
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.master.journal.JournalType;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.nio.file.Paths;
+
+/**
+ * Tests for {@link JournalToolTest}.
+ */
+@PrepareForTest({JournalTool.class})
+@RunWith(PowerMockRunner.class)
+public class JournalToolTest {
+
+  @Before
+  public void before() throws Exception {
+    ServerConfiguration.reset();
+    PowerMockito.spy(JournalTool.class);
+    PowerMockito.doNothing().when(JournalTool.class, "dumpJournal");
+  }
+
+  @Test
+  public void defaultJournalDir() throws Throwable {
+    JournalTool.main(new String[0]);
+    String inputUri = Whitebox.getInternalState(JournalTool.class, "sInputDir");
+    Assert.assertEquals(ServerConfiguration.get(PropertyKey.MASTER_JOURNAL_FOLDER), inputUri);
+  }
+
+  @Test
+  public void hdfsJournalDir() throws Throwable {
+    String journalPath = "hdfs://namenode:port/alluxio/journal";
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_FOLDER, journalPath);
+
+    JournalTool.main(new String[0]);
+    String inputUri = Whitebox.getInternalState(JournalTool.class, "sInputDir");
+    Assert.assertEquals(journalPath, inputUri);
+  }
+
+  @Test
+  public void absoluteLocalJournalInput() throws Throwable {
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.EMBEDDED);
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_FOLDER,
+        "hdfs://namenode:port/alluxio/journal");
+
+    String journalPath = "/path/to/local/file";
+    JournalTool.main(new String[]{"-inputDir", journalPath});
+    String inputUri = Whitebox.getInternalState(JournalTool.class, "sInputDir");
+    Assert.assertEquals(journalPath, inputUri);
+  }
+
+  @Test
+  public void relativeLocalJournalInput() throws Throwable {
+    String journalPath = "fileA";
+    JournalTool.main(new String[]{"-inputDir", journalPath});
+    String inputUri = Whitebox.getInternalState(JournalTool.class, "sInputDir");
+    Assert.assertEquals(
+        Paths.get(System.getProperty("user.dir"), journalPath).toString(), inputUri);
+  }
+}


### PR DESCRIPTION
The journal dumper is broken when running against non-local UFS journal like HDFS.
The inputDir was new File(HDFSUri).getAbsolutePath() which is invalid.
