### PR TITLE
Enable HTTPS when SSE is enabled on S3

### DIFF
--- a/docs/en/ufs/S3.md
+++ b/docs/en/ufs/S3.md
@@ -137,7 +137,8 @@ for more details.
 ### Enabling Server Side Encryption
 
 You may encrypt your data stored in S3. The encryption is only valid for data at rest in S3 and will
-be transferred in decrypted form when read by clients.
+be transferred in decrypted form when read by clients. Note, enabling this will also enable HTTPS
+to comply with requirements for reading/writing objects.
 
 Enable this feature by configuring `conf/alluxio-site.properties`:
 

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -156,7 +156,8 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
         .setSocketTimeout((int) conf.getMs(PropertyKey.UNDERFS_S3_SOCKET_TIMEOUT));
 
     // HTTP protocol
-    if (Boolean.parseBoolean(conf.get(PropertyKey.UNDERFS_S3_SECURE_HTTP_ENABLED))) {
+    if (Boolean.parseBoolean(conf.get(PropertyKey.UNDERFS_S3_SECURE_HTTP_ENABLED))
+        || Boolean.parseBoolean(conf.get(PropertyKey.UNDERFS_S3_SERVER_SIDE_ENCRYPTION_ENABLED))) {
       clientConf.setProtocol(Protocol.HTTPS);
     } else {
       clientConf.setProtocol(Protocol.HTTP);


### PR DESCRIPTION
When enabling SSE, PUT/GET requests to S3 must use HTTPS or the response will be a 403. Instead of having the user specify the need for HTTPS manually, we should enable it by default whenever SSE is specified.