### PR TITLE
[DOCFIX] Adjust alluxio-site.properties.template to use ASYNC_THROUGH

### DIFF
--- a/conf/alluxio-site.properties.template
+++ b/conf/alluxio-site.properties.template
@@ -28,4 +28,4 @@
 
 # User properties
 # alluxio.user.file.readtype.default=CACHE
-# alluxio.user.file.writetype.default=MUST_CACHE
+# alluxio.user.file.writetype.default=ASYNC_THROUGH


### PR DESCRIPTION
This is a follow-up to PR #12871 where the "Getting Started" doc was adjusted to reflect the `alluxio.user.file.writetype.default` value changed from `MUST_CACHE` to `ASYNC_THROUGH`. 
- This default value can be seen in [PropertyKey.java](https://github.com/Alluxio/alluxio/blob/master/core/common/src/main/java/alluxio/conf/PropertyKey.java#L2117) 