### PR TITLE
Add counter for worker-side clients

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -848,7 +848,7 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey WORKER_ACTIVE_CLIENTS =
       new Builder("Worker.ActiveClients")
-          .setDescription("The number of active client reading or writing to this worker")
+          .setDescription("The number of clients actively reading from or writing to this worker")
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(true)
           .build();

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -847,7 +847,7 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setIsClusterAggregated(true)
           .build();
   public static final MetricKey WORKER_ACTIVE_CLIENTS =
-      new Builder("Worker.ActiveClientCount")
+      new Builder("Worker.ActiveClients")
           .setDescription("The number of active client reading or writing to this worker")
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(true)

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -846,6 +846,12 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(true)
           .build();
+  public static final MetricKey WORKER_ACTIVE_CLIENTS =
+      new Builder("Worker.ActiveClientCount")
+          .setDescription("The number of active client reading or writing to this worker")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(true)
+          .build();
   public static final MetricKey WORKER_ASYNC_CACHE_DUPLICATE_REQUESTS =
       new Builder("Worker.AsyncCacheDuplicateRequests")
           .setDescription("Total number of duplicated async cache request received by this worker")

--- a/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
+++ b/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
@@ -14,12 +14,18 @@ package alluxio.worker;
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.Sessions;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.util.CommonUtils;
+import alluxio.worker.block.DefaultBlockWorker;
 
+import com.codahale.metrics.Counter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
+
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.List;
@@ -85,6 +91,7 @@ public final class SessionCleaner implements Runnable, Closeable {
         for (SessionCleanable sc : mSessionCleanables) {
           sc.cleanupSession(session);
         }
+        Metrics.WORKER_ACTIVE_CLIENTS.dec();
       }
     }
   }
@@ -94,5 +101,13 @@ public final class SessionCleaner implements Runnable, Closeable {
    */
   public void close() {
     mRunning = false;
+  }
+
+  @ThreadSafe
+  public static final class Metrics {
+    private static final Counter WORKER_ACTIVE_CLIENTS =
+        MetricsSystem.counter(MetricKey.WORKER_ACTIVE_CLIENTS.getName());
+
+    private Metrics() {} // prevent instantiation
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
+++ b/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
@@ -14,18 +14,12 @@ package alluxio.worker;
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.Sessions;
-import alluxio.metrics.MetricKey;
-import alluxio.metrics.MetricsSystem;
 import alluxio.util.CommonUtils;
-import alluxio.worker.block.DefaultBlockWorker;
 
-import com.codahale.metrics.Counter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.NotThreadSafe;
-import javax.annotation.concurrent.ThreadSafe;
-
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.List;
@@ -91,7 +85,6 @@ public final class SessionCleaner implements Runnable, Closeable {
         for (SessionCleanable sc : mSessionCleanables) {
           sc.cleanupSession(session);
         }
-        Metrics.WORKER_ACTIVE_CLIENTS.dec();
       }
     }
   }
@@ -101,13 +94,5 @@ public final class SessionCleaner implements Runnable, Closeable {
    */
   public void close() {
     mRunning = false;
-  }
-
-  @ThreadSafe
-  public static final class Metrics {
-    private static final Counter WORKER_ACTIVE_CLIENTS =
-        MetricsSystem.counter(MetricKey.WORKER_ACTIVE_CLIENTS.getName());
-
-    private Metrics() {} // prevent instantiation
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -370,6 +370,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
       throw new WorkerOutOfSpaceException(ExceptionMessage.CANNOT_REQUEST_SPACE
           .getMessageWithUrl(RuntimeConstants.ALLUXIO_DEBUG_DOCS_URL, address, blockId), e);
     }
+    Metrics.WORKER_ACTIVE_CLIENTS.inc();
     return createdBlock.getPath();
   }
 
@@ -633,6 +634,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
     while (retryPolicy.attempt()) {
       BlockReader reader = createLocalBlockReader(sessionId, blockId, request.getStart());
       if (reader != null) {
+        Metrics.WORKER_ACTIVE_CLIENTS.inc();
         return reader;
       }
       boolean checkUfs =
@@ -644,6 +646,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
       }
       // When the block does not exist in Alluxio but exists in UFS, try to open the UFS block.
       try {
+        Metrics.WORKER_ACTIVE_CLIENTS.inc();
         return createUfsBlockReader(request.getSessionId(), request.getId(), request.getStart(),
             request.isPositionShort(), request.getOpenUfsBlockOptions());
       } catch (Exception e) {
@@ -666,6 +669,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   public void cleanupSession(long sessionId) {
     mLocalBlockStore.cleanupSession(sessionId);
     mUnderFileSystemBlockStore.cleanupSession(sessionId);
+    Metrics.WORKER_ACTIVE_CLIENTS.dec();
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -419,8 +419,11 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
 
   @Override
   public long lockBlock(long sessionId, long blockId) {
-    Metrics.WORKER_ACTIVE_CLIENTS.inc();
-    return mLocalBlockStore.lockBlockNoException(sessionId, blockId);
+    long lockId = mLocalBlockStore.lockBlockNoException(sessionId, blockId);
+    if (lockId != INVALID_LOCK_ID) {
+      Metrics.WORKER_ACTIVE_CLIENTS.inc();
+    }
+    return lockId;
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -57,6 +57,7 @@ import alluxio.worker.block.meta.TempBlockMeta;
 import alluxio.worker.file.FileSystemMasterClient;
 import alluxio.worker.grpc.GrpcExecutors;
 
+import com.codahale.metrics.Counter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.io.Closer;
@@ -288,6 +289,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   public void abortBlock(long sessionId, long blockId) throws BlockAlreadyExistsException,
       BlockDoesNotExistException, InvalidWorkerStateException, IOException {
     mLocalBlockStore.abortBlock(sessionId, blockId);
+    Metrics.WORKER_ACTIVE_CLIENTS.dec();
   }
 
   @Override
@@ -327,6 +329,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
     } finally {
       mBlockMasterClientPool.release(blockMasterClient);
       mLocalBlockStore.unlockBlock(lockId);
+      Metrics.WORKER_ACTIVE_CLIENTS.dec();
     }
   }
 
@@ -415,6 +418,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
 
   @Override
   public long lockBlock(long sessionId, long blockId) {
+    Metrics.WORKER_ACTIVE_CLIENTS.inc();
     return mLocalBlockStore.lockBlockNoException(sessionId, blockId);
   }
 
@@ -536,6 +540,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   @Override
   public void unlockBlock(long lockId) throws BlockDoesNotExistException {
     mLocalBlockStore.unlockBlock(lockId);
+    Metrics.WORKER_ACTIVE_CLIENTS.dec();
   }
 
   @Override
@@ -670,6 +675,8 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
    */
   @ThreadSafe
   public static final class Metrics {
+    private static final Counter WORKER_ACTIVE_CLIENTS =
+        MetricsSystem.counter(MetricKey.WORKER_ACTIVE_CLIENTS.getName());
 
     /**
      * Registers metric gauges.


### PR DESCRIPTION
### What changes are proposed in this pull request?

Introduce a new counter to track the number of active clients talking to a worker

### Why are the changes needed?

As requested by community user, we want to expose the number of active clients on the worker side,
so user can decide if it is safe to remove a worker.

### Does this PR introduce any user-facing changes?

A new metrics `Worker.ActiveClients`

