### PR TITLE
Add retry options to GCS requests

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -671,6 +671,48 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_GCS_RETRY_INITIAL_DELAY_MS =
+      new Builder(Name.UNDERFS_GCS_RETRY_INITIAL_DELAY_MS)
+          .setDefaultValue(1000)
+          .setDescription("Initial delay before attempting the retry on the ufs")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_GCS_RETRY_MAX_DELAY_MS =
+      new Builder(Name.UNDERFS_GCS_RETRY_MAX_DELAY_MS)
+          .setDefaultValue(1000 * 60)  // 1 min
+          .setDescription("Maximum delay before attempting the retry on the ufs")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_GCS_RETRY_DELAY_MULTIPLIER =
+      new Builder(Name.UNDERFS_GCS_RETRY_DELAY_MULTIPLIER)
+          .setDefaultValue(2)
+          .setDescription("Delay multiplier while retrying requests on the ufs")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_GCS_RETRY_JITTER =
+      new Builder(Name.UNDERFS_GCS_RETRY_JITTER)
+          .setDefaultValue(true)
+          .setDescription("Enable delay jitter while retrying requests on the ufs")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_GCS_RETRY_TOTAL_DURATION_MS =
+      new Builder(Name.UNDERFS_GCS_RETRY_TOTAL_DURATION_MS)
+          .setDefaultValue(5 * 1000 * 60) // 5 mins
+          .setDescription("Maximum retry duration on the ufs")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_GCS_RETRY_MAX =
+      new Builder(Name.UNDERFS_GCS_RETRY_MAX)
+          .setDefaultValue(60)
+          .setDescription("Maximum Number of retries on the ufs")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_GCS_VERSION =
       new Builder(Name.UNDERFS_GCS_VERSION)
           .setDefaultValue(2)
@@ -716,48 +758,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "will not attempt to discover locality information from the under storage "
               + "because locality is impossible. This will improve performance. The default "
               + "value is true.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
-          .setScope(Scope.SERVER)
-          .build();
-  public static final PropertyKey UNDERFS_RETRY_INITIAL_DELAY_MS =
-      new Builder(Name.UNDERFS_RETRY_INITIAL_DELAY_MS)
-          .setDefaultValue(1000)
-          .setDescription("Initial delay before attempting the retry on the ufs")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
-          .setScope(Scope.SERVER)
-          .build();
-  public static final PropertyKey UNDERFS_RETRY_MAX_DELAY_MS =
-      new Builder(Name.UNDERFS_RETRY_MAX_DELAY_MS)
-          .setDefaultValue(1000 * 60)  // 1 min
-          .setDescription("Maximum delay before attempting the retry on the ufs")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
-          .setScope(Scope.SERVER)
-          .build();
-  public static final PropertyKey UNDERFS_RETRY_DELAY_MULTIPLIER =
-      new Builder(Name.UNDERFS_RETRY_DELAY_MULTIPLIER)
-          .setDefaultValue(2)
-          .setDescription("Delay multiplier while retrying requests on the ufs")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
-          .setScope(Scope.SERVER)
-          .build();
-  public static final PropertyKey UNDERFS_RETRY_JITTER =
-      new Builder(Name.UNDERFS_RETRY_JITTER)
-          .setDefaultValue(true)
-          .setDescription("Enable delay jitter while retrying requests on the ufs")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
-          .setScope(Scope.SERVER)
-          .build();
-  public static final PropertyKey UNDERFS_RETRY_TOTAL_DURATION_MS =
-      new Builder(Name.UNDERFS_RETRY_TOTAL_DURATION_MS)
-          .setDefaultValue(5 * 1000 * 60) // 5 mins
-          .setDescription("Maximum retry duration on the ufs")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
-          .setScope(Scope.SERVER)
-          .build();
-  public static final PropertyKey UNDERFS_RETRY_MAX =
-      new Builder(Name.UNDERFS_RETRY_MAX)
-          .setDefaultValue(60)
-          .setDescription("Maximum Number of retries on the ufs")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
@@ -5229,23 +5229,23 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.gcs.directory.suffix";
     public static final String UNDERFS_GCS_OWNER_ID_TO_USERNAME_MAPPING =
         "alluxio.underfs.gcs.owner.id.to.username.mapping";
+    public static final String UNDERFS_GCS_RETRY_INITIAL_DELAY_MS =
+        "alluxio.underfs.gcs.retry.initial.delay";
+    public static final String UNDERFS_GCS_RETRY_MAX_DELAY_MS =
+        "alluxio.underfs.gcs.retry.max.delay";
+    public static final String UNDERFS_GCS_RETRY_DELAY_MULTIPLIER =
+        "alluxio.underfs.gcs.retry.delay.multiplier";
+    public static final String UNDERFS_GCS_RETRY_JITTER =
+        "alluxio.underfs.gcs.retry.jitter";
+    public static final String UNDERFS_GCS_RETRY_TOTAL_DURATION_MS =
+        "alluxio.underfs.gcs.retry.total.duration";
+    public static final String UNDERFS_GCS_RETRY_MAX =
+        "alluxio.underfs.gcs.retry.max";
     public static final String UNDERFS_GCS_VERSION = "alluxio.underfs.gcs.version";
     public static final String UNDERFS_HDFS_CONFIGURATION = "alluxio.underfs.hdfs.configuration";
     public static final String UNDERFS_HDFS_IMPL = "alluxio.underfs.hdfs.impl";
     public static final String UNDERFS_HDFS_PREFIXES = "alluxio.underfs.hdfs.prefixes";
     public static final String UNDERFS_HDFS_REMOTE = "alluxio.underfs.hdfs.remote";
