### PR TITLE
Remove ceph module from underfs temporarily

### DIFF
--- a/underfs/pom.xml
+++ b/underfs/pom.xml
@@ -25,7 +25,6 @@
   <modules>
     <module>abfs</module>
     <module>adl</module>
-    <module>cephfs</module>
     <module>cephfs-hadoop</module>
     <module>cos</module>
     <module>cosn</module>


### PR DESCRIPTION
Remove ceph module from underfs pom so that it will be skipped for maven build. Temporary workaround for #13309 