### PR TITLE
Force election after switching leader modes in RaftJournalTest

### DIFF
--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -396,13 +396,15 @@ public class RaftJournalTest {
   }
 
   private void promoteFollower() throws Exception {
-    System.out.printf("Leader is leader? %s", mLeaderJournalSystem.isLeader());
-    changeToFollower(mLeaderJournalSystem);
-    System.out.printf("Follower is leader? %s", mFollowerJournalSystem.isLeader());
+    Assert.assertTrue(mLeaderJournalSystem.isLeader());
+    Assert.assertFalse(mFollowerJournalSystem.isLeader());
+    // Triggering rigged election via reflection to switch the leader.
     changeToFollower(mLeaderJournalSystem);
     changeToCandidate(mFollowerJournalSystem);
-    CommonUtils.waitFor("follower becomes leader",
-        () -> mFollowerJournalSystem.isLeader(), mWaitOptions);
+    CommonUtils.waitFor("follower becomes leader", () -> mFollowerJournalSystem.isLeader(),
+        mWaitOptions);
+    Assert.assertFalse(mLeaderJournalSystem.isLeader());
+    Assert.assertTrue(mFollowerJournalSystem.isLeader());
     mFollowerJournalSystem.gainPrimacy();
   }
 
@@ -534,7 +536,7 @@ public class RaftJournalTest {
     Class<?> raftServerImpl = (Class.forName("org.apache.ratis.server.impl.RaftServerImpl"));
     Method method = raftServerImpl.getDeclaredMethod("changeToCandidate", boolean.class);
     method.setAccessible(true);
-    method.invoke(serverImpl, false);
+    method.invoke(serverImpl, true);
   }
 
   @VisibleForTesting


### PR DESCRIPTION
### What changes are proposed in this pull request?
Sending correct argument via reflection to force election upon switching election modes for RATIS nodes.

### Why are the changes needed?
Without this change, election might not get triggered and test will timeout waiting for seeing the new leader.

Fix https://github.com/Alluxio/alluxio/issues/13746