### PR TITLE
Remove precondition string concat cost

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1067,7 +1067,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
             BlockLocation location = entry.getKey();
             Preconditions.checkState(location.getWorkerId() == workerInfo.getId(),
                 "BlockLocation has a different workerId %s from the request sender's workerId %s!",
-                        location.getWorkerId(), workerInfo.getId());
+                    location.getWorkerId(), workerInfo.getId());
             mBlockStore.addLocation(blockId, location);
             mLostBlocks.remove(blockId);
           } else {

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1066,8 +1066,8 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
             workerInfo.addBlock(blockId);
             BlockLocation location = entry.getKey();
             Preconditions.checkState(location.getWorkerId() == workerInfo.getId(),
-                "BlockLocation has a different workerId %s from the request sender's workerId %s!",
-                    location.getWorkerId(), workerInfo.getId());
+                "BlockLocation has a different workerId %s from the request sender's workerId %s",
+                location.getWorkerId(), workerInfo.getId());
             mBlockStore.addLocation(blockId, location);
             mLostBlocks.remove(blockId);
           } else {

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1064,12 +1064,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
           Optional<BlockMeta> block = mBlockStore.getBlock(blockId);
           if (block.isPresent()) {
             workerInfo.addBlock(blockId);
-            BlockLocation location = entry.getKey();
-            Preconditions.checkState(location.getWorkerId() == workerInfo.getId(),
-                String.format("BlockLocation has a different workerId %s from "
-                    + "the request sender's workerId %s!",
-                        location.getWorkerId(), workerInfo.getId()));
-            mBlockStore.addLocation(blockId, location);
+            mBlockStore.addLocation(blockId, entry.getKey());
             mLostBlocks.remove(blockId);
           } else {
             invalidBlockCount++;

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1068,7 +1068,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
             Preconditions.checkState(location.getWorkerId() == workerInfo.getId(),
                 "BlockLocation has a different workerId %s from the request sender's workerId %s!",
                         location.getWorkerId(), workerInfo.getId());
-            mBlockStore.addLocation(blockId, entry.getKey());
+            mBlockStore.addLocation(blockId, location);
             mLostBlocks.remove(blockId);
           } else {
             invalidBlockCount++;

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1064,6 +1064,10 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
           Optional<BlockMeta> block = mBlockStore.getBlock(blockId);
           if (block.isPresent()) {
             workerInfo.addBlock(blockId);
+            BlockLocation location = entry.getKey();
+            Preconditions.checkState(location.getWorkerId() == workerInfo.getId(),
+                "BlockLocation has a different workerId %s from the request sender's workerId %s!",
+                        location.getWorkerId(), workerInfo.getId());
             mBlockStore.addLocation(blockId, entry.getKey());
             mLostBlocks.remove(blockId);
           } else {


### PR DESCRIPTION
### What changes are proposed in this pull request?

The `Precondition` check will generate a string per block and induce extra method invocation. The cost is significant both in execution time and heap allocation.

### Why are the changes needed?

The change saves heap allocation for registerWorker call by 75%, compared to without this change. However the Precondition check was brought in by https://github.com/Alluxio/alluxio/pull/13461. That means this PR does not improve the performance of `registerWorker` compared to previous Alluxio version, instead it brings the performance back to normal.

### Does this PR introduce any user facing changes?

NA
