### PR TITLE
Prevent NPE for AbstractFileSystemShellTest

### DIFF
--- a/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
@@ -54,12 +54,12 @@ import javax.annotation.Nullable;
  * The base class for all the {@link FileSystemShell} test classes.
  */
 public abstract class AbstractFileSystemShellTest extends AbstractShellIntegrationTest {
-  public static LocalAlluxioCluster sLocalAlluxioCluster = null;
-  public static FileSystem sFileSystem = null;
-  public static FileSystemShell sFsShell = null;
+  public static LocalAlluxioCluster sLocalAlluxioCluster;
+  public static FileSystem sFileSystem;
+  public static FileSystemShell sFsShell;
   protected static JobMaster sJobMaster;
-  protected static LocalAlluxioJobCluster sLocalAlluxioJobCluster = null;
-  protected static JobShell sJobShell = null;
+  protected static LocalAlluxioJobCluster sLocalAlluxioJobCluster;
+  protected static JobShell sJobShell;
 
   /*
    * The user and group mappings for testing are:
@@ -129,9 +129,15 @@ public abstract class AbstractFileSystemShellTest extends AbstractShellIntegrati
 
   @AfterClass
   public static void afterClass() throws Exception {
-    sFsShell.close();
-    sLocalAlluxioJobCluster.stop();
-    sJobShell.close();
+    if (sFsShell != null) {
+      sFsShell.close();
+    }
+    if (sLocalAlluxioJobCluster != null) {
+      sLocalAlluxioJobCluster.stop();
+    }
+    if (sJobShell != null) {
+      sJobShell.close();
+    }
   }
 
   /**


### PR DESCRIPTION
Motivated by test results https://github.com/Alluxio/alluxio/pull/13215/checks?check_run_id=2328363200

```
Error: 6.229 [ERROR] alluxio.client.cli.fs.command.RmCommandIntegrationTest  Time elapsed: 72.654 s  <<< ERROR!
java.lang.NullPointerException
	at alluxio.client.cli.fs.AbstractFileSystemShellTest.afterClass(AbstractFileSystemShellTest.java:132)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.RunAfters.invokeMethod(RunAfters.java:46)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:33)
	at alluxio.testutils.LocalAlluxioClusterResource$1.evaluate(LocalAlluxioClusterResource.java:195)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
```