### PR TITLE
[SMALLFIX] Change alluxio.logger.type property to hidden

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -333,7 +333,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey LOGGER_TYPE =
       new Builder(Name.LOGGER_TYPE)
           .setDefaultValue("Console")
-          .setDescription("This controls which logger the process uses. This is only set by code.")
+          .setDescription("This controls which logger the process uses. "
+              + "This is only set by test code.")
           .setIsHidden(true)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.ALL)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -333,7 +333,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey LOGGER_TYPE =
       new Builder(Name.LOGGER_TYPE)
           .setDefaultValue("Console")
-          .setDescription("The type of logger.")
+          .setDescription("This controls which logger the process uses. This is only set by code.")
+          .setIsHidden(true)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.ALL)
           .build();


### PR DESCRIPTION
This property is only used in tests. It also should not be set explicitly by the users. It's confusing to display the property on the doc page.
<img width="905" alt="Screen Shot 2021-04-29 at 4 53 54 PM" src="https://user-images.githubusercontent.com/14806853/116525859-8a012f80-a90b-11eb-8cad-74f52a729686.png">
