### PR TITLE
Fix the job server or job worker starts failed and typo

### DIFF
--- a/job/server/pom.xml
+++ b/job/server/pom.xml
@@ -56,6 +56,10 @@
       <artifactId>jersey-container-servlet-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
     </dependency>

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
@@ -47,7 +47,7 @@ public class HdfsUnderFileSystemFactory implements UnderFileSystemFactory {
   public boolean supportsPath(String path) {
     // This loads the static configuration from the JVM's system properties and the site properties
     // file at the time of instantiation. Because of this, setting the property
-    // UNDERFS_HDFS_PREFIXES programatically *not* work.
+    // UNDERFS_HDFS_PREFIXES programmatically *not* work.
     AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
 
     if (path != null) {
@@ -68,7 +68,7 @@ public class HdfsUnderFileSystemFactory implements UnderFileSystemFactory {
   public boolean supportsPath(String path, UnderFileSystemConfiguration conf) {
     if (path != null) {
       // This loads the configuration from the JVM's system properties and the site properties file
-      // on disk. Because of this, setting the property UNDERFS_HDFS_PREFIXES programatically *not*
+      // on disk. Because of this, setting the property UNDERFS_HDFS_PREFIXES programmatically *not*
       // work.
       AlluxioConfiguration alluxioConf = new InstancedConfiguration(ConfigurationUtils.defaults());
 


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix the job server or job worker starts failed and typo

### Why are the changes needed?
The job server or job worker depend on `JobMasterWebServer` and `JobWorkWebServer`. When the job server or job worker starts failed with not using `bin` shell. so the pom must add dependencies.

### Does this PR introduce any user facing changes?
NO
