### PR TITLE
Fix the job server service hangs on when set a no privileged path

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -35,7 +35,6 @@ import alluxio.proto.journal.Journal.JournalEntry;
 import alluxio.util.CommonUtils;
 import alluxio.util.LogUtils;
 import alluxio.util.WaitForOptions;
-import alluxio.util.io.FileUtils;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -71,10 +70,12 @@ import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.file.AccessDeniedException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1026,12 +1027,18 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   public void format() throws IOException {
     File journalPath = mConf.getPath();
     if (journalPath.isDirectory()) {
-      org.apache.commons.io.FileUtils.cleanDirectory(mConf.getPath());
+      if (alluxio.util.io.FileUtils.isStorageDirAccessible(journalPath.getPath())) {
+        FileUtils.cleanDirectory(journalPath);
+      } else {
+        throw new AccessDeniedException(journalPath.getPath());
+      }
     } else {
       if (journalPath.exists()) {
-        FileUtils.delete(journalPath.getAbsolutePath());
+        FileUtils.forceDelete(journalPath);
       }
-      journalPath.mkdirs();
+      if (!journalPath.mkdirs()) {
+        throw new AccessDeniedException(journalPath.getPath());
+      }
     }
   }
 
@@ -1043,7 +1050,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   }
 
   /**
-   * @return whether it is allowed to take a local shapshot
+   * @return whether it is allowed to take a local snapshot
    */
   public boolean isSnapshotAllowed() {
     return mSnapshotAllowed.get();

--- a/job/server/src/main/java/alluxio/master/AlluxioJobMasterProcess.java
+++ b/job/server/src/main/java/alluxio/master/AlluxioJobMasterProcess.java
@@ -84,6 +84,9 @@ public class AlluxioJobMasterProcess extends MasterProcess {
     mFileSystem = FileSystem.Factory.create(mFsContext);
     mUfsManager = new JobUfsManager();
     try {
+      if (!mJournalSystem.isFormatted()) {
+        mJournalSystem.format();
+      }
       // Create master.
       mJobMaster = new JobMaster(
           new MasterContext(mJournalSystem, null, mUfsManager), mFileSystem, mFsContext,


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix the job server service hangs on when  set alluxio.master.journal.folder a no privileged path.

### Why are the changes needed?
Fix the job server service hangs on when  set alluxio.master.journal.folder a no privileged path.
Because of ratis's bug. See this pr `https://github.com/apache/ratis/pull/477`.

### Does this PR introduce any user facing changes?
No