### PR TITLE
Log warning on orphaned blocks

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1079,8 +1079,10 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
         }
       }
     }
-    LOG.warn("{} invalid blocks found on worker {} in total", invalidBlockCount,
-        workerInfo.getWorkerAddress().getHost());
+    if (invalidBlockCount > 0) {
+      LOG.warn("{} invalid blocks found on worker {} in total", invalidBlockCount,
+          workerInfo.getWorkerAddress().getHost());
+    }
   }
 
   /**
@@ -1103,8 +1105,10 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
         workerInfo.updateToRemovedBlock(true, block);
       }
     }
-    LOG.warn("{} blocks marked as orphaned from worker {}", orphanedBlockCount,
-        workerInfo.getWorkerAddress().getHost());
+    if (orphanedBlockCount > 0) {
+      LOG.warn("{} blocks marked as orphaned from worker {}", orphanedBlockCount,
+          workerInfo.getWorkerAddress().getHost());
+    }
   }
 
   @Override


### PR DESCRIPTION
Log a warning on unrecognized/orphaned blocks from worker only when the counts are >0

This is a follow-up for https://github.com/Alluxio/alluxio/pull/13520 where the warning message is logged regardless of the count.