### PR TITLE
Improve error message on connection failure

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -275,8 +275,9 @@ public abstract class AbstractClient implements Client {
           new ServiceNotFoundException(lastConnectFailure.getMessage(), lastConnectFailure));
     }
 
-    throw new UnavailableException(String.format("Failed to connect to %s @ %s after %s attempts",
-        getServiceName(), mAddress, retryPolicy.getAttemptCount()), lastConnectFailure);
+    throw new UnavailableException(String.format("Failed to connect to master (%s) after %s "
+            + "attempts of %s",
+        mAddress, retryPolicy.getAttemptCount(), getServiceName()), lastConnectFailure);
   }
 
   /**


### PR DESCRIPTION
Before:

```
$ bin/alluxio fs ls /
Failed to connect to FileSystemMasterClient @ localhost:19998 after 8 attempts
```

After:

```
$ bin/alluxio fs ls /
Failed to connect to master (localhost:19998) after 8 attempts of FileSystemMasterClient
```