### PR TITLE
Add journal checkpoint warnings on UI

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2605,6 +2605,16 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_WEB_JOURNAL_CHECKPOINT_WARNING_THRESHOLD_TIME =
+      new Builder(Name.MASTER_WEB_JOURNAL_CHECKPOINT_WARNING_THRESHOLD_TIME)
+          .setDefaultValue(Constants.DAY * 3)
+          .setIsHidden(true)
+          .setDescription("The amount of time since the last checkpoint and when the number of "
+              + "journal entries is greater than " + Name.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES
+              + " which causes a warning to be displayed in the web UI ")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_WHITELIST =
       new Builder(Name.MASTER_WHITELIST)
           .setDefaultValue("/")
@@ -5818,6 +5828,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_WEB_BIND_HOST = "alluxio.master.web.bind.host";
     public static final String MASTER_WEB_HOSTNAME = "alluxio.master.web.hostname";
     public static final String MASTER_WEB_PORT = "alluxio.master.web.port";
+    public static final String MASTER_WEB_JOURNAL_CHECKPOINT_WARNING_THRESHOLD_TIME =
+        "alluxio.master.journal.checkpoint.warning.threshold.time";
     public static final String MASTER_WHITELIST = "alluxio.master.whitelist";
     public static final String MASTER_WORKER_CONNECT_WAIT_TIME =
         "alluxio.master.worker.connect.wait.time";

