### PR TITLE
Fix backup lock acquisition

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1465,7 +1465,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT =
       new Builder(Name.MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT)
-          .setDefaultValue("12h")
+          .setDefaultValue("2h")
           .setDescription("The max duration for a grace-cycle.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1822,10 +1822,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL =
       new Builder(Name.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL)
-          .setAlias("alluxio.master.worker.heartbeat.interval")
           .setDefaultValue("5min")
+          .setDescription("The interval between Alluxio master detections to find lost "
+              + "files based on updates from Alluxio workers.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey MASTER_LOST_WORKER_DETECTION_INTERVAL =
+      new Builder(Name.MASTER_LOST_WORKER_DETECTION_INTERVAL)
+          .setDefaultValue("10sec")
           .setDescription("The interval between Alluxio master detections to find lost workers "
-              + "and files based on updates from Alluxio workers.")
+              + "based on updates from Alluxio workers.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
@@ -5147,6 +5154,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_FORMAT_FILE_PREFIX = "alluxio.master.format.file.prefix";
     public static final String MASTER_STANDBY_HEARTBEAT_INTERVAL =
         "alluxio.master.standby.heartbeat.interval";
+    public static final String MASTER_LOST_WORKER_DETECTION_INTERVAL =
+        "alluxio.master.lost.worker.detection.interval";
     public static final String MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL =
         "alluxio.master.lost.worker.file.detection.interval";
     public static final String MASTER_HEARTBEAT_TIMEOUT =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1465,7 +1465,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT =
       new Builder(Name.MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT)
-          .setDefaultValue("2h")
+          .setDefaultValue("12h")
           .setDescription("The max duration for a grace-cycle.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
@@ -1823,7 +1823,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL =
       new Builder(Name.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL)
           .setAlias("alluxio.master.worker.heartbeat.interval")
-          .setDefaultValue("10sec")
+          .setDefaultValue("5min")
           .setDescription("The interval between Alluxio master detections to find lost workers "
               + "and files based on updates from Alluxio workers.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1831,6 +1831,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey MASTER_LOST_WORKER_DETECTION_INTERVAL =
       new Builder(Name.MASTER_LOST_WORKER_DETECTION_INTERVAL)
           .setDefaultValue("10sec")
+          .setAlias("alluxio.master.worker.heartbeat.interval")
           .setDescription("The interval between Alluxio master detections to find lost workers "
               + "based on updates from Alluxio workers.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)

--- a/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
@@ -121,6 +121,7 @@ public final class ConfigurationTestUtils {
         PathUtils.concatPath(System.getProperty("user.dir"), "../webui"));
     conf.put(PropertyKey.WORKER_RAMDISK_SIZE, "100MB");
     conf.put(PropertyKey.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL, "15ms");
+    conf.put(PropertyKey.MASTER_LOST_WORKER_DETECTION_INTERVAL, "15ms");
     conf.put(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "15ms");
     conf.put(PropertyKey.WORKER_NETWORK_NETTY_WORKER_THREADS, "2");
 

--- a/core/server/common/src/main/java/alluxio/master/StateLockManager.java
+++ b/core/server/common/src/main/java/alluxio/master/StateLockManager.java
@@ -211,9 +211,10 @@ public class StateLockManager {
           throw new TimeoutException(ExceptionMessage.STATE_LOCK_TIMED_OUT
               .getMessage(lockOptions.getGraceCycleTimeoutMs() + mForcedDurationMs));
         }
-      } finally {
-        // Deactivate interrupter if active.
+      } catch (Throwable throwable) {
+        // Deactivate interrupter if lock acquisition was not successful.
         deactivateInterruptCycle();
+        throw throwable;
       }
     }
 

--- a/core/server/common/src/main/java/alluxio/master/StateLockManager.java
+++ b/core/server/common/src/main/java/alluxio/master/StateLockManager.java
@@ -142,10 +142,6 @@ public class StateLockManager {
           exclusiveOnlyRemainingMs, PropertyKey.Name.MASTER_BACKUP_STATE_LOCK_EXCLUSIVE_DURATION);
       throw new IllegalStateException(safeModeMsg);
     }
-    // Check if the active interrupt cycle is on, we do not try to obtain the shared lock
-    if (mInterrupterFuture != null) {
-      throw new InterruptedException("Active Interrupt Cycle is on, Do not acquire shared lock");
-    }
     // Register thread for interrupt cycle.
     mSharedWaitersAndHolders.add(Thread.currentThread());
     // Grab the lock interruptibly.

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -374,7 +374,7 @@ public final class DefaultBlockMaster extends CoreMaster implements BlockMaster 
     if (isLeader) {
       mLostWorkerDetectionService = getExecutorService().submit(new HeartbeatThread(
           HeartbeatContext.MASTER_LOST_WORKER_DETECTION, new LostWorkerDetectionHeartbeatExecutor(),
-          (int) ServerConfiguration.getMs(PropertyKey.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL),
+          (int) ServerConfiguration.getMs(PropertyKey.MASTER_LOST_WORKER_DETECTION_INTERVAL),
           ServerConfiguration.global(), mMasterContext.getUserState()));
     }
   }

--- a/core/server/master/src/test/java/alluxio/master/journal/JournalContextTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/JournalContextTest.java
@@ -155,6 +155,8 @@ public class JournalContextTest {
       CommonUtils.waitFor("journal context created", journalContextCreated::get,
           WaitForOptions.defaults().setTimeoutMs(5 * Constants.SECOND_MS).setInterval(10));
     } finally {
+      thread.interrupt();
+      thread.join();
       thread2.interrupt();
       thread2.join();
     }

--- a/core/server/master/src/test/java/alluxio/master/journal/JournalContextTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/JournalContextTest.java
@@ -131,15 +131,17 @@ public class JournalContextTest {
         mMasterContext.getStateLockManager().lockExclusive(StateLockOptions.defaults());
 
     AtomicBoolean journalContextCreated = new AtomicBoolean(false);
-
-    Thread thread = new Thread(() -> {
+    Runnable run = () -> {
       // new journal contexts should be blocked
       try (JournalContext journalContext = mBlockMaster.createJournalContext()) {
         journalContextCreated.set(true);
       } catch (UnavailableException e) {
         throw new RuntimeException("Failed to create journal context", e);
       }
-    });
+    };
+
+    Thread thread = new Thread(run);
+    Thread thread2 = new Thread(run);
     thread.start();
 
     try {
@@ -149,11 +151,12 @@ public class JournalContextTest {
 
       // after un-pausing, new journal contexts can be created
       lock.close();
+      thread2.run();
       CommonUtils.waitFor("journal context created", journalContextCreated::get,
           WaitForOptions.defaults().setTimeoutMs(5 * Constants.SECOND_MS).setInterval(10));
     } finally {
-      thread.interrupt();
-      thread.join();
+      thread2.interrupt();
+      thread2.join();
     }
   }
 

--- a/tests/src/test/java/alluxio/client/fs/io/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileOutStreamIntegrationTest.java
@@ -238,7 +238,7 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
       os.cancel();
     }
     long gracePeriod = ServerConfiguration
-        .getMs(PropertyKey.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL) * 2;
+        .getMs(PropertyKey.MASTER_LOST_WORKER_DETECTION_INTERVAL) * 2;
     CommonUtils.sleepMs(gracePeriod);
     List<WorkerInfo> workers =
         mLocalAlluxioClusterResource.get().getLocalAlluxioMaster().getMasterProcess()


### PR DESCRIPTION
This PR disables the interruption threads once we give up on the back up process. Previous behavior causes all future RPCs to fail because it is not able to obtain shared state lock.

This PR also updates the default value for alluxio.master.lost.worker.file.detection.interval to 5mins from 10secs.