### PR TITLE
Update and improve conformance of S3 API

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CopyObjectResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CopyObjectResult.java
@@ -1,0 +1,53 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+/**
+ * Result of an S3 Copy.
+ */
+@JacksonXmlRootElement(localName = "CopyObjectResult")
+public class CopyObjectResult {
+
+  private final String mETag;
+  private final String mLastModified;
+
+  /**
+   * Create a new {@link CopyObjectResult}.
+   *
+   * @param etag etag included in the result
+   * @param lastModifiedEpoch epoch time in ms which is converted to a timestamp string in the
+   *                          output
+   */
+  public CopyObjectResult(String etag, long lastModifiedEpoch) {
+    mETag = etag;
+    mLastModified = S3RestUtils.toS3Date(lastModifiedEpoch);
+  }
+
+  /**
+   * @return the ETag
+   */
+  @JacksonXmlProperty(localName = "ETag")
+  public String getEtag() {
+    return mETag;
+  }
+
+  /**
+   * @return the last modified timestamp
+   */
+  @JacksonXmlProperty(localName = "LastModified")
+  public String getLastModified() {
+    return mLastModified;
+  }
+}

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListAllMyBucketsResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListAllMyBucketsResult.java
@@ -73,7 +73,7 @@ public class ListAllMyBucketsResult {
     }
 
     /**
-     * @return the name of the bucket
+     * @return the creation timestamp for the bucket
      */
     @JacksonXmlProperty(localName = "CreationDate")
     public String getCreationDate() {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListAllMyBucketsResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListAllMyBucketsResult.java
@@ -11,10 +11,14 @@
 
 package alluxio.proxy.s3;
 
+import alluxio.client.file.URIStatus;
+
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -30,8 +34,12 @@ public class ListAllMyBucketsResult {
    *
    * @param names names of all of the buckets
    */
-  public ListAllMyBucketsResult(List<String> names) {
-    mBuckets = names.stream().map((name) -> new Bucket(name)).collect(Collectors.toList());
+  public ListAllMyBucketsResult(List<URIStatus> names) {
+    mBuckets =
+        names.stream().map((uriStatus) -> new Bucket(uriStatus.getName(),
+            LocalDateTime.ofEpochSecond(
+                uriStatus.getCreationTimeMs() / 1000L, 0, ZoneOffset.UTC).toString()))
+            .collect(Collectors.toList());
   }
 
   /**
@@ -49,9 +57,11 @@ public class ListAllMyBucketsResult {
   @JacksonXmlRootElement(localName = "Bucket")
   public class Bucket {
     private String mName;
+    private String mCreationDate;
 
-    private Bucket(String name) {
+    private Bucket(String name, String creationDate) {
       mName = name;
+      mCreationDate = creationDate;
     }
 
     /**
@@ -60,6 +70,14 @@ public class ListAllMyBucketsResult {
     @JacksonXmlProperty(localName = "Name")
     public String getName() {
       return mName;
+    }
+
+    /**
+     * @return the name of the bucket
+     */
+    @JacksonXmlProperty(localName = "CreationDate")
+    public String getCreationDate() {
+      return mCreationDate;
     }
   }
 }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
@@ -24,6 +24,8 @@ public final class ListBucketOptions {
   private String mMarker;
   private String mPrefix;
   private int mMaxKeys;
+  private String mDelimiter;
+  private String mEncodingType;
 
   /**
    * Creates a default {@link ListBucketOptions}.
@@ -41,6 +43,8 @@ public final class ListBucketOptions {
     mMarker = "";
     mPrefix = "";
     mMaxKeys = DEFAULT_MAX_KEYS;
+    mDelimiter = "/";
+    mEncodingType = "url";
   }
 
   /**
@@ -62,6 +66,20 @@ public final class ListBucketOptions {
    */
   public int getMaxKeys() {
     return mMaxKeys;
+  }
+
+  /**
+   * @return the delimiter
+   */
+  public String getDelimiter() {
+    return mDelimiter;
+  }
+
+  /**
+   * @return the encoding type
+   */
+  public String getEncodingType() {
+    return mEncodingType;
   }
 
   /**
@@ -91,6 +109,24 @@ public final class ListBucketOptions {
     return this;
   }
 
+  /**
+   * @param delimiter the delimiter
+   * @return the updated object
+   */
+  public ListBucketOptions setDelimiter(String delimiter) {
+    mDelimiter = delimiter;
+    return this;
+  }
+
+  /**
+   * @param encodingType the encoding type
+   * @return the updated object
+   */
+  public ListBucketOptions setEncodingType(String encodingType) {
+    mEncodingType = encodingType;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -102,12 +138,15 @@ public final class ListBucketOptions {
     ListBucketOptions that = (ListBucketOptions) o;
     return Objects.equal(mMarker, that.mMarker)
         && Objects.equal(mPrefix, that.mPrefix)
-        && Objects.equal(mMaxKeys, that.mMaxKeys);
+        && Objects.equal(mMaxKeys, that.mMaxKeys)
+        && Objects.equal(mDelimiter, that.mDelimiter)
+        && Objects.equal(mEncodingType, that.mEncodingType)
+        ;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mMarker, mPrefix, mMaxKeys);
+    return Objects.hashCode(mMarker, mPrefix, mMaxKeys, mDelimiter, mEncodingType);
   }
 
   @Override
@@ -116,6 +155,8 @@ public final class ListBucketOptions {
         .add("marker", mMarker)
         .add("prefix", mPrefix)
         .add("maxKeys", mMaxKeys)
+        .add("delimiter", mDelimiter)
+        .add("encodingType", mEncodingType)
         .toString();
   }
 }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -13,6 +13,7 @@ package alluxio.proxy.s3;
 
 import alluxio.client.file.URIStatus;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
@@ -31,6 +32,7 @@ import java.util.stream.Collectors;
  * It will be encoded into an XML string to be returned as a response for the REST call.
  */
 @JacksonXmlRootElement(localName = "ListBucketResult")
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ListBucketResult {
   private static final Logger LOG = LoggerFactory.getLogger(ListBucketResult.class);
 
@@ -61,7 +63,13 @@ public class ListBucketResult {
   private List<Content> mContents;
 
   // List of common prefixes (aka. folders)
-  private List<Prefix> mCommonPrefixes;
+  private CommonPrefixes mCommonPrefixes;
+
+  // delimiter used to process keys
+  private String mDelimiter;
+
+  // encoding type of params. Usually "url"
+  private String mEncodingType;
 
   /**
    * Creates an {@link ListBucketResult}.
@@ -81,25 +89,20 @@ public class ListBucketResult {
     mPrefix = options.getPrefix();
     mMarker = options.getMarker();
     mMaxKeys = options.getMaxKeys();
+    mDelimiter = options.getDelimiter();
+    mEncodingType = options.getEncodingType();
 
-    Collections.sort(children, new URIStatusComparator());
+    children.sort(new URIStatusComparator());
 
     final List<URIStatus> keys = children.stream()
         .filter((status) -> status.getPath().compareTo(mMarker) > 0)
         .limit(mMaxKeys)
         .collect(Collectors.toList());
 
-    mKeyCount = keys.size();
-    mIsTruncated = mKeyCount == mMaxKeys;
-
-    if (mIsTruncated) {
-      mNextMarker = keys.get(keys.size() - 1).getPath();
-    }
-
     final Map<Boolean, List<URIStatus>> typeToStatus = keys.stream()
-        .collect(Collectors.groupingBy((status) -> status.isFolder()));
-    final List<URIStatus> objectsList = typeToStatus.getOrDefault(false, Collections.EMPTY_LIST);
-    final List<URIStatus> prefixList = typeToStatus.getOrDefault(true, Collections.EMPTY_LIST);
+        .collect(Collectors.groupingBy(URIStatus::isFolder));
+    final List<URIStatus> objectsList = typeToStatus.getOrDefault(false, Collections.emptyList());
+    final List<URIStatus> prefixList = typeToStatus.getOrDefault(true, Collections.emptyList());
 
     mContents = new ArrayList<>();
     for (URIStatus status : objectsList) {
@@ -110,15 +113,24 @@ public class ListBucketResult {
       ));
     }
 
-    final ArrayList<Prefix> commonPrefixes = new ArrayList<>();
+    final ArrayList<String> commonPrefixes = new ArrayList<>();
     for (URIStatus status : prefixList) {
       final String path = status.getPath();
-      // remove both ends of "/" character in the path as well as bucket name
-      // add "/" at end to show it's a folder (or else, aws cli crashes with index out of bounds)
-      commonPrefixes.add(new Prefix(path.substring(mName.length() + 2) + "/"));
+      // remove both ends of "/" character
+      commonPrefixes.add(path.substring(mName.length() + 2) + mDelimiter);
     }
 
-    mCommonPrefixes = commonPrefixes;
+    mKeyCount = mContents.size() + commonPrefixes.size();
+    mIsTruncated = mKeyCount == mMaxKeys;
+    if (mIsTruncated) {
+      mNextMarker = keys.get(keys.size() - 1).getPath();
+    }
+
+    if (!commonPrefixes.isEmpty())  {
+      mCommonPrefixes = new CommonPrefixes(commonPrefixes);
+    } else {
+      mCommonPrefixes = null;
+    }
   }
 
   /**
@@ -138,6 +150,14 @@ public class ListBucketResult {
   }
 
   /**
+   * @return the number of keys included in the response
+   */
+  @JacksonXmlProperty(localName = "MaxKeys")
+  public int getMaxKeys() {
+    return mMaxKeys;
+  }
+
+  /**
    * @return false if all results are returned, otherwise true
    */
   @JacksonXmlProperty(localName = "IsTruncated")
@@ -151,6 +171,22 @@ public class ListBucketResult {
   @JacksonXmlProperty(localName = "Prefix")
   public String getPrefix() {
     return mPrefix;
+  }
+
+  /**
+   * @return the delimiter
+   */
+  @JacksonXmlProperty(localName = "Delimiter")
+  public String getDelimiter() {
+    return mDelimiter;
+  }
+
+  /**
+   * @return the prefix
+   */
+  @JacksonXmlProperty(localName = "EncodingType")
+  public String getEncodingType() {
+    return mEncodingType;
   }
 
   /**
@@ -182,27 +218,27 @@ public class ListBucketResult {
    * @return the common prefixes
    */
   @JacksonXmlProperty(localName = "CommonPrefixes")
-  @JacksonXmlElementWrapper(useWrapping = false)
-  public List<Prefix> getCommonPrefixes() {
+  public CommonPrefixes getCommonPrefixes() {
     return mCommonPrefixes;
   }
 
   /**
-   * Prefix Object.
+   * Common Prefixes list placeholder object.
    */
-  public class Prefix {
-    private final String mPrefix;
+  public class CommonPrefixes {
+    private final List<String> mCommonPrefixes;
 
-    private Prefix(String prefix) {
-      mPrefix = prefix;
+    private CommonPrefixes(List<String> commonPrefixes) {
+      mCommonPrefixes = commonPrefixes;
     }
 
     /**
-     * @return the prefix string
+     * @return the list of common prefixes
      */
     @JacksonXmlProperty(localName = "Prefix")
-    public String getPrefix() {
-      return mPrefix;
+    @JacksonXmlElementWrapper(useWrapping = false)
+    public List<String> getCommonPrefixes() {
+      return mCommonPrefixes;
     }
   }
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -182,7 +182,7 @@ public class ListBucketResult {
   }
 
   /**
-   * @return the prefix
+   * @return the encoding type of the result
    */
   @JacksonXmlProperty(localName = "EncodingType")
   public String getEncodingType() {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -38,6 +38,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.io.BaseEncoding;
 import com.google.common.io.ByteStreams;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +47,6 @@ import java.io.InputStream;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -110,7 +110,7 @@ public final class S3RestServiceHandler {
   }
 
   /**
-   * Gets the user from the authorization header string.
+   * Gets the user from the authorization header string for AWS Signature Version 4.
    * @param authorization the authorization header string
    * @return the user
    */
@@ -121,18 +121,23 @@ public final class S3RestServiceHandler {
     }
 
     // The valid pattern for Authorization is "AWS <AWSAccessKeyId>:<Signature>"
-    int spaceIndex = authorization.indexOf(' ');
-    if (spaceIndex == -1) {
+    // Parse the authorization header defined at
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
+    // All other authorization types are deprecated or EOL (as of writing)
+
+    // We only care about the credential key, so split the header by " " and then take everything
+    // after the "=" and before the first "/"
+    String[] fields = authorization.split(" ");
+    if (fields.length < 2) {
       return null;
     }
-    String stripped = authorization.substring(spaceIndex + 1);
-
-    int colonIndex = stripped.indexOf(':');
-    if (colonIndex == -1) {
+    String credentials = fields[1];
+    String[] creds = credentials.split("=");
+    if (creds.length < 2) {
       return null;
     }
 
-    final String user = stripped.substring(0, colonIndex);
+    final String user = creds[1].substring(0, creds[1].indexOf("/")).trim();
     if (user.isEmpty()) {
       return null;
     }
@@ -161,24 +166,22 @@ public final class S3RestServiceHandler {
   @Path("/")
   public Response listAllMyBuckets(@HeaderParam("Authorization") String authorization) {
 
-    return S3RestUtils.call("", new S3RestUtils.RestCallable<ListAllMyBucketsResult>() {
-      @Override
-      public ListAllMyBucketsResult call() throws S3Exception {
-        String user = getUserFromAuthorization(authorization);
+    return S3RestUtils.call("", () -> {
+      String user = getUserFromAuthorization(authorization);
 
-        List<URIStatus> objects;
-        try {
-          objects = getFileSystem(authorization).listStatus(new AlluxioURI("/"));
-        } catch (AlluxioException | IOException e) {
-          throw new RuntimeException(e);
-        }
-
-        final List<String> buckets = objects.stream()
-            .filter((uri) -> uri.getOwner().equals(user))
-            .map((uri) -> uri.getName()).collect(Collectors.toList());
-        ListAllMyBucketsResult response = new ListAllMyBucketsResult(buckets);
-        return response;
+      List<URIStatus> objects;
+      try {
+        objects = getFileSystem(authorization).listStatus(new AlluxioURI("/"));
+      } catch (AlluxioException | IOException e) {
+        throw new RuntimeException(e);
       }
+
+      final List<URIStatus> buckets = objects.stream()
+          .filter((uri) -> uri.getOwner().equals(user))
+          // debatable (?) potentially breaks backcompat(?)
+          .filter(URIStatus::isFolder)
+          .collect(Collectors.toList());
+      return new ListAllMyBucketsResult(buckets);
     });
   }
 
@@ -189,6 +192,7 @@ public final class S3RestServiceHandler {
    * @param markerParam the optional marker param
    * @param prefixParam the optional prefix param
    * @param delimiterParam the optional delimiter param
+   * @param encodingTypeParam optional encoding type param
    * @param maxKeysParam the optional max keys param
    * @return the response object
    */
@@ -200,53 +204,57 @@ public final class S3RestServiceHandler {
                             @QueryParam("marker") final String markerParam,
                             @QueryParam("prefix") final String prefixParam,
                             @QueryParam("delimiter") final String delimiterParam,
+                            @QueryParam("encoding-type") final String encodingTypeParam,
                             @QueryParam("max-keys") final int maxKeysParam) {
-    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<ListBucketResult>() {
-      @Override
-      public ListBucketResult call() throws S3Exception {
-        Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
+    return S3RestUtils.call(bucket, () -> {
+      Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
 
-        String marker = markerParam;
-        if (marker == null) {
-          marker = "";
-        }
-
-        String prefix = prefixParam;
-        if (prefix == null) {
-          prefix = "";
-        }
-
-        String delimiter = delimiterParam;
-        if (delimiter == null) {
-          delimiter = AlluxioURI.SEPARATOR;
-        }
-
-        int maxKeys = maxKeysParam;
-        if (maxKeys <= 0) {
-          maxKeys = ListBucketOptions.DEFAULT_MAX_KEYS;
-        }
-
-        String path = parsePath(AlluxioURI.SEPARATOR + bucket, prefix, delimiter);
-
-        final FileSystem fs = getFileSystem(authorization);
-        checkPathIsAlluxioDirectory(fs, path);
-
-        List<URIStatus> children;
-        ListBucketOptions listBucketOptions = ListBucketOptions.defaults()
-            .setMarker(marker)
-            .setPrefix(prefix)
-            .setMaxKeys(maxKeys);
-        try {
-          children = fs.listStatus(new AlluxioURI(path));
-        } catch (IOException | AlluxioException e) {
-          throw new RuntimeException(e);
-        }
-        ListBucketResult response = new ListBucketResult(
-            bucket,
-            children,
-            listBucketOptions);
-        return response;
+      String marker = markerParam;
+      if (marker == null) {
+        marker = "";
       }
+
+      String prefix = prefixParam;
+      if (prefix == null) {
+        prefix = "";
+      }
+
+      String delimiter = delimiterParam;
+      if (delimiter == null) {
+        delimiter = AlluxioURI.SEPARATOR;
+      }
+
+      String encodingType = encodingTypeParam;
+      if (encodingType == null) {
+        encodingType = "url";
+      }
+
+      int maxKeys = maxKeysParam;
+      if (maxKeys <= 0) {
+        maxKeys = ListBucketOptions.DEFAULT_MAX_KEYS;
+      }
+
+      String path = parsePath(AlluxioURI.SEPARATOR + bucket, prefix, delimiter);
+
+      final FileSystem fs = getFileSystem(authorization);
+
+      List<URIStatus> children;
+      ListBucketOptions listBucketOptions = ListBucketOptions.defaults()
+          .setMarker(marker)
+          .setPrefix(prefix)
+          .setMaxKeys(maxKeys)
+          .setDelimiter(delimiter)
+          .setEncodingType(encodingType)
+          ;
+      try {
+        children = fs.listStatus(new AlluxioURI(path));
+      } catch (IOException | AlluxioException e) {
+        throw new RuntimeException(e);
+      }
+      return new ListBucketResult(
+          bucket,
+          children,
+          listBucketOptions);
     });
   }
 
@@ -261,24 +269,21 @@ public final class S3RestServiceHandler {
   //@ReturnType("java.lang.Void")
   public Response createBucket(@HeaderParam("Authorization") String authorization,
                                @PathParam("bucket") final String bucket) {
-    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
-      @Override
-      public Response.Status call() throws S3Exception {
-        Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
+    return S3RestUtils.call(bucket, () -> {
+      Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
 
-        String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
+      String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
 
-        final FileSystem fs = getFileSystem(authorization);
-        // Create the bucket.
-        CreateDirectoryPOptions options =
-            CreateDirectoryPOptions.newBuilder().setWriteType(getS3WriteType()).build();
-        try {
-          fs.createDirectory(new AlluxioURI(bucketPath), options);
-        } catch (Exception e) {
-          throw toBucketS3Exception(e, bucketPath);
-        }
-        return Response.Status.OK;
+      final FileSystem fs = getFileSystem(authorization);
+      // Create the bucket.
+      CreateDirectoryPOptions options =
+          CreateDirectoryPOptions.newBuilder().setWriteType(getS3WriteType()).build();
+      try {
+        fs.createDirectory(new AlluxioURI(bucketPath), options);
+      } catch (Exception e) {
+        throw toBucketS3Exception(e, bucketPath);
       }
+      return Response.Status.OK;
     });
   }
 
@@ -293,26 +298,23 @@ public final class S3RestServiceHandler {
   //@ReturnType("java.lang.Void")
   public Response deleteBucket(@HeaderParam("Authorization") String authorization,
                                @PathParam("bucket") final String bucket) {
-    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
-      @Override
-      public Response.Status call() throws S3Exception {
-        Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
-        String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
+    return S3RestUtils.call(bucket, () -> {
+      Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
+      String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
 
-        final FileSystem fs = getFileSystem(authorization);
-        checkPathIsAlluxioDirectory(fs, bucketPath);
+      final FileSystem fs = getFileSystem(authorization);
+      checkPathIsAlluxioDirectory(fs, bucketPath);
 
-        // Delete the bucket.
-        DeletePOptions options = DeletePOptions.newBuilder().setAlluxioOnly(ServerConfiguration
-            .get(PropertyKey.PROXY_S3_DELETE_TYPE).equals(Constants.S3_DELETE_IN_ALLUXIO_ONLY))
-            .build();
-        try {
-          fs.delete(new AlluxioURI(bucketPath), options);
-        } catch (Exception e) {
-          throw toBucketS3Exception(e, bucketPath);
-        }
-        return Response.Status.NO_CONTENT;
+      // Delete the bucket.
+      DeletePOptions options = DeletePOptions.newBuilder().setAlluxioOnly(ServerConfiguration
+          .get(PropertyKey.PROXY_S3_DELETE_TYPE).equals(Constants.S3_DELETE_IN_ALLUXIO_ONLY))
+          .build();
+      try {
+        fs.delete(new AlluxioURI(bucketPath), options);
+      } catch (Exception e) {
+        throw toBucketS3Exception(e, bucketPath);
       }
+      return Response.Status.NO_CONTENT;
     });
   }
 
@@ -320,6 +322,7 @@ public final class S3RestServiceHandler {
    * @summary uploads an object or part of an object in multipart upload
    * @param authorization header parameter authorization
    * @param contentMD5 the optional Base64 encoded 128-bit MD5 digest of the object
+   * @param copySource the source path to copy the new file from
    * @param bucket the bucket name
    * @param object the object name
    * @param partNumber the identification of the part of the object in multipart upload,
@@ -330,62 +333,59 @@ public final class S3RestServiceHandler {
    */
   @PUT
   @Path(OBJECT_PARAM)
-  //@ReturnType("java.lang.Void")
   @Consumes(MediaType.WILDCARD)
   public Response createObjectOrUploadPart(@HeaderParam("Authorization") String authorization,
                                            @HeaderParam("Content-MD5") final String contentMD5,
+                                           @HeaderParam("x-amz-copy-source") String copySource,
                                            @PathParam("bucket") final String bucket,
                                            @PathParam("object") final String object,
                                            @QueryParam("partNumber") final Integer partNumber,
                                            @QueryParam("uploadId") final Long uploadId,
                                            final InputStream is) {
-    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response>() {
-      @Override
-      public Response call() throws S3Exception {
-        Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
-        Preconditions.checkNotNull(object, "required 'object' parameter is missing");
-        Preconditions.checkArgument((partNumber == null && uploadId == null)
-            || (partNumber != null && uploadId != null),
-            "'partNumber' and 'uploadId' parameter should appear together or be "
-            + "missing together.");
+    return S3RestUtils.call(bucket, () -> {
+      Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
+      Preconditions.checkNotNull(object, "required 'object' parameter is missing");
+      Preconditions.checkArgument((partNumber == null && uploadId == null)
+          || (partNumber != null && uploadId != null),
+          "'partNumber' and 'uploadId' parameter should appear together or be "
+          + "missing together.");
 
-        String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
+      String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
 
-        final FileSystem fs = getFileSystem(authorization);
-        checkPathIsAlluxioDirectory(fs, bucketPath);
+      final FileSystem fs = getFileSystem(authorization);
+      checkPathIsAlluxioDirectory(fs, bucketPath);
 
-        String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
+      String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
 
-        if (objectPath.endsWith(AlluxioURI.SEPARATOR)) {
-          // Need to create a folder
-          try {
-            fs.createDirectory(new AlluxioURI(objectPath));
-          } catch (IOException | AlluxioException e) {
-            throw toObjectS3Exception(e, objectPath);
-          }
-          return Response.ok().build();
-        }
-
-        if (partNumber != null) {
-          // This object is part of a multipart upload, should be uploaded into the temporary
-          // directory first.
-          String tmpDir = S3RestUtils.getMultipartTemporaryDirForObject(bucketPath, object);
-          checkUploadId(fs, new AlluxioURI(tmpDir), uploadId);
-          objectPath = tmpDir + AlluxioURI.SEPARATOR + Integer.toString(partNumber);
-        }
-        AlluxioURI objectURI = new AlluxioURI(objectPath);
-
+      if (objectPath.endsWith(AlluxioURI.SEPARATOR)) {
+        // Need to create a folder
         try {
-          CreateFilePOptions options = CreateFilePOptions.newBuilder().setRecursive(true)
-              .setWriteType(getS3WriteType()).build();
-          FileOutStream os = fs.createFile(objectURI, options);
-          MessageDigest md5 = MessageDigest.getInstance("MD5");
-          DigestOutputStream digestOutputStream = new DigestOutputStream(os, md5);
+          fs.createDirectory(new AlluxioURI(objectPath));
+        } catch (IOException | AlluxioException e) {
+          throw toObjectS3Exception(e, objectPath);
+        }
+        return Response.ok().build();
+      }
 
-          try {
+      if (partNumber != null) {
+        // This object is part of a multipart upload, should be uploaded into the temporary
+        // directory first.
+        String tmpDir = S3RestUtils.getMultipartTemporaryDirForObject(bucketPath, object);
+        checkUploadId(fs, new AlluxioURI(tmpDir), uploadId);
+        objectPath = tmpDir + AlluxioURI.SEPARATOR + partNumber;
+      }
+      AlluxioURI objectURI = new AlluxioURI(objectPath);
+
+      CreateFilePOptions options =
+          CreateFilePOptions.newBuilder().setRecursive(true).setWriteType(getS3WriteType()).build();
+      // not copying from an existing file
+      if (copySource == null) {
+        try {
+          MessageDigest md5 = MessageDigest.getInstance("MD5");
+          FileOutStream os = fs.createFile(objectURI, options);
+
+          try (DigestOutputStream digestOutputStream = new DigestOutputStream(os, md5)) {
             ByteStreams.copy(is, digestOutputStream);
-          } finally {
-            digestOutputStream.close();
           }
 
           byte[] digest = md5.digest();
@@ -402,6 +402,27 @@ public final class S3RestServiceHandler {
 
           String entityTag = Hex.encodeHexString(digest);
           return Response.ok().tag(entityTag).build();
+        } catch (Exception e) {
+          throw toObjectS3Exception(e, objectPath);
+        }
+      } else {
+        try (FileInStream in = fs.openFile(
+            new AlluxioURI(AlluxioURI.SEPARATOR + copySource));
+            FileOutStream out = fs.createFile(objectURI)) {
+          MessageDigest md5 = MessageDigest.getInstance("MD5");
+          try (DigestOutputStream digestOut = new DigestOutputStream(out, md5)) {
+            IOUtils.copyLarge(in, digestOut, new byte[8 * Constants.MB]);
+            byte[] digest = md5.digest();
+            String entityTag = Hex.encodeHexString(digest);
+            return new CopyObjectResult(entityTag, System.currentTimeMillis());
+          } catch (IOException e) {
+            try {
+              out.cancel();
+            } catch (Throwable t2) {
+              e.addSuppressed(t2);
+            }
+            throw e;
+          }
         } catch (Exception e) {
           throw toObjectS3Exception(e, objectPath);
         }
@@ -442,23 +463,20 @@ public final class S3RestServiceHandler {
   private Response initiateMultipartUpload(final FileSystem fs,
                                            final String bucket,
                                            final String object) {
-    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<InitiateMultipartUploadResult>() {
-      @Override
-      public InitiateMultipartUploadResult call() throws S3Exception {
-        String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
-        checkPathIsAlluxioDirectory(fs, bucketPath);
-        String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
-        AlluxioURI multipartTemporaryDir =
-            new AlluxioURI(S3RestUtils.getMultipartTemporaryDirForObject(bucketPath, object));
+    return S3RestUtils.call(bucket, () -> {
+      String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
+      checkPathIsAlluxioDirectory(fs, bucketPath);
+      String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
+      AlluxioURI multipartTemporaryDir =
+          new AlluxioURI(S3RestUtils.getMultipartTemporaryDirForObject(bucketPath, object));
 
-        try {
-          fs.createDirectory(multipartTemporaryDir);
-          // Use the file ID of multipartTemporaryDir as the upload ID.
-          long uploadId = fs.getStatus(multipartTemporaryDir).getFileId();
-          return new InitiateMultipartUploadResult(bucket, object, Long.toString(uploadId));
-        } catch (Exception e) {
-          throw toObjectS3Exception(e, objectPath);
-        }
+      try {
+        fs.createDirectory(multipartTemporaryDir);
+        // Use the file ID of multipartTemporaryDir as the upload ID.
+        long uploadId = fs.getStatus(multipartTemporaryDir).getFileId();
+        return new InitiateMultipartUploadResult(bucket, object, Long.toString(uploadId));
+      } catch (Exception e) {
+        throw toObjectS3Exception(e, objectPath);
       }
     });
   }
@@ -470,44 +488,38 @@ public final class S3RestServiceHandler {
                                            final String bucket,
                                            final String object,
                                            final long uploadId) {
-    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<CompleteMultipartUploadResult>() {
-      @Override
-      public CompleteMultipartUploadResult call() throws S3Exception {
-        String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
-        checkPathIsAlluxioDirectory(fs, bucketPath);
-        String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
-        AlluxioURI multipartTemporaryDir =
-            new AlluxioURI(S3RestUtils.getMultipartTemporaryDirForObject(bucketPath, object));
-        checkUploadId(fs, multipartTemporaryDir, uploadId);
+    return S3RestUtils.call(bucket, () -> {
+      String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
+      checkPathIsAlluxioDirectory(fs, bucketPath);
+      String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
+      AlluxioURI multipartTemporaryDir =
+          new AlluxioURI(S3RestUtils.getMultipartTemporaryDirForObject(bucketPath, object));
+      checkUploadId(fs, multipartTemporaryDir, uploadId);
 
-        try {
-          List<URIStatus> parts = fs.listStatus(multipartTemporaryDir);
-          Collections.sort(parts, new URIStatusNameComparator());
+      try {
+        List<URIStatus> parts = fs.listStatus(multipartTemporaryDir);
+        parts.sort(new URIStatusNameComparator());
 
-          CreateFilePOptions options = CreateFilePOptions.newBuilder().setRecursive(true)
-              .setWriteType(getS3WriteType()).build();
-          FileOutStream os = fs.createFile(new AlluxioURI(objectPath), options);
-          MessageDigest md5 = MessageDigest.getInstance("MD5");
-          DigestOutputStream digestOutputStream = new DigestOutputStream(os, md5);
+        CreateFilePOptions options = CreateFilePOptions.newBuilder().setRecursive(true)
+            .setWriteType(getS3WriteType()).build();
+        FileOutStream os = fs.createFile(new AlluxioURI(objectPath), options);
+        MessageDigest md5 = MessageDigest.getInstance("MD5");
 
-          try {
-            for (URIStatus part : parts) {
-              try (FileInStream is = fs.openFile(new AlluxioURI(part.getPath()))) {
-                ByteStreams.copy(is, digestOutputStream);
-              }
+        try (DigestOutputStream digestOutputStream = new DigestOutputStream(os, md5)) {
+          for (URIStatus part : parts) {
+            try (FileInStream is = fs.openFile(new AlluxioURI(part.getPath()))) {
+              ByteStreams.copy(is, digestOutputStream);
             }
-          } finally {
-            digestOutputStream.close();
           }
-
-          fs.delete(multipartTemporaryDir,
-              DeletePOptions.newBuilder().setRecursive(true).build());
-
-          String entityTag = Hex.encodeHexString(md5.digest());
-          return new CompleteMultipartUploadResult(objectPath, bucket, object, entityTag);
-        } catch (Exception e) {
-          throw toObjectS3Exception(e, objectPath);
         }
+
+        fs.delete(multipartTemporaryDir,
+            DeletePOptions.newBuilder().setRecursive(true).build());
+
+        String entityTag = Hex.encodeHexString(md5.digest());
+        return new CompleteMultipartUploadResult(objectPath, bucket, object, entityTag);
+      } catch (Exception e) {
+        throw toObjectS3Exception(e, objectPath);
       }
     });
   }
@@ -521,34 +533,30 @@ public final class S3RestServiceHandler {
    */
   @HEAD
   @Path(OBJECT_PARAM)
-  //@ReturnType("java.lang.Void")
   public Response getObjectMetadata(@HeaderParam("Authorization") String authorization,
                                     @PathParam("bucket") final String bucket,
                                     @PathParam("object") final String object) {
-    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response>() {
-      @Override
-      public Response call() throws S3Exception {
-        Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
-        Preconditions.checkNotNull(object, "required 'object' parameter is missing");
+    return S3RestUtils.call(bucket, () -> {
+      Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
+      Preconditions.checkNotNull(object, "required 'object' parameter is missing");
 
-        String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
+      String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
 
-        final FileSystem fs = getFileSystem(authorization);
-        checkPathIsAlluxioDirectory(fs, bucketPath);
-        String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
-        AlluxioURI objectURI = new AlluxioURI(objectPath);
+      final FileSystem fs = getFileSystem(authorization);
+      checkPathIsAlluxioDirectory(fs, bucketPath);
+      String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
+      AlluxioURI objectURI = new AlluxioURI(objectPath);
 
-        try {
-          URIStatus status = fs.getStatus(objectURI);
-          // TODO(cc): Consider how to respond with the object's ETag.
-          return Response.ok()
-              .lastModified(new Date(status.getLastModificationTimeMs()))
-              .header(S3Constants.S3_ETAG_HEADER, "\"" + status.getLastModificationTimeMs() + "\"")
-              .header(S3Constants.S3_CONTENT_LENGTH_HEADER, status.getLength())
-              .build();
-        } catch (Exception e) {
-          throw toObjectS3Exception(e, objectPath);
-        }
+      try {
+        URIStatus status = fs.getStatus(objectURI);
+        // TODO(cc): Consider how to respond with the object's ETag.
+        return Response.ok()
+            .lastModified(new Date(status.getLastModificationTimeMs()))
+            .header(S3Constants.S3_ETAG_HEADER, "\"" + status.getLastModificationTimeMs() + "\"")
+            .header(S3Constants.S3_CONTENT_LENGTH_HEADER, status.getLength())
+            .build();
+      } catch (Exception e) {
+        throw toObjectS3Exception(e, objectPath);
       }
     });
   }
@@ -587,34 +595,31 @@ public final class S3RestServiceHandler {
                              final String bucket,
                              final String object,
                              final long uploadId) {
-    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<ListPartsResult>() {
-      @Override
-      public ListPartsResult call() throws S3Exception {
-        String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
-        checkPathIsAlluxioDirectory(fs, bucketPath);
+    return S3RestUtils.call(bucket, () -> {
+      String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
+      checkPathIsAlluxioDirectory(fs, bucketPath);
 
-        AlluxioURI tmpDir = new AlluxioURI(
-            S3RestUtils.getMultipartTemporaryDirForObject(bucketPath, object));
-        checkUploadId(fs, tmpDir, uploadId);
+      AlluxioURI tmpDir = new AlluxioURI(
+          S3RestUtils.getMultipartTemporaryDirForObject(bucketPath, object));
+      checkUploadId(fs, tmpDir, uploadId);
 
-        try {
-          List<URIStatus> statuses = fs.listStatus(tmpDir);
-          Collections.sort(statuses, new URIStatusNameComparator());
+      try {
+        List<URIStatus> statuses = fs.listStatus(tmpDir);
+        statuses.sort(new URIStatusNameComparator());
 
-          List<ListPartsResult.Part> parts = new ArrayList<>();
-          for (URIStatus status : statuses) {
-            parts.add(ListPartsResult.Part.fromURIStatus(status));
-          }
-
-          ListPartsResult result = new ListPartsResult();
-          result.setBucket(bucketPath);
-          result.setKey(object);
-          result.setUploadId(Long.toString(uploadId));
-          result.setParts(parts);
-          return result;
-        } catch (Exception e) {
-          throw toObjectS3Exception(e, tmpDir.getPath());
+        List<ListPartsResult.Part> parts = new ArrayList<>();
+        for (URIStatus status : statuses) {
+          parts.add(ListPartsResult.Part.fromURIStatus(status));
         }
+
+        ListPartsResult result = new ListPartsResult();
+        result.setBucket(bucketPath);
+        result.setKey(object);
+        result.setUploadId(Long.toString(uploadId));
+        result.setParts(parts);
+        return result;
+      } catch (Exception e) {
+        throw toObjectS3Exception(e, tmpDir.getPath());
       }
     });
   }
@@ -623,29 +628,26 @@ public final class S3RestServiceHandler {
                              final String bucket,
                              final String object,
                              final String range) {
-    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response>() {
-      @Override
-      public Response call() throws S3Exception {
+    return S3RestUtils.call(bucket, () -> {
 
-        String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
-        checkPathIsAlluxioDirectory(fs, bucketPath);
-        String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
-        AlluxioURI objectURI = new AlluxioURI(objectPath);
+      String bucketPath = parsePath(AlluxioURI.SEPARATOR + bucket);
+      checkPathIsAlluxioDirectory(fs, bucketPath);
+      String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
+      AlluxioURI objectURI = new AlluxioURI(objectPath);
 
-        try {
-          URIStatus status = fs.getStatus(objectURI);
-          FileInStream is = fs.openFile(objectURI);
-          S3RangeSpec s3Range = S3RangeSpec.Factory.create(range);
-          RangeFileInStream ris = RangeFileInStream.Factory.create(is, status.getLength(), s3Range);
-          // TODO(cc): Consider how to respond with the object's ETag.
-          return Response.ok(ris)
-              .lastModified(new Date(status.getLastModificationTimeMs()))
-              .header(S3Constants.S3_ETAG_HEADER, "\"" + status.getLastModificationTimeMs() + "\"")
-              .header(S3Constants.S3_CONTENT_LENGTH_HEADER, s3Range.getLength(status.getLength()))
-              .build();
-        } catch (Exception e) {
-          throw toObjectS3Exception(e, objectPath);
-        }
+      try {
+        URIStatus status = fs.getStatus(objectURI);
+        FileInStream is = fs.openFile(objectURI);
+        S3RangeSpec s3Range = S3RangeSpec.Factory.create(range);
+        RangeFileInStream ris = RangeFileInStream.Factory.create(is, status.getLength(), s3Range);
+        // TODO(cc): Consider how to respond with the object's ETag.
+        return Response.ok(ris)
+            .lastModified(new Date(status.getLastModificationTimeMs()))
+            .header(S3Constants.S3_ETAG_HEADER, "\"" + status.getLastModificationTimeMs() + "\"")
+            .header(S3Constants.S3_CONTENT_LENGTH_HEADER, s3Range.getLength(status.getLength()))
+            .build();
+      } catch (Exception e) {
+        throw toObjectS3Exception(e, objectPath);
       }
     });
   }
@@ -660,29 +662,25 @@ public final class S3RestServiceHandler {
    */
   @DELETE
   @Path(OBJECT_PARAM)
-  //@ReturnType("java.lang.Void")
   public Response deleteObjectOrAbortMultipartUpload(
       @HeaderParam("Authorization") String authorization,
       @PathParam("bucket") final String bucket,
       @PathParam("object") final String object,
       @QueryParam("uploadId") final Long uploadId) {
-    return S3RestUtils.call(bucket, new S3RestUtils.RestCallable<Response.Status>() {
-      @Override
-      public Response.Status call() throws S3Exception {
-        Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
-        Preconditions.checkNotNull(object, "required 'object' parameter is missing");
+    return S3RestUtils.call(bucket, () -> {
+      Preconditions.checkNotNull(bucket, "required 'bucket' parameter is missing");
+      Preconditions.checkNotNull(object, "required 'object' parameter is missing");
 
-        final FileSystem fs = getFileSystem(authorization);
+      final FileSystem fs = getFileSystem(authorization);
 
-        if (uploadId != null) {
-          abortMultipartUpload(fs, bucket, object, uploadId);
-        } else {
-          deleteObject(fs, bucket, object);
-        }
-
-        // Note: the normal response for S3 delete key is 204 NO_CONTENT, not 200 OK
-        return Response.Status.NO_CONTENT;
+      if (uploadId != null) {
+        abortMultipartUpload(fs, bucket, object, uploadId);
+      } else {
+        deleteObject(fs, bucket, object);
       }
+
+      // Note: the normal response for S3 delete key is 204 NO_CONTENT, not 200 OK
+      return Response.Status.NO_CONTENT;
     });
   }
 
@@ -758,7 +756,7 @@ public final class S3RestServiceHandler {
       prefix = "";
     }
 
-    if (delimiter == null) {
+    if (delimiter == null || delimiter.isEmpty()) {
       delimiter = AlluxioURI.SEPARATOR;
     }
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -448,6 +448,7 @@ public final class S3RestServiceHandler {
   @Path(OBJECT_PARAM)
   // TODO(cc): investigate on how to specify multiple return types, and how to decouple the REST
   // endpoints where the only difference is the query parameter.
+  @Consumes({MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_XML})
   public Response initiateOrCompleteMultipartUpload(
       @HeaderParam("Authorization") String authorization,
       @PathParam("bucket") final String bucket,

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -162,7 +162,7 @@ public final class S3RestServiceHandler {
   }
 
   /**
-   * Lists all buckets owned by you
+   * Lists all buckets owned by you.
    *
    * @param authorization header parameter authorization
    * @return the response object

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -120,10 +120,14 @@ public final class S3RestServiceHandler {
       return null;
     }
 
-    // The valid pattern for Authorization is "AWS <AWSAccessKeyId>:<Signature>"
     // Parse the authorization header defined at
     // https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
     // All other authorization types are deprecated or EOL (as of writing)
+    // Example Header value (spaces turned to line breaks):
+    // AWS4-HMAC-SHA256
+    // Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,
+    // SignedHeaders=host;range;x-amz-date,
+    // Signature=fe5f80f77d5fa3beca038a248ff027d0445342fe2855ddc963176630326f1024
 
     // We only care about the credential key, so split the header by " " and then take everything
     // after the "=" and before the first "/"
@@ -158,12 +162,12 @@ public final class S3RestServiceHandler {
   }
 
   /**
-   * @summary lists all buckets owned by you
+   * Lists all buckets owned by you
+   *
    * @param authorization header parameter authorization
    * @return the response object
    */
   @GET
-  @Path("/")
   public Response listAllMyBuckets(@HeaderParam("Authorization") String authorization) {
 
     return S3RestUtils.call("", () -> {

--- a/core/server/proxy/src/test/java/alluxio/proxy/s3/S3RestServiceHandlerTest.java
+++ b/core/server/proxy/src/test/java/alluxio/proxy/s3/S3RestServiceHandlerTest.java
@@ -12,6 +12,7 @@
 package alluxio.proxy.s3;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
@@ -19,8 +20,9 @@ public class S3RestServiceHandlerTest {
 
   @Test
   public void userFromAuthorization() throws Exception {
-    assertEquals(null, S3RestServiceHandler.getUserFromAuthorization("AWS :randomtext"));
-    assertEquals("test", S3RestServiceHandler.getUserFromAuthorization("AWS test:"));
-    assertEquals(null, S3RestServiceHandler.getUserFromAuthorization(""));
+    assertNull(S3RestServiceHandler.getUserFromAuthorization("AWS-SHA256-HMAC Credential=/asd"));
+    assertEquals("test", S3RestServiceHandler.getUserFromAuthorization(
+        "AWS-SHA256-HMAC Credential=test/asd"));
+    assertNull(S3RestServiceHandler.getUserFromAuthorization(""));
   }
 }

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -12,6 +12,7 @@
 package alluxio.client.rest;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
@@ -141,12 +142,12 @@ public final class S3ClientRestApiTest extends RestApiTest {
         HttpMethod.GET, expected, requestOptions).run();
 
     expected = new ListAllMyBucketsResult(Lists.newArrayList(testStatus("bucket0")));
-    requestOptions.setAuthorization("AWS user0:");
+    requestOptions.setAuthorization("AWS4-HMAC-SHA256 Credential=user0/20210631");
     new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + "/", NO_PARAMS,
         HttpMethod.GET, expected, requestOptions).run();
 
     expected = new ListAllMyBucketsResult(Lists.newArrayList(testStatus("bucket1")));
-    requestOptions.setAuthorization("AWS user1:");
+    requestOptions.setAuthorization("AWS4-HMAC-SHA256 Credential=user1/20210631");
     new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + "/", NO_PARAMS,
         HttpMethod.GET, expected, requestOptions).run();
   }
@@ -180,7 +181,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
     assertEquals("file0", expected.getContents().get(0).getKey());
     assertEquals("file1", expected.getContents().get(1).getKey());
-    assertEquals(Lists.newArrayList("folder0", "folder1"),
+    assertEquals(Lists.newArrayList("folder0/", "folder1/"),
         expected.getCommonPrefixes().getCommonPrefixes());
 
     statuses = mFileSystem.listStatus(new AlluxioURI("/bucket/folder0"));
@@ -197,7 +198,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
     assertEquals("folder0/file0", expected.getContents().get(0).getKey());
     assertEquals("folder0/file1", expected.getContents().get(1).getKey());
-    assertEquals(0, expected.getCommonPrefixes().getCommonPrefixes().size());
+    assertNull(expected.getCommonPrefixes());
   }
 
   @Test
@@ -227,7 +228,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
 
     assertEquals("file0", expected.getContents().get(0).getKey());
-    assertEquals(0, expected.getCommonPrefixes().getCommonPrefixes().size());
+    assertNull(expected.getCommonPrefixes());
 
     parameters.put("marker", nextMarker);
 
@@ -240,7 +241,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
 
     assertEquals("file1", expected.getContents().get(0).getKey());
-    assertEquals(0, expected.getCommonPrefixes().getCommonPrefixes().size());
+    assertNull(expected.getCommonPrefixes());
 
     parameters.put("marker", nextMarker);
 
@@ -253,7 +254,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
 
     assertEquals(0, expected.getContents().size());
-    assertEquals(Lists.newArrayList("folder0"),
+    assertEquals(Lists.newArrayList("folder0/"),
         expected.getCommonPrefixes().getCommonPrefixes());
   }
 

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -134,21 +134,27 @@ public final class S3ClientRestApiTest extends RestApiTest {
     setAttributeOptions = SetAttributePOptions.newBuilder().setOwner("user1").build();
     mFileSystem.setAttribute(new AlluxioURI("/bucket1"), setAttributeOptions);
 
-    ListAllMyBucketsResult expected = new ListAllMyBucketsResult(Collections.EMPTY_LIST);
+    ListAllMyBucketsResult expected = new ListAllMyBucketsResult(Collections.emptyList());
     final TestCaseOptions requestOptions = TestCaseOptions.defaults()
         .setContentType(TestCaseOptions.XML_CONTENT_TYPE);
     new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + "/", NO_PARAMS,
         HttpMethod.GET, expected, requestOptions).run();
 
-    expected = new ListAllMyBucketsResult(Lists.newArrayList("bucket0"));
+    expected = new ListAllMyBucketsResult(Lists.newArrayList(testStatus("bucket0")));
     requestOptions.setAuthorization("AWS user0:");
     new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + "/", NO_PARAMS,
         HttpMethod.GET, expected, requestOptions).run();
 
-    expected = new ListAllMyBucketsResult(Lists.newArrayList("bucket1"));
+    expected = new ListAllMyBucketsResult(Lists.newArrayList(testStatus("bucket1")));
     requestOptions.setAuthorization("AWS user1:");
     new TestCase(mHostname, mPort, S3_SERVICE_PREFIX + "/", NO_PARAMS,
         HttpMethod.GET, expected, requestOptions).run();
+  }
+
+  private URIStatus testStatus(String name) {
+    FileInfo f = new FileInfo().setName(name)
+        .setCreationTimeMs(System.currentTimeMillis());
+    return new URIStatus(f);
   }
 
   @Test
@@ -174,11 +180,8 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
     assertEquals("file0", expected.getContents().get(0).getKey());
     assertEquals("file1", expected.getContents().get(1).getKey());
-
-    final List<ListBucketResult.Prefix> commonPrefixes = expected.getCommonPrefixes();
-    assertEquals(2, commonPrefixes.size());
-    assertEquals("folder0/", commonPrefixes.get(0).getPrefix());
-    assertEquals("folder1/", commonPrefixes.get(1).getPrefix());
+    assertEquals(Lists.newArrayList("folder0", "folder1"),
+        expected.getCommonPrefixes().getCommonPrefixes());
 
     statuses = mFileSystem.listStatus(new AlluxioURI("/bucket/folder0"));
 
@@ -194,7 +197,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
     assertEquals("folder0/file0", expected.getContents().get(0).getKey());
     assertEquals("folder0/file1", expected.getContents().get(1).getKey());
-    assertEquals(0, expected.getCommonPrefixes().size());
+    assertEquals(0, expected.getCommonPrefixes().getCommonPrefixes().size());
   }
 
   @Test
@@ -224,7 +227,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
 
     assertEquals("file0", expected.getContents().get(0).getKey());
-    assertEquals(0, expected.getCommonPrefixes().size());
+    assertEquals(0, expected.getCommonPrefixes().getCommonPrefixes().size());
 
     parameters.put("marker", nextMarker);
 
@@ -237,7 +240,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
 
     assertEquals("file1", expected.getContents().get(0).getKey());
-    assertEquals(0, expected.getCommonPrefixes().size());
+    assertEquals(0, expected.getCommonPrefixes().getCommonPrefixes().size());
 
     parameters.put("marker", nextMarker);
 
@@ -250,10 +253,8 @@ public final class S3ClientRestApiTest extends RestApiTest {
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
 
     assertEquals(0, expected.getContents().size());
-
-    final List<ListBucketResult.Prefix> commonPrefixes = expected.getCommonPrefixes();
-    assertEquals(1, commonPrefixes.size());
-    assertEquals("folder0/", commonPrefixes.get(0).getPrefix());
+    assertEquals(Lists.newArrayList("folder0"),
+        expected.getCommonPrefixes().getCommonPrefixes());
   }
 
   @Test


### PR DESCRIPTION
### What changes are proposed in this pull request?

Improve conformance of the S3 API to the specification defined by AWS.

### Why are the changes needed?

The AWS CLI does not work for many standard operations (e.g. listing buckets, setting max number of return keys, copying between buckets)

### Does this PR introduce any user facing changes?

This affects some of the values from the S3 API to be in-line with more of the S3 REST API specification. It can potentially break backwards compatibility with previous versions. 

### PR Summary

This PR is a a serious of small changes and improvements to the S3
API which improves the conformance to the specification defined
by the AWS Rest API reference at
https://docs.aws.amazon.com/AmazonS3/latest/API/Type_API_Reference.html

A short summary of the changes:

- Implement the CopyObjectResult type for bucket-bucket transfers
- Make the ListAllMyBucketsResult conform to the spec. Added
creationDate and proper timestamps to results
- ListBucketOptions now includes the delimiter and encoding type
parameters
- the listBucketResult uses the CommonPrefix type and now includes
the delimiter and encoding type. Additionally, make sure keyCount
and truncation takes into account the common prefixes
-  Update the S3RestServiceHandler to use Java 8 lambda language
features
- Update credentials to use the latest amazon authorization format
- A potentially breaking change which causes a ListAllMyBuckets result
to only return folders


