### PR TITLE
Do not have the ProbalisticReviewer unnecessarily reject

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -637,14 +637,13 @@ public class TieredBlockStore implements BlockStore {
     BlockMetadataView allocatorView =
         new BlockMetadataAllocatorView(mMetaManager, options.canUseReservedSpace());
     try {
-      // Allocate from given location.
-      dirView = mAllocator.allocateBlockWithView(sessionId, options.getSize(),
-          options.getLocation(), allocatorView, false);
-      if (dirView != null) {
-        return dirView;
-      }
-
       if (options.isForceLocation()) {
+        // Try allocating from given location. Do not have it reject if there is space.
+        dirView = mAllocator.allocateBlockWithView(sessionId, options.getSize(),
+            options.getLocation(), allocatorView, true);
+        if (dirView != null) {
+          return null;
+        }
         if (options.isEvictionAllowed()) {
           LOG.debug("Free space for block expansion: freeing {} bytes on {}. ",
                   options.getSize(), options.getLocation());
@@ -666,6 +665,12 @@ public class TieredBlockStore implements BlockStore {
           return null;
         }
       } else {
+        // Try allocating from given location. This may probabilistically reject.
+        dirView = mAllocator.allocateBlockWithView(sessionId, options.getSize(),
+            options.getLocation(), allocatorView, false);
+        if (dirView != null) {
+          return dirView;
+        }
         LOG.debug("Allocate to anyTier for {} bytes on {}", options.getSize(),
                 options.getLocation());
         dirView = mAllocator.allocateBlockWithView(sessionId, options.getSize(),

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -665,7 +665,7 @@ public class TieredBlockStore implements BlockStore {
           return null;
         }
       } else {
-        // Try allocating from given location. This may probabilistically reject.
+        // Try allocating from given location. This may be rejected by the review logic.
         dirView = mAllocator.allocateBlockWithView(sessionId, options.getSize(),
             options.getLocation(), allocatorView, false);
         if (dirView != null) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -642,7 +642,7 @@ public class TieredBlockStore implements BlockStore {
         dirView = mAllocator.allocateBlockWithView(sessionId, options.getSize(),
             options.getLocation(), allocatorView, true);
         if (dirView != null) {
-          return null;
+          return dirView;
         }
         if (options.isEvictionAllowed()) {
           LOG.debug("Free space for block expansion: freeing {} bytes on {}. ",

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -638,7 +638,7 @@ public class TieredBlockStore implements BlockStore {
         new BlockMetadataAllocatorView(mMetaManager, options.canUseReservedSpace());
     try {
       if (options.isForceLocation()) {
-        // Try allocating from given location. Do not have it reject if there is space.
+        // Try allocating from given location. Skip the review because the location is forced.
         dirView = mAllocator.allocateBlockWithView(sessionId, options.getSize(),
             options.getLocation(), allocatorView, true);
         if (dirView != null) {


### PR DESCRIPTION
Many calls to TieredBlockStore.allocateSpace comes from TieredBlockStore.requestSpace either through 

"ShortCircuitBlockWriteHandler -> DefaultBlockWorker" or
"UnderFileSystemBlockReader"

(Block Expansion)

All usages of this has forceLocation true and evictionAllowed true.

So instead of https://github.com/Alluxio/alluxio/pull/12486 having the effect of using lower tier storage probabilistically. The code instead probabilistically evicted more things in the first tier leading to more churn.
