### PR TITLE
Log when it is a file

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -879,7 +879,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
           ensureFullPathAndUpdateCache(inodePath);
 
           FileInfo fileInfo = getFileInfoInternal(inodePath);
-          if (!fileInfo.isCompleted()) {
+          if (!fileInfo.isFolder() && (!fileInfo.isCompleted())) {
             LOG.warn("File {} is not yet completed. getStatus will see incomplete metadata.",
                 fileInfo.getPath());
           }


### PR DESCRIPTION
When we get status for an incomplete file, we should produce a logging message. 
Currently, we do not check if it is a file. 

