### PR TITLE
[SMALLFIX] Add tini to Docker image

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -42,15 +42,15 @@ ARG ALLUXIO_UID=1000
 ARG ALLUXIO_GID=1000
 ARG ENABLE_DYNAMIC_USER=false
 
-# Add Tini since it isn't included in Ubuntu by default
-# - https://github.com/krallin/tini
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/local/bin/tini
-RUN chmod +x /usr/local/bin/tini
-
 # Specify versions for known vulnerabilities reported by trivy scan
 # RUN apk --no-cache --update add bash libc6-compat shadow tini 'libbz2>=1.0.6-r7' 'sqlite-libs>=3.28.0-r3' && \
 #    rm -rf /var/cache/apk/*
+
+# Add Tini
+# - https://github.com/krallin/tini
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/local/bin/tini
+RUN chmod +x /usr/local/bin/tini
 
 RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common && \
   add-apt-repository -y ppa:openjdk-r/ppa && \

--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -42,6 +42,12 @@ ARG ALLUXIO_UID=1000
 ARG ALLUXIO_GID=1000
 ARG ENABLE_DYNAMIC_USER=false
 
+# Add Tini since it isn't included in Ubuntu by default
+# - https://github.com/krallin/tini
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/local/bin/tini
+RUN chmod +x /usr/local/bin/tini
+
 # Specify versions for known vulnerabilities reported by trivy scan
 # RUN apk --no-cache --update add bash libc6-compat shadow tini 'libbz2>=1.0.6-r7' 'sqlite-libs>=3.28.0-r3' && \
 #    rm -rf /var/cache/apk/*

--- a/integration/docker/Dockerfile.fuse
+++ b/integration/docker/Dockerfile.fuse
@@ -46,6 +46,12 @@ ARG ALLUXIO_UID=1000
 ARG ALLUXIO_GID=1000
 ARG ENABLE_DYNAMIC_USER=false
 
+# Add Tini since it isn't included in Ubuntu by default
+# - https://github.com/krallin/tini
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/local/bin/tini
+RUN chmod +x /usr/local/bin/tini
+
 RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository -y ppa:openjdk-r/ppa && \
 	apt-get update && \

--- a/integration/docker/Dockerfile.fuse
+++ b/integration/docker/Dockerfile.fuse
@@ -48,7 +48,7 @@ ARG ENABLE_DYNAMIC_USER=false
 
 # Add Tini since it isn't included in Ubuntu by default
 # - https://github.com/krallin/tini
-ENV TINI_VERSION v0.19.0
+ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/local/bin/tini
 RUN chmod +x /usr/local/bin/tini
 


### PR DESCRIPTION
This change is being made to fix PR #13204 where we switched the Alluxio Docker base image from Alpine to Ubuntu.

Alpine has [tini](https://github.com/krallin/tini) included as a [package](https://pkgs.alpinelinux.org/package/edge/community/x86/tini) that we previously installed via `apk`.

Since our Helm charts rely on `tini` for the `command: ["tini", "--", "/entrypoint.sh"]`  (see [here](https://github.com/Alluxio/alluxio/blob/master/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml#L91) for an example), the quickest fix for now is to just add `tini` to the Docker image again.