### PR TITLE
Support update config

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/meta/MetaMasterConfigClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/meta/MetaMasterConfigClient.java
@@ -75,4 +75,13 @@ public interface MetaMasterConfigClient extends Client {
    * @param path the path
    */
   void removePathConfiguration(AlluxioURI path) throws IOException;
+
+  /**
+   * Updates properties.
+   *
+   * @param propertiesMap the properties map to be updated
+   * @return the update properties status map
+   */
+  Map<PropertyKey, Boolean> updateConfiguration(
+      Map<PropertyKey, String> propertiesMap) throws IOException;
 }

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -124,6 +124,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     private ConsistencyCheckLevel mConsistencyCheckLevel = ConsistencyCheckLevel.IGNORE;
     private Scope mScope = Scope.ALL;
     private DisplayType mDisplayType = DisplayType.DEFAULT;
+    private boolean mIsDynamic = true;
 
     /**
      * @param name name of the property
@@ -250,6 +251,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     }
 
     /**
+     * @param dynamic whether the property could be updated dynamically
+     * @return the updated builder instance
+     */
+    public Builder setIsDynamic(boolean dynamic) {
+      mIsDynamic = dynamic;
+      return this;
+    }
+
+    /**
      * Creates and registers the property key.
      *
      * @return the created property key instance
@@ -277,7 +287,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
 
       PropertyKey key = new PropertyKey(mName, mDescription, defaultSupplier, mAlias,
           mIgnoredSiteProperty, mIsHidden, mConsistencyCheckLevel, mScope, mDisplayType,
-          mIsBuiltIn);
+          mIsBuiltIn, mIsDynamic);
       return key;
     }
 
@@ -296,6 +306,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue(String.format("${%s}/conf", Name.HOME))
           .setDescription("The directory containing files used to configure Alluxio.")
           .setIgnoredSiteProperty(true)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.ALL)
+          .build();
+  public static final PropertyKey CONF_DYNAMIC_UPDATE_ENABLED =
+      new Builder(Name.CONF_DYNAMIC_UPDATE_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("Whether to support dynamic update property.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.ALL)
           .build();
@@ -4823,6 +4840,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "authentication is enabled. Server trusts whoever the client claims to be.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.ALL)
+          .setIsDynamic(false)
           .build();
   public static final PropertyKey SECURITY_AUTHORIZATION_PERMISSION_ENABLED =
       new Builder(Name.SECURITY_AUTHORIZATION_PERMISSION_ENABLED)
@@ -4830,6 +4848,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("Whether to enable access control based on file permission.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.ALL)
+          .setIsDynamic(false)
           .build();
   public static final PropertyKey SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP =
       new Builder(Name.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP)
@@ -5247,6 +5266,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   @ThreadSafe
   public static final class Name {
     public static final String CONF_DIR = "alluxio.conf.dir";
+    public static final String CONF_DYNAMIC_UPDATE_ENABLED =
+        "alluxio.conf.dynamic.update.enabled";
     public static final String CONF_VALIDATION_ENABLED = "alluxio.conf.validation.enabled";
     public static final String DEBUG = "alluxio.debug";
     public static final String EXTENSIONS_DIR = "alluxio.extensions.dir";
@@ -6598,6 +6619,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   /** The displayType which indicates how the property value should be displayed. **/
   private final DisplayType mDisplayType;
 
