### PR TITLE
Fix replicate job loading non-persisted files

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -515,9 +515,9 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
       } catch (Exception ee) {
         LOG.warn("Failed to close UFS block", ee);
       }
-      throw new IOException(String.format("Failed to get UFS block reader, sessionId=%d, "
-              + "blockId=%d, offset=%d, positionShort=%s, options=%s",
-          sessionId, blockId, offset, positionShort, options), e);
+      throw new IOException(String.format("Failed to read from UFS, sessionId=%d, "
+              + "blockId=%d, offset=%d, positionShort=%s, options=%s: %s",
+          sessionId, blockId, offset, positionShort, options, e.toString()), e);
     }
   }
 
@@ -643,8 +643,8 @@ public final class DefaultBlockWorker extends AbstractWorker implements BlockWor
             request.isPositionShort(), request.getOpenUfsBlockOptions());
       } catch (Exception e) {
         throw new UnavailableException(
-            String.format("Failed to read block ID=%s from tiered " + "storage and UFS tier: %s",
-                request.getId(), e.getMessage()));
+            String.format("Failed to read block ID=%s from tiered storage and UFS tier: %s",
+                request.getId(), e.toString()));
       }
     }
     throw new UnavailableException(ExceptionMessage.UFS_BLOCK_ACCESS_TOKEN_UNAVAILABLE

--- a/job/server/src/main/java/alluxio/job/util/JobUtils.java
+++ b/job/server/src/main/java/alluxio/job/util/JobUtils.java
@@ -130,7 +130,8 @@ public final class JobUtils {
           ExceptionMessage.PINNED_TO_MULTIPLE_MEDIUMTYPES.getMessage(status.getPath()));
     }
 
-    if (pinnedLocation.isEmpty()) {
+    // when the data to load is persisted, simply use local worker to load from UFS
+    if (pinnedLocation.isEmpty() && status.isPersisted()) {
       OpenFilePOptions openOptions =
           OpenFilePOptions.newBuilder().setReadType(ReadPType.CACHE_PROMOTE).build();
       InStreamOptions inOptions = new InStreamOptions(status, openOptions, conf);

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -103,7 +103,6 @@ public final class ReplicateDefinitionTest {
   private FileSystem mMockFileSystem;
   private JobServerContext mMockJobServerContext;
   private UfsManager mMockUfsManager;
-  private BlockInStream mBlockInStream;
   private BlockInfo mTestBlockInfo;
   private URIStatus mTestStatus;
 
@@ -126,6 +125,7 @@ public final class ReplicateDefinitionTest {
     when(mMockBlockStore.getInfo(TEST_BLOCK_ID)).thenReturn(mTestBlockInfo);
     mTestStatus = new URIStatus(
         new FileInfo().setPath(TEST_PATH).setBlockIds(Lists.newArrayList(TEST_BLOCK_ID))
+            .setPersisted(true)
             .setFileBlockInfos(Lists.newArrayList(
                 new FileBlockInfo().setBlockInfo(mTestBlockInfo))));
   }


### PR DESCRIPTION
Fix an bug introduced in https://github.com/Alluxio/alluxio/pull/13146, causing `setReplication` command to fail when data has not been persisted.