### PR TITLE
Fix backup suspend timeout

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1369,6 +1369,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_BACKUP_SUSPEND_TIMEOUT =
+      new Builder(Name.MASTER_BACKUP_SUSPEND_TIMEOUT)
+          .setDefaultValue("1min")
+          .setDescription("Timeout for when suspend request is not followed by a backup request.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_DAILY_BACKUP_ENABLED =
       new Builder(Name.MASTER_DAILY_BACKUP_ENABLED)
           .setDefaultValue(false)
@@ -5113,6 +5120,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.backup.state.lock.forced.duration";
     public static final String MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_INTERVAL =
         "alluxio.master.backup.state.lock.interrupt.cycle.interval";
+    public static final String MASTER_BACKUP_SUSPEND_TIMEOUT =
+        "alluxio.master.backup.suspend.timeout";
     public static final String MASTER_SHELL_BACKUP_STATE_LOCK_GRACE_MODE =
         "alluxio.master.shell.backup.state.lock.grace.mode";
     public static final String MASTER_SHELL_BACKUP_STATE_LOCK_TRY_DURATION =

--- a/core/server/common/src/main/java/alluxio/master/StateLockManager.java
+++ b/core/server/common/src/main/java/alluxio/master/StateLockManager.java
@@ -16,6 +16,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.resource.LockResource;
+import alluxio.retry.RetryUtils;
 import alluxio.util.ThreadFactoryUtils;
 import alluxio.util.ThreadUtils;
 
@@ -23,6 +24,7 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -162,7 +164,24 @@ public class StateLockManager {
    * @throws InterruptedException if interrupting during locking
    */
   public LockResource lockExclusive(StateLockOptions lockOptions)
-      throws TimeoutException, InterruptedException {
+      throws TimeoutException, InterruptedException, IOException {
+    return lockExclusive(lockOptions, null);
+  }
+
+  /**
+   * Locks the state exclusively.
+   *
+   * @param lockOptions exclusive lock options
+   * @param beforeAttempt a function which runs before each lock attempt and returns whether the
+   *                      lock should continue
+   * @return the lock resource
+   * @throws TimeoutException if locking times out
+   * @throws InterruptedException if interrupting during locking
+   * @throws IOException if the beforeAttempt functions fails
+   */
+  public LockResource lockExclusive(StateLockOptions lockOptions,
+      RetryUtils.RunnableThrowsIOException beforeAttempt)
+      throws TimeoutException, InterruptedException, IOException {
     LOG.debug("Thread-{} entered lockExclusive().", ThreadUtils.getCurrentThreadIdentifier());
     // Run the grace cycle.
     StateLockOptions.GraceMode graceMode = lockOptions.getGraceMode();
@@ -175,6 +194,9 @@ public class StateLockManager {
         LOG.info("Thread-{} entered grace-cycle of try-sleep: {}ms-{}ms for the total of {}ms",
             ThreadUtils.getCurrentThreadIdentifier(), lockOptions.getGraceCycleTryMs(),
             lockOptions.getGraceCycleSleepMs(), lockOptions.getGraceCycleTimeoutMs());
+      }
+      if (beforeAttempt != null) {
+        beforeAttempt.run();
       }
       if (mStateLock.writeLock().tryLock(lockOptions.getGraceCycleTryMs(), TimeUnit.MILLISECONDS)) {
         lockAcquired = true;
@@ -203,6 +225,9 @@ public class StateLockManager {
           mSharedWaitersAndHolders.stream().map((th) -> Long.toString(th.getId()))
               .collect(Collectors.joining(",")));
       try {
+        if (beforeAttempt != null) {
+          beforeAttempt.run();
+        }
         if (!mStateLock.writeLock().tryLock(mForcedDurationMs, TimeUnit.MILLISECONDS)) {
           throw new TimeoutException(ExceptionMessage.STATE_LOCK_TIMED_OUT
               .getMessage(lockOptions.getGraceCycleTimeoutMs() + mForcedDurationMs));

--- a/core/server/master/src/main/java/alluxio/master/backup/BackupLeaderRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupLeaderRole.java
@@ -285,6 +285,7 @@ public class BackupLeaderRole extends AbstractBackupRole {
         Map<String, Long> journalSequences;
         try (LockResource stateLockResource = mStateLockManager.lockExclusive(stateLockOptions,
             () -> {
+              // Suspend journals on current follower for every lock attempt.
               LOG.info("Suspending journals at backup-worker: {}", workerEntry.getValue());
               sendMessageBlocking(workerEntry.getKey(), new BackupSuspendMessage());
             })) {


### PR DESCRIPTION
Currently delegated backup would timeout on suspend when the primary master takes long time to acquire exclusive lock during busy hours. This change adds a function in state lock manager to allow suspend of journal before every retry of lock, which should greatly improve the chance of keeping secondary master ready during the locking stage.