### PR TITLE
Do not include secondary master by default in LocalAlluxioCluster

### DIFF
--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
@@ -138,7 +138,7 @@ public final class LocalAlluxioCluster extends AbstractLocalAlluxioCluster {
 
   @Override
   public void startMasters() throws Exception {
-    mMaster = LocalAlluxioMaster.create(mWorkDirectory, true);
+    mMaster = LocalAlluxioMaster.create(mWorkDirectory, false);
     mMaster.start();
   }
 

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
@@ -60,6 +60,7 @@ public final class LocalAlluxioCluster extends AbstractLocalAlluxioCluster {
 
   /**
    * @param numWorkers the number of workers to run
+   * @param includeSecondary weather to include the secondary master
    */
   public LocalAlluxioCluster(int numWorkers, boolean includeSecondary) {
     super(numWorkers);

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
@@ -47,20 +47,23 @@ public final class LocalAlluxioCluster extends AbstractLocalAlluxioCluster {
 
   private static final Logger LOG = LoggerFactory.getLogger(LocalAlluxioCluster.class);
 
+  private boolean mIncludeSecondary;
+
   private LocalAlluxioMaster mMaster;
 
   /**
    * Runs a test Alluxio cluster with a single Alluxio worker.
    */
   public LocalAlluxioCluster() {
-    this(1);
+    this(1, false);
   }
 
   /**
    * @param numWorkers the number of workers to run
    */
-  public LocalAlluxioCluster(int numWorkers) {
+  public LocalAlluxioCluster(int numWorkers, boolean includeSecondary) {
     super(numWorkers);
+    mIncludeSecondary = includeSecondary;
   }
 
   @Override
@@ -138,7 +141,7 @@ public final class LocalAlluxioCluster extends AbstractLocalAlluxioCluster {
 
   @Override
   public void startMasters() throws Exception {
-    mMaster = LocalAlluxioMaster.create(mWorkDirectory, false);
+    mMaster = LocalAlluxioMaster.create(mWorkDirectory, mIncludeSecondary);
     mMaster.start();
   }
 

--- a/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
+++ b/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
@@ -70,6 +70,7 @@ public class JournalToolTest extends BaseIntegrationTest {
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource.Builder()
+          .setIncludeSecondary(true)
           .setProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS.toString())
           .setProperty(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES,
               Integer.toString(CHECKPOINT_SIZE))

--- a/tests/src/test/java/alluxio/server/ft/journal/ufs/SecondaryMasterTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/ufs/SecondaryMasterTest.java
@@ -27,6 +27,7 @@ public class SecondaryMasterTest extends BaseIntegrationTest {
   @Rule
   public LocalAlluxioClusterResource mClusterResource =
       new LocalAlluxioClusterResource.Builder()
+          .setIncludeSecondary(true)
           .setProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS.toString())
           .setProperty(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, 10)
           .setProperty(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 1)

--- a/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
+++ b/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
@@ -83,6 +83,9 @@ public final class LocalAlluxioClusterResource implements TestRule {
   /** Number of Alluxio workers in the cluster. */
   private final int mNumWorkers;
 
+  /** Weather to include the secondary master. */
+  private final boolean mIncludeSecondary;
+
   /**
    * If true (default), we start the cluster before running a test method. Otherwise, the method
    * must start the cluster explicitly.
@@ -105,9 +108,10 @@ public final class LocalAlluxioClusterResource implements TestRule {
    * @param numWorkers the number of Alluxio workers to launch
    * @param configuration configuration for configuring the cluster
    */
-  private LocalAlluxioClusterResource(boolean startCluster, int numWorkers,
-      Map<PropertyKey, String> configuration) {
+  private LocalAlluxioClusterResource(boolean startCluster, boolean includeSecondary,
+                                      int numWorkers, Map<PropertyKey, String> configuration) {
     mStartCluster = startCluster;
+    mIncludeSecondary = includeSecondary;
     mNumWorkers = numWorkers;
     mConfiguration.putAll(configuration);
     MetricsSystem.resetCountersAndGauges();
@@ -142,7 +146,7 @@ public final class LocalAlluxioClusterResource implements TestRule {
   public void start() throws Exception {
     AuthenticatedClientUser.remove();
     // Create a new cluster.
-    mLocalAlluxioCluster = new LocalAlluxioCluster(mNumWorkers);
+    mLocalAlluxioCluster = new LocalAlluxioCluster(mNumWorkers, mIncludeSecondary);
     // Init configuration for integration test
     mLocalAlluxioCluster.initConfiguration(mTestName);
     // Overwrite the test configuration with test specific parameters
@@ -230,6 +234,7 @@ public final class LocalAlluxioClusterResource implements TestRule {
    */
   public static class Builder {
     private boolean mStartCluster;
+    private boolean mIncludeSecondary;
     private int mNumWorkers;
     private Map<PropertyKey, String> mConfiguration;
 
@@ -238,6 +243,7 @@ public final class LocalAlluxioClusterResource implements TestRule {
      */
     public Builder() {
       mStartCluster = true;
+      mIncludeSecondary = false;
       mNumWorkers = 1;
       mConfiguration = new HashMap<>();
     }
@@ -247,6 +253,14 @@ public final class LocalAlluxioClusterResource implements TestRule {
      */
     public Builder setStartCluster(boolean startCluster) {
       mStartCluster = startCluster;
+      return this;
+    }
+
+    /**
+     * @param includeSecondary whether to include the secondary master
+     */
+    public Builder setIncludeSecondary(boolean includeSecondary) {
+      mIncludeSecondary = includeSecondary;
       return this;
     }
 
@@ -271,7 +285,8 @@ public final class LocalAlluxioClusterResource implements TestRule {
      * @return a {@link LocalAlluxioClusterResource} for the current builder values
      */
     public LocalAlluxioClusterResource build() {
-      return new LocalAlluxioClusterResource(mStartCluster, mNumWorkers, mConfiguration);
+      return new LocalAlluxioClusterResource(mStartCluster, mIncludeSecondary, mNumWorkers,
+          mConfiguration);
     }
   }
 

--- a/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
+++ b/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
@@ -109,7 +109,7 @@ public final class LocalAlluxioClusterResource implements TestRule {
    * @param configuration configuration for configuring the cluster
    */
   private LocalAlluxioClusterResource(boolean startCluster, boolean includeSecondary,
-                                      int numWorkers, Map<PropertyKey, String> configuration) {
+      int numWorkers, Map<PropertyKey, String> configuration) {
     mStartCluster = startCluster;
     mIncludeSecondary = includeSecondary;
     mNumWorkers = numWorkers;


### PR DESCRIPTION
The goal of this PR is to make tests faster/less flaky.