### PR TITLE
Fix PathTranslator to compare path prefixes by path components

### DIFF
--- a/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
@@ -11,8 +11,11 @@
 
 package alluxio.table.common.udb;
 
+import alluxio.AlluxioURI;
 import alluxio.conf.ServerConfiguration;
+import alluxio.exception.InvalidPathException;
 import alluxio.util.ConfigurationUtils;
+import alluxio.util.io.PathUtils;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -27,7 +30,7 @@ import java.io.IOException;
 public class PathTranslator {
   private static final Logger LOG = LoggerFactory.getLogger(PathTranslator.class);
 
-  private BiMap<String, String> mPathMap;
+  private final BiMap<AlluxioURI, AlluxioURI> mPathMap;
 
   /**
    * Construct a path translator.
@@ -45,16 +48,7 @@ public class PathTranslator {
    * @return PathTranslator object
    */
   public PathTranslator addMapping(String alluxioPath, String ufsPath) {
-    while (alluxioPath.endsWith("/")) {
-      // strip trailing slashes
-      alluxioPath = alluxioPath.substring(0, alluxioPath.length() - 1);
-    }
-
-    while (ufsPath.endsWith("/")) {
-      // strip trailing slashes
-      ufsPath = ufsPath.substring(0, ufsPath.length() - 1);
-    }
-    mPathMap.put(alluxioPath, ufsPath);
+    mPathMap.put(new AlluxioURI(alluxioPath), new AlluxioURI(ufsPath));
     return this;
   }
 
@@ -66,23 +60,48 @@ public class PathTranslator {
    * @throws IOException if the ufs path is not mounted
    */
   public String toAlluxioPath(String ufsPath) throws IOException {
-    for (BiMap.Entry<String, String> entry : mPathMap.entrySet()) {
-      if (ufsPath.startsWith(entry.getValue())) {
-        // return ufsPath if set the key and value to be same when bypass path.
-        if (entry.getKey().equals(entry.getValue())) {
-          return ufsPath;
+    String suffix = ufsPath.endsWith("/") ? "/" : "";
+    AlluxioURI ufsUri = new AlluxioURI(ufsPath);
+    // first look for an exact match
+    if (mPathMap.inverse().containsKey(ufsUri)) {
+      return mPathMap.inverse().get(ufsUri).toString() + suffix;
+    }
+    // otherwise match by longest prefix
+    BiMap.Entry<AlluxioURI, AlluxioURI> longestPrefix = null;
+    int longestPrefixDepth = -1;
+    for (BiMap.Entry<AlluxioURI, AlluxioURI> entry : mPathMap.entrySet()) {
+      try {
+        AlluxioURI valueUri = entry.getValue();
+        if (valueUri.isAncestorOf(ufsUri) && valueUri.getDepth() > longestPrefixDepth) {
+          longestPrefix = entry;
+          longestPrefixDepth = valueUri.getDepth();
         }
-        String alluxioPath = entry.getKey() + ufsPath.substring(entry.getValue().length());
-        if (alluxioPath.startsWith("/")) {
-          // scheme/authority are missing, so prefix with the scheme and authority
-          alluxioPath =
-              ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global()) + alluxioPath;
-        }
-        return alluxioPath;
+      } catch (InvalidPathException e) {
+        throw new IOException(e);
       }
     }
-    // TODO(yuzhu): instead of throwing an exception, mount the path?
-    throw new IOException(String
-        .format("Failed to translate ufs path (%s). Mapping missing from translator", ufsPath));
+    if (longestPrefix == null) {
+      // TODO(yuzhu): instead of throwing an exception, mount the path?
+      throw new IOException(String
+          .format("Failed to translate ufs path (%s). Mapping missing from translator", ufsPath));
+    }
+    if (longestPrefix.getKey().equals(longestPrefix.getValue())) {
+      // return ufsPath if set the key and value to be same when bypass path.
+      return ufsPath;
+    }
+    try {
+      String difference = PathUtils.subtractPaths(ufsUri.getPath(),
+          longestPrefix.getValue().getPath());
+      AlluxioURI mappedUri = longestPrefix.getKey().join(difference);
+      if (!mappedUri.hasScheme() || !mappedUri.hasAuthority()) {
+        // scheme/authority are missing, so prefix with the scheme and authority
+        AlluxioURI baseUri = new AlluxioURI(
+            ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global()) + "/");
+        mappedUri = new AlluxioURI(baseUri, mappedUri.getPath(), false);
+      }
+      return mappedUri.toString() + suffix;
+    } catch (InvalidPathException e) {
+      throw new IOException(e);
+    }
   }
 }

--- a/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
@@ -93,8 +93,8 @@ public class PathTranslator {
       String difference = PathUtils.subtractPaths(ufsUri.getPath(),
           longestPrefix.getValue().getPath());
       AlluxioURI mappedUri = longestPrefix.getKey().join(difference);
-      if (!mappedUri.hasScheme() || !mappedUri.hasAuthority()) {
-        // scheme/authority are missing, so prefix with the scheme and authority
+      if (!mappedUri.hasScheme()) {
+        // scheme is missing, so prefix with the scheme and authority
         AlluxioURI baseUri = new AlluxioURI(
             ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global()) + "/");
         mappedUri = new AlluxioURI(baseUri, mappedUri.getPath(), false);

--- a/table/server/common/src/test/java/alluxio/table/common/udb/PathTranslatorTest.java
+++ b/table/server/common/src/test/java/alluxio/table/common/udb/PathTranslatorTest.java
@@ -110,4 +110,17 @@ public class PathTranslatorTest {
     assertEquals("alluxio:///table_b/part1",
         mTranslator.toAlluxioPath("ufs://a/table11/part1"));
   }
+
+  @Test
+  public void deepestMatch() throws Exception {
+    mTranslator.addMapping("alluxio:///db1/tables/table1", "ufs://a/db1/table1");
+    mTranslator.addMapping("alluxio:///db1/fragments/a", "ufs://a/db1");
+    mTranslator.addMapping("alluxio:///db1/fragments/b", "ufs://b/db1");
+    assertEquals("alluxio:///db1/tables/table1/part1",
+        mTranslator.toAlluxioPath("ufs://a/db1/table1/part1"));
+    assertEquals("alluxio:///db1/fragments/b/table1/part1",
+        mTranslator.toAlluxioPath("ufs://b/db1/table1/part1"));
+    assertEquals("alluxio:///db1/fragments/a/table2/part1",
+        mTranslator.toAlluxioPath("ufs://a/db1/table2/part1"));
+  }
 }

--- a/table/server/common/src/test/java/alluxio/table/common/udb/PathTranslatorTest.java
+++ b/table/server/common/src/test/java/alluxio/table/common/udb/PathTranslatorTest.java
@@ -36,21 +36,21 @@ public class PathTranslatorTest {
 
   @Test
   public void noMapping() throws Exception {
-    mTranslator.addMapping("alluxio://master/my/table/directory", "ufs://a/the/ufs/location");
+    mTranslator.addMapping("alluxio:///my/table/directory", "ufs://a/the/ufs/location");
     mException.expect(IOException.class);
     mTranslator.toAlluxioPath("ufs://b/no/mapping");
   }
 
   @Test
   public void noMappingSingleLevel() throws Exception {
-    mTranslator.addMapping("alluxio://master/my/table/directory", "ufs://a/the/ufs/location");
+    mTranslator.addMapping("alluxio:///my/table/directory", "ufs://a/the/ufs/location");
     mException.expect(IOException.class);
     mTranslator.toAlluxioPath("ufs://a/the/ufs/no_loc");
   }
 
   @Test
   public void exactMatch() throws Exception {
-    String alluxioPath  = "alluxio://master/my/table/directory";
+    String alluxioPath  = "alluxio:///my/table/directory";
     String ufsPath = "ufs://a/the/ufs/location";
     mTranslator.addMapping(alluxioPath, ufsPath);
     assertEquals(alluxioPath, mTranslator.toAlluxioPath(ufsPath));
@@ -58,7 +58,7 @@ public class PathTranslatorTest {
 
   @Test
   public void singleSubDirectory() throws Exception {
-    String alluxioPath  = "alluxio://master/my/table/directory";
+    String alluxioPath  = "alluxio:///my/table/directory";
     String ufsPath = "ufs://a/the/ufs/location";
     mTranslator.addMapping(alluxioPath, ufsPath);
     assertEquals(PathUtils.concatPath(alluxioPath, "subdir"),
@@ -67,7 +67,7 @@ public class PathTranslatorTest {
 
   @Test
   public void multipleSubdir() throws Exception {
-    String alluxioPath  = "alluxio://master/my/table/directory";
+    String alluxioPath  = "alluxio:///my/table/directory";
     String ufsPath = "ufs://a/the/ufs/location";
     mTranslator.addMapping(alluxioPath, ufsPath);
     assertEquals(PathUtils.concatPath(alluxioPath, "subdir/a/b/c"),
@@ -76,7 +76,7 @@ public class PathTranslatorTest {
 
   @Test
   public void samePathDifferentUfs() throws Exception {
-    String alluxioPath  = "alluxio://master/my/table/directory";
+    String alluxioPath  = "alluxio:///my/table/directory";
     String ufsPath = "/the/ufs/location";
     mTranslator.addMapping(alluxioPath, "ufs-a://" + ufsPath);
     mException.expect(IOException.class);
@@ -85,7 +85,7 @@ public class PathTranslatorTest {
 
   @Test
   public void noSchemeUfs() throws Exception {
-    String alluxioPath  = "alluxio://master/my/table/directory";
+    String alluxioPath  = "alluxio:///my/table/directory";
     String ufsPath = "/the/ufs/location";
     mTranslator.addMapping(alluxioPath, ufsPath);
     assertEquals(alluxioPath, mTranslator.toAlluxioPath(ufsPath));
@@ -93,7 +93,7 @@ public class PathTranslatorTest {
 
   @Test
   public void trailingSeparator() throws Exception {
-    String alluxioPath  = "alluxio://master/my/table/directory";
+    String alluxioPath  = "alluxio:///my/table/directory";
     String ufsPath = "/the/ufs/location";
     mTranslator.addMapping(alluxioPath + "/", ufsPath + "/");
     assertEquals(alluxioPath, mTranslator.toAlluxioPath(ufsPath));
@@ -105,9 +105,9 @@ public class PathTranslatorTest {
 
   @Test
   public void prefixBoundaryWithinPathComponent() throws Exception {
-    mTranslator.addMapping("alluxio://master/table_a", "ufs://a/table1");
-    mTranslator.addMapping("alluxio://master/table_b", "ufs://a/table11");
-    assertEquals("alluxio://master/table_b/part1",
+    mTranslator.addMapping("alluxio:///table_a", "ufs://a/table1");
+    mTranslator.addMapping("alluxio:///table_b", "ufs://a/table11");
+    assertEquals("alluxio:///table_b/part1",
         mTranslator.toAlluxioPath("ufs://a/table11/part1"));
   }
 }

--- a/table/server/common/src/test/java/alluxio/table/common/udb/PathTranslatorTest.java
+++ b/table/server/common/src/test/java/alluxio/table/common/udb/PathTranslatorTest.java
@@ -36,21 +36,21 @@ public class PathTranslatorTest {
 
   @Test
   public void noMapping() throws Exception {
-    mTranslator.addMapping("alluxio:///my/table/directory", "ufs://a/the/ufs/location");
+    mTranslator.addMapping("alluxio://master/my/table/directory", "ufs://a/the/ufs/location");
     mException.expect(IOException.class);
     mTranslator.toAlluxioPath("ufs://b/no/mapping");
   }
 
   @Test
   public void noMappingSingleLevel() throws Exception {
-    mTranslator.addMapping("alluxio:///my/table/directory", "ufs://a/the/ufs/location");
+    mTranslator.addMapping("alluxio://master/my/table/directory", "ufs://a/the/ufs/location");
     mException.expect(IOException.class);
     mTranslator.toAlluxioPath("ufs://a/the/ufs/no_loc");
   }
 
   @Test
   public void exactMatch() throws Exception {
-    String alluxioPath  = "alluxio:///my/table/directory";
+    String alluxioPath  = "alluxio://master/my/table/directory";
     String ufsPath = "ufs://a/the/ufs/location";
     mTranslator.addMapping(alluxioPath, ufsPath);
     assertEquals(alluxioPath, mTranslator.toAlluxioPath(ufsPath));
@@ -58,7 +58,7 @@ public class PathTranslatorTest {
 
   @Test
   public void singleSubDirectory() throws Exception {
-    String alluxioPath  = "alluxio:///my/table/directory";
+    String alluxioPath  = "alluxio://master/my/table/directory";
     String ufsPath = "ufs://a/the/ufs/location";
     mTranslator.addMapping(alluxioPath, ufsPath);
     assertEquals(PathUtils.concatPath(alluxioPath, "subdir"),
@@ -67,7 +67,7 @@ public class PathTranslatorTest {
 
   @Test
   public void multipleSubdir() throws Exception {
-    String alluxioPath  = "alluxio:///my/table/directory";
+    String alluxioPath  = "alluxio://master/my/table/directory";
     String ufsPath = "ufs://a/the/ufs/location";
     mTranslator.addMapping(alluxioPath, ufsPath);
     assertEquals(PathUtils.concatPath(alluxioPath, "subdir/a/b/c"),
@@ -76,16 +76,16 @@ public class PathTranslatorTest {
 
   @Test
   public void samePathDifferentUfs() throws Exception {
-    String alluxioPath  = "alluxio:///my/table/directory";
+    String alluxioPath  = "alluxio://master/my/table/directory";
     String ufsPath = "/the/ufs/location";
-    mTranslator.addMapping(alluxioPath, "ufs_a://" + ufsPath);
+    mTranslator.addMapping(alluxioPath, "ufs-a://" + ufsPath);
     mException.expect(IOException.class);
-    mTranslator.toAlluxioPath("ufs_b://" + ufsPath);
+    mTranslator.toAlluxioPath("ufs-b://" + ufsPath);
   }
 
   @Test
   public void noSchemeUfs() throws Exception {
-    String alluxioPath  = "alluxio:///my/table/directory";
+    String alluxioPath  = "alluxio://master/my/table/directory";
     String ufsPath = "/the/ufs/location";
     mTranslator.addMapping(alluxioPath, ufsPath);
     assertEquals(alluxioPath, mTranslator.toAlluxioPath(ufsPath));
@@ -93,7 +93,7 @@ public class PathTranslatorTest {
 
   @Test
   public void trailingSeparator() throws Exception {
-    String alluxioPath  = "alluxio:///my/table/directory";
+    String alluxioPath  = "alluxio://master/my/table/directory";
     String ufsPath = "/the/ufs/location";
     mTranslator.addMapping(alluxioPath + "/", ufsPath + "/");
     assertEquals(alluxioPath, mTranslator.toAlluxioPath(ufsPath));
@@ -101,5 +101,13 @@ public class PathTranslatorTest {
     mTranslator.addMapping(alluxioPath, ufsPath);
     assertEquals(alluxioPath, mTranslator.toAlluxioPath(ufsPath));
     assertEquals(alluxioPath + "/", mTranslator.toAlluxioPath(ufsPath + "/"));
+  }
+
+  @Test
+  public void prefixBoundaryWithinPathComponent() throws Exception {
+    mTranslator.addMapping("alluxio://master/table_a", "ufs://a/table1");
+    mTranslator.addMapping("alluxio://master/table_b", "ufs://a/table11");
+    assertEquals("alluxio://master/table_b/part1",
+        mTranslator.toAlluxioPath("ufs://a/table11/part1"));
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Previously, `PathTranslator` erroneously:

1. finds a prefix of `ufsPath` by simply checking with `String.startsWith()`. This fails to handle the case where the boundary falls within a path component. This case is now covered in the `prefixBoundaryWithinPathComponent` test;
2. chooses an arbitary prefix of `ufsPath` (the first returned during map iteration) even if there are multiple eligible choices. This is fixed by choosing the deepest prefix instead.

### Why are the changes needed?

It's a bug fix.

### Does this PR introduce any user facing changes?

No.
