### PR TITLE
Fix PathTranslator to compare path prefixes by path components

### DIFF
--- a/table/server/common/pom.xml
+++ b/table/server/common/pom.xml
@@ -56,6 +56,8 @@
       <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
+
+    <!-- Internal test dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-common</artifactId>

--- a/table/server/common/pom.xml
+++ b/table/server/common/pom.xml
@@ -56,5 +56,12 @@
       <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
@@ -17,7 +17,6 @@ import alluxio.exception.InvalidPathException;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.io.PathUtils;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import org.slf4j.Logger;
@@ -33,8 +32,12 @@ public class PathTranslator {
 
   private final BiMap<AlluxioURI, AlluxioURI> mPathMap;
 
-  @VisibleForTesting
-  static String sSchemeAuthorityPrefix = null;
+  private static final String sSchemeAuthorityPrefix;
+
+  static {
+    sSchemeAuthorityPrefix =
+        ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global());
+  }
 
   /**
    * Construct a path translator.
@@ -110,10 +113,6 @@ public class PathTranslator {
 
   private static AlluxioURI checkAndAddSchemeAuthority(AlluxioURI input) {
     if (!input.hasScheme()) {
-      if (sSchemeAuthorityPrefix == null) {
-        sSchemeAuthorityPrefix =
-            ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global());
-      }
       AlluxioURI baseUri = new AlluxioURI(sSchemeAuthorityPrefix);
       return new AlluxioURI(baseUri, input.getPath(), false);
     }

--- a/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
@@ -29,12 +29,10 @@ import java.io.IOException;
  */
 public class PathTranslator {
   private static final Logger LOG = LoggerFactory.getLogger(PathTranslator.class);
-
-  private final BiMap<AlluxioURI, AlluxioURI> mPathMap;
-
   private static final String SCHEME_AUTHORITY_PREFIX =
       ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global());
   private static final AlluxioURI BASE_URI = new AlluxioURI(SCHEME_AUTHORITY_PREFIX);
+  private final BiMap<AlluxioURI, AlluxioURI> mPathMap;
 
   /**
    * Construct a path translator.

--- a/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
@@ -32,12 +32,9 @@ public class PathTranslator {
 
   private final BiMap<AlluxioURI, AlluxioURI> mPathMap;
 
-  private static final String SCHEME_AUTHORITY_PREFIX;
-
-  static {
-    SCHEME_AUTHORITY_PREFIX =
-        ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global());
-  }
+  private static final String SCHEME_AUTHORITY_PREFIX =
+      ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global());
+  private static final AlluxioURI BASE_URI = new AlluxioURI(SCHEME_AUTHORITY_PREFIX);
 
   /**
    * Construct a path translator.
@@ -113,8 +110,7 @@ public class PathTranslator {
 
   private static AlluxioURI checkAndAddSchemeAuthority(AlluxioURI input) {
     if (!input.hasScheme()) {
-      AlluxioURI baseUri = new AlluxioURI(SCHEME_AUTHORITY_PREFIX);
-      return new AlluxioURI(baseUri, input.getPath(), false);
+      return new AlluxioURI(BASE_URI, input.getPath(), false);
     }
     return input;
   }

--- a/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
@@ -32,10 +32,10 @@ public class PathTranslator {
 
   private final BiMap<AlluxioURI, AlluxioURI> mPathMap;
 
-  private static final String sSchemeAuthorityPrefix;
+  private static final String SCHEME_AUTHORITY_PREFIX;
 
   static {
-    sSchemeAuthorityPrefix =
+    SCHEME_AUTHORITY_PREFIX =
         ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global());
   }
 
@@ -113,7 +113,7 @@ public class PathTranslator {
 
   private static AlluxioURI checkAndAddSchemeAuthority(AlluxioURI input) {
     if (!input.hasScheme()) {
-      AlluxioURI baseUri = new AlluxioURI(sSchemeAuthorityPrefix);
+      AlluxioURI baseUri = new AlluxioURI(SCHEME_AUTHORITY_PREFIX);
       return new AlluxioURI(baseUri, input.getPath(), false);
     }
     return input;

--- a/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
@@ -11,8 +11,11 @@
 
 package alluxio.table.common.udb;
 
+import alluxio.AlluxioURI;
 import alluxio.conf.ServerConfiguration;
+import alluxio.exception.InvalidPathException;
 import alluxio.util.ConfigurationUtils;
+import alluxio.util.io.PathUtils;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -27,7 +30,7 @@ import java.io.IOException;
 public class PathTranslator {
   private static final Logger LOG = LoggerFactory.getLogger(PathTranslator.class);
 
-  private BiMap<String, String> mPathMap;
+  private final BiMap<AlluxioURI, AlluxioURI> mPathMap;
 
   /**
    * Construct a path translator.
@@ -45,16 +48,7 @@ public class PathTranslator {
    * @return PathTranslator object
    */
   public PathTranslator addMapping(String alluxioPath, String ufsPath) {
-    while (alluxioPath.endsWith("/")) {
-      // strip trailing slashes
-      alluxioPath = alluxioPath.substring(0, alluxioPath.length() - 1);
-    }
-
-    while (ufsPath.endsWith("/")) {
-      // strip trailing slashes
-      ufsPath = ufsPath.substring(0, ufsPath.length() - 1);
-    }
-    mPathMap.put(alluxioPath, ufsPath);
+    mPathMap.put(new AlluxioURI(alluxioPath), new AlluxioURI(ufsPath));
     return this;
   }
 
