### PR TITLE
Add journal space monitor

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2047,8 +2047,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey MASTER_JOURNAL_SPACE_MONITOR_INTERVAL =
       new Builder(Name.MASTER_JOURNAL_SPACE_MONITOR_INTERVAL)
       .setDefaultValue("10min")
-      .setDescription("How often to check and update information on space utilization of the"
-          + " journal disk. This is currently only compatible with linux-based systems")
+      .setDescription(String.format("How often to check and update information on space "
+          + "utilization of the journal disk. This is currently only compatible with linux-based"
+          + "systems and when %s is configured to EMBEDDED", Name.MASTER_JOURNAL_TYPE))
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2006,6 +2006,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_JOURNAL_SPACE_MONITOR_PERCENT_FREE_THRESHOLD =
+      new Builder(Name.MASTER_JOURNAL_SPACE_MONITOR_PERCENT_FREE_THRESHOLD)
+          .setDefaultValue(10)
+          .setDescription("When the percent of free space on any disk which backs the journal "
+              + "falls below this percentage, begin logging warning messages to let "
+              + "administrators know the journal disk(s) may be running low on space.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_JOURNAL_TOLERATE_CORRUPTION =
       new Builder(Name.MASTER_JOURNAL_TOLERATE_CORRUPTION)
           .setDefaultValue(false)
@@ -2032,6 +2041,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue("10MB")
           .setDescription("If a log file is bigger than this value, it will rotate to next "
               + "file.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_JOURNAL_SPACE_MONITOR_INTERVAL =
+      new Builder(Name.MASTER_JOURNAL_SPACE_MONITOR_INTERVAL)
+      .setDefaultValue("10min")
+      .setDescription("How often to check and update information on space utilization of the"
+          + " journal disk. This is currently only compatible with linux-based systems")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
@@ -5328,6 +5345,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_JOURNAL_FOLDER = "alluxio.master.journal.folder";
     public static final String MASTER_JOURNAL_INIT_FROM_BACKUP =
         "alluxio.master.journal.init.from.backup";
+    public static final String MASTER_JOURNAL_SPACE_MONITOR_INTERVAL =
+        "alluxio.master.journal.space.monitor.interval";
+    public static final String MASTER_JOURNAL_SPACE_MONITOR_PERCENT_FREE_THRESHOLD
+        = "alluxio.master.journal.space.monitor.percent.free.threshold";
     public static final String MASTER_JOURNAL_TOLERATE_CORRUPTION
         = "alluxio.master.journal.tolerate.corruption";
     public static final String MASTER_JOURNAL_TYPE = "alluxio.master.journal.type";

--- a/core/common/src/main/java/alluxio/heartbeat/HeartbeatContext.java
+++ b/core/common/src/main/java/alluxio/heartbeat/HeartbeatContext.java
@@ -32,28 +32,29 @@ public final class HeartbeatContext {
   public static final String JOB_MASTER_LOST_WORKER_DETECTION = "Job Master Lost Worker Detection";
   public static final String JOB_WORKER_COMMAND_HANDLING =
       "Job Worker Command Handling";
-  public static final String MASTER_PERSISTENCE_CHECKER = "Master Persistence Checker";
-  public static final String MASTER_PERSISTENCE_SCHEDULER = "Master Persistence Scheduler";
-  public static final String MASTER_REPLICATION_CHECK = "Master Replication Check";
+  public static final String MASTER_ACTIVE_UFS_SYNC = "Master Active UFS Sync";
   public static final String MASTER_BLOCK_INTEGRITY_CHECK = "Master Block Integrity Check";
-  public static final String MASTER_CLUSTER_METRICS_UPDATER = "Master Cluster Metrics Updater";
   public static final String MASTER_CHECKPOINT_SCHEDULING = "Master Checkpoint Scheduling";
+  public static final String MASTER_CLUSTER_METRICS_UPDATER = "Master Cluster Metrics Updater";
   public static final String MASTER_DAILY_BACKUP = "Master Daily Backup";
   public static final String MASTER_FILE_RECOMPUTATION = "Master File Recomputation";
+  public static final String MASTER_JOURNAL_SPACE_MONITOR = "Master Journal Space Monitor";
   public static final String MASTER_LOG_CONFIG_REPORT_SCHEDULING
       = "Master Log Config Report Scheduling";
   public static final String MASTER_LOST_FILES_DETECTION = "Master Lost Files Detection";
   public static final String MASTER_LOST_MASTER_DETECTION = "Master Lost Master Detection";
   public static final String MASTER_LOST_WORKER_DETECTION = "Master Lost Worker Detection";
-  public static final String MASTER_ORPHANED_METRICS_CLEANER = "Master Orphaned Metrics Cleaner";
   public static final String MASTER_METRICS_SYNC = "Master Metrics Sync";
   public static final String MASTER_METRICS_TIME_SERIES = "Master Metrics Time Series";
-  public static final String MASTER_UFS_CLEANUP = "Master Ufs Cleanup";
-  public static final String MASTER_UPDATE_CHECK = "Master Update Check";
-  public static final String MASTER_TTL_CHECK = "Master TTL Check";
-  public static final String MASTER_ACTIVE_UFS_SYNC = "Master Active UFS Sync";
+  public static final String MASTER_ORPHANED_METRICS_CLEANER = "Master Orphaned Metrics Cleaner";
+  public static final String MASTER_PERSISTENCE_CHECKER = "Master Persistence Checker";
+  public static final String MASTER_PERSISTENCE_SCHEDULER = "Master Persistence Scheduler";
+  public static final String MASTER_REPLICATION_CHECK = "Master Replication Check";
   public static final String MASTER_TABLE_TRANSFORMATION_MONITOR =
       "Master Table Transformation Monitor";
+  public static final String MASTER_TTL_CHECK = "Master TTL Check";
+  public static final String MASTER_UFS_CLEANUP = "Master Ufs Cleanup";
+  public static final String MASTER_UPDATE_CHECK = "Master Update Check";
   public static final String META_MASTER_SYNC = "Meta Master Sync";
   public static final String WORKER_BLOCK_SYNC = "Worker Block Sync";
   public static final String WORKER_CLIENT = "Worker Client";
@@ -64,35 +65,36 @@ public final class HeartbeatContext {
 
   static {
     sTimerClasses = new HashMap<>();
-    sTimerClasses.put(MASTER_PERSISTENCE_CHECKER, SLEEPING_TIMER_CLASS);
-    sTimerClasses.put(MASTER_PERSISTENCE_SCHEDULER, SLEEPING_TIMER_CLASS);
-    sTimerClasses.put(MASTER_REPLICATION_CHECK, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(JOB_MASTER_LOST_WORKER_DETECTION, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(JOB_WORKER_COMMAND_HANDLING, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(MASTER_ACTIVE_UFS_SYNC, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_BLOCK_INTEGRITY_CHECK, SLEEPING_TIMER_CLASS);
-    sTimerClasses.put(MASTER_CLUSTER_METRICS_UPDATER, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_CHECKPOINT_SCHEDULING, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(MASTER_CLUSTER_METRICS_UPDATER, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_DAILY_BACKUP, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_FILE_RECOMPUTATION, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(MASTER_JOURNAL_SPACE_MONITOR, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_LOG_CONFIG_REPORT_SCHEDULING, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_LOST_FILES_DETECTION, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_LOST_MASTER_DETECTION, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_LOST_WORKER_DETECTION, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(MASTER_METRICS_SYNC, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(MASTER_METRICS_TIME_SERIES, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(MASTER_PERSISTENCE_CHECKER, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(MASTER_ORPHANED_METRICS_CLEANER, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(MASTER_PERSISTENCE_SCHEDULER, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(MASTER_REPLICATION_CHECK, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(MASTER_TABLE_TRANSFORMATION_MONITOR, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(MASTER_TTL_CHECK, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_UFS_CLEANUP, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(MASTER_UPDATE_CHECK, SLEEPING_TIMER_CLASS);
-    sTimerClasses.put(MASTER_TTL_CHECK, SLEEPING_TIMER_CLASS);
-    sTimerClasses.put(MASTER_ACTIVE_UFS_SYNC, SLEEPING_TIMER_CLASS);
-    sTimerClasses.put(MASTER_TABLE_TRANSFORMATION_MONITOR, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(META_MASTER_SYNC, SLEEPING_TIMER_CLASS);
-    sTimerClasses.put(WORKER_FILESYSTEM_MASTER_SYNC, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(WORKER_BLOCK_SYNC, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(WORKER_CLIENT, SLEEPING_TIMER_CLASS);
+    sTimerClasses.put(WORKER_FILESYSTEM_MASTER_SYNC, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(WORKER_PIN_LIST_SYNC, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(WORKER_SPACE_RESERVER, SLEEPING_TIMER_CLASS);
     sTimerClasses.put(WORKER_STORAGE_HEALTH, SLEEPING_TIMER_CLASS);
-    sTimerClasses.put(MASTER_METRICS_SYNC, SLEEPING_TIMER_CLASS);
-    sTimerClasses.put(MASTER_ORPHANED_METRICS_CLEANER, SLEEPING_TIMER_CLASS);
-    sTimerClasses.put(MASTER_METRICS_TIME_SERIES, SLEEPING_TIMER_CLASS);
   }
 
   private HeartbeatContext() {} // to prevent initialization

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -320,6 +320,17 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("Total number of inodes (inode metadata) cached.")
           .setMetricType(MetricType.GAUGE)
           .build();
+  public static final MetricKey MASTER_JOURNAL_SPACE_FREE_BYTES =
+      new Builder(Name.MASTER_JOURNAL_SPACE_FREE_BYTES)
+          .setDescription("Bytes left on the journal disk(s) for an Alluxio master")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_JOURNAL_SPACE_FREE_PERCENT =
+      new Builder(Name.MASTER_JOURNAL_SPACE_FREE_PERCENT)
+          .setDescription(
+              "Percentage of free space left on the journal disk(s) for an Alluxio master")
+          .setMetricType(MetricType.GAUGE)
+          .build();
   public static final MetricKey MASTER_TOTAL_PATHS =
       new Builder(Name.MASTER_TOTAL_PATHS)
           .setDescription("Total number of files and directory in Alluxio namespace")
@@ -1289,6 +1300,9 @@ public final class MetricKey implements Comparable<MetricKey> {
     public static final String MASTER_INODE_CACHE_LOAD_TIMES = "Master.InodeCacheLoadTimes";
     public static final String MASTER_INODE_CACHE_MISSES = "Master.InodeCacheMisses";
     public static final String MASTER_INODE_CACHE_SIZE = "Master.InodeCacheSize";
+
+    public static final String MASTER_JOURNAL_SPACE_FREE_BYTES = "Master.JournalFreeBytes";
+    public static final String MASTER_JOURNAL_SPACE_FREE_PERCENT = "Master.JournalFreePercent";
 
     public static final String MASTER_TOTAL_PATHS = "Master.TotalPaths";
 

--- a/core/common/src/main/java/alluxio/wire/JournalDiskInfo.java
+++ b/core/common/src/main/java/alluxio/wire/JournalDiskInfo.java
@@ -1,0 +1,89 @@
+package alluxio.wire;
+
+import com.google.common.base.MoreObjects;
+
+import java.io.Serializable;
+
+/**
+ * A class representing the state of a physical device.
+ */
+public class JournalDiskInfo implements Serializable {
+  private static final long serialVersionUID = 12938071234234123L;
+
+  private final String mDiskPath;
+  private final long mUsedBytes;
+  private final long mTotalAllocatedBytes;
+  private final long mAvailableBytes;
+  private final double mPercentAvailable;
+  private final String mMountPath;
+
+  /**
+   * Create a new instance of {@link JournalDiskInfo} representing the current utilization for a
+   * particular block device.
+   *
+   * @param diskPath            the path to the raw device
+   * @param totalAllocatedBytes the total filesystem
+   * @param usedBytes           the amount of bytes used by the filesystem
+   * @param availableBytes      the amount of bytes available on the filesystem
+   * @param mountPath           the path where the device is mounted
+   */
+  public JournalDiskInfo(String diskPath, long totalAllocatedBytes, long usedBytes,
+      long availableBytes, String mountPath) {
+    mDiskPath = diskPath;
+    mTotalAllocatedBytes = totalAllocatedBytes * 1024;
+    mUsedBytes = usedBytes * 1024;
+    mAvailableBytes = availableBytes * 1024;
+    mMountPath = mountPath;
+    mPercentAvailable = 100 * ((double) mAvailableBytes / (mAvailableBytes + mUsedBytes));
+  }
+
+  /**
+   * @return the raw device path
+   */
+  public String getDiskPath() {
+    return mDiskPath;
+  }
+
+  /**
+   * @return the bytes used by the device
+   */
+  public long getUsedBytes() {
+    return mUsedBytes;
+  }
+
+  /**
+   * @return the total bytes allocated for the filesystem on this device
+   */
+  public long getTotalAllocatedBytes() {
+    return mTotalAllocatedBytes;
+  }
+
+  /**
+   * @return the remaining available bytes on this disk
+   */
+  public long getAvailableBytes() {
+    return mAvailableBytes;
+  }
+
+  /**
+   * @return the path where this disk is mounted
+   */
+  public String getMountPath() {
+    return mMountPath;
+  }
+
+  /**
+   * @return the percent of remaining space available on this disk
+   */
+  public double getPercentAvailable() {
+    return mPercentAvailable;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("diskPath", mDiskPath)
+        .add("totalAllocatedBytes", mTotalAllocatedBytes).add("usedBytes", mUsedBytes)
+        .add("availableBytes", mAvailableBytes).add("percentAvailable", mPercentAvailable)
+        .add("mountPath", mMountPath).toString();
+  }
+}

--- a/core/common/src/main/java/alluxio/wire/JournalDiskInfo.java
+++ b/core/common/src/main/java/alluxio/wire/JournalDiskInfo.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.wire;
 
 import com.google.common.base.MoreObjects;

--- a/core/common/src/main/java/alluxio/wire/MasterWebUIMetrics.java
+++ b/core/common/src/main/java/alluxio/wire/MasterWebUIMetrics.java
@@ -41,6 +41,7 @@ public final class MasterWebUIMetrics implements Serializable {
   private Map<String, String> mUfsReadSize;
   private Map<String, String> mUfsWriteSize;
   private List<TimeSeries> mTimeSeriesMetrics;
+  private List<JournalDiskInfo> mJournalDiskMetrics;
   private String mCacheHitLocal;
   private String mCacheHitRemote;
   private String mCacheMiss;
@@ -333,6 +334,13 @@ public final class MasterWebUIMetrics implements Serializable {
    */
   public List<TimeSeries> getTimeSeriesMetrics() {
     return mTimeSeriesMetrics;
+  }
+
+  /**
+   * @return the journal disk metrics
+   */
+  public List<JournalDiskInfo> getJournalDiskMetrics() {
+    return mJournalDiskMetrics;
   }
 
   /**
@@ -657,6 +665,15 @@ public final class MasterWebUIMetrics implements Serializable {
    */
   public MasterWebUIMetrics setTimeSeriesMetrics(List<TimeSeries> timeSeries) {
     mTimeSeriesMetrics = timeSeries;
+    return this;
+  }
+
+  /**
+   * @param journalDiskMetrics the disk metrics to set
+   * @return the updated {@link MasterWebUIMetrics} object
+   */
+  public MasterWebUIMetrics setJournalDiskMetrics(List<JournalDiskInfo> journalDiskMetrics) {
+    mJournalDiskMetrics = journalDiskMetrics;
     return this;
   }
 

--- a/core/common/src/main/java/alluxio/wire/MasterWebUIOverview.java
+++ b/core/common/src/main/java/alluxio/wire/MasterWebUIOverview.java
@@ -42,6 +42,7 @@ public final class MasterWebUIOverview implements Serializable {
   private String mDiskFreeCapacity;
   private String mDiskUsedCapacity;
   private String mFreeCapacity;
+  private List<String> mJournalDiskWarnings;
   private String mLiveWorkerNodes;
   private String mMasterNodeAddress;
   private String mStartTime;
@@ -143,6 +144,13 @@ public final class MasterWebUIOverview implements Serializable {
    */
   public String getFreeCapacity() {
     return mFreeCapacity;
+  }
+
+  /**
+   * @return the journal disk warnings
+   */
+  public List<String> getJournalDiskWarnings() {
+    return mJournalDiskWarnings;
   }
 
   /**
@@ -327,6 +335,15 @@ public final class MasterWebUIOverview implements Serializable {
    */
   public MasterWebUIOverview setFreeCapacity(String freeCapacity) {
     mFreeCapacity = freeCapacity;
+    return this;
+  }
+
+  /**
+    * @param journalDiskWarnings the list of journal disk warnings
+   * @return the updated {@link MasterWebUIOverview} object
+   */
+  public MasterWebUIOverview setJournalDiskWarnings(List<String> journalDiskWarnings) {
+    mJournalDiskWarnings = journalDiskWarnings;
     return this;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -316,6 +316,8 @@ public final class AlluxioMasterRestServiceHandler {
         response.setDiskCapacity("UNKNOWN").setDiskUsedCapacity("UNKNOWN")
             .setDiskFreeCapacity("UNKNOWN");
       }
+      mMetaMaster.getJournalSpaceMonitor().map(monitor ->
+          response.setJournalDiskWarnings(monitor.getJournalDiskWarnings()));
 
       return response;
     }, ServerConfiguration.global());
@@ -1038,6 +1040,15 @@ public final class AlluxioMasterRestServiceHandler {
       response.setUfsOps(ufsOpsMap);
 
       response.setTimeSeriesMetrics(mFileSystemMaster.getTimeSeries());
+      mMetaMaster.getJournalSpaceMonitor().map(monitor -> {
+        try {
+          return response.setJournalDiskMetrics(monitor.getDiskInfo());
+        } catch (IOException e) {
+          LogUtils.warnWithException(LOG,
+              "Failed to populate journal disk information for WebUI metrics.", e);
+        }
+        return response;
+      });
 
       return response;
     }, ServerConfiguration.global());

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -445,7 +445,7 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
 
   @Override
   public Optional<JournalSpaceMonitor> getJournalSpaceMonitor() {
-    return mJournalSpaceMonitor == null ? Optional.empty() : Optional.of(mJournalSpaceMonitor);
+    return Optional.ofNullable(mJournalSpaceMonitor);
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -45,6 +45,7 @@ import alluxio.master.backup.BackupRole;
 import alluxio.master.backup.BackupWorkerRole;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.journal.JournalContext;
+import alluxio.master.journal.JournalType;
 import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.master.meta.checkconf.ServerConfigurationChecker;
 import alluxio.master.meta.checkconf.ServerConfigurationStore;
@@ -55,6 +56,7 @@ import alluxio.resource.LockResource;
 import alluxio.underfs.UfsManager;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.IdUtils;
+import alluxio.util.OSUtils;
 import alluxio.util.ThreadFactoryUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.util.executor.ExecutorServiceFactory;
@@ -76,9 +78,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -159,6 +163,9 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
 
   /** Used to manage backup role. */
   private BackupRole mBackupRole;
+
+  @Nullable
+  private final JournalSpaceMonitor mJournalSpaceMonitor;
 
   /**
    * Journaled state for MetaMaster.
@@ -252,6 +259,12 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
 
     mPathProperties = new PathProperties();
     mState = new State();
+    if (ServerConfiguration.getEnum(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.class)
+        .equals(JournalType.EMBEDDED) && OSUtils.isLinux()) {
+      mJournalSpaceMonitor = new JournalSpaceMonitor(ServerConfiguration.global());
+    } else {
+      mJournalSpaceMonitor = null;
+    }
   }
 
   @Override
@@ -306,6 +319,12 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
         mDailyBackup = new DailyMetadataBackup(this, Executors.newSingleThreadScheduledExecutor(
             ThreadFactoryUtils.build("DailyMetadataBackup-%d", true)), mUfsManager);
         mDailyBackup.start();
+      }
+      if (mJournalSpaceMonitor != null) {
+        getExecutorService().submit(new HeartbeatThread(
+            HeartbeatContext.MASTER_JOURNAL_SPACE_MONITOR, mJournalSpaceMonitor,
+            ServerConfiguration.getMs(PropertyKey.MASTER_JOURNAL_SPACE_MONITOR_INTERVAL),
+            ServerConfiguration.global(), mMasterContext.getUserState()));
       }
       if (mState.getClusterID().equals(INVALID_CLUSTER_ID)) {
         try (JournalContext context = createJournalContext()) {
@@ -422,6 +441,11 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
   @Override
   public ConfigHash getConfigHash() {
     return new ConfigHash(ServerConfiguration.hash(), mPathProperties.hash());
+  }
+
+  @Override
+  public Optional<JournalSpaceMonitor> getJournalSpaceMonitor() {
+    return mJournalSpaceMonitor == null ? Optional.empty() : Optional.of(mJournalSpaceMonitor);
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/meta/JournalSpaceMonitor.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/JournalSpaceMonitor.java
@@ -1,0 +1,253 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.meta;
+
+import alluxio.AlluxioURI;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.heartbeat.HeartbeatExecutor;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
+import alluxio.shell.CommandReturn;
+import alluxio.util.LogUtils;
+import alluxio.util.ShellUtils;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * A heartbeat executor which periodically tracks the amount of disk space available for a
+ * particular path, generally the disk holding the journal.
+ *
+ * This monitor is only applicable to systems which are running on the Linux OS and which are
+ * running the embedded journal. Other configurations are invalid. Running this monitor on such
+ * systems is undefined behavior.
+ */
+public class JournalSpaceMonitor implements HeartbeatExecutor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JournalSpaceMonitor.class);
+
+  /**
+   * Convenience method for {@link #JournalSpaceMonitor(String, long)}.
+   *
+   * @param configuration the current alluxio configuration
+   */
+  public JournalSpaceMonitor(AlluxioConfiguration configuration) {
+    this(configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER), configuration.getLong(
+        PropertyKey.MASTER_JOURNAL_SPACE_MONITOR_PERCENT_FREE_THRESHOLD));
+  }
+
+  private final String mJournalPath;
+  private final long mWarnCapacityPercentThreshold;
+
+  // Used to store information for metrics gauges
+  private Map<String, DiskInfo> mMetricInfo = new HashMap<>();
+
+  /**
+   *
+   * @param journalPath the path to the journal location
+   * @param warnCapacityPercentThreshold when a device utilization falls below this threshold,
+   *                                     emit warnings to the log
+   */
+  public JournalSpaceMonitor(String journalPath, long warnCapacityPercentThreshold) {
+    Preconditions.checkArgument(Files.exists(Paths.get(journalPath)),
+        "journal path must exist");
+    mJournalPath = journalPath;
+    mWarnCapacityPercentThreshold = warnCapacityPercentThreshold;
+  }
+
+  /**
+   * Gets the raw output from the {@code df} command.
+   *
+   * This method is used to allow testing of the JournalSpaceMonitor code.
+   *
+   * @return the output from the {@code df} command
+   * @throws IOException if retrieving the output fails
+   */
+  @VisibleForTesting
+  CommandReturn getRawDiskInfo() throws IOException {
+    return ShellUtils.execCommandWithOutput("df", "-k", "-P", mJournalPath);
+  }
+
+  /**
+   * Gets the current disk information from the system for the journal path.
+   *
+   * @return a list of the disks that back the journal path. Many systems will just have one
+   * disk. Depending on the configuration multiple disks may back the journal path, in which
+   * case we report information on all of them
+   * @throws IOException when obtaining the disk information fails
+   */
+  protected synchronized List<DiskInfo> getDiskInfo() throws IOException {
+    // command allowed by the POSIX specification
+    CommandReturn output = getRawDiskInfo();
+    if (output.getExitCode() != 0) {
+      throw new IOException("Command failed with exit code " + output.getExitCode());
+    }
+    List<DiskInfo> infos = Arrays.stream(output.getOutput().split("\n"))
+        .skip(1)
+        .map(infoLine -> Arrays.stream(infoLine.split(" "))
+              .map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toList()))
+        .filter(data -> data.size() >= 6)
+        .map(data -> {
+          String diskPath = data.get(0);
+          // total size is not necessarily (used size + available size)
+          long totalSize = Long.parseLong(data.get(1));
+          long usedSize = Long.parseLong(data.get(2));
+          long availableSize = Long.parseLong(data.get(3));
+          String mountedFs = data.get(5);
+          return new DiskInfo(diskPath, totalSize, usedSize, availableSize, mountedFs);
+        }).collect(Collectors.toList());
+    mMetricInfo = infos.stream().collect(Collectors.toMap(DiskInfo::getDiskPath, f -> f));
+    infos.forEach(info -> {
+      MetricsSystem.registerGaugeIfAbsent(MetricsSystem.getMetricName(
+              MetricKey.MASTER_JOURNAL_SPACE_FREE_BYTES.getName()
+                  + "Device" + MetricsSystem.escape(new AlluxioURI(info.getDiskPath()))), () -> {
+          DiskInfo metricInfo = mMetricInfo.get(info.getDiskPath());
+          if (metricInfo != null) {
+            return metricInfo.getAvailableBytes();
+          } else {
+            return -1;
+          }
+        });
+      MetricsSystem.registerGaugeIfAbsent(MetricsSystem.getMetricName(
+          MetricKey.MASTER_JOURNAL_SPACE_FREE_PERCENT.getName()
+              + "Device" + MetricsSystem.escape(new AlluxioURI(info.getDiskPath()))), () -> {
+          DiskInfo metricInfo = mMetricInfo.get(info.getDiskPath());
+          if (metricInfo != null) {
+            return metricInfo.getPercentAvailable();
+          } else {
+            return -1;
+          }
+        });
+    });
+    return infos;
+  }
+
+  @Override
+  public void heartbeat() throws InterruptedException {
+    try {
+      List<DiskInfo> currentInfo = getDiskInfo();
+      currentInfo.forEach(info -> {
+        if (info.getPercentAvailable() < mWarnCapacityPercentThreshold) {
+          LOG.warn(String.format(
+              "The journal disk %s backing the journal has only %.2f%% space left - %s",
+              info.getDiskPath(), info.getPercentAvailable(), info));
+        }
+      });
+    } catch (IOException e) {
+      LogUtils.warnWithException(LOG, "Failed to get journal disk information", e);
+    }
+  }
+
+  @Override
+  public void close() {
+    // noop
+  }
+
+  /**
+   * A class representing the state of a physical device.
+   */
+  public static class DiskInfo {
+    private final String mDiskPath;
+    private final long mUsedBytes;
+    private final long mTotalAllocatedBytes;
+    private final long mAvailableBytes;
+    private final double mPercentAvailable;
+    private final String mMountPath;
+
+    /**
+     * Create a new instance of {@link DiskInfo} representing the current utilization for a
+     * particular block device.
+     *
+     * @param diskPath the path to the raw device
+     * @param totalAllocatedBytes the total filesystem
+     * @param usedBytes the amount of bytes used by the filesystem
+     * @param availableBytes the amount of bytes available on the filesystem
+     * @param mountPath the path where the device is mounted
+     */
+    public DiskInfo(String diskPath, long totalAllocatedBytes, long usedBytes, long availableBytes,
+        String mountPath) {
+      mDiskPath = diskPath;
+      mTotalAllocatedBytes = totalAllocatedBytes * 1024;
+      mUsedBytes = usedBytes * 1024;
+      mAvailableBytes = availableBytes * 1024;
+      mMountPath = mountPath;
+      mPercentAvailable = 100 * ((double) mAvailableBytes / (mAvailableBytes + mUsedBytes));
+    }
+
+    /**
+     * @return the raw device path
+     */
+    public String getDiskPath() {
+      return mDiskPath;
+    }
+
+    /**
+     * @return the bytes used by the device
+     */
+    public long getUsedBytes() {
+      return mUsedBytes;
+    }
+
+    /**
+     * @return the total bytes allocated for the filesystem on this device
+     */
+    public long getTotalAllocatedBytes() {
+      return mTotalAllocatedBytes;
+    }
+
+    /**
+     * @return the remaining available bytes on this disk
+     */
+    public long getAvailableBytes() {
+      return mAvailableBytes;
+    }
+
+    /**
+     * @return the path where this disk is mounted
+     */
+    public String getMountPath() {
+      return mMountPath;
+    }
+
+    /**
+     * @return the percent of remaining space available on this disk
+     */
+    public double getPercentAvailable() {
+      return mPercentAvailable;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("diskPath", mDiskPath)
+          .add("totalAllocatedBytes", mTotalAllocatedBytes)
+          .add("usedBytes", mUsedBytes)
+          .add("availableBytes", mAvailableBytes)
+          .add("percentAvailable", mPercentAvailable)
+          .add("mountPath", mMountPath)
+          .toString();
+    }
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/meta/MetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/MetaMaster.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -55,6 +56,11 @@ public interface MetaMaster extends BackupOps, Master {
    * @return hashes of cluster and path level configuration
    */
   ConfigHash getConfigHash();
+
+  /**
+   * @return the journal space monitor if supported by the current configuration
+   */
+  Optional<JournalSpaceMonitor> getJournalSpaceMonitor();
 
   /**
    * Sets properties for a path.

--- a/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
+++ b/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
@@ -64,13 +64,16 @@ public final class AlluxioMasterProcessTest {
   private int mWebPort;
 
   @Before
-  public void before() {
+  public void before() throws Exception {
     ServerConfiguration.reset();
     mRpcPort = mRpcPortRule.getPort();
     mWebPort = mWebPortRule.getPort();
     ServerConfiguration.set(PropertyKey.MASTER_RPC_PORT, mRpcPort);
     ServerConfiguration.set(PropertyKey.MASTER_WEB_PORT, mWebPort);
     ServerConfiguration.set(PropertyKey.MASTER_METASTORE_DIR, mFolder.getRoot().getAbsolutePath());
+    String journalPath = PathUtils.concatPath(mFolder.getRoot(), "journal");
+    FileUtils.createDir(journalPath);
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_FOLDER, journalPath);
   }
 
   @Test

--- a/core/server/master/src/test/java/alluxio/master/meta/JournalSpaceMonitorTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/JournalSpaceMonitorTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.doThrow;
 import alluxio.TestLoggerRule;
 import alluxio.shell.CommandReturn;
 import alluxio.util.OSUtils;
+import alluxio.wire.JournalDiskInfo;
 
 import org.apache.log4j.Level;
 import org.junit.Assume;
@@ -48,7 +49,7 @@ public class JournalSpaceMonitorTest {
   }
 
   @Test
-  public void testNonExitentJournalPath() {
+  public void testNonExistentJournalPath() {
     assertThrows(IllegalArgumentException.class,
         () -> new JournalSpaceMonitor("/nonexistent/path", 10));
   }
@@ -58,9 +59,9 @@ public class JournalSpaceMonitorTest {
     JournalSpaceMonitor monitor = Mockito.spy(
         new JournalSpaceMonitor(Paths.get(".").toAbsolutePath().toString(), 10));
     doReturn(new CommandReturn(0, CMD_RETURN_MOCK)).when(monitor).getRawDiskInfo();
-    List<JournalSpaceMonitor.DiskInfo> infos = monitor.getDiskInfo();
+    List<JournalDiskInfo> infos = monitor.getDiskInfo();
     assertEquals(1, infos.size());
-    JournalSpaceMonitor.DiskInfo info = infos.get(0);
+    JournalDiskInfo info = infos.get(0);
     assertEquals("/dev/nvme0n1p2", info.getDiskPath());
     assertEquals(959863856L * 1024, info.getTotalAllocatedBytes());
     assertEquals(145802864L * 1024, info.getUsedBytes());

--- a/core/server/master/src/test/java/alluxio/master/meta/JournalSpaceMonitorTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/JournalSpaceMonitorTest.java
@@ -1,0 +1,98 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.meta;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+import alluxio.TestLoggerRule;
+import alluxio.shell.CommandReturn;
+import alluxio.util.OSUtils;
+
+import org.apache.log4j.Level;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class JournalSpaceMonitorTest {
+
+  private static final String CMD_RETURN_MOCK =
+      "Filesystem     1024-blocks      Used Available Capacity Mounted on\n"
+          + "/dev/nvme0n1p2   959863856 145802864 765232784      17% /";
+
+  @Rule
+  public TestLoggerRule mLogger = new TestLoggerRule();
+
+  @BeforeClass
+  public static void beforeClass() {
+    Assume.assumeTrue(OSUtils.isLinux());
+  }
+
+  @Test
+  public void testNonExitentJournalPath() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new JournalSpaceMonitor("/nonexistent/path", 10));
+  }
+
+  @Test
+  public void testSuccessfulInfo() throws IOException  {
+    JournalSpaceMonitor monitor = Mockito.spy(
+        new JournalSpaceMonitor(Paths.get(".").toAbsolutePath().toString(), 10));
+    doReturn(new CommandReturn(0, CMD_RETURN_MOCK)).when(monitor).getRawDiskInfo();
+    List<JournalSpaceMonitor.DiskInfo> infos = monitor.getDiskInfo();
+    assertEquals(1, infos.size());
+    JournalSpaceMonitor.DiskInfo info = infos.get(0);
+    assertEquals("/dev/nvme0n1p2", info.getDiskPath());
+    assertEquals(959863856L * 1024, info.getTotalAllocatedBytes());
+    assertEquals(145802864L * 1024, info.getUsedBytes());
+    assertEquals(765232784L * 1024, info.getAvailableBytes());
+    assertEquals(83.0, Math.floor(info.getPercentAvailable()), 0.1);
+  }
+
+  @Test
+  public void testFailedInfo() throws IOException  {
+    JournalSpaceMonitor monitor = Mockito.spy(
+        new JournalSpaceMonitor(Paths.get(".").toAbsolutePath().toString(), 10));
+    doThrow(new IOException("couldnt run")).when(monitor).getRawDiskInfo();
+    assertThrows(IOException.class, monitor::getDiskInfo);
+  }
+
+  @Test
+  public void testLoggingPositive() throws IOException, InterruptedException {
+    JournalSpaceMonitor monitor = Mockito.spy(
+        new JournalSpaceMonitor(Paths.get(".").toAbsolutePath().toString(), 90));
+    doReturn(new CommandReturn(0, CMD_RETURN_MOCK)).when(monitor).getRawDiskInfo();
+    monitor.heartbeat();
+    assertTrue(mLogger.wasLoggedWithLevel("The journal disk /dev/nvme0n1p2 backing the journal "
+        + "has only .* space left", Level.WARN));
+  }
+
+  @Test
+  public void testLoggingNegative() throws IOException, InterruptedException {
+    JournalSpaceMonitor monitor = Mockito.spy(
+        new JournalSpaceMonitor(Paths.get(".").toAbsolutePath().toString(), 10));
+    doReturn(new CommandReturn(0, CMD_RETURN_MOCK)).when(monitor).getRawDiskInfo();
+    monitor.heartbeat();
+    assertFalse(mLogger.wasLoggedWithLevel("The journal disk /dev/nvme0n1p2 backing the journal "
+        + "has only .* space left", Level.WARN));
+  }
+}

--- a/table/server/master/src/test/java/alluxio/master/table/TableMasterFactoryTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/TableMasterFactoryTest.java
@@ -31,14 +31,21 @@ import alluxio.underfs.MasterUfsManager;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.nio.file.Files;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class TableMasterFactoryTest {
 
   private CoreMasterContext mContext;
+
+  @ClassRule
+  public static TemporaryFolder mTemp = new TemporaryFolder();
 
   @Before
   public void before() {
@@ -50,6 +57,7 @@ public class TableMasterFactoryTest {
         .setInodeStoreFactory(x -> new HeapInodeStore())
         .setUfsManager(new MasterUfsManager())
         .build();
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_FOLDER, mTemp.getRoot().getAbsolutePath());
   }
 
   @After

--- a/table/server/master/src/test/java/alluxio/master/table/TableMasterFactoryTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/TableMasterFactoryTest.java
@@ -32,11 +32,9 @@ import alluxio.underfs.MasterUfsManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.nio.file.Files;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -45,7 +43,7 @@ public class TableMasterFactoryTest {
   private CoreMasterContext mContext;
 
   @ClassRule
-  public static TemporaryFolder mTemp = new TemporaryFolder();
+  public static TemporaryFolder sTemp = new TemporaryFolder();
 
   @Before
   public void before() {
@@ -57,7 +55,7 @@ public class TableMasterFactoryTest {
         .setInodeStoreFactory(x -> new HeapInodeStore())
         .setUfsManager(new MasterUfsManager())
         .build();
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_FOLDER, mTemp.getRoot().getAbsolutePath());
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_FOLDER, sTemp.getRoot().getAbsolutePath());
   }
 
   @After

--- a/webui/README.md
+++ b/webui/README.md
@@ -58,7 +58,7 @@ NOTE: `coverage-ci` is meant to run tests once and quit (for continuous integrat
 #### Developing within the webui project
 
 1. Follow the prerequisite instructions above.
-1. Enable CORS for the alluxio RESTful api endpoints by setting `alluxio.webui.enable.cors=true` in `conf/alluxio-site.properties`
+1. Enable CORS for the alluxio RESTful api endpoints by setting `alluxio.web.cors.enabled=true` in `conf/alluxio-site.properties`
 1. Start a development server in one of the following ways:
     1. For all packages: `npm run start`
     1. For each package independently:

--- a/webui/master/src/constants/types/IJournalDiskInfo.tsx
+++ b/webui/master/src/constants/types/IJournalDiskInfo.tsx
@@ -1,0 +1,20 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+export interface IJournalDiskInfo {
+    diskPath: string;
+    usedBytes: number;
+    totalAllocatedBytes: number;
+    availableBytes: number;
+    percentAvailable: number;
+    mountPath: string;
+  }
+  

--- a/webui/master/src/constants/types/IJournalDiskInfo.tsx
+++ b/webui/master/src/constants/types/IJournalDiskInfo.tsx
@@ -10,11 +10,10 @@
  */
 
 export interface IJournalDiskInfo {
-    diskPath: string;
-    usedBytes: number;
-    totalAllocatedBytes: number;
-    availableBytes: number;
-    percentAvailable: number;
-    mountPath: string;
-  }
-  
+  diskPath: string;
+  usedBytes: number;
+  totalAllocatedBytes: number;
+  availableBytes: number;
+  percentAvailable: number;
+  mountPath: string;
+}

--- a/webui/master/src/containers/pages/Metrics/Metrics.tsx
+++ b/webui/master/src/containers/pages/Metrics/Metrics.tsx
@@ -25,7 +25,7 @@ import { IApplicationState } from '../../../store';
 import { fetchRequest as metricsFetchRequest } from '../../../store/metrics/actions';
 import { fetchRequest as overviewFetchRequest } from '../../../store/overview/actions';
 import { IMetrics } from '../../../store/metrics/types';
-import { createAlertErrors } from '@alluxio/common-ui/src/utilities';
+import { bytesToString, createAlertErrors } from '@alluxio/common-ui/src/utilities';
 import { ICommonState } from '@alluxio/common-ui/src/constants';
 import { IJournalDiskInfo } from '../../../constants/types/IJournalDiskInfo';
 
@@ -307,9 +307,9 @@ export class MetricsPresenter extends React.Component<AllProps> {
                 return (
                   <tr key={idx}>
                     <td>{info.diskPath}</td>
-                    <td>{info.totalAllocatedBytes}</td>
-                    <td>{info.usedBytes}</td>
-                    <td>{info.availableBytes}</td>
+                    <td>{bytesToString(info.totalAllocatedBytes)}</td>
+                    <td>{bytesToString(info.usedBytes)}</td>
+                    <td>{bytesToString(info.availableBytes)}</td>
                     <td>{info.percentAvailable.toFixed(2)}%</td>
                     <td>{info.mountPath}</td>
                   </tr>

--- a/webui/master/src/containers/pages/Metrics/Metrics.tsx
+++ b/webui/master/src/containers/pages/Metrics/Metrics.tsx
@@ -292,31 +292,33 @@ export class MetricsPresenter extends React.Component<AllProps> {
           </div>
         ))}
         {Object.keys(data.journalDiskMetrics).map((key: string) => (
-        <div key={key} className="col-12">
-          <h5>Alluxio Master Journal Disk Status</h5>
-          <Table hover={true}>
-            <tbody>
-              <tr>
-                <th>Device Path</th>
-                <th>Allocated Bytes</th>
-                <th>Used Bytes</th>
-                <th>Available Bytes</th>
-                <th>Percent Available</th>
-                <th>Mount Path</th>
-              </tr>
-              {data.journalDiskMetrics.map((info: IJournalDiskInfo, idx: number) => {
-                return <tr key={idx}>
-                  <td>{info.diskPath}</td>
-                  <td>{info.totalAllocatedBytes}</td>
-                  <td>{info.usedBytes}</td>
-                  <td>{info.availableBytes}</td>
-                  <td>{info.percentAvailable.toFixed(2)}%</td>
-                  <td>{info.mountPath}</td>
+          <div key={key} className="col-12">
+            <h5>Alluxio Master Journal Disk Status</h5>
+            <Table hover={true}>
+              <tbody>
+                <tr>
+                  <th>Device Path</th>
+                  <th>Allocated Bytes</th>
+                  <th>Used Bytes</th>
+                  <th>Available Bytes</th>
+                  <th>Percent Available</th>
+                  <th>Mount Path</th>
                 </tr>
-              })}
-            </tbody>
-          </Table>
-        </div>
+                {data.journalDiskMetrics.map((info: IJournalDiskInfo, idx: number) => {
+                  return (
+                    <tr key={idx}>
+                      <td>{info.diskPath}</td>
+                      <td>{info.totalAllocatedBytes}</td>
+                      <td>{info.usedBytes}</td>
+                      <td>{info.availableBytes}</td>
+                      <td>{info.percentAvailable.toFixed(2)}%</td>
+                      <td>{info.mountPath}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </Table>
+          </div>
         ))}
       </React.Fragment>
     );

--- a/webui/master/src/containers/pages/Metrics/Metrics.tsx
+++ b/webui/master/src/containers/pages/Metrics/Metrics.tsx
@@ -27,6 +27,7 @@ import { fetchRequest as overviewFetchRequest } from '../../../store/overview/ac
 import { IMetrics } from '../../../store/metrics/types';
 import { createAlertErrors } from '@alluxio/common-ui/src/utilities';
 import { ICommonState } from '@alluxio/common-ui/src/constants';
+import { IJournalDiskInfo } from '../../../constants/types/IJournalDiskInfo';
 
 interface IPropsFromState extends ICommonState {
   alluxioStartTime: string;
@@ -289,6 +290,33 @@ export class MetricsPresenter extends React.Component<AllProps> {
               </tbody>
             </Table>
           </div>
+        ))}
+        {Object.keys(data.journalDiskMetrics).map((key: string) => (
+        <div key={key} className="col-12">
+          <h5>Alluxio Master Journal Disk Status</h5>
+          <Table hover={true}>
+            <tbody>
+              <tr>
+                <th>Device Path</th>
+                <th>Allocated Bytes</th>
+                <th>Used Bytes</th>
+                <th>Available Bytes</th>
+                <th>Percent Available</th>
+                <th>Mount Path</th>
+              </tr>
+              {data.journalDiskMetrics.map((info: IJournalDiskInfo, idx: number) => {
+                return <tr key={idx}>
+                  <td>{info.diskPath}</td>
+                  <td>{info.totalAllocatedBytes}</td>
+                  <td>{info.usedBytes}</td>
+                  <td>{info.availableBytes}</td>
+                  <td>{info.percentAvailable.toFixed(2)}%</td>
+                  <td>{info.mountPath}</td>
+                </tr>
+              })}
+            </tbody>
+          </Table>
+        </div>
         ))}
       </React.Fragment>
     );

--- a/webui/master/src/containers/pages/Metrics/Metrics.tsx
+++ b/webui/master/src/containers/pages/Metrics/Metrics.tsx
@@ -291,35 +291,33 @@ export class MetricsPresenter extends React.Component<AllProps> {
             </Table>
           </div>
         ))}
-        {Object.keys(data.journalDiskMetrics).map((key: string) => (
-          <div key={key} className="col-12">
-            <h5>Alluxio Master Journal Disk Status</h5>
-            <Table hover={true}>
-              <tbody>
-                <tr>
-                  <th>Device Path</th>
-                  <th>Allocated Bytes</th>
-                  <th>Used Bytes</th>
-                  <th>Available Bytes</th>
-                  <th>Percent Available</th>
-                  <th>Mount Path</th>
-                </tr>
-                {data.journalDiskMetrics.map((info: IJournalDiskInfo, idx: number) => {
-                  return (
-                    <tr key={idx}>
-                      <td>{info.diskPath}</td>
-                      <td>{info.totalAllocatedBytes}</td>
-                      <td>{info.usedBytes}</td>
-                      <td>{info.availableBytes}</td>
-                      <td>{info.percentAvailable.toFixed(2)}%</td>
-                      <td>{info.mountPath}</td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </Table>
-          </div>
-        ))}
+        <div className="col-12">
+          <h5>Alluxio Master Journal Disk Status</h5>
+          <Table hover={true}>
+            <tbody>
+              <tr>
+                <th>Device Path</th>
+                <th>Allocated Bytes</th>
+                <th>Used Bytes</th>
+                <th>Available Bytes</th>
+                <th>Percent Available</th>
+                <th>Mount Path</th>
+              </tr>
+              {data.journalDiskMetrics.map((info: IJournalDiskInfo, idx: number) => {
+                return (
+                  <tr key={idx}>
+                    <td>{info.diskPath}</td>
+                    <td>{info.totalAllocatedBytes}</td>
+                    <td>{info.usedBytes}</td>
+                    <td>{info.availableBytes}</td>
+                    <td>{info.percentAvailable.toFixed(2)}%</td>
+                    <td>{info.mountPath}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </Table>
+        </div>
       </React.Fragment>
     );
   }

--- a/webui/master/src/containers/pages/Metrics/__snapshots__/Metrics.test.tsx.snap
+++ b/webui/master/src/containers/pages/Metrics/__snapshots__/Metrics.test.tsx.snap
@@ -329,5 +329,40 @@ exports[`Metrics Shallow component Matches snapshot 1`] = `
       </tbody>
     </Table>
   </div>
+  <div
+    className="col-12"
+  >
+    <h5>
+      Alluxio Master Journal Disk Status
+    </h5>
+    <Table
+      hover={true}
+      responsiveTag="div"
+      tag="table"
+    >
+      <tbody>
+        <tr>
+          <th>
+            Device Path
+          </th>
+          <th>
+            Allocated Bytes
+          </th>
+          <th>
+            Used Bytes
+          </th>
+          <th>
+            Available Bytes
+          </th>
+          <th>
+            Percent Available
+          </th>
+          <th>
+            Mount Path
+          </th>
+        </tr>
+      </tbody>
+    </Table>
+  </div>
 </Fragment>
 `;

--- a/webui/master/src/containers/pages/Overview/Overview.tsx
+++ b/webui/master/src/containers/pages/Overview/Overview.tsx
@@ -141,18 +141,20 @@ export class OverviewPresenter extends React.Component<AllProps> {
 
     const warningRender = warnings.map((warning: string, idx: number) => (
       <tr key={idx}>
-        <td colSpan={2} className={className}>{warning}</td>
+        <td colSpan={2} className={className}>
+          {warning}
+        </td>
       </tr>
     ));
     const header = (
-      <tr key="-1" >
-          <th colSpan={2} scope="row" className={className}>
-            Journal Disk Warning{warnings.length > 1 ? "s" : ""}
-          </th>
+      <tr key="-1">
+        <th colSpan={2} scope="row" className={className}>
+          Journal Disk Warning{warnings.length > 1 ? 's' : ''}
+        </th>
       </tr>
     );
-    warningRender.unshift(header)
-    
+    warningRender.unshift(header);
+
     return <React.Fragment>{warningRender}</React.Fragment>;
   }
 

--- a/webui/master/src/containers/pages/Overview/Overview.tsx
+++ b/webui/master/src/containers/pages/Overview/Overview.tsx
@@ -140,17 +140,15 @@ export class OverviewPresenter extends React.Component<AllProps> {
     }
 
     const warningRender = warnings.map((warning: string, idx: number) => (
-    <tr key={idx}>
-      <th scope="row" className={className}>
-        Journal Disk Warning
-      </th>
-      <td className={className}>{warning}</td>
+      <tr key={idx}>
+        <th scope="row" className={className}>
+          Journal Disk Warning
+        </th>
+        <td className={className}>{warning}</td>
       </tr>
-    ))
+    ));
 
-    return <React.Fragment>
-      {warningRender}
-    </React.Fragment> 
+    return <React.Fragment>{warningRender}</React.Fragment>;
   }
 
   private renderConfigurationIssues(issues: IScopedPropertyInfo[], className: string): JSX.Element | null {

--- a/webui/master/src/containers/pages/Overview/Overview.tsx
+++ b/webui/master/src/containers/pages/Overview/Overview.tsx
@@ -67,6 +67,7 @@ export class OverviewPresenter extends React.Component<AllProps> {
               </tr>
               {this.renderConfigurationIssues(data.configCheckErrors, 'text-error')}
               {this.renderConfigurationIssues(data.configCheckWarns, 'text-warning')}
+              {this.renderJournalDiskWarnings(data.journalDiskWarnings, 'text-warning')}
             </tbody>
           </Table>
         </div>
@@ -131,6 +132,25 @@ export class OverviewPresenter extends React.Component<AllProps> {
         </div>
       </React.Fragment>
     );
+  }
+
+  private renderJournalDiskWarnings(warnings: string[], className: string): JSX.Element | null {
+    if (!warnings || !warnings.length) {
+      return null;
+    }
+
+    const warningRender = warnings.map((warning: string, idx: number) => (
+    <tr key={idx}>
+      <th scope="row" className={className}>
+        Journal Disk Warning
+      </th>
+      <td className={className}>{warning}</td>
+      </tr>
+    ))
+
+    return <React.Fragment>
+      {warningRender}
+    </React.Fragment> 
   }
 
   private renderConfigurationIssues(issues: IScopedPropertyInfo[], className: string): JSX.Element | null {

--- a/webui/master/src/containers/pages/Overview/Overview.tsx
+++ b/webui/master/src/containers/pages/Overview/Overview.tsx
@@ -141,13 +141,18 @@ export class OverviewPresenter extends React.Component<AllProps> {
 
     const warningRender = warnings.map((warning: string, idx: number) => (
       <tr key={idx}>
-        <th scope="row" className={className}>
-          Journal Disk Warning
-        </th>
-        <td className={className}>{warning}</td>
+        <td colSpan={2} className={className}>{warning}</td>
       </tr>
     ));
-
+    const header = (
+      <tr key="-1" >
+          <th colSpan={2} scope="row" className={className}>
+            Journal Disk Warning{warnings.length > 1 ? "s" : ""}
+          </th>
+      </tr>
+    );
+    warningRender.unshift(header)
+    
     return <React.Fragment>{warningRender}</React.Fragment>;
   }
 

--- a/webui/master/src/store/metrics/reducer.tsx
+++ b/webui/master/src/store/metrics/reducer.tsx
@@ -27,6 +27,7 @@ export const initialMetricsState: IMetricsState = {
     operationMetrics: {},
     rpcInvocationMetrics: {},
     timeSeriesMetrics: [],
+    journalDiskMetrics: [],
     totalBytesReadLocal: '',
     totalBytesReadLocalThroughput: '',
     totalBytesReadDomainSocket: '',

--- a/webui/master/src/store/metrics/types.tsx
+++ b/webui/master/src/store/metrics/types.tsx
@@ -13,6 +13,7 @@ import { LineSerieData } from '@nivo/line';
 import { AxiosResponse } from 'axios';
 
 import { ICounter } from '@alluxio/common-ui/src/constants';
+import { IJournalDiskInfo } from '../../constants/types/IJournalDiskInfo';
 
 export interface IMetrics {
   cacheHitLocal: string;
@@ -26,6 +27,7 @@ export interface IMetrics {
     [key: string]: ICounter;
   };
   timeSeriesMetrics: LineSerieData[];
+  journalDiskMetrics: IJournalDiskInfo[];
   totalBytesReadLocal: string;
   totalBytesReadLocalThroughput: string;
   totalBytesReadDomainSocket: string;

--- a/webui/master/src/store/overview/reducer.tsx
+++ b/webui/master/src/store/overview/reducer.tsx
@@ -24,6 +24,7 @@ export const initialOverviewState: IOverviewState = {
     diskFreeCapacity: '',
     diskUsedCapacity: '',
     freeCapacity: '',
+    journalDiskWarnings: [],
     liveWorkerNodes: 0,
     masterNodeAddress: '',
     startTime: '',

--- a/webui/master/src/store/overview/types.tsx
+++ b/webui/master/src/store/overview/types.tsx
@@ -23,6 +23,7 @@ export interface IOverview {
   diskFreeCapacity: string;
   diskUsedCapacity: string;
   freeCapacity: string;
+  journalDiskWarnings: string[];
   liveWorkerNodes: number;
   masterNodeAddress: string;
   startTime: string;


### PR DESCRIPTION
 This new monitor tracks utilization of disks when Alluxio is
 is configured to use the embedded journal. The monitor logs messages
 when available disk space falls below a configurable percentage. The
 disk utilization metrics are exposed in the logs when the threshold is
 reached, but can also now be found as metrics as well as in the Alluxio
 master's web interface.

 Implementation details:
 The monitor is implemented as a heartbeat thread in the
 DefaultMetaMaster. It gets disk utilization by using the `df` command
 that is by default included with nearly all linux distributions, including
 within bare containers such as alpine, ubuntu, and centos. The command
 and arguments used are all POSIX-compatible, so this should be portable
 but for now is limited to Linux.

 For metrics, the actual disk values are not retrieved on every call to
 the metrics endpoint but rather they are only updated on the configured
 heartbeat interval.