### PR TITLE
Fix helm-chart logserver secretVolumeMounts space Indent

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
+++ b/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
@@ -181,9 +181,9 @@ resources:
 
 {{- define "alluxio.logserver.secretVolumeMounts" -}}
   {{- range $key, $val := .Values.secrets.logserver }}
-            - name: secret-{{ $key }}-volume
-              mountPath: /secrets/{{ $val }}
-              readOnly: true
+          - name: secret-{{ $key }}-volume
+            mountPath: /secrets/{{ $val }}
+            readOnly: true
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
`alluxio.logserver.secretVolumeMounts` in `_helpers.tpl` has wrong space Indent. If use hadoop config, it will report this error:
```
Error: YAML parse error on alluxio/templates/logserver/deployment.yaml: error converting YAML to JSON: yaml: line 69: did not find expected key
```

Now, try to fix this.