### PR TITLE
Move metrics handler to webserver

### DIFF
--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -14,6 +14,9 @@ package alluxio.web;
 import alluxio.AlluxioURI;
 import alluxio.conf.ServerConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.metrics.MetricsSystem;
+import alluxio.metrics.sink.MetricsServlet;
+import alluxio.metrics.sink.PrometheusMetricsServlet;
 
 import com.google.common.base.Preconditions;
 import org.eclipse.jetty.security.ConstraintMapping;
@@ -50,6 +53,9 @@ public abstract class WebServer {
   private final ServerConnector mServerConnector;
   private final ConstraintSecurityHandler mSecurityHandler;
   protected final ServletContextHandler mServletContextHandler;
+  private final MetricsServlet mMetricsServlet = new MetricsServlet(MetricsSystem.METRIC_REGISTRY);
+  private final PrometheusMetricsServlet mPMetricsServlet = new PrometheusMetricsServlet(
+      MetricsSystem.METRIC_REGISTRY);
 
   /**
    * Creates a new instance of {@link WebServer}. It pairs URLs with servlets and sets the webapp
@@ -103,7 +109,8 @@ public abstract class WebServer {
 
     mServletContextHandler.addServlet(StacksServlet.class, "/stacks");
     HandlerList handlers = new HandlerList();
-    handlers.setHandlers(new Handler[] {mServletContextHandler, new DefaultHandler()});
+    handlers.setHandlers(new Handler[] {mMetricsServlet.getHandler(), mPMetricsServlet.getHandler(),
+        mServletContextHandler, new DefaultHandler()});
     mServer.setHandler(handlers);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -29,8 +29,6 @@ import alluxio.master.journal.JournalUtils;
 import alluxio.master.journal.raft.RaftJournalSystem;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
-import alluxio.metrics.sink.MetricsServlet;
-import alluxio.metrics.sink.PrometheusMetricsServlet;
 import alluxio.resource.CloseableResource;
 import alluxio.security.user.ServerUserState;
 import alluxio.underfs.MasterUfsManager;
@@ -63,10 +61,6 @@ import javax.annotation.concurrent.ThreadSafe;
 @NotThreadSafe
 public class AlluxioMasterProcess extends MasterProcess {
   private static final Logger LOG = LoggerFactory.getLogger(AlluxioMasterProcess.class);
-
-  private final MetricsServlet mMetricsServlet = new MetricsServlet(MetricsSystem.METRIC_REGISTRY);
-  private final PrometheusMetricsServlet mPMetricsServlet = new PrometheusMetricsServlet(
-      MetricsSystem.METRIC_REGISTRY);
 
   /** The master registry. */
   private final MasterRegistry mRegistry;
@@ -251,10 +245,6 @@ public class AlluxioMasterProcess extends MasterProcess {
     mWebServer =
         new MasterWebServer(ServiceType.MASTER_WEB.getServiceName(), mWebBindAddress, this);
     // reset master web port
-    // Add the metrics servlet to the web server.
-    mWebServer.addHandler(mMetricsServlet.getHandler());
-    // Add the prometheus metrics servlet to the web server.
-    mWebServer.addHandler(mPMetricsServlet.getHandler());
     // start web ui
     mWebServer.start();
   }

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -15,8 +15,6 @@ import alluxio.Constants;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.metrics.MetricsSystem;
-import alluxio.metrics.sink.MetricsServlet;
-import alluxio.metrics.sink.PrometheusMetricsServlet;
 import alluxio.network.ChannelType;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.WorkerUfsManager;
@@ -64,10 +62,6 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
 
   /** If started (i.e. not null), this server is used to serve local data transfer. */
   private DataServer mDomainSocketDataServer;
-
-  private final MetricsServlet mMetricsServlet = new MetricsServlet(MetricsSystem.METRIC_REGISTRY);
-  private final PrometheusMetricsServlet mPMetricsServlet = new PrometheusMetricsServlet(
-      MetricsSystem.METRIC_REGISTRY);
 
   /** The worker registry. */
   private WorkerRegistry mRegistry;
@@ -234,8 +228,6 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
     startWorkers();
 
     // Start serving the web server, this will not block.
-    mWebServer.addHandler(mMetricsServlet.getHandler());
-    mWebServer.addHandler(mPMetricsServlet.getHandler());
     mWebServer.start();
 
     // Start monitor jvm

--- a/job/server/src/main/java/alluxio/master/AlluxioJobMasterProcess.java
+++ b/job/server/src/main/java/alluxio/master/AlluxioJobMasterProcess.java
@@ -27,8 +27,6 @@ import alluxio.master.journal.JournalMasterClientServiceHandler;
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.JournalUtils;
 import alluxio.master.journal.raft.RaftJournalSystem;
-import alluxio.metrics.MetricsSystem;
-import alluxio.metrics.sink.MetricsServlet;
 import alluxio.security.user.ServerUserState;
 import alluxio.underfs.JobUfsManager;
 import alluxio.underfs.UfsManager;
@@ -72,8 +70,6 @@ public class AlluxioJobMasterProcess extends MasterProcess {
 
   /** The manager for all ufs. */
   private UfsManager mUfsManager;
-
-  private final MetricsServlet mMetricsServlet = new MetricsServlet(MetricsSystem.METRIC_REGISTRY);
 
   AlluxioJobMasterProcess(JournalSystem journalSystem) {
     super(journalSystem, ServiceType.JOB_MASTER_RPC, ServiceType.JOB_MASTER_WEB);
@@ -194,7 +190,6 @@ public class AlluxioJobMasterProcess extends MasterProcess {
     stopRejectingWebServer();
     mWebServer =
         new JobMasterWebServer(ServiceType.JOB_MASTER_WEB.getServiceName(), mWebBindAddress, this);
-    mWebServer.addHandler(mMetricsServlet.getHandler());
     mWebServer.start();
   }
 

--- a/job/server/src/main/java/alluxio/worker/AlluxioJobWorkerProcess.java
+++ b/job/server/src/main/java/alluxio/worker/AlluxioJobWorkerProcess.java
@@ -20,8 +20,6 @@ import alluxio.grpc.GrpcServer;
 import alluxio.grpc.GrpcServerAddress;
 import alluxio.grpc.GrpcServerBuilder;
 import alluxio.grpc.GrpcService;
-import alluxio.metrics.MetricsSystem;
-import alluxio.metrics.sink.MetricsServlet;
 import alluxio.security.user.ServerUserState;
 import alluxio.underfs.JobUfsManager;
 import alluxio.underfs.UfsManager;
@@ -83,8 +81,6 @@ public final class AlluxioJobWorkerProcess implements JobWorkerProcess {
 
   /** The manager for all ufs. */
   private UfsManager mUfsManager;
-
-  private final MetricsServlet mMetricsServlet = new MetricsServlet(MetricsSystem.METRIC_REGISTRY);
 
   /**
    * Constructor of {@link AlluxioJobWorker}.
@@ -172,7 +168,6 @@ public final class AlluxioJobWorkerProcess implements JobWorkerProcess {
     // NOTE: the order to start different services is sensitive. If you change it, do it cautiously.
 
     // Start serving the web server, this will not block.
-    mWebServer.addHandler(mMetricsServlet.getHandler());
     mWebServer.start();
 
     // Start each worker


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support prometheus servlet to all the server, include master, worker, job master, job worker, alluxioProxy.

### Why are the changes needed?

With this PR, we can easily to get prometheus style metrics from all the servers.

### Does this PR introduce any user facing changes?

Add `/metrics/json` and `/metrics/prometheus` servlet to all servers of alluxio.
