### PR TITLE
Prevent unnecessary inode syncing

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -67,7 +67,6 @@ import com.google.common.base.MoreObjects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collection;
@@ -82,6 +81,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.function.Function;
+
+import javax.annotation.Nullable;
 
 /**
  * This class is responsible for maintaining the logic which surrounds syncing metadata between
@@ -569,9 +570,16 @@ public class InodeSyncStream {
       }
     }
 
-    syncChildren = syncChildren
-        && inode.isDirectory()
-        && mDescendantType != DescendantType.NONE;
+    // Only sync children when
+    // (1) DescendantType.ALL or (2) syncing root of this stream && DescendantType.ONE
+    if (mDescendantType == DescendantType.ONE) {
+      syncChildren =
+          syncChildren && inode.isDirectory() && mRootScheme.getPath().equals(inodePath.getUri());
+    } else if (mDescendantType == DescendantType.ALL) {
+      syncChildren = syncChildren && inode.isDirectory();
+    } else {
+      syncChildren = false;
+    }
 
     Map<String, Inode> inodeChildren = new HashMap<>();
     if (syncChildren) {

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -49,6 +49,7 @@ import alluxio.util.CommonUtils;
 import alluxio.util.FileSystemOptions;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.FileUtils;
+import alluxio.util.io.PathUtils;
 
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
@@ -163,6 +164,23 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
     checkGetStatus(EXISTING_DIR, options, true);
   }
 
+  // https://github.com/Alluxio/alluxio/issues/12372
+  @Test
+  public void getStatusDirSyncOnlyTouchingChildren() throws Exception {
+    String dir1 = PathUtils.concatPath(EXISTING_DIR, "dir_should_sync");
+    String dir2 = PathUtils.concatPath(dir1, "dir_should_not_sync");
+    new File(ufsPath(dir1)).mkdirs();
+    new File(ufsPath(dir2)).mkdirs();
+    GetStatusPOptions optionsAlways = GetStatusPOptions.newBuilder()
+        .setLoadMetadataType(LoadMetadataPType.NEVER)
+        .setCommonOptions(PSYNC_ALWAYS).build();
+    checkGetStatus(EXISTING_DIR, optionsAlways, true);
+    ListStatusPOptions optionsNever = ListStatusPOptions.newBuilder()
+        .setLoadMetadataType(LoadMetadataPType.NEVER).setCommonOptions(PSYNC_NEVER)
+        .setRecursive(false).build();
+    checkListStatus(dir2, optionsNever, false);
+  }
+
   @Test
   public void listDirSync() throws Exception {
     ListStatusPOptions options = ListStatusPOptions.newBuilder()
@@ -174,6 +192,23 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
     writeUfsFile(ufsPath(NEW_FILE), 2);
 
     checkListStatus(ROOT_DIR, options, true);
+  }
+
+  // https://github.com/Alluxio/alluxio/issues/12372
+  @Test
+  public void listDirSyncOnlyTouchingChildren() throws Exception {
+    String dir1 = PathUtils.concatPath(EXISTING_DIR, "dir_should_sync");
+    String dir2 = PathUtils.concatPath(dir1, "dir_should_not_sync");
+    new File(ufsPath(dir1)).mkdirs();
+    new File(ufsPath(dir2)).mkdirs();
+    ListStatusPOptions optionsAlways = ListStatusPOptions.newBuilder()
+        .setLoadMetadataType(LoadMetadataPType.NEVER).setRecursive(false)
+        .setCommonOptions(PSYNC_ALWAYS).build();
+    checkListStatus(EXISTING_DIR, optionsAlways, true);
+    ListStatusPOptions optionsNever = ListStatusPOptions.newBuilder()
+        .setLoadMetadataType(LoadMetadataPType.NEVER).setCommonOptions(PSYNC_NEVER)
+        .setRecursive(false).build();
+    checkListStatus(dir2, optionsNever, false);
   }
 
   @Test


### PR DESCRIPTION
Fix https://github.com/Alluxio/alluxio/issues/12372

Before this PR, running
```
bin/alluxio fs ls -Dalluxio.user.file.metadata.sync.interval=0 /path
```
will trigger syncing inodes:
(1) `/path`
(2) `/path/{children}`
(3) `/path/{children}/{children}` (added to pending inode queue when
`InodeSyncStream` traversing (2))

Reading (3) is unnecessary w.r.t. the command we are interested. This PR
check and prevent setting flag `syncChildren` unnecessarily.

In addition, this patch also saves one unnecessary RPC on ls command.

pr-link: Alluxio/alluxio#12441
change-id: cid-d1db929879e7e3a50b4e4a324391f7112dd8ef17