### PR TITLE
Combine createFile and completeFile when sync metadata

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/CompleteFileResult.java
+++ b/core/server/master/src/main/java/alluxio/master/file/CompleteFileResult.java
@@ -1,0 +1,49 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file;
+
+import alluxio.proto.journal.File;
+
+/**
+ * Complete File Result containing two update entries to the journal.
+ */
+public class CompleteFileResult {
+  private File.UpdateInodeEntry mUpdateInodeEntry;
+  private File.UpdateInodeFileEntry mUpdateInodeFileEntry;
+
+  /**
+   * Construct a complete file result object.
+   */
+  CompleteFileResult(File.UpdateInodeEntry updateInodeEntry,
+      File.UpdateInodeFileEntry updateInodeFileEntry) {
+    mUpdateInodeEntry = updateInodeEntry;
+    mUpdateInodeFileEntry = updateInodeFileEntry;
+  }
+
+  /**
+   * Get the updateInodeEntry object.
+   *
+   * @return the inode update object
+   */
+  public File.UpdateInodeEntry getUpdateInodeEntry() {
+    return mUpdateInodeEntry;
+  }
+
+  /**
+   * Get the update inode file object.
+   *
+   * @return the inode file update object
+   */
+  public File.UpdateInodeFileEntry getUpdateInodeFileEntry() {
+    return mUpdateInodeFileEntry;
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1342,7 +1342,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
         throw e;
       }
       // Even readonly mount points should be able to complete a file, for UFS reads in CACHE mode.
-      CompleteFileResult completeFileResult = completeFileInternal(inodePath,
+      CompleteFileResult completeFileResult = completeFileWithResults(inodePath,
           inodePath.getInode(), context);
 
       // We could introduce a concept of composite entries, so that these two entries could
@@ -1362,56 +1362,8 @@ public final class DefaultFileSystemMaster extends CoreMaster
     }
   }
 
