### PR TITLE
Support bypass table when attach and sync db

### DIFF
--- a/docs/en/core-services/Catalog.md
+++ b/docs/en/core-services/Catalog.md
@@ -102,10 +102,22 @@ $ ${ALLUXIO_HOME}/bin/alluxio table attachdb --db alluxio_db hive \
     thrift://metastore_host:9083 default
 ```
 
+If you want specify config file for the UDB, please add `attachdb` option `-o catalog.db.config.file`.
+Each time you want to affect the config file, you can use `alluxio table sync`.
+
+If you want to write a configuration file for the UDB, please configure it like the following given example.
+It must contain an array `bypassSet`, the comma-separated table names will be bypassed.
+
+```json
+{
+  "bypassSet" : ["table1", "table2"]
+}
+```
+
 > **Note:** When databases are attached, all tables are synced from the configured UDB.
 If out-of-band updates occur to the database or table and the user wants query results to reflect
 the updates, the database must be synced. See [Syncing Databases](#syncing-databases) for more
-information.
+information. 
 
 ### Exploring Attached Databases
 
@@ -212,7 +224,7 @@ $ ${ALLUXIO_HOME}/bin/alluxio table sync alluxio_db
 ```
 
 This sync command will update the Alluxio catalog metadata according to the updates, deletions,
-and additions in the UDB tables.
+and additions in the UDB tables, it will update db config as well.
 
 ## Using Alluxio Structured Data with Presto
 

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -1433,6 +1433,7 @@ Here are the additional properties possible for the `-o` options:
     * `<UDB_TYPE>`: the UDB type
     * `<UFS_PREFIX>`: the UFS path prefix that the mount properties are for
     * `<MOUNT_PROPERTY>`: an Alluxio mount property
+  * `catalog.db.config.file`: the config file for the UDB, you can specify bypass table by this option.
   * `catalog.db.ignore.udb.tables`: comma-separated list of table names to ignore from the UDB
   * `catalog.db.sync.threads`: number of parallel threads to use to sync with the UDB. If too large,
   the sync may overload the UDB, and if set too low, syncing a database with many tables make take

--- a/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
@@ -68,7 +68,7 @@ public class PathTranslator {
   public String toAlluxioPath(String ufsPath) throws IOException {
     for (BiMap.Entry<String, String> entry : mPathMap.entrySet()) {
       if (ufsPath.startsWith(entry.getValue())) {
-        // return ufsPath if key and value are same.
+        // return ufsPath if set the key and value to be same when bypass path.
         if (entry.getKey().equals(entry.getValue())) {
           return ufsPath;
         }

--- a/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
@@ -68,6 +68,10 @@ public class PathTranslator {
   public String toAlluxioPath(String ufsPath) throws IOException {
     for (BiMap.Entry<String, String> entry : mPathMap.entrySet()) {
       if (ufsPath.startsWith(entry.getValue())) {
+        // return ufsPath if key and value are same.
+        if (entry.getKey().equals(entry.getValue())) {
+          return ufsPath;
+        }
         String alluxioPath = entry.getKey() + ufsPath.substring(entry.getValue().length());
         if (alluxioPath.startsWith("/")) {
           // scheme/authority are missing, so prefix with the scheme and authority

--- a/table/server/common/src/main/java/alluxio/table/common/udb/UnderDatabase.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/UnderDatabase.java
@@ -38,9 +38,10 @@ public interface UnderDatabase {
 
   /**
    * @param tableName the table name
+   * @param bypass whether bypass this table
    * @return the {@link UdbTable} for the specified table name
    */
-  UdbTable getTable(String tableName) throws IOException;
+  UdbTable getTable(String tableName, boolean bypass) throws IOException;
 
   /**
    * @return the {@link UdbContext}

--- a/table/server/master/src/main/java/alluxio/master/table/CatalogProperty.java
+++ b/table/server/master/src/main/java/alluxio/master/table/CatalogProperty.java
@@ -40,5 +40,5 @@ public class CatalogProperty extends BaseProperty {
           Integer.toString(DEFAULT_DB_SYNC_THREADS));
   public static final CatalogProperty DB_CONFIG_FILE =
       new CatalogProperty("catalog.db.config.file",
-          "The config file for the UDB.", "");
+          "The config file for the UDB.", "<catalog.db.config.file>");
 }

--- a/table/server/master/src/main/java/alluxio/master/table/CatalogProperty.java
+++ b/table/server/master/src/main/java/alluxio/master/table/CatalogProperty.java
@@ -38,4 +38,7 @@ public class CatalogProperty extends BaseProperty {
               + "overload the UDB, and if set too low, syncing a database with many tables may "
               + "take a long time.",
           Integer.toString(DEFAULT_DB_SYNC_THREADS));
+  public static final CatalogProperty DB_CONFIG_FILE =
+      new CatalogProperty("catalog.db.config.file",
+          "The config file for the UDB.", "");
 }

--- a/table/server/master/src/main/java/alluxio/master/table/DbConfig.java
+++ b/table/server/master/src/main/java/alluxio/master/table/DbConfig.java
@@ -1,0 +1,35 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.table;
+
+import java.util.Set;
+
+/**
+ * The Alluxio db config information.
+ */
+public final class DbConfig {
+  private Set<String> mBypassSet;
+
+  /**
+   * @param bypassSet the bypass set
+   */
+  public void setBypassSet(Set<String> bypassSet) {
+    mBypassSet = bypassSet;
+  }
+
+  /**
+   * @return the bypass set
+   */
+  public Set<String> getBypassSet() {
+    return mBypassSet;
+  }
+}

--- a/table/server/master/src/test/java/alluxio/master/table/TestDatabase.java
+++ b/table/server/master/src/test/java/alluxio/master/table/TestDatabase.java
@@ -111,7 +111,7 @@ public class TestDatabase implements UnderDatabase {
   }
 
   @Override
-  public UdbTable getTable(String tableName) throws IOException {
+  public UdbTable getTable(String tableName, boolean bypass) throws IOException {
     checkDbName();
     if (!mUdbTables.containsKey(tableName)) {
       throw new NotFoundException("Table " + tableName + " does not exist.");

--- a/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/GlueDatabase.java
+++ b/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/GlueDatabase.java
@@ -331,7 +331,7 @@ public class GlueDatabase implements UnderDatabase {
   }
 
   @Override
-  public UdbTable getTable(String tableName) throws IOException {
+  public UdbTable getTable(String tableName, boolean bypass) throws IOException {
     Table table;
     List<Partition> partitions;
     try {

--- a/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/GlueDatabase.java
+++ b/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/GlueDatabase.java
@@ -236,7 +236,8 @@ public class GlueDatabase implements UnderDatabase {
   }
 
   @VisibleForTesting
-  private PathTranslator mountAlluxioPaths(Table table, List<Partition> partitions)
+  private PathTranslator mountAlluxioPaths(Table table, List<Partition> partitions,
+      boolean bypass)
       throws IOException {
     String tableName = table.getName();
     AlluxioURI ufsUri;
@@ -245,6 +246,10 @@ public class GlueDatabase implements UnderDatabase {
 
     try {
       PathTranslator pathTranslator = new PathTranslator();
+      if (bypass) {
+        pathTranslator.addMapping(glueUfsUri, glueUfsUri);
+        return pathTranslator;
+      }
       ufsUri = new AlluxioURI(table.getStorageDescriptor().getLocation());
       pathTranslator.addMapping(
           UdbUtils.mountAlluxioPath(
@@ -342,7 +347,7 @@ public class GlueDatabase implements UnderDatabase {
       table = getClient().getTable(tableRequest).getTable();
 
       partitions = batchGetPartitions(getClient(), tableName);
-      PathTranslator pathTranslator = mountAlluxioPaths(table, partitions);
+      PathTranslator pathTranslator = mountAlluxioPaths(table, partitions, bypass);
 
       List<Column> partitionColumns;
       if (table.getPartitionKeys() == null) {

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
@@ -142,7 +142,8 @@ public class HiveDatabase implements UnderDatabase {
     }
   }
 
-  private PathTranslator mountAlluxioPaths(Table table, List<Partition> partitions)
+  private PathTranslator mountAlluxioPaths(Table table, List<Partition> partitions,
+      boolean bypass)
       throws IOException {
     String tableName = table.getTableName();
     AlluxioURI ufsUri;
@@ -151,6 +152,10 @@ public class HiveDatabase implements UnderDatabase {
 
     try {
       PathTranslator pathTranslator = new PathTranslator();
+      if (bypass) {
+        pathTranslator.addMapping(hiveUfsUri, hiveUfsUri);
+        return pathTranslator;
+      }
       ufsUri = new AlluxioURI(table.getSd().getLocation());
       pathTranslator.addMapping(
           UdbUtils.mountAlluxioPath(tableName,
@@ -200,7 +205,7 @@ public class HiveDatabase implements UnderDatabase {
   }
 
   @Override
-  public UdbTable getTable(String tableName) throws IOException {
+  public UdbTable getTable(String tableName, boolean bypass) throws IOException {
     try {
       Table table;
       List<Partition> partitions;
@@ -240,7 +245,7 @@ public class HiveDatabase implements UnderDatabase {
         }
       }
 
-      PathTranslator pathTranslator = mountAlluxioPaths(table, partitions);
+      PathTranslator pathTranslator = mountAlluxioPaths(table, partitions, bypass);
       List<ColumnStatisticsInfo> colStats =
           columnStats.stream().map(HiveUtils::toProto).collect(Collectors.toList());
       // construct table layout


### PR DESCRIPTION
This PR supply a new option `catalog.db.config.file` to describe detail information or concrete special behavior for the database. Now, i add a json format file which contains `bypassSet`, if tables are in it, they will be bypassed.

Bypass here means return the udb location directly to client, so that client can read data through ufs directly.

This is an example of db config file.

```json
{
  "bypassSet" : ["person1", "person2"]
}

```

We can use the db config file when `attachdb` and `sync`.

```
bin/alluxio table attachdb hive thrift://localhost:9083 test -o catalog.db.config.file=/etc/alluxio/conf/db-test.json
bin/alluxio table sync test
```


I create 3 table named `person` `person1` and `person2`, now I bypass `person1` and `person2`, left `person` in Alluxio.

As a test result, I show the table content by execute SQL `select * from <TABLE_NAME>` in alluxio cli. It's clearly show that the person and person1 are different, because I modified the content to distinguish whether the data is from Alluxio or ufs.


![image](https://user-images.githubusercontent.com/17329931/118996652-a2b8ae80-b9ba-11eb-9407-e0c151e8e2eb.png)
