### PR TITLE
Remove Dockerfile.fuse ref from generate-tarball

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -221,7 +221,6 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 		"integration/docker/conf/alluxio-env.sh.template",
 		"integration/docker/conf/alluxio-site.properties.template",
 		"integration/docker/Dockerfile",
-		"integration/docker/Dockerfile.fuse",
 		"integration/docker/entrypoint.sh",
 		"integration/fuse/bin/alluxio-fuse",
 		"integration/metrics/docker-compose-master.yaml",


### PR DESCRIPTION
### What changes are proposed in this pull request?

remove reference to Dockerfile.fuse

### Why are the changes needed?

Dockerfile.fuse was removed in #13756

### Does this PR introduce any user facing changes?

no