### PR TITLE
Move container level securityContext to pod level

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -150,4 +150,4 @@
 
 0.6.14
 
-- Migrate master StatefuleSet and worker DaemonSet securityContext to Pod-level (see Issue #13096)
+- Migrate master StatefulSet and worker DaemonSet securityContext to Pod-level (see Issue [#13096](https://github.com/Alluxio/alluxio/issues/13096))

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -145,4 +145,9 @@
 - Add a table of keys and default values for the Helm templates in README
 
 0.6.13
+
 - Add remote logger for Alluxio services, putting the centralized logs in emptyDir/hostPath/PVC
+
+0.6.14
+
+- Migrate master StatefuleSet and worker DaemonSet securityContext to Pod-level (see Issue #13096)

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.13
+version: 0.6.14
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -68,14 +68,14 @@ spec:
 {{ toYaml .Values.nodeSelector | trim | indent 8  }}
       {{- end }}
       securityContext:
+        runAsUser: {{ .Values.user }}
+        runAsGroup: {{ .Values.group }}
         fsGroup: {{ .Values.fsGroup }}
       initContainers:
       {{- if .Values.journal.format.runFormat}}
       - name: journal-format
         image: {{ .Values.image }}:{{ .Values.imageTag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
-        securityContext:
-          runAsUser: {{ .Values.user }}
         command: ["alluxio","formatJournal"]
         volumeMounts:
           - name: alluxio-journal
@@ -85,9 +85,6 @@ spec:
         - name: alluxio-master
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            runAsUser: {{ .Values.user }}
-            runAsGroup: {{ .Values.group }}
           {{- if .Values.master.resources  }}
 {{ include "alluxio.master.resources" . | indent 10 }}
           {{- end }}
@@ -155,9 +152,6 @@ spec:
         - name: alluxio-job-master
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            runAsUser: {{ .Values.user }}
-            runAsGroup: {{ .Values.group }}
           {{- if .Values.jobMaster.resources  }}
 {{ include "alluxio.jobMaster.resources" . | indent 10 }}
           {{- end }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
@@ -53,6 +53,8 @@ spec:
       hostPID: {{ $hostPID }}
       dnsPolicy: {{ .Values.worker.dnsPolicy | default ($hostNetwork | ternary "ClusterFirstWithHostNet" "ClusterFirst") }}
       securityContext:
+        runAsUser: {{ .Values.user }}
+        runAsGroup: {{ .Values.group }}
         fsGroup: {{ .Values.fsGroup }}
       nodeSelector:
       {{- if .Values.worker.nodeSelector }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
@@ -66,9 +66,6 @@ spec:
         - name: alluxio-worker
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            runAsUser: {{ .Values.user }}
-            runAsGroup: {{ .Values.group }}
           {{- if .Values.worker.resources  }}
 {{ include "alluxio.worker.resources" . | indent 10 }}
           {{- end }}
@@ -124,9 +121,6 @@ spec:
             {{- end }}
         - name: alluxio-job-worker
           image: {{ .Values.image }}:{{ .Values.imageTag }}
-          securityContext:
-            runAsUser: {{ .Values.user }}
-            runAsGroup: {{ .Values.group }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- if .Values.jobWorker.resources  }}
 {{ include "alluxio.jobWorker.resources" . | indent 10 }}


### PR DESCRIPTION
When using Alluxio worker in Kubernetes, the Daemonset template mounts the directory `/opt/domain`. However previously when doing so the worker would crash with the following error:

```
2021-03-13 00:32:55,274 INFO  GrpcDataServer - Alluxio worker gRPC server started, listening on /0.0.0.0:29999
2021-03-13 00:32:55,275 INFO  AlluxioWorkerProcess - Domain socket data server is enabled at /opt/domain/b7f2d035-e081-4a55-a9d3-a87351d8daad.
2021-03-13 00:32:55,281 WARN  RetryUtils - Failed to Starting gRPC server (attempt 1): java.io.IOException: Failed to bind
2021-03-13 00:32:55,482 WARN  RetryUtils - Failed to Starting gRPC server (attempt 2): java.io.IOException: Failed to bind
2021-03-13 00:32:55,883 WARN  RetryUtils - Failed to Starting gRPC server (attempt 3): java.io.IOException: Failed to bind
2021-03-13 00:32:56,384 WARN  RetryUtils - Failed to Starting gRPC server (attempt 4): java.io.IOException: Failed to bind
2021-03-13 00:32:56,885 WARN  RetryUtils - Failed to Starting gRPC server (attempt 5): java.io.IOException: Failed to bind
2021-03-13 00:32:57,386 WARN  RetryUtils - Failed to Starting gRPC server (attempt 6): java.io.IOException: Failed to bind
2021-03-13 00:32:57,387 ERROR GrpcDataServer - Alluxio worker gRPC server failed to start on /opt/domain/b7f2d035-e081-4a55-a9d3-a87351d8daad
java.io.IOException: Failed to bind
    at io.grpc.netty.NettyServer.start(NettyServer.java:252)
    at io.grpc.internal.ServerImpl.start(ServerImpl.java:184)
    at io.grpc.internal.ServerImpl.start(ServerImpl.java:90)
    at alluxio.grpc.GrpcServer.lambda$start$0(GrpcServer.java:77)
    at alluxio.retry.RetryUtils.retry(RetryUtils.java:39)
    at alluxio.grpc.GrpcServer.start(GrpcServer.java:77)
    at alluxio.worker.grpc.GrpcDataServer.<init>(GrpcDataServer.java:107)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
    at alluxio.util.CommonUtils.createNewClassInstance(CommonUtils.java:285)
    at alluxio.worker.DataServer$Factory.create(DataServer.java:47)
    at alluxio.worker.AlluxioWorkerProcess.<init>(AlluxioWorkerProcess.java:162)
    at alluxio.worker.WorkerProcess$Factory.create(WorkerProcess.java:46)
    at alluxio.worker.WorkerProcess$Factory.create(WorkerProcess.java:38)
    at alluxio.worker.AlluxioWorker.main(AlluxioWorker.java:72)
Caused by: io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Permission denied
2021-03-13 00:32:57,391 ERROR AlluxioWorker - Fatal error: Failed to create worker process
java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException: Alluxio worker gRPC server failed to start on /opt/domain/b7f2d035-e081-4a55-a9d3-a87351d8daad
    at alluxio.worker.AlluxioWorkerProcess.<init>(AlluxioWorkerProcess.java:168)
    at alluxio.worker.WorkerProcess$Factory.create(WorkerProcess.java:46)
    at alluxio.worker.WorkerProcess$Factory.create(WorkerProcess.java:38)
    at alluxio.worker.AlluxioWorker.main(AlluxioWorker.java:72)
Caused by: java.lang.RuntimeException: java.lang.RuntimeException: Alluxio worker gRPC server failed to start on /opt/domain/b7f2d035-e081-4a55-a9d3-a87351d8daad
    at alluxio.util.CommonUtils.createNewClassInstance(CommonUtils.java:287)
    at alluxio.worker.DataServer$Factory.create(DataServer.java:47)
    at alluxio.worker.AlluxioWorkerProcess.<init>(AlluxioWorkerProcess.java:162)
    ... 3 more
Caused by: java.lang.RuntimeException: Alluxio worker gRPC server failed to start on /opt/domain/b7f2d035-e081-4a55-a9d3-a87351d8daad
    at alluxio.worker.grpc.GrpcDataServer.<init>(GrpcDataServer.java:112)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
    at alluxio.util.CommonUtils.createNewClassInstance(CommonUtils.java:285)
    ... 5 more
Caused by: java.io.IOException: Failed to bind
    at io.grpc.netty.NettyServer.start(NettyServer.java:252)
    at io.grpc.internal.ServerImpl.start(ServerImpl.java:184)
    at io.grpc.internal.ServerImpl.start(ServerImpl.java:90)
    at alluxio.grpc.GrpcServer.lambda$start$0(GrpcServer.java:77)
    at alluxio.retry.RetryUtils.retry(RetryUtils.java:39)
    at alluxio.grpc.GrpcServer.start(GrpcServer.java:77)
    at alluxio.worker.grpc.GrpcDataServer.<init>(GrpcDataServer.java:107)
    ... 10 more
Caused by: io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Permission denied
```

Upon investigating the `alluxio-worker` container in my Alluxio worker pod, we see that `/opt/domain` gets mounted with `root:root` as the user:group:
```
[kubernetes@ip-172-31-76-132 shortcircuit]$ kubectl exec -it alluxio-worker-b28rm -c alluxio-job-worker /bin/bash
bash-4.4$ ls -l /opt
total 4
lrwxrwxrwx    1 alluxio  alluxio         13 Mar  5 20:17 alluxio -> alluxio-2.5.0
drwxr-xr-x    1 alluxio  alluxio         30 Mar  5 19:52 alluxio-2.5.0
drwxr-xr-x    3 root     root          4096 Mar  5 20:18 arthas
drwxr-xr-x    3 root     root           104 Mar  5 20:18 async-profiler
drwxr-xr-x    2 root     root             6 Mar 12 23:51 domain
```

According to the [Kubernetes SecurityContext docs](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) using `fsGroup` should have been sufficient but it appears that the volume is still being mounted with the default user:group of root:root.

This PR adds `runAsRoot` and `runAsGroup` to the top-level `SecurityContext` to enforce the volume to be mounted with the correct user:group permissions.

## Alternative solution
A more hacky approach which is [commonly suggested](https://serverfault.com/a/907160) is to use an `initContainer` to `chown` the volume mount directly as this will persist during the Pod's lifecycle.

## Testing
Both approaches have been tested by @ZhuTopher in a standalone K8s deployment on EC2. Additional details about the setup are available [here](https://github.com/Alluxio/alluxio/issues/13022#issuecomment-797840435)