### PR TITLE
Add HiveCacheContext into the CacheContext

### DIFF
--- a/core/common/src/main/java/alluxio/client/file/CacheContext.java
+++ b/core/common/src/main/java/alluxio/client/file/CacheContext.java
@@ -162,9 +162,9 @@ public class CacheContext {
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("cacheIdentifier", mCacheIdentifier)
-        .add("cacheHiveContext", mHiveCacheContext)
         .add("cacheQuota", mCacheQuota)
         .add("cacheScope", mCacheScope)
+        .add("hiveCacheContext", mHiveCacheContext)
         .toString();
   }
 }

--- a/core/common/src/main/java/alluxio/client/file/CacheContext.java
+++ b/core/common/src/main/java/alluxio/client/file/CacheContext.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 public class CacheContext {
   /** Used in Prestodb to indicate the cache quota for a file. */
   private CacheQuota mCacheQuota = CacheQuota.UNLIMITED;
+
   /** Used in Prestodb to indicate the cache scope. */
   private CacheScope mCacheScope = CacheScope.GLOBAL;
 
@@ -99,16 +100,6 @@ public class CacheContext {
   }
 
   /**
-   *
-   * @param hiveCacheContext the hive cache context to use
-   * @return the updated {@code CacheContext}
-   */
-  public CacheContext setHiveCacheContext(HiveCacheContext hiveCacheContext) {
-    mHiveCacheContext = hiveCacheContext;
-    return this;
-  }
-
-  /**
    * @param cacheQuota the cache quota
    * @return the updated {@code CacheContext}
    */
@@ -123,6 +114,15 @@ public class CacheContext {
    */
   public CacheContext setCacheScope(CacheScope cacheScope) {
     mCacheScope = cacheScope;
+    return this;
+  }
+
+  /**
+   * @param hiveCacheContext the hive cache context
+   * @return the updated {@code CacheContext}
+   */
+  public CacheContext setHiveCacheContext(HiveCacheContext hiveCacheContext) {
+    mHiveCacheContext = hiveCacheContext;
     return this;
   }
 

--- a/core/common/src/main/java/alluxio/client/file/CacheContext.java
+++ b/core/common/src/main/java/alluxio/client/file/CacheContext.java
@@ -11,6 +11,7 @@
 
 package alluxio.client.file;
 
+import alluxio.client.hive.HiveCacheContext;
 import alluxio.client.quota.CacheQuota;
 import alluxio.client.quota.CacheScope;
 
@@ -28,6 +29,10 @@ public class CacheContext {
   private CacheQuota mCacheQuota = CacheQuota.UNLIMITED;
   /** Used in Prestodb to indicate the cache scope. */
   private CacheScope mCacheScope = CacheScope.GLOBAL;
+
+  /** Used in Prestodb to indicate the hiveContext for a file. */
+  private HiveCacheContext mHiveCacheContext = null;
+
   /**
    * Used in Prestodb to uniquely identify a file in Alluxio local cache.
    * Note that, though the filePath can be a unique identifier, it can be a long string
@@ -63,6 +68,14 @@ public class CacheContext {
   }
 
   /**
+   * @return the hive cache context
+   */
+  @Nullable
+  public HiveCacheContext getHiveCacheContext() {
+    return mHiveCacheContext;
+  }
+
+  /**
    * @return the cache quota
    */
   public CacheQuota getCacheQuota() {
@@ -82,6 +95,16 @@ public class CacheContext {
    */
   public CacheContext setCacheIdentifier(String identifier) {
     mCacheIdentifier = identifier;
+    return this;
+  }
+
+  /**
+   *
+   * @param hiveCacheContext the hive cache context to use
+   * @return the updated {@code CacheContext}
+   */
+  public CacheContext setHiveCacheContext(HiveCacheContext hiveCacheContext) {
+    mHiveCacheContext = hiveCacheContext;
     return this;
   }
 
@@ -125,19 +148,21 @@ public class CacheContext {
     }
     CacheContext that = (CacheContext) o;
     return Objects.equals(mCacheIdentifier, that.mCacheIdentifier)
+        && Objects.equals(mHiveCacheContext, that.mHiveCacheContext)
         && Objects.equals(mCacheQuota, that.mCacheQuota)
         && Objects.equals(mCacheScope, that.mCacheScope);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(mCacheQuota, mCacheScope, mCacheIdentifier);
+    return Objects.hash(mCacheQuota, mCacheScope, mCacheIdentifier, mHiveCacheContext);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("cacheIdentifier", mCacheIdentifier)
+        .add("cacheHiveContext", mHiveCacheContext)
         .add("cacheQuota", mCacheQuota)
         .add("cacheScope", mCacheScope)
         .toString();

--- a/core/common/src/main/java/alluxio/client/hive/HiveCacheContext.java
+++ b/core/common/src/main/java/alluxio/client/hive/HiveCacheContext.java
@@ -1,0 +1,77 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.hive;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+
+/**
+ * Data structure that stores and returns Hive related Cache Scope
+ */
+public class HiveCacheContext
+{
+  private final String mDatabase;
+  private final String mTable;
+  private final String mPartition;
+
+  public HiveCacheContext(String database, String table, String partition)
+  {
+    this.mDatabase = database;
+    this.mTable = table;
+    this.mPartition = partition;
+  }
+
+  public String getDatabase()
+  {
+    return mDatabase;
+  }
+
+  public String getTable()
+  {
+    return mTable;
+  }
+
+  public String getPartition()
+  {
+    return mPartition;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HiveCacheContext that = (HiveCacheContext) o;
+    return java.util.Objects.equals(mDatabase, that.mDatabase)
+        && java.util.Objects.equals(mTable, that.mTable)
+        && java.util.Objects.equals(mPartition, that.mPartition);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hashCode(mDatabase, mTable, mPartition);
+  }
+
+  @Override
+  public String toString()
+  {
+    return MoreObjects.toStringHelper(this)
+        .add("database", mDatabase)
+        .add("table", mTable)
+        .add("Partition", mPartition)
+        .toString();
+  }
+}

--- a/core/common/src/main/java/alluxio/client/hive/HiveCacheContext.java
+++ b/core/common/src/main/java/alluxio/client/hive/HiveCacheContext.java
@@ -81,8 +81,8 @@ public class HiveCacheContext {
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("database", mDatabase)
+        .add("partition", mPartition)
         .add("table", mTable)
-        .add("Partition", mPartition)
         .toString();
   }
 }

--- a/core/common/src/main/java/alluxio/client/hive/HiveCacheContext.java
+++ b/core/common/src/main/java/alluxio/client/hive/HiveCacheContext.java
@@ -14,34 +14,47 @@ package alluxio.client.hive;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
+import javax.annotation.Nullable;
+
 /**
- * Data structure that stores and returns Hive related Cache Scope
+ * Data structure that stores and returns Hive related Cache Scope.
  */
-public class HiveCacheContext
-{
+public class HiveCacheContext {
   private final String mDatabase;
   private final String mTable;
   private final String mPartition;
 
-  public HiveCacheContext(String database, String table, String partition)
-  {
-    this.mDatabase = database;
-    this.mTable = table;
-    this.mPartition = partition;
+  /**
+   * Constructor.
+   * @param database    the database name
+   * @param table       the table name
+   * @param partition   the partition name
+   */
+  public HiveCacheContext(String database, String table, String partition) {
+    mDatabase = database;
+    mTable = table;
+    mPartition = partition;
   }
 
-  public String getDatabase()
-  {
+  /**
+   * @return the database in the hive cache context
+   */
+  public String getDatabase() {
     return mDatabase;
   }
 
-  public String getTable()
-  {
+  /**
+   * @return the table in the hive cache context
+   */
+  public String getTable() {
     return mTable;
   }
 
-  public String getPartition()
-  {
+  /**
+   * @return the partition in the hive cache context
+   */
+  @Nullable
+  public String getPartition() {
     return mPartition;
   }
 
@@ -60,14 +73,12 @@ public class HiveCacheContext
   }
 
   @Override
-  public int hashCode()
-  {
+  public int hashCode() {
     return Objects.hashCode(mDatabase, mTable, mPartition);
   }
 
   @Override
-  public String toString()
-  {
+  public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("database", mDatabase)
         .add("table", mTable)

--- a/core/common/src/test/java/alluxio/client/file/CacheContextTest.java
+++ b/core/common/src/test/java/alluxio/client/file/CacheContextTest.java
@@ -14,6 +14,7 @@ package alluxio.client.file;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import alluxio.client.hive.HiveCacheContext;
 import alluxio.client.quota.CacheQuota;
 import alluxio.client.quota.CacheScope;
 
@@ -27,6 +28,7 @@ public class CacheContextTest {
     assertEquals(CacheQuota.UNLIMITED, defaultContext.getCacheQuota());
     assertEquals(CacheScope.GLOBAL, defaultContext.getCacheScope());
     assertNull(defaultContext.getCacheIdentifier());
+    assertNull(defaultContext.getHiveCacheContext());
   }
 
   @Test
@@ -34,9 +36,11 @@ public class CacheContextTest {
     CacheContext context = CacheContext.defaults()
         .setCacheQuota(new CacheQuota())
         .setCacheScope(CacheScope.create("db.table"))
-        .setCacheIdentifier("1234");
+        .setCacheIdentifier("1234")
+        .setHiveCacheContext(new HiveCacheContext("db", "tb", "partition"));
     assertEquals(new CacheQuota(), context.getCacheQuota());
     assertEquals(CacheScope.create("db.table"), context.getCacheScope());
     assertEquals("1234", context.getCacheIdentifier());
+    assertEquals(new HiveCacheContext("db", "tb", "partition"), context.getHiveCacheContext());
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR add HiveCacheContext into CacheContext

### Why are the changes needed?
HiveCacheContext contains the hive-related information like schema, table, partition, this information later will be used to identify whether the corresponding file needs to be cached and its caching TTL.

### Does this PR introduce any user facing changes?
N/A
