### PR TITLE
[DOCFIX] Improve Docker POSIX doc

### DIFF
--- a/docs/en/deploy/Running-Alluxio-On-Docker.md
+++ b/docs/en/deploy/Running-Alluxio-On-Docker.md
@@ -466,7 +466,7 @@ For example, the following commands run the alluxio-fuse container as a long-run
 
 Run the Alluxio FUSE service to create a FUSE mount in the host bind-mounted directory:
 ```console
-$ docker run --rm \
+$ docker run -d --rm \
     --net=host \
     --name=alluxio-fuse \
     -v /tmp/mnt:/mnt:rshared \


### PR DESCRIPTION
When enabling POSIX API using docker, launching the container in background would be more user friendly, so that they don't have to use a new tab/window.