@@ -66,23 +60,48 @@ public class PathTranslator {
    * @throws IOException if the ufs path is not mounted
    */
   public String toAlluxioPath(String ufsPath) throws IOException {
-    for (BiMap.Entry<String, String> entry : mPathMap.entrySet()) {
-      if (ufsPath.startsWith(entry.getValue())) {
-        // return ufsPath if set the key and value to be same when bypass path.
-        if (entry.getKey().equals(entry.getValue())) {
-          return ufsPath;
+    String suffix = ufsPath.endsWith("/") ? "/" : "";
+    AlluxioURI ufsUri = new AlluxioURI(ufsPath);
+    // first look for an exact match
+    if (mPathMap.inverse().containsKey(ufsUri)) {
+      return mPathMap.inverse().get(ufsUri).toString() + suffix;
+    }
+    // otherwise match by longest prefix
+    BiMap.Entry<AlluxioURI, AlluxioURI> longestPrefix = null;
+    int longestPrefixDepth = -1;
+    for (BiMap.Entry<AlluxioURI, AlluxioURI> entry : mPathMap.entrySet()) {
+      try {
+        AlluxioURI valueUri = entry.getValue();
+        if (valueUri.isAncestorOf(ufsUri) && valueUri.getDepth() > longestPrefixDepth) {
+          longestPrefix = entry;
+          longestPrefixDepth = valueUri.getDepth();
         }
-        String alluxioPath = entry.getKey() + ufsPath.substring(entry.getValue().length());
-        if (alluxioPath.startsWith("/")) {
-          // scheme/authority are missing, so prefix with the scheme and authority
-          alluxioPath =
-              ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global()) + alluxioPath;
-        }
-        return alluxioPath;
+      } catch (InvalidPathException e) {
+        throw new IOException(e);
       }
     }
-    // TODO(yuzhu): instead of throwing an exception, mount the path?
-    throw new IOException(String
-        .format("Failed to translate ufs path (%s). Mapping missing from translator", ufsPath));
+    if (longestPrefix == null) {
+      // TODO(yuzhu): instead of throwing an exception, mount the path?
+      throw new IOException(String
+          .format("Failed to translate ufs path (%s). Mapping missing from translator", ufsPath));
+    }
+    if (longestPrefix.getKey().equals(longestPrefix.getValue())) {
+      // return ufsPath if set the key and value to be same when bypass path.
+      return ufsPath;
+    }
+    try {
+      String difference = PathUtils.subtractPaths(ufsUri.getPath(),
+          longestPrefix.getValue().getPath());
+      AlluxioURI mappedUri = longestPrefix.getKey().join(difference);
+      if (!mappedUri.hasScheme()) {
+        // scheme is missing, so prefix with the scheme and authority
+        AlluxioURI baseUri = new AlluxioURI(
+            ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global()) + "/");
+        mappedUri = new AlluxioURI(baseUri, mappedUri.getPath(), false);
+      }
+      return mappedUri.toString() + suffix;
+    } catch (InvalidPathException e) {
+      throw new IOException(e);
+    }
   }
 }

--- a/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
@@ -33,6 +33,9 @@ public class PathTranslator {
 
   private final BiMap<AlluxioURI, AlluxioURI> mPathMap;
 
+  @VisibleForTesting
+  static String sSchemeAuthorityPrefix = null;
+
   /**
    * Construct a path translator.
    */
@@ -105,16 +108,15 @@ public class PathTranslator {
     }
   }
 
-  private AlluxioURI checkAndAddSchemeAuthority(AlluxioURI input) {
+  private static AlluxioURI checkAndAddSchemeAuthority(AlluxioURI input) {
     if (!input.hasScheme()) {
-      AlluxioURI baseUri = new AlluxioURI(getSchemeAuthority() + "/");
+      if (sSchemeAuthorityPrefix == null) {
+        sSchemeAuthorityPrefix =
+            ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global());
+      }
+      AlluxioURI baseUri = new AlluxioURI(sSchemeAuthorityPrefix);
       return new AlluxioURI(baseUri, input.getPath(), false);
     }
     return input;
-  }
-
-  @VisibleForTesting
-  String getSchemeAuthority() {
-    return ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global());
   }
 }

