### PR TITLE
Implement durable MEM-type worker cache

### DIFF
--- a/bin/alluxio-common.sh
+++ b/bin/alluxio-common.sh
@@ -17,7 +17,24 @@ if [[ "$-" == *x* ]]; then
 fi
 BIN=$(cd "$( dirname "$( readlink "$0" || echo "$0" )" )"; pwd)
 
-# Utility functions for alluxio scripts 
+### Utility functions for alluxio scripts ###
+
+# Fetches the specified property from Alluxio configuration
+function get_alluxio_property() {
+  local property_key="${1:-}"
+  if [[ -z ${property_key} ]]; then
+    echo "No property provided to get_alluxio_property()"
+    exit 1
+  fi
+
+  local property=$(${BIN}/alluxio getConf ${property_key})
+  if [[ ${?} -ne 0 ]]; then
+    echo "Failed to fetch value for Alluxio property key: ${property_key}"
+    exit 1
+  fi
+
+  echo "${property}"
+}
 
 # Generates an array of ramdisk paths in global variable RAMDISKARRAY 
 function get_ramdisk_array() {

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -16,12 +16,12 @@
 
 USAGE="Usage: alluxio-start.sh [-hNwm] [-i backup] ACTION [MOPT] [-f] [-c cache]
 Where ACTION is one of:
-  all [MOPT]                \tStart all masters, proxies, and workers.
+  all [MOPT] [-c cache]     \tStart all masters, proxies, and workers.
   job_master                \tStart the job_master on this node.
   job_masters               \tStart job_masters on master nodes.
   job_worker                \tStart a job_worker on this node.
   job_workers               \tStart job_workers on worker nodes.
-  local [MOPT]              \tStart all processes locally.
+  local [MOPT] [-c cache]   \tStart all processes locally.
   master                    \tStart the local master on this node.
   secondary_master          \tStart the local secondary master on this node.
   masters                   \tStart masters on master nodes.
@@ -262,7 +262,12 @@ start_worker() {
     exit 1
   fi
 
-  if [[ ! -z "${cache}" && -d "${cache}" ]] ; then
+  if [[ ! -z "${cache}" ]] ; then
+    if [[ ! -d "${cache}" ]] ; then
+      echo "Cache path ${cache} is not a directory; aborting"
+      exit 1
+    fi
+
     echo "Populating worker MEM-type caches with contents from ${cache}"
 
     num_tiers=$(get_alluxio_property "alluxio.worker.tieredstore.levels")

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -14,25 +14,25 @@
 
 #start up alluxio
 
-USAGE="Usage: alluxio-start.sh [-hNwm] [-i backup] ACTION [MOPT] [-f]
+USAGE="Usage: alluxio-start.sh [-hNwm] [-i backup] ACTION [MOPT] [-f] [-c cache]
 Where ACTION is one of:
-  all [MOPT]         \tStart all masters, proxies, and workers.
-  job_master         \tStart the job_master on this node.
-  job_masters        \tStart job_masters on master nodes.
-  job_worker         \tStart a job_worker on this node.
-  job_workers        \tStart job_workers on worker nodes.
-  local [MOPT]       \tStart all processes locally.
-  master             \tStart the local master on this node.
-  secondary_master   \tStart the local secondary master on this node.
-  masters            \tStart masters on master nodes.
-  proxy              \tStart the proxy on this node.
-  proxies            \tStart proxies on master and worker nodes.
-  safe               \tScript will run continuously and start the master if it's not running.
-  worker [MOPT]      \tStart a worker on this node.
-  workers [MOPT]     \tStart workers on worker nodes.
-  logserver          \tStart the logserver
-  restart_worker     \tRestart a failed worker on this node.
-  restart_workers    \tRestart any failed workers on worker nodes.
+  all [MOPT]                \tStart all masters, proxies, and workers.
+  job_master                \tStart the job_master on this node.
+  job_masters               \tStart job_masters on master nodes.
+  job_worker                \tStart a job_worker on this node.
+  job_workers               \tStart job_workers on worker nodes.
+  local [MOPT]              \tStart all processes locally.
+  master                    \tStart the local master on this node.
+  secondary_master          \tStart the local secondary master on this node.
+  masters                   \tStart masters on master nodes.
+  proxy                     \tStart the proxy on this node.
+  proxies                   \tStart proxies on master and worker nodes.
+  safe                      \tScript will run continuously and start the master if it's not running.
+  worker  [MOPT] [-c cache] \tStart a worker on this node.
+  workers [MOPT] [-c cache] \tStart workers on worker nodes.
+  logserver                 \tStart the logserver
+  restart_worker            \tRestart a failed worker on this node.
+  restart_workers           \tRestart any failed workers on worker nodes.
 
 MOPT (Mount Option) is one of:
   Mount    \tMount the configured RamFS if it is not already mounted.
@@ -44,6 +44,8 @@ MOPT (Mount Option) is one of:
 
 -a         asynchronously start all processes. The script may exit before all
            processes have been started.
+-c cache   populate the worker cache for each worker node from the specified
+           directory (relative to each worker node's host filesystem).
 -f         format Journal, UnderFS Data and Workers Folder on master.
 -h         display this help.
 -i backup  a journal backup to restore the master from. The backup should be
@@ -260,13 +262,50 @@ start_worker() {
     exit 1
   fi
 
+  if [[ ! -z "${cache}" && -d "${cache}" ]] ; then
+    echo "Populating worker MEM-type caches with contents from ${cache}"
+
+    num_tiers=$(get_alluxio_property "alluxio.worker.tieredstore.levels")
+    for ((i=0;i<num_tiers;i++)); do
+      echo "Checking Worker tiered store level ${i}..."
+
+      tier_types=$(get_alluxio_property "alluxio.worker.tieredstore.level${i}.dirs.mediumtype")
+      tier_dirs=$(get_alluxio_property "alluxio.worker.tieredstore.level${i}.dirs.path")
+      # Use "Internal Field Separator (IFS)" variable to split strings on a
+      # delimeter and parse into an array
+      # - https://stackoverflow.com/a/918931
+      IFS=',' read -ra tier_types_arr <<< "${tier_types}"
+      IFS=',' read -ra tier_dirs_arr <<< "${tier_dirs}"
+
+      # iterate over the array elements using indices
+      # - https://stackoverflow.com/a/6723516
+      for j in "${!tier_types_arr[@]}"; do
+        tier_type=${tier_types_arr[$j]}
+        if [[ "${tier_type}" -eq "MEM" ]]; then
+          tier_dir=${tier_dirs_arr[$j]}
+
+          echo "Populating Worker tiered store at ${tier_dir} with ${cache}/tier${i}/${tier_dir}"
+          cp -a "${cache}/tier${i}/${tier_dir}/." "${tier_dir}/"
+          if [[ ${?} -ne 0 ]]; then
+            echo "Failed to copy directory from ${cache}/tier${i}/${tier_dir} to ${tier_dir}"
+            exit 2
+          fi
+        fi
+      done
+    done
+  fi
+
   echo "Starting worker @ $(hostname -f). Logging to ${ALLUXIO_LOGS_DIR}"
   (ALLUXIO_WORKER_JAVA_OPTS=${ALLUXIO_WORKER_JAVA_OPTS} \
      nohup ${BIN}/launch-process worker > ${ALLUXIO_LOGS_DIR}/worker.out 2>&1 ) &
 }
 
 start_workers() {
-  ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio-start.sh" "-a" "worker" $1
+  start_opts=""
+  if [[ -n ${cache} ]]; then
+    start_opts="-c ${cache}"
+  fi
+  ${LAUNCHER} "${BIN}/alluxio-workers.sh" "${BIN}/alluxio-start.sh" "-a" "worker" $1 ${start_opts}
 }
 
 restart_worker() {
@@ -415,11 +454,20 @@ main() {
       ;;
   esac
 
-  FORMAT=$1
-  if [[ ! -z "${FORMAT}" && "${FORMAT}" != "-f" ]]; then
-    echo -e "${USAGE}" >&2
-    exit 1
-  fi
+  while getopts "fc:" o; do
+    case "${o}" in
+      f)
+        FORMAT="-f"
+        ;;
+      c)
+        cache="${OPTARG}"
+        ;;
+      *)
+        echo -e "${USAGE}" >&2
+        exit 1
+        ;;
+    esac
+  done
 
   MONITOR_NODES=
   if [[ ! "${async}" ]]; then

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -298,11 +298,15 @@ start_worker() {
         fi
 
         # recursively delete all (including hidden) files of the ramdisk
-        find "${dir}" -mindepth 1 -delete
+        # - avoiding deleting the directory itself to avoid permission
+        #   changes/requirements on the parent directory
+        shopt -s dotglob
+        rm -rf "${dir}/"*
+        shopt -u dotglob
 
         # recursively copy all contents of the src directory
         # (including hidden files) to the destination directory
-        cp -dR "${cache}/${dir}/." "${dir}/"
+        cp -R "${cache}/${dir}/." "${dir}/"
         if [[ ${?} -ne 0 ]]; then
           echo "Failed to populate ramcache at ${dir} with ${cache}/${dir}"
           exit 2

--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -462,6 +462,7 @@ main() {
       ;;
   esac
 
+  OPTIND=1 # reset for `getopts`
   while getopts "fc:" o; do
     case "${o}" in
       f)

--- a/bin/alluxio-stop.sh
+++ b/bin/alluxio-stop.sh
@@ -80,7 +80,11 @@ stop_worker() {
     if [[ -d "${cache}" ]]; then
       echo "Directory already exists at ${cache}; overwritting its contents"
       # recursively delete all (including hidden) files of the ramdisk
-      find "${cache}" -mindepth 1 -delete
+      # - avoiding deleting the directory itself to avoid permission
+      #   changes/requirements on the parent directory
+      shopt -s dotglob
+      rm -rf "${cache}/"*
+      shopt -u dotglob
     elif [[ -e "${cache}" ]]; then
       echo "Non-directory file already exists at the path ${cache}; aborting"
       exit 1
@@ -112,7 +116,7 @@ stop_worker() {
 
       # recursively copy all contents of the src directory
       # (including hidden files) to the destination directory
-      cp -dR "${dir}/." "${cache}/${dir}/"
+      cp -R "${dir}/." "${cache}/${dir}/"
       if [[ ${?} -ne 0 ]]; then
         echo "Failed to copy worker ramcache from ${dir} to ${cache}/${dir}"
         exit 1


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add a flag to the `alluxio-start.sh` and `alluxio-stop.sh` scripts to allow for persisting/populating the MEM-type worker caches to/from a local directory.

### Why are the changes needed?

Allows for durable worker MEM-type cache during host machine restarts.

### Does this PR introduce any user facing changes?

Changes the `USAGE` output from the `alluxio-start.sh` and `alluxio-stop.sh` scripts.