+  /** Whether the property could be updated dynamically. */
+  private final boolean mDynamic;
+
   /**
    * @param name String of this property
    * @param description String description of this property key
@@ -6614,7 +6638,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   private PropertyKey(String name, String description, DefaultSupplier defaultSupplier,
       String[] aliases, boolean ignoredSiteProperty, boolean isHidden,
       ConsistencyCheckLevel consistencyCheckLevel, Scope scope, DisplayType displayType,
-      boolean isBuiltIn) {
+      boolean isBuiltIn, boolean dynamic) {
     mName = Preconditions.checkNotNull(name, "name");
     // TODO(binfan): null check after we add description for each property key
     mDescription = Strings.isNullOrEmpty(description) ? "N/A" : description;
@@ -6626,6 +6650,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     mScope = scope;
     mDisplayType = displayType;
     mIsBuiltIn = isBuiltIn;
+    mDynamic = dynamic;
   }
 
   /**
@@ -6633,7 +6658,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
    */
   private PropertyKey(String name) {
     this(name, null, new DefaultSupplier(() -> null, "null"), null, false, false,
-        ConsistencyCheckLevel.IGNORE, Scope.ALL, DisplayType.DEFAULT, true);
+        ConsistencyCheckLevel.IGNORE, Scope.ALL, DisplayType.DEFAULT, true, true);
   }
 
   /**
@@ -6781,6 +6806,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
    */
   public boolean isBuiltIn() {
     return mIsBuiltIn;
+  }
+
+  /**
+   * @return true if this property can be updated dynamically during runtime
+   */
+  public boolean isDynamic() {
+    return mDynamic;
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4559,9 +4559,14 @@ public final class DefaultFileSystemMaster extends CoreMaster
    */
   private FileSystemMasterAuditContext createAuditContext(String command, AlluxioURI srcPath,
       @Nullable AlluxioURI dstPath, @Nullable Inode srcInode) {
+    // Audit log may be enabled during runtime
+    AsyncUserAccessAuditLogWriter auditLogWriter = null;
+    if (ServerConfiguration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED)) {
+      auditLogWriter = mAsyncAuditLogWriter;
+    }
     FileSystemMasterAuditContext auditContext =
-        new FileSystemMasterAuditContext(mAsyncAuditLogWriter);
-    if (mAsyncAuditLogWriter != null) {
+        new FileSystemMasterAuditContext(auditLogWriter);
+    if (auditLogWriter != null) {
       String user = null;
       String ugi = "";
       try {

--- a/core/server/master/src/main/java/alluxio/master/meta/MetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/MetaMaster.java
@@ -164,4 +164,10 @@ public interface MetaMaster extends BackupOps, Master {
    * @return the hostname of the master that did the checkpoint
    */
   String checkpoint() throws IOException;
+
+  /**
+   * @param propertiesMap properties to update
+   * @return the update properties status map
+   */
+  Map<String, Boolean> updateConfiguration(Map<String, String> propertiesMap);
 }

--- a/core/server/master/src/main/java/alluxio/master/meta/MetaMasterConfigurationServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/MetaMasterConfigurationServiceHandler.java
@@ -22,6 +22,8 @@ import alluxio.grpc.RemovePathConfigurationPRequest;
 import alluxio.grpc.RemovePathConfigurationPResponse;
 import alluxio.grpc.SetPathConfigurationPRequest;
 import alluxio.grpc.SetPathConfigurationPResponse;
+import alluxio.grpc.UpdateConfigurationPRequest;
+import alluxio.grpc.UpdateConfigurationPResponse;
 import alluxio.wire.ConfigHash;
 
 import io.grpc.stub.StreamObserver;
@@ -126,5 +128,18 @@ public final class MetaMasterConfigurationServiceHandler
         }
         return RemovePathConfigurationPResponse.getDefaultInstance();
       }, "removePathConfiguration", "request=%s", responseObserver, request);
+  }
+
+  @Override
+  public void updateConfiguration(
+      UpdateConfigurationPRequest request,
+      StreamObserver<UpdateConfigurationPResponse> responseObserver) {
+    RpcUtils.call(LOG, () -> {
+      Map<String, Boolean> result =
+          mMetaMaster.updateConfiguration(request.getPropertiesMap());
+      return UpdateConfigurationPResponse.newBuilder()
+          .putAllStatus(result)
+          .build();
+    }, "updateConfiguration", "request=%s", responseObserver, request);
   }
 }

