### PR TITLE
Print web metrics servlet page as human-readable format

### DIFF
--- a/core/server/common/src/main/java/alluxio/metrics/sink/MetricsServlet.java
+++ b/core/server/common/src/main/java/alluxio/metrics/sink/MetricsServlet.java
@@ -59,7 +59,8 @@ public class MetricsServlet implements Sink {
         response.setContentType("application/json");
         response.setStatus(HttpServletResponse.SC_OK);
         response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-        String result = mObjectMapper.writeValueAsString(mMetricsRegistry);
+        String result = mObjectMapper.writerWithDefaultPrettyPrinter()
+            .writeValueAsString(mMetricsRegistry);
         response.getWriter().println(result);
       }
     };


### PR DESCRIPTION
### What changes are proposed in this pull request?

Pretty print the metrics/json web servlet

### Why are the changes needed?

Easier for users to view all the metrics exposed by master/worker/fuse

### Does this PR introduce any user facing changes?

Yeah, for web UI  metrics/json/ page, it will show json string as well formatted human readable string instead of the natural json string
