### PR TITLE
[SMALLFIX] Add debug log on BlockMaster request size

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -143,7 +143,8 @@ public final class BlockMasterWorkerServiceHandler extends
   public void registerWorker(RegisterWorkerPRequest request,
       StreamObserver<RegisterWorkerPResponse> responseObserver) {
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Register worker request is {} bytes, containing {} blocks", request.getSerializedSize(),
+      LOG.debug("Register worker request is {} bytes, containing {} blocks",
+              request.getSerializedSize(),
               request.getCurrentBlocksCount());
     }
 

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -61,6 +61,12 @@ public final class BlockMasterWorkerServiceHandler extends
   @Override
   public void blockHeartbeat(BlockHeartbeatPRequest request,
       StreamObserver<BlockHeartbeatPResponse> responseObserver) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Block heartbeat request is {} bytes, {} added blocks and {} removed blocks",
+              request.getSerializedSize(),
+              request.getAddedBlocksCount(),
+              request.getRemovedBlockIdsCount());
+    }
 
     final long workerId = request.getWorkerId();
     final Map<String, Long> capacityBytesOnTiers =
@@ -136,6 +142,11 @@ public final class BlockMasterWorkerServiceHandler extends
   @Override
   public void registerWorker(RegisterWorkerPRequest request,
       StreamObserver<RegisterWorkerPResponse> responseObserver) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Register worker request is {} bytes, containing {} blocks", request.getSerializedSize(),
+              request.getCurrentBlocksCount());
+    }
+
     final long workerId = request.getWorkerId();
     final List<String> storageTiers = request.getStorageTiersList();
     final Map<String, Long> totalBytesOnTiers = request.getTotalBytesOnTiersMap();


### PR DESCRIPTION
When the worker has a large number of blocks the request can be big for worker register and block heartbeat. Adding a little debug log for better traffic visibility.