### PR TITLE
Update FileInfo when the file is committed

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -272,11 +272,15 @@ public class BaseFileSystem implements FileSystem {
   public URIStatus getStatus(AlluxioURI path, final GetStatusPOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException {
     checkUri(path);
-    return rpc(client -> {
+    URIStatus status = rpc(client -> {
       GetStatusPOptions mergedOptions = FileSystemOptions.getStatusDefaults(
-          mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
+              mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
       return client.getStatus(path, mergedOptions);
     });
+    if (!status.isCompleted()) {
+      LOG.warn("File {} is not yet completed. getStatus will see incomplete metadata.", path);
+    }
+    return status;
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -274,7 +274,7 @@ public class BaseFileSystem implements FileSystem {
     checkUri(path);
     URIStatus status = rpc(client -> {
       GetStatusPOptions mergedOptions = FileSystemOptions.getStatusDefaults(
-              mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
+          mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
       return client.getStatus(path, mergedOptions);
     });
     if (!status.isCompleted()) {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -916,6 +916,10 @@ public final class DefaultFileSystemMaster extends CoreMaster
     fileInfo.setInMemoryPercentage(getInMemoryPercentage(inode));
     fileInfo.setInAlluxioPercentage(getInAlluxioPercentage(inode));
     if (inode.isFile()) {
+      if (!fileInfo.isCompleted()) {
+        LOG.warn("File {} is not yet completed. getStatus will see incomplete metadata.",
+                fileInfo.getPath());
+      }
       try {
         fileInfo.setFileBlockInfos(getFileBlockInfoListInternal(inodePath));
       } catch (InvalidPathException e) {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -923,8 +923,9 @@ public final class DefaultFileSystemMaster extends CoreMaster
       }
     }
     // Rehydrate missing block-infos for persisted files.
-    if (fileInfo.getBlockIds().size() > fileInfo.getFileBlockInfos().size()
-        && inode.isPersisted()) {
+    if (fileInfo.isCompleted()
+          && fileInfo.getBlockIds().size() > fileInfo.getFileBlockInfos().size()
+          && inode.isPersisted()) {
       List<Long> missingBlockIds = fileInfo.getBlockIds().stream()
           .filter((bId) -> fileInfo.getFileBlockInfo(bId) != null).collect(Collectors.toList());
 

--- a/tests/src/test/java/alluxio/client/fs/io/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileOutStreamIntegrationTest.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileOutStream;
+import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
@@ -246,5 +247,24 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
     for (WorkerInfo worker : workers) {
       Assert.assertEquals(0, worker.getUsedBytes());
     }
+  }
+
+  @Test
+  public void getStatusBeforeClose() throws Exception {
+    AlluxioURI path = new AlluxioURI(PathUtils.uniqPath());
+    try (FileOutStream os = mFileSystem.createFile(path, CreateFilePOptions.newBuilder()
+            .setWriteType(mWriteType.toProto()).setRecursive(true).build())) {
+      System.out.println(mWriteType);
+      for (int i = 0; i < 3; i++) {
+        os.write(BufferUtils.getIncreasingByteArray(i * BLOCK_SIZE_BYTES, BLOCK_SIZE_BYTES));
+        URIStatus status = mFileSystem.getStatus(path);
+        System.out.format("Iter %s, BlockIds=%s, BlockInfo=%s%n", i, status.getBlockIds(), status.getFileBlockInfos());
+        System.out.println(status);
+      }
+      os.write(BufferUtils.getIncreasingByteArray(3 * BLOCK_SIZE_BYTES, 1));
+    }
+    URIStatus status = mFileSystem.getStatus(path);
+    System.out.format("After close, BlockIds=%s, BlockInfo=%s%n", status.getBlockIds(), status.getFileBlockInfos());
+    System.out.println(status);
   }
 }

--- a/tests/src/test/java/alluxio/client/fs/io/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileOutStreamIntegrationTest.java
@@ -260,7 +260,7 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
         URIStatus status = mFileSystem.getStatus(path);
         if (!mWriteType.isThrough()) {
           // When the writeType is THROUGH, we only see the blocks when the file is committed
-          // When the file is not committed, we do not see the FileBlockInfo
+          // When the file is not committed, we only see incomplete FileBlockInfo
           Assert.assertEquals(i + 1, status.getBlockIds().size());
         }
       }


### PR DESCRIPTION
Fixes https://github.com/Alluxio/alluxio/issues/13128
When this guard is added the issue does not happen anymore.

The trade-off is, when we `getFileInfo` on a file that is currently being written, the number of `BlockId` and `FileBlockInfo` we get will mismatch. I don't think that is a problem.