### PR TITLE
Clean up incomplete files if sync is interrupted

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -896,7 +896,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
    * @param inodePath the {@link LockedInodePath} to get the {@link FileInfo} for
    * @return the {@link FileInfo} for the given inode
    */
-  private FileInfo getFileInfoInternal(LockedInodePath inodePath)
+  FileInfo getFileInfoInternal(LockedInodePath inodePath)
       throws FileDoesNotExistException, UnavailableException {
     Inode inode = inodePath.getInode();
     AlluxioURI uri = inodePath.getUri();

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -824,6 +824,8 @@ public class InodeSyncStream {
         LOG.debug("File not created yet, do not need to clean up: {}", ex.toString());
       } catch (DirectoryNotEmptyException ex) {
         LOG.warn("Trying to remove a directory, expecting a file: {}", ex.toString());
+      } catch (Throwable ex) {
+        e.addSuppressed(ex);
       }
       throw e;
     }

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -821,7 +821,7 @@ public class InodeSyncStream {
               .mergeFrom(DeletePOptions.newBuilder().setAlluxioOnly(true)));
         }
       } catch (FileDoesNotExistException ex) {
-        LOG.debug("File not created yet, do not need to clean up: {}", ex.toString());
+        LOG.info("File not created yet, do not need to clean up: {}", ex.toString());
       } catch (DirectoryNotEmptyException ex) {
         LOG.warn("Trying to remove a directory, expecting a file: {}", ex.toString());
       } catch (Throwable ex) {

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -40,7 +40,6 @@ import alluxio.master.file.contexts.GetStatusContext;
 import alluxio.master.file.contexts.LoadMetadataContext;
 import alluxio.master.file.contexts.SetAttributeContext;
 import alluxio.master.file.meta.Inode;
-import alluxio.master.file.meta.InodeFile;
 import alluxio.master.file.meta.InodeLockManager;
 import alluxio.master.file.meta.InodeTree;
 import alluxio.master.file.meta.InodeTree.LockPattern;
@@ -74,7 +73,6 @@ import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
@@ -252,6 +250,7 @@ public class InodeSyncStream {
     this(rootScheme, fsMaster, rpcContext, descendantType, options, null, null, null,
         isGetFileInfo, forceSync, loadOnly);
   }
+
   /**
    * Sync the metadata according the the root path the stream was created with.
    *


### PR DESCRIPTION
It is possible for syncMetadata process to be interrupted due to user cancellation or IOExceptions. 
We need to recover from incomplete files if we happen to have created the file but not completed the file. 