### PR TITLE
Skip caching large files

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -50,6 +50,7 @@ import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.LoadMetadataPType;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.OpenFilePOptions;
+import alluxio.grpc.ReadPType;
 import alluxio.grpc.RenamePOptions;
 import alluxio.grpc.ScheduleAsyncPersistencePOptions;
 import alluxio.grpc.SetAclAction;
@@ -384,6 +385,12 @@ public class BaseFileSystem implements FileSystem {
             .setAccessMode(Bits.READ)
             .setUpdateTimestamps(options.getUpdateLastAccessTime())
             .build());
+    long cacheThresholdBytes = conf.getBytes(PropertyKey.USER_FILE_CACHE_THRESHOLD);
+    if (cacheThresholdBytes != 0 && status.getLength() > cacheThresholdBytes) {
+      options = OpenFilePOptions.getDefaultInstance().toBuilder()
+              .setReadType(ReadPType.NO_CACHE)
+              .mergeFrom(options).build();
+    }
     return openFile(status, options);
   }
 

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3994,6 +3994,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_FILE_CACHE_THRESHOLD =
+        new Builder(Name.USER_FILE_CACHE_THRESHOLD)
+                .setDefaultValue("0")
+                .setDescription("File size exceeding the threshold will not be cached. The default"
+                        + " value 0 indicates that all files will be cached if needed.")
+                .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+                .setScope(Scope.CLIENT)
+                .build();
   public static final PropertyKey USER_LOCAL_READER_CHUNK_SIZE_BYTES =
       new Builder(Name.USER_LOCAL_READER_CHUNK_SIZE_BYTES)
           .setDefaultValue("8MB")
@@ -5797,6 +5805,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_FILE_WRITE_TYPE_DEFAULT = "alluxio.user.file.writetype.default";
     public static final String USER_FILE_WRITE_TIER_DEFAULT =
         "alluxio.user.file.write.tier.default";
+    public static final String USER_FILE_CACHE_THRESHOLD = "alluxio.user.file.cache.threshold";
     public static final String USER_HOSTNAME = "alluxio.user.hostname";
     public static final String USER_LOCAL_READER_CHUNK_SIZE_BYTES =
         "alluxio.user.local.reader.chunk.size.bytes";


### PR DESCRIPTION
Memory is relatively small, in order to avoid misreading large files, resulting in frequent memory swaps and improve overall cache hit rate , I want to have a configuration to limit caching behavior. 
For example, I have five 2G files and one 5G file in 10G  of  memory space. If Alluxio does not cache large files, it will increase the overall hit rate.

It can also limit the threshold of small file size as well (I will add such configuration later).If this PR makes sense I can add UT later.