### PR TITLE
Improve distributedLoad

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -129,11 +129,7 @@ public final class AlluxioBlockStore {
   public BlockInStream getInStream(long blockId, InStreamOptions options,
       Map<WorkerNetAddress, Long> failedWorkers) throws IOException {
     // Get the latest block info from master
-    BlockInfo info;
-    try (CloseableResource<BlockMasterClient> masterClientResource =
-             mContext.acquireBlockMasterClientResource()) {
-      info = masterClientResource.get().getBlockInfo(blockId);
-    }
+    BlockInfo info = getInfo(blockId);
     return getInStream(info, options, failedWorkers);
   }
 

--- a/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
@@ -152,7 +152,7 @@ public final class LoadDefinition
 
     for (LoadTask task : tasks) {
       JobUtils.loadBlock(status, context.getFsContext(), task.getBlockId());
-      LOG.info("Loaded block " + task.getBlockId());
+      LOG.info("Loaded file " + config.getFilePath() + " block " + task.getBlockId());
     }
     return null;
   }

--- a/job/server/src/main/java/alluxio/job/util/JobUtils.java
+++ b/job/server/src/main/java/alluxio/job/util/JobUtils.java
@@ -11,11 +11,13 @@
 
 package alluxio.job.util;
 
+import alluxio.Constants;
 import alluxio.client.Cancelable;
 import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.BlockLocationPolicy;
 import alluxio.client.block.policy.LocalFirstPolicy;
