### PR TITLE
Update Apache Ratis API to 2.0.0

### DIFF
--- a/core/server/common/pom.xml
+++ b/core/server/common/pom.xml
@@ -37,12 +37,10 @@
     <dependency>
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-server</artifactId>
-      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-grpc</artifactId>
-      <version>2.0.0</version>
     </dependency>
     <!-- TODO(lu) remove catalyst dependency which used for serialization and move to Grpc impl -->
     <dependency>

--- a/core/server/common/pom.xml
+++ b/core/server/common/pom.xml
@@ -37,10 +37,12 @@
     <dependency>
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-server</artifactId>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-grpc</artifactId>
+      <version>2.0.0</version>
     </dependency>
     <!-- TODO(lu) remove catalyst dependency which used for serialization and move to Grpc impl -->
     <dependency>

--- a/core/server/common/src/main/java/alluxio/master/journal/MasterJournalContext.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/MasterJournalContext.java
@@ -23,7 +23,7 @@ import alluxio.retry.TimeoutRetry;
 
 import com.google.common.base.Preconditions;
 import io.grpc.Status;
-import org.apache.ratis.protocol.NotLeaderException;
+import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -40,7 +40,6 @@ import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
-import org.apache.ratis.server.impl.RaftServerProxy;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.server.storage.RaftStorage;
@@ -295,14 +294,14 @@ public class JournalStateMachine extends BaseStateMachine {
   }
 
   @Override
