### PR TITLE
Add number of directories to FuseIOBench

### DIFF
--- a/stress/common/src/main/java/alluxio/stress/fuse/FuseIOParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/fuse/FuseIOParameters.java
@@ -16,9 +16,6 @@ import alluxio.stress.Parameters;
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
 
-import java.util.Collections;
-import java.util.List;
-
 /**
  * This class holds all the Fuse IO related parameters. All fields are public for easier json
  * ser/de without all the getters and setters.
@@ -34,7 +31,7 @@ public final class FuseIOParameters extends Parameters {
   public FuseIOOperation mOperation;
 
   @Parameter(names = {"--threads"}, description = "the number of concurrent threads to use")
-  public List<Integer> mThreads = Collections.singletonList(1);
+  public int mThreads = 1;
 
   @Parameter(names = {"--local-path"},
       description = "The local filesystem directory or Fuse mount point to perform operations in")
@@ -48,12 +45,13 @@ public final class FuseIOParameters extends Parameters {
           description = "The buffer size for IO operations. (1k, 16k, etc.)")
   public String mBufferSize = "64k";
 
-  @Parameter(names = {"--num-files"},
-      description = "The number of files for the test")
-  public int mNumFiles = 1000;
+  @Parameter(names = {"--num-files-per-dir"},
+      description = "The number of files per directory for the test")
+  public int mNumFilesPerDir = 1000;
 
   @Parameter(names = {"--num-dirs"},
-          description = "The number of directories that the files will be evenly distributed into")
+      description = "The number of directories that the files will be evenly distributed into."
+          + "It is suggested to be a multiple of the number of threads.")
   public int mNumDirs = 1;
 
   @Parameter(names = {"--duration"},

--- a/stress/common/src/main/java/alluxio/stress/fuse/FuseIOParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/fuse/FuseIOParameters.java
@@ -52,6 +52,10 @@ public final class FuseIOParameters extends Parameters {
       description = "The number of files for the test")
   public int mNumFiles = 1000;
 
+  @Parameter(names = {"--num-dirs"},
+          description = "The number of directories that the files will be evenly distributed into")
+  public int mNumDirs = 1;
+
   @Parameter(names = {"--duration"},
       description = "The length of time to run the benchmark. (1m, 10m, 60s, 10000ms, etc.)")
   public String mDuration = "30s";

--- a/stress/common/src/main/java/alluxio/stress/fuse/FuseIOParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/fuse/FuseIOParameters.java
@@ -46,12 +46,12 @@ public final class FuseIOParameters extends Parameters {
   public String mBufferSize = "64k";
 
   @Parameter(names = {"--num-files-per-dir"},
-      description = "The number of files per directory for the test")
+      description = "The number of files per directory")
   public int mNumFilesPerDir = 1000;
 
   @Parameter(names = {"--num-dirs"},
       description = "The number of directories that the files will be evenly distributed into."
-          + "It is suggested to be a multiple of the number of threads.")
+          + "It must be at least the number of threads and preferably a multiple of it.")
   public int mNumDirs = 1;
 
   @Parameter(names = {"--duration"},

--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -79,7 +79,7 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
       if (mParameters.mNumFiles % numOfThreads != 0) {
         throw new IllegalArgumentException(String
             .format("Number of files (%d) must be a multiple of the number of threads (%d)",
-                    mParameters.mNumFiles, numOfThreads));
+                mParameters.mNumFiles, numOfThreads));
       }
     }
     if (mParameters.mReadRandom) {

--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -162,7 +162,7 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
             entry.getKey(), toSummaryStatistics(entry.getValue()));
       }
     }
-   
+
     return summaryStatistics;
   }
 

--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -72,15 +72,14 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
   public void prepare() throws Exception {
     if (mParameters.mNumFiles % mParameters.mNumDirs != 0) {
       throw new IllegalArgumentException(String
-          .format("Number of files (%d) must be a multiple of number of directories (%d)",
+          .format("Number of files (%d) must be a multiple of the number of directories (%d)",
               mParameters.mNumFiles, mParameters.mNumDirs));
     }
-    int numFilesPerDir = mParameters.mNumFiles / mParameters.mNumDirs;
     for (Integer numOfThreads: mParameters.mThreads) {
       if (mParameters.mNumFiles % numOfThreads != 0) {
         throw new IllegalArgumentException(String
-            .format("Number of files (%d) must be a multiple of the number threads (%d)",
-                numOfThreads, numFilesPerDir));
+            .format("Number of files (%d) must be a multiple of the number of threads (%d)",
+                    mParameters.mNumFiles, numOfThreads));
       }
     }
     if (mParameters.mReadRandom) {

--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -302,7 +302,7 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
             long ioBytes = applyOperation(filePath);
 
             // Done reading/writing one file
-            if (ioBytes < 0) {
+            if (ioBytes <= 0) {
               break;
             }
             // Start recording after the warmup


### PR DESCRIPTION
The number of files must be a multiple of number of directories, so each directory has same amount of files.
The number of files must be a multiple of number of threads, so each thread processes same amount of files.

@LuQQiu PTAL. Much cleaner than last time. Thanks!