### PR TITLE
Fix ArrayIndexOutOfBoundsException when using shared.caching.reader

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/SharedGrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/SharedGrpcDataReader.java
@@ -25,14 +25,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.lang.Math;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
-
-import java.lang.Math;
 
 /**
  * A shared gRPC data reader that cache blocks data for multi-thread accessing.
@@ -67,7 +66,7 @@ public class SharedGrpcDataReader implements DataReader {
   }
 
   private static ReentrantReadWriteLock getLock(long blockId) {
-    return BLOCK_LOCKS[math.floorMod(HASH_FUNC.hashLong(blockId).asInt(), BLOCK_LOCKS.length)];
+    return BLOCK_LOCKS[Math.floorMod(HASH_FUNC.hashLong(blockId).asInt(), BLOCK_LOCKS.length)];
   }
 
   private final long mBlockId;

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/SharedGrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/SharedGrpcDataReader.java
@@ -65,7 +65,7 @@ public class SharedGrpcDataReader implements DataReader {
   }
 
   private static ReentrantReadWriteLock getLock(long blockId) {
-    return BLOCK_LOCKS[HASH_FUNC.hashLong(blockId).asInt() % BLOCK_LOCKS.length];
+    return BLOCK_LOCKS[math.floorMod(HASH_FUNC.hashLong(blockId).asInt(), BLOCK_LOCKS.length)];
   }
 
   private final long mBlockId;

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/SharedGrpcDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/SharedGrpcDataReader.java
@@ -32,6 +32,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import java.lang.Math;
+
 /**
  * A shared gRPC data reader that cache blocks data for multi-thread accessing.
  *


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix issue https://github.com/Alluxio/alluxio/issues/13125

With shared.caching.reader is enabled, alluxio may generate `java.lang.ArrayIndexOutOfBoundsException` when accessing `BLOCK_LOCKS`.

### Why are the changes needed?

This problem is caused by `core/client/fs/src/main/java/alluxio/client/block/stream/SharedGrpcDataReader.java`

```java
  private static ReentrantReadWriteLock getLock(long blockId) {
    return BLOCK_LOCKS[HASH_FUNC.hashLong(blockId).asInt() % BLOCK_LOCKS.length];
  }
```

`HASH_FUNC` is murmur3_32, it may generate negative number (depend on input blockId, see https://github.com/google/guava/blob/master/guava-tests/test/com/google/common/hash/Murmur3Hash32Test.java#L36 ). Thus it will finally get a negative index while accessing `BLOCK_LOCKS`. We need  a `abs` before mod or just `floorMod` instead of `%`. 

### Does this PR introduce any user facing changes?

No.
