### PR TITLE
Add Helm chart support for k8s node tolerations

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -163,3 +163,7 @@
 0.6.17
 
 - Add hostAliases in Master and Worker Pods
+
+0.6.18
+
+- Add support for Node tolerations

--- a/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
@@ -52,7 +52,8 @@ spec:
       tolerations:
       {{- if .Values.fuse.tolerations }}
 {{ toYaml .Values.fuse.tolerations | trim | indent 8  }}
-      {{- else if .Values.tolerations }}
+      {{- end }}
+      {{- if .Values.tolerations }}
 {{ toYaml .Values.tolerations | trim | indent 8  }}
       {{- end }}
       securityContext:

--- a/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
@@ -49,6 +49,12 @@ spec:
       {{- else if .Values.nodeSelector }}
 {{ toYaml .Values.nodeSelector | trim | indent 8  }}
       {{- end }}
+      tolerations:
+      {{- if .Values.fuse.tolerations }}
+{{ toYaml .Values.fuse.tolerations | trim | indent 8  }}
+      {{- else if .Values.tolerations }}
+{{ toYaml .Values.tolerations | trim | indent 8  }}
+      {{- end }}
       securityContext:
         runAsUser: {{ .Values.fuse.user }}
         runAsGroup: {{ .Values.fuse.group }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/logserver/deployment.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/logserver/deployment.yaml
@@ -41,6 +41,18 @@ spec:
         heritage: {{ .Release.Service }}
         role: alluxio-logserver
     spec:
+      nodeSelector:
+      {{- if .Values.logserver.nodeSelector }}
+{{ toYaml .Values.logserver.nodeSelector | trim | indent 8  }}
+      {{- else if .Values.nodeSelector }}
+{{ toYaml .Values.nodeSelector | trim | indent 8  }}
+      {{- end }}
+      tolerations:
+      {{- if .Values.logserver.tolerations }}
+{{ toYaml .Values.logserver.tolerations | trim | indent 8  }}
+      {{- else if .Values.tolerations }}
+{{ toYaml .Values.tolerations | trim | indent 8  }}
+      {{- end }}
       containers:
         - name: alluxio-logserver
           image: {{ .Values.image }}:{{ .Values.imageTag }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/logserver/deployment.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/logserver/deployment.yaml
@@ -50,7 +50,8 @@ spec:
       tolerations:
       {{- if .Values.logserver.tolerations }}
 {{ toYaml .Values.logserver.tolerations | trim | indent 8  }}
-      {{- else if .Values.tolerations }}
+      {{- end }}
+      {{- if .Values.tolerations }}
 {{ toYaml .Values.tolerations | trim | indent 8  }}
       {{- end }}
       containers:

--- a/integration/kubernetes/helm-chart/alluxio/templates/logserver/deployment.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/logserver/deployment.yaml
@@ -41,12 +41,6 @@ spec:
         heritage: {{ .Release.Service }}
         role: alluxio-logserver
     spec:
-      nodeSelector:
-      {{- if .Values.logserver.nodeSelector }}
-{{ toYaml .Values.logserver.nodeSelector | trim | indent 8  }}
-      {{- else if .Values.nodeSelector }}
-{{ toYaml .Values.nodeSelector | trim | indent 8  }}
-      {{- end }}
       tolerations:
       {{- if .Values.logserver.tolerations }}
 {{ toYaml .Values.logserver.tolerations | trim | indent 8  }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -73,7 +73,8 @@ spec:
       tolerations:
       {{- if .Values.master.tolerations }}
 {{ toYaml .Values.master.tolerations | trim | indent 8  }}
-      {{- else if .Values.tolerations }}
+      {{- end }}
+      {{- if .Values.tolerations }}
 {{ toYaml .Values.tolerations | trim | indent 8  }}
       {{- end }}
       securityContext:

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -70,6 +70,12 @@ spec:
       {{- else if .Values.nodeSelector }}
 {{ toYaml .Values.nodeSelector | trim | indent 8  }}
       {{- end }}
+      tolerations:
+      {{- if .Values.master.tolerations }}
+{{ toYaml .Values.master.tolerations | trim | indent 8  }}
+      {{- else if .Values.tolerations }}
+{{ toYaml .Values.tolerations | trim | indent 8  }}
+      {{- end }}
       securityContext:
         runAsUser: {{ .Values.user }}
         runAsGroup: {{ .Values.group }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
@@ -65,6 +65,12 @@ spec:
       {{- else if .Values.nodeSelector }}
 {{ toYaml .Values.nodeSelector | trim | indent 8  }}
       {{- end }}
+      tolerations:
+      {{- if .Values.worker.tolerations }}
+{{ toYaml .Values.worker.tolerations | trim | indent 8  }}
+      {{- else if .Values.tolerations }}
+{{ toYaml .Values.tolerations | trim | indent 8  }}
+      {{- end }}
       containers:
         - name: alluxio-worker
           image: {{ .Values.image }}:{{ .Values.imageTag }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
@@ -68,7 +68,8 @@ spec:
       tolerations:
       {{- if .Values.worker.tolerations }}
 {{ toYaml .Values.worker.tolerations | trim | indent 8  }}
-      {{- else if .Values.tolerations }}
+      {{- end }}
+      {{- if .Values.tolerations }}
 {{ toYaml .Values.tolerations | trim | indent 8  }}
       {{- end }}
       containers:

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -416,6 +416,7 @@ logserver:
   # dnsPolicy: ClusterFirst
   # JVM options specific to the logserver container
   jvmOptions:
+  nodeSelector: {}
   tolerations: []
   # volumeType controls the type of log volume.
   # It can be "persistentVolumeClaim" or "hostPath" or "emptyDir"

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -46,9 +46,10 @@ properties:
 # Use labels to run Alluxio on a subset of the K8s nodes
 # nodeSelector: {}
 
-# A list of k8s Node taints to allow scheduling on.
+# A list of K8s Node taints to allow scheduling on.
 # See the Kubernetes docs for more info:
 # - https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+# eg: tolerations: [ {"key": "env", "operator": "Equal", "value": "prod", "effect": "NoSchedule"} ]
 # tolerations: []
 
 ## Master ##

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -46,6 +46,11 @@ properties:
 # Use labels to run Alluxio on a subset of the K8s nodes
 # nodeSelector: {}
 
+# A list of k8s Node taints to allow scheduling on.
+# See the Kubernetes docs for more info:
+# - https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+# tolerations: []
+
 ## Master ##
 
 master:
@@ -84,6 +89,7 @@ master:
   # JVM options specific to the master container
   jvmOptions:
   nodeSelector: {}
+  tolerations: []
   podAnnotations: {}
 
 jobMaster:
@@ -178,6 +184,7 @@ worker:
   # JVM options specific to the worker container
   jvmOptions:
   nodeSelector: {}
+  tolerations: []
   podAnnotations: {}
 
 jobWorker:
@@ -302,6 +309,8 @@ fuse:
     limits:
       cpu: "4"
       memory: "4G"
+  nodeSelector: {}
+  tolerations: []
   podAnnotations: {}
 
 
@@ -407,6 +416,7 @@ logserver:
   # JVM options specific to the logserver container
   jvmOptions:
   nodeSelector: {}
+  tolerations: []
   # volumeType controls the type of log volume.
   # It can be "persistentVolumeClaim" or "hostPath" or "emptyDir"
   volumeType: persistentVolumeClaim

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -416,7 +416,6 @@ logserver:
   # dnsPolicy: ClusterFirst
   # JVM options specific to the logserver container
   jvmOptions:
-  nodeSelector: {}
   tolerations: []
   # volumeType controls the type of log volume.
   # It can be "persistentVolumeClaim" or "hostPath" or "emptyDir"


### PR DESCRIPTION
This PR is being made to address git [issue #13203](https://github.com/Alluxio/alluxio/issues/13203).

I tested that the Helm chart rendered using the following in my `config.yaml`
```
tolerations: [ {"key": "test", "operator": "Equal", "value": "test", "effect": "NoSchedule"} ]
```

and that the tolerations worked as intended on k8s nodes I tainted using `kubectl taint nodes <node> test=test:NoSchedule`

**Note:** I tested the Helm chart using all default values; so no FUSE nor logging-server deployments.