### PR TITLE
Fix Passive TTL on files does not take effect #13411

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -137,11 +137,6 @@ public class InodeSyncStream {
 
   private static final Logger LOG = LoggerFactory.getLogger(InodeSyncStream.class);
 
-  private static final FileSystemMasterCommonPOptions NO_TTL_OPTION =
-      FileSystemMasterCommonPOptions.newBuilder()
-          .setTtl(-1)
-          .build();
-
   /** The root path. Should be locked with a write lock. */
   private final LockingScheme mRootScheme;
 
@@ -720,7 +715,7 @@ public class InodeSyncStream {
     }
     LoadMetadataContext ctx = LoadMetadataContext.mergeFrom(
         LoadMetadataPOptions.newBuilder()
-            .setCommonOptions(NO_TTL_OPTION)
+            .setCommonOptions(mSyncOptions)
             .setCreateAncestors(true)
             .setLoadDescendantType(GrpcUtils.toProto(descendantType)))
         .setUfsStatus(status);
@@ -779,8 +774,8 @@ public class InodeSyncStream {
             LoadMetadataContext loadMetadataContext =
                 LoadMetadataContext.mergeFrom(LoadMetadataPOptions.newBuilder()
                     .setLoadDescendantType(LoadDescendantPType.NONE)
-                    // No Ttl on loaded files
-                    .setCommonOptions(NO_TTL_OPTION)
+                    // inherit Ttl from the parent
+                    .setCommonOptions(context.getOptions().getCommonOptions())
                     .setCreateAncestors(false))
                 .setUfsStatus(childStatus);
             try (LockedInodePath descendant = inodePath

--- a/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
@@ -419,7 +419,7 @@ public class LoadMetadataIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testNoTtlOnLoadedFiles() throws Exception {
+  public void testTtlOnLoadedFiles() throws Exception {
     int created = createUfsFiles(2);
     ServerConfiguration.set(PropertyKey.USER_FILE_METADATA_LOAD_TYPE,
         LoadMetadataType.ONCE.toString());
@@ -435,7 +435,13 @@ public class LoadMetadataIntegrationTest extends BaseIntegrationTest {
     List<URIStatus> list = mFileSystem.listStatus(new AlluxioURI("/mnt"), options);
     assertEquals(created + EXTRA_DIR_FILES, list.size());
     list.forEach(stat -> {
-      assertEquals(-1, stat.getTtl());
+      if (stat.getPath().startsWith("/mnt/mustcache")) {
+        assertEquals(-1, stat.getTtl());
+        assertEquals(TtlAction.DELETE, stat.getTtlAction());
+      } else {
+        assertEquals(10000, stat.getTtl());
+        assertEquals(TtlAction.FREE, stat.getTtlAction());
+      }
     });
   }
 


### PR DESCRIPTION
Fix Passive TTL on files does not take effect #13411.

When client exec stat/list/read operations first time, make sure alluxio.user.file.create.ttl and alluxio.user.file.create.ttl.action options from client take effect.