### PR TITLE
Make worker start timeout configurable

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3212,6 +3212,16 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
+  public static final PropertyKey WORKER_REGISTRY_START_TIMEOUT =
+      new Builder(Name.WORKER_REGISTRY_START_TIMEOUT)
+          .setDefaultValue("1min")
+          .setDescription("Timeout if the worker registry startup takes longer than the "
+              + "specified time. The worker registry contains all worker factory classes "
+              + "that implements alluxio.worker.workerFactory. During the startup, the "
+              + "worker registry will use the worker factories to create worker processes.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.WORKER)
+          .build();
   // The default is set to 11. One client is reserved for some light weight operations such as
   // heartbeat. The other 10 clients are used by commitBlock issued from the worker to the block
   // master.
@@ -5902,6 +5912,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.block.master.client.pool.size";
     public static final String WORKER_PRINCIPAL = "alluxio.worker.principal";
     public static final String WORKER_RAMDISK_SIZE = "alluxio.worker.ramdisk.size";
+    public static final String WORKER_REGISTRY_START_TIMEOUT =
+        "alluxio.worker.registry.start.timeout";
     public static final String WORKER_REVIEWER_PROBABILISTIC_HARDLIMIT_BYTES =
             "alluxio.worker.reviewer.probabilistic.hardlimit.bytes";
     public static final String WORKER_REVIEWER_PROBABILISTIC_SOFTLIMIT_BYTES =

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker;
 
-import alluxio.Constants;
 import alluxio.RuntimeConstants;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -113,11 +113,8 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
           return null;
         });
       }
-      // In the worst case, each worker factory is blocked waiting for the dependent servers to be
-      // registered at worker registry, so the maximum timeout here is set to the multiply of
-      // the number of factories by the default timeout of getting a worker from the registry.
       CommonUtils.invokeAll(callables,
-          (long) callables.size() * Constants.DEFAULT_REGISTRY_GET_TIMEOUT_MS);
+          ServerConfiguration.getMs(PropertyKey.WORKER_REGISTRY_START_TIMEOUT));
 
       // Setup web server
       mWebServer =


### PR DESCRIPTION
Currently the worker start timeout is 1min which is not configurable. The timeout is for worker registry startup which calls all `WorkerFactory` children classes to create corresponding workers. Currently there is only `BlockWorkerFactory` which creates a `BlockWorker`. 

The startup time of a `BlockWorker` involves initializing the tiered storage, which might take longer than 1min if the tiered storage is slow or there are too many blocks. In such cases 1 minute may be too short and cause flakiness or inability to start the worker. 

This change makes the timeout configurable.