### PR TITLE
Prevent loading child inode metadata when not required

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -522,7 +522,8 @@ public class InodeSyncStream {
     // The requested path already exists in Alluxio.
     Inode inode = inodePath.getInode();
     // initialize sync children to true if it is a listStatus call on a directory
-    boolean syncChildren = inode.isDirectory() && !mIsGetFileInfo;
+    boolean syncChildren = inode.isDirectory() && !mIsGetFileInfo
+        && !mDescendantType.equals(DescendantType.NONE);
 
     // if the lock pattern is WRITE_EDGE, then we can sync (update or delete). Otherwise, if it is
     // we can only load metadata.
@@ -629,15 +630,11 @@ public class InodeSyncStream {
       }
     }
 
-    // Only sync children when
-    // (1) DescendantType.ALL or (2) syncing root of this stream && DescendantType.ONE
+    // sync plan does not know about the root of the sync
+    // if DescendantType.ONE we only sync children if we are syncing root of this stream
     if (mDescendantType == DescendantType.ONE) {
       syncChildren =
-          syncChildren && inode.isDirectory() && mRootScheme.getPath().equals(inodePath.getUri());
-    } else if (mDescendantType == DescendantType.ALL) {
-      syncChildren = syncChildren && inode.isDirectory();
-    } else {
-      syncChildren = false;
+          syncChildren && mRootScheme.getPath().equals(inodePath.getUri());
     }
 
     Map<String, Inode> inodeChildren = new HashMap<>();

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -693,8 +693,8 @@ public class InodeSyncStream {
       FileAlreadyCompletedException, InvalidFileSizeException, BlockInfoException {
     UfsStatus status = mStatusCache.fetchStatusIfAbsent(inodePath.getUri(), mMountTable);
     DescendantType descendantType = mDescendantType;
-    if (descendantType.equals(DescendantType.ONE) &&
-        !inodePath.getUri().equals(mRootScheme.getPath())) {
+    if (descendantType.equals(DescendantType.ONE)
+        && !inodePath.getUri().equals(mRootScheme.getPath())) {
       descendantType = DescendantType.NONE;
     }
     LoadMetadataContext ctx = LoadMetadataContext.mergeFrom(

--- a/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
@@ -215,6 +215,16 @@ public class LoadMetadataIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
+  public void loadMetadataListDir() throws Exception {
+    ListStatusPOptions listOptions =
+        ListStatusPOptions.newBuilder().setRecursive(false)
+            .setLoadMetadataType(LoadMetadataPType.ONCE)
+            .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(-1)
+            ).build();
+    checkListStatus("/mnt/", listOptions, true, true, 3);
+  }
+
+  @Test
   public void loadMetadataAlways() throws Exception {
     GetStatusPOptions options =
         GetStatusPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.ALWAYS).build();

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -684,7 +684,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
     }
     List<URIStatus> status;
     try (Context.CancellableContext c = Context.current()
-        .withDeadlineAfter(100, TimeUnit.MILLISECONDS,
+        .withDeadlineAfter(10, TimeUnit.MILLISECONDS,
             Executors.newScheduledThreadPool(1))) {
       Context toRestore = c.attach();
       try {
@@ -698,24 +698,26 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
             return Collections.<URIStatus>emptyList();
           }
         });
-        Thread.sleep(200);
+        Thread.sleep(20);
         c.cancel(new AlluxioException("test exception"));
       } finally {
         c.detach(toRestore);
       }
     }
+    // cancelled call should not return any results
     assertEquals(0, status.size());
     status = mFileSystem.listStatus(new AlluxioURI("/"), ListStatusPOptions.newBuilder()
         .setRecursive(true)
         .setCommonOptions(FileSystemOptions.commonDefaults(
             mFileSystem.getConf()).toBuilder().setSyncIntervalMs(-1).build()).build());
     final int TOTAL_FILE_COUNT = 20103;
+    // verify that the previous sync did not complete
     assertTrue(status.size() < TOTAL_FILE_COUNT);
     for (URIStatus stat : status) {
       assertTrue(stat.isCompleted());
     }
     status = mFileSystem.listStatus(new AlluxioURI("/"), ListStatusPOptions.newBuilder()
-        .setRecursive(true).setCommonOptions(PSYNC_LARGE_INTERVAL).build());
+        .setRecursive(true).setCommonOptions(PSYNC_ALWAYS).build());
     assertEquals(TOTAL_FILE_COUNT, status.size());
   }
 

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -684,7 +684,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
     }
     List<URIStatus> status;
     try (Context.CancellableContext c = Context.current()
-        .withDeadlineAfter(10, TimeUnit.MILLISECONDS,
+        .withDeadlineAfter(1, TimeUnit.MILLISECONDS,
             Executors.newScheduledThreadPool(1))) {
       Context toRestore = c.attach();
       try {
@@ -698,7 +698,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
             return Collections.<URIStatus>emptyList();
           }
         });
-        Thread.sleep(20);
+        Thread.sleep(5);
         c.cancel(new AlluxioException("test exception"));
       } finally {
         c.detach(toRestore);


### PR DESCRIPTION
Previously, loadMetadata on a single level of directory would load that directory and its children, causing unnecessary delay. 
This prevents that from happening by changing the descendant type when we are loading a non-base path.  