### PR TITLE
Keep FUSE JNI libraries in image

### DIFF
--- a/integration/docker/Dockerfile.fuse
+++ b/integration/docker/Dockerfile.fuse
@@ -29,7 +29,8 @@ RUN cd /opt && \
     ln -s alluxio-* alluxio
 
 # Remove the UFS libraries from the container, as the fuse daemon doesn't need them
-RUN rm -rf /opt/alluxio/lib/*
+# Make sure to keep the JNI FUSE libraries
+RUN find /opt/alluxio/lib/ -type f -not -name 'libjnifuse*' -delete
 
 RUN if [ ${ENABLE_DYNAMIC_USER} = "true" ] ; then \
        chmod -R 777 /opt/* ; \


### PR DESCRIPTION
The current image deletes the FUSE JNI libraries resulting in an error: https://github.com/Alluxio/alluxio/issues/13052

Keep the FUSE JNI libraries in the image.