### PR TITLE
[DOCFIX] Add details to tutorials

### DIFF
--- a/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
+++ b/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
@@ -68,9 +68,57 @@ alluxio.master.mount.table.root.ufs=<STORAGE_URI>
   is used as the under storage system, the value can be set to
   `alluxio.master.mount.table.root.ufs=s3://bucket/dir/`
 
+Append thehost name of each node into conf/masters and conf/workers accordingly.
+{% accordian nodeconfig % }
+{% collapsible Example: master node from Amazon S3 % }
 Append the hostname of each Alluxio master node to a new line into `conf/masters` 
-and the hostname of each Alluxio worker node to a new line into `conf/workers`.
-Each host name should have its own line.
+Comment out `localhost` if necessary.
+```
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+# An Alluxio master will be started on each of the machines listed below.
+#
+# In HA mode, Alluxio will use internal leader election or Zookeeper leader election
+# to decide which of the masters should act as the primary. In non-HA mode, the master started
+# on the host identified by the first entry in this file will act as the primary; the remaining hosts
+# will be used to start a secondary; which are responsible for journal compaction.
+#
+# The multi-master Zookeeper HA mode requires that all the masters can access
+# the same journal through a shared medium (e.g. HDFS or NFS).
+# localhost
+ec2-1-234-56-789.compute-1.amazonaws.com
+```
+{% endcollapsible % }
+{% collapsible Example: worker node from Amazon S3 % }
+Append the hostname of each Alluxio worker node to a new line into `conf/workers`
+Comment out `localhost` if necessary.
+```
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+# An Alluxio Worker will be started on each of the machines listed below.
+# localhost
+ec2-9-876-54-321.compute-1.amazonaws.com
+```
+{% endcollapsible % }
+{% endaccordion %}
 
 Next, copy the configuration file to all the Alluxio worker nodes.
 The following built-in utility will copy the configuration files to all master and worker

--- a/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
+++ b/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
@@ -68,57 +68,18 @@ alluxio.master.mount.table.root.ufs=<STORAGE_URI>
   is used as the under storage system, the value can be set to
   `alluxio.master.mount.table.root.ufs=s3://bucket/dir/`
 
-Append thehost name of each node into conf/masters and conf/workers accordingly.
-{% accordion nodeconfig % }
-  {% collapsible Example: master node from Amazon S3 % }
-Append the hostname of each Alluxio master node to a new line into `conf/masters`. 
+Append the hostname of each node into `conf/masters` and `conf/workers` accordingly.
+Append the hostname of each Alluxio master node to a new line into `conf/masters`,
+and the hostname of each worker node to a new line into `conf/worers`.
 Comment out `localhost` if necessary.
+For example, in `conf/masters`, we can add the hostnames of two master nodes in the following format:
 ```
-#
-# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
-# (the "License"). You may not use this work except in compliance with the License, which is
-# available at www.apache.org/licenses/LICENSE-2.0
-#
-# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied, as more fully set forth in the License.
-#
-# See the NOTICE file distributed with this work for information regarding copyright ownership.
-#
-
-# An Alluxio master will be started on each of the machines listed below.
-#
-# In HA mode, Alluxio will use internal leader election or Zookeeper leader election
-# to decide which of the masters should act as the primary. In non-HA mode, the master started
-# on the host identified by the first entry in this file will act as the primary; the remaining hosts
-# will be used to start a secondary; which are responsible for journal compaction.
-#
 # The multi-master Zookeeper HA mode requires that all the masters can access
 # the same journal through a shared medium (e.g. HDFS or NFS).
 # localhost
-ec2-1-234-56-789.compute-1.amazonaws.com
+ec2-1-111-11-111.compute-1.amazonaws.com
+ec2-2-222-22-222.compute-2.amazonaws.com
 ```
-  {% endcollapsible % }
-  {% collapsible Example: worker node from Amazon S3 % }
-Append the hostname of each Alluxio worker node to a new line into `conf/workers`.
-Comment out `localhost` if necessary.
-```
-#
-# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
-# (the "License"). You may not use this work except in compliance with the License, which is
-# available at www.apache.org/licenses/LICENSE-2.0
-#
-# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied, as more fully set forth in the License.
-#
-# See the NOTICE file distributed with this work for information regarding copyright ownership.
-#
-
-# An Alluxio Worker will be started on each of the machines listed below.
-# localhost
-ec2-9-876-54-321.compute-1.amazonaws.com
-```
-  {% endcollapsible % }
-{% endaccordion %}
 
 Next, copy the configuration file to all the Alluxio worker nodes.
 The following built-in utility will copy the configuration files to all master and worker

--- a/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
+++ b/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
@@ -71,7 +71,7 @@ alluxio.master.mount.table.root.ufs=<STORAGE_URI>
 Append thehost name of each node into conf/masters and conf/workers accordingly.
 {% accordian nodeconfig % }
 {% collapsible Example: master node from Amazon S3 % }
-Append the hostname of each Alluxio master node to a new line into `conf/masters` 
+Append the hostname of each Alluxio master node to a new line into `conf/masters`. 
 Comment out `localhost` if necessary.
 ```
 #
@@ -99,7 +99,7 @@ ec2-1-234-56-789.compute-1.amazonaws.com
 ```
 {% endcollapsible % }
 {% collapsible Example: worker node from Amazon S3 % }
-Append the hostname of each Alluxio worker node to a new line into `conf/workers`
+Append the hostname of each Alluxio worker node to a new line into `conf/workers`.
 Comment out `localhost` if necessary.
 ```
 #

--- a/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
+++ b/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
@@ -69,7 +69,7 @@ alluxio.master.mount.table.root.ufs=<STORAGE_URI>
   `alluxio.master.mount.table.root.ufs=s3://bucket/dir/`
 
 Append thehost name of each node into conf/masters and conf/workers accordingly.
-{% accordian nodeconfig % }
+{% accordion nodeconfig % }
 {% collapsible Example: master node from Amazon S3 % }
 Append the hostname of each Alluxio master node to a new line into `conf/masters`. 
 Comment out `localhost` if necessary.

--- a/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
+++ b/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
@@ -29,7 +29,7 @@ To deploy Alluxio in production, we highly recommend running Alluxio masters in
   $ tar -xvzpf alluxio-{{site.ALLUXIO_VERSION_STRING}}-bin.tar.gz
   ```
   
-* Enable SSH login without password from the master node to worker nodes.
+* Enable SSH login without password from the master node to worker nodes and from the master node to itself.
   You can add a public SSH key for the host into `~/.ssh/authorized_keys`.
   See [this tutorial](http://www.linuxproblem.org/art_9.html) for more details.
 * TCP traffic across all nodes is allowed.
@@ -60,11 +60,17 @@ alluxio.master.mount.table.root.ufs=<STORAGE_URI>
   mount to the Alluxio root.
   This shared storage system must be accessible by the master node and all worker nodes.
   Examples include `alluxio.master.mount.table.root.ufs=hdfs://1.2.3.4:9000/alluxio/root/`, or 
-  `alluxio.master.mount.table.root.ufs=s3://bucket/dir/`.
+  `alluxio.master.mount.table.root.ufs=s3://bucket/dir/`
+  (See [this tutorial](https://docs.alluxio.io/os/user/stable/en/ufs/S3.html#running-alluxio-locally-with-s3) 
+  for more details about configuring Amazon S3 as Alluxio's under storage system).
+
+Then, append the host name of all the Alluxio master nodes into `conf/masters` 
+and the host name of all the Alluxio workers node into `conf/workers`.
 
 Next, copy the configuration file to all the Alluxio worker nodes.
 The following built-in utility will copy the configuration files to all master and worker
 nodes specified in the `conf/masters` and `conf/workers` files respectively.
+Note that the inbound rules and ports of each node need to allow access from all the other nodes in the cluster.
 
 ```console
 $ ./bin/alluxio copyDir conf/

--- a/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
+++ b/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
@@ -59,18 +59,22 @@ alluxio.master.mount.table.root.ufs=<STORAGE_URI>
 - The second property `alluxio.master.mount.table.root.ufs` sets to the URI of the under store to
   mount to the Alluxio root.
   This shared storage system must be accessible by the master node and all worker nodes.
-  Examples include `alluxio.master.mount.table.root.ufs=hdfs://1.2.3.4:9000/alluxio/root/`, or 
+  
+  For example, when [HDFS]({{ '/en/ufs/HDFS.html#basic-setup' | relativize_url }})
+  is used as the under storage system, the value of this property can be set to
+  `alluxio.master.mount.table.root.ufs=hdfs://1.2.3.4:9000/alluxio/root/`
+  
+  When [Amazon S3]({{ '/en/ufs/S3.html#basic-setup' | relativize_url }})
+  is used as the under storage system, the value can be set to
   `alluxio.master.mount.table.root.ufs=s3://bucket/dir/`
-  (See [this tutorial](https://docs.alluxio.io/os/user/stable/en/ufs/S3.html#running-alluxio-locally-with-s3) 
-  for more details about configuring Amazon S3 as Alluxio's under storage system).
 
-Then, append the host name of all the Alluxio master nodes into `conf/masters` 
-and the host name of all the Alluxio workers node into `conf/workers`.
+Append the hostname of each Alluxio master node to a new line into `conf/masters` 
+and the hostname of each Alluxio worker node to a new line into `conf/workers`.
+Each host name should have its own line.
 
 Next, copy the configuration file to all the Alluxio worker nodes.
 The following built-in utility will copy the configuration files to all master and worker
 nodes specified in the `conf/masters` and `conf/workers` files respectively.
-Note that the inbound rules and ports of each node need to allow access from all the other nodes in the cluster.
 
 ```console
 $ ./bin/alluxio copyDir conf/

--- a/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
+++ b/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
@@ -70,7 +70,7 @@ alluxio.master.mount.table.root.ufs=<STORAGE_URI>
 
 Append thehost name of each node into conf/masters and conf/workers accordingly.
 {% accordion nodeconfig % }
-{% collapsible Example: master node from Amazon S3 % }
+  {% collapsible Example: master node from Amazon S3 % }
 Append the hostname of each Alluxio master node to a new line into `conf/masters`. 
 Comment out `localhost` if necessary.
 ```
@@ -97,8 +97,8 @@ Comment out `localhost` if necessary.
 # localhost
 ec2-1-234-56-789.compute-1.amazonaws.com
 ```
-{% endcollapsible % }
-{% collapsible Example: worker node from Amazon S3 % }
+  {% endcollapsible % }
+  {% collapsible Example: worker node from Amazon S3 % }
 Append the hostname of each Alluxio worker node to a new line into `conf/workers`.
 Comment out `localhost` if necessary.
 ```
@@ -117,7 +117,7 @@ Comment out `localhost` if necessary.
 # localhost
 ec2-9-876-54-321.compute-1.amazonaws.com
 ```
-{% endcollapsible % }
+  {% endcollapsible % }
 {% endaccordion %}
 
 Next, copy the configuration file to all the Alluxio worker nodes.


### PR DESCRIPTION
Added the following details due to the confusions some new users had:

- Not knowing to put the master host name in conf/masters and worker’s host name in conf/workers
- Needing further information about Amazon S3 when reading the example of setting S3 bucket as the alluxio.master.mount.table.root.ufs.
- Not knowing to set passwordless ssh from the master node to itself
- Not knowing to config the inbound rules and ports for the nodes