### PR TITLE
Fix StackFS mount options in alluxio-fuse script

### DIFF
--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -50,7 +50,8 @@ mount_fuse() {
     -m ${mount_point} \
     -r ${alluxio_root}"
   if [[ ${STACK_FS} -eq "1" ]]; then
-    stackfs_mount_option=`echo "${full_mount_option}" | sed -E 's/([^,]+)/-o\1/g'`
+    stackfs_mount_option=`echo "${full_mount_option}" | sed -E 's/([^,]+)/-o\1/g' | sed -E 's/,/ /g'`
+
     cmd="${JAVA} -cp ${CLASSPATH} ${JAVA_OPTS} ${ALLUXIO_FUSE_JAVA_OPTS} \
     alluxio.fuse.StackMain \
     ${mount_point} \


### PR DESCRIPTION
StackMain required fuse mount options to be passed in "-obig_writes -okernel_cache" format.
Modify the alluxio-fuse script to match the requirement
