### PR TITLE
Fix monitor process when passing Java Opts for Remote debugging 

### DIFF
--- a/bin/alluxio-monitor.sh
+++ b/bin/alluxio-monitor.sh
@@ -52,7 +52,8 @@ get_env() {
   CLASSPATH=${ALLUXIO_CLIENT_CLASSPATH}
   ALLUXIO_TASK_LOG="${ALLUXIO_LOGS_DIR}/task.log"
 
-  # Remove the remote debug configuration to avoid the error: "transport error 20: bind failed: Address already in use."
+  # Remove the remote debug configuration to avoid the error: "transport error 20: bind failed: Address already in use." 
+  # See https://github.com/Alluxio/alluxio/issues/10958
   ALLUXIO_MASTER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_MASTER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')
   ALLUXIO_WORKER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_WORKER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')
   ALLUXIO_JOB_MASTER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_JOB_MASTER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')

--- a/bin/alluxio-monitor.sh
+++ b/bin/alluxio-monitor.sh
@@ -51,6 +51,12 @@ get_env() {
   . ${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh
   CLASSPATH=${ALLUXIO_CLIENT_CLASSPATH}
   ALLUXIO_TASK_LOG="${ALLUXIO_LOGS_DIR}/task.log"
+
+  # Remove the remote debug configuration to avoid the error: "transport error 20: bind failed: Address already in use."
+  ALLUXIO_MASTER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_MASTER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')
+  ALLUXIO_WORKER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_WORKER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')
+  ALLUXIO_JOB_MASTER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_JOB_MASTER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')
+  ALLUXIO_JOB_WORKER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_JOB_WORKER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')
 }
 
 prepare_monitor() {
@@ -83,22 +89,23 @@ run_monitor() {
   local node_type=$1
   local mode=$2
   local alluxio_config="${ALLUXIO_JAVA_OPTS}"
+
   case "${node_type}" in
     master)
       monitor_exec=alluxio.master.AlluxioMasterMonitor
-      alluxio_config="${alluxio_config} ${ALLUXIO_MASTER_JAVA_OPTS}"
+      alluxio_config="${alluxio_config} ${ALLUXIO_MASTER_MONITOR_JAVA_OPTS}"
       ;;
     worker)
       monitor_exec=alluxio.worker.AlluxioWorkerMonitor
-      alluxio_config="${alluxio_config} ${ALLUXIO_WORKER_JAVA_OPTS}"
+      alluxio_config="${alluxio_config} ${ALLUXIO_WORKER_MONITOR_JAVA_OPTS}"
       ;;
     job_master)
       monitor_exec=alluxio.master.job.AlluxioJobMasterMonitor
-      alluxio_config="${alluxio_config} ${ALLUXIO_JOB_MASTER_JAVA_OPTS}"
+      alluxio_config="${alluxio_config} ${ALLUXIO_JOB_MASTER_MONITOR_JAVA_OPTS}"
       ;;
     job_worker)
       monitor_exec=alluxio.worker.job.AlluxioJobWorkerMonitor
-      alluxio_config="${alluxio_config} ${ALLUXIO_JOB_WORKER_JAVA_OPTS}"
+      alluxio_config="${alluxio_config} ${ALLUXIO_JOB_WORKER_MONITOR_JAVA_OPTS}"
       ;;
     proxy)
       monitor_exec=alluxio.proxy.AlluxioProxyMonitor


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the remote debug error info as follows:
<img width="1222" alt="截屏2021-06-06 下午3 53 59" src="https://user-images.githubusercontent.com/4209464/120924651-2dadde80-c707-11eb-9ae3-1eb350831db0.png">

### Why are the changes needed?
resolve #10958

The reason for this issue is that the same remote debug parameters are specified when AlluxioMasterMonitor is started after AlluxioMaster starts.

Similarly, other processes also have the same problem, such as AlluxioWorker, AlluxioJobMaster, and AlluxioJobWorker.

In fact, all monitor processes, such as AlluxioMasterMonitor, AlluxioWorkerMonitor, etc., are run once. So no remote debug parameters are required for them.
### Does this PR introduce _any_ user-facing change?

Nothing.
