### PR TITLE
Fix async cache error

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -399,10 +399,18 @@ public class AlluxioFileInStream extends FileInStream {
       if (cache && (mLastBlockIdCached != blockId)) {
         // Construct the async cache request
         long blockLength = mOptions.getBlockInfo(blockId).getLength();
+        String host = dataSource.getHost();
+        // ALLUXIO-11172: If the worker is in a container, use the container hostname
+        // to establish the connection.
+        if (!dataSource.getContainerHost().equals("")) {
+          LOG.debug("Worker is in a container. Use container host {} instead of physical host {}",
+              dataSource.getContainerHost(), host);
+          host = dataSource.getContainerHost();
+        }
         AsyncCacheRequest request =
             AsyncCacheRequest.newBuilder().setBlockId(blockId).setLength(blockLength)
                 .setOpenUfsBlockOptions(mOptions.getOpenUfsBlockOptions(blockId))
-                .setSourceHost(dataSource.getHost()).setSourcePort(dataSource.getDataPort())
+                .setSourceHost(host).setSourcePort(dataSource.getDataPort())
                 .build();
         if (mPassiveCachingEnabled && mContext.hasProcessLocalWorker()) {
           mContext.getProcessLocalWorker().asyncCache(request);

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -400,7 +400,7 @@ public class AlluxioFileInStream extends FileInStream {
         // Construct the async cache request
         long blockLength = mOptions.getBlockInfo(blockId).getLength();
         String host = dataSource.getHost();
-        // ALLUXIO-11172: If the worker is in a container, use the container hostname
+        // issues#11172: If the worker is in a container, use the container hostname
         // to establish the connection.
         if (!dataSource.getContainerHost().equals("")) {
           LOG.debug("Worker is in a container. Use container host {} instead of physical host {}",

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -648,7 +648,7 @@ public final class NetworkAddressUtils {
       address = new DomainSocketAddress(netAddress.getDomainSocketPath());
     } else {
       String host = netAddress.getHost();
-      // ALLUXIO-11172: If the worker is in a container, use the container hostname
+      // issues#11172: If the worker is in a container, use the container hostname
       // to establish the connection.
       if (!netAddress.getContainerHost().equals("")) {
         LOG.debug("Worker is in a container. Use container host {} instead of physical host {}",


### PR DESCRIPTION
### What changes are proposed in this pull request?

If container host configured, use it instead of worker host. Otherwise, asyncCache will never successful caused by `Failed to connect to remote block worker`

### Why are the changes needed?

```
2021-07-20 09:10:08,054 WARN  AsyncCacheRequestManager - Failed to async cache block 60767076352 from remote worker (x.x.x.x/x.x.x.x:29999) on copying the block: java.io.IOException: Failed to connect to remote block worker: GrpcServerAddress{HostName=x.x.x.x, SocketAddress=x.x.x.x/x.x.x.x:29999}
```

The x.x.x.x is node hostname.

### Does this PR introduce any user facing changes?

No