### PR TITLE
Add cluster_cache_hit_rate metric

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -782,6 +782,11 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("Bytes write per minute throughput to all Alluxio UFSes by all workers")
           .setMetricType(MetricType.GAUGE)
           .build();
+  public static final MetricKey CLUSTER_CACHE_HIT_RATE =
+      new Builder("Cluster.CacheHitRate")
+          .setDescription("Cache hit rate: (# bytes read from cache) / (# bytes requested)")
+          .setMetricType(MetricType.GAUGE)
+          .build();
   public static final MetricKey CLUSTER_CAPACITY_TOTAL =
       new Builder("Cluster.CapacityTotal")
           .setDescription("Total capacity (in bytes) on all tiers, on all workers of Alluxio")

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -172,7 +172,7 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
   public void start(Boolean isLeader) throws IOException {
     super.start(isLeader);
     if (isLeader) {
-      mMetricsStore.initCounterKeys();
+      mMetricsStore.initMetricKeys();
       mMetricsStore.clear();
       getExecutorService().submit(new HeartbeatThread(
           HeartbeatContext.MASTER_CLUSTER_METRICS_UPDATER, new ClusterMetricsUpdater(),

--- a/core/server/master/src/test/java/alluxio/master/metrics/MetricsStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metrics/MetricsStoreTest.java
@@ -35,7 +35,7 @@ public class MetricsStoreTest {
   public void before() {
     MetricsSystem.resetAllMetrics();
     mMetricStore = new MetricsStore(new SystemClock());
-    mMetricStore.initCounterKeys();
+    mMetricStore.initMetricKeys();
   }
 
   @Test


### PR DESCRIPTION
Address #13724

### What changes are proposed in this pull request?

Add a gauge metric in MetricsStore.java, CLUSTER_CACHE_HIT_RATE = 1 - CLUSTER_BYTES_READ_UFS_ALL/(CLUSTER_BYTES_READ_DIRECT + CLUSTER_BYTES_READ_REMOTE + CLUSTER_BYTES_READ_DOMAIN)

### Why are the changes needed?

We want to add a metric cluster_cache_hit_rate and now we can only calculate by ourselves

### Does this PR introduce any user facing changes?

Users can get a new metric
