### PR TITLE
Change jnr-fuse version to 0.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
       <dependency>
         <groupId>com.github.serceman</groupId>
         <artifactId>jnr-fuse</artifactId>
-        <version>0.5.3</version>
+        <version>0.5.5</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
 because the older version was only available on bintray, and bintray/jcenter is no longer available starting may 1