### PR TITLE
Add hostAliases in Master and Worker Pods

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -159,3 +159,7 @@
 0.6.16
 
 - Change helm-chart fuse hostPath type from File to CharDevice
+
+0.6.17
+
+- Add hostAliases in Master and Worker Pods

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.16
+version: 0.6.17
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
+++ b/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
@@ -381,3 +381,14 @@ livenessProbe:
     claimName: "{{ .Values.logserver.pvcName }}"
 {{- end }}
 {{- end -}}
+
+{{- define "alluxio.hostAliases" -}}
+hostAliases:
+{{- range .Values.hostAliases }}
+- ip: {{ .ip }}
+  hostnames:
+  {{- range .hostnames }}
+  - {{ . }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -60,14 +60,7 @@ spec:
     {{- end }}
     spec:
       {{ if .Values.hostAliases }}
-      hostAliases:
-        {{- range .Values.hostAliases }}
-        - ip: {{ .ip }}
-          hostnames:
-            {{- range .hostnames }}
-            - {{ . }}
-            {{- end }}
-        {{- end }}
+      {{- include "alluxio.hostAliases" . | nindent 6 }}
       {{ end }}
       hostNetwork: {{ $hostNetwork }}
       dnsPolicy: {{ .Values.master.dnsPolicy | default ($hostNetwork | ternary "ClusterFirstWithHostNet" "ClusterFirst") }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -59,6 +59,16 @@ spec:
       {{- end }}
     {{- end }}
     spec:
+      {{ if .Values.hostAliases }}
+      hostAliases:
+        {{- range .Values.hostAliases }}
+        - ip: {{ .ip }}
+          hostnames:
+            {{- range .hostnames }}
+            - {{ . }}
+            {{- end }}
+        {{- end }}
+      {{ end }}
       hostNetwork: {{ $hostNetwork }}
       dnsPolicy: {{ .Values.master.dnsPolicy | default ($hostNetwork | ternary "ClusterFirstWithHostNet" "ClusterFirst") }}
       nodeSelector:

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
@@ -52,6 +52,16 @@ spec:
       hostNetwork: {{ $hostNetwork }}
       hostPID: {{ $hostPID }}
       dnsPolicy: {{ .Values.worker.dnsPolicy | default ($hostNetwork | ternary "ClusterFirstWithHostNet" "ClusterFirst") }}
+      {{ if .Values.hostAliases }}
+      hostAliases:
+        {{- range .Values.hostAliases }}
+        - ip: {{ .ip }}
+          hostnames:
+            {{- range .hostnames }}
+            - {{ . }}
+            {{- end }}
+        {{- end }}
+      {{ end }}
       securityContext:
         runAsUser: {{ .Values.user }}
         runAsGroup: {{ .Values.group }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
@@ -53,14 +53,7 @@ spec:
       hostPID: {{ $hostPID }}
       dnsPolicy: {{ .Values.worker.dnsPolicy | default ($hostNetwork | ternary "ClusterFirstWithHostNet" "ClusterFirst") }}
       {{ if .Values.hostAliases }}
-      hostAliases:
-        {{- range .Values.hostAliases }}
-        - ip: {{ .ip }}
-          hostnames:
-            {{- range .hostnames }}
-            - {{ . }}
-            {{- end }}
-        {{- end }}
+      {{- include "alluxio.hostAliases" . | nindent 6 }}
       {{ end }}
       securityContext:
         runAsUser: {{ .Values.user }}

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -436,3 +436,11 @@ logserver:
   medium: ""
   size: 4Gi
 
+# The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+# It is mainly to provide the external host address for HDFS.
+# Example:
+# hostAliases:
+# - ip: "192.168.0.1"
+#   hostnames:
+#     - "example1.com"
+#     - "example2.com"

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -437,7 +437,7 @@ logserver:
   size: 4Gi
 
 # The pod's HostAliases. HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-# It is mainly to provide the external host address for HDFS.
+# It is mainly to provide the external host addresses for services not in the K8s cluster, like HDFS.
 # Example:
 # hostAliases:
 # - ip: "192.168.0.1"


### PR DESCRIPTION
Add hostAliases to master statefulset.yaml and worker daemonset.yaml . Sometimes, Hadoop hosts is not configured in k8s cluster nodes or in DNS, so that we need to add `hostAliases` to let alluxio to identify Hadoop's hostname.

