### PR TITLE
Enable /mnt/alluxio-fuse as default worker fuse mount

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2742,9 +2742,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey WORKER_FUSE_MOUNT_POINT =
       new Builder(Name.WORKER_FUSE_MOUNT_POINT)
+          .setDefaultValue("/mnt/alluxio-fuse")
           .setDescription("The absolute local filesystem path that this worker will "
-              + "mount Alluxio path to. If the value is not set, no Fuse application"
-              + "will be mounted in this worker.")
+              + "mount Alluxio path to.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();

--- a/docs/en/api/POSIX-API.md
+++ b/docs/en/api/POSIX-API.md
@@ -171,18 +171,18 @@ When the worker starts, the Fuse is mounted based on worker configuration.
 When the worker ends, the embedded Fuse is unmounted automatically.
 If you want to modify your Fuse mount, change the configuration and restart the worker process.
 
-Enable FUSE on worker by setting the following properties in the `${ALLUXIO_HOME}/conf/alluxio-site.properties` for workers:
+Enable FUSE on worker by setting `alluxio.worker.fuse.enabled` to `true` in the `${ALLUXIO_HOME}/conf/alluxio-site.properties`:
 
 ```
 alluxio.worker.fuse.enabled=true
-alluxio.worker.fuse.mount.point=<mount_point>
 ```
 
-By default, Fuse on worker will mount the Alluxio root path `/` to the configured mount point with no extra mount options.
-You can change the alluxio path and mount options through Alluxio configuration:
+By default, Fuse on worker will mount the Alluxio root path `/` to default local mount point `/mnt/alluxio-fuse` with no extra mount options.
+You can change the alluxio path, mount point, and mount options through Alluxio configuration:
 
 ```
 alluxio.worker.fuse.mount.alluxio.path=<alluxio_path>
+alluxio.worker.fuse.mount.point=<mount_point>
 alluxio.worker.fuse.mount.options=<list of mount options separated by comma>
 ```
 

--- a/docs/en/deploy/Running-Alluxio-On-Docker.md
+++ b/docs/en/deploy/Running-Alluxio-On-Docker.md
@@ -430,7 +430,6 @@ $ docker run -d \
        -Dalluxio.worker.ramdisk.size=1G \
        -Dalluxio.master.hostname=localhost \
        -Dalluxio.worker.fuse.enabled=true \
-       -Dalluxio.worker.fuse.mount.point=/mnt/alluxio-fuse" \
     alluxio/{{site.ALLUXIO_DOCKER_IMAGE}} worker
 ```
 
@@ -441,8 +440,8 @@ To change this path to `/foo/bar/alluxio-fuse` on host file system, replace `/tm
 capability.
 - `--device /dev/fuse` shares host device `/dev/fuse` with the container.
 - Property `alluxio.worker.fuse.enabled=true` enables FUSE support on this worker.
-- Property `alluxio.worker.fuse.mount.point=/mnt/alluxio-fuse` specifies the mount point to
-`/mnt/alluxio-fuse` inside this worker container.
+The default fuse mount point is `/mnt/alluxio-fuse` in the worker container which will be created at runtime if not exist.
+To change the fuse mount point, specify `alluxio.worker.fuse.mount.point=<mount_point>`.
 
 Once this container is launched successfully, one can access Alluxio via host path `/tmp/mnt/alluxio-fuse`.
 This is because local path `/mnt` in worker container is mapped to host path `/tmp/mnt`,


### PR DESCRIPTION
Set the default value of worker fuse mount point to reduce user configuration in using worker fuse.
