### PR TITLE
Replace total active job count limit with a single batch job limit

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -59,7 +59,8 @@ public final class ReplicationChecker implements HeartbeatExecutor {
   private static final Logger LOG = LoggerFactory.getLogger(ReplicationChecker.class);
   private static final Logger SAMPLING_LOG = new SamplingLogger(LOG, 10L * Constants.MINUTE_MS);
 
-  /** Maximum number of active jobs to be submitted to the job service. **/
+  // Maximum number of active jobs to be submitted to the job service in a
+  // single run of the replication checker
   private final int mMaxSingleBatch;
 
   /** Handler to the inode tree. */

--- a/core/server/master/src/test/java/alluxio/master/file/replication/ReplicationCheckerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/replication/ReplicationCheckerTest.java
@@ -470,11 +470,11 @@ public final class ReplicationCheckerTest {
     replicateRequests.clear();
 
     mReplicationChecker.heartbeat();
-    Assert.assertEquals(0, replicateRequests.size());
+    Assert.assertEquals(2, replicateRequests.size());
 
     mMockReplicationHandler.setJobStatus(1, Status.FAILED);
     mReplicationChecker.heartbeat();
-    Assert.assertEquals(1, replicateRequests.size());
+    Assert.assertEquals(2, replicateRequests.size());
     Assert.assertEquals(2, replicateRequests.values().toArray()[0]);
 
     replicateRequests.clear();


### PR DESCRIPTION
### What changes are proposed in this pull request?

Before this change, the replication checker issues O(n) rpc calls to check the status of every job it submitted, resulting in a large delay.
Instead of limiting the number of active job outstanding submitted by the replication checker, we will limit the number of jobs submitted in one iteration.  This is a temporary solution until proper accounting and resource isolation is implemented on the job service. 


### Why are the changes needed?
Free replication checker from doing many rpcs and not being able to make progress

### Does this PR introduce any user facing changes?
No