### PR TITLE
Enable webui ( master,worker) run normally when start Alluxio in IDE

### DIFF
--- a/core/server/master/pom.xml
+++ b/core/server/master/pom.xml
@@ -70,6 +70,11 @@
       <groupId>org.rocksdb</groupId>
       <artifactId>rocksdbjni</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Internal dependencies -->
     <dependency>

--- a/core/server/worker/pom.xml
+++ b/core/server/worker/pom.xml
@@ -70,6 +70,11 @@
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Internal dependencies -->
     <dependency>


### PR DESCRIPTION
Before this PR:
I want to run Alluxio in my IDE.But it has such error
![image](https://user-images.githubusercontent.com/31469905/116167803-a5194700-a733-11eb-85f6-7c6f8fa71831.png)
and master.log
`org.glassfish.jersey.message.internal.WriterInterceptorExecutor$TerminalWriterInterceptor aroundWriteTo
 MessageBodyWriter not found for media type=application/json, type=class alluxio.wire.MasterWebUIInit, genericType=class alluxio.wire.MasterWebUIInit`

After this PR:
(It has no effect on packaging Alluxio cause it is `provided`)
master:
![image](https://user-images.githubusercontent.com/31469905/116167889-d85bd600-a733-11eb-87fa-b247645adf88.png)
worker:
![image](https://user-images.githubusercontent.com/31469905/116167902-df82e400-a733-11eb-8c3d-66b6dcfffbc2.png)

