### PR TITLE
Fix the button of logs tab page cannot work issue

### DIFF
--- a/webui/common/src/components/HOCs/withFetchDataFromPath/__snapshots__/withFetchDataFromPath.test.tsx.snap
+++ b/webui/common/src/components/HOCs/withFetchDataFromPath/__snapshots__/withFetchDataFromPath.test.tsx.snap
@@ -18,6 +18,6 @@ exports[`withFetchData HOC Shallow component Matches snapshot - renders WrappedC
       "path": "",
     }
   }
-  upateRequestParameter={[Function]}
+  updateRequestParameter={[Function]}
 />
 `;

--- a/webui/common/src/components/HOCs/withFetchDataFromPath/withFetchDataFromPath.tsx
+++ b/webui/common/src/components/HOCs/withFetchDataFromPath/withFetchDataFromPath.tsx
@@ -64,7 +64,7 @@ export function withFetchDataFromPath<T extends IFetchDataFromPathProps>(
         <WrappedComponent
           {...this.props}
           {...this.state}
-          upateRequestParameter={this.updateRequestParameter}
+          updateRequestParameter={this.updateRequestParameter}
           queryStringSuffix={this.getQueryStringSuffix()}
         />
       );

--- a/webui/master/src/containers/pages/Browse/Browse.test.tsx
+++ b/webui/master/src/containers/pages/Browse/Browse.test.tsx
@@ -42,7 +42,7 @@ describe('Browse', () => {
       loading: false,
       textAreaHeight: 0,
       request: {},
-      upateRequestParameter: sinon.spy(),
+      updateRequestParameter: sinon.spy(),
     };
   });
 

--- a/webui/master/src/containers/pages/Browse/Browse.tsx
+++ b/webui/master/src/containers/pages/Browse/Browse.tsx
@@ -52,7 +52,7 @@ interface IBrowseProps {
   queryStringSuffix: string;
   request: IRequest;
   textAreaHeight: number;
-  upateRequestParameter: (reqParam: string, value: string | undefined) => void;
+  updateRequestParameter: (reqParam: string, value: string | undefined) => void;
 }
 
 export type AllProps = IPropsFromState & IBrowseProps & IPropsFromDispatch;
@@ -254,13 +254,13 @@ export class BrowsePresenter extends React.Component<AllProps> {
 
   private createInputChangeHandler(reqParam: string): (e: React.ChangeEvent<HTMLInputElement>) => void {
     return (event: React.ChangeEvent<HTMLInputElement>): void => {
-      this.props.upateRequestParameter(reqParam, event.target.value);
+      this.props.updateRequestParameter(reqParam, event.target.value);
     };
   }
 
   private createButtonHandler(reqParam: string, value: string | undefined): () => void {
     return (): void => {
-      this.props.upateRequestParameter(reqParam, value);
+      this.props.updateRequestParameter(reqParam, value);
     };
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

While using log web page to open log file, the end button or offset input textbox didn’t work

### Why are the changes needed?

This is a simple bug, the `updateRequestParameter` was named to `upateRequestParameter` in the browse.tsx and withFetchDataFromPath.tsx, but named to `updateRequestParameter` in the `Logs.tsx`.

So I found error call stack in the browser console

```
Uncaught TypeError: a.props.updateRequestParameter is not a function
    at t.<anonymous> (Logs.tsx:128)
    at t.n.onClick (Button.js:52)
    at Object.<anonymous> (react-dom.production.min.js:49)
    at d (react-dom.production.min.js:69)
    at react-dom.production.min.js:73
    at T (react-dom.production.min.js:140)
    at j (react-dom.production.min.js:169)
    at k (react-dom.production.min.js:158)
    at C (react-dom.production.min.js:232)
    at On (react-dom.production.min.js:1718)
```

### Does this PR introduce any user facing changes?

No