### PR TITLE
Add scheme and authority if authority is missing in PathTranslator

### DIFF
--- a/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
@@ -93,8 +93,8 @@ public class PathTranslator {
       String difference = PathUtils.subtractPaths(ufsUri.getPath(),
           longestPrefix.getValue().getPath());
       AlluxioURI mappedUri = longestPrefix.getKey().join(difference);
-      if (!mappedUri.hasScheme()) {
-        // scheme is missing, so prefix with the scheme and authority
+      if (!mappedUri.hasScheme() || !mappedUri.hasAuthority()) {
+        // if scheme or authority is missing, so prefix with the scheme and authority
         AlluxioURI baseUri = new AlluxioURI(
             ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global()) + "/");
         mappedUri = new AlluxioURI(baseUri, mappedUri.getPath(), false);


### PR DESCRIPTION
### What changes are proposed in this pull request?

The path translator needs to return a full URI path because the client might not be able to resolve relative path. 

### Why are the changes needed?

Fixing an issue where the catalog service client can't locate the table path. 

### Does this PR introduce any user facing changes?
No