### PR TITLE
Fix exception propagation for RPC connection retries

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -124,10 +124,14 @@ public abstract class AbstractClient implements Client {
 
   protected long getRemoteServiceVersion() throws AlluxioStatusException {
     // Calling directly as this method is subject to an encompassing retry loop.
-    return mVersionService
-        .getServiceVersion(
-            GetServiceVersionPRequest.newBuilder().setServiceType(getRemoteServiceType()).build())
-        .getVersion();
+    try {
+      return mVersionService
+          .getServiceVersion(
+              GetServiceVersionPRequest.newBuilder().setServiceType(getRemoteServiceType()).build())
+          .getVersion();
+    } catch (Throwable t) {
+      throw AlluxioStatusException.fromThrowable(t);
+    }
   }
 
   /**

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -130,8 +130,9 @@ public class PollingMasterInquireClient implements MasterInquireClient {
         LOG.debug("Timeout while connecting to {}", address);
         continue;
       } catch (AlluxioStatusException e) {
-        throw new RuntimeException(
-            String.format("Received exception from %s. message: %s", address, e.getMessage()), e);
+        LOG.error("Error while connecting to {}. {}", address, e);
+        // Breaking the loop on non filtered error.
+        break;
       }
     }
     return null;


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix exception propagation during RPC connection to server.

### Why are the changes needed?

Sometimes, gRPC throws some unexpected exceptions when target is unavailable. When these go unhandled, they end up failing the RPC.