### PR TITLE
Fix helm-chart master statefulset.yaml env space Indent

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -107,8 +107,8 @@ spec:
                 fieldPath: status.podIP
           {{- end }}
           {{- range $key, $value := .Values.master.env }}
-            - name: "{{ $key }}"
-              value: "{{ $value }}"
+          - name: "{{ $key }}"
+            value: "{{ $value }}"
           {{- end }}
           envFrom:
           - configMapRef:


### PR DESCRIPTION
If `env` is set for the master, the space indentation of the current helm template is not aligned with the context. So that helm will report error like this:
```
Error: YAML parse error on alluxio/templates/master/statefulset.yaml: error converting YAML to JSON: yaml: line 81: did not find expected key
```

This PR try to fix the space Indent in `master/statefulset.yaml`