### PR TITLE
Improve logging message on exceptions

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BufferCachingGrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BufferCachingGrpcDataReader.java
@@ -144,8 +144,8 @@ public class BufferCachingGrpcDataReader {
       mStream.send(mReadRequest.toBuilder().setOffsetReceived(mPosToRead).build());
     } catch (Exception e) {
       // nothing is done as the receipt is sent at best effort
-      LOG.debug("Failed to send receipt of data to worker {} for request {}: {}.", mAddress,
-          mReadRequest, e.getMessage());
+      LOG.debug("Failed to send receipt of data to worker {} for request {}", mAddress,
+          mReadRequest, e);
     }
     Preconditions.checkState(mPosToRead - mReadRequest.getOffset() <= mReadRequest.getLength());
     return buffer;

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/UfsFallbackLocalFileDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/UfsFallbackLocalFileDataWriter.java
@@ -59,7 +59,7 @@ public final class UfsFallbackLocalFileDataWriter implements DataWriter {
           blockId, blockSize, options);
     } catch (ResourceExhaustedException e) {
       LOG.warn("Fallback to create new block {} in UFS due to a failure of insufficient space on "
-          + "the local worker: {}", blockId, e.getMessage());
+          + "the local worker: {}", blockId, e.toString());
     }
     // Failed to create the local writer due to insufficient space, fallback to gRPC data writer
     // directly
