### PR TITLE
Fix NoClassDefFoundError #13527

### DIFF
--- a/shaded/hadoop/pom.xml
+++ b/shaded/hadoop/pom.xml
@@ -189,6 +189,7 @@
                   <include>com.google.guava:*</include>
                   <include>com.google.protobuf:*</include>
                   <include>com.google.code.findbugs:*</include>
+                  <include>com.google.re2j:*</include>
                   <include>asm:asm</include>
                   <include>io.netty:netty:*</include>
                   <include>io.netty:netty-all:*</include>

--- a/shaded/ozone/pom.xml
+++ b/shaded/ozone/pom.xml
@@ -144,6 +144,7 @@
                   <include>com.google.guava:*</include>
                   <include>com.google.protobuf:*</include>
                   <include>com.google.code.findbugs:*</include>
+                  <include>com.google.re2j:*</include>
                   <include>asm:asm</include>
                   <include>io.netty:netty:*</include>
                   <include>io.netty:netty-all:*</include>


### PR DESCRIPTION
Fix NoClassDefFoundError when dfs.namenode.kerberos.principal.pattern is set #13527
When ufs is kerberosed HDFS and dfs.namenode.kerberos.principal.pattern is set in hdfs-site.xml, the Alluxio couldn't set up IO streams with HDFS. The cause is java.lang.NoClassDefFoundError: alluxio/shaded/hdfs/com/google/re2j/PatternSyntaxException.
Shaded the dependency com.google.re2j in alluxio-shaded-hadoop and alluxio-shaded-ozone modules.