### PR TITLE
Deprecate ExpectedException.none() in alluxio.client

### DIFF
--- a/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -11,7 +11,7 @@
 
 package alluxio.client.block;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -56,9 +56,7 @@ import com.google.common.collect.Sets;
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -144,9 +142,6 @@ public final class AlluxioBlockStoreTest {
     }
   }
 
-  @Rule
-  public ExpectedException mException = ExpectedException.none();
-
   private BlockMasterClient mMasterClient;
   private BlockWorkerClient mWorkerClient;
   private AlluxioBlockStore mBlockStore;
@@ -192,8 +187,7 @@ public final class AlluxioBlockStoreTest {
             .setLocationPolicy((workerOptions) -> {
               throw new RuntimeException("policy threw exception");
             });
-    mException.expect(Exception.class);
-    mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options);
+    assertThrows(Exception.class, () -> mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options));
   }
 
   @Test
@@ -201,10 +195,10 @@ public final class AlluxioBlockStoreTest {
     OutStreamOptions options =
         OutStreamOptions.defaults(mClientContext).setBlockSizeBytes(BLOCK_LENGTH)
             .setWriteType(WriteType.MUST_CACHE).setLocationPolicy(null);
-    mException.expect(NullPointerException.class);
-    mException.expectMessage(
-        PreconditionMessage.BLOCK_WRITE_LOCATION_POLICY_UNSPECIFIED.toString());
-    mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options);
+    Exception e = assertThrows(NullPointerException.class,
+            () -> mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options));
+    assertTrue(e.getMessage()
+            .contains(PreconditionMessage.BLOCK_WRITE_LOCATION_POLICY_UNSPECIFIED.toString()));
   }
 
   @Test
@@ -216,10 +210,10 @@ public final class AlluxioBlockStoreTest {
             .setWriteType(WriteType.MUST_CACHE)
             .setLocationPolicy(
                 new MockBlockLocationPolicy(Lists.<WorkerNetAddress>newArrayList()));
-    mException.expect(UnavailableException.class);
-    mException
-        .expectMessage(ExceptionMessage.NO_SPACE_FOR_BLOCK_ON_WORKER.getMessage(BLOCK_LENGTH));
-    mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options);
+    Exception e = assertThrows(UnavailableException.class,
+            () -> mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options));
+    assertTrue(e.getMessage()
+            .contains(ExceptionMessage.NO_SPACE_FOR_BLOCK_ON_WORKER.getMessage(BLOCK_LENGTH)));
   }
 
   @Test
@@ -321,9 +315,9 @@ public final class AlluxioBlockStoreTest {
             sConf);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
     when(mContext.getCachedWorkers()).thenReturn(Collections.emptyList());
-    mException.expect(UnavailableException.class);
-    mException.expectMessage(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
-    mBlockStore.getInStream(BLOCK_ID, options).getAddress();
+    Exception e = assertThrows(UnavailableException.class,
+            () -> mBlockStore.getInStream(BLOCK_ID, options).getAddress());
+    assertTrue(e.getMessage().contains(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage()));
   }
 
   @Test
@@ -333,10 +327,9 @@ public final class AlluxioBlockStoreTest {
     InStreamOptions options =
         new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(sConf), sConf);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
-
-    mException.expect(UnavailableException.class);
-    mException.expectMessage("unavailable in both Alluxio and UFS");
-    mBlockStore.getInStream(BLOCK_ID, options).getAddress();
+    Exception e = assertThrows(UnavailableException.class,
+            () -> mBlockStore.getInStream(BLOCK_ID, options).getAddress());
+    assertTrue(e.getMessage().contains("unavailable in both Alluxio and UFS"));
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -11,7 +11,9 @@
 
 package alluxio.client.block;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -195,8 +197,8 @@ public final class AlluxioBlockStoreTest {
     OutStreamOptions options =
         OutStreamOptions.defaults(mClientContext).setBlockSizeBytes(BLOCK_LENGTH)
             .setWriteType(WriteType.MUST_CACHE).setLocationPolicy(null);
-    Exception e = assertThrows(NullPointerException.class,
-            () -> mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options));
+    Exception e = assertThrows(NullPointerException.class, () ->
+            mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options));
     assertTrue(e.getMessage()
             .contains(PreconditionMessage.BLOCK_WRITE_LOCATION_POLICY_UNSPECIFIED.toString()));
   }
@@ -210,8 +212,8 @@ public final class AlluxioBlockStoreTest {
             .setWriteType(WriteType.MUST_CACHE)
             .setLocationPolicy(
                 new MockBlockLocationPolicy(Lists.<WorkerNetAddress>newArrayList()));
-    Exception e = assertThrows(UnavailableException.class,
-            () -> mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options));
+    Exception e = assertThrows(UnavailableException.class, () ->
+            mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options));
     assertTrue(e.getMessage()
             .contains(ExceptionMessage.NO_SPACE_FOR_BLOCK_ON_WORKER.getMessage(BLOCK_LENGTH)));
   }
@@ -231,9 +233,9 @@ public final class AlluxioBlockStoreTest {
           }
         });
 
-    OutStreamOptions options =
-        OutStreamOptions.defaults(mClientContext).setBlockSizeBytes(BLOCK_LENGTH).setLocationPolicy(
-            new MockBlockLocationPolicy(Lists.newArrayList(WORKER_NET_ADDRESS_LOCAL)))
+    OutStreamOptions options = OutStreamOptions.defaults(mClientContext)
+            .setBlockSizeBytes(BLOCK_LENGTH).setLocationPolicy(
+              new MockBlockLocationPolicy(Lists.newArrayList(WORKER_NET_ADDRESS_LOCAL)))
             .setWriteType(WriteType.MUST_CACHE);
     BlockOutStream stream = mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options);
     assertEquals(WORKER_NET_ADDRESS_LOCAL, stream.getAddress());
