### PR TITLE
[DOCFIX] Add Hive file storage format as textfile

### DIFF
--- a/docs/cn/compute/Hive.md
+++ b/docs/cn/compute/Hive.md
@@ -58,6 +58,7 @@ occupation STRING,
 zipcode STRING)
 ROW FORMAT DELIMITED
 FIELDS TERMINATED BY '|'
+STORED AS TEXTFILE
 LOCATION 'alluxio://master_hostname:port/ml-100k';
 ```
 


### PR DESCRIPTION
When I followed the steps in the documentation to create the U_USER table, I found that I cannot read the U_USER table in Hive. But, I could see the table when I set the format of the U_USER table to textfile.