### PR TITLE
Improve the metric of shadow cache for relatively small working set

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -11,8 +11,7 @@
 
 package alluxio.client.file.cache;
 
-import alluxio.client.quota.CacheQuota;
-import alluxio.client.quota.CacheScope;
+import alluxio.client.file.CacheContext;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.metrics.MetricKey;
@@ -151,7 +150,7 @@ public interface CacheManager extends AutoCloseable {
    * @return true if the put was successful, false otherwise
    */
   default boolean put(PageId pageId, byte[] page) {
-    return put(pageId, page, CacheScope.GLOBAL, CacheQuota.UNLIMITED);
+    return put(pageId, page, CacheContext.defaults());
   }
 
   /**
@@ -160,11 +159,10 @@ public interface CacheManager extends AutoCloseable {
    *
    * @param pageId page identifier
    * @param page page data
-   * @param cacheScope scope of this request
-   * @param cacheQuota cache quota
+   * @param cacheContext cache related context
    * @return true if the put was successful, false otherwise
    */
-  boolean put(PageId pageId, byte[] page, CacheScope cacheScope, CacheQuota cacheQuota);
+  boolean put(PageId pageId, byte[] page, CacheContext cacheContext);
 
   /**
    * Reads the entire page if the queried page is found in the cache, stores the result in buffer.
@@ -190,7 +188,25 @@ public interface CacheManager extends AutoCloseable {
    * @param offsetInBuffer offset in the destination buffer to write
    * @return number of bytes read, 0 if page is not found, -1 on errors
    */
-  int get(PageId pageId, int pageOffset, int bytesToRead, byte[] buffer, int offsetInBuffer);
+  default int get(PageId pageId, int pageOffset, int bytesToRead, byte[] buffer,
+      int offsetInBuffer) {
+    return get(pageId, pageOffset, bytesToRead, buffer, offsetInBuffer, CacheContext.defaults());
+  }
+
+  /**
+   * Reads a part of a page if the queried page is found in the cache, stores the result in
+   * buffer.
+   *
+   * @param pageId page identifier
+   * @param pageOffset offset into the page
+   * @param bytesToRead number of bytes to read in this page
+   * @param buffer destination buffer to write
+   * @param offsetInBuffer offset in the destination buffer to write
+   * @param cacheContext cache related context
+   * @return number of bytes read, 0 if page is not found, -1 on errors
+   */
+  int get(PageId pageId, int pageOffset, int bytesToRead, byte[] buffer, int offsetInBuffer,
+      CacheContext cacheContext);
 
   /**
    * Deletes a page from the cache.

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
@@ -11,8 +11,7 @@
 
 package alluxio.client.file.cache;
 
-import alluxio.client.quota.CacheQuota;
-import alluxio.client.quota.CacheScope;
+import alluxio.client.file.CacheContext;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 
@@ -47,11 +46,11 @@ public class NoExceptionCacheManager implements CacheManager {
   }
 
   @Override
-  public boolean put(PageId pageId, byte[] page, CacheScope cacheScope, CacheQuota cacheQuota) {
+  public boolean put(PageId pageId, byte[] page, CacheContext cacheContext) {
     try {
-      return mCacheManager.put(pageId, page, cacheScope, cacheQuota);
+      return mCacheManager.put(pageId, page, cacheContext);
     } catch (Exception e) {
-      LOG.error("Failed to put page {}, scope {}, quota {}", pageId, cacheScope, cacheQuota, e);
+      LOG.error("Failed to put page {}, cacheContext {}", pageId, cacheContext, e);
       Metrics.PUT_ERRORS.inc();
       return false;
     }
@@ -75,6 +74,20 @@ public class NoExceptionCacheManager implements CacheManager {
       return mCacheManager.get(pageId, pageOffset, bytesToRead, buffer, offsetInBuffer);
     } catch (Exception e) {
       LOG.error("Failed to get page {}, offset {}", pageId, pageOffset, e);
+      Metrics.GET_ERRORS.inc();
+      return -1;
+    }
+  }
+
+  @Override
+  public int get(PageId pageId, int pageOffset, int bytesToRead, byte[] buffer,
+      int offsetInBuffer, CacheContext cacheContext) {
+    try {
+      return mCacheManager
+          .get(pageId, pageOffset, bytesToRead, buffer, offsetInBuffer, cacheContext);
+    } catch (Exception e) {
+      LOG.error("Failed to get page {}, offset {} cacheContext {}", pageId, pageOffset,
+          cacheContext, e);
       Metrics.GET_ERRORS.inc();
       return -1;
     }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
@@ -17,8 +17,7 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
-import alluxio.client.quota.CacheQuota;
-import alluxio.client.quota.CacheScope;
+import alluxio.client.file.CacheContext;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.io.BufferUtils;
@@ -185,7 +184,7 @@ public final class CacheManagerWithShadowCacheTest {
     private final HashMap<PageId, byte[]> mCache = new HashMap<>();
 
     @Override
-    public boolean put(PageId pageId, byte[] page, CacheScope cacheScope, CacheQuota cacheQuota) {
+    public boolean put(PageId pageId, byte[] page, CacheContext cacheContext) {
       if (!mCache.containsKey(pageId)) {
         mCache.put(pageId, page);
       }
@@ -194,7 +193,7 @@ public final class CacheManagerWithShadowCacheTest {
 
     @Override
     public int get(PageId pageId, int pageOffset, int bytesToRead, byte[] buffer,
-        int offsetInBuffer) {
+        int offsetInBuffer, CacheContext cacheContext) {
       if (!mCache.containsKey(pageId)) {
         return 0;
       }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
  */
 public final class CacheManagerWithShadowCacheTest {
   private static final int PAGE_SIZE_BYTES = Constants.KB;
+  private static final int BLOOMFILTER_NUM = 4;
   private static final PageId PAGE_ID1 = new PageId("0L", 0L);
   private static final PageId PAGE_ID2 = new PageId("1L", 1L);
   private static final byte[] PAGE1 = BufferUtils.getIncreasingByteArray(PAGE_SIZE_BYTES);
@@ -44,6 +45,7 @@ public final class CacheManagerWithShadowCacheTest {
   @Before
   public void before() throws Exception {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SHADOW_WINDOW, "20s");
+    mConf.set(PropertyKey.USER_CLIENT_CACHE_SHADOW_BLOOMFILTER_NUM, BLOOMFILTER_NUM);
     mCacheManager = new CacheManagerWithShadowCache(new KVCacheManager(), mConf);
     mCacheManager.stopUpdate();
   }
@@ -130,10 +132,26 @@ public final class CacheManagerWithShadowCacheTest {
   }
 
   @Test
-  public void getExist() throws Exception {
+  public void getExistInWindow() throws Exception {
     mCacheManager.put(PAGE_ID1, PAGE1);
     assertEquals(PAGE_SIZE_BYTES, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
     assertArrayEquals(PAGE1, mBuf);
+    assertEquals(mCacheManager.getShadowCacheBytes(), PAGE1.length);
+  }
+
+  @Test
+  public void getExistInRollingWindow() throws Exception {
+    mCacheManager.put(PAGE_ID1, PAGE1);
+    for (int i = 0; i < BLOOMFILTER_NUM; i++) {
+      mCacheManager.switchBloomFilter();
+    }
+    mCacheManager.put(PAGE_ID2, PAGE1);
+    //PAGE_ID1 is evicted, only PAGE_ID2 in the shadow cache
+    assertEquals(mCacheManager.getShadowCacheBytes(), PAGE2.length);
+    //PAGE_ID1 is not in the shadow cache but still in the normal cache
+    assertEquals(PAGE_SIZE_BYTES, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
+    //PAGE_ID1 is added to the shadow cache again by 'get'
+    assertEquals(mCacheManager.getShadowCacheBytes(), PAGE1.length + PAGE2.length);
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -12,13 +12,12 @@
 package alluxio.client.file.cache;
 
 import alluxio.AlluxioURI;
+import alluxio.client.file.CacheContext;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.MockFileInStream;
 import alluxio.client.file.URIStatus;
-import alluxio.client.quota.CacheQuota;
-import alluxio.client.quota.CacheScope;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
@@ -536,7 +535,7 @@ public class LocalCacheFileInStreamTest {
     }
 
     @Override
-    public boolean put(PageId pageId, byte[] page, CacheScope cacheScope, CacheQuota cacheQuota) {
+    public boolean put(PageId pageId, byte[] page, CacheContext cacheContext) {
       mPages.put(pageId, page);
       mPagesCached++;
       return true;
@@ -544,7 +543,7 @@ public class LocalCacheFileInStreamTest {
 
     @Override
     public int get(PageId pageId, int pageOffset, int bytesToRead, byte[] buffer,
-        int offsetInBuffer) {
+        int offsetInBuffer, CacheContext cacheContext) {
       if (!mPages.containsKey(pageId)) {
         return 0;
       }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/LocalCacheFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/LocalCacheFileSystem.java
@@ -139,7 +139,7 @@ public class LocalCacheFileSystem extends org.apache.hadoop.fs.FileSystem {
         .setGroup(externalFileStatus.getGroup());
     // FilePath is a unique identifier for a file, however it can be a long string
     // hence using md5 hash of the file path as the identifier in the cache.
-    CacheContext context = new CacheContext().setCacheIdentifier(
+    CacheContext context = CacheContext.defaults().setCacheIdentifier(
         md5().hashString(externalFileStatus.getPath().toString(), UTF_8).toString());
     URIStatus status = new URIStatus(info, context);
     return open(status, bufferSize);

--- a/core/common/src/main/java/alluxio/client/file/CacheContext.java
+++ b/core/common/src/main/java/alluxio/client/file/CacheContext.java
@@ -37,10 +37,13 @@ public class CacheContext {
   private String mCacheIdentifier = null;
 
   /**
-   * Constructs CacheContext.
+   * @return the default CacheContext
    */
-  public CacheContext() {
+  public static CacheContext defaults() {
+    return new CacheContext();
   }
+
+  private CacheContext() {} // prevent instantiation
 
   /**
    * Returns an string as a hint from computation to indicate the file.

--- a/core/common/src/test/java/alluxio/client/file/CacheContextTest.java
+++ b/core/common/src/test/java/alluxio/client/file/CacheContextTest.java
@@ -23,7 +23,7 @@ public class CacheContextTest {
 
   @Test
   public void defaults() {
-    CacheContext defaultContext = new CacheContext();
+    CacheContext defaultContext = CacheContext.defaults();
     assertEquals(CacheQuota.UNLIMITED, defaultContext.getCacheQuota());
     assertEquals(CacheScope.GLOBAL, defaultContext.getCacheScope());
     assertNull(defaultContext.getCacheIdentifier());
@@ -31,7 +31,7 @@ public class CacheContextTest {
 
   @Test
   public void setters() {
-    CacheContext context = new CacheContext()
+    CacheContext context = CacheContext.defaults()
         .setCacheQuota(new CacheQuota())
         .setCacheScope(CacheScope.create("db.table"))
         .setCacheIdentifier("1234");


### PR DESCRIPTION
### What changes are proposed in this pull request?

Update the shadow cache metrics in 'get' method

Expose shadow cache metrics by calling the incrementCounts method in CacheContext

### Why are the changes needed?
Without this change, the shadow cache metrics would be only updated in 'get' method, which might cause the size of working set inaccurate (far below the real value) especially when the working set is lower than the cache capacity.

Our customer can also get table level metrics by overriding the incrementCounts method