--- a/table/server/common/src/test/java/alluxio/table/common/udb/PathTranslatorTest.java
+++ b/table/server/common/src/test/java/alluxio/table/common/udb/PathTranslatorTest.java
@@ -19,7 +19,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 
@@ -110,6 +109,8 @@ public class PathTranslatorTest {
     mTranslator.addMapping("alluxio:///table_b", "ufs://a/table11");
     assertEquals("alluxio:///table_b/part1",
         mTranslator.toAlluxioPath("ufs://a/table11/part1"));
+    assertEquals("alluxio:///table_a/part1",
+        mTranslator.toAlluxioPath("ufs://a/table1/part1"));
   }
 
   @Test
@@ -155,18 +156,17 @@ public class PathTranslatorTest {
 
   @Test
   public void alluxioUriPurePath() throws Exception {
+    PathTranslator.sSchemeAuthorityPrefix = "alluxio://master";
     mTranslator.addMapping("/db1/tables/table1", "ufs://a/db1/table1");
-    PathTranslator spy = Mockito.spy(mTranslator);
-    Mockito.doReturn("alluxio://master").when(spy).getSchemeAuthority();
     // non-exact match
     assertEquals("alluxio://master/db1/tables/table1/part1",
-        spy.toAlluxioPath("ufs://a/db1/table1/part1"));
+        mTranslator.toAlluxioPath("ufs://a/db1/table1/part1"));
     // exact match
     assertEquals("alluxio://master/db1/tables/table1",
-        spy.toAlluxioPath("ufs://a/db1/table1"));
+        mTranslator.toAlluxioPath("ufs://a/db1/table1"));
     // trailing slash is preserved
     assertEquals("alluxio://master/db1/tables/table1/",
-        spy.toAlluxioPath("ufs://a/db1/table1/"));
+        mTranslator.toAlluxioPath("ufs://a/db1/table1/"));
   }
 
   @Test

