### PR TITLE
Remove the version replacement for Dockerfile.fuse

### DIFF
--- a/dev/scripts/update-versions.sh
+++ b/dev/scripts/update-versions.sh
@@ -100,7 +100,6 @@ function update_k8s() {
 
 function update_dockerfiles() {
     perl -pi -e "s/${1}/${2}/g" integration/docker/Dockerfile
-    perl -pi -e "s/${1}/${2}/g" integration/docker/Dockerfile.fuse
 }
 
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove the version replacement for Dockerfile.fuse in the dev/scripts/update-versions.sh

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. the update-versions script is failing because Dockerfile.fuse had been deleted

### Does this PR introduce any user facing changes?

No
