### PR TITLE
Fix failures reading data from HDFS files when HDFS EC is enabled

### DIFF
--- a/shaded/hadoop/pom.xml
+++ b/shaded/hadoop/pom.xml
@@ -161,10 +161,6 @@
                   <shadedPattern>${shading.prefix}.org.apache.curator</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.apache.hadoop.io.erasurecode</pattern>
-                  <shadedPattern>${shading.prefix}.org.apache.hadoop.io.erasurecode</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>org.apache.http</pattern>
                   <shadedPattern>${shading.prefix}.org.apache.http</shadedPattern>
                 </relocation>

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -162,8 +162,8 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
         try {
           Class.forName(HDFS_EC_CODEC_REGISTRY_CLASS);
         } catch (ClassNotFoundException e) {
-          LOG.warn("Cannot initialize HDFS EC CodecRegistry. " +
-              "HDFS EC will not be supported: {}", e.toString());
+          LOG.warn("Cannot initialize HDFS EC CodecRegistry. "
+              + "HDFS EC will not be supported: {}", e.toString());
         }
       }
     } finally {

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -90,6 +90,10 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
   private static final String HDFS_ACTIVESYNC_PROVIDER_CLASS =
       "alluxio.underfs.hdfs.activesync.SupportedHdfsActiveSyncProvider";
 
+  /** Name of the class for the Hdfs EC Codec Registry. **/
+  private static final String HDFS_EC_CODEC_REGISTRY_CLASS =
+      "org.apache.hadoop.io.erasurecode.CodecRegistry";
+
   private final LoadingCache<String, FileSystem> mUserFs;
   private final HdfsAclProvider mHdfsAclProvider;
 
@@ -148,6 +152,9 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
       // Set Hadoop UGI configuration to ensure UGI can be initialized by the shaded classes for
       // group service.
       UserGroupInformation.setConfiguration(hdfsConf);
+      Class.forName(HDFS_EC_CODEC_REGISTRY_CLASS);
+    } catch (ClassNotFoundException e) {
+      LOG.warn("Cannot initialize HDFS EC CodecRegistry. HDFS EC will not be supported.");
     } finally {
       Thread.currentThread().setContextClassLoader(currentClassLoader);
     }


### PR DESCRIPTION
Fix #13532 (Failed to read data from HDFS files when HDFS EC is enabled)

  When alluxio use HDFS client to read EC files, the client will use the ContextClassLoader to initialize CodecRegistry which will load RawErasureCoderFactory. The ClassLoader of HDFS Configuration should be the same with CodecRegistry, otherwise we will get the error java.lang.NoClassDefFoundError: Could not initialize class org.apache.hadoop.io.erasurecode.CodecRegistry.