### PR TITLE
Fix process local read write client side logics and add unit tests

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -204,9 +204,20 @@ public final class AlluxioBlockStore {
               .setLocations(locations))
           .setBlockWorkerInfos(blockWorkerInfo);
       dataSource = policy.getWorker(getWorkerOptions);
-      if (dataSource != null && mContext.hasProcessLocalWorker()
-          && dataSource.equals(mContext.getNodeLocalWorker())) {
-        dataSourceType = BlockInStreamSource.PROCESS_LOCAL;
+      if (dataSource != null) {
+        if (mContext.hasProcessLocalWorker()
+            && dataSource.equals(mContext.getNodeLocalWorker())) {
+          dataSourceType = BlockInStreamSource.PROCESS_LOCAL;
+          LOG.debug("Create BlockInStream to read data from UFS through process local worker {}",
+              dataSource);
+        } else {
+          LOG.debug("Create BlockInStream to read data from UFS through worker {} "
+              + "(client embedded in local worker process: {},"
+                  + "client co-located with worker in different processes: {}, "
+                  + "local worker address: {})",
+              dataSource, mContext.hasProcessLocalWorker(), mContext.hasNodeLocalWorker(),
+              mContext.hasNodeLocalWorker() ? mContext.getNodeLocalWorker() : "N/A");
+        }
       }
     }
 

--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -204,7 +204,6 @@ public final class AlluxioBlockStore {
               .setLocations(locations))
           .setBlockWorkerInfos(blockWorkerInfo);
       dataSource = policy.getWorker(getWorkerOptions);
-      // TODO(lu) update the bytesReadUfs metrics
       if (dataSource != null && mContext.hasProcessLocalWorker()
           && dataSource.equals(mContext.getNodeLocalWorker())) {
         dataSourceType = BlockInStreamSource.PROCESS_LOCAL;

--- a/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/AlluxioBlockStore.java
@@ -204,7 +204,13 @@ public final class AlluxioBlockStore {
               .setLocations(locations))
           .setBlockWorkerInfos(blockWorkerInfo);
       dataSource = policy.getWorker(getWorkerOptions);
+      // TODO(lu) update the bytesReadUfs metrics
+      if (dataSource != null && mContext.hasProcessLocalWorker()
+          && dataSource.equals(mContext.getNodeLocalWorker())) {
+        dataSourceType = BlockInStreamSource.PROCESS_LOCAL;
+      }
     }
+
     if (dataSource == null) {
       throw new UnavailableException(ExceptionMessage.NO_WORKER_AVAILABLE.getMessage());
     }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -460,10 +461,12 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
   }
 
   /**
-   * @return whether the reader is reading data directly from a local file
+   * @return the underlying data reader
    */
-  public DataReader.DataReaderType getDataReaderType() {
-    return mDataReaderFactory.getDataReaderType();
+  @VisibleForTesting
+  @Nullable
+  public DataReader getDataReader() {
+    return mDataReader;
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -461,12 +460,11 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
   }
 
   /**
-   * @return the underlying data reader
+   * @return the underlying data reader factory
    */
   @VisibleForTesting
-  @Nullable
-  public DataReader getDataReader() {
-    return mDataReader;
+  public DataReader.Factory getDataReaderFactory() {
+    return mDataReaderFactory;
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -106,6 +106,8 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
     if (dataSourceType == BlockInStreamSource.PROCESS_LOCAL) {
       // Interaction between the current client and the worker it embedded to should
       // go through worker internal communication directly without RPC involves
+      LOG.debug("Creating worker process local input stream for block {} @ {}",
+          blockId, dataSource);
       return createProcessLocalBlockInStream(context, dataSource, blockId, blockSize, options);
     }
 

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -459,8 +459,8 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
   /**
    * @return whether the reader is reading data directly from a local file
    */
-  public boolean isShortCircuit() {
-    return mDataReaderFactory.isShortCircuit();
+  public DataReader.DataReaderType getDataReaderType() {
+    return mDataReaderFactory.getDataReaderType();
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -103,8 +103,7 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
     long blockId = info.getBlockId();
     long blockSize = info.getLength();
 
-    if (dataSourceType == BlockInStreamSource.PROCESS_LOCAL
-        && dataSource.equals(context.getNodeLocalWorker())) {
+    if (dataSourceType == BlockInStreamSource.PROCESS_LOCAL) {
       // Interaction between the current client and the worker it embedded to should
       // go through worker internal communication directly without RPC involves
       return createProcessLocalBlockInStream(context, dataSource, blockId, blockSize, options);

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -136,8 +136,11 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
     }
 
     // gRPC
-    LOG.debug("Creating gRPC input stream for block {} @ {} from client {} reading through {}",
-        blockId, dataSource, NetworkAddressUtils.getClientHostName(alluxioConf), dataSource);
+    LOG.debug("Creating gRPC input stream for block {} @ {} from client {} reading through {} ("
+        + "data locates in the local worker {}, shortCircuitEnabled {}, "
+        + "shortCircuitPreferred {}, sourceSupportDomainSocket {})",
+        blockId, dataSource, NetworkAddressUtils.getClientHostName(alluxioConf), dataSource,
+        sourceIsLocal, shortCircuit, shortCircuitPreferred, sourceSupportsDomainSocket);
     return createGrpcBlockInStream(context, dataSource, dataSourceType, blockId,
         blockSize, options);
   }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataReader.java
@@ -137,8 +137,8 @@ public final class BlockWorkerDataReader implements DataReader {
     }
 
     @Override
-    public boolean isShortCircuit() {
-      return false;
+    public DataReaderType getDataReaderType() {
+      return DataReaderType.BLOCK_WORKER;
     }
 
     @Override

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataReader.java
@@ -137,11 +137,6 @@ public final class BlockWorkerDataReader implements DataReader {
     }
 
     @Override
-    public DataReaderType getDataReaderType() {
-      return DataReaderType.BLOCK_WORKER;
-    }
-
-    @Override
     public void close() throws IOException {}
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DataReader.java
@@ -25,8 +25,15 @@ public interface DataReader extends Closeable {
    * The data reader type represents different ways to read data.
    */
   enum DataReaderType {
-    BLOCK_WORKER, // Read from a worker in the same process
-    GRPC, // Read from a worker through gRPC
+    /**
+     * Read from a worker in the same process.
+     * This is used by fuse client in the worker process.
+     */
+    BLOCK_WORKER,
+    /**
+     * Reads from a worker through gRPC.
+     */
+    GRPC,
     /**
      * Reads from a local block directly.
      * Usually used when the client and worker are on the same node but in the different processes.

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DataReader.java
@@ -22,31 +22,6 @@ import java.io.IOException;
 public interface DataReader extends Closeable {
 
   /**
-   * The data reader type represents different ways to read data.
-   */
-  enum DataReaderType {
-    /**
-     * Read from a worker in the same process.
-     * This is used by fuse client in the worker process.
-     */
-    BLOCK_WORKER,
-    /**
-     * Reads from a worker through gRPC.
-     */
-    GRPC,
-    /**
-     * Reads from a local block directly.
-     * Usually used when the client and worker are on the same node but in the different processes.
-     */
-    SHORT_CIRCUIT,
-    /**
-     * Shared gRPC data reader that cache blocks data for multi-thread accessing.
-     */
-    SHARED,
-    TEST // Mock data reader for testing
-  }
-
-  /**
    * Reads a chunk. The caller needs to release the chunk.
    *
    * @return the data buffer or null if EOF is reached
@@ -70,10 +45,5 @@ public interface DataReader extends Closeable {
      * @return the created object
      */
     DataReader create(long offset, long len) throws IOException;
-
-    /**
-     * @return the data reader type
-     */
-    DataReaderType getDataReaderType();
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DataReader.java
@@ -22,14 +22,21 @@ import java.io.IOException;
 public interface DataReader extends Closeable {
 
   /**
-   * The data reader type.
+   * The data reader type represents different ways to read data.
    */
   enum DataReaderType {
-    BLOCK_WORKER,
-    GRPC,
+    BLOCK_WORKER, // Read from a worker in the same process
+    GRPC, // Read from a worker through gRPC
+    /**
+     * Reads from a local block directly.
+     * Usually used when the client and worker are on the same node but in the different processes.
+     */
     SHORT_CIRCUIT,
+    /**
+     * Shared gRPC data reader that cache blocks data for multi-thread accessing.
+     */
     SHARED,
-    TEST
+    TEST // Mock data reader for testing
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DataReader.java
@@ -22,6 +22,17 @@ import java.io.IOException;
 public interface DataReader extends Closeable {
 
   /**
+   * The data reader type.
+   */
+  enum DataReaderType {
+    BLOCK_WORKER,
+    GRPC,
+    SHORT_CIRCUIT,
+    SHARED,
+    TEST
+  }
+
+  /**
    * Reads a chunk. The caller needs to release the chunk.
    *
    * @return the data buffer or null if EOF is reached
@@ -47,8 +58,8 @@ public interface DataReader extends Closeable {
     DataReader create(long offset, long len) throws IOException;
 
     /**
-     * @return whether this factory generates data readers which perform short-circuit reads
+     * @return the data reader type
      */
-    boolean isShortCircuit();
+    DataReaderType getDataReaderType();
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DataWriter.java
@@ -70,8 +70,7 @@ public interface DataWriter extends Closeable, Cancelable {
         return BlockWorkerDataWriter.create(context, blockId, blockSize, options);
       }
 
-      if (workerIsLocal
-          && shortCircuit
+      if (workerIsLocal && shortCircuit
           && (shortCircuitPreferred || !NettyUtils.isDomainSocketSupported(address))) {
         if (ufsFallbackEnabled) {
           LOG.info("Creating UFS-fallback short circuit output stream for block {} @ {}", blockId,

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
@@ -241,11 +241,6 @@ public final class GrpcDataReader implements DataReader {
     }
 
     @Override
-    public DataReaderType getDataReaderType() {
-      return DataReaderType.GRPC;
-    }
-
-    @Override
     public void close() throws IOException {}
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/GrpcDataReader.java
@@ -241,8 +241,8 @@ public final class GrpcDataReader implements DataReader {
     }
 
     @Override
-    public boolean isShortCircuit() {
-      return false;
+    public DataReaderType getDataReaderType() {
+      return DataReaderType.GRPC;
     }
 
     @Override

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataReader.java
@@ -166,8 +166,8 @@ public final class LocalFileDataReader implements DataReader {
     }
 
     @Override
-    public boolean isShortCircuit() {
-      return true;
+    public DataReaderType getDataReaderType() {
+      return DataReaderType.SHORT_CIRCUIT;
     }
 
     @Override

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataReader.java
@@ -166,11 +166,6 @@ public final class LocalFileDataReader implements DataReader {
     }
 
     @Override
-    public DataReaderType getDataReaderType() {
-      return DataReaderType.SHORT_CIRCUIT;
-    }
-
-    @Override
     public void close() throws IOException {
       if (mClosed) {
         return;

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/SharedGrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/SharedGrpcDataReader.java
@@ -180,8 +180,8 @@ public class SharedGrpcDataReader implements DataReader {
     }
 
     @Override
-    public boolean isShortCircuit() {
-      return false;
+    public DataReaderType getDataReaderType() {
+      return DataReaderType.SHARED;
     }
 
     @Override

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/SharedGrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/SharedGrpcDataReader.java
@@ -180,11 +180,6 @@ public class SharedGrpcDataReader implements DataReader {
     }
 
     @Override
-    public DataReaderType getDataReaderType() {
-      return DataReaderType.SHARED;
-    }
-
-    @Override
     public void close() throws IOException {}
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -430,7 +430,8 @@ public class AlluxioFileInStream extends FileInStream {
 
   private void handleRetryableException(BlockInStream stream, IOException e) {
     WorkerNetAddress workerAddress = stream.getAddress();
-    LOG.warn("Failed to read block {} of file {} from worker {}, will retry: {}",
+    LOG.warn("Failed to read block {} of file {} from worker {}. "
+        + "This worker will be skipped for future read operations, will retry: {}.",
         stream.getId(), mStatus.getPath(), workerAddress, e.getMessage());
     try {
       stream.close();
@@ -439,7 +440,7 @@ public class AlluxioFileInStream extends FileInStream {
       LOG.warn("Failed to close input stream for block {} of file {}: {}",
           stream.getId(), mStatus.getPath(), ex.getMessage());
     }
-
+    // TODO(lu) consider recovering failed workers
     mFailedWorkers.put(workerAddress, System.currentTimeMillis());
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -432,13 +432,13 @@ public class AlluxioFileInStream extends FileInStream {
     WorkerNetAddress workerAddress = stream.getAddress();
     LOG.warn("Failed to read block {} of file {} from worker {}. "
         + "This worker will be skipped for future read operations, will retry: {}.",
-        stream.getId(), mStatus.getPath(), workerAddress, e.getMessage());
+        stream.getId(), mStatus.getPath(), workerAddress, e.toString());
     try {
       stream.close();
     } catch (Exception ex) {
       // Do not throw doing a best effort close
       LOG.warn("Failed to close input stream for block {} of file {}: {}",
-          stream.getId(), mStatus.getPath(), ex.getMessage());
+          stream.getId(), mStatus.getPath(), ex.toString());
     }
     // TODO(lu) consider recovering failed workers
     mFailedWorkers.put(workerAddress, System.currentTimeMillis());

--- a/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -28,7 +28,8 @@ import alluxio.client.block.policy.options.GetWorkerOptions;
 import alluxio.client.block.stream.BlockInStream;
 import alluxio.client.block.stream.BlockOutStream;
 import alluxio.client.block.stream.BlockWorkerClient;
-import alluxio.client.block.stream.DataReader;
+import alluxio.client.block.stream.BlockWorkerDataReader;
+import alluxio.client.block.stream.GrpcDataReader;
 import alluxio.client.block.stream.NoopClosableResource;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
@@ -331,7 +332,7 @@ public final class AlluxioBlockStoreTest {
 
     BlockInStream stream = mBlockStore.getInStream(BLOCK_ID, options);
     assertEquals(local, stream.getAddress());
-    assertEquals(DataReader.DataReaderType.GRPC, stream.getDataReaderType());
+    assertEquals(GrpcDataReader.class.getName(), stream.getDataReader().getClass().getName());
   }
 
   @Test
@@ -423,7 +424,8 @@ public final class AlluxioBlockStoreTest {
     BlockInStream stream = mBlockStore.getInStream(BLOCK_ID, new InStreamOptions(
         new URIStatus(new FileInfo().setBlockIds(Lists.newArrayList(BLOCK_ID))), sConf));
     assertEquals(local, stream.getAddress());
-    assertEquals(DataReader.DataReaderType.BLOCK_WORKER, stream.getDataReaderType());
+    assertEquals(BlockWorkerDataReader.class.getName(),
+        stream.getDataReader().getClass().getName());
   }
 
   @Test
@@ -448,7 +450,8 @@ public final class AlluxioBlockStoreTest {
 
     BlockInStream stream = mBlockStore.getInStream(BLOCK_ID, options);
     assertEquals(local, stream.getAddress());
-    assertEquals(DataReader.DataReaderType.BLOCK_WORKER, stream.getDataReaderType());
+    assertEquals(BlockWorkerDataReader.class.getName(),
+        stream.getDataReader().getClass().getName());
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import alluxio.ClientContext;
+import alluxio.ConfigurationRule;
 import alluxio.ConfigurationTestUtils;
 import alluxio.client.WriteType;
 import alluxio.client.block.policy.BlockLocationPolicy;
@@ -69,6 +70,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.util.AbstractMap;
@@ -287,28 +289,49 @@ public final class AlluxioBlockStoreTest {
   }
 
   @Test
-  public void getInStreamUfs() throws Exception {
-    WorkerNetAddress worker1 = new WorkerNetAddress().setHost("worker1");
-    WorkerNetAddress worker2 = new WorkerNetAddress().setHost("worker2");
+  public void getInStreamUfsMockLocaltion() throws Exception {
+    try (Closeable c = new ConfigurationRule(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY,
+        MockBlockLocationPolicy.class.getTypeName(), sConf).toResource()) {
+      WorkerNetAddress worker1 = new WorkerNetAddress().setHost("worker1");
+      WorkerNetAddress worker2 = new WorkerNetAddress().setHost("worker2");
+      BlockInfo info = new BlockInfo().setBlockId(0);
+      URIStatus dummyStatus = new URIStatus(new FileInfo().setPersisted(true)
+          .setBlockIds(Collections.singletonList(0L))
+          .setFileBlockInfos(Collections.singletonList(new FileBlockInfo().setBlockInfo(info))));
+      OpenFilePOptions readOptions = OpenFilePOptions.newBuilder().build();
+      InStreamOptions options = new InStreamOptions(dummyStatus, readOptions, sConf);
+      ((MockBlockLocationPolicy) options.getUfsReadLocationPolicy())
+          .setHosts(Arrays.asList(worker1, worker2));
+      when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
+      when(mContext.getCachedWorkers()).thenReturn(
+          Lists.newArrayList(new BlockWorkerInfo(worker1, -1, -1),
+              new BlockWorkerInfo(worker2, -1, -1)));
+
+      // Location policy chooses worker1 first.
+      assertEquals(worker1, mBlockStore.getInStream(BLOCK_ID, options).getAddress());
+      // Location policy chooses worker2 second.
+      assertEquals(worker2, mBlockStore.getInStream(BLOCK_ID, options).getAddress());
+    }
+  }
+
+  @Test
+  public void getInStreamUfsLocalFirst() throws Exception {
+    WorkerNetAddress remote = new WorkerNetAddress().setHost("remote");
+    WorkerNetAddress local = new WorkerNetAddress().setHost(WORKER_HOSTNAME_LOCAL);
     BlockInfo info = new BlockInfo().setBlockId(0);
     URIStatus dummyStatus =
         new URIStatus(new FileInfo().setPersisted(true).setBlockIds(Collections.singletonList(0L))
             .setFileBlockInfos(Collections.singletonList(new FileBlockInfo().setBlockInfo(info))));
-    sConf.set(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY,
-        MockBlockLocationPolicy.class.getTypeName());
     OpenFilePOptions readOptions = OpenFilePOptions.newBuilder().build();
     InStreamOptions options = new InStreamOptions(dummyStatus, readOptions, sConf);
-    ((MockBlockLocationPolicy) options.getUfsReadLocationPolicy())
-        .setHosts(Arrays.asList(worker1, worker2));
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
     when(mContext.getCachedWorkers()).thenReturn(
-        Lists.newArrayList(new BlockWorkerInfo(worker1, -1, -1),
-            new BlockWorkerInfo(worker2, -1, -1)));
+        Lists.newArrayList(new BlockWorkerInfo(remote, 100, 0),
+            new BlockWorkerInfo(local, 100, 0)));
 
-    // Location policy chooses worker1 first.
-    assertEquals(worker1, mBlockStore.getInStream(BLOCK_ID, options).getAddress());
-    // Location policy chooses worker2 second.
-    assertEquals(worker2, mBlockStore.getInStream(BLOCK_ID, options).getAddress());
+    BlockInStream stream = mBlockStore.getInStream(BLOCK_ID, options);
+    assertEquals(local, stream.getAddress());
+    assertEquals(DataReader.DataReaderType.GRPC, stream.getDataReaderType());
   }
 
   @Test
@@ -396,9 +419,35 @@ public final class AlluxioBlockStoreTest {
     when(mContext.hasProcessLocalWorker()).thenReturn(true);
     BlockWorker blockWorker = Mockito.mock(BlockWorker.class);
     when(mContext.getProcessLocalWorker()).thenReturn(blockWorker);
+
     BlockInStream stream = mBlockStore.getInStream(BLOCK_ID, new InStreamOptions(
         new URIStatus(new FileInfo().setBlockIds(Lists.newArrayList(BLOCK_ID))), sConf));
-    assertEquals(local,stream.getAddress());
+    assertEquals(local, stream.getAddress());
+    assertEquals(DataReader.DataReaderType.BLOCK_WORKER, stream.getDataReaderType());
+  }
+
+  @Test
+  public void getInStreamUfsProcessLocal() throws Exception {
+    WorkerNetAddress remote = new WorkerNetAddress().setHost("remote");
+    WorkerNetAddress local = new WorkerNetAddress().setHost(WORKER_HOSTNAME_LOCAL);
+    BlockInfo info = new BlockInfo().setBlockId(0);
+    URIStatus dummyStatus =
+        new URIStatus(new FileInfo().setPersisted(true).setBlockIds(Collections.singletonList(0L))
+            .setFileBlockInfos(Collections.singletonList(new FileBlockInfo().setBlockInfo(info))));
+    OpenFilePOptions readOptions = OpenFilePOptions.newBuilder().build();
+    InStreamOptions options = new InStreamOptions(dummyStatus, readOptions, sConf);
+    when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
+    when(mContext.getCachedWorkers()).thenReturn(
+        Lists.newArrayList(new BlockWorkerInfo(remote, 100, 0),
+            new BlockWorkerInfo(local, 100, 0)));
+
+    when(mContext.getNodeLocalWorker()).thenReturn(local);
+    when(mContext.hasProcessLocalWorker()).thenReturn(true);
+    BlockWorker blockWorker = Mockito.mock(BlockWorker.class);
+    when(mContext.getProcessLocalWorker()).thenReturn(blockWorker);
+
+    BlockInStream stream = mBlockStore.getInStream(BLOCK_ID, options);
+    assertEquals(local, stream.getAddress());
     assertEquals(DataReader.DataReaderType.BLOCK_WORKER, stream.getDataReaderType());
   }
 

--- a/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/AlluxioBlockStoreTest.java
@@ -332,7 +332,8 @@ public final class AlluxioBlockStoreTest {
 
     BlockInStream stream = mBlockStore.getInStream(BLOCK_ID, options);
     assertEquals(local, stream.getAddress());
-    assertEquals(GrpcDataReader.class.getName(), stream.getDataReader().getClass().getName());
+    assertEquals(GrpcDataReader.Factory.class.getName(),
+        stream.getDataReaderFactory().getClass().getName());
   }
 
   @Test
@@ -424,8 +425,8 @@ public final class AlluxioBlockStoreTest {
     BlockInStream stream = mBlockStore.getInStream(BLOCK_ID, new InStreamOptions(
         new URIStatus(new FileInfo().setBlockIds(Lists.newArrayList(BLOCK_ID))), sConf));
     assertEquals(local, stream.getAddress());
-    assertEquals(BlockWorkerDataReader.class.getName(),
-        stream.getDataReader().getClass().getName());
+    assertEquals(BlockWorkerDataReader.Factory.class.getName(),
+        stream.getDataReaderFactory().getClass().getName());
   }
 
   @Test
@@ -450,8 +451,8 @@ public final class AlluxioBlockStoreTest {
 
     BlockInStream stream = mBlockStore.getInStream(BLOCK_ID, options);
     assertEquals(local, stream.getAddress());
-    assertEquals(BlockWorkerDataReader.class.getName(),
-        stream.getDataReader().getClass().getName());
+    assertEquals(BlockWorkerDataReader.Factory.class.getName(),
+        stream.getDataReaderFactory().getClass().getName());
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
@@ -93,7 +93,8 @@ public class BlockInStreamTest {
     BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.NODE_LOCAL;
     BlockInStream stream =
         BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType, mOptions);
-    assertEquals(LocalFileDataReader.class.getName(), stream.getDataReader().getClass().getName());
+    assertEquals(LocalFileDataReader.Factory.class.getName(),
+        stream.getDataReaderFactory().getClass().getName());
   }
 
   @Test
@@ -102,7 +103,8 @@ public class BlockInStreamTest {
     BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.REMOTE;
     BlockInStream stream =
         BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType, mOptions);
-    assertEquals(GrpcDataReader.class.getName(), stream.getDataReader().getClass().getName());
+    assertEquals(GrpcDataReader.Factory.class.getName(),
+        stream.getDataReaderFactory().getClass().getName());
   }
 
   @Test
@@ -111,7 +113,8 @@ public class BlockInStreamTest {
     BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.UFS;
     BlockInStream stream =
         BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType, mOptions);
-    assertEquals(GrpcDataReader.class.getName(), stream.getDataReader().getClass().getName());
+    assertEquals(GrpcDataReader.Factory.class.getName(),
+        stream.getDataReaderFactory().getClass().getName());
   }
 
   @Test
@@ -125,7 +128,8 @@ public class BlockInStreamTest {
           BlockInStream.BlockInStreamSource.NODE_LOCAL;
       BlockInStream stream =
           BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType, mOptions);
-      assertEquals(GrpcDataReader.class.getName(), stream.getDataReader().getClass().getName());
+      assertEquals(GrpcDataReader.Factory.class.getName(),
+          stream.getDataReaderFactory().getClass().getName());
     }
   }
 
@@ -141,7 +145,8 @@ public class BlockInStreamTest {
     BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.NODE_LOCAL;
     BlockInStream stream = BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType,
         mOptions);
-    assertEquals(GrpcDataReader.class.getName(), stream.getDataReader().getClass().getName());
+    assertEquals(GrpcDataReader.Factory.class.getName(),
+        stream.getDataReaderFactory().getClass().getName());
   }
 
   @Test
@@ -155,7 +160,7 @@ public class BlockInStreamTest {
         BlockInStream.BlockInStreamSource.PROCESS_LOCAL;
     BlockInStream stream =
         BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType, mOptions);
-    assertEquals(BlockWorkerDataReader.class.getName(),
-        stream.getDataReader().getClass().getName());
+    assertEquals(BlockWorkerDataReader.Factory.class.getName(),
+        stream.getDataReaderFactory().getClass().getName());
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
@@ -54,7 +54,7 @@ import java.util.Collections;
  * Tests the {@link BlockInStream} class's static methods.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({FileSystemContext.class, NettyUtils.class})
+@PrepareForTest({NettyUtils.class})
 public class BlockInStreamTest {
   private FileSystemContext mMockContext;
   private BlockInfo mInfo;
@@ -64,8 +64,8 @@ public class BlockInStreamTest {
 
   @Before
   public void before() throws Exception {
-    BlockWorkerClient workerClient = PowerMockito.mock(BlockWorkerClient.class);
-    ClientCallStreamObserver requestObserver = PowerMockito.mock(ClientCallStreamObserver.class);
+    BlockWorkerClient workerClient = Mockito.mock(BlockWorkerClient.class);
+    ClientCallStreamObserver requestObserver = Mockito.mock(ClientCallStreamObserver.class);
     when(requestObserver.isReady()).thenReturn(true);
     when(workerClient.openLocalBlock(any(StreamObserver.class)))
         .thenAnswer(new Answer() {
@@ -79,11 +79,11 @@ public class BlockInStreamTest {
       mResponseObserver.onCompleted();
       return null;
     }).when(requestObserver).onNext(any(OpenLocalBlockRequest.class));
-    mMockContext = PowerMockito.mock(FileSystemContext.class);
-    PowerMockito.when(mMockContext.acquireBlockWorkerClient(Matchers.any(WorkerNetAddress.class)))
+    mMockContext = Mockito.mock(FileSystemContext.class);
+    when(mMockContext.acquireBlockWorkerClient(Matchers.any(WorkerNetAddress.class)))
         .thenReturn(new NoopClosableResource<>(workerClient));
-    PowerMockito.when(mMockContext.getClientContext()).thenReturn(ClientContext.create(mConf));
-    PowerMockito.when(mMockContext.getClusterConf()).thenReturn(mConf);
+    when(mMockContext.getClientContext()).thenReturn(ClientContext.create(mConf));
+    when(mMockContext.getClusterConf()).thenReturn(mConf);
     mInfo = new BlockInfo().setBlockId(1);
     mOptions = new InStreamOptions(new URIStatus(new FileInfo().setBlockIds(Collections
         .singletonList(1L))), mConf);
@@ -148,20 +148,6 @@ public class BlockInStreamTest {
 
   @Test
   public void createProcessLocal() throws Exception {
-    WorkerNetAddress dataSource = new WorkerNetAddress();
-    when(mMockContext.getNodeLocalWorker()).thenReturn(dataSource);
-    when(mMockContext.getClientContext()).thenReturn(ClientContext.create(mConf));
-    BlockWorker blockWorker = Mockito.mock(BlockWorker.class);
-    when(mMockContext.getProcessLocalWorker()).thenReturn(blockWorker);
-    BlockInStream.BlockInStreamSource dataSourceType =
-        BlockInStream.BlockInStreamSource.PROCESS_LOCAL;
-    BlockInStream stream =
-        BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType, mOptions);
-    assertEquals(DataReaderType.BLOCK_WORKER, stream.getDataReaderType());
-  }
-
-  @Test
-  public void createUfsProcessLocal() throws Exception {
     WorkerNetAddress dataSource = new WorkerNetAddress();
     when(mMockContext.getNodeLocalWorker()).thenReturn(dataSource);
     when(mMockContext.getClientContext()).thenReturn(ClientContext.create(mConf));

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
@@ -11,8 +11,6 @@
 
 package alluxio.client.block.stream;
 
-import static alluxio.client.block.stream.DataReader.DataReaderType;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -95,7 +93,7 @@ public class BlockInStreamTest {
     BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.NODE_LOCAL;
     BlockInStream stream =
         BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType, mOptions);
-    assertEquals(DataReaderType.SHORT_CIRCUIT, stream.getDataReaderType());
+    assertEquals(LocalFileDataReader.class.getName(), stream.getDataReader().getClass().getName());
   }
 
   @Test
@@ -104,7 +102,7 @@ public class BlockInStreamTest {
     BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.REMOTE;
     BlockInStream stream =
         BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType, mOptions);
-    assertEquals(DataReaderType.GRPC, stream.getDataReaderType());
+    assertEquals(GrpcDataReader.class.getName(), stream.getDataReader().getClass().getName());
   }
 
   @Test
@@ -113,7 +111,7 @@ public class BlockInStreamTest {
     BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.UFS;
     BlockInStream stream =
         BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType, mOptions);
-    assertEquals(DataReaderType.GRPC, stream.getDataReaderType());
+    assertEquals(GrpcDataReader.class.getName(), stream.getDataReader().getClass().getName());
   }
 
   @Test
@@ -127,7 +125,7 @@ public class BlockInStreamTest {
           BlockInStream.BlockInStreamSource.NODE_LOCAL;
       BlockInStream stream =
           BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType, mOptions);
-      assertEquals(DataReaderType.GRPC, stream.getDataReaderType());
+      assertEquals(GrpcDataReader.class.getName(), stream.getDataReader().getClass().getName());
     }
   }
 
@@ -143,7 +141,7 @@ public class BlockInStreamTest {
     BlockInStream.BlockInStreamSource dataSourceType = BlockInStream.BlockInStreamSource.NODE_LOCAL;
     BlockInStream stream = BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType,
         mOptions);
-    assertEquals(DataReaderType.GRPC, stream.getDataReaderType());
+    assertEquals(GrpcDataReader.class.getName(), stream.getDataReader().getClass().getName());
   }
 
   @Test
@@ -157,6 +155,7 @@ public class BlockInStreamTest {
         BlockInStream.BlockInStreamSource.PROCESS_LOCAL;
     BlockInStream stream =
         BlockInStream.create(mMockContext, mInfo, dataSource, dataSourceType, mOptions);
-    assertEquals(DataReaderType.BLOCK_WORKER, stream.getDataReaderType());
+    assertEquals(BlockWorkerDataReader.class.getName(),
+        stream.getDataReader().getClass().getName());
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataReaderTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataReaderTest.java
@@ -38,11 +38,8 @@ import io.netty.buffer.ByteBuf;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,8 +48,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({FileSystemContext.class, WorkerNetAddress.class})
 public final class GrpcDataReaderTest {
   private static final int CHUNK_SIZE = 1024;
   private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(4);
@@ -68,11 +63,11 @@ public final class GrpcDataReaderTest {
 
   @Before
   public void before() throws Exception {
-    mContext = PowerMockito.mock(FileSystemContext.class);
+    mContext = Mockito.mock(FileSystemContext.class);
     when(mContext.getClientContext())
         .thenReturn(ClientContext.create(ConfigurationTestUtils.defaults()));
     when(mContext.getClusterConf()).thenReturn(ConfigurationTestUtils.defaults());
-    mAddress = mock(WorkerNetAddress.class);
+    mAddress = new WorkerNetAddress().setHost("localhost").setDataPort(1234);
     ReadRequest.Builder readRequestBuilder =
         ReadRequest.newBuilder().setBlockId(BLOCK_ID).setChunkSize(CHUNK_SIZE);
     mFactory = new GrpcDataReader.Factory(mContext, mAddress, readRequestBuilder);

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
@@ -95,8 +95,8 @@ public class TestBlockInStream extends BlockInStream {
     }
 
     @Override
-    public boolean isShortCircuit() {
-      return mShortCircuit;
+    public DataReader.DataReaderType getDataReaderType() {
+      return DataReader.DataReaderType.TEST;
     }
 
     @Override

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
@@ -95,11 +95,6 @@ public class TestBlockInStream extends BlockInStream {
     }
 
     @Override
-    public DataReader.DataReaderType getDataReaderType() {
-      return DataReader.DataReaderType.TEST;
-    }
-
-    @Override
     public void close() {}
   }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/stream/BlockWorkerDataReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/stream/BlockWorkerDataReaderTest.java
@@ -87,8 +87,9 @@ public class BlockWorkerDataReaderTest {
           .put(PropertyKey.WORKER_TIERED_STORE_LEVEL0_DIRS_PATH, mMemDir)
           .put(PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCKS, String.valueOf(LOCK_NUM))
           .put(PropertyKey.WORKER_RPC_PORT, "0")
-          .put(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, AlluxioTestDirectory
-              .createTemporaryDirectory("BlockWorkerDataReaderTest").getAbsolutePath()).build(), mConf);
+          .put(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS,
+              AlluxioTestDirectory.createTemporaryDirectory("BlockWorkerDataReaderTest")
+                  .getAbsolutePath()).build(), mConf);
 
   @Before
   public void before() throws Exception {
@@ -163,10 +164,12 @@ public class BlockWorkerDataReaderTest {
         .setLength(CHUNK_SIZE * 5)
         .setBlockSizeBytes(CHUNK_SIZE)
         .setFileBlockInfos(Collections.singletonList(new FileBlockInfo().setBlockInfo(info))));
-    OpenFilePOptions readOptions = OpenFilePOptions.newBuilder().setReadType(ReadPType.NO_CACHE).build();
+    OpenFilePOptions readOptions = OpenFilePOptions.newBuilder()
+        .setReadType(ReadPType.NO_CACHE).build();
     InStreamOptions options = new InStreamOptions(dummyStatus, readOptions, mConf);
 
-    BlockWorkerDataReader.Factory factory = new BlockWorkerDataReader.Factory(mBlockWorker, BLOCK_ID, CHUNK_SIZE, options);
+    BlockWorkerDataReader.Factory factory = new BlockWorkerDataReader
+        .Factory(mBlockWorker, BLOCK_ID, CHUNK_SIZE, options);
     int len = CHUNK_SIZE * 3 / 2;
     try (DataReader dataReader = factory.create(0, len)) {
       validateBuffer(dataReader.readChunk(), 0, CHUNK_SIZE);


### PR DESCRIPTION
Fixes #13766 
### What changes are proposed in this pull request?
Support fuse read from worker through internal method call when cache miss.
Add worker is local check to correct fuse write to process local worker logics.
Add process local read write related metrics

### Why are the changes needed?
When cache miss, the local worker can still help fetch the data from UFS and provide to the internal client without RPC involved.
Remove the unneeded RPC overhead between Fuse and Worker.
Correct the fuse write to local worker logics

### Does this PR introduce any user facing changes?
No
