### PR TITLE
Change download url for arthas in Dockerfile

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends software-proper
   rm -rf /var/lib/apt/lists/*
 
 # Install arthas(https://github.com/alibaba/arthas) for analyzing performance bottleneck
-RUN wget -qO /tmp/arthas.zip "http://maven.aliyun.com/repository/public/com/taobao/arthas/arthas-packaging/3.4.6/arthas-packaging-3.4.6-bin.zip" && \
+RUN wget -qO /tmp/arthas.zip "https://github.com/alibaba/arthas/releases/download/arthas-all-3.4.6/arthas-bin.zip" && \
   mkdir -p /opt/arthas && \
   unzip /tmp/arthas.zip -d /opt/arthas && \
   rm /tmp/arthas.zip


### PR DESCRIPTION
### What changes are proposed in this pull request?
Changes the url to download arthas 3.4.6 to one hosted by github

### Why are the changes needed?
The original url, hosted by maven.aliyun.com, is sometimes unavailable, causing errors when building the docker image. 

### Does this PR introduce any user facing changes?
Nope