### PR TITLE
Support cache Not exist status

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCachingBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCachingBaseFileSystem.java
@@ -52,7 +52,6 @@ public class MetadataCachingBaseFileSystem extends BaseFileSystem {
   private final MetadataCache mMetadataCache;
   private final ExecutorService mAccessTimeUpdater;
   private final boolean mDisableUpdateFileAccessTime;
-  private final boolean mNotFoundResultCacheEnabled;
 
   /**
    * @param context the fs context
@@ -72,9 +71,6 @@ public class MetadataCachingBaseFileSystem extends BaseFileSystem {
     // asynchronously update access time.
     mAccessTimeUpdater = new ThreadPoolExecutor(0, masterClientThreads, THREAD_KEEPALIVE_SECOND,
         TimeUnit.SECONDS, new SynchronousQueue<>());
-    mNotFoundResultCacheEnabled =
-        mFsContext.getClusterConf().getBoolean(
-            PropertyKey.USER_METADATA_CACHE_NOT_FOUND_RESULT_CACHE_ENABLED);
   }
 
   @Override
@@ -87,9 +83,7 @@ public class MetadataCachingBaseFileSystem extends BaseFileSystem {
         status = super.getStatus(path, options);
         mMetadataCache.put(path, status);
       } catch (FileDoesNotExistException e) {
-        if (mNotFoundResultCacheEnabled) {
-          mMetadataCache.put(path, NOT_FOUND_STATUS);
-        }
+        mMetadataCache.put(path, NOT_FOUND_STATUS);
         throw e;
       }
     } else if (status == NOT_FOUND_STATUS) {

--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCachingBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCachingBaseFileSystem.java
@@ -47,11 +47,11 @@ public class MetadataCachingBaseFileSystem extends BaseFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(BaseFileSystem.class);
   private static final int THREAD_KEEPALIVE_SECOND = 60;
   private static final int THREAD_TERMINATION_TIMEOUT_MS = 10000;
+  private static final URIStatus NOT_FOUND_STATUS = new URIStatus(new FileInfo());
 
   private final MetadataCache mMetadataCache;
   private final ExecutorService mAccessTimeUpdater;
   private final boolean mDisableUpdateFileAccessTime;
-  private static final URIStatus NOT_FOUND_STATUS = new URIStatus(new FileInfo());
 
   /**
    * @param context the fs context

--- a/core/client/fs/src/test/java/alluxio/client/file/MetadataCachingBaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/MetadataCachingBaseFileSystemTest.java
@@ -162,7 +162,7 @@ public class MetadataCachingBaseFileSystemTest {
     try {
       mFs.getStatus(NOT_EXIST_FILE);
       Assert.fail("Failed while getStatus for a non-exist path.");
-    } catch (FileDoesNotExistException e){
+    } catch (FileDoesNotExistException e) {
       // expected exception thrown. test passes
     }
     assertEquals(1, mFileSystemMasterClient.getStatusRpcCount(NOT_EXIST_FILE));
@@ -170,7 +170,7 @@ public class MetadataCachingBaseFileSystemTest {
     try {
       mFs.getStatus(NOT_EXIST_FILE);
       Assert.fail("Failed while getStatus for a non-exist path.");
-    } catch (FileDoesNotExistException e){
+    } catch (FileDoesNotExistException e) {
       // expected exception thrown. test passes
     }
     assertEquals(1, mFileSystemMasterClient.getStatusRpcCount(NOT_EXIST_FILE));

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4248,17 +4248,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
-  public static final PropertyKey USER_METADATA_CACHE_NOT_FOUND_RESULT_CACHE_ENABLED =
-      new Builder(Name.USER_METADATA_CACHE_NOT_FOUND_RESULT_CACHE_ENABLED)
-          .setDefaultValue(false)
-          .setDescription("If this is enabled, FileDoesNotExistException will be cached. "
-              + "The cached metadata will be evicted when it expires after "
-              + Name.USER_METADATA_CACHE_EXPIRATION_TIME
-              + " or the cache size is over the limit of "
-              + Name.USER_METADATA_CACHE_MAX_SIZE + ".")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.CLIENT)
-          .build();
   public static final PropertyKey USER_METADATA_CACHE_MAX_SIZE =
       new Builder(Name.USER_METADATA_CACHE_MAX_SIZE)
           .setDefaultValue(100000)
@@ -6152,8 +6141,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.metadata.cache.enabled";
     public static final String USER_METADATA_CACHE_MAX_SIZE =
         "alluxio.user.metadata.cache.max.size";
-    public static final String USER_METADATA_CACHE_NOT_FOUND_RESULT_CACHE_ENABLED =
-        "alluxio.user.metadata.cache.enabled";
     public static final String USER_METADATA_CACHE_EXPIRATION_TIME =
         "alluxio.user.metadata.cache.expiration.time";
     public static final String USER_METRICS_COLLECTION_ENABLED =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4248,6 +4248,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_METADATA_CACHE_NOT_FOUND_RESULT_CACHE_ENABLED =
+      new Builder(Name.USER_METADATA_CACHE_NOT_FOUND_RESULT_CACHE_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("If this is enabled, FileDoesNotExistException will be cached. "
+              + "The cached metadata will be evicted when it expires after "
+              + Name.USER_METADATA_CACHE_EXPIRATION_TIME
+              + " or the cache size is over the limit of "
+              + Name.USER_METADATA_CACHE_MAX_SIZE + ".")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_METADATA_CACHE_MAX_SIZE =
       new Builder(Name.USER_METADATA_CACHE_MAX_SIZE)
           .setDefaultValue(100000)
@@ -6141,6 +6152,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.metadata.cache.enabled";
     public static final String USER_METADATA_CACHE_MAX_SIZE =
         "alluxio.user.metadata.cache.max.size";
+    public static final String USER_METADATA_CACHE_NOT_FOUND_RESULT_CACHE_ENABLED =
+        "alluxio.user.metadata.cache.enabled";
     public static final String USER_METADATA_CACHE_EXPIRATION_TIME =
         "alluxio.user.metadata.cache.expiration.time";
     public static final String USER_METRICS_COLLECTION_ENABLED =


### PR DESCRIPTION
### What changes are proposed in this pull request?

If a file or dir is not exist, `getStatus` will throw FileDoesNotExistException, and metadataCache will never cache this result, client will try to call rpc server again next time.

### Why are the changes needed?

Cache the special URIStatus `NOT_FOUND_STATUS` while met FileDoesNotExistException, when cache hit, re-throw the exception again.

### Does this PR introduce any user facing changes?

NO.
