### PR TITLE
Revert "Add unbuffer support for impala"

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -525,15 +525,4 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
   public long getId() {
     return mId;
   }
-
-  /**
-   * Close the buffer source for cache stream.
-   */
-  public void unbuffer() {
-    try {
-      closeDataReader();
-    } catch (IOException e) {
-      LOG.error("Failed to close DataReader", e);
-    }
-  }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -458,14 +458,4 @@ public class AlluxioFileInStream extends FileInStream {
     // TODO(lu) consider recovering failed workers
     mFailedWorkers.put(workerAddress, System.currentTimeMillis());
   }
-
-  @Override
-  public void unbuffer() {
-    if (mBlockInStream != null) {
-      mBlockInStream.unbuffer();
-    }
-    if (mCachedPositionedReadStream != null) {
-      mCachedPositionedReadStream.unbuffer();
-    }
-  }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -100,9 +100,4 @@ public abstract class FileInStream extends InputStream
     }
     return nread;
   }
-
-  /**
-   * Close the buffer source for cache stream.
-   */
-  public void unbuffer() {}
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -251,13 +251,6 @@ public class LocalCacheFileInStream extends FileInStream {
     mPosition = pos;
   }
 
-  @Override
-  public void unbuffer() {
-    if (mExternalFileInStream != null) {
-      mExternalFileInStream.unbuffer();
-    }
-  }
-
   /**
    * Convenience method to ensure the stream is not closed.
    */

--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -791,54 +791,6 @@ public final class AlluxioFileInStreamTest {
   }
 
   @Test
