### PR TITLE
Report error if any of the sync paths failed in syncMetadata

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2453,6 +2453,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.MASTER)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
+  public static final PropertyKey MASTER_METADATA_SYNC_REPORT_FAILURE =
+      new Builder(Name.MASTER_METADATA_SYNC_REPORT_FAILURE)
+          .setDescription("Report failure if any metadata sync fails")
+          .setScope(Scope.MASTER)
+          .setDefaultValue(true)
+          .setIsHidden(true)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .build();
   public static final PropertyKey MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE =
       new Builder(Name.MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE)
           .setDefaultSupplier(() -> Runtime.getRuntime().availableProcessors(),
@@ -5316,6 +5324,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metadata.sync.concurrency.level";
     public static final String MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE =
         "alluxio.master.metadata.sync.executor.pool.size";
+    public static final String MASTER_METADATA_SYNC_REPORT_FAILURE =
+        "alluxio.master.metadata.sync.report.failure";
     public static final String MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE =
         "alluxio.master.metadata.sync.ufs.prefetch.pool.size";
     public static final String MASTER_METASTORE = "alluxio.master.metastore";

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -396,6 +396,10 @@ public class InodeSyncStream {
               elapsedTime.toMillis(), mRootScheme);
     }
     boolean success = syncPathCount > 0;
+    if (ServerConfiguration.getBoolean(PropertyKey.MASTER_METADATA_SYNC_REPORT_FAILURE)) {
+      // There should not be any failed or outstanding jobs
+      success = (failedSyncPathCount == 0) && mSyncPathJobs.isEmpty() && mPendingPaths.isEmpty();
+    }
     if (success) {
       // update the sync path cache for the root of the sync
       // TODO(gpang): Do we need special handling for failures and thread interrupts?

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -678,8 +678,8 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
     for (int i = 0; i < 100; i++) {
       new File(ufsPath("/dir" + i)).mkdirs();
       for (int j = 0; j < 100; j++) {
-        new File(ufsPath("/dir" + i + "/dir" +j)).mkdirs();
-        writeUfsFile(ufsPath("/dir" + i + "/dir" +j + "/file"), 1);
+        new File(ufsPath("/dir" + i + "/dir" + j)).mkdirs();
+        writeUfsFile(ufsPath("/dir" + i + "/dir" + j + "/file"), 1);
       }
     }
     List<URIStatus> status;

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -715,8 +715,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
       assertTrue(stat.isCompleted());
     }
     status = mFileSystem.listStatus(new AlluxioURI("/"), ListStatusPOptions.newBuilder()
-        .setRecursive(true)
-        .setLoadMetadataType(LoadMetadataPType.ONCE).setCommonOptions(PSYNC_NEVER).build());
+        .setRecursive(true).setCommonOptions(PSYNC_LARGE_INTERVAL).build());
     assertEquals(TOTAL_FILE_COUNT, status.size());
   }
 

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -716,8 +716,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
     }
     status = mFileSystem.listStatus(new AlluxioURI("/"), ListStatusPOptions.newBuilder()
         .setRecursive(true)
-        .setCommonOptions(FileSystemOptions.commonDefaults(
-            mFileSystem.getConf()).toBuilder().setSyncIntervalMs(0).build()).build());
+        .setLoadMetadataType(LoadMetadataPType.ONCE).setCommonOptions(PSYNC_NEVER).build());
     assertEquals(TOTAL_FILE_COUNT, status.size());
   }
 

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -709,13 +709,13 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
         .setRecursive(true)
         .setCommonOptions(FileSystemOptions.commonDefaults(
             mFileSystem.getConf()).toBuilder().setSyncIntervalMs(-1).build()).build());
-    // All first level directories are synced.
-    assertEquals(103, status.size());
+    final int TOTAL_FILE_COUNT = 20103;
+    assertTrue(status.size() < TOTAL_FILE_COUNT);
     status = mFileSystem.listStatus(new AlluxioURI("/"), ListStatusPOptions.newBuilder()
         .setRecursive(true)
         .setCommonOptions(FileSystemOptions.commonDefaults(
             mFileSystem.getConf()).toBuilder().setSyncIntervalMs(0).build()).build());
