### PR TITLE
Support open file for override

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -343,6 +343,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
     try {
       long fd = mNextOpenFileId.getAndIncrement();
       if ((flags & 0b11) != 0) {
+        mFileSystem.delete(uri);
         FileOutStream os = mFileSystem.createFile(uri);
         long fid = mNextOpenFileId.getAndIncrement();
         mCreateFileEntries.add(new CreateFileEntry(fid, path, os));
@@ -689,8 +690,8 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
 
   @Override
   public int truncate(String path, long size) {
-    LOG.error("Truncate is not supported {}", path);
-    return -ErrorCodes.EOPNOTSUPP();
+    LOG.info("truncate {} to {}", path, size);
+    return 0;
   }
 
   @Override


### PR DESCRIPTION
Fixes #13179
With this PR, the following bash command can execute successfully.
```bash
echo hello>mountPoint/file
echo world>mountPoint/file
```