### PR TITLE
Support bypassing by partitions

### DIFF
--- a/docs/en/core-services/Catalog.md
+++ b/docs/en/core-services/Catalog.md
@@ -102,17 +102,28 @@ $ ${ALLUXIO_HOME}/bin/alluxio table attachdb --db alluxio_db hive \
     thrift://metastore_host:9083 default
 ```
 
-If you want specify config file for the UDB, please add `attachdb` option `-o catalog.db.config.file`.
-Each time you want to affect the config file, you can use `alluxio table sync`.
+If you want to specify a config file for the UDB, please append an option `-o catalog.db.config.file` to
+`attachdb` command.
+After each time you made changes to the config file, you can use `alluxio table sync` to apply the changes.
 
-If you want to write a configuration file for the UDB, please configure it like the following given example.
-It must contain an array `bypassSet`, the comma-separated table names will be bypassed.
+The configuration file is in JSON format, and can contain these configurations:
 
-```json
-{
-  "bypassSet" : ["table1", "table2"]
-}
-```
+1. Tables and partitions bypassing specification:
+
+    ```json
+    {
+      "bypass": {
+        "tables": [
+          "table1",
+          {"table": "table2", "partitions": ["table2_part1", "table2_part2"]}
+        ]
+      }
+    }
+    ```
+
+    You can specify which tables and partitions within these tables should be bypassed from Alluxio.
+    By specifying only the table name, all partitions of that table, if any, will be bypassed. Otherwise, 
+    you can specify specific partitions to bypass.
 
 > **Note:** When databases are attached, all tables are synced from the configured UDB.
 If out-of-band updates occur to the database or table and the user wants query results to reflect

--- a/docs/en/core-services/Catalog.md
+++ b/docs/en/core-services/Catalog.md
@@ -102,13 +102,20 @@ $ ${ALLUXIO_HOME}/bin/alluxio table attachdb --db alluxio_db hive \
     thrift://metastore_host:9083 default
 ```
 
-If you want to specify a config file for the UDB, please append an option `-o catalog.db.config.file` to
+#### UDB Configuration File
+
+To specify a configuration file for the UDB, append an option `-o catalog.db.config.file` to
 `attachdb` command.
-After each time you made changes to the config file, you can use `alluxio table sync` to apply the changes.
+Each time the configuration file is changed, you can use `alluxio table sync` to apply the changes.
 
 The configuration file is in JSON format, and can contain these configurations:
 
 1. Tables and partitions bypassing specification:
