### PR TITLE
Improve Worker Interface and implementation

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -188,8 +188,9 @@ public final class AlluxioBlockStore {
           BlockLocationUtils.nearest(mTieredIdentity, tieredLocations, mContext.getClusterConf());
       if (nearest.isPresent()) {
         dataSource = nearest.get().getFirst();
-        dataSourceType = nearest.get().getSecond() ? mContext.isWorkerInternalClient()
-            ? BlockInStreamSource.EMBEDDED : BlockInStreamSource.LOCAL : BlockInStreamSource.REMOTE;
+        dataSourceType = nearest.get().getSecond() ? mContext.hasProcessLocalWorker()
+            ? BlockInStreamSource.PROCESS_LOCAL : BlockInStreamSource.NODE_LOCAL
+            : BlockInStreamSource.REMOTE;
       }
     }
     // Can't get data from Alluxio, get it from the UFS instead

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataReader.java
@@ -146,6 +146,7 @@ public final class BlockWorkerDataReader implements DataReader {
         return;
       }
       mReader.close();
+      mClosed = true;
     }
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataReader.java
@@ -31,8 +31,7 @@ import java.nio.ByteBuffer;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * A data reader that issues from a client embedded in a worker
- * to read data from the worker directly via internal communication channel.
+ * A data reader that reads from a worker in the same process of this client directly.
  *
  * This data reader is similar to read from local worker via {@link GrpcDataReader}
  * except that all communication with the local worker is via internal method call
@@ -120,7 +119,7 @@ public final class BlockWorkerDataReader implements DataReader {
           .fromProto(options.getOptions().getReadType()).isPromote();
       mReadRequestPartial = ReadRequest.newBuilder()
           .setBlockId(blockId).setPromote(isPromote).build();
-      mBlockWorker = context.getInternalBlockWorker();
+      mBlockWorker = context.getProcessLocalWorker();
     }
 
     @Override
