### PR TITLE
Avoid caching invalid entity (null entiry) into memory

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
@@ -176,21 +176,22 @@ public abstract class Cache<K, V> implements Closeable {
    * @param value the value
    */
   public void put(K key, V value) {
-    mMap.compute(key, (k, entry) -> {
-      onPut(key, value);
-      if (entry == null && cacheIsFull()) {
-        writeToBackingStore(key, value);
-        return null;
-      }
-      if (entry == null || entry.mValue == null) {
-        onCacheUpdate(key, value);
-        return new Entry(key, value);
-      }
+    onPut(key, value);
+    Entry entry = mMap.get(key);
+    if(entry == null && cacheIsFull()) {
+      writeToBackingStore(key, value);
+      return;
+    }
+
+    if(entry == null || entry.mValue == null) {
+      onCacheUpdate(key, value);
+      entry = new Entry(key, value);
+    } else {
       entry.mValue = value;
       entry.mReferenced = true;
       entry.mDirty = true;
-      return entry;
-    });
+    }
+    mMap.put(key, entry);
     wakeEvictionThreadIfNecessary();
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?
Avoid caching invalid entity (null entiry) into memory

### Why are the changes needed?
if entry is null，there is no need to add it to the cache. There is no point in caching a null entity, and it will be evicted soon。


### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
