### PR TITLE
Fix Fuse write then read problem in async release and support umount

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4611,6 +4611,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey FUSE_UMOUNT_WAITTIME =
+      new Builder(Name.FUSE_UMOUNT_WAITTIME)
+          .setDefaultValue("1min")
+          .setDescription("The maximum wait time to wait for all file in stream and out stream "
+              + "closed in Fuse umount() operation.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey FUSE_USER_GROUP_TRANSLATION_ENABLED =
       new Builder(Name.FUSE_USER_GROUP_TRANSLATION_ENABLED)
           .setDefaultValue(false)
@@ -5925,6 +5933,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         = "alluxio.fuse.shared.caching.reader.enabled";
     public static final String FUSE_LOGGING_THRESHOLD = "alluxio.fuse.logging.threshold";
     public static final String FUSE_MAXWRITE_BYTES = "alluxio.fuse.maxwrite.bytes";
+    public static final String FUSE_UMOUNT_WAITTIME =
+        "alluxio.fuse.umount.waittime";
     public static final String FUSE_USER_GROUP_TRANSLATION_ENABLED =
         "alluxio.fuse.user.group.translation.enabled";
 

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4611,11 +4611,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)
           .build();
-  public static final PropertyKey FUSE_UMOUNT_WAITTIME =
-      new Builder(Name.FUSE_UMOUNT_WAITTIME)
+  public static final PropertyKey FUSE_UMOUNT_TIMEOUT =
+      new Builder(Name.FUSE_UMOUNT_TIMEOUT)
           .setDefaultValue("1min")
-          .setDescription("The maximum wait time to wait for all file in stream and out stream "
-              + "closed in Fuse umount() operation.")
+          .setDescription("The timeout to wait for all in progress file read and write to finish "
+              + "before unmounting the Fuse filesystem. After the timeout, "
+              + "all in progress file read will be forced to stop "
+              + "and all in progress file write will be abandoned.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)
           .build();
@@ -5933,8 +5935,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         = "alluxio.fuse.shared.caching.reader.enabled";
     public static final String FUSE_LOGGING_THRESHOLD = "alluxio.fuse.logging.threshold";
     public static final String FUSE_MAXWRITE_BYTES = "alluxio.fuse.maxwrite.bytes";
-    public static final String FUSE_UMOUNT_WAITTIME =
-        "alluxio.fuse.umount.waittime";
+    public static final String FUSE_UMOUNT_TIMEOUT =
+        "alluxio.fuse.umount.timeout";
     public static final String FUSE_USER_GROUP_TRANSLATION_ENABLED =
         "alluxio.fuse.user.group.translation.enabled";
 

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -502,7 +502,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
             is.close();
           }
         } finally {
-          mReleasingWriteEntries.remove(fd);
+          mReleasingReadEntries.remove(fd);
         }
       }
     } catch (Throwable e) {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -691,10 +691,8 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
 
   @Override
   public void umount() {
-    // Try our best effort to close all the in/out streams
-
-    // Release operation is async, we need to make sure
-    // all in/out streams are closed before umount the fuse
+    // Release operation is async, we will try our best efforts to
+    // close all opened file in/out stream before umounting the fuse
     if (!mCreateFileEntries.isEmpty() || !mOpenFileEntries.isEmpty()) {
       LOG.info("Waiting for all file out stream closed");
       try {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -484,13 +484,13 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
         // Remove earlier to try best effort to avoid write() - async release() - getAttr()
         // without waiting for file completed and return 0 bytes file size error
         mCreateFileEntries.remove(ce);
-        mReleasingWriteEntries.put(ce.getId(), ce);
+        mReleasingWriteEntries.put(fd, ce);
         try {
           synchronized (ce) {
             ce.close();
           }
         } finally {
-          mReleasingWriteEntries.remove(ce);
+          mReleasingWriteEntries.remove(fd);
         }
       }
       if (is != null) {


### PR DESCRIPTION
Previous commit https://github.com/Alluxio/alluxio/commit/8f618358891ca89f753b369316d58221e8fb9b74
enlarges the race condition window in a access pattern of `write()` - `release()` (async unfortunately) - `getAttr()`.

In `getAttr()`, a special logic is added to wait for the writing file to completed before getting file size information.
`getAttr()` can happen in any cases. When it's in `write()` - `getAttr()` - `write()` process, we don't want it to block waiting file completed. When it's written by other threads or it's in `write()` - `release()` - `getAttr()`, we do want it to block waiting file completed.

This PR introducing new concurrent hash maps for the releasing entries to fulfill the `getAttr()` logics and `umount` logics().