### PR TITLE
Switch GRPC and WEB start sequence

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -281,6 +281,7 @@ public class AlluxioMasterProcess extends MasterProcess {
    */
   protected void startServing(String startMessage, String stopMessage) {
     MetricsSystem.startSinks(ServerConfiguration.get(PropertyKey.METRICS_CONF_FILE));
+    startServingRPCServer();
     LOG.info("Alluxio master web server version {} starting{}. webAddress={}",
         RuntimeConstants.VERSION, startMessage, mWebBindAddress);
     startServingWebServer();
@@ -289,7 +290,8 @@ public class AlluxioMasterProcess extends MasterProcess {
         "Alluxio master version {} started{}. bindAddress={}, connectAddress={}, webAddress={}",
         RuntimeConstants.VERSION, startMessage, mRpcBindAddress, mRpcConnectAddress,
         mWebBindAddress);
-    startServingRPCServer();
+    // Wait until the server is shut down.
+    mGrpcServer.awaitTermination();
     LOG.info("Alluxio master ended{}", stopMessage);
   }
 
@@ -333,9 +335,6 @@ public class AlluxioMasterProcess extends MasterProcess {
       mGrpcServer = serverBuilder.build().start();
       mSafeModeManager.notifyRpcServerStarted();
       LOG.info("Started Alluxio master gRPC server on address {}", mRpcConnectAddress);
-
-      // Wait until the server is shut down.
-      mGrpcServer.awaitTermination();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -290,7 +290,7 @@ public class AlluxioMasterProcess extends MasterProcess {
         "Alluxio master version {} started{}. bindAddress={}, connectAddress={}, webAddress={}",
         RuntimeConstants.VERSION, startMessage, mRpcBindAddress, mRpcConnectAddress,
         mWebBindAddress);
-    // Wait until the server is shut down.
+    // Blocks until RPC server is shut down. (via #stopServing)
     mGrpcServer.awaitTermination();
     LOG.info("Alluxio master ended{}", stopMessage);
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Switching GRPC and WEB start sequence.

### Why are the changes needed?

In my tests I found that grpc starts quickly (about 1s) but the web service takes about 15s. Switching the order can make GRPC  accept the request earlier but the impact on the web service is minimal when from follower to leader,

### Does this PR introduce any user facing changes?

no user facing changes.