-  /**
-   * Complete File Result containing two update entries to the journal.
-   */
-  public class CompleteFileResult {
-    private UpdateInodeEntry mUpdateInodeEntry;
-    private UpdateInodeFileEntry mUpdateInodeFileEntry;
-
-    /**
-     * Construct a complete file result object.
-     */
-    CompleteFileResult(UpdateInodeEntry updateInodeEntry,
-        UpdateInodeFileEntry updateInodeFileEntry) {
-      mUpdateInodeEntry = updateInodeEntry;
-      mUpdateInodeFileEntry = updateInodeFileEntry;
-    }
-
-    /**
-     * Get the updateInodeEntry object.
-     *
-     * @return the inode update object
-     */
-    public UpdateInodeEntry getUpdateInodeEntry() {
-      return mUpdateInodeEntry;
-    }
-
-    /**
-     * Get the update inode file object.
-     *
-     * @return the inode file update object
-     */
-    public UpdateInodeFileEntry getUpdateInodeFileEntry() {
-      return mUpdateInodeFileEntry;
-    }
-  }
-
-  /**
-   * Completes a file. After a file is completed, it cannot be written to.
-   *
-   * There are two cases here.
-   * If the file is still being created, we pass inode in addition to inodePath.
-   * If the file is already created, inodePath should be complete and
-   * we should be able to get its inode from it.
-   *
-   * @param inodePath the {@link LockedInodePath} to complete
-   * @param inode the inode to complete
-   * @param context the method context
-   *
-   * @return completeFileResult
-   */
-  public CompleteFileResult completeFileInternal(LockedInodePath inodePath,
+  @Override
+  public CompleteFileResult completeFileWithResults(LockedInodePath inodePath,
       Inode inode, CompleteFileContext context)
       throws InvalidPathException, FileDoesNotExistException, BlockInfoException,
       FileAlreadyCompletedException, InvalidFileSizeException, UnavailableException {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1597,7 +1597,12 @@ public final class DefaultFileSystemMaster extends CoreMaster
       context.setCacheable(true);
     }
     // If the create succeeded, the list of created inodes will not be empty.
-    List<Inode> created = mInodeTree.createPath(rpcContext, inodePath, context);
+    List<Inode> created;
+    if (context.getCompletionContext() == null) {
+      created = mInodeTree.createPath(rpcContext, inodePath, context);
+    } else {
+      created = mInodeTree.createPath(rpcContext, inodePath, context, this);
+    }
 
     if (context.isPersisted()) {
       // The path exists in UFS, so it is no longer absent. The ancestors exist in UFS, but the

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -43,6 +43,8 @@ import alluxio.master.file.contexts.SetAclContext;
 import alluxio.master.file.contexts.SetAttributeContext;
 import alluxio.master.file.contexts.WorkerHeartbeatContext;
 import alluxio.master.file.meta.FileSystemMasterView;
+import alluxio.master.file.meta.Inode;
+import alluxio.master.file.meta.LockedInodePath;
 import alluxio.master.file.meta.PersistenceState;
 import alluxio.metrics.TimeSeries;
 import alluxio.security.authorization.AclEntry;
@@ -210,6 +212,25 @@ public interface FileSystemMaster extends Master {
       throws BlockInfoException, FileDoesNotExistException, InvalidPathException,
       InvalidFileSizeException, FileAlreadyCompletedException, AccessControlException,
       UnavailableException;
+
+  /**
+   * Completes a file. After a file is completed, it cannot be written to.
+   *
+   * There are two cases here.
+   * If the file is still being created, we pass inode in addition to inodePath.
+   * If the file is already created, inodePath should be complete and
+   * we should be able to get its inode from it.
+   *
+   * @param inodePath the {@link LockedInodePath} to complete
+   * @param inode the inode to complete
+   * @param context the method context
+   *
+   * @return completeFileResult
+   */
+  CompleteFileResult completeFileWithResults(LockedInodePath inodePath,
+      Inode inode, CompleteFileContext context) throws InvalidPathException,
+      FileDoesNotExistException, BlockInfoException,
+      FileAlreadyCompletedException, InvalidFileSizeException, UnavailableException;
 
   /**
    * Creates a file (not a directory) for a given path.

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -228,7 +228,8 @@ public interface FileSystemMaster extends Master {
    */
   FileInfo createFile(AlluxioURI path, CreateFileContext context)
       throws AccessControlException, InvalidPathException, FileAlreadyExistsException,
-      BlockInfoException, IOException, FileDoesNotExistException, FileAlreadyCompletedException, InvalidFileSizeException;
+      BlockInfoException, IOException, FileDoesNotExistException,
+      FileAlreadyCompletedException, InvalidFileSizeException;
 
   /**
    * Gets a new block id for the next block of a given file to write to.

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -228,7 +228,7 @@ public interface FileSystemMaster extends Master {
    */
   FileInfo createFile(AlluxioURI path, CreateFileContext context)
       throws AccessControlException, InvalidPathException, FileAlreadyExistsException,
-      BlockInfoException, IOException, FileDoesNotExistException;
+      BlockInfoException, IOException, FileDoesNotExistException, FileAlreadyCompletedException, InvalidFileSizeException;
 
   /**
    * Gets a new block id for the next block of a given file to write to.
@@ -326,7 +326,7 @@ public interface FileSystemMaster extends Master {
    */
   long createDirectory(AlluxioURI path, CreateDirectoryContext context)
       throws InvalidPathException, FileAlreadyExistsException, IOException, AccessControlException,
-      FileDoesNotExistException;
+      FileDoesNotExistException, FileAlreadyCompletedException, InvalidFileSizeException;
 
   /**
    * Renames a file to a destination.
@@ -419,7 +419,7 @@ public interface FileSystemMaster extends Master {
    */
   void mount(AlluxioURI alluxioPath, AlluxioURI ufsPath, MountContext context)
       throws FileAlreadyExistsException, FileDoesNotExistException, InvalidPathException,
-      IOException, AccessControlException;
+      IOException, AccessControlException, FileAlreadyCompletedException, InvalidFileSizeException;
 
   /**
    * Unmounts a UFS path previously mounted onto an Alluxio path.

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -829,7 +829,7 @@ public class InodeSyncStream {
    */
   static void loadDirectoryMetadata(RpcContext rpcContext, LockedInodePath inodePath,
       LoadMetadataContext context, MountTable mountTable, DefaultFileSystemMaster fsMaster)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException {
+      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException, FileAlreadyCompletedException, InvalidFileSizeException {
     if (inodePath.fullPathExists()) {
       return;
     }

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -829,7 +829,8 @@ public class InodeSyncStream {
    */
   static void loadDirectoryMetadata(RpcContext rpcContext, LockedInodePath inodePath,
       LoadMetadataContext context, MountTable mountTable, DefaultFileSystemMaster fsMaster)
-      throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException, FileAlreadyCompletedException, InvalidFileSizeException {
+      throws FileDoesNotExistException, InvalidPathException,
+      IOException, FileAlreadyCompletedException, InvalidFileSizeException {
     if (inodePath.fullPathExists()) {
       return;
     }

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CreateFileContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CreateFileContext.java
@@ -17,12 +17,14 @@ import alluxio.util.FileSystemOptions;
 
 import com.google.common.base.MoreObjects;
 
+import javax.annotation.Nullable;
+
 /**
  * Implementation of {@link OperationContext} used to merge and wrap {@link CreateFilePOptions}.
  */
 public class CreateFileContext
     extends CreatePathContext<CreateFilePOptions.Builder, CreateFileContext> {
-
+  private CompleteFileContext mCompletionContext;
   private boolean mCacheable;
 
   /**
@@ -33,6 +35,7 @@ public class CreateFileContext
   private CreateFileContext(CreateFilePOptions.Builder optionsBuilder) {
     super(optionsBuilder);
     mCacheable = false;
+    mCompletionContext = null;
   }
 
   /**
@@ -80,11 +83,29 @@ public class CreateFileContext
     return this;
   }
 
+  /**
+   * @return completion context if the file is created and completed at the same time
+   */
+  @Nullable
+  public CompleteFileContext getCompletionContext() {
+    return mCompletionContext;
+  }
+
+  /**
+   * @param completionContext completion context to set when creating
+   * @return the updated context
+   */
+  public CreateFileContext setCompletionContext(@Nullable CompleteFileContext completionContext) {
+    mCompletionContext = completionContext;
+    return getThis();
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("PathContext", super.toString())
         .add("Cacheable", mCacheable)
+        .add("CompleteFileContext", mCompletionContext)
         .toString();
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -936,25 +936,26 @@ public class InodeTree implements DelegatingJournaled {
       return createdInodes;
     }
     // if processing is required, must be a create file and contain completeFileContext
-    Preconditions.checkState(context instanceof CreateFileContext);
-    CompleteFileContext completeFileContext
-        = ((CreateFileContext) context).getCompletionContext();
-    Preconditions.checkNotNull(completeFileContext);
-    Inode inode = Inode.wrap(newInode);
-    DefaultFileSystemMaster.CompleteFileResult completeFileResult =
-        fileSystemMaster.completeFileInternal(inodePath, inode, completeFileContext);
-    UpdateInodeEntry inodeEntry = completeFileResult.getUpdateInodeEntry();
-    UpdateInodeFileEntry fileEntry = completeFileResult.getUpdateInodeFileEntry();
-    newInode.asFile().setCompleted(true).setLength(fileEntry.getLength())
-        .setUfsFingerprint(inodeEntry.getUfsFingerprint())
-        .setBlockIds(fileEntry.getSetBlocksList());
+    if (context instanceof CreateFileContext) {
+      CompleteFileContext completeFileContext
+          = ((CreateFileContext) context).getCompletionContext();
+      Preconditions.checkNotNull(completeFileContext);
+      Inode inode = Inode.wrap(newInode);
+      DefaultFileSystemMaster.CompleteFileResult completeFileResult =
+          fileSystemMaster.completeFileInternal(inodePath, inode, completeFileContext);
+      UpdateInodeEntry inodeEntry = completeFileResult.getUpdateInodeEntry();
+      UpdateInodeFileEntry fileEntry = completeFileResult.getUpdateInodeFileEntry();
+      newInode.asFile().setCompleted(true).setLength(fileEntry.getLength())
+          .setUfsFingerprint(inodeEntry.getUfsFingerprint())
+          .setBlockIds(fileEntry.getSetBlocksList());
 
-    mState.applyAndJournal(rpcContext, newInode,
-        inodePath.getUri().getPath());
+      mState.applyAndJournal(rpcContext, newInode,
+          inodePath.getUri().getPath());
 
-    inodePath.addNextInode(inode);
-    createdInodes.add(inode);
-    LOG.debug("Create complete file: File Created: {} parent: {}", newInode, currentInodeDirectory);
+      inodePath.addNextInode(inode);
+      createdInodes.add(inode);
+      LOG.debug("Create complete file: File Created: {} parent: {}", newInode, currentInodeDirectory);
+    }
     return createdInodes;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -29,7 +29,8 @@ import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.master.block.ContainerIdGenerable;
-import alluxio.master.file.DefaultFileSystemMaster;
+import alluxio.master.file.CompleteFileResult;
+import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.RpcContext;
 import alluxio.master.file.contexts.CompleteFileContext;
 import alluxio.master.file.contexts.CreateDirectoryContext;
@@ -705,7 +706,7 @@ public class InodeTree implements DelegatingJournaled {
    *         option is false
    */
   public List<Inode> createPath(RpcContext rpcContext, LockedInodePath inodePath,
-      CreatePathContext<?, ?> context, DefaultFileSystemMaster fileSystemMaster)
+      CreatePathContext<?, ?> context, FileSystemMaster fileSystemMaster)
       throws FileAlreadyExistsException, BlockInfoException,
       InvalidPathException, IOException, FileDoesNotExistException,
       FileAlreadyCompletedException, InvalidFileSizeException {
@@ -941,8 +942,8 @@ public class InodeTree implements DelegatingJournaled {
           = ((CreateFileContext) context).getCompletionContext();
       Preconditions.checkNotNull(completeFileContext);
       Inode inode = Inode.wrap(newInode);
-      DefaultFileSystemMaster.CompleteFileResult completeFileResult =
-          fileSystemMaster.completeFileInternal(inodePath, inode, completeFileContext);
+      CompleteFileResult completeFileResult =
+          fileSystemMaster.completeFileWithResults(inodePath, inode, completeFileContext);
       UpdateInodeEntry inodeEntry = completeFileResult.getUpdateInodeEntry();
       UpdateInodeFileEntry fileEntry = completeFileResult.getUpdateInodeFileEntry();
       newInode.asFile().setCompleted(true).setLength(fileEntry.getLength())

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -954,7 +954,8 @@ public class InodeTree implements DelegatingJournaled {
 
       inodePath.addNextInode(inode);
       createdInodes.add(inode);
-      LOG.debug("Create complete file: File Created: {} parent: {}", newInode, currentInodeDirectory);
+      LOG.debug("Create complete file: File Created: {} parent: {}", newInode,
+          currentInodeDirectory);
     }
     return createdInodes;
   }

--- a/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -25,8 +25,10 @@ import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.BlockInfoException;
 import alluxio.exception.ExceptionMessage;
+import alluxio.exception.FileAlreadyCompletedException;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
+import alluxio.exception.InvalidFileSizeException;
 import alluxio.exception.InvalidPathException;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
@@ -719,7 +721,7 @@ public final class InodeTreeTest {
   // Helper to create a path.
   private List<Inode> createPath(InodeTree root, AlluxioURI path, CreatePathContext<?, ?> context)
       throws FileAlreadyExistsException, BlockInfoException, InvalidPathException, IOException,
-      FileDoesNotExistException {
+      FileDoesNotExistException, FileAlreadyCompletedException, InvalidFileSizeException {
     try (LockedInodePath inodePath = root.lockInodePath(path, LockPattern.WRITE_EDGE)) {
       return root.createPath(RpcContext.NOOP, inodePath, context);
     }


### PR DESCRIPTION
Before this change, syncMetadata writes an inode journal entry and then two additional updateInode entries to complete the file. This combines three entries into one so that we do not have a failure mode where the first inode entry is inserted and incomplete files are left behind. 