+import alluxio.client.block.stream.BlockInStream;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.InStreamOptions;
@@ -51,6 +53,8 @@ import java.util.concurrent.ConcurrentMap;
  * Utility class to make it easier to write jobs.
  */
 public final class JobUtils {
+  // a read buffer that should be ignored
+  private static byte[] sIgnoredReadBuf = new byte[8 * Constants.MB];
   private static final IndexDefinition<BlockWorkerInfo, WorkerNetAddress> WORKER_ADDRESS_INDEX =
       new IndexDefinition<BlockWorkerInfo, WorkerNetAddress>(true) {
         @Override
@@ -106,13 +110,10 @@ public final class JobUtils {
   public static void loadBlock(URIStatus status, FileSystemContext context, long blockId)
       throws AlluxioException, IOException {
     AlluxioBlockStore blockStore = AlluxioBlockStore.create(context);
-
-    String localHostName = NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC,
-        ServerConfiguration.global());
-    List<BlockWorkerInfo> workerInfoList = context.getCachedWorkers();
+    AlluxioConfiguration conf = ServerConfiguration.global();
+    String localHostName = NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC, conf);
     WorkerNetAddress localNetAddress = null;
-
-    for (BlockWorkerInfo workerInfo : workerInfoList) {
+    for (BlockWorkerInfo workerInfo : context.getCachedWorkers()) {
       if (workerInfo.getNetAddress().getHost().equals(localHostName)) {
         localNetAddress = workerInfo.getNetAddress();
         break;
@@ -128,13 +129,32 @@ public final class JobUtils {
       throw new AlluxioException(
           ExceptionMessage.PINNED_TO_MULTIPLE_MEDIUMTYPES.getMessage(status.getPath()));
     }
+
+    if (pinnedLocation.isEmpty()) {
+      OpenFilePOptions openOptions =
+          OpenFilePOptions.newBuilder().setReadType(ReadPType.CACHE_PROMOTE).build();
+      InStreamOptions inOptions = new InStreamOptions(status, openOptions, conf);
+      BlockInfo info = status.getBlockInfo(blockId);
+      if (info == null) {
+        // we shall not reach here
+        throw new AlluxioException("Invalid block Id " + blockId + ", status " + status);
+      }
+      try (InputStream inputStream = BlockInStream.create(context, info, localNetAddress,
+          BlockInStream.BlockInStreamSource.UFS, inOptions)) {
+        while (inputStream.read(sIgnoredReadBuf) != -1) {
+        }
+      } catch (Throwable t) {
+        throw t;
+      }
+      return;
+    }
+    // TODO(bin): remove the following case when we consolidate tier and medium
     // since there is only one element in the set, we take the first element in the set
-    String medium = pinnedLocation.isEmpty() ? "" : pinnedLocation.iterator().next();
+    String medium = pinnedLocation.iterator().next();
 
     OpenFilePOptions openOptions =
         OpenFilePOptions.newBuilder().setReadType(ReadPType.NO_CACHE).build();
 
-    AlluxioConfiguration conf = ServerConfiguration.global();
     InStreamOptions inOptions = new InStreamOptions(status, openOptions, conf);
     // Set read location policy always to local first for loading blocks for job tasks
     inOptions.setUfsReadLocationPolicy(BlockLocationPolicy.Factory.create(

--- a/job/server/src/main/java/alluxio/job/util/JobUtils.java
+++ b/job/server/src/main/java/alluxio/job/util/JobUtils.java
@@ -134,11 +134,7 @@ public final class JobUtils {
       OpenFilePOptions openOptions =
           OpenFilePOptions.newBuilder().setReadType(ReadPType.CACHE_PROMOTE).build();
       InStreamOptions inOptions = new InStreamOptions(status, openOptions, conf);
-      BlockInfo info = status.getBlockInfo(blockId);
-      if (info == null) {
-        // we shall not reach here
-        throw new AlluxioException("Invalid block Id " + blockId + ", status " + status);
-      }
+      BlockInfo info = Preconditions.checkNotNull(status.getBlockInfo(blockId));
       try (InputStream inputStream = BlockInStream.create(context, info, localNetAddress,
           BlockInStream.BlockInStreamSource.UFS, inOptions)) {
         while (inputStream.read(sIgnoredReadBuf) != -1) {

--- a/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
+++ b/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
@@ -255,7 +255,8 @@ public final class PlanCoordinator {
           if (mPlanInfo.getErrorMessage().isEmpty()) {
             mPlanInfo.setErrorType(info.getErrorType());
             mPlanInfo.setErrorMessage("Task execution failed: " + info.getErrorMessage());
-            LOG.info("Job failed Id={} Error={}", mPlanInfo.getId(), info.getErrorMessage());
+            LOG.info("Job failed Id={} Config={} Error={}", mPlanInfo.getId(),
+                mPlanInfo.getJobConfig(), info.getErrorMessage());
           }
           // setStatus after setting the message to propagate error message up
           // through statusChangeCallback
@@ -264,7 +265,8 @@ public final class PlanCoordinator {
         case CANCELED:
           if (mPlanInfo.getStatus() != Status.FAILED) {
             if (mPlanInfo.getStatus() != Status.CANCELED) {
-              LOG.info("Job cancelled Id={}", mPlanInfo.getId());
+              LOG.info("Job cancelled Id={} Config={}",
+                  mPlanInfo.getId(), mPlanInfo.getJobConfig());
             }
             mPlanInfo.setStatus(Status.CANCELED);
           }
@@ -275,6 +277,7 @@ public final class PlanCoordinator {
           }
           break;
         case COMPLETED:
+          LOG.info("Job completed Id={} Config={}", mPlanInfo.getId(), mPlanInfo.getJobConfig());
           completed++;
           break;
         case CREATED:

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -154,6 +154,7 @@ public final class ReplicateDefinitionTest {
     String path = "/test";
     URIStatus status = new URIStatus(
         new FileInfo().setPath(path).setBlockIds(Lists.newArrayList(TEST_BLOCK_ID))
+            .setMediumTypes(Sets.newHashSet("MEM"))
             .setFileBlockInfos(Lists.newArrayList(
                 new FileBlockInfo().setBlockInfo(
                     new BlockInfo().setBlockId(TEST_BLOCK_ID).setLength(TEST_BLOCK_SIZE)))));

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -11,8 +11,8 @@
 
 package alluxio.job.plan.replicate;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -70,7 +70,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -78,7 +77,8 @@ import java.util.Set;
  * Tests {@link ReplicateConfig}.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({AlluxioBlockStore.class, FileSystemContext.class, JobServerContext.class})
+@PrepareForTest({AlluxioBlockStore.class, FileSystemContext.class, JobServerContext.class,
+    BlockInStream.class})
 public final class ReplicateDefinitionTest {
   private static final long TEST_BLOCK_ID = 1L;
   private static final long TEST_BLOCK_SIZE = 512L;
@@ -96,18 +96,22 @@ public final class ReplicateDefinitionTest {
   private static final WorkerInfo WORKER_INFO_1 = new WorkerInfo().setAddress(ADDRESS_1);
   private static final WorkerInfo WORKER_INFO_2 = new WorkerInfo().setAddress(ADDRESS_2);
   private static final WorkerInfo WORKER_INFO_3 = new WorkerInfo().setAddress(ADDRESS_3);
+  private static String TEST_PATH = "/test";
 
   private FileSystemContext mMockFileSystemContext;
   private AlluxioBlockStore mMockBlockStore;
   private FileSystem mMockFileSystem;
   private JobServerContext mMockJobServerContext;
   private UfsManager mMockUfsManager;
+  private BlockInStream mBlockInStream;
+  private BlockInfo mTestBlockInfo;
+  private URIStatus mTestStatus;
 
   @Rule
   public final ExpectedException mThrown = ExpectedException.none();
 
   @Before
-  public void before() {
+  public void before() throws Exception {
     mMockFileSystemContext = PowerMockito.mock(FileSystemContext.class);
     when(mMockFileSystemContext.getClientContext())
         .thenReturn(ClientContext.create(ServerConfiguration.global()));
@@ -116,27 +120,27 @@ public final class ReplicateDefinitionTest {
     mMockUfsManager = mock(UfsManager.class);
     mMockJobServerContext =
         new JobServerContext(mMockFileSystem, mMockFileSystemContext, mMockUfsManager);
+    PowerMockito.mockStatic(AlluxioBlockStore.class);
+    when(AlluxioBlockStore.create(mMockFileSystemContext)).thenReturn(mMockBlockStore);
+    mTestBlockInfo = new BlockInfo().setBlockId(TEST_BLOCK_ID).setLength(TEST_BLOCK_SIZE);
+    when(mMockBlockStore.getInfo(TEST_BLOCK_ID)).thenReturn(mTestBlockInfo);
+    mTestStatus = new URIStatus(
+        new FileInfo().setPath(TEST_PATH).setBlockIds(Lists.newArrayList(TEST_BLOCK_ID))
+            .setFileBlockInfos(Lists.newArrayList(
+                new FileBlockInfo().setBlockInfo(mTestBlockInfo))));
   }
 
   /**
    * Helper function to select executors.
    *
-   * @param blockLocations where the block is store currently
    * @param numReplicas how many replicas to replicate or evict
    * @param workerInfoList a list of current available job workers
    * @return the selection result
    */
   private Set<Pair<WorkerInfo, SerializableVoid>> selectExecutorsTestHelper(
-      List<BlockLocation> blockLocations, int numReplicas, List<WorkerInfo> workerInfoList)
+      int numReplicas, List<WorkerInfo> workerInfoList)
       throws Exception {
-    BlockInfo blockInfo = new BlockInfo().setBlockId(TEST_BLOCK_ID);
-    blockInfo.setLocations(blockLocations);
-    when(mMockBlockStore.getInfo(TEST_BLOCK_ID)).thenReturn(blockInfo);
-    PowerMockito.mockStatic(AlluxioBlockStore.class);
-    when(AlluxioBlockStore.create(mMockFileSystemContext)).thenReturn(mMockBlockStore);
-
-    String path = "/test";
-    ReplicateConfig config = new ReplicateConfig(path, TEST_BLOCK_ID, numReplicas);
+    ReplicateConfig config = new ReplicateConfig(TEST_PATH, TEST_BLOCK_ID, numReplicas);
     ReplicateDefinition definition = new ReplicateDefinition();
     return definition.selectExecutors(config, workerInfoList,
         new SelectExecutorsContext(1, mMockJobServerContext));
@@ -151,36 +155,33 @@ public final class ReplicateDefinitionTest {
    */
   private void runTaskReplicateTestHelper(List<BlockWorkerInfo> blockWorkers,
       BlockInStream mockInStream, BlockOutStream mockOutStream) throws Exception {
-    String path = "/test";
-    URIStatus status = new URIStatus(
-        new FileInfo().setPath(path).setBlockIds(Lists.newArrayList(TEST_BLOCK_ID))
-            .setMediumTypes(Sets.newHashSet("MEM"))
-            .setFileBlockInfos(Lists.newArrayList(
-                new FileBlockInfo().setBlockInfo(
-                    new BlockInfo().setBlockId(TEST_BLOCK_ID).setLength(TEST_BLOCK_SIZE)))));
-    when(mMockFileSystem.getStatus(any(AlluxioURI.class))).thenReturn(status);
-
+    when(mMockFileSystem.getStatus(any(AlluxioURI.class))).thenReturn(mTestStatus);
     when(mMockFileSystemContext.getCachedWorkers()).thenReturn(blockWorkers);
     when(mMockBlockStore.getInStream(anyLong(),
             any(InStreamOptions.class))).thenReturn(mockInStream);
+    PowerMockito.mockStatic(BlockInStream.class);
+    when(BlockInStream.create(any(FileSystemContext.class), any(BlockInfo.class),
+        any(WorkerNetAddress.class), any(BlockInStreamSource.class), any(InStreamOptions.class)))
+        .thenReturn(mockInStream);
     when(
         mMockBlockStore.getOutStream(eq(TEST_BLOCK_ID), eq(TEST_BLOCK_SIZE), eq(LOCAL_ADDRESS),
             any(OutStreamOptions.class))).thenReturn(mockOutStream);
     when(mMockBlockStore.getInfo(TEST_BLOCK_ID))
-        .thenReturn(new BlockInfo().setBlockId(TEST_BLOCK_ID)
+        .thenReturn(mTestBlockInfo
             .setLocations(Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1))));
     PowerMockito.mockStatic(AlluxioBlockStore.class);
     when(AlluxioBlockStore.create(mMockFileSystemContext)).thenReturn(mMockBlockStore);
 
-    ReplicateConfig config = new ReplicateConfig(path, TEST_BLOCK_ID, 1 /* value not used */);
+    ReplicateConfig config = new ReplicateConfig(TEST_PATH, TEST_BLOCK_ID, 1 /* value not used */);
     ReplicateDefinition definition = new ReplicateDefinition();
     definition.runTask(config, null, new RunTaskContext(1, 1, mMockJobServerContext));
   }
 
   @Test
   public void selectExecutorsOnlyOneWorkerAvailable() throws Exception {
+    mTestBlockInfo.setLocations(Lists.newArrayList());
     Set<Pair<WorkerInfo, SerializableVoid>> result =
-        selectExecutorsTestHelper(Lists.<BlockLocation>newArrayList(), 1,
+        selectExecutorsTestHelper(1,
             Lists.newArrayList(WORKER_INFO_1));
     Set<Pair<WorkerInfo, SerializableVoid>> expected = Sets.newHashSet();
     expected.add(new Pair<>(WORKER_INFO_1, null));
@@ -190,8 +191,10 @@ public final class ReplicateDefinitionTest {
 
   @Test
   public void selectExecutorsOnlyOneWorkerValid() throws Exception {
+    mTestBlockInfo.setLocations(
+        Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)));
     Set<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
-        Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 1,
+        1,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2));
     Set<Pair<WorkerInfo, SerializableVoid>> expected = Sets.newHashSet();
     expected.add(new Pair<>(WORKER_INFO_2, null));
@@ -201,8 +204,10 @@ public final class ReplicateDefinitionTest {
 
   @Test
   public void selectExecutorsTwoWorkersValid() throws Exception {
+    mTestBlockInfo.setLocations(
+        Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)));
     Set<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
-        Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 2,
+        2,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2, WORKER_INFO_3));
     Set<Pair<WorkerInfo, SerializableVoid>> expected = Sets.newHashSet();
     expected.add(new Pair<>(WORKER_INFO_2, null));
@@ -213,8 +218,10 @@ public final class ReplicateDefinitionTest {
 
   @Test
   public void selectExecutorsOneOutOFTwoWorkersValid() throws Exception {
+    mTestBlockInfo.setLocations(
+        Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)));
     Set<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
-        Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 1,
+        1,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2, WORKER_INFO_3));
     // select one worker out of two
     assertEquals(1, result.size());
@@ -223,8 +230,10 @@ public final class ReplicateDefinitionTest {
 
   @Test
   public void selectExecutorsNoWorkerValid() throws Exception {
+    mTestBlockInfo.setLocations(
+        Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)));
     Set<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
-        Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 1,
+        1,
         Lists.newArrayList(WORKER_INFO_1));
     Set<Pair<WorkerInfo, SerializableVoid>> expected = ImmutableSet.of();
     // select none as no choice left
@@ -233,8 +242,10 @@ public final class ReplicateDefinitionTest {
 
   @Test
   public void selectExecutorsInsufficientWorkerValid() throws Exception {
+    mTestBlockInfo.setLocations(
+        Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)));
     Set<Pair<WorkerInfo, SerializableVoid>> result = selectExecutorsTestHelper(
-        Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1)), 2,
+        2,
         Lists.newArrayList(WORKER_INFO_1, WORKER_INFO_2));
     Set<Pair<WorkerInfo, SerializableVoid>> expected = Sets.newHashSet();
     expected.add(new Pair<>(WORKER_INFO_2, null));
@@ -258,9 +269,10 @@ public final class ReplicateDefinitionTest {
   }
 
   @Test
-  public void runTaskLocalBlockWorker() throws Exception {
+  public void runTaskLocalBlockWorkerPinnedMedium() throws Exception {
+    // file is pinned on a medium
+    mTestStatus.getFileInfo().setMediumTypes(Sets.newHashSet("MEM"));
     byte[] input = BufferUtils.getIncreasingByteArray(0, (int) TEST_BLOCK_SIZE);
-
     TestBlockInStream mockInStream =
         new TestBlockInStream(input, TEST_BLOCK_ID, input.length, false,
             BlockInStreamSource.NODE_LOCAL);
@@ -268,11 +280,27 @@ public final class ReplicateDefinitionTest {
         new TestBlockOutStream(ByteBuffer.allocate(MAX_BYTES), TEST_BLOCK_SIZE);
     BlockWorkerInfo localBlockWorker = new BlockWorkerInfo(LOCAL_ADDRESS, TEST_BLOCK_SIZE, 0);
     runTaskReplicateTestHelper(Lists.newArrayList(localBlockWorker), mockInStream, mockOutStream);
-    assertTrue(Arrays.equals(input, mockOutStream.getWrittenData()));
+    assertArrayEquals(input, mockOutStream.getWrittenData());
+  }
+
+  @Test
+  public void runTaskLocalBlockWorker() throws Exception {
+    byte[] input = BufferUtils.getIncreasingByteArray(0, (int) TEST_BLOCK_SIZE);
+
+    TestBlockInStream mockInStream =
+        new TestBlockInStream(input, TEST_BLOCK_ID, input.length, false,
+            BlockInStreamSource.NODE_LOCAL);
+    BlockOutStream unusedBlockOutStream = mock(BlockOutStream.class);
+    BlockWorkerInfo localBlockWorker = new BlockWorkerInfo(LOCAL_ADDRESS, TEST_BLOCK_SIZE, 0);
+    runTaskReplicateTestHelper(
+        Lists.newArrayList(localBlockWorker), mockInStream, unusedBlockOutStream);
+    assertEquals(TEST_BLOCK_SIZE, mockInStream.getBytesRead());
   }
 
   @Test
   public void runTaskInputIOException() throws Exception {
+    // file is pinned on a medium
+    mTestStatus.getFileInfo().setMediumTypes(Sets.newHashSet("MEM"));
     BlockInStream mockInStream = mock(BlockInStream.class);
     BlockOutStream mockOutStream = mock(BlockOutStream.class);
 

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -96,7 +96,7 @@ public final class ReplicateDefinitionTest {
   private static final WorkerInfo WORKER_INFO_1 = new WorkerInfo().setAddress(ADDRESS_1);
   private static final WorkerInfo WORKER_INFO_2 = new WorkerInfo().setAddress(ADDRESS_2);
   private static final WorkerInfo WORKER_INFO_3 = new WorkerInfo().setAddress(ADDRESS_3);
-  private static String TEST_PATH = "/test";
+  private static final String TEST_PATH = "/test";
 
   private FileSystemContext mMockFileSystemContext;
   private AlluxioBlockStore mMockBlockStore;


### PR DESCRIPTION
Improve efficiency of `distributedLoad` in two fold:
1. calling `BlockInStream.create` to obtain the InputStream without RPC, where the original  `blockStore.getOutStream(blockId,...)`  makes one RPC to master to get blockInfo.
2. removing using `BlockOutStream` and only reads the block data to alluxio job worker without writing it back to the block store on worker. This will further save at least two RPCs and the overhead to transfer data back to worker.

Note that, the original code is not removed to handle the case Pinned Media, because currently reading a block does not support promoting this block to a medium but only a tier. After discussed with @calvinjia , we will leave this once we consolidate medium and tier on worker