### PR TITLE
Fix libcephfs version error by maintain a public repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,8 +165,8 @@
     <update.check.host>https://diagnostics.alluxio.io</update.check.host>
     <findbugs.skip>false</findbugs.skip>
     <create.dependency.reduced.pom>false</create.dependency.reduced.pom>
-    <cephfs-hadoop.version>0.80.6</cephfs-hadoop.version>
-    <libcephfs.version>0.80.5</libcephfs.version>
+    <cephfs-hadoop.version>0.0.1</cephfs-hadoop.version>
+    <libcephfs.version>0.0.1</libcephfs.version>
   </properties>
 
   <modules>
@@ -215,12 +215,12 @@
         <version>1.78</version>
       </dependency>
       <dependency>
-        <groupId>com.ceph.fs</groupId>
+        <groupId>io.github.opendataio</groupId>
         <artifactId>cephfs-hadoop</artifactId>
         <version>${cephfs-hadoop.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.ceph</groupId>
+        <groupId>io.github.opendataio</groupId>
         <artifactId>libcephfs</artifactId>
         <version>${libcephfs.version}</version>
       </dependency>

--- a/underfs/cephfs-hadoop/pom.xml
+++ b/underfs/cephfs-hadoop/pom.xml
@@ -30,12 +30,8 @@
   <dependencies>
     <!-- External dependencies -->
     <dependency>
-      <groupId>com.ceph.fs</groupId>
+      <groupId>io.github.opendataio</groupId>
       <artifactId>cephfs-hadoop</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.ceph</groupId>
-      <artifactId>libcephfs</artifactId>
     </dependency>
     <!-- Internal dependencies -->
     <dependency>

--- a/underfs/cephfs/pom.xml
+++ b/underfs/cephfs/pom.xml
@@ -28,7 +28,7 @@
   <dependencies>
     <!-- External dependencies -->
     <dependency>
-      <groupId>com.ceph</groupId>
+      <groupId>io.github.opendataio</groupId>
       <artifactId>libcephfs</artifactId>
     </dependency>
 


### PR DESCRIPTION
Fix #13309

Create two repo
https://github.com/opendataio/cephfs-hadoop
https://github.com/opendataio/libcephfs

And deployed them to 
https://repo1.maven.org/maven2/io/github/opendataio/cephfs-hadoop/0.0.1/
https://repo1.maven.org/maven2/io/github/opendataio/libcephfs/0.0.1/

So that we can use these dependency by 

```xml
      <dependency>
        <groupId>io.github.opendataio</groupId>
        <artifactId>cephfs-hadoop</artifactId>
        <version>${cephfs-hadoop.version}</version>
      </dependency>
      <dependency>
        <groupId>io.github.opendataio</groupId>
        <artifactId>libcephfs</artifactId>
        <version>${libcephfs.version}</version>
      </dependency>
```


# test

```bash
mvn clean install -U --no-transfer-progress -T 2C -DskipTests -Dmaven.javadoc.skip -Dcheckstyle.skip -Dlicense.skip -Dfindbugs.skip > build.log

mvn javadoc:aggregate --no-transfer-progress -T 2C -Dcheckstyle.skip -Dlicense.skip -Dfindbugs.skip > doc.log
```

[build.log](https://github.com/Alluxio/alluxio/files/6433411/build.log)
[doc.log](https://github.com/Alluxio/alluxio/files/6433412/doc.log)