@@ -315,8 +317,8 @@ public final class AlluxioBlockStoreTest {
             sConf);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
     when(mContext.getCachedWorkers()).thenReturn(Collections.emptyList());
-    Exception e = assertThrows(UnavailableException.class,
-            () -> mBlockStore.getInStream(BLOCK_ID, options).getAddress());
+    Exception e = assertThrows(UnavailableException.class, () ->
+            mBlockStore.getInStream(BLOCK_ID, options).getAddress());
     assertTrue(e.getMessage().contains(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage()));
   }
 
@@ -327,8 +329,8 @@ public final class AlluxioBlockStoreTest {
     InStreamOptions options =
         new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(sConf), sConf);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
-    Exception e = assertThrows(UnavailableException.class,
-            () -> mBlockStore.getInStream(BLOCK_ID, options).getAddress());
+    Exception e = assertThrows(UnavailableException.class, () ->
+            mBlockStore.getInStream(BLOCK_ID, options).getAddress());
     assertTrue(e.getMessage().contains("unavailable in both Alluxio and UFS"));
   }
 

--- a/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -198,9 +198,9 @@ public final class AlluxioBlockStoreTest {
         OutStreamOptions.defaults(mClientContext).setBlockSizeBytes(BLOCK_LENGTH)
             .setWriteType(WriteType.MUST_CACHE).setLocationPolicy(null);
     Exception e = assertThrows(NullPointerException.class, () ->
-            mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options));
+        mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options));
     assertTrue(e.getMessage()
-            .contains(PreconditionMessage.BLOCK_WRITE_LOCATION_POLICY_UNSPECIFIED.toString()));
+        .contains(PreconditionMessage.BLOCK_WRITE_LOCATION_POLICY_UNSPECIFIED.toString()));
   }
 
   @Test
@@ -213,9 +213,9 @@ public final class AlluxioBlockStoreTest {
             .setLocationPolicy(
                 new MockBlockLocationPolicy(Lists.<WorkerNetAddress>newArrayList()));
     Exception e = assertThrows(UnavailableException.class, () ->
-            mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options));
+        mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options));
     assertTrue(e.getMessage()
-            .contains(ExceptionMessage.NO_SPACE_FOR_BLOCK_ON_WORKER.getMessage(BLOCK_LENGTH)));
+        .contains(ExceptionMessage.NO_SPACE_FOR_BLOCK_ON_WORKER.getMessage(BLOCK_LENGTH)));
   }
 
   @Test
@@ -234,8 +234,8 @@ public final class AlluxioBlockStoreTest {
         });
 
     OutStreamOptions options = OutStreamOptions.defaults(mClientContext)
-            .setBlockSizeBytes(BLOCK_LENGTH).setLocationPolicy(
-              new MockBlockLocationPolicy(Lists.newArrayList(WORKER_NET_ADDRESS_LOCAL)))
+        .setBlockSizeBytes(BLOCK_LENGTH).setLocationPolicy(
+            new MockBlockLocationPolicy(Lists.newArrayList(WORKER_NET_ADDRESS_LOCAL)))
             .setWriteType(WriteType.MUST_CACHE);
     BlockOutStream stream = mBlockStore.getOutStream(BLOCK_ID, BLOCK_LENGTH, options);
     assertEquals(WORKER_NET_ADDRESS_LOCAL, stream.getAddress());
@@ -318,7 +318,7 @@ public final class AlluxioBlockStoreTest {
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
     when(mContext.getCachedWorkers()).thenReturn(Collections.emptyList());
     Exception e = assertThrows(UnavailableException.class, () ->
-            mBlockStore.getInStream(BLOCK_ID, options).getAddress());
+        mBlockStore.getInStream(BLOCK_ID, options).getAddress());
     assertTrue(e.getMessage().contains(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage()));
   }
 
@@ -330,7 +330,7 @@ public final class AlluxioBlockStoreTest {
         new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(sConf), sConf);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
     Exception e = assertThrows(UnavailableException.class, () ->
-            mBlockStore.getInStream(BLOCK_ID, options).getAddress());
+        mBlockStore.getInStream(BLOCK_ID, options).getAddress());
     assertTrue(e.getMessage().contains("unavailable in both Alluxio and UFS"));
   }
 

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcBlockingStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcBlockingStreamTest.java
@@ -12,10 +12,7 @@
 package alluxio.client.block.stream;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -148,7 +145,6 @@ public final class GrpcBlockingStreamTest {
     mThrown.expect(UnauthenticatedException.class);
     mThrown.expectMessage(containsString(TEST_MESSAGE));
     mResponseObserver.onError(Status.UNAUTHENTICATED.asRuntimeException());
-
     mStream.send(WriteRequest.newBuilder().build(), TIMEOUT);
   }
 
