### PR TITLE
Attempt to fix RocksDB SegFaulting Occasionally

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -151,8 +151,8 @@ public class RocksBlockStore implements BlockStore {
     byte[] startKey = RocksUtils.toByteArray(id, 0);
     byte[] endKey = RocksUtils.toByteArray(id, Long.MAX_VALUE);
 
-    try (RocksIterator iter = db().newIterator(mBlockLocationsColumn.get(),
-        new ReadOptions().setIterateUpperBound(new Slice(endKey)))) {
+    final ReadOptions readOptions = new ReadOptions().setIterateUpperBound(new Slice(endKey));
+    try (RocksIterator iter = db().newIterator(mBlockLocationsColumn.get(), readOptions)) {
       iter.seek(startKey);
       List<BlockLocation> locations = new ArrayList<>();
       for (; iter.isValid(); iter.next()) {


### PR DESCRIPTION
RocksDB engineer claims that it is possible for the readOptions to get garbage collected during iteration because RocksIterator doesn't hold a reference to the object but instead a native resource owned by readOptions.