### PR TITLE
Support to skip corrupt journal entry when recovering from backup

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2008,8 +2008,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.MASTER_JOURNAL_TOLERATE_CORRUPTION)
           .setDefaultValue(false)
           .setDescription("Whether to tolerate master state corruption "
-              + "when standby master replaying journal. If enabled, errors from applying journal "
-              + "to master metadata will only be logged instead of forcing master to exit. "
+              + "when leader master recovering from backup and standby master replaying journal. "
+              + "If enabled, errors from applying journal to master metadata will only be logged "
+              + "instead of forcing master to exit. "
               + "This property should be used sparingly.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setIsHidden(true)

--- a/core/server/common/src/main/java/alluxio/master/BackupManager.java
+++ b/core/server/common/src/main/java/alluxio/master/BackupManager.java
@@ -305,8 +305,8 @@ public class BackupManager {
                   master.applyAndJournal(masterJCMap.get(master), entry);
                   appliedEntryCount.incrementAndGet();
                 } catch (Exception e) {
-                  JournalUtils.handleJournalReplayFailure(LOG, e, "Failed to apply " +
-                          "journal entry to master %s. Entry: %s", masterName, entry);
+                  JournalUtils.handleJournalReplayFailure(LOG, e, "Failed to apply "
+                          + "journal entry to master %s. Entry: %s", masterName, entry);
                 }
               }
             } finally {


### PR DESCRIPTION
Support to skip corrupt journal entry when recovering from backup, similar to the implementation in `alluxio.master.journal.raft.BufferedJournalApplier#applyToMaster`.

We can configure `alluxio.master.journal.tolerate.corruption` to control whether it is enabled or not.

Fix https://github.com/Alluxio/alluxio/issues/12959