@@ -158,10 +154,11 @@ public final class GrpcBlockingStreamTest {
   @Test
   public void sendFailsAfterClosed() throws Exception {
     mStream.close();
-    mThrown.expect(CancelledException.class);
-    mThrown.expectMessage(containsString(TEST_MESSAGE));
-
-    mStream.send(WriteRequest.newBuilder().build(), TIMEOUT);
+    // TODO(jiacheng): Change all message check to this flavor
+    Exception e = assertThrows(CancelledException.class,
+            () -> mStream.send(WriteRequest.newBuilder().build(), TIMEOUT));
+    System.out.println(e.getMessage());
+    assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 
   /**

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcBlockingStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcBlockingStreamTest.java
@@ -11,8 +11,11 @@
 
 package alluxio.client.block.stream;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -33,9 +36,7 @@ import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.StreamObserver;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -58,9 +59,6 @@ public final class GrpcBlockingStreamTest {
   private ClientResponseObserver<WriteRequest, WriteResponse> mResponseObserver;
   private GrpcBlockingStream<WriteRequest, WriteResponse> mStream;
   private Runnable mOnReadyHandler;
-
-  @Rule
-  public ExpectedException mThrown = ExpectedException.none();
 
   /**
    * Set up gRPC interface mocks.
@@ -142,10 +140,10 @@ public final class GrpcBlockingStreamTest {
    */
   @Test
   public void sendError() throws Exception {
-    mThrown.expect(UnauthenticatedException.class);
-    mThrown.expectMessage(containsString(TEST_MESSAGE));
     mResponseObserver.onError(Status.UNAUTHENTICATED.asRuntimeException());
-    mStream.send(WriteRequest.newBuilder().build(), TIMEOUT);
+    Exception e = assertThrows(CancelledException.class,
+        () -> mStream.send(WriteRequest.newBuilder().build(), TIMEOUT));
+    assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 
   /**
@@ -154,10 +152,8 @@ public final class GrpcBlockingStreamTest {
   @Test
   public void sendFailsAfterClosed() throws Exception {
     mStream.close();
-    // TODO(jiacheng): Change all message check to this flavor
     Exception e = assertThrows(CancelledException.class,
-            () -> mStream.send(WriteRequest.newBuilder().build(), TIMEOUT));
-    System.out.println(e.getMessage());
+        () -> mStream.send(WriteRequest.newBuilder().build(), TIMEOUT));
     assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 
@@ -167,10 +163,9 @@ public final class GrpcBlockingStreamTest {
   @Test
   public void sendFailsAfterCanceled() throws Exception {
     mStream.cancel();
-    mThrown.expect(CancelledException.class);
-    mThrown.expectMessage(containsString(TEST_MESSAGE));
-
-    mStream.send(WriteRequest.newBuilder().build(), TIMEOUT);
+    Exception e = assertThrows(CancelledException.class, () ->
+            mStream.send(WriteRequest.newBuilder().build(), TIMEOUT));
+    assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 
   /**
@@ -179,10 +174,9 @@ public final class GrpcBlockingStreamTest {
   @Test
   public void receiveFailsAfterCanceled() throws Exception {
     mStream.cancel();
-    mThrown.expect(CancelledException.class);
-    mThrown.expectMessage(containsString(TEST_MESSAGE));
-
-    mStream.receive(TIMEOUT);
+    Exception e = assertThrows(CancelledException.class, () ->
+            mStream.receive(TIMEOUT));
+    assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 
   /**
@@ -190,11 +184,10 @@ public final class GrpcBlockingStreamTest {
    */
   @Test
   public void receiveError() throws Exception {
-    mThrown.expect(UnauthenticatedException.class);
-    mThrown.expectMessage(containsString(TEST_MESSAGE));
     mResponseObserver.onError(Status.UNAUTHENTICATED.asRuntimeException());
-
-    mStream.receive(TIMEOUT);
+    Exception e = assertThrows(UnauthenticatedException.class, () ->
+            mStream.receive(TIMEOUT));
+    assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 
   /**
@@ -203,10 +196,9 @@ public final class GrpcBlockingStreamTest {
   @Test
   public void sendFailsAfterTimeout() throws Exception {
     when(mRequestObserver.isReady()).thenReturn(false);
-    mThrown.expect(DeadlineExceededException.class);
-    mThrown.expectMessage(containsString(TEST_MESSAGE));
-
-    mStream.send(WriteRequest.newBuilder().build(), SHORT_TIMEOUT);
+    Exception e = assertThrows(DeadlineExceededException.class, () ->
+            mStream.send(WriteRequest.newBuilder().build(), SHORT_TIMEOUT));
+    assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 
   /**
@@ -214,10 +206,9 @@ public final class GrpcBlockingStreamTest {
    */
   @Test
   public void receiveFailsAfterTimeout() throws Exception {
-    mThrown.expect(DeadlineExceededException.class);
-    mThrown.expectMessage(containsString(TEST_MESSAGE));
-
-    mStream.receive(SHORT_TIMEOUT);
+    Exception e = assertThrows(DeadlineExceededException.class, () ->
+            mStream.receive(SHORT_TIMEOUT));
+    assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 
   /**
@@ -295,8 +286,6 @@ public final class GrpcBlockingStreamTest {
    */
   @Test
   public void receiveErrorWhenBufferFull() throws Exception {
-    mThrown.expect(UnauthenticatedException.class);
-    mThrown.expectMessage(containsString(TEST_MESSAGE));
     WriteResponse[] responses = Stream.generate(() -> WriteResponse.newBuilder().build())
         .limit(BUFFER_SIZE).toArray(WriteResponse[]::new);
     for (WriteResponse response : responses) {
@@ -304,10 +293,13 @@ public final class GrpcBlockingStreamTest {
     }
     mResponseObserver.onError(Status.UNAUTHENTICATED.asRuntimeException());
 
-    for (WriteResponse response : responses) {
-      WriteResponse actualResponse = mStream.receive(TIMEOUT);
-      assertEquals(response, actualResponse);
-    }
+    Exception e = assertThrows(UnauthenticatedException.class, () -> {
+      for (WriteResponse response : responses) {
+        WriteResponse actualResponse = mStream.receive(TIMEOUT);
+        assertEquals(response, actualResponse);
+      }
+    });
+    assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 
   /**
@@ -361,9 +353,9 @@ public final class GrpcBlockingStreamTest {
 
     WriteResponse actualResponse = mStream.receive(SHORT_TIMEOUT);
     assertEquals(responses[0], actualResponse);
-    mThrown.expect(DeadlineExceededException.class);
-    mThrown.expectMessage(containsString(TEST_MESSAGE));
 
-    mStream.waitForComplete(SHORT_TIMEOUT);
+    Exception e = assertThrows(DeadlineExceededException.class, () ->
+            mStream.waitForComplete(SHORT_TIMEOUT));
+    assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcBlockingStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcBlockingStreamTest.java
@@ -141,7 +141,7 @@ public final class GrpcBlockingStreamTest {
   @Test
   public void sendError() throws Exception {
     mResponseObserver.onError(Status.UNAUTHENTICATED.asRuntimeException());
-    Exception e = assertThrows(CancelledException.class,
+    Exception e = assertThrows(UnauthenticatedException.class,
         () -> mStream.send(WriteRequest.newBuilder().build(), TIMEOUT));
     assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcBlockingStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcBlockingStreamTest.java
@@ -175,7 +175,7 @@ public final class GrpcBlockingStreamTest {
   public void receiveFailsAfterCanceled() throws Exception {
     mStream.cancel();
     Exception e = assertThrows(CancelledException.class, () ->
-            mStream.receive(TIMEOUT));
+        mStream.receive(TIMEOUT));
     assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 
@@ -186,7 +186,7 @@ public final class GrpcBlockingStreamTest {
   public void receiveError() throws Exception {
     mResponseObserver.onError(Status.UNAUTHENTICATED.asRuntimeException());
     Exception e = assertThrows(UnauthenticatedException.class, () ->
-            mStream.receive(TIMEOUT));
+        mStream.receive(TIMEOUT));
     assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 
@@ -197,7 +197,7 @@ public final class GrpcBlockingStreamTest {
   public void sendFailsAfterTimeout() throws Exception {
     when(mRequestObserver.isReady()).thenReturn(false);
     Exception e = assertThrows(DeadlineExceededException.class, () ->
-            mStream.send(WriteRequest.newBuilder().build(), SHORT_TIMEOUT));
+        mStream.send(WriteRequest.newBuilder().build(), SHORT_TIMEOUT));
     assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 
@@ -207,7 +207,7 @@ public final class GrpcBlockingStreamTest {
   @Test
   public void receiveFailsAfterTimeout() throws Exception {
     Exception e = assertThrows(DeadlineExceededException.class, () ->
-            mStream.receive(SHORT_TIMEOUT));
+        mStream.receive(SHORT_TIMEOUT));
     assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 
@@ -355,7 +355,7 @@ public final class GrpcBlockingStreamTest {
     assertEquals(responses[0], actualResponse);
 
     Exception e = assertThrows(DeadlineExceededException.class, () ->
-            mStream.waitForComplete(SHORT_TIMEOUT));
+        mStream.waitForComplete(SHORT_TIMEOUT));
     assertTrue(e.getMessage().contains(TEST_MESSAGE));
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
@@ -12,11 +12,11 @@
 package alluxio.client.file;
 
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
-
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
@@ -62,9 +62,7 @@ import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
@@ -89,9 +87,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class FileOutStreamTest {
 
   private static InstancedConfiguration sConf = ConfigurationTestUtils.defaults();
-
-  @Rule
-  public ExpectedException mException = ExpectedException.none();
 
   private static final long BLOCK_LENGTH = 100L;
   private static final AlluxioURI FILE_NAME = new AlluxioURI("/file");
@@ -459,9 +454,9 @@ public class FileOutStreamTest {
     OutStreamOptions options = OutStreamOptions.defaults(mClientContext)
         .setLocationPolicy((getWorkerOptions) -> null)
         .setWriteType(WriteType.CACHE_THROUGH);
-    mException.expect(UnavailableException.class);
-    mException.expectMessage(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
-    mTestStream = createTestStream(FILE_NAME, options);
+    assertThrows(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage(), UnavailableException.class, () -> {
+      mTestStream = createTestStream(FILE_NAME, options);
+    });
   }
 
   private void verifyIncreasingBytesWritten(int len) {

--- a/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
@@ -454,9 +454,8 @@ public class FileOutStreamTest {
     OutStreamOptions options = OutStreamOptions.defaults(mClientContext)
         .setLocationPolicy((getWorkerOptions) -> null)
         .setWriteType(WriteType.CACHE_THROUGH);
-    assertThrows(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage(), UnavailableException.class, () -> {
-      mTestStream = createTestStream(FILE_NAME, options);
-    });
+    assertThrows(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage(), UnavailableException.class,
+        () -> mTestStream = createTestStream(FILE_NAME, options));
   }
 
   private void verifyIncreasingBytesWritten(int len) {

--- a/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
@@ -454,8 +454,9 @@ public class FileOutStreamTest {
     OutStreamOptions options = OutStreamOptions.defaults(mClientContext)
         .setLocationPolicy((getWorkerOptions) -> null)
         .setWriteType(WriteType.CACHE_THROUGH);
-    assertThrows(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage(), UnavailableException.class,
+    Exception e = assertThrows(UnavailableException.class,
         () -> mTestStream = createTestStream(FILE_NAME, options));
+    assertTrue(e.getMessage().contains(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage()));
   }
 
   private void verifyIncreasingBytesWritten(int len) {

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemCacheTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemCacheTest.java
@@ -12,7 +12,11 @@
 package alluxio.client.file;
 
 import static alluxio.client.file.FileSystemCache.Key;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.InstancedConfiguration;
@@ -112,15 +116,15 @@ public class FileSystemCacheTest {
 
   @Test
   public void listStatusClosed() throws IOException, AlluxioException {
-    assertThrows(FileSystemCache.InstanceCachingFileSystem.CLOSED_FS_ERROR_MESSAGE,
-      IOException.class,
-      () -> {
-        Key key1 = createTestFSKey("user1");
-        FileSystem fs1 = mFileSystemCache.get(key1);
-        fs1.close();
-        assertTrue(fs1.isClosed());
-        fs1.listStatus(new AlluxioURI("/"));
-      });
+    Exception e = assertThrows(IOException.class, () -> {
+      Key key1 = createTestFSKey("user1");
+      FileSystem fs1 = mFileSystemCache.get(key1);
+      fs1.close();
+      assertTrue(fs1.isClosed());
+      fs1.listStatus(new AlluxioURI("/"));
+    });
+    assertTrue(e.getMessage()
+            .contains(FileSystemCache.InstanceCachingFileSystem.CLOSED_FS_ERROR_MESSAGE));
   }
 
   private Key createTestFSKey(String username) {

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemCacheTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemCacheTest.java
@@ -12,10 +12,7 @@
 package alluxio.client.file;
 
 import static alluxio.client.file.FileSystemCache.Key;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.InstancedConfiguration;
@@ -23,9 +20,7 @@ import alluxio.exception.AlluxioException;
 import alluxio.security.User;
 import alluxio.util.ConfigurationUtils;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.security.Principal;
@@ -35,9 +30,6 @@ import java.util.Set;
 import javax.security.auth.Subject;
 
 public class FileSystemCacheTest {
-  @Rule
-  public ExpectedException mThrown = ExpectedException.none();
-
   private FileSystemCache mFileSystemCache = new FileSystemCache();
 
   // Helper method to get the underlying delegated file system from cache
@@ -120,13 +112,15 @@ public class FileSystemCacheTest {
 
   @Test
   public void listStatusClosed() throws IOException, AlluxioException {
-    mThrown.expect(IOException.class);
-    mThrown.expectMessage(FileSystemCache.InstanceCachingFileSystem.CLOSED_FS_ERROR_MESSAGE);
-    Key key1 = createTestFSKey("user1");
-    FileSystem fs1 = mFileSystemCache.get(key1);
-    fs1.close();
-    assertTrue(fs1.isClosed());
-    fs1.listStatus(new AlluxioURI("/"));
+    assertThrows(FileSystemCache.InstanceCachingFileSystem.CLOSED_FS_ERROR_MESSAGE,
+      IOException.class,
+      () -> {
+        Key key1 = createTestFSKey("user1");
+        FileSystem fs1 = mFileSystemCache.get(key1);
+        fs1.close();
+        assertTrue(fs1.isClosed());
+        fs1.listStatus(new AlluxioURI("/"));
+      });
   }
 
   private Key createTestFSKey(String username) {

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemCacheTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemCacheTest.java
@@ -124,7 +124,7 @@ public class FileSystemCacheTest {
       fs1.listStatus(new AlluxioURI("/"));
     });
     assertTrue(e.getMessage()
-            .contains(FileSystemCache.InstanceCachingFileSystem.CLOSED_FS_ERROR_MESSAGE));
+        .contains(FileSystemCache.InstanceCachingFileSystem.CLOSED_FS_ERROR_MESSAGE));
   }
 
   private Key createTestFSKey(String username) {

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemFactoryTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemFactoryTest.java
@@ -11,12 +11,6 @@
 
 package alluxio.client.file;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import alluxio.SystemPropertyRule;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
@@ -28,9 +22,7 @@ import alluxio.util.ConfigurationUtils;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -42,11 +34,9 @@ import java.util.Set;
 
 import javax.security.auth.Subject;
 
+import static org.junit.Assert.*;
+
 public class FileSystemFactoryTest {
-
-  @Rule
-  public ExpectedException mThrown = ExpectedException.none();
-
   @Before
   public void before() {
     ConfigurationUtils.reloadProperties();
@@ -110,8 +100,7 @@ public class FileSystemFactoryTest {
 
   @Test
   public void nullSubjectTest()  {
-    mThrown.expect(NullPointerException.class);
-    FileSystem.Factory.get(null);
+    assertThrows(NullPointerException.class, () -> FileSystem.Factory.get(null));
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemFactoryTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemFactoryTest.java
@@ -11,6 +11,13 @@
 
 package alluxio.client.file;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import alluxio.SystemPropertyRule;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
@@ -33,8 +40,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.security.auth.Subject;
-
-import static org.junit.Assert.*;
 
 public class FileSystemFactoryTest {
   @Before

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/DefaultMetaStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/DefaultMetaStoreTest.java
@@ -11,6 +11,8 @@
 
 package alluxio.client.file.cache;
 
+import static org.junit.Assert.assertThrows;
+
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.exception.PageNotFoundException;
@@ -18,8 +20,6 @@ import alluxio.exception.PageNotFoundException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertThrows;
 
 /**
  * Tests for the {@link DefaultMetaStore} class.
@@ -61,8 +61,6 @@ public class DefaultMetaStoreTest {
 
   @Test
   public void removeNotExist() throws Exception {
-    // TODO(jiacheng)
-//    mThrown.expect(PageNotFoundException.class);
     assertThrows(PageNotFoundException.class, () -> mMetaStore.removePage(mPage));
     Assert.assertEquals(mPageInfo, mMetaStore.removePage(mPage));
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/DefaultMetaStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/DefaultMetaStoreTest.java
@@ -17,17 +17,14 @@ import alluxio.exception.PageNotFoundException;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertThrows;
 
 /**
  * Tests for the {@link DefaultMetaStore} class.
  */
 public class DefaultMetaStoreTest {
-  @Rule
-  public final ExpectedException mThrown = ExpectedException.none();
-
   protected final PageId mPage = new PageId("1L", 2L);
   protected final PageInfo mPageInfo = new PageInfo(mPage, 1024);
   protected final InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
@@ -64,7 +61,9 @@ public class DefaultMetaStoreTest {
 
   @Test
   public void removeNotExist() throws Exception {
-    mThrown.expect(PageNotFoundException.class);
+    // TODO(jiacheng)
+//    mThrown.expect(PageNotFoundException.class);
+    assertThrows(PageNotFoundException.class, () -> mMetaStore.removePage(mPage));
     Assert.assertEquals(mPageInfo, mMetaStore.removePage(mPage));
   }
 
@@ -83,8 +82,7 @@ public class DefaultMetaStoreTest {
 
   @Test
   public void getPageInfoNotExist() throws Exception {
-    mThrown.expect(PageNotFoundException.class);
-    mMetaStore.getPageInfo(mPage);
+    assertThrows(PageNotFoundException.class, () -> mMetaStore.getPageInfo(mPage));
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/DefaultMetaStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/DefaultMetaStoreTest.java
@@ -61,8 +61,9 @@ public class DefaultMetaStoreTest {
 
   @Test
   public void removeNotExist() throws Exception {
-    assertThrows(PageNotFoundException.class, () -> mMetaStore.removePage(mPage));
-    Assert.assertEquals(mPageInfo, mMetaStore.removePage(mPage));
+    assertThrows(PageNotFoundException.class, () -> {
+      Assert.assertEquals(mPageInfo, mMetaStore.removePage(mPage));
+    });
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -55,7 +55,6 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
 
 /**
  * Tests for the {@link LocalCacheManager} class.

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -485,7 +485,7 @@ public final class LocalCacheManagerTest {
   public void getNotEnoughSpaceException() throws Exception {
     byte[] buf = new byte[PAGE1.length - 1];
     assertThrows(IllegalArgumentException.class, () ->
-            mCacheManager.get(PAGE_ID1, PAGE1.length, buf, 0));
+        mCacheManager.get(PAGE_ID1, PAGE1.length, buf, 0));
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -11,13 +11,6 @@
 
 package alluxio.client.file.cache;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.file.cache.evictor.CacheEvictor;
@@ -43,7 +36,6 @@ import com.google.common.collect.Streams;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
@@ -55,6 +47,9 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
+
+import static org.junit.Assert.*;
 
 /**
  * Tests for the {@link LocalCacheManager} class.
@@ -77,9 +72,6 @@ public final class LocalCacheManagerTest {
 
   @Rule
   public TemporaryFolder mTemp = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException mThrown = ExpectedException.none();
 
   @Before
   public void before() throws Exception {
@@ -487,8 +479,8 @@ public final class LocalCacheManagerTest {
   @Test
   public void getNotEnoughSpaceException() throws Exception {
     byte[] buf = new byte[PAGE1.length - 1];
-    mThrown.expect(IllegalArgumentException.class);
-    mCacheManager.get(PAGE_ID1, PAGE1.length, buf, 0);
+    assertThrows(IllegalArgumentException.class, () ->
+            mCacheManager.get(PAGE_ID1, PAGE1.length, buf, 0));
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -11,6 +11,14 @@
 
 package alluxio.client.file.cache;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.file.cache.evictor.CacheEvictor;
@@ -48,8 +56,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
-
-import static org.junit.Assert.*;
 
 /**
  * Tests for the {@link LocalCacheManager} class.

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/TimeBoundPageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/TimeBoundPageStoreTest.java
@@ -88,7 +88,7 @@ public class TimeBoundPageStoreTest {
     mPageStore.put(PAGE_ID, PAGE);
     mTimeBoundPageStore.delete(PAGE_ID);
     assertThrows(PageNotFoundException.class, () ->
-            mPageStore.get(PAGE_ID, 0, PAGE.length, mBuf, 0));
+        mPageStore.get(PAGE_ID, 0, PAGE.length, mBuf, 0));
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/TimeBoundPageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/TimeBoundPageStoreTest.java
@@ -12,11 +12,7 @@
 package alluxio.client.file.cache;
 
 import static java.util.concurrent.Executors.newScheduledThreadPool;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
@@ -29,7 +25,6 @@ import alluxio.util.io.BufferUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
@@ -53,8 +48,6 @@ public class TimeBoundPageStoreTest {
 
   @Rule
   public TemporaryFolder mTemp = new TemporaryFolder();
-  @Rule
-  public ExpectedException mThrown = ExpectedException.none();
 
   @Before
   public void before() throws Exception {
@@ -89,8 +82,8 @@ public class TimeBoundPageStoreTest {
   public void delete() throws Exception {
     mPageStore.put(PAGE_ID, PAGE);
     mTimeBoundPageStore.delete(PAGE_ID);
-    mThrown.expect(PageNotFoundException.class);
-    mPageStore.get(PAGE_ID, 0, PAGE.length, mBuf, 0);
+    assertThrows(PageNotFoundException.class, () ->
+            mPageStore.get(PAGE_ID, 0, PAGE.length, mBuf, 0));
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/TimeBoundPageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/TimeBoundPageStoreTest.java
@@ -12,7 +12,12 @@
 package alluxio.client.file.cache;
 
 import static java.util.concurrent.Executors.newScheduledThreadPool;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
@@ -11,10 +11,6 @@
 
 package alluxio.client.file.cache.store;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import alluxio.Constants;
 import alluxio.ProjectConstants;
 import alluxio.client.file.cache.PageId;
@@ -28,7 +24,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -44,6 +39,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class PageStoreTest {
@@ -63,9 +60,6 @@ public class PageStoreTest {
 
   @Rule
   public TemporaryFolder mTemp = new TemporaryFolder();
-
-  @Rule
-  public final ExpectedException mThrown = ExpectedException.none();
 
   @Before
   public void before() throws Exception {
@@ -120,8 +114,8 @@ public class PageStoreTest {
     PageId id = new PageId("0", 0);
     mPageStore.put(id, BufferUtils.getIncreasingByteArray(len));
     byte[] buf = new byte[1024];
-    mThrown.expect(IllegalArgumentException.class);
-    mPageStore.get(id, offset, len, buf, 0);
+    assertThrows(IllegalArgumentException.class,
+            () -> mPageStore.get(id, offset, len, buf, 0));
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
@@ -11,6 +11,11 @@
 
 package alluxio.client.file.cache.store;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+
 import alluxio.Constants;
 import alluxio.ProjectConstants;
 import alluxio.client.file.cache.PageId;
@@ -39,8 +44,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
-import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class PageStoreTest {
@@ -114,8 +117,8 @@ public class PageStoreTest {
     PageId id = new PageId("0", 0);
     mPageStore.put(id, BufferUtils.getIncreasingByteArray(len));
     byte[] buf = new byte[1024];
-    assertThrows(IllegalArgumentException.class,
-            () -> mPageStore.get(id, offset, len, buf, 0));
+    assertThrows(IllegalArgumentException.class, () ->
+        mPageStore.get(id, offset, len, buf, 0));
   }
 
   @Test

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemApiTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemApiTest.java
@@ -11,6 +11,11 @@
 
 package alluxio.hadoop;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
@@ -23,8 +28,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URI;
-
-import static org.junit.Assert.*;
 
 /**
  * Tests for {@link AbstractFileSystem}. Unlike {@link AbstractFileSystemTest}, these tests only
@@ -52,9 +55,10 @@ public final class AbstractFileSystemApiTest {
   @Test
   public void unknownAuthorityTriggersWarning() throws IOException {
     URI unknown = URI.create("alluxio://test/");
-    assertThrows("Authority \"test\" is unknown. The client can not be configured with "
-            + "the authority from " + unknown, Exception.class,
-            () -> FileSystem.get(unknown, new org.apache.hadoop.conf.Configuration()));
+    Exception e = assertThrows(Exception.class, () ->
+            FileSystem.get(unknown, new org.apache.hadoop.conf.Configuration()));
+    assertTrue(e.getMessage().contains("Authority \"test\" is unknown. "
+            + "The client can not be configured with the authority from " + unknown));
   }
 
   @Test

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemApiTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemApiTest.java
@@ -11,10 +11,6 @@
 
 package alluxio.hadoop;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
@@ -24,10 +20,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.net.URI;
+
+import static org.junit.Assert.*;
 
 /**
  * Tests for {@link AbstractFileSystem}. Unlike {@link AbstractFileSystemTest}, these tests only
@@ -37,9 +34,6 @@ public final class AbstractFileSystemApiTest {
 
   @Rule
   public TestLoggerRule mTestLogger = new TestLoggerRule();
-
-  @Rule
-  public ExpectedException mThrown = ExpectedException.none();
 
   private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
 
@@ -58,9 +52,9 @@ public final class AbstractFileSystemApiTest {
   @Test
   public void unknownAuthorityTriggersWarning() throws IOException {
     URI unknown = URI.create("alluxio://test/");
-    mThrown.expectMessage("Authority \"test\" is unknown. The client can not be configured with "
-        + "the authority from " + unknown);
-    FileSystem.get(unknown, new org.apache.hadoop.conf.Configuration());
+    assertThrows("Authority \"test\" is unknown. The client can not be configured with "
+            + "the authority from " + unknown, Exception.class,
+            () -> FileSystem.get(unknown, new org.apache.hadoop.conf.Configuration()));
   }
 
   @Test

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemApiTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemApiTest.java
@@ -56,9 +56,9 @@ public final class AbstractFileSystemApiTest {
   public void unknownAuthorityTriggersWarning() throws IOException {
     URI unknown = URI.create("alluxio://test/");
     Exception e = assertThrows(Exception.class, () ->
-            FileSystem.get(unknown, new org.apache.hadoop.conf.Configuration()));
+        FileSystem.get(unknown, new org.apache.hadoop.conf.Configuration()));
     assertTrue(e.getMessage().contains("Authority \"test\" is unknown. "
-            + "The client can not be configured with the authority from " + unknown));
+        + "The client can not be configured with the authority from " + unknown));
   }
 
   @Test

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -52,9 +52,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -94,9 +92,6 @@ public class AbstractFileSystemTest {
 
   private InstancedConfiguration mConfiguration = ConfigurationTestUtils.defaults();
   private FileSystemContext mMockFileSystemContext = mock(FileSystemContext.class);
-
-  @Rule
-  public ExpectedException mExpectedException = ExpectedException.none();
 
   /**
    * Sets up the configuration before a test runs.

--- a/core/common/src/test/java/alluxio/worker/block/io/LocalFileBlockReaderTest.java
+++ b/core/common/src/test/java/alluxio/worker/block/io/LocalFileBlockReaderTest.java
@@ -100,11 +100,6 @@ public class LocalFileBlockReaderTest {
     // Read entire block by setting the length to be block size.
     buffer = mReader.read(0, TEST_BLOCK_SIZE);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
-
-    // Read entire block by setting the length to be -1
-    int length = -1;
-    buffer = mReader.read(0, length);
-    assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
   }
 
   /**

--- a/core/common/src/test/java/alluxio/worker/block/io/LocalFileBlockReaderTest.java
+++ b/core/common/src/test/java/alluxio/worker/block/io/LocalFileBlockReaderTest.java
@@ -11,6 +11,8 @@
 
 package alluxio.worker.block.io;
 
+import static org.junit.Assert.assertThrows;
+
 import alluxio.exception.status.FailedPreconditionException;
 import alluxio.util.io.BufferUtils;
 
@@ -18,7 +20,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
@@ -35,10 +36,6 @@ public class LocalFileBlockReaderTest {
   /** Rule to create a new temporary folder during each test. */
   @Rule
   public TemporaryFolder mFolder = new TemporaryFolder();
-
-  /** The exception expected to be thrown. */
-  @Rule
-  public ExpectedException mThrown = ExpectedException.none();
 
   /**
    * Sets up the file path and file block reader before a test runs.
@@ -82,9 +79,9 @@ public class LocalFileBlockReaderTest {
    */
   @Test
   public void readWithInvalidArgument() throws Exception {
-    mThrown.expect(IllegalArgumentException.class);
-    mThrown.expectMessage("exceeding fileSize");
-    mReader.read(TEST_BLOCK_SIZE - 1, 2);
+    assertThrows("exceeding fileSize", IllegalArgumentException.class, () -> {
+      mReader.read(TEST_BLOCK_SIZE - 1, 2);
+    });
   }
 
   /**
@@ -110,7 +107,8 @@ public class LocalFileBlockReaderTest {
   @Test
   public void close() throws Exception {
     mReader.close();
-    mThrown.expect(IOException.class);
-    mReader.read(0, TEST_BLOCK_SIZE);
+    assertThrows(IOException.class, () -> {
+      mReader.read(0, TEST_BLOCK_SIZE);
+    });
   }
 }

--- a/core/common/src/test/java/alluxio/worker/block/io/LocalFileBlockReaderTest.java
+++ b/core/common/src/test/java/alluxio/worker/block/io/LocalFileBlockReaderTest.java
@@ -12,6 +12,7 @@
 package alluxio.worker.block.io;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import alluxio.exception.status.FailedPreconditionException;
 import alluxio.util.io.BufferUtils;
@@ -58,7 +59,7 @@ public class LocalFileBlockReaderTest {
     ByteBuffer buffer = ByteBuffer.allocate((int) TEST_BLOCK_SIZE);
     int bytesRead = channel.read(buffer);
     Assert.assertEquals(TEST_BLOCK_SIZE, bytesRead);
-    Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
+    assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
   }
 
   @Test
@@ -79,9 +80,10 @@ public class LocalFileBlockReaderTest {
    */
   @Test
   public void readWithInvalidArgument() throws Exception {
-    assertThrows("exceeding fileSize", IllegalArgumentException.class, () -> {
+    Exception e = assertThrows(IllegalArgumentException.class, () -> {
       mReader.read(TEST_BLOCK_SIZE - 1, 2);
     });
+    assertTrue(e.getMessage().contains("exceeding fileSize"));
   }
 
   /**
@@ -93,11 +95,16 @@ public class LocalFileBlockReaderTest {
 
     // Read 1/4 block by setting the length to be 1/4 of the block size.
     buffer = mReader.read(0, TEST_BLOCK_SIZE / 4);
-    Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE / 4, buffer));
+    assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE / 4, buffer));
 
     // Read entire block by setting the length to be block size.
     buffer = mReader.read(0, TEST_BLOCK_SIZE);
-    Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
+    assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
+
+    // Read entire block by setting the length to be -1
+    int length = -1;
+    buffer = mReader.read(0, length);
+    assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
   }
 
   /**


### PR DESCRIPTION
`ExpectedException.none()` is deprecated in JUnit 4.13. It's recommended to change it to `Assert.assertThrows`.

```
package org.junit.rules;
public class ExpectedException implements TestRule {
    /**
     * Returns a {@linkplain TestRule rule} that expects no exception to
     * be thrown (identical to behavior without this rule).
     *
     * @deprecated Since 4.13
     * {@link org.junit.Assert#assertThrows(Class, org.junit.function.ThrowingRunnable)
     * Assert.assertThrows} can be used to verify that your code throws a specific
     * exception.
     */
    @Deprecated
    public static ExpectedException none() {
        return new ExpectedException();
    }
```

Considering the number of tests to update, I will do this module by module. This PR takes care of the client package.