### PR TITLE
Bump up worker start timeout

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -117,7 +117,7 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
       // registered at worker registry, so the maximum timeout here is set to the multiply of
       // the number of factories by the default timeout of getting a worker from the registry.
       CommonUtils.invokeAll(callables,
-          (long) callables.size() * Constants.DEFAULT_REGISTRY_GET_TIMEOUT_MS);
+          (long) callables.size() * 10 * Constants.DEFAULT_REGISTRY_GET_TIMEOUT_MS);
 
       // Setup web server
       mWebServer =


### PR DESCRIPTION
### What changes are proposed in this pull request?

The previous value can be too short for worker registration in some use cases, bump up the default timeout to 10 minutes for worker start.

### Why are the changes needed?

Without this change, the worker registration will reach the time out by registering a large number of blocks.

### Does this PR introduce any user facing changes?

No.
