### PR TITLE
Support logLevel for job master/worker

### DIFF
--- a/job/server/src/main/java/alluxio/master/AlluxioJobMasterRestServiceHandler.java
+++ b/job/server/src/main/java/alluxio/master/AlluxioJobMasterRestServiceHandler.java
@@ -15,6 +15,7 @@ import alluxio.conf.ServerConfiguration;
 import alluxio.conf.ConfigurationValueOptions;
 import alluxio.RestUtils;
 import alluxio.RuntimeConstants;
+import alluxio.util.LogUtils;
 import alluxio.web.JobMasterWebServer;
 import alluxio.wire.AlluxioJobMasterInfo;
 
@@ -27,6 +28,7 @@ import java.util.Map;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
@@ -43,6 +45,10 @@ import javax.ws.rs.core.Response;
 @Produces(MediaType.APPLICATION_JSON)
 public final class AlluxioJobMasterRestServiceHandler {
   public static final String SERVICE_PREFIX = "job_master";
+  // log
+  public static final String LOG_LEVEL = "logLevel";
+  public static final String LOG_ARGUMENT_NAME = "logName";
+  public static final String LOG_ARGUMENT_LEVEL = "level";
 
   // endpoints
   public static final String GET_INFO = "info";
@@ -89,6 +95,20 @@ public final class AlluxioJobMasterRestServiceHandler {
               .setWorkers(mJobMaster.getJobMaster().getWorkerInfoList());
       return result;
     }, ServerConfiguration.global());