--- a/core/common/src/main/java/alluxio/wire/MasterWebUIMetrics.java
+++ b/core/common/src/main/java/alluxio/wire/MasterWebUIMetrics.java
@@ -42,6 +42,8 @@ public final class MasterWebUIMetrics implements Serializable {
   private Map<String, String> mUfsWriteSize;
   private List<TimeSeries> mTimeSeriesMetrics;
   private List<JournalDiskInfo> mJournalDiskMetrics;
+  private String mJournalLastCheckpointTime;
+  private long mJournalEntriesSinceCheckpoint;
   private String mCacheHitLocal;
   private String mCacheHitRemote;
   private String mCacheMiss;
@@ -341,6 +343,20 @@ public final class MasterWebUIMetrics implements Serializable {
    */
   public List<JournalDiskInfo> getJournalDiskMetrics() {
     return mJournalDiskMetrics;
+  }
+
+  /**
+   * @return the last journal checkpoint time
+   */
+  public String getJournalLastCheckpointTime() {
+    return mJournalLastCheckpointTime;
+  }
+
+  /**
+   * @return the last journal checkpoint time
+   */
+  public long getJournalEntriesSinceCheckpoint() {
+    return mJournalEntriesSinceCheckpoint;
   }
 
   /**
@@ -674,6 +690,24 @@ public final class MasterWebUIMetrics implements Serializable {
    */
   public MasterWebUIMetrics setJournalDiskMetrics(List<JournalDiskInfo> journalDiskMetrics) {
     mJournalDiskMetrics = journalDiskMetrics;
+    return this;
+  }
+
+  /**
+   * @param lastCheckpointTime the last journal checkpoint time
+   * @return the updated metrics object
+   */
+  public MasterWebUIMetrics setJournalLastCheckpointTime(String lastCheckpointTime) {
+    mJournalLastCheckpointTime = lastCheckpointTime;
+    return this;
+  }
+
+  /**
+   * @param entriesSinceCheckpoint the last journal checkpoint time
+   * @return the updated metrics object
+   */
+  public MasterWebUIMetrics setJournalEntriesSinceCheckpoint(long entriesSinceCheckpoint) {
+    mJournalEntriesSinceCheckpoint = entriesSinceCheckpoint;
     return this;
   }
 

--- a/core/common/src/main/java/alluxio/wire/MasterWebUIOverview.java
+++ b/core/common/src/main/java/alluxio/wire/MasterWebUIOverview.java
@@ -43,6 +43,7 @@ public final class MasterWebUIOverview implements Serializable {
   private String mDiskUsedCapacity;
   private String mFreeCapacity;
   private List<String> mJournalDiskWarnings;
+  private String mJournalCheckpointTimeWarning;
   private String mLiveWorkerNodes;
   private String mMasterNodeAddress;
   private String mStartTime;
@@ -144,6 +145,13 @@ public final class MasterWebUIOverview implements Serializable {
    */
   public String getFreeCapacity() {
     return mFreeCapacity;
+  }
+
+  /**
+   * @return the journal checkpoint time warning
+   */
+  public String getJournalCheckpointTimeWarning() {
+    return mJournalCheckpointTimeWarning;
   }
 
   /**
@@ -335,6 +343,15 @@ public final class MasterWebUIOverview implements Serializable {
    */
   public MasterWebUIOverview setFreeCapacity(String freeCapacity) {
     mFreeCapacity = freeCapacity;
+    return this;
+  }
+
+  /**
+   * @param journalCheckpointTimeWarning the journal checkpoint time warning
+   * @return the updated {@link MasterWebUIOverview} object
+   */
+  public MasterWebUIOverview setJournalCheckpointTimeWarning(String journalCheckpointTimeWarning) {
+    mJournalCheckpointTimeWarning = journalCheckpointTimeWarning;
     return this;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -345,10 +345,10 @@ public final class AlluxioMasterRestServiceHandler {
               + "prevent the master from serving requests while checkpointing.";
           response.setJournalCheckpointTimeWarning(String.format("Journal has not checkpointed in "
               + "a timely manner since passing the checkpoint threshold (%d/%d). Last checkpoint:"
-              + " %s. t is recommended to use the fsadmin tool to force a checkpoint. " + advice,
+              + " %s. %s",
               entriesSinceCkpt,
               ServerConfiguration.getLong(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES),
-              time));
+              time, advice));
         }
       }
 

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -340,9 +340,12 @@ public final class AlluxioMasterRestServiceHandler {
           String time = lastCkptTime > 0 ? ZonedDateTime
               .ofInstant(Instant.ofEpochMilli(lastCkptTime), ZoneOffset.UTC)
               .format(DateTimeFormatter.ISO_INSTANT) : "N/A";
+          String advice = ConfigurationUtils.isHaMode(ServerConfiguration.global()) ? ""
+              : "It is recommended to use the fsadmin tool to checkpoint the journal. This will "
+              + "prevent the master from serving requests while checkpointing.";
           response.setJournalCheckpointTimeWarning(String.format("Journal has not checkpointed in "
               + "a timely manner since passing the checkpoint threshold (%d/%d). Last checkpoint:"
-              + " %s. It is recommended to use the fsadmin tool to force a checkpoint.",
+              + " %s. t is recommended to use the fsadmin tool to force a checkpoint. " + advice,
               entriesSinceCkpt,
               ServerConfiguration.getLong(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES),
               time));

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -1082,20 +1082,26 @@ public final class AlluxioMasterRestServiceHandler {
         response.setJournalDiskMetrics(Collections.emptyList());
       }
 
-      long lastCheckpointTime =
-          (Long) gauges.get(MetricKey.MASTER_JOURNAL_LAST_CHECKPOINT_TIME.getName()).getValue();
-      long entriesSinceCheckpoint =
-          (Long) gauges.get(MetricKey.MASTER_JOURNAL_ENTRIES_SINCE_CHECKPOINT.getName()).getValue();
-      response.setJournalEntriesSinceCheckpoint(entriesSinceCheckpoint);
-      String time;
-      if (lastCheckpointTime > 0) {
-        time = ZonedDateTime
-            .ofInstant(Instant.ofEpochMilli(lastCheckpointTime), ZoneOffset.UTC)
-            .format(DateTimeFormatter.ISO_INSTANT);
-      } else {
-        time = "N/A";
+      Gauge lastCheckpointTimeGauge =
+          gauges.get(MetricKey.MASTER_JOURNAL_LAST_CHECKPOINT_TIME.getName());
+      Gauge entriesSinceCheckpointGauge =
+          gauges.get(MetricKey.MASTER_JOURNAL_ENTRIES_SINCE_CHECKPOINT.getName());
+
+      if (entriesSinceCheckpointGauge != null) {
+        response.setJournalEntriesSinceCheckpoint((long) entriesSinceCheckpointGauge.getValue());
       }
-      response.setJournalLastCheckpointTime(time);
+      if (lastCheckpointTimeGauge != null) {
+        long lastCheckpointTime = (long) lastCheckpointTimeGauge.getValue();
+        String time;
+        if (lastCheckpointTime > 0) {
+          time = ZonedDateTime
+              .ofInstant(Instant.ofEpochMilli(lastCheckpointTime), ZoneOffset.UTC)
+              .format(DateTimeFormatter.ISO_INSTANT);
+        } else {
+          time = "N/A";
+        }
+        response.setJournalLastCheckpointTime(time);
+      }
 
       return response;
     }, ServerConfiguration.global());

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -332,22 +332,22 @@ public final class AlluxioMasterRestServiceHandler {
         long entriesSinceCkpt = (Long) entriesSinceGauge.getValue();
         long lastCkptTime = (Long) lastCkPtGauge.getValue();
         long timeSinceCkpt = System.currentTimeMillis() - lastCkptTime;
-        boolean over72Hrs = timeSinceCkpt > ServerConfiguration.getMs(
+        boolean overThreshold = timeSinceCkpt > ServerConfiguration.getMs(
             PropertyKey.MASTER_WEB_JOURNAL_CHECKPOINT_WARNING_THRESHOLD_TIME);
         boolean passedThreshold = entriesSinceCkpt > ServerConfiguration
             .getLong(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES);
-        if (lastCkptTime > 0 && passedThreshold && over72Hrs) {
-          String time = ZonedDateTime
+        if (passedThreshold && overThreshold) {
+          String time = lastCkptTime > 0 ? ZonedDateTime
               .ofInstant(Instant.ofEpochMilli(lastCkptTime), ZoneOffset.UTC)
-              .format(DateTimeFormatter.ISO_INSTANT);
+              .format(DateTimeFormatter.ISO_INSTANT) : "N/A";
           response.setJournalCheckpointTimeWarning(String.format("Journal has not checkpointed in "
               + "a timely manner since passing the checkpoint threshold (%d/%d). Last checkpoint:"
-              + " %s", entriesSinceCkpt,
+              + " %s. It is recommended to use the fsadmin tool to force a checkpoint.",
+              entriesSinceCkpt,
               ServerConfiguration.getLong(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES),
               time));
         }
       }
-
 
       return response;
     }, ServerConfiguration.global());
@@ -1096,7 +1096,6 @@ public final class AlluxioMasterRestServiceHandler {
         time = "N/A";
       }
       response.setJournalLastCheckpointTime(time);
-
 
       return response;
     }, ServerConfiguration.global());

