### PR TITLE
[DOCFIX] Update README alluxio version

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ Here are examples to declare the dependecies on  `alluxio-shaded-client` using M
   <dependency>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-shaded-client</artifactId>
-    <version>2.3.0</version>
+    <version>2.6.0-SNAPSHOT</version>
   </dependency>
   ```
 
 - SBT
   ```
-  libraryDependencies += "org.alluxio" % "alluxio-shaded-client" % "2.3.0"
+  libraryDependencies += "org.alluxio" % "alluxio-shaded-client" % "2.6.0-SNAPSHOT"
   ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ Here are examples to declare the dependecies on  `alluxio-shaded-client` using M
   <dependency>
     <groupId>org.alluxio</groupId>
     <artifactId>alluxio-shaded-client</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.5.0-2</version>
   </dependency>
   ```
 
 - SBT
   ```
-  libraryDependencies += "org.alluxio" % "alluxio-shaded-client" % "2.6.0-SNAPSHOT"
+  libraryDependencies += "org.alluxio" % "alluxio-shaded-client" % "2.5.0-2"
   ```
 
 ## Contributing


### PR DESCRIPTION
I notice that in file ./dev/scripts/update-versions.sh, here are lines to update the version of README when updating project version. However, the alluxio version in README is still 2.3.0, because the update version script failed to update README since it has the wrong 'old version'. So I update the version of README to latest version of the project, and then the update version script will correctly recognize the old version of README and update it.
```bash
# Arguments:
#  $1: old version
#  $2: new version
function update_readme() {
    perl -pi -e "s/${1}/${2}/g" README.md
}
```