### PR TITLE
Allow load to read from another worker and force to local worker

### DIFF
--- a/job/server/src/main/java/alluxio/job/util/JobUtils.java
+++ b/job/server/src/main/java/alluxio/job/util/JobUtils.java
@@ -131,7 +131,8 @@ public final class JobUtils {
           ExceptionMessage.PINNED_TO_MULTIPLE_MEDIUMTYPES.getMessage(status.getPath()));
     }
 
-    // when the data to load is persisted, simply use local worker to load from UFS or an worker
+    // when the data to load is persisted, simply use local worker to load
+    // from ufs (e.g. distributed load) or from a remote worker (e.g. setReplication)
     if (pinnedLocation.isEmpty() && status.isPersisted()) {
       OpenFilePOptions openOptions =
           OpenFilePOptions.newBuilder().setReadType(ReadPType.CACHE_PROMOTE).build();

--- a/job/server/src/main/java/alluxio/job/util/JobUtils.java
+++ b/job/server/src/main/java/alluxio/job/util/JobUtils.java
@@ -17,7 +17,6 @@ import alluxio.client.block.AlluxioBlockStore;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.BlockLocationPolicy;
 import alluxio.client.block.policy.LocalFirstPolicy;
-import alluxio.client.block.stream.BlockInStream;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.InStreamOptions;

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -73,6 +73,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -161,6 +162,8 @@ public final class ReplicateDefinitionTest {
     when(mMockFileSystemContext.getCachedWorkers()).thenReturn(blockWorkers);
     when(mMockBlockStore.getInStream(anyLong(),
             any(InStreamOptions.class))).thenReturn(mockInStream);
+    when(mMockBlockStore.getInStream(any(BlockInfo.class),
+        any(InStreamOptions.class), any(Map.class))).thenReturn(mockInStream);
     PowerMockito.mockStatic(BlockInStream.class);
     when(BlockInStream.create(any(FileSystemContext.class), any(BlockInfo.class),
         any(WorkerNetAddress.class), any(BlockInStreamSource.class), any(InStreamOptions.class)))


### PR DESCRIPTION
The earlier change can potentially cause undesired load balance among workers.
Because it always respects the alluxio configuration instead of LocalFirst.

Also it always loads from the ufs instead of potentially from another worker when
it is already in alluxio memory. (e.g. When replication checker runs load)