### PR TITLE
[DOCFIX] Remove invalid link in CephFS doc

### DIFF
--- a/docs/en/ufs/CephFS.md
+++ b/docs/en/ufs/CephFS.md
@@ -17,9 +17,7 @@ two different implementations of under storage system for [CephFS](https://docs.
 ## Prerequisites
 
 ### Deploy Alluxio binary package
-The Alluxio binaries must be on your machine. You can either
-[compile Alluxio]({{ '/en/contributor/Building-Alluxio-From-Source.html' | relativize_url }}), or
-[download the binaries locally]({{ '/en/deploy/Running-Alluxio-Locally.html' | relativize_url }}).
+The Alluxio binaries must be on your machine. [Download the binaries locally]({{ '/en/deploy/Running-Alluxio-Locally.html' | relativize_url }}).
 
 ### Install Dependences
 According to [ceph packages install](https://docs.ceph.com/en/latest/install/get-packages/) to install below packages:


### PR DESCRIPTION
### What changes are proposed in this pull request?

Please outline the changes and how this PR fixes the issue.

There was a "compile Alluxio" link that pointed to an invalid page. Other Storage Integration docs only point to a link to download binaries. So, that invalid link is now removed and the Prerequisite section matches the other Storage docs. 

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.

To prevent invalid page and reroute to the Overview page. 

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui

The docs are being changed.