### PR TITLE
Add RocksDB.open retry logic

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
@@ -149,6 +149,7 @@ public final class RocksStore implements Closeable {
     while (retryPolicy.attempt()) {
       try {
         mDb = RocksDB.open(mDbOpts, mDbPath, cfDescriptors, columns);
+        break;
       } catch (RocksDBException e) {
         // sometimes the previous terminated process's lock may not have been fully cleared yet
         // retry until timeout to make sure that isn't the case

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
@@ -15,6 +15,8 @@ import alluxio.Constants;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.CheckpointOutputStream;
 import alluxio.master.journal.checkpoint.CheckpointType;
+import alluxio.retry.TimeoutRetry;
+import alluxio.util.CommonUtils;
 import alluxio.util.TarUtils;
 import alluxio.util.io.FileUtils;
 
@@ -49,6 +51,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class RocksStore implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(RocksStore.class);
+  public static final int ROCKS_OPEN_RETRY_TIMEOUT = 20 * 1000;
 
   private final String mDbPath;
   private final String mDbCheckpointPath;
@@ -142,7 +145,20 @@ public final class RocksStore implements Closeable {
     cfDescriptors.addAll(mColumnFamilyDescriptors);
     // a list which will hold the handles for the column families once the db is opened
     List<ColumnFamilyHandle> columns = new ArrayList<>();
-    mDb = RocksDB.open(mDbOpts, mDbPath, cfDescriptors, columns);
+    final TimeoutRetry retryPolicy = new TimeoutRetry(ROCKS_OPEN_RETRY_TIMEOUT, 100);
+    RocksDBException lastException = null;
+    while (retryPolicy.attempt()) {
+      try {
+        mDb = RocksDB.open(mDbOpts, mDbPath, cfDescriptors, columns);
+      } catch (RocksDBException e) {
+        // sometimes the previous terminated process's lock may not have been fully cleared yet
+        // retry until timeout to make sure that isn't the case
+        lastException = e;
+      }
+    }
+    if (mDb == null && lastException != null) {
+      throw lastException;
+    }
     mCheckpoint = Checkpoint.create(mDb);
     for (int i = 0; i < columns.size() - 1; i++) {
       // Skip the default column.

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
@@ -16,7 +16,6 @@ import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.CheckpointOutputStream;
 import alluxio.master.journal.checkpoint.CheckpointType;
 import alluxio.retry.TimeoutRetry;
-import alluxio.util.CommonUtils;
 import alluxio.util.TarUtils;
 import alluxio.util.io.FileUtils;
 

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
@@ -50,7 +50,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class RocksStore implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(RocksStore.class);
-  public static final int ROCKS_OPEN_RETRY_TIMEOUT = 20 * 1000;
+  public static final int ROCKS_OPEN_RETRY_TIMEOUT = 20 * Constants.SECOND_MS;
 
   private final String mDbPath;
   private final String mDbCheckpointPath;


### PR DESCRIPTION
When doing a quick restart of an alluxio master process with RocksDB, the previous RocksDB may not have been fully cleared yet if the previous process didn't terminate gracefully. Add a timeout around connection so the previous connection lock times out before.