### PR TITLE
Fix helm-chart fuse hostpath type from File to CharDevice

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -155,3 +155,7 @@
 0.6.15
 
 - Fix incorrect indentation in logserver secret volume mount
+
+0.6.16
+
+- Change helm-chart fuse hostPath type from File to CharDevice

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.15
+version: 0.6.16
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
@@ -130,7 +130,7 @@ spec:
         - name: alluxio-fuse-device
           hostPath:
             path: /dev/fuse
-            type: File
+            type: CharDevice
         - name: alluxio-fuse-mount
           hostPath:
             path: {{ .Values.fuse.mountPath | dir }}


### PR DESCRIPTION
In k8s 1.19+ , `hostPathType` needs to be more accurate, otherwise the following error will be reported:
```
MountVolume.SetUp failed for volume "alluxio-fuse-device" : hostPath type check failed: /dev/fuse is not a file
```
In Node use `file` command to check `/dev/fuse` type:
```shell
$ file fuse
fuse: character special (10/229)
```

So that Maybe we should change `hostPathType` from  `File` to `CharDevice`