### PR TITLE
Move block list merging from master to worker

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -15,6 +15,7 @@ import alluxio.RpcUtils;
 import alluxio.grpc.BlockHeartbeatPRequest;
 import alluxio.grpc.BlockHeartbeatPResponse;
 import alluxio.grpc.BlockMasterWorkerServiceGrpc;
+import alluxio.grpc.BlockStoreLocationProto;
 import alluxio.grpc.CommitBlockInUfsPRequest;
 import alluxio.grpc.CommitBlockInUfsPResponse;
 import alluxio.grpc.CommitBlockPRequest;
@@ -174,12 +175,18 @@ public final class BlockMasterWorkerServiceHandler extends
                  * Therefore we just fail on merging.
                  */
                 (e1, e2) -> {
-                  throw new AssertionError(
-                      String.format(
-                          "One registerWorker request contains two block id lists for the "
-                                  + "same BlockLocation.%n"
-                                  + "Existing: %s%n New: %s",
-                          e1, e2));
+//                  System.out.println(entries);
+//                  LocationBlockIdListEntry k1 = entries.get(0);
+//                  LocationBlockIdListEntry k2 = entries.get(1);
+//                  BlockStoreLocationProto p1 = k1.getKey();
+//                  throw new AssertionError(
+//                      String.format(
+//                          "One registerWorker request contains two block id lists for the "
+//                                  + "same BlockLocation.%n"
+//                                  + "Existing: %s%n New: %s",
+//                          e1, e2));
+                  e1.addAll(e2);
+                  return e1;
                 }));
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -84,10 +84,14 @@ public final class BlockMasterWorkerServiceHandler extends
                     e -> Block.BlockLocation.newBuilder().setTier(e.getKey().getTierAlias())
                         .setMediumType(e.getKey().getMediumType()).build(),
                     e -> e.getValue().getBlockIdList(),
+                    /**
+                     * The merger function is invoked on key collisions to merge the values.
+                     * In fact this merger should never be invoked because the list is deduplicated
+                     * by {@link BlockMasterClient#heartbeat} before sending to the master.
+                     */
                     (e1, e2) -> {
-                      List<Long> e3 = new ArrayList<>(e1);
-                      e3.addAll(e2);
-                      return e3;
+                      e1.addAll(e2);
+                      return e1;
                     }));
 
     final List<Metric> metrics = request.getOptions().getMetricsList()

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -157,8 +157,7 @@ public final class BlockMasterWorkerServiceHandler extends
 
   /**
    * This converts the flattened list of block locations back to a map.
-   * This relies on the unique guarantee from
-   * {@link alluxio.worker.block.BlockMasterClient#heartbeat}.
+   * This relies on the unique guarantee from the worker-side serialization.
    * If a duplicated key is seen, an AssertionError will be thrown.
    * */
   private Map<Block.BlockLocation, List<Long>> reconstructBlocksOnLocationMap(
@@ -175,18 +174,11 @@ public final class BlockMasterWorkerServiceHandler extends
                  * Therefore we just fail on merging.
                  */
                 (e1, e2) -> {
-//                  System.out.println(entries);
-//                  LocationBlockIdListEntry k1 = entries.get(0);
-//                  LocationBlockIdListEntry k2 = entries.get(1);
-//                  BlockStoreLocationProto p1 = k1.getKey();
-//                  throw new AssertionError(
-//                      String.format(
-//                          "One registerWorker request contains two block id lists for the "
-//                                  + "same BlockLocation.%n"
-//                                  + "Existing: %s%n New: %s",
-//                          e1, e2));
-                  e1.addAll(e2);
-                  return e1;
+                  throw new AssertionError(
+                      String.format(
+                          "Request contains two block id lists for the "
+                              + "same BlockLocation.%nExisting: %s%n New: %s",
+                          e1, e2));
                 }));
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -76,7 +76,7 @@ public final class BlockMasterWorkerServiceHandler extends
     final Map<String, StorageList> lostStorageMap = request.getLostStorageMap();
 
     final Map<Block.BlockLocation, List<Long>> addedBlocksMap =