--- a/table/server/common/src/test/java/alluxio/table/common/udb/PathTranslatorTest.java
+++ b/table/server/common/src/test/java/alluxio/table/common/udb/PathTranslatorTest.java
@@ -27,6 +27,11 @@ import org.junit.rules.ExpectedException;
 import java.io.IOException;
 
 public class PathTranslatorTest {
+  private static final String MASTER_HOSTNAME = "master";
+  private static final String MASTER_RPC_PORT = "11111";
+  private static final String ALLUXIO_URI_AUTHORITY = "alluxio://" + MASTER_HOSTNAME;
+  private static final String ALLUXIO_URI_AUTHORITY_WITH_PORT =
+      ALLUXIO_URI_AUTHORITY + ":" + MASTER_RPC_PORT;
 
   @Rule
   public ExpectedException mException = ExpectedException.none();
@@ -34,8 +39,8 @@ public class PathTranslatorTest {
   @Rule
   public ConfigurationRule mConfiguration =
       new ConfigurationRule(
-          ImmutableMap.of(PropertyKey.MASTER_HOSTNAME, "master",
-            PropertyKey.MASTER_RPC_PORT, "19998"),
+          ImmutableMap.of(PropertyKey.MASTER_HOSTNAME, MASTER_HOSTNAME,
+            PropertyKey.MASTER_RPC_PORT, MASTER_RPC_PORT),
           ServerConfiguration.global());
 
   private PathTranslator mTranslator;
@@ -153,15 +158,16 @@ public class PathTranslatorTest {
 
   @Test
   public void alluxioUriWithSchemeAndAuthority() throws Exception {
-    mTranslator.addMapping("alluxio://master/db1/tables/table1", "ufs://a/db1/table1");
+    mTranslator.addMapping(
+        ALLUXIO_URI_AUTHORITY + "/db1/tables/table1", "ufs://a/db1/table1");
     // non-exact match
-    assertEquals("alluxio://master/db1/tables/table1/part1",
+    assertEquals(ALLUXIO_URI_AUTHORITY + "/db1/tables/table1/part1",
         mTranslator.toAlluxioPath("ufs://a/db1/table1/part1"));
     // exact match
-    assertEquals("alluxio://master/db1/tables/table1",
+    assertEquals(ALLUXIO_URI_AUTHORITY + "/db1/tables/table1",
         mTranslator.toAlluxioPath("ufs://a/db1/table1"));
     // trailing slash is preserved
-    assertEquals("alluxio://master/db1/tables/table1/",
+    assertEquals(ALLUXIO_URI_AUTHORITY + "/db1/tables/table1/",
         mTranslator.toAlluxioPath("ufs://a/db1/table1/"));
   }
 
@@ -169,13 +175,13 @@ public class PathTranslatorTest {
   public void alluxioUriPurePath() throws Exception {
     mTranslator.addMapping("/db1/tables/table1", "ufs://a/db1/table1");
     // non-exact match
-    assertEquals("alluxio://master:19998/db1/tables/table1/part1",
+    assertEquals(ALLUXIO_URI_AUTHORITY_WITH_PORT + "/db1/tables/table1/part1",
         mTranslator.toAlluxioPath("ufs://a/db1/table1/part1"));
     // exact match
-    assertEquals("alluxio://master:19998/db1/tables/table1",
+    assertEquals(ALLUXIO_URI_AUTHORITY_WITH_PORT + "/db1/tables/table1",
         mTranslator.toAlluxioPath("ufs://a/db1/table1"));
     // trailing slash is preserved
-    assertEquals("alluxio://master:19998/db1/tables/table1/",
+    assertEquals(ALLUXIO_URI_AUTHORITY_WITH_PORT + "/db1/tables/table1/",
         mTranslator.toAlluxioPath("ufs://a/db1/table1/"));
   }
 

--- a/table/server/common/src/test/java/alluxio/table/common/udb/PathTranslatorTest.java
+++ b/table/server/common/src/test/java/alluxio/table/common/udb/PathTranslatorTest.java
@@ -13,8 +13,12 @@ package alluxio.table.common.udb;
 
 import static org.junit.Assert.assertEquals;
 
+import alluxio.ConfigurationRule;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.util.io.PathUtils;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,6 +30,13 @@ public class PathTranslatorTest {
 
   @Rule
   public ExpectedException mException = ExpectedException.none();
+
+  @Rule
+  public ConfigurationRule mConfiguration =
+      new ConfigurationRule(
+          ImmutableMap.of(PropertyKey.MASTER_HOSTNAME, "master",
+            PropertyKey.MASTER_RPC_PORT, "19998"),
+          ServerConfiguration.global());
 
   private PathTranslator mTranslator;
 
@@ -156,16 +167,15 @@ public class PathTranslatorTest {
 
   @Test
   public void alluxioUriPurePath() throws Exception {
-    PathTranslator.sSchemeAuthorityPrefix = "alluxio://master";
     mTranslator.addMapping("/db1/tables/table1", "ufs://a/db1/table1");
     // non-exact match
-    assertEquals("alluxio://master/db1/tables/table1/part1",
+    assertEquals("alluxio://master:19998/db1/tables/table1/part1",
         mTranslator.toAlluxioPath("ufs://a/db1/table1/part1"));
     // exact match
-    assertEquals("alluxio://master/db1/tables/table1",
+    assertEquals("alluxio://master:19998/db1/tables/table1",
         mTranslator.toAlluxioPath("ufs://a/db1/table1"));
     // trailing slash is preserved
-    assertEquals("alluxio://master/db1/tables/table1/",
+    assertEquals("alluxio://master:19998/db1/tables/table1/",
         mTranslator.toAlluxioPath("ufs://a/db1/table1/"));
   }
 


### PR DESCRIPTION
Fix a bug introduced in #13663. See https://github.com/Alluxio/alluxio/pull/13688#issuecomment-869016271

The exact match optimization was not properly handled to return a URI with scheme and authority. This has been fixed and tests added.