### PR TITLE
Move asyncCache logics to DefaultBlockWorker

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
@@ -60,24 +60,22 @@ public class AsyncCacheRequestManager {
   private final BlockWorker mBlockWorker;
   private final ConcurrentHashMap<Long, AsyncCacheRequest> mPendingRequests;
   private final String mLocalWorkerHostname;
-  private final FileSystemContext mFsContext;
+  private final FileSystemContext mFsContext =
+      FileSystemContext.create(ServerConfiguration.global());
   /** Keeps track of the number of rejected cache requests. */
   private final AtomicLong mNumRejected = new AtomicLong(0);
 
   /**
    * @param service thread pool to run the background caching work
    * @param blockWorker handler to the block worker
-   * @param fsContext context used to instantiate {@link RemoteBlockReader}
    */
-  public AsyncCacheRequestManager(ExecutorService service, BlockWorker blockWorker,
-      FileSystemContext fsContext) {
+  public AsyncCacheRequestManager(ExecutorService service, BlockWorker blockWorker) {
     mAsyncCacheExecutor = service;
     mBlockWorker = blockWorker;
     mPendingRequests = new ConcurrentHashMap<>();
     mLocalWorkerHostname =
         NetworkAddressUtils.getLocalHostName(
             (int) ServerConfiguration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
-    mFsContext = fsContext;
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -16,6 +16,7 @@ import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.InvalidWorkerStateException;
 import alluxio.exception.UfsBlockAccessTokenUnavailableException;
 import alluxio.exception.WorkerOutOfSpaceException;
+import alluxio.grpc.AsyncCacheRequest;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.wire.FileInfo;
 import alluxio.worker.SessionCleanable;
@@ -376,6 +377,13 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @param sessionId the id of the client
    */
   void sessionHeartbeat(long sessionId);
+
+  /**
+   * Submits the async cache request to async cache manager to execute.
+   *
+   * @param request the async cache request
+   */
+  void submitAsyncCacheRequest(AsyncCacheRequest request);
 
   /**
    * Sets the pinlist for the underlying block store. Typically called by {@link PinListSync}.

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * Executors for gRPC block server.
  */
 @ThreadSafe
-final class GrpcExecutors {
+public final class GrpcExecutors {
   private static final long THREAD_STOP_MS = Constants.SECOND_MS * 10;
   private static final int THREADS_MIN = 4;
 


### PR DESCRIPTION
PR3 for #12830
Move asyncCache logics to DefaultBlockWorker so that it can be called by both internal client and outside gRPC client.