### PR TITLE
Remove unused enum field of alluxio.exception.ExceptionMessage

### DIFF
--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -40,7 +40,6 @@ public enum ExceptionMessage {
   BLOCK_SIZE_INVALID("Block size of {0} is invalid. Block size must be > 0 bytes."),
   CANNOT_REQUEST_SPACE("Not enough space left on worker {0} to store blockId {1,number,#}."),
   NO_SPACE_FOR_BLOCK_ON_WORKER("There is no worker with enough space for a new block of size {0}"),
-  NO_WORKER_AVAILABLE_ON_ADDRESS("No Alluxio worker available for address {0}"),
   NO_WORKER_AVAILABLE("No available Alluxio worker found"),
 
   // active sync


### PR DESCRIPTION
Remove unused enum field alluxio.exception.ExceptionMessage#NO_WORKER_AVAILABLE_ON_ADDRESS

Fix Alluxio/new-contributor-tasks#574