-            reconstructBlocksOnLocationMap(request.getAddedBlocksList());
+        reconstructBlocksOnLocationMap(request.getAddedBlocksList());
 
     final List<Metric> metrics = request.getOptions().getMetricsList()
         .stream().map(Metric::fromProto).collect(Collectors.toList());
@@ -158,26 +158,26 @@ public final class BlockMasterWorkerServiceHandler extends
    * This converts the flattened list of block locations back to a map.
    * This relies on the unique guarantee from the worker-side serialization.
    * If a duplicated key is seen, an AssertionError will be thrown.
+   * The key is {@link Block.BlockLocation}, where the hash code is determined by
+   * tier alias and medium type.
    * */
   private Map<Block.BlockLocation, List<Long>> reconstructBlocksOnLocationMap(
           List<LocationBlockIdListEntry> entries) {
     return entries.stream().collect(
-            Collectors.toMap(
-                e -> Block.BlockLocation.newBuilder().setTier(e.getKey().getTierAlias())
-                        .setMediumType(e.getKey().getMediumType()).build(),
-                e -> e.getValue().getBlockIdList(),
-                /**
-                 * The merger function is invoked on key collisions to merge the values.
-                 * In fact this merger should never be invoked because the list is deduplicated
-                 * by {@link BlockMasterClient#heartbeat} before sending to the master.
-                 * Therefore we just fail on merging.
-                 */
-                (e1, e2) -> {
-                  throw new AssertionError(
-                      String.format(
-                          "Request contains two block id lists for the "
-                              + "same BlockLocation.%nExisting: %s%n New: %s",
-                          e1, e2));
-                }));
+        Collectors.toMap(
+            e -> Block.BlockLocation.newBuilder().setTier(e.getKey().getTierAlias())
+                .setMediumType(e.getKey().getMediumType()).build(),
+            e -> e.getValue().getBlockIdList(),
+            /**
+             * The merger function is invoked on key collisions to merge the values.
+             * In fact this merger should never be invoked because the list is deduplicated
+             * by {@link BlockMasterClient#heartbeat} before sending to the master.
+             * Therefore we just fail on merging.
+             */
+            (e1, e2) -> {
+              throw new AssertionError(
+                String.format("Request contains two block id lists for the "
+                  + "same BlockLocation.%nExisting: %s%n New: %s", e1, e2));
+            }));
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -15,7 +15,6 @@ import alluxio.RpcUtils;
 import alluxio.grpc.BlockHeartbeatPRequest;
 import alluxio.grpc.BlockHeartbeatPResponse;
 import alluxio.grpc.BlockMasterWorkerServiceGrpc;
-import alluxio.grpc.BlockStoreLocationProto;
 import alluxio.grpc.CommitBlockInUfsPRequest;
 import alluxio.grpc.CommitBlockInUfsPResponse;
 import alluxio.grpc.CommitBlockPRequest;

