### PR TITLE
Reduce unnecessary prefetching in metadata sync

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -514,11 +514,11 @@ public class InodeSyncStream {
     boolean deletedInode = false;
     // whether we need to load metadata for the current path
     boolean loadMetadata = mLoadOnly;
-    boolean syncChildren = true;
     LOG.trace("Syncing inode metadata {}", inodePath.getUri());
 
     // The requested path already exists in Alluxio.
     Inode inode = inodePath.getInode();
+    boolean syncChildren = inode.isDirectory();
 
     // if the lock pattern is WRITE_EDGE, then we can sync (update or delete). Otherwise, if it is
     // we can only load metadata.

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -657,7 +657,7 @@ public class InodeSyncStream {
       loadMetadataForPath(inodePath);
     }
 
-    if (syncChildren && mDescendantType == DescendantType.ALL) {
+    if (syncChildren) {
       // Iterate over Alluxio children and process persisted children.
       mInodeStore.getChildren(inode.asDirectory()).forEach(childInode -> {
         // If we are only loading non-existing metadata, then don't process any child which
@@ -670,7 +670,7 @@ public class InodeSyncStream {
         AlluxioURI child = inodePath.getUri().joinUnsafe(childInode.getName());
         mPendingPaths.add(child);
         // This asynchronously schedules a job to pre-fetch the statuses into the cache.
-        if (childInode.isDirectory()) {
+        if (childInode.isDirectory() && mDescendantType == DescendantType.ALL) {
           mStatusCache.prefetchChildren(child, mMountTable);
         }
       });

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -625,6 +625,15 @@ public class InodeSyncStream {
       }
     }
 
+    // Only sync children when
+    // (1) DescendantType.ALL or (2) syncing root of this stream && DescendantType.ONE
+    if (mDescendantType == DescendantType.ONE) {
+      syncChildren =
+          syncChildren && inode.isDirectory() && mRootScheme.getPath().equals(inodePath.getUri());
+    } else if (mDescendantType == DescendantType.ALL) {
+      syncChildren = syncChildren && inode.isDirectory();
+    }
+
     Map<String, Inode> inodeChildren = new HashMap<>();
     if (syncChildren) {
       // maps children name to inode

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -625,17 +625,6 @@ public class InodeSyncStream {
       }
     }
 
-    // Only sync children when
-    // (1) DescendantType.ALL or (2) syncing root of this stream && DescendantType.ONE
-    if (mDescendantType == DescendantType.ONE) {
-      syncChildren =
-          syncChildren && inode.isDirectory() && mRootScheme.getPath().equals(inodePath.getUri());
-    } else if (mDescendantType == DescendantType.ALL) {
-      syncChildren = syncChildren && inode.isDirectory();
-    } else {
-      syncChildren = false;
-    }
-
     Map<String, Inode> inodeChildren = new HashMap<>();
     if (syncChildren) {
       // maps children name to inode
@@ -668,7 +657,7 @@ public class InodeSyncStream {
       loadMetadataForPath(inodePath);
     }
 
-    if (syncChildren) {
+    if (syncChildren && mDescendantType == DescendantType.ALL) {
       // Iterate over Alluxio children and process persisted children.
       mInodeStore.getChildren(inode.asDirectory()).forEach(childInode -> {
         // If we are only loading non-existing metadata, then don't process any child which

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -518,7 +518,8 @@ public class InodeSyncStream {
 
     // The requested path already exists in Alluxio.
     Inode inode = inodePath.getInode();
-    boolean syncChildren = inode.isDirectory();
+    // initialize sync children to true if it is a listStatus call on a directory
+    boolean syncChildren = inode.isDirectory() && !mIsGetFileInfo;
 
     // if the lock pattern is WRITE_EDGE, then we can sync (update or delete). Otherwise, if it is
     // we can only load metadata.

--- a/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
@@ -67,6 +67,9 @@ public class LoadMetadataIntegrationTest extends BaseIntegrationTest {
   private static final long SLEEP_MS = Constants.SECOND_MS / 2;
   private static final int EXTRA_DIR_FILES = 6;
 
+  private static final FileSystemMasterCommonPOptions PSYNC_ALWAYS =
+      FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(0).build();
+
   private FileSystem mFileSystem;
 
   @Rule
@@ -270,6 +273,39 @@ public class LoadMetadataIntegrationTest extends BaseIntegrationTest {
     // so no need to go to the ufs
     checkGetStatus("/mnt/dir1/dirA/dirB/file", options, false, false, 0);
   }
+
+  @Test
+  public void listStatusLoadsFile() throws Exception {
+    GetStatusPOptions getStatusOptions =
+        GetStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.ONCE).build();
+    ListStatusPOptions lsOptions =
+        ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.ALWAYS)
+            .setCommonOptions(PSYNC_ALWAYS).build();
+    // load metadata for dirA with 'ALWAYS'
+    checkListStatus("/mnt/dir1/dirA", lsOptions, true,
+        true, 3);
+
+    // the file should already be loaded
+    checkGetStatus("/mnt/dir1/dirA/file", getStatusOptions, true,
+        true, 0);
+  }
+
+  @Test
+  public void getStatusDoesNotLoadFile() throws Exception {
+    GetStatusPOptions getStatusOptions =
+        GetStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.ONCE).build();
+    ListStatusPOptions lsOptions =
+        ListStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.ALWAYS)
+            .setCommonOptions(PSYNC_ALWAYS).build();
+    // load metadata for dirA with 'ALWAYS'
+    checkGetStatus("/mnt/dir1/dirA", getStatusOptions, true,
+        true, 2);
+
+    // the file should NOT already be loaded
+    checkGetStatus("/mnt/dir1/dirA/file", getStatusOptions, true,
+        true, 1);
+  }
+
 
   @Test
   public void loadMetadataOnceAfterUfsDelete() throws Exception {

--- a/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
@@ -306,7 +306,6 @@ public class LoadMetadataIntegrationTest extends BaseIntegrationTest {
         true, 1);
   }
 
-
   @Test
   public void loadMetadataOnceAfterUfsDelete() throws Exception {
     GetStatusPOptions options =


### PR DESCRIPTION
Previously, when we only list one level of directory, we still add the children to the workqueue and prefetch children's children from ufs.  That is not necessary. 

This fixes that issue. 