### PR TITLE
Bump the version of leveldbjni to 5.18.4 to support ARM platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
     <grpc.version>1.28.1</grpc.version>
     <netty.version>4.1.51.Final</netty.version>
-    <rocksdb.version>5.15.10</rocksdb.version>
+    <rocksdb.version>5.18.4</rocksdb.version>
     <hadoop.version>3.3.0</hadoop.version>
     <jacoco.version>0.8.5</jacoco.version>
     <java.version>1.8</java.version>


### PR DESCRIPTION
Current version of leveldbjni dependency cannot support ARM64 platform,
this change bump the version to 5.18.4 to support ARM64 platform.

A special rocksdbjni version for aarch64 has been released by rocksdb community. [1][2]
[1] https://github.com/facebook/rocksdb/releases/tag/v5.18.4
[2] facebook/rocksdb#6250

Fix #12818