### PR TITLE
[DOCFIX] Fix GCS doc navtabs title

### DIFF
--- a/docs/en/ufs/GCS.md
+++ b/docs/en/ufs/GCS.md
@@ -110,7 +110,7 @@ alluxio.master.hostname=localhost
 ```
 
 Then, mount GCS:
-{% navtabs rootMount %}
+{% navtabs nestedMount %}
 {% navtab GCS version 1 %}
 ```console
 $ ./bin/alluxio fs mount \


### PR DESCRIPTION
navtabs cannot have the same title, otherwise interacting with one can affect others with the same title