### PR TITLE
Add counters for BlockReader streams

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -875,6 +875,24 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey WORKER_BLOCKS_READ_LOCAL =
+      new Builder("Worker.BlocksReadLocal")
+          .setDescription("Total number of local blocks read by this worker.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey WORKER_BLOCKS_READ_REMOTE =
+      new Builder("Worker.BlocksReadRemote")
+          .setDescription("Total number of a remote blocks read by this worker.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey WORKER_BLOCKS_READ_UFS =
+      new Builder("Worker.BlocksReadUfs")
+          .setDescription("Total number of a UFS blocks read by this worker.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey WORKER_BYTES_READ_DIRECT =
       new Builder("Worker.BytesReadDirect")
           .setDescription("Total number of bytes read from Alluxio storage managed by this worker "

--- a/core/common/src/main/java/alluxio/worker/block/io/LocalFileBlockReader.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/LocalFileBlockReader.java
@@ -11,6 +11,10 @@
 
 package alluxio.worker.block.io;
 
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
+
+import com.codahale.metrics.Counter;
 import com.google.common.base.Preconditions;
 import com.google.common.io.Closer;
 import io.netty.buffer.ByteBuf;
@@ -28,6 +32,9 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class LocalFileBlockReader extends BlockReader {
+  private static final Counter BLOCKS_READ_LOCAL =
+      MetricsSystem.counter(MetricKey.WORKER_BLOCKS_READ_LOCAL.getName());
+
   private final String mFilePath;
   private final RandomAccessFile mLocalFile;
   private final FileChannel mLocalFileChannel;
@@ -110,6 +117,7 @@ public class LocalFileBlockReader extends BlockReader {
       mCloser.close();
     } finally {
       mClosed = true;
+      BLOCKS_READ_LOCAL.inc();
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/RemoteBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/RemoteBlockReader.java
@@ -13,10 +13,13 @@ package alluxio.worker.block;
 
 import alluxio.client.block.stream.BlockInStream;
 import alluxio.client.file.FileSystemContext;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.block.io.BlockReader;
 
+import com.codahale.metrics.Counter;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 
@@ -30,6 +33,9 @@ import java.nio.channels.ReadableByteChannel;
  * Reads a block from a remote worker node. This should only be used for reading entire blocks.
  */
 public class RemoteBlockReader extends BlockReader {
+  private static final Counter BLOCKS_READ_REMOTE =
+      MetricsSystem.counter(MetricKey.WORKER_BLOCKS_READ_REMOTE.getName());
+
   private final long mBlockId;
   private final long mBlockSize;
   private final InetSocketAddress mDataSource;
@@ -104,6 +110,7 @@ public class RemoteBlockReader extends BlockReader {
       mChannel.close();
     }
     mClosed = true;
+    BLOCKS_READ_REMOTE.inc();
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
@@ -20,6 +20,8 @@ import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.InvalidWorkerStateException;
 import alluxio.exception.PreconditionMessage;
 import alluxio.exception.status.AlluxioStatusException;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.resource.CloseableResource;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UnderFileSystem;
@@ -29,6 +31,7 @@ import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
 import alluxio.worker.block.meta.UnderFileSystemBlockMeta;
 
+import com.codahale.metrics.Counter;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
@@ -48,6 +51,10 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public final class UnderFileSystemBlockReader extends BlockReader {
   private static final Logger LOG = LoggerFactory.getLogger(UnderFileSystemBlockReader.class);
+
+  /** Metrics. */
+  private static final Counter BLOCKS_READ_UFS =
+      MetricsSystem.counter(MetricKey.WORKER_BLOCKS_READ_UFS.getName());
 
   /** An object storing the mapping of tier aliases to ordinals. */
   private final StorageTierAssoc mStorageTierAssoc = new WorkerStorageTierAssoc();
@@ -276,6 +283,7 @@ public final class UnderFileSystemBlockReader extends BlockReader {
       mUfsResource.close();
     } finally {
       mClosed = true;
+      BLOCKS_READ_UFS.inc();
     }
   }
 


### PR DESCRIPTION
Adds simple Counter metrics for UFS vs. Remote vs. Local block streams.

**W.I.P: Still undergoing testing**