@@ -97,7 +97,7 @@ public final class UfsFallbackLocalFileDataWriter implements DataWriter {
         return;
       } catch (ResourceExhaustedException e) {
         LOG.warn("Fallback to write to UFS for block {} due to a failure of insufficient space "
-            + "on the local worker: {}", mBlockId, e.getMessage());
+            + "on the local worker: {}", mBlockId, e.toString());
         mIsWritingToLocal = false;
       }
       try {

--- a/core/client/fs/src/main/java/alluxio/client/metrics/ClientMasterSync.java
+++ b/core/client/fs/src/main/java/alluxio/client/metrics/ClientMasterSync.java
@@ -122,11 +122,10 @@ public final class ClientMasterSync {
       InetSocketAddress masterAddr = mInquireClient.getPrimaryRpcAddress();
       mContext.loadConf(masterAddr, true, false);
     } catch (UnavailableException e) {
-      SAMPLING_LOG.error("Failed to get master address during initialization: {}", e.toString());
+      SAMPLING_LOG.error("Failed to get master address during initialization", e);
       return false;
     } catch (AlluxioStatusException ae) {
-      SAMPLING_LOG.error("Failed to load configuration from "
-          + "meta master during initialization: {}", ae.toString());
+      SAMPLING_LOG.error("Failed to load configuration from meta master during initialization", ae);
       return false;
     }
     return true;

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -261,7 +261,7 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
       mFileSystem.delete(uri, options);
       return true;
     } catch (InvalidPathException | FileDoesNotExistException e) {
-      LOG.warn("delete failed: {}", e.getMessage());
+      LOG.warn("delete failed: {}", e.toString());
       return false;
     } catch (AlluxioException e) {
       throw new IOException(e);
@@ -657,7 +657,7 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
     try {
       mFileSystem.rename(srcPath, dstPath);
     } catch (FileDoesNotExistException e) {
-      LOG.warn("rename failed: {}", e.getMessage());
+      LOG.warn("rename failed: {}", e.toString());
       return false;
     } catch (AlluxioException e) {
       ensureExists(srcPath);
@@ -665,14 +665,14 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
       try {
         dstStatus = mFileSystem.getStatus(dstPath);
       } catch (IOException | AlluxioException e2) {
-        LOG.warn("rename failed: {}", e.getMessage());
+        LOG.warn("rename failed: {}", e.toString());
         return false;
       }
       // If the destination is an existing folder, try to move the src into the folder
       if (dstStatus != null && dstStatus.isFolder()) {
         dstPath = dstPath.joinUnsafe(srcPath.getName());
       } else {
-        LOG.warn("rename failed: {}", e.getMessage());
+        LOG.warn("rename failed: {}", e.toString());
         return false;
       }
       try {

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -275,9 +275,10 @@ public abstract class AbstractClient implements Client {
           new ServiceNotFoundException(lastConnectFailure.getMessage(), lastConnectFailure));
     }
 
-    throw new UnavailableException(String.format("Failed to connect to master (%s) after %s "
-            + "attempts of %s",
-        mAddress, retryPolicy.getAttemptCount(), getServiceName()), lastConnectFailure);
+    throw new UnavailableException(String.format(
+        "Failed to connect to master (%s) after %s attempts." +
+        "Please check if Alluxio master is currently running on \"%s\". Service=\"%s\"",
+        mAddress, retryPolicy.getAttemptCount(), mAddress, getServiceName()), lastConnectFailure);
   }
 
   /**

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -264,7 +264,7 @@ public abstract class AbstractClient implements Client {
               retryPolicy.getAttemptCount()));
     }
 
-    /**
+    /*
      * Throw as-is if {@link UnauthenticatedException} occurred.
      */
     if (lastConnectFailure instanceof UnauthenticatedException) {
@@ -275,10 +275,12 @@ public abstract class AbstractClient implements Client {
           new ServiceNotFoundException(lastConnectFailure.getMessage(), lastConnectFailure));
     }
 
-    throw new UnavailableException(String.format(
-        "Failed to connect to master (%s) after %s attempts." +
-        "Please check if Alluxio master is currently running on \"%s\". Service=\"%s\"",
-        mAddress, retryPolicy.getAttemptCount(), mAddress, getServiceName()), lastConnectFailure);
+    throw new UnavailableException(
+        String.format(
+            "Failed to connect to master (%s) after %s attempts."
+                + "Please check if Alluxio master is currently running on \"%s\". Service=\"%s\"",
+            mAddress, retryPolicy.getAttemptCount(), mAddress, getServiceName()),
+        lastConnectFailure);
   }
 
   /**

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -238,8 +238,8 @@ public abstract class AbstractClient implements Client {
             getServiceName(), mAddress);
         return;
       } catch (IOException e) {
-        LOG.debug("Failed to connect ({}) with {} @ {}: {}", retryPolicy.getAttemptCount(),
-            getServiceName(), mAddress, e.getMessage());
+        LOG.debug("Failed to connect ({}) with {} @ {}", retryPolicy.getAttemptCount(),
+            getServiceName(), mAddress, e);
         lastConnectFailure = e;
         if (e instanceof UnauthenticatedException) {
           // If there has been a failure in opening GrpcChannel, it's possible because

--- a/core/common/src/main/java/alluxio/grpc/GrpcSerializationUtils.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcSerializationUtils.java
@@ -164,7 +164,7 @@ public class GrpcSerializationUtils {
         return (ByteBuf) sReadableByteBuf.get(buffer);
       }
     } catch (Exception e) {
-      LOG.warn("Failed to get data buffer from stream: {}.", e.getMessage());
+      LOG.warn("Failed to get data buffer from stream: {}.", e.toString());
       return null;
     }
     return null;
@@ -194,7 +194,7 @@ public class GrpcSerializationUtils {
       }
       return true;
     } catch (Exception e) {
-      LOG.warn("Failed to add data buffer to stream: {}.", e.getMessage());
+      LOG.warn("Failed to add data buffer to stream: {}.", e.toString());
       return false;
     }
   }

--- a/core/common/src/main/java/alluxio/metrics/sink/CsvSink.java
+++ b/core/common/src/main/java/alluxio/metrics/sink/CsvSink.java
@@ -122,7 +122,7 @@ public class CsvSink implements Sink {
       try {
         dir.mkdirs();
       } catch (SecurityException e) {
-        LOG.warn("Fail to create directory {} for CSV sink, {}", dir, e.getMessage());
+        LOG.warn("Fail to create directory {} for CSV sink, {}", dir, e.toString());
       }
     }
   }

--- a/core/common/src/main/java/alluxio/security/user/BaseUserState.java
+++ b/core/common/src/main/java/alluxio/security/user/BaseUserState.java
@@ -50,7 +50,7 @@ public abstract class BaseUserState implements UserState {
       tryLogin();
     } catch (UnauthenticatedException e) {
       if (!LOG.isDebugEnabled()) {
-        LOG.warn("Subject login failed from {}: {}", this.getClass().getName(), e.getMessage());
+        LOG.warn("Subject login failed from {}: {}", this.getClass().getName(), e.toString());
       } else {
         LOG.error(String.format("Subject login failed from %s: ", this.getClass().getName()), e);
       }

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -108,7 +108,7 @@ public interface UnderFileSystem extends Closeable {
         } catch (Throwable e) {
           // Catching Throwable rather than Exception to catch service loading errors
           errors.add(e);
-          LOG.warn("Failed to create UnderFileSystem by factory {}: {}", factory, e.getMessage());
+          LOG.warn("Failed to create UnderFileSystem by factory {}: {}", factory, e.toString());
         } finally {
           Thread.currentThread().setContextClassLoader(previousClassLoader);
         }

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -305,7 +305,7 @@ public final class CommonUtils {
       result = ShellUtils.execCommand(ShellUtils.getGroupsForUserCommand(user));
     } catch (ExitCodeException e) {
       // if we didn't get the group - just return empty list
-      LOG.warn("got exception trying to get groups for user " + user + ": " + e.getMessage());
+      LOG.warn("got exception trying to get groups for user {}: {}", user, e.toString());
       return groups;
     }
 

--- a/core/common/src/main/java/alluxio/util/io/BufferUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/BufferUtils.java
@@ -109,7 +109,7 @@ public final class BufferUtils {
       sByteBufferCleanerMethod.invoke(theUnsafe, buffer);
     } catch (Exception e) {
       LOG.warn("Failed to unmap direct ByteBuffer: {}, error message: {}",
-          buffer.getClass().getName(), e.getMessage());
+          buffer.getClass().getName(), e.toString());
     }
   }
 
@@ -157,7 +157,7 @@ public final class BufferUtils {
       sCleanerCleanMethod.invoke(cleaner);
     } catch (Exception e) {
       LOG.warn("Failed to unmap direct ByteBuffer: {}, error message: {}",
-                buffer.getClass().getName(), e.getMessage());
+          buffer.getClass().getName(), e.toString());
     } finally {
       // Force to drop reference to the buffer to clean
       buffer = null;

--- a/core/server/common/src/main/java/alluxio/RestUtils.java
+++ b/core/server/common/src/main/java/alluxio/RestUtils.java
@@ -54,14 +54,14 @@ public final class RestUtils {
         AuthenticatedClientUser.set(ServerUserState.global().getUser().getName());
       }
     } catch (IOException e) {
-      LOG.warn("Failed to set AuthenticatedClientUser in REST service handler: {}", e.getMessage());
+      LOG.warn("Failed to set AuthenticatedClientUser in REST service handler: {}", e.toString());
       return createErrorResponse(e, alluxioConf);
     }
 
     try {
       return createResponse(callable.call(), alluxioConf, headers);
     } catch (Exception e) {
-      LOG.warn("Unexpected error invoking rest endpoint: {}", e.getMessage());
+      LOG.warn("Unexpected error invoking rest endpoint: {}", e.toString());
       return createErrorResponse(e, alluxioConf);
     }
   }

--- a/core/server/common/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/common/src/main/java/alluxio/RpcUtils.java
@@ -119,7 +119,7 @@ public final class RpcUtils {
         MetricsSystem.counter(getQualifiedFailureMetricName(methodName)).inc();
         if (!logger.isDebugEnabled()) {
           logger.warn("Exit (Error): {}: {}, Error={}", methodName,
-              String.format(description, args), e.getMessage());
+              String.format(description, args), e.toString());
         }
       }
       throw AlluxioStatusException.fromAlluxioException(e).toGrpcStatusException();
@@ -129,7 +129,7 @@ public final class RpcUtils {
         MetricsSystem.counter(getQualifiedFailureMetricName(methodName)).inc();
         if (!logger.isDebugEnabled()) {
           logger.warn("Exit (Error): {}: {}, Error={}", methodName,
-              String.format(description, args), e);
+              String.format(description, args), e.toString());
         }
       }
       throw AlluxioStatusException.fromIOException(e).toGrpcStatusException();
@@ -173,7 +173,7 @@ public final class RpcUtils {
       }
     } catch (Exception e) {
       logger.warn("Exit(stream) (Error): {}: {}, Error={}", methodName,
-          String.format(description, args), e);
+          String.format(description, args), e.toString());
       MetricsSystem.counter(getQualifiedFailureMetricName(methodName)).inc();
       callable.exceptionCaught(e);
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
@@ -121,7 +121,7 @@ public class LocalFirstRaftClient implements Closeable {
       try {
         mClient.close();
       } catch (IOException e) {
-        LogUtils.warnWithException(LOG, "Failed to close client: {}", e.getMessage());
+        LogUtils.warnWithException(LOG, "Failed to close client: {}", e.toString());
       }
       mClient = mClientSupplier.get();
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
@@ -455,7 +455,7 @@ public class SnapshotReplicationManager {
         try {
           reply = job.getValue().get();
         } catch (Exception e) {
-          LOG.warn("Exception thrown while requesting snapshot info {}", e.getMessage());
+          LOG.warn("Exception thrown while requesting snapshot info {}", e.toString());
           continue;
         }
         if (reply.getException() != null) {
@@ -468,7 +468,7 @@ public class SnapshotReplicationManager {
           response = JournalQueryResponse.parseFrom(
               reply.getMessage().getContent().asReadOnlyByteBuffer());
         } catch (InvalidProtocolBufferException e) {
-          LOG.warn("Failed to parse response {}", e.getMessage());
+          LOG.warn("Failed to parse response {}", e.toString());
           continue;
         }
         LOG.debug("Received snapshot info from follower {} - {}", peerId, response);

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
@@ -252,7 +252,7 @@ public final class UfsJournalCheckpointThread extends Thread {
           mJournalReader.close();
         } catch (IOException ee) {
           LOG.warn("{}: Failed to close the journal reader with error {}.", mMaster.getName(),
-              ee.getMessage());
+              ee.toString());
         }
         long nextSequenceNumber = mJournalReader.getNextSequenceNumber();
 
@@ -275,7 +275,7 @@ public final class UfsJournalCheckpointThread extends Thread {
                 mJournalReader.close();
               } catch (IOException e) {
                 LOG.warn("{}: Failed to close the journal reader with error {}.", mMaster.getName(),
-                    e.getMessage());
+                    e.toString());
               }
             }
             return;
@@ -315,7 +315,7 @@ public final class UfsJournalCheckpointThread extends Thread {
       mNextSequenceNumberToCheckpoint = mJournal.getNextSequenceNumberToCheckpoint();
     } catch (IOException e) {
       LOG.warn("{}: Failed to get the next sequence number to checkpoint with error {}.",
-          mMaster.getName(), e.getMessage());
+          mMaster.getName(), e.toString());
       return;
     }
     if (nextSequenceNumber - mNextSequenceNumberToCheckpoint < mCheckpointPeriodEntries) {

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointWriter.java
@@ -113,7 +113,7 @@ final class UfsJournalCheckpointWriter extends FilterOutputStream {
     } catch (IOException e) {
       if (!mUfs.exists(dst)) {
         LOG.warn("Failed to commit checkpoint from {} to {} with error {}.",
-            mTmpCheckpointFileLocation, dst, e.getMessage());
+            mTmpCheckpointFileLocation, dst, e.toString());
       }
       try {
         mUfs.deleteFile(mTmpCheckpointFileLocation.toString());

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalGarbageCollector.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalGarbageCollector.java
@@ -77,7 +77,7 @@ final class UfsJournalGarbageCollector implements Closeable {
     try {
       snapshot = UfsJournalSnapshot.getSnapshot(mJournal);
     } catch (IOException e) {
-      LOG.warn("Failed to get journal snapshot with error {}.", e.getMessage());
+      LOG.warn("Failed to get journal snapshot with error {}.", e.toString());
       return;
     }
     long checkpointSequenceNumber = 0;

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
@@ -318,7 +318,7 @@ final class UfsJournalLogWriter implements JournalWriter {
       checkIsWritable();
     } catch (JournalClosedException e) {
       // Do not throw error, just ignore if the journal is not writable
-      LOG.warn("Skipping completeLog() since journal is not writable. error: {}", e.getMessage());
+      LOG.warn("Skipping completeLog() since journal is not writable. error: {}", e.toString());
       return;
     }
     String current = currentLog.getLocation().toString();
@@ -337,7 +337,7 @@ final class UfsJournalLogWriter implements JournalWriter {
       checkIsWritable();
     } catch (JournalClosedException e) {
       // Do not throw error, just ignore if the journal is not writable
-      LOG.warn("Skipping completeLog() since journal is not writable. error: {}", e.getMessage());
+      LOG.warn("Skipping completeLog() since journal is not writable. error: {}", e.toString());
       return;
     }
     LOG.info(String

--- a/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
+++ b/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
@@ -149,7 +149,7 @@ public abstract class AbstractUfsManager implements UfsManager {
       try {
         connectUfs(fs);
       } catch (IOException e) {
-        LOG.warn("Failed to perform initial connect to UFS {}: {}", ufsUri, e.getMessage());
+        LOG.warn("Failed to perform initial connect to UFS {}: {}", ufsUri, e.toString());
       }
       return fs;
     }

--- a/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
@@ -198,7 +198,7 @@ public class BackupWorkerRole extends AbstractBackupRole {
         LOG.info("Attempt to resume journal application.");
         mJournalSystem.resume();
       } catch (Exception e) {
-        LOG.warn("Failed to resume journal application: {}", e.getMessage());
+        LOG.warn("Failed to resume journal application: {}", e.toString());
       }
     }
     LOG.warn("Backup interrupted successfully.");

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1834,13 +1834,10 @@ public final class DefaultFileSystemMaster extends CoreMaster
                 checkUfsMode(alluxioUriToDelete, OperationType.WRITE);
                 // Attempt to delete node if all children were deleted successfully
                 ufsDeleter.delete(alluxioUriToDelete, inodeToDelete);
-              } catch (AccessControlException e) {
+              } catch (AccessControlException | IOException e) {
                 // In case ufs is not writable, we will still attempt to delete other entries
                 // if any as they may be from a different mount point
-                LOG.warn(e.getMessage());
-                failureReason = e.getMessage();
-              } catch (IOException e) {
-                LOG.warn(e.getMessage());
+                LOG.warn("Failed to delete {}: {}", alluxioUriToDelete, e.toString());
                 failureReason = e.getMessage();
               }
             }
@@ -3913,7 +3910,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
           try {
             checkUfsMode(uri, OperationType.WRITE);
           } catch (Exception e) {
-            LOG.warn("Unable to schedule persist request for path {}: {}", uri, e.getMessage());
+            LOG.warn("Unable to schedule persist request for path {}: {}", uri, e.toString());
             // Retry when ufs mode permits operation
             remove = false;
             continue;

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3904,7 +3904,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
             uri = inodePath.getUri();
           } catch (FileDoesNotExistException e) {
             LOG.debug("The file (id={}) to be persisted was not found. Likely this file has been "
-                + "removed by users : {}", fileId, e.getMessage());
+                + "removed by users", fileId, e);
             continue;
           }
           try {
@@ -3927,7 +3927,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
           }
         } catch (FileDoesNotExistException | InvalidPathException e) {
           LOG.warn("The file {} (id={}) to be persisted was not found : {}", uri, fileId,
-              e.getMessage());
+              e.toString());
           LOG.debug("Exception: ", e);
         } catch (UnavailableException e) {
           LOG.warn("Failed to persist file {}, will retry later: {}", uri, e.toString());
@@ -3943,7 +3943,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
           return;
         } catch (Exception e) {
           LOG.warn("Unexpected exception encountered when scheduling the persist job for file {} "
-              + "(id={}) : {}", uri, fileId, e.getMessage());
+              + "(id={}) : {}", uri, fileId, e.toString());
           LOG.debug("Exception: ", e);
         } finally {
           if (remove) {
@@ -4059,7 +4059,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
         }
       } catch (FileDoesNotExistException | InvalidPathException e) {
         LOG.warn("The file {} (id={}) to be persisted was not found: {}", job.getUri(), fileId,
-            e.getMessage());
+            e.toString());
         LOG.debug("Exception: ", e);
         // Cleanup the temporary file.
         if (ufsClient != null) {
@@ -4071,7 +4071,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
         LOG.warn(
             "Unexpected exception encountered when trying to complete persistence of a file {} "
                 + "(id={}) : {}",
-            job.getUri(), fileId, e.getMessage());
+            job.getUri(), fileId, e.toString());
         LOG.debug("Exception: ", e);
         if (ufsClient != null) {
           try (CloseableResource<UnderFileSystem> ufsResource = ufsClient.acquireUfsResource()) {
@@ -4185,13 +4185,13 @@ public final class DefaultFileSystemMaster extends CoreMaster
               job.setCancelState(PersistJob.CancelState.CANCELING);
             } catch (alluxio.exception.status.NotFoundException e) {
               LOG.warn("Persist job (id={}) for file {} (id={}) to cancel was not found: {}",
-                  job.getId(), job.getUri(), fileId, e.getMessage());
+                  job.getId(), job.getUri(), fileId, e.toString());
               LOG.debug("Exception: ", e);
               mPersistJobs.remove(fileId);
               continue;
             } catch (Exception e) {
               LOG.warn("Unexpected exception encountered when cancelling a persist job (id={}) for "
-                  + "file {} (id={}) : {}", job.getId(), job.getUri(), fileId, e.getMessage());
+                  + "file {} (id={}) : {}", job.getId(), job.getUri(), fileId, e.toString());
               LOG.debug("Exception: ", e);
             } finally {
               mJobMasterClientPool.release(client);
@@ -4234,7 +4234,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
         } catch (Exception e) {
           LOG.warn("Exception encountered when trying to retrieve the status of a "
                   + " persist job (id={}) for file {} (id={}): {}.", jobId, job.getUri(), fileId,
-              e.getMessage());
+              e.toString());
           LOG.debug("Exception: ", e);
           mPersistJobs.remove(fileId);
           mPersistRequests.put(fileId, job.getTimer());
@@ -4316,14 +4316,13 @@ public final class DefaultFileSystemMaster extends CoreMaster
   }
 
   private static void cleanup(UnderFileSystem ufs, String ufsPath) {
-    final String errMessage = "Failed to delete UFS file {}.";
     if (!ufsPath.isEmpty()) {
       try {
         if (!ufs.deleteExistingFile(ufsPath)) {
-          LOG.warn(errMessage, ufsPath);
+          LOG.warn("Failed to delete UFS file {}.", ufsPath);
         }
       } catch (IOException e) {
-        LOG.warn(errMessage, ufsPath, e);
+        LOG.warn("Failed to delete UFS file {}: {}", ufsPath, e.toString());
       }
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
@@ -239,7 +239,7 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
       return mMountTable.getMountInfo(resolution.getMountId());
     } catch (Exception e) {
       // Catch Exception in case the mount point doesn't exist currently.
-      LOG.warn("Failed to get mount info for path {}. message: {}", alluxioUri, e.getMessage());
+      LOG.warn("Failed to get mount info for path {}. message: {}", alluxioUri, e.toString());
       return null;
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -259,7 +259,7 @@ public final class ReplicationChecker implements HeartbeatExecutor {
               LOG.warn(
                   "Unexpected exception encountered when starting a migration job (uri={},"
                       + " block ID={}, workerHost= {}) : {}",
-                  inodePath.getUri(), blockId, entry.getKey(), e.getMessage());
+                  inodePath.getUri(), blockId, entry.getKey(), e.toString());
               LOG.debug("Exception: ", e);
             }
           }
@@ -358,14 +358,13 @@ public final class ReplicationChecker implements HeartbeatExecutor {
           LOG.warn("The job service is busy, will retry later. {}", e.toString());
           return;
         } catch (UnavailableException e) {
-          LOG.warn("Unable to complete the replication check: {}, will retry later.",
-              e.getMessage());
+          LOG.warn("Unable to complete the replication check: {}, will retry later.", e.toString());
           return;
         } catch (Exception e) {
           SAMPLING_LOG.warn(
               "Unexpected exception encountered when starting a {} job (uri={},"
                   + " block ID={}, num replicas={}) : {}",
-              mode, uri, blockId, numReplicas, e.getMessage());
+              mode, uri, blockId, numReplicas, e.toString());
           LOG.debug("Job service unexpected exception: ", e);
         }
       }

--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -240,7 +240,7 @@ public final class ReplicationChecker implements HeartbeatExecutor {
             // Cannot find this block in Alluxio from BlockMaster, possibly persisted in UFS
           } catch (UnavailableException e) {
             // The block master is not available, wait for the next heartbeat
-            LOG.warn("The block master is not available: {}", e.getMessage());
+            LOG.warn("The block master is not available: {}", e.toString());
             return;
           }
           if (blockInfo == null) {
@@ -265,7 +265,7 @@ public final class ReplicationChecker implements HeartbeatExecutor {
           }
         }
       } catch (FileDoesNotExistException e) {
-        LOG.warn("Failed to check replication level for inode id {} : {}", inodeId, e.getMessage());
+        LOG.warn("Failed to check replication level for inode id {} : {}", inodeId, e.toString());
       }
     }
   }
@@ -298,7 +298,7 @@ public final class ReplicationChecker implements HeartbeatExecutor {
             // Cannot find this block in Alluxio from BlockMaster, possibly persisted in UFS
           } catch (UnavailableException e) {
             // The block master is not available, wait for the next heartbeat
-            LOG.warn("The block master is not available: {}", e.getMessage());
+            LOG.warn("The block master is not available: {}", e.toString());
             return;
           }
           int currentReplicas = (blockInfo == null) ? 0 : blockInfo.getLocations().size();
@@ -334,7 +334,7 @@ public final class ReplicationChecker implements HeartbeatExecutor {
           }
         }
       } catch (FileDoesNotExistException e) {
-        LOG.warn("Failed to check replication level for inode id {} : {}", inodeId, e.getMessage());
+        LOG.warn("Failed to check replication level for inode id {} : {}", inodeId, e.toString());
       }
 
       for (Triple<AlluxioURI, Long, Integer> entry : requests) {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -52,7 +52,7 @@ public final class S3RestUtils {
         AuthenticatedClientUser.set(ServerUserState.global().getUser().getName());
       }
     } catch (IOException e) {
-      LOG.warn("Failed to set AuthenticatedClientUser in REST service handler: {}", e.getMessage());
+      LOG.warn("Failed to set AuthenticatedClientUser in REST service handler: {}", e.toString());
       return createErrorResponse(new S3Exception(e, resource, S3ErrorCode.INTERNAL_ERROR));
     }
 

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -335,7 +335,7 @@ public final class AlluxioWorkerRestServiceHandler {
             }
           } catch (Exception e) {
             // The file might have been deleted, log a warning and ignore this file.
-            LOG.warn("Unable to get file info for fileId {}. {}", fileId, e.getMessage());
+            LOG.warn("Unable to get file info for fileId {}. {}", fileId, e.toString());
           }
         }
         response.setFileInfos(uiFileInfos);

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
@@ -174,7 +174,7 @@ public class AsyncCacheRequestManager {
       try {
         mBlockWorker.abortBlock(Sessions.ASYNC_CACHE_WORKER_SESSION_ID, blockId);
       } catch (AlluxioException | IOException ee) {
-        LOG.warn("Failed to abort block {}: {}", blockId, ee.getMessage());
+        LOG.warn("Failed to abort block {}: {}", blockId, ee.toString());
       }
       return false;
     }

--- a/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AsyncCacheRequestManager.java
@@ -102,7 +102,7 @@ public class AsyncCacheRequestManager {
           "Failed to cache block locally (async & best effort) as the thread pool is at capacity."
               + " To increase, update the parameter '%s'. numRejected: {} error: {}",
           PropertyKey.Name.WORKER_NETWORK_ASYNC_CACHE_MANAGER_THREADS_MAX), mNumRejected.get(),
-          e.getMessage());
+          e.toString());
     } catch (Exception e) {
       LOG.warn("Failed to submit async cache request. request: {}", request, e);
       ASYNC_CACHE_FAILED_BLOCKS.inc();
@@ -158,7 +158,7 @@ public class AsyncCacheRequestManager {
     } catch (AlluxioException | IOException e) {
       LOG.warn(
           "Failed to async cache block {} from remote worker ({}) on creating the temp block: {}",
-          blockId, sourceAddress, e.getMessage());
+          blockId, sourceAddress, e.toString());
       return false;
     }
     try (BlockReader reader =
@@ -170,7 +170,7 @@ public class AsyncCacheRequestManager {
       return true;
     } catch (AlluxioException | IOException e) {
       LOG.warn("Failed to async cache block {} from remote worker ({}) on copying the block: {}",
-          blockId, sourceAddress, e.getMessage());
+          blockId, sourceAddress, e.toString());
       try {
         mBlockWorker.abortBlock(Sessions.ASYNC_CACHE_WORKER_SESSION_ID, blockId);
       } catch (AlluxioException | IOException ee) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/PinListSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/PinListSync.java
@@ -55,7 +55,7 @@ public final class PinListSync implements HeartbeatExecutor {
       mBlockWorker.updatePinList(pinList);
     } catch (Exception e) {
       // An error occurred, retry after 1 second or error if sync timeout is reached
-      LOG.warn("Failed to receive pinlist: {}", e.getMessage());
+      LOG.warn("Failed to receive pinlist: {}", e.toString());
       LOG.debug("Exception: ", e);
       // TODO(gene): Add this method to AbstractMasterClient.
       // mMasterClient.resetConnection();

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -449,8 +449,7 @@ public class TieredBlockStore implements BlockStore {
             sessionId);
         abortBlockInternal(sessionId, tempBlockMeta.getBlockId());
       } catch (Exception e) {
-        LOG.error("Failed to cleanup tempBlock {} due to {}", tempBlockMeta.getBlockId(),
-            e.getMessage());
+        LOG.error("Failed to cleanup tempBlock {}", tempBlockMeta.getBlockId(), e);
       }
     }
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
@@ -369,7 +369,7 @@ public final class UnderFileSystemBlockReader extends BlockReader {
     } catch (IOException | AlluxioException e) {
       LOG.warn(
           "Failed to update block writer for UFS block [blockId: {}, ufsPath: {}, offset: {}]: {}",
-          mBlockMeta.getBlockId(), mBlockMeta.getUnderFileSystemPath(), offset, e.getMessage());
+          mBlockMeta.getBlockId(), mBlockMeta.getUnderFileSystemPath(), offset, e.toString());
       mBlockWriter = null;
     }
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
@@ -190,7 +190,7 @@ public final class UnderFileSystemBlockReader extends BlockReader {
             (int) (mInStreamPos - mBlockWriter.getPosition()));
         mBlockWriter.append(buffer.duplicate());
       } catch (Exception e) {
-        LOG.warn("Failed to cache data read from UFS (on read()): {}", e.getMessage());
+        LOG.warn("Failed to cache data read from UFS (on read()): {}", e.toString());
         try {
           cancelBlockWriter();
         } catch (IOException ee) {
@@ -240,7 +240,7 @@ public final class UnderFileSystemBlockReader extends BlockReader {
           mBlockWriter.append(bufCopy);
         }
       } catch (Exception e) {
-        LOG.warn("Failed to cache data read from UFS (on transferTo()): {}", e.getMessage());
+        LOG.warn("Failed to cache data read from UFS (on transferTo()): {}", e.toString());
         cancelBlockWriter();
       }
     }

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageTier.java
@@ -147,8 +147,7 @@ public final class DefaultStorageTier implements StorageTier {
     try {
       info = ShellUtils.getUnixMountInfo();
     } catch (IOException e) {
-      LOG.warn("Failed to get mount information for verifying memory capacity: {}",
-          e.getMessage());
+      LOG.warn("Failed to get mount information for verifying memory capacity: {}", e.toString());
       return;
     }
     boolean foundMountInfo = false;

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageTier.java
@@ -110,7 +110,7 @@ public final class DefaultStorageTier implements StorageTier {
         totalCapacity += capacity;
         mDirs.put(i, dir);
       } catch (IOException | InvalidPathException e) {
-        LOG.error("Unable to initialize storage directory at {}: {}", dirPaths[i], e.getMessage());
+        LOG.error("Unable to initialize storage directory at {}", dirPaths[i], e);
         mLostStorage.add(dirPaths[i]);
         continue;
       }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/AbstractWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/AbstractWriteHandler.java
@@ -319,7 +319,7 @@ abstract class AbstractWriteHandler<T extends WriteRequestContext<?>> {
       mContext.setError(error);
       cleanupRequest(mContext);
     } catch (Exception e) {
-      LOG.warn("Failed to cleanup states with error {}.", e.getMessage());
+      LOG.warn("Failed to cleanup states with error {}.", e.toString());
     } finally {
       replyError();
     }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -554,10 +554,9 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
         try {
           mWorker.moveBlock(request.getSessionId(), request.getId(), 0);
         } catch (BlockDoesNotExistException e) {
-          LOG.debug("Block {} to promote does not exist in Alluxio: {}", request.getId(),
-              e.getMessage());
+          LOG.debug("Block {} to promote does not exist in Alluxio", request.getId(), e);
         } catch (Exception e) {
-          LOG.warn("Failed to promote block {}: {}", request.getId(), e.getMessage());
+          LOG.warn("Failed to promote block {}: {}", request.getId(), e.toString());
         }
       }
       BlockReader reader = mWorker.createBlockReader(request);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
@@ -78,10 +78,9 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
             try {
               mWorker.moveBlock(mSessionId, mRequest.getBlockId(), 0);
             } catch (BlockDoesNotExistException e) {
-              LOG.debug("Block {} to promote does not exist in Alluxio: {}", mRequest.getBlockId(),
-                  e.getMessage());
+              LOG.debug("Block {} to promote does not exist in Alluxio", mRequest.getBlockId(), e);
             } catch (Exception e) {
-              LOG.warn("Failed to promote block {}: {}", mRequest.getBlockId(), e.getMessage());
+              LOG.warn("Failed to promote block {}: {}", mRequest.getBlockId(), e.toString());
             }
           }
           mLockId = mWorker.lockBlock(mSessionId, mRequest.getBlockId());
@@ -109,7 +108,7 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
             mWorker.unlockBlock(mLockId);
           } catch (BlockDoesNotExistException ee) {
             LOG.warn("Failed to unlock lock {} of block {} with error {}.",
-                mLockId, mRequest.getBlockId(), e);
+                mLockId, mRequest.getBlockId(), e.toString());
           }
           mLockId = BlockWorker.INVALID_LOCK_ID;
         }
@@ -127,7 +126,7 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
         mWorker.unlockBlock(mLockId);
       } catch (BlockDoesNotExistException e) {
         LOG.warn("Failed to unlock lock {} of block {} with error {}.",
-            mLockId, mRequest.getBlockId(), e.getMessage());
+            mLockId, mRequest.getBlockId(), e.toString());
       }
       mWorker.cleanupSession(mSessionId);
     }
@@ -147,7 +146,7 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
             mWorker.unlockBlock(mLockId);
           } catch (BlockDoesNotExistException e) {
             LOG.warn("Failed to unlock lock {} of block {} with error {}.",
-                mLockId, mRequest.getBlockId(), e.getMessage());
+                mLockId, mRequest.getBlockId(), e.toString());
           }
           mLockId = BlockWorker.INVALID_LOCK_ID;
         } else if (mRequest != null) {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -122,7 +122,7 @@ public final class AlluxioFuse {
     try (FileSystem fs = FileSystem.Factory.create(fsContext)) {
       launchFuse(fs, conf, opts, true);
     } catch (IOException e) {
-      LOG.error(e.getMessage());
+      LOG.error("Failed to launch FUSE", e);
       System.exit(-1);
     }
   }

--- a/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationTool.java
+++ b/integration/tools/hms/src/main/java/alluxio/cli/HmsValidationTool.java
@@ -94,8 +94,8 @@ public class HmsValidationTool implements ValidationTool {
     } catch (RuntimeException e) {
       // Try not to throw exception on the construction function
       // The hms validation tool itself should return failed message if the given config is invalid
-      LOG.error("Failed to process hms validation tool config from config map {}: {}",
-          configMap, e.getMessage());
+      LOG.error("Failed to process hms validation tool config from config map {}",
+          configMap, e);
     }
     return new HmsValidationTool(metastoreUri, database, tables, socketTimeout);
   }

--- a/job/common/src/main/java/alluxio/job/wire/TaskInfo.java
+++ b/job/common/src/main/java/alluxio/job/wire/TaskInfo.java
@@ -282,8 +282,7 @@ public class TaskInfo implements JobInfo {
       result = mResult == null ? null : ByteBuffer.wrap(SerializationUtils.serialize(mResult));
     } catch (IOException e) {
       // TODO(bradley) better error handling
-      LOG.warn("Failed to serialize {} : {}", mResult, e.getMessage());
-      LOG.warn("Exception: ", e);
+      LOG.error("Failed to serialize {}", mResult, e);
     }
 
     alluxio.grpc.JobInfo.Builder taskInfoBuilder =

--- a/job/server/src/main/java/alluxio/master/AlluxioJobMasterProcess.java
+++ b/job/server/src/main/java/alluxio/master/AlluxioJobMasterProcess.java
@@ -93,7 +93,7 @@ public class AlluxioJobMasterProcess extends MasterProcess {
           new MasterContext(mJournalSystem, null, mUfsManager), mFileSystem, mFsContext,
           mUfsManager);
     } catch (Exception e) {
-      LOG.error(e.getMessage(), e);
+      LOG.error("Failed to create job master", e);
       throw Throwables.propagate(e);
     }
   }
@@ -172,7 +172,7 @@ public class AlluxioJobMasterProcess extends MasterProcess {
     try {
       mJobMaster.stop();
     } catch (IOException e) {
-      LOG.error(e.getMessage(), e);
+      LOG.error("Failed to stop job master", e);
       throw Throwables.propagate(e);
     }
   }

--- a/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
+++ b/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
@@ -121,7 +121,7 @@ public final class PlanCoordinator {
       taskAddressToArgs =
           definition.selectExecutors(mPlanInfo.getJobConfig(), workersInfoListCopy, context);
     } catch (Exception e) {
-      LOG.warn("Failed to select executor. {})", e.getMessage());
+      LOG.warn("Failed to select executor. {})", e.toString());
       LOG.info("Exception: ", e);
       mPlanInfo.setStatus(Status.FAILED);
       mPlanInfo.setErrorType(ErrorUtils.getErrorType(e));

--- a/job/server/src/main/java/alluxio/worker/AlluxioJobWorkerProcess.java
+++ b/job/server/src/main/java/alluxio/worker/AlluxioJobWorkerProcess.java
@@ -122,7 +122,7 @@ public final class AlluxioJobWorkerProcess implements JobWorkerProcess {
       mRpcConnectAddress = NetworkAddressUtils.getConnectAddress(ServiceType.JOB_WORKER_RPC,
           ServerConfiguration.global());
     } catch (Exception e) {
-      LOG.error(e.getMessage(), e);
+      LOG.error("Failed to create JobWorkerProcess", e);
       throw Throwables.propagate(e);
     }
   }

--- a/shell/src/main/java/alluxio/cli/ValidateConf.java
+++ b/shell/src/main/java/alluxio/cli/ValidateConf.java
@@ -39,7 +39,7 @@ public final class ValidateConf {
       new InstancedConfiguration(ConfigurationUtils.defaults()).validate();
       LOG.info("Configuration is valid.");
     } catch (IllegalStateException e) {
-      LOG.error("Configuration is invalid: {}", e.getMessage());
+      LOG.error("Configuration is invalid", e);
       System.exit(-1);
     }
     System.exit(0);

--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractFileSystemCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractFileSystemCommand.java
@@ -96,7 +96,7 @@ public abstract class AbstractFileSystemCommand implements Command {
         runPlainPath(path, cl);
       } catch (AlluxioException | IOException e) {
         LOG.error(String.format("error processing path: %s", path), e);
-        errorMessages.add(e.getMessage() != null ? e.getMessage() : e.toString());
+        errorMessages.add(e.toString());
       }
     }
 

--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractFileSystemCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractFileSystemCommand.java
@@ -96,7 +96,7 @@ public abstract class AbstractFileSystemCommand implements Command {
         runPlainPath(path, cl);
       } catch (AlluxioException | IOException e) {
         LOG.error(String.format("error processing path: %s", path), e);
-        errorMessages.add(e.toString());
+        errorMessages.add(e.getMessage() != null ? e.getMessage() : e.toString());
       }
     }
 

--- a/table/server/master/src/main/java/alluxio/master/table/transform/TransformManager.java
+++ b/table/server/master/src/main/java/alluxio/master/table/transform/TransformManager.java
@@ -332,7 +332,7 @@ public class TransformManager implements DelegatingJournaled {
           }
         } catch (NotFoundException e) {
           String error = ExceptionMessage.TRANSFORM_JOB_ID_NOT_FOUND_IN_JOB_SERVICE.getMessage(
-              jobId, job.getDb(), job.getTable(), e.getMessage());
+              jobId, job.getDb(), job.getTable(), e.toString());
           LOG.warn(error);
           handleJobError(job, Status.FAILED, error);
         } catch (IOException e) {

--- a/table/server/master/src/main/java/alluxio/master/table/transform/TransformManager.java
+++ b/table/server/master/src/main/java/alluxio/master/table/transform/TransformManager.java
@@ -332,7 +332,7 @@ public class TransformManager implements DelegatingJournaled {
           }
         } catch (NotFoundException e) {
           String error = ExceptionMessage.TRANSFORM_JOB_ID_NOT_FOUND_IN_JOB_SERVICE.getMessage(
-              jobId, job.getDb(), job.getTable(), e.toString());
+              jobId, job.getDb(), job.getTable(), e.getMessage());
           LOG.warn(error);
           handleJobError(job, Status.FAILED, error);
         } catch (IOException e) {

--- a/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/GlueDatabase.java
+++ b/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/GlueDatabase.java
@@ -310,7 +310,7 @@ public class GlueDatabase implements UnderDatabase {
           .getColumnStatisticsList().stream().map(GlueUtils::toProto).collect(Collectors.toList());
     } catch (AmazonClientException e) {
       LOG.warn("Cannot get the table column statistics info for table {}.{} with error {}.",
-          dbName, tableName, e.getMessage());
+          dbName, tableName, e.toString());
     }
     return Collections.emptyList();
   }
@@ -325,7 +325,7 @@ public class GlueDatabase implements UnderDatabase {
       return partColumnStatistic;
     } catch (AmazonClientException e) {
       LOG.warn("Cannot get the partition column statistics info for table {}.{} with error {}.",
-          dbName, tableName, e.getMessage());
+          dbName, tableName, e.toString());
     }
     return Collections.emptyList();
   }

--- a/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephFSUnderFileSystem.java
+++ b/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephFSUnderFileSystem.java
@@ -280,7 +280,7 @@ public class CephFSUnderFileSystem extends ConsistentUnderFileSystem
         int fd = openInternal(path, flags, mode);
         return new CephOutputStream(mMount, fd);
       } catch (IOException e) {
-        LOG.warn("Retry count {} : {}", retryPolicy.getAttemptCount(), e.getMessage());
+        LOG.warn("Retry count {} : {}", retryPolicy.getAttemptCount(), e.toString());
         te = e;
       }
     }
@@ -297,7 +297,7 @@ public class CephFSUnderFileSystem extends ConsistentUnderFileSystem
         try {
           return deleteInternal(path, options.isRecursive());
         } catch (IOException e) {
-          LOG.warn("Retry count {} : {}", retryPolicy.getAttemptCount(), e.getMessage());
+          LOG.warn("Retry count {} : {}", retryPolicy.getAttemptCount(), e.toString());
           te = e;
         }
       }
@@ -316,7 +316,7 @@ public class CephFSUnderFileSystem extends ConsistentUnderFileSystem
         try {
           return deleteInternal(path, false);
         } catch (IOException e) {
-          LOG.warn("Retry count {} : {}", retryPolicy.getAttemptCount(), e.getMessage());
+          LOG.warn("Retry count {} : {}", retryPolicy.getAttemptCount(), e.toString());
           te = e;
         }
       }
@@ -529,7 +529,7 @@ public class CephFSUnderFileSystem extends ConsistentUnderFileSystem
         return true;
       } catch (IOException e) {
         LOG.warn("{} try to make directory for {} : {}", retryPolicy.getAttemptCount(), path,
-            e.getMessage());
+            e.toString());
         te = e;
       }
     }
@@ -556,7 +556,7 @@ public class CephFSUnderFileSystem extends ConsistentUnderFileSystem
         }
         return inputStream;
       } catch (IOException e) {
-        LOG.warn("{} try to open {} : {}", retryPolicy.getAttemptCount(), path, e.getMessage());
+        LOG.warn("{} try to open {} : {}", retryPolicy.getAttemptCount(), path, e.toString());
         te = e;
       }
     }
@@ -725,7 +725,7 @@ public class CephFSUnderFileSystem extends ConsistentUnderFileSystem
         return true;
       } catch (IOException e) {
         LOG.warn("{} try to rename {} to {} : {}", retryPolicy.getAttemptCount(), src, dst,
-            e.getMessage());
+            e.toString());
         te = e;
       }
     }

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -333,7 +333,7 @@ public class GCSUnderFileSystem extends ObjectUnderFileSystem {
       }
     } catch (ServiceException e) {
       LOG.warn("Failed to get Google account owner, proceeding with defaults owner {}. {}",
-          accountOwner, e.getMessage());
+          accountOwner, e.toString());
     }
 
     short bucketMode =

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -342,7 +342,7 @@ public class GCSUnderFileSystem extends ObjectUnderFileSystem {
       GSAccessControlList acl = mClient.getBucketAcl(mBucketName);
       bucketMode = GCSUtils.translateBucketAcl(acl, accountOwnerId);
     } catch (ServiceException e) {
-      LOG.warn("Failed to inherit bucket ACLs, proceeding with defaults. {}", e.getMessage());
+      LOG.warn("Failed to inherit bucket ACLs, proceeding with defaults. {}", e.toString());
     }
 
     // No group in GCS ACL, returns the account owner for group.

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/v2/GCSV2OutputStream.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/v2/GCSV2OutputStream.java
@@ -132,9 +132,9 @@ public final class GCSV2OutputStream extends OutputStream {
         }
       }
     } catch (ClosedChannelException e) {
-      LOG.error("Channel already closed, possible duplicate close call.", e.toString());
+      LOG.error("Channel already closed, possible duplicate close call.", e);
     } catch (IOException e) {
-      LOG.error("Failed to upload {} to {}: {}", mKey, mBucketName, e.toString());
+      LOG.error("Failed to upload {} to {}", mKey, mBucketName, e);
       throw e;
     }
   }

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/v2/GCSV2UnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/v2/GCSV2UnderFileSystem.java
@@ -210,7 +210,7 @@ public class GCSV2UnderFileSystem extends ObjectUnderFileSystem {
             Storage.BlobListOption.currentDirectory());
       }
     } catch (StorageException e) {
-      LOG.error("Failed to get object listing result of {}: {}", key, e.toString());
+      LOG.error("Failed to get object listing result of {}", key, e);
       throw new IOException(e);
     }
     if (blobPage != null && blobPage.getValues().iterator().hasNext()) {

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -548,7 +548,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
         return true;
       } catch (IOException e) {
         LOG.warn("{} try to make directory for {} : {}", retryPolicy.getAttemptCount(), path,
-            e.getMessage());
+            e.toString());
         te = e;
       }
     }
@@ -610,7 +610,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
         LOG.debug("Using original API to HDFS");
         return new HdfsUnderFileInputStream(inputStream);
       } catch (IOException e) {
-        LOG.warn("{} try to open {} : {}", retryPolicy.getAttemptCount(), path, e.getMessage());
+        LOG.warn("{} try to open {} : {}", retryPolicy.getAttemptCount(), path, e.toString());
         te = e;
         if (options.getRecoverFailedOpen() && dfs != null && e.getMessage().toLowerCase()
             .startsWith("cannot obtain block length for")) {
@@ -669,15 +669,16 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
       FileStatus fileStatus = hdfs.getFileStatus(new Path(path));
       hdfs.setOwner(fileStatus.getPath(), user, group);
     } catch (IOException e) {
-      LOG.warn("Failed to set owner for {} with user: {}, group: {}", path, user, group);
-      LOG.debug("Exception : ", e);
-      LOG.warn("In order for Alluxio to modify ownership of local files, "
-          + "Alluxio should be running as an HDFS superuser.");
-      if (!Boolean.valueOf(mUfsConf.get(PropertyKey.UNDERFS_ALLOW_SET_OWNER_FAILURE))) {
+      LOG.debug("Exception: ", e);
+      if (!mUfsConf.getBoolean(PropertyKey.UNDERFS_ALLOW_SET_OWNER_FAILURE)) {
+        LOG.warn("Failed to set owner for {} with user: {}, group: {}: {}. "
+            + "Running Alluxio as superuser is required to modify ownership of local files",
+            path, user, group, e.toString());
         throw e;
       } else {
-        LOG.warn("Failure is ignored, which may cause permission inconsistency between "
-            + "Alluxio and HDFS.");
+        LOG.warn("Failed to set owner for {} with user: {}, group: {}: {}. "
+            + "This failure is ignored but may cause permission inconsistency between Alluxio "
+            + "and local under file system", path, user, group, e.toString());
       }
     }
   }
@@ -790,7 +791,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
         return hdfs.rename(new Path(src), new Path(dst));
       } catch (IOException e) {
         LOG.warn("{} try to rename {} to {} : {}", retryPolicy.getAttemptCount(), src, dst,
-            e.getMessage());
+            e.toString());
         te = e;
       }
     }

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -280,7 +280,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
         }
         return outputStream;
       } catch (IOException e) {
-        LOG.warn("Attempt count {} : {} ", retryPolicy.getAttemptCount(), e.getMessage());
+        LOG.warn("Attempt count {} : {} ", retryPolicy.getAttemptCount(), e.toString());
         te = e;
       }
     }
@@ -365,7 +365,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
         Collections.addAll(ret, names);
       }
     } catch (IOException e) {
-      LOG.debug("Unable to get file location for {} : {}", path, e.getMessage());
+      LOG.debug("Unable to get file location for {}", path, e);
     }
     return ret;
   }
@@ -689,7 +689,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
       FileStatus fileStatus = hdfs.getFileStatus(new Path(path));
       hdfs.setPermission(fileStatus.getPath(), new FsPermission(mode));
     } catch (IOException e) {
-      LOG.warn("Fail to set permission for {} with perm {} : {}", path, mode, e.getMessage());
+      LOG.warn("Fail to set permission for {} with perm {} : {}", path, mode, e.toString());
       throw e;
     }
   }
@@ -744,7 +744,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
       try {
         return hdfs.delete(new Path(path), recursive);
       } catch (IOException e) {
-        LOG.warn("Attempt count {} : {}", retryPolicy.getAttemptCount(), e.getMessage());
+        LOG.warn("Attempt count {} : {}", retryPolicy.getAttemptCount(), e.toString());
         te = e;
       }
     }

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -323,7 +323,7 @@ public class LocalUnderFileSystem extends ConsistentUnderFileSystem
           setOwner(file.getPath(), options.getOwner(), options.getGroup());
         } catch (IOException e) {
           LOG.warn("Failed to update the ufs dir ownership, default values will be used: {}",
-              e.getMessage());
+              e.toString());
         }
         return true;
       }
@@ -349,7 +349,7 @@ public class LocalUnderFileSystem extends ConsistentUnderFileSystem
           setOwner(dirToMake.getAbsolutePath(), options.getOwner(), options.getGroup());
         } catch (IOException e) {
           LOG.warn("Failed to update the ufs dir ownership, default values will be used: {}",
-              e.getMessage());
+              e.toString());
         }
       } else {
         return false;
@@ -402,15 +402,16 @@ public class LocalUnderFileSystem extends ConsistentUnderFileSystem
         FileUtils.changeLocalFileGroup(path, group);
       }
     } catch (IOException e) {
-      LOG.warn("Failed to set owner for {} with user: {}, group: {}", path, user, group);
       LOG.debug("Exception: ", e);
-      LOG.warn("In order for Alluxio to modify ownership of local files, "
-          + "Alluxio should be the local file system superuser.");
       if (!mUfsConf.getBoolean(PropertyKey.UNDERFS_ALLOW_SET_OWNER_FAILURE)) {
+        LOG.warn("Failed to set owner for {} with user: {}, group: {}: {}. "
+            + "Running Alluxio as superuser is required to modify ownership of local files",
+            path, user, group, e.toString());
         throw e;
       } else {
-        LOG.warn("Failure is ignored, which may cause permission inconsistency between "
-            + "Alluxio and local under file system.");
+        LOG.warn("Failed to set owner for {} with user: {}, group: {}: {}. "
+            + "This failure is ignored but may cause permission inconsistency between Alluxio "
+            + "and local under file system", path, user, group, e.toString());
       }
     }
   }

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3ALowLevelOutputStream.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3ALowLevelOutputStream.java
@@ -267,7 +267,7 @@ public class S3ALowLevelOutputStream extends OutputStream {
       waitForAllPartsUpload();
       completeMultiPartUpload();
     } catch (Exception e) {
-      LOG.error("Failed to upload {}: {}", mKey, e.toString());
+      LOG.error("Failed to upload {}", mKey, e);
       throw new IOException(e);
     }
   }

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AOutputStream.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AOutputStream.java
@@ -150,7 +150,7 @@ public class S3AOutputStream extends OutputStream {
       PutObjectRequest putReq = new PutObjectRequest(mBucketName, path, mFile).withMetadata(meta);
       mManager.upload(putReq).waitForUploadResult();
     } catch (Exception e) {
-      LOG.error("Failed to upload {}: {}", path, e.toString());
+      LOG.error("Failed to upload {}", path, e);
       throw new IOException(e);
     } finally {
       // Delete the temporary file on the local machine if the transfer manager completed the

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -564,7 +564,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
           accountOwner = owner.getDisplayName() != null ? owner.getDisplayName() : owner.getId();
         }
       } catch (AmazonClientException e) {
-        LOG.warn("Failed to inherit bucket ACLs, proceeding with defaults. {}", e.getMessage());
+        LOG.warn("Failed to inherit bucket ACLs, proceeding with defaults. {}", e.toString());
       }
     }
 

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/KeystoneV3AccessProvider.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/KeystoneV3AccessProvider.java
@@ -69,7 +69,7 @@ public class KeystoneV3AccessProvider implements AccessProvider {
                 new Scope(new Project(mAccountConfig.getTenantName()))));
         requestBody = new ObjectMapper().writeValueAsString(request);
       } catch (JsonProcessingException e) {
-        LOG.error("Error processing JSON request: {}", e.getMessage());
+        LOG.error("Error processing JSON request", e);
         return null;
       }
 
@@ -117,7 +117,7 @@ public class KeystoneV3AccessProvider implements AccessProvider {
                   mAccountConfig.getPreferredRegion(), publicURL, token);
               return access;
             } catch (JsonProcessingException e) {
-              LOG.error("Error processing JSON response: {}", e.getMessage());
+              LOG.error("Error processing JSON response", e);
               return null;
             }
           }
@@ -125,7 +125,7 @@ public class KeystoneV3AccessProvider implements AccessProvider {
       }
     } catch (IOException e) {
       // Unable to authenticate
-      LOG.error("Exception authenticating using KeystoneV3 {}", e.getMessage());
+      LOG.error("Exception authenticating using KeystoneV3", e);
       return null;
     }
   }

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftMockOutputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftMockOutputStream.java
@@ -69,7 +69,7 @@ public class SwiftMockOutputStream extends OutputStream {
       mFile = new File(PathUtils.concatPath(CommonUtils.getTmpDir(tmpDirs), UUID.randomUUID()));
       mOutputStream  = new BufferedOutputStream(new FileOutputStream(mFile));
     } catch (Exception e) {
-      LOG.error(e.getMessage());
+      LOG.error("Failed to construct SwiftMockOutputStream", e);
       throw new IOException(e);
     }
   }

--- a/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftOutputStream.java
+++ b/underfs/swift/src/main/java/alluxio/underfs/swift/SwiftOutputStream.java
@@ -41,7 +41,7 @@ public class SwiftOutputStream extends OutputStream {
       mOutputStream  = httpCon.getOutputStream();
       mHttpCon = httpCon;
     } catch (Exception e) {
-      LOG.error(e.getMessage());
+      LOG.error("Failed to construct SwiftOutputStream", e);
       throw new IOException(e);
     }
   }
@@ -76,7 +76,7 @@ public class SwiftOutputStream extends OutputStream {
       }
       is.close();
     } catch (Exception e) {
-      LOG.error(e.getMessage());
+      LOG.error("Failed to close SwiftOutputStream", e);
       if (is != null) {
         is.close();
       }

--- a/underfs/web/src/main/java/alluxio/underfs/web/WebUnderFileSystem.java
+++ b/underfs/web/src/main/java/alluxio/underfs/web/WebUnderFileSystem.java
@@ -239,7 +239,7 @@ public class WebUnderFileSystem extends ConsistentUnderFileSystem {
         Date parsedDate = dateFormat.parse(datetime);
         timestamp = parsedDate.getTime();
       } catch (Exception e) {
-        LOG.error("Failed to format {} to a timestamp, {}", datetime, e.getMessage());
+        LOG.error("Failed to format {} to a timestamp", datetime, e);
       }
     }
     return timestamp;
@@ -251,7 +251,7 @@ public class WebUnderFileSystem extends ConsistentUnderFileSystem {
     try {
       doc = Jsoup.connect(path).get();
     } catch (Exception e) {
-      LOG.error("Failed to get content from URL {}, {}", path, e.getMessage());
+      LOG.error("Failed to get content from URL {}", path, e);
       return null;
     }
 


### PR DESCRIPTION
Improve logging messages to be consistent with our documentation: 
https://docs.alluxio.io/os/user/edge/en/contributor/Code-Conventions.html#log-level-guidelines

Essentially, we 
1. prefer `e.toString()` to `e.getMessage()` in warn logging
2. prefer leaving exception `e` as the last argument for `LOG.error` to print the stack trace

Also fix some incorrect usage of logging,

- Fix `logger.warn("Exit(stream) (Error): {}: {}, Error={}", methodName, String.format(description, args), e);`
which will give output of:

```
2021-05-07 20:06:31,676 WARN  ShortCircuitBlockReadHandler - Exit(stream) (Error): OpenBlock: Session=0, Request=null, Error={}
alluxio.exception.BlockDoesNotExistException: blockId 5553258511 not found
	at alluxio.worker.grpc.ShortCircuitBlockReadHandler$1.call(ShortCircuitBlockReadHandler.java:90)
	at alluxio.worker.grpc.ShortCircuitBlockReadHandler$1.call(ShortCircuitBlockReadHandler.java:69)
	at alluxio.RpcUtils.streamingRPCAndLog(RpcUtils.java:163)
	at alluxio.worker.grpc.ShortCircuitBlockReadHandler.onNext(ShortCircuitBlockReadHandler.java:69)
	at alluxio.worker.grpc.ShortCircuitBlockReadHandler.onNext(ShortCircuitBlockReadHandler.java:36)
	at io.grpc.stub.ServerCalls$StreamingServerCallHandler$StreamingServerCallListener.onMessage(ServerCalls.java:255)
...
```

- Fix https://github.com/Alluxio/alluxio/issues/11197