--- a/webui/master/src/containers/App/__snapshots__/App.test.tsx.snap
+++ b/webui/master/src/containers/App/__snapshots__/App.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`App Shallow component Matches snapshot 1`] = `
               "url": "/metrics",
             },
             Object {
-              "innerText": "Mount Table",
+              "innerText": "MountTable",
               "url": "/mounttable",
             },
           ]
@@ -169,7 +169,7 @@ exports[`App Shallow component Matches snapshot 1`] = `
               "url": "/workers",
             },
             Object {
-              "innerText": "Mount Table",
+              "innerText": "MountTable",
               "url": "/mounttable",
             },
           ]

--- a/webui/master/src/containers/App/__snapshots__/App.test.tsx.snap
+++ b/webui/master/src/containers/App/__snapshots__/App.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`App Shallow component Matches snapshot 1`] = `
               "url": "/metrics",
             },
             Object {
-              "innerText": "MountTable",
+              "innerText": "Mount Table",
               "url": "/mounttable",
             },
           ]
@@ -169,7 +169,7 @@ exports[`App Shallow component Matches snapshot 1`] = `
               "url": "/workers",
             },
             Object {
-              "innerText": "MountTable",
+              "innerText": "Mount Table",
               "url": "/mounttable",
             },
           ]

--- a/webui/master/src/containers/pages/Metrics/Metrics.tsx
+++ b/webui/master/src/containers/pages/Metrics/Metrics.tsx
@@ -318,6 +318,21 @@ export class MetricsPresenter extends React.Component<AllProps> {
             </tbody>
           </Table>
         </div>
+        <div className="col-12">
+          <h5>Alluxio Master Journal Checkpoint Status</h5>
+          <Table hover={true}>
+            <tbody>
+              <tr>
+                <th>Last Checkpoint Time</th>
+                <th>Journal Entries Since Checkpoint</th>
+              </tr>
+              <tr key="0">
+                    <td>{data.journalLastCheckpointTime}</td>
+                    <td>{data.journalEntriesSinceCheckpoint}</td>
+                  </tr>
+            </tbody>
+          </Table>
+        </div>
       </React.Fragment>
     );
   }

