### PR TITLE
Deprecate .Values.fuse.{image, imageTag, imagePullPolicy} in helm

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
@@ -81,8 +81,8 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
         - name: alluxio-fuse
-          image: {{ .Values.fuse.image }}:{{ .Values.fuse.imageTag }}
-          imagePullPolicy: {{ .Values.fuse.imagePullPolicy }}
+          image: {{ .Values.image }}:{{ .Values.imageTag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- if .Values.fuse.resources  }}
           resources:
             {{- if .Values.fuse.resources.limits }}

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -290,9 +290,6 @@ fuse:
     # Extra environment variables for the fuse pod
     # Example:
     # JAVA_HOME: /opt/java
-  image: alluxio/alluxio
-  imageTag: 2.7.0-SNAPSHOT
-  imagePullPolicy: IfNotPresent
   # Change both to true to deploy FUSE
   enabled: false
   clientEnabled: false


### PR DESCRIPTION
In Kubernetes helm, replace .Values.fuse.{image, imageTag, imagePullPolicy} with .Values.{image, imageTag, imagePullPolicy}, because alluxio-fuse is using the same docker image as master/worker do and thus has the exact same settings.

