### PR TITLE
Refactor BlockMaster interface to avoid copying the lost block set

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -30,6 +30,7 @@ import alluxio.wire.BlockInfo;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -211,9 +212,22 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
       List<Metric> metrics);
 
   /**
-   * @return the block ids of lost blocks in Alluxio
-   */
-  Set<Long> getLostBlocks();
+   * @return whether the block is considered lost in Alluxio
+   * */
+  boolean hasLostBlock(long blockId);
+
+  /**
+   * Returns an {@link Iterator} over the lost blocks.
+   * Note that the iterator should not be shared across threads.
+   *
+   * @return an Iterator
+   * */
+  Iterator<Long> getLostBlocksIterator();
+
+  /**
+   * @return the number of lost blocks in Alluxio
+   * */
+  int getLostBlocksCount();
 
   /**
    * Reports the ids of the blocks lost on workers.

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -212,6 +212,7 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
       List<Metric> metrics);
 
   /**
+   * @param blockId the block ID
    * @return whether the block is considered lost in Alluxio
    * */
   boolean hasLostBlock(long blockId);

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -29,6 +29,7 @@ import alluxio.wire.Address;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
+import com.google.common.annotations.VisibleForTesting;
 
 import java.util.Iterator;
 import java.util.List;
@@ -214,20 +215,21 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
   /**
    * @param blockId the block ID
    * @return whether the block is considered lost in Alluxio
-   * */
-  boolean hasLostBlock(long blockId);
+   */
+  boolean isBlockLost(long blockId);
 
   /**
    * Returns an {@link Iterator} over the lost blocks.
    * Note that the iterator should not be shared across threads.
    *
    * @return an Iterator
-   * */
+   */
   Iterator<Long> getLostBlocksIterator();
 
   /**
    * @return the number of lost blocks in Alluxio
-   * */
+   */
+  @VisibleForTesting
   int getLostBlocksCount();
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -29,6 +29,7 @@ import alluxio.wire.Address;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
+
 import com.google.common.annotations.VisibleForTesting;
 
 import java.util.Iterator;

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1023,8 +1023,18 @@ public final class DefaultBlockMaster extends CoreMaster implements BlockMaster 
   }
 
   @Override
-  public Set<Long> getLostBlocks() {
-    return ImmutableSet.copyOf(mLostBlocks);
+  public boolean hasLostBlock(long blockId) {
+    return mLostBlocks.contains(blockId);
+  }
+
+  @Override
+  public Iterator<Long> getLostBlocksIterator() {
+    return mLostBlocks.iterator();
+  }
+
+  @Override
+  public int getLostBlocksCount() {
+    return mLostBlocks.size();
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1023,7 +1023,7 @@ public final class DefaultBlockMaster extends CoreMaster implements BlockMaster 
   }
 
   @Override
-  public boolean hasLostBlock(long blockId) {
+  public boolean isBlockLost(long blockId) {
     return mLostBlocks.contains(blockId);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -196,6 +196,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -2685,12 +2686,20 @@ public final class DefaultFileSystemMaster extends CoreMaster
   @Override
   public List<Long> getLostFiles() {
     Set<Long> lostFiles = new HashSet<>();
-    for (long blockId : mBlockMaster.getLostBlocks()) {
+    Iterator<Long> iter = mBlockMaster.getLostBlocksIterator();
+    while (iter.hasNext()) {
+      long blockId = iter.next();
       // the file id is the container id of the block id
       long containerId = BlockId.getContainerId(blockId);
       long fileId = IdUtils.createFileId(containerId);
       lostFiles.add(fileId);
     }
+//    for (long blockId : mBlockMaster.getLostBlocks()) {
+//      // the file id is the container id of the block id
+//      long containerId = BlockId.getContainerId(blockId);
+//      long fileId = IdUtils.createFileId(containerId);
+//      lostFiles.add(fileId);
+//    }
     return new ArrayList<>(lostFiles);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2694,12 +2694,6 @@ public final class DefaultFileSystemMaster extends CoreMaster
       long fileId = IdUtils.createFileId(containerId);
       lostFiles.add(fileId);
     }
-//    for (long blockId : mBlockMaster.getLostBlocks()) {
-//      // the file id is the container id of the block id
-//      long containerId = BlockId.getContainerId(blockId);
-//      long fileId = IdUtils.createFileId(containerId);
-//      lostFiles.add(fileId);
-//    }
     return new ArrayList<>(lostFiles);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -321,7 +321,7 @@ public final class ReplicationChecker implements HeartbeatExecutor {
               }
               if (currentReplicas < minReplicas) {
                 // if this file is not persisted and block master thinks it is lost, no effort made
-                if (!file.isPersisted() && mBlockMaster.hasLostBlock(blockId)) {
+                if (!file.isPersisted() && mBlockMaster.isBlockLost(blockId)) {
                   continue;
                 }
                 requests.add(new ImmutableTriple<>(inodePath.getUri(), blockId,

--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -272,7 +272,6 @@ public final class ReplicationChecker implements HeartbeatExecutor {
 
   private void check(Set<Long> inodes, ReplicationHandler handler, Mode mode)
       throws InterruptedException {
-    Set<Long> lostBlocks = mBlockMaster.getLostBlocks();
     for (long inodeId : inodes) {
       if (mActiveJobToInodeID.size() >= mMaxActiveJobs) {
         return;
@@ -322,7 +321,7 @@ public final class ReplicationChecker implements HeartbeatExecutor {
               }
               if (currentReplicas < minReplicas) {
                 // if this file is not persisted and block master thinks it is lost, no effort made
-                if (!file.isPersisted() && lostBlocks.contains(blockId)) {
+                if (!file.isPersisted() && mBlockMaster.hasLostBlock(blockId)) {
                   continue;
                 }
                 requests.add(new ImmutableTriple<>(inodePath.getUri(), blockId,

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -308,7 +308,7 @@ public final class FileSystemMasterTest {
         ImmutableMap.of(), ImmutableMap.of(), mMetrics);
     // Verify the muted Free command on worker1.
     assertEquals(Command.newBuilder().setCommandType(CommandType.Nothing).build(), heartbeat1);
-    assertFalse(mBlockMaster.getLostBlocks().contains(blockId));
+    assertFalse(mBlockMaster.hasLostBlock(blockId));
 
     // verify the file is deleted
     assertEquals(IdUtils.INVALID_FILE_ID, mFileSystemMaster.getFileId(NESTED_FILE_URI));

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -308,7 +308,7 @@ public final class FileSystemMasterTest {
         ImmutableMap.of(), ImmutableMap.of(), mMetrics);
     // Verify the muted Free command on worker1.
     assertEquals(Command.newBuilder().setCommandType(CommandType.Nothing).build(), heartbeat1);
-    assertFalse(mBlockMaster.hasLostBlock(blockId));
+    assertFalse(mBlockMaster.isBlockLost(blockId));
 
     // verify the file is deleted
     assertEquals(IdUtils.INVALID_FILE_ID, mFileSystemMaster.getFileId(NESTED_FILE_URI));

--- a/tests/src/test/java/alluxio/client/fs/FreeAndDeleteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FreeAndDeleteIntegrationTest.java
@@ -110,7 +110,7 @@ public final class FreeAndDeleteIntegrationTest extends BaseIntegrationTest {
     assertTrue(blockInfo.getLocations().isEmpty());
     assertFalse(bw.hasBlockMeta(blockId));
     // Verify the removed block is added to LostBlocks list.
-    assertTrue(bm.hasLostBlock(blockInfo.getBlockId()));
+    assertTrue(bm.isBlockLost(blockInfo.getBlockId()));
 
     mFileSystem.delete(filePath);
 

--- a/tests/src/test/java/alluxio/client/fs/FreeAndDeleteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FreeAndDeleteIntegrationTest.java
@@ -89,7 +89,7 @@ public final class FreeAndDeleteIntegrationTest extends BaseIntegrationTest {
     final BlockWorker bw =
         mLocalAlluxioClusterResource.get().getWorkerProcess().getWorker(BlockWorker.class);
     assertTrue(bw.hasBlockMeta(blockId));
-    assertTrue(bm.getLostBlocks().isEmpty());
+    assertEquals(0, bm.getLostBlocksCount());
 
     mFileSystem.free(filePath);
 
@@ -110,7 +110,7 @@ public final class FreeAndDeleteIntegrationTest extends BaseIntegrationTest {
     assertTrue(blockInfo.getLocations().isEmpty());
     assertFalse(bw.hasBlockMeta(blockId));
     // Verify the removed block is added to LostBlocks list.
-    assertTrue(bm.getLostBlocks().contains(blockInfo.getBlockId()));
+    assertTrue(bm.hasLostBlock(blockInfo.getBlockId()));
 
     mFileSystem.delete(filePath);
 
@@ -125,7 +125,7 @@ public final class FreeAndDeleteIntegrationTest extends BaseIntegrationTest {
     // Verify the blocks are not in mLostBlocks.
     CommonUtils.waitFor("block is removed from mLostBlocks", () -> {
       try {
-        return bm.getLostBlocks().isEmpty();
+        return 0 == bm.getLostBlocksCount();
       } catch (Exception e) {
         return false;
       }

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-//    o.sync();
+    o.sync();
     //#else
     o.hflush();
     //#endif

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-    o.sync();
+//    o.sync();
     //#else
     o.hflush();
     //#endif


### PR DESCRIPTION
This is a better approach of achieving https://github.com/Alluxio/alluxio/pull/13454

The current implementation copies the `DefaultBlockMaster.mLostBlocks` to whoever is using the set. This change improves the `BlockMaster` interface to avoid the need to copy that collection. The `mLostBlocks` set can be huge when there are workers lost. Also the cost is very high because we just copy on every read.