### PR TITLE
Extract HiveClientPool as an abstract class to facilitate testing

### DIFF
--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
@@ -32,6 +32,7 @@ import alluxio.table.under.hive.util.HiveClientPoolCache;
 import alluxio.table.under.hive.util.HiveClientPool;
 import alluxio.util.io.PathUtils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
@@ -83,6 +84,16 @@ public class HiveDatabase implements UnderDatabase {
     mConnectionUri = connectionUri;
     mHiveDbName = hiveDbName;
     mClientPool = CLIENT_POOL_CACHE.getPool(connectionUri);
+  }
+
+  @VisibleForTesting
+  HiveDatabase(UdbContext udbContext, UdbConfiguration configuration,
+               HiveClientPool clientPool, String connectionUri, String hiveDbName) {
+    mUdbContext = udbContext;
+    mConfiguration = configuration;
+    mConnectionUri = connectionUri;
+    mHiveDbName = hiveDbName;
+    mClientPool = clientPool;
   }
 
   /**

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/HiveDatabase.java
@@ -29,7 +29,7 @@ import alluxio.table.common.udb.UdbTable;
 import alluxio.table.common.udb.UdbUtils;
 import alluxio.table.common.udb.UnderDatabase;
 import alluxio.table.under.hive.util.HiveClientPoolCache;
-import alluxio.table.under.hive.util.HiveClientPool;
+import alluxio.table.under.hive.util.AbstractHiveClientPool;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -75,20 +75,20 @@ public class HiveDatabase implements UnderDatabase {
 
   private static final HiveClientPoolCache CLIENT_POOL_CACHE = new HiveClientPoolCache();
   /** Hive client is not thread-safe, so use a client pool for concurrency. */
