### PR TITLE
Fix metrics of Master.RpcQueueLength

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -320,7 +320,7 @@ public class AlluxioMasterProcess extends MasterProcess {
 
       serverBuilder.executor(mRPCExecutor);
       MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_RPC_QUEUE_LENGTH.getName(),
-              mRPCExecutor::getQueuedTaskCount);
+              mRPCExecutor::getQueuedSubmissionCount);
 
       for (Master master : mRegistry.getServers()) {
         registerServices(serverBuilder, master.getServices());


### PR DESCRIPTION
### What changes are proposed in this pull request?

Obtain accurate metrics of Master.RpcQueueLength

### Why are the changes needed?

method of getQueuedTaskCount cannot be collected correctly, so change collection method to getQueuedSubmissionCount.

