### PR TITLE
Add read time metrics for client local cache

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -155,8 +155,8 @@ public class LocalCacheFileInStream extends FileInStream {
           cacheContext
               .incrementCounter(MetricKey.CLIENT_CACHE_BYTES_READ_CACHE.getMetricName(), bytesRead);
           cacheContext.incrementCounter(
-              MetricKey.CLIENT_CACHE_PAGE_READ_CACHE_TIME_MS.getMetricName(),
-              readTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));
+              MetricKey.CLIENT_CACHE_PAGE_READ_CACHE_TIME_NS.getMetricName(),
+              readTimeStopwatch.elapsed(TimeUnit.NANOSECONDS));
         }
       } else {
         // on local cache miss, read a complete page from external storage. This will always make
@@ -174,8 +174,8 @@ public class LocalCacheFileInStream extends FileInStream {
             cacheContext.incrementCounter(
                 MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getMetricName(), bytesLeftInPage);
             cacheContext.incrementCounter(
-                MetricKey.CLIENT_CACHE_PAGE_READ_EXTERNAL_TIME_MS.getMetricName(),
-                readTimeStopwatch.elapsed(TimeUnit.MILLISECONDS)
+                MetricKey.CLIENT_CACHE_PAGE_READ_EXTERNAL_TIME_NS.getMetricName(),
+                readTimeStopwatch.elapsed(TimeUnit.NANOSECONDS)
             );
           }
           mCacheManager.put(pageId, page, mCacheContext);

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -63,7 +63,7 @@ public class LocalCacheFileInStream extends FileInStream {
   private boolean mClosed = false;
   private boolean mEOF = false;
 
-  Stopwatch mStopwatch;
+  private final Stopwatch mStopwatch;
 
   /**
    * Interface to wrap open method of file system.

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -63,8 +63,7 @@ public class LocalCacheFileInStream extends FileInStream {
   private boolean mClosed = false;
   private boolean mEOF = false;
 
-  @VisibleForTesting
-  Ticker mTicker = Ticker.systemTicker();
+  Stopwatch mStopwatch;
 
   /**
    * Interface to wrap open method of file system.
@@ -89,6 +88,12 @@ public class LocalCacheFileInStream extends FileInStream {
    */
   public LocalCacheFileInStream(URIStatus status, FileInStreamOpener fileOpener,
       CacheManager cacheManager, AlluxioConfiguration conf) {
+    this(status, fileOpener, cacheManager, conf, Stopwatch.createUnstarted(Ticker.systemTicker()));
+  }
+
+  @VisibleForTesting
+  LocalCacheFileInStream(URIStatus status, FileInStreamOpener fileOpener,
+      CacheManager cacheManager, AlluxioConfiguration conf, Stopwatch stopwatch) {
     mPageSize = conf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE);
     mExternalFileInStreamOpener = fileOpener;
     mCacheManager = cacheManager;
@@ -101,6 +106,7 @@ public class LocalCacheFileInStream extends FileInStream {
       mCacheContext = CacheContext.defaults();
     }
     Metrics.registerGauges();
+    mStopwatch = stopwatch;
   }
 
   @Override
@@ -132,7 +138,6 @@ public class LocalCacheFileInStream extends FileInStream {
     int totalBytesRead = 0;
     long currentPosition = pos;
     long lengthToRead = Math.min(len, mStatus.getLength() - pos);
-    Stopwatch readTimeStopwatch = Stopwatch.createUnstarted(mTicker);
     // for each page, check if it is available in the cache
     while (totalBytesRead < lengthToRead) {
       long currentPage = currentPosition / mPageSize;
@@ -146,11 +151,11 @@ public class LocalCacheFileInStream extends FileInStream {
       } else {
         pageId = new PageId(Long.toString(mStatus.getFileId()), currentPage);
       }
-      readTimeStopwatch.start();
+      mStopwatch.reset().start();
       int bytesRead =
           mCacheManager.get(pageId, currentPageOffset, bytesLeftInPage, b, off + totalBytesRead,
               mCacheContext);
-      readTimeStopwatch.stop();
+      mStopwatch.stop();
       if (bytesRead > 0) {
         totalBytesRead += bytesRead;
         currentPosition += bytesRead;
@@ -160,15 +165,14 @@ public class LocalCacheFileInStream extends FileInStream {
               .incrementCounter(MetricKey.CLIENT_CACHE_BYTES_READ_CACHE.getMetricName(), bytesRead);
           cacheContext.incrementCounter(
               MetricKey.CLIENT_CACHE_PAGE_READ_CACHE_TIME_NS.getMetricName(),
-              readTimeStopwatch.elapsed(TimeUnit.NANOSECONDS));
+              mStopwatch.elapsed(TimeUnit.NANOSECONDS));
         }
       } else {
         // on local cache miss, read a complete page from external storage. This will always make
         // progress or throw an exception
-        readTimeStopwatch.reset();
-        readTimeStopwatch.start();
+        mStopwatch.reset().start();
         byte[] page = readExternalPage(currentPosition, readType);
-        readTimeStopwatch.stop();
+        mStopwatch.stop();
         if (page.length > 0) {
           System.arraycopy(page, currentPageOffset, b, off + totalBytesRead, bytesLeftInPage);
           totalBytesRead += bytesLeftInPage;
@@ -179,7 +183,7 @@ public class LocalCacheFileInStream extends FileInStream {
                 MetricKey.CLIENT_CACHE_BYTES_REQUESTED_EXTERNAL.getMetricName(), bytesLeftInPage);
             cacheContext.incrementCounter(
                 MetricKey.CLIENT_CACHE_PAGE_READ_EXTERNAL_TIME_NS.getMetricName(),
-                readTimeStopwatch.elapsed(TimeUnit.NANOSECONDS)
+                mStopwatch.elapsed(TimeUnit.NANOSECONDS)
             );
           }
           mCacheManager.put(pageId, page, mCacheContext);

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -21,15 +21,16 @@ import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 
 import com.codahale.metrics.Meter;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Ticker;
 import com.google.common.io.Closer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -61,6 +62,9 @@ public class LocalCacheFileInStream extends FileInStream {
   private long mPosition = 0;
   private boolean mClosed = false;
   private boolean mEOF = false;
+
+  @VisibleForTesting
+  Ticker mTicker = Ticker.systemTicker();
 
   /**
    * Interface to wrap open method of file system.
@@ -128,7 +132,7 @@ public class LocalCacheFileInStream extends FileInStream {
     int totalBytesRead = 0;
     long currentPosition = pos;
     long lengthToRead = Math.min(len, mStatus.getLength() - pos);
-    Stopwatch readTimeStopwatch = Stopwatch.createUnstarted();
+    Stopwatch readTimeStopwatch = Stopwatch.createUnstarted(mTicker);
     // for each page, check if it is available in the cache
     while (totalBytesRead < lengthToRead) {
       long currentPage = currentPosition / mPageSize;

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -55,6 +55,7 @@ import alluxio.wire.FileInfo;
 import alluxio.wire.MountPointInfo;
 import alluxio.wire.SyncPointInfo;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -456,8 +457,8 @@ public class LocalCacheFileInStreamTest {
     );
     LocalCacheFileInStream stream =
         new LocalCacheFileInStream(fs.getStatus(testFileName),
-            (status) -> fs.openFile(status, OpenFilePOptions.getDefaultInstance()), manager, sConf);
-    stream.mTicker = timeSource;
+            (status) -> fs.openFile(status, OpenFilePOptions.getDefaultInstance()), manager, sConf,
+            Stopwatch.createUnstarted(timeSource));
 
     Assert.assertArrayEquals(testData, ByteStreams.toByteArray(stream));
     long timeReadCache = recordedMetrics.get(

--- a/core/common/src/main/java/alluxio/client/file/CacheContext.java
+++ b/core/common/src/main/java/alluxio/client/file/CacheContext.java
@@ -43,7 +43,11 @@ public class CacheContext {
     return new CacheContext();
   }
 
-  protected CacheContext() {} // prevent instantiation
+  /**
+   * Expected to be inherited in PrestoDB or other local cache caller.
+   * Subclasses could override the callback methods such as incrementCounter
+   */
+  protected CacheContext() {}
 
   /**
    * Returns an string as a hint from computation to indicate the file.

--- a/core/common/src/main/java/alluxio/client/file/CacheContext.java
+++ b/core/common/src/main/java/alluxio/client/file/CacheContext.java
@@ -43,7 +43,7 @@ public class CacheContext {
     return new CacheContext();
   }
 
-  private CacheContext() {} // prevent instantiation
+  protected CacheContext() {} // prevent instantiation
 
   /**
    * Returns an string as a hint from computation to indicate the file.

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1180,6 +1180,20 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.METER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_PAGE_READ_CACHE_TIME_MS =
+      new Builder("Client.CachePageReadCacheTimeMs")
+          .setDescription("Time in milliseconds taken to read a page from the client cache "
+              + "when the cache hits.")
+          .setMetricType(MetricType.METER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_CACHE_PAGE_READ_EXTERNAL_TIME_MS =
+      new Builder("Client.CachePageReadExternalTimeMs")
+          .setDescription("Time in milliseconds taken to read a page from external source "
+              + "when the cache misses.")
+          .setMetricType(MetricType.METER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_BYTES_EVICTED =
       new Builder("Client.CacheBytesEvicted")
           .setDescription("Total number of bytes evicted from the client cache.")

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1180,16 +1180,16 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.METER)
           .setIsClusterAggregated(false)
           .build();
-  public static final MetricKey CLIENT_CACHE_PAGE_READ_CACHE_TIME_MS =
+  public static final MetricKey CLIENT_CACHE_PAGE_READ_CACHE_TIME_NS =
       new Builder("Client.CachePageReadCacheTimeMs")
-          .setDescription("Time in milliseconds taken to read a page from the client cache "
+          .setDescription("Time in nanoseconds taken to read a page from the client cache "
               + "when the cache hits.")
           .setMetricType(MetricType.METER)
           .setIsClusterAggregated(false)
           .build();
-  public static final MetricKey CLIENT_CACHE_PAGE_READ_EXTERNAL_TIME_MS =
+  public static final MetricKey CLIENT_CACHE_PAGE_READ_EXTERNAL_TIME_NS =
       new Builder("Client.CachePageReadExternalTimeMs")
-          .setDescription("Time in milliseconds taken to read a page from external source "
+          .setDescription("Time in nanoseconds taken to read a page from external source "
               + "when the cache misses.")
           .setMetricType(MetricType.METER)
           .setIsClusterAggregated(false)

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1181,14 +1181,14 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setIsClusterAggregated(false)
           .build();
   public static final MetricKey CLIENT_CACHE_PAGE_READ_CACHE_TIME_NS =
-      new Builder("Client.CachePageReadCacheTimeMs")
+      new Builder("Client.CachePageReadCacheTimeNanos")
           .setDescription("Time in nanoseconds taken to read a page from the client cache "
               + "when the cache hits.")
           .setMetricType(MetricType.METER)
           .setIsClusterAggregated(false)
           .build();
   public static final MetricKey CLIENT_CACHE_PAGE_READ_EXTERNAL_TIME_NS =
-      new Builder("Client.CachePageReadExternalTimeMs")
+      new Builder("Client.CachePageReadExternalTimeNanos")
           .setDescription("Time in nanoseconds taken to read a page from external source "
               + "when the cache misses.")
           .setMetricType(MetricType.METER)


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add two metrics for tracking read IO time concerning client cache.

### Why are the changes needed?

Collect statistics about read IO time in cases of cache hits and misses, to provide insights about local cache performance.

### Does this PR introduce any user facing changes?

No.