-  private final HiveClientPool mClientPool;
+  private final AbstractHiveClientPool mClientPool;
 
   private HiveDatabase(UdbContext udbContext, UdbConfiguration configuration,
       String connectionUri, String hiveDbName) {
-    mUdbContext = udbContext;
-    mConfiguration = configuration;
-    mConnectionUri = connectionUri;
-    mHiveDbName = hiveDbName;
-    mClientPool = CLIENT_POOL_CACHE.getPool(connectionUri);
+    this(udbContext,
+        configuration,
+        connectionUri,
+        hiveDbName,
+        CLIENT_POOL_CACHE.getPool(connectionUri));
   }
 
   @VisibleForTesting
   HiveDatabase(UdbContext udbContext, UdbConfiguration configuration,
-               HiveClientPool clientPool, String connectionUri, String hiveDbName) {
+               String connectionUri, String hiveDbName, AbstractHiveClientPool clientPool) {
     mUdbContext = udbContext;
     mConfiguration = configuration;
     mConnectionUri = connectionUri;

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/AbstractHiveClientPool.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/AbstractHiveClientPool.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 /**
  * A pool for hive clients.
  */
-public abstract class HiveClientPool extends DynamicResourcePool<IMetaStoreClient> {
-  protected HiveClientPool(Options options) {
+public abstract class AbstractHiveClientPool extends DynamicResourcePool<IMetaStoreClient> {
+  protected AbstractHiveClientPool(Options options) {
     super(options);
   }
 

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/DefaultHiveClientPool.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/DefaultHiveClientPool.java
@@ -1,0 +1,112 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.table.under.hive.util;
+
+import static alluxio.conf.PropertyKey.TABLE_UDB_HIVE_CLIENTPOOL_MAX;
+import static alluxio.conf.PropertyKey.TABLE_UDB_HIVE_CLIENTPOOL_MIN;
+
+import alluxio.Constants;
+import alluxio.conf.ServerConfiguration;
+import alluxio.resource.CloseableResource;
+import alluxio.util.ThreadFactoryUtils;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A pool for hive clients, since hive clients are not thread safe.
+ */
+@ThreadSafe
+public final class DefaultHiveClientPool extends HiveClientPool {
+  private static final ScheduledExecutorService GC_EXECUTOR =
+      new ScheduledThreadPoolExecutor(1, ThreadFactoryUtils.build("HiveClientPool-GC-%d", true));
+  private static final HiveMetaHookLoader NOOP_HOOK = table -> null;
+
+  private final long mGcThresholdMs;
+  private final String mConnectionUri;
+
+  /**
+   * Creates a new hive client client pool.
+   *
+   * @param connectionUri the connect uri for the hive metastore
+   */
+  public DefaultHiveClientPool(String connectionUri) {
+    super(Options.defaultOptions()
+        .setMinCapacity(ServerConfiguration.getInt(TABLE_UDB_HIVE_CLIENTPOOL_MIN))
+        .setMaxCapacity(ServerConfiguration.getInt(TABLE_UDB_HIVE_CLIENTPOOL_MAX))
+        .setGcIntervalMs(5L * Constants.MINUTE_MS)
+        .setGcExecutor(GC_EXECUTOR));
+    mConnectionUri = connectionUri;
+    mGcThresholdMs = 5L * Constants.MINUTE_MS;
+  }
+
+  @Override
+  protected void closeResource(IMetaStoreClient client) {
+    client.close();
+  }
+
+  @Override
+  protected IMetaStoreClient createNewResource() throws IOException {
+    // Hive uses/saves the thread context class loader.
+    ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      // use the extension class loader
+      Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+      HiveConf conf = new HiveConf();
+      conf.verifyAndSet("hive.metastore.uris", mConnectionUri);
+
+      IMetaStoreClient client = HMSClientFactory.newInstance(
+          RetryingMetaStoreClient.getProxy(conf, NOOP_HOOK, HiveMetaStoreClient.class.getName()));
+      return client;
+    } catch (NullPointerException | TException e) {
+      // HiveMetaStoreClient throws a NPE if the uri is not a uri for hive metastore
+      throw new IOException(String
+          .format("Failed to create client to hive metastore: %s. error: %s", mConnectionUri,
+              e.getMessage()), e);
+    } finally {
+      Thread.currentThread().setContextClassLoader(currentClassLoader);
+    }
+  }
+
+  @Override
+  protected boolean isHealthy(IMetaStoreClient client) {
+    // there is no way to check if a hive client is connected.
+    // TODO(gpang): periodically and asynchronously check the health of clients
+    return true;
+  }
+
+  @Override
+  protected boolean shouldGc(ResourceInternal<IMetaStoreClient> clientResourceInternal) {
+    return System.currentTimeMillis() - clientResourceInternal
+        .getLastAccessTimeMs() > mGcThresholdMs;
+  }
+
+  @Override
+  public CloseableResource<IMetaStoreClient> acquireClientResource() throws IOException {
+    return new CloseableResource<IMetaStoreClient>(acquire()) {
+      @Override
+      public void close() {
+        release(get());
+      }
+    };
+  }
+}

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/DefaultHiveClientPool.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/DefaultHiveClientPool.java
@@ -36,7 +36,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * A pool for hive clients, since hive clients are not thread safe.
  */
 @ThreadSafe
-public final class DefaultHiveClientPool extends HiveClientPool {
+public final class DefaultHiveClientPool extends AbstractHiveClientPool {
   private static final ScheduledExecutorService GC_EXECUTOR =
       new ScheduledThreadPoolExecutor(1, ThreadFactoryUtils.build("HiveClientPool-GC-%d", true));
   private static final HiveMetaHookLoader NOOP_HOOK = table -> null;

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveClientPool.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveClientPool.java
@@ -11,105 +11,19 @@
 
 package alluxio.table.under.hive.util;
 
-import static alluxio.conf.PropertyKey.TABLE_UDB_HIVE_CLIENTPOOL_MAX;
-import static alluxio.conf.PropertyKey.TABLE_UDB_HIVE_CLIENTPOOL_MIN;
-
-import alluxio.Constants;
-import alluxio.conf.ServerConfiguration;
 import alluxio.resource.CloseableResource;
 import alluxio.resource.DynamicResourcePool;
-import alluxio.util.ThreadFactoryUtils;
-
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
-import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
-import org.apache.thrift.TException;
 
 import java.io.IOException;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 
-import javax.annotation.concurrent.ThreadSafe;
-
-/**
- * A pool for hive clients, since hive clients are not thread safe.
- */
-@ThreadSafe
-public final class HiveClientPool extends DynamicResourcePool<IMetaStoreClient> {
-  private static final ScheduledExecutorService GC_EXECUTOR =
-      new ScheduledThreadPoolExecutor(1, ThreadFactoryUtils.build("HiveClientPool-GC-%d", true));
-  private static final HiveMetaHookLoader NOOP_HOOK = table -> null;
-
-  private final long mGcThresholdMs;
-  private final String mConnectionUri;
-
-  /**
-   * Creates a new hive client client pool.
-   *
-   * @param connectionUri the connect uri for the hive metastore
-   */
-  public HiveClientPool(String connectionUri) {
-    super(Options.defaultOptions()
-        .setMinCapacity(ServerConfiguration.getInt(TABLE_UDB_HIVE_CLIENTPOOL_MIN))
-        .setMaxCapacity(ServerConfiguration.getInt(TABLE_UDB_HIVE_CLIENTPOOL_MAX))
-        .setGcIntervalMs(5L * Constants.MINUTE_MS)
-        .setGcExecutor(GC_EXECUTOR));
-    mConnectionUri = connectionUri;
-    mGcThresholdMs = 5L * Constants.MINUTE_MS;
-  }
-
-  @Override
-  protected void closeResource(IMetaStoreClient client) {
-    client.close();
-  }
-
-  @Override
-  protected IMetaStoreClient createNewResource() throws IOException {
-    // Hive uses/saves the thread context class loader.
-    ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
-    try {
-      // use the extension class loader
-      Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
-      HiveConf conf = new HiveConf();
-      conf.verifyAndSet("hive.metastore.uris", mConnectionUri);
-
-      IMetaStoreClient client = HMSClientFactory.newInstance(
-          RetryingMetaStoreClient.getProxy(conf, NOOP_HOOK, HiveMetaStoreClient.class.getName()));
-      return client;
-    } catch (NullPointerException | TException e) {
-      // HiveMetaStoreClient throws a NPE if the uri is not a uri for hive metastore
-      throw new IOException(String
-          .format("Failed to create client to hive metastore: %s. error: %s", mConnectionUri,
-              e.getMessage()), e);
-    } finally {
-      Thread.currentThread().setContextClassLoader(currentClassLoader);
-    }
-  }
-
-  @Override
-  protected boolean isHealthy(IMetaStoreClient client) {
-    // there is no way to check if a hive client is connected.
-    // TODO(gpang): periodically and asynchronously check the health of clients
-    return true;
-  }
-
-  @Override
-  protected boolean shouldGc(ResourceInternal<IMetaStoreClient> clientResourceInternal) {
-    return System.currentTimeMillis() - clientResourceInternal
-        .getLastAccessTimeMs() > mGcThresholdMs;
+public abstract class HiveClientPool extends DynamicResourcePool<IMetaStoreClient> {
+  protected HiveClientPool(Options options) {
+    super(options);
   }
 
   /**
    * @return a closeable resource for the hive client
    */
-  public CloseableResource<IMetaStoreClient> acquireClientResource() throws IOException {
-    return new CloseableResource<IMetaStoreClient>(acquire()) {
-      @Override
-      public void close() {
-        release(get());
-      }
-    };
-  }
+  public abstract CloseableResource<IMetaStoreClient> acquireClientResource() throws IOException;
 }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveClientPool.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveClientPool.java
@@ -13,10 +13,14 @@ package alluxio.table.under.hive.util;
 
 import alluxio.resource.CloseableResource;
 import alluxio.resource.DynamicResourcePool;
+
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 
 import java.io.IOException;
 
+/**
+ * A pool for hive clients.
+ */
 public abstract class HiveClientPool extends DynamicResourcePool<IMetaStoreClient> {
   protected HiveClientPool(Options options) {
     super(options);

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveClientPoolCache.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveClientPoolCache.java
@@ -38,7 +38,7 @@ public class HiveClientPoolCache {
       if (pool != null) {
         return pool;
       } else {
-        return new HiveClientPool(connectionURI);
+        return new DefaultHiveClientPool(connectionURI);
       }
     });
   }

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveClientPoolCache.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/HiveClientPoolCache.java
@@ -18,7 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * This class implements a cache for Client connection pools for Hive Clients.
  */
 public class HiveClientPoolCache {
-  private final Map<String, HiveClientPool> mClientPools;
+  private final Map<String, AbstractHiveClientPool> mClientPools;
 
   /**
    * Constructor for the Client Pool cache.
@@ -33,7 +33,7 @@ public class HiveClientPoolCache {
    * @param connectionURI connection which serves as key
    * @return hive client pool
    */
-  public HiveClientPool getPool(String connectionURI) {
+  public AbstractHiveClientPool getPool(String connectionURI) {
     return mClientPools.compute(connectionURI, (uri, pool) -> {
       if (pool != null) {
         return pool;


### PR DESCRIPTION
### What changes are proposed in this pull request?

Extract `HiveClientPool` as an abstract class to facilitate testing.

### Why are the changes needed?

Currently there is no way to inject a mocked `IMetaStoreClient` into `HiveDatabase`. Adding the ability to do so facilitates unit testing.

### Does this PR introduce any user facing changes?

No.
