### PR TITLE
[DOCFIX] Improve remote logging doc

### DIFF
--- a/docs/en/operation/Remote-Logging.md
+++ b/docs/en/operation/Remote-Logging.md
@@ -67,7 +67,7 @@ The following lines would need to be added to `conf/alluxio-env.sh` to enable re
 
 ```bash
 ALLUXIO_LOGSERVER_HOSTNAME=AlluxioLogServer
-ALLUXIO_LOGSERVER_PORT=45600
+ALLUXIO_LOGSERVER_PORT="45600"
 ```
 > Note: You MUST set BOTH variables.
 
@@ -154,5 +154,13 @@ configuration:
 log4j.rootLogger=DEBUG, CLIENT_REMOTE_LOGGER
 ```
 
-Again, refer to the documentation for the corresponding framework linked in the previous section
-to locate the log4j configuration file.
+> Note: refer to the documentation for the corresponding framework to locate the log4j configuration file.
+
+## Advanced Setup
+
+### Remote Logging in K8s
+
+Enabling remote logging in K8s is different from that in a physical cluster.
+
+See [Enable Remote Logging in K8s]({{ '/en/deploy/Running-Alluxio-On-Kubernetes.html#enable-remote-logging' | relativize_url }})
+for detailed instructions.


### PR DESCRIPTION
2 changes:
1. Change the port from number to string, as in a K8s configmap the number format will lead to a parsing error, only the string format will work.
2. Add a link to remote logging setup in k8s as that's much different