### PR TITLE
Remove dependency on Java JPS

### DIFF
--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -82,11 +82,7 @@ umount_fuse() {
 }
 
 fuse_stat() {
-  local jps="jps"
-  if [[ ! -z ${JAVA_HOME} ]]; then
-    jps="${JAVA_HOME}/bin/jps"
-  fi
-  local fuse_info=$("${jps}" | grep AlluxioFuse)
+  local fuse_info=$(ps aux | grep [A]lluxioFuse)
   if [[ -z ${fuse_info} ]]; then
     echo "No mount point found. AlluxioFuse process is not running."
     echo -e "${MOUNT_USAGE}"


### PR DESCRIPTION
[`jps`](https://docs.oracle.com/javase/7/docs/technotes/tools/share/jps.html) is part of the JDK, but not of the JRE. By removing this dependency and only relying on `ps` Alluxio FUSE can be run with Java JRE, which is much lighter than the JDK.

Another reason to remove the `jps` depencency is that the jps documentation mentions that:
> _NOTE: This utility is unsupported and may not be available in future versions of the JDK._

I tested this with both OpenJDK 8 JRE and OpenJDK 11 JRE.