### PR TITLE
Stop iterating lost files when journal is not available

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
+++ b/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
@@ -65,7 +65,8 @@ final class LostFileDetector implements HeartbeatExecutor {
       } catch (FileDoesNotExistException e) {
         LOG.debug("Exception trying to get inode from inode tree", e);
       } catch (UnavailableException e) {
-        LOG.warn("Failed to run lost file detector: {}", e.toString());
+        LOG.warn("Journal is not available. Backing off. Error: {}", e.toString());
+        break;
       }
     }
   }


### PR DESCRIPTION
LostFileDetector accesses journal directly, and should back off from enumeration if the journal becomes unavailable (i.e. closed).
Fixes https://github.com/Alluxio/alluxio/issues/13904
