### PR TITLE
Stop only grpc server when a master lose primary

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/MasterProcess.java
+++ b/core/server/common/src/main/java/alluxio/master/MasterProcess.java
@@ -193,32 +193,44 @@ public abstract class MasterProcess implements Process {
     }
   }
 
+  /**
+   * Return primary selector.
+   * @return primary selector
+   */
   public PrimarySelector getPrimarySelector() {
-    return new PrimarySelector() {
-      @Override
-      public void start(InetSocketAddress localAddress) throws IOException {
+    return SingleMasterPrimarySelector.INSTANCE;
+  }
 
-      }
+  /**
+   * A primary selector when only have one master node.
+   */
+  public static class SingleMasterPrimarySelector implements PrimarySelector{
 
-      @Override
-      public void stop() throws IOException {
+    public static final SingleMasterPrimarySelector INSTANCE = new SingleMasterPrimarySelector();
 
-      }
+    private SingleMasterPrimarySelector() {
+    }
 
-      @Override
-      public State getState() {
-        return State.PRIMARY;
-      }
+    @Override
+    public void start(InetSocketAddress localAddress) throws IOException {
+    }
 
-      @Override
-      public Scoped onStateChange(Consumer<State> listener) {
-        return null;
-      }
+    @Override
+    public void stop() throws IOException {
+    }
 
-      @Override
-      public void waitForState(State state) throws InterruptedException {
+    @Override
+    public State getState() {
+      return State.PRIMARY;
+    }
 
-      }
-    };
+    @Override
+    public Scoped onStateChange(Consumer<State> listener) {
+      return null;
+    }
+
+    @Override
+    public void waitForState(State state) throws InterruptedException {
+    }
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/MasterProcess.java
+++ b/core/server/common/src/main/java/alluxio/master/MasterProcess.java
@@ -25,6 +25,7 @@ import alluxio.network.RejectingServer;
 import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.WaitForOptions;
+import alluxio.util.interfaces.Scoped;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.web.WebServer;
 
@@ -37,6 +38,7 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 
 /**
  * Defines a set of methods which any {@link MasterProcess} should implement.
@@ -64,7 +66,6 @@ public abstract class MasterProcess implements Process {
    * Rejecting servers for used by backup masters to reserve ports but reject connection requests.
    */
   private RejectingServer mRejectingRpcServer;
-  private RejectingServer mRejectingWebServer;
 
   /** The RPC server. */
   protected GrpcServer mGrpcServer;
@@ -183,28 +184,41 @@ public abstract class MasterProcess implements Process {
       mRejectingRpcServer = new RejectingServer(mRpcBindAddress);
       mRejectingRpcServer.start();
     }
-    if (mRejectingWebServer == null) {
-      mRejectingWebServer = new RejectingServer(mWebBindAddress);
-      mRejectingWebServer.start();
-    }
   }
 
-  protected void stopRejectingRpcServer() {
+  protected void stopRejectingServers() {
     if (mRejectingRpcServer != null) {
       mRejectingRpcServer.stopAndJoin();
       mRejectingRpcServer = null;
     }
   }
 
-  protected void stopRejectingWebServer() {
-    if (mRejectingWebServer != null) {
-      mRejectingWebServer.stopAndJoin();
-      mRejectingWebServer = null;
-    }
-  }
+  public PrimarySelector getPrimarySelector() {
+    return new PrimarySelector() {
+      @Override
+      public void start(InetSocketAddress localAddress) throws IOException {
 
-  protected void stopRejectingServers() {
-    stopRejectingRpcServer();
-    stopRejectingWebServer();
+      }
+
+      @Override
+      public void stop() throws IOException {
+
+      }
+
+      @Override
+      public State getState() {
+        return State.PRIMARY;
+      }
+
+      @Override
+      public Scoped onStateChange(Consumer<State> listener) {
+        return null;
+      }
+
+      @Override
+      public void waitForState(State state) throws InterruptedException {
+
+      }
+    };
   }
 }

--- a/core/server/common/src/main/java/alluxio/web/RedirectFilter.java
+++ b/core/server/common/src/main/java/alluxio/web/RedirectFilter.java
@@ -56,7 +56,7 @@ public class RedirectFilter implements Filter {
   /**
    * Initializes the redirect filter.
    *
-   * @param primarySelector primary selector.
+   * @param primarySelector primary selector
    */
   public RedirectFilter(PrimarySelector primarySelector) {
     this(primarySelector, null);
@@ -65,8 +65,8 @@ public class RedirectFilter implements Filter {
   /**
    * Initializes the redirect filter.
    *
-   * @param primarySelector primary selector.
-   * @param getWebPortSupplier the supplier to get primary master web port.
+   * @param primarySelector primary selector
+   * @param getWebPortSupplier the supplier to get primary master web port
    */
   public RedirectFilter(PrimarySelector primarySelector, Supplier<Integer> getWebPortSupplier) {
     mPrimarySelector = primarySelector;
@@ -75,7 +75,6 @@ public class RedirectFilter implements Filter {
 
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {
-
   }
 
   @Override
@@ -104,14 +103,15 @@ public class RedirectFilter implements Filter {
       if (mGetWebPortSupplier != null) {
         int webPort = mGetWebPortSupplier.get();
         // Forward the request.
-        String leaderWebAddress = "http://" + primaryAddress.getHostString() + ":" + webPort +httpRequest.getRequestURI();
+        String leaderWebAddress = "http://" + primaryAddress.getHostString() + ":"
+            + webPort + httpRequest.getRequestURI();
         LOG.debug("redirect request to {}", leaderWebAddress);
         httpResponse.sendRedirect(leaderWebAddress);
         return;
       }
       httpResponse.sendError(500,
-              "The current node is not the primary node, and the primary node is located in " +
-                      primaryAddress);
+          "The current node is not the primary node, and the primary node is located in "
+          + primaryAddress);
     } catch (UnavailableException e) {
       httpResponse.sendError(500, "The primary is unavailable.");
     }
@@ -119,7 +119,6 @@ public class RedirectFilter implements Filter {
 
   @Override
   public void destroy() {
-
   }
 
   private boolean isPrimary() {
@@ -127,8 +126,8 @@ public class RedirectFilter implements Filter {
   }
 
   private InetSocketAddress getPrimaryAddress() throws UnavailableException {
-    MasterInquireClient client =
-            MasterInquireClient.Factory.create(ServerConfiguration.global(), ServerUserState.global());
+    MasterInquireClient client = MasterInquireClient.Factory.create(
+        ServerConfiguration.global(), ServerUserState.global());
 
     return client.getPrimaryRpcAddress();
   }

--- a/core/server/common/src/main/java/alluxio/web/RedirectFilter.java
+++ b/core/server/common/src/main/java/alluxio/web/RedirectFilter.java
@@ -1,0 +1,135 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.web;
+
+import alluxio.conf.ServerConfiguration;
+import alluxio.exception.status.UnavailableException;
+import alluxio.master.MasterInquireClient;
+import alluxio.master.PrimarySelector;
+import alluxio.security.user.ServerUserState;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * The {@link RedirectFilter} enables redirecting request to primary master node when current node
+ * is not primary.
+ */
+public class RedirectFilter implements Filter {
+  private static final Logger LOG = LoggerFactory.getLogger(RedirectFilter.class);
+
+  private static final Pattern[] NO_REDIRECTION_PATH_PATTERNS = new Pattern[]{
+      Pattern.compile("/metrics/json"),
+      Pattern.compile("/metrics/prometheus")
+  };
+
+  /** primary selector. */
+  private final PrimarySelector mPrimarySelector;
+
+  /** primary selector. */
+  private final Supplier<Integer> mGetWebPortSupplier;
+
+  /**
+   * Initializes the redirect filter.
+   *
+   * @param primarySelector primary selector.
+   */
+  public RedirectFilter(PrimarySelector primarySelector) {
+    this(primarySelector, null);
+  }
+
+  /**
+   * Initializes the redirect filter.
+   *
+   * @param primarySelector primary selector.
+   * @param getWebPortSupplier the supplier to get primary master web port.
+   */
+  public RedirectFilter(PrimarySelector primarySelector, Supplier<Integer> getWebPortSupplier) {
+    mPrimarySelector = primarySelector;
+    mGetWebPortSupplier = getWebPortSupplier;
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+          throws IOException, ServletException {
+    HttpServletResponse httpResponse = (HttpServletResponse) response;
+    if (isPrimary()) {
+      // The master is the primary, continue
+      chain.doFilter(request, response);
+      return;
+    }
+    HttpServletRequest httpRequest = (HttpServletRequest) request;
+    String path = httpRequest.getRequestURI();
+    // Do not redirect for some path
+    for (Pattern pattern : NO_REDIRECTION_PATH_PATTERNS) {
+      Matcher matcher = pattern.matcher(path);
+      if (matcher.find()) {
+        chain.doFilter(request, response);
+        return;
+      }
+    }
+
+    try {
+      // Generate the primary address
+      InetSocketAddress primaryAddress = getPrimaryAddress();
+      if (mGetWebPortSupplier != null) {
+        int webPort = mGetWebPortSupplier.get();
+        // Forward the request.
+        String leaderWebAddress = "http://" + primaryAddress.getHostString() + ":" + webPort +httpRequest.getRequestURI();
+        LOG.debug("redirect request to {}", leaderWebAddress);
+        httpResponse.sendRedirect(leaderWebAddress);
+        return;
+      }
+      httpResponse.sendError(500,
+              "The current node is not the primary node, and the primary node is located in " +
+                      primaryAddress);
+    } catch (UnavailableException e) {
+      httpResponse.sendError(500, "The primary is unavailable.");
+    }
+  }
+
+  @Override
+  public void destroy() {
+
+  }
+
+  private boolean isPrimary() {
+    return mPrimarySelector.getState() == PrimarySelector.State.PRIMARY;
+  }
+
+  private InetSocketAddress getPrimaryAddress() throws UnavailableException {
+    MasterInquireClient client =
+            MasterInquireClient.Factory.create(ServerConfiguration.global(), ServerUserState.global());
+
+    return client.getPrimaryRpcAddress();
+  }
+}

--- a/core/server/common/src/main/java/alluxio/web/RedirectFilter.java
+++ b/core/server/common/src/main/java/alluxio/web/RedirectFilter.java
@@ -80,12 +80,18 @@ public class RedirectFilter implements Filter {
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
           throws IOException, ServletException {
-    HttpServletResponse httpResponse = (HttpServletResponse) response;
+    if (!(response instanceof HttpServletResponse
+            && request instanceof HttpServletRequest)) {
+      // Not http servlet, continue
+      chain.doFilter(request, response);
+      return;
+    }
     if (isPrimary()) {
       // The master is the primary, continue
       chain.doFilter(request, response);
       return;
     }
+    HttpServletResponse httpResponse = (HttpServletResponse) response;
     HttpServletRequest httpRequest = (HttpServletRequest) request;
     String path = httpRequest.getRequestURI();
     // Do not redirect for some path

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -157,6 +157,9 @@ public class AlluxioMasterProcess extends MasterProcess {
     mJournalSystem.start();
     mJournalSystem.gainPrimacy();
     startMasters(true);
+    MetricsSystem.startSinks(ServerConfiguration.get(PropertyKey.METRICS_CONF_FILE));
+    startJvmMonitorProcess();
+    startServingWebServer();
     startServing();
   }
 
@@ -166,6 +169,11 @@ public class AlluxioMasterProcess extends MasterProcess {
     if (isServing()) {
       stopServing();
     }
+    stopWebServer();
+    if (mJvmPauseMonitor != null) {
+      mJvmPauseMonitor.stop();
+    }
+    MetricsSystem.stopSinks();
     closeMasters();
     mJournalSystem.stop();
   }
@@ -247,7 +255,8 @@ public class AlluxioMasterProcess extends MasterProcess {
    * server and starting web ui.
    */
   protected void startServingWebServer() {
-    stopRejectingWebServer();
+    LOG.info("Alluxio master web server version {} starting. webAddress={}",
+        RuntimeConstants.VERSION, mWebBindAddress);
     mWebServer =
         new MasterWebServer(ServiceType.MASTER_WEB.getServiceName(), mWebBindAddress, this);
     // reset master web port
@@ -257,6 +266,17 @@ public class AlluxioMasterProcess extends MasterProcess {
     mWebServer.addHandler(mPMetricsServlet.getHandler());
     // start web ui
     mWebServer.start();
+  }
+
+  /**
+   * Stop web server.
+   * @throws Exception if failed when close web server
+   */
+  protected void stopWebServer() throws Exception {
+    if (mWebServer != null) {
+      mWebServer.stop();
+      mWebServer = null;
+    }
   }
 
   /**
@@ -280,12 +300,8 @@ public class AlluxioMasterProcess extends MasterProcess {
    * @param stopMessage empty string or the message that the master loses the leadership
    */
   protected void startServing(String startMessage, String stopMessage) {
-    MetricsSystem.startSinks(ServerConfiguration.get(PropertyKey.METRICS_CONF_FILE));
+    stopRejectingServers();
     startServingRPCServer();
-    LOG.info("Alluxio master web server version {} starting{}. webAddress={}",
-        RuntimeConstants.VERSION, startMessage, mWebBindAddress);
-    startServingWebServer();
-    startJvmMonitorProcess();
     LOG.info(
         "Alluxio master version {} started{}. bindAddress={}, connectAddress={}, webAddress={}",
         RuntimeConstants.VERSION, startMessage, mRpcBindAddress, mRpcConnectAddress,
@@ -301,7 +317,6 @@ public class AlluxioMasterProcess extends MasterProcess {
    */
   protected void startServingRPCServer() {
     try {
-      stopRejectingRpcServer();
       LOG.info("Starting Alluxio master gRPC server on address {}", mRpcBindAddress);
       GrpcServerBuilder serverBuilder = GrpcServerBuilder.forAddress(
           GrpcServerAddress.create(mRpcConnectAddress.getHostName(), mRpcBindAddress),
@@ -360,14 +375,6 @@ public class AlluxioMasterProcess extends MasterProcess {
         Thread.currentThread().interrupt();
       }
     }
-    if (mJvmPauseMonitor != null) {
-      mJvmPauseMonitor.stop();
-    }
-    if (mWebServer != null) {
-      mWebServer.stop();
-      mWebServer = null;
-    }
-    MetricsSystem.stopSinks();
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -83,6 +83,9 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       mJournalSystem.waitForCatchup();
     }
 
+    MetricsSystem.startSinks(ServerConfiguration.get(PropertyKey.METRICS_CONF_FILE));
+    startJvmMonitorProcess();
+    startServingWebServer();
     try {
       mLeaderSelector.start(getRpcAddress());
     } catch (IOException e) {
@@ -215,5 +218,10 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
     } catch (TimeoutException e) {
       return false;
     }
+  }
+
+  @Override
+  public PrimarySelector getPrimarySelector() {
+    return mLeaderSelector;
   }
 }

--- a/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
+++ b/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
@@ -87,7 +87,7 @@ public final class MasterWebServer extends WebServer {
     RedirectFilter redirectFilter = new RedirectFilter(masterProcess.getPrimarySelector(),
         ()-> mFileSystem.getConf().getInt(PropertyKey.MASTER_WEB_PORT));
     FilterHolder filterHolder = new FilterHolder(redirectFilter);
-    mServletContextHandler.addFilter(filterHolder,"/*",
+    mServletContextHandler.addFilter(filterHolder, "/*",
         EnumSet.of(DispatcherType.REQUEST, DispatcherType.FORWARD, DispatcherType.INCLUDE));
 
     // STATIC assets

--- a/job/server/src/main/java/alluxio/master/FaultTolerantAlluxioJobMasterProcess.java
+++ b/job/server/src/main/java/alluxio/master/FaultTolerantAlluxioJobMasterProcess.java
@@ -61,6 +61,7 @@ final class FaultTolerantAlluxioJobMasterProcess extends AlluxioJobMasterProcess
       throw new RuntimeException(e);
     }
 
+    startServingWebServer();
     while (!Thread.interrupted()) {
       if (mServingThread == null) {
         // We are in secondary mode. Nothing to do until we become the primary.
@@ -110,5 +111,10 @@ final class FaultTolerantAlluxioJobMasterProcess extends AlluxioJobMasterProcess
     } catch (TimeoutException e) {
       return false;
     }
+  }
+
+  @Override
+  public PrimarySelector getPrimarySelector() {
+    return mLeaderSelector;
   }
 }

--- a/job/server/src/main/java/alluxio/web/JobMasterWebServer.java
+++ b/job/server/src/main/java/alluxio/web/JobMasterWebServer.java
@@ -15,13 +15,16 @@ import alluxio.Constants;
 import alluxio.master.AlluxioJobMasterProcess;
 import alluxio.util.io.PathUtils;
 
+import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 
 import java.net.InetSocketAddress;
+import java.util.EnumSet;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import javax.servlet.DispatcherType;
 import javax.servlet.ServletException;
 
 /**
@@ -60,5 +63,9 @@ public final class JobMasterWebServer extends WebServer {
     ServletHolder servletHolder = new ServletHolder("Alluxio Job Master Web Service", servlet);
     mServletContextHandler
         .addServlet(servletHolder, PathUtils.concatPath(Constants.REST_API_PREFIX, "*"));
+    RedirectFilter redirectFilter = new RedirectFilter(jobMaster.getPrimarySelector());
+    FilterHolder filterHolder = new FilterHolder(redirectFilter);
+    mServletContextHandler.addFilter(filterHolder,"/*",
+        EnumSet.of(DispatcherType.REQUEST, DispatcherType.FORWARD, DispatcherType.INCLUDE));
   }
 }

--- a/job/server/src/main/java/alluxio/web/JobMasterWebServer.java
+++ b/job/server/src/main/java/alluxio/web/JobMasterWebServer.java
@@ -65,7 +65,7 @@ public final class JobMasterWebServer extends WebServer {
         .addServlet(servletHolder, PathUtils.concatPath(Constants.REST_API_PREFIX, "*"));
     RedirectFilter redirectFilter = new RedirectFilter(jobMaster.getPrimarySelector());
     FilterHolder filterHolder = new FilterHolder(redirectFilter);
-    mServletContextHandler.addFilter(filterHolder,"/*",
+    mServletContextHandler.addFilter(filterHolder, "/*",
         EnumSet.of(DispatcherType.REQUEST, DispatcherType.FORWARD, DispatcherType.INCLUDE));
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Only stop grpc server when a master lose primary. 

fix #13740 
fix #13840 

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. improve leader-follower switching performance
  2. can get metrics info although master is not leader.
 
### Does this PR introduce any user facing changes?

can use follower master address to use webui.
