### PR TITLE
Catch UnsatisfiedLinkError for alluxio.worker.ramdisk.size, improve desc

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2819,7 +2819,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               return "1GB";
             }
           }, "2/3 of total system memory, or 1GB if system memory size cannot be determined")
-          .setDescription("Memory capacity of each worker node.")
+          .setDescription("Memory capacity of each worker node. "
+                  + "It is recommended to set this value explicitly. "
+                  + "If you are running Alluxio workers in a containerized environment, "
+                  + "your Java runtime may return incorrect system memory "
+                  + "(i.e. the host memory instead of the container memory). "
+                  + "You should upgrade your JDK version according to "
+                  + "https://bugs.openjdk.java.net/browse/JDK-8226575.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2813,7 +2813,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               OperatingSystemMXBean operatingSystemMXBean =
                   (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
               return operatingSystemMXBean.getTotalPhysicalMemorySize() * 2 / 3;
-            } catch (Exception e) {
+            } catch (Throwable e) {
               // The package com.sun.management may not be available on every platform.
               // fallback to a reasonable size.
               return "1GB";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2820,12 +2820,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
             }
           }, "2/3 of total system memory, or 1GB if system memory size cannot be determined")
           .setDescription("Memory capacity of each worker node. "
-                  + "It is recommended to set this value explicitly. "
-                  + "If you are running Alluxio workers in a containerized environment, "
-                  + "your Java runtime may return incorrect system memory "
-                  + "(i.e. the host memory instead of the container memory). "
-                  + "You should upgrade your JDK version according to "
-                  + "https://bugs.openjdk.java.net/browse/JDK-8226575.")
+                  + "It is recommended to set this value explicitly.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();


### PR DESCRIPTION
When running Alluxio client in a environment without com.sun.management, an UnsatisfiedLinkError will be thrown. The current code only catches `Exception` so not able to catch `UnsatisfiedLinkError`.

Also the current implementation can give incorrect ram disk size in a containerized environment. Improve the description to reflect that.

Related to https://github.com/Alluxio/alluxio/issues/12882