### PR TITLE
Use npm ci for Web UI for installing dependencies

### DIFF
--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -53,7 +53,7 @@
             </goals>
             <phase>process-sources</phase>
             <configuration>
-              <arguments>install --production --no-save --no-package-lock --no-shrinkwrap</arguments>
+              <arguments>ci</arguments>
             </configuration>
           </execution>
         </executions>
@@ -96,8 +96,7 @@
               <arguments>
                 <argument>node_modules/.bin/lerna</argument>
                 <argument>bootstrap</argument>
-                <argument>--</argument>
-                <argument>--production  --no-save --no-package-lock --no-shrinkwrap</argument>
+                <argument>--ci</argument>
               </arguments>
             </configuration>
           </execution>
@@ -170,6 +169,8 @@
             <exclude>**/node_modules/**</exclude>
             <exclude>node/**</exclude>
             <exclude>**/build/**</exclude>
+            <exclude>**/*.snap</exclude>
+            <exclude>**/coverage/**</exclude>
             <!-- auto-generated css -->
             <exclude>**/*.css</exclude>
           </excludes>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Use `npm ci` instead of `npm install` - helps speeds up installs since it is meant to be used in automated environments such as test platforms, continuous integration, and deployment -- or any situation that requires a clean install of dependencies. 

most people won't be adding/tweaking dependencies.
 
ref - https://docs.npmjs.com/cli/v6/commands/npm-ci

### Why are the changes needed?


### Does this PR introduce any user facing changes?
