### PR TITLE
Fix unused builder for syncing when setting attributes

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -616,8 +616,7 @@ public class InodeSyncStream {
               // Only set group if not empty
               builder.setGroup(group);
             }
-            SetAttributeContext ctx = SetAttributeContext
-                .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode(mode).toProto()))
+            SetAttributeContext ctx = SetAttributeContext.mergeFrom(builder)
                 .setUfsFingerprint(ufsFingerprint);
             mFsMaster.setAttributeSingleFile(mRpcContext, inodePath, false, opTimeMs, ctx);
           }

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTest.java
@@ -171,10 +171,6 @@ public final class FileSystemMasterSyncMetadataTest {
     Mockito.when(mUfs.getFileStatus(nestedFilePath.toString())).thenReturn(nestedFileStatus);
     Mockito.when(mUfs.exists(nestedFilePath.toString())).thenReturn(true);
 
-    // Mount
-    AlluxioURI mountLocal = new AlluxioURI("/mnt/local");
-    mFileSystemMaster.mount(mountLocal, ufsMount, MountContext.defaults());
-
     // Create directory in Alluxio only
     AlluxioURI dir1 = new AlluxioURI("/mnt/local/dir1");
     mFileSystemMaster.createDirectory(dir1, CreateDirectoryContext.defaults());
@@ -193,7 +189,7 @@ public final class FileSystemMasterSyncMetadataTest {
 
     // Verify owner/group is not empty
     FileInfo mountLocalInfo =
-        mFileSystemMaster.getFileInfo(mountLocal, GetStatusContext.defaults());
+        mFileSystemMaster.getFileInfo(new AlluxioURI("/mnt/local"), GetStatusContext.defaults());
     assertEquals(mountLocalInfo.getOwner(),
         mFileSystemMaster.getFileInfo(dir1, GetStatusContext.defaults()).getOwner());
     assertEquals(mountLocalInfo.getGroup(),


### PR DESCRIPTION

### What changes are proposed in this pull request?

Utilize the unused SetAttribute builder in the metadat sync code.

I confirmed in a previous incarnation of this code
(https://github.com/Alluxio/alluxio/blame/cc0f1308f4a020cab6099a6622e26a729fe4b755/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java#L3567-L3580)
That the builder was in-fact being used. Seems like it was lost in
translation when migrating the sync code.

Fixes #13796 

### Why are the changes needed?

Could potentially miss updating the owner on the file.

### Does this PR introduce any user facing changes?

no