### PR TITLE
Add configuration to stop master process on demotion

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1953,6 +1953,18 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_JOURNAL_EXIT_ON_DEMOTION =
+      new Builder(Name.MASTER_JOURNAL_EXIT_ON_DEMOTION)
+          .setDefaultValue(false)
+          .setDescription("(Experimental) When this flag is set to true, the master process may "
+              + "start as the primary or secondary in a quorum, but at any point in time after "
+              + "becoming a primary it is demoted to secondary, the process will shut down. This "
+              + "leaves the responsibility of restarting the master to re-join the quorum (e.g. in"
+              + " case of a journal failure on a particular node) to an external entity such as "
+              + "kubernetes or systemd.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_UFS_JOURNAL_MAX_CATCHUP_TIME =
       new Builder(Name.MASTER_UFS_JOURNAL_MAX_CATCHUP_TIME)
           .setDefaultValue("10min")
@@ -5276,6 +5288,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.lock.pool.concurrency.level";
     public static final String MASTER_JOURNAL_CATCHUP_PROTECT_ENABLED =
         "alluxio.master.journal.catchup.protect.enabled";
+    public static final String MASTER_JOURNAL_EXIT_ON_DEMOTION =
+        "alluxio.master.journal.exit.on.demotion";
     public static final String MASTER_JOURNAL_FLUSH_BATCH_TIME_MS =
         "alluxio.master.journal.flush.batch.time";
     public static final String MASTER_JOURNAL_FLUSH_TIMEOUT_MS =

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -105,6 +105,11 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
         mLeaderSelector.waitForState(State.SECONDARY);
         if (ServerConfiguration.getBoolean(PropertyKey.MASTER_JOURNAL_EXIT_ON_DEMOTION)) {
           stop();
+        } else {
+          if (!mRunning) {
+            break;
+          }
+          losePrimacy();
         }
       }
     }

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -103,7 +103,9 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       }
       if (gainPrimacy()) {
         mLeaderSelector.waitForState(State.SECONDARY);
-        stop();
+        if (ServerConfiguration.getBoolean(PropertyKey.MASTER_JOURNAL_EXIT_ON_DEMOTION)) {
+          stop();
+        }
       }
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -91,6 +91,9 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
     }
 
     while (!Thread.interrupted()) {
+      if (!mRunning) {
+        break;
+      }
       if (ServerConfiguration.getBoolean(PropertyKey.MASTER_JOURNAL_CATCHUP_PROTECT_ENABLED)) {
         mJournalSystem.waitForCatchup();
       }
@@ -100,10 +103,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       }
       if (gainPrimacy()) {
         mLeaderSelector.waitForState(State.SECONDARY);
-        if (!mRunning) {
-          break;
-        }
-        losePrimacy();
+        stop();
       }
     }
   }
@@ -187,6 +187,13 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
     if (mLeaderSelector != null) {
       mLeaderSelector.stop();
     }
+  }
+
+  /**
+   * @return whether the master is running
+   */
+  protected boolean isRunning() {
+    return mRunning;
   }
 
   @Override

--- a/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
+++ b/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
@@ -102,6 +102,31 @@ public final class AlluxioMasterProcessTest {
     startStopTest(master);
   }
 
+  @Test
+  public void stopAfterSecondaryTransition() throws Exception {
+    ControllablePrimarySelector primarySelector = new ControllablePrimarySelector();
+    primarySelector.setState(PrimarySelector.State.PRIMARY);
+    FaultTolerantAlluxioMasterProcess master = new FaultTolerantAlluxioMasterProcess(
+        new NoopJournalSystem(), primarySelector);
+    Thread t = new Thread(() -> {
+      try {
+        master.start();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+    t.start();
+    waitForServing(ServiceType.MASTER_RPC);
+    waitForServing(ServiceType.MASTER_WEB);
+    assertTrue(isBound(mRpcPort));
+    assertTrue(isBound(mWebPort));
+    primarySelector.setState(PrimarySelector.State.SECONDARY);
+    t.join(10000);
+    assertFalse(isBound(mRpcPort));
+    assertFalse(isBound(mWebPort));
+    assertFalse(master.isRunning());
+  }
+
   /**
    * This test ensures that given a root UFS which is <i>not</i> local, that we can still provide a
    * local path to an Alluxio backup and start the master.

--- a/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
+++ b/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
@@ -106,6 +106,7 @@ public final class AlluxioMasterProcessTest {
   public void stopAfterSecondaryTransition() throws Exception {
     ControllablePrimarySelector primarySelector = new ControllablePrimarySelector();
     primarySelector.setState(PrimarySelector.State.PRIMARY);
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_EXIT_ON_DEMOTION, "true");
     FaultTolerantAlluxioMasterProcess master = new FaultTolerantAlluxioMasterProcess(
         new NoopJournalSystem(), primarySelector);
     Thread t = new Thread(() -> {

--- a/core/server/master/src/test/java/alluxio/master/ControllablePrimarySelector.java
+++ b/core/server/master/src/test/java/alluxio/master/ControllablePrimarySelector.java
@@ -1,0 +1,22 @@
+package alluxio.master;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+/**
+ * A primary selector which allows the user to set the states manually.
+ *
+ * After creation, you must set the initial state to your desired initial state with
+ * {@link #setState(State)}.
+ */
+public class ControllablePrimarySelector extends AbstractPrimarySelector {
+  @Override
+  public void start(InetSocketAddress localAddress) throws IOException {
+      // nothing to do
+  }
+
+  @Override
+  public void stop() throws IOException {
+    // nothing to do
+  }
+}

--- a/core/server/master/src/test/java/alluxio/master/ControllablePrimarySelector.java
+++ b/core/server/master/src/test/java/alluxio/master/ControllablePrimarySelector.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.master;
 
 import java.io.IOException;

--- a/docs/en/operation/Journal.md
+++ b/docs/en/operation/Journal.md
@@ -389,3 +389,21 @@ $ ./bin/alluxio readJournal
 ```
 
 See [here]({{ '/en/operation/User-CLI.html' | relativize_url }}#readjournal) for more detailed usage.
+
+
+### Exiting upon Demotion
+
+By default Alluxio will transition masters from primaries to secondaries.
+During this process the JVM is _not_ shut down at any point.
+This occasionally leaves behind resources and may lead to a bloated memory footprint.
+To avoid taking up too much memory this, there is a flag which forces a master JVM to exit once it
+has been demoted from a primary to a secondary.
+This moves the responsibility of restarting the process to join the quorum as a secondary to a
+process supervisor such as a Kubernetes cluster manager or systemd.
+
+To configure this behavior for an Alluxio master, set the following configuration inside of 
+`alluxio-site.properties`
+
+```properties
+alluxio.master.journal.exit.on.demotion=true
+```


### PR DESCRIPTION
The code changes here are relatively simple. When the
FaultTolerantAlluxioMasterProcess changes state from primary to
secondary, then instead of switching states and continuing operation, we
should trigger the JVM to exit instead.

The reasoning behind this change is that the implementation to clean up
between state changes is not sound and leaves additional resources
hanging around which accumulate if enough state changes occur.
Defaulting to this behavior places the restart responsibility elsewhere,
but guarantees a clean slate and no resource leaks upon startup.

This is implemented with little change by simply placing a call to
stop() once the primary selector changes to the SECONDARY state
within the FTAMP. A simple new test is added to verify this behavior

The behavior by default is hidden behind the flag
alluxio.master.journal.exit.on.demotion. It is false by default and when
set to true, the masters will exhibit the behavior described above.

Additional considerations may want to be taken into account when this
is made the default behavior. We may want to consider additional
recommended guidelines for process supervision on bare metal machines
using systemd. K8s deployments should not be affected as the default
behavior is usually to restart the pod anyway.