### PR TITLE
[DOCFIX] Add security opt parameter to run the FUSE docker image

### DIFF
--- a/docs/en/deploy/Running-Alluxio-On-Docker.md
+++ b/docs/en/deploy/Running-Alluxio-On-Docker.md
@@ -409,6 +409,7 @@ $ docker run --rm \
     -e "ALLUXIO_JAVA_OPTS=-Dalluxio.master.hostname=localhost" \
     --cap-add SYS_ADMIN \
     --device /dev/fuse \
+    --security-opt apparmor:unconfined \
     alluxio/{{site.ALLUXIO_DOCKER_IMAGE}}-fuse fuse
 ```
 


### PR DESCRIPTION
The current tutorial is broken as documented in https://github.com/Alluxio/alluxio/issues/12943 .

The `docker run` command to run the alluxio-fuse image was missing `--security-opt apparmor:unconfined` to allow it to create mounts. This fixes the tutorial.

Fix https://github.com/Alluxio/alluxio/issues/12712
Fix https://github.com/Alluxio/alluxio/issues/12943 