### PR TITLE
Allocate real blockSize when loading files for distributedLoad

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -20,6 +20,7 @@ import alluxio.client.block.policy.options.GetWorkerOptions;
 import alluxio.client.block.stream.BlockInStream;
 import alluxio.client.block.stream.BlockInStream.BlockInStreamSource;
 import alluxio.client.block.stream.BlockOutStream;
+import alluxio.client.block.stream.DataWriter;
 import alluxio.client.block.util.BlockLocationUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.options.InStreamOptions;
@@ -27,11 +28,9 @@ import alluxio.client.file.options.OutStreamOptions;
 import alluxio.collections.Pair;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.PreconditionMessage;
-import alluxio.exception.status.ResourceExhaustedException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.network.TieredIdentityFactory;
 import alluxio.resource.CloseableResource;
-import alluxio.util.FormatUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.BlockLocation;
 import alluxio.wire.TieredIdentity;
@@ -241,8 +240,7 @@ public final class AlluxioBlockStore {
    * Gets a stream to write data to a block. The stream can only be backed by Alluxio storage.
    *
    * @param blockId the block to write
-   * @param blockSize the standard block size to write, or -1 if the block already exists (and this
-   *        stream is just storing the block in Alluxio again)
+   * @param blockSize the standard block size to write
    * @param address the address of the worker to write the block to, fails if the worker cannot
    *        serve the request
    * @param options the output stream options
@@ -251,20 +249,13 @@ public final class AlluxioBlockStore {
    */
   public BlockOutStream getOutStream(long blockId, long blockSize, WorkerNetAddress address,
       OutStreamOptions options) throws IOException {
-    if (blockSize == -1) {
-      try (CloseableResource<BlockMasterClient> blockMasterClientResource =
-          mContext.acquireBlockMasterClientResource()) {
-        blockSize = blockMasterClientResource.get().getBlockInfo(blockId).getLength();
-      }
-    }
     // No specified location to write to.
-    if (address == null) {
-      throw new ResourceExhaustedException(ExceptionMessage.NO_SPACE_FOR_BLOCK_ON_WORKER
-          .getMessage(FormatUtils.getSizeFromBytes(blockSize)));
-    }
-    LOG.debug("Create block outstream for {} of block size {} at address {}, using options: {}",
+    Preconditions.checkNotNull(address, "address");
+    LOG.debug("Create BlockOutStream for {} of block size {} at address {}, using options: {}",
         blockId, blockSize, address, options);
-    return BlockOutStream.create(mContext, blockId, blockSize, address, options);
+    DataWriter dataWriter =
+        DataWriter.Factory.create(mContext, blockId, blockSize, address, options);
+    return new BlockOutStream(dataWriter, blockSize, address);
   }
 
   /**
@@ -272,8 +263,7 @@ public final class AlluxioBlockStore {
    * Alluxio storage.
    *
    * @param blockId the block to write
-   * @param blockSize the standard block size to write, or -1 if the block already exists (and this
-   *        stream is just storing the block in Alluxio again)
+   * @param blockSize the standard block size to write
    * @param options the output stream option
    * @return a {@link BlockOutStream} which can be used to write data to the block in a streaming
    *         fashion

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockOutStream.java
@@ -51,30 +51,13 @@ public class BlockOutStream extends OutputStream implements BoundedStream, Cance
   private boolean mClosed;
 
   /**
-   * Creates an {@link BlockOutStream}.
-   *
-   * @param context the file system context
-   * @param blockId the block ID
-   * @param blockSize the block size in bytes
-   * @param address the Alluxio worker address
-   * @param options the out stream options
-   * @return the {@link OutputStream} object
-   */
-  public static BlockOutStream create(FileSystemContext context, long blockId, long blockSize,
-      WorkerNetAddress address, OutStreamOptions options) throws IOException {
-    DataWriter dataWriter =
-        DataWriter.Factory.create(context, blockId, blockSize, address, options);
-    return new BlockOutStream(dataWriter, blockSize, address);
-  }
-
-  /**
    * Constructs a new {@link BlockOutStream} with only one {@link DataWriter}.
    *
    * @param dataWriter the data writer
    * @param length the length of the stream
    * @param address the Alluxio worker address
    */
-  protected BlockOutStream(DataWriter dataWriter, long length, WorkerNetAddress address) {
+  public BlockOutStream(DataWriter dataWriter, long length, WorkerNetAddress address) {
     mCloser = Closer.create();
     mLength = length;
     mAddress = address;

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DataWriter.java
@@ -72,7 +72,7 @@ public interface DataWriter extends Closeable, Cancelable {
               context, address, blockId, blockSize, options);
         }
         LOG.debug("Creating short circuit output stream for block {} @ {}", blockId, address);
-        return LocalFileDataWriter.create(context, address, blockId, options);
+        return LocalFileDataWriter.create(context, address, blockId, blockSize, options);
       } else {
         LOG.debug("Creating gRPC output stream for block {} @ {} from client {}", blockId, address,
             NetworkAddressUtils.getClientHostName(alluxioConf));

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataWriter.java
@@ -127,7 +127,8 @@ public final class GrpcDataWriter implements DataWriter {
     mWriterBufferSizeMessages = conf.getInt(PropertyKey.USER_STREAMING_WRITER_BUFFER_SIZE_MESSAGES);
     mWriterCloseTimeoutMs = conf.getMs(PropertyKey.USER_STREAMING_WRITER_CLOSE_TIMEOUT);
     mWriterFlushTimeoutMs = conf.getMs(PropertyKey.USER_STREAMING_WRITER_FLUSH_TIMEOUT);
-    long reservedBytes = conf.getBytes(PropertyKey.USER_FILE_RESERVED_BYTES);
+    // in cases we know precise block size, make more accurate reservation.
+    long reservedBytes = Math.min(mLength, conf.getBytes(PropertyKey.USER_FILE_RESERVED_BYTES));
 
     WriteRequestCommand.Builder builder =
         WriteRequestCommand.newBuilder().setId(id).setTier(options.getWriteTier()).setType(type)

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
@@ -82,7 +82,8 @@ public final class LocalFileDataWriter implements DataWriter {
           conf.getInt(PropertyKey.USER_STREAMING_WRITER_BUFFER_SIZE_MESSAGES);
       long fileBufferBytes = conf.getBytes(PropertyKey.USER_FILE_BUFFER_BYTES);
       long dataTimeout = conf.getMs(PropertyKey.USER_STREAMING_DATA_TIMEOUT);
-      long reservedBytes = blockSize;
+      // in cases we know precise block size, make more accurate reservation.
+      long reservedBytes = Math.min(blockSize, conf.getBytes(PropertyKey.USER_FILE_RESERVED_BYTES));
 
       CreateLocalBlockRequest.Builder builder =
           CreateLocalBlockRequest.newBuilder().setBlockId(blockId).setTier(options.getWriteTier())

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataWriter.java
@@ -63,12 +63,13 @@ public final class LocalFileDataWriter implements DataWriter {
    * @param context the file system context
    * @param address the worker network address
    * @param blockId the block ID
+   * @param blockSize the block size in bytes
    * @param options the output stream options
    * @return the {@link LocalFileDataWriter} created
    */
   public static LocalFileDataWriter create(final FileSystemContext context,
       final WorkerNetAddress address,
-      long blockId, OutStreamOptions options) throws IOException {
+      long blockId, long blockSize, OutStreamOptions options) throws IOException {
     AlluxioConfiguration conf = context.getClusterConf();
     long chunkSize = conf.getBytes(PropertyKey.USER_LOCAL_WRITER_CHUNK_SIZE_BYTES);
 
@@ -81,7 +82,7 @@ public final class LocalFileDataWriter implements DataWriter {
           conf.getInt(PropertyKey.USER_STREAMING_WRITER_BUFFER_SIZE_MESSAGES);
       long fileBufferBytes = conf.getBytes(PropertyKey.USER_FILE_BUFFER_BYTES);
       long dataTimeout = conf.getMs(PropertyKey.USER_STREAMING_DATA_TIMEOUT);
-      long reservedBytes = conf.getBytes(PropertyKey.USER_FILE_RESERVED_BYTES);
+      long reservedBytes = blockSize;
 
       CreateLocalBlockRequest.Builder builder =
           CreateLocalBlockRequest.newBuilder().setBlockId(blockId).setTier(options.getWriteTier())

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/UfsFallbackLocalFileDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/UfsFallbackLocalFileDataWriter.java
@@ -54,7 +54,7 @@ public final class UfsFallbackLocalFileDataWriter implements DataWriter {
       throws IOException {
     try {
       LocalFileDataWriter localFilePacketWriter =
-          LocalFileDataWriter.create(context, address, blockId, options);
+          LocalFileDataWriter.create(context, address, blockId, blockSize, options);
       return new UfsFallbackLocalFileDataWriter(localFilePacketWriter, null, context, address,
           blockId, blockSize, options);
     } catch (ResourceExhaustedException e) {

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/LocalFileDataWriterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/LocalFileDataWriterTest.java
@@ -93,7 +93,7 @@ public class LocalFileDataWriterTest {
   @Test
   public void streamCancelled() throws Exception {
     LocalFileDataWriter writer = LocalFileDataWriter.create(mContext, mAddress, BLOCK_ID,
-        OutStreamOptions.defaults(mClientContext));
+        128 /* unused */, OutStreamOptions.defaults(mClientContext));
 
     // Cancel stream before cancelling the writer
     PowerMockito.when(mStream.isCanceled()).thenReturn(true);
@@ -110,7 +110,7 @@ public class LocalFileDataWriterTest {
   @Test
   public void streamClosed() throws Exception {
     LocalFileDataWriter writer = LocalFileDataWriter.create(mContext, mAddress, BLOCK_ID,
-        OutStreamOptions.defaults(mClientContext));
+        128 /* unused */, OutStreamOptions.defaults(mClientContext));
 
     // Close stream before closing the writer
     PowerMockito.when(mStream.isCanceled()).thenReturn(true);

--- a/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
@@ -14,6 +14,7 @@ package alluxio.job.plan.load;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.client.block.BlockWorkerInfo;
+import alluxio.client.file.URIStatus;
 import alluxio.collections.Pair;
 import alluxio.exception.status.FailedPreconditionException;
 import alluxio.job.plan.AbstractVoidPlanDefinition;
@@ -138,9 +139,16 @@ public final class LoadDefinition
   @Override
   public SerializableVoid runTask(LoadConfig config, ArrayList<LoadTask> tasks,
       RunTaskContext context) throws Exception {
+
+    // TODO(jiri): Replace with internal client that uses file ID once the internal client is
+    // factored out of the core server module. The reason to prefer using file ID for this job is
+    // to avoid the the race between "replicate" and "rename", so that even a file to replicate is
+    // renamed, the job is still working on the correct file.
+    URIStatus status = context.getFileSystem().getStatus(new AlluxioURI(config.getFilePath()));
+
     for (LoadTask task : tasks) {
       JobUtils.loadBlock(
-          context.getFileSystem(), context.getFsContext(), config.getFilePath(), task.getBlockId());
+          status, context.getFsContext(), task.getBlockId());
       LOG.info("Loaded block " + task.getBlockId());
     }
     return null;

--- a/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
@@ -147,8 +147,7 @@ public final class LoadDefinition
     URIStatus status = context.getFileSystem().getStatus(new AlluxioURI(config.getFilePath()));
 
     for (LoadTask task : tasks) {
-      JobUtils.loadBlock(
-          status, context.getFsContext(), task.getBlockId());
+      JobUtils.loadBlock(status, context.getFsContext(), task.getBlockId());
       LOG.info("Loaded block " + task.getBlockId());
     }
     return null;

--- a/job/server/src/main/java/alluxio/job/util/JobUtils.java
+++ b/job/server/src/main/java/alluxio/job/util/JobUtils.java
@@ -11,13 +11,11 @@
 
 package alluxio.job.util;
 
-import alluxio.AlluxioURI;
 import alluxio.client.Cancelable;
 import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.BlockLocationPolicy;
 import alluxio.client.block.policy.LocalFirstPolicy;
-import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.InStreamOptions;
@@ -33,10 +31,12 @@ import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
+import alluxio.wire.BlockInfo;
 import alluxio.wire.BlockLocation;
 import alluxio.wire.FileBlockInfo;
 import alluxio.wire.WorkerNetAddress;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
 
@@ -99,13 +99,11 @@ public final class JobUtils {
   /**
    * Loads a block into the local worker. If the block doesn't exist in Alluxio, it will be read
    * from the UFS.
-   *
-   * @param fs the filesystem
+   *  @param status the uriStatus
    * @param context filesystem context
-   * @param path the file path of the block to load
    * @param blockId the id of the block to load
    */
-  public static void loadBlock(FileSystem fs, FileSystemContext context, String path, long blockId)
+  public static void loadBlock(URIStatus status, FileSystemContext context, long blockId)
       throws AlluxioException, IOException {
     AlluxioBlockStore blockStore = AlluxioBlockStore.create(context);
 
@@ -125,15 +123,10 @@ public final class JobUtils {
           .getMessage(blockId));
     }
 
-    // TODO(jiri): Replace with internal client that uses file ID once the internal client is
-    // factored out of the core server module. The reason to prefer using file ID for this job is
-    // to avoid the the race between "replicate" and "rename", so that even a file to replicate is
-    // renamed, the job is still working on the correct file.
-    URIStatus status = fs.getStatus(new AlluxioURI(path));
-
     Set<String> pinnedLocation = status.getPinnedMediumTypes();
     if (pinnedLocation.size() > 1) {
-      throw new AlluxioException(ExceptionMessage.PINNED_TO_MULTIPLE_MEDIUMTYPES.getMessage(path));
+      throw new AlluxioException(
+          ExceptionMessage.PINNED_TO_MULTIPLE_MEDIUMTYPES.getMessage(status.getPath()));
     }
     // since there is only one element in the set, we take the first element in the set
     String medium = pinnedLocation.isEmpty() ? "" : pinnedLocation.iterator().next();
@@ -143,7 +136,7 @@ public final class JobUtils {
 
     AlluxioConfiguration conf = ServerConfiguration.global();
     InStreamOptions inOptions = new InStreamOptions(status, openOptions, conf);
-    // Set read location policy always to loca first for loading blocks for job tasks
+    // Set read location policy always to local first for loading blocks for job tasks
     inOptions.setUfsReadLocationPolicy(BlockLocationPolicy.Factory.create(
         LocalFirstPolicy.class.getCanonicalName(), conf));
 
@@ -154,8 +147,11 @@ public final class JobUtils {
         LocalFirstPolicy.class.getCanonicalName(), conf));
 
     // use -1 to reuse the existing block size for this block
+    BlockInfo blockInfo = status.getBlockInfo(blockId);
+    Preconditions.checkNotNull(blockInfo, "Can not find block %s in status %s", blockId, status);
+    long blockSize = blockInfo.getLength();
     try (OutputStream outputStream =
-        blockStore.getOutStream(blockId, -1, localNetAddress, outOptions)) {
+        blockStore.getOutStream(blockId, blockSize, localNetAddress, outOptions)) {
       try (InputStream inputStream = blockStore.getInStream(blockId, inOptions)) {
         ByteStreams.copy(inputStream, outputStream);
       } catch (Throwable t) {

--- a/job/server/src/main/java/alluxio/job/util/JobUtils.java
+++ b/job/server/src/main/java/alluxio/job/util/JobUtils.java
@@ -146,7 +146,6 @@ public final class JobUtils {
     outOptions.setLocationPolicy(BlockLocationPolicy.Factory.create(
         LocalFirstPolicy.class.getCanonicalName(), conf));
 
-    // use -1 to reuse the existing block size for this block
     BlockInfo blockInfo = status.getBlockInfo(blockId);
     Preconditions.checkNotNull(blockInfo, "Can not find block %s in status %s", blockId, status);
     long blockSize = blockInfo.getLength();

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -162,7 +162,7 @@ public final class ReplicateDefinitionTest {
     when(mMockBlockStore.getInStream(anyLong(),
             any(InStreamOptions.class))).thenReturn(mockInStream);
     when(
-        mMockBlockStore.getOutStream(eq(TEST_BLOCK_ID), eq(-1L), eq(LOCAL_ADDRESS),
+        mMockBlockStore.getOutStream(eq(TEST_BLOCK_ID), eq(TEST_BLOCK_SIZE), eq(LOCAL_ADDRESS),
             any(OutStreamOptions.class))).thenReturn(mockOutStream);
     when(mMockBlockStore.getInfo(TEST_BLOCK_ID))
         .thenReturn(new BlockInfo().setBlockId(TEST_BLOCK_ID)

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -155,7 +155,8 @@ public final class ReplicateDefinitionTest {
     URIStatus status = new URIStatus(
         new FileInfo().setPath(path).setBlockIds(Lists.newArrayList(TEST_BLOCK_ID))
             .setFileBlockInfos(Lists.newArrayList(
-                new FileBlockInfo().setBlockInfo(new BlockInfo().setBlockId(TEST_BLOCK_ID)))));
+                new FileBlockInfo().setBlockInfo(
+                    new BlockInfo().setBlockId(TEST_BLOCK_ID).setLength(TEST_BLOCK_SIZE)))));
     when(mMockFileSystem.getStatus(any(AlluxioURI.class))).thenReturn(status);
 
     when(mMockFileSystemContext.getCachedWorkers()).thenReturn(blockWorkers);


### PR DESCRIPTION
In issue #13005, `distributedLoad` failed due to reserving too much space (e.g., 128MB space reserved just for loading 300KB files). 
When write concurrency is high, it can take a lot of wasted space and possibly causing `distributedLoad` failed.

This PR
1. makes better estimation on DataWriter to reserve bytes 
2. optimizes the performance of `distributedLoad` by reducing master RPCs by moving `getStatus` call out of loop

Fix https://github.com/Alluxio/alluxio/issues/13005
