### PR TITLE
Add an option for active job count

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  * It provides handling for submitting multiple jobs and handling retries of them.
  */
 public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCommand {
-  private static final int DEFAULT_ACTIVE_JOBS = 3000;
+  protected static final int DEFAULT_ACTIVE_JOBS = 3000;
 
   protected List<JobAttempt> mSubmittedJobAttempts;
   protected int mActiveJobs;

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
@@ -49,15 +49,16 @@ import javax.annotation.concurrent.ThreadSafe;
 public class DistributedCpCommand extends AbstractDistributedJobCommand {
   private String mWriteType;
 
-  private static final Option JOB_COUNT_OPTION =
+  private static final Option ACTIVE_JOB_COUNT_OPTION =
       Option.builder()
-          .longOpt("job-count")
+          .longOpt("active-jobs")
           .required(false)
           .hasArg(true)
           .numberOfArgs(1)
           .type(Number.class)
-          .argName("job count")
-          .desc("Number of active jobs to run at the same time"
+          .argName("active job count")
+          .desc("Number of active jobs that can run at the same time. Later jobs must wait. "
+                  + "The default upper limit is "
                   + AbstractDistributedJobCommand.DEFAULT_ACTIVE_JOBS)
           .build();
 
@@ -75,7 +76,7 @@ public class DistributedCpCommand extends AbstractDistributedJobCommand {
 
   @Override
   public Options getOptions() {
-    return new Options().addOption(JOB_COUNT_OPTION);
+    return new Options().addOption(ACTIVE_JOB_COUNT_OPTION);
   }
 
   @Override
@@ -85,7 +86,7 @@ public class DistributedCpCommand extends AbstractDistributedJobCommand {
 
   @Override
   public String getUsage() {
-    return "distributedCp [--job-count <num>] <src> <dst>";
+    return "distributedCp [--active-jobs <num>] <src> <dst>";
   }
 
   @Override
@@ -95,9 +96,9 @@ public class DistributedCpCommand extends AbstractDistributedJobCommand {
 
   @Override
   public int run(CommandLine cl) throws AlluxioException, IOException {
-    mActiveJobs = FileSystemShellUtils.getIntArg(cl, JOB_COUNT_OPTION,
+    mActiveJobs = FileSystemShellUtils.getIntArg(cl, ACTIVE_JOB_COUNT_OPTION,
             AbstractDistributedJobCommand.DEFAULT_ACTIVE_JOBS);
-    System.out.format("Allow up to %s concurrent jobs%n", mActiveJobs);
+    System.out.format("Allow up to %s active jobs%n", mActiveJobs);
 
     String[] args = cl.getArgs();
     AlluxioURI srcPath = new AlluxioURI(args[0]);

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
@@ -14,6 +14,7 @@ package alluxio.cli.fs.command;
 import alluxio.AlluxioURI;
 import alluxio.annotation.PublicApi;
 import alluxio.cli.CommandUtils;
+import alluxio.cli.fs.FileSystemShellUtils;
 import alluxio.cli.fs.command.job.JobAttempt;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
@@ -33,6 +34,8 @@ import alluxio.retry.RetryPolicy;
 import alluxio.util.io.PathUtils;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 import java.io.IOException;
 
@@ -45,6 +48,18 @@ import javax.annotation.concurrent.ThreadSafe;
 @PublicApi
 public class DistributedCpCommand extends AbstractDistributedJobCommand {
   private String mWriteType;
+
+  private static final Option JOB_COUNT_OPTION =
+      Option.builder()
+          .longOpt("job-count")
+          .required(false)
+          .hasArg(true)
+          .numberOfArgs(1)
+          .type(Number.class)
+          .argName("job count")
+          .desc("Number of active jobs to run at the same time"
+                  + AbstractDistributedJobCommand.DEFAULT_ACTIVE_JOBS)
+          .build();
 
   /**
    * @param fsContext the filesystem context of Alluxio
@@ -59,12 +74,31 @@ public class DistributedCpCommand extends AbstractDistributedJobCommand {
   }
 
   @Override
+  public Options getOptions() {
+    return new Options().addOption(JOB_COUNT_OPTION);
+  }
+
+  @Override
   public void validateArgs(CommandLine cl) throws InvalidArgumentException {
     CommandUtils.checkNumOfArgsEquals(this, cl, 2);
   }
 
   @Override
+  public String getUsage() {
+    return "distributedCp [--job-count <num>] <src> <dst>";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Copies a file or directory in parallel at file level.";
+  }
+
+  @Override
   public int run(CommandLine cl) throws AlluxioException, IOException {
+    mActiveJobs = FileSystemShellUtils.getIntArg(cl, JOB_COUNT_OPTION,
+            AbstractDistributedJobCommand.DEFAULT_ACTIVE_JOBS);
+    System.out.format("Allow up to %s concurrent jobs%n", mActiveJobs);
+
     String[] args = cl.getArgs();
     AlluxioURI srcPath = new AlluxioURI(args[0]);
     AlluxioURI dstPath = new AlluxioURI(args[1]);
@@ -143,16 +177,6 @@ public class DistributedCpCommand extends AbstractDistributedJobCommand {
     }
     System.out.println("Copying " + srcPath + " to " + dstPath);
     mSubmittedJobAttempts.add(newJob(srcPath, dstPath));
-  }
-
-  @Override
-  public String getUsage() {
-    return "distributedCp <src> <dst>";
-  }
-
-  @Override
-  public String getDescription() {
-    return "Copies a file or directory in parallel at file level.";
   }
 
   private static String computeTargetPath(String path, String source, String destination)

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -53,15 +53,16 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
           .argName("replicas")
           .desc("Number of block replicas of each loaded file, default: " + DEFAULT_REPLICATION)
           .build();
-  private static final Option JOB_COUNT_OPTION =
+  private static final Option ACTIVE_JOB_COUNT_OPTION =
       Option.builder()
-          .longOpt("job-count")
+          .longOpt("active-jobs")
           .required(false)
           .hasArg(true)
           .numberOfArgs(1)
           .type(Number.class)
-          .argName("job count")
-          .desc("Number of active jobs to run at the same time"
+          .argName("active job count")
+          .desc("Number of active jobs that can run at the same time. Later jobs must wait. "
+                  + "The default upper limit is "
                   + AbstractDistributedJobCommand.DEFAULT_ACTIVE_JOBS)
           .build();
 
@@ -81,7 +82,7 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
 
   @Override
   public Options getOptions() {
-    return new Options().addOption(REPLICATION_OPTION).addOption(JOB_COUNT_OPTION);
+    return new Options().addOption(REPLICATION_OPTION).addOption(ACTIVE_JOB_COUNT_OPTION);
   }
 
   @Override
@@ -91,7 +92,7 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
 
   @Override
   public String getUsage() {
-    return "distributedLoad [--replication <num>] [--job-count <num>] <path>";
+    return "distributedLoad [--replication <num>] [--active-jobs <num>] <path>";
   }
 
   @Override
@@ -101,9 +102,9 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
 
   @Override
   public int run(CommandLine cl) throws AlluxioException, IOException {
-    mActiveJobs = FileSystemShellUtils.getIntArg(cl, JOB_COUNT_OPTION,
+    mActiveJobs = FileSystemShellUtils.getIntArg(cl, ACTIVE_JOB_COUNT_OPTION,
             AbstractDistributedJobCommand.DEFAULT_ACTIVE_JOBS);
-    System.out.format("Allow up to %s concurrent jobs%n", mActiveJobs);
+    System.out.format("Allow up to %s active jobs%n", mActiveJobs);
 
     String[] args = cl.getArgs();
     AlluxioURI path = new AlluxioURI(args[0]);

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -53,6 +53,17 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
           .argName("replicas")
           .desc("Number of block replicas of each loaded file, default: " + DEFAULT_REPLICATION)
           .build();
+  private static final Option JOB_COUNT_OPTION =
+      Option.builder()
+          .longOpt("job-count")
+          .required(false)
+          .hasArg(true)
+          .numberOfArgs(1)
+          .type(Number.class)
+          .argName("job count")
+          .desc("Number of active jobs to run at the same time"
+                  + AbstractDistributedJobCommand.DEFAULT_ACTIVE_JOBS)
+          .build();
 
   /**
    * Constructs a new instance to load a file or directory in Alluxio space.
@@ -70,7 +81,7 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
 
   @Override
   public Options getOptions() {
-    return new Options().addOption(REPLICATION_OPTION);
+    return new Options().addOption(REPLICATION_OPTION).addOption(JOB_COUNT_OPTION);
   }
 
   @Override
@@ -79,7 +90,21 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
   }
 
   @Override
+  public String getUsage() {
+    return "distributedLoad [--replication <num>] [--job-count <num>] <path>";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Loads a file or all files in a directory into Alluxio space.";
+  }
+
+  @Override
   public int run(CommandLine cl) throws AlluxioException, IOException {
+    mActiveJobs = FileSystemShellUtils.getIntArg(cl, JOB_COUNT_OPTION,
+            AbstractDistributedJobCommand.DEFAULT_ACTIVE_JOBS);
+    System.out.format("Allow up to %s concurrent jobs%n", mActiveJobs);
+
     String[] args = cl.getArgs();
     AlluxioURI path = new AlluxioURI(args[0]);
     int replication = FileSystemShellUtils.getIntArg(cl, REPLICATION_OPTION, DEFAULT_REPLICATION);
@@ -153,16 +178,6 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
         addJob(uriStatus, replication);
       }
     });
-  }
-
-  @Override
-  public String getUsage() {
-    return "distributedLoad [--replication <num>] <path>";
-  }
-
-  @Override
-  public String getDescription() {
-    return "Loads a file or all files in a directory into Alluxio space.";
   }
 
   private class LoadJobAttempt extends JobAttempt {


### PR DESCRIPTION
Commands like distributedLoad and distributedCp submits jobs to the cluster job service. The command creates 1 job for each file. By default the command allows up to 3000 jobs to be submitted and waiting for completion. When there are many distributedLoad/Cp commands running by many users, there may be too many jobs in the queue for the job service.

This change intends to add a way to throttle the job submission speed at the command side. Especially when the distributedLoad/Cp jobs are submitted with automated scripts, we may want less than 3000 jobs to run with each command. Maybe find a balance between speed and resource claim, like 1000 or 500.

Volume control on Alluxio job service is beyond the scope of this PR.

Example:
```
$ bin/alluxio fs distributedLoad --job-count 1000 /                      
Allow 1000 active jobs
...
```