+  }
+
+  /**
+   * @summary set the Alluxio log information
+   * @param logName the log's name
+   * @param level the log level
+   * @return the response object
+   */
+  @POST
+  @Path(LOG_LEVEL)
+  public Response logLevel(@QueryParam(LOG_ARGUMENT_NAME) final String logName,
+                           @QueryParam(LOG_ARGUMENT_LEVEL) final String level) {
+    return RestUtils.call(() -> LogUtils.setLogLevel(logName, level),
+            ServerConfiguration.global());
   }
 
   private Map<String, String> getConfigurationInternal(boolean raw) {

--- a/job/server/src/main/java/alluxio/worker/AlluxioJobWorkerRestServiceHandler.java
+++ b/job/server/src/main/java/alluxio/worker/AlluxioJobWorkerRestServiceHandler.java
@@ -15,6 +15,7 @@ import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.RestUtils;
 import alluxio.RuntimeConstants;
+import alluxio.util.LogUtils;
 import alluxio.web.JobWorkerWebServer;
 import alluxio.wire.AlluxioJobWorkerInfo;
 
@@ -30,6 +31,7 @@ import java.util.TreeMap;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
@@ -46,6 +48,10 @@ import javax.ws.rs.core.Response;
 @Produces(MediaType.APPLICATION_JSON)
 public final class  AlluxioJobWorkerRestServiceHandler {
   public static final String SERVICE_PREFIX = "job_worker";
+  // log
+  public static final String LOG_LEVEL = "logLevel";
+  public static final String LOG_ARGUMENT_NAME = "logName";
+  public static final String LOG_ARGUMENT_LEVEL = "level";
 
   // endpoints
   public static final String GET_INFO = "info";
@@ -91,6 +97,20 @@ public final class  AlluxioJobWorkerRestServiceHandler {
               .setVersion(RuntimeConstants.VERSION);
       return result;
     }, ServerConfiguration.global());
+  }
+
+  /**
+   * @summary set the Alluxio log information
+   * @param logName the log's name
+   * @param level the log level
+   * @return the response object
+   */
+  @POST
+  @Path(LOG_LEVEL)
+  public Response logLevel(@QueryParam(LOG_ARGUMENT_NAME) final String logName,
+                           @QueryParam(LOG_ARGUMENT_LEVEL) final String level) {
+    return RestUtils.call(() -> LogUtils.setLogLevel(logName, level),
+            ServerConfiguration.global());
   }
 
   private Map<String, String> getConfigurationInternal(boolean raw) {

--- a/shell/src/main/java/alluxio/cli/LogLevel.java
+++ b/shell/src/main/java/alluxio/cli/LogLevel.java
@@ -16,14 +16,18 @@ import alluxio.Constants;
 import alluxio.annotation.PublicApi;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.file.FileSystemContext;
+import alluxio.client.job.JobMasterClient;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.job.wire.JobWorkerHealth;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.network.HttpUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 import alluxio.wire.LogInfo;
 import alluxio.wire.WorkerNetAddress;
+import alluxio.worker.job.JobMasterClientContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.cli.CommandLine;
@@ -35,6 +39,8 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,10 +54,15 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 @PublicApi
 public final class LogLevel {
+  private static final Logger LOG = LoggerFactory.getLogger(LogLevel.class);
+
   private static final String LOG_LEVEL = "logLevel";
   private static final String ROLE_WORKERS = "workers";
   private static final String ROLE_MASTER = "master";
   private static final String ROLE_WORKER = "worker";
+  private static final String ROLE_JOB_MASTER = "job_master";
+  private static final String ROLE_JOB_WORKER = "job_worker";
+  private static final String ROLE_JOB_WORKERS = "job_workers";
   private static final String TARGET_SEPARATOR = ",";
   private static final String TARGET_OPTION_NAME = "target";
   private static final Option TARGET_OPTION =
@@ -142,14 +153,47 @@ public final class LogLevel {
       if (target.equals(ROLE_MASTER)) {
         String masterHost = NetworkAddressUtils.getConnectHost(ServiceType.MASTER_WEB, conf);
         int masterPort = NetworkAddressUtils.getPort(ServiceType.MASTER_WEB, conf);
-        targetInfoList.add(new TargetInfo(masterHost, masterPort, ROLE_MASTER));
+        TargetInfo master = new TargetInfo(masterHost, masterPort, ROLE_MASTER);
+        System.out.format("Setting log level on master %s:%s%n", master.mHost, master.mPort);
+        targetInfoList.add(master);
+      } else if (target.equals(ROLE_JOB_MASTER)) {
+        String jobMasterHost = NetworkAddressUtils.getConnectHost(ServiceType.JOB_MASTER_WEB, conf);
+        int jobMasterPort = NetworkAddressUtils.getPort(ServiceType.JOB_MASTER_WEB, conf);
+        TargetInfo jobMaster = new TargetInfo(jobMasterHost, jobMasterPort, ROLE_JOB_MASTER);
+        System.out.format("Setting log level on job master %s:%s%n",
+                jobMaster.mHost, jobMaster.mPort);
+        targetInfoList.add(jobMaster);
       } else if (target.equals(ROLE_WORKERS)) {
         List<BlockWorkerInfo> workerInfoList =
             FileSystemContext.create(ClientContext.create(conf)).getCachedWorkers();
+        if (workerInfoList.size() == 0) {
+          System.out.println("No workers found");
+          System.exit(1);
+        }
         for (BlockWorkerInfo workerInfo : workerInfoList) {
           WorkerNetAddress netAddress = workerInfo.getNetAddress();
-          targetInfoList.add(
-              new TargetInfo(netAddress.getHost(), netAddress.getWebPort(), ROLE_WORKER));
+          TargetInfo worker = new TargetInfo(netAddress.getHost(),
+                  netAddress.getWebPort(), ROLE_WORKER);
+          System.out.format("Setting log level on worker %s:%s%n",
+                  worker.mHost, worker.mPort);
+          targetInfoList.add(worker);
+        }
+      } else if (target.equals(ROLE_JOB_WORKERS)) {
+        JobMasterClientContext context = JobMasterClientContext
+                .newBuilder(ClientContext.create(conf)).build();
+        JobMasterClient client = JobMasterClient.Factory.create(context);
+        List<JobWorkerHealth> jobWorkerInfoList = client.getAllWorkerHealth();
+        if (jobWorkerInfoList.size() == 0) {
+          System.out.println("No job workers found");
+          System.exit(1);
+        }
+        int jobWorkerPort = conf.getInt(PropertyKey.JOB_WORKER_WEB_PORT);
+        for (JobWorkerHealth jobWorkerInfo : jobWorkerInfoList) {
+          String jobWorkerHost = jobWorkerInfo.getHostname();
+          TargetInfo jobWorker = new TargetInfo(jobWorkerHost, jobWorkerPort, ROLE_JOB_WORKER);
+          System.out.format("Setting log level on job worker %s:%s%n",
+                  jobWorker.mHost, jobWorker.mPort);
+          targetInfoList.add(jobWorker);
         }
       } else if (target.contains(":")) {
         String[] hostPortPair = target.split(":");
@@ -192,6 +236,7 @@ public final class LogLevel {
     if (level != null) {
       uriBuilder.addParameter(LEVEL_OPTION_NAME, level);
     }
+    LOG.info("Setting log level on %s%n", uriBuilder.toString());
     HttpUtils.post(uriBuilder.toString(), "", 5000, inputStream -> {
       ObjectMapper mapper = new ObjectMapper();
       LogInfo logInfo = mapper.readValue(inputStream, LogInfo.class);


### PR DESCRIPTION
`logLevel` command currently only works for master and workers. This change enables the command to set log level on job master/workers.