### PR TITLE
Support FUSE opt user_allow_other by default in docker images

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -40,7 +40,7 @@ ARG ALLUXIO_USERNAME=alluxio
 ARG ALLUXIO_GROUP=alluxio
 ARG ALLUXIO_UID=1000
 ARG ALLUXIO_GID=1000
-ARG ENABLE_DYNAMIC_USER=false
+ARG ENABLE_DYNAMIC_USER=true
 
 # Specify versions for known vulnerabilities reported by trivy scan
 # RUN apk --no-cache --update add bash libc6-compat shadow tini 'libbz2>=1.0.6-r7' 'sqlite-libs>=3.28.0-r3' && \
@@ -93,8 +93,6 @@ RUN if [ ${ALLUXIO_USERNAME} != "root" ] \
       chmod -R g=u /journal && \
       mkdir /mnt/alluxio-fuse && \
       chown -R ${ALLUXIO_UID}:${ALLUXIO_GID} /mnt/alluxio-fuse; \
-      mkdir /mnt/alluxio-fuse2 && \
-      chown -R ${ALLUXIO_UID}:${ALLUXIO_GID} /mnt/alluxio-fuse2; \
     fi
 
 # Docker 19.03+ required to expand variables in --chown argument

--- a/integration/docker/Dockerfile.fuse
+++ b/integration/docker/Dockerfile.fuse
@@ -44,7 +44,7 @@ ARG ALLUXIO_USERNAME=alluxio
 ARG ALLUXIO_GROUP=alluxio
 ARG ALLUXIO_UID=1000
 ARG ALLUXIO_GID=1000
-ARG ENABLE_DYNAMIC_USER=false
+ARG ENABLE_DYNAMIC_USER=true
 
 # Add Tini since it isn't included in Ubuntu by default
 # - https://github.com/krallin/tini


### PR DESCRIPTION
Fix https://github.com/Alluxio/alluxio/issues/13322

After this PR 

```
$ docker run -it -u root --entrypoint='' <NewAlluxioImageBuilt> cat /etc/fuse.conf
user_allow_other
```

@cheyang  let me know if you see any concerns to turn this on