### PR TITLE
Start standby master web server

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2687,6 +2687,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey SECONDARY_MASTER_WEB_ENABLED =
+      new Builder(Name.SECONDARY_MASTER_WEB_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("Whether to enable second master web server.")
+          .setScope(Scope.SERVER)
+          .build();
 
   //
   // File system master related properties
@@ -5802,6 +5808,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     //
     public static final String SECONDARY_MASTER_METASTORE_DIR =
         "alluxio.secondary.master.metastore.dir";
+    public static final String SECONDARY_MASTER_WEB_ENABLED =
+        "alluxio.secondary.master.web.enabled";
 
     //
     // Worker related properties

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -150,6 +150,7 @@ public class AlluxioMasterProcess extends MasterProcess {
   public void start() throws Exception {
     mJournalSystem.start();
     mJournalSystem.gainPrimacy();
+    startServingWebServer();
     startMasters(true);
     startServing();
   }
@@ -157,6 +158,10 @@ public class AlluxioMasterProcess extends MasterProcess {
   @Override
   public void stop() throws Exception {
     stopRejectingServers();
+    if (mWebServer != null) {
+      mWebServer.stop();
+      mWebServer = null;
+    }
     if (isServing()) {
       stopServing();
     }
@@ -274,7 +279,6 @@ public class AlluxioMasterProcess extends MasterProcess {
     startServingRPCServer();
     LOG.info("Alluxio master web server version {} starting{}. webAddress={}",
         RuntimeConstants.VERSION, startMessage, mWebBindAddress);
-    startServingWebServer();
     startJvmMonitorProcess();
     LOG.info(
         "Alluxio master version {} started{}. bindAddress={}, connectAddress={}, webAddress={}",
@@ -352,10 +356,6 @@ public class AlluxioMasterProcess extends MasterProcess {
     }
     if (mJvmPauseMonitor != null) {
       mJvmPauseMonitor.stop();
-    }
-    if (mWebServer != null) {
-      mWebServer.stop();
-      mWebServer = null;
     }
     MetricsSystem.stopSinks();
   }

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -60,6 +60,11 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       PrimarySelector leaderSelector) {
     super(journalSystem);
     try {
+      if (ServerConfiguration.getBoolean(PropertyKey.SECONDARY_MASTER_WEB_ENABLED)
+          && mWebServer != null) {
+        mWebServer.stop();
+        mWebServer = null;
+      }
       stopServing();
     } catch (Exception e) {
       throw new RuntimeException(e);
@@ -89,7 +94,9 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       LOG.error(e.getMessage(), e);
       throw new RuntimeException(e);
     }
-    startServingWebServer();
+    if (ServerConfiguration.getBoolean(PropertyKey.SECONDARY_MASTER_WEB_ENABLED)) {
+      startServingWebServer();
+    }
 
     while (!Thread.interrupted()) {
       if (!mRunning) {

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -89,6 +89,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       LOG.error(e.getMessage(), e);
       throw new RuntimeException(e);
     }
+    startServingWebServer();
 
     while (!Thread.interrupted()) {
       if (!mRunning) {


### PR DESCRIPTION
### What changes are proposed in this pull request?
Start web server for standby master, FIx #13840 
1. In FaultTolerantAlluxioMasterProcess.start(), move the startWebServing() function before waiting raft leader selection loop. 
2. In AlluxioMasterProcess.start(), add startWebServing() to keep none Ha case work.
3. Remove startWebServing() from  AlluxioMasterProcess.startServing().
4. Remove stop web server logic from AlluxioMasterProcess.stopServing.
5. Add stop web server logic to AlluxioMasterProcess.stop().
### Why are the changes needed?
It help us get some useful  metric info from standby master.
Please clarify why the changes are needed. For instance,
No
### Does this PR introduce any user facing changes?
No
Please list the user-facing changes introduced by your change, including
No