-  public void notifyIndexUpdate(long term, long index) {
-    super.notifyIndexUpdate(term, index);
+  public void notifyTermIndexUpdated(long term, long index) {
+    super.notifyTermIndexUpdated(term, index);
     CompletableFuture.runAsync(mJournalSystem::updateGroup);
   }
 
   private long getNextIndex() {
     try {
-      return ((RaftServerProxy) mServer).getImpl(mRaftGroupId).getState().getLog().getNextIndex();
+      return mServer.getDivision(mRaftGroupId).getRaftLog().getNextIndex();
     } catch (IOException e) {
       throw new IllegalStateException("Cannot obtain raft log index", e);
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
@@ -84,9 +84,10 @@ public class LocalFirstRaftClient implements Closeable {
   private CompletableFuture<RaftClientReply> sendLocalRequest(Message message,
       TimeDuration timeout) throws IOException {
     LOG.trace("Sending local message {}", message);
+    // ClientId, ServerId, and GroupId must not be null
     RaftClientRequest request = RaftClientRequest.newBuilder()
             .setClientId(mLocalClientId)
-            .setServerId(null)
+            .setServerId(mServer.getId())
             .setGroupId(RaftJournalSystem.RAFT_GROUP_ID)
             .setCallId(RaftJournalSystem.nextCallId())
             .setMessage(message)

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/LocalFirstRaftClient.java
@@ -16,12 +16,12 @@ import alluxio.conf.PropertyKey;
 import alluxio.util.LogUtils;
 
 import org.apache.ratis.client.RaftClient;
-import org.apache.ratis.protocol.AlreadyClosedException;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.Message;
-import org.apache.ratis.protocol.NotLeaderException;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftClientRequest;
+import org.apache.ratis.protocol.exceptions.AlreadyClosedException;
+import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
@@ -84,9 +84,16 @@ public class LocalFirstRaftClient implements Closeable {
   private CompletableFuture<RaftClientReply> sendLocalRequest(Message message,
       TimeDuration timeout) throws IOException {
     LOG.trace("Sending local message {}", message);
-    return mServer.submitClientRequestAsync(
-        new RaftClientRequest(mLocalClientId, null, RaftJournalSystem.RAFT_GROUP_ID,
-            RaftJournalSystem.nextCallId(), message, RaftClientRequest.writeRequestType(), null))
+    RaftClientRequest request = RaftClientRequest.newBuilder()
+            .setClientId(mLocalClientId)
+            .setServerId(null)
+            .setGroupId(RaftJournalSystem.RAFT_GROUP_ID)
+            .setCallId(RaftJournalSystem.nextCallId())
+            .setMessage(message)
+            .setType(RaftClientRequest.writeRequestType())
+            .setSlidingWindowEntry(null)
+            .build();
+    return mServer.submitClientRequestAsync(request)
         .thenApply(reply -> handleLocalException(message, reply, timeout));
   }
 
@@ -130,7 +137,7 @@ public class LocalFirstRaftClient implements Closeable {
   private CompletableFuture<RaftClientReply> sendRemoteRequest(Message message) {
     ensureClient();
     LOG.trace("Sending remote message {}", message);
-    return mClient.sendAsync(message).exceptionally(t -> {
+    return mClient.async().send(message).exceptionally(t -> {
       handleRemoteException(t);
       throw new CompletionException(t.getCause());
     });

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotDownloader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotDownloader.java
@@ -123,7 +123,7 @@ public class SnapshotDownloader<S, R> implements ClientResponseObserver<S, R> {
   }
 
   private void onNextInternal(R response) throws IOException {
-    TermIndex termIndex = TermIndex.newTermIndex(
+    TermIndex termIndex = TermIndex.valueOf(
         mDataGetter.apply(response).getSnapshotTerm(),
         mDataGetter.apply(response).getSnapshotIndex());
     if (mTermIndex == null) {

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -547,7 +547,7 @@ public class RaftJournalTest {
     getStateMethod.setAccessible(true);
     Object serverStateObj = getStateMethod.invoke(serverImplObj);
     Class<?> serverStateClass = Class.forName("org.apache.ratis.server.impl.ServerState");
-    Method getCurrentTermMethod = serverStateClass.getMethod("getCurrentTerm");
+    Method getCurrentTermMethod = serverStateClass.getDeclaredMethod("getCurrentTerm");
     getCurrentTermMethod.setAccessible(true);
     long currentTermObj = (long) getCurrentTermMethod.invoke(serverStateObj);
 

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalWriterTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalWriterTest.java
@@ -52,10 +52,18 @@ public class RaftJournalWriterTest {
 
   private void setupRaftJournalWriter() throws IOException  {
     mClient = mock(LocalFirstRaftClient.class);
-    RaftClientReply reply = new RaftClientReply(ClientId.randomId(),
-        RaftGroupMemberId.valueOf(RaftJournalUtils.getPeerId(new InetSocketAddress(1)),
-            RaftGroupId.valueOf(UUID.fromString("02511d47-d67c-49a3-9011-abb3109a44c1"))),
-        1L, true, Message.valueOf("mp"), null, 1L, null);
+    RaftClientReply reply = RaftClientReply.newBuilder()
+            .setClientId(ClientId.randomId())
+            .setServerId(
+              RaftGroupMemberId.valueOf(RaftJournalUtils.getPeerId(new InetSocketAddress(1)),
+              RaftGroupId.valueOf(UUID.fromString("02511d47-d67c-49a3-9011-abb3109a44c1")))
+            ).setCallId(1L)
+            .setSuccess(true)
+            .setMessage(Message.valueOf("mp"))
+            .setException(null)
+            .setLogIndex(1L)
+            .setCommitInfos(null)
+            .build();
 
     CompletableFuture<RaftClientReply> future = new CompletableFuture<RaftClientReply>() {
       @Override

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -32,7 +32,6 @@ import io.grpc.stub.StreamObserver;
 import org.apache.commons.io.FileUtils;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
-import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -86,11 +85,8 @@ public class SnapshotReplicationManagerTest {
       JournalQueryRequest queryRequest = JournalQueryRequest.parseFrom(
           message.getContent().asReadOnlyByteBuffer());
       Message response = mFollowerSnapshotManager.handleRequest(queryRequest);
-      RaftClientReply reply = RaftClientReply.newBuilder()
-              .setRequest(Mockito.mock(RaftClientRequest.class))
-              .setMessage(response)
-              .setGroupId(null)
-              .build();
+      RaftClientReply reply = Mockito.mock(RaftClientReply.class);
+      Mockito.when(reply.getMessage()).thenReturn(response);
       return CompletableFuture.completedFuture(reply);
     });
     mLeaderStore = getSimpleStateMachineStorage();

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <parquet.version>1.11.0</parquet.version>
     <protobuf.version>3.12.4</protobuf.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <ratis.version>1.0.0</ratis.version>
+    <ratis.version>2.0.0</ratis.version>
     <slf4j.version>1.7.30</slf4j.version>
     <jackson.version>2.11.1</jackson.version>
     <ozone.version>1.0.0</ozone.version>

--- a/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
+++ b/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
@@ -39,8 +39,9 @@ import alluxio.testutils.IntegrationTestUtils;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.util.io.PathUtils;
 
-import org.apache.ratis.server.impl.RaftServerConstants;
+import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.storage.RaftStorage;
+import org.apache.ratis.server.storage.RaftStorageImpl;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 import org.hamcrest.Matchers;
@@ -217,10 +218,10 @@ public class JournalToolTest extends BaseIntegrationTest {
   }
 
   private long getCurrentRatisSnapshotIndex(String journalFolder) throws Throwable {
-    try (RaftStorage storage = new RaftStorage(
+    try (RaftStorage storage = new RaftStorageImpl(
         new File(RaftJournalUtils.getRaftJournalDir(new File(journalFolder)),
             RaftJournalSystem.RAFT_GROUP_UUID.toString()),
-        RaftServerConstants.StartupOption.REGULAR)) {
+            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault())) {
       SimpleStateMachineStorage stateMachineStorage = new SimpleStateMachineStorage();
       stateMachineStorage.init(storage);
       SingleFileSnapshotInfo snapshot = stateMachineStorage.getLatestSnapshot();

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTest.java
@@ -42,8 +42,8 @@ import alluxio.util.network.NetworkAddressUtils;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.ratis.protocol.Message;
-import org.apache.ratis.server.impl.RaftServerConstants;
-import org.apache.ratis.server.storage.RaftStorage;
+import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.server.storage.RaftStorageImpl;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 import org.junit.After;
@@ -139,7 +139,8 @@ public final class EmbeddedJournalIntegrationTest extends BaseIntegrationTest {
     mCluster.stopMasters();
 
     SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
-    storage.init(new RaftStorage(raftDir, RaftServerConstants.StartupOption.REGULAR));
+    storage.init(new RaftStorageImpl(raftDir,
+            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault()));
     SingleFileSnapshotInfo snapshot = storage.findLatestSnapshot();
     assertNotNull(snapshot);
     mCluster.notifySuccess();
@@ -178,7 +179,8 @@ public final class EmbeddedJournalIntegrationTest extends BaseIntegrationTest {
     waitForSnapshot(raftDir);
     mCluster.stopMaster(catchUpMasterIndex);
     SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
-    storage.init(new RaftStorage(raftDir, RaftServerConstants.StartupOption.REGULAR));
+    storage.init(new RaftStorageImpl(raftDir,
+            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault()));
     SingleFileSnapshotInfo snapshot = storage.findLatestSnapshot();
     assertNotNull(snapshot);
     mCluster.notifySuccess();


### PR DESCRIPTION
### What changes are proposed in this pull request?
Updating the Apache Ratis API from v1.0.0 to v2.0.0

### Why are the changes needed?
This upgrade will allow Alluxio to use the new TransferLeadership functionality in Ratis 2.0.0. This will allow Alluxio masters to gracefully give up their leadership manually.

### Does this PR introduce any user facing changes?
No

Fixes #13680