### PR TITLE
Support get_fuse_context for JNI-fuse

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -149,7 +149,10 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem {
 
   private void setUserGroupIfNeeded(AlluxioURI uri) throws Exception {
     SetAttributePOptions.Builder attributeOptionsBuilder = SetAttributePOptions.newBuilder();
+    ByteBuffer buffer = this.getLibFuse().get_fuse_context();
     FuseContext fc = getContext();
+    // TODO(maobaolong): open it after PR12836 merged.
+//    FuseContext fc = FuseContext.of(buffer);
     long uid = fc.uid.get();
     long gid = fc.gid.get();
     if (gid != DEFAULT_GID) {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -150,9 +150,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem {
   private void setUserGroupIfNeeded(AlluxioURI uri) throws Exception {
     SetAttributePOptions.Builder attributeOptionsBuilder = SetAttributePOptions.newBuilder();
     ByteBuffer buffer = this.getLibFuse().fuse_get_context();
-    FuseContext fc = getContext();
-    // TODO(maobaolong): open it after PR12836 merged.
-//    FuseContext fc = FuseContext.of(buffer);
+    FuseContext fc = FuseContext.of(buffer);
     long uid = fc.uid.get();
     long gid = fc.gid.get();
     if (gid != DEFAULT_GID) {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -149,7 +149,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem {
 
   private void setUserGroupIfNeeded(AlluxioURI uri) throws Exception {
     SetAttributePOptions.Builder attributeOptionsBuilder = SetAttributePOptions.newBuilder();
-    ByteBuffer buffer = this.getLibFuse().get_fuse_context();
+    ByteBuffer buffer = this.getLibFuse().fuse_get_context();
     FuseContext fc = getContext();
     // TODO(maobaolong): open it after PR12836 merged.
 //    FuseContext fc = FuseContext.of(buffer);

--- a/integration/fuse/src/main/java/alluxio/jnifuse/AbstractFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/jnifuse/AbstractFuseFileSystem.java
@@ -308,4 +308,8 @@ public abstract class AbstractFuseFileSystem implements FuseFileSystem {
       return -ErrorCodes.EIO();
     }
   }
+
+  protected LibFuse getLibFuse() {
+    return libFuse;
+  }
 }

--- a/integration/fuse/src/main/java/alluxio/jnifuse/LibFuse.java
+++ b/integration/fuse/src/main/java/alluxio/jnifuse/LibFuse.java
@@ -11,7 +11,11 @@
 
 package alluxio.jnifuse;
 
+import java.nio.ByteBuffer;
+
 public class LibFuse {
 
   public native int fuse_main_real(AbstractFuseFileSystem fs, int argc, String[] argv);
+
+  public native ByteBuffer get_fuse_context();
 }

--- a/integration/fuse/src/main/java/alluxio/jnifuse/LibFuse.java
+++ b/integration/fuse/src/main/java/alluxio/jnifuse/LibFuse.java
@@ -17,5 +17,5 @@ public class LibFuse {
 
   public native int fuse_main_real(AbstractFuseFileSystem fs, int argc, String[] argv);
 
-  public native ByteBuffer get_fuse_context();
+  public native ByteBuffer fuse_get_context();
 }

--- a/integration/fuse/src/main/native/libjnifuse/jnifuse_helper.cc
+++ b/integration/fuse/src/main/native/libjnifuse/jnifuse_helper.cc
@@ -80,6 +80,14 @@ jint JNICALL Java_alluxio_jnifuse_FuseFillDir_fill(JNIEnv *env, jobject obj,
   return ret;
 }
 
+jobject JNICALL Java_alluxio_jnifuse_LibFuse_get_1fuse_1context(JNIEnv *env, jobject obj) {
+  LOGD("enter get_fuse_context");
+  struct fuse_context *cxt = fuse_get_context();
+  jobject fibuf =
+    env->NewDirectByteBuffer((void *)cxt, sizeof(struct fuse_context));
+  return fibuf;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/integration/fuse/src/main/native/libjnifuse/jnifuse_helper.cc
+++ b/integration/fuse/src/main/native/libjnifuse/jnifuse_helper.cc
@@ -80,7 +80,7 @@ jint JNICALL Java_alluxio_jnifuse_FuseFillDir_fill(JNIEnv *env, jobject obj,
   return ret;
 }
 
-jobject JNICALL Java_alluxio_jnifuse_LibFuse_get_1fuse_1context(JNIEnv *env, jobject obj) {
+jobject JNICALL Java_alluxio_jnifuse_LibFuse_fuse_1get_1context(JNIEnv *env, jobject obj) {
   LOGD("enter get_fuse_context");
   struct fuse_context *cxt = fuse_get_context();
   jobject fibuf =


### PR DESCRIPTION
Without this feature, create file could be failed caused by that both the owner and group are all 0 from the mock fuse context, and non-root user have no permission to change owner and group.