### PR TITLE
Close lock while traversing for all exceptions

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -414,9 +414,9 @@ public class InodeTree implements DelegatingJournaled {
         new LockedInodePath(uri, mInodeStore, mInodeLockManager, getRoot(), lockPattern, tryLock);
     try {
       inodePath.traverse();
-    } catch (InvalidPathException e) {
+    } catch (Throwable t) {
       inodePath.close();
-      throw e;
+      throw t;
     }
     return inodePath;
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Locking an inode path might leave locks when runtime exceptions are thrown.
This fix ensures there won't be a lock leak for all exceptions.
