### PR TITLE
[DOCFIX] Improve Basic-Logging doc

### DIFF
--- a/docs/en/operation/Basic-Logging.md
+++ b/docs/en/operation/Basic-Logging.md
@@ -50,7 +50,8 @@ Here are the documentation to configure individual application logs including
 
 ## Configuring Log Levels
 
-Alluxio uses the following four logging levels:
+Alluxio uses the following five logging levels:
+- `TRACE`: verbose information, only useful for debugging a certain method or class
 - `DEBUG`: fine-grained information, most useful for debugging purpose.
 - `INFO`: messages that highlight the status of progress.
 - `WARN`: potentially harmful events that users may need to know but the process will still continue running.
@@ -222,6 +223,9 @@ $ ./bin/alluxio logLevel \
 --target master --level=DEBUG
 ```
 
+Similarly, you can update the log level for these classes in the `conf/log4j.properties` file.
+You need to restart the relevant processes for the log4j properties to take effect.
+
 ### Logging UnderFileSystem Operations
 
 Sometimes it can be useful to log all operations on under storage. 
@@ -242,6 +246,9 @@ You can see operations in corresponding master or worker logs like below:
 2020-06-02 11:28:21,824 DEBUG UnderFileSystemWithLogging - Exit (OK): GetSpace: path=/opt/alluxio/underFSStorage, type=SPACE_USED
 ```
 
+Similarly, you can update the log level for these classes in the `conf/log4j.properties` file.
+You need to restart the relevant processes for the log4j properties to take effect.
+
 ### Identifying Expensive Client RPCs / FUSE calls
 
 When debugging the performance, it is often useful to understand which RPCs take most of the time
@@ -261,4 +268,27 @@ Example results are:
 FREE_BYTES, CAPACITY_BYTES]) returned BlockMasterInfo{capacityBytes=11453246122,
 capacityBytesOnTiers={}, freeBytes=11453237930, liveWorkerNum=0, lostWorkerNum=0, usedBytes=8192, usedBytesOnTiers={}} in 600 ms
 2020-03-08 23:40:44,374 WARN  AlluxioFuseFileSystem - statfs(path=/) returned 0 in 1200 ms
+```
+
+### Redirect debug log for certain classes
+
+Sometimes it is useful to separate the log for certain classes to a separate log.
+This can be useful for reasons including but not limited to:
+1. Clearly separate the wanted logs for further analysis.
+1. Avoid `master.log` or `worker.log` being too big or have too many files created by log rotation.
+1. Use a separate logger to send logs to a remote endpoint like a socket.
+
+This can be achieved by adding a separate logger in the `conf/log4j.properties`.
+For example, the below example redirects debug logs of `alluxio.master.StateLockManager` to a separate set of files,
+so the `master.log` will not be full of the DEBUG logs created by `alluxio.master.StateLockManager`.
+
+```properties
+log4j.category.alluxio.master.StateLockManager=DEBUG, slm
+log4j.additivity.alluxio.master.StateLockManager=false
+log4j.appender.slm=org.apache.log4j.RollingFileAppender
+log4j.appender.slm.File=<ALLUXIO_HOME>/logs/statelock.log
+log4j.appender.slm.MaxFileSize=10MB
+log4j.appender.slm.MaxBackupIndex=100
+log4j.appender.slm.layout=org.apache.log4j.PatternLayout
+log4j.appender.slm.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
 ```

--- a/docs/en/operation/Basic-Logging.md
+++ b/docs/en/operation/Basic-Logging.md
@@ -270,7 +270,7 @@ capacityBytesOnTiers={}, freeBytes=11453237930, liveWorkerNum=0, lostWorkerNum=0
 2020-03-08 23:40:44,374 WARN  AlluxioFuseFileSystem - statfs(path=/) returned 0 in 1200 ms
 ```
 
-### Redirect debug log for certain classes
+### Redirecting debug log for certain classes
 
 Sometimes it is useful to separate the log for certain classes to a separate log.
 This can be useful for reasons including but not limited to:

--- a/docs/en/operation/Basic-Logging.md
+++ b/docs/en/operation/Basic-Logging.md
@@ -283,12 +283,12 @@ For example, the below example redirects debug logs of `alluxio.master.StateLock
 so the `master.log` will not be full of the DEBUG logs created by `alluxio.master.StateLockManager`.
 
 ```properties
-log4j.category.alluxio.master.StateLockManager=DEBUG, slm
+log4j.category.alluxio.master.StateLockManager=DEBUG, State_LOCK_LOGGER
 log4j.additivity.alluxio.master.StateLockManager=false
-log4j.appender.slm=org.apache.log4j.RollingFileAppender
-log4j.appender.slm.File=<ALLUXIO_HOME>/logs/statelock.log
-log4j.appender.slm.MaxFileSize=10MB
-log4j.appender.slm.MaxBackupIndex=100
-log4j.appender.slm.layout=org.apache.log4j.PatternLayout
-log4j.appender.slm.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.State_LOCK_LOGGER=org.apache.log4j.RollingFileAppender
+log4j.appender.State_LOCK_LOGGER.File=<ALLUXIO_HOME>/logs/statelock.log
+log4j.appender.State_LOCK_LOGGER.MaxFileSize=10MB
+log4j.appender.State_LOCK_LOGGER.MaxBackupIndex=100
+log4j.appender.State_LOCK_LOGGER.layout=org.apache.log4j.PatternLayout
+log4j.appender.State_LOCK_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
 ```


### PR DESCRIPTION
1. Some classes like `InodeSyncStream` uses TRACE level log, mention that.
2. Add a way to add a separate logger for certain classes. This can be helpful in many scenarios.