--- a/core/transport/src/main/proto/grpc/meta_master.proto
+++ b/core/transport/src/main/proto/grpc/meta_master.proto
@@ -190,25 +190,27 @@ message GetConfigHashPResponse {
   * to query cluster configuration.
   */
 service MetaMasterConfigurationService {
-    /**
-     * Returns a list of Alluxio runtime configuration information.
-     */
-    rpc GetConfiguration (GetConfigurationPOptions) returns (GetConfigurationPResponse);
+  /**
+   * Returns a list of Alluxio runtime configuration information.
+   */
+  rpc GetConfiguration (GetConfigurationPOptions) returns (GetConfigurationPResponse);
 
-    /**
-     * Sets a property for a path.
-     */
-    rpc SetPathConfiguration (SetPathConfigurationPRequest) returns (SetPathConfigurationPResponse);
+  /**
+   * Sets a property for a path.
+   */
+  rpc SetPathConfiguration (SetPathConfigurationPRequest) returns (SetPathConfigurationPResponse);
 
-    /**
-     * Removes properties for a path, if the keys are empty, it means remove all properties.
-     */
-    rpc RemovePathConfiguration (RemovePathConfigurationPRequest) returns (RemovePathConfigurationPResponse);
+  /**
+   * Removes properties for a path, if the keys are empty, it means remove all properties.
+   */
+  rpc RemovePathConfiguration (RemovePathConfigurationPRequest) returns (RemovePathConfigurationPResponse);
 
-    /**
-     * Returns the hashes of cluster and path level configurations.
-     */
-    rpc GetConfigHash (GetConfigHashPOptions) returns (GetConfigHashPResponse);
+  /**
+   * Returns the hashes of cluster and path level configurations.
+   */
+  rpc GetConfigHash (GetConfigHashPOptions) returns (GetConfigHashPResponse);
+
+  rpc UpdateConfiguration(UpdateConfigurationPRequest) returns (UpdateConfigurationPResponse);
 }
 
 message GetMasterIdPOptions {}
@@ -242,6 +244,14 @@ message MasterHeartbeatPRequest {
 }
 message MasterHeartbeatPResponse {
   optional MetaCommand command = 1;
+}
+
+message UpdateConfigurationPRequest {
+  map<string, string> properties = 1;
+}
+
+message UpdateConfigurationPResponse {
+  map<string, bool> status = 1;
 }
 
 /**

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/UpdateConfCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/UpdateConfCommand.java
@@ -1,0 +1,98 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.cli.fsadmin.command;
+
+import alluxio.annotation.PublicApi;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.cli.CommandLine;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * Update config for an existing service.
+ */
+@ThreadSafe
+@PublicApi
+public final class UpdateConfCommand extends AbstractFsAdminCommand {
+
+  /**
+   * @param context fsadmin command context
+   * @param alluxioConf Alluxio configuration
+   */
+  public UpdateConfCommand(Context context, AlluxioConfiguration alluxioConf) {
+    super(context);
+  }
+
+  @Override
+  public String getCommandName() {
+    return "updateConf";
+  }
+
+  @Override
+  public int run(CommandLine cl) throws IOException {
+    int errorCode = 0;
+    Map<PropertyKey, String> properties = new HashMap<>();
+    for (String arg : cl.getArgList()) {
+      if (arg.contains("=")) {
+        String[] kv = arg.split("=");
+        if (kv.length != 2) {
+          System.err.println(
+              "Failed to parse %s, expecting argument in the format of \"key=val\", arg)");
+          return -3;
+        }
+        properties.put(PropertyKey.getOrBuildCustom(kv[0]), kv[1]);
+      }
+    }
+
+    if (properties.size() == 0) {
+      System.out.println("No config to update");
+      return -1;
+    }
+
+    Map<PropertyKey, Boolean> result =
+        mMetaConfigClient.updateConfiguration(properties);
+    System.out.println("Updated " + result.size() + " configs");
+    for (Entry<PropertyKey, Boolean> entry : result.entrySet()) {
+      if (!entry.getValue()) {
+        System.out.println("Failed to Update " + entry.getKey().getName());
+        errorCode = -2;
+      }
+    }
+
+    return errorCode;
+  }
+
+  @Override
+  public String getUsage() {
+    return "updateConf key1=val1 [key2=val2 ...]";
+  }
+
+  /**
+   * @return command's description
+   */
+  @VisibleForTesting
+  public static String description() {
+    return "Update config for alluxio master.";
+  }
+
+  @Override
+  public String getDescription() {
+    return description();
+  }
+}

--- a/tests/src/test/java/alluxio/client/cli/fs/AbstractShellIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/AbstractShellIntegrationTest.java
@@ -42,6 +42,7 @@ public abstract class AbstractShellIntegrationTest extends BaseIntegrationTest {
           .setProperty(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS, Integer.MAX_VALUE)
           .setProperty(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "CACHE_THROUGH")
           .setProperty(PropertyKey.USER_FILE_RESERVED_BYTES, SIZE_BYTES / 2)
+          .setProperty(PropertyKey.CONF_DYNAMIC_UPDATE_ENABLED, true)
           .build();
 
   @Rule

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/UpdateConfIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/UpdateConfIntegrationTest.java
@@ -1,0 +1,63 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.cli.fsadmin.command;
+
+import alluxio.cli.fsadmin.command.UpdateConfCommand;
+import alluxio.client.cli.fsadmin.AbstractFsAdminShellTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for updateConf command.
+ */
+public final class UpdateConfIntegrationTest extends AbstractFsAdminShellTest {
+
+  @Test
+  public void unknownOption() {
+    int ret = mFsAdminShell.run("updateConf", "--unknown");
+    Assert.assertEquals(-1, ret);
+    String output = mOutput.toString();
+    Assert.assertEquals(UpdateConfCommand.description(), lastLine(output));
+  }
+
+  @Test
+  public void updateUnknownKey() {
+    int ret = mFsAdminShell.run("updateConf", "unknown-key=unknown-value");
+    Assert.assertEquals(-2, ret);
+    ret = mFsAdminShell.run("updateConf", "unknown-key");
+    Assert.assertEquals(-1, ret);
+    ret = mFsAdminShell.run("updateConf", "unknown-key=1=2");
+    Assert.assertEquals(-3, ret);
+  }
+
+  @Test
+  public void updateNormal() {
+    int ret = mFsAdminShell.run("updateConf", "alluxio.master.worker.timeout=4min");
+    Assert.assertEquals(0, ret);
+  }
+
+  @Test
+  public void updateNonDynamicKey() {
+    int ret = mFsAdminShell.run("updateConf",
+        "alluxio.security.authorization.permission.enabled=false");
+    Assert.assertEquals(-2, ret);
+  }
+
+  private String lastLine(String output) {
+    String[] lines = output.split("\n");
+    if (lines.length > 0) {
+      return lines[lines.length - 1];
+    }
+    return "";
+  }
+}


### PR DESCRIPTION
Fix #13513

bin/alluxio fsadmin updateConf alluxio.master.worker.timeout=4min


![image](https://user-images.githubusercontent.com/17329931/120227035-01afda80-c27b-11eb-93e1-337e42645d95.png)



![image](https://user-images.githubusercontent.com/17329931/120226990-ec3ab080-c27a-11eb-8154-59d13851baab.png)



Now support dynamic update properties have been tested are:

- alluxio.master.unsafe.direct.persist.object.enabled
- alluxio.master.worker.timeout
- alluxio.master.audit.logging.enabled
- alluxio.master.ufs.managed.blocking.enabled
- alluxio.master.metastore.inode.inherit.owner.and.group

pr-link: Alluxio/alluxio#13514
change-id: cid-58e9469b8db6f962adf700067ff4c86d714bcadd
