### PR TITLE
[SMALLFIX] Fix NPE in Allocator and add some UT for Reviewer

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -629,10 +629,8 @@ public class TieredBlockStore implements BlockStore {
           // Block expansion are forcing the location. We do not want the review's opinion.
           dirView = mAllocator.allocateBlockWithView(sessionId, options.getSize(),
               options.getLocation(), allocatorView.refreshView(), true);
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Allocation after freeing space for block expansion. availableBytes: {}",
-                dirView.getAvailableBytes());
-          }
+          LOG.debug("Allocation after freeing space for block expansion. availableBytes: {}",
+                  dirView == null ? 0 : dirView.getAvailableBytes());
           if (dirView == null) {
             LOG.error("Target tier: {} has no evictable space to store {} bytes for session: {}",
                 options.getLocation(), options.getSize(), sessionId);
@@ -671,7 +669,8 @@ public class TieredBlockStore implements BlockStore {
           // Skip the review as we want the allocation to be in the place we just freed
           dirView = mAllocator.allocateBlockWithView(sessionId, options.getSize(),
               BlockStoreLocation.anyTier(), allocatorView.refreshView(), true);
-          LOG.debug("Allocation after freeing space for block creation: {}", dirView);
+          LOG.debug("Allocation after freeing space for block creation. availableBytes: {}",
+                  dirView == null ? 0 : dirView.getAvailableBytes());
         }
       }
       if (dirView == null) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -629,8 +629,10 @@ public class TieredBlockStore implements BlockStore {
           // Block expansion are forcing the location. We do not want the review's opinion.
           dirView = mAllocator.allocateBlockWithView(sessionId, options.getSize(),
               options.getLocation(), allocatorView.refreshView(), true);
-          LOG.debug("Allocation after freeing space for block expansion. availableBytes: {}",
-                  dirView == null ? 0 : dirView.getAvailableBytes());
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Allocation after freeing space for block expansion, {}", dirView == null
+                ? "no available dir." : "available bytes in dir: " + dirView.getAvailableBytes());
+          }
           if (dirView == null) {
             LOG.error("Target tier: {} has no evictable space to store {} bytes for session: {}",
                 options.getLocation(), options.getSize(), sessionId);
@@ -669,8 +671,10 @@ public class TieredBlockStore implements BlockStore {
           // Skip the review as we want the allocation to be in the place we just freed
           dirView = mAllocator.allocateBlockWithView(sessionId, options.getSize(),
               BlockStoreLocation.anyTier(), allocatorView.refreshView(), true);
-          LOG.debug("Allocation after freeing space for block creation. availableBytes: {}",
-                  dirView == null ? 0 : dirView.getAvailableBytes());
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Allocation after freeing space for block creation, {} ", dirView == null
+                ? "no available dir." : "available bytes in dir: " + dirView.getAvailableBytes());
+          }
         }
       }
       if (dirView == null) {

--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorTestBase.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorTestBase.java
@@ -26,7 +26,9 @@ import alluxio.worker.block.meta.StorageDir;
 import alluxio.worker.block.meta.StorageDirView;
 import alluxio.worker.block.meta.StorageTier;
 import alluxio.worker.block.meta.TempBlockMeta;
+import alluxio.worker.block.reviewer.MockReviewer;
 
+import com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -89,6 +91,10 @@ public class AllocatorTestBase {
     String alluxioHome = mTestFolder.newFolder().getAbsolutePath();
     ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, "false");
     ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, "false");
+    ServerConfiguration.set(PropertyKey.WORKER_REVIEWER_CLASS,
+            "alluxio.worker.block.reviewer.MockReviewer");
+    // Reviewer will not reject by default.
+    MockReviewer.resetBytesToReject(Sets.newHashSet());
     TieredBlockStoreTestUtils.setupConfWithMultiTier(alluxioHome, TIER_LEVEL, TIER_ALIAS,
         TIER_PATH, TIER_CAPACITY_BYTES, TIER_MEDIA_TYPE, null);
     mManager = BlockMetadataManager.createBlockMetadataManager();