@@ -129,7 +128,7 @@ public final class BlockWorkerDataReader implements DataReader {
           .setOffset(offset).setLength(len).build();
       mBlockReadRequest = new BlockReadRequest(mReadRequestPartial);
       try {
-        mReader = mBlockWorker.newBlockReader(mBlockReadRequest);
+        mReader = mBlockWorker.createBlockReader(mBlockReadRequest);
         return new BlockWorkerDataReader(mReader, offset, len, mChunkSize);
       } catch (Exception e) {
         throw new IOException(e);
@@ -146,11 +145,7 @@ public final class BlockWorkerDataReader implements DataReader {
       if (mClosed) {
         return;
       }
-      try {
-        mBlockWorker.closeBlockReader(mReader, mBlockReadRequest);
-      } catch (Exception e) {
-        throw new IOException(e);
-      }
+      mReader.close();
     }
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataWriter.java
@@ -66,13 +66,13 @@ public final class BlockWorkerDataWriter implements DataWriter {
     AlluxioConfiguration conf = context.getClusterConf();
     int chunkSize = (int) conf.getBytes(PropertyKey.USER_LOCAL_WRITER_CHUNK_SIZE_BYTES);
     long reservedBytes = Math.min(blockSize, conf.getBytes(PropertyKey.USER_FILE_RESERVED_BYTES));
-    BlockWorker blockWorker = context.getInternalBlockWorker();
+    BlockWorker blockWorker = context.getProcessLocalWorker();
     Preconditions.checkNotNull(blockWorker, "blockWorker");
     long sessionId = SessionIdUtils.createSessionId();
     try {
       blockWorker.createBlock(sessionId, blockId, options.getWriteTier(), options.getMediumType(),
           reservedBytes);
-      BlockWriter blockWriter = blockWorker.getBlockWriter(sessionId, blockId);
+      BlockWriter blockWriter = blockWorker.createBlockWriter(sessionId, blockId);
       return new BlockWorkerDataWriter(sessionId, blockId, options, blockWriter, blockWorker,
           chunkSize, reservedBytes, conf);
     } catch (BlockAlreadyExistsException | WorkerOutOfSpaceException | BlockDoesNotExistException

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DataWriter.java
@@ -63,7 +63,7 @@ public interface DataWriter extends Closeable, Cancelable {
       boolean ufsFallbackEnabled = options.getWriteType() == WriteType.ASYNC_THROUGH
           && alluxioConf.getBoolean(PropertyKey.USER_FILE_UFS_TIER_ENABLED);
 
-      if (context.isWorkerInternalClient() && !ufsFallbackEnabled) {
+      if (context.hasProcessLocalWorker() && !ufsFallbackEnabled) {
         return BlockWorkerDataWriter.create(context, blockId, blockSize, options);
       }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -411,7 +411,8 @@ public class AlluxioFileInStream extends FileInStream {
           return;
         }
         WorkerNetAddress worker;
-        if (mPassiveCachingEnabled && mContext.hasNodeLocalWorker()) { // send request to local worker
+        if (mPassiveCachingEnabled && mContext.hasNodeLocalWorker()) {
+          // send request to local worker
           worker = mContext.getNodeLocalWorker();
         } else { // send request to data source
           worker = dataSource;

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -277,8 +277,8 @@ public class AlluxioFileInStream extends FileInStream {
         retry = mRetryPolicySupplier.get();
         lastException = null;
         BlockInStream.BlockInStreamSource source = mCachedPositionedReadStream.getSource();
-        if (source != BlockInStream.BlockInStreamSource.LOCAL
-            && source != BlockInStream.BlockInStreamSource.EMBEDDED) {
+        if (source != BlockInStream.BlockInStreamSource.NODE_LOCAL
+            && source != BlockInStream.BlockInStreamSource.PROCESS_LOCAL) {
           triggerAsyncCaching(mCachedPositionedReadStream);
         }
         if (bytesRead == mBlockSize - offset) {
@@ -377,8 +377,8 @@ public class AlluxioFileInStream extends FileInStream {
       if (stream == mBlockInStream) { // if stream is instance variable, set to null
         mBlockInStream = null;
       }
-      if (blockSource == BlockInStream.BlockInStreamSource.LOCAL
-          || blockSource == BlockInStream.BlockInStreamSource.EMBEDDED) {
+      if (blockSource == BlockInStream.BlockInStreamSource.NODE_LOCAL
+          || blockSource == BlockInStream.BlockInStreamSource.PROCESS_LOCAL) {
         return;
       }
       triggerAsyncCaching(stream);
@@ -405,14 +405,14 @@ public class AlluxioFileInStream extends FileInStream {
                 .setOpenUfsBlockOptions(mOptions.getOpenUfsBlockOptions(blockId))
                 .setSourceHost(dataSource.getHost()).setSourcePort(dataSource.getDataPort())
                 .build();
-        if (mPassiveCachingEnabled && mContext.isWorkerInternalClient()) {
-          mContext.getInternalBlockWorker().submitAsyncCacheRequest(request);
+        if (mPassiveCachingEnabled && mContext.hasProcessLocalWorker()) {
+          mContext.getProcessLocalWorker().asyncCache(request);
           mLastBlockIdCached = blockId;
           return;
         }
         WorkerNetAddress worker;
-        if (mPassiveCachingEnabled && mContext.hasLocalWorker()) { // send request to local worker
-          worker = mContext.getLocalWorker();
+        if (mPassiveCachingEnabled && mContext.hasNodeLocalWorker()) { // send request to local worker
+          worker = mContext.getNodeLocalWorker();
         } else { // send request to data source
           worker = dataSource;
         }

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -197,8 +197,7 @@ public class FileSystemContext implements Closeable {
     ClientContext ctx = ClientContext.create(subject, conf);
     MasterInquireClient inquireClient =
         MasterInquireClient.Factory.create(ctx.getClusterConf(), ctx.getUserState());
-    FileSystemContext context = new FileSystemContext(ctx.getClusterConf(),
-        blockWorker);
+    FileSystemContext context = new FileSystemContext(ctx.getClusterConf(), blockWorker);
     context.init(ctx, inquireClient);
     return context;
   }
@@ -240,8 +239,7 @@ public class FileSystemContext implements Closeable {
    * @param conf Alluxio configuration
    * @param blockWorker block worker
    */
-  private FileSystemContext(AlluxioConfiguration conf,
-      @Nullable BlockWorker blockWorker) {
+  private FileSystemContext(AlluxioConfiguration conf, @Nullable BlockWorker blockWorker) {
     mId = IdUtils.createFileSystemContextId();
     mBlockWorker = blockWorker;
     mWorkerRefreshPolicy =
@@ -587,26 +585,25 @@ public class FileSystemContext implements Closeable {
   /**
    * @return if the current client is embedded in a worker
    */
-  public synchronized boolean isWorkerInternalClient() {
+  public synchronized boolean hasProcessLocalWorker() {
     return mBlockWorker != null;
   }
 
   /**
-   * Acquires the internal block worker
-   * as a gateway for worker internal clients to communicate with
-   * the local worker directly without going through external RPC frameworks.
+   * Acquires the internal block worker as a gateway for worker internal clients to communicate
+   * with the local worker directly without going through external RPC frameworks.
    *
-   * @return the acquired block worker
+   * @return the acquired block worker or null if this client is not interal to a block worker
    */
   @Nullable
-  public BlockWorker getInternalBlockWorker() {
+  public BlockWorker getProcessLocalWorker() {
     return mBlockWorker;
   }
 
   /**
    * @return if there is a local worker running the same machine
    */
-  public synchronized boolean hasLocalWorker() throws IOException {
+  public synchronized boolean hasNodeLocalWorker() throws IOException {
     if (!mLocalWorkerInitialized) {
       initializeLocalWorker();
     }
@@ -616,7 +613,7 @@ public class FileSystemContext implements Closeable {
   /**
    * @return a local worker running the same machine, or null if none is found
    */
-  public synchronized WorkerNetAddress getLocalWorker() throws IOException {
+  public synchronized WorkerNetAddress getNodeLocalWorker() throws IOException {
     if (!mLocalWorkerInitialized) {
       initializeLocalWorker();
     }

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
@@ -89,7 +89,7 @@ public class BlockInStreamTest {
   @Test
   public void createShortCircuit() throws Exception {
     WorkerNetAddress dataSource = new WorkerNetAddress();
-    BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.LOCAL;
+    BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.NODE_LOCAL;
     BlockInStream stream =
         BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType, mOptions);
     assertTrue(stream.isShortCircuit());
@@ -120,7 +120,7 @@ public class BlockInStreamTest {
             .toResource()) {
       WorkerNetAddress dataSource = new WorkerNetAddress();
       when(mMockContext.getClientContext()).thenReturn(ClientContext.create(mConf));
-      BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.LOCAL;
+      BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.NODE_LOCAL;
       BlockInStream stream =
           BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType, mOptions);
       assertFalse(stream.isShortCircuit());
@@ -136,7 +136,7 @@ public class BlockInStreamTest {
     PowerMockito.when(NettyUtils.isDomainSocketSupported(Matchers.any(WorkerNetAddress.class)))
         .thenReturn(true);
     WorkerNetAddress dataSource = new WorkerNetAddress();
-    BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.LOCAL;
+    BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.NODE_LOCAL;
     BlockInStream stream = BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType,
         mOptions);
     assertFalse(stream.isShortCircuit());

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
@@ -120,7 +120,8 @@ public class BlockInStreamTest {
             .toResource()) {
       WorkerNetAddress dataSource = new WorkerNetAddress();
       when(mMockContext.getClientContext()).thenReturn(ClientContext.create(mConf));
-      BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.NODE_LOCAL;
+      BlockInStream.BlockInStreamSource dataSourceType =
+          BlockInStream.BlockInStreamSource.NODE_LOCAL;
       BlockInStream stream =
           BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType, mOptions);
       assertFalse(stream.isShortCircuit());

--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -96,8 +96,8 @@ public final class AlluxioFileInStreamTest {
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][] {
-      {BlockInStreamSource.EMBEDDED},
-      {BlockInStreamSource.LOCAL},
+      {BlockInStreamSource.PROCESS_LOCAL},
+      {BlockInStreamSource.NODE_LOCAL},
       {BlockInStreamSource.UFS},
       {BlockInStreamSource.REMOTE}
     });
@@ -131,7 +131,7 @@ public final class AlluxioFileInStreamTest {
     when(mContext.getClientContext()).thenReturn(ClientContext.create(sConf));
     when(mContext.getClusterConf()).thenReturn(sConf);
     when(mContext.getPathConf(any(AlluxioURI.class))).thenReturn(sConf);
-    PowerMockito.when(mContext.getLocalWorker()).thenReturn(new WorkerNetAddress());
+    PowerMockito.when(mContext.getNodeLocalWorker()).thenReturn(new WorkerNetAddress());
     mBlockStore = mock(AlluxioBlockStore.class);
     PowerMockito.mockStatic(AlluxioBlockStore.class);
     PowerMockito.when(AlluxioBlockStore.create(mContext)).thenReturn(mBlockStore);
@@ -403,7 +403,7 @@ public final class AlluxioFileInStreamTest {
   @Test
   public void testSeekWithNoLocalWorker() throws IOException {
     // Overrides the get local worker call
-    PowerMockito.when(mContext.getLocalWorker()).thenReturn(null);
+    PowerMockito.when(mContext.getNodeLocalWorker()).thenReturn(null);
     OpenFilePOptions options =
         OpenFilePOptions.newBuilder().setReadType(ReadPType.CACHE_PROMOTE).build();
     mTestStream =

--- a/core/common/src/main/java/alluxio/util/io/BufferUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/BufferUtils.java
@@ -11,6 +11,7 @@
 
 package alluxio.util.io;
 
+import alluxio.Constants;
 import alluxio.util.CommonUtils;
 
 import com.google.common.base.Preconditions;
@@ -358,8 +359,7 @@ public final class BufferUtils {
    */
   public static void fastCopy(final ReadableByteChannel src, final WritableByteChannel dest)
       throws IOException {
-    // TODO(yupeng): make the buffer size configurable
-    final ByteBuffer buffer = ByteBuffer.allocateDirect(16 * 1024);
+    final ByteBuffer buffer = ByteBuffer.allocateDirect(4 * Constants.MB);
 
     while (src.read(buffer) != -1) {
       buffer.flip();

--- a/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -213,7 +213,7 @@ public interface BlockWorker extends Worker, SessionCleanable {
    *
    * @param sessionId the id of the client
    * @param blockId the id of the block to move
-   * @param tierAlias the alias of the tier to move the block to
+   * @param tier the tier to move the block to
    * @throws BlockDoesNotExistException if blockId cannot be found
    * @throws BlockAlreadyExistsException if blockId already exists in committed blocks of the
    *         newLocation
@@ -221,7 +221,7 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @throws WorkerOutOfSpaceException if newLocation does not have enough extra space to hold the
    *         block
    */
-  void moveBlock(long sessionId, long blockId, String tierAlias)
+  void moveBlock(long sessionId, long blockId, int tier)
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
       WorkerOutOfSpaceException, IOException;
 
@@ -245,22 +245,6 @@ public interface BlockWorker extends Worker, SessionCleanable {
       WorkerOutOfSpaceException, IOException;
 
   /**
-   * Gets the path to the block file in local storage. The block must be a permanent block, and the
-   * caller must first obtain the lock on the block.
-   *
-   * @param sessionId the id of the client
-   * @param blockId the id of the block to read
-   * @param lockId the id of the lock on this block
-   * @return a string representing the path to this block in local storage
-   * @throws BlockDoesNotExistException if the blockId cannot be found in committed blocks or lockId
-   *         cannot be found
-   * @throws InvalidWorkerStateException if sessionId or blockId is not the same as that in the
-   *         LockRecord of lockId
-   */
-  String getLocalBlockPath(long sessionId, long blockId, long lockId)
-      throws BlockDoesNotExistException, InvalidWorkerStateException;
-
-  /**
    * Creates the block reader to read from Alluxio block or UFS block.
    * Owner of this block reader must close it or lock will leak.
    *
@@ -276,22 +260,6 @@ public interface BlockWorker extends Worker, SessionCleanable {
   BlockReader createBlockReader(BlockReadRequest request) throws
       BlockAlreadyExistsException, BlockDoesNotExistException,
       InvalidWorkerStateException, WorkerOutOfSpaceException, IOException;
-
-  /**
-   * Creates the block reader to read the local cached block starting from given block offset.
-   * Owner of this block reader must close it or lock will leak.
-   *
-   * @param sessionId the id of the client
-   * @param blockId the id of the block to read
-   * @param lockId the id of the lock on this block
-   * @param offset the offset within this block
-   * @return the block reader for the block
-   * @throws BlockDoesNotExistException if lockId is not found
-   * @throws InvalidWorkerStateException if sessionId or blockId is not the same as that in the
-   *         LockRecord of lockId
-   */
-  BlockReader createLocalBlockReader(long sessionId, long blockId, long lockId, long offset)
-      throws BlockDoesNotExistException, InvalidWorkerStateException, IOException;
 
   /**
    * Creates a block reader to read a UFS block starting from given block offset.

--- a/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -250,16 +250,11 @@ public interface BlockWorker extends Worker, SessionCleanable {
    *
    * @param request the block read request
    * @return a block reader to read data from
-   * @throws BlockAlreadyExistsException if it fails to commit the block to Alluxio block store
-   *         because the block exists in the Alluxio block store after opening the ufs block reader
    * @throws BlockDoesNotExistException if the requested block does not exist in this worker
-   * @throws InvalidWorkerStateException if blockId does not belong to sessionId
-   * @throws WorkerOutOfSpaceException if there is no enough space
    * @throws IOException if it fails to get block reader
    */
-  BlockReader createBlockReader(BlockReadRequest request) throws
-      BlockAlreadyExistsException, BlockDoesNotExistException,
-      InvalidWorkerStateException, WorkerOutOfSpaceException, IOException;
+  BlockReader createBlockReader(BlockReadRequest request)
+      throws BlockDoesNotExistException, IOException;
 
   /**
    * Creates a block reader to read a UFS block starting from given block offset.

--- a/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -14,7 +14,6 @@ package alluxio.worker.block;
 import alluxio.exception.BlockAlreadyExistsException;
 import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.InvalidWorkerStateException;
-import alluxio.exception.UfsBlockAccessTokenUnavailableException;
 import alluxio.exception.WorkerOutOfSpaceException;
 import alluxio.grpc.AsyncCacheRequest;
 import alluxio.proto.dataserver.Protocol;
@@ -94,7 +93,7 @@ public interface BlockWorker extends Worker, SessionCleanable {
 
   /**
    * Creates a block in Alluxio managed space.
-   * Calls {@link #getBlockWriter} to get a writer for writing to the block.
+   * Calls {@link #createBlockWriter} to get a writer for writing to the block.
    * The block will be temporary until it is committed by {@link #commitBlock} .
    * Throws an {@link IllegalArgumentException} if the location does not belong to tiered storage.
    *
@@ -132,7 +131,7 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @throws BlockAlreadyExistsException if a committed block with the same ID exists
    * @throws InvalidWorkerStateException if the worker state is invalid
    */
-  BlockWriter getBlockWriter(long sessionId, long blockId)
+  BlockWriter createBlockWriter(long sessionId, long blockId)
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
       IOException;
 
@@ -262,8 +261,8 @@ public interface BlockWorker extends Worker, SessionCleanable {
       throws BlockDoesNotExistException, InvalidWorkerStateException;
 
   /**
-   * Gets the block reader to read from Alluxio block or UFS block.
-   * This operation must be paired with {@link #closeBlockReader}.
+   * Creates the block reader to read from Alluxio block or UFS block.
+   * Owner of this block reader must close it or lock will leak.
    *
    * @param request the block read request
    * @return a block reader to read data from
@@ -274,35 +273,40 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @throws WorkerOutOfSpaceException if there is no enough space
    * @throws IOException if it fails to get block reader
    */
-  BlockReader newBlockReader(BlockReadRequest request) throws
+  BlockReader createBlockReader(BlockReadRequest request) throws
       BlockAlreadyExistsException, BlockDoesNotExistException,
       InvalidWorkerStateException, WorkerOutOfSpaceException, IOException;
 
   /**
-   * Gets the block reader for the block for non short-circuit reads.
+   * Creates the block reader to read the local cached block starting from given block offset.
+   * Owner of this block reader must close it or lock will leak.
    *
    * @param sessionId the id of the client
    * @param blockId the id of the block to read
    * @param lockId the id of the lock on this block
+   * @param offset the offset within this block
    * @return the block reader for the block
    * @throws BlockDoesNotExistException if lockId is not found
    * @throws InvalidWorkerStateException if sessionId or blockId is not the same as that in the
    *         LockRecord of lockId
    */
-  BlockReader newLocalBlockReader(long sessionId, long blockId, long lockId)
+  BlockReader createLocalBlockReader(long sessionId, long blockId, long lockId, long offset)
       throws BlockDoesNotExistException, InvalidWorkerStateException, IOException;
 
   /**
-   * Gets a block reader to read a UFS block for non short-circuit reads.
+   * Creates a block reader to read a UFS block starting from given block offset.
+   * Owner of this block reader must close it to cleanup state.
    *
    * @param sessionId the client session ID
    * @param blockId the ID of the UFS block to read
    * @param offset the offset within the block
    * @param positionShort whether the operation is using positioned read to a small buffer size
+   * @param options the options
    * @return the block reader instance
    * @throws BlockDoesNotExistException if the block does not exist in the UFS block store
    */
-  BlockReader newUfsBlockReader(long sessionId, long blockId, long offset, boolean positionShort)
+  BlockReader createUfsBlockReader(long sessionId, long blockId, long offset, boolean positionShort,
+      Protocol.OpenUfsBlockOptions options)
       throws BlockDoesNotExistException, IOException;
 
   /**
@@ -339,35 +343,11 @@ public interface BlockWorker extends Worker, SessionCleanable {
   void unlockBlock(long lockId) throws BlockDoesNotExistException;
 
   /**
-   * Releases the lock with the specified session and block id.
-   *
-   * @param sessionId the session id
-   * @param blockId the block id
-   * @return false if it fails to unlock due to the lock is not found
-   */
-  // TODO(calvin): Remove when lock and reads are separate operations.
-  boolean unlockBlock(long sessionId, long blockId);
-
-  /**
-   * Cleans data reader and related blocks after using the block reader obtained
-   * from {@link #newBlockReader}.
-   *
-   * @param reader the to be cleaned block reader
-   * @param request the block read request which used to get block reader
-   * @throws BlockAlreadyExistsException if it fails to commit the block to Alluxio block store
-   *         because the block exists in the Alluxio block store when closing the ufs block
-   * @throws WorkerOutOfSpaceException if there is not enough space
-   * @throws IOException if it fails to get block reader
-   */
-  void closeBlockReader(BlockReader reader, BlockReadRequest request)
-      throws BlockAlreadyExistsException, WorkerOutOfSpaceException, IOException;
-
-  /**
    * Submits the async cache request to async cache manager to execute.
    *
    * @param request the async cache request
    */
-  void submitAsyncCacheRequest(AsyncCacheRequest request);
+  void asyncCache(AsyncCacheRequest request);
 
   /**
    * Sets the pinlist for the underlying block store.
@@ -383,37 +363,6 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @return the file info
    */
   FileInfo getFileInfo(long fileId) throws IOException;
-
-  /**
-   * Opens a UFS block. It registers the block metadata information to the UFS block store. It
-   * throws an {@link UfsBlockAccessTokenUnavailableException} if the number of concurrent readers
-   * on this block exceeds a threshold.
-   *
-   * @param sessionId the session ID
-   * @param blockId the block ID
-   * @param options the options
-   * @return whether the UFS block is successfully opened
-   * @throws BlockAlreadyExistsException if the UFS block already exists in the
-   *         UFS block store
-   */
-  boolean openUfsBlock(long sessionId, long blockId, Protocol.OpenUfsBlockOptions options)
-      throws BlockAlreadyExistsException;
-
-  /**
-   * Closes a UFS block for a client session. It also commits the block to Alluxio block store
-   * if the UFS block has been cached successfully.
-   *
-   * @param sessionId the session ID
-   * @param blockId the block ID
-   * @throws BlockAlreadyExistsException if it fails to commit the block to Alluxio block store
-   *         because the block exists in the Alluxio block store
-   * @throws BlockDoesNotExistException if the UFS block does not exist in the
-   *         UFS block store
-   * @throws WorkerOutOfSpaceException the the worker does not have enough space to commit the block
-   */
-  void closeUfsBlock(long sessionId, long blockId)
-      throws BlockAlreadyExistsException, BlockDoesNotExistException, IOException,
-      WorkerOutOfSpaceException;
 
   /**
    * Clears the worker metrics.

--- a/core/common/src/main/java/alluxio/worker/block/io/DelegatingBlockReader.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/DelegatingBlockReader.java
@@ -28,6 +28,8 @@ public class DelegatingBlockReader extends BlockReader {
 
   /**
    * Default constructor for the abstract reader implementations.
+   * @param blockReader block reader
+   * @param closeable closer
    */
   public DelegatingBlockReader(BlockReader blockReader, Closeable closeable) {
     mCloser = Closer.create();

--- a/core/common/src/main/java/alluxio/worker/block/io/DelegatingBlockReader.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/DelegatingBlockReader.java
@@ -1,0 +1,77 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block.io;
+
+import com.google.common.io.Closer;
+import io.netty.buffer.ByteBuf;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+
+/**
+ * An delegating reader class.
+ */
+public class DelegatingBlockReader extends BlockReader {
+  private final BlockReader mBlockReader;
+  private final Closer mCloser;
+
+  /**
+   * Default constructor for the abstract reader implementations.
+   */
+  public DelegatingBlockReader(BlockReader blockReader, Closeable closeable) {
+    mCloser = Closer.create();
+    mBlockReader = mCloser.register(blockReader);
+    mCloser.register(closeable);
+  }
+
+  @Override
+  public ByteBuffer read(long offset, long length) throws IOException {
+    return mBlockReader.read(offset, length);
+  }
+
+  @Override
+  public long getLength() {
+    return mBlockReader.getLength();
+  }
+
+  @Override
+  public ReadableByteChannel getChannel() {
+    return mBlockReader.getChannel();
+  }
+
+  @Override
+  public int transferTo(ByteBuf buf) throws IOException {
+    return mBlockReader.transferTo(buf);
+  }
+
+  @Override
+  public boolean isClosed() {
+    return mBlockReader.isClosed();
+  }
+
+  @Override
+  public String getLocation() {
+    return mBlockReader.getLocation();
+  }
+
+  @Override
+  public String toString() {
+    return mBlockReader.toString();
+  }
+
+  @Override
+  public void close() throws IOException {
+    mCloser.close();
+  }
+}

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
@@ -56,8 +56,7 @@ public class AsyncCacheRequestManager {
   private final BlockWorker mBlockWorker;
   private final ConcurrentHashMap<Long, AsyncCacheRequest> mPendingRequests;
   private final String mLocalWorkerHostname;
-  private final FileSystemContext mFsContext =
-      FileSystemContext.create(ServerConfiguration.global());
+  private final FileSystemContext mFsContext;
   /** Keeps track of the number of rejected cache requests. */
   private final AtomicLong mNumRejected = new AtomicLong(0);
 
@@ -65,9 +64,11 @@ public class AsyncCacheRequestManager {
    * @param service thread pool to run the background caching work
    * @param blockWorker handler to the block worker
    */
-  public AsyncCacheRequestManager(ExecutorService service, BlockWorker blockWorker) {
+  public AsyncCacheRequestManager(ExecutorService service, BlockWorker blockWorker,
+      FileSystemContext fsContext) {
     mAsyncCacheExecutor = service;
     mBlockWorker = blockWorker;
+    mFsContext = fsContext;
     mPendingRequests = new ConcurrentHashMap<>();
     mLocalWorkerHostname =
         NetworkAddressUtils.getLocalHostName(
@@ -149,19 +150,8 @@ public class AsyncCacheRequestManager {
    */
   private boolean cacheBlockFromUfs(long blockId, long blockSize,
       Protocol.OpenUfsBlockOptions openUfsBlockOptions) {
-    // Check if the block has been requested in UFS block store
-    try {
-      if (!mBlockWorker
-          .openUfsBlock(Sessions.ASYNC_CACHE_UFS_SESSION_ID, blockId, openUfsBlockOptions)) {
-        LOG.warn("Failed to async cache block {} from UFS on opening the block", blockId);
-        return false;
-      }
-    } catch (BlockAlreadyExistsException e) {
-      // It is already cached
-      return true;
-    }
-    try (BlockReader reader = mBlockWorker
-        .newUfsBlockReader(Sessions.ASYNC_CACHE_UFS_SESSION_ID, blockId, 0, false)) {
+    try (BlockReader reader = mBlockWorker.createUfsBlockReader(
+        Sessions.ASYNC_CACHE_UFS_SESSION_ID, blockId, 0, false, openUfsBlockOptions)) {
       // Read the entire block, caching to block store will be handled internally in UFS block store
       // Note that, we read from UFS with a smaller buffer to avoid high pressure on heap
       // memory when concurrent async requests are received and thus trigger GC.
@@ -175,13 +165,6 @@ public class AsyncCacheRequestManager {
       // This is only best effort
       LOG.warn("Failed to async cache block {} from UFS on copying the block: {}", blockId, e);
       return false;
-    } finally {
-      try {
-        mBlockWorker.closeUfsBlock(Sessions.ASYNC_CACHE_UFS_SESSION_ID, blockId);
-      } catch (AlluxioException | IOException ee) {
-        LOG.warn("Failed to close UFS block {}: {}", blockId, ee);
-        return false;
-      }
     }
     return true;
   }
@@ -211,7 +194,7 @@ public class AsyncCacheRequestManager {
     try (BlockReader reader =
         new RemoteBlockReader(mFsContext, blockId, blockSize, sourceAddress, openUfsBlockOptions);
          BlockWriter writer = mBlockWorker
-             .getBlockWriter(Sessions.ASYNC_CACHE_WORKER_SESSION_ID, blockId)) {
+             .createBlockWriter(Sessions.ASYNC_CACHE_WORKER_SESSION_ID, blockId)) {
       BufferUtils.fastCopy(reader.getChannel(), writer.getChannel());
       mBlockWorker.commitBlock(Sessions.ASYNC_CACHE_WORKER_SESSION_ID, blockId, false);
       return true;

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
@@ -63,6 +63,7 @@ public class AsyncCacheRequestManager {
   /**
    * @param service thread pool to run the background caching work
    * @param blockWorker handler to the block worker
+   * @param fsContext context
    */
   public AsyncCacheRequestManager(ExecutorService service, BlockWorker blockWorker,
       FileSystemContext fsContext) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
@@ -15,6 +15,7 @@ import alluxio.exception.BlockAlreadyExistsException;
 import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.InvalidWorkerStateException;
 import alluxio.exception.WorkerOutOfSpaceException;
+import alluxio.exception.status.DeadlineExceededException;
 import alluxio.worker.SessionCleanable;
 import alluxio.worker.block.evictor.EvictionPlan;
 import alluxio.worker.block.io.BlockReader;
@@ -285,9 +286,11 @@ public interface BlockStore extends SessionCleanable, Closeable {
    * @param location the location of the block
    * @throws InvalidWorkerStateException if block id has not been committed
    * @throws BlockDoesNotExistException if block can not be found
+   * @throws DeadlineExceededException if locking takes longer than timeout
    */
   void removeBlock(long sessionId, long blockId, BlockStoreLocation location)
-      throws InvalidWorkerStateException, BlockDoesNotExistException, IOException;
+      throws InvalidWorkerStateException, BlockDoesNotExistException, DeadlineExceededException,
+      IOException;
 
   /**
    * Notifies the block store that a block was accessed so the block store could update accordingly

--- a/core/server/worker/src/main/java/alluxio/worker/block/FuseManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/FuseManager.java
@@ -34,7 +34,7 @@ import java.util.List;
 public class FuseManager implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(FuseManager.class);
   private static final String FUSE_OPTION_SEPARATOR = ",";
-  private final BlockWorker mBlockWorker;
+  private final FileSystemContext mFsContext;
   /** Use to umount Fuse application during stop. */
   private FuseUmountable mFuseUmountable;
   /** Use to close resources during stop. */
@@ -43,10 +43,10 @@ public class FuseManager implements Closeable {
   /**
    * Constructs a new {@link FuseManager}.
    *
-   * @param blockWorker the block worekr
+   * @param fsContext fs context
    */
-  public FuseManager(BlockWorker blockWorker) {
-    mBlockWorker = blockWorker;
+  public FuseManager(FileSystemContext fsContext) {
+    mFsContext = fsContext;
     mResourceCloser = Closer.create();
   }
 
@@ -84,9 +84,7 @@ public class FuseManager implements Closeable {
           conf.getBoolean(PropertyKey.FUSE_DEBUG_ENABLED), fuseOptions);
       // TODO(lu) consider launching fuse in a separate thread as blocking operation
       // so that we can know about the fuse application status
-      FileSystemContext fsContext = mResourceCloser
-          .register(FileSystemContext.create(null, conf, mBlockWorker));
-      FileSystem fileSystem = mResourceCloser.register(FileSystem.Factory.create(fsContext));
+      FileSystem fileSystem = mResourceCloser.register(FileSystem.Factory.create(mFsContext));
       mFuseUmountable = AlluxioFuse.launchFuse(fileSystem, conf, options, false);
     } catch (Throwable throwable) {
       // TODO(lu) for already mounted application, unmount first and then remount

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -418,7 +418,7 @@ public class TieredBlockStore implements BlockStore {
     }
 
     try (LockResource r = new LockResource(mMetadataWriteLock)) {
-      removeBlockInternal(blockMeta);
+      removeBlockFileAndMeta(blockMeta);
     } finally {
       mLockManager.unlockBlock(lockId);
     }
@@ -821,7 +821,7 @@ public class TieredBlockStore implements BlockStore {
       if (evictorView.isBlockEvictable(blockToDelete)) {
         try {
           BlockMeta blockMeta = mMetaManager.getBlockMeta(blockToDelete);
-          removeBlockInternal(blockMeta);
+          removeBlockFileAndMeta(blockMeta);
           blocksRemoved++;
           for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
             synchronized (listener) {
@@ -954,7 +954,7 @@ public class TieredBlockStore implements BlockStore {
    * @throws InvalidWorkerStateException if the block to remove is a temp block
    * @throws BlockDoesNotExistException if this block can not be found
    */
-  private void removeBlockInternal(BlockMeta blockMeta)
+  private void removeBlockFileAndMeta(BlockMeta blockMeta)
       throws BlockDoesNotExistException, IOException {
     String filePath = blockMeta.getPath();
     Files.delete(Paths.get(filePath));

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -478,9 +478,10 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
      * @param context context of the request to complete
      */
     private void completeRequest(BlockReadRequestContext context) throws Exception {
+      BlockReader reader = context.getBlockReader();
       try {
-        if (context.getBlockReader() != null) {
-          context.getBlockReader().close();
+        if (reader != null) {
+          reader.close();
         }
       } finally {
         context.setBlockReader(null);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -566,8 +566,6 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
         AlluxioURI ufsMountPointUri =
             ((UnderFileSystemBlockReader) reader).getUfsMountPointUri();
         String ufsString = MetricsSystem.escape(ufsMountPointUri);
-        context.setBlockReader(reader);
-
         MetricKey counterKey = MetricKey.WORKER_BYTES_READ_UFS;
         MetricKey meterKey = MetricKey.WORKER_BYTES_READ_UFS_THROUGHPUT;
         context.setCounter(MetricsSystem.counterWithTags(counterKey.getName(),

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -478,9 +478,10 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
      * @param context context of the request to complete
      */
     private void completeRequest(BlockReadRequestContext context) throws Exception {
-      BlockReader reader = null;
       try {
-        mWorker.closeBlockReader(context.getBlockReader(), context.getRequest());
+        if (context.getBlockReader() != null) {
+          context.getBlockReader().close();
+        }
       } finally {
         context.setBlockReader(null);
       }
@@ -560,7 +561,7 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
           LOG.warn("Failed to promote block {}: {}", request.getId(), e.getMessage());
         }
       }
-      BlockReader reader = mWorker.newBlockReader(request);
+      BlockReader reader = mWorker.createBlockReader(request);
       context.setBlockReader(reader);
       if (reader instanceof UnderFileSystemBlockReader) {
         AlluxioURI ufsMountPointUri =

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -13,7 +13,6 @@ package alluxio.worker.grpc;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
-import alluxio.WorkerStorageTierAssoc;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.BlockDoesNotExistException;
@@ -553,8 +552,7 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
       // TODO(calvin): Update the locking logic so this can be done better
       if (request.isPromote()) {
         try {
-          mWorker.moveBlock(request.getSessionId(), request.getId(),
-              new WorkerStorageTierAssoc().getAlias(0));
+          mWorker.moveBlock(request.getSessionId(), request.getId(), 0);
         } catch (BlockDoesNotExistException e) {
           LOG.debug("Block {} to promote does not exist in Alluxio: {}", request.getId(),
               e.getMessage());

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerClientServiceHandler.java
@@ -150,7 +150,7 @@ public class BlockWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorker
   public void asyncCache(AsyncCacheRequest request,
       StreamObserver<AsyncCacheResponse> responseObserver) {
     RpcUtils.call(LOG, () -> {
-      mBlockWorker.submitAsyncCacheRequest(request);
+      mBlockWorker.asyncCache(request);
       return AsyncCacheResponse.getDefaultInstance();
     }, "asyncCache", "request=%s", responseObserver, request);
   }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWriteHandler.java
@@ -129,7 +129,7 @@ public final class BlockWriteHandler extends AbstractWriteHandler<BlockWriteRequ
     }
     if (context.getBlockWriter() == null) {
       context.setBlockWriter(
-          mWorker.getBlockWriter(request.getSessionId(), request.getId()));
+          mWorker.createBlockWriter(request.getSessionId(), request.getId()));
     }
     Preconditions.checkState(context.getBlockWriter() != null);
     int sz = buf.readableBytes();

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
@@ -195,7 +195,7 @@ public class DefaultBlockWorkerTest {
     assertTrue(path.startsWith(mHddDir));
   }
 
- @Test
+  @Test
   public void getTempBlockWriter() throws Exception {
     long blockId = mRandom.nextLong();
     long sessionId = mRandom.nextLong();

--- a/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
@@ -178,9 +178,8 @@ public class NoopBlockWorker implements BlockWorker {
   }
 
   @Override
-  public BlockReader createBlockReader(BlockReadRequest request) throws IOException,
-      BlockDoesNotExistException, InvalidWorkerStateException,
-      BlockAlreadyExistsException, WorkerOutOfSpaceException {
+  public BlockReader createBlockReader(BlockReadRequest request)
+      throws BlockDoesNotExistException, IOException {
     return null;
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
@@ -82,7 +82,7 @@ public class NoopBlockWorker implements BlockWorker {
   }
 
   @Override
-  public BlockWriter getBlockWriter(long sessionId, long blockId)
+  public BlockWriter createBlockWriter(long sessionId, long blockId)
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
       IOException {
     return null;
@@ -145,14 +145,15 @@ public class NoopBlockWorker implements BlockWorker {
   }
 
   @Override
-  public BlockReader newLocalBlockReader(long sessionId, long blockId, long lockId)
+  public BlockReader createLocalBlockReader(long sessionId, long blockId, long lockId, long offset)
       throws BlockDoesNotExistException, InvalidWorkerStateException, IOException {
     return null;
   }
 
   @Override
-  public BlockReader newUfsBlockReader(long sessionId, long blockId, long offset,
-      boolean positionShort) throws BlockDoesNotExistException, IOException {
+  public BlockReader createUfsBlockReader(long sessionId, long blockId, long offset,
+      boolean positionShort, Protocol.OpenUfsBlockOptions options)
+      throws BlockDoesNotExistException, IOException {
     return null;
   }
 
@@ -174,12 +175,7 @@ public class NoopBlockWorker implements BlockWorker {
   }
 
   @Override
-  public boolean unlockBlock(long sessionId, long blockId) {
-    return false;
-  }
-
-  @Override
-  public void submitAsyncCacheRequest(AsyncCacheRequest request) {
+  public void asyncCache(AsyncCacheRequest request) {
     // noop
   }
 
@@ -194,28 +190,10 @@ public class NoopBlockWorker implements BlockWorker {
   }
 
   @Override
-  public boolean openUfsBlock(long sessionId, long blockId, Protocol.OpenUfsBlockOptions options)
-      throws BlockAlreadyExistsException {
-    return false;
-  }
-
-  @Override
-  public void closeUfsBlock(long sessionId, long blockId) throws BlockAlreadyExistsException,
-      BlockDoesNotExistException, IOException, WorkerOutOfSpaceException {
-    // noop
-  }
-
-  @Override
-  public BlockReader newBlockReader(BlockReadRequest request) throws IOException,
+  public BlockReader createBlockReader(BlockReadRequest request) throws IOException,
       BlockDoesNotExistException, InvalidWorkerStateException,
       BlockAlreadyExistsException, WorkerOutOfSpaceException {
     return null;
-  }
-
-  @Override
-  public void closeBlockReader(BlockReader reader, BlockReadRequest request)
-      throws IOException, BlockAlreadyExistsException, WorkerOutOfSpaceException {
-    // noop
   }
 
   @Override

--- a/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
@@ -125,7 +125,7 @@ public class NoopBlockWorker implements BlockWorker {
   }
 
   @Override
-  public void moveBlock(long sessionId, long blockId, String tierAlias)
+  public void moveBlock(long sessionId, long blockId, int tier)
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
       WorkerOutOfSpaceException, IOException {
     // noop
@@ -136,18 +136,6 @@ public class NoopBlockWorker implements BlockWorker {
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
       WorkerOutOfSpaceException, IOException {
     // noop
-  }
-
-  @Override
-  public String getLocalBlockPath(long sessionId, long blockId, long lockId)
-      throws BlockDoesNotExistException, InvalidWorkerStateException {
-    return null;
-  }
-
-  @Override
-  public BlockReader createLocalBlockReader(long sessionId, long blockId, long lockId, long offset)
-      throws BlockDoesNotExistException, InvalidWorkerStateException, IOException {
-    return null;
   }
 
   @Override

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/BlockReadHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/BlockReadHandlerTest.java
@@ -87,7 +87,7 @@ public class BlockReadHandlerTest {
     mBlockReader = new LocalFileBlockReader(mFile.getPath());
     mBlockWorker = new NoopBlockWorker() {
       @Override
-      public BlockReader newBlockReader(BlockReadRequest request) throws IOException {
+      public BlockReader createBlockReader(BlockReadRequest request) throws IOException {
         ((FileChannel) mBlockReader.getChannel()).position(request.getStart());
         return mBlockReader;
       }

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/BlockWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/BlockWriteHandlerTest.java
@@ -44,7 +44,7 @@ public final class BlockWriteHandlerTest extends AbstractWriteHandlerTest {
     mFile = mTestFolder.newFile();
     mBlockWorker = new NoopBlockWorker() {
       @Override
-      public BlockWriter getBlockWriter(long sessionId, long blockId) {
+      public BlockWriter createBlockWriter(long sessionId, long blockId) {
         return mBlockWriter;
       }
     };

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -246,7 +246,8 @@ public final class ReplicateDefinitionTest {
     byte[] input = BufferUtils.getIncreasingByteArray(0, (int) TEST_BLOCK_SIZE);
 
     TestBlockInStream mockInStream =
-        new TestBlockInStream(input, TEST_BLOCK_ID, input.length, false, BlockInStreamSource.NODE_LOCAL);
+        new TestBlockInStream(input, TEST_BLOCK_ID, input.length, false,
+            BlockInStreamSource.NODE_LOCAL);
     TestBlockOutStream mockOutStream =
         new TestBlockOutStream(ByteBuffer.allocate(MAX_BYTES), TEST_BLOCK_SIZE);
     mThrown.expect(NotFoundException.class);
@@ -260,7 +261,8 @@ public final class ReplicateDefinitionTest {
     byte[] input = BufferUtils.getIncreasingByteArray(0, (int) TEST_BLOCK_SIZE);
 
     TestBlockInStream mockInStream =
-        new TestBlockInStream(input, TEST_BLOCK_ID, input.length, false, BlockInStreamSource.NODE_LOCAL);
+        new TestBlockInStream(input, TEST_BLOCK_ID, input.length, false,
+            BlockInStreamSource.NODE_LOCAL);
     TestBlockOutStream mockOutStream =
         new TestBlockOutStream(ByteBuffer.allocate(MAX_BYTES), TEST_BLOCK_SIZE);
     BlockWorkerInfo localBlockWorker = new BlockWorkerInfo(LOCAL_ADDRESS, TEST_BLOCK_SIZE, 0);

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -246,7 +246,7 @@ public final class ReplicateDefinitionTest {
     byte[] input = BufferUtils.getIncreasingByteArray(0, (int) TEST_BLOCK_SIZE);
 
     TestBlockInStream mockInStream =
-        new TestBlockInStream(input, TEST_BLOCK_ID, input.length, false, BlockInStreamSource.LOCAL);
+        new TestBlockInStream(input, TEST_BLOCK_ID, input.length, false, BlockInStreamSource.NODE_LOCAL);
     TestBlockOutStream mockOutStream =
         new TestBlockOutStream(ByteBuffer.allocate(MAX_BYTES), TEST_BLOCK_SIZE);
     mThrown.expect(NotFoundException.class);
@@ -260,7 +260,7 @@ public final class ReplicateDefinitionTest {
     byte[] input = BufferUtils.getIncreasingByteArray(0, (int) TEST_BLOCK_SIZE);
 
     TestBlockInStream mockInStream =
-        new TestBlockInStream(input, TEST_BLOCK_ID, input.length, false, BlockInStreamSource.LOCAL);
+        new TestBlockInStream(input, TEST_BLOCK_ID, input.length, false, BlockInStreamSource.NODE_LOCAL);
     TestBlockOutStream mockOutStream =
         new TestBlockOutStream(ByteBuffer.allocate(MAX_BYTES), TEST_BLOCK_SIZE);
     BlockWorkerInfo localBlockWorker = new BlockWorkerInfo(LOCAL_ADDRESS, TEST_BLOCK_SIZE, 0);

--- a/shell/src/main/java/alluxio/cli/fs/command/LoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LoadCommand.java
@@ -99,7 +99,7 @@ public final class LoadCommand extends AbstractFileSystemCommand {
       OpenFilePOptions options =
           OpenFilePOptions.newBuilder().setReadType(ReadPType.CACHE_PROMOTE).build();
       if (local) {
-        if (!mFsContext.hasLocalWorker()) {
+        if (!mFsContext.hasNodeLocalWorker()) {
           System.out.println("When local option is specified,"
               + " there must be a local worker available");
           return;

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -65,7 +65,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -695,7 +695,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
                 .setCommonOptions(FileSystemOptions.commonDefaults(
                     mFileSystem.getConf()).toBuilder().setSyncIntervalMs(0).build()).build());
           } catch (Exception e) {
-            return new ArrayList<>();
+            return Collections.<URIStatus>emptyList();
           }
         });
         Thread.sleep(200);


### PR DESCRIPTION
- Rename `BlockInStreamSource` to be `PROCESS_LOCAL` and `NODE_LOCAL`
- Remove `BlockWorker.closeBlockReader` (newly added) and make the cleanup logic into `BlockReader.close`
- Rename  `BlockWorker. submitAsyncCacheRequest` (newly added) to `BlockWorker.asyncCache` for simplicity
- Share the same `fsContext` among `FuseManager` and `AsyncCacheRequestManager`
- Remove `BlockWorker.unlockBlock(sessionId, blockId)` -- no more necessary
- Combine `BlockWorker.openUfsBlock` to `BlockWorker.createUfsBlockReader` and put cleanup logic into this block reader's `close` method.
- Put `unlock` logic to the `close` method of `LocalBlockReader`