### PR TITLE
Fix regression in AbsentUfsPathCache

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -12,6 +12,7 @@
 package alluxio.master.file;
 
 import alluxio.AlluxioURI;
+import alluxio.Constants;
 import alluxio.client.WriteType;
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
@@ -48,6 +49,7 @@ import alluxio.master.file.meta.LockedInodePath;
 import alluxio.master.file.meta.LockingScheme;
 import alluxio.master.file.meta.MountTable;
 import alluxio.master.file.meta.MutableInodeFile;
+import alluxio.master.file.meta.UfsAbsentPathCache;
 import alluxio.master.file.meta.UfsSyncPathCache;
 import alluxio.master.file.meta.UfsSyncUtils;
 import alluxio.master.journal.MergeJournalContext;
@@ -119,6 +121,15 @@ import javax.annotation.Nullable;
  *
  */
 public class InodeSyncStream {
+  /**
+   * Return status of a sync result.
+   */
+  public enum SyncStatus {
+    OK,
+    FAILED,
+    NOT_NEEDED
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(InodeSyncStream.class);
 
   private static final FileSystemMasterCommonPOptions NO_TTL_OPTION =
@@ -209,17 +220,18 @@ public class InodeSyncStream {
    * @param isGetFileInfo whether the caller is {@link FileSystemMaster#getFileInfo}
    * @param forceSync whether to sync inode metadata no matter what
    * @param loadOnly whether to only load new metadata, rather than update existing metadata
+   * @param loadAlways whether to always load new metadata from the ufs, even if a file or
+   *                   directory has been previous found to not exist
    */
   public InodeSyncStream(LockingScheme rootPath, DefaultFileSystemMaster fsMaster,
       RpcContext rpcContext, DescendantType descendantType, FileSystemMasterCommonPOptions options,
       @Nullable FileSystemMasterAuditContext auditContext,
       @Nullable Function<LockedInodePath, Inode> auditContextSrcInodeFunc,
       @Nullable DefaultFileSystemMaster.PermissionCheckFunction permissionCheckOperation,
-      boolean isGetFileInfo, boolean forceSync, boolean loadOnly) {
+      boolean isGetFileInfo, boolean forceSync, boolean loadOnly, boolean loadAlways) {
     mPendingPaths = new ConcurrentLinkedQueue<>();
     mDescendantType = descendantType;
     mRpcContext = rpcContext;
-    mStatusCache = new UfsStatusCache(fsMaster.mSyncPrefetchExecutor);
     mMetadataSyncService = fsMaster.mSyncMetadataExecutor;
     mForceSync = forceSync;
     mRootScheme = rootPath;
@@ -236,6 +248,21 @@ public class InodeSyncStream {
     mAuditContext = auditContext;
     mAuditContextSrcInodeFunc = auditContextSrcInodeFunc;
     mPermissionCheckOperation = permissionCheckOperation;
+    // If an absent cache entry was more recent than this value, then it is valid for this sync
+    long validCacheTime;
+    if (loadOnly) {
+      if (loadAlways) {
+        validCacheTime = UfsAbsentPathCache.NEVER;
+      } else {
+        validCacheTime = UfsAbsentPathCache.ALWAYS;
+      }
+    } else {
+      long syncInterval = options.hasSyncIntervalMs() ? options.getSyncIntervalMs() :
+          ServerConfiguration.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL);
+      validCacheTime = System.currentTimeMillis() - syncInterval;
+    }
+    mStatusCache = new UfsStatusCache(fsMaster.mSyncPrefetchExecutor,
+        fsMaster.getAbsentPathCache(), validCacheTime);
   }
 
   /**
@@ -249,20 +276,22 @@ public class InodeSyncStream {
    * @param isGetFileInfo whether the caller is {@link FileSystemMaster#getFileInfo}
    * @param forceSync whether to sync inode metadata no matter what
    * @param loadOnly whether to only load new metadata, rather than update existing metadata
+   * @param loadAlways whether to always load new metadata from the ufs, even if a file or
+   *                   directory has been previous found to not exist
    */
   public InodeSyncStream(LockingScheme rootScheme, DefaultFileSystemMaster fsMaster,
       RpcContext rpcContext, DescendantType descendantType, FileSystemMasterCommonPOptions options,
-      boolean isGetFileInfo, boolean forceSync, boolean loadOnly) {
+      boolean isGetFileInfo, boolean forceSync, boolean loadOnly, boolean loadAlways) {
     this(rootScheme, fsMaster, rpcContext, descendantType, options, null, null, null,
-        isGetFileInfo, forceSync, loadOnly);
+        isGetFileInfo, forceSync, loadOnly, loadAlways);
   }
 
   /**
    * Sync the metadata according the the root path the stream was created with.
    *
-   * @return true if at least one path was synced
+   * @return SyncStatus object
    */
-  public boolean sync() throws AccessControlException, InvalidPathException {
+  public SyncStatus sync() throws AccessControlException, InvalidPathException {
     // The high-level process for the syncing is:
     // 1. Given an Alluxio path, determine if it is not consistent with the corresponding UFS path.
     //     this means the UFS path does not exist, or has metadata which differs from Alluxio
@@ -273,6 +302,9 @@ public class InodeSyncStream {
     int syncPathCount = 0;
     int failedSyncPathCount = 0;
     int stopNum = -1; // stop syncing when we've processed this many paths. -1 for infinite
+    if (!mRootScheme.shouldSync() && !mForceSync) {
+      return SyncStatus.NOT_NEEDED;
+    }
     long start = Long.MAX_VALUE;
     if (LOG.isDebugEnabled()) {
       start = System.currentTimeMillis();
@@ -310,6 +342,7 @@ public class InodeSyncStream {
         | IOException e) {
       LogUtils.warnWithException(LOG, "Failed to sync metadata on root path {}",
           toString(), e);
+      failedSyncPathCount++;
     } finally {
       // regardless of the outcome, remove the UfsStatus for this path from the cache
       mStatusCache.remove(mRootScheme.getPath());
@@ -403,7 +436,7 @@ public class InodeSyncStream {
     }
     mStatusCache.cancelAllPrefetch();
     mSyncPathJobs.forEach(f -> f.cancel(true));
-    return success;
+    return success ? SyncStatus.OK : SyncStatus.FAILED;
   }
 
   /**
@@ -500,18 +533,29 @@ public class InodeSyncStream {
       }
       persistingLock.get().close();
 
-      UfsStatus cachedStatus = mStatusCache.getStatus(inodePath.getUri());
+      UfsStatus cachedStatus = null;
+      boolean fileNotFound = false;
+      try {
+        cachedStatus = mStatusCache.getStatus(inodePath.getUri());
+      } catch (FileNotFoundException e) {
+        fileNotFound = true;
+      }
       MountTable.Resolution resolution = mMountTable.resolve(inodePath.getUri());
       AlluxioURI ufsUri = resolution.getUri();
       try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
         UnderFileSystem ufs = ufsResource.get();
         String ufsFingerprint;
         Fingerprint ufsFpParsed;
-        if (cachedStatus == null) {
+        // When the status is not cached and it was not due to file not found, we retry
+        if (fileNotFound) {
+          ufsFingerprint = Constants.INVALID_UFS_FINGERPRINT;
+          ufsFpParsed = Fingerprint.parse(ufsFingerprint);
+        } else if (cachedStatus == null) {
           // TODO(david): change the interface so that getFingerprint returns a parsed fingerprint
           ufsFingerprint = ufs.getFingerprint(ufsUri.toString());
           ufsFpParsed = Fingerprint.parse(ufsFingerprint);
         } else {
+          // When the status is cached
           Pair<AccessControlList, DefaultAccessControlList> aclPair =
               ufs.getAclPair(ufsUri.toString());
 
@@ -643,7 +687,6 @@ public class InodeSyncStream {
   private void loadMetadataForPath(LockedInodePath inodePath)
       throws InvalidPathException, AccessControlException, IOException, FileDoesNotExistException,
       FileAlreadyCompletedException, InvalidFileSizeException, BlockInfoException {
-
     UfsStatus status = mStatusCache.fetchStatusIfAbsent(inodePath.getUri(), mMountTable);
     LoadMetadataContext ctx = LoadMetadataContext.mergeFrom(
         LoadMetadataPOptions.newBuilder()

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -359,6 +359,7 @@ public final class MountTable implements DelegatingJournaled {
     try (LockResource r = new LockResource(mReadLock)) {
       String path = uri.getPath();
       LOG.debug("Resolving {}", path);
+      PathUtils.validatePath(uri.getPath());
       // This will re-acquire the read lock, but that is allowed.
       String mountPoint = getMountPoint(uri);
       if (mountPoint != null) {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/NoopUfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/NoopUfsAbsentPathCache.java
@@ -35,7 +35,12 @@ public final class NoopUfsAbsentPathCache implements UfsAbsentPathCache {
   }
 
   @Override
-  public void process(AlluxioURI path, List<Inode> prefixInodes) {
+  public void processAsync(AlluxioURI path, List<Inode> prefixInodes) {
+    // Do nothing
+  }
+
+  @Override
+  public void addSinglePath(AlluxioURI path) {
     // Do nothing
   }
 
@@ -45,7 +50,7 @@ public final class NoopUfsAbsentPathCache implements UfsAbsentPathCache {
   }
 
   @Override
-  public boolean isAbsent(AlluxioURI path) {
+  public boolean isAbsentSince(AlluxioURI path, long absentSince) {
     return false;
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsAbsentPathCache.java
@@ -24,14 +24,24 @@ import java.util.List;
  * Cache for recording information about paths that are not present in UFS.
  */
 public interface UfsAbsentPathCache {
+  long ALWAYS = -1;
+  long NEVER = Long.MAX_VALUE;
+
   /**
-   * Processes the given path for the cache. This will sequentially walk down the path to find
-   * components which do and do not exist in the UFS, and updates the cache accordingly.
+   * Processes the given path for the cache. This will asynchronously and sequentially walk down
+   * the path to find components which do and do not exist in the UFS, and updates the cache
+   * accordingly.
    *
    * @param path the path to process for the cache
    * @param prefixInodes the existing inodes for the path prefix
    */
-  void process(AlluxioURI path, List<Inode> prefixInodes);
+  void processAsync(AlluxioURI path, List<Inode> prefixInodes);
+
+  /**
+   * Add a single path to the absent cache synchronously.
+   * @param path the path to process for the cache
+   */
+  void addSinglePath(AlluxioURI path);
 
   /**
    * Processes the given path that already exists. This will sequentially walk down the path and
@@ -42,13 +52,15 @@ public interface UfsAbsentPathCache {
   void processExisting(AlluxioURI path);
 
   /**
-   * Returns true if the given path is absent, according to this cache. A path is absent if one of
-   * its ancestors is absent.
+   * Returns true if the given path was found to be absent since absentSince, according to this
+   * cache.
+   * A path is absent if one of its ancestors is absent.
    *
    * @param path the path to check
+   * @param absentSince the time when the cache entry would be considered valid
    * @return true if the path is absent according to the cache
    */
-  boolean isAbsent(AlluxioURI path);
+  boolean isAbsentSince(AlluxioURI path, long absentSince);
 
   /**
    * Factory class for {@link UfsAbsentPathCache}.

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -208,6 +208,7 @@ message LoadMetadataPOptions {
   optional bool createAncestors = 2;
   optional fscommon.LoadDescendantPType loadDescendantType = 3;
   optional FileSystemMasterCommonPOptions commonOptions = 4;
+  optional LoadMetadataPType loadType = 5;
 }
 
 enum PAclEntryType {


### PR DESCRIPTION
Add a time stamp to indicate last refreshed time on the absent cache
entries.
Use absent cache to avoid UFS accesses when possible in the metadata
sync and load Metadata processes.

Added more comprehensive integration tests that ensures the number of
accesses to the UFS through SleepingUnderFileSystem and unit tests for
the absent cache.

fixes #12833 because now instead of checking /a, /a/b, /a/b/c for non
existent directories, we will only access the UFS once for /a because of
absent cache. We know /a/b, /a/b/c can not exist on the UFS.

Co-authored-by: David Zhu <david@alluxio.com>

pr-link: Alluxio/alluxio#12956
change-id: cid-1c836c95416214ca0256a0d62feafe78d7cf8489