### PR TITLE
[SMALLFIX] Update some integration test names

### DIFF
--- a/tests/src/test/java/alluxio/client/fs/FileSystemReadonlyIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemReadonlyIntegrationTest.java
@@ -34,7 +34,7 @@ import java.util.Map;
 /**
  * Test behavior of {@link FileSystemMaster}, when the paths are readonly.
  */
-public class FileSystemReadonlyTest {
+public class FileSystemReadonlyIntegrationTest {
   @ClassRule
   public static LocalAlluxioClusterResource sLocalAlluxioClusterResource =
           new LocalAlluxioClusterResource.Builder()

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileInStreamIntegrationTest.java
@@ -35,7 +35,7 @@ import java.util.List;
 /**
  * Tests the concurrency of {@link FileInStream}.
  */
-public final class FileInStreamConcurrencyIntegrationTest extends BaseIntegrationTest {
+public final class ConcurrentFileInStreamIntegrationTest extends BaseIntegrationTest {
   private static final int BLOCK_SIZE = 30;
   private static int sNumReadThreads =
       ServerConfiguration.getInt(PropertyKey.USER_BLOCK_MASTER_CLIENT_POOL_SIZE_MAX) * 10;

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemIntegrationTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 /**
  * Tests the correctness of concurrent operations.
  */
-public final class FileSystemConcurrencyTest extends BaseIntegrationTest {
+public final class ConcurrentFileSystemIntegrationTest extends BaseIntegrationTest {
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource.Builder().build();

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterCreateIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterCreateIntegrationTest.java
@@ -55,7 +55,7 @@ import java.util.List;
  * The tests also validate that operations are concurrent by injecting a short sleep in the
  * critical code path. Tests will timeout if the critical section is performed serially.
  */
-public class ConcurrentFileSystemMasterCreateTest extends BaseIntegrationTest {
+public class ConcurrentFileSystemMasterCreateIntegrationTest extends BaseIntegrationTest {
   private static final String TEST_USER = "test";
   private static final int CONCURRENCY_FACTOR = 50;
   /** Duration to sleep during the rename call to show the benefits of concurrency. */

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterLoadMetadataIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterLoadMetadataIntegrationTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 /**
  * Tests loading UFS metadata many times concurrently.
  */
-public final class ConcurrentFileSystemMasterLoadMetadataTest {
+public final class ConcurrentFileSystemMasterLoadMetadataIntegrationTest {
   private static final int CONCURRENCY_FACTOR = 20;
   private FileSystem mFileSystem;
 

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
@@ -56,7 +56,7 @@ import java.util.concurrent.CyclicBarrier;
  * The tests also validate that operations are concurrent by injecting a short sleep in the
  * critical code path. Tests will timeout if the critical section is performed serially.
  */
-public class ConcurrentFileSystemMasterSetTtlTest extends BaseIntegrationTest {
+public class ConcurrentFileSystemMasterSetTtlIntegrationTest extends BaseIntegrationTest {
   private static final String TEST_USER = "test";
   private static final int CONCURRENCY_FACTOR = 50;
   /** Duration to sleep during the rename call to show the benefits of concurrency. */

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentRecursiveCreateIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentRecursiveCreateIntegrationTest.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Tests the correctness of concurrent recursive creates.
  */
-public class ConcurrentRecursiveCreateTest extends BaseIntegrationTest {
+public class ConcurrentRecursiveCreateIntegrationTest extends BaseIntegrationTest {
   private static final int NUM_TOP_LEVEL_DIRS = 10;
 
   @Rule


### PR DESCRIPTION
Integration tests should be named with suffix `IntegrationTest` at least. If it specifies to validate the concurrency correctness, the prefix will be `Concurrent`.