### PR TITLE
Archive Surefire Reports and do not archive logserver project

### DIFF
--- a/.github/workflows/java11_integration_tests.yml
+++ b/.github/workflows/java11_integration_tests.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           name: artifact
           path: |
+            **/target/surefire-reports/*
             **/target/artifacts/*
             **/target/logs/*
-            log*
           retention-days: 7

--- a/.github/workflows/java11_integration_tests_webui.yml
+++ b/.github/workflows/java11_integration_tests_webui.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           name: artifact
           path: |
+            **/target/surefire-reports/*
             **/target/artifacts/*
             **/target/logs/*
-            log*
           retention-days: 7

--- a/.github/workflows/java11_unit_tests.yml
+++ b/.github/workflows/java11_unit_tests.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           name: artifact
           path: |
+            **/target/surefire-reports/*
             **/target/artifacts/*
             **/target/logs/*
-            log*
           retention-days: 7

--- a/.github/workflows/java11_unit_tests_webui.yml
+++ b/.github/workflows/java11_unit_tests_webui.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           name: artifact
           path: |
+            **/target/surefire-reports/*
             **/target/artifacts/*
             **/target/logs/*
-            log*
           retention-days: 7

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           name: artifact
           path: |
+            **/target/surefire-reports/*
             **/target/artifacts/*
             **/target/logs/*
-            log*
           retention-days: 7

--- a/.github/workflows/java8_integration_tests_webui.yml
+++ b/.github/workflows/java8_integration_tests_webui.yml
@@ -64,9 +64,9 @@ jobs:
         with:
           name: artifact
           path: |
+            **/target/surefire-reports/*
             **/target/artifacts/*
             **/target/logs/*
-            log*
           retention-days: 7
       - name: "Upload Code Coverage Report"
         uses: codecov/codecov-action@v1

--- a/.github/workflows/java8_unit_tests.yml
+++ b/.github/workflows/java8_unit_tests.yml
@@ -66,9 +66,9 @@ jobs:
         with:
           name: artifact
           path: |
+            **/target/surefire-reports/*
             **/target/artifacts/*
             **/target/logs/*
-            log*
           retention-days: 7
       - name: "Upload Code Coverage Report"
         uses: codecov/codecov-action@v1

--- a/.github/workflows/java8_unit_tests_webui.yml
+++ b/.github/workflows/java8_unit_tests_webui.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           name: artifact
           path: |
+            **/target/surefire-reports/*
             **/target/artifacts/*
             **/target/logs/*
-            log*
           retention-days: 7


### PR DESCRIPTION
The things that were getting archived as a result of log* was log/README.md (useless) and the logserver project. Remove those.

Add surefire-reports because they contain useful information especially when the VM crashes.