### PR TITLE
Group mount tables and partitions in a database

### DIFF
--- a/table/server/common/src/main/java/alluxio/table/common/udb/UdbContext.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/UdbContext.java
@@ -98,4 +98,12 @@ public class UdbContext {
   public AlluxioURI getTableLocation(String tableName) {
     return CatalogPathUtils.getTablePathUdb(mDbName, tableName, mType);
   }
+
+  /**
+   * @param ufsUri ufs location of the fragment
+   * @return the AlluxioURI of the fragment in Alluxio filesystem
+   */
+  public AlluxioURI getFragmentLocation(AlluxioURI ufsUri) {
+    return CatalogPathUtils.getFragmentsPath(mDbName, ufsUri);
+  }
 }

--- a/table/server/common/src/main/java/alluxio/table/common/udb/UdbProperty.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/UdbProperty.java
@@ -23,6 +23,11 @@ import org.slf4j.LoggerFactory;
 public class UdbProperty extends BaseProperty {
   private static final Logger LOG = LoggerFactory.getLogger(UdbProperty.class);
 
+  public static final UdbProperty GROUP_MOUNT_POINTS =
+      new UdbProperty(
+          "mount.group_mount_points",
+          "Whether to group mount points",
+          "false");
   /**
    * Creates an instance.
    *

--- a/table/server/common/src/main/java/alluxio/table/common/udb/UdbUtils.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/UdbUtils.java
@@ -36,32 +36,31 @@ public class UdbUtils {
   /**
    * Mount ufs path to alluxio path.
    *
-   * @param tableName Table name
    * @param ufsUri the uri of ufs
-   * @param tableUri the alluxio uri for table
+   * @param alluxioUri alluxio uri of the mount point
    * @param udbContext udb context
    * @param udbConfiguration Udb configurations
-   * @return table uri
+   * @return mounted Alluxio path
    * @throws IOException
    * @throws AlluxioException
    */
-  public static String mountAlluxioPath(String tableName, AlluxioURI ufsUri, AlluxioURI tableUri,
-      UdbContext udbContext, UdbConfiguration udbConfiguration)
+  public static String mountAlluxioPath(AlluxioURI ufsUri, AlluxioURI alluxioUri,
+                                        UdbContext udbContext, UdbConfiguration udbConfiguration)
       throws IOException, AlluxioException {
     if (Objects.equals(ufsUri.getScheme(), Constants.SCHEME)) {
       // already an alluxio uri, return the alluxio uri
       return ufsUri.toString();
     }
     try {
-      tableUri = udbContext.getFileSystem().reverseResolve(ufsUri);
-      LOG.debug("Trying to mount table {} location {}, but it is already mounted at location {}",
-          tableName, ufsUri, tableUri);
-      return tableUri.getPath();
+      alluxioUri = udbContext.getFileSystem().reverseResolve(ufsUri);
+      LOG.debug("Trying to mount ufs location {}, but it is already mounted at location {}",
+          ufsUri, alluxioUri);
+      return alluxioUri.getPath();
     } catch (InvalidPathException e) {
       // ufs path not mounted, continue
     }
     // make sure the parent exists
-    udbContext.getFileSystem().createDirectory(tableUri.getParent(),
+    udbContext.getFileSystem().createDirectory(alluxioUri.getParent(),
         CreateDirectoryPOptions.newBuilder().setRecursive(true).setAllowExists(true).build());
     Map<String, String> mountOptionMap = udbConfiguration.getMountOption(
         String.format("%s://%s/", ufsUri.getScheme(), ufsUri.getAuthority().toString()));
@@ -75,10 +74,10 @@ public class UdbUtils {
         option.putProperties(entry.getKey(), entry.getValue());
       }
     }
-    udbContext.getFileSystem().mount(tableUri, ufsUri, option.build());
+    udbContext.getFileSystem().mount(alluxioUri, ufsUri, option.build());
 
-    LOG.info("mounted table {} location {} to Alluxio location {} with mountOption {}",
-        tableName, ufsUri, tableUri, option.build());
-    return tableUri.getPath();
+    LOG.info("mounted ufs location {} to Alluxio location {} with mountOption {}",
+        ufsUri, alluxioUri, option.build());
+    return alluxioUri.getPath();
   }
 }

--- a/table/server/common/src/main/java/alluxio/table/common/udb/UnderDatabase.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/UnderDatabase.java
@@ -15,6 +15,7 @@ import alluxio.master.table.DatabaseInfo;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 /**
  * The database interface.
@@ -38,10 +39,9 @@ public interface UnderDatabase {
 
   /**
    * @param tableName the table name
-   * @param bypassSpec table and partition bypass specification
    * @return the {@link UdbTable} for the specified table name
    */
-  UdbTable getTable(String tableName, UdbBypassSpec bypassSpec) throws IOException;
+  UdbTable getTable(String tableName) throws IOException;
 
   /**
    * @return the {@link UdbContext}
@@ -52,4 +52,11 @@ public interface UnderDatabase {
    * @return get database info
    */
   DatabaseInfo getDatabaseInfo() throws IOException;
+
+  /**
+   * Mount the tables. Should be called only once, and before calls to {@link #getTable(String)}.
+   * @param tableNames table names
+   * @param bypassSpec bypassSpec
+   */
+  void mount(Set<String> tableNames, UdbBypassSpec bypassSpec) throws IOException;
 }

--- a/table/server/master/src/test/java/alluxio/master/table/TestDatabase.java
+++ b/table/server/master/src/test/java/alluxio/master/table/TestDatabase.java
@@ -23,6 +23,7 @@ import alluxio.table.common.udb.UdbTable;
 import alluxio.table.common.udb.UnderDatabase;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -112,7 +113,18 @@ public class TestDatabase implements UnderDatabase {
   }
 
   @Override
