### PR TITLE
Address race condition for async persist

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1260,6 +1260,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   /**
    * Master related properties.
    */
+  public static final PropertyKey MASTER_ASYNC_PERSIST_SIZE_VALIDATION =
+      new Builder(Name.MASTER_ASYNC_PERSIST_SIZE_VALIDATION)
+          .setDefaultValue(true)
+          .setDescription("Checks if the size of an async persist file matches the original file "
+              + "and fails the async persist job if not.")
+          .setIsHidden(true)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_AUDIT_LOGGING_ENABLED =
       new Builder(Name.MASTER_AUDIT_LOGGING_ENABLED)
           .setDefaultValue(false)
@@ -5108,6 +5117,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     //
     // Master related properties
     //
+    public static final String MASTER_ASYNC_PERSIST_SIZE_VALIDATION =
+        "alluxio.master.async.persist.size.validation";
     public static final String MASTER_AUDIT_LOGGING_ENABLED =
         "alluxio.master.audit.logging.enabled";
     public static final String MASTER_AUDIT_LOGGING_QUEUE_CAPACITY =

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3979,8 +3979,8 @@ public final class DefaultFileSystemMaster extends CoreMaster
                         + "length: %d, UFS actual length: %d. This may be due to a concurrent "
                         + "modification to the file in Alluxio space, in which case this error can "
                         + "be safely ignored as the persist will be retried. If the UFS length is "
-                        + "expected to be different than Alluxio length, set " +
-                        PropertyKey.Name.MASTER_ASYNC_PERSIST_SIZE_VALIDATION + " to false.",
+                        + "expected to be different than Alluxio length, set "
+                        + PropertyKey.Name.MASTER_ASYNC_PERSIST_SIZE_VALIDATION + " to false.",
                         tempUfsPath, inode.getLength(), status.getContentLength()));
                   }
                 }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3975,9 +3975,13 @@ public final class DefaultFileSystemMaster extends CoreMaster
                 if (ufsStatus.isFile()) {
                   UfsFileStatus status = (UfsFileStatus) ufsStatus;
                   if (status.getContentLength() != inode.getLength()) {
-                    throw new IOException(String.format("%s size does not match. Alluxio expected"
-                        + "length: %d, UFS actual length: %d", tempUfsPath,
-                        inode.getLength(), status.getContentLength()));
+                    throw new IOException(String.format("%s size does not match. Alluxio expected "
+                        + "length: %d, UFS actual length: %d. This may be due to a concurrent "
+                        + "modification to the file in Alluxio space, in which case this error can "
+                        + "be safely ignored as the persist will be retried. If the UFS length is "
+                        + "expected to be different than Alluxio length, set " +
+                        PropertyKey.Name.MASTER_ASYNC_PERSIST_SIZE_VALIDATION + " to false.",
+                        tempUfsPath, inode.getLength(), status.getContentLength()));
                   }
                 }
               }


### PR DESCRIPTION
Fixes a race condition where if a file is scheduled for async persist changes in between submitting the async persist request and starting the async persist request, the wrong data will be written for the original file.

I was able to reproduce this consistently with a unit test and adding a timing delay to the job service.
Not including the test because it would require a hook in the job service for timing delays, perhaps this is something we can add in the future when we have a framework for controlling timings between different services.

For reference the test:

```
  @Test
  public void persistMultiRename() throws Exception {
    String testFilePath = "/testPersist/multiRenameTestFile";
    FileSystemTestUtils.createByteFile(sFileSystem, testFilePath, WritePType.MUST_CACHE, 2);
    sFileSystem.persist(new AlluxioURI(testFilePath));
    CommonUtils.sleepMs(1000);
    sFileSystem.rename(new AlluxioURI(testFilePath), new AlluxioURI(testFilePath + 2));
    FileSystemTestUtils.createByteFile(sFileSystem, testFilePath, WritePType.MUST_CACHE, 1);
    CommonUtils.sleepMs(3000);
    sFileSystem.persist(new AlluxioURI(testFilePath));
    sFileSystem.rename(new AlluxioURI(testFilePath), new AlluxioURI(testFilePath + 1));
    for (int i = 2; i > 0; i--) {
      final AlluxioURI uri = new AlluxioURI(testFilePath + i);
      CommonUtils.waitFor("File to be persisted", () -> {
        try {
          return sFileSystem.getStatus(uri).isPersisted();
        } catch (Exception e) {
          return false;
        }
      }, WaitForOptions.defaults().setTimeoutMs(10000));
      checkFilePersisted(uri, i);
    }
  }
```

Without the fix this will result in writing two 1 byte files. With the fix, one job will fail and retry, on the retry the correct (renamed) path will be picked up and both files will have the appropriate length.

Adding a hidden flag to enable/disable and will remove in a later patch.