### PR TITLE
Add replay statistics for journal startup

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/AbstractJournalProgressLogger.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AbstractJournalProgressLogger.java
@@ -1,0 +1,99 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.journal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.OptionalLong;
+import java.util.StringJoiner;
+
+/**
+ * Class to abstract out progress logging for journal replay.
+ */
+public abstract class AbstractJournalProgressLogger {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractJournalProgressLogger.class);
+
+  // could have been configurable. decided it is not really necessary.
+  /** Max time to wait before actually logging. */
+  private static final long MAX_LOG_INTERVAL_MS = 30_000;
+
+  private long mLastMeasuredTime;
+  private long mLastCommitIdx;
+  private long mLogCount;
+
+  private final OptionalLong mEndCommitIdx;
+
+  /**
+   * Creates a new instance of {@link AbstractJournalProgressLogger}.
+   *
+   * @param endComitIdx the final commit index in the journal. Used to estimate completion time
+   */
+  public AbstractJournalProgressLogger(OptionalLong endComitIdx) {
+    mEndCommitIdx = endComitIdx;
+    mLastMeasuredTime = System.currentTimeMillis();
+    mLastCommitIdx = 0L;
+    mLogCount = 0;
+  }
+
+  /**
+   * @return the last applied commit index to a journal
+   */
+  public abstract long getLastAppliedIndex();
+
+  /**
+   * @return the name of the journal
+   */
+  public abstract String getJournalName();
+
+  /**
+   * Logs the progress of journal replay.
+   *
+   * This method rate limits itself on when it actually calculates and logs the message. If it is
+   * called too frequently, then it will essentially be a no-op. The return value indicates whether
+   * a message was logged or not as a result of calling the method.
+   *
+   * @return true is a message is logged, false otherwise
+   */
+  public boolean logProgress() {
+    long now = System.currentTimeMillis();
+    long nextLogTime =
+        1000L * Math.min(1L << (mLogCount > 30 ? 30 : mLogCount), MAX_LOG_INTERVAL_MS);
+    // Exit early if log is called too fast.
+    if ((now - mLastMeasuredTime) < nextLogTime) {
+      return false;
+    }
+    mLogCount++;
+    long currCommitIdx = getLastAppliedIndex();
+    long timeSinceLastMeasure = (now - mLastMeasuredTime);
+    long commitIdxRead = currCommitIdx - mLastCommitIdx;
+    double commitIdxRateS = 1000 * ((double) commitIdxRead) / timeSinceLastMeasure;
+    StringJoiner logMsg = new StringJoiner("|");
+    logMsg.add(getJournalName());
+    logMsg.add(String.format("current SN: %d", currCommitIdx));
+    logMsg.add(String.format("entries in last %dms=%d", timeSinceLastMeasure, commitIdxRead));
+    if (mEndCommitIdx.isPresent()) {
+      long commitsRemaining = mEndCommitIdx.getAsLong() - currCommitIdx;
+      double expectedTimeRemaining = ((double) commitsRemaining) / commitIdxRateS;
+      if (commitsRemaining > 0) {
+        logMsg.add(String.format("est. commits left: %d", commitsRemaining));
+      }
+      if (!Double.isNaN(expectedTimeRemaining) && !Double.isInfinite(expectedTimeRemaining)) {
+        logMsg.add(String.format("est. time remaining: %.2fms", expectedTimeRemaining));
+      }
+    }
+    LOG.info(logMsg.toString());
+    mLastMeasuredTime = now;
+    mLastCommitIdx = currCommitIdx;
+    return true;
+  }
+}

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -616,6 +616,13 @@ public class JournalStateMachine extends BaseStateMachine {
   }
 
   /**
+   * @return the last raft log index which was applied to the state machine
+   */
+  public long getLastAppliedCommitIndex() {
+    return mLastAppliedCommitIndex;
+  }
+
+  /**
    * @return whether the state machine is in the process of taking a snapshot
    */
   public boolean isSnapshotting() {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalProgressLogger.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalProgressLogger.java
@@ -1,0 +1,45 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.journal.raft;
+
+import alluxio.master.journal.AbstractJournalProgressLogger;
+
+import java.util.OptionalLong;
+
+/**
+ * Logs journal replay progress for the {@link RaftJournalSystem}.
+ */
+public class RaftJournalProgressLogger extends AbstractJournalProgressLogger {
+
+  private final JournalStateMachine mJournal;
+
+  /**
+   * Creates a new instance of the logger.
+   *
+   * @param journal the journal being replayed
+   * @param endCommitIdx the final commit index in the log to estimate completion times
+   */
+  public RaftJournalProgressLogger(JournalStateMachine journal, OptionalLong endCommitIdx) {
+    super(endCommitIdx);
+    mJournal = journal;
+  }
+
+  @Override
+  public long getLastAppliedIndex() {
+    return mJournal.getLastAppliedCommitIndex();
+  }
+
+  @Override
+  public String getJournalName() {
+    return "embedded journal";
+  }
+}

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -583,9 +583,9 @@ public class RaftJournalSystem extends AbstractJournalSystem {
       // If for some reason there is more than one..it should be fine as it only
       // affects the completion time estimate in the logs.
       synchronized (this) { // synchronized to appease findbugs; shouldn't make any difference
+        RaftPeerId serverId = mServer.getId();
         Optional<RaftProtos.CommitInfoProto> commitInfo = getGroupInfo().getCommitInfos().stream()
-            .filter(commit ->
-                mServer.getId().equals(RaftPeerId.valueOf(commit.getServer().getId())))
+            .filter(commit -> serverId.equals(RaftPeerId.valueOf(commit.getServer().getId())))
             .findFirst();
         if (commitInfo.isPresent()) {
           endCommitIndex = OptionalLong.of(commitInfo.get().getCommitIndex());

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -568,7 +568,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
    * The caller is responsible for detecting and responding to leadership changes.
    */
   private void catchUp(JournalStateMachine stateMachine, LocalFirstRaftClient client)
-          throws TimeoutException, InterruptedException {
+      throws TimeoutException, InterruptedException {
     long startTime = System.currentTimeMillis();
     long waitBeforeRetry = ServerConfiguration.global()
         .getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_CATCHUP_RETRY_WAIT);
@@ -580,10 +580,10 @@ public class RaftJournalSystem extends AbstractJournalSystem {
       endCommitIndex = getGroupInfo().getCommitInfos().stream()
           .mapToLong(RaftProtos.CommitInfoProto::getCommitIndex).min();
     } catch (IOException e) {
-      LOG.warn("Failed to get raft log information before replay."
-          + " Replay statistics will not be available:", e);
+      LogUtils.warnWithException(LOG, "Failed to get raft log information before replay."
+          + " Replay statistics will not be available", e);
     }
-    long lastMeasuredSeqNum = stateMachine.getLastAppliedSequenceNumber();
+
     long lastMeasuredTime = startTime;
     long lastCommitIdx = 0L;
 

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalProgressLogger.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalProgressLogger.java
@@ -1,0 +1,50 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.journal.ufs;
+
+import alluxio.master.journal.AbstractJournalProgressLogger;
+
+import java.util.OptionalLong;
+import java.util.function.Supplier;
+
+/**
+ * Journal replay logger for the {@link UfsJournal}.
+ */
+public class UfsJournalProgressLogger extends AbstractJournalProgressLogger {
+
+  private final UfsJournal mJournal;
+  private final Supplier<Long> mCommitSupplier;
+
+  /**
+   * Creates a new instance of the journal replay progress logger.
+   *
+   * @param journal the journal being replayed
+   * @param endCommitIdx the final commit index (sequence number) in the journal
+   * @param lastIndexSupplier supplier that gives the last applied commit (sequence number)
+   */
+  public UfsJournalProgressLogger(UfsJournal journal, OptionalLong endCommitIdx,
+      Supplier<Long> lastIndexSupplier) {
+    super(endCommitIdx);
+    mJournal = journal;
+    mCommitSupplier = lastIndexSupplier;
+  }
+
+  @Override
+  public long getLastAppliedIndex() {
+    return mCommitSupplier.get();
+  }
+
+  @Override
+  public String getJournalName() {
+    return mJournal.toString();
+  }
+}

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalReader.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayDeque;
-import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Queue;
 
@@ -211,7 +210,8 @@ public final class UfsJournalReader implements JournalReader {
    * opening a new one.
    */
   private void updateInputStream() throws IOException {
-    if (mInputStream != null && (mInputStream.mFile.isIncompleteLog() || !mInputStream.isDone(mNextSequenceNumber))) {
+    if (mInputStream != null && (mInputStream.mFile.isIncompleteLog()
+        || !mInputStream.isDone(mNextSequenceNumber))) {
       return;
     }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalReader.java
@@ -20,6 +20,7 @@ import alluxio.proto.journal.Journal;
 import alluxio.proto.journal.Journal.JournalEntry;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.OpenOptions;
+import alluxio.util.LogUtils;
 
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
@@ -293,7 +294,7 @@ public final class UfsJournalReader implements JournalReader {
         reader.updateInputStream();
       }
     } catch (IOException e) {
-      LOG.warn("Failed to get last SN from journal: ", e);
+      LogUtils.warnWithException(LOG, "Failed to get last SN from journal", e);
       return OptionalLong.empty();
     }
     return OptionalLong.of(endSN);


### PR DESCRIPTION
This change adds some new logging messages to the master while
replaying the  journal. Specifically, it will now log the rate of
journal entries applied to the state machine during the startup process.
The number of entries in a particular interval are logged along with the
current commit index and the expected entries remaining and estimated
time left.

In the embedded journal Instead, we use the Ratis "Commit Index"
which represents batches of journal entries applied to the raft log. We are
able to get the last commit index as well as track the most recently
applied index which gives us the ability to provide the estimated time
remaining. The last SN is more readily available in the UFSJournal
since we control that implementation.

A new function for the UfsJournalReader needed to be added in order to
find the highest sequence number is within a particular journal. This
allows us to get the estimated entries remaining and time left during
the replay. The method should take O(N) with the number of journal
log files. It does not read data from the log files. In the case where
there is an error determining the highest SN, an empty optional is
returned in which case the information about expected finish time and
number of entries remaining is omitted.

There is a case where an error occurs when retrieving the final commit
index. In this case, the optional variable with the index will not be
populated and the estimated time remaining statistics will not be
calculated, only the measured rate of entries being applied.