### PR TITLE
Handle client cache failure on "no space left on device"

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -420,6 +420,11 @@ public class LocalCacheManager implements CacheManager {
         mPageStore.put(pageId, page);
         Metrics.BYTES_WRITTEN_CACHE.mark(page.length);
         return PutResult.OK;
+      } catch (ResourceExhaustedException e) {
+        undoAddPage(pageId);
+        LOG.error("Failed to add page {} to pageStore", pageId, e);
+        Metrics.PUT_STORE_WRITE_NO_SPACE_ERRORS.inc();
+        return PutResult.NO_SPACE_LEFT;
       } catch (IOException e) {
         // Failed to add page, remove new page from metastoree
         undoAddPage(pageId);

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -305,9 +305,11 @@ public class LocalCacheManager implements CacheManager {
           // page is not large enough to cover the space needed by this page. Try again
           continue;
         case NO_SPACE_LEFT:
-          // failed put attempt due to "No space left on device" error. This can happen when
-          // configured cache capacity is larger than what's available, or other disk issues.
-          // In this case, we need to force data to be evicted in retry, or hit ratio will drop.
+          // failed put attempt due to "No space left on device" error. This can happen on
+          // misconfiguration (e.g., cache capacity is larger than what's available), disk issues,
+          // or under-estimation of file system overhead (e.g., writing a file of 10B may result
+          // in 512 B on disk). In this case, we need to force data to be evicted in retries,
+          // otherwise hitratio may drop due to inability to write new data to cache.
           forcedToEvict = true;
           continue;
         case OTHER:

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -16,6 +16,7 @@ import alluxio.client.file.cache.store.PageStoreOptions;
 import alluxio.client.file.cache.store.PageStoreType;
 import alluxio.client.file.cache.store.RocksPageStore;
 import alluxio.exception.PageNotFoundException;
+import alluxio.exception.status.ResourceExhaustedException;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.io.FileUtils;
@@ -115,8 +116,10 @@ public interface PageStore extends AutoCloseable {
    *
    * @param pageId page identifier
    * @param page page data
+   * @throws ResourceExhaustedException when there is not enough space found on disk
+   * @throws IOException when the store fails to write this page
    */
-  void put(PageId pageId, byte[] page) throws IOException;
+  void put(PageId pageId, byte[] page) throws ResourceExhaustedException, IOException;
 
   /**
    * Gets a page from the store to the destination buffer.

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -58,7 +58,7 @@ public interface PageStore extends AutoCloseable {
    * @throws IOException if I/O error happens
    */
   static PageStore open(PageStoreOptions options) throws IOException {
-    LOG.info("Creating PageStore with option={}", options.toString());
+    LOG.info("Opening PageStore with option={}", options.toString());
     final PageStore pageStore;
     switch (options.getType()) {
       case LOCAL:
@@ -98,7 +98,7 @@ public interface PageStore extends AutoCloseable {
   static void initialize(PageStoreOptions options) throws IOException {
     String rootPath = options.getRootDir();
     Files.createDirectories(Paths.get(rootPath));
-    LOG.debug("Clean cache directory {}", rootPath);
+    LOG.info("Cleaning cache directory {}", rootPath);
     try (Stream<Path> stream = Files.list(Paths.get(rootPath))) {
       stream.forEach(path -> {
         try {

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -41,10 +41,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public class LocalPageStore implements PageStore {
   private static final Logger LOG = LoggerFactory.getLogger(LocalPageStore.class);
-  // We assume there will be some overhead using local fs as a page store,
-  // i.e., with 1GB space allocated, we
-  // expect no more than 1024MB / (1 + LOCAL_OVERHEAD_RATIO) logical data stored
-  private static final double LOCAL_OVERHEAD_RATIO = 0.005;
   private static final String ERROR_NO_SPACE_LEFT = "No space left on device";
   private final String mRoot;
   private final long mPageSize;
@@ -60,7 +56,7 @@ public class LocalPageStore implements PageStore {
   public LocalPageStore(LocalPageStoreOptions options) {
     mRoot = options.getRootDir();
     mPageSize = options.getPageSize();
-    mCapacity = (long) (options.getCacheSize() / (1 + LOCAL_OVERHEAD_RATIO));
+    mCapacity = (long) (options.getCacheSize() / (1 + options.getOverheadRatio()));
     mFileBuckets = options.getFileBuckets();
     // normalize the path to deal with trailing slash
     Path rootDir = Paths.get(mRoot);

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStoreOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStoreOptions.java
@@ -17,6 +17,10 @@ import com.google.common.base.MoreObjects;
  * Options used to instantiate the {@link LocalPageStore}.
  */
 public class LocalPageStoreOptions extends PageStoreOptions {
+  // We assume there will be some overhead using local fs as a page store,
+  // i.e., with 1GB space allocated, we
+  // expect no more than 1024MB / (1 + LOCAL_OVERHEAD_RATIO) logical data stored
+  private static final double LOCAL_OVERHEAD_RATIO = 0.05;
 
   /**
    * The number of file buckets. It is recommended to set this to a high value if the number of
@@ -29,6 +33,7 @@ public class LocalPageStoreOptions extends PageStoreOptions {
    */
   public LocalPageStoreOptions() {
     mFileBuckets = 1000;
+    mOverheadRatio = LocalPageStoreOptions.LOCAL_OVERHEAD_RATIO;
   }
 
   /**
@@ -58,6 +63,7 @@ public class LocalPageStoreOptions extends PageStoreOptions {
         .add("AlluxioVersion", mAlluxioVersion)
         .add("CacheSize", mCacheSize)
         .add("FileBuckets", mFileBuckets)
+        .add("OverheadRatio", mOverheadRatio)
         .add("PageSize", mPageSize)
         .add("RootDir", mRootDir)
         .add("TimeoutDuration", mTimeoutDuration)

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/PageStoreOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/PageStoreOptions.java
@@ -43,12 +43,15 @@ public abstract class PageStoreOptions {
             storeType.name()));
     }
     Path rootDir = PageStore.getStorePath(storeType, conf.get(PropertyKey.USER_CLIENT_CACHE_DIR));
-    options.setRootDir(rootDir.toString());
-    options.setPageSize(conf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE));
-    options.setCacheSize(conf.getBytes(PropertyKey.USER_CLIENT_CACHE_SIZE));
-    options.setAlluxioVersion(conf.get(PropertyKey.VERSION));
-    options.setTimeoutDuration(conf.getMs(PropertyKey.USER_CLIENT_CACHE_TIMEOUT_DURATION));
-    options.setTimeoutThreads(conf.getInt(PropertyKey.USER_CLIENT_CACHE_TIMEOUT_THREADS));
+    options.setRootDir(rootDir.toString())
+        .setPageSize(conf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE))
+        .setCacheSize(conf.getBytes(PropertyKey.USER_CLIENT_CACHE_SIZE))
+        .setAlluxioVersion(conf.get(PropertyKey.VERSION))
+        .setTimeoutDuration(conf.getMs(PropertyKey.USER_CLIENT_CACHE_TIMEOUT_DURATION))
+        .setTimeoutThreads(conf.getInt(PropertyKey.USER_CLIENT_CACHE_TIMEOUT_THREADS));
+    if (conf.isSet(PropertyKey.USER_CLIENT_CACHE_STORE_OVERHEAD)) {
+      options.setOverheadRatio(conf.getDouble(PropertyKey.USER_CLIENT_CACHE_STORE_OVERHEAD));
+    }
     return options;
   }
 
@@ -97,10 +100,19 @@ public abstract class PageStoreOptions {
   protected int mTimeoutThreads;
 
   /**
-   * @param rootDir the root directory where pages are stored
+   * A fraction value representing the storage overhead.
+   * i.e., with 1GB allocated cache space, and 10% storage overhead we
+   * expect no more than 1024MB / (1 + 10%) user data to store
    */
-  public void setRootDir(String rootDir) {
+  protected double mOverheadRatio;
+
+  /**
+   * @param rootDir the root directory where pages are stored
+   * @return the updated options
+   */
+  public PageStoreOptions setRootDir(String rootDir) {
     mRootDir = rootDir;
+    return this;
   }
 
   /**
@@ -119,9 +131,11 @@ public abstract class PageStoreOptions {
 
   /**
    * @param pageSize the size of the page in bytes
+   * @return the updated options
    */
-  public void setPageSize(long pageSize) {
+  public PageStoreOptions setPageSize(long pageSize) {
     mPageSize = pageSize;
+    return this;
   }
 
   /**
@@ -133,9 +147,11 @@ public abstract class PageStoreOptions {
 
   /**
    * @param cacheSize the size of the cache in bytes
+   * @return the updated options
    */
-  public void setCacheSize(long cacheSize) {
+  public PageStoreOptions setCacheSize(long cacheSize) {
     mCacheSize = cacheSize;
+    return this;
   }
 
   /**
@@ -147,9 +163,11 @@ public abstract class PageStoreOptions {
 
   /**
    * @param alluxioVersion Alluxio client version
+   * @return the updated options
    */
-  public void setAlluxioVersion(String alluxioVersion) {
+  public PageStoreOptions setAlluxioVersion(String alluxioVersion) {
     mAlluxioVersion = alluxioVersion;
+    return this;
   }
 
   /**
@@ -161,9 +179,11 @@ public abstract class PageStoreOptions {
 
   /**
    * @param timeout timeout duration for page store operations in ms
+   * @return the updated options
    */
-  public void setTimeoutDuration(long timeout) {
+  public PageStoreOptions setTimeoutDuration(long timeout) {
     mTimeoutDuration = timeout;
+    return this;
   }
 
   /**
@@ -175,8 +195,26 @@ public abstract class PageStoreOptions {
 
   /**
    * @param threads number of threads for handling timeout
+   * @return the updated options
    */
-  public void setTimeoutThreads(int threads) {
+  public PageStoreOptions setTimeoutThreads(int threads) {
     mTimeoutThreads = threads;
+    return this;
+  }
+
+  /**
+   * @return the fraction of space allocated for storage overhead
+   */
+  public double getOverheadRatio() {
+    return mOverheadRatio;
+  }
+
+  /**
+   * @param overheadRatio the fraction of space allocated for storage overhead
+   * @return the updated options
+   */
+  public PageStoreOptions setOverheadRatio(double overheadRatio) {
+    mOverheadRatio = overheadRatio;
+    return this;
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
@@ -45,10 +45,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class RocksPageStore implements PageStore {
   private static final Logger LOG = LoggerFactory.getLogger(RocksPageStore.class);
   private static final byte[] CONF_KEY = "CONF".getBytes();
-  // TODO(feng): consider making the overhead ratio configurable
-  // We assume 20% overhead using Rocksdb as a page store, i.e., with 1GB space allocated, we
-  // expect no more than 1024MB/(1+20%)=853MB logical data stored
-  private static final double ROCKS_OVERHEAD_RATIO = 0.2;
 
   private final long mCapacity;
   private final RocksDB mDb;
@@ -96,7 +92,7 @@ public class RocksPageStore implements PageStore {
    */
   private RocksPageStore(RocksPageStoreOptions options, RocksDB rocksDB) {
     mOptions = options;
-    mCapacity = (long) (options.getCacheSize() / (1 + ROCKS_OVERHEAD_RATIO));
+    mCapacity = (long) (options.getCacheSize() / (1 + options.getOverheadRatio()));
     mDb = rocksDB;
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStoreOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStoreOptions.java
@@ -22,6 +22,11 @@ import org.rocksdb.CompressionType;
  * Options used to instantiate {@link RocksPageStore}.
  */
 public class RocksPageStoreOptions extends PageStoreOptions {
+  // TODO(feng): consider making the overhead ratio configurable
+  // We assume 20% overhead using Rocksdb as a page store, i.e., with 1GB space allocated, we
+  // expect no more than 1024MB/(1+20%)=853MB logical data stored
+  private static final double ROCKS_OVERHEAD_RATIO = 0.2;
+
   /** The max page size that can be stored. */
   private int mMaxPageSize;
 
@@ -43,6 +48,7 @@ public class RocksPageStoreOptions extends PageStoreOptions {
     mWriteBufferSize = 64 * Constants.MB;
     mMaxBufferPoolSize = 32;
     mCompressionType = CompressionType.NO_COMPRESSION;
+    mOverheadRatio = ROCKS_OVERHEAD_RATIO;
   }
 
   /**
@@ -135,6 +141,7 @@ public class RocksPageStoreOptions extends PageStoreOptions {
         .add("CompressionType", mCompressionType)
         .add("MaxBufferPoolSize", mMaxBufferPoolSize)
         .add("MaxPageSize", mMaxPageSize)
+        .add("OverheadRatio", mOverheadRatio)
         .add("PageSize", mPageSize)
         .add("RootDir", mRootDir)
         .add("TimeoutDuration", mTimeoutDuration)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3922,6 +3922,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_CLIENT_CACHE_STORE_OVERHEAD =
+      new Builder(Name.USER_CLIENT_CACHE_STORE_OVERHEAD)
+          .setDescription("A fraction value representing the storage overhead. "
+              + "For example, with 1GB allocated cache space, and 10% storage overhead we expect "
+              + "no more than 1024MB / (1 + 10%) user data to store.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_CLIENT_CACHE_LOCAL_STORE_FILE_BUCKETS =
       new Builder(Name.USER_CLIENT_CACHE_LOCAL_STORE_FILE_BUCKETS)
           .setDefaultValue("1000")
@@ -5734,6 +5742,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.client.cache.quota.enabled";
     public static final String USER_CLIENT_CACHE_SIZE =
         "alluxio.user.client.cache.size";
+    public static final String USER_CLIENT_CACHE_STORE_OVERHEAD =
+        "alluxio.user.client.cache.store.overhead";
     public static final String USER_CLIENT_CACHE_STORE_TYPE =
         "alluxio.user.client.cache.store.type";
     public static final String USER_CLIENT_CACHE_TIMEOUT_DURATION =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3913,20 +3913,20 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_CLIENT_CACHE_STORE_OVERHEAD =
+      new Builder(Name.USER_CLIENT_CACHE_STORE_OVERHEAD)
+          .setDescription("A fraction value representing the storage overhead writing to disk. "
+              + "For example, with 1GB allocated cache space, and 10% storage overhead we expect "
+              + "no more than 1024MB / (1 + 10%) user data to store.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_CLIENT_CACHE_STORE_TYPE =
       new Builder(Name.USER_CLIENT_CACHE_STORE_TYPE)
           .setDefaultValue("LOCAL")
           .setDescription("The type of page store to use for client-side cache. Can be either "
               + "`LOCAL` or `ROCKS`. The `LOCAL` page store stores all pages in a directory, "
               + "the `ROCKS` page store utilizes rocksDB to persist the data.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.CLIENT)
-          .build();
-  public static final PropertyKey USER_CLIENT_CACHE_STORE_OVERHEAD =
-      new Builder(Name.USER_CLIENT_CACHE_STORE_OVERHEAD)
-          .setDescription("A fraction value representing the storage overhead. "
-              + "For example, with 1GB allocated cache space, and 10% storage overhead we expect "
-              + "no more than 1024MB / (1 + 10%) user data to store.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1179,8 +1179,9 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey CLIENT_CACHE_PUT_STORE_WRITE_NO_SPACE_ERRORS =
       new Builder(Name.CLIENT_CACHE_PUT_STORE_WRITE_NO_SPACE_ERRORS)
-          .setDescription("Number of failures when putting cached data in the client cache due to"
-              + " failed writes to page store but disk is full before reaching cache capacity.")
+          .setDescription("Number of failures when putting cached data in the client cache but"
+              + " getting disk is full while cache capacity is not achieved. This can happen if"
+              + " the storage overhead ratio to write data is underestimated.")
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1177,6 +1177,13 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_PUT_STORE_WRITE_NO_SPACE_ERRORS =
+      new Builder(Name.CLIENT_CACHE_PUT_STORE_WRITE_NO_SPACE_ERRORS)
+          .setDescription("Number of failures when putting cached data in the client cache due to"
+              + " failed writes to page store but disk is full before reaching cache capacity.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_STORE_DELETE_TIMEOUT =
       new Builder(Name.CLIENT_CACHE_STORE_DELETE_TIMEOUT)
           .setDescription("Number of timeouts when deleting pages from page store.")
@@ -1489,6 +1496,8 @@ public final class MetricKey implements Comparable<MetricKey> {
         "Client.CachePutStoreDeleteErrors";
     public static final String CLIENT_CACHE_PUT_STORE_WRITE_ERRORS =
         "Client.CachePutStoreWriteErrors";
+    public static final String CLIENT_CACHE_PUT_STORE_WRITE_NO_SPACE_ERRORS =
+        "Client.CachePutStoreWriteNoSpaceErrors";
     public static final String CLIENT_CACHE_STORE_DELETE_TIMEOUT =
         "Client.CacheStoreDeleteTimeout";
     public static final String CLIENT_CACHE_STORE_GET_TIMEOUT =

--- a/tests/src/test/java/alluxio/client/fs/LocalCacheManagerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LocalCacheManagerIntegrationTest.java
@@ -66,6 +66,7 @@ public final class LocalCacheManagerIntegrationTest extends BaseIntegrationTest 
     mConf.set(PropertyKey.USER_CLIENT_CACHE_DIR, mTemp.getRoot().getPath());
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED, false);
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_RESTORE_ENABLED, false);
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_STORE_OVERHEAD, 0);
   }
 
   @After

--- a/tests/src/test/java/alluxio/client/fs/io/LocalCacheFileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/LocalCacheFileInStreamIntegrationTest.java
@@ -50,6 +50,7 @@ public final class LocalCacheFileInStreamIntegrationTest extends BaseIntegration
           .setProperty(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, Constants.MB)
           .setProperty(PropertyKey.USER_CLIENT_CACHE_ENABLED, true)
           .setProperty(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED, false)
+          .setProperty(PropertyKey.USER_CLIENT_CACHE_STORE_OVERHEAD, 0)
           .build();
 
   @Rule


### PR DESCRIPTION
This happens when (1) cache is configured with wrong and smaller capacity, (2) for some reason disk capacity allocated to Alluxio was "stolen" by other applications, or (3) alluxio cache is under-counting the real space used on disk (e.g., due to bugs, inode overhead and etc).

This PR aim to
1. add a metrics to monitor and report when `no space left on device` happens
2. force evicting items in a retry in this case
3.  add a new flag `alluxio.user.client.cache.store.overhead` to allow users to set the space overhead when writing data to disk

Fix https://github.com/prestodb/presto/issues/15972