-    assertEquals(20103, status.size());
+    assertEquals(TOTAL_FILE_COUNT, status.size());
   }
 
   @LocalAlluxioClusterResource.Config(

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -27,6 +27,7 @@ import alluxio.client.file.FileSystemUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
+import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
@@ -53,6 +54,7 @@ import alluxio.util.io.PathUtils;
 
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
+import io.grpc.Context;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -63,9 +65,12 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -655,6 +660,62 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
         mFileSystem.listStatus(new AlluxioURI(alluxioPath(EXISTING_DIR)), listStatusPOptions);
     Assert.assertNotNull(statusListAfterSleeping);
     assertEquals(1, statusListAfterSleeping.size());
+  }
+
+  /** This is a timing based test and may become flaky.
+   *  The goal is to simulate a user interrupted listStatus call.
+   *
+   *  In this case, the user's listStatus should have synced the first level directory but have
+   *  not completed the second level directory sync. Thus resulting in a partial sync.
+   */
+  @LocalAlluxioClusterResource.Config(
+      confParams = {
+          PropertyKey.Name.USER_FILE_METADATA_LOAD_TYPE, "NEVER"
+      })
+  @Test
+  public void interruptSync() throws Exception {
+    // make large nested directories/files in UFS
+    for (int i = 0; i < 100; i++) {
+      new File(ufsPath("/dir" + i)).mkdirs();
+      for (int j = 0; j < 100; j++) {
+        new File(ufsPath("/dir" + i + "/dir" +j)).mkdirs();
+        writeUfsFile(ufsPath("/dir" + i + "/dir" +j + "/file"), 1);
+      }
+    }
+    List<URIStatus> status;
+    try (Context.CancellableContext c = Context.current()
+        .withDeadlineAfter(100, TimeUnit.MILLISECONDS,
+            Executors.newScheduledThreadPool(1))) {
+      Context toRestore = c.attach();
+      try {
+        status = Context.current().withCancellation().call(() -> {
+          try {
+            return mFileSystem.listStatus(new AlluxioURI("/"), ListStatusPOptions.newBuilder()
+                .setRecursive(true)
+                .setCommonOptions(FileSystemOptions.commonDefaults(
+                    mFileSystem.getConf()).toBuilder().setSyncIntervalMs(0).build()).build());
+          } catch (Exception e) {
+            return new ArrayList<>();
+          }
+        });
+        Thread.sleep(200);
+        c.cancel(new AlluxioException("test exception"));
+      } finally {
+        c.detach(toRestore);
+      }
+    }
+    assertEquals(0, status.size());
+    status = mFileSystem.listStatus(new AlluxioURI("/"), ListStatusPOptions.newBuilder()
+        .setRecursive(true)
+        .setCommonOptions(FileSystemOptions.commonDefaults(
+            mFileSystem.getConf()).toBuilder().setSyncIntervalMs(-1).build()).build());
+    // All first level directories are synced.
+    assertEquals(103, status.size());
+    status = mFileSystem.listStatus(new AlluxioURI("/"), ListStatusPOptions.newBuilder()
+        .setRecursive(true)
+        .setCommonOptions(FileSystemOptions.commonDefaults(
+            mFileSystem.getConf()).toBuilder().setSyncIntervalMs(0).build()).build());
+    assertEquals(20103, status.size());
   }
 
   @LocalAlluxioClusterResource.Config(

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -711,6 +711,9 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
             mFileSystem.getConf()).toBuilder().setSyncIntervalMs(-1).build()).build());
     final int TOTAL_FILE_COUNT = 20103;
     assertTrue(status.size() < TOTAL_FILE_COUNT);
+    for (URIStatus stat : status) {
+      assertTrue(stat.isCompleted());
+    }
     status = mFileSystem.listStatus(new AlluxioURI("/"), ListStatusPOptions.newBuilder()
         .setRecursive(true)
         .setCommonOptions(FileSystemOptions.commonDefaults(


### PR DESCRIPTION
Before this change, if any path was successfully synced, we return success from syncMetadata. 
After this change, we only return success if there was no failures and all paths have been synced without interruption.

This also fixes an issue where an interrupted syncmetadata is considered synced by the file system master and will not be synced again until sync interval passes. 