### PR TITLE
Remove extra HashSet creation for pinned list

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -1094,7 +1094,7 @@ public class InodeTree implements DelegatingJournaled {
    * @return the set of file ids which are pinned
    */
   public Set<Long> getPinIdSet() {
-    return new HashSet<>(mState.getPinnedInodeFileIds());
+    return mState.getPinnedInodeFileIds();
   }
 
   /**


### PR DESCRIPTION
In `InodeTreePersistentState` we return a `Collections.unmodifiableSet` wrapped around the pinned list. Then in `InodeTree` we create a HashSet copy from it yet again. This is redundant.

Eventually the `getPinnedFileIds` call should be changed to a list-watch mechanism where the worker lists all the pinned IDs then just incrementally watch the changes. But that is not trivial and is not done in this PR.