### PR TITLE
[DOCFIX] Fix minor grammar errors in WEB.md

### DIFF
--- a/docs/en/overview/Getting-Started.md
+++ b/docs/en/overview/Getting-Started.md
@@ -392,7 +392,7 @@ Different frameworks and applications work with Alluxio.
 
 ## FAQ
 
-### Why do I keep getting "Operation not permitted" for ssh and alluxio 
+### Why do I keep getting "Operation not permitted" for ssh and alluxio? 
 
 For the users who are using macOS 11(Big Sur) or later, when running the command
 ```console
@@ -409,6 +409,6 @@ To fix it, open `System Preferences` and open `Sharing`.
 
 On the left, check the box next to `Remote Login`. If there is `Allow full access to remote users` as shown in the 
 image, check the box next to it. Besides, click the `+` button and add yourself to the list of users that are allowed
-for Remote Login you are not already in it.
+for Remote Login if you are not already in it.
 
 

--- a/docs/en/ufs/WEB.md
+++ b/docs/en/ufs/WEB.md
@@ -47,7 +47,13 @@ alluxio.underfs.web.header.last.modified=<WEB_HEADER_LAST_MODIFIED>
 alluxio.underfs.web.parent.names=<WEB_PARENT_NAMES>
 alluxio.underfs.web.titles=<WEB_TITLES>
 ```
-Here, alluxio.underfs.web.connnection.timeout is the timeout setting for a http connection(unit: second, default: 60s). alluxio.underfs.web.header.last.modified represents the format to parse the last modified field for a directory or a file from a http response header (default: "EEE, dd MMM yyyy HH:mm:ss zzz"). alluxio.underfs.web.parent.names indicates the start row index of the files list, which can be set as multiple flags seperated by a comma (default: "Parent Directory,..,../"). alluxio.underfs.web.titles means the "web page title" flags to check it is a directory or not which can be also set with multiple values seperated by a comma (default: "Index of ,Directory listing for ").
+Here, alluxio.underfs.web.connnection.timeout is the timeout setting for an http connection(unit: second, default: 60s). 
+alluxio.underfs.web.header.last.modified represents the format to parse the last modified field for a directory 
+or a file from an http response header (default: "EEE, dd MMM yyyy HH:mm:ss zzz"). 
+alluxio.underfs.web.parent.names indicates the start row index of the files list, 
+which can be set as multiple flags separated by commas (default: "Parent Directory,..,../"). 
+alluxio.underfs.web.titles is a flag that can be used to check if a web page is a directory. 
+It can also be set with multiple values separated by commas (default: "Index of ,Directory listing for ").
 
 ### NESTED MOUNT
 

--- a/docs/en/ufs/WEB.md
+++ b/docs/en/ufs/WEB.md
@@ -47,12 +47,13 @@ alluxio.underfs.web.header.last.modified=<WEB_HEADER_LAST_MODIFIED>
 alluxio.underfs.web.parent.names=<WEB_PARENT_NAMES>
 alluxio.underfs.web.titles=<WEB_TITLES>
 ```
-Here, alluxio.underfs.web.connnection.timeout is the timeout setting for an http connection(unit: second, default: 60s). 
-alluxio.underfs.web.header.last.modified represents the format to parse the last modified field for a directory 
+Here, `alluxio.underfs.web.connnection.timeout` is the timeout setting for an http connection
+(unit: second, default: 60s). 
+`alluxio.underfs.web.header.last.modified` represents the format to parse the last modified field for a directory 
 or a file from an http response header (default: "EEE, dd MMM yyyy HH:mm:ss zzz"). 
-alluxio.underfs.web.parent.names indicates the start row index of the files list, 
+`alluxio.underfs.web.parent.names` indicates the start row index of the files list, 
 which can be set as multiple flags separated by commas (default: "Parent Directory,..,../"). 
-alluxio.underfs.web.titles is a flag that can be used to check if a web page is a directory. 
+`alluxio.underfs.web.titles` is a flag that can be used to check if a web page is a directory. 
 It can also be set with multiple values separated by commas (default: "Index of ,Directory listing for ").
 
 ### NESTED MOUNT


### PR DESCRIPTION
Changed "a http" to "an http" and changed the wording of the explanation of alluxio.underfs.web.titles.