### PR TITLE
Add a name suffix to distinguish AsyncJournalWriter threads

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
@@ -138,6 +138,7 @@ public final class AsyncJournalWriter {
   /**
    * If this is UFS journal, we have one AsyncJournalWriter threads per journal.
    * We use this suffix to distinguish different threads.
+   * If this is RAFT embedded journal, there is only one AsyncJournalWriter thread.
    */
   private String mJournalName = "Raft";
 

--- a/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
@@ -146,7 +146,7 @@ public final class AsyncJournalWriter {
    * It goes over the {@code mTicketList} after every flush session and releases waiters.
    */
   private Thread mFlushThread = new Thread(this::doFlush,
-"AsyncJournalWriterThread-" + mJournalName);
+      "AsyncJournalWriterThread-" + mJournalName);
 
   /**
    * Used to give permits to flush thread to start processing immediately.
@@ -187,7 +187,8 @@ public final class AsyncJournalWriter {
    * @param journalSinks a supplier for journal sinks
    * @param journalName the journal source name
    */
-  public AsyncJournalWriter(JournalWriter journalWriter, Supplier<Set<JournalSink>> journalSinks, String journalName) {
+  public AsyncJournalWriter(JournalWriter journalWriter, Supplier<Set<JournalSink>> journalSinks,
+      String journalName) {
     this(journalWriter, journalSinks);
     mJournalName = journalName;
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
@@ -136,10 +136,17 @@ public final class AsyncJournalWriter {
   private final Set<FlushTicket> mTicketSet = new ConcurrentHashSet<>();
 
   /**
+   * If this is UFS journal, we have one AsyncJournalWriter threads per journal.
+   * We use this suffix to distinguish different threads.
+   */
+  private String mJournalName = "Raft";
+
+  /**
    * Dedicated thread for writing and flushing entries in journal queue.
    * It goes over the {@code mTicketList} after every flush session and releases waiters.
    */
-  private Thread mFlushThread = new Thread(this::doFlush, "AsyncJournalWriterThread");
+  private Thread mFlushThread = new Thread(this::doFlush,
+"AsyncJournalWriterThread-" + mJournalName);
 
   /**
    * Used to give permits to flush thread to start processing immediately.
@@ -171,6 +178,18 @@ public final class AsyncJournalWriter {
         TimeUnit.MILLISECONDS);
     mJournalSinks = journalSinks;
     mFlushThread.start();
+  }
+
+  /**
+   * Creates a {@link AsyncJournalWriter}.
+   *
+   * @param journalWriter a journal writer to write to
+   * @param journalSinks a supplier for journal sinks
+   * @param journalName the journal source name
+   */
+  public AsyncJournalWriter(JournalWriter journalWriter, Supplier<Set<JournalSink>> journalSinks, String journalName) {
+    this(journalWriter, journalSinks);
+    mJournalName = journalName;
   }
 
   /**

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -448,7 +448,6 @@ public class RaftJournalSystem extends AbstractJournalSystem {
 
     Preconditions.checkState(mRaftJournalWriter == null);
     mRaftJournalWriter = new RaftJournalWriter(nextSN, client);
-    // TODO(jiacheng): pass sth here?
     mAsyncJournalWriter
         .set(new AsyncJournalWriter(mRaftJournalWriter, () -> getJournalSinks(null)));
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -448,6 +448,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
 
     Preconditions.checkState(mRaftJournalWriter == null);
     mRaftJournalWriter = new RaftJournalWriter(nextSN, client);
+    // TODO(jiacheng): pass sth here?
     mAsyncJournalWriter
         .set(new AsyncJournalWriter(mRaftJournalWriter, () -> getJournalSinks(null)));
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
@@ -268,7 +268,7 @@ public class UfsJournal implements Journal {
 
     nextSequenceNumber = catchUp(nextSequenceNumber);
     mWriter = new UfsJournalLogWriter(this, nextSequenceNumber);
-    mAsyncWriter = new AsyncJournalWriter(mWriter, mJournalSinks);
+    mAsyncWriter = new AsyncJournalWriter(mWriter, mJournalSinks, mMaster.getName());
     mState.set(State.PRIMARY);
     LOG.info("{}: journal switched to primary mode. location: {}", mMaster.getName(), mLocation);
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

There can be multiple AsyncJournalWriter threads, add a thread name suffix to distinguish them.

### Why are the changes needed?

Makes jstack debugging easier

### Does this PR introduce any user facing changes?

NA
