### PR TITLE
Fix process local block in stream

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -107,7 +107,8 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
     long blockId = info.getBlockId();
     long blockSize = info.getLength();
 
-    if (dataSourceType == BlockInStreamSource.PROCESS_LOCAL && dataSource.equals(context.getNodeLocalWorker())) {
+    if (dataSourceType == BlockInStreamSource.PROCESS_LOCAL
+        && dataSource.equals(context.getNodeLocalWorker())) {
       // Interaction between the current client and the worker it embedded to should
       // go through worker internal communication directly without RPC involves
       return createProcessLocalBlockInStream(context, dataSource, blockId, blockSize, options);

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -107,7 +107,7 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
     long blockId = info.getBlockId();
     long blockSize = info.getLength();
 
-    if (dataSourceType == BlockInStreamSource.PROCESS_LOCAL) {
+    if (dataSourceType == BlockInStreamSource.PROCESS_LOCAL && dataSource.equals(context.getNodeLocalWorker())) {
       // Interaction between the current client and the worker it embedded to should
       // go through worker internal communication directly without RPC involves
       return createProcessLocalBlockInStream(context, dataSource, blockId, blockSize, options);


### PR DESCRIPTION
When data locate in other nodes, use the GrpcBlockingStream to read from other nodes instead of reading from the local node and refetching data from UFS.