### PR TITLE
Fix a regression of uncleaned directories

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -17,6 +17,7 @@ import alluxio.client.file.cache.PageStore;
 import alluxio.exception.PageNotFoundException;
 import alluxio.exception.status.ResourceExhaustedException;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -70,8 +72,8 @@ public class LocalPageStore implements PageStore {
     Path p = getFilePath(pageId);
     try {
       if (!Files.exists(p)) {
-        Path parent = Preconditions.checkNotNull(p.getParent(),
-            "parent of cache file should not be null");
+        Path parent =
+            Preconditions.checkNotNull(p.getParent(), "parent of cache file should not be null");
         Files.createDirectories(parent);
         Files.createFile(p);
       }
@@ -93,21 +95,22 @@ public class LocalPageStore implements PageStore {
   public int get(PageId pageId, int pageOffset, int bytesToRead, byte[] buffer, int bufferOffset)
       throws IOException, PageNotFoundException {
     Preconditions.checkArgument(pageOffset >= 0, "page offset should be non-negative");
-    Preconditions.checkArgument(buffer.length >= bufferOffset, "page offset %s should be "
-        + "less or equal than buffer length %s", bufferOffset, buffer.length);
+    Preconditions.checkArgument(buffer.length >= bufferOffset,
+        "page offset %s should be " + "less or equal than buffer length %s", bufferOffset,
+        buffer.length);
     Path p = getFilePath(pageId);
     if (!Files.exists(p)) {
       throw new PageNotFoundException(p.toString());
     }
     long pageLength = p.toFile().length();
-    Preconditions.checkArgument(pageOffset <= pageLength,
-        "page offset %s exceeded page size %s", pageOffset, pageLength);
+    Preconditions.checkArgument(pageOffset <= pageLength, "page offset %s exceeded page size %s",
+        pageOffset, pageLength);
     try (RandomAccessFile localFile = new RandomAccessFile(p.toString(), "r")) {
       int bytesSkipped = localFile.skipBytes(pageOffset);
       if (pageOffset != bytesSkipped) {
         throw new IOException(
-            String.format("Failed to read page %s (%s) from offset %s: %s bytes skipped", pageId,
-                p, pageOffset, bytesSkipped));
+            String.format("Failed to read page %s (%s) from offset %s: %s bytes skipped", pageId, p,
+                pageOffset, bytesSkipped));
       }
       int bytesRead = 0;
       int bytesLeft = (int) Math.min(pageLength - pageOffset, buffer.length - bufferOffset);
@@ -131,9 +134,31 @@ public class LocalPageStore implements PageStore {
       throw new PageNotFoundException(p.toString());
     }
     Files.delete(p);
+    // Cleaning up parent directory may lead to a race condition if one thread is removing a page as
+    // well as its parent dir corresponding to the fileId, while another thread is adding
+    // a different page from the same file in the same directory.
+    // Note that, because (1) the chance of this type of racing is really low and
+    // (2) even a race happens, the only penalty is an extra cache put failure;
+    // whereas without the cleanup, there can be an unbounded amount of empty directories
+    // uncleaned which takes an unbounded amount of space possibly.
+    // We have seen the overhead goes up to a few hundred GBs due to inode storage overhead
+    // TODO(binfan): remove the coupled fileId/pagIdex encoding with storage path, so the total
+    // number of directories can be bounded.
+    Path parent =
+        Preconditions.checkNotNull(p.getParent(), "parent of cache file should not be null");
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(parent)) {
+      if (!stream.iterator().hasNext()) {
+        Files.delete(parent);
+      }
+    }
   }
 
-  private Path getFilePath(PageId pageId) {
+  /**
+   * @param pageId page Id
+   * @return the local file system path to store this page
+   */
+  @VisibleForTesting
+  public Path getFilePath(PageId pageId) {
     // TODO(feng): encode fileId with URLEncoder to escape invalid characters for file name
     return Paths.get(mRoot, Long.toString(mPageSize), getFileBucket(pageId.getFileId()),
         pageId.getFileId(), Long.toString(pageId.getPageIndex()));
@@ -196,9 +221,7 @@ public class LocalPageStore implements PageStore {
   @Override
   public Stream<PageInfo> getPages() throws IOException {
     Path rootDir = Paths.get(mRoot);
-    return Files.walk(rootDir)
-          .filter(Files::isRegularFile)
-          .map(this::getPageInfo);
+    return Files.walk(rootDir).filter(Files::isRegularFile).map(this::getPageInfo);
   }
 
   @Override

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/LocalPageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/LocalPageStoreTest.java
@@ -13,6 +13,8 @@ package alluxio.client.file.cache.store;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import alluxio.client.file.cache.PageId;
 import alluxio.client.file.cache.PageStore;
@@ -23,6 +25,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
@@ -70,6 +73,18 @@ public class LocalPageStoreTest {
     }
     assertEquals(10, Files.list(
         Paths.get(mOptions.getRootDir(), Long.toString(mOptions.getPageSize()))).count());
+  }
+
+  @Test
+  public void cleanFileAndDirectory() throws Exception {
+    LocalPageStore pageStore = new LocalPageStore(mOptions);
+    PageId pageId = new PageId("0", 0);
+    pageStore.put(pageId, "test".getBytes());
+    Path p = pageStore.getFilePath(pageId);
+    assertTrue(Files.exists(p));
+    pageStore.delete(pageId);
+    assertFalse(Files.exists(p));
+    assertFalse(Files.exists(p.getParent()));
   }
 
   private void helloWorldTest(PageStore store) throws Exception {


### PR DESCRIPTION
Fixed a regression introduced in #12813 , where I was fixing a potential race (benign) on creating/removing local file system directories but leaving an unbounded amount of directories.
