### PR TITLE
Support Web server for fuse process

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4830,6 +4830,24 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey FUSE_WEB_BIND_HOST =
+      new Builder(Name.FUSE_WEB_BIND_HOST)
+          .setDefaultValue("0.0.0.0")
+          .setDescription("The hostname Alluxio FUSE web UI binds to.")
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey FUSE_WEB_HOSTNAME =
+      new Builder(Name.FUSE_WEB_HOSTNAME)
+          .setDescription("The hostname of Alluxio FUSE web UI.")
+          .setScope(Scope.ALL)
+          .build();
+  public static final PropertyKey FUSE_WEB_PORT =
+      new Builder(Name.FUSE_WEB_PORT)
+          .setDefaultValue(49999)
+          .setDescription("The port Alluxio FUSE web UI runs on.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
 
   //
   // Security related properties
@@ -6213,6 +6231,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.fuse.umount.timeout";
     public static final String FUSE_USER_GROUP_TRANSLATION_ENABLED =
         "alluxio.fuse.user.group.translation.enabled";
+    public static final String FUSE_WEB_BIND_HOST = "alluxio.fuse.web.bind.host";
+    public static final String FUSE_WEB_HOSTNAME = "alluxio.fuse.web.hostname";
+    public static final String FUSE_WEB_PORT = "alluxio.fuse.web.port";
 
     //
     // Security related properties

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4830,11 +4830,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey FUSE_WEB_ENABLED =
+      new Builder(Name.FUSE_WEB_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("Whether to enable FUSE web server.")
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey FUSE_WEB_BIND_HOST =
       new Builder(Name.FUSE_WEB_BIND_HOST)
           .setDefaultValue("0.0.0.0")
           .setDescription("The hostname Alluxio FUSE web UI binds to.")
-          .setScope(Scope.MASTER)
+          .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey FUSE_WEB_HOSTNAME =
       new Builder(Name.FUSE_WEB_HOSTNAME)
@@ -4845,8 +4851,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.FUSE_WEB_PORT)
           .setDefaultValue(49999)
           .setDescription("The port Alluxio FUSE web UI runs on.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.MASTER)
+          .setScope(Scope.CLIENT)
           .build();
 
   //
@@ -6231,6 +6236,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.fuse.umount.timeout";
     public static final String FUSE_USER_GROUP_TRANSLATION_ENABLED =
         "alluxio.fuse.user.group.translation.enabled";
+    public static final String FUSE_WEB_ENABLED = "alluxio.fuse.web.enabled";
     public static final String FUSE_WEB_BIND_HOST = "alluxio.fuse.web.bind.host";
     public static final String FUSE_WEB_HOSTNAME = "alluxio.fuse.web.hostname";
     public static final String FUSE_WEB_PORT = "alluxio.fuse.web.port";

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -72,6 +72,11 @@ public final class NetworkAddressUtils {
    */
   public enum ServiceType {
     /**
+     * FUSE web service (Jetty).
+     */
+    FUSE_WEB("Alluxio FUSE Web service", PropertyKey.FUSE_WEB_HOSTNAME,
+        PropertyKey.FUSE_WEB_BIND_HOST, PropertyKey.FUSE_WEB_PORT),
+    /**
      * Job master Raft service (Netty). The bind and connect hosts are the same because the
      * underlying Raft implementation doesn't differentiate between bind and connect hosts.
      */

--- a/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
@@ -222,6 +222,9 @@ public class NetworkAddressUtilsTest {
 
     // connect host and wildcard bind host with port
     switch (service) {
+      case FUSE_WEB:
+        mConfiguration.set(PropertyKey.FUSE_WEB_PORT, "20000");
+        break;
       case JOB_MASTER_RAFT:
         mConfiguration.set(PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_PORT, "20000");
         break;

--- a/integration/fuse/pom.xml
+++ b/integration/fuse/pom.xml
@@ -45,6 +45,11 @@
     <!-- Internal dependencies -->
     <dependency>
       <groupId>org.alluxio</groupId>
+      <version>${project.version}</version>
+      <artifactId>alluxio-core-server-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-fs</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -18,12 +18,14 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.jnifuse.FuseException;
 import alluxio.metrics.MetricsSystem;
 import alluxio.retry.RetryUtils;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.FileUtils;
 
+import alluxio.util.network.NetworkAddressUtils;
 import com.google.common.base.Preconditions;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -119,6 +121,12 @@ public final class AlluxioFuse {
     }
     CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.CLIENT);
     MetricsSystem.startSinks(conf.get(PropertyKey.METRICS_CONF_FILE));
+    FuseWebServer mWebServer = new FuseWebServer(
+        NetworkAddressUtils.ServiceType.FUSE_WEB.getServiceName(),
+        NetworkAddressUtils.getBindAddress(
+            NetworkAddressUtils.ServiceType.FUSE_WEB,
+            ServerConfiguration.global()));
+    mWebServer.start();
     try (FileSystem fs = FileSystem.Factory.create(fsContext)) {
       launchFuse(fs, conf, opts, true);
     } catch (IOException e) {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -122,12 +122,12 @@ public final class AlluxioFuse {
     CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.CLIENT);
     MetricsSystem.startSinks(conf.get(PropertyKey.METRICS_CONF_FILE));
     if (conf.getBoolean(PropertyKey.FUSE_WEB_ENABLED)) {
-      FuseWebServer mWebServer = new FuseWebServer(
+      FuseWebServer webServer = new FuseWebServer(
           NetworkAddressUtils.ServiceType.FUSE_WEB.getServiceName(),
           NetworkAddressUtils.getBindAddress(
               NetworkAddressUtils.ServiceType.FUSE_WEB,
               ServerConfiguration.global()));
-      mWebServer.start();
+      webServer.start();
     }
     try (FileSystem fs = FileSystem.Factory.create(fsContext)) {
       launchFuse(fs, conf, opts, true);

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -24,8 +24,8 @@ import alluxio.metrics.MetricsSystem;
 import alluxio.retry.RetryUtils;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.FileUtils;
-
 import alluxio.util.network.NetworkAddressUtils;
+
 import com.google.common.base.Preconditions;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -121,12 +121,14 @@ public final class AlluxioFuse {
     }
     CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.CLIENT);
     MetricsSystem.startSinks(conf.get(PropertyKey.METRICS_CONF_FILE));
-    FuseWebServer mWebServer = new FuseWebServer(
-        NetworkAddressUtils.ServiceType.FUSE_WEB.getServiceName(),
-        NetworkAddressUtils.getBindAddress(
-            NetworkAddressUtils.ServiceType.FUSE_WEB,
-            ServerConfiguration.global()));
-    mWebServer.start();
+    if (conf.getBoolean(PropertyKey.FUSE_WEB_ENABLED)) {
+      FuseWebServer mWebServer = new FuseWebServer(
+          NetworkAddressUtils.ServiceType.FUSE_WEB.getServiceName(),
+          NetworkAddressUtils.getBindAddress(
+              NetworkAddressUtils.ServiceType.FUSE_WEB,
+              ServerConfiguration.global()));
+      mWebServer.start();
+    }
     try (FileSystem fs = FileSystem.Factory.create(fsContext)) {
       launchFuse(fs, conf, opts, true);
     } catch (IOException e) {

--- a/integration/fuse/src/main/java/alluxio/fuse/FuseWebServer.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/FuseWebServer.java
@@ -1,0 +1,33 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.fuse;
+
+import alluxio.web.WebServer;
+
+import java.net.InetSocketAddress;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Fuse web server.
+ */
+@NotThreadSafe
+public final class FuseWebServer extends WebServer {
+  /**
+   * Creates a new instance of {@link FuseWebServer}. It pairs URLs with servlets.
+   *
+   * @param serviceName name of the web service
+   * @param address address of the server
+   */
+  public FuseWebServer(String serviceName, InetSocketAddress address) {
+    super(serviceName, address);
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support FUSE Web server, leverage this, we can get stacks, metrics restfulapi.

### Why are the changes needed?

We want to monitor FUSE server by prometheus, and get the thread stacks of FUSE in the web browser.

### Does this PR introduce any user facing changes?

Bring webserver to FUSE server.

If you want open fuse web server, set `alluxio.fuse.web.enabled=true` is necessary.
