### PR TITLE
[DOCFIX] Modify wordings in Prepare Docker Volume to Persist Data

### DIFF
--- a/docs/en/deploy/Running-Alluxio-On-Docker.md
+++ b/docs/en/deploy/Running-Alluxio-On-Docker.md
@@ -53,18 +53,21 @@ The data doesn’t persist when that container no longer exists. [Docker volumes
 are the preferred way to save data outside the containers. The following two types of Docker volumes are used the most:
 
 + **Host Volume**: You manage where in the Docker host's file system to store and share the
-containers data. To create a host volume, run:
+containers data. To create a host volume, include the following when launching your containers:
 
   ```console
   $ docker run -v /path/on/host:/path/in/container ...
   ```
   The file or directory is referenced by its full path on the Docker host. It can exist on the Docker host already, or it will be created automatically if it does not yet exist.
 
-+ **Named Volume**: Docker manage where they are located. It should be be referred to by specific names.
-To create a named volume, run:
++ **Named Volume**: Docker manage where they are located. It should be referred to by specific names.
+To create a named volume, first run:
 
   ```console
   $ docker volume create volumeName
+  ```
+  Then include the following when launching your containers:
+  ```console
   $ docker run -v volumeName:/path/in/container ...
   ```
 
@@ -73,7 +76,7 @@ the host volume is recommended, since it is the easiest type of volume
 to use and very performant. More importantly, you know where to refer to the data in the host
 file system and you can manipulate the files directly and easily outside the containers.
 
-Therefore, we will use the host volume and mount the host directory `/tmp/alluxio_ufs` to the
+For example, we will use the host volume and mount the host directory `/tmp/alluxio_ufs` to the
 container location `/opt/alluxio/underFSStorage`, which is the default setting for the
 Alluxio UFS root mount point in the Alluxio docker image:
 


### PR DESCRIPTION
The original wordings in section 2 Prepare Docker Volume to Persist Data in Deploy Alluxio on Docker (https://docs.alluxio.io/os/user/stable/en/deploy/Running-Alluxio-On-Docker.html#prepare-docker-volume-to-persist-data), where they instruct users to "run" the commands to create a host/named volume, may lead users to actually run the command. Instead they should be included in the complete command which is introduced in section 3.

Fix typo where there are two consecutive "be".

The "Therefore" in the later part of the same section can be a little bit strong, considering that both the host directory and the container location are just examples. 