### PR TITLE
Fix the IndexOutOfBoundsException when reading one file

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -106,7 +106,7 @@ public class LocalCacheFileInStream extends FileInStream {
     byte[] b = new byte[buf.remaining()];
     int totalBytesRead =
         readInternal(b, off, len, ReadType.READ_INTO_BYTE_BUFFER, mPosition, false);
-    buf.put(b, off, len);
+    buf.put(b, off, totalBytesRead);
     return totalBytesRead;
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -106,6 +106,9 @@ public class LocalCacheFileInStream extends FileInStream {
     byte[] b = new byte[buf.remaining()];
     int totalBytesRead =
         readInternal(b, off, len, ReadType.READ_INTO_BYTE_BUFFER, mPosition, false);
+    if (totalBytesRead == -1) {
+      return -1;
+    }
     buf.put(b, off, totalBytesRead);
     return totalBytesRead;
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -122,6 +122,24 @@ public class LocalCacheFileInStreamTest {
   }
 
   @Test
+  public void readIllegalLengthThroughReadByteBufferMethod() throws Exception {
+    int fileSize = 10;
+    byte[] fileData = BufferUtils.getIncreasingByteArray(fileSize);
+    ByteArrayCacheManager manager = new ByteArrayCacheManager();
+    LocalCacheFileInStream stream = setupWithSingleFile(fileData, manager);
+
+    byte[] readData = new byte[fileSize];
+    ByteBuffer buffer = ByteBuffer.wrap(readData);
+    try {
+      int totalBytesRead = stream.read(buffer,0, fileSize + 1);
+      Assert.assertEquals(fileSize, totalBytesRead);
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.fail(e.getMessage());
+    }
+  }
+
+  @Test
   public void readPartialPage() throws Exception {
     int fileSize = PAGE_SIZE;
     byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -130,13 +130,8 @@ public class LocalCacheFileInStreamTest {
 
     byte[] readData = new byte[fileSize];
     ByteBuffer buffer = ByteBuffer.wrap(readData);
-    try {
-      int totalBytesRead = stream.read(buffer, 0, fileSize + 1);
-      Assert.assertEquals(-1, totalBytesRead);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.fail(e.getMessage());
-    }
+    int totalBytesRead = stream.read(buffer, 0, fileSize + 1);
+    Assert.assertEquals(-1, totalBytesRead);
   }
 
   @Test
@@ -148,13 +143,8 @@ public class LocalCacheFileInStreamTest {
 
     byte[] readData = new byte[fileSize];
     ByteBuffer buffer = ByteBuffer.wrap(readData);
-    try {
-      int totalBytesRead = stream.read(buffer, 0, fileSize + 1);
-      Assert.assertEquals(fileSize, totalBytesRead);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.fail(e.getMessage());
-    }
+    int totalBytesRead = stream.read(buffer, 0, fileSize + 1);
+    Assert.assertEquals(fileSize, totalBytesRead);
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -122,6 +122,24 @@ public class LocalCacheFileInStreamTest {
   }
 
   @Test
+  public void readEmptyFileThroughReadByteBufferMethod() throws Exception {
+    int fileSize = 0;
+    byte[] fileData = BufferUtils.getIncreasingByteArray(fileSize);
+    ByteArrayCacheManager manager = new ByteArrayCacheManager();
+    LocalCacheFileInStream stream = setupWithSingleFile(fileData, manager);
+
+    byte[] readData = new byte[fileSize];
+    ByteBuffer buffer = ByteBuffer.wrap(readData);
+    try {
+      int totalBytesRead = stream.read(buffer, 0, fileSize + 1);
+      Assert.assertEquals(-1, totalBytesRead);
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.fail(e.getMessage());
+    }
+  }
+
+  @Test
   public void readIllegalLengthThroughReadByteBufferMethod() throws Exception {
     int fileSize = 10;
     byte[] fileData = BufferUtils.getIncreasingByteArray(fileSize);

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -122,7 +122,7 @@ public class LocalCacheFileInStreamTest {
   }
 
   @Test
-  public void readEmptyFileThroughReadByteBufferMethod() throws Exception {
+  public void readEmptyFileThroughReadByteBuffer() throws Exception {
     int fileSize = 0;
     byte[] fileData = BufferUtils.getIncreasingByteArray(fileSize);
     ByteArrayCacheManager manager = new ByteArrayCacheManager();
@@ -135,7 +135,7 @@ public class LocalCacheFileInStreamTest {
   }
 
   @Test
-  public void readIllegalLengthThroughReadByteBufferMethod() throws Exception {
+  public void readThroughReadByteBuffer() throws Exception {
     int fileSize = 10;
     byte[] fileData = BufferUtils.getIncreasingByteArray(fileSize);
     ByteArrayCacheManager manager = new ByteArrayCacheManager();

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -131,7 +131,7 @@ public class LocalCacheFileInStreamTest {
     byte[] readData = new byte[fileSize];
     ByteBuffer buffer = ByteBuffer.wrap(readData);
     try {
-      int totalBytesRead = stream.read(buffer,0, fileSize + 1);
+      int totalBytesRead = stream.read(buffer, 0, fileSize + 1);
       Assert.assertEquals(fileSize, totalBytesRead);
     } catch (Exception e) {
       e.printStackTrace();


### PR DESCRIPTION
### What changes are proposed in this pull request?

This pr resolves the  https://github.com/Alluxio/alluxio/issues/13824 that when the given buffer's length is larger than it read, it will throw IndexOutOfBoundsException.

This occurs when the length of a given buffer minus offset is greater than the actual read data.
 
### Why are the changes needed?
It's one bug

### Does this PR introduce any user facing changes?
No