-  public UdbTable getTable(String tableName, UdbBypassSpec bypassSpec) throws IOException {
+  public void mount(Set<String> tableNames, UdbBypassSpec bypassSpec) throws IOException {
+    checkDbName();
+    Set<String> nonExistentTableNames = Sets.difference(tableNames, mUdbTables.keySet());
+    if (nonExistentTableNames.size() != 0) {
+      throw new NotFoundException(String.format("Tables [%s] do not exist",
+          String.join(", ", nonExistentTableNames)));
+    }
+    // else, do nothing
+  }
+
+  @Override
+  public UdbTable getTable(String tableName) throws IOException {
     checkDbName();
     if (!mUdbTables.containsKey(tableName)) {
       throw new NotFoundException("Table " + tableName + " does not exist.");

--- a/table/server/underdb/hive/src/test/java/alluxio/table/under/hive/HiveDatabaseTest.java
+++ b/table/server/underdb/hive/src/test/java/alluxio/table/under/hive/HiveDatabaseTest.java
@@ -12,26 +12,70 @@
 package alluxio.table.under.hive;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
+import alluxio.AlluxioURI;
+import alluxio.ConfigurationRule;
+import alluxio.client.file.DelegatingFileSystem;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.FileAlreadyExistsException;
+import alluxio.exception.InvalidPathException;
+import alluxio.grpc.CreateDirectoryPOptions;
+import alluxio.grpc.MountPOptions;
+import alluxio.resource.CloseableResource;
+import alluxio.table.common.udb.UdbBypassSpec;
 import alluxio.table.common.udb.UdbConfiguration;
 import alluxio.table.common.udb.UdbContext;
+import alluxio.table.common.udb.UdbProperty;
+import alluxio.table.under.hive.util.TestHiveClientPool;
+import alluxio.util.io.PathUtils;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.hive.common.FileUtils;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.thrift.TException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class HiveDatabaseTest {
 
   private static final String DB_NAME = "test";
+  public static final String DB_TYPE = "hive";
+  public static final String CONNECTION_URI = "thrift://not_running:9083";
   private static final Map<String, String> CONF = new HashMap<>();
 
   @Rule
   public ExpectedException mExpection = ExpectedException.none();
+
+  @Rule
+  public ConfigurationRule mConfiguration =
+      new ConfigurationRule(
+          ImmutableMap.of(PropertyKey.MASTER_HOSTNAME, "master",
+              PropertyKey.MASTER_RPC_PORT, "10000"),
+          ServerConfiguration.global());
 
   private UdbContext mUdbContext;
   private UdbConfiguration mUdbConf;
@@ -39,7 +83,7 @@ public class HiveDatabaseTest {
   @Before
   public void before() {
     mUdbContext =
-        new UdbContext(null, null, "hive", "thrift://not_running:9083", DB_NAME, DB_NAME);
+        new UdbContext(null, null, DB_TYPE, CONNECTION_URI, DB_NAME, DB_NAME);
     mUdbConf = new UdbConfiguration(CONF);
   }
 
@@ -52,7 +96,7 @@ public class HiveDatabaseTest {
   public void createEmptyName() {
     mExpection.expect(IllegalArgumentException.class);
     UdbContext udbContext =
-        new UdbContext(null, null, "hive", "thrift://not_running:9083", "", DB_NAME);
+        new UdbContext(null, null, DB_TYPE, CONNECTION_URI, "", DB_NAME);
     assertEquals(DB_NAME,
         HiveDatabase.create(udbContext, new UdbConfiguration(ImmutableMap.of())).getName());
   }
@@ -61,7 +105,7 @@ public class HiveDatabaseTest {
   public void createNullName() {
     mExpection.expect(IllegalArgumentException.class);
     UdbContext udbContext =
-        new UdbContext(null, null, "hive", "thrift://not_running:9083", null, DB_NAME);
+        new UdbContext(null, null, DB_TYPE, CONNECTION_URI, null, DB_NAME);
     assertEquals(DB_NAME,
         HiveDatabase.create(udbContext, new UdbConfiguration(ImmutableMap.of())).getName());
   }
@@ -69,7 +113,7 @@ public class HiveDatabaseTest {
   @Test
   public void createEmptyConnectionUri() {
     mExpection.expect(IllegalArgumentException.class);
-    UdbContext udbContext = new UdbContext(null, null, "hive", "", DB_NAME, DB_NAME);
+    UdbContext udbContext = new UdbContext(null, null, DB_TYPE, "", DB_NAME, DB_NAME);
     assertEquals(DB_NAME, HiveDatabase.create(udbContext,
         new UdbConfiguration(ImmutableMap.of())).getName());
   }
@@ -77,7 +121,7 @@ public class HiveDatabaseTest {
   @Test
   public void createNullConnectionUri() {
     mExpection.expect(IllegalArgumentException.class);
-    UdbContext udbContext = new UdbContext(null, null, "hive", null, DB_NAME, DB_NAME);
+    UdbContext udbContext = new UdbContext(null, null, DB_TYPE, null, DB_NAME, DB_NAME);
     assertEquals(DB_NAME, HiveDatabase.create(udbContext,
         new UdbConfiguration(ImmutableMap.of())).getName());
   }
@@ -89,5 +133,239 @@ public class HiveDatabaseTest {
         "prop2", "value2"
     );
     assertEquals(DB_NAME, HiveDatabase.create(mUdbContext, new UdbConfiguration(props)).getName());
+  }
+
+  @Test
+  public void notGroupingMountPointsTablesOnly() throws Exception {
+    MountRecordingFileSystem fs = new MountRecordingFileSystem();
+    mUdbContext = new UdbContext(null, fs, DB_TYPE, CONNECTION_URI, DB_NAME, DB_NAME);
+    mUdbConf =
+        new UdbConfiguration(ImmutableMap.of(UdbProperty.GROUP_MOUNT_POINTS.getName(), "false"));
+    TestTable table = new TestTable("table1");
+    HiveDatabase database = new HiveDatabase(
+        mUdbContext,
+        mUdbConf,
+        mUdbContext.getConnectionUri(),
+        mUdbContext.getUdbDbName(),
+        new MockedHiveClientPool(
+            ImmutableList.of(table.toHiveTable()),
+            ImmutableList.of())
+    );
+
+    UdbBypassSpec bypassSpec = new UdbBypassSpec(ImmutableMap.of());
+    database.mount(ImmutableSet.of(table.getName()), bypassSpec);
+    assertEquals(mUdbContext.getTableLocation(table.getName()),
+        fs.getMountPoints().inverse().get(new AlluxioURI(table.getLocation())));
+  }
+
+  @Test
+  public void notGroupingMountPointsWithPartitions() throws Exception {
+    MountRecordingFileSystem fs = new MountRecordingFileSystem();
+    mUdbContext = new UdbContext(null, fs, DB_TYPE, CONNECTION_URI, DB_NAME, DB_NAME);
+    mUdbConf =
+        new UdbConfiguration(ImmutableMap.of(UdbProperty.GROUP_MOUNT_POINTS.getName(), "false"));
+    TestTable table = new TestTable("table1").setPartitionKeys(ImmutableList.of("col1", "col2"));
+    TestPartition partition = new TestPartition(table, ImmutableList.of("1", "2"));
+    HiveDatabase database = new HiveDatabase(
+        mUdbContext,
+        mUdbConf,
+        mUdbContext.getConnectionUri(),
+        mUdbContext.getUdbDbName(),
+        new MockedHiveClientPool(
+            ImmutableList.of(table.toHiveTable()),
+            ImmutableList.of(partition.toHivePartition()))
+    );
+
+    UdbBypassSpec bypassSpec = new UdbBypassSpec(ImmutableMap.of());
+    database.mount(ImmutableSet.of(table.getName()), bypassSpec);
+    AlluxioURI pathInAlluxio = fs.getMountPoints().inverse().get(new AlluxioURI(table.getLocation()));
+    assertEquals(mUdbContext.getTableLocation(table.getName()), pathInAlluxio);
+    assertTrue(pathInAlluxio.isAncestorOf(
+        fs.reverseResolve(new AlluxioURI(table.getLocation()).join(partition.getName()))));
+  }
+
+  private static class TestTable {
+    private final String mName;
+    private String mLocation;
+    private List<String> mPartitionKeys;
+
+    public TestTable(String name) {
+      mName = name;
+      mLocation = PathUtils.concatPath(CONNECTION_URI, DB_NAME, mName);
+      mPartitionKeys = ImmutableList.of();
+    }
+
+    public TestTable(TestTable table) {
+      mName = table.mName;
+      mLocation = table.mLocation;
+      mPartitionKeys = table.mPartitionKeys;
+    }
+
+    public String getName() {
+      return mName;
+    }
+
+    public String getLocation() {
+      return mLocation;
+    }
+
+    public TestTable setLocationPrefix(String locationPrefix) {
+      mLocation = PathUtils.concatPath(locationPrefix, mName);
+      return this;
+    }
+
+    public List<String> getPartitionKeys() {
+      return mPartitionKeys;
+    }
+
+    public TestTable setPartitionKeys(List<String> partitionKeys) {
+      mPartitionKeys = partitionKeys;
+      return this;
+    }
+
+    public Table toHiveTable() {
+      Table table = new Table();
+      table.setTableName(mName);
+      table.setDbName(DB_NAME);
+      table.setPartitionKeys(mPartitionKeys.stream().map((key) -> {
+        FieldSchema schema = new FieldSchema();
+        schema.setName(key);
+        return schema;
+      }).collect(Collectors.toList()));
+      StorageDescriptor tableSd = new StorageDescriptor();
+      tableSd.setLocation(mLocation);
+      table.setSd(tableSd);
+      return table;
+    }
+  }
+
+  private static class TestPartition {
+    private final List<String> mValues;
+    private final String mPartitionName;
+    private String mLocation;
+
+    public TestPartition(TestTable parentTable, List<String> values) {
+      Preconditions.checkArgument(parentTable.getPartitionKeys().size() == values.size());
+      mValues = values;
+      mPartitionName = FileUtils.makePartName(parentTable.getPartitionKeys(), mValues);
+      mLocation = PathUtils.concatPath(parentTable.getLocation(), mPartitionName);
+    }
+
+    public List<String> getValues() {
+      return mValues;
+    }
+
+    public String getName() {
+      return mPartitionName;
+    }
+
+    public String getLocation() {
+      return mLocation;
+    }
+
+    public TestPartition setLocationPrefix(String locationPrefix) {
+      mLocation = PathUtils.concatPath(locationPrefix, mPartitionName);
+      return this;
+    }
+
+    public Partition toHivePartition() {
+      Partition part = new Partition();
+      part.setValues(mValues);
+      StorageDescriptor partSd = new StorageDescriptor();
+      partSd.setLocation(mLocation);
+      part.setSd(partSd);
+      return part;
+    }
+  }
+
+  private static class MockedHiveClientPool extends TestHiveClientPool {
+    private final IMetaStoreClient mMockedClient;
+
+    public MockedHiveClientPool(List<Table> tables, List<Partition> partitions) {
+      super();
+      mMockedClient = Mockito.mock(IMetaStoreClient.class);
+      try {
+        Database db = new Database();
+        db.setName(DB_NAME);
+        db.setLocationUri(CONNECTION_URI);
+        when(mMockedClient.getDatabase(DB_NAME)).thenReturn(db);
+
+        for (Table table : tables) {
+          String tableName = table.getTableName();
+          when(mMockedClient.getTable(DB_NAME, tableName)).thenReturn(table);
+          when(mMockedClient.listPartitions(eq(DB_NAME), eq(tableName), eq((short) -1)))
+              .thenReturn(partitions);
+        }
+      } catch (TException e) {
+        // mocked client does not really throw exception
+      }
+    }
+
+    @Override
+    protected IMetaStoreClient createNewResource() throws IOException {
+      return mMockedClient;
+    }
+    @Override
+    public CloseableResource<IMetaStoreClient> acquireClientResource() throws IOException {
+      return new CloseableResource<IMetaStoreClient>(acquire()) {
+        @Override
+        public void close() {
+          release(get());
+        }
+      };
+    }
+  }
+
+  /**
+   * A dummy file system that records all mount points.
+   */
+  private static class MountRecordingFileSystem extends DelegatingFileSystem {
+    private final BiMap<AlluxioURI, AlluxioURI> mMountPoints;
+
+    public MountRecordingFileSystem() {
+      super(null);
+      mMountPoints = HashBiMap.create();
+    }
+
+    public BiMap<AlluxioURI, AlluxioURI> getMountPoints() {
+      return mMountPoints;
+    }
+
+    @Override
+    public void createDirectory(AlluxioURI path, CreateDirectoryPOptions options)
+        throws FileAlreadyExistsException, InvalidPathException, IOException, AlluxioException {
+      // pretend the directory is created successfully and do nothing
+    }
+
+    @Override
+    public AlluxioURI reverseResolve(AlluxioURI ufsUri) throws IOException, AlluxioException {
+      if (mMountPoints.inverse().containsKey(ufsUri)) {
+        return mMountPoints.inverse().get(ufsUri);
+      }
+      BiMap.Entry<AlluxioURI, AlluxioURI> longestPrefix = null;
+      int longestPrefixDepth = -1;
+      for (BiMap.Entry<AlluxioURI, AlluxioURI> entry : mMountPoints.entrySet()) {
+        AlluxioURI valueUri = entry.getValue();
+        if (valueUri.isAncestorOf(ufsUri) && valueUri.getDepth() > longestPrefixDepth) {
+          longestPrefix = entry;
+          longestPrefixDepth = valueUri.getDepth();
+        }
+      }
+      if (longestPrefix != null) {
+        String difference = PathUtils.subtractPaths(ufsUri.getPath(),
+            longestPrefix.getValue().getPath());
+        return longestPrefix.getKey().join(difference);
+      }
+      throw new InvalidPathException("Not found: " + ufsUri);
+    }
+
+    @Override
+    public void mount(AlluxioURI alluxioPath, AlluxioURI ufsPath, MountPOptions options)
+        throws IOException, AlluxioException {
+      if (mMountPoints.containsKey(alluxioPath)) {
+        throw new FileAlreadyExistsException(alluxioPath.toString());
+      }
+      mMountPoints.put(alluxioPath, ufsPath);
+    }
   }
 }

--- a/table/server/underdb/hive/src/test/java/alluxio/table/under/hive/HiveDatabaseTest.java
+++ b/table/server/underdb/hive/src/test/java/alluxio/table/under/hive/HiveDatabaseTest.java
@@ -37,7 +37,6 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -56,13 +55,16 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class HiveDatabaseTest {
 
   private static final String DB_NAME = "test";
-  public static final String DB_TYPE = "hive";
-  public static final String CONNECTION_URI = "thrift://not_running:9083";
+  private static final String DB_TYPE = "hive";
+  private static final String CONNECTION_URI = "thrift://not_running:9083";
+  private static final String DB_LOCATION = PathUtils.concatPath("hdfs://node1/", DB_NAME);
+  private static final String DB_ALT_LOCATION = PathUtils.concatPath("hdfs://node2/", DB_NAME);
   private static final Map<String, String> CONF = new HashMap<>();
   private static final UdbBypassSpec EMPTY_BYPASS_SPEC = new UdbBypassSpec(ImmutableMap.of());
 
@@ -81,6 +83,8 @@ public class HiveDatabaseTest {
   private final MountRecordingFileSystem mFs = new MountRecordingFileSystem();
   private final IMetaStoreClient mMockedClient = Mockito.mock(IMetaStoreClient.class);
   private final MockedHiveClientPool mClientPool = new MockedHiveClientPool(mMockedClient);
+  private final UdbContext mUdbContextWithFs =
+      new UdbContext(null, mFs, DB_TYPE, CONNECTION_URI, DB_NAME, DB_NAME);
 
   @Before
   public void before() {
@@ -138,73 +142,182 @@ public class HiveDatabaseTest {
   }
 
   @Test
-  public void notGroupingMountPointsTablesOnly() throws Exception {
-    TestTable table = new TestTable("table1");
-    mockTablesAndPartitions(mMockedClient,
-        ImmutableList.of(table.toHiveTable()), ImmutableList.of());
-    UdbContext udbContext = new UdbContext(null, mFs, DB_TYPE, CONNECTION_URI, DB_NAME, DB_NAME);
-    UdbConfiguration udbConf =
-        new UdbConfiguration(ImmutableMap.of(UdbProperty.GROUP_MOUNT_POINTS.getName(), "false"));
-    HiveDatabase database = new HiveDatabase(
-        udbContext,
-        udbConf,
-        udbContext.getConnectionUri(),
-        udbContext.getUdbDbName(),
-        mClientPool
-    );
-    database.mount(ImmutableSet.of(table.getName()), EMPTY_BYPASS_SPEC);
+  public void mountTablesOnly() throws Exception {
+    Map<TestTable, List<TestPartition>> tables = ImmutableList.of("table1", "table2").stream()
+        .map((name) -> TestTable.createWithNoPartitions(name, DB_LOCATION))
+        .collect(ImmutableMap.toImmutableMap((table) -> table, (table) -> ImmutableList.of()));
+    UdbConfiguration udbConf = getUdbConfigWithGroupMountEnabled(false);
+    createDatabaseAndMountTables(tables, udbConf);
 
-    AlluxioURI expectedTableLocation = udbContext.getTableLocation(table.getName());
-    AlluxioURI actualTableLocation =
-        mFs.getMountPoints().inverse().get(new AlluxioURI(table.getLocation()));
-    assertEquals(expectedTableLocation, actualTableLocation);
+    Map<AlluxioURI, AlluxioURI> expectedMountPoints = tables.keySet().stream().collect(
+        ImmutableMap.toImmutableMap(
+            // key: the mount point of the table in Alluxio
+            (table) -> mUdbContextWithFs.getTableLocation(table.getName()),
+            // value: the ufs uri of the table
+            (table) -> new AlluxioURI(table.getLocation())
+    ));
+    assertEquals(expectedMountPoints, mFs.getMountPoints());
   }
 
   @Test
-  public void notGroupingMountPointsWithPartitions() throws Exception {
-    TestTable table = new TestTable("table1").setPartitionKeys(ImmutableList.of("col1", "col2"));
-    TestPartition partition = new TestPartition(table, ImmutableList.of("1", "2"));
-    mockTablesAndPartitions(mMockedClient,
-        ImmutableList.of(table.toHiveTable()),
-        ImmutableList.of(partition.toHivePartition()));
-    UdbContext udbContext = new UdbContext(null, mFs, DB_TYPE, CONNECTION_URI, DB_NAME, DB_NAME);
+  public void mountTableWithPartitions() throws Exception {
+    TestTable table =
+        TestTable.createWithPartitionKeys("table1", DB_LOCATION, ImmutableList.of("key1"));
+    List<TestPartition> partitions = ImmutableList.of(
+        TestPartition.createWithKeyValue(table.getLocation(),
+            ImmutableList.of("key1"), ImmutableList.of("value1")),
+        TestPartition.createWithKeyValue(table.getLocation(),
+            ImmutableList.of("key1"), ImmutableList.of("value2")));
+    UdbConfiguration udbConf = getUdbConfigWithGroupMountEnabled(false);
+    createDatabaseAndMountTables(ImmutableMap.of(table, partitions), udbConf);
+
+    AlluxioURI tableMountPoint = mUdbContextWithFs.getTableLocation(table.getName());
+    // no separate mount point for the partitions since they're co-located with the parent table,
+    // which is already mounted
+    assertEquals(ImmutableMap.of(tableMountPoint, new AlluxioURI(table.getLocation())),
+        mFs.getMountPoints());
+  }
+
+  @Test
+  public void mountTableWithPartitionOfDifferentPrefix() throws Exception {
+    TestTable table = TestTable.createWithDummyPartitionKeys("table1", DB_LOCATION);
+    TestPartition partition =
+        TestPartition.createWithDummyValues(PathUtils.concatPath(DB_ALT_LOCATION, table.getName()));
     UdbConfiguration udbConf =
-        new UdbConfiguration(ImmutableMap.of(UdbProperty.GROUP_MOUNT_POINTS.getName(), "false"));
-    HiveDatabase database = new HiveDatabase(
-        udbContext,
-        udbConf,
-        udbContext.getConnectionUri(),
-        udbContext.getUdbDbName(),
-        mClientPool
-    );
-    database.mount(ImmutableSet.of(table.getName()), EMPTY_BYPASS_SPEC);
+        new UdbConfiguration(ImmutableMap.of(
+            UdbProperty.GROUP_MOUNT_POINTS.getName(), "false",
+            Property.ALLOW_DIFF_PART_LOC_PREFIX.getName(), "true"
+        ));
+    createDatabaseAndMountTables(ImmutableMap.of(table, ImmutableList.of(partition)), udbConf);
 
-    AlluxioURI actualTableMountPoint =
-        mFs.getMountPoints().inverse().get(new AlluxioURI(table.getLocation()));
-    AlluxioURI expectedTableMountPoint = udbContext.getTableLocation(table.getName());
-    assertEquals(expectedTableMountPoint, actualTableMountPoint);
+    AlluxioURI tableMountPoint = mUdbContextWithFs.getTableLocation(table.getName());
+    AlluxioURI partitionMountPoint = tableMountPoint.join(partition.getName());
+    assertEquals(
+        ImmutableMap.of(
+            tableMountPoint, new AlluxioURI(table.getLocation()),
+            partitionMountPoint, new AlluxioURI(partition.getLocation())),
+        mFs.getMountPoints());
+  }
 
-    AlluxioURI expectedPartitionMountPoint = expectedTableMountPoint.join(partition.getName());
-    AlluxioURI actualPartitionMountPoint =
-        mFs.reverseResolve(new AlluxioURI(partition.getLocation()));
-    assertEquals(actualPartitionMountPoint, expectedPartitionMountPoint);
+  @Test
+  public void mountTableWithPartitionDisallowingDifferentPrefix() throws Exception {
+    TestTable table = TestTable.createWithDummyPartitionKeys("table1", DB_LOCATION);
+    TestPartition partition =
+        TestPartition.createWithDummyValues(PathUtils.concatPath(DB_ALT_LOCATION, table.getName()));
+    UdbConfiguration udbConf =
+        new UdbConfiguration(ImmutableMap.of(
+            UdbProperty.GROUP_MOUNT_POINTS.getName(), "false",
+            Property.ALLOW_DIFF_PART_LOC_PREFIX.getName(), "false"
+        ));
+    createDatabaseAndMountTables(ImmutableMap.of(table, ImmutableList.of(partition)), udbConf);
+
+    AlluxioURI tableMountPoint = mUdbContextWithFs.getTableLocation(table.getName());
+    // the partition is ignored
+    assertEquals(
+        "The partition should be ignored since it has a different location prefix"
+            + "and configuration disallowing such partitions",
+        ImmutableMap.of(tableMountPoint, new AlluxioURI(table.getLocation())),
+        mFs.getMountPoints());
+  }
+
+  @Test
+  public void groupingMountPointsTablesOnly() throws Exception {
+    Map<TestTable, List<TestPartition>> tables = ImmutableList.of("table1", "table2").stream()
+        .map((name) -> TestTable.createWithNoPartitions(name, DB_LOCATION))
+        .collect(ImmutableMap.toImmutableMap(Function.identity(), (table) -> ImmutableList.of()));
+    UdbConfiguration udbConf = getUdbConfigWithGroupMountEnabled(true);
+    createDatabaseAndMountTables(tables, udbConf);
+
+    AlluxioURI dbUfsLocation = new AlluxioURI(DB_LOCATION);
+    AlluxioURI dbMountPoint = mUdbContext.getFragmentLocation(dbUfsLocation);
+    // all the tables share the same location prefix at the database level
+    // so the mount points are grouped
+    assertEquals(
+        ImmutableMap.of(dbMountPoint, dbUfsLocation),
+        mFs.getMountPoints());
+  }
+
+  @Test
+  public void groupingMountPointsWithColocatedPartitions() throws Exception {
+    TestTable table = TestTable.createWithDummyPartitionKeys("table1", DB_LOCATION);
+    TestPartition partition = TestPartition.createColocatedWithDummyValues(table);
+    UdbConfiguration udbConf = getUdbConfigWithGroupMountEnabled(true);
+    createDatabaseAndMountTables(ImmutableMap.of(table, ImmutableList.of(partition)), udbConf);
+
+    AlluxioURI dbUfsLocation = new AlluxioURI(DB_LOCATION);
+    AlluxioURI dbMountPoint = mUdbContext.getFragmentLocation(dbUfsLocation);
+    assertEquals(
+        ImmutableMap.of(dbMountPoint, dbUfsLocation),
+        mFs.getMountPoints());
+  }
+
+  @Test
+  public void groupingMountPointsWithNonColocatedPartitions() throws Exception {
+    TestTable table = TestTable.createWithDummyPartitionKeys("table1", DB_LOCATION);
+    TestPartition colocatedPartition = TestPartition.createColocatedWithDummyValues(table);
+    TestPartition nonColocatedPartition = TestPartition.createWithDummyValues(DB_ALT_LOCATION);
+    UdbConfiguration udbConf =
+        new UdbConfiguration(ImmutableMap.of(
+            UdbProperty.GROUP_MOUNT_POINTS.getName(), "true",
+            Property.ALLOW_DIFF_PART_LOC_PREFIX.getName(), "true"
+        ));
+    createDatabaseAndMountTables(
+        ImmutableMap.of(table, ImmutableList.of(colocatedPartition, nonColocatedPartition)),
+        udbConf);
+
+    AlluxioURI dbUfsLocation = new AlluxioURI(DB_LOCATION);
+    AlluxioURI dbMountPoint = mUdbContext.getFragmentLocation(dbUfsLocation);
+    AlluxioURI partitionUfsLocation = new AlluxioURI(nonColocatedPartition.getLocation());
+    AlluxioURI partitionMountPoint =
+        mUdbContext.getTableLocation(table.getName()).join(nonColocatedPartition.getName());
+    assertEquals(
+        ImmutableMap.of(dbMountPoint, dbUfsLocation, partitionMountPoint, partitionUfsLocation),
+        mFs.getMountPoints());
+  }
+
+  @Test
+  public void groupingMountPointsWithNonColocatedTables() throws Exception {
+    TestTable colocatedTable = TestTable.createWithNoPartitions("colocated", DB_LOCATION);
+    TestTable nonColocatedTable = TestTable.createWithNoPartitions("nonColocated", DB_ALT_LOCATION);
+    UdbConfiguration udbConf = getUdbConfigWithGroupMountEnabled(true);
+    createDatabaseAndMountTables(
+        ImmutableMap.of(colocatedTable, ImmutableList.of(), nonColocatedTable, ImmutableList.of()),
+        udbConf);
+
+    AlluxioURI dbUfsLocation = new AlluxioURI(DB_LOCATION);
+    AlluxioURI dbMountPoint = mUdbContext.getFragmentLocation(dbUfsLocation);
+    AlluxioURI nonColocatedLocation = new AlluxioURI(nonColocatedTable.getLocation());
+    AlluxioURI nonColocatedMountPoint = mUdbContext.getTableLocation(nonColocatedTable.getName());
+    assertEquals(
+        ImmutableMap.of(dbMountPoint, dbUfsLocation, nonColocatedMountPoint, nonColocatedLocation),
+        mFs.getMountPoints());
   }
 
   private static class TestTable {
+    public static final List<String> DUMMY_PARTITION_KEYS = ImmutableList.of("col1", "col2");
+    public static final List<String> DUMMY_PARTITION_VALUES = ImmutableList.of("val1", "val2");
     private final String mName;
-    private String mLocation;
-    private List<String> mPartitionKeys;
+    private final String mLocation;
+    private final List<String> mPartitionKeys;
 
-    public TestTable(String name) {
+    private TestTable(String name, String location, List<String> partitionKeys) {
       mName = name;
-      mLocation = PathUtils.concatPath(CONNECTION_URI, DB_NAME, mName);
-      mPartitionKeys = ImmutableList.of();
+      mLocation = location;
+      mPartitionKeys = partitionKeys;
     }
 
-    public TestTable(TestTable table) {
-      mName = table.mName;
-      mLocation = table.mLocation;
-      mPartitionKeys = table.mPartitionKeys;
+    public static TestTable createWithPartitionKeys(String name,
+                                                    String locationPrefix,
+                                                    List<String> keys) {
+      return new TestTable(name, PathUtils.concatPath(locationPrefix, name), keys);
+    }
+
+    public static TestTable createWithDummyPartitionKeys(String name, String locationPrefix) {
+      return createWithPartitionKeys(name, locationPrefix, DUMMY_PARTITION_KEYS);
+    }
+
+    public static TestTable createWithNoPartitions(String name, String locationPrefix) {
+      return createWithPartitionKeys(name, locationPrefix, ImmutableList.of());
     }
 
     public String getName() {
@@ -215,29 +328,17 @@ public class HiveDatabaseTest {
       return mLocation;
     }
 
-    public TestTable setLocationPrefix(String locationPrefix) {
-      mLocation = PathUtils.concatPath(locationPrefix, mName);
-      return this;
-    }
-
-    public List<String> getPartitionKeys() {
-      return mPartitionKeys;
-    }
-
-    public TestTable setPartitionKeys(List<String> partitionKeys) {
-      mPartitionKeys = partitionKeys;
-      return this;
-    }
-
     public Table toHiveTable() {
       Table table = new Table();
       table.setTableName(mName);
       table.setDbName(DB_NAME);
-      table.setPartitionKeys(mPartitionKeys.stream().map((key) -> {
-        FieldSchema schema = new FieldSchema();
-        schema.setName(key);
-        return schema;
-      }).collect(Collectors.toList()));
+      table.setPartitionKeys(
+          mPartitionKeys.stream().map((key) -> {
+            FieldSchema schema = new FieldSchema();
+            schema.setName(key);
+            return schema;
+          }).collect(Collectors.toList())
+      );
       StorageDescriptor tableSd = new StorageDescriptor();
       tableSd.setLocation(mLocation);
       table.setSd(tableSd);
@@ -246,15 +347,38 @@ public class HiveDatabaseTest {
   }
 
   private static class TestPartition {
+    private final List<String> mKeys;
     private final List<String> mValues;
     private final String mPartitionName;
-    private String mLocation;
+    private final String mLocation;
 
-    public TestPartition(TestTable parentTable, List<String> values) {
-      Preconditions.checkArgument(parentTable.getPartitionKeys().size() == values.size());
+    private TestPartition(List<String> keys, List<String> values,
+                          String partitionName, String location) {
+      mKeys = keys;
       mValues = values;
-      mPartitionName = FileUtils.makePartName(parentTable.getPartitionKeys(), mValues);
-      mLocation = PathUtils.concatPath(parentTable.getLocation(), mPartitionName);
+      mPartitionName = partitionName;
+      mLocation = location;
+    }
+
+    public static TestPartition createWithKeyValue(String locationPrefix,
+                                                   List<String> keys, List<String> values) {
+      Preconditions.checkArgument(keys.size() == values.size());
+      String partName = FileUtils.makePartName(keys, values);
+      return new TestPartition(keys, values, partName,
+          PathUtils.concatPath(locationPrefix, partName));
+    }
+
+    public static TestPartition createWithDummyValues(String locationPrefix) {
+      return createWithKeyValue(locationPrefix,
+          TestTable.DUMMY_PARTITION_KEYS, TestTable.DUMMY_PARTITION_VALUES);
+    }
+
+    public static TestPartition createColocatedWithDummyValues(TestTable parentTable) {
+      return createWithDummyValues(parentTable.getLocation());
+    }
+
+    public List<String> getKeys() {
+      return mKeys;
     }
 
     public List<String> getValues() {
@@ -269,11 +393,6 @@ public class HiveDatabaseTest {
       return mLocation;
     }
 
-    public TestPartition setLocationPrefix(String locationPrefix) {
-      mLocation = PathUtils.concatPath(locationPrefix, mPartitionName);
-      return this;
-    }
-
     public Partition toHivePartition() {
       Partition part = new Partition();
       part.setValues(mValues);
@@ -284,20 +403,47 @@ public class HiveDatabaseTest {
     }
   }
 
+  private static UdbConfiguration getUdbConfigWithGroupMountEnabled(boolean isEnabled) {
+    return new UdbConfiguration(
+        ImmutableMap.of(UdbProperty.GROUP_MOUNT_POINTS.getName(),
+        ((Boolean) isEnabled).toString()));
+  }
+
+  private HiveDatabase createDatabaseAndMountTables(
+      Map<TestTable, List<TestPartition>> tablePartitions,
+      UdbConfiguration configuration)
+      throws IOException {
+    ImmutableMap.Builder<Table, List<Partition>> builder  = new ImmutableMap.Builder<>();
+    tablePartitions.forEach((table, partitions) -> builder.put(
+        table.toHiveTable(),
+        partitions.stream().map(TestPartition::toHivePartition).collect(Collectors.toList())));
+    mockTablesAndPartitions(mMockedClient, builder.build());
+    HiveDatabase database = new HiveDatabase(
+        mUdbContextWithFs,
+        configuration,
+        mUdbContextWithFs.getConnectionUri(),
+        mUdbContextWithFs.getUdbDbName(),
+        mClientPool
+    );
+    database.mount(
+        tablePartitions.keySet().stream().map(TestTable::getName).collect(Collectors.toSet()),
+        EMPTY_BYPASS_SPEC);
+    return database;
+  }
+
   private static void mockTablesAndPartitions(IMetaStoreClient mockedClient,
-                                              List<Table> tables,
-                                              List<Partition> partitions) {
+                                              Map<Table, List<Partition>> tablePartitions) {
     try {
       Database db = new Database();
       db.setName(DB_NAME);
-      db.setLocationUri(CONNECTION_URI);
+      db.setLocationUri(DB_LOCATION);
       when(mockedClient.getDatabase(DB_NAME)).thenReturn(db);
 
-      for (Table table : tables) {
-        String tableName = table.getTableName();
-        when(mockedClient.getTable(DB_NAME, tableName)).thenReturn(table);
+      for (Map.Entry<Table, List<Partition>> entry: tablePartitions.entrySet()) {
+        String tableName = entry.getKey().getTableName();
+        when(mockedClient.getTable(DB_NAME, tableName)).thenReturn(entry.getKey());
         when(mockedClient.listPartitions(eq(DB_NAME), eq(tableName), eq((short) -1)))
-            .thenReturn(partitions);
+            .thenReturn(entry.getValue());
       }
     } catch (TException e) {
       throw new IllegalStateException("Unexpected exception from a mocked client", e);
@@ -352,6 +498,8 @@ public class HiveDatabaseTest {
      * Instead, manually create the expected path according to the logic in production code
      * that derives in-Alluxio paths from UFS paths (e.g. table locations are derived from DB name
      * and table name by {@link UdbContext#getTableLocation(String)}).
+     *
+     * @throws InvalidPathException when neither the UFS uri nor any of its ancestors is mounted
      */
     @Override
     public AlluxioURI reverseResolve(AlluxioURI ufsUri) throws IOException, AlluxioException {

--- a/table/server/underdb/hive/src/test/java/alluxio/table/under/hive/util/TestHiveClientPool.java
+++ b/table/server/underdb/hive/src/test/java/alluxio/table/under/hive/util/TestHiveClientPool.java
@@ -1,0 +1,67 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.table.under.hive.util;
+
+import alluxio.exception.status.UnimplementedException;
+import alluxio.resource.CloseableResource;
+import alluxio.util.ThreadFactoryUtils;
+
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+
+import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+/**
+ * A pool that does nothing, used for testing.
+ */
+public class TestHiveClientPool extends AbstractHiveClientPool {
+  private static final ScheduledExecutorService GC_EXECUTOR =
+      new ScheduledThreadPoolExecutor(1, ThreadFactoryUtils.build("TestHiveClientPool-GC-%d", true));
+  /**
+   * Creates a new instance with default options from {@link Options#defaultOptions()}.
+   */
+  public TestHiveClientPool() {
+    super(Options.defaultOptions().setGcExecutor(GC_EXECUTOR));
+  }
+
+  /**
+   * Creates a new instance.
+   * @param options options of the resource pool
+   */
+  public TestHiveClientPool(Options options) {
+    super(options);
+  }
+
+  @Override
+  protected boolean shouldGc(ResourceInternal<IMetaStoreClient> resourceInternal) {
+    return false;
+  }
+
+  @Override
+  protected boolean isHealthy(IMetaStoreClient resource) {
+    return true;
+  }
+
+  @Override
+  protected void closeResource(IMetaStoreClient resource) throws IOException {}
+
+  @Override
+  protected IMetaStoreClient createNewResource() throws IOException {
+    throw new UnsupportedOperationException("createNewResource");
+  }
+
+  @Override
+  public CloseableResource<IMetaStoreClient> acquireClientResource() throws IOException {
+    throw new UnsupportedOperationException("acquireClientResource");
+  }
+}

--- a/table/server/underdb/hive/src/test/java/alluxio/table/under/hive/util/TestHiveClientPool.java
+++ b/table/server/underdb/hive/src/test/java/alluxio/table/under/hive/util/TestHiveClientPool.java
@@ -11,7 +11,6 @@
 
 package alluxio.table.under.hive.util;
 
-import alluxio.exception.status.UnimplementedException;
 import alluxio.resource.CloseableResource;
 import alluxio.util.ThreadFactoryUtils;
 
@@ -25,8 +24,8 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
  * A pool that does nothing, used for testing.
  */
 public class TestHiveClientPool extends AbstractHiveClientPool {
-  private static final ScheduledExecutorService GC_EXECUTOR =
-      new ScheduledThreadPoolExecutor(1, ThreadFactoryUtils.build("TestHiveClientPool-GC-%d", true));
+  private static final ScheduledExecutorService GC_EXECUTOR = new ScheduledThreadPoolExecutor(1,
+      ThreadFactoryUtils.build("TestHiveClientPool-GC-%d", true));
   /**
    * Creates a new instance with default options from {@link Options#defaultOptions()}.
    */

--- a/table/server/underdb/hive/src/test/java/alluxio/table/under/hive/util/TestHiveClientPool.java
+++ b/table/server/underdb/hive/src/test/java/alluxio/table/under/hive/util/TestHiveClientPool.java
@@ -62,6 +62,11 @@ public class TestHiveClientPool extends AbstractHiveClientPool {
 
   @Override
   public CloseableResource<IMetaStoreClient> acquireClientResource() throws IOException {
-    throw new UnsupportedOperationException("acquireClientResource");
+    return new CloseableResource<IMetaStoreClient>(acquire()) {
+      @Override
+      public void close() {
+        release(get());
+      }
+    };
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

If multiple partitions in a table share the same storage location prefix, we can mount the parent table instead of mounting every partitions, thus reducing number of mount points.

Summary of the changes:

1. Some variables are renamed to better reflect their role and functionality: 
    * previously, `ufsUri`, `alluxioUri` and `hiveUfsUri` are used for both table and partition uris, and reused between the two sections where table and partitions mount are handled, respectively. This can be confusing when reading the code because one needs to track what a variable actually stands for, a table uri or a partition uri.
    * previously, `hiveUfsUri` is actually a string representation of a UFS URI (for both the table's and partitions'), and `ufsUri` and `hiveUfsUri` are real `AlluxioURI` objects. It is now split and renamed to `tableUfsPath` and `partitionUfsPath`, respectively.
2. The logic of grouping partition mounts is:
    1. for each partition of a table, if its storage location shares the same prefix with its containing table (`tableUfsUri.isAncestorOf(partitionUfsUri)`), it does not need to be mounted separately. We have already mounted the table, so the partition can be accessed through the table's path.
    2. otherwise, check a config entry to see of we allow partitions that reside outside the directory of the containing table. If so, mount the partition individually. If not, just ignore the partition.
    3. add path mappings for all partitions that share the common path prefix with the table.
3. The code throwing IOException now uses `String.format()` instead of string concatenations. 

### Why are the changes needed?

Fixes #13529.

### Does this PR introduce any user facing changes?

Yes. As of commit 5326f0c146e68f9d3923e2d42d2a2d3089f33d8f, the command line config opiton `catalog.db.ignore.udb.tables` is moved into the config file `catalog.db.config.file` and is thus deprecated.

