### PR TITLE
Improve error msg when mount point already exists

### DIFF
--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -251,7 +251,8 @@ public enum ExceptionMessage {
       "{0} {1} specified above max threshold of cluster, specified={2}, max={3}"),
 
   // mounting
-  MOUNT_POINT_ALREADY_EXISTS("Mount point {0} already exists"),
+  MOUNT_POINT_ALREADY_EXISTS("Mount point target path {0} already exists in Alluxio namespace. "
+      + "Try mounting to another path."),
   MOUNT_POINT_PREFIX_OF_ANOTHER("Mount point {0} is a prefix of {1}"),
   MOUNT_PATH_SHADOWS_PARENT_UFS(
       "Mount path {0} shadows an existing path {1} in the parent underlying filesystem"),


### PR DESCRIPTION
### What changes are proposed in this pull request?

When a user accidentally mounts to a path that exists in Alluxio, the error is like "Mount point <path> already exists". This can be misunderstood as the path is already a mount point. And when they attempt to unmount <path>, they will realize that path is not a mount point and panic.

An example flow looks like below:
```
[hadoop@ip-18-22-4-73 ~]$ alluxio fs mount
hdfs://ip-18-22-4-73.ec2.internal:8020/                 on  /hdfs_comp  (hdfs, capacity=144.43GB, used=16.15MB(0%), not read-only, not shared, properties={})
hdfs://blah:8020/  on  /           (hdfs, capacity=144.43GB, used=37.78GB(26%), not read-only, not shared, properties={alluxio.underfs.version=hadoop-2.8, alluxio.underfs.hdfs.remote=true, alluxio.underfs.hdfs.configuration=/opt/alluxio/conf/core-site.xml:/opt/alluxio/conf/hdfs-site.xml})

[hadoop@ip-18-22-4-73 ~]$ alluxio fs mount /s3 s3://alluxio.test/demo/
Mount point /s3 already exists

[hadoop@ip-18-22-4-73 ~]$ alluxio fs umount /s3
Failed to unmount /s3. Please ensure the path is an existing mount point.
```

I'm attempting to make natural language suck a little less by rephrasing.

### Why are the changes needed?

See above

### Does this PR introduce any user facing changes?

They see a better exception msg