### PR TITLE
Fix ufs read metrics

### DIFF
--- a/core/common/src/main/java/alluxio/worker/block/io/DelegatingBlockReader.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/DelegatingBlockReader.java
@@ -38,8 +38,7 @@ public class DelegatingBlockReader extends BlockReader {
   }
 
   /**
-   * Return the delegate.
-   * @return return the delegate
+   * @return the delegate
    */
   public BlockReader getDelegate() {
     return mBlockReader;

--- a/core/common/src/main/java/alluxio/worker/block/io/DelegatingBlockReader.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/DelegatingBlockReader.java
@@ -37,6 +37,14 @@ public class DelegatingBlockReader extends BlockReader {
     mCloser.register(closeable);
   }
 
+  /**
+   * Return the delegate.
+   * @return return the delegate
+   */
+  public BlockReader getDelegate() {
+    return mBlockReader;
+  }
+
   @Override
   public ByteBuffer read(long offset, long length) throws IOException {
     return mBlockReader.read(offset, length);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -566,9 +566,16 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
           || (reader instanceof DelegatingBlockReader
           && ((DelegatingBlockReader) reader).getDelegate()
           instanceof UnderFileSystemBlockReader)) {
-        AlluxioURI ufsMountPointUri =
-            ((UnderFileSystemBlockReader) ((DelegatingBlockReader) reader).getDelegate())
-                .getUfsMountPointUri();
+        AlluxioURI ufsMountPointUri;
+        if (reader instanceof DelegatingBlockReader) {
+          ufsMountPointUri =
+              ((UnderFileSystemBlockReader) ((DelegatingBlockReader) reader).getDelegate())
+                  .getUfsMountPointUri();
+        } else {
+          ufsMountPointUri =
+              ((UnderFileSystemBlockReader) reader).getUfsMountPointUri();
+        }
+
         String ufsString = MetricsSystem.escape(ufsMountPointUri);
         MetricKey counterKey = MetricKey.WORKER_BYTES_READ_UFS;
         MetricKey meterKey = MetricKey.WORKER_BYTES_READ_UFS_THROUGHPUT;

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -34,6 +34,7 @@ import alluxio.wire.BlockReadRequest;
 import alluxio.worker.block.BlockWorker;
 import alluxio.worker.block.UnderFileSystemBlockReader;
 import alluxio.worker.block.io.BlockReader;
+import alluxio.worker.block.io.DelegatingBlockReader;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
@@ -561,9 +562,12 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
       }
       BlockReader reader = mWorker.createBlockReader(request);
       context.setBlockReader(reader);
-      if (reader instanceof UnderFileSystemBlockReader) {
+      if (reader instanceof DelegatingBlockReader
+          && ((DelegatingBlockReader) reader).getDelegate()
+          instanceof UnderFileSystemBlockReader) {
         AlluxioURI ufsMountPointUri =
-            ((UnderFileSystemBlockReader) reader).getUfsMountPointUri();
+            ((UnderFileSystemBlockReader) ((DelegatingBlockReader) reader).getDelegate())
+                .getUfsMountPointUri();
         String ufsString = MetricsSystem.escape(ufsMountPointUri);
         MetricKey counterKey = MetricKey.WORKER_BYTES_READ_UFS;
         MetricKey meterKey = MetricKey.WORKER_BYTES_READ_UFS_THROUGHPUT;

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -568,13 +568,10 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
           instanceof UnderFileSystemBlockReader)) {
         AlluxioURI ufsMountPointUri;
         if (reader instanceof DelegatingBlockReader) {
-          ufsMountPointUri =
-              ((UnderFileSystemBlockReader) ((DelegatingBlockReader) reader).getDelegate())
-                  .getUfsMountPointUri();
-        } else {
-          ufsMountPointUri =
-              ((UnderFileSystemBlockReader) reader).getUfsMountPointUri();
+          reader = ((DelegatingBlockReader) reader).getDelegate();
         }
+        ufsMountPointUri =
+            ((UnderFileSystemBlockReader) reader).getUfsMountPointUri();
 
         String ufsString = MetricsSystem.escape(ufsMountPointUri);
         MetricKey counterKey = MetricKey.WORKER_BYTES_READ_UFS;

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -562,9 +562,10 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
       }
       BlockReader reader = mWorker.createBlockReader(request);
       context.setBlockReader(reader);
-      if (reader instanceof DelegatingBlockReader
+      if (reader instanceof UnderFileSystemBlockReader
+          || (reader instanceof DelegatingBlockReader
           && ((DelegatingBlockReader) reader).getDelegate()
-          instanceof UnderFileSystemBlockReader) {
+          instanceof UnderFileSystemBlockReader)) {
         AlluxioURI ufsMountPointUri =
             ((UnderFileSystemBlockReader) ((DelegatingBlockReader) reader).getDelegate())
                 .getUfsMountPointUri();


### PR DESCRIPTION
Because we can not rely on the UnderFileSystemBlockReader type 