### PR TITLE
Support write,chmod,chown,rename in StackFS

### DIFF
--- a/core/common/src/main/java/alluxio/util/io/FileUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/FileUtils.java
@@ -14,6 +14,7 @@ package alluxio.util.io;
 import alluxio.AlluxioURI;
 import alluxio.exception.InvalidPathException;
 
+import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,11 +142,10 @@ public final class FileUtils {
    * @param mode the file mode
    * @return posix file permissions
    */
-  public static Set<PosixFilePermission> translateModeToPosixPermissions(int mode)
-      throws IOException {
+  public static Set<PosixFilePermission> translateModeToPosixPermissions(int mode) {
     Set<PosixFilePermission> perms = new HashSet<>();
     // add owners permission
-    Preconditions.checkArgument(mode >=0, "Mode can not be a negative value");
+    Preconditions.checkArgument(mode >= 0, "Mode can not be a negative value");
     if ((mode & 0400) != 0) {
       perms.add(PosixFilePermission.OWNER_READ);
     }

--- a/core/common/src/main/java/alluxio/util/io/FileUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/FileUtils.java
@@ -145,6 +145,9 @@ public final class FileUtils {
       throws IOException {
     Set<PosixFilePermission> perms = new HashSet<>();
     // add owners permission
+    if (mode < 0) {
+      throw new IOException("Mode can not be a negative value");
+    }
     if ((mode & 0400) != 0) {
       perms.add(PosixFilePermission.OWNER_READ);
     }

--- a/core/common/src/main/java/alluxio/util/io/FileUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/FileUtils.java
@@ -35,6 +35,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.nio.file.attribute.UserPrincipal;
 import java.nio.file.attribute.UserPrincipalLookupService;
+import java.util.HashSet;
 import java.util.Set;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -132,6 +133,48 @@ public final class FileUtils {
       mode += permission.contains(action) ? 1 : 0;
     }
     return (short) mode;
+  }
+
+  /**
+   * Translate mode to posix file permissions.
+   *
+   * @param mode the file mode
+   * @return posix file permissions
+   */
+  public static Set<PosixFilePermission> translateModeToPosixPermissions(int mode)
+      throws IOException {
+    Set<PosixFilePermission> perms = new HashSet<>();
+    // add owners permission
+    if ((mode & 0400) > 0) {
+      perms.add(PosixFilePermission.OWNER_READ);
+    }
+    if ((mode & 0200) > 0) {
+      perms.add(PosixFilePermission.OWNER_WRITE);
+    }
+    if ((mode & 0100) > 0) {
+      perms.add(PosixFilePermission.OWNER_EXECUTE);
+    }
+    // add group permissions
+    if ((mode & 0040) > 0) {
+      perms.add(PosixFilePermission.GROUP_READ);
+    }
+    if ((mode & 0020) > 0) {
+      perms.add(PosixFilePermission.GROUP_WRITE);
+    }
+    if ((mode & 0010) > 0) {
+      perms.add(PosixFilePermission.GROUP_EXECUTE);
+    }
+    // add others permissions
+    if ((mode & 0004) > 0) {
+      perms.add(PosixFilePermission.OTHERS_READ);
+    }
+    if ((mode & 0002) > 0) {
+      perms.add(PosixFilePermission.OTHERS_WRITE);
+    }
+    if ((mode & 0001) > 0) {
+      perms.add(PosixFilePermission.OTHERS_EXECUTE);
+    }
+    return perms;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/io/FileUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/FileUtils.java
@@ -145,33 +145,33 @@ public final class FileUtils {
       throws IOException {
     Set<PosixFilePermission> perms = new HashSet<>();
     // add owners permission
-    if ((mode & 0400) > 0) {
+    if ((mode & 0400) != 0) {
       perms.add(PosixFilePermission.OWNER_READ);
     }
-    if ((mode & 0200) > 0) {
+    if ((mode & 0200) != 0) {
       perms.add(PosixFilePermission.OWNER_WRITE);
     }
-    if ((mode & 0100) > 0) {
+    if ((mode & 0100) != 0) {
       perms.add(PosixFilePermission.OWNER_EXECUTE);
     }
     // add group permissions
-    if ((mode & 0040) > 0) {
+    if ((mode & 0040) != 0) {
       perms.add(PosixFilePermission.GROUP_READ);
     }
-    if ((mode & 0020) > 0) {
+    if ((mode & 0020) != 0) {
       perms.add(PosixFilePermission.GROUP_WRITE);
     }
-    if ((mode & 0010) > 0) {
+    if ((mode & 0010) != 0) {
       perms.add(PosixFilePermission.GROUP_EXECUTE);
     }
     // add others permissions
-    if ((mode & 0004) > 0) {
+    if ((mode & 0004) != 0) {
       perms.add(PosixFilePermission.OTHERS_READ);
     }
-    if ((mode & 0002) > 0) {
+    if ((mode & 0002) != 0) {
       perms.add(PosixFilePermission.OTHERS_WRITE);
     }
-    if ((mode & 0001) > 0) {
+    if ((mode & 0001) != 0) {
       perms.add(PosixFilePermission.OTHERS_EXECUTE);
     }
     return perms;

--- a/core/common/src/main/java/alluxio/util/io/FileUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/FileUtils.java
@@ -145,9 +145,7 @@ public final class FileUtils {
       throws IOException {
     Set<PosixFilePermission> perms = new HashSet<>();
     // add owners permission
-    if (mode < 0) {
-      throw new IOException("Mode can not be a negative value");
-    }
+    Preconditions.checkArgument(mode >=0, "Mode can not be a negative value");
     if ((mode & 0400) != 0) {
       perms.add(PosixFilePermission.OWNER_READ);
     }

--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -50,13 +50,14 @@ mount_fuse() {
     -m ${mount_point} \
     -r ${alluxio_root}"
   if [[ ${STACK_FS} -eq "1" ]]; then
+    stackfs_mount_option=`echo "${full_mount_option}" | sed -E 's/([^,]+)/-o\1/g'`
     cmd="${JAVA} -cp ${CLASSPATH} ${JAVA_OPTS} ${ALLUXIO_FUSE_JAVA_OPTS} \
     alluxio.fuse.StackMain \
-    ${alluxio_root} \
     ${mount_point} \
-    ${full_mount_option}"
+    ${alluxio_root} \
+    ${stackfs_mount_option}"
 
-    echo "Starting StackFS process: mounting src local path \"${alluxio_root}\" to dst local path \"${mount_point}\" with options=\"${full_mount_option}\""
+    echo "Starting StackFS process: mounting src local path \"${alluxio_root}\" to dst local path \"${mount_point}\" with options=\"${stackfs_mount_option}\""
   else
     echo "Starting AlluxioFuse process: mounting alluxio path \"${alluxio_root}\" to local mount point \"${mount_point}\" with options=\"${full_mount_option}\""
   fi
@@ -94,15 +95,20 @@ umount_fuse() {
 
 fuse_stat() {
   local fuse_info=$(ps aux | grep [A]lluxioFuse)
-  if [[ -z ${fuse_info} ]]; then
-    echo "No mount point found. AlluxioFuse process is not running."
-    echo -e "${MOUNT_USAGE}"
-    return 1
-  else
+  if [[ -n ${fuse_info} ]]; then
     echo -e "pid\tmount_point\talluxio_path"
     echo -e "$(ps aux | grep [A]lluxioFuse | awk -F' ' '{print $2 "\t" $(NF-2) "\t" $NF}')"
     return 0
   fi
+  fuse_info=$(ps aux | grep [S]tackMain)
+  if [[ -n ${fuse_info} ]]; then
+    echo -e "pid\tmount_point\tsource_path"
+    echo -e "$(ps aux | grep [S]tackMain | awk -F' ' '{print $2 "\t" $(NF-2) "\t" $(NF-1)}')"
+    return 0
+  fi
+  echo "No mount point found. AlluxioFuse process is not running."
+  echo -e "${MOUNT_USAGE}"
+  return 1
 }
 
 USAGE_MSG="Usage:\n\talluxio-fuse [mount|umount|stat]

--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -49,7 +49,18 @@ mount_fuse() {
     -o ${full_mount_option} \
     -m ${mount_point} \
     -r ${alluxio_root}"
-  echo "Starting AlluxioFuse process: mounting alluxio path \"${alluxio_root}\" to local mount point \"${mount_point}\" with options=\"${full_mount_option}\""
+  if [[ ${STACK_FS} -eq "1" ]]; then
+    cmd="${JAVA} -cp ${CLASSPATH} ${JAVA_OPTS} ${ALLUXIO_FUSE_JAVA_OPTS} \
+    alluxio.fuse.StackMain \
+    ${alluxio_root} \
+    ${mount_point} \
+    ${full_mount_option}"
+
+    echo "Starting StackFS process: mounting src local path \"${alluxio_root}\" to dst local path \"${mount_point}\" with options=\"${full_mount_option}\""
+  else
+    echo "Starting AlluxioFuse process: mounting alluxio path \"${alluxio_root}\" to local mount point \"${mount_point}\" with options=\"${full_mount_option}\""
+  fi
+
   if [[ ${NO_DAEMON} -eq "1" ]]; then
     exec ${cmd}
   else
@@ -108,7 +119,8 @@ Usage:\talluxio-fuse mount [-n] [-o <mount option>] <mount_point> [alluxio_path]
 \talluxio-fuse mount
 
 -o \tmount options for the fuse daemon
--n \tno-daemon. This launches the process in the foreground and logs to stdout"
+-n \tno-daemon. This launches the process in the foreground and logs to stdout
+-s \tstackFS. This launches StackFS process for testing purpose"
 
 if [[ $# -lt 1 ]]; then
   echo -e "${USAGE_MSG}" >&2
@@ -124,13 +136,16 @@ fi
 case $1 in
   mount)
     shift
-    while getopts "o:n" option; do
+    while getopts "o:ns" option; do
       case "${option}" in
         o)
           mount_option=${OPTARG}
           ;;
         n)
           NO_DAEMON="1"
+          ;;
+        s)
+          STACK_FS="1"
           ;;
         *)
           echo -e "${MOUNT_USAGE}" >&2

--- a/integration/fuse/src/main/java/alluxio/fuse/StackMain.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/StackMain.java
@@ -24,11 +24,11 @@ public class StackMain {
    */
   public static void main(String[] args) {
     if (args.length < 2) {
-      System.out.println("Usage: <root> <mountPoint> <fuseOpts...>");
+      System.out.println("Usage: <mountPoint> <sourcePath> <fuseOpts e.g. -obig_writes...>");
       System.exit(1);
     }
-    Path root = Paths.get(args[0]);
-    Path mountPoint = Paths.get(args[1]);
+    Path root = Paths.get(args[1]);
+    Path mountPoint = Paths.get(args[0]);
     StackFS fs = new StackFS(root, mountPoint);
     String[] fuseOpts = new String[args.length - 2];
     System.arraycopy(args, 2, fuseOpts, 0, args.length - 2);


### PR DESCRIPTION
Support StackFS operations with alluxio-fuse script
```
$ integration/fuse/bin/alluxio-fuse mount -s fuseMount fuseBeMounted
Starting StackFS process: mounting src local path "fuseBeMounted" to dst local path "fuseMount" with options="-obig_writes"
$ integration/fuse/bin/alluxio-fuse stat
pid	mount_point	source_path
94231	fuseMount	fuseBeMounted
$ integration/fuse/bin/alluxio-fuse umount fuseMount
Unmount fuse at fuseMount (PID: 94231).
```
Support write related operations in StackFS.