### PR TITLE
Bump version of proto-backwards-compatibility plugin to 1.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
       <dependency>
         <groupId>com.salesforce.servicelibs</groupId>
         <artifactId>proto-backwards-compatibility</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.6</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>


### PR DESCRIPTION
Bump version of proto-backwards-compatibility plugin to 1.0.6 to support ARM64 platform