### PR TITLE
Upgrade aws-sdk version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
   <properties>
     <argLine></argLine>
     <apache.curator.version>4.2.0</apache.curator.version>
-    <aws.amazonaws.version>1.11.215</aws.amazonaws.version>
+    <aws.amazonaws.version>1.11.815</aws.amazonaws.version>
     <build.path>build</build.path>
     <catalyst.version>1.2.1</catalyst.version>
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
@@ -195,6 +195,11 @@
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-core</artifactId>
+        <version>${aws.amazonaws.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-sts</artifactId>
         <version>${aws.amazonaws.version}</version>
       </dependency>
       <dependency>

--- a/underfs/s3a/pom.xml
+++ b/underfs/s3a/pom.xml
@@ -37,6 +37,10 @@
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
     </dependency>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-sts</artifactId>
+      </dependency>
     <!--aws sdk requires jaxb binding at runtime-->
     <dependency>
       <groupId>com.sun.xml.bind</groupId>

--- a/underfs/s3a/pom.xml
+++ b/underfs/s3a/pom.xml
@@ -37,10 +37,10 @@
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
     </dependency>
-      <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-sts</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sts</artifactId>
+    </dependency>
     <!--aws sdk requires jaxb binding at runtime-->
     <dependency>
       <groupId>com.sun.xml.bind</groupId>


### PR DESCRIPTION
The aws sdk version currently is 1.11.215 which is more than 4 yrs old. This PR upgrades it to 1.11.815 which has enhanced DefaultAWSCredentialsProviderChain. This adds credentials to be received from web-identity-token file.

Refer [aws sdk documentation](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html ) for more details.