-  public void unbufferAroundRead() throws Exception {
-    byte[] buffer = new byte[(int) (mFileSize / 2)];
-    mTestStream.unbuffer();
-    mTestStream.read(buffer);
-    mTestStream.unbuffer();
-    assertArrayEquals(BufferUtils.getIncreasingByteArray((int) (mFileSize / 2)), buffer);
-  }
-
-  @Test
-  public void multiUnbufferAroundSeek() throws Exception {
-    int seekAmount = (int) (BLOCK_LENGTH / 2);
-    int readAmount = (int) (BLOCK_LENGTH * 2);
-    byte[] buffer = new byte[readAmount];
-    mTestStream.unbuffer();
-    mTestStream.seek(seekAmount);
-    mTestStream.unbuffer();
-    mTestStream.read(buffer);
-    assertArrayEquals(BufferUtils.getIncreasingByteArray(seekAmount, readAmount), buffer);
-
-    byte[] expected = mBlockSource != BlockInStreamSource.REMOTE ? new byte[0]
-        : BufferUtils.getIncreasingByteArray((int) BLOCK_LENGTH, (int) BLOCK_LENGTH);
-
-    mTestStream.unbuffer();
-    mTestStream.seek(seekAmount + readAmount);
-    mTestStream.unbuffer();
-    mTestStream.seek((long) (BLOCK_LENGTH * 3.1));
-    mTestStream.unbuffer();
-    assertEquals(BufferUtils.byteToInt((byte) (BLOCK_LENGTH * 3.1)), mTestStream.read());
-    mTestStream.seek(mFileSize);
-  }
-
-  @Test
-  public void multiUnbufferAroundSkip() throws Exception {
-    int skipAmount = (int) (BLOCK_LENGTH / 2);
-    int readAmount = (int) (BLOCK_LENGTH * 2);
-    byte[] buffer = new byte[readAmount];
-    mTestStream.unbuffer();
-    mTestStream.skip(skipAmount);
-    mTestStream.unbuffer();
-    mTestStream.read(buffer);
-    assertArrayEquals(BufferUtils.getIncreasingByteArray(skipAmount, readAmount), buffer);
-
-    assertEquals(0, mTestStream.skip(0));
-    assertEquals(BLOCK_LENGTH / 2, mTestStream.skip(BLOCK_LENGTH / 2));
-    assertEquals(BufferUtils.byteToInt((byte) (BLOCK_LENGTH * 3)), mTestStream.read());
-  }
-
-  @Test
   public void getPos() throws Exception {
     assertEquals(0, mTestStream.getPos());
     mTestStream.read();

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -469,38 +469,6 @@ public class LocalCacheFileInStreamTest {
   }
 
   @Test
-  public void testUnbuffer() throws Exception {
-    int fileSize = PAGE_SIZE;
-    byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
-    ByteArrayCacheManager manager = new ByteArrayCacheManager();
-    LocalCacheFileInStream stream = setupWithSingleFile(testData, manager);
-
-    int partialReadSize = fileSize / 5;
-    int offset = fileSize / 5;
-
-    byte[] cacheMiss = new byte[partialReadSize];
-    stream.unbuffer();
-    stream.seek(offset);
-    stream.unbuffer();
-    Assert.assertEquals(partialReadSize, stream.read(cacheMiss));
-    stream.unbuffer();
-    Assert.assertArrayEquals(
-        Arrays.copyOfRange(testData, offset, offset + partialReadSize), cacheMiss);
-    Assert.assertEquals(0, manager.mPagesServed);
-    Assert.assertEquals(1, manager.mPagesCached);
-
-    byte[] cacheHit = new byte[partialReadSize];
-    stream.unbuffer();
-    stream.seek(offset);
-    stream.unbuffer();
-    Assert.assertEquals(partialReadSize, stream.read(cacheHit));
-    stream.unbuffer();
-    Assert.assertArrayEquals(
-        Arrays.copyOfRange(testData, offset, offset + partialReadSize), cacheHit);
-    Assert.assertEquals(1, manager.mPagesServed);
-  }
-
-  @Test
   public void cacheMetricCacheHitReadTime() throws Exception {
     byte[] testData = BufferUtils.getIncreasingByteArray(PAGE_SIZE);
     AlluxioURI testFileName = new AlluxioURI("/test");

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
@@ -19,12 +19,9 @@ import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileDoesNotExistException;
 
 import org.apache.hadoop.fs.ByteBufferReadable;
-import org.apache.hadoop.fs.CanUnbuffer;
 import org.apache.hadoop.fs.FileSystem.Statistics;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
-import org.apache.hadoop.fs.StreamCapabilities;
-import org.apache.hadoop.util.StringUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +39,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class HdfsFileInputStream extends InputStream implements Seekable, PositionedReadable,
-    ByteBufferReadable, StreamCapabilities, CanUnbuffer {
+    ByteBufferReadable {
   private static final Logger LOG = LoggerFactory.getLogger(HdfsFileInputStream.class);
 
   private final Statistics mStatistics;
@@ -206,20 +203,5 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
       throw new IOException("Cannot skip bytes in a closed stream.");
     }
     return mInputStream.skip(n);
-  }
-
-  @Override
-  public boolean hasCapability(String capability) {
-    switch (StringUtils.toLowerCase(capability)) {
-      case StreamCapabilities.UNBUFFER:
-        return true;
-      default:
-        return false;
-    }
-  }
-
-  @Override
-  public void unbuffer() {
-    mInputStream.unbuffer();
   }
 }


### PR DESCRIPTION
Reverts Alluxio/alluxio#13733

[StreamCapabilities](https://hadoop.apache.org/docs/r3.0.0/api/org/apache/hadoop/fs/class-use/StreamCapabilities.html) is introduced in hadoop3, which breaks classloading when running Hadoop2 with Alluxio client on classpath

```
err: exit status 1 Failed to finish cmd "/tmp/hadoop/bin/hdfs dfsadmin -safemode wait"
stderr: <OpenJDK 64-Bit Server VM warning: You have loaded library /tmp/hadoop which might have disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
21/08/06 08:53:42 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Exception in thread "main" java.util.ServiceConfigurationError: org.apache.hadoop.fs.FileSystem: Provider alluxio.hadoop.FileSystem could not be instantiated
	at java.util.ServiceLoader.fail(ServiceLoader.java:232)
	at java.util.ServiceLoader.access$100(ServiceLoader.java:185)
	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:384)
	at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404)
	at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
	at org.apache.hadoop.fs.FileSystem.loadFileSystems(FileSystem.java:2623)
	at org.apache.hadoop.fs.FileSystem.getFileSystemClass(FileSystem.java:2634)
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2651)
	at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:92)
	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2687)
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2669)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:371)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:170)
	at org.apache.hadoop.fs.FsShell.getFS(FsShell.java:74)
	at org.apache.hadoop.hdfs.tools.DFSAdmin.getDFS(DFSAdmin.java:440)
	at org.apache.hadoop.hdfs.tools.DFSAdmin.setSafeMode(DFSAdmin.java:575)
	at org.apache.hadoop.hdfs.tools.DFSAdmin.run(DFSAdmin.java:1785)
	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:70)
	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:84)
	at org.apache.hadoop.hdfs.tools.DFSAdmin.main(DFSAdmin.java:1959)
Caused by: java.lang.NoClassDefFoundError: org/apache/hadoop/fs/StreamCapabilities
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.lang.Class.privateGetDeclaredConstructors(Class.java:2671)
	at java.lang.Class.getConstructor0(Class.java:3075)
	at java.lang.Class.newInstance(Class.java:412)
	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:380)
	... 17 more
Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.fs.StreamCapabilities
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	... 34 more

```