+
+    You can specify some tables and partitions to be bypassed from Alluxio, so that they will not be
+    cached in Alluxio, instead clients will be directed to access them directly from the UDB. 
+    This can be helpful when some tables and partitions are large, and accommodating them in the cache
+    is undesirable.
 
     ```json
     {

--- a/docs/en/core-services/Catalog.md
+++ b/docs/en/core-services/Catalog.md
@@ -115,7 +115,7 @@ The configuration file is in JSON format, and can contain these configurations:
     You can specify some tables and partitions to be bypassed from Alluxio, so that they will not be
     cached in Alluxio, instead clients will be directed to access them directly from the UDB. 
     This can be helpful when some tables and partitions are large, and accommodating them in the cache
-    is undesirable.
+    is undesirable. An example configuration is like the following:
 
     ```json
     {
@@ -129,8 +129,11 @@ The configuration file is in JSON format, and can contain these configurations:
     ```
 
     You can specify which tables and partitions within these tables should be bypassed from Alluxio.
-    By specifying only the table name, all partitions of that table, if any, will be bypassed. Otherwise, 
-    you can specify specific partitions to bypass.
+    By specifying only the table name, all partitions of that table, if any, will be bypassed. 
+    Otherwise, you can specify specific partitions to bypass.
+    
+    In the example above, table 1 is fully bypassed. Partition 1 and 2 of table 2 are bypassed, 
+    and any other partitions, if any, are not.
 
 > **Note:** When databases are attached, all tables are synced from the configured UDB.
 If out-of-band updates occur to the database or table and the user wants query results to reflect

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -1436,7 +1436,7 @@ Here are the additional properties possible for the `-o` options:
   * `catalog.db.config.file`: the config file for the UDB, 
     you can configure which tables and partitions to bypass from Alluxio in a configuration specified 
     by this option. 
-    See [UDB Configuration File]({{ '/en/core-services/Catalog.md#udb-configuration-file' | relativize_url }}) 
+    See [UDB Configuration File]({{ '/en/core-services/Catalog.html#udb-configuration-file' | relativize_url }}) 
     for details.
   * `catalog.db.ignore.udb.tables`: comma-separated list of table names to ignore from the UDB
   * `catalog.db.sync.threads`: number of parallel threads to use to sync with the UDB. If too large,

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -1433,7 +1433,8 @@ Here are the additional properties possible for the `-o` options:
     * `<UDB_TYPE>`: the UDB type
     * `<UFS_PREFIX>`: the UFS path prefix, or a regex string starts with `regex:` that the mount properties are for
     * `<MOUNT_PROPERTY>`: an Alluxio mount property
-  * `catalog.db.config.file`: the config file for the UDB, you can specify bypass table by this option.
+  * `catalog.db.config.file`: the config file for the UDB, 
+    you can configure which tables and partitions should be bypassed from Alluxio by this option.
   * `catalog.db.ignore.udb.tables`: comma-separated list of table names to ignore from the UDB
   * `catalog.db.sync.threads`: number of parallel threads to use to sync with the UDB. If too large,
   the sync may overload the UDB, and if set too low, syncing a database with many tables make take

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -1434,7 +1434,10 @@ Here are the additional properties possible for the `-o` options:
     * `<UFS_PREFIX>`: the UFS path prefix, or a regex string starts with `regex:` that the mount properties are for
     * `<MOUNT_PROPERTY>`: an Alluxio mount property
   * `catalog.db.config.file`: the config file for the UDB, 
-    you can configure which tables and partitions should be bypassed from Alluxio by this option.
+    you can configure which tables and partitions to bypass from Alluxio in a configuration specified 
+    by this option. 
+    See [UDB Configuration File]({{ /en/core-services/Catalog.md#udb-configuration-file | relativize_url }}) 
+    for details.
   * `catalog.db.ignore.udb.tables`: comma-separated list of table names to ignore from the UDB
   * `catalog.db.sync.threads`: number of parallel threads to use to sync with the UDB. If too large,
   the sync may overload the UDB, and if set too low, syncing a database with many tables make take

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -1436,7 +1436,7 @@ Here are the additional properties possible for the `-o` options:
   * `catalog.db.config.file`: the config file for the UDB, 
     you can configure which tables and partitions to bypass from Alluxio in a configuration specified 
     by this option. 
-    See [UDB Configuration File]({{ /en/core-services/Catalog.md#udb-configuration-file | relativize_url }}) 
+    See [UDB Configuration File]({{ '/en/core-services/Catalog.md#udb-configuration-file' | relativize_url }}) 
     for details.
   * `catalog.db.ignore.udb.tables`: comma-separated list of table names to ignore from the UDB
   * `catalog.db.sync.threads`: number of parallel threads to use to sync with the UDB. If too large,

--- a/table/server/common/src/main/java/alluxio/table/common/udb/UdbBypassSpec.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/UdbBypassSpec.java
@@ -18,6 +18,11 @@ import java.util.Set;
  * Tables and partitions bypassing specification.
  */
 public final class UdbBypassSpec {
+  /**
+   * Map of table name to set of partition names.
+   * Keyed by a table's name, the value set contains names of partitions in that table.
+   * An empty set indicates all partitions of that table, if any, should be bypassed.
+   */
   private final Map<String, Set<String>> mTablePartMap;
 
   /**
@@ -32,9 +37,9 @@ public final class UdbBypassSpec {
    *
    * @param tableName the table name
    * @return true if the table is configured to be bypassed, false otherwise
-   * @see UdbBypassSpec#isFullyBypassedTable(String)
+   * @see UdbBypassSpec#hasFullTable(String)
    */
-  public boolean isBypassedTable(String tableName) {
+  public boolean hasTable(String tableName) {
     return mTablePartMap.containsKey(tableName);
   }
 
@@ -43,11 +48,11 @@ public final class UdbBypassSpec {
    *
    * @param tableName the table name
    * @return true if the table is configured to be fully bypassed, false otherwise
-   * @see UdbBypassSpec#isBypassedTable(String)
+   * @see UdbBypassSpec#hasTable(String)
    */
-  public boolean isFullyBypassedTable(String tableName) {
+  public boolean hasFullTable(String tableName) {
     // empty set indicates all partitions should be bypassed
-    return isBypassedTable(tableName) && mTablePartMap.get(tableName).size() == 0;
+    return hasTable(tableName) && mTablePartMap.get(tableName).size() == 0;
   }
 
   /**
@@ -57,17 +62,15 @@ public final class UdbBypassSpec {
    * @param partitionName the partition name
    * @return true if the partition should be bypassed, false otherwise
    */
-  public boolean isBypassedPartition(String tableName, String partitionName) {
-    if (!isBypassedTable(tableName)) {
+  public boolean hasPartition(String tableName, String partitionName) {
+    if (!hasTable(tableName)) {
       return false;
     }
-
     Set<String> parts = mTablePartMap.get(tableName);
     if (parts.size() == 0) {
       // empty set indicates all partitions should be bypassed
       return true;
     }
-
     return parts.contains(partitionName);
   }
 }

--- a/table/server/common/src/main/java/alluxio/table/common/udb/UdbBypassSpec.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/UdbBypassSpec.java
@@ -42,12 +42,12 @@ public final class UdbBypassSpec {
    * Checks if all partitions of a table should be bypassed.
    *
    * @param tableName the table name
-   * @return true if the table is configured to be bypassed, false otherwise
+   * @return true if the table is configured to be fully bypassed, false otherwise
    * @see UdbBypassSpec#isBypassedTable(String)
    */
   public boolean isFullyBypassedTable(String tableName) {
     // empty set indicates all partitions should be bypassed
-    return mTablePartMap.containsKey(tableName) && mTablePartMap.get(tableName).size() == 0;
+    return isBypassedTable(tableName) && mTablePartMap.get(tableName).size() == 0;
   }
 
   /**
@@ -60,14 +60,14 @@ public final class UdbBypassSpec {
   public boolean isBypassedPartition(String tableName, String partitionName) {
     if (!isBypassedTable(tableName)) {
       return false;
-    } else {
-      Set<String> parts = mTablePartMap.get(tableName);
-      if (parts.size() == 0) {
-        // empty set indicates all partitions should be bypassed
-        return true;
-      } else {
-        return parts.contains(partitionName);
-      }
     }
+
+    Set<String> parts = mTablePartMap.get(tableName);
+    if (parts.size() == 0) {
+      // empty set indicates all partitions should be bypassed
+      return true;
+    }
+
+    return parts.contains(partitionName);
   }
 }

--- a/table/server/common/src/main/java/alluxio/table/common/udb/UdbBypassSpec.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/UdbBypassSpec.java
@@ -1,0 +1,73 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.table.common.udb;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tables and partitions bypassing specification.
+ */
+public final class UdbBypassSpec {
+  private final Map<String, Set<String>> mTablePartMap;
+
+  /**
+   * @param tablePartMap table to partition map
+   */
+  public UdbBypassSpec(Map<String, Set<String>> tablePartMap) {
+    mTablePartMap = tablePartMap;
+  }
+
+  /**
+   * Checks if a table should be bypassed.
+   *
+   * @param tableName the table name
+   * @return true if the table is configured to be bypassed, false otherwise
+   * @see UdbBypassSpec#isFullyBypassedTable(String)
+   */
+  public boolean isBypassedTable(String tableName) {
+    return mTablePartMap.containsKey(tableName);
+  }
+
+  /**
+   * Checks if all partitions of a table should be bypassed.
+   *
+   * @param tableName the table name
+   * @return true if the table is configured to be bypassed, false otherwise
+   * @see UdbBypassSpec#isBypassedTable(String)
+   */
+  public boolean isFullyBypassedTable(String tableName) {
+    // empty set indicates all partitions should be bypassed
+    return mTablePartMap.containsKey(tableName) && mTablePartMap.get(tableName).size() == 0;
+  }
+
+  /**
+   * Checks by a partition's name if it should be bypassed.
+   *
+   * @param tableName the table name
+   * @param partitionName the partition name
+   * @return true if the partition should be bypassed, false otherwise
+   */
+  public boolean isBypassedPartition(String tableName, String partitionName) {
+    if (!isBypassedTable(tableName)) {
+      return false;
+    } else {
+      Set<String> parts = mTablePartMap.get(tableName);
+      if (parts.size() == 0) {
+        // empty set indicates all partitions should be bypassed
+        return true;
+      } else {
+        return parts.contains(partitionName);
+      }
+    }
+  }
+}

--- a/table/server/common/src/main/java/alluxio/table/common/udb/UnderDatabase.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/UnderDatabase.java
@@ -38,10 +38,10 @@ public interface UnderDatabase {
 
   /**
    * @param tableName the table name
-   * @param bypass whether bypass this table
+   * @param bypassSpec table and partition bypass specification
    * @return the {@link UdbTable} for the specified table name
    */
-  UdbTable getTable(String tableName, boolean bypass) throws IOException;
+  UdbTable getTable(String tableName, UdbBypassSpec bypassSpec) throws IOException;
 
   /**
    * @return the {@link UdbContext}

--- a/table/server/common/src/test/java/alluxio/table/common/udb/UdbBypassSpecTest.java
+++ b/table/server/common/src/test/java/alluxio/table/common/udb/UdbBypassSpecTest.java
@@ -1,0 +1,54 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.table.common.udb;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+public class UdbBypassSpecTest {
+  @Test
+  public void tableAndPartitionNames() {
+    UdbBypassSpec spec = new UdbBypassSpec(
+        ImmutableMap.of("table1", ImmutableSet.of("part1", "part2")));
+    assertTrue(spec.hasTable("table1"));
+    assertFalse(spec.hasFullTable("table1"));
+    assertTrue(spec.hasPartition("table1", "part1"));
+    assertTrue(spec.hasPartition("table1", "part2"));
+    assertFalse(spec.hasPartition("table1", "part3"));
+  }
+
+  @Test
+  public void tableNamesOnly() {
+    UdbBypassSpec spec = new UdbBypassSpec(
+        ImmutableMap.of("table2", ImmutableSet.of()));
+    assertTrue(spec.hasTable("table2"));
+    assertTrue(spec.hasFullTable("table2"));
+    assertTrue(spec.hasPartition("table2", "part1"));
+    assertTrue(spec.hasPartition("table2", "part2"));
+    assertTrue(spec.hasPartition("table2", "part3"));
+  }
+
+  @Test
+  public void nonExistentTable() {
+    UdbBypassSpec spec = new UdbBypassSpec(
+        ImmutableMap.of("table3", ImmutableSet.of()));
+    assertFalse(spec.hasTable("table4"));
+    assertFalse(spec.hasFullTable("table4"));
+    assertFalse(spec.hasPartition("table4", "part1"));
+    assertFalse(spec.hasPartition("table4", "part2"));
+    assertFalse(spec.hasPartition("table4", "part3"));
+  }
+}

--- a/table/server/master/src/main/java/alluxio/master/table/Database.java
+++ b/table/server/master/src/main/java/alluxio/master/table/Database.java
@@ -215,8 +215,9 @@ public class Database implements Journaled {
       try {
         mDbConfig = mapper.readValue(new File(mConfigPath), DbConfig.class);
       } catch (JsonProcessingException e) {
-        LOG.warn(String.format("Failed to deserialize UDB config file %s, stays unsynced: {}",
-            mConfigPath), e.toString());
+        LOG.error("Failed to deserialize UDB config file {}, stays unsynced",
+            mConfigPath, e);
+        throw e;
       }
     }
     DatabaseInfo newDbInfo = mUdb.getDatabaseInfo();

--- a/table/server/master/src/main/java/alluxio/master/table/Database.java
+++ b/table/server/master/src/main/java/alluxio/master/table/Database.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -210,13 +211,15 @@ public class Database implements Journaled {
     // Synchronization is necessary if accessed concurrently from multiple threads
     SyncStatus.Builder builder = SyncStatus.newBuilder();
 
-    if (Files.exists(Paths.get(mConfigPath))) {
+    if (!mConfigPath.equals(CatalogProperty.DB_CONFIG_FILE.getDefaultValue())) {
+      if (!Files.exists(Paths.get(mConfigPath))) {
+        throw new FileNotFoundException(mConfigPath);
+      }
       ObjectMapper mapper = new ObjectMapper();
       try {
         mDbConfig = mapper.readValue(new File(mConfigPath), DbConfig.class);
       } catch (JsonProcessingException e) {
-        LOG.error("Failed to deserialize UDB config file {}, stays unsynced",
-            mConfigPath, e);
+        LOG.error("Failed to deserialize UDB config file {}, stays unsynced", mConfigPath, e);
         throw e;
       }
     }

--- a/table/server/master/src/main/java/alluxio/master/table/Database.java
+++ b/table/server/master/src/main/java/alluxio/master/table/Database.java
@@ -30,6 +30,7 @@ import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Sets;
@@ -211,7 +212,12 @@ public class Database implements Journaled {
 
     if (Files.exists(Paths.get(mConfigPath))) {
       ObjectMapper mapper = new ObjectMapper();
-      mDbConfig = mapper.readValue(new File(mConfigPath), DbConfig.class);
+      try {
+        mDbConfig = mapper.readValue(new File(mConfigPath), DbConfig.class);
+      } catch (JsonProcessingException e) {
+        LOG.error(String.format("failed to deserialize UDB config file %s, stays unsynced",
+            mConfigPath), e);
+      }
     }
     DatabaseInfo newDbInfo = mUdb.getDatabaseInfo();
     if (!newDbInfo.equals(mDatabaseInfo)) {

--- a/table/server/master/src/main/java/alluxio/master/table/Database.java
+++ b/table/server/master/src/main/java/alluxio/master/table/Database.java
@@ -215,8 +215,8 @@ public class Database implements Journaled {
       try {
         mDbConfig = mapper.readValue(new File(mConfigPath), DbConfig.class);
       } catch (JsonProcessingException e) {
-        LOG.error(String.format("failed to deserialize UDB config file %s, stays unsynced",
-            mConfigPath), e);
+        LOG.warn(String.format("Failed to deserialize UDB config file %s, stays unsynced: {}",
+            mConfigPath), e.toString());
       }
     }
     DatabaseInfo newDbInfo = mUdb.getDatabaseInfo();

--- a/table/server/master/src/main/java/alluxio/master/table/DbConfig.java
+++ b/table/server/master/src/main/java/alluxio/master/table/DbConfig.java
@@ -27,27 +27,26 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Preconditions;
 
 import java.io.IOException;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
  * The Alluxio db config information.
  */
 public final class DbConfig {
-  private BypassEntry mBypassEntry;
+  private final BypassEntry mBypassEntry;
 
   /**
    * @param bypassEntry bypass entry
    */
   @JsonCreator
   public DbConfig(@JsonProperty("bypass") @Nullable BypassEntry bypassEntry) {
-    mBypassEntry = bypassEntry == null ? new BypassEntry(new HashSet<>()) : bypassEntry;
+    mBypassEntry = bypassEntry == null ? new BypassEntry(Collections.emptySet()) : bypassEntry;
   }
 
   /**
@@ -56,7 +55,7 @@ public final class DbConfig {
    * @return an empty config instance
    */
   public static DbConfig empty() {
-    return new DbConfig(new BypassEntry(new HashSet<>()));
+    return new DbConfig(new BypassEntry(Collections.emptySet()));
   }
 
   /**
@@ -64,13 +63,6 @@ public final class DbConfig {
    */
   public BypassEntry getBypassEntry() {
     return mBypassEntry;
-  }
-
-  /**
-   * @param bypassEntry bypass entry
-   */
-  public void setBypassEntry(@Nonnull BypassEntry bypassEntry) {
-    mBypassEntry = bypassEntry;
   }
 
   /**
@@ -92,7 +84,7 @@ public final class DbConfig {
      */
     @JsonCreator
     public BypassEntry(@JsonProperty("tables") @Nullable Set<BypassTableEntry> entries) {
-      mEntries = entries == null ? new HashSet<>() : entries;
+      mEntries = entries == null ? Collections.emptySet() : entries;
     }
 
     /**
@@ -196,7 +188,7 @@ public final class DbConfig {
       } else if (node.isTextual()) {
         // single table name, all partitions are bypassed
         tableName = node.asText();
-        partitions = new HashSet<>();
+        partitions = Collections.emptySet();
       } else {
         // a {"table": "table", "partitions": ["part1", "part2"]} object
         if (!node.hasNonNull("table")) {
@@ -206,7 +198,7 @@ public final class DbConfig {
         JsonNode partitionsList = node.get("partitions");
         partitions = mapper.convertValue(partitionsList,  new TypeReference<Set<String>>() {});
         if (partitions == null) {
-          partitions = new HashSet<>();
+          partitions = Collections.emptySet();
         }
       }
       return new BypassTableEntry(tableName, partitions);

--- a/table/server/master/src/main/java/alluxio/master/table/DbConfig.java
+++ b/table/server/master/src/main/java/alluxio/master/table/DbConfig.java
@@ -191,11 +191,13 @@ public final class DbConfig {
       JsonNode node = mapper.readTree(jp);
       String tableName;
       Set<String> partitions;
-      if (node.isTextual()) {
+      if (!node.isTextual() && !node.isObject()) {
+        throw new JsonParseException(mapper.treeAsTokens(node), "invalid syntax");
+      } else if (node.isTextual()) {
         // single table name, all partitions are bypassed
         tableName = node.asText();
         partitions = new HashSet<>();
-      } else if (node.isObject()) {
+      } else {
         // a {"table": "table", "partitions": ["part1", "part2"]} object
         if (!node.hasNonNull("table")) {
           throw new JsonParseException(mapper.treeAsTokens(node), "missing table name");
@@ -206,8 +208,6 @@ public final class DbConfig {
         if (partitions == null) {
           partitions = new HashSet<>();
         }
-      } else {
-        throw new JsonParseException(mapper.treeAsTokens(node), "invalid syntax");
       }
       return new BypassTableEntry(tableName, partitions);
     }

--- a/table/server/master/src/main/java/alluxio/master/table/DbConfig.java
+++ b/table/server/master/src/main/java/alluxio/master/table/DbConfig.java
@@ -11,25 +11,198 @@
 
 package alluxio.master.table;
 
+import alluxio.table.common.udb.UdbBypassSpec;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.Preconditions;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * The Alluxio db config information.
  */
 public final class DbConfig {
-  private Set<String> mBypassSet;
+  private BypassEntry mBypassEntry;
 
   /**
-   * @param bypassSet the bypass set
+   * @param bypassEntry bypass entry
    */
-  public void setBypassSet(Set<String> bypassSet) {
-    mBypassSet = bypassSet;
+  @JsonCreator
+  public DbConfig(@JsonProperty("bypass") @Nullable BypassEntry bypassEntry) {
+    mBypassEntry = bypassEntry == null ? new BypassEntry(new HashSet<>()) : bypassEntry;
   }
 
   /**
-   * @return the bypass set
+   * Returns an empty configuration.
+   *
+   * @return an empty config instance
    */
-  public Set<String> getBypassSet() {
-    return mBypassSet;
+  public static DbConfig empty() {
+    return new DbConfig(new BypassEntry(new HashSet<>()));
+  }
+
+  /**
+   * @return the {@link BypassEntry} from config file
+   */
+  public BypassEntry getBypassEntry() {
+    return mBypassEntry;
+  }
+
+  /**
+   * @param bypassEntry bypass entry
+   */
+  public void setBypassEntry(@Nonnull BypassEntry bypassEntry) {
+    mBypassEntry = bypassEntry;
+  }
+
+  /**
+   * @return the {@link UdbBypassSpec} object
+   */
+  public UdbBypassSpec getUdbBypassSpec() {
+    return mBypassEntry.toUdbBypassSpec();
+  }
+
+  /**
+   * Bypass configuration entry from config file.
+   */
+  public static final class BypassEntry {
+    @JsonProperty("tables")
+    private final Set<BypassTableEntry> mEntries;
+
+    /**
+     * @param entries set of {@link BypassTableEntry}s
+     */
+    @JsonCreator
+    public BypassEntry(@JsonProperty("tables") @Nullable Set<BypassTableEntry> entries) {
+      mEntries = entries == null ? new HashSet<>() : entries;
+    }
+
+    /**
+     * Converts to a {@link UdbBypassSpec} object.
+     *
+     * @return the {@link UdbBypassSpec} object
+     */
+    public UdbBypassSpec toUdbBypassSpec() {
+      Map<String, Set<String>> map = mEntries.stream().collect(
+          Collectors.toMap(BypassTableEntry::getTable, BypassTableEntry::getPartitions));
+      return new UdbBypassSpec(map);
+    }
+
+    /**
+     * @return tables bypassed
+     */
+    public Set<String> getBypassedTables() {
+      return mEntries.stream().map(BypassTableEntry::getTable).collect(Collectors.toSet());
+    }
+  }
+
+  /**
+   * Table to partitions mapping.
+   */
+  @JsonDeserialize(using = BypassTableEntryDeserializer.class)
+  public static class BypassTableEntry {
+    private final String mTableName;
+    private final Set<String> mPartitions;
+
+    /**
+     * @param tableName table name
+     * @param partitions partition names
+     */
+    @JsonCreator
+    public BypassTableEntry(@JsonProperty("table") String tableName,
+                            @JsonProperty("partitions") Set<String> partitions) {
+      Preconditions.checkArgument(!tableName.isEmpty(), "empty table name");
+      mTableName = tableName;
+      mPartitions = partitions;
+    }
+
+    /**
+     * @return table name
+     */
+    public String getTable() {
+      return mTableName;
+    }
+
+    /**
+     * @return partition names
+     */
+    public Set<String> getPartitions() {
+      return mPartitions;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      } else if (other == null) {
+        return false;
+      } else if (getClass() != other.getClass()) {
+        return false;
+      }
+      BypassTableEntry entry = (BypassTableEntry) other;
+      return Objects.equals(mTableName, entry.mTableName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(mTableName);
+    }
+  }
+
+  /**
+   * Deserializer of BypassTableEntry
+   *
+   * Enables flexible syntax: either a single table name can be specified, and all belonging
+   * partitions will be bypassed;
+   * or an object of form
+   * {"table": "tableName", "partitions": ["part1", "part2"]}
+   * can be used, and individual partitions can be specified.
+   */
+  public static class BypassTableEntryDeserializer extends JsonDeserializer<BypassTableEntry> {
+    @Override
+    public BypassTableEntry deserialize(JsonParser jp, DeserializationContext cxt)
+        throws IOException, JsonProcessingException {
+      ObjectMapper mapper = (ObjectMapper) jp.getCodec();
+      JsonNode node = mapper.readTree(jp);
+      String tableName;
+      Set<String> partitions;
+      if (node.isTextual()) {
+        // single table name, all partitions are bypassed
+        tableName = node.asText();
+        partitions = new HashSet<>();
+      } else if (node.isObject()) {
+        // a {"table": "table", "partitions": ["part1", "part2"]} object
+        if (!node.hasNonNull("table")) {
+          throw new JsonParseException(mapper.treeAsTokens(node), "missing table name");
+        }
+        tableName = node.get("table").asText();
+        JsonNode partitionsList = node.get("partitions");
+        partitions = mapper.convertValue(partitionsList,  new TypeReference<Set<String>>() {});
+        if (partitions == null) {
+          partitions = new HashSet<>();
+        }
+      } else {
+        throw new JsonParseException(mapper.treeAsTokens(node), "invalid syntax");
+      }
+      return new BypassTableEntry(tableName, partitions);
+    }
   }
 }

--- a/table/server/master/src/main/java/alluxio/master/table/DbConfig.java
+++ b/table/server/master/src/main/java/alluxio/master/table/DbConfig.java
@@ -112,6 +112,13 @@ public final class DbConfig {
     public Set<String> getBypassedTables() {
       return mEntries.stream().map(BypassTableEntry::getTable).collect(Collectors.toSet());
     }
+
+    /**
+     * @return {@link BypassTableEntry}s
+     */
+    public Set<BypassTableEntry> getBypassTableEntries() {
+      return mEntries;
+    }
   }
 
   /**

--- a/table/server/master/src/test/java/alluxio/master/table/DbConfigTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/DbConfigTest.java
@@ -44,7 +44,7 @@ public class DbConfigTest {
     );
     for (String input : src) {
       DbConfig config = mMapper.readValue(input, DbConfig.class);
-      assertEquals(config.getBypassEntry().getBypassedTables().size(), 0);
+      assertEquals(0, config.getBypassEntry().getBypassedTables().size());
     }
   }
 
@@ -52,7 +52,7 @@ public class DbConfigTest {
   public void tableNamesOnly() throws Exception {
     DbConfig config = mMapper.readValue(
         "{\"bypass\": {\"tables\": [\"table1\", \"table2\"]}}", DbConfig.class);
-    assertEquals(config.getBypassEntry().getBypassedTables(), ImmutableSet.of("table1", "table2"));
+    assertEquals(ImmutableSet.of("table1", "table2"), config.getBypassEntry().getBypassedTables());
   }
 
   @Test

--- a/table/server/master/src/test/java/alluxio/master/table/DbConfigTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/DbConfigTest.java
@@ -97,7 +97,7 @@ public class DbConfigTest {
         mMapper.readValue("{\"tables\": [\"table1\"]}", DbConfig.BypassEntry.class);
     assertEquals(ImmutableSet.of("table1"), entry.getBypassedTables());
     UdbBypassSpec spec = entry.toUdbBypassSpec();
-    assertTrue(spec.isBypassedTable("table1"));
+    assertTrue(spec.hasTable("table1"));
   }
 
   /* DbConfig tests */

--- a/table/server/master/src/test/java/alluxio/master/table/DbConfigTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/DbConfigTest.java
@@ -1,0 +1,88 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.table;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import alluxio.table.common.udb.UdbBypassSpec;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+
+public class DbConfigTest {
+  private ObjectMapper mMapper;
+
+  @Before
+  public void before() {
+    mMapper = new ObjectMapper();
+  }
+
+  @Test
+  public void empty() throws Exception {
+    List<String> src = ImmutableList.of(
+        "{}",
+        "{\"bypass\": null}",
+        "{\"bypass\": {}}",
+        "{\"bypass\": {\"tables\": []}}"
+    );
+    for (String input : src) {
+      DbConfig config = mMapper.readValue(input, DbConfig.class);
+      assertEquals(config.getBypassEntry().getBypassedTables().size(), 0);
+    }
+  }
+
+  @Test
+  public void tableNamesOnly() throws Exception {
+    DbConfig config = mMapper.readValue(
+        "{\"bypass\": {\"tables\": [\"table1\", \"table2\"]}}", DbConfig.class);
+    assertEquals(config.getBypassEntry().getBypassedTables(), ImmutableSet.of("table1", "table2"));
+  }
+
+  @Test
+  public void tableNamesAndPartitions() throws Exception {
+    DbConfig config = mMapper.readValue(
+        "{\"bypass\": {\"tables\": [\"table1\", {\"table\": \"table2\", "
+        + "\"partitions\": [\"t2p1\", \"t2p2\"]}]}}",
+        DbConfig.class
+    );
+    UdbBypassSpec spec = config.getUdbBypassSpec();
+    assertTrue(spec.isBypassedTable("table1"));
+    assertTrue(spec.isFullyBypassedTable("table1"));
+
+    assertTrue(spec.isBypassedTable("table2"));
+    assertFalse(spec.isFullyBypassedTable("table2"));
+
+    assertTrue(spec.isBypassedPartition("table1", "t1p1"));
+    assertTrue(spec.isBypassedPartition("table1", "t1p2"));
+
+    assertTrue(spec.isBypassedPartition("table2", "t2p1"));
+    assertTrue(spec.isBypassedPartition("table2", "t2p2"));
+    assertFalse(spec.isBypassedPartition("table2", "t2p3"));
+  }
+
+  @Test
+  public void missingPartitions() throws Exception {
+    DbConfig config = mMapper.readValue(
+        "{\"bypass\": {\"tables\": [{\"table\": \"table1\"}]}}",
+        DbConfig.class
+    );
+    assertTrue(config.getUdbBypassSpec().isFullyBypassedTable("table1"));
+  }
+}

--- a/table/server/master/src/test/java/alluxio/master/table/TestDatabase.java
+++ b/table/server/master/src/test/java/alluxio/master/table/TestDatabase.java
@@ -16,6 +16,7 @@ import alluxio.collections.ConcurrentHashSet;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.table.PrincipalType;
+import alluxio.table.common.udb.UdbBypassSpec;
 import alluxio.table.common.udb.UdbConfiguration;
 import alluxio.table.common.udb.UdbContext;
 import alluxio.table.common.udb.UdbTable;
@@ -111,7 +112,7 @@ public class TestDatabase implements UnderDatabase {
   }
 
   @Override
-  public UdbTable getTable(String tableName, boolean bypass) throws IOException {
+  public UdbTable getTable(String tableName, UdbBypassSpec bypassSpec) throws IOException {
     checkDbName();
     if (!mUdbTables.containsKey(tableName)) {
       throw new NotFoundException("Table " + tableName + " does not exist.");

--- a/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/GlueDatabase.java
+++ b/table/server/underdb/glue/src/main/java/alluxio/table/under/glue/GlueDatabase.java
@@ -247,7 +247,7 @@ public class GlueDatabase implements UnderDatabase {
 
     try {
       PathTranslator pathTranslator = new PathTranslator();
-      if (bypassSpec.isFullyBypassedTable(tableName)) {
+      if (bypassSpec.hasFullTable(tableName)) {
         pathTranslator.addMapping(glueUfsUri, glueUfsUri);
         return pathTranslator;
       }
@@ -283,7 +283,7 @@ public class GlueDatabase implements UnderDatabase {
                 mGlueDbName,
                 mGlueConfiguration.get(Property.CATALOG_ID));
           }
-          if (bypassSpec.isBypassedPartition(tableName, partitionName)) {
+          if (bypassSpec.hasPartition(tableName, partitionName)) {
             pathTranslator.addMapping(partitionUri.getPath(), partitionUri.getPath());
             continue;
           }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
@@ -156,7 +156,7 @@ public class HiveDatabase implements UnderDatabase {
 
     try {
       PathTranslator pathTranslator = new PathTranslator();
-      if (bypassSpec.isFullyBypassedTable(tableName)) {
+      if (bypassSpec.hasFullTable(tableName)) {
         pathTranslator.addMapping(hiveUfsUri, hiveUfsUri);
         return pathTranslator;
       }
@@ -185,7 +185,7 @@ public class HiveDatabase implements UnderDatabase {
             LOG.warn("Error making partition name for table {}, partition {}", tableName,
                 part.getValues().toString());
           }
-          if (bypassSpec.isBypassedPartition(tableName, partName)) {
+          if (bypassSpec.hasPartition(tableName, partName)) {
             pathTranslator.addMapping(partitionUri.getPath(), partitionUri.getPath());
             continue;
           }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
@@ -22,6 +22,7 @@ import alluxio.resource.CloseableResource;
 import alluxio.table.common.UdbPartition;
 import alluxio.table.common.layout.HiveLayout;
 import alluxio.table.common.udb.PathTranslator;
+import alluxio.table.common.udb.UdbBypassSpec;
 import alluxio.table.common.udb.UdbConfiguration;
 import alluxio.table.common.udb.UdbContext;
 import alluxio.table.common.udb.UdbTable;
@@ -146,7 +147,7 @@ public class HiveDatabase implements UnderDatabase {
   }
 
   private PathTranslator mountAlluxioPaths(Table table, List<Partition> partitions,
-      boolean bypass)
+      UdbBypassSpec bypassSpec)
       throws IOException {
     String tableName = table.getTableName();
     AlluxioURI ufsUri;
@@ -155,7 +156,7 @@ public class HiveDatabase implements UnderDatabase {
 
     try {
       PathTranslator pathTranslator = new PathTranslator();
-      if (bypass) {
+      if (bypassSpec.isFullyBypassedTable(tableName)) {
         pathTranslator.addMapping(hiveUfsUri, hiveUfsUri);
         return pathTranslator;
       }
@@ -184,6 +185,10 @@ public class HiveDatabase implements UnderDatabase {
             LOG.warn("Error making partition name for table {}, partition {}", tableName,
                 part.getValues().toString());
           }
+          if (bypassSpec.isBypassedPartition(tableName, partName)) {
+            pathTranslator.addMapping(partitionUri.getPath(), partitionUri.getPath());
+            continue;
+          }
           alluxioUri = new AlluxioURI(PathUtils.concatPath(
               mUdbContext.getTableLocation(tableName).getPath(), partName));
 
@@ -208,7 +213,7 @@ public class HiveDatabase implements UnderDatabase {
   }
 
   @Override
-  public UdbTable getTable(String tableName, boolean bypass) throws IOException {
+  public UdbTable getTable(String tableName, UdbBypassSpec bypassSpec) throws IOException {
     try {
       Table table;
       List<Partition> partitions;
@@ -248,7 +253,7 @@ public class HiveDatabase implements UnderDatabase {
         }
       }
 
-      PathTranslator pathTranslator = mountAlluxioPaths(table, partitions, bypass);
+      PathTranslator pathTranslator = mountAlluxioPaths(table, partitions, bypassSpec);
       List<ColumnStatisticsInfo> colStats =
           columnStats.stream().map(HiveUtils::toProto).collect(Collectors.toList());
       // construct table layout


### PR DESCRIPTION
### What changes were proposed in this pull request?

Following PR #13455, this PR allows bypassing by partition names.

To allow partition specification, the syntax of the config file `catalog.db.config.file` has been changed. It now looks like this:

```json
{
  "bypass": {
    "tables": [
      "table1",
      {"table": "table2", "partitions": ["table2_part1", "table2_part2"]}
    ]
  }
}
```


### Why are the changes needed?

More fine-grained control over which partitions to bypass.

### Does this PR introduce _any_ user-facing change?

Yes. The syntax of the config file is changed.