### PR TITLE
Support multiple custom versions of hadoop by generate-tarball

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -49,7 +49,7 @@ func Single(args []string) error {
 	singleCmd.Parse(args[2:]) // error handling by flag.ExitOnError
 
 	if customUfsModuleFlag != "" {
-		customUfsModules := strings.Split(customUfsModuleFlag, "$")
+		customUfsModules := strings.Split(customUfsModuleFlag, "%")
 		for _, customUfsModule := range customUfsModules {
 			customUfsModuleFlagArray := strings.Split(customUfsModule, "|")
 			if len(customUfsModuleFlagArray) == 2 {

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -49,13 +49,16 @@ func Single(args []string) error {
 	singleCmd.Parse(args[2:]) // error handling by flag.ExitOnError
 
 	if customUfsModuleFlag != "" {
-		customUfsModuleFlagArray := strings.Split(customUfsModuleFlag, "|")
-		if len(customUfsModuleFlagArray) == 2 {
-			customUfsModuleFlagArray[1] = strings.ReplaceAll(customUfsModuleFlagArray[1], ",", " ")
-			ufsModules["ufs-"+customUfsModuleFlagArray[0]] = module{customUfsModuleFlagArray[0], true, customUfsModuleFlagArray[1]}
-		} else {
-			fmt.Fprintf(os.Stderr, "customUfsModuleFlag specified, but invalid: %s\n", customUfsModuleFlag)
-			os.Exit(1)
+		customUfsModules := strings.Split(customUfsModuleFlag, "$")
+		for _, customUfsModule := range customUfsModules {
+			customUfsModuleFlagArray := strings.Split(customUfsModule, "|")
+			if len(customUfsModuleFlagArray) == 2 {
+				customUfsModuleFlagArray[1] = strings.ReplaceAll(customUfsModuleFlagArray[1], ",", " ")
+				ufsModules["ufs-"+customUfsModuleFlagArray[0]] = module{customUfsModuleFlagArray[0], true, customUfsModuleFlagArray[1]}
+			} else {
+				fmt.Fprintf(os.Stderr, "customUfsModuleFlag specified, but invalid: %s\n", customUfsModuleFlag)
+				os.Exit(1)
+			}
 		}
 	}
 	if err := updateRootFlags(); err != nil {

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/root.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/root.go
@@ -43,7 +43,8 @@ func checkRootFlags() error {
 // these flags provide additional settings unrelated to tarball generation
 func additionalFlags(cmd *flag.FlagSet) {
 	cmd.StringVar(&customUfsModuleFlag, "custom-ufs-modules", "",
-		"a percent-separated list of custom under fs modules which has the form of a pipe-separated pair of the module name and its comma-separated maven arguments. eg. hadoop-x.y|-pl,underfs/hdfs,-Pufs-hadoop-X,-Dufs.hadoop.version=x.y.z")
+		"a percent-separated list of custom ufs modules which has the form of a pipe-separated pair of the module name and its comma-separated maven arguments."+
+			" e.g. hadoop-a.b|-pl,underfs/hdfs,-Pufs-hadoop-A,-Dufs.hadoop.version=a.b.c%hadoop-x.y|-pl,underfs/hdfs,-Pufs-hadoop-X,-Dufs.hadoop.version=x.y.z")
 	cmd.BoolVar(&debugFlag, "debug", false, "whether to run this tool in debug mode to generate additional console output")
 	cmd.StringVar(&ufsModulesFlag, "ufs-modules", strings.Join(defaultModules(ufsModules), ","),
 		fmt.Sprintf("a comma-separated list of ufs modules to compile into the distribution tarball(s). Specify 'all' to build all ufs modules. Supported ufs modules: [%v]", strings.Join(validModules(ufsModules), ",")))

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/root.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/root.go
@@ -43,7 +43,7 @@ func checkRootFlags() error {
 // these flags provide additional settings unrelated to tarball generation
 func additionalFlags(cmd *flag.FlagSet) {
 	cmd.StringVar(&customUfsModuleFlag, "custom-ufs-modules", "",
-		"a dollar-separated list of custom under fs modules which has the form of a pipe-separated pair of the module name and its comma-separated maven arguments. eg. hadoop-x.y|-pl,underfs/hdfs,-Pufs-hadoop-X,-Dufs.hadoop.version=x.y.z")
+		"a percent-separated list of custom under fs modules which has the form of a pipe-separated pair of the module name and its comma-separated maven arguments. eg. hadoop-x.y|-pl,underfs/hdfs,-Pufs-hadoop-X,-Dufs.hadoop.version=x.y.z")
 	cmd.BoolVar(&debugFlag, "debug", false, "whether to run this tool in debug mode to generate additional console output")
 	cmd.StringVar(&ufsModulesFlag, "ufs-modules", strings.Join(defaultModules(ufsModules), ","),
 		fmt.Sprintf("a comma-separated list of ufs modules to compile into the distribution tarball(s). Specify 'all' to build all ufs modules. Supported ufs modules: [%v]", strings.Join(validModules(ufsModules), ",")))

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/root.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/root.go
@@ -42,7 +42,7 @@ func checkRootFlags() error {
 // common flags that are used regardless of subcommand type
 // these flags provide additional settings unrelated to tarball generation
 func additionalFlags(cmd *flag.FlagSet) {
-	cmd.StringVar(&customUfsModuleFlag, "custom-ufs-modules", "",
+	cmd.StringVar(&customUfsModuleFlag, "custom-ufs-module", "",
 		"a percent-separated list of custom ufs modules which has the form of a pipe-separated pair of the module name and its comma-separated maven arguments."+
 			" e.g. hadoop-a.b|-pl,underfs/hdfs,-Pufs-hadoop-A,-Dufs.hadoop.version=a.b.c%hadoop-x.y|-pl,underfs/hdfs,-Pufs-hadoop-X,-Dufs.hadoop.version=x.y.z")
 	cmd.BoolVar(&debugFlag, "debug", false, "whether to run this tool in debug mode to generate additional console output")

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/root.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/root.go
@@ -42,7 +42,8 @@ func checkRootFlags() error {
 // common flags that are used regardless of subcommand type
 // these flags provide additional settings unrelated to tarball generation
 func additionalFlags(cmd *flag.FlagSet) {
-	cmd.StringVar(&customUfsModuleFlag, "custom-ufs-module", "", "a pipe-separated pair of the module name and its comma-separated maven arguments. ex. hadoop-x.y|-pl,underfs/hdfs,-Pufs-hadoop-X,-Dufs.hadoop.version=x.y.z")
+	cmd.StringVar(&customUfsModuleFlag, "custom-ufs-modules", "",
+		"a dollar-separated list of custom under fs modules which has the form of a pipe-separated pair of the module name and its comma-separated maven arguments. eg. hadoop-x.y|-pl,underfs/hdfs,-Pufs-hadoop-X,-Dufs.hadoop.version=x.y.z")
 	cmd.BoolVar(&debugFlag, "debug", false, "whether to run this tool in debug mode to generate additional console output")
 	cmd.StringVar(&ufsModulesFlag, "ufs-modules", strings.Join(defaultModules(ufsModules), ","),
 		fmt.Sprintf("a comma-separated list of ufs modules to compile into the distribution tarball(s). Specify 'all' to build all ufs modules. Supported ufs modules: [%v]", strings.Join(validModules(ufsModules), ",")))


### PR DESCRIPTION
Support multiple custom versions of hadoop when tarballing with the generate-tarball.sh
#12406 only support single hadoop version.