### PR TITLE
Fix master cannot open stacks page issue

### DIFF
--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -26,7 +26,6 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.slf4j.Logger;
@@ -102,13 +101,10 @@ public abstract class WebServer {
       disableMethod(s);
     }
 
+    mServletContextHandler.addServlet(StacksServlet.class, "/stacks");
     HandlerList handlers = new HandlerList();
     handlers.setHandlers(new Handler[] {mServletContextHandler, new DefaultHandler()});
     mServer.setHandler(handlers);
-    ServletHolder stacksServletHolder =
-        new ServletHolder("Alluxio Master Web Service", new StacksServlet());
-    mServletContextHandler
-        .addServlet(stacksServletHolder, "/stacks");
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix master cannot open stacks page issue

### Why are the changes needed?

Now proxy process can access stacks page by `http://<HOSTNAME>:39999/stacks`, but master process cannot be accessed through `http://<HOSTNAME>:19999/stacks` now.

### Does this PR introduce any user facing changes?

No.


Now, alluxio master and proxy process can get the stacks info from `/stacks` 

![image](https://user-images.githubusercontent.com/17329931/122633629-1fe75880-d10c-11eb-9705-67535e31434e.png)