--- a/core/server/master/src/test/java/alluxio/master/block/BlockMasterWorkerServiceHandlerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/BlockMasterWorkerServiceHandlerTest.java
@@ -1,0 +1,173 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.block;
+
+import static org.junit.Assert.assertThrows;
+
+import alluxio.clock.ManualClock;
+import alluxio.grpc.BlockHeartbeatPRequest;
+import alluxio.grpc.BlockHeartbeatPResponse;
+import alluxio.grpc.BlockIdList;
+import alluxio.grpc.BlockStoreLocationProto;
+import alluxio.grpc.LocationBlockIdListEntry;
+import alluxio.grpc.RegisterWorkerPOptions;
+import alluxio.grpc.RegisterWorkerPRequest;
+import alluxio.grpc.RegisterWorkerPResponse;
+import alluxio.master.CoreMasterContext;
+import alluxio.master.MasterRegistry;
+import alluxio.master.MasterTestUtils;
+import alluxio.master.metrics.MetricsMaster;
+import alluxio.master.metrics.MetricsMasterFactory;
+import alluxio.util.ThreadFactoryUtils;
+import alluxio.util.executor.ExecutorServiceFactories;
+import alluxio.worker.block.BlockStoreLocation;
+
+import com.google.common.collect.ImmutableList;
+import io.grpc.stub.StreamObserver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class BlockMasterWorkerServiceHandlerTest {
+  private BlockMaster mBlockMaster;
+  private MasterRegistry mRegistry;
+  private ManualClock mClock;
+  private ExecutorService mExecutorService;
+  private MetricsMaster mMetricsMaster;
+  private BlockMasterWorkerServiceHandler mHandler;
+
+  /**
+   * Sets up the dependencies before a test runs.
+   */
+  @Before
+  public void before() throws Exception {
+    mRegistry = new MasterRegistry();
+    CoreMasterContext masterContext = MasterTestUtils.testMasterContext();
+    mMetricsMaster = new MetricsMasterFactory().create(mRegistry, masterContext);
+    mClock = new ManualClock();
+    mExecutorService =
+            Executors.newFixedThreadPool(2, ThreadFactoryUtils.build("TestBlockMaster-%d", true));
+    mBlockMaster = new DefaultBlockMaster(mMetricsMaster, masterContext, mClock,
+            ExecutorServiceFactories.constantExecutorServiceFactory(mExecutorService));
+    mRegistry.add(BlockMaster.class, mBlockMaster);
+    mRegistry.start(true);
+    mHandler = new BlockMasterWorkerServiceHandler(mBlockMaster);
+  }
+
+  @After
+  public void after() throws Exception {
+    mRegistry.stop();
+  }
+
+  @Test
+  public void registerWorkerFailsOnDuplicateBlockLocation() throws Exception {
+    long workerId = 1L;
+
+    // Prepare LocationBlockIdListEntry objects
+    BlockStoreLocation loc = new BlockStoreLocation("MEM", 0);
+    BlockStoreLocationProto locationProto = BlockStoreLocationProto.newBuilder()
+            .setTierAlias(loc.tierAlias())
+            .setMediumType(loc.mediumType())
+            .build();
+
+    BlockIdList blockIdList1 = BlockIdList.newBuilder()
+            .addAllBlockId(ImmutableList.of(1L, 2L)).build();
+    LocationBlockIdListEntry listEntry1 = LocationBlockIdListEntry.newBuilder()
+            .setKey(locationProto).setValue(blockIdList1).build();
+
+    BlockIdList blockIdList2 = BlockIdList.newBuilder()
+            .addAllBlockId(ImmutableList.of(3L, 4L)).build();
+    LocationBlockIdListEntry listEntry2 = LocationBlockIdListEntry.newBuilder()
+            .setKey(locationProto).setValue(blockIdList2).build();
+
+    // The request is not deduplicated, the
+    RegisterWorkerPRequest request = RegisterWorkerPRequest.newBuilder()
+            .setWorkerId(workerId)
+            .addStorageTiers("MEM")
+            .putTotalBytesOnTiers("MEM", 1000L).putUsedBytesOnTiers("MEM", 0L)
+            .setOptions(RegisterWorkerPOptions.getDefaultInstance())
+            .addCurrentBlocks(listEntry1)
+            .addCurrentBlocks(listEntry2)
+            .build();
+
+    // Noop response observer
+    StreamObserver<RegisterWorkerPResponse> noopResponseObserver =
+        new StreamObserver<RegisterWorkerPResponse>() {
+          @Override
+          public void onNext(RegisterWorkerPResponse response) {
+          }
+
+          @Override
+          public void onError(Throwable t) {
+          }
+
+          @Override
+          public void onCompleted() {
+          }
+        };
+
+    assertThrows(AssertionError.class, () -> {
+      mHandler.registerWorker(request, noopResponseObserver);
+    });
+  }
+
+  @Test
+  public void workerHeartbeatFailsOnDuplicateBlockLocation() throws Exception {
+    long workerId = 1L;
+
+    // Prepare LocationBlockIdListEntry objects
+    BlockStoreLocation loc = new BlockStoreLocation("MEM", 0);
+    BlockStoreLocationProto locationProto = BlockStoreLocationProto.newBuilder()
+            .setTierAlias(loc.tierAlias())
+            .setMediumType(loc.mediumType())
+            .build();
+
+    BlockIdList blockIdList1 = BlockIdList.newBuilder()
+            .addAllBlockId(ImmutableList.of(1L, 2L)).build();
+    LocationBlockIdListEntry listEntry1 = LocationBlockIdListEntry.newBuilder()
+            .setKey(locationProto).setValue(blockIdList1).build();
+
+    BlockIdList blockIdList2 = BlockIdList.newBuilder()
+            .addAllBlockId(ImmutableList.of(3L, 4L)).build();
+    LocationBlockIdListEntry listEntry2 = LocationBlockIdListEntry.newBuilder()
+            .setKey(locationProto).setValue(blockIdList2).build();
+
+    BlockHeartbeatPRequest request = BlockHeartbeatPRequest.newBuilder()
+            .setWorkerId(workerId)
+            .addAddedBlocks(listEntry1)
+            .addAddedBlocks(listEntry2)
+            .build();
+
+    // Noop response observer
+    StreamObserver<BlockHeartbeatPResponse> noopResponseObserver =
+        new StreamObserver<BlockHeartbeatPResponse>() {
+          @Override
+          public void onNext(BlockHeartbeatPResponse response) {
+          }
+
+          @Override
+          public void onError(Throwable t) {
+          }
+
+          @Override
+          public void onCompleted() {
+          }
+        };
+
+    assertThrows(AssertionError.class, () -> {
+      mHandler.blockHeartbeat(request, noopResponseObserver);
+    });
+  }
+}

--- a/core/server/master/src/test/java/alluxio/master/block/BlockMasterWorkerServiceHandlerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/BlockMasterWorkerServiceHandlerTest.java
@@ -106,16 +106,13 @@ public class BlockMasterWorkerServiceHandlerTest {
     StreamObserver<RegisterWorkerPResponse> noopResponseObserver =
         new StreamObserver<RegisterWorkerPResponse>() {
           @Override
-          public void onNext(RegisterWorkerPResponse response) {
-          }
+          public void onNext(RegisterWorkerPResponse response) {}
 
           @Override
-          public void onError(Throwable t) {
-          }
+          public void onError(Throwable t) {}
 
           @Override
-          public void onCompleted() {
-          }
+          public void onCompleted() {}
         };
 
     assertThrows(AssertionError.class, () -> {
@@ -154,16 +151,13 @@ public class BlockMasterWorkerServiceHandlerTest {
     StreamObserver<BlockHeartbeatPResponse> noopResponseObserver =
         new StreamObserver<BlockHeartbeatPResponse>() {
           @Override
-          public void onNext(BlockHeartbeatPResponse response) {
-          }
+          public void onNext(BlockHeartbeatPResponse response) {}
 
           @Override
-          public void onError(Throwable t) {
-          }
+          public void onError(Throwable t) {}
 
           @Override
-          public void onCompleted() {
-          }
+          public void onCompleted() {}
         };
 
     assertThrows(AssertionError.class, () -> {

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -144,12 +143,15 @@ public class BlockMasterClient extends AbstractMasterClient {
 
   /**
    * Converts the block list map to proto.
-   * Because the list is flattened from a map, in the list no two LocationBlockIdListEntry items
-   * have the same BlockStoreLocation.
-   * */
+   * Because the list is flattened from a map, in the list no two
+   * {@link LocationBlockIdListEntry} items have the same BlockStoreLocation.
+   *
+   * @param blockListOnLocation a map from block location to the block list
+   * @return a flattened and deduplicated list
+   */
   @VisibleForTesting
-  public List<LocationBlockIdListEntry> convertBlockListMapToProto(
-      Map<BlockStoreLocation, List<Long>> blockListOnLocation) {
+  List<LocationBlockIdListEntry> convertBlockListMapToProto(
+          Map<BlockStoreLocation, List<Long>> blockListOnLocation) {
     final List<LocationBlockIdListEntry> entryList = new ArrayList<>();
 
     Map<BlockStoreLocationProto, List<Long>> tierToBlocks = new HashMap<>();
@@ -175,6 +177,7 @@ public class BlockMasterClient extends AbstractMasterClient {
 
     return entryList;
   }
+
   /**
    * The method the worker should periodically execute to heartbeat back to the master.
    *

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
@@ -146,6 +146,7 @@ public class BlockMasterClient extends AbstractMasterClient {
    * */
   private List<LocationBlockIdListEntry> convertBlockListMapToProto(
       Map<BlockStoreLocation, List<Long>> blockListOnLocation) {
+    // TODO(jiacheng): This doesn't really do dedup because BlockStoreLocation dirIndex is lost
     final List<LocationBlockIdListEntry> entryList = new ArrayList<>();
     for (Map.Entry<BlockStoreLocation, List<Long>> entry : blockListOnLocation.entrySet()) {
       BlockStoreLocation loc = entry.getKey();

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
@@ -34,11 +34,14 @@ import alluxio.master.MasterClientContext;
 import alluxio.grpc.GrpcUtils;
 import alluxio.wire.WorkerNetAddress;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -144,21 +147,29 @@ public class BlockMasterClient extends AbstractMasterClient {
    * Because the list is flattened from a map, in the list no two LocationBlockIdListEntry items
    * have the same BlockStoreLocation.
    * */
-  private List<LocationBlockIdListEntry> convertBlockListMapToProto(
+  @VisibleForTesting
+  public List<LocationBlockIdListEntry> convertBlockListMapToProto(
       Map<BlockStoreLocation, List<Long>> blockListOnLocation) {
-    // TODO(jiacheng): This doesn't really do dedup because BlockStoreLocation dirIndex is lost
     final List<LocationBlockIdListEntry> entryList = new ArrayList<>();
+
+    Map<BlockStoreLocationProto, List<Long>> tierToBlocks = new HashMap<>();
     for (Map.Entry<BlockStoreLocation, List<Long>> entry : blockListOnLocation.entrySet()) {
       BlockStoreLocation loc = entry.getKey();
-      List<Long> entryValue = entry.getValue();
       BlockStoreLocationProto locationProto = BlockStoreLocationProto.newBuilder()
           .setTierAlias(loc.tierAlias())
           .setMediumType(loc.mediumType())
           .build();
-
-      BlockIdList blockIdList = BlockIdList.newBuilder().addAllBlockId(entryValue).build();
+      if (tierToBlocks.containsKey(locationProto)) {
+        tierToBlocks.get(locationProto).addAll(entry.getValue());
+      } else {
+        List<Long> blockList = new ArrayList<>(entry.getValue());
+        tierToBlocks.put(locationProto, blockList);
+      }
+    }
+    for (Map.Entry<BlockStoreLocationProto, List<Long>> entry : tierToBlocks.entrySet()) {
+      BlockIdList blockIdList = BlockIdList.newBuilder().addAllBlockId(entry.getValue()).build();
       LocationBlockIdListEntry listEntry = LocationBlockIdListEntry.newBuilder()
-          .setKey(locationProto).setValue(blockIdList).build();
+          .setKey(entry.getKey()).setValue(blockIdList).build();
       entryList.add(listEntry);
     }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
@@ -142,9 +142,12 @@ public class BlockMasterClient extends AbstractMasterClient {
   }
 
   /**
-   * Converts the block list map to proto.
-   * Because the list is flattened from a map, in the list no two
-   * {@link LocationBlockIdListEntry} items have the same BlockStoreLocation.
+   * Converts the block list map to a proto list.
+   * Because the list is flattened from a map, in the list no two {@link LocationBlockIdListEntry}
+   * instances shall have the same {@link BlockStoreLocationProto}.
+   * The uniqueness of {@link BlockStoreLocationProto} is determined by tier alias and medium type.
+   * That means directories with the same tier alias and medium type will be merged into the same
+   * {@link LocationBlockIdListEntry}.
    *
    * @param blockListOnLocation a map from block location to the block list
    * @return a flattened and deduplicated list

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
@@ -139,6 +139,10 @@ public class BlockMasterClient extends AbstractMasterClient {
     }, LOG, "GetId", "address=%s", address);
   }
 
+  /**
+   * Converts the block list map to proto.
+   * The output list will not contain duplicate keys.
+   * */
   private List<LocationBlockIdListEntry> convertBlockListMapToProto(
       Map<BlockStoreLocation, List<Long>> blockListOnLocation) {
     final List<LocationBlockIdListEntry> entryList = new ArrayList<>();

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
@@ -141,7 +141,8 @@ public class BlockMasterClient extends AbstractMasterClient {
 
   /**
    * Converts the block list map to proto.
-   * The output list will not contain duplicate keys.
+   * Because the list is flattened from a map, in the list no two LocationBlockIdListEntry items
+   * have the same BlockStoreLocation.
    * */
   private List<LocationBlockIdListEntry> convertBlockListMapToProto(
       Map<BlockStoreLocation, List<Long>> blockListOnLocation) {

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockMasterClientTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockMasterClientTest.java
@@ -1,0 +1,83 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block;
+
+import static org.junit.Assert.assertEquals;
+
+import alluxio.ClientContext;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.ServerConfiguration;
+import alluxio.grpc.BlockStoreLocationProto;
+import alluxio.grpc.LocationBlockIdListEntry;
+import alluxio.master.MasterClientContext;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class BlockMasterClientTest {
+  private InstancedConfiguration mConf = ServerConfiguration.global();
+
+  @Test
+  public void convertBlockListMapToProtoMergeDirsInSameTier() {
+    BlockMasterClient client = new BlockMasterClient(
+        MasterClientContext.newBuilder(ClientContext.create(mConf)).build());
+
+    Map<BlockStoreLocation, List<Long>> blockMap = new HashMap<>();
+    BlockStoreLocation memDir0 = new BlockStoreLocation("MEM", 0);
+    blockMap.put(memDir0, Arrays.asList(1L, 2L, 3L));
+    BlockStoreLocation memDir1 = new BlockStoreLocation("MEM", 1);
+    blockMap.put(memDir1, Arrays.asList(4L, 5L, 6L, 7L));
+    BlockStoreLocation ssdDir0 = new BlockStoreLocation("SSD", 0);
+    blockMap.put(ssdDir0, Arrays.asList(11L, 12L, 13L, 14L));
+    BlockStoreLocation ssdDir1 = new BlockStoreLocation("SSD", 1);
+    blockMap.put(ssdDir1, Arrays.asList(15L, 16L, 17L, 18L, 19L));
+
+    List<LocationBlockIdListEntry> protoList = client.convertBlockListMapToProto(blockMap);
+    assertEquals(2, protoList.size());
+    BlockStoreLocationProto memLocationProto = BlockStoreLocationProto.newBuilder()
+        .setTierAlias("MEM").setMediumType("").build();
+    BlockStoreLocationProto ssdLocationProto = BlockStoreLocationProto.newBuilder()
+        .setTierAlias("SSD").setMediumType("").build();
+    Set<BlockStoreLocationProto> blockLocations = protoList.stream()
+        .map(LocationBlockIdListEntry::getKey).collect(Collectors.toSet());
+    assertEquals(ImmutableSet.of(memLocationProto, ssdLocationProto), blockLocations);
+
+    LocationBlockIdListEntry firstEntry = protoList.get(0);
+    if (firstEntry.getKey().getTierAlias().equals("MEM")) {
+      LocationBlockIdListEntry memTierEntry = protoList.get(0);
+      List<Long> memProtoBlockList = memTierEntry.getValue().getBlockIdList();
+      assertEquals(ImmutableSet.of(1L, 2L, 3L, 4L, 5L, 6L, 7L),
+              new HashSet<>(memProtoBlockList));
+      LocationBlockIdListEntry ssdTierEntry = protoList.get(1);
+      List<Long> ssdProtoBlockList = ssdTierEntry.getValue().getBlockIdList();
+      assertEquals(ImmutableSet.of(11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L),
+              new HashSet<>(ssdProtoBlockList));
+    } else {
+      LocationBlockIdListEntry memTierEntry = protoList.get(1);
+      List<Long> memProtoBlockList = memTierEntry.getValue().getBlockIdList();
+      assertEquals(Arrays.asList(1L, 2L, 3L, 4L, 5L, 6L, 7L),
+              new HashSet<>(memProtoBlockList));
+      LocationBlockIdListEntry ssdTierEntry = protoList.get(0);
+      List<Long> ssdProtoBlockList = ssdTierEntry.getValue().getBlockIdList();
+      assertEquals(ImmutableSet.of(11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L),
+              new HashSet<>(ssdProtoBlockList));
+    }
+  }
+}

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockMasterClientTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockMasterClientTest.java
@@ -73,7 +73,7 @@ public class BlockMasterClientTest {
     } else {
       LocationBlockIdListEntry memTierEntry = protoList.get(1);
       List<Long> memProtoBlockList = memTierEntry.getValue().getBlockIdList();
-      assertEquals(Arrays.asList(1L, 2L, 3L, 4L, 5L, 6L, 7L),
+      assertEquals(ImmutableSet.of(1L, 2L, 3L, 4L, 5L, 6L, 7L),
               new HashSet<>(memProtoBlockList));
       LocationBlockIdListEntry ssdTierEntry = protoList.get(0);
       List<Long> ssdProtoBlockList = ssdTierEntry.getValue().getBlockIdList();

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockMasterClientTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockMasterClientTest.java
@@ -49,6 +49,7 @@ public class BlockMasterClientTest {
     BlockStoreLocation ssdDir1 = new BlockStoreLocation("SSD", 1);
     blockMap.put(ssdDir1, Arrays.asList(15L, 16L, 17L, 18L, 19L));
 
+    // Directories on the same tier will be merged together
     List<LocationBlockIdListEntry> protoList = client.convertBlockListMapToProto(blockMap);
     assertEquals(2, protoList.size());
     BlockStoreLocationProto memLocationProto = BlockStoreLocationProto.newBuilder()

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-//    o.sync();
+    o.sync();
     //#else
     o.hflush();
     //#endif

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-    o.sync();
+//    o.sync();
     //#else
     o.hflush();
     //#endif


### PR DESCRIPTION
Currently on worker register and heartbeat, the worker will flatten a `Map<BlockStoreLocation, List<Long>>` to a `List<LocationBlockIdListEntry>` and send to the master. `LocationBlockIdListEntry` is a key-value pair `BlockStoreLocationProto:BlockIdList`.  

The problem with this approach is `BlockStoreLocation` is a tuple `<tier,medium,dirIndex>` whereas `BlockStoreLocationProto` is a pair `<tier,medium>`. Basically in map flattening, the `List<LocationBlockIdListEntry>` contains more than one `LocationBlockIdListEntry` with the same `BlockStoreLocationProto:BlockIdList`. When the master receives the list, it will reconstruct the map using `BlockStoreLocationProto` as the key. At this step, there will be key collision because the worker can have more directories with the same `<tier, medium>`. On collision, the master will merge the block lists, which can induce huge list reconstructions.

This change ensures the block lists of the same `<tier,medium>` (from different directories) are merged before sending to the master.