### PR TITLE
Improve server-side logging

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -179,6 +179,7 @@ log4j.appender.FUSE_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%
 
 # Disable noisy DEBUG logs
 log4j.logger.io.grpc.netty.NettyServerHandler=OFF
+log4j.logger.com.amazonaws.util.EC2MetadataUtils=OFF
 
 # Disable noisy INFO logs from ratis
 log4j.logger.org.apache.ratis.grpc.server.GrpcLogAppender=ERROR

--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -178,8 +178,8 @@ log4j.appender.FUSE_LOGGER.layout=org.apache.log4j.PatternLayout
 log4j.appender.FUSE_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
 
 # Disable noisy DEBUG logs
-log4j.logger.io.grpc.netty.NettyServerHandler=OFF
 log4j.logger.com.amazonaws.util.EC2MetadataUtils=OFF
+log4j.logger.io.grpc.netty.NettyServerHandler=OFF
 
 # Disable noisy INFO logs from ratis
 log4j.logger.org.apache.ratis.grpc.server.GrpcLogAppender=ERROR

--- a/core/server/common/src/main/java/alluxio/ProcessUtils.java
+++ b/core/server/common/src/main/java/alluxio/ProcessUtils.java
@@ -32,7 +32,8 @@ public final class ProcessUtils {
   public static void run(Process process) {
     try {
       LOG.info("Starting {}.", process);
-      LOG.info("Running under Java {}", System.getProperty("java.version"));
+      LOG.info("Alluxio version: {}-{}", RuntimeConstants.VERSION, ProjectConstants.REVISION);
+      LOG.info("Java version: {}", System.getProperty("java.version"));
       process.start();
       LOG.info("Stopping {}.", process);
       System.exit(0);

--- a/core/server/master/src/main/java/alluxio/master/meta/checkconf/ServerConfigurationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/checkconf/ServerConfigurationChecker.java
@@ -128,7 +128,7 @@ public class ServerConfigurationChecker {
   public synchronized void logConfigReport() {
     ConfigStatus reportStatus = mConfigCheckReport.getConfigStatus();
     if (reportStatus.equals(ConfigStatus.PASSED)) {
-      LOG.info(CONSISTENT_CONFIGURATION_INFO);
+      LOG.debug(CONSISTENT_CONFIGURATION_INFO);
     } else if (reportStatus.equals(ConfigStatus.WARN)) {
       LOG.warn("{}\nWarnings: {}", INCONSISTENT_CONFIGURATION_INFO,
           mConfigCheckReport.getConfigWarns().values().stream()

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -12,7 +12,6 @@
 package alluxio.worker;
 
 import alluxio.Constants;
-import alluxio.RuntimeConstants;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.metrics.MetricsSystem;

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -233,7 +233,6 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
     // Requirement: NetAddress set in WorkerContext, so block worker can initialize BlockMasterSync
     // Consequence: worker id is granted
     startWorkers();
-    LOG.info("Started {} with id {}", this, mRegistry.get(BlockWorker.class).getWorkerId());
 
     // Start serving the web server, this will not block.
     mWebServer.addHandler(mMetricsServlet.getHandler());
@@ -251,9 +250,8 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
     }
 
     // Start serving RPC, this will block
-    LOG.info("Alluxio worker version {} started. "
-            + "bindHost={}, connectHost={}, rpcPort={}, webPort={}",
-        RuntimeConstants.VERSION,
+    LOG.info("Alluxio worker started. id={}, bindHost={}, connectHost={}, rpcPort={}, webPort={}",
+        mRegistry.get(BlockWorker.class).getWorkerId(),
         NetworkAddressUtils.getBindHost(ServiceType.WORKER_RPC, ServerConfiguration.global()),
         NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC, ServerConfiguration.global()),
         NetworkAddressUtils.getPort(ServiceType.WORKER_RPC, ServerConfiguration.global()),


### PR DESCRIPTION
### What changes are proposed in this pull request?

Simplify the logging based on user feedback

- Remove excessive logging like “2021-06-01 10:09:25,353 INFO  ServerConfigurationChecker - All server-side configurations are consistent.”
- Add master/worker logging with version
- Remove noisy logging like `WARN  EC2MetadataUtils - Unable to retrieve the requested metadata (/latest/meta-data/product-codes). Failed to connect to service endpoint: `

### Why are the changes needed?

Clean up logging to ease debugging experience

### Does this PR introduce any user facing changes?

No