### PR TITLE
Convert AsyncCacheExecutor to use UniqueBlockingQueue 

### DIFF
--- a/core/common/src/main/java/alluxio/util/executor/UniqueBlockingQueue.java
+++ b/core/common/src/main/java/alluxio/util/executor/UniqueBlockingQueue.java
@@ -27,7 +27,11 @@ import java.util.concurrent.TimeUnit;
  */
 public class UniqueBlockingQueue<T> extends AbstractQueue<T> implements BlockingQueue<T> {
   private ConcurrentHashSet<T> mElementSet = new ConcurrentHashSet<>();
-  private BlockingQueue<T> mBlockingQueue = new LinkedBlockingQueue<>();
+  private BlockingQueue<T> mBlockingQueue;
+
+  public UniqueBlockingQueue(int capacity) {
+    mBlockingQueue = new LinkedBlockingQueue<>(capacity);
+  }
 
   @Override
   public synchronized void put(T e) throws InterruptedException {

--- a/core/common/src/main/java/alluxio/util/executor/UniqueBlockingQueue.java
+++ b/core/common/src/main/java/alluxio/util/executor/UniqueBlockingQueue.java
@@ -1,0 +1,149 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util.executor;
+
+import alluxio.collections.ConcurrentHashSet;
+
+import java.util.AbstractQueue;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A blocking queue containing only unique elements, based on LinkedBlockingQueue implementation.
+ *
+ * @param <T> element type
+ */
+public class UniqueBlockingQueue<T> extends AbstractQueue<T> implements BlockingQueue<T> {
+  private ConcurrentHashSet<T> mElementSet = new ConcurrentHashSet<>();
+  private BlockingQueue<T> mBlockingQueue = new LinkedBlockingQueue<>();
+
+  @Override
+  public synchronized void put(T e) throws InterruptedException {
+    if (!mElementSet.contains(e)) {
+      mElementSet.add(e);
+      mBlockingQueue.put(e);
+    }
+  }
+
+  @Override
+  public synchronized boolean offer(T e) {
+    // the interface description suggests that offer can only fail for capacity reason, but we
+    // are failing for uniqueness reasons.
+    if (mElementSet.contains(e)) {
+      return false;
+    }
+    if (mBlockingQueue.offer(e)) {
+      mElementSet.add(e);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public synchronized boolean offer(T e, long timeout, TimeUnit unit) throws InterruptedException {
+    // the interface description suggests that offer can only fail for capacity reason, but we
+    // are failing for uniqueness reasons.
+    if (mElementSet.contains(e)) {
+      return false;
+    }
+    if (mBlockingQueue.offer(e, timeout, unit)) {
+      mElementSet.add(e);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public T take() throws InterruptedException {
+    T e = mBlockingQueue.take();
+    mElementSet.remove(e);
+    return e;
+  }
+
+  @Override
+  public int remainingCapacity() {
+    return mBlockingQueue.remainingCapacity();
+  }
+
+  @Override
+  public int drainTo(Collection<? super T> c) {
+    return drainTo(c, Integer.MAX_VALUE);
+  }
+
+  @Override
+  public int drainTo(Collection<? super T> c, int maxElements) {
+    int numberOfElements = mBlockingQueue.drainTo(c, maxElements);
+    if (numberOfElements > 0) {
+      mElementSet.removeAll(c);
+    }
+    return numberOfElements;
+  }
+
+  @Override
+  public Iterator<T> iterator() {
+    Iterator<T> iter = mBlockingQueue.iterator();
+    Iterator<T> it = new Iterator<T>() {
+      private T mLastElem = null;
+      @Override
+      public boolean hasNext() {
+        return iter.hasNext();
+      }
+
+      @Override
+      public T next() {
+        mLastElem = iter.next();
+        return mLastElem;
+      }
+
+      @Override
+      public void remove() {
+        iter.remove();
+        if (mLastElem != null) {
+          mElementSet.remove(mLastElem);
+        }
+        mLastElem = null;
+      }
+    };
+    return it;
+  }
+
+  @Override
+  public int size() {
+    return mBlockingQueue.size();
+  }
+
+  @Override
+  public T poll() {
+    T e = mBlockingQueue.poll();
+    if (e != null) {
+      mElementSet.remove(e);
+    }
+    return e;
+  }
+
+  @Override
+  public T poll(long timeout, TimeUnit unit) throws InterruptedException {
+    T e = mBlockingQueue.poll(timeout, unit);
+    if (e != null) {
+      mElementSet.remove(e);
+    }
+    return e;
+  }
+
+  @Override
+  public T peek() {
+    return mBlockingQueue.peek();
+  }
+}

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
@@ -87,46 +87,13 @@ public class AsyncCacheRequestManager {
   public void submitRequest(AsyncCacheRequest request) {
     ASYNC_CACHE_REQUESTS.inc();
     long blockId = request.getBlockId();
-    long blockLength = request.getLength();
     if (mPendingRequests.putIfAbsent(blockId, request) != null) {
       // This block is already planned.
       ASYNC_CACHE_DUPLICATE_REQUESTS.inc();
       return;
     }
     try {
-      mAsyncCacheExecutor.submit(() -> {
-        boolean result = false;
-        try {
-          boolean isSourceLocal = mLocalWorkerHostname.equals(request.getSourceHost());
-          // Check if the block has already been cached on this worker
-          if (mBlockWorker.hasBlockMeta(blockId)) {
-            ASYNC_CACHE_DUPLICATE_REQUESTS.inc();
-            return;
-          }
-          Protocol.OpenUfsBlockOptions openUfsBlockOptions = request.getOpenUfsBlockOptions();
-          // Depends on the request, cache the target block from different sources
-          if (isSourceLocal) {
-            ASYNC_CACHE_UFS_BLOCKS.inc();
-            result = cacheBlockFromUfs(blockId, blockLength, openUfsBlockOptions);
-          } else {
-            ASYNC_CACHE_REMOTE_BLOCKS.inc();
-            InetSocketAddress sourceAddress =
-                new InetSocketAddress(request.getSourceHost(), request.getSourcePort());
-            result = cacheBlockFromRemoteWorker(
-                    blockId, blockLength, sourceAddress, openUfsBlockOptions);
-          }
-          LOG.debug("Result of async caching block {}: {}", blockId, result);
-        } catch (Exception e) {
-          LOG.warn("Async cache task failed. request: {}", request, e);
-        } finally {
-          if (result) {
-            ASYNC_CACHE_SUCCEEDED_BLOCKS.inc();
-          } else {
-            ASYNC_CACHE_FAILED_BLOCKS.inc();
-          }
-          mPendingRequests.remove(blockId);
-        }
-      });
+      mAsyncCacheExecutor.submit(new AsyncCacheTask(request));
     } catch (RejectedExecutionException e) {
       // RejectedExecutionException may be thrown in extreme cases when the
       // gRPC thread pool is drained due to highly concurrent caching workloads. In these cases,
@@ -230,6 +197,78 @@ public class AsyncCacheRequestManager {
         LOG.warn("Failed to abort block {}: {}", blockId, ee.getMessage());
       }
       return false;
+    }
+  }
+
+  /**
+   * AsyncCacheTask is a runnable task that can be considered equal if
+   * the blockId of the request is the same.
+   */
+  private class AsyncCacheTask implements Runnable {
+    private final AsyncCacheRequest mRequest;
+
+    /**
+     * Constructor for an AsyncCacheTask.
+     *
+     * @param request an AsyncCacheRequest
+     */
+    AsyncCacheTask(AsyncCacheRequest request) {
+      mRequest = request;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!(obj instanceof AsyncCacheTask)) {
+        return false;
+      }
+      AsyncCacheTask that = ((AsyncCacheTask) obj);
+      if (mRequest == that.mRequest) {
+        return true;
+      }
+      if ((this.mRequest == null && that.mRequest != null) || (this.mRequest != null && that.mRequest == null)) {
+        return false;
+      }
+      return mRequest.getBlockId() == that.mRequest.getBlockId();
+    }
+
+    @Override
+    public void run() {
+      boolean result = false;
+      long blockId = mRequest.getBlockId();
+      long blockLength = mRequest.getLength();
+      try {
+        boolean isSourceLocal = mLocalWorkerHostname.equals(mRequest.getSourceHost());
+        // Check if the block has already been cached on this worker
+        if (mBlockWorker.hasBlockMeta(mRequest.getBlockId())) {
+          ASYNC_CACHE_DUPLICATE_REQUESTS.inc();
+          return;
+        }
+        Protocol.OpenUfsBlockOptions openUfsBlockOptions = mRequest.getOpenUfsBlockOptions();
+        // Depends on the request, cache the target block from different sources
+        if (isSourceLocal) {
+          ASYNC_CACHE_UFS_BLOCKS.inc();
+          result = cacheBlockFromUfs(blockId, blockLength, openUfsBlockOptions);
+        } else {
+          ASYNC_CACHE_REMOTE_BLOCKS.inc();
+          InetSocketAddress sourceAddress =
+              new InetSocketAddress(mRequest.getSourceHost(), mRequest.getSourcePort());
+          result = cacheBlockFromRemoteWorker(
+              blockId, blockLength, sourceAddress, openUfsBlockOptions);
+        }
+        LOG.debug("Result of async caching block {}: {}", blockId, result);
+      } catch (Exception e) {
+        LOG.warn("Async cache task failed. request: {}", mRequest, e);
+      } finally {
+        if (result) {
+          ASYNC_CACHE_SUCCEEDED_BLOCKS.inc();
+        } else {
+          ASYNC_CACHE_FAILED_BLOCKS.inc();
+        }
+        mPendingRequests.remove(blockId);
+      }
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
@@ -17,6 +17,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.security.User;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.util.ThreadFactoryUtils;
+import alluxio.util.executor.UniqueBlockingQueue;
 
 import java.util.List;
 import java.util.concurrent.AbstractExecutorService;
@@ -40,7 +41,7 @@ final class GrpcExecutors {
       new ImpersonateThreadPoolExecutor(new ThreadPoolExecutor(THREADS_MIN,
           ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_ASYNC_CACHE_MANAGER_THREADS_MAX),
           THREAD_STOP_MS, TimeUnit.MILLISECONDS,
-          new LinkedBlockingQueue<>(ServerConfiguration.getInt(
+          new UniqueBlockingQueue<>(ServerConfiguration.getInt(
                   PropertyKey.WORKER_NETWORK_ASYNC_CACHE_MANAGER_QUEUE_MAX)),
           ThreadFactoryUtils.build("AsyncCacheManagerExecutor-%d", true)));
 


### PR DESCRIPTION
This is done so that duplicated tasks are not added to the queue, causing the queue to fill up and eventually start rejecting legitimate async caching requests. 