--- a/webui/master/src/containers/pages/Metrics/Metrics.tsx
+++ b/webui/master/src/containers/pages/Metrics/Metrics.tsx
@@ -327,9 +327,9 @@ export class MetricsPresenter extends React.Component<AllProps> {
                 <th>Journal Entries Since Checkpoint</th>
               </tr>
               <tr>
-                    <td>{data.journalLastCheckpointTime}</td>
-                    <td>{data.journalEntriesSinceCheckpoint}</td>
-                  </tr>
+                <td>{data.journalLastCheckpointTime}</td>
+                <td>{data.journalEntriesSinceCheckpoint}</td>
+              </tr>
             </tbody>
           </Table>
         </div>

--- a/webui/master/src/containers/pages/Metrics/Metrics.tsx
+++ b/webui/master/src/containers/pages/Metrics/Metrics.tsx
@@ -326,7 +326,7 @@ export class MetricsPresenter extends React.Component<AllProps> {
                 <th>Last Checkpoint Time</th>
                 <th>Journal Entries Since Checkpoint</th>
               </tr>
-              <tr key="0">
+              <tr>
                     <td>{data.journalLastCheckpointTime}</td>
                     <td>{data.journalEntriesSinceCheckpoint}</td>
                   </tr>

--- a/webui/master/src/containers/pages/Metrics/__snapshots__/Metrics.test.tsx.snap
+++ b/webui/master/src/containers/pages/Metrics/__snapshots__/Metrics.test.tsx.snap
@@ -364,5 +364,34 @@ exports[`Metrics Shallow component Matches snapshot 1`] = `
       </tbody>
     </Table>
   </div>
+  <div
+    className="col-12"
+  >
+    <h5>
+      Alluxio Master Journal Checkpoint Status
+    </h5>
+    <Table
+      hover={true}
+      responsiveTag="div"
+      tag="table"
+    >
+      <tbody>
+        <tr>
+          <th>
+            Last Checkpoint Time
+          </th>
+          <th>
+            Journal Entries Since Checkpoint
+          </th>
+        </tr>
+        <tr>
+          <td />
+          <td>
+            0
+          </td>
+        </tr>
+      </tbody>
+    </Table>
+  </div>
 </Fragment>
 `;

--- a/webui/master/src/containers/pages/Overview/Overview.tsx
+++ b/webui/master/src/containers/pages/Overview/Overview.tsx
@@ -68,6 +68,7 @@ export class OverviewPresenter extends React.Component<AllProps> {
               {this.renderConfigurationIssues(data.configCheckErrors, 'text-error')}
               {this.renderConfigurationIssues(data.configCheckWarns, 'text-warning')}
               {this.renderJournalDiskWarnings(data.journalDiskWarnings, 'text-warning')}
+              {this.renderJournalCheckpointWarning(data.journalCheckpointTimeWarning, 'text-warning')}
             </tbody>
           </Table>
         </div>
@@ -132,6 +133,21 @@ export class OverviewPresenter extends React.Component<AllProps> {
         </div>
       </React.Fragment>
     );
+  }
+
+  private renderJournalCheckpointWarning(warning: string, className: string): JSX.Element | null {
+    if (!warning || warning == "") {
+      return null;
+    }
+
+    return (
+      <tr key="0">
+        <td colSpan={2} className={className}>
+          {warning}
+        </td>
+      </tr>
+    );
+
   }
 
   private renderJournalDiskWarnings(warnings: string[], className: string): JSX.Element | null {

--- a/webui/master/src/containers/pages/Overview/Overview.tsx
+++ b/webui/master/src/containers/pages/Overview/Overview.tsx
@@ -136,7 +136,7 @@ export class OverviewPresenter extends React.Component<AllProps> {
   }
 
   private renderJournalCheckpointWarning(warning: string, className: string): JSX.Element | null {
-    if (!warning || warning == "") {
+    if (!warning || warning == '') {
       return null;
     }
 
@@ -147,7 +147,6 @@ export class OverviewPresenter extends React.Component<AllProps> {
         </td>
       </tr>
     );
-
   }
 
   private renderJournalDiskWarnings(warnings: string[], className: string): JSX.Element | null {

--- a/webui/master/src/containers/pages/Overview/Overview.tsx
+++ b/webui/master/src/containers/pages/Overview/Overview.tsx
@@ -141,7 +141,7 @@ export class OverviewPresenter extends React.Component<AllProps> {
     }
 
     return (
-      <tr key="0">
+      <tr key="journal-ckpt-warning-0">
         <td colSpan={2} className={className}>
           {warning}
         </td>

--- a/webui/master/src/store/metrics/reducer.tsx
+++ b/webui/master/src/store/metrics/reducer.tsx
@@ -28,6 +28,8 @@ export const initialMetricsState: IMetricsState = {
     rpcInvocationMetrics: {},
     timeSeriesMetrics: [],
     journalDiskMetrics: [],
+    journalLastCheckpointTime: "",
+    journalEntriesSinceCheckpoint: 0,
     totalBytesReadLocal: '',
     totalBytesReadLocalThroughput: '',
     totalBytesReadDomainSocket: '',

--- a/webui/master/src/store/metrics/reducer.tsx
+++ b/webui/master/src/store/metrics/reducer.tsx
@@ -28,7 +28,7 @@ export const initialMetricsState: IMetricsState = {
     rpcInvocationMetrics: {},
     timeSeriesMetrics: [],
     journalDiskMetrics: [],
-    journalLastCheckpointTime: "",
+    journalLastCheckpointTime: '',
     journalEntriesSinceCheckpoint: 0,
     totalBytesReadLocal: '',
     totalBytesReadLocalThroughput: '',

--- a/webui/master/src/store/metrics/types.tsx
+++ b/webui/master/src/store/metrics/types.tsx
@@ -28,6 +28,8 @@ export interface IMetrics {
   };
   timeSeriesMetrics: LineSerieData[];
   journalDiskMetrics: IJournalDiskInfo[];
+  journalLastCheckpointTime: string;
+  journalEntriesSinceCheckpoint: number;
   totalBytesReadLocal: string;
   totalBytesReadLocalThroughput: string;
   totalBytesReadDomainSocket: string;

--- a/webui/master/src/store/overview/reducer.tsx
+++ b/webui/master/src/store/overview/reducer.tsx
@@ -24,6 +24,7 @@ export const initialOverviewState: IOverviewState = {
     diskFreeCapacity: '',
     diskUsedCapacity: '',
     freeCapacity: '',
+    journalCheckpointTimeWarning: "",
     journalDiskWarnings: [],
     liveWorkerNodes: 0,
     masterNodeAddress: '',

--- a/webui/master/src/store/overview/reducer.tsx
+++ b/webui/master/src/store/overview/reducer.tsx
@@ -24,7 +24,7 @@ export const initialOverviewState: IOverviewState = {
     diskFreeCapacity: '',
     diskUsedCapacity: '',
     freeCapacity: '',
-    journalCheckpointTimeWarning: "",
+    journalCheckpointTimeWarning: '',
     journalDiskWarnings: [],
     liveWorkerNodes: 0,
     masterNodeAddress: '',

--- a/webui/master/src/store/overview/types.tsx
+++ b/webui/master/src/store/overview/types.tsx
@@ -23,6 +23,7 @@ export interface IOverview {
   diskFreeCapacity: string;
   diskUsedCapacity: string;
   freeCapacity: string;
+  journalCheckpointTimeWarning: string;
   journalDiskWarnings: string[];
   liveWorkerNodes: number;
   masterNodeAddress: string;


### PR DESCRIPTION
### What changes are proposed in this pull request?

Adding warnings to the UI overview page when the journal has not checkpointed in some time after reaching the journal entry checkpoint period. Also, add the two checkpoint metrics (last checkpoint time and entries since checkpoint) to the metrics tab.

New overview page warning:

![image](https://user-images.githubusercontent.com/3464508/123139176-c7190800-d40a-11eb-8deb-f6f444b35ad4.png)

Metrics page addition:

![image](https://user-images.githubusercontent.com/3464508/123139207-d13b0680-d40a-11eb-86dd-6c2a7d29d533.png)

### Why are the changes needed?

This is required to help alert users to potential issues with their system if the journal has not checkpointed when it is supposed to. 

### Does this PR introduce any user facing changes?

- Addition of a hidden property key to change the time period which causes the warning to show up on the overview page. It is marked as hidden because no one _should_ need to configure this value, but it may be desirable. It is also useful for testing.
- Web UI additions (see screenshots). New section on the metrics page and new potential warning in the overview.