### PR TITLE
Cleanup counters in local client cache

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -380,7 +380,7 @@ public class LocalCacheManager implements CacheManager {
           // Failed to evict page, remove new page from metastore as there will not be enough space
           undoAddPage(pageId);
         }
-        LOG.error("Failed to delete page {}: {}", pageId, e);
+        LOG.error("Failed to delete page {} from pageStore", pageId, e);
         Metrics.PUT_STORE_DELETE_ERRORS.inc();
         return PutResult.OTHER;
       }
@@ -467,7 +467,7 @@ public class LocalCacheManager implements CacheManager {
         try {
           mMetaStore.removePage(pageId);
         } catch (PageNotFoundException e) {
-          LOG.error("Failed to delete page {}: {}", pageId, e);
+          LOG.error("Failed to delete page {} from metaStore: {}", pageId, e);
           Metrics.DELETE_NON_EXISTING_PAGE_ERRORS.inc();
           Metrics.DELETE_ERRORS.inc();
           return false;
@@ -586,7 +586,7 @@ public class LocalCacheManager implements CacheManager {
     try {
       mPageStore.delete(pageId);
     } catch (IOException | PageNotFoundException e) {
-      LOG.error("Failed to delete page {}: {}", pageId, e);
+      LOG.error("Failed to delete page {} from pageStore: {}", pageId, e);
       return false;
     }
     return true;

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -297,7 +297,7 @@ public class LocalCacheManager implements CacheManager {
       // note that, we only evict one item a time in putAttempt. So it is possible the evicted
       // page is not large enough to cover the space needed by this page. Try again
     }
-    Metrics.PUT_EVICTION_ERRORS.inc();
+    Metrics.PUT_INSUFFICIENT_SPACE_ERRORS.inc();
     return false;
   }
 
@@ -353,15 +353,12 @@ public class LocalCacheManager implements CacheManager {
       // metalock. Evictor will be updated inside metastore.
       try (LockResource r3 = new LockResource(mMetaLock.writeLock())) {
         if (mMetaStore.hasPage(pageId)) {
-          LOG.debug("{} is already inserted by a racing thread", pageId);
-          // TODO(binfan): we should return more informative result in the future
           return PutResult.OK;
         }
         try {
           mMetaStore.removePage(victimPageInfo.getPageId());
-        } catch (Exception e) {
-          undoAddPage(pageId);
-          LOG.error("Page {} is unavailable to evict, likely due to a benign race",
+        } catch (PageNotFoundException e) {
+          LOG.warn("Page {} is unavailable to evict, likely due to a benign race",
               victimPageInfo.getPageId());
           Metrics.PUT_BENIGN_RACING_ERRORS.inc();
           return PutResult.OTHER;
@@ -661,6 +658,9 @@ public class LocalCacheManager implements CacheManager {
     /** Errors when adding pages due to benign racing eviction. */
     private static final Counter PUT_BENIGN_RACING_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_BENIGN_RACING_ERRORS.getName());
+    /** Errors when adding pages due to insufficient space made after eviction. */
+    private static final Counter PUT_INSUFFICIENT_SPACE_ERRORS =
+        MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_INSUFFICIENT_SPACE_ERRORS.getName());
     /** Errors when cache is not ready to add pages. */
     private static final Counter PUT_NOT_READY_ERRORS =
         MetricsSystem.counter(MetricKey.CLIENT_CACHE_PUT_NOT_READY_ERRORS.getName());

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -127,13 +126,6 @@ public class LocalPageStore implements PageStore {
       throw new PageNotFoundException(p.toString());
     }
     Files.delete(p);
-    Path parent = Preconditions.checkNotNull(p.getParent(),
-        "parent of cache file should not be null");
-    try (DirectoryStream<Path> stream = Files.newDirectoryStream(parent)) {
-      if (!stream.iterator().hasNext()) {
-        Files.delete(parent);
-      }
-    }
   }
 
   private Path getFilePath(PageId pageId) {

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -987,6 +987,13 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_PUT_INSUFFICIENT_SPACE_ERRORS =
+      new Builder(Name.CLIENT_CACHE_PUT_INSUFFICIENT_SPACE_ERRORS)
+          .setDescription("Number of failures when putting cached data in the client cache due to"
+              + " insufficient space made after eviction.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_PUT_BENIGN_RACING_ERRORS =
       new Builder(Name.CLIENT_CACHE_PUT_BENIGN_RACING_ERRORS)
           .setDescription("Number of failures when adding pages due to racing eviction. This error"
@@ -1284,6 +1291,8 @@ public final class MetricKey implements Comparable<MetricKey> {
         "Client.CachePutEvictionErrors";
     public static final String CLIENT_CACHE_PUT_BENIGN_RACING_ERRORS =
         "Client.CachePutBenignRacingErrors";
+    public static final String CLIENT_CACHE_PUT_INSUFFICIENT_SPACE_ERRORS =
+        "Client.CachePutInsufficientSpaceErrors";
     public static final String CLIENT_CACHE_PUT_NOT_READY_ERRORS =
         "Client.CachePutNotReadyErrors";
     public static final String CLIENT_CACHE_PUT_STORE_DELETE_ERRORS =


### PR DESCRIPTION
two improvements:
1. Added new counter "Client.CachePutInsufficientSpaceErrors" indicating the failed put due to insufficient space made after eviction attempts.
2. Remove unnecessary cleanup which may artificially bump error counters
3. Remove unnecessary directory cleanup which has potential race condition to fail put unnecessarily