### PR TITLE
Fix integer overflow in usedPercentage

### DIFF
--- a/shell/src/main/java/alluxio/cli/fsadmin/report/UfsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/UfsCommand.java
@@ -61,7 +61,7 @@ public class UfsCommand {
 
       String usedPercentageInfo = "";
       if (capacityBytes > 0) {
-        int usedPercentage = (int) (100L * usedBytes / capacityBytes);
+        int usedPercentage = (int) (100.0 * usedBytes / capacityBytes);
         usedPercentageInfo = String.format("(%s%%)", usedPercentage);
       }
 


### PR DESCRIPTION
100PB * 100 will overflow a 64 bit integer.
For example:
hdfs, capacity=130.71PB, used=106.79PB(-43%)