### PR TITLE
Replace lock to double check to reduce heap memory cost

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -619,7 +619,7 @@ public final class AlluxioFuseFileSystem extends FuseStubFS {
     int rd = 0;
     int nread = 0;
     synchronized (oe) {
-      if (!mOpenFiles.contains(fd)) {
+      if (!mOpenFiles.contains(oe)) {
         LOG.error("Cannot find fd for {} in table", path);
         return -ErrorCodes.EBADFD();
       }

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -28,7 +28,6 @@ import alluxio.jnifuse.FuseFillDir;
 import alluxio.jnifuse.struct.FileStat;
 import alluxio.jnifuse.struct.FuseContext;
 import alluxio.jnifuse.struct.FuseFileInfo;
-import alluxio.resource.LockResource;
 import alluxio.security.authorization.Mode;
 import alluxio.util.ThreadUtils;
 
@@ -36,7 +35,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.util.concurrent.Striped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +47,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReadWriteLock;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -74,10 +71,6 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem {
   private final LoadingCache<String, Long> mGidCache;
   private final AtomicLong mNextOpenFileId = new AtomicLong(0);
   private final String mFsName;
-
-  private static final int LOCK_SIZE = 2048;
-  /** A readwrite lock pool to guard individual files based on striping. */
-  private final Striped<ReadWriteLock> mFileLocks = Striped.readWriteLock(LOCK_SIZE);
 
   private final Map<Long, FileInStream> mOpenFileEntries = new ConcurrentHashMap<>();
   private final Map<Long, FileOutStream> mCreateFileEntries = new ConcurrentHashMap<>();
@@ -323,19 +316,25 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem {
     int rd = 0;
     final int sz = (int) size;
     long fd = fi.fh.get();
-    // FileInStream is not thread safe
-    try (LockResource r1 = new LockResource(mFileLocks.get(fd).writeLock())) {
+    try {
       FileInStream is = mOpenFileEntries.get(fd);
       if (is == null) {
         LOG.error("Cannot find fd {} for {}", fd, path);
         return -ErrorCodes.EBADFD();
       }
-      is.seek(offset);
       final byte[] dest = new byte[sz];
-      while (rd >= 0 && nread < size) {
-        rd = is.read(dest, nread, sz - nread);
-        if (rd >= 0) {
-          nread += rd;
+      // FileInStream is not thread safe
+      synchronized (is) {
+        if (!mOpenFileEntries.containsKey(fd)) {
+          LOG.error("Cannot find fd {} for {}", fd, path);
+          return -ErrorCodes.EBADFD();
+        }
+        is.seek(offset);
+        while (rd >= 0 && nread < size) {
+          rd = is.read(dest, nread, sz - nread);
+          if (rd >= 0) {
+            nread += rd;
+          }
         }
       }
 
@@ -401,7 +400,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem {
 
   private int releaseInternal(String path, FuseFileInfo fi) {
     long fd = fi.fh.get();
-    try (LockResource r1 = new LockResource(mFileLocks.get(fd).writeLock())) {
+    try {
       FileInStream is = mOpenFileEntries.remove(fd);
       FileOutStream os = mCreateFileEntries.remove(fd);
       if (is == null && os == null) {
@@ -409,10 +408,14 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem {
         return -ErrorCodes.EBADFD();
       }
       if (is != null) {
-        is.close();
+        synchronized (is) {
+          is.close();
+        }
       }
       if (os != null) {
-        os.close();
+        synchronized (os) {
+          os.close();
+        }
       }
     } catch (Throwable e) {
       LOG.error("Failed closing {}", path, e);


### PR DESCRIPTION
For the existing code of `AlluxioJniFuseFileSystem`, it use a `2048` ReadWrite lock pool as the guards for each fd, there are 3 reason why I purpose to remove it by a double check.

- Reduce the heap memory for the `LOCK_SIZE`, now the constant is `2048`, so the reason seems too weak.
- We can only have 2048 lock in the same time, if there are more other unrelated files operation, they will hang for waiting lock resource other then acquire lock.
- `2048` is a hard code here, and we can use double check to replace these unnecessary locks, this PR will clear the code.
- Synchronized block is recommend to use if we have no strong reason to use `ReentrantReadWriteLock`. We don't use the readlock at all, we also don't use fair lock. So, to simplify code, we'd better to replace it.