### PR TITLE
Fix OOM for object size calculation

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
@@ -20,6 +20,8 @@ import alluxio.master.file.meta.EdgeEntry;
 import alluxio.master.file.meta.Inode;
 import alluxio.master.file.meta.InodeDirectoryView;
 import alluxio.master.file.meta.MutableInode;
+import alluxio.master.file.meta.MutableInodeDirectory;
+import alluxio.master.file.meta.MutableInodeFile;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.master.journal.checkpoint.CheckpointOutputStream;
@@ -32,6 +34,7 @@ import alluxio.proto.meta.InodeMeta;
 import alluxio.util.ObjectSizeCalculator;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -61,7 +64,8 @@ public class HeapInodeStore implements InodeStore {
     super();
     if (ServerConfiguration.getBoolean(PropertyKey.MASTER_METRICS_HEAP_ENABLED)) {
       MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_INODE_HEAP_SIZE.getName(),
-          () -> ObjectSizeCalculator.getObjectSize(this));
+          () -> ObjectSizeCalculator.getObjectSize(mInodes,
+          ImmutableSet.of(Long.class, MutableInodeFile.class, MutableInodeDirectory.class)));
     }
   }
 


### PR DESCRIPTION
Uses a conservative estimate rather than walking the object tree, because that can lead to OOM

Object size estimation is traditionally done by walking the object tree using reflection, but it can pull in very large object with references to many other objects, and quickly grow in size. 

We estimate the object size, and particular collection size by assuming each element of a collection has uniform size. therefore, we do not traverse deep into the object. 