@@ -136,10 +142,9 @@ public class AllocatorTestBase {
 
     mTestBlockId++;
 
-    // We skip the review here as we do not want the Reviewer's opinion to affect the test
     StorageDirView dirView =
         allocator.allocateBlockWithView(SESSION_ID, blockSize, location,
-                getMetadataEvictorView(), true);
+                getMetadataEvictorView(), false);
     TempBlockMeta tempBlockMeta =
         dirView == null ? null : dirView.createTempBlockMeta(SESSION_ID, mTestBlockId, blockSize);
 
@@ -151,7 +156,7 @@ public class AllocatorTestBase {
       StorageDir pDir = tempBlockMeta.getParentDir();
       StorageTier pTier = pDir.getParentTier();
 
-      assertTrue(pDir.getDirIndex() == dirIndex);
+      assertEquals(dirIndex, pDir.getDirIndex());
       assertEquals(tierAlias, pTier.getTierAlias());
 
       //update the dir meta info

--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/GreedyAllocatorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/GreedyAllocatorTest.java
@@ -13,7 +13,9 @@ package alluxio.worker.block.allocator;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.worker.block.reviewer.MockReviewer;
 
+import com.google.common.collect.Sets;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -145,6 +147,30 @@ public final class GreedyAllocatorTest extends AllocatorTestBase {
     //  1      └───── 500
     //  0               ├─── 0
     //  1               ├─── 1300   <--- alloc
+    //  2               └─── 3000
+    //
+
+    /** Reviewer's opinion affects the test */
+    MockReviewer.resetBytesToReject(Sets.newHashSet(500L));
+
+    assertTempBlockMeta(mAllocator, mAnyTierLoc, 100, true, "HDD", 1);
+    //
+    // idx | tier1 | tier2 | tier3
+    //  0      0
+    //  0      ├───── 0
+    //  1      └───── 500
+    //  0               ├─── 0
+    //  1               ├─── 1200   <--- alloc
+    //  2               └─── 3000
+    //
+    assertTempBlockMeta(mAllocator, mAnyDirInTierLoc2, 100, false, "", 0);
+    //
+    // idx | tier1 | tier2 | tier3
+    //  0      0
+    //  0      ├───── 0
+    //  1      └───── 500
+    //  0               ├─── 0
+    //  1               ├─── 1200
     //  2               └─── 3000
     //
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/MaxFreeAllocatorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/MaxFreeAllocatorTest.java
@@ -13,7 +13,9 @@ package alluxio.worker.block.allocator;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.worker.block.reviewer.MockReviewer;
 
+import com.google.common.collect.Sets;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -85,6 +87,39 @@ public final class MaxFreeAllocatorTest extends AllocatorTestBase {
     //  1      └───── 0
     //  0               ├─── 3000
     //  1               ├─── 3000
+    //  2               └─── 3000
+    //
+
+    /** Reviewer's opinion affects the test */
+    MockReviewer.resetBytesToReject(Sets.newHashSet(700L, 2700L, 3000L));
+    assertTempBlockMeta(mAllocator, mAnyTierLoc, 300, true, "HDD", 0);
+    //
+    // idx | tier1 | tier2 | tier3
+    //  0     700
+    //  0      ├───── 200
+    //  1      └───── 0
+    //  0               ├─── 2700   <--- alloc
+    //  1               ├─── 3000
+    //  2               └─── 3000
+    //
+    assertTempBlockMeta(mAllocator, mAnyTierLoc, 300, true, "HDD", 1);
+    //
+    // idx | tier1 | tier2 | tier3
+    //  0     700
+    //  0      ├───── 200
+    //  1      └───── 0
+    //  0               ├─── 2700
+    //  1               ├─── 2700  <--- alloc
+    //  2               └─── 3000
+    //
+    assertTempBlockMeta(mAllocator, mAnyDirInTierLoc1, 300, false, "", 0);
+    //
+    // idx | tier1 | tier2 | tier3
+    //  0     700
+    //  0      ├───── 200
+    //  1      └───── 0
+    //  0               ├─── 2700
+    //  1               ├─── 2700
     //  2               └─── 3000
     //
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/RoundRobinAllocatorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/RoundRobinAllocatorTest.java
@@ -13,7 +13,9 @@ package alluxio.worker.block.allocator;
 
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.worker.block.reviewer.MockReviewer;
 
+import com.google.common.collect.Sets;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -226,6 +228,28 @@ public final class RoundRobinAllocatorTest extends AllocatorTestBase {
     //  1      └───── 100
     //  0               ├─── 1800
     //  1               ├─── 700   <--- alloc
+    //  2               └─── 0
+    //
+
+    /** Reviewer's opinion affects the test */
+    MockReviewer.resetBytesToReject(Sets.newHashSet(200L));
+
+    assertTempBlockMeta(mAllocator, mAnyTierLoc, 50, true, "SSD", 1);
+    // idx | tier1 | tier2 | tier3
+    //  0    200
+    //  0      ├───── 0
+    //  1      └───── 50   <--- alloc
+    //  0               ├─── 1800
+    //  1               ├─── 700
+    //  2               └─── 0
+    //
+    assertTempBlockMeta(mAllocator, mAnyDirInTierLoc1, 50, false, "", 0);
+    // idx | tier1 | tier2 | tier3
+    //  0    200
+    //  0      ├───── 0
+    //  1      └───── 50
+    //  0               ├─── 1800
+    //  1               ├─── 700
     //  2               └─── 0
     //
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/reviewer/MockReviewer.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/reviewer/MockReviewer.java
@@ -1,0 +1,39 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block.reviewer;
+
+import alluxio.worker.block.meta.StorageDirView;
+
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+
+/**
+ * An implementation of {@link Reviewer}. This is used to Reviewer unit test.
+ * If a directory's `availableBytes` matches the bytes in `BYTES_TO_REJECT`,
+ * allocation will be rejected.
+ */
+public class MockReviewer implements Reviewer {
+
+    private static final Set<Long> BYTES_TO_REJECT = Sets.newHashSet();
+
+    public static void resetBytesToReject(Set<Long> bytes) {
+        BYTES_TO_REJECT.clear();
+        BYTES_TO_REJECT.addAll(bytes);
+    }
+
+    @Override
+    public boolean acceptAllocation(StorageDirView dirView) {
+        long availableBytes = dirView.getAvailableBytes();
+        return !BYTES_TO_REJECT.contains(availableBytes);
+    }
+}

--- a/core/server/worker/src/test/java/alluxio/worker/block/reviewer/MockReviewer.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/reviewer/MockReviewer.java
@@ -24,16 +24,16 @@ import java.util.Set;
  */
 public class MockReviewer implements Reviewer {
 
-    private static final Set<Long> BYTES_TO_REJECT = Sets.newHashSet();
+  private static final Set<Long> BYTES_TO_REJECT = Sets.newHashSet();
 
-    public static void resetBytesToReject(Set<Long> bytes) {
-        BYTES_TO_REJECT.clear();
-        BYTES_TO_REJECT.addAll(bytes);
-    }
+  public static void resetBytesToReject(Set<Long> bytes) {
+    BYTES_TO_REJECT.clear();
+    BYTES_TO_REJECT.addAll(bytes);
+  }
 
-    @Override
-    public boolean acceptAllocation(StorageDirView dirView) {
-        long availableBytes = dirView.getAvailableBytes();
-        return !BYTES_TO_REJECT.contains(availableBytes);
-    }
+  @Override
+  public boolean acceptAllocation(StorageDirView dirView) {
+    long availableBytes = dirView.getAvailableBytes();
+    return !BYTES_TO_REJECT.contains(availableBytes);
+  }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/reviewer/MockReviewer.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/reviewer/MockReviewer.java
@@ -18,7 +18,7 @@ import com.google.common.collect.Sets;
 import java.util.Set;
 
 /**
- * An implementation of {@link Reviewer}. This is used to Reviewer unit test.
+ * An implementation of {@link Reviewer}. This is used for Reviewer unit test.
  * If a directory's `availableBytes` matches the bytes in `BYTES_TO_REJECT`,
  * allocation will be rejected.
  */


### PR DESCRIPTION
1. Allocator may  allocate null dirView ,`dirView.getAvailableBytes()`  is NPE and dirView has no toString implementation.
2. Add some UT for `Reviewer`