### PR TITLE
Add additional debug messages to persist waiting

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -156,10 +156,16 @@ public final class FileSystemUtils {
     LOG.debug("Start to persist {}", uri.getPath());
     fs.persist(uri, ScheduleAsyncPersistencePOptions
         .newBuilder().setPersistenceWaitTime(persistenceWaitTime).build());
+    LOG.debug("Waiting for persist result for path {}, with persistence wait time {}"
+            + " and time out {}",
+        uri.getPath(), persistenceWaitTime, timeoutMs);
     CommonUtils.waitForResult(String.format("%s to be persisted", uri) , () -> {
       try {
+        LOG.debug("Polling file system master for the status of {}", uri);
         return fs.getStatus(uri);
       } catch (Exception e) {
+        LOG.debug("Exception when attempting to getStatus while waiting for persistence {}",
+            e.toString());
         Throwables.throwIfUnchecked(e);
         throw new RuntimeException(e);
       }

--- a/shell/src/main/java/alluxio/cli/fs/command/PersistCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/PersistCommand.java
@@ -220,6 +220,7 @@ public final class PersistCommand extends AbstractFileSystemCommand {
           }
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
+          LOG.warn("Interrupted while waiting for persistence ", e);
           throw e;
         } catch (TimeoutException e) {
           String timeoutMsg =


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add more debug messages to diagnose persist delays

### Why are the changes needed?

We do not understand why the client thread stopped polling the file system master. 

### Does this PR introduce any user facing changes?
More logging