### PR TITLE
Update logLevel help message and related doc etc

### DIFF
--- a/docs/en/operation/Basic-Logging.md
+++ b/docs/en/operation/Basic-Logging.md
@@ -86,16 +86,7 @@ runtime.
 The Alluxio shell comes with a `logLevel` command that returns the current value of
 or updates the log level of a particular class on specific instances.
 Users are able to change Alluxio server-side log levels at runtime.
-
-The command follows the format `alluxio logLevel --logName=NAME [--target=<master|worker|host:port>] [--level=LEVEL]`,
-where:
-* `--logName <arg>` indicates the logger's class (e.g. `alluxio.master.file.DefaultFileSystemMaster`)
-* `--target <arg>` lists the Alluxio master or workers to set.
-The target could be of the form `<master|workers|host:webPort>` and multiple targets can be listed as comma-separated entries.
-The `host:webPort` format can only be used when referencing a worker.
-The default target value is all masters and workers.
-* `--level <arg>` If provided, the command changes to the given logger level,
-otherwise it returns the current logger level.
+See the [logLevel command documentation]({{ '/en/operation/User-CLI.html#loglevel' | relativize_url }}) for more details.
 
 For example, the following command sets the logger level of the class `alluxio.underfs.hdfs.HdfsUnderFileSystem` to
 `DEBUG` on master as well as a worker at `192.168.100.100:30000`:
@@ -123,10 +114,10 @@ Furthermore, you can turn on Alluxio debug logging when you are troubleshooting 
 in a running cluster, and turn it off when you are done.
 ```console
 # Turn on Alluxio debug logging and start debugging
-$ ./bin/alluxio logLevel --logName=alluxio --target=master,workers --level=DEBUG
+$ ./bin/alluxio logLevel --logName=alluxio --level=DEBUG
 
 # Turn off Alluxio debug logging when you are done
-$ ./bin/alluxio logLevel --logName=alluxio --target=master,workers --level=INFO
+$ ./bin/alluxio logLevel --logName=alluxio --level=INFO
 ```
 
 For more information, refer to the help text of the `logLevel` command by running `./bin/alluxio logLevel`

--- a/docs/en/operation/Basic-Logging.md
+++ b/docs/en/operation/Basic-Logging.md
@@ -86,7 +86,8 @@ runtime.
 The Alluxio shell comes with a `logLevel` command that returns the current value of
 or updates the log level of a particular class on specific instances.
 Users are able to change Alluxio server-side log levels at runtime.
-See the [logLevel command documentation]({{ '/en/operation/User-CLI.html#loglevel' | relativize_url }}) for more details.
+See the [logLevel command documentation]({{ '/en/operation/User-CLI.html#loglevel' | relativize_url }})
+for the command options.
 
 For example, the following command sets the logger level of the class `alluxio.underfs.hdfs.HdfsUnderFileSystem` to
 `DEBUG` on master as well as a worker at `192.168.100.100:30000`:
@@ -119,8 +120,6 @@ $ ./bin/alluxio logLevel --logName=alluxio --level=DEBUG
 # Turn off Alluxio debug logging when you are done
 $ ./bin/alluxio logLevel --logName=alluxio --level=INFO
 ```
-
-For more information, refer to the help text of the `logLevel` command by running `./bin/alluxio logLevel`
 
 ## Enabling Advanced Logging
 

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -208,11 +208,11 @@ Status: CANCELED
 The `logLevel` command returns the current value of or updates the log level of a particular class
 on specific instances. Users are able to change Alluxio server-side log levels at runtime.
 
-The command follows the format `alluxio logLevel --logName=NAME [--target=<master|worker|host:port>] [--level=LEVEL]`,
+The command follows the format `alluxio logLevel --logName=NAME [--target=<master|workers|job_master|job_workers|host:port>] [--level=LEVEL]`,
 where:
 * `--logName <arg>` indicates the logger's class (e.g. `alluxio.master.file.DefaultFileSystemMaster`)
 * `--target <arg>` lists the Alluxio master or workers to set.
-The target could be of the form `<master|workers|host:webPort>` and multiple targets can be listed as comma-separated entries.
+The target could be of the form `<master|workers|job_master|job_workers|host:webPort>` and multiple targets can be listed as comma-separated entries.
 The `host:webPort` format can only be used when referencing a worker.
 The default target value is all masters and workers.
 * `--level <arg>` If provided, the command changes to the given logger level,

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -214,9 +214,11 @@ where:
 * `--target <arg>` lists the Alluxio master or workers to set.
 The target could be of the form `<master|workers|job_master|job_workers|host:webPort>` and multiple targets can be listed as comma-separated entries.
 The `host:webPort` format can only be used when referencing a worker.
-The default target value is the master, job master, all workers and job workers.
+The default target value is the local master, local job master, all workers and job workers.
 * `--level <arg>` If provided, the command changes to the given logger level,
 otherwise it returns the current logger level.
+> Note: To set the log level on a master/job_master, run the command on the current leading master.
+> You can find which is the leader by running `alluxio fs leader`.
 
 See [here]({{ '/en/operation/Basic-Logging.html#modifying-server-logging-at-runtime' | relativize_url }})
 for more examples.

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -214,23 +214,12 @@ where:
 * `--target <arg>` lists the Alluxio master or workers to set.
 The target could be of the form `<master|workers|job_master|job_workers|host:webPort>` and multiple targets can be listed as comma-separated entries.
 The `host:webPort` format can only be used when referencing a worker.
-The default target value is all masters and workers.
+The default target value is the master, job master, all workers and job workers.
 * `--level <arg>` If provided, the command changes to the given logger level,
 otherwise it returns the current logger level.
 
-For example, the following command sets the logger level of the class `alluxio.heartbeat.HeartbeatContext` to
-`DEBUG` on master as well as a worker at `192.168.100.100:30000`:
-
-```console
-$ ./bin/alluxio logLevel --logName=alluxio.heartbeat.HeartbeatContext \
-  --target=master,192.168.100.100:30000 --level=DEBUG
-```
-
-And the following command returns the log level of the class `alluxio.heartbeat.HeartbeatContext` among all the workers:
-```console
-$ ./bin/alluxio logLevel --logName=alluxio.heartbeat.HeartbeatContext \
-  --target=workers
-```
+See [here]({{ '/en/operation/Basic-Logging.html#modifying-server-logging-at-runtime' | relativize_url }})
+for more examples.
 
 > Note: This command requires the Alluxio cluster to be running.
 

--- a/shell/src/main/java/alluxio/cli/LogLevel.java
+++ b/shell/src/main/java/alluxio/cli/LogLevel.java
@@ -151,6 +151,7 @@ public final class LogLevel {
     List<TargetInfo> targetInfoList = new ArrayList<>();
     for (String target : targets) {
       if (target.equals(ROLE_MASTER)) {
+        // TODO(jiacheng): make this support HA master
         String masterHost = NetworkAddressUtils.getConnectHost(ServiceType.MASTER_WEB, conf);
         int masterPort = NetworkAddressUtils.getPort(ServiceType.MASTER_WEB, conf);
         TargetInfo master = new TargetInfo(masterHost, masterPort, ROLE_MASTER);

--- a/shell/src/main/java/alluxio/cli/LogLevel.java
+++ b/shell/src/main/java/alluxio/cli/LogLevel.java
@@ -70,10 +70,10 @@ public final class LogLevel {
           .required(false)
           .longOpt(TARGET_OPTION_NAME)
           .hasArg(true)
-          .desc("<master|workers|host:webPort>."
+          .desc("<master|workers|job_master|job_workers|host:webPort>."
               + " A list of targets separated by " + TARGET_SEPARATOR + " can be specified."
               + " host:webPort pair must be one of workers."
-              + " Default target is master and all workers")
+              + " Default target is master, job master, all workers and all job workers.")
           .build();
   private static final String LOG_NAME_OPTION_NAME = "logName";
   private static final Option LOG_NAME_OPTION =
@@ -196,6 +196,7 @@ public final class LogLevel {
           targetInfoList.add(jobWorker);
         }
       } else if (target.contains(":")) {
+        // TODO(jiacheng): Support all other roles, not just worker
         String[] hostPortPair = target.split(":");
         int port = Integer.parseInt(hostPortPair[1]);
         targetInfoList.add(new TargetInfo(hostPortPair[0], port, ROLE_WORKER));
@@ -236,7 +237,7 @@ public final class LogLevel {
     if (level != null) {
       uriBuilder.addParameter(LEVEL_OPTION_NAME, level);
     }
-    LOG.info("Setting log level on %s%n", uriBuilder.toString());
+    LOG.info("Setting log level on {}", uriBuilder.toString());
     HttpUtils.post(uriBuilder.toString(), "", 5000, inputStream -> {
       ObjectMapper mapper = new ObjectMapper();
       LogInfo logInfo = mapper.readValue(inputStream, LogInfo.class);

--- a/shell/src/main/java/alluxio/cli/LogLevel.java
+++ b/shell/src/main/java/alluxio/cli/LogLevel.java
@@ -141,7 +141,7 @@ public final class LogLevel {
         targets = new String[]{argTarget};
       }
     } else {
-      targets = new String[]{ROLE_MASTER, ROLE_WORKERS};
+      targets = new String[]{ROLE_MASTER, ROLE_JOB_MASTER, ROLE_WORKERS, ROLE_JOB_WORKERS};
     }
     return getTargetInfos(targets, conf);
   }


### PR DESCRIPTION
This addresses some missing points in https://github.com/Alluxio/alluxio/commit/0c72e4e63688dbee776b24139f86cf2b495150cd
1. Add relevant doc mentioning the job master and job workers are now supported
2. Improve the relevant doc
3. When `--target` is not specified, all targets should include the job master and job workers
4. Identified a few issues in the `logLevel` command. Added TODOs for further PRs to resolve.