### PR TITLE
Avoid IllegalArgumentException without message from ForkJoinPool

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -305,6 +305,16 @@ public class AlluxioMasterProcess extends MasterProcess {
           GrpcServerAddress.create(mRpcConnectAddress.getHostName(), mRpcBindAddress),
           ServerConfiguration.global(), ServerUserState.global());
 
+      int parallelism = ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM);
+      Preconditions.checkArgument(parallelism > 0,
+              String.format("Starting Alluxio master gRPC thread pool with %s executors! "
+                              + "Please set %s to a valid number!",
+                      parallelism, PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM.toString()));
+      Preconditions.checkArgument(parallelism <= ServerConfiguration.getInt(
+              PropertyKey.MASTER_RPC_EXECUTOR_MAX_POOL_SIZE),
+              String.format("%s cannot be greater than %s!",
+                      PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM.toString(),
+                      PropertyKey.MASTER_RPC_EXECUTOR_MAX_POOL_SIZE.toString()));
       mRPCExecutor = new ForkJoinPool(
           ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM),
           ThreadFactoryUtils.buildFjp("master-rpc-pool-thread-%d", true),

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -304,17 +304,6 @@ public class AlluxioMasterProcess extends MasterProcess {
       GrpcServerBuilder serverBuilder = GrpcServerBuilder.forAddress(
           GrpcServerAddress.create(mRpcConnectAddress.getHostName(), mRpcBindAddress),
           ServerConfiguration.global(), ServerUserState.global());
-
-      int parallelism = ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM);
-      Preconditions.checkArgument(parallelism > 0,
-              String.format("Starting Alluxio master gRPC thread pool with %s executors! "
-                              + "Please set %s to a valid number!",
-                      parallelism, PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM.toString()));
-      Preconditions.checkArgument(parallelism <= ServerConfiguration.getInt(
-              PropertyKey.MASTER_RPC_EXECUTOR_MAX_POOL_SIZE),
-              String.format("%s cannot be greater than %s!",
-                      PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM.toString(),
-                      PropertyKey.MASTER_RPC_EXECUTOR_MAX_POOL_SIZE.toString()));
       mRPCExecutor = new ForkJoinPool(
           ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM),
           ThreadFactoryUtils.buildFjp("master-rpc-pool-thread-%d", true),
@@ -384,6 +373,26 @@ public class AlluxioMasterProcess extends MasterProcess {
     return "Alluxio master @" + mRpcConnectAddress;
   }
 
+  private static void validateRPCExecutor() {
+    int parallelism = ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM);
+    Preconditions.checkArgument(parallelism > 0,
+            String.format("Cannot start Alluxio master gRPC thread pool with %s=%s! "
+                            + "The parallelism must be greater than 0!",
+                    PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM.toString(), parallelism));
+    int maxPoolSize = ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_MAX_POOL_SIZE);
+    Preconditions.checkArgument(parallelism <= maxPoolSize,
+            String.format("Cannot start Alluxio master gRPC thread pool with "
+                            + "%s=%s greater than %s=%s!",
+                    PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM.toString(), parallelism,
+                    PropertyKey.MASTER_RPC_EXECUTOR_MAX_POOL_SIZE.toString(), maxPoolSize));
+    long keepAliveMs = ServerConfiguration.getMs(PropertyKey.MASTER_RPC_EXECUTOR_KEEPALIVE);
+    Preconditions.checkArgument(keepAliveMs > 0L,
+            String.format("Cannot start Alluxio master gRPC thread pool with %s=%s. "
+                            + "The keepalive time must be greater than 0!",
+                    PropertyKey.MASTER_RPC_EXECUTOR_KEEPALIVE.toString(),
+                    keepAliveMs));
+  }
+
   /**
    * Factory for creating {@link AlluxioMasterProcess}.
    */
@@ -395,6 +404,7 @@ public class AlluxioMasterProcess extends MasterProcess {
      * @return a new instance of {@link MasterProcess} using the given sockets for the master
      */
     public static AlluxioMasterProcess create() {
+      validateRPCExecutor();
       URI journalLocation = JournalUtils.getJournalLocation();
       JournalSystem journalSystem = new JournalSystem.Builder()
           .setLocation(journalLocation).build(ProcessType.MASTER);

--- a/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
+++ b/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
@@ -164,7 +164,8 @@ public final class AlluxioMasterProcessTest {
     ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM, "4");
     ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_MAX_POOL_SIZE, "3");
     mException.expect(IllegalArgumentException.class);
-    mException.expectMessage(String.format("%s=%s cannot be greater than %s=%s!",
+    mException.expectMessage(String.format("Cannot start Alluxio master gRPC thread pool with "
+                    + "%s=%s greater than %s=%s!",
             PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM.toString(), 4,
             PropertyKey.MASTER_RPC_EXECUTOR_MAX_POOL_SIZE.toString(), 3));
     AlluxioMasterProcess.Factory.create();

--- a/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
+++ b/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
@@ -32,6 +32,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
@@ -55,6 +56,9 @@ public final class AlluxioMasterProcessTest {
 
   @Rule
   public TemporaryFolder mFolder = new TemporaryFolder();
+
+  @Rule
+  public ExpectedException mException = ExpectedException.none();
 
   private int mRpcPort;
   private int mWebPort;
@@ -133,6 +137,61 @@ public final class AlluxioMasterProcessTest {
     });
     t.start();
     startStopTest(master);
+  }
+
+  @Test
+  public void startZeroParallelism() {
+    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM, "0");
+    mException.expect(IllegalArgumentException.class);
+    mException.expectMessage(String.format("Cannot start Alluxio master gRPC thread pool with "
+                    + "%s=%s! The parallelism must be greater than 0!",
+            PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM.toString(), 0));
+    AlluxioMasterProcess.Factory.create();
+  }
+
+  @Test
+  public void startNegativeParallelism() {
+    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM, "-1");
+    mException.expect(IllegalArgumentException.class);
+    mException.expectMessage(String.format("Cannot start Alluxio master gRPC thread pool with"
+                    + " %s=%s! The parallelism must be greater than 0!",
+            PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM.toString(), -1));
+    AlluxioMasterProcess.Factory.create();
+  }
+
+  @Test
+  public void startInvalidMaxPoolSize() {
+    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM, "4");
+    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_MAX_POOL_SIZE, "3");
+    mException.expect(IllegalArgumentException.class);
+    mException.expectMessage(String.format("%s=%s cannot be greater than %s=%s!",
+            PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM.toString(), 4,
+            PropertyKey.MASTER_RPC_EXECUTOR_MAX_POOL_SIZE.toString(), 3));
+    AlluxioMasterProcess.Factory.create();
+  }
+
+  @Test
+  public void startZeroKeepAliveTime() {
+    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_KEEPALIVE, "0");
+    mException.expect(IllegalArgumentException.class);
+    mException.expectMessage(
+            String.format("Cannot start Alluxio master gRPC thread pool with %s=%s. "
+                    + "The keepalive time must be greater than 0!",
+            PropertyKey.MASTER_RPC_EXECUTOR_KEEPALIVE.toString(),
+            0));
+    AlluxioMasterProcess.Factory.create();
+  }
+
+  @Test
+  public void startNegativeKeepAliveTime() {
+    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_KEEPALIVE, "-1");
+    mException.expect(IllegalArgumentException.class);
+    mException.expectMessage(
+            String.format("Cannot start Alluxio master gRPC thread pool with %s=%s. "
+                            + "The keepalive time must be greater than 0!",
+                    PropertyKey.MASTER_RPC_EXECUTOR_KEEPALIVE.toString(),
+                    -1));
+    AlluxioMasterProcess.Factory.create();
   }
 
   private void startStopTest(AlluxioMasterProcess master) throws Exception {


### PR DESCRIPTION
Creating ForkJoinPool with unreasonable arguments will lead to IAE without a message, which is confusing. The logic is below:
```
package alluxio.concurrent.jsr;
public ForkJoinPool(int parallelism, ForkJoinWorkerThreadFactory factory,
    UncaughtExceptionHandler handler, boolean asyncMode, int corePoolSize, int maximumPoolSize,
    int minimumRunnable, Predicate<? super ForkJoinPool> saturate, long keepAliveTime,
    TimeUnit unit) {
  // check, encode, pack parameters
  if (parallelism <= 0 || parallelism > MAX_CAP || maximumPoolSize < parallelism
      || keepAliveTime <= 0L)
    throw new IllegalArgumentException();
```

Before:
```
2021-02-04 12:19:29,867 ERROR ProcessUtils - Uncaught exception while running Alluxio master @localhost:19998, stopping it and exiting. Exception "java.lang.IllegalArgumentException", Root Cause "java.lang.IllegalArgumentException"
java.lang.IllegalArgumentException
        at alluxio.concurrent.jsr.ForkJoinPool.<init>(ForkJoinPool.java:757)
        at alluxio.master.AlluxioMasterProcess.startServingRPCServer(AlluxioMasterProcess.java:353)
        at alluxio.master.AlluxioMasterProcess.startServing(AlluxioMasterProcess.java:320)
        at alluxio.master.MasterProcess.startServing(MasterProcess.java:128)
        at alluxio.master.AlluxioMasterProcess.start(AlluxioMasterProcess.java:188)
        at alluxio.ProcessUtils.run(ProcessUtils.java:36)
        at alluxio.master.AlluxioMaster.main(AlluxioMaster.java:55)
```

After:
```
2021-02-06 11:28:42,414 ERROR FaultTolerantAlluxioMasterProcess - Fatal error: Exception thrown in main serving thread
java.lang.IllegalArgumentException: Cannot start Alluxio master gRPC thread pool with alluxio.master.rpc.executor.parallelism=0! The parallelism must be greater than 0!
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:142)
        at alluxio.master.AlluxioMasterProcess.startServingRPCServer(AlluxioMasterProcess.java:309)
        at alluxio.master.AlluxioMasterProcess.startServing(AlluxioMasterProcess.java:292)
        at alluxio.master.FaultTolerantAlluxioMasterProcess.lambda$gainPrimacy$1(FaultTolerantAlluxioMasterProcess.java:130)
        at java.lang.Thread.run(Thread.java:748)
```
or
```
2021-02-06 11:37:40,880 ERROR FaultTolerantAlluxioMasterProcess - Fatal error: Exception thrown in main serving thread
java.lang.IllegalArgumentException: Cannot start Alluxio master gRPC thread pool with alluxio.master.rpc.executor.parallelism=4 greater than alluxio.master.rpc.executor.max.pool.size=3!
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:142)
        at alluxio.master.AlluxioMasterProcess.startServingRPCServer(AlluxioMasterProcess.java:313)
        at alluxio.master.AlluxioMasterProcess.startServing(AlluxioMasterProcess.java:292)
        at alluxio.master.FaultTolerantAlluxioMasterProcess.lambda$gainPrimacy$1(FaultTolerantAlluxioMasterProcess.java:130)
        at java.lang.Thread.run(Thread.java:748)
```
or
```
2021-02-06 11:37:40,880 ERROR FaultTolerantAlluxioMasterProcess - Fatal error: Exception thrown in main serving thread
java.lang.IllegalArgumentException: Cannot start Alluxio master gRPC thread pool with alluxio.master.rpc.executor.keepalive=0! The keepalive time must be greater than 0!
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:142)
        at alluxio.master.AlluxioMasterProcess.startServingRPCServer(AlluxioMasterProcess.java:313)
        at alluxio.master.AlluxioMasterProcess.startServing(AlluxioMasterProcess.java:292)
        at alluxio.master.FaultTolerantAlluxioMasterProcess.lambda$gainPrimacy$1(FaultTolerantAlluxioMasterProcess.java:130)
        at java.lang.Thread.run(Thread.java:748)
```