### PR TITLE
Cancel sync job in middle of ufs calls if client cancelled

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2514,7 +2514,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE =
       new Builder(Name.MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE)
-          .setDefaultSupplier(() -> Runtime.getRuntime().availableProcessors(),
+          .setDefaultSupplier(() -> 10 * Runtime.getRuntime().availableProcessors(),
               "The number of threads which can concurrently fetch metadata from UFSes during a "
                   + "metadata sync operations")
           .setDescription("The number of threads used to fetch UFS objects for all metadata sync"

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2514,7 +2514,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE =
       new Builder(Name.MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE)
-          .setDefaultSupplier(() -> 10 * Runtime.getRuntime().availableProcessors(),
+          .setDefaultSupplier(() -> Runtime.getRuntime().availableProcessors(),
               "The number of threads which can concurrently fetch metadata from UFSes during a "
                   + "metadata sync operations")
           .setDescription("The number of threads used to fetch UFS objects for all metadata sync"

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -86,10 +86,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
@@ -498,6 +501,20 @@ public class InodeSyncStream {
     }
   }
 
+  private Object getFromUfs(Callable<Object> task) throws InterruptedException {
+    final Future<Object> future = mFsMaster.mSyncPrefetchExecutor.submit(task);
+    while (true) {
+      try {
+        return future.get(1, TimeUnit.SECONDS);
+      } catch (TimeoutException e) {
+        mRpcContext.throwIfCancelled();
+      } catch (ExecutionException e) {
+        LogUtils.warnWithException(LOG, "Failed to get result for prefetch job", e);
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
   /**
    * Sync inode metadata with the UFS state.
    *
@@ -509,7 +526,7 @@ public class InodeSyncStream {
       InterruptedException {
     if (inodePath.getLockPattern() != LockPattern.WRITE_EDGE && !mLoadOnly) {
       throw new RuntimeException(String.format(
-          "syncExistingInodeMetadata was called on %s when only locked with %s. Load metadata"
+          "syncExistingInodeMetadata was called on d%s when only locked with %s. Load metadata"
           + " only was not specified.", inodePath.getUri(), inodePath.getLockPattern()));
     }
 
@@ -561,13 +578,13 @@ public class InodeSyncStream {
           ufsFpParsed = Fingerprint.parse(ufsFingerprint);
         } else if (cachedStatus == null) {
           // TODO(david): change the interface so that getFingerprint returns a parsed fingerprint
-          ufsFingerprint = ufs.getFingerprint(ufsUri.toString());
+          ufsFingerprint = (String) getFromUfs(() -> ufs.getFingerprint(ufsUri.toString()));
           ufsFpParsed = Fingerprint.parse(ufsFingerprint);
         } else {
           // When the status is cached
           Pair<AccessControlList, DefaultAccessControlList> aclPair =
-              ufs.getAclPair(ufsUri.toString());
-
+              (Pair<AccessControlList, DefaultAccessControlList>)
+                  getFromUfs(() -> ufs.getAclPair(ufsUri.toString()));
           if (aclPair == null || aclPair.getFirst() == null || !aclPair.getFirst().hasExtended()) {
             ufsFpParsed = Fingerprint.create(ufs.getUnderFSType(), cachedStatus);
           } else {
@@ -644,8 +661,9 @@ public class InodeSyncStream {
           .forEach(child -> inodeChildren.put(child.getName(), child));
 
       // Fetch and populate children into the cache
+      mStatusCache.prefetchChildren(inodePath.getUri(), mMountTable);
       Collection<UfsStatus> listStatus = mStatusCache
-          .fetchChildrenIfAbsent(inodePath.getUri(), mMountTable);
+          .fetchChildrenIfAbsent(mRpcContext, inodePath.getUri(), mMountTable);
       // Iterate over UFS listings and process UFS children.
       if (listStatus != null) {
         for (UfsStatus ufsChildStatus : listStatus) {
@@ -740,8 +758,8 @@ public class InodeSyncStream {
         // now load all children if required
         LoadDescendantPType type = context.getOptions().getLoadDescendantType();
         if (type != LoadDescendantPType.NONE) {
-          Collection<UfsStatus> children = mStatusCache.fetchChildrenIfAbsent(inodePath.getUri(),
-              mMountTable);
+          Collection<UfsStatus> children = mStatusCache.fetchChildrenIfAbsent(mRpcContext,
+              inodePath.getUri(), mMountTable);
           if (children == null) {
             LOG.debug("fetching children for {} returned null", inodePath.getUri());
             return;

--- a/core/server/master/src/main/java/alluxio/master/file/RpcContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/RpcContext.java
@@ -20,6 +20,8 @@ import alluxio.master.journal.NoopJournalContext;
 import alluxio.proto.journal.Journal.JournalEntry;
 
 import com.google.common.base.Throwables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.util.List;
@@ -38,6 +40,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class RpcContext implements Closeable, Supplier<JournalContext> {
+  private static final Logger LOG = LoggerFactory.getLogger(RpcContext.class);
   public static final RpcContext NOOP = new RpcContext(NoopBlockDeletionContext.INSTANCE,
       NoopJournalContext.INSTANCE, new InternalOperationContext());
 

--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -14,6 +14,7 @@ package alluxio.underfs;
 import alluxio.AlluxioURI;
 import alluxio.collections.ConcurrentHashSet;
 import alluxio.exception.InvalidPathException;
+import alluxio.master.file.RpcContext;
 import alluxio.master.file.meta.MountTable;
 import alluxio.master.file.meta.UfsAbsentPathCache;
 import alluxio.resource.CloseableResource;
@@ -32,6 +33,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -202,6 +205,7 @@ public class UfsStatusCache {
    * parameter is true, fetch them from the UFS and store them in the cache. Otherwise, simply
    * return null.
    *
+   * @param rpcContext the rpcContext of the source of this call
    * @param path the Alluxio path to get the children of
    * @param mountTable the Alluxio mount table
    * @param useFallback whether or not to fall back to calling the UFS
@@ -210,22 +214,29 @@ public class UfsStatusCache {
    * @throws InvalidPathException if the alluxio path can't be resolved to a UFS mount
    */
   @Nullable
-  public Collection<UfsStatus> fetchChildrenIfAbsent(AlluxioURI path, MountTable mountTable,
-      boolean useFallback)
+  public Collection<UfsStatus> fetchChildrenIfAbsent(RpcContext rpcContext, AlluxioURI path,
+                                                     MountTable mountTable, boolean useFallback)
       throws InterruptedException, InvalidPathException {
     Future<Collection<UfsStatus>> prefetchJob = mActivePrefetchJobs.get(path);
     if (prefetchJob != null) {
-      try {
-        return prefetchJob.get();
-      } catch (InterruptedException | ExecutionException e) {
-        LogUtils.warnWithException(LOG, "Failed to get result for prefetch job on alluxio path {}",
-            path, e);
-        if (e instanceof InterruptedException) {
-          Thread.currentThread().interrupt();
-          throw (InterruptedException) e;
+      while (true) {
+        try {
+          return prefetchJob.get(100, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+          if (rpcContext != null) {
+            rpcContext.throwIfCancelled();
+          }
+        } catch (InterruptedException | ExecutionException e) {
+          LogUtils.warnWithException(LOG,
+              "Failed to get result for prefetch job on alluxio path {}", path, e);
+          if (e instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+            throw (InterruptedException) e;
+          }
+          break;
+        } finally {
+          mActivePrefetchJobs.remove(path);
         }
-      } finally {
-        mActivePrefetchJobs.remove(path);
       }
     }
     Collection<UfsStatus> children = getChildren(path);
@@ -245,15 +256,17 @@ public class UfsStatusCache {
    * Will always return statuses from the UFS whether or not they exist in the cache, and whether
    * a prefetch job was scheduled or not.
    *
+   * @param rpcContext the rpcContext of the source of this call
    * @param path the Alluxio path
    * @param mountTable the Alluxio mount table
    * @return child UFS statuses of the alluxio path
    * @throws InvalidPathException if the alluxio path can't be resolved to a UFS mount
    */
   @Nullable
-  public Collection<UfsStatus> fetchChildrenIfAbsent(AlluxioURI path, MountTable mountTable)
+  public Collection<UfsStatus> fetchChildrenIfAbsent(RpcContext rpcContext, AlluxioURI path,
+                                                     MountTable mountTable)
       throws InterruptedException, InvalidPathException {
-    return fetchChildrenIfAbsent(path, mountTable, true);
+    return fetchChildrenIfAbsent(rpcContext, path, mountTable, true);
   }
 
   /**
@@ -309,8 +322,8 @@ public class UfsStatusCache {
   /**
    * Submit a request to asynchronously fetch the statuses corresponding to a given directory.
    *
-   * Retrieve any fetched statuses by calling {@link #fetchChildrenIfAbsent(AlluxioURI, MountTable)}
-   * with the same Alluxio path.
+   * Retrieve any fetched statuses by calling
+   * {@link #fetchChildrenIfAbsent(RpcContext, AlluxioURI, MountTable)} with the same Alluxio path.
    *
    * If no {@link ExecutorService} was provided to this object before instantiation, this method is
    * a no-op.

--- a/core/server/master/src/test/java/alluxio/underfs/UfsStatusCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/underfs/UfsStatusCacheTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
@@ -28,14 +29,22 @@ import alluxio.Constants;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.InvalidPathException;
 import alluxio.grpc.MountPOptions;
+import alluxio.master.file.BlockDeletionContext;
+import alluxio.master.file.RpcContext;
+import alluxio.master.file.contexts.CallTracker;
+import alluxio.master.file.contexts.OperationContext;
 import alluxio.master.file.meta.MountTable;
 import alluxio.master.file.meta.NoopUfsAbsentPathCache;
 import alluxio.master.file.meta.UfsAbsentPathCache;
 import alluxio.master.file.meta.options.MountInfo;
+import alluxio.master.journal.JournalContext;
 import alluxio.underfs.local.LocalUnderFileSystem;
 import alluxio.util.IdUtils;
 import alluxio.util.io.PathUtils;
 
+import com.google.common.collect.Lists;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -139,7 +148,7 @@ public class UfsStatusCacheTest {
       mCache.prefetchChildren(new AlluxioURI("/" + Character.getName(i)), mMountTable);
     }
     mCache.cancelAllPrefetch();
-    assertNull(mCache.fetchChildrenIfAbsent(new AlluxioURI("/" + Character.getName(89)),
+    assertNull(mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/" + Character.getName(89)),
         mMountTable, false));
   }
 
@@ -148,7 +157,7 @@ public class UfsStatusCacheTest {
     createUfsDirs("a");
     createUfsFile("a/b");
     Collection<UfsStatus> children = mCache
-        .fetchChildrenIfAbsent(new AlluxioURI("/a"), mMountTable);
+        .fetchChildrenIfAbsent(null, new AlluxioURI("/a"), mMountTable);
     assertEquals(1, children.size());
     children.forEach(stat -> assertEquals("b", stat.getName()));
   }
@@ -165,7 +174,7 @@ public class UfsStatusCacheTest {
     Thread t = new Thread(() -> {
       try {
         try {
-          mCache.fetchChildrenIfAbsent(new AlluxioURI("/"), mMountTable);
+          mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/"), mMountTable);
           fail("Should not have been able to fetch children");
         } catch (InterruptedException | InvalidPathException e) {
           // Assert interrupted flag was set properly.
@@ -183,6 +192,51 @@ public class UfsStatusCacheTest {
   }
 
   @Test
+  public void testFetchCancel() throws Exception {
+    spyUfs();
+    doAnswer((Answer<UfsStatus[]>) invocation -> {
+      Thread.sleep(30 * Constants.HOUR_MS);
+      return new UfsStatus[] {Mockito.mock(UfsStatus.class)};
+    }).when(mUfs).listStatus(any(String.class));
+    mCache.prefetchChildren(new AlluxioURI("/"), mMountTable);
+
+    final BlockDeletionContext bdc = mock(BlockDeletionContext.class);
+    final JournalContext jc = mock(JournalContext.class);
+    final OperationContext oc = mock(OperationContext.class);
+    when(oc.getCancelledTrackers()).thenReturn(Lists.newArrayList());
+    final RpcContext rpcContext = new RpcContext(bdc, jc, oc);
+
+    AtomicReference<RuntimeException> ref = new AtomicReference<>(null);
+    Thread t = new Thread(() -> {
+      try {
+        mCache.fetchChildrenIfAbsent(rpcContext, new AlluxioURI("/"), mMountTable);
+        fail("Should not have been able to fetch children");
+      } catch (RuntimeException e) {
+        ref.set(e);
+      } catch (InterruptedException | InvalidPathException e) {
+        // do nothing
+      }
+    });
+    t.start();
+    when(oc.getCancelledTrackers()).thenReturn(Lists.newArrayList(new CallTracker() {
+      @Override
+      public boolean isCancelled() {
+        return true;
+      }
+
+      @Override
+      public Type getType() {
+        return Type.GRPC_CLIENT_TRACKER;
+      }
+    }));
+    t.join();
+    final RuntimeException runtimeException = ref.get();
+    assertNotNull(runtimeException);
+    MatcherAssert.assertThat(runtimeException.getMessage(),
+        Matchers.stringContainsInOrder("Call cancelled"));
+  }
+
+  @Test
   public void testFetchExecutionException() throws Exception {
     spyUfs();
     // Now test execution exception
@@ -195,7 +249,7 @@ public class UfsStatusCacheTest {
       try {
         try {
           assertNull("Should return null when fetching children",
-              mCache.fetchChildrenIfAbsent(new AlluxioURI("/"), mMountTable, false));
+              mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/"), mMountTable, false));
         } catch (InterruptedException | InvalidPathException e) {
           // Thread should not be interrupted if interrupt not called
           assertFalse(Thread.currentThread().isInterrupted());
@@ -226,7 +280,8 @@ public class UfsStatusCacheTest {
     assertEquals(stat, mCache.getStatus(path));
     assertEquals(statChild, mCache.getStatus(pathChild));
     assertEquals(Collections.singleton(statChild), mCache.getChildren(path));
-    assertEquals(Collections.singleton(statChild), mCache.fetchChildrenIfAbsent(path, mMountTable));
+    assertEquals(Collections.singleton(statChild),
+        mCache.fetchChildrenIfAbsent(null, path, mMountTable));
 
     mCache.remove(path);
     assertNull(mCache.getStatus(path));
@@ -250,15 +305,18 @@ public class UfsStatusCacheTest {
     mCache.prefetchChildren(new AlluxioURI("/mnt/dir1/dir0"), mMountTable);
     mCache.prefetchChildren(new AlluxioURI("/mnt/dir2/dir0"), mMountTable);
     Collection<UfsStatus> children;
-    children = mCache.fetchChildrenIfAbsent(new AlluxioURI("/mnt/dir1/dir0"), mMountTable, false);
+    children = mCache.fetchChildrenIfAbsent(
+        null, new AlluxioURI("/mnt/dir1/dir0"), mMountTable, false);
     assertNotNull(children);
     assertEquals(1, children.size());
     children.forEach(s -> assertEquals("dir2", s.getName()));
-    children = mCache.fetchChildrenIfAbsent(new AlluxioURI("/mnt/dir2/dir0"), mMountTable, false);
+    children = mCache.fetchChildrenIfAbsent(
+        null, new AlluxioURI("/mnt/dir2/dir0"), mMountTable, false);
     assertNotNull(children);
     assertEquals(1, children.size());
     children.forEach(s -> assertEquals("dir3", s.getName()));
-    children = mCache.fetchChildrenIfAbsent(new AlluxioURI("/mnt/dir1/dir0"), mMountTable, false);
+    children = mCache.fetchChildrenIfAbsent(
+        null, new AlluxioURI("/mnt/dir1/dir0"), mMountTable, false);
     assertNotNull(children);
     assertEquals(1, children.size());
     children.forEach(s -> assertEquals("dir2", s.getName()));
@@ -271,10 +329,10 @@ public class UfsStatusCacheTest {
     mCache.prefetchChildren(new AlluxioURI("/dir0/dir0"), mMountTable);
     mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable);
     Collection<UfsStatus> statuses =
-        mCache.fetchChildrenIfAbsent(new AlluxioURI("/dir0/dir0"), mMountTable, false);
+        mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/dir0/dir0"), mMountTable, false);
     assertEquals(1, statuses.size());
     statuses.forEach(s -> assertEquals("file", s.getName()));
-    statuses = mCache.fetchChildrenIfAbsent(new AlluxioURI("/dir0"), mMountTable, false);
+    statuses = mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/dir0"), mMountTable, false);
     assertEquals(1, statuses.size());
     statuses.forEach(s -> assertEquals("dir0", s.getName()));
   }
@@ -300,11 +358,11 @@ public class UfsStatusCacheTest {
     assertNotNull(f1);
     assertTrue("first future is cancelled", f1.isCancelled());
     Collection<UfsStatus> statuses =
-        mCache.fetchChildrenIfAbsent(new AlluxioURI("/dir0/dir0"), mMountTable, true);
+        mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/dir0/dir0"), mMountTable, true);
     assertEquals(1, statuses.size());
     statuses.forEach(s -> assertEquals("file", s.getName()));
     l.unlock();
-    statuses = mCache.fetchChildrenIfAbsent(new AlluxioURI("/dir0"), mMountTable, false);
+    statuses = mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/dir0"), mMountTable, false);
     assertNotNull(f2);
     assertTrue("second future should be finished", f2.isDone());
     assertEquals(1, statuses.size());
@@ -317,7 +375,7 @@ public class UfsStatusCacheTest {
     mCache = new UfsStatusCache(null, new NoopUfsAbsentPathCache(),
         UfsAbsentPathCache.ALWAYS);
     mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable);
-    assertNull(mCache.fetchChildrenIfAbsent(new AlluxioURI("/dir0"), mMountTable, false));
+    assertNull(mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/dir0"), mMountTable, false));
   }
 
   @Test
@@ -345,7 +403,7 @@ public class UfsStatusCacheTest {
     assertNull(mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable)); // rejected
     l.unlock();
     Collection<UfsStatus> statuses =
-        mCache.fetchChildrenIfAbsent(new AlluxioURI("/dir0"), mMountTable, false);
+        mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/dir0"), mMountTable, false);
     assertEquals(1, statuses.size());
     statuses.forEach(s -> assertEquals("dir1", s.getName()));
   }

--- a/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
@@ -86,7 +86,8 @@ public class LoadMetadataIntegrationTest extends BaseIntegrationTest {
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
-      new LocalAlluxioClusterResource.Builder().build();
+      new LocalAlluxioClusterResource.Builder()
+          .setProperty(PropertyKey.MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE, 4).build();
 
   @ClassRule
   public static UnderFileSystemFactoryRegistryRule sUnderfilesystemfactoryregistry =

--- a/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
@@ -87,7 +87,7 @@ public class LoadMetadataIntegrationTest extends BaseIntegrationTest {
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource.Builder()
-          .setProperty(PropertyKey.MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE, 4).build();
+          .setProperty(PropertyKey.MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE, 2).build();
 
   @ClassRule
   public static UnderFileSystemFactoryRegistryRule sUnderfilesystemfactoryregistry =


### PR DESCRIPTION
The previous version slowed down the sync because the number of prefetch threads were much smaller than the number of rpc threads that were performing a sync in many cases.