### PR TITLE
Fix format error when raft cluster hostname different with localhost

### DIFF
--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -694,4 +694,28 @@ public final class NetworkAddressUtils {
       channel.shutdown();
     }
   }
+
+  /**
+   * @param clusterAddresses addresses of all nodes in the Raft cluster
+   * @param conf Alluxio configuration
+   * @return true if the cluster addresses contain the local IP, false otherwise
+   */
+  public static boolean containsLocalIp(List<InetSocketAddress> clusterAddresses,
+      AlluxioConfiguration conf) {
+    String localAddressIp = getLocalIpAddress((int) conf.getMs(PropertyKey
+        .NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
+    for (InetSocketAddress addr : clusterAddresses) {
+      String clusterNodeIp;
+      try {
+        clusterNodeIp = InetAddress.getByName(addr.getHostName()).getHostAddress();
+        if (clusterNodeIp.equals(localAddressIp)) {
+          return true;
+        }
+      } catch (UnknownHostException e) {
+        LOG.error("Get raft cluster node ip by hostname({}) failed",
+            addr.getHostName(), e);
+      }
+    }
+    return false;
+  }
 }

--- a/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
@@ -12,6 +12,8 @@
 package alluxio.util.network;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import alluxio.ConfigurationRule;
 import alluxio.ConfigurationTestUtils;
@@ -29,6 +31,8 @@ import org.junit.Test;
 import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Tests for the {@link NetworkAddressUtils} class.
@@ -40,6 +44,33 @@ public class NetworkAddressUtilsTest {
   @After
   public void after() {
     mConfiguration = ConfigurationTestUtils.defaults();
+  }
+
+  @Test
+  public void testContainsLocalIP() {
+    List<InetSocketAddress> clusterAddresses = new ArrayList<>();
+    InetSocketAddress raftNodeAddress1 = new InetSocketAddress(NetworkAddressUtils
+        .getLocalHostName(
+            (int) mConfiguration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS)),
+        10);
+    InetSocketAddress raftNodeAddress2 = new InetSocketAddress("host2", 20);
+    InetSocketAddress raftNodeAddress3 = new InetSocketAddress("host3", 30);
+    clusterAddresses.add(raftNodeAddress1);
+    clusterAddresses.add(raftNodeAddress2);
+    clusterAddresses.add(raftNodeAddress3);
+    assertTrue(NetworkAddressUtils.containsLocalIp(clusterAddresses, mConfiguration));
+  }
+
+  @Test
+  public void testNotContainsLocalIP() {
+    List<InetSocketAddress> clusterAddresses = new ArrayList<>();
+    InetSocketAddress raftNodeAddress1 = new InetSocketAddress("host1", 10);
+    InetSocketAddress raftNodeAddress2 = new InetSocketAddress("host2", 20);
+    InetSocketAddress raftNodeAddress3 = new InetSocketAddress("host3", 30);
+    clusterAddresses.add(raftNodeAddress1);
+    clusterAddresses.add(raftNodeAddress2);
+    clusterAddresses.add(raftNodeAddress3);
+    assertFalse(NetworkAddressUtils.containsLocalIp(clusterAddresses, mConfiguration));
   }
 
   /**

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalConfiguration.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalConfiguration.java
@@ -57,7 +57,9 @@ public class RaftJournalConfiguration {
     Preconditions.checkState(getMaxLogSize() <= Integer.MAX_VALUE,
         "{} has value {} but must not exceed {}", PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX,
         getMaxLogSize(), Integer.MAX_VALUE);
-    Preconditions.checkState(getClusterAddresses().contains(getLocalAddress()),
+    Preconditions.checkState(getClusterAddresses().contains(getLocalAddress())
+            || NetworkAddressUtils.containsLocalIp(getClusterAddresses(),
+        ServerConfiguration.global()),
         "The cluster addresses (%s) must contain the local master address (%s)",
         getClusterAddresses(), getLocalAddress());
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?
This pr is to fix issue #13595
Please outline the changes and how this PR fixes the issue.
 If hostname is not one of raft cluster hostname list, add a second round check related ip. 
### Why are the changes needed?
In some case, we can't change cluster adresss dns name specificed by config file and the node's hostname, so maybe  local hostname is not one of raft cluster hostname list, then the format action will throw error in the validate process.  
### Does this PR introduce any user facing changes?
No change