### PR TITLE
Print all live masters addresses to fsadmin report

### DIFF
--- a/shell/src/main/java/alluxio/cli/fsadmin/report/SummaryCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/SummaryCommand.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 /**
  * Prints Alluxio cluster summarized information.
@@ -78,13 +79,16 @@ public class SummaryCommand {
   private void printMetaMasterInfo() throws IOException {
     mIndentationLevel++;
     Set<MasterInfoField> masterInfoFilter = new HashSet<>(Arrays
-        .asList(MasterInfoField.LEADER_MASTER_ADDRESS, MasterInfoField.WEB_PORT,
-            MasterInfoField.RPC_PORT, MasterInfoField.START_TIME_MS,
-            MasterInfoField.UP_TIME_MS, MasterInfoField.VERSION,
-            MasterInfoField.SAFE_MODE, MasterInfoField.ZOOKEEPER_ADDRESSES));
+        .asList(MasterInfoField.LEADER_MASTER_ADDRESS,
+          MasterInfoField.MASTER_ADDRESSES, MasterInfoField.WEB_PORT,
+          MasterInfoField.RPC_PORT, MasterInfoField.START_TIME_MS,
+          MasterInfoField.UP_TIME_MS, MasterInfoField.VERSION,
+          MasterInfoField.SAFE_MODE, MasterInfoField.ZOOKEEPER_ADDRESSES));
     MasterInfo masterInfo = mMetaMasterClient.getMasterInfo(masterInfoFilter);
 
     print("Master Address: " + masterInfo.getLeaderMasterAddress());
+    print("Live Masters Addresses: " + masterInfo.getMasterAddressesList().stream().map(netAddress
+        -> netAddress.getHost() + ":" + netAddress.getRpcPort()).collect(Collectors.toList()));
     print("Web Port: " + masterInfo.getWebPort());
     print("Rpc Port: " + masterInfo.getRpcPort());
     print("Started: " + CommonUtils.convertMsToDate(masterInfo.getStartTimeMs(),

--- a/shell/src/main/java/alluxio/cli/fsadmin/report/SummaryCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/SummaryCommand.java
@@ -86,7 +86,7 @@ public class SummaryCommand {
           MasterInfoField.SAFE_MODE, MasterInfoField.ZOOKEEPER_ADDRESSES));
     MasterInfo masterInfo = mMetaMasterClient.getMasterInfo(masterInfoFilter);
 
-    print("Master Address: " + masterInfo.getLeaderMasterAddress());
+    print("Leader Master Address: " + masterInfo.getLeaderMasterAddress());
     print("Live Masters Addresses: " + masterInfo.getMasterAddressesList().stream().map(netAddress
         -> netAddress.getHost() + ":" + netAddress.getRpcPort()).collect(Collectors.toList()));
     print("Web Port: " + masterInfo.getWebPort());

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
@@ -21,6 +21,7 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.MasterInfo;
+import alluxio.grpc.NetAddress;
 import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 import alluxio.wire.BlockMasterInfo;
@@ -57,6 +58,9 @@ public class SummaryCommandTest {
     mMetaMasterClient = mock(MetaMasterClient.class);
     MasterInfo masterInfo = MasterInfo.newBuilder()
         .setLeaderMasterAddress("testAddress")
+        .addMasterAddresses(NetAddress.newBuilder().setHost("testAddress").build())
+        .addMasterAddresses(NetAddress.newBuilder().setHost("testAddress2").build())
+        .addMasterAddresses(NetAddress.newBuilder().setHost("testAddress3").build())
         .setWebPort(1231)
         .setRpcPort(8462)
         .setStartTimeMs(1131242343122L)
@@ -116,6 +120,7 @@ public class SummaryCommandTest {
     String startTime =  CommonUtils.convertMsToDate(1131242343122L, dateFormatPattern);
     List<String> expectedOutput = Arrays.asList("Alluxio cluster summary: ",
         "    Master Address: testAddress",
+        "    Live Masters Addresses: [testAddress:0, testAddress2:0, testAddress3:0]",
         "    Web Port: 1231",
         "    Rpc Port: 8462",
         "    Started: " + startTime,

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
@@ -119,7 +119,7 @@ public class SummaryCommandTest {
     // Skip checking startTime which relies on system time zone
     String startTime =  CommonUtils.convertMsToDate(1131242343122L, dateFormatPattern);
     List<String> expectedOutput = Arrays.asList("Alluxio cluster summary: ",
-        "    Master Address: testAddress",
+        "    Leader Master Address: testAddress",
         "    Live Masters Addresses: [testAddress:0, testAddress2:0, testAddress3:0]",
         "    Web Port: 1231",
         "    Rpc Port: 8462",

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
@@ -119,7 +119,7 @@ public class SummaryCommandTest {
     // Skip checking startTime which relies on system time zone
     String startTime =  CommonUtils.convertMsToDate(1131242343122L, dateFormatPattern);
     List<String> expectedOutput = Arrays.asList("Alluxio cluster summary: ",
-        "    Leader Master Address: testAddress",
+        "    Leader Master Address: testAddress:8462",
         "    Live Masters Addresses: [testAddress:8462, testAddress2:975, testAddress3:976]",
         "    Web Port: 1231",
         "    Rpc Port: 8462",

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
@@ -57,10 +57,10 @@ public class SummaryCommandTest {
     // Prepare mock meta master client
     mMetaMasterClient = mock(MetaMasterClient.class);
     MasterInfo masterInfo = MasterInfo.newBuilder()
-        .setLeaderMasterAddress("testAddress")
-        .addMasterAddresses(NetAddress.newBuilder().setHost("testAddress").build())
-        .addMasterAddresses(NetAddress.newBuilder().setHost("testAddress2").build())
-        .addMasterAddresses(NetAddress.newBuilder().setHost("testAddress3").build())
+        .setLeaderMasterAddress("testAddress:8462")
+        .addMasterAddresses(NetAddress.newBuilder().setHost("testAddress").setRpcPort(8462).build())
+        .addMasterAddresses(NetAddress.newBuilder().setHost("testAddress2").setRpcPort(975).build())
+        .addMasterAddresses(NetAddress.newBuilder().setHost("testAddress3").setRpcPort(976).build())
         .setWebPort(1231)
         .setRpcPort(8462)
         .setStartTimeMs(1131242343122L)
@@ -120,7 +120,7 @@ public class SummaryCommandTest {
     String startTime =  CommonUtils.convertMsToDate(1131242343122L, dateFormatPattern);
     List<String> expectedOutput = Arrays.asList("Alluxio cluster summary: ",
         "    Leader Master Address: testAddress",
-        "    Live Masters Addresses: [testAddress:0, testAddress2:0, testAddress3:0]",
+        "    Live Masters Addresses: [testAddress:8462, testAddress2:975, testAddress3:976]",
         "    Web Port: 1231",
         "    Rpc Port: 8462",
         "    Started: " + startTime,


### PR DESCRIPTION
When doing command `fsadmin report`, not only the leader master address is showed, all addresses of live masters are now being printed for more complete information.