### PR TITLE
Add metric of jvm pause monitor

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1483,13 +1483,15 @@ public final class MetricKey implements Comparable<MetricKey> {
            .build();
   public static final MetricKey INFO_TIME_EXCEEDED =
        new Builder("JvmPauseMonitor.infoTimeExceeded")
-           .setDescription("The times sleep time exceed mInfoThreshold , need to record a info level log.")
+           .setDescription("The times sleep time exceed threshold of info level,"
+                   + " need to record a info level log.")
            .setMetricType(MetricType.GAUGE)
            .setIsClusterAggregated(false)
            .build();
   public static final MetricKey WARN_TIME_EXCEEDED =
        new Builder("JvmPauseMonitor.warnTimeExceeded")
-           .setDescription("the times sleep time exceed mWarnThreshold , need to record a warn level log.")
+           .setDescription("the times sleep time exceed threshold of warn level,"
+                   + " need to record a warn level log.")
            .setMetricType(MetricType.GAUGE)
            .setIsClusterAggregated(false)
            .build();

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1477,19 +1477,19 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey TOTAL_EXTRA_TIME =
        new Builder("JvmPauseMonitor.totalExtraTime")
-           .setDescription("Total extra sleep time.")
+           .setDescription("The total time of jvm thread sleep.")
            .setMetricType(MetricType.GAUGE)
            .setIsClusterAggregated(false)
            .build();
   public static final MetricKey INFO_TIME_EXCEEDED =
        new Builder("JvmPauseMonitor.infoTimeExceeded")
-           .setDescription("Times extra sleep time exceed INFO.")
+           .setDescription("The times sleep time exceed mInfoThreshold , need to record a info level log.")
            .setMetricType(MetricType.GAUGE)
            .setIsClusterAggregated(false)
            .build();
   public static final MetricKey WARN_TIME_EXCEEDED =
        new Builder("JvmPauseMonitor.warnTimeExceeded")
-           .setDescription("Times extra sleep time exceed WARN.")
+           .setDescription("the times sleep time exceed mWarnThreshold , need to record a warn level log.")
            .setMetricType(MetricType.GAUGE)
            .setIsClusterAggregated(false)
            .build();

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1477,21 +1477,23 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey TOTAL_EXTRA_TIME =
        new Builder("JvmPauseMonitor.totalExtraTime")
-           .setDescription("The total time of jvm thread sleep.")
+           .setDescription("The total time that JVM slept and didn't do GC")
            .setMetricType(MetricType.GAUGE)
            .setIsClusterAggregated(false)
            .build();
   public static final MetricKey INFO_TIME_EXCEEDED =
        new Builder("JvmPauseMonitor.infoTimeExceeded")
-           .setDescription("The times sleep time exceed threshold of info level,"
-                   + " need to record a info level log.")
+           .setDescription(String.format("The total number of times that JVM slept and the sleep"
+               + " period is larger than the info level threshold defined by %s",
+               PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS.getName()))
            .setMetricType(MetricType.GAUGE)
            .setIsClusterAggregated(false)
            .build();
   public static final MetricKey WARN_TIME_EXCEEDED =
        new Builder("JvmPauseMonitor.warnTimeExceeded")
-           .setDescription("the times sleep time exceed threshold of warn level,"
-                   + " need to record a warn level log.")
+            .setDescription(String.format("The total number of times that JVM slept and the sleep"
+                + " period is larger than the warn level threshold defined by %s",
+                PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS.getName()))
            .setMetricType(MetricType.GAUGE)
            .setIsClusterAggregated(false)
            .build();

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1475,6 +1475,24 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.GAUGE)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey TOTAL_EXTRA_TIME =
+       new Builder("JvmPauseMonitor.totalExtraTime")
+           .setDescription("Total extra sleep time.")
+           .setMetricType(MetricType.GAUGE)
+           .setIsClusterAggregated(false)
+           .build();
+  public static final MetricKey INFO_TIME_EXCEEDED =
+       new Builder("JvmPauseMonitor.infoTimeExceeded")
+           .setDescription("Times extra sleep time exceed INFO.")
+           .setMetricType(MetricType.GAUGE)
+           .setIsClusterAggregated(false)
+           .build();
+  public static final MetricKey WARN_TIME_EXCEEDED =
+       new Builder("JvmPauseMonitor.warnTimeExceeded")
+           .setDescription("Times extra sleep time exceed WARN.")
+           .setMetricType(MetricType.GAUGE)
+           .setIsClusterAggregated(false)
+           .build();
 
   /**
    * Registers the given key to the global key map.

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -259,6 +259,15 @@ public class AlluxioMasterProcess extends MasterProcess {
           ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS),
           ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS));
       mJvmPauseMonitor.start();
+      MetricsSystem.registerGaugeIfAbsent(
+              MetricsSystem.getMetricName(MetricKey.TOTAL_EXTRA_TIME.getName()),
+              mJvmPauseMonitor::getTotalExtraTime);
+      MetricsSystem.registerGaugeIfAbsent(
+              MetricsSystem.getMetricName(MetricKey.INFO_TIME_EXCEEDED.getName()),
+              mJvmPauseMonitor::getInfoTimeExceeded);
+      MetricsSystem.registerGaugeIfAbsent(
+              MetricsSystem.getMetricName(MetricKey.WARN_TIME_EXCEEDED.getName()),
+              mJvmPauseMonitor::getWarnTimeExceeded);
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -14,6 +14,7 @@ package alluxio.worker;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
+import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.network.ChannelType;
 import alluxio.underfs.UfsManager;
@@ -238,6 +239,15 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
               ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS),
               ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS));
       mJvmPauseMonitor.start();
+      MetricsSystem.registerGaugeIfAbsent(
+              MetricsSystem.getMetricName(MetricKey.TOTAL_EXTRA_TIME.getName()),
+              mJvmPauseMonitor::getTotalExtraTime);
+      MetricsSystem.registerGaugeIfAbsent(
+              MetricsSystem.getMetricName(MetricKey.INFO_TIME_EXCEEDED.getName()),
+              mJvmPauseMonitor::getInfoTimeExceeded);
+      MetricsSystem.registerGaugeIfAbsent(
+              MetricsSystem.getMetricName(MetricKey.WARN_TIME_EXCEEDED.getName()),
+              mJvmPauseMonitor::getWarnTimeExceeded);
     }
 
     // Start serving RPC, this will block


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add metric of jvm pause monitor.

### Why are the changes needed?

We want to use the data in jvmPauseMonitor to monitor the pause situation when the alluxio cluster provides services


