### PR TITLE
Convert the configuration files to mount options when Mount

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,6 +470,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-common</artifactId>
+        <version>${hadoop.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-minicluster</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -67,6 +67,16 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>jsr311-api</artifactId>
+          <groupId>javax.ws.rs</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
     <!-- Internal dependencies -->
     <dependency>

--- a/shell/src/main/java/alluxio/cli/fs/command/MountCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/MountCommand.java
@@ -24,6 +24,8 @@ import com.google.common.collect.Maps;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 import java.util.Map;
@@ -62,6 +64,14 @@ public final class MountCommand extends AbstractFileSystemCommand {
           .valueSeparator('=')
           .desc("options associated with this mount point")
           .build();
+  private static final Option CONFIG_FILE_OPTION =
+      Option.builder()
+          .longOpt("cfgfile")
+          .required(false)
+          .hasArg(true)
+          .numberOfArgs(1)
+          .desc("config file path associated with this mount point")
+          .build();
 
   /**
    * @param fsContext the filesystem of Alluxio
@@ -78,7 +88,7 @@ public final class MountCommand extends AbstractFileSystemCommand {
   @Override
   public Options getOptions() {
     return new Options().addOption(READONLY_OPTION).addOption(SHARED_OPTION)
-        .addOption(OPTION_OPTION);
+        .addOption(OPTION_OPTION).addOption(CONFIG_FILE_OPTION);
   }
 
   @Override
@@ -99,6 +109,16 @@ public final class MountCommand extends AbstractFileSystemCommand {
     if (cl.hasOption(SHARED_OPTION.getLongOpt())) {
       optionsBuilder.setShared(true);
     }
+    if (cl.hasOption(CONFIG_FILE_OPTION.getLongOpt())) {
+      String[] cfgFiles = cl.getOptionValues(CONFIG_FILE_OPTION.getLongOpt());
+      Configuration hdfsConf = new Configuration(false);
+      for (String path : cfgFiles) {
+        if (!path.isEmpty()) {
+          hdfsConf.addResource(new Path(path));
+        }
+      }
+      optionsBuilder.putAllProperties(hdfsConf.getPropsWithPrefix(""));
+    }
     if (cl.hasOption(OPTION_OPTION.getLongOpt())) {
       Properties properties = cl.getOptionProperties(OPTION_OPTION.getLongOpt());
       optionsBuilder.putAllProperties(Maps.fromProperties(properties));
@@ -110,7 +130,8 @@ public final class MountCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "mount [--readonly] [--shared] [--option <key=val>] <alluxioPath> <ufsURI>";
+    return "mount [--readonly] [--shared] [--option <key=val>] [--cfgfile <cfgFilePath>] "
+        + "<alluxioPath> <ufsURI>";
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/MountCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/MountCommand.java
@@ -64,13 +64,13 @@ public final class MountCommand extends AbstractFileSystemCommand {
           .valueSeparator('=')
           .desc("options associated with this mount point")
           .build();
-  private static final Option CONFIG_FILE_OPTION =
+  private static final Option HDFS_CONF_OPTION =
       Option.builder()
-          .longOpt("cfgfile")
+          .longOpt("hdfsconf")
           .required(false)
           .hasArg(true)
           .numberOfArgs(1)
-          .desc("config file path associated with this mount point")
+          .desc("path to its config files for an HDFS mount point")
           .build();
 
   /**
@@ -88,7 +88,7 @@ public final class MountCommand extends AbstractFileSystemCommand {
   @Override
   public Options getOptions() {
     return new Options().addOption(READONLY_OPTION).addOption(SHARED_OPTION)
-        .addOption(OPTION_OPTION).addOption(CONFIG_FILE_OPTION);
+        .addOption(OPTION_OPTION).addOption(HDFS_CONF_OPTION);
   }
 
   @Override
@@ -109,8 +109,8 @@ public final class MountCommand extends AbstractFileSystemCommand {
     if (cl.hasOption(SHARED_OPTION.getLongOpt())) {
       optionsBuilder.setShared(true);
     }
-    if (cl.hasOption(CONFIG_FILE_OPTION.getLongOpt())) {
-      String[] cfgFiles = cl.getOptionValues(CONFIG_FILE_OPTION.getLongOpt());
+    if (cl.hasOption(HDFS_CONF_OPTION.getLongOpt())) {
+      String[] cfgFiles = cl.getOptionValues(HDFS_CONF_OPTION.getLongOpt());
       Configuration hdfsConf = new Configuration(false);
       for (String path : cfgFiles) {
         if (!path.isEmpty()) {
@@ -130,7 +130,7 @@ public final class MountCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "mount [--readonly] [--shared] [--option <key=val>] [--cfgfile <cfgFilePath>] "
+    return "mount [--readonly] [--shared] [--option <key=val>] [--hdfsconf <hdfsConfigFilePath>] "
         + "<alluxioPath> <ufsURI>";
   }
 


### PR DESCRIPTION
Fixes #12599

If the `alluxio.underfs.hdfs.configuration` mount option start with "kv@", then extract the key value to mount options.