### PR TITLE
Fix regression in AbsentUfsPathCache

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -358,6 +358,7 @@ public final class MountTable implements DelegatingJournaled {
     try (LockResource r = new LockResource(mReadLock)) {
       String path = uri.getPath();
       LOG.debug("Resolving {}", path);
+      PathUtils.validatePath(uri.getPath());
       // This will re-acquire the read lock, but that is allowed.
       String mountPoint = getMountPoint(uri);
       if (mountPoint != null) {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/NoopUfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/NoopUfsAbsentPathCache.java
@@ -35,7 +35,12 @@ public final class NoopUfsAbsentPathCache implements UfsAbsentPathCache {
   }
 
   @Override
-  public void process(AlluxioURI path, List<Inode> prefixInodes) {
+  public void processAsync(AlluxioURI path, List<Inode> prefixInodes) {
+    // Do nothing
+  }
+
+  @Override
+  public void addSinglePath(AlluxioURI path) {
     // Do nothing
   }
 
@@ -45,7 +50,7 @@ public final class NoopUfsAbsentPathCache implements UfsAbsentPathCache {
   }
 
   @Override
-  public boolean isAbsent(AlluxioURI path) {
+  public boolean isAbsentSince(AlluxioURI path, long absentSince) {
     return false;
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsAbsentPathCache.java
@@ -24,14 +24,24 @@ import java.util.List;
  * Cache for recording information about paths that are not present in UFS.
  */
 public interface UfsAbsentPathCache {
+  long ALWAYS = -1;
+  long NEVER = Long.MAX_VALUE;
+
   /**
-   * Processes the given path for the cache. This will sequentially walk down the path to find
-   * components which do and do not exist in the UFS, and updates the cache accordingly.
+   * Processes the given path for the cache. This will asynchronously and sequentially walk down
+   * the path to find components which do and do not exist in the UFS, and updates the cache
+   * accordingly.
    *
    * @param path the path to process for the cache
    * @param prefixInodes the existing inodes for the path prefix
    */
-  void process(AlluxioURI path, List<Inode> prefixInodes);
+  void processAsync(AlluxioURI path, List<Inode> prefixInodes);
+
+  /**
+   * Add a single path to the absent cache synchronously.
+   * @param path the path to process for the cache
+   */
+  void addSinglePath(AlluxioURI path);
 
   /**
    * Processes the given path that already exists. This will sequentially walk down the path and
@@ -42,13 +52,15 @@ public interface UfsAbsentPathCache {
   void processExisting(AlluxioURI path);
 
   /**
-   * Returns true if the given path is absent, according to this cache. A path is absent if one of
-   * its ancestors is absent.
+   * Returns true if the given path was found to be absent since absentSince, according to this
+   * cache.
+   * A path is absent if one of its ancestors is absent.
    *
    * @param path the path to check
+   * @param absentSince the time when the cache entry would be considered valid
    * @return true if the path is absent according to the cache
    */
-  boolean isAbsent(AlluxioURI path);
+  boolean isAbsentSince(AlluxioURI path, long absentSince);
 
   /**
    * Factory class for {@link UfsAbsentPathCache}.

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -197,6 +197,7 @@ message LoadMetadataPOptions {
   optional bool createAncestors = 2;
   optional fscommon.LoadDescendantPType loadDescendantType = 3;
   optional FileSystemMasterCommonPOptions commonOptions = 4;
+  optional LoadMetadataPType loadType = 5;
 }
 
 enum PAclEntryType {


### PR DESCRIPTION
Cherry-pick  committed PR #12956 into target branch branch-2.3
-----------
Add a time stamp to indicate last refreshed time on the absent cache
entries.
Use absent cache to avoid UFS accesses when possible in the metadata
sync and load Metadata processes.

Added more comprehensive integration tests that ensures the number of
accesses to the UFS through SleepingUnderFileSystem and unit tests for
the absent cache.

fixes #12833 because now instead of checking /a, /a/b, /a/b/c for non
existent directories, we will only access the UFS once for /a because of
absent cache. We know /a/b, /a/b/c can not exist on the UFS.

Co-authored-by: David Zhu <david@alluxio.com>

pr-link: Alluxio/alluxio#12956
change-id: cid-1c836c95416214ca0256a0d62feafe78d7cf8489