### PR TITLE
Add resource loading fallback logic to ExtensionClassLoader

### DIFF
--- a/core/common/src/main/java/alluxio/extensions/ExtensionsClassLoader.java
+++ b/core/common/src/main/java/alluxio/extensions/ExtensionsClassLoader.java
@@ -90,6 +90,7 @@ public class ExtensionsClassLoader extends URLClassLoader {
     Enumeration<URL> resources = super.getResources(name);
     // Falls back to default class loader if not found in the URL class loader
     if (!resources.hasMoreElements()) {
+      LOG.debug("Falling back to default class loader for loading resource {}", name);
       return mDefaultClassloader.getResources(name);
     }
     return resources;

--- a/core/common/src/main/java/alluxio/extensions/ExtensionsClassLoader.java
+++ b/core/common/src/main/java/alluxio/extensions/ExtensionsClassLoader.java
@@ -14,8 +14,10 @@ package alluxio.extensions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Enumeration;
 
 /**
  * An isolated {@link ClassLoader} for loading extensions to core Alluxio. This class loader first
@@ -81,5 +83,15 @@ public class ExtensionsClassLoader extends URLClassLoader {
     } catch (ClassNotFoundException e) {
       return mDefaultClassloader.loadClass(name, resolve);
     }
+  }
+
+  @Override
+  public Enumeration<URL> getResources(String name) throws IOException {
+    Enumeration<URL> resources = super.getResources(name);
+    // Falls back to default class loader if not found in the URL class loader
+    if (!resources.hasMoreElements()) {
+      return mDefaultClassloader.getResources(name);
+    }
+    return resources;
   }
 }


### PR DESCRIPTION
Some extensions perform resource loading during initialization which can fail in the URLClassLoader logic. This change adds a fallback logic to look for resource in the default class loader.