### PR TITLE
Get job ids with filters

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -152,7 +152,9 @@ public final class ReplicationChecker implements HeartbeatExecutor {
       activeJobIds.addAll(completedMoveJobIds);
       activeJobIds.addAll(completedReplicateJobIds);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      // It is possible the job master process is not answering rpcs, log but do not throw the exception
+      // which will kill the replication checker thread.
+      LOG.debug("Failed to contact job master to get updated list of replication jobs {}", e);
     }
 
     mActiveJobToInodeID.keySet().removeIf(jobId -> !activeJobIds.contains(jobId));

--- a/core/server/master/src/test/java/alluxio/master/file/replication/ReplicationCheckerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/replication/ReplicationCheckerTest.java
@@ -69,6 +69,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -114,6 +115,13 @@ public final class ReplicationCheckerTest {
         return mJobStatus.get(jobId);
       }
       return Status.RUNNING;
+    }
+
+    @Override
+    public List<Long> findJobs(String jobName, Set<Status> statusList) throws IOException {
+      return mJobStatus.entrySet().stream()
+          .filter(x -> statusList.isEmpty() || statusList.contains(x.getValue()))
+          .map(x -> x.getKey()).collect(Collectors.toList());
     }
 
     @Override

--- a/core/server/master/src/test/java/alluxio/master/file/replication/ReplicationCheckerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/replication/ReplicationCheckerTest.java
@@ -477,6 +477,8 @@ public final class ReplicationCheckerTest {
     Assert.assertEquals(2, replicateRequests.values().toArray()[1]);
     replicateRequests.clear();
 
+    mMockReplicationHandler.setJobStatus(1, Status.RUNNING);
+    mMockReplicationHandler.setJobStatus(2, Status.RUNNING);
     mReplicationChecker.heartbeat();
     Assert.assertEquals(0, replicateRequests.size());
 

--- a/core/transport/src/main/proto/grpc/job_master.proto
+++ b/core/transport/src/main/proto/grpc/job_master.proto
@@ -123,6 +123,7 @@ message GetJobStatusDetailedPResponse {
 message ListAllPOptions {
   repeated Status status = 1;
   optional string name = 2;
+  optional bool jobIdOnly = 3;
 }
 message ListAllPRequest {
   optional ListAllPOptions options = 1;

--- a/core/transport/src/main/proto/grpc/job_master.proto
+++ b/core/transport/src/main/proto/grpc/job_master.proto
@@ -120,7 +120,10 @@ message GetJobStatusDetailedPResponse {
   optional JobInfo jobInfo = 1;
 }
 
-message ListAllPOptions {}
+message ListAllPOptions {
+  repeated Status status = 1;
+  optional string name = 2;
+}
 message ListAllPRequest {
   optional ListAllPOptions options = 1;
 }

--- a/job/client/src/main/java/alluxio/client/job/JobMasterClient.java
+++ b/job/client/src/main/java/alluxio/client/job/JobMasterClient.java
@@ -76,6 +76,13 @@ public interface JobMasterClient extends Client {
   JobServiceSummary getJobServiceSummary() throws IOException;
 
   /**
+   * @return list all job ids
+   */
+  default List<Long> list() throws IOException {
+    return list(ListAllPOptions.getDefaultInstance());
+  }
+
+  /**
    * @param option list options
    * @return the list of ids of all jobs
    */

--- a/job/client/src/main/java/alluxio/client/job/JobMasterClient.java
+++ b/job/client/src/main/java/alluxio/client/job/JobMasterClient.java
@@ -12,6 +12,7 @@
 package alluxio.client.job;
 
 import alluxio.Client;
+import alluxio.grpc.ListAllPOptions;
 import alluxio.job.JobConfig;
 import alluxio.job.wire.JobInfo;
 import alluxio.job.wire.JobServiceSummary;
@@ -75,9 +76,10 @@ public interface JobMasterClient extends Client {
   JobServiceSummary getJobServiceSummary() throws IOException;
 
   /**
+   * @param option list options
    * @return the list of ids of all jobs
    */
-  List<Long> list() throws IOException;
+  List<Long> list(ListAllPOptions option) throws IOException;
 
   /**
    * @return the list of all jobInfos

--- a/job/client/src/main/java/alluxio/client/job/RetryHandlingJobMasterClient.java
+++ b/job/client/src/main/java/alluxio/client/job/RetryHandlingJobMasterClient.java
@@ -115,7 +115,9 @@ public final class RetryHandlingJobMasterClient extends AbstractMasterClient
   @Override
   public List<Long> list(ListAllPOptions option) throws IOException {
     return retryRPC(() -> mClient.listAll(
-        ListAllPRequest.newBuilder().setOptions(option).build()).getJobIdsList(),
+        ListAllPRequest.newBuilder()
+            .setOptions(option.toBuilder().setJobIdOnly(true)).build())
+            .getJobIdsList(),
         RPC_LOG, "List", "");
   }
 

--- a/job/client/src/main/java/alluxio/client/job/RetryHandlingJobMasterClient.java
+++ b/job/client/src/main/java/alluxio/client/job/RetryHandlingJobMasterClient.java
@@ -19,6 +19,7 @@ import alluxio.grpc.GetJobServiceSummaryPRequest;
 import alluxio.grpc.GetJobStatusDetailedPRequest;
 import alluxio.grpc.GetJobStatusPRequest;
 import alluxio.grpc.JobMasterClientServiceGrpc;
+import alluxio.grpc.ListAllPOptions;
 import alluxio.grpc.ListAllPRequest;
 import alluxio.grpc.RunPRequest;
 import alluxio.grpc.ServiceType;
@@ -112,8 +113,9 @@ public final class RetryHandlingJobMasterClient extends AbstractMasterClient
   }
 
   @Override
-  public List<Long> list() throws IOException {
-    return retryRPC(() -> mClient.listAll(ListAllPRequest.getDefaultInstance()).getJobIdsList(),
+  public List<Long> list(ListAllPOptions option) throws IOException {
+    return retryRPC(() -> mClient.listAll(
+        ListAllPRequest.newBuilder().setOptions(option).build()).getJobIdsList(),
         RPC_LOG, "List", "");
   }
 

--- a/job/client/src/main/java/alluxio/job/plan/replicate/DefaultReplicationHandler.java
+++ b/job/client/src/main/java/alluxio/job/plan/replicate/DefaultReplicationHandler.java
@@ -16,9 +16,13 @@ import alluxio.client.job.JobMasterClient;
 import alluxio.client.job.JobMasterClientPool;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.NotFoundException;
+import alluxio.grpc.ListAllPOptions;
 import alluxio.job.wire.Status;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -47,6 +51,14 @@ public final class DefaultReplicationHandler implements ReplicationHandler {
       // if the job status doesn't exist, assume the job has failed
       return Status.FAILED;
     }
+  }
+
+  @Override
+  public List<Long> findJobs(String jobName, Set<Status> status) throws IOException {
+    final JobMasterClient client = mJobMasterClientPool.acquire();
+    return client.list(ListAllPOptions.newBuilder().setName(jobName)
+        .addAllStatus(status.stream().map(Status::toProto).collect(Collectors.toSet()))
+        .build());
   }
 
   @Override

--- a/job/client/src/main/java/alluxio/job/plan/replicate/ReplicationHandler.java
+++ b/job/client/src/main/java/alluxio/job/plan/replicate/ReplicationHandler.java
@@ -16,6 +16,8 @@ import alluxio.exception.AlluxioException;
 import alluxio.job.wire.Status;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Interface for adjusting the replication level of blocks.
@@ -28,6 +30,14 @@ public interface ReplicationHandler {
    * @throws IOException if a non-Alluxio error is encountered
    */
   Status getJobStatus(long jobId) throws IOException;
+
+  /**
+   * @param jobName name of the job
+   * @param statusList job status
+   * @return a list of job ids that match the criteria
+   * @throws IOException if a non-Alluxio error is encountered
+   */
+  List<Long> findJobs(String jobName, Set<Status> statusList) throws IOException;
 
   /**
    * Decreases the block replication level by a target number of replicas.

--- a/job/server/src/main/java/alluxio/master/job/JobMasterClientRestServiceHandler.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMasterClientRestServiceHandler.java
@@ -14,6 +14,7 @@ package alluxio.master.job;
 import alluxio.Constants;
 import alluxio.RestUtils;
 import alluxio.conf.ServerConfiguration;
+import alluxio.grpc.ListAllPOptions;
 import alluxio.job.JobConfig;
 import alluxio.job.ServiceConstants;
 import alluxio.job.wire.JobInfo;
@@ -135,7 +136,7 @@ public final class JobMasterClientRestServiceHandler {
     return RestUtils.call(new RestUtils.RestCallable<List<Long>>() {
       @Override
       public List<Long> call() throws Exception {
-        return mJobMaster.list();
+        return mJobMaster.list(ListAllPOptions.getDefaultInstance());
       }
     }, ServerConfiguration.global());
   }

--- a/job/server/src/main/java/alluxio/master/job/JobMasterClientServiceHandler.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMasterClientServiceHandler.java
@@ -79,8 +79,8 @@ public class JobMasterClientServiceHandler
   public void getJobStatusDetailed(GetJobStatusDetailedPRequest request,
                                    StreamObserver<GetJobStatusDetailedPResponse>
                                        responseObserver) {
-    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<GetJobStatusDetailedPResponse>) () ->
-    {
+    RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<GetJobStatusDetailedPResponse>) ()
+        -> {
       return GetJobStatusDetailedPResponse.newBuilder()
           .setJobInfo(mJobMaster.getStatus(request.getJobId(), true).toProto()).build();
     }, "getJobStatusDetailed", "request=%s", responseObserver, request);
@@ -100,7 +100,7 @@ public class JobMasterClientServiceHandler
   public void listAll(ListAllPRequest request, StreamObserver<ListAllPResponse> responseObserver) {
     RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<ListAllPResponse>) () -> {
       ListAllPResponse.Builder builder = ListAllPResponse.newBuilder()
-          .addAllJobIds(mJobMaster.list());
+          .addAllJobIds(mJobMaster.list(request.getOptions()));
       for (JobInfo jobInfo : mJobMaster.listDetailed()) {
         builder.addJobInfos(jobInfo.toProto());
       }

--- a/job/server/src/main/java/alluxio/master/job/JobMasterClientServiceHandler.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMasterClientServiceHandler.java
@@ -99,10 +99,13 @@ public class JobMasterClientServiceHandler
   @Override
   public void listAll(ListAllPRequest request, StreamObserver<ListAllPResponse> responseObserver) {
     RpcUtils.call(LOG, (RpcUtils.RpcCallableThrowsIOException<ListAllPResponse>) () -> {
+      List<Long> jobList = mJobMaster.list(request.getOptions());
       ListAllPResponse.Builder builder = ListAllPResponse.newBuilder()
-          .addAllJobIds(mJobMaster.list(request.getOptions()));
-      for (JobInfo jobInfo : mJobMaster.listDetailed()) {
-        builder.addJobInfos(jobInfo.toProto());
+          .addAllJobIds(jobList);
+      if (!(request.getOptions().hasJobIdOnly() && request.getOptions().getJobIdOnly())) {
+        for (Long id : jobList) {
+          builder.addJobInfos(mJobMaster.getStatus(id).toProto());
+        }
       }
       return builder.build();
     }, "listAll", "request=%s", responseObserver, request);

--- a/job/server/src/main/java/alluxio/master/job/JobMasterClientServiceHandler.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMasterClientServiceHandler.java
@@ -30,7 +30,6 @@ import alluxio.grpc.RunPRequest;
 import alluxio.grpc.RunPResponse;
 import alluxio.job.JobConfig;
 import alluxio.job.util.SerializationUtils;
-import alluxio.job.wire.JobInfo;
 import alluxio.job.wire.JobWorkerHealth;
 
 import com.google.common.base.Preconditions;

--- a/job/server/src/main/java/alluxio/master/job/plan/PlanTracker.java
+++ b/job/server/src/main/java/alluxio/master/job/plan/PlanTracker.java
@@ -36,10 +36,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -279,5 +282,20 @@ public class PlanTracker {
    */
   public Stream<PlanInfo> failed() {
     return mFailed.stream();
+  }
+
+  /**
+   * @param name job name filter
+   * @param statusList status list filter
+   * @return job ids matching conditions
+   */
+  public Set<Long> findJobs(String name, List<Status> statusList) {
+    return mCoordinators.entrySet().stream()
+        .filter(x ->
+            statusList.isEmpty()
+                || statusList.contains(x.getValue().getPlanInfoWire(false).getStatus())
+                && (name == null || name.isEmpty()
+                || x.getValue().getPlanInfoWire(false).getName().equals(name)))
+        .map(Map.Entry::getKey).collect(Collectors.toSet());
   }
 }

--- a/job/server/src/main/java/alluxio/master/job/workflow/WorkflowTracker.java
+++ b/job/server/src/main/java/alluxio/master/job/workflow/WorkflowTracker.java
@@ -32,10 +32,13 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * The {@link WorkflowTracker}.
@@ -144,6 +147,23 @@ public class WorkflowTracker {
       res.add(getStatus(workflowId, false));
     }
     return res;
+  }
+
+  /**
+   * @param name job name filter
+   * @param statusList status list filter
+   * @return job ids matching conditions
+   */
+  public Set<Long> findJobs(String name, List<Status> statusList) {
+    Set<Long> jobs = new HashSet<>();
+    for (Long workflowId : mWorkflows.entrySet().stream()
+        .filter(x -> statusList.isEmpty() || statusList.contains(x.getValue().getStatus()))
+        .map(Map.Entry::getKey).collect(Collectors.toList())) {
+      if (name == null || name.isEmpty() || mWorkflows.get(workflowId).getName().equals(name)) {
+        jobs.add(workflowId);
+      }
+    }
+    return jobs;
   }
 
   /**

--- a/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
+++ b/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
@@ -53,6 +53,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -124,9 +125,31 @@ public final class JobMasterTest {
             anyList(), anyLong(), any(JobConfig.class), any(Consumer.class)))
         .thenReturn(coordinator);
     TestPlanConfig jobConfig = new TestPlanConfig("/test");
+    List<Long> jobIdList = new ArrayList<>();
     for (long i = 0; i < TEST_JOB_MASTER_JOB_CAPACITY; i++) {
-      mJobMaster.run(jobConfig);
+      jobIdList.add(mJobMaster.run(jobConfig));
     }
+    final List<Long> list = mJobMaster.list(ListAllPOptions.getDefaultInstance());
+    Assert.assertEquals(jobIdList, list);
+    Assert.assertEquals(TEST_JOB_MASTER_JOB_CAPACITY,
+        mJobMaster.list(ListAllPOptions.getDefaultInstance()).size());
+  }
+
+  @Test
+  public void list() throws Exception {
+    PlanCoordinator coordinator = PowerMockito.mock(PlanCoordinator.class);
+    mockStatic(PlanCoordinator.class);
+    when(
+        PlanCoordinator.create(any(CommandManager.class), any(JobServerContext.class),
+            anyList(), anyLong(), any(JobConfig.class), any(Consumer.class)))
+        .thenReturn(coordinator);
+    TestPlanConfig jobConfig = new TestPlanConfig("/test");
+    List<Long> jobIdList = new ArrayList<>();
+    for (long i = 0; i < TEST_JOB_MASTER_JOB_CAPACITY; i++) {
+      jobIdList.add(mJobMaster.run(jobConfig));
+    }
+    final List<Long> list = mJobMaster.list(ListAllPOptions.getDefaultInstance());
+    Assert.assertEquals(jobIdList, list);
     Assert.assertEquals(TEST_JOB_MASTER_JOB_CAPACITY,
         mJobMaster.list(ListAllPOptions.getDefaultInstance()).size());
   }

--- a/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
+++ b/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
@@ -25,6 +25,7 @@ import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.ResourceExhaustedException;
+import alluxio.grpc.ListAllPOptions;
 import alluxio.job.JobConfig;
 import alluxio.job.JobServerContext;
 import alluxio.job.SleepJobConfig;
@@ -126,7 +127,8 @@ public final class JobMasterTest {
     for (long i = 0; i < TEST_JOB_MASTER_JOB_CAPACITY; i++) {
       mJobMaster.run(jobConfig);
     }
-    Assert.assertEquals(TEST_JOB_MASTER_JOB_CAPACITY, mJobMaster.list().size());
+    Assert.assertEquals(TEST_JOB_MASTER_JOB_CAPACITY,
+        mJobMaster.list(ListAllPOptions.getDefaultInstance()).size());
   }
 
   @Test

--- a/job/server/src/test/java/alluxio/master/job/plan/PlanTrackerTest.java
+++ b/job/server/src/test/java/alluxio/master/job/plan/PlanTrackerTest.java
@@ -23,11 +23,13 @@ import alluxio.exception.status.ResourceExhaustedException;
 import alluxio.job.JobServerContext;
 import alluxio.job.SleepJobConfig;
 import alluxio.job.meta.JobIdGenerator;
+import alluxio.job.wire.Status;
 import alluxio.master.job.command.CommandManager;
 import alluxio.master.job.workflow.WorkflowTracker;
 import alluxio.util.FormatUtils;
 import alluxio.wire.WorkerInfo;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Rule;
@@ -76,6 +78,17 @@ public class PlanTrackerTest {
     fillJobTracker(CAPACITY);
     mException.expect(ResourceExhaustedException.class);
     addJob(100);
+  }
+
+  @Test
+  public void testJobListing() throws Exception {
+    assertEquals("tracker should be empty", 0, mTracker.coordinators().size());
+    assertEquals(0, mTracker.findJobs("Sleep", ImmutableList.of(Status.CREATED)).size());
+    addJob(500);
+    assertEquals(1, mTracker.findJobs("Sleep", ImmutableList.of(Status.CREATED)).size());
+    finishAllJobs();
+    assertEquals(0, mTracker.findJobs("Sleep", ImmutableList.of(Status.CREATED)).size());
+    assertEquals(1, mTracker.findJobs("Sleep", ImmutableList.of(Status.FAILED)).size());
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/cli/fs/command/PinCommandMultipleMediaIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/PinCommandMultipleMediaIntegrationTest.java
@@ -68,7 +68,7 @@ public final class PinCommandMultipleMediaIntegrationTest extends BaseIntegratio
           .setProperty(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "CACHE_THROUGH")
           .setProperty(PropertyKey.USER_FILE_RESERVED_BYTES, SIZE_BYTES / 2)
           // multiple media
-          .setProperty(PropertyKey.MASTER_REPLICATION_CHECK_INTERVAL_MS, "100ms")
+          .setProperty(PropertyKey.MASTER_REPLICATION_CHECK_INTERVAL_MS, "500ms")
           .setProperty(PropertyKey.WORKER_TIERED_STORE_LEVELS, "2")
           .setProperty(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS
               .format(1), Constants.MEDIUM_SSD)

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-    // o.sync();
+    o.sync();
     //#else
     o.hflush();
     //#endif

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-    o.sync();
+    // o.sync();
     //#else
     o.hflush();
     //#endif

--- a/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
@@ -13,6 +13,7 @@ package alluxio.client.rest;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
+import alluxio.grpc.ListAllPOptions;
 import alluxio.job.JobConfig;
 import alluxio.job.ServiceConstants;
 import alluxio.job.SleepJobConfig;
@@ -98,7 +99,8 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
   @Test
   public void run() throws Exception {
     final long jobId = startJob(new SleepJobConfig(200));
-    Assert.assertEquals(1, mJobMaster.list().size());
+    Assert.assertEquals(1,
+        mJobMaster.list(ListAllPOptions.getDefaultInstance()).size());
     waitForStatus(jobId, Status.COMPLETED);
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Use the existing interface of job master to allow filtering of jobs by name and by job status

### Why are the changes needed?
Currently, there is no way for client to efficiently look up job status and find incomplete jobs with a specific name/type
This leads to O(n) rpc calls from replicationChecker every heartbeat.

### Does this PR introduce any user facing changes?
No
