### PR TITLE
Disable interrupt-cycle by default to avoid RPC interruption

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1535,7 +1535,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_ENABLED =
       new Builder(Name.MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_ENABLED)
-          .setDefaultValue(true)
+          .setDefaultValue(false)
           .setDescription("This controls whether RPCs that are waiting/holding state-lock "
               + "in shared-mode will be interrupted while state-lock is taken exclusively.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)


### PR DESCRIPTION
### What changes are proposed in this pull request?
Disable interrupting user RPCs when backup is not able to acquire the lock.

### Why are the changes needed?
Interrupt cycling is n invasive process that has been noticed in many environments to cause disruption for user workflows.