-    public static final String UNDERFS_RETRY_INITIAL_DELAY_MS =
-        "alluxio.underfs.retry.initial.delay";
-    public static final String UNDERFS_RETRY_MAX_DELAY_MS =
-        "alluxio.underfs.retry.max.delay";
-    public static final String UNDERFS_RETRY_DELAY_MULTIPLIER =
-        "alluxio.underfs.retry.delay.multiplier";
-    public static final String UNDERFS_RETRY_JITTER =
-        "alluxio.underfs.retry.jitter";
-    public static final String UNDERFS_RETRY_TOTAL_DURATION_MS =
-        "alluxio.underfs.retry.total.duration";
-    public static final String UNDERFS_RETRY_MAX =
-        "alluxio.underfs.retry.max";
     public static final String UNDERFS_WEB_HEADER_LAST_MODIFIED =
         "alluxio.underfs.web.header.last.modified";
     public static final String UNDERFS_WEB_CONNECTION_TIMEOUT =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -719,6 +719,41 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_RETRY_INITIAL_DELAY_MS =
+      new Builder(Name.UNDERFS_RETRY_INITIAL_DELAY_MS)
+          .setDefaultValue(1000)
+          .setDescription("Initial delay before attempting the retry on the ufs")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_RETRY_MAX_DELAY_MS =
+      new Builder(Name.UNDERFS_RETRY_MAX_DELAY_MS)
+          .setDefaultValue(1000 * 60)  // 1 min
+          .setDescription("Maximum delay before attempting the retry on the ufs")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_RETRY_DELAY_MULTIPLIER =
+      new Builder(Name.UNDERFS_RETRY_DELAY_MULTIPLIER)
+          .setDefaultValue(2)
+          .setDescription("Delay multiplier while retrying requests on the ufs")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_RETRY_TOTAL_DURATION_MS =
+      new Builder(Name.UNDERFS_RETRY_TOTAL_DURATION_MS)
+          .setDefaultValue(5 * 1000 * 60) // 5 mins
+          .setDescription("Maximum retry duration on the ufs")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_RETRY_MAX =
+      new Builder(Name.UNDERFS_RETRY_MAX)
+          .setDefaultValue(60)
+          .setDescription("Maximum Number of retries on the ufs")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_WEB_HEADER_LAST_MODIFIED =
       new Builder(Name.UNDERFS_WEB_HEADER_LAST_MODIFIED)
           .setDefaultValue("EEE, dd MMM yyyy HH:mm:ss zzz")
@@ -5192,6 +5227,16 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_HDFS_IMPL = "alluxio.underfs.hdfs.impl";
     public static final String UNDERFS_HDFS_PREFIXES = "alluxio.underfs.hdfs.prefixes";
     public static final String UNDERFS_HDFS_REMOTE = "alluxio.underfs.hdfs.remote";
+    public static final String UNDERFS_RETRY_INITIAL_DELAY_MS =
+        "alluxio.underfs.retry.initial.delay";
+    public static final String UNDERFS_RETRY_MAX_DELAY_MS =
+        "alluxio.underfs.retry.max.delay";
+    public static final String UNDERFS_RETRY_DELAY_MULTIPLIER =
+        "alluxio.underfs.retry.delay.multiplier";
+    public static final String UNDERFS_RETRY_TOTAL_DURATION_MS =
+        "alluxio.underfs.retry.total.duration";
+    public static final String UNDERFS_RETRY_MAX =
+        "alluxio.underfs.retry.max";
     public static final String UNDERFS_WEB_HEADER_LAST_MODIFIED =
         "alluxio.underfs.web.header.last.modified";
     public static final String UNDERFS_WEB_CONNECTION_TIMEOUT =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -740,6 +740,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_RETRY_JITTER =
+      new Builder(Name.UNDERFS_RETRY_JITTER)
+          .setDefaultValue(true)
+          .setDescription("Enable delay jitter while retrying requests on the ufs")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_RETRY_TOTAL_DURATION_MS =
       new Builder(Name.UNDERFS_RETRY_TOTAL_DURATION_MS)
           .setDefaultValue(5 * 1000 * 60) // 5 mins
@@ -5233,6 +5240,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.retry.max.delay";
     public static final String UNDERFS_RETRY_DELAY_MULTIPLIER =
         "alluxio.underfs.retry.delay.multiplier";
+    public static final String UNDERFS_RETRY_JITTER =
+        "alluxio.underfs.retry.jitter";
     public static final String UNDERFS_RETRY_TOTAL_DURATION_MS =
         "alluxio.underfs.retry.total.duration";
     public static final String UNDERFS_RETRY_MAX =

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/v2/GCSV2UnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/v2/GCSV2UnderFileSystem.java
@@ -25,6 +25,7 @@ import alluxio.util.io.PathUtils;
 
 import com.google.api.client.util.Base64;
 import com.google.api.gax.paging.Page;
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -36,6 +37,7 @@ import com.google.common.collect.Lists;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.threeten.bp.Duration;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -87,8 +89,20 @@ public class GCSV2UnderFileSystem extends ObjectUnderFileSystem {
       credentials = GoogleCredentials.getApplicationDefault();
       LOG.info("Created GCSV2UnderFileSystem with default Google application credentials");
     }
-
-    Storage storage = StorageOptions.newBuilder().setCredentials(credentials).build().getService();
+    Storage storage = StorageOptions.newBuilder().setRetrySettings(
+        RetrySettings.newBuilder()
+            .setInitialRetryDelay(
+                Duration.ofMillis(conf.getInt(PropertyKey.UNDERFS_RETRY_INITIAL_DELAY_MS)))
+            .setMaxRetryDelay(
+                Duration.ofMillis(conf.getInt(PropertyKey.UNDERFS_RETRY_MAX_DELAY_MS)))
+            .setRetryDelayMultiplier(
+                conf.getInt(PropertyKey.UNDERFS_RETRY_DELAY_MULTIPLIER))
+            .setMaxAttempts(conf.getInt(PropertyKey.UNDERFS_RETRY_MAX))
+            .setTotalTimeout(
+                Duration.ofMillis(conf.getInt(PropertyKey.UNDERFS_RETRY_TOTAL_DURATION_MS)))
+            .setJittered(true)
+            .build())
+        .setCredentials(credentials).build().getService();
     return new GCSV2UnderFileSystem(uri, storage, bucketName, conf);
   }
 

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/v2/GCSV2UnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/v2/GCSV2UnderFileSystem.java
@@ -92,15 +92,15 @@ public class GCSV2UnderFileSystem extends ObjectUnderFileSystem {
     Storage storage = StorageOptions.newBuilder().setRetrySettings(
         RetrySettings.newBuilder()
             .setInitialRetryDelay(
-                Duration.ofMillis(conf.getInt(PropertyKey.UNDERFS_RETRY_INITIAL_DELAY_MS)))
+                Duration.ofMillis(conf.getInt(PropertyKey.UNDERFS_GCS_RETRY_INITIAL_DELAY_MS)))
             .setMaxRetryDelay(
-                Duration.ofMillis(conf.getInt(PropertyKey.UNDERFS_RETRY_MAX_DELAY_MS)))
+                Duration.ofMillis(conf.getInt(PropertyKey.UNDERFS_GCS_RETRY_MAX_DELAY_MS)))
             .setRetryDelayMultiplier(
-                conf.getInt(PropertyKey.UNDERFS_RETRY_DELAY_MULTIPLIER))
-            .setMaxAttempts(conf.getInt(PropertyKey.UNDERFS_RETRY_MAX))
+                conf.getInt(PropertyKey.UNDERFS_GCS_RETRY_DELAY_MULTIPLIER))
+            .setMaxAttempts(conf.getInt(PropertyKey.UNDERFS_GCS_RETRY_MAX))
             .setTotalTimeout(
-                Duration.ofMillis(conf.getInt(PropertyKey.UNDERFS_RETRY_TOTAL_DURATION_MS)))
-            .setJittered(conf.getBoolean(PropertyKey.UNDERFS_RETRY_JITTER))
+                Duration.ofMillis(conf.getInt(PropertyKey.UNDERFS_GCS_RETRY_TOTAL_DURATION_MS)))
+            .setJittered(conf.getBoolean(PropertyKey.UNDERFS_GCS_RETRY_JITTER))
             .build())
         .setCredentials(credentials).build().getService();
     return new GCSV2UnderFileSystem(uri, storage, bucketName, conf);

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/v2/GCSV2UnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/v2/GCSV2UnderFileSystem.java
@@ -100,7 +100,7 @@ public class GCSV2UnderFileSystem extends ObjectUnderFileSystem {
             .setMaxAttempts(conf.getInt(PropertyKey.UNDERFS_RETRY_MAX))
             .setTotalTimeout(
                 Duration.ofMillis(conf.getInt(PropertyKey.UNDERFS_RETRY_TOTAL_DURATION_MS)))
-            .setJittered(true)
+            .setJittered(conf.getBoolean(PropertyKey.UNDERFS_RETRY_JITTER))
             .build())
         .setCredentials(credentials).build().getService();
     return new GCSV2UnderFileSystem(uri, storage, bucketName, conf);


### PR DESCRIPTION
For requests sent to the GCS, especially data transfer requests, we should enable GCS's internal retry mechanism. 
This allows us to do that. 

The delay starts with initial delay, delay is multiplied by the multiplier on subsequent retries, until the delay reaches maximum delay. The retry will last until the maximum number of retries is reached or the maximum duration is reached. 