### PR TITLE
Reduce unnecessary creation of breadcrumbs

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -949,8 +949,8 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
       String folderName = convertToFolderName(dir);
       if (!mUfsConf.isReadOnly() && mBreadcrumbsEnabled
           && Arrays.stream(objs.getObjectStatuses()).noneMatch(
-              x -> x.mContentLength==0 && x.getName().equals(folderName))) {
-         mkdirsInternal(dir);
+              x -> x.mContentLength == 0 && x.getName().equals(folderName))) {
+        mkdirsInternal(dir);
       }
       return objs;
     }

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -945,7 +946,9 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     if (objs != null && ((objs.getObjectStatuses() != null && objs.getObjectStatuses().length > 0)
         || (objs.getCommonPrefixes() != null && objs.getCommonPrefixes().length > 0))) {
       // If the breadcrumb exists, this is a no-op
-      if (!mUfsConf.isReadOnly() && mBreadcrumbsEnabled) {
+      if (!mUfsConf.isReadOnly() && mBreadcrumbsEnabled
+          && Arrays.stream(objs.getObjectStatuses()).noneMatch(
+              x -> x.mContentLength==0 && x.getName().equals(dir))) {
         mkdirsInternal(dir);
       }
       return objs;
@@ -1050,11 +1053,6 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
           int childNameIndex = child.lastIndexOf(PATH_SEPARATOR);
           child = childNameIndex != -1 ? child.substring(0, childNameIndex) : child;
           if (!child.isEmpty() && !children.containsKey(child)) {
-            // This directory has not been created through Alluxio.
-            if (!mUfsConf.isReadOnly()
-                && mUfsConf.getBoolean(PropertyKey.UNDERFS_OBJECT_STORE_BREADCRUMBS_ENABLED)) {
-              mkdirsInternal(commonPrefix);
-            }
             // If both a file and a directory existed with the same name, the path will be
             // treated as a directory
             ObjectPermissions permissions = getPermissions();

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -945,11 +945,12 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     // If there are, this is a folder and we can create the necessary metadata
     if (objs != null && ((objs.getObjectStatuses() != null && objs.getObjectStatuses().length > 0)
         || (objs.getCommonPrefixes() != null && objs.getCommonPrefixes().length > 0))) {
-      // If the breadcrumb exists, this is a no-op
+      // Do not recreate the breadcrumb if it already exists
+      String folderName = convertToFolderName(dir);
       if (!mUfsConf.isReadOnly() && mBreadcrumbsEnabled
           && Arrays.stream(objs.getObjectStatuses()).noneMatch(
-              x -> x.mContentLength==0 && x.getName().equals(dir))) {
-        mkdirsInternal(dir);
+              x -> x.mContentLength==0 && x.getName().equals(folderName))) {
+         mkdirsInternal(dir);
       }
       return objs;
     }


### PR DESCRIPTION
This PR prevents breadcrumbs from being recreated everytime we issue a listStatus request. 
The main idea is to check for breadcrumb's existence before creating it and only create it when a directory is listed not when it is listed as a child of another directory. 