### PR TITLE
[SMALLFIX] Improve of set java home

### DIFF
--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -22,8 +22,10 @@
 # (https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html),
 # and is respected by both external jobs and Alluxio servers (or shell).
 
-# The java implementation to use. By default, this environment variable is REQUIRED on ALL platforms!
-# JAVA_HOME=
+# JVM is required to run Alluxio.
+# If its path is not set in Shell, please specify either of following environment variables
+# JAVA_HOME
+# JAVA
 
 # The directory where log files are stored. (Default: ${ALLUXIO_HOME}/logs).
 # ALLUXIO_LOGS_DIR

--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -22,6 +22,9 @@
 # (https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html),
 # and is respected by both external jobs and Alluxio servers (or shell).
 
+# The java implementation to use. By default, this environment variable is REQUIRED on ALL platforms!
+# JAVA_HOME=
+
 # The directory where log files are stored. (Default: ${ALLUXIO_HOME}/logs).
 # ALLUXIO_LOGS_DIR
 

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -46,7 +46,7 @@ if [[ -z "${JAVA}" ]]; then
   elif [[ -n "$(which java 2>/dev/null)" ]]; then
     JAVA=$(which java)
   else
-    echo "Error: Cannot find 'java' on path or under \$JAVA_HOME/bin/."
+    echo "Error: Cannot find 'java' on path or under \$JAVA_HOME/bin/. Please set JAVA_HOME in alluxio-env.sh or user bash profile."
     exit 1
   fi
 fi


### PR DESCRIPTION
Due to no-login shell does not source `/etc/profile`, we always get `Cannot find 'java'` error when we just set `JAVA_HOME` in `/etc/profile`.
It's better to have a more friendly tip.