### PR TITLE
Prevent leader from writing to embedded journal after stepping down

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1599,7 +1599,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED)
           .setDefaultValue(false)
-          .setDescription("Whether the journal writer will write to remote master.")
+          .setDescription("Whether the journal writer will write to remote master. This is "
+              + "disabled by default and should not be turned on unless Alluxio encounters issues "
+              + "with local journal write.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .setIsHidden(true)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1596,6 +1596,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED =
+      new Builder(Name.MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("Whether the journal writer will write to remote master.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .setIsHidden(true)
+          .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_WRITE_TIMEOUT =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_WRITE_TIMEOUT)
           .setDefaultValue("30sec")
@@ -5151,6 +5159,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.embedded.journal.shutdown.timeout";
     public static final String MASTER_EMBEDDED_JOURNAL_WRITE_LOCAL_FIRST_ENABLED =
         "alluxio.master.embedded.journal.write.local.first.enabled";
+    public static final String MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED =
+        "alluxio.master.embedded.journal.write.remote.enabled";
     public static final String MASTER_EMBEDDED_JOURNAL_WRITE_TIMEOUT =
         "alluxio.master.embedded.journal.write.timeout";
     public static final String MASTER_EMBEDDED_JOURNAL_SNAPSHOT_REPLICATION_CHUNK_SIZE =

--- a/core/server/common/src/main/java/alluxio/master/journal/MasterJournalContext.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/MasterJournalContext.java
@@ -21,6 +21,7 @@ import alluxio.retry.RetryPolicy;
 import alluxio.retry.TimeoutRetry;
 
 import com.google.common.base.Preconditions;
+import org.apache.ratis.protocol.NotLeaderException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,11 +75,11 @@ public final class MasterJournalContext implements JournalContext {
       try {
         mAsyncJournalWriter.flush(mFlushCounter);
         return;
-      } catch (IOException e) {
-        LOG.warn("Journal flush failed. retrying...", e);
-      } catch (JournalClosedException e) {
+      } catch (NotLeaderException | JournalClosedException e) {
         throw new UnavailableException(String.format("Failed to complete request: %s",
             e.getMessage()), e);
+      } catch (IOException e) {
+        LOG.warn("Journal flush failed. retrying...", e);
       } catch (Throwable e) {
         ProcessUtils.fatalError(LOG, e, "Journal flush failed");
       }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
@@ -44,7 +44,7 @@ public class LocalFirstRaftClient implements Closeable {
   private final Supplier<RaftClient> mClientSupplier;
   private ClientId mLocalClientId;
   private volatile RaftClient mClient;
-  private boolean mEnableRemoteClient = false;
+  private boolean mEnableRemoteClient;
 
   /**
    * @param server the local raft server
@@ -57,6 +57,8 @@ public class LocalFirstRaftClient implements Closeable {
     mServer = server;
     mClientSupplier = clientSupplier;
     mLocalClientId = localClientId;
+    mEnableRemoteClient = configuration.getBoolean(
+        PropertyKey.MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED);
     if (mEnableRemoteClient && !configuration.getBoolean(
         PropertyKey.MASTER_EMBEDDED_JOURNAL_WRITE_LOCAL_FIRST_ENABLED)) {
       ensureClient();

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
@@ -44,6 +44,7 @@ public class LocalFirstRaftClient implements Closeable {
   private final Supplier<RaftClient> mClientSupplier;
   private ClientId mLocalClientId;
   private volatile RaftClient mClient;
+  private boolean mEnableRemoteClient = false;
 
   /**
    * @param server the local raft server
@@ -56,7 +57,8 @@ public class LocalFirstRaftClient implements Closeable {
     mServer = server;
     mClientSupplier = clientSupplier;
     mLocalClientId = localClientId;
-    if (!configuration.getBoolean(PropertyKey.MASTER_EMBEDDED_JOURNAL_WRITE_LOCAL_FIRST_ENABLED)) {
+    if (mEnableRemoteClient && !configuration.getBoolean(
+        PropertyKey.MASTER_EMBEDDED_JOURNAL_WRITE_LOCAL_FIRST_ENABLED)) {
       ensureClient();
     }
   }
@@ -70,7 +72,7 @@ public class LocalFirstRaftClient implements Closeable {
    */
   public CompletableFuture<RaftClientReply> sendAsync(Message message,
       TimeDuration timeout) throws IOException {
-    if (mClient == null) {
+    if (!mEnableRemoteClient || mClient == null) {
       return sendLocalRequest(message, timeout);
     } else {
       return sendRemoteRequest(message);
@@ -89,7 +91,7 @@ public class LocalFirstRaftClient implements Closeable {
   private RaftClientReply handleLocalException(Message message, RaftClientReply reply,
       TimeDuration timeout) {
     LOG.trace("Message {} received reply {}", message, reply);
-    if (reply.getException() != null) {
+    if (mEnableRemoteClient && reply.getException() != null) {
       if (reply.getException() instanceof NotLeaderException) {
         LOG.info("Local master is no longer a leader, falling back to remote client.");
         try {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -855,4 +855,9 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     mPrimarySelector.notifyStateChanged(
         isLeader ? PrimarySelector.State.PRIMARY : PrimarySelector.State.SECONDARY);
   }
+
+  @VisibleForTesting
+  synchronized RaftServer getRaftServer() {
+    return mServer;
+  }
 }

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -79,8 +79,6 @@ public class RaftJournalTest {
       mFollowerJournalSystem = journalSystems.get(0);
     }
     // Transition primary journal to primacy state.
-//    mFollowerJournalSystem.notifyLeadershipStateChanged(false);
-//    mLeaderJournalSystem.notifyLeadershipStateChanged(true);
     mLeaderJournalSystem.gainPrimacy();
   }
 

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -454,16 +454,17 @@ public class RaftJournalTest {
       CommonUtils.waitFor("Advancing to start.", () -> countingMaster.getApplyCount() > 0,
           mWaitOptions);
 
-    // Gain primacy in follower journal and validate it catches up.
-    mLeaderJournalSystem.notifyLeadershipStateChanged(false);
-    mFollowerJournalSystem.notifyLeadershipStateChanged(true);
-    mFollowerJournalSystem.gainPrimacy();
-    // Can't use countingMaster because Raft stops applying entries for primary journals.
-    // Using JournalSystem#getCurrentSequences() API instead.
-    CommonUtils.waitFor(
-        "full state acquired after resume", () -> mFollowerJournalSystem.getCurrentSequenceNumbers()
-            .values().stream().distinct().collect(Collectors.toList()).get(0) == entryCount - 1,
-        mWaitOptions);
+      // Gain primacy in follower journal and validate it catches up.
+      mLeaderJournalSystem.notifyLeadershipStateChanged(false);
+      mFollowerJournalSystem.notifyLeadershipStateChanged(true);
+      mFollowerJournalSystem.gainPrimacy();
+      // Can't use countingMaster because Raft stops applying entries for primary journals.
+      // Using JournalSystem#getCurrentSequences() API instead.
+      CommonUtils.waitFor(
+          "full state acquired after resume",
+          () -> mFollowerJournalSystem.getCurrentSequenceNumbers()
+              .values().stream().distinct().collect(Collectors.toList()).get(0) == entryCount - 1,
+          mWaitOptions);
 
       // Follower should no longer be suspended after becoming primary.
       Assert.assertFalse(mFollowerJournalSystem.isSuspended());
@@ -528,7 +529,6 @@ public class RaftJournalTest {
     CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
     return journalSystems;
   }
-
 
   @VisibleForTesting
   void changeToCandidate(RaftJournalSystem journalSystem) throws Exception {

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.master.journal.raft;
 
+import alluxio.ConfigurationRule;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.QuorumServerInfo;
@@ -23,6 +24,9 @@ import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.network.NetworkAddressUtils;
 
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.ratis.server.impl.RaftServerImpl;
+import org.apache.ratis.server.impl.RaftServerProxy;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -31,6 +35,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.Closeable;
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.util.ArrayList;
@@ -66,18 +72,20 @@ public class RaftJournalTest {
     // Assign references for leader/follower journal systems.
     mLeaderJournalSystem = journalSystems.get(0);
     mFollowerJournalSystem = journalSystems.get(1);
+    CommonUtils.waitFor("a leader is elected",
+        () -> mFollowerJournalSystem.isLeader() || mLeaderJournalSystem.isLeader(), mWaitOptions);
     if (journalSystems.get(1).isLeader()) {
       mLeaderJournalSystem = journalSystems.get(1);
       mFollowerJournalSystem = journalSystems.get(0);
     }
     // Transition primary journal to primacy state.
-    mFollowerJournalSystem.notifyLeadershipStateChanged(false);
-    mLeaderJournalSystem.notifyLeadershipStateChanged(true);
+//    mFollowerJournalSystem.notifyLeadershipStateChanged(false);
+//    mLeaderJournalSystem.notifyLeadershipStateChanged(true);
     mLeaderJournalSystem.gainPrimacy();
   }
 
   @After
-  public void After() throws Exception {
+  public void after() throws Exception {
     mLeaderJournalSystem.stop();
     mFollowerJournalSystem.stop();
   }
@@ -342,9 +350,7 @@ public class RaftJournalTest {
     // Assert that no entries applied by suspended journal system.
     Assert.assertEquals(0, countingMaster.getApplyCount());
     // Gain primacy in follower journal and validate it catches up.
-    mLeaderJournalSystem.notifyLeadershipStateChanged(false);
-    mFollowerJournalSystem.notifyLeadershipStateChanged(true);
-    mFollowerJournalSystem.gainPrimacy();
+    promoteFollower();
     CommonUtils.waitFor(
         "full state acquired after resume", () -> mFollowerJournalSystem.getCurrentSequenceNumbers()
             .values().stream().distinct().collect(Collectors.toList()).get(0) == entryCount - 1,
@@ -384,9 +390,7 @@ public class RaftJournalTest {
 
     Assert.assertEquals(catchupIndex + 1, countingMaster.getApplyCount());
     // Gain primacy in follower journal and validate it catches up.
-    mLeaderJournalSystem.notifyLeadershipStateChanged(false);
-    mFollowerJournalSystem.notifyLeadershipStateChanged(true);
-    mFollowerJournalSystem.gainPrimacy();
+    promoteFollower();
     CommonUtils.waitFor("full state acquired after resume",
         () -> countingMaster.getApplyCount() == entryCount, mWaitOptions);
 
@@ -394,44 +398,61 @@ public class RaftJournalTest {
     Assert.assertFalse(mFollowerJournalSystem.isSuspended());
   }
 
+  private void promoteFollower() throws Exception {
+    System.out.printf("Leader is leader? %s", mLeaderJournalSystem.isLeader());
+    changeToFollower(mLeaderJournalSystem);
+    System.out.printf("Follower is leader? %s", mFollowerJournalSystem.isLeader());
+    changeToFollower(mLeaderJournalSystem);
+    changeToCandidate(mFollowerJournalSystem);
+    CommonUtils.waitFor("follower becomes leader",
+        () -> mFollowerJournalSystem.isLeader(), mWaitOptions);
+    mFollowerJournalSystem.gainPrimacy();
+  }
+
   @Test
   public void gainPrimacyDuringCatchup() throws Exception {
-    // Create a counting master implementation that counts how many journal entries it processed.
-    CountingDummyFileSystemMaster countingMaster = new CountingDummyFileSystemMaster();
-    mFollowerJournalSystem.createJournal(countingMaster);
+    // TODO(feng): remove this test when remote journal write is deprecated
+    after();
+    try (Closeable r = new ConfigurationRule(
+        PropertyKey.MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED, "true",
+        ServerConfiguration.global()).toResource()) {
+      before();
+      // Create a counting master implementation that counts how many journal entries it processed.
+      CountingDummyFileSystemMaster countingMaster = new CountingDummyFileSystemMaster();
+      mFollowerJournalSystem.createJournal(countingMaster);
 
-    // Using a large entry count for catching transition while in-progress.
-    final int entryCount = 100000;
+      // Using a large entry count for catching transition while in-progress.
+      final int entryCount = 100000;
 
-    // Suspend follower journal system.
-    mFollowerJournalSystem.suspend(null);
-    // Catch up follower journal to a large index to be able to transition while in progress.
-    final long catchupIndex = entryCount - 5;
-    Map<String, Long> backupSequences = new HashMap<>();
-    backupSequences.put("FileSystemMaster", catchupIndex);
-    CatchupFuture catchupFuture = mFollowerJournalSystem.catchup(backupSequences);
+      // Suspend follower journal system.
+      mFollowerJournalSystem.suspend(null);
+      // Catch up follower journal to a large index to be able to transition while in progress.
+      final long catchupIndex = entryCount - 5;
+      Map<String, Long> backupSequences = new HashMap<>();
+      backupSequences.put("FileSystemMaster", catchupIndex);
+      CatchupFuture catchupFuture = mFollowerJournalSystem.catchup(backupSequences);
 
-    // Create entries in parallel on the leader journal context.
-    // These will be replicated to follower journal context.
-    ForkJoinPool.commonPool().submit(() -> {
-      try (JournalContext journalContext =
-          mLeaderJournalSystem.createJournal(new NoopMaster()).createJournalContext()) {
-        for (int i = 0; i < entryCount; i++) {
-          journalContext
-              .append(
-                  alluxio.proto.journal.Journal.JournalEntry.newBuilder()
-                      .setInodeLastModificationTime(
-                          File.InodeLastModificationTimeEntry.newBuilder().setId(i).build())
-                      .build());
+      // Create entries in parallel on the leader journal context.
+      // These will be replicated to follower journal context.
+      ForkJoinPool.commonPool().submit(() -> {
+        try (JournalContext journalContext =
+                 mLeaderJournalSystem.createJournal(new NoopMaster()).createJournalContext()) {
+          for (int i = 0; i < entryCount; i++) {
+            journalContext
+                .append(
+                    alluxio.proto.journal.Journal.JournalEntry.newBuilder()
+                        .setInodeLastModificationTime(
+                            File.InodeLastModificationTimeEntry.newBuilder().setId(i).build())
+                        .build());
+          }
+        } catch (Exception e) {
+          Assert.fail(String.format("Failed while writing entries: %s", e.toString()));
         }
-      } catch (Exception e) {
-        Assert.fail(String.format("Failed while writing entries: %s", e.toString()));
-      }
-    });
+      });
 
-    // Wait until advancing starts.
-    CommonUtils.waitFor("Advancing to start.", () -> countingMaster.getApplyCount() > 0,
-        mWaitOptions);
+      // Wait until advancing starts.
+      CommonUtils.waitFor("Advancing to start.", () -> countingMaster.getApplyCount() > 0,
+          mWaitOptions);
 
     // Gain primacy in follower journal and validate it catches up.
     mLeaderJournalSystem.notifyLeadershipStateChanged(false);
@@ -444,8 +465,9 @@ public class RaftJournalTest {
             .values().stream().distinct().collect(Collectors.toList()).get(0) == entryCount - 1,
         mWaitOptions);
 
-    // Follower should no longer be suspended after becoming primary.
-    Assert.assertFalse(mFollowerJournalSystem.isSuspended());
+      // Follower should no longer be suspended after becoming primary.
+      Assert.assertFalse(mFollowerJournalSystem.isSuspended());
+    }
   }
 
   /**
@@ -505,6 +527,26 @@ public class RaftJournalTest {
     }
     CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
     return journalSystems;
+  }
+
+
+  @VisibleForTesting
+  void changeToCandidate(RaftJournalSystem journalSystem) throws Exception {
+    RaftServerImpl serverImpl = ((RaftServerProxy) journalSystem.getRaftServer()).getImpl(
+        RaftJournalSystem.RAFT_GROUP_ID);
+    Method method = serverImpl.getClass().getDeclaredMethod("changeToCandidate");
+    method.setAccessible(true);
+    method.invoke(serverImpl);
+  }
+
+  @VisibleForTesting
+  void changeToFollower(RaftJournalSystem journalSystem) throws Exception {
+    RaftServerImpl serverImpl = ((RaftServerProxy) journalSystem.getRaftServer()).getImpl(
+        RaftJournalSystem.RAFT_GROUP_ID);
+    Method method = serverImpl.getClass().getDeclaredMethod("changeToFollower",
+        long.class, boolean.class, Object.class);
+    method.setAccessible(true);
+    method.invoke(serverImpl, serverImpl.getState().getCurrentTerm(), true, "test");
   }
 
   /**


### PR DESCRIPTION
Existing Alluxio master with embedded journal will attempt to write to the quorum even after it stepped down in various failure situation, journaling a bunch of inconsistent master states as a result. Even though the new master has a catchup process to wait for these journal entries before serving request, there is a chance for the old leader to send it after the period ends and corrupt the journal.

This change updates the journal writer to only write to local raft server by default. This should prevent any remote write request from an old leader at the cost of some temporary request failures during the fail over.