### PR TITLE
Add metrics for inode and block heap sizes

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -64,6 +64,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   private static final Cache<String, Boolean> REGEXP_CACHE = CacheBuilder.newBuilder()
       .maximumSize(1024)
       .build();
+
   /**
    * The consistency check level to apply to a certain property key.
    * User can run "alluxio validateEnv all cluster.conf.consistent" to validate the consistency of
@@ -2034,6 +2035,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_METRICS_HEAP_ENABLED =
+      new Builder(Name.MASTER_METRICS_HEAP_ENABLED)
+          .setDefaultValue(true)
+          .setDescription("Enable master heap estimate metrics")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+
   public static final PropertyKey MASTER_HOSTNAME =
       new Builder(Name.MASTER_HOSTNAME)
           .setDescription("The hostname of Alluxio master.")
@@ -5641,6 +5650,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metastore.inode.inherit.owner.and.group";
     public static final String MASTER_PERSISTENCE_CHECKER_INTERVAL_MS =
         "alluxio.master.persistence.checker.interval";
+    public static final String MASTER_METRICS_HEAP_ENABLED =
+        "alluxio.master.metrics.heap.enabled";
     public static final String MASTER_METRICS_SERVICE_THREADS =
         "alluxio.master.metrics.service.threads";
     public static final String MASTER_METRICS_TIME_SERIES_INTERVAL =

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -364,6 +364,17 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("Total number of blocks in Alluxio")
           .setMetricType(MetricType.COUNTER)
           .build();
+  public static final MetricKey MASTER_INODE_HEAP_SIZE =
+      new Builder("Master.InodeHeapSize")
+          .setDescription("An estimate of the inode heap size")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_BLOCK_HEAP_SIZE =
+      new Builder("Master.BlockHeapSize")
+          .setDescription("An estimate of the blocks heap size")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+
 
   // Backup Restore
   public static final MetricKey MASTER_LAST_BACKUP_ENTRIES_COUNT =

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -375,7 +375,6 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.GAUGE)
           .build();
 
-
   // Backup Restore
   public static final MetricKey MASTER_LAST_BACKUP_ENTRIES_COUNT =
       new Builder("Master.LastBackupEntriesCount")

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -22,6 +22,7 @@ import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.network.NetworkAddressUtils;
 
+import com.codahale.metrics.CachedGauge;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
@@ -552,6 +553,24 @@ public final class MetricsSystem {
   public static synchronized <T> void registerGaugeIfAbsent(String name, Gauge<T> metric) {
     if (!METRIC_REGISTRY.getMetrics().containsKey(name)) {
       METRIC_REGISTRY.register(name, metric);
+    }
+  }
+
+  /**
+   * Registers a cached gauge if it has not been registered.
+   *
+   * @param name the gauge name
+   * @param metric the gauge
+   * @param <T> the type
+   */
+  public static synchronized <T> void registerCachedGaugeIfAbsent(String name, Gauge<T> metric) {
+    if (!METRIC_REGISTRY.getMetrics().containsKey(name)) {
+      METRIC_REGISTRY.register(name, new CachedGauge<T>(10, TimeUnit.MINUTES) {
+        @Override
+        protected T loadValue() {
+          return metric.getValue();
+        }
+      });
     }
   }
 

--- a/core/common/src/main/java/alluxio/util/ObjectSizeCalculator.java
+++ b/core/common/src/main/java/alluxio/util/ObjectSizeCalculator.java
@@ -11,8 +11,6 @@
 
 package alluxio.util;
 
-import alluxio.metrics.MetricsSystem;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
@@ -30,9 +28,13 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -52,6 +54,7 @@ import java.util.Set;
  */
 public class ObjectSizeCalculator {
   private static final Logger LOG = LoggerFactory.getLogger(ObjectSizeCalculator.class);
+  private int mArraySize = -1;
 
   /**
    * Describes constant memory overheads for various constructs in a JVM implementation.
@@ -116,8 +119,25 @@ public class ObjectSizeCalculator {
    * retains
    * @throws UnsupportedOperationException if the current vm memory layout cannot be detected
    */
-  public static long getObjectSize(Object obj) throws UnsupportedOperationException {
+  public static long getObjectSize(Object obj)
+      throws UnsupportedOperationException {
     return obj == null ? 0 : new ObjectSizeCalculator(CurrentLayout.SPEC).calculateObjectSize(obj);
+  }
+
+  /**
+   * Given an object, returns the total allocated size, in bytes, of the object
+   * and all other objects reachable from it.  Attempts to to detect the current JVM memory layout,
+   * but may fail with {@link UnsupportedOperationException};
+   *
+   * @param obj the object; can be null
+   * @param constantClasses a set of classes that are considered constant sized
+   *
+   * @return the total allocated size of the object and all other objects it
+   */
+  public static long getObjectSize(Object obj, Set<Class<?>> constantClasses)
+      throws UnsupportedOperationException {
+    return obj == null ? 0 : new ObjectSizeCalculator(CurrentLayout.SPEC, constantClasses)
+        .calculateObjectSize(obj);
   }
 
   // Fixed object header size for arrays.
@@ -133,16 +153,18 @@ public class ObjectSizeCalculator {
   // added.
   private final int mSuperClassPadding;
 
-  private final LoadingCache<Class<?>, ClassSizeInfo> mClassInfos =
-      CacheBuilder.newBuilder().build(new CacheLoader<Class<?>, ClassSizeInfo>() {
-        public ClassSizeInfo load(Class<?> clazz) {
-          return new ClassSizeInfo(clazz);
-        }
-      });
+  private final LoadingCache<Class<?>, ClassSizeInfo> mClassInfos;
 
   private final Set<Object> mVisited = Sets.newIdentityHashSet();
-  private final Deque<Object> mPending = new ArrayDeque<Object>(16 * 1024);
+  private final Deque<Object> mPending = new ArrayDeque<>(16 * 1024);
+  private final Set<Class<?>> mConstantSizeClass;
+  private final Map<Class<?>, Long> mClassSizeCache;
+  private boolean mEstimateArray = false;
+  private Set<Class<?>> mConstantClass = new HashSet<>();
+
   private long mSize;
+  private int mRecursionDepth = 0;
+  private static final int MAX_RECURSION = 5;
 
   /**
    * Creates an object size calculator that can calculate object sizes for a given
@@ -151,12 +173,54 @@ public class ObjectSizeCalculator {
    * @param memoryLayoutSpecification a description of the JVM memory layout
    */
   public ObjectSizeCalculator(MemoryLayoutSpecification memoryLayoutSpecification) {
+    this(memoryLayoutSpecification, Collections.EMPTY_SET);
+  }
+
+  /**
+   * Creates an object size calculator that can calculate object sizes for a given
+   * {@code memoryLayoutSpecification}.
+   *
+   * @param memoryLayoutSpecification a description of the JVM memory layout
+   * @param constSizeClass constant sized classes
+   */
+  public ObjectSizeCalculator(MemoryLayoutSpecification memoryLayoutSpecification,
+      Set<Class<?>> constSizeClass) {
     Preconditions.checkNotNull(memoryLayoutSpecification);
+    Preconditions.checkNotNull(constSizeClass);
     mArrayHeaderSize = memoryLayoutSpecification.getArrayHeaderSize();
     mObjectHeaderSize = memoryLayoutSpecification.getObjectHeaderSize();
     mObjectPadding = memoryLayoutSpecification.getObjectPadding();
     mReferenceSize = memoryLayoutSpecification.getReferenceSize();
     mSuperClassPadding = memoryLayoutSpecification.getSuperclassFieldPadding();
+    mConstantSizeClass = constSizeClass;
+    if (!mConstantSizeClass.isEmpty()) {
+      mEstimateArray = true;
+    }
+    mClassSizeCache = new HashMap<>();
+    mClassInfos = CacheBuilder.newBuilder().build(new CacheLoader<Class<?>, ClassSizeInfo>() {
+      public ClassSizeInfo load(Class<?> clazz) {
+        return new ClassSizeInfo(clazz);
+      }
+    });
+  }
+
+  /**
+   * Creates an object size calculator based on a previous one.
+   *
+   * @param calc previous calculator
+   */
+  public ObjectSizeCalculator(ObjectSizeCalculator calc) {
+    mArrayHeaderSize = calc.mArrayHeaderSize;
+    mObjectHeaderSize = calc.mObjectHeaderSize;
+    mObjectPadding = calc.mObjectPadding;
+    mReferenceSize = calc.mReferenceSize;
+    mSuperClassPadding = calc.mSuperClassPadding;
+    mConstantSizeClass = calc.mConstantSizeClass;
+    // share class info between calculators
+    mClassInfos = calc.mClassInfos;
+    mClassSizeCache = calc.mClassSizeCache;
+    mEstimateArray = calc.mEstimateArray;
+    mRecursionDepth = calc.mRecursionDepth;
   }
 
   /**
@@ -176,9 +240,11 @@ public class ObjectSizeCalculator {
   public synchronized long calculateObjectSize(Object obj) {
     // Breadth-first traversal instead of naive depth-first with recursive
     // implementation, so we don't blow the stack traversing long linked lists.
+    boolean init = true;
     try {
       for (;;) {
-        visit(obj);
+        visit(obj, init);
+        init = false;
         if (mPending.isEmpty()) {
           return mSize;
         }
@@ -191,11 +257,13 @@ public class ObjectSizeCalculator {
     }
   }
 
-  private void visit(Object obj) {
-    if (mVisited.contains(obj)) {
+  private void visit(Object obj, boolean init) {
+    if (obj == null || mVisited.contains(obj)
+        || (!init && mConstantClass.contains(obj.getClass()))) {
       return;
     }
     final Class<?> clazz = obj.getClass();
+
     if (clazz == ArrayElementsVisitor.class) {
       ((ArrayElementsVisitor) obj).visit(this);
     } else {
@@ -203,6 +271,9 @@ public class ObjectSizeCalculator {
       if (clazz.isArray()) {
         visitArray(obj);
       } else {
+        if (Map.class.isAssignableFrom(clazz)) {
+          mArraySize = ((Map) obj).size();
+        }
         try {
           mClassInfos.getUnchecked(clazz).visit(obj, this);
         } catch (ExecutionError e) {
@@ -239,7 +310,7 @@ public class ObjectSizeCalculator {
           break;
         }
         default: {
-          enqueue(new ArrayElementsVisitor((Object[]) array));
+          enqueue(new ArrayElementsVisitor((Object[]) array, ((Object[]) array).length));
         }
       }
     }
@@ -249,17 +320,89 @@ public class ObjectSizeCalculator {
     increaseSize(roundTo(mArrayHeaderSize + length * elementSize, mObjectPadding));
   }
 
+  private long getClassSizeRecursive(Class<?> type, Object obj) {
+    if (mClassSizeCache.containsKey(type)) {
+      return mClassSizeCache.get(type);
+    }
+    if (mEstimateArray && (mRecursionDepth < MAX_RECURSION)) {
+      ObjectSizeCalculator recCalc = new ObjectSizeCalculator(this);
+      recCalc.mRecursionDepth++;
+      recCalc.mConstantClass.add(type);
+      if (type.getEnclosingClass() != null) {
+        recCalc.mConstantClass.add(type.getEnclosingClass());
+      }
+      long size = recCalc.calculateObjectSize(obj);
+      mClassSizeCache.put(type, size);
+      return size;
+    } else {
+      throw new UnsupportedOperationException(type.toString() + " is not a constant size class");
+    }
+  }
+
   private static class ArrayElementsVisitor {
     private final Object[] mArray;
 
-    ArrayElementsVisitor(Object[] array) {
+    ArrayElementsVisitor(Object[] array, long size) {
       mArray = array;
     }
 
+    private boolean isElementConstant(ObjectSizeCalculator calc,
+        Class<?> componentType, Object firstElement, int count) {
+      if (count < 0) {
+        return false;
+      }
+      if (calc.mConstantSizeClass.contains(firstElement.getClass())) {
+        return true;
+      }
+      Field [] fields = componentType.getDeclaredFields();
+      for (Field f : fields) {
+        Class<?> clazz = f.getType();
+        if (clazz.isPrimitive() || clazz.equals(componentType)
+            || f.getType().equals(componentType.getEnclosingClass())) {
+          continue;
+        }
+        f.setAccessible(true);
+        try {
+          Object obj = f.get(firstElement);
+          if (obj == null || obj.getClass().isPrimitive() || obj.getClass().equals(componentType)
+              || calc.mConstantSizeClass.contains(obj.getClass()) || obj == firstElement
+              || isElementConstant(calc, obj.getClass(), obj, count - 1)) {
+            continue;
+          }
+        } catch (IllegalAccessException e) {
+          return false;
+        }
+        return false;
+      }
+      return true;
+    }
+
     public void visit(ObjectSizeCalculator calc) {
+      final Class<?> componentType = mArray.getClass().getComponentType();
+      int arraySize = calc.mArraySize >= 0 ? calc.mArraySize : mArray.length;
+      int i = 0;
+      while (i < mArray.length && mArray[i] == null) {
+        i++;
+      }
+
+      try {
+        if (mArray != null && mArray.length != 0 && calc.mEstimateArray && i < mArray.length) {
+          if (arraySize > 10000 && mArray[i] != null) {
+            // When the component is a constant size data type
+            if (isElementConstant(calc, componentType, mArray[i], MAX_RECURSION)) {
+              long size = calc.getClassSizeRecursive(componentType, mArray[i]);
+              calc.increaseSize(arraySize * size);
+              calc.mArraySize = -1;
+              return;
+            }
+          }
+        }
+      } catch (UnsupportedOperationException e) {
+        LOG.info(e.getMessage());
+      }
       for (Object elem : mArray) {
         if (elem != null) {
-          calc.visit(elem);
+          calc.visit(elem, false);
         }
       }
     }
@@ -290,7 +433,7 @@ public class ObjectSizeCalculator {
 
     public ClassSizeInfo(Class<?> clazz) {
       long fieldsSize = 0;
-      final List<Field> referenceFields = new LinkedList<Field>();
+      List<Field> referenceFields = new LinkedList<Field>();
       for (Field f : clazz.getDeclaredFields()) {
         if (Modifier.isStatic(f.getModifiers())) {
           continue;
@@ -300,7 +443,10 @@ public class ObjectSizeCalculator {
           fieldsSize += getPrimitiveFieldSize(type);
         } else {
           f.setAccessible(true);
-          referenceFields.add(f);
+          if (f.getDeclaringClass().equals(clazz)
+              && !f.getType().equals(clazz.getEnclosingClass())) {
+            referenceFields.add(f);
+          }
           fieldsSize += mReferenceSize;
         }
       }
@@ -323,7 +469,9 @@ public class ObjectSizeCalculator {
     public void enqueueReferencedObjects(Object obj, ObjectSizeCalculator calc) {
       for (Field f : mReferencedFields) {
         try {
-          calc.enqueue(f.get(obj));
+          if (!calc.mConstantClass.contains(f.getType())) {
+            calc.enqueue(f.get(obj));
+          }
         } catch (IllegalAccessException e) {
           final AssertionError ae = new AssertionError(
               "Unexpected denial of access to " + f);
@@ -354,7 +502,7 @@ public class ObjectSizeCalculator {
   static MemoryLayoutSpecification getEffectiveMemoryLayoutSpecification() {
     final String vmName = System.getProperty("java.vm.name");
     if (vmName == null || !(vmName.startsWith("Java HotSpot(TM) ")
-        || vmName.startsWith("OpenJDK") || vmName.startsWith("TwitterJDK"))) {
+        || vmName.startsWith("OpenJDK"))) {
       throw new UnsupportedOperationException(
           "ObjectSizeCalculator only supported on HotSpot VM");
     }

--- a/core/common/src/main/java/alluxio/util/ObjectSizeCalculator.java
+++ b/core/common/src/main/java/alluxio/util/ObjectSizeCalculator.java
@@ -47,6 +47,8 @@ import java.util.Set;
  * switch, it can not detect
  * this fact and will report incorrect sizes, as it will presume the default JVM
  * behavior.
+ *
+ * Adapted from https://github.com/twitter-archive/commons/blob/master/src/java/com/twitter/common/objectsize/ObjectSizeCalculator.java
  */
 public class ObjectSizeCalculator {
   private static final Logger LOG = LoggerFactory.getLogger(ObjectSizeCalculator.class);

--- a/core/common/src/main/java/alluxio/util/ObjectSizeCalculator.java
+++ b/core/common/src/main/java/alluxio/util/ObjectSizeCalculator.java
@@ -1,0 +1,447 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Sets;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Contains utility methods for calculating the memory usage of objects. It
+ * only works on the HotSpot JVM, and infers the actual memory layout (32 bit
+ * vs. 64 bit word size, compressed object pointers vs. uncompressed) from
+ * best available indicators. It can reliably detect a 32 bit vs. 64 bit JVM.
+ * It can only make an educated guess at whether compressed OOPs are used,
+ * though; specifically, it knows what the JVM's default choice of OOP
+ * compression would be based on HotSpot version and maximum heap sizes, but if
+ * the choice is explicitly overridden with the <tt>-XX:{+|-}UseCompressedOops</tt> command line
+ * switch, it can not detect
+ * this fact and will report incorrect sizes, as it will presume the default JVM
+ * behavior.
+ */
+public class ObjectSizeCalculator {
+
+  /**
+   * Describes constant memory overheads for various constructs in a JVM implementation.
+   */
+  public interface MemoryLayoutSpecification {
+
+    /**
+     * Returns the fixed overhead of an array of any type or length in this JVM.
+     *
+     * @return the fixed overhead of an array
+     */
+    int getArrayHeaderSize();
+
+    /**
+     * Returns the fixed overhead of for any {@link Object} subclass in this JVM.
+     *
+     * @return the fixed overhead of any object
+     */
+    int getObjectHeaderSize();
+
+    /**
+     * Returns the quantum field size for a field owned by an object in this JVM.
+     *
+     * @return the quantum field size for an object
+     */
+    int getObjectPadding();
+
+    /**
+     * Returns the fixed size of an object reference in this JVM.
+     *
+     * @return the size of all object references
+     */
+    int getReferenceSize();
+
+    /**
+     * Returns the quantum field size for a field owned by one of an object's ancestor superclasses
+     * in this JVM.
+     *
+     * @return the quantum field size for a superclass field
+     */
+    int getSuperclassFieldPadding();
+  }
+
+  private static class CurrentLayout {
+    private static final MemoryLayoutSpecification SPEC =
+        getEffectiveMemoryLayoutSpecification();
+  }
+
+  /**
+   * Given an object, returns the total allocated size, in bytes, of the object
+   * and all other objects reachable from it.  Attempts to to detect the current JVM memory layout,
+   * but may fail with {@link UnsupportedOperationException};
+   *
+   * @param obj the object; can be null. Passing in a {@link java.lang.Class} object doesn't do
+   *            anything special, it measures the size of all objects
+   *            reachable through it (which will include its class loader, and by
+   *            extension, all other Class objects loaded by
+   *            the same loader, and all the parent class loaders). It doesn't provide the
+   *            size of the static fields in the JVM class that the Class object
+   *            represents.
+   * @return the total allocated size of the object and all other objects it
+   * retains
+   * @throws UnsupportedOperationException if the current vm memory layout cannot be detected
+   */
+  public static long getObjectSize(Object obj) throws UnsupportedOperationException {
+    return obj == null ? 0 : new ObjectSizeCalculator(CurrentLayout.SPEC).calculateObjectSize(obj);
+  }
+
+  // Fixed object header size for arrays.
+  private final int mArrayHeaderSize;
+  // Fixed object header size for non-array objects.
+  private final int mObjectHeaderSize;
+  // Padding for the object size - if the object size is not an exact multiple
+  // of this, it is padded to the next multiple.
+  private final int mObjectPadding;
+  // Size of reference (pointer) fields.
+  private final int mReferenceSize;
+  // Padding for the fields of superclass before fields of subclasses are
+  // added.
+  private final int mSuperClassPadding;
+
+  private final LoadingCache<Class<?>, ClassSizeInfo> mClassInfos =
+      CacheBuilder.newBuilder().build(new CacheLoader<Class<?>, ClassSizeInfo>() {
+        public ClassSizeInfo load(Class<?> clazz) {
+          return new ClassSizeInfo(clazz);
+        }
+      });
+
+  private final Set<Object> mVisited = Sets.newIdentityHashSet();
+  private final Deque<Object> mPending = new ArrayDeque<Object>(16 * 1024);
+  private long mSize;
+
+  /**
+   * Creates an object size calculator that can calculate object sizes for a given
+   * {@code memoryLayoutSpecification}.
+   *
+   * @param memoryLayoutSpecification a description of the JVM memory layout
+   */
+  public ObjectSizeCalculator(MemoryLayoutSpecification memoryLayoutSpecification) {
+    Preconditions.checkNotNull(memoryLayoutSpecification);
+    mArrayHeaderSize = memoryLayoutSpecification.getArrayHeaderSize();
+    mObjectHeaderSize = memoryLayoutSpecification.getObjectHeaderSize();
+    mObjectPadding = memoryLayoutSpecification.getObjectPadding();
+    mReferenceSize = memoryLayoutSpecification.getReferenceSize();
+    mSuperClassPadding = memoryLayoutSpecification.getSuperclassFieldPadding();
+  }
+
+  /**
+   * Given an object, returns the total allocated size, in bytes, of the object
+   * and all other objects reachable from it.
+   *
+   * @param obj the object; can be null. Passing in a {@link java.lang.Class} object doesn't do
+   *            anything special, it measures the size of all objects
+   *            reachable through it (which will include its class loader, and by
+   *            extension, all other Class objects loaded by
+   *            the same loader, and all the parent class loaders). It doesn't provide the
+   *            size of the static fields in the JVM class that the Class object
+   *            represents.
+   * @return the total allocated size of the object and all other objects it
+   * retains
+   */
+  public synchronized long calculateObjectSize(Object obj) {
+    // Breadth-first traversal instead of naive depth-first with recursive
+    // implementation, so we don't blow the stack traversing long linked lists.
+    try {
+      for (;;) {
+        visit(obj);
+        if (mPending.isEmpty()) {
+          return mSize;
+        }
+        obj = mPending.removeFirst();
+      }
+    } finally {
+      mVisited.clear();
+      mPending.clear();
+      mSize = 0;
+    }
+  }
+
+  private void visit(Object obj) {
+    if (mVisited.contains(obj)) {
+      return;
+    }
+    final Class<?> clazz = obj.getClass();
+    if (clazz == ArrayElementsVisitor.class) {
+      ((ArrayElementsVisitor) obj).visit(this);
+    } else {
+      mVisited.add(obj);
+      if (clazz.isArray()) {
+        visitArray(obj);
+      } else {
+        mClassInfos.getUnchecked(clazz).visit(obj, this);
+      }
+    }
+  }
+
+  private void visitArray(Object array) {
+    final Class<?> componentType = array.getClass().getComponentType();
+    final int length = Array.getLength(array);
+    if (componentType.isPrimitive()) {
+      increaseByArraySize(length, getPrimitiveFieldSize(componentType));
+    } else {
+      increaseByArraySize(length, mReferenceSize);
+      // If we didn't use an ArrayElementsVisitor, we would be enqueueing every
+      // element of the array here instead. For large arrays, it would
+      // tremendously enlarge the queue. In essence, we're compressing it into
+      // a small command object instead. This is different than immediately
+      // visiting the elements, as their visiting is scheduled for the end of
+      // the current queue.
+      switch (length) {
+        case 0: {
+          break;
+        }
+        case 1: {
+          enqueue(Array.get(array, 0));
+          break;
+        }
+        default: {
+          enqueue(new ArrayElementsVisitor((Object[]) array));
+        }
+      }
+    }
+  }
+
+  private void increaseByArraySize(int length, long elementSize) {
+    increaseSize(roundTo(mArrayHeaderSize + length * elementSize, mObjectPadding));
+  }
+
+  private static class ArrayElementsVisitor {
+    private final Object[] mArray;
+
+    ArrayElementsVisitor(Object[] array) {
+      mArray = array;
+    }
+
+    public void visit(ObjectSizeCalculator calc) {
+      for (Object elem : mArray) {
+        if (elem != null) {
+          calc.visit(elem);
+        }
+      }
+    }
+  }
+
+  void enqueue(Object obj) {
+    if (obj != null) {
+      mPending.addLast(obj);
+    }
+  }
+
+  void increaseSize(long objectSize) {
+    mSize += objectSize;
+  }
+
+  @VisibleForTesting
+  static long roundTo(long x, int multiple) {
+    return ((x + multiple - 1) / multiple) * multiple;
+  }
+
+  private class ClassSizeInfo {
+    // Padded fields + header size
+    private final long mObjectSize;
+    // Only the fields size - used to calculate the subclasses' memory
+    // footprint.
+    private final long mFieldSize;
+    private final Field[] mReferencedFields;
+
+    public ClassSizeInfo(Class<?> clazz) {
+      long fieldsSize = 0;
+      final List<Field> referenceFields = new LinkedList<Field>();
+      for (Field f : clazz.getDeclaredFields()) {
+        if (Modifier.isStatic(f.getModifiers())) {
+          continue;
+        }
+        final Class<?> type = f.getType();
+        if (type.isPrimitive()) {
+          fieldsSize += getPrimitiveFieldSize(type);
+        } else {
+          f.setAccessible(true);
+          referenceFields.add(f);
+          fieldsSize += mReferenceSize;
+        }
+      }
+      final Class<?> superClass = clazz.getSuperclass();
+      if (superClass != null) {
+        final ClassSizeInfo superClassInfo = mClassInfos.getUnchecked(superClass);
+        fieldsSize += roundTo(superClassInfo.mFieldSize, mSuperClassPadding);
+        referenceFields.addAll(Arrays.asList(superClassInfo.mReferencedFields));
+      }
+      mFieldSize = fieldsSize;
+      mObjectSize = roundTo(mObjectHeaderSize + fieldsSize, mObjectPadding);
+      mReferencedFields = referenceFields.toArray(new Field[referenceFields.size()]);
+    }
+
+    void visit(Object obj, ObjectSizeCalculator calc) {
+      calc.increaseSize(mObjectSize);
+      enqueueReferencedObjects(obj, calc);
+    }
+
+    public void enqueueReferencedObjects(Object obj, ObjectSizeCalculator calc) {
+      for (Field f : mReferencedFields) {
+        try {
+          calc.enqueue(f.get(obj));
+        } catch (IllegalAccessException e) {
+          final AssertionError ae = new AssertionError(
+              "Unexpected denial of access to " + f);
+          ae.initCause(e);
+          throw ae;
+        }
+      }
+    }
+  }
+
+  private static long getPrimitiveFieldSize(Class<?> type) {
+    if (type == boolean.class || type == byte.class) {
+      return 1;
+    }
+    if (type == char.class || type == short.class) {
+      return 2;
+    }
+    if (type == int.class || type == float.class) {
+      return 4;
+    }
+    if (type == long.class || type == double.class) {
+      return 8;
+    }
+    throw new AssertionError("Encountered unexpected primitive type " + type.getName());
+  }
+
+  @VisibleForTesting
+  static MemoryLayoutSpecification getEffectiveMemoryLayoutSpecification() {
+    final String vmName = System.getProperty("java.vm.name");
+    if (vmName == null || !(vmName.startsWith("Java HotSpot(TM) ")
+        || vmName.startsWith("OpenJDK") || vmName.startsWith("TwitterJDK"))) {
+      throw new UnsupportedOperationException(
+          "ObjectSizeCalculator only supported on HotSpot VM");
+    }
+
+    final String dataModel = System.getProperty("sun.arch.data.model");
+    if ("32".equals(dataModel)) {
+      // Running with 32-bit data model
+      return new MemoryLayoutSpecification() {
+        @Override
+        public int getArrayHeaderSize() {
+          return 12;
+        }
+
+        @Override
+        public int getObjectHeaderSize() {
+          return 8;
+        }
+
+        @Override
+        public int getObjectPadding() {
+          return 8;
+        }
+
+        @Override
+        public int getReferenceSize() {
+          return 4;
+        }
+
+        @Override
+        public int getSuperclassFieldPadding() {
+          return 4;
+        }
+      };
+    } else if (!"64".equals(dataModel)) {
+      throw new UnsupportedOperationException("Unrecognized value '"
+          + dataModel + "' of sun.arch.data.model system property");
+    }
+
+    final String strVmVersion = System.getProperty("java.vm.version");
+    final int vmVersion = Integer.parseInt(strVmVersion.substring(0,
+        strVmVersion.indexOf('.')));
+    if (vmVersion >= 17) {
+      long maxMemory = 0;
+      for (MemoryPoolMXBean mp : ManagementFactory.getMemoryPoolMXBeans()) {
+        maxMemory += mp.getUsage().getMax();
+      }
+      if (maxMemory < 30L * 1024 * 1024 * 1024) {
+        // HotSpot 17.0 and above use compressed OOPs below 30GB of RAM total
+        // for all memory pools (yes, including code cache).
+        return new MemoryLayoutSpecification() {
+          @Override
+          public int getArrayHeaderSize() {
+            return 16;
+          }
+
+          @Override
+          public int getObjectHeaderSize() {
+            return 12;
+          }
+
+          @Override
+          public int getObjectPadding() {
+            return 8;
+          }
+
+          @Override
+          public int getReferenceSize() {
+            return 4;
+          }
+
+          @Override
+          public int getSuperclassFieldPadding() {
+            return 4;
+          }
+        };
+      }
+    }
+
+    // In other cases, it's a 64-bit uncompressed OOPs object model
+    return new MemoryLayoutSpecification() {
+      @Override
+      public int getArrayHeaderSize() {
+        return 24;
+      }
+
+      @Override
+      public int getObjectHeaderSize() {
+        return 16;
+      }
+
+      @Override
+      public int getObjectPadding() {
+        return 8;
+      }
+
+      @Override
+      public int getReferenceSize() {
+        return 8;
+      }
+
+      @Override
+      public int getSuperclassFieldPadding() {
+        return 8;
+      }
+    };
+  }
+}

--- a/core/common/src/test/java/alluxio/util/ObjectSizeCalculatorTest.java
+++ b/core/common/src/test/java/alluxio/util/ObjectSizeCalculatorTest.java
@@ -1,0 +1,223 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util;
+
+import static org.junit.Assert.assertEquals;
+
+import alluxio.util.ObjectSizeCalculator.MemoryLayoutSpecification;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ObjectSizeCalculatorTest {
+  private int mArrayHeaderSize;
+  private int mObjectHeaderSize;
+  private int mReferenceHeaderSize;
+  private int mSuperClassPaddingSize;
+  private ObjectSizeCalculator mObjectSizeCalculator;
+
+  @Before
+  public void setUp() {
+    MemoryLayoutSpecification memoryLayoutSpecification =
+        new MemoryLayoutSpecification() {
+          @Override
+          public int getArrayHeaderSize() {
+            return 16;
+          }
+
+          @Override
+          public int getObjectHeaderSize() {
+            return 12;
+          }
+
+          @Override
+          public int getObjectPadding() {
+            return 8;
+          }
+
+          @Override
+          public int getReferenceSize() {
+            return 4;
+          }
+
+          @Override
+          public int getSuperclassFieldPadding() {
+            return 4;
+          }
+        };
+
+    mArrayHeaderSize = memoryLayoutSpecification.getArrayHeaderSize();
+    mObjectHeaderSize = memoryLayoutSpecification.getObjectHeaderSize();
+    mReferenceHeaderSize = memoryLayoutSpecification.getReferenceSize();
+    mSuperClassPaddingSize = memoryLayoutSpecification.getSuperclassFieldPadding();
+
+    mObjectSizeCalculator = new ObjectSizeCalculator(memoryLayoutSpecification);
+  }
+
+  @Test
+  public void testRounding() {
+    assertEquals(0, roundTo(0, 8));
+    assertEquals(8, roundTo(1, 8));
+    assertEquals(8, roundTo(7, 8));
+    assertEquals(8, roundTo(8, 8));
+    assertEquals(16, roundTo(9, 8));
+    assertEquals(16, roundTo(15, 8));
+    assertEquals(16, roundTo(16, 8));
+    assertEquals(24, roundTo(17, 8));
+  }
+
+  @Test
+  public void testObjectSize() {
+    assertSizeIs(mObjectHeaderSize, new Object());
+  }
+
+  static class ObjectWithFields {
+    int mLength;
+    int mOffset;
+    int mHashcode;
+    char[] mData = {};
+  }
+
+  @Test
+  public void testObjectWithFields() {
+    assertSizeIs(mObjectHeaderSize + 3 * 4 + mReferenceHeaderSize
+        + mArrayHeaderSize, new ObjectWithFields());
+  }
+
+  public static class Class1 {
+    private boolean mBool;
+  }
+
+  @Test
+  public void testOneBooleanSize() {
+    assertSizeIs(mObjectHeaderSize + 1, new Class1());
+  }
+
+  public static class Class2 extends Class1 {
+    private int mInteger;
+  }
+
+  @Test
+  public void testSimpleSubclassSize() {
+    assertSizeIs(mObjectHeaderSize + roundTo(1, mSuperClassPaddingSize) + 4, new Class2());
+  }
+
+  @Test
+  public void testZeroLengthArray() {
+    assertSizeIs(mArrayHeaderSize, new byte[0]);
+    assertSizeIs(mArrayHeaderSize, new int[0]);
+    assertSizeIs(mArrayHeaderSize, new long[0]);
+    assertSizeIs(mArrayHeaderSize, new Object[0]);
+  }
+
+  @Test
+  public void testByteArrays() {
+    assertSizeIs(mArrayHeaderSize + 1, new byte[1]);
+    assertSizeIs(mArrayHeaderSize + 8, new byte[8]);
+    assertSizeIs(mArrayHeaderSize + 9, new byte[9]);
+  }
+
+  @Test
+  public void testCharArrays() {
+    assertSizeIs(mArrayHeaderSize + 2 * 1, new char[1]);
+    assertSizeIs(mArrayHeaderSize + 2 * 4, new char[4]);
+    assertSizeIs(mArrayHeaderSize + 2 * 5, new char[5]);
+  }
+
+  @Test
+  public void testIntArrays() {
+    assertSizeIs(mArrayHeaderSize + 4 * 1, new int[1]);
+    assertSizeIs(mArrayHeaderSize + 4 * 2, new int[2]);
+    assertSizeIs(mArrayHeaderSize + 4 * 3, new int[3]);
+  }
+
+  @Test
+  public void testLongArrays() {
+    assertSizeIs(mArrayHeaderSize + 8 * 1, new long[1]);
+    assertSizeIs(mArrayHeaderSize + 8 * 2, new long[2]);
+    assertSizeIs(mArrayHeaderSize + 8 * 3, new long[3]);
+  }
+
+  @Test
+  public void testObjectArrays() {
+    assertSizeIs(mArrayHeaderSize + mReferenceHeaderSize * 1, new Object[1]);
+    assertSizeIs(mArrayHeaderSize + mReferenceHeaderSize * 2, new Object[2]);
+    assertSizeIs(mArrayHeaderSize + mReferenceHeaderSize * 3, new Object[3]);
+    assertSizeIs(mArrayHeaderSize + mReferenceHeaderSize * 1, new String[1]);
+    assertSizeIs(mArrayHeaderSize + mReferenceHeaderSize * 2, new String[2]);
+    assertSizeIs(mArrayHeaderSize + mReferenceHeaderSize * 3, new String[3]);
+  }
+
+  public static class Circular {
+    Circular mCircular;
+  }
+
+  @Test
+  public void testCircular() {
+    Circular c1 = new Circular();
+    long size = mObjectSizeCalculator.calculateObjectSize(c1);
+    c1.mCircular = c1;
+    assertEquals(size, mObjectSizeCalculator.calculateObjectSize(c1));
+  }
+
+  static class ComplexObject<T> {
+    static class Node<T> {
+      final T mVal;
+      Node<T> mPrev;
+      Node<T> mNext;
+
+      Node(T value) {
+        mVal = value;
+      }
+    }
+
+    private Node<T> mFirst;
+    private Node<T> mLast;
+
+    void add(T item) {
+      Node<T> node = new Node<T>(item);
+      if (mFirst == null) {
+        mFirst = node;
+      } else {
+        mLast.mNext = node;
+        node.mPrev = mLast;
+      }
+      mLast = node;
+    }
+  }
+
+  @Test
+  public void testComplexObject() {
+    ComplexObject<Object> l = new ComplexObject<Object>();
+    l.add(new Object());
+    l.add(new Object());
+    l.add(new Object());
+
+    long expectedSize = 0;
+    // The complex object itself plus first and last refs.
+    expectedSize += roundTo(mObjectHeaderSize + 2 * mReferenceHeaderSize, 8);
+    // 3 Nodes - each with 3 object references.
+    expectedSize += roundTo(mObjectHeaderSize + 3 * mReferenceHeaderSize, 8) * 3;
+    // 3 vanilla objects contained in the node values.
+    expectedSize += roundTo(mObjectHeaderSize, 8) * 3;
+
+    assertSizeIs(expectedSize, l);
+  }
+
+  private void assertSizeIs(long size, Object o) {
+    assertEquals(roundTo(size, 8), mObjectSizeCalculator.calculateObjectSize(o));
+  }
+
+  private static long roundTo(long x, int multiple) {
+    return ObjectSizeCalculator.roundTo(x, multiple);
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreePersistentState.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreePersistentState.java
@@ -40,12 +40,14 @@ import alluxio.resource.CloseableIterator;
 import alluxio.resource.LockResource;
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
+import alluxio.util.CommonUtils;
 import alluxio.util.StreamUtils;
 import alluxio.util.proto.ProtoUtils;
 
 import com.google.common.base.Preconditions;
 import org.HdrHistogram.Histogram;
 import org.HdrHistogram.Recorder;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -158,11 +160,19 @@ public class InodeTreePersistentState implements Journaled {
    */
   public Histogram getFileSizeHistogram() {
     synchronized (mFileSizeHistogram) {
-      mRemovedFileHistogram = mRemovedFileRecorder.getIntervalHistogram(mRemovedFileHistogram);
-      mCreatedFileHistogram = mCreatedFileRecorder.getIntervalHistogram(mCreatedFileHistogram);
-      mFileSizeHistogram.add(mCreatedFileHistogram);
-      mFileSizeHistogram.subtract(mRemovedFileHistogram);
-      return mFileSizeHistogram.copy();
+      try {
+        mRemovedFileHistogram = mRemovedFileRecorder.getIntervalHistogram(mRemovedFileHistogram);
+        mCreatedFileHistogram = mCreatedFileRecorder.getIntervalHistogram(mCreatedFileHistogram);
+        mFileSizeHistogram.add(mCreatedFileHistogram);
+        if (mRemovedFileHistogram.getTotalCount() != 0) {
+          mFileSizeHistogram.subtract(mRemovedFileHistogram);
+        }
+        return mFileSizeHistogram.copy();
+      } catch (Exception e) {
+        LOG.info("Unexpected exception in generating file size histogram\n"
+            + e.getMessage() + "\n" + ExceptionUtils.getStackTrace(e));
+        throw e;
+      }
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreePersistentState.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreePersistentState.java
@@ -40,7 +40,6 @@ import alluxio.resource.CloseableIterator;
 import alluxio.resource.LockResource;
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.DefaultAccessControlList;
-import alluxio.util.CommonUtils;
 import alluxio.util.StreamUtils;
 import alluxio.util.proto.ProtoUtils;
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreePersistentState.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreePersistentState.java
@@ -164,7 +164,8 @@ public class InodeTreePersistentState implements Journaled {
         mRemovedFileHistogram = mRemovedFileRecorder.getIntervalHistogram(mRemovedFileHistogram);
         mCreatedFileHistogram = mCreatedFileRecorder.getIntervalHistogram(mCreatedFileHistogram);
         mFileSizeHistogram.add(mCreatedFileHistogram);
-        if (mRemovedFileHistogram.getTotalCount() != 0) {
+        if (mFileSizeHistogram.getTotalCount() != 0
+            && mRemovedFileHistogram.getTotalCount() != 0) {
           mFileSizeHistogram.subtract(mRemovedFileHistogram);
         }
         return mFileSizeHistogram.copy();

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
@@ -34,6 +34,7 @@ import alluxio.metrics.MetricsSystem;
 import alluxio.resource.LockResource;
 import alluxio.resource.RWLockResource;
 import alluxio.util.ConfigurationUtils;
+import alluxio.util.ObjectSizeCalculator;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -144,6 +145,10 @@ public final class CachingInodeStore implements InodeStore, Closeable {
     mInodeCache = new InodeCache(cacheConf);
     mEdgeCache = new EdgeCache(cacheConf);
     mListingCache = new ListingCache(cacheConf);
+    MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_INODE_HEAP_SIZE.getName(),
+        () -> ObjectSizeCalculator.getObjectSize(mInodeCache)
+            + ObjectSizeCalculator.getObjectSize(mEdgeCache)
+            + ObjectSizeCalculator.getObjectSize(mListingCache));
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
@@ -149,20 +149,22 @@ public final class CachingInodeStore implements InodeStore, Closeable {
     mInodeCache = new InodeCache(cacheConf);
     mEdgeCache = new EdgeCache(cacheConf);
     mListingCache = new ListingCache(cacheConf);
-    MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_INODE_HEAP_SIZE.getName(),
-        () -> {
-          try {
-            return ObjectSizeCalculator.getObjectSize(mInodeCache.mMap,
-                ImmutableSet.of(Long.class, MutableInodeFile.class, MutableInodeDirectory.class))
-                + ObjectSizeCalculator.getObjectSize(mEdgeCache.mMap,
-                ImmutableSet.of(Long.class, Edge.class))
-                + ObjectSizeCalculator.getObjectSize(mListingCache.mMap,
-                ImmutableSet.of(Long.class, ListingCache.ListingCacheEntry.class));
-          } catch (NullPointerException e) {
-            LOG.info(Throwables.getStackTraceAsString(e));
-            throw e;
-          }
-        });
+    if (conf.getBoolean(PropertyKey.MASTER_METRICS_HEAP_ENABLED)) {
+      MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_INODE_HEAP_SIZE.getName(),
+          () -> {
+            try {
+              return ObjectSizeCalculator.getObjectSize(mInodeCache.mMap,
+                  ImmutableSet.of(Long.class, MutableInodeFile.class, MutableInodeDirectory.class))
+                  + ObjectSizeCalculator.getObjectSize(mEdgeCache.mMap,
+                  ImmutableSet.of(Long.class, Edge.class))
+                  + ObjectSizeCalculator.getObjectSize(mListingCache.mMap,
+                  ImmutableSet.of(Long.class, ListingCache.ListingCacheEntry.class));
+            } catch (NullPointerException e) {
+              LOG.info(Throwables.getStackTraceAsString(e));
+              throw e;
+            }
+          });
+    }
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapBlockStore.java
@@ -13,8 +13,11 @@ package alluxio.master.metastore.heap;
 
 import alluxio.collections.TwoKeyConcurrentMap;
 import alluxio.master.metastore.BlockStore;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.proto.meta.Block.BlockLocation;
 import alluxio.proto.meta.Block.BlockMeta;
+import alluxio.util.ObjectSizeCalculator;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,6 +42,12 @@ public class HeapBlockStore implements BlockStore {
   // Map from block id to block locations.
   public final TwoKeyConcurrentMap<Long, Long, BlockLocation, Map<Long, BlockLocation>>
       mBlockLocations = new TwoKeyConcurrentMap<>(() -> new HashMap<>(4));
+
+  public HeapBlockStore() {
+    super();
+    MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_BLOCK_HEAP_SIZE.getName(),
+        () -> ObjectSizeCalculator.getObjectSize(this));
+  }
 
   @Override
   public Optional<BlockMeta> getBlock(long id) {

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapBlockStore.java
@@ -12,6 +12,8 @@
 package alluxio.master.metastore.heap;
 
 import alluxio.collections.TwoKeyConcurrentMap;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.master.metastore.BlockStore;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
@@ -49,8 +51,10 @@ public class HeapBlockStore implements BlockStore {
    */
   public HeapBlockStore() {
     super();
-    MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_BLOCK_HEAP_SIZE.getName(),
-        () -> ObjectSizeCalculator.getObjectSize(this));
+    if (ServerConfiguration.getBoolean(PropertyKey.MASTER_METRICS_HEAP_ENABLED)) {
+      MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_BLOCK_HEAP_SIZE.getName(),
+          () -> ObjectSizeCalculator.getObjectSize(this));
+    }
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapBlockStore.java
@@ -43,6 +43,10 @@ public class HeapBlockStore implements BlockStore {
   public final TwoKeyConcurrentMap<Long, Long, BlockLocation, Map<Long, BlockLocation>>
       mBlockLocations = new TwoKeyConcurrentMap<>(() -> new HashMap<>(4));
 
+  /**
+   * constructor a HeapBlockStore.
+   *
+   */
   public HeapBlockStore() {
     super();
     MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_BLOCK_HEAP_SIZE.getName(),

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
@@ -52,6 +52,9 @@ public class HeapInodeStore implements InodeStore {
   private final TwoKeyConcurrentMap<Long, String, Long, Map<String, Long>> mEdges =
       new TwoKeyConcurrentMap<>(() -> new ConcurrentHashMap<>(4));
 
+  /**
+   * Construct a heap inode store.
+   */
   public HeapInodeStore() {
     super();
     MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_INODE_HEAP_SIZE.getName(),

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
@@ -14,6 +14,8 @@ package alluxio.master.metastore.heap;
 import static java.util.stream.Collectors.toList;
 
 import alluxio.collections.TwoKeyConcurrentMap;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.master.file.meta.EdgeEntry;
 import alluxio.master.file.meta.Inode;
 import alluxio.master.file.meta.InodeDirectoryView;
@@ -57,8 +59,10 @@ public class HeapInodeStore implements InodeStore {
    */
   public HeapInodeStore() {
     super();
-    MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_INODE_HEAP_SIZE.getName(),
-        () -> ObjectSizeCalculator.getObjectSize(this));
+    if (ServerConfiguration.getBoolean(PropertyKey.MASTER_METRICS_HEAP_ENABLED)) {
+      MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_INODE_HEAP_SIZE.getName(),
+          () -> ObjectSizeCalculator.getObjectSize(this));
+    }
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
@@ -24,7 +24,10 @@ import alluxio.master.journal.checkpoint.CheckpointOutputStream;
 import alluxio.master.journal.checkpoint.CheckpointType;
 import alluxio.master.metastore.InodeStore;
 import alluxio.master.metastore.ReadOption;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.proto.meta.InodeMeta;
+import alluxio.util.ObjectSizeCalculator;
 
 import com.google.common.base.Preconditions;
 
@@ -48,6 +51,12 @@ public class HeapInodeStore implements InodeStore {
   // Map from inode id to ids of children of that inode. The inner maps are ordered by child name.
   private final TwoKeyConcurrentMap<Long, String, Long, Map<String, Long>> mEdges =
       new TwoKeyConcurrentMap<>(() -> new ConcurrentHashMap<>(4));
+
+  public HeapInodeStore() {
+    super();
+    MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_INODE_HEAP_SIZE.getName(),
+        () -> ObjectSizeCalculator.getObjectSize(this));
+  }
 
   @Override
   public void remove(Long inodeId) {


### PR DESCRIPTION
Use reflection to walk through inode and block object to estimate the size of heap usage by inode and block data structures. 

Assumption: constant inode and block structure size to achieve reasonable time estimate