### PR TITLE
Improve CephInputStream to be thread safe

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1148,7 +1148,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey UNDERFS_CEPHFS_AUTH_KEYFILE =
       new Builder(Name.UNDERFS_CEPHFS_AUTH_KEYFILE)
-          .setDefaultValue("/etc/ceph/keyfile")
           .setDescription("Path to CephX authentication key file.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
@@ -5410,7 +5409,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_CEPHFS_MON_HOST =
         "alluxio.underfs.cephfs.mon.host";
     public static final String UNDERFS_CEPHFS_MDS_NAMESPACE =
-        "alluxio.underfs.cephfs.mds.namespce";
+        "alluxio.underfs.cephfs.mds.namespace";
     public static final String UNDERFS_CEPHFS_MOUNT_UID =
         "alluxio.underfs.cephfs.mount.uid";
     public static final String UNDERFS_CEPHFS_MOUNT_GID =

--- a/pom.xml
+++ b/pom.xml
@@ -805,7 +805,7 @@
       <dependency>
         <artifactId>xstream</artifactId>
         <groupId>com.thoughtworks.xstream</groupId>
-        <version>1.4.16</version>
+        <version>1.4.17</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
ufs/cephfs: improve CephInputStream to be thread safe
xstream: update to 1.4.17 to improve safety level
because 1.4.16 of XStream is vulnerable to a Remote Command Execution attack
http://x-stream.github.io/CVE-2021-29505.html

Signed-off-by: Xue Yantao jhonxue@tencent.com