### PR TITLE
Add additional logging to track persist requests

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -153,6 +153,7 @@ public final class FileSystemUtils {
   public static void persistAndWait(final FileSystem fs, final AlluxioURI uri,
       long persistenceWaitTime, int timeoutMs) throws FileDoesNotExistException, IOException,
       AlluxioException, TimeoutException, InterruptedException {
+    LOG.debug("Start to persist {}", uri.getPath());
     fs.persist(uri, ScheduleAsyncPersistencePOptions
         .newBuilder().setPersistenceWaitTime(persistenceWaitTime).build());
     CommonUtils.waitForResult(String.format("%s to be persisted", uri) , () -> {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3846,6 +3846,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
       long jobId;
       JobMasterClient client = mJobMasterClientPool.acquire();
       try {
+        LOG.debug("Schedule async persist job for {}", uri.getPath());
         jobId = client.run(config);
       } finally {
         mJobMasterClientPool.release(client);
@@ -3877,6 +3878,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
      */
     @Override
     public void heartbeat() throws InterruptedException {
+      LOG.debug("Async Persist heartbeat start");
       java.util.concurrent.TimeUnit.SECONDS.sleep(mQuietPeriodSeconds);
       // Process persist requests.
       for (long fileId : mPersistRequests.keySet()) {


### PR DESCRIPTION
### What changes are proposed in this pull request?
Add more logging to get timing information about a persist request throughout the system

### Why are the changes needed?
 To understand async persist performance better

### Does this PR introduce any user facing changes?
No