### PR TITLE
Support export ratis metrics

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -30,6 +30,7 @@ import alluxio.master.journal.AbstractJournalSystem;
 import alluxio.master.journal.AsyncJournalWriter;
 import alluxio.master.journal.CatchupFuture;
 import alluxio.master.journal.Journal;
+import alluxio.metrics.sink.RatisDropwizardExports;
 import alluxio.proto.journal.Journal.JournalEntry;
 import alluxio.util.CommonUtils;
 import alluxio.util.LogUtils;
@@ -168,6 +169,9 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   private final RaftJournalConfiguration mConf;
   /** Controls whether state machine can take snapshots. */
   private final AtomicBoolean mSnapshotAllowed;
+
+  private final Map<String, RatisDropwizardExports> ratisMetricsMap =
+      new ConcurrentHashMap<>();
 
   /**
    * Listens to the Ratis server to detect gaining or losing primacy. The lifecycle for this
@@ -374,6 +378,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
         PropertyKey.MASTER_EMBEDDED_JOURNAL_TRANSPORT_MAX_INBOUND_MESSAGE_SIZE);
     GrpcConfigKeys.setMessageSizeMax(properties,
         SizeInBytes.valueOf(messageSize));
+    RatisDropwizardExports.registerRatisMetricReporters(ratisMetricsMap);
 
     // TODO(feng): clean up embedded journal configuration
     // build server

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -170,7 +170,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   /** Controls whether state machine can take snapshots. */
   private final AtomicBoolean mSnapshotAllowed;
 
-  private final Map<String, RatisDropwizardExports> ratisMetricsMap =
+  private final Map<String, RatisDropwizardExports> mRatisMetricsMap =
       new ConcurrentHashMap<>();
 
   /**
@@ -378,7 +378,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
         PropertyKey.MASTER_EMBEDDED_JOURNAL_TRANSPORT_MAX_INBOUND_MESSAGE_SIZE);
     GrpcConfigKeys.setMessageSizeMax(properties,
         SizeInBytes.valueOf(messageSize));
-    RatisDropwizardExports.registerRatisMetricReporters(ratisMetricsMap);
+    RatisDropwizardExports.registerRatisMetricReporters(mRatisMetricsMap);
 
     // TODO(feng): clean up embedded journal configuration
     // build server

--- a/core/server/common/src/main/java/alluxio/metrics/sink/PrometheusMetricsServlet.java
+++ b/core/server/common/src/main/java/alluxio/metrics/sink/PrometheusMetricsServlet.java
@@ -38,7 +38,7 @@ public class PrometheusMetricsServlet implements Sink {
    * @param registry the metric registry to register
    */
   public PrometheusMetricsServlet(MetricRegistry registry) {
-    mCollectorRegistry = new CollectorRegistry();
+    mCollectorRegistry = CollectorRegistry.defaultRegistry;
     mCollectorRegistry.register(new DropwizardExports(registry));
   }
 

--- a/core/server/common/src/main/java/alluxio/metrics/sink/RatisDropwizardExports.java
+++ b/core/server/common/src/main/java/alluxio/metrics/sink/RatisDropwizardExports.java
@@ -1,0 +1,62 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.metrics.sink;
+
+import com.codahale.metrics.MetricRegistry;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.dropwizard.DropwizardExports;
+import io.prometheus.client.dropwizard.samplebuilder.DefaultSampleBuilder;
+import org.apache.ratis.metrics.MetricRegistries;
+import org.apache.ratis.metrics.RatisMetricRegistry;
+
+import java.util.Map;
+
+/**
+ * Collect Dropwizard metrics, but rename ratis specific metrics.
+ */
+public class RatisDropwizardExports extends DropwizardExports {
+
+  /**
+   * Creates a new DropwizardExports with a {@link DefaultSampleBuilder}.
+   *
+   * @param registry a metric registry to export in prometheus.
+   */
+  public RatisDropwizardExports(MetricRegistry registry) {
+    super(registry, new RatisNameRewriteSampleBuilder());
+  }
+
+  public static void registerRatisMetricReporters(
+      Map<String, RatisDropwizardExports> ratisMetricsMap) {
+    MetricRegistries.global().addReporterRegistration(
+        r1 -> registerDropwizard(r1, ratisMetricsMap),
+        r2 -> deregisterDropwizard(r2, ratisMetricsMap));
+  }
+
+  private static void registerDropwizard(RatisMetricRegistry registry,
+      Map<String, RatisDropwizardExports> ratisMetricsMap) {
+    RatisDropwizardExports rde = new RatisDropwizardExports(
+        registry.getDropWizardMetricRegistry());
+    CollectorRegistry.defaultRegistry.register(rde);
+    String name = registry.getMetricRegistryInfo().getName();
+    ratisMetricsMap.putIfAbsent(name, rde);
+  }
+
+  private static void deregisterDropwizard(RatisMetricRegistry registry,
+      Map<String, RatisDropwizardExports> ratisMetricsMap) {
+    String name = registry.getMetricRegistryInfo().getName();
+    Collector c = ratisMetricsMap.remove(name);
+    if (c != null) {
+      CollectorRegistry.defaultRegistry.unregister(c);
+    }
+  }
+}

--- a/core/server/common/src/main/java/alluxio/metrics/sink/RatisDropwizardExports.java
+++ b/core/server/common/src/main/java/alluxio/metrics/sink/RatisDropwizardExports.java
@@ -29,12 +29,16 @@ public class RatisDropwizardExports extends DropwizardExports {
   /**
    * Creates a new DropwizardExports with a {@link DefaultSampleBuilder}.
    *
-   * @param registry a metric registry to export in prometheus.
+   * @param registry a metric registry to export in prometheus
    */
   public RatisDropwizardExports(MetricRegistry registry) {
     super(registry, new RatisNameRewriteSampleBuilder());
   }
 
+  /**
+   * Register ratis metric to metricRegistry.
+   * @param ratisMetricsMap a map to store the registered metrics
+   */
   public static void registerRatisMetricReporters(
       Map<String, RatisDropwizardExports> ratisMetricsMap) {
     MetricRegistries.global().addReporterRegistration(

--- a/core/server/common/src/main/java/alluxio/metrics/sink/RatisNameRewriteSampleBuilder.java
+++ b/core/server/common/src/main/java/alluxio/metrics/sink/RatisNameRewriteSampleBuilder.java
@@ -43,7 +43,6 @@ public class RatisNameRewriteSampleBuilder extends DefaultSampleBuilder {
     mFollowerPatterns
         .add(Pattern.compile("follower_([^_]*)_.*"));
     mFollowerPatterns.add(Pattern.compile("([^_]*)_peerCommitIndex"));
-
   }
 
   @Override
@@ -61,11 +60,7 @@ public class RatisNameRewriteSampleBuilder extends DefaultSampleBuilder {
             "Ratis dropwizard {} metrics are converted to {} with tag "
                 + "keys/values {},{}", dropwizardName, name, names, values);
       }
-      return super
-          .createSample(name, nameSuffix,
-              names,
-              values, value);
-
+      return super.createSample(name, nameSuffix, names, values, value);
     } else {
       return super
           .createSample(dropwizardName, nameSuffix, additionalLabelNames,

--- a/core/server/common/src/main/java/alluxio/metrics/sink/RatisNameRewriteSampleBuilder.java
+++ b/core/server/common/src/main/java/alluxio/metrics/sink/RatisNameRewriteSampleBuilder.java
@@ -1,0 +1,107 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.metrics.sink;
+
+import static org.apache.ratis.metrics.RatisMetrics.RATIS_APPLICATION_NAME_METRICS;
+
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+import io.prometheus.client.dropwizard.samplebuilder.DefaultSampleBuilder;
+import org.apache.logging.log4j.util.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Collect Dropwizard metrics and rename ratis specific metrics.
+ */
+public class RatisNameRewriteSampleBuilder extends DefaultSampleBuilder {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RatisNameRewriteSampleBuilder.class);
+
+  private List<Pattern> mFollowerPatterns = new ArrayList<>();
+
+  protected RatisNameRewriteSampleBuilder() {
+    mFollowerPatterns
+        .add(Pattern.compile(
+            "grpc_log_appender_follower_(.*)_(latency|success|inconsistency)"
+                + ".*"));
+    mFollowerPatterns
+        .add(Pattern.compile("follower_([^_]*)_.*"));
+    mFollowerPatterns.add(Pattern.compile("([^_]*)_peerCommitIndex"));
+
+  }
+
+  @Override
+  public Sample createSample(String dropwizardName, String nameSuffix,
+      List<String> additionalLabelNames, List<String> additionalLabelValues,
+      double value) {
+    //this is a ratis metrics, where the second part is an instance id.
+    if (dropwizardName.startsWith(RATIS_APPLICATION_NAME_METRICS)) {
+      List<String> names = new ArrayList<>(additionalLabelNames);
+      List<String> values = new ArrayList<>(additionalLabelValues);
+      String name = normalizeRatisMetric(dropwizardName, names, values);
+
+      if (LOG.isTraceEnabled()) {
+        LOG.trace(
+            "Ratis dropwizard {} metrics are converted to {} with tag "
+                + "keys/values {},{}", dropwizardName, name, names, values);
+      }
+      return super
+          .createSample(name, nameSuffix,
+              names,
+              values, value);
+
+    } else {
+      return super
+          .createSample(dropwizardName, nameSuffix, additionalLabelNames,
+              additionalLabelValues, value);
+    }
+  }
+
+  protected String normalizeRatisMetric(String dropwizardName,
+      List<String> names,
+      List<String> values) {
+
+    List<String> nameParts =
+        new ArrayList<>(Arrays.asList(dropwizardName.split("\\.")));
+    //second part is id or id@group_id
+    if (nameParts.size() > 2) {
+      String[] identifiers = nameParts.get(2).split("@");
+      names.add("instance");
+      values.add(identifiers[0]);
+      if (identifiers.length > 1) {
+        names.add("group");
+        values.add(identifiers[1]);
+      }
+      nameParts.remove(2);
+    }
+
+    if (nameParts.size() > 2) {
+      for (Pattern pattern : mFollowerPatterns) {
+        Matcher matcher = pattern.matcher(nameParts.get(2));
+        if (matcher.matches()) {
+          names.add("follower");
+          String followerId = matcher.group(1);
+          values.add(followerId);
+          nameParts.set(2, nameParts.get(2).replace(followerId + "_", ""));
+        }
+      }
+    }
+    return Strings.join(nameParts, '.');
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Export ratis related metrics

### Why are the changes needed?

There are lots of useful Ratis metrics, but not exported from alluxio, now just export it.

The following is the main point of this PR, I add two Consumer to ratis `MetricRegistries`
```java
MetricRegistries.global().addReporterRegistration(
        r1 -> registerDropwizard(r1, ratisMetricsMap),
        r2 -> deregisterDropwizard(r2, ratisMetricsMap));
```

The implementation of `addReporterRegistration` is 

```java
  public void addReporterRegistration(Consumer<RatisMetricRegistry> reporterRegistration,
      Consumer<RatisMetricRegistry> stopReporter) {
    this.reporterRegistrations.add(reporterRegistration);
    this.stopReporters.add(stopReporter);
  }
```

And there are two hook point as following

```java
  @Override
  public RatisMetricRegistry create(MetricRegistryInfo info) {
    return registries.put(info, () -> {
      if (reporterRegistrations.isEmpty()) {
        LOG.warn(
            "First MetricRegistry has been created without registering reporters. You may need to call" +
                " MetricRegistries.global().addReporterRegistration(...) before.");
      }
      RatisMetricRegistry registry = factory.create(info);
      reporterRegistrations.forEach(reg -> reg.accept(registry));
      return registry;
    });
  }

  @Override
  public boolean remove(MetricRegistryInfo key) {
    RatisMetricRegistry registry = registries.get(key);
    if (registry != null) {
      stopReporters.forEach(reg -> reg.accept(registry));
    }

    return registries.remove(key) == null;
  }
```

So the alluxio new metric added when ratis metric created, alluxio metric removed when ratis metric removed.

### Does this PR introduce any user facing changes?

After this PR, `/metrics/prometheus` servlet will display ratis metrics.

all of the metrics from my test env is :

```
# HELP ratis_client_message_metrics_client_E93E60A0CC1D__localhost_19200_ratis_grpc_RaftClientProtocolService_ordered_OK_received_executed Generated from Dropwizard metric import (metric=ratis.client_message_metrics.client-E93E60A0CC1D->localhost_19200.client-E93E60A0CC1D->localhost_19200_ratis.grpc.RaftClientProtocolService_ordered_OK_received_executed, type=com.codahale.metrics.Counter)
# TYPE ratis_client_message_metrics_client_E93E60A0CC1D__localhost_19200_ratis_grpc_RaftClientProtocolService_ordered_OK_received_executed gauge
ratis_client_message_metrics_client_E93E60A0CC1D__localhost_19200_ratis_grpc_RaftClientProtocolService_ordered_OK_received_executed{instance="client-E93E60A0CC1D->localhost_19200",} 2.0
# HELP ratis_client_message_metrics_client_E93E60A0CC1D__localhost_19200_ratis_grpc_RaftClientProtocolService_ordered_started_total Generated from Dropwizard metric import (metric=ratis.client_message_metrics.client-E93E60A0CC1D->localhost_19200.client-E93E60A0CC1D->localhost_19200_ratis.grpc.RaftClientProtocolService_ordered_started_total, type=com.codahale.metrics.Counter)
# TYPE ratis_client_message_metrics_client_E93E60A0CC1D__localhost_19200_ratis_grpc_RaftClientProtocolService_ordered_started_total gauge
ratis_client_message_metrics_client_E93E60A0CC1D__localhost_19200_ratis_grpc_RaftClientProtocolService_ordered_started_total{instance="client-E93E60A0CC1D->localhost_19200",} 2.0
# HELP ratis_leader_election_lastLeaderElapsedTime Generated from Dropwizard metric import (metric=ratis.leader_election.localhost_19200@group-ABB3109A44C1.lastLeaderElapsedTime, type=org.apache.ratis.server.metrics.LeaderElectionMetrics$$Lambda$334/1156022716)
# TYPE ratis_leader_election_lastLeaderElapsedTime gauge
ratis_leader_election_lastLeaderElapsedTime{instance="localhost_19200",group="group-ABB3109A44C1",} 0.0
# HELP ratis_leader_election_timeoutCount Generated from Dropwizard metric import (metric=ratis.leader_election.localhost_19200@group-ABB3109A44C1.timeoutCount, type=com.codahale.metrics.Counter)
# TYPE ratis_leader_election_timeoutCount gauge
ratis_leader_election_timeoutCount{instance="localhost_19200",group="group-ABB3109A44C1",} 1.0
# HELP ratis_leader_election_electionCount Generated from Dropwizard metric import (metric=ratis.leader_election.localhost_19200@group-ABB3109A44C1.electionCount, type=com.codahale.metrics.Counter)
# TYPE ratis_leader_election_electionCount gauge
ratis_leader_election_electionCount{instance="localhost_19200",group="group-ABB3109A44C1",} 1.0
# HELP ratis_leader_election_lastLeaderElectionElapsedTime Generated from Dropwizard metric import (metric=ratis.leader_election.localhost_19200@group-ABB3109A44C1.lastLeaderElectionElapsedTime, type=org.apache.ratis.server.metrics.LeaderElectionMetrics$$Lambda$336/1098531807)
# TYPE ratis_leader_election_lastLeaderElectionElapsedTime gauge
ratis_leader_election_lastLeaderElectionElapsedTime{instance="localhost_19200",group="group-ABB3109A44C1",} 23184.0
# HELP ratis_leader_election_electionTime Generated from Dropwizard metric import (metric=ratis.leader_election.localhost_19200@group-ABB3109A44C1.electionTime, type=com.codahale.metrics.Timer)
# TYPE ratis_leader_election_electionTime summary
ratis_leader_election_electionTime{quantile="0.5",instance="localhost_19200",group="group-ABB3109A44C1",} 0.083016026
ratis_leader_election_electionTime{quantile="0.75",instance="localhost_19200",group="group-ABB3109A44C1",} 0.083016026
ratis_leader_election_electionTime{quantile="0.95",instance="localhost_19200",group="group-ABB3109A44C1",} 0.083016026
ratis_leader_election_electionTime{quantile="0.98",instance="localhost_19200",group="group-ABB3109A44C1",} 0.083016026
ratis_leader_election_electionTime{quantile="0.99",instance="localhost_19200",group="group-ABB3109A44C1",} 0.083016026
ratis_leader_election_electionTime{quantile="0.999",instance="localhost_19200",group="group-ABB3109A44C1",} 0.083016026
ratis_leader_election_electionTime_count{instance="localhost_19200",group="group-ABB3109A44C1",} 1.0
# HELP ratis_state_machine_appliedIndex Generated from Dropwizard metric import (metric=ratis.state_machine.localhost_19200@group-ABB3109A44C1.appliedIndex, type=org.apache.ratis.server.impl.StateMachineMetrics$$Lambda$362/1297836716)
# TYPE ratis_state_machine_appliedIndex gauge
ratis_state_machine_appliedIndex{instance="localhost_19200",group="group-ABB3109A44C1",} 416.0
# HELP ratis_state_machine_applyCompletedIndex Generated from Dropwizard metric import (metric=ratis.state_machine.localhost_19200@group-ABB3109A44C1.applyCompletedIndex, type=org.apache.ratis.server.impl.StateMachineMetrics$$Lambda$364/1249875355)
# TYPE ratis_state_machine_applyCompletedIndex gauge
ratis_state_machine_applyCompletedIndex{instance="localhost_19200",group="group-ABB3109A44C1",} 416.0
# HELP ratis_server_message_metrics_localhost_19200_ratis_grpc_RaftClientProtocolService_ordered_started_total Generated from Dropwizard metric import (metric=ratis.server_message_metrics.localhost_19200.localhost_19200_ratis.grpc.RaftClientProtocolService_ordered_started_total, type=com.codahale.metrics.Counter)
# TYPE ratis_server_message_metrics_localhost_19200_ratis_grpc_RaftClientProtocolService_ordered_started_total gauge
ratis_server_message_metrics_localhost_19200_ratis_grpc_RaftClientProtocolService_ordered_started_total{instance="localhost_19200",} 2.0
# HELP ratis_server_message_metrics_localhost_19200_ratis_grpc_RaftClientProtocolService_ordered_OK_completed_total Generated from Dropwizard metric import (metric=ratis.server_message_metrics.localhost_19200.localhost_19200_ratis.grpc.RaftClientProtocolService_ordered_OK_completed_total, type=com.codahale.metrics.Counter)
# TYPE ratis_server_message_metrics_localhost_19200_ratis_grpc_RaftClientProtocolService_ordered_OK_completed_total gauge
ratis_server_message_metrics_localhost_19200_ratis_grpc_RaftClientProtocolService_ordered_OK_completed_total{instance="localhost_19200",} 2.0
# HELP Master_CreateFileOps Generated from Dropwizard metric import (metric=Master.CreateFileOps, type=com.codahale.metrics.Counter)
# TYPE Master_CreateFileOps gauge
Master_CreateFileOps 0.0
# HELP Cluster_BytesReadDomain Generated from Dropwizard metric import (metric=Cluster.BytesReadDomain, type=com.codahale.metrics.Counter)
# TYPE Cluster_BytesReadDomain gauge
Cluster_BytesReadDomain 0.0
# HELP pools_Code_Cache_max Generated from Dropwizard metric import (metric=pools.Code-Cache.max, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$51/343965883)
# TYPE pools_Code_Cache_max gauge
pools_Code_Cache_max 2.5165824E8
# HELP pools_PS_Survivor_Space_committed Generated from Dropwizard metric import (metric=pools.PS-Survivor-Space.committed, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$53/280884709)
# TYPE pools_PS_Survivor_Space_committed gauge
pools_PS_Survivor_Space_committed 1.7301504E7
# HELP Master_TotalPaths Generated from Dropwizard metric import (metric=Master.TotalPaths, type=alluxio.master.file.DefaultFileSystemMaster$Metrics$$Lambda$133/211264745)
# TYPE Master_TotalPaths gauge
Master_TotalPaths 21.0
# HELP Master_JournalEntriesSinceCheckPoint Generated from Dropwizard metric import (metric=Master.JournalEntriesSinceCheckPoint, type=alluxio.master.journal.raft.JournalStateMachine$$Lambda$150/885851948)
# TYPE Master_JournalEntriesSinceCheckPoint gauge
Master_JournalEntriesSinceCheckPoint 417.0
# HELP Cluster_BytesReadLocal Generated from Dropwizard metric import (metric=Cluster.BytesReadLocal, type=com.codahale.metrics.Counter)
# TYPE Cluster_BytesReadLocal gauge
Cluster_BytesReadLocal 0.0
# HELP Cluster_CapacityFree Generated from Dropwizard metric import (metric=Cluster.CapacityFree, type=alluxio.master.block.DefaultBlockMaster$Metrics$$Lambda$92/449982780)
# TYPE Cluster_CapacityFree gauge
Cluster_CapacityFree 0.0
# HELP log_fatal_count Generated from Dropwizard metric import (metric=log.fatal.count, type=alluxio.metrics.LogStateCounterSet$$Lambda$68/418304857)
# TYPE log_fatal_count gauge
log_fatal_count 0.0
# HELP Cluster_RootUfsCapacityFree Generated from Dropwizard metric import (metric=Cluster.RootUfsCapacityFree, type=alluxio.master.file.DefaultFileSystemMaster$Metrics$$Lambda$137/1967676501)
# TYPE Cluster_RootUfsCapacityFree gauge
Cluster_RootUfsCapacityFree 7.8572138496E10
# HELP Master_JournalGainPrimacyTimer Generated from Dropwizard metric import (metric=Master.JournalGainPrimacyTimer, type=com.codahale.metrics.Timer)
# TYPE Master_JournalGainPrimacyTimer summary
Master_JournalGainPrimacyTimer{quantile="0.5",} 0.0
Master_JournalGainPrimacyTimer{quantile="0.75",} 0.0
Master_JournalGainPrimacyTimer{quantile="0.95",} 0.0
Master_JournalGainPrimacyTimer{quantile="0.98",} 0.0
Master_JournalGainPrimacyTimer{quantile="0.99",} 0.0
Master_JournalGainPrimacyTimer{quantile="0.999",} 0.0
Master_JournalGainPrimacyTimer_count 0.0
# HELP pools_PS_Eden_Space_init Generated from Dropwizard metric import (metric=pools.PS-Eden-Space.init, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$54/1847509784)
# TYPE pools_PS_Eden_Space_init gauge
pools_PS_Eden_Space_init 6.7108864E7
# HELP pools_PS_Eden_Space_used_after_gc Generated from Dropwizard metric import (metric=pools.PS-Eden-Space.used-after-gc, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$55/2114650936)
# TYPE pools_PS_Eden_Space_used_after_gc gauge
pools_PS_Eden_Space_used_after_gc 0.0
# HELP Cluster_BytesReadDomainThroughput Generated from Dropwizard metric import (metric=Cluster.BytesReadDomainThroughput, type=alluxio.master.metrics.DefaultMetricsMaster$2)
# TYPE Cluster_BytesReadDomainThroughput gauge
Cluster_BytesReadDomainThroughput 0.0
# HELP pools_PS_Survivor_Space_used_after_gc Generated from Dropwizard metric import (metric=pools.PS-Survivor-Space.used-after-gc, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$55/2114650936)
# TYPE pools_PS_Survivor_Space_used_after_gc gauge
pools_PS_Survivor_Space_used_after_gc 0.0
# HELP Master_EmbeddedJournalSnapshotReplayTimer Generated from Dropwizard metric import (metric=Master.EmbeddedJournalSnapshotReplayTimer, type=com.codahale.metrics.Timer)
# TYPE Master_EmbeddedJournalSnapshotReplayTimer summary
Master_EmbeddedJournalSnapshotReplayTimer{quantile="0.5",} 0.0
Master_EmbeddedJournalSnapshotReplayTimer{quantile="0.75",} 0.0
Master_EmbeddedJournalSnapshotReplayTimer{quantile="0.95",} 0.0
Master_EmbeddedJournalSnapshotReplayTimer{quantile="0.98",} 0.0
Master_EmbeddedJournalSnapshotReplayTimer{quantile="0.99",} 0.0
Master_EmbeddedJournalSnapshotReplayTimer{quantile="0.999",} 0.0
Master_EmbeddedJournalSnapshotReplayTimer_count 0.0
# HELP Master_AbsentCacheMisses Generated from Dropwizard metric import (metric=Master.AbsentCacheMisses, type=alluxio.master.file.meta.AsyncUfsAbsentPathCache$$Lambda$125/406838828)
# TYPE Master_AbsentCacheMisses gauge
Master_AbsentCacheMisses 0.0
# HELP waiting_count Generated from Dropwizard metric import (metric=waiting.count, type=com.codahale.metrics.jvm.ThreadStatesGaugeSet$$Lambda$58/1875308878)
# TYPE waiting_count gauge
waiting_count 15.0
# HELP Master_InodeCacheHits Generated from Dropwizard metric import (metric=Master.InodeCacheHits, type=com.codahale.metrics.Counter)
# TYPE Master_InodeCacheHits gauge
Master_InodeCacheHits 36.0
# HELP Cluster_CapacityUsedTierHDD Generated from Dropwizard metric import (metric=Cluster.CapacityUsedTierHDD, type=alluxio.master.block.DefaultBlockMaster$Metrics$2)
# TYPE Cluster_CapacityUsedTierHDD gauge
Cluster_CapacityUsedTierHDD 0.0
# HELP pools_PS_Survivor_Space_used Generated from Dropwizard metric import (metric=pools.PS-Survivor-Space.used, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$52/230835489)
# TYPE pools_PS_Survivor_Space_used gauge
pools_PS_Survivor_Space_used 0.0
# HELP Master_LastBackupTimeMs Generated from Dropwizard metric import (metric=Master.LastBackupTimeMs, type=alluxio.master.BackupManager$$Lambda$71/1864350231)
# TYPE Master_LastBackupTimeMs gauge
Master_LastBackupTimeMs -1.0
# HELP Master_GetFileBlockInfoOps Generated from Dropwizard metric import (metric=Master.GetFileBlockInfoOps, type=com.codahale.metrics.Counter)
# TYPE Master_GetFileBlockInfoOps gauge
Master_GetFileBlockInfoOps 0.0
# HELP Master_InodeCacheMisses Generated from Dropwizard metric import (metric=Master.InodeCacheMisses, type=com.codahale.metrics.Counter)
# TYPE Master_InodeCacheMisses gauge
Master_InodeCacheMisses 5.0
# HELP Master_InodeHeapSize Generated from Dropwizard metric import (metric=Master.InodeHeapSize, type=alluxio.metrics.MetricsSystem$1)
# TYPE Master_InodeHeapSize gauge
Master_InodeHeapSize 1.6787264E7
# HELP Master_RpcQueueLength Generated from Dropwizard metric import (metric=Master.RpcQueueLength, type=alluxio.master.AlluxioMasterProcess$$Lambda$666/1437209965)
# TYPE Master_RpcQueueLength gauge
Master_RpcQueueLength 0.0
# HELP pools_PS_Survivor_Space_max Generated from Dropwizard metric import (metric=pools.PS-Survivor-Space.max, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$51/343965883)
# TYPE pools_PS_Survivor_Space_max gauge
pools_PS_Survivor_Space_max 1.7301504E7
# HELP Master_EdgeCacheMisses Generated from Dropwizard metric import (metric=Master.EdgeCacheMisses, type=com.codahale.metrics.Counter)
# TYPE Master_EdgeCacheMisses gauge
Master_EdgeCacheMisses 1.0
# HELP pools_PS_Old_Gen_used Generated from Dropwizard metric import (metric=pools.PS-Old-Gen.used, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$52/230835489)
# TYPE pools_PS_Old_Gen_used gauge
pools_PS_Old_Gen_used 4.288068E7
# HELP Master_InodeCacheLoadTimes Generated from Dropwizard metric import (metric=Master.InodeCacheLoadTimes, type=com.codahale.metrics.Counter)
# TYPE Master_InodeCacheLoadTimes gauge
Master_InodeCacheLoadTimes 642887.0
# HELP Master_MountOps Generated from Dropwizard metric import (metric=Master.MountOps, type=com.codahale.metrics.Counter)
# TYPE Master_MountOps gauge
Master_MountOps 0.0
# HELP Master_PerUfsOpConnectFromMaster_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage Generated from Dropwizard metric import (metric=Master.PerUfsOpConnectFromMaster.UFS:%2FUsers%2Fmbl%2Fprojects%2Fgithub%2Falluxio-2%2FunderFSStorage, type=alluxio.master.metrics.DefaultMetricsMaster$1)
# TYPE Master_PerUfsOpConnectFromMaster_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage gauge
Master_PerUfsOpConnectFromMaster_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage 0.0
# HELP Cluster_CapacityFreeTierMEM Generated from Dropwizard metric import (metric=Cluster.CapacityFreeTierMEM, type=alluxio.master.block.DefaultBlockMaster$Metrics$3)
# TYPE Cluster_CapacityFreeTierMEM gauge
Cluster_CapacityFreeTierMEM 0.0
# HELP log_error_count Generated from Dropwizard metric import (metric=log.error.count, type=alluxio.metrics.LogStateCounterSet$$Lambda$67/1376400422)
# TYPE log_error_count gauge
log_error_count 0.0
# HELP heap_usage Generated from Dropwizard metric import (metric=heap.usage, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$1)
# TYPE heap_usage gauge
heap_usage 0.034319128776703255
# HELP Master_GetNewBlockOps Generated from Dropwizard metric import (metric=Master.GetNewBlockOps, type=com.codahale.metrics.Counter)
# TYPE Master_GetNewBlockOps gauge
Master_GetNewBlockOps 0.0
# HELP Master_LastBackupEntriesCount Generated from Dropwizard metric import (metric=Master.LastBackupEntriesCount, type=alluxio.master.BackupManager$$Lambda$31/89387388)
# TYPE Master_LastBackupEntriesCount gauge
Master_LastBackupEntriesCount -1.0
# HELP total_used Generated from Dropwizard metric import (metric=total.used, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$40/517210187)
# TYPE total_used gauge
total_used 2.10201432E8
# HELP Master_GetSpace_User:mbl_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local Generated from Dropwizard metric import (metric=Master.GetSpace.User:mbl.UFS:%2FUsers%2Fmbl%2Fprojects%2Fgithub%2Falluxio-2%2FunderFSStorage.UFS_TYPE:local, type=com.codahale.metrics.Timer)
# TYPE Master_GetSpace_User:mbl_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local summary
Master_GetSpace_User:mbl_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.5",} 3.10609E-4
Master_GetSpace_User:mbl_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.75",} 3.10609E-4
Master_GetSpace_User:mbl_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.95",} 3.10609E-4
Master_GetSpace_User:mbl_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.98",} 3.10609E-4
Master_GetSpace_User:mbl_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.99",} 3.10609E-4
Master_GetSpace_User:mbl_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.999",} 3.10609E-4
Master_GetSpace_User:mbl_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local_count 2.0
# HELP log_warn_count Generated from Dropwizard metric import (metric=log.warn.count, type=alluxio.metrics.LogStateCounterSet$$Lambda$66/1698097425)
# TYPE log_warn_count gauge
log_warn_count 1.0
# HELP Cluster_BytesWrittenDomain Generated from Dropwizard metric import (metric=Cluster.BytesWrittenDomain, type=com.codahale.metrics.Counter)
# TYPE Cluster_BytesWrittenDomain gauge
Cluster_BytesWrittenDomain 0.0
# HELP Master_SetAclOps Generated from Dropwizard metric import (metric=Master.SetAclOps, type=com.codahale.metrics.Counter)
# TYPE Master_SetAclOps gauge
Master_SetAclOps 0.0
# HELP blocked_count Generated from Dropwizard metric import (metric=blocked.count, type=com.codahale.metrics.jvm.ThreadStatesGaugeSet$$Lambda$58/1875308878)
# TYPE blocked_count gauge
blocked_count 0.0
# HELP Master_getConfiguration Generated from Dropwizard metric import (metric=Master.getConfiguration, type=com.codahale.metrics.Timer)
# TYPE Master_getConfiguration summary
Master_getConfiguration{quantile="0.5",} 0.017267135
Master_getConfiguration{quantile="0.75",} 0.017267135
Master_getConfiguration{quantile="0.95",} 0.017267135
Master_getConfiguration{quantile="0.98",} 0.017267135
Master_getConfiguration{quantile="0.99",} 0.017267135
Master_getConfiguration{quantile="0.999",} 0.017267135
Master_getConfiguration_count 1.0
# HELP pools_PS_Old_Gen_usage Generated from Dropwizard metric import (metric=pools.PS-Old-Gen.usage, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$3)
# TYPE pools_PS_Old_Gen_usage gauge
pools_PS_Old_Gen_usage 0.014974076596863844
# HELP Cluster_CapacityUsedTierSSD Generated from Dropwizard metric import (metric=Cluster.CapacityUsedTierSSD, type=alluxio.master.block.DefaultBlockMaster$Metrics$2)
# TYPE Cluster_CapacityUsedTierSSD gauge
Cluster_CapacityUsedTierSSD 0.0
# HELP Cluster_CapacityFreeTierHDD Generated from Dropwizard metric import (metric=Cluster.CapacityFreeTierHDD, type=alluxio.master.block.DefaultBlockMaster$Metrics$3)
# TYPE Cluster_CapacityFreeTierHDD gauge
Cluster_CapacityFreeTierHDD 0.0
# HELP Cluster_BytesWrittenUfsAll Generated from Dropwizard metric import (metric=Cluster.BytesWrittenUfsAll, type=com.codahale.metrics.Counter)
# TYPE Cluster_BytesWrittenUfsAll gauge
Cluster_BytesWrittenUfsAll 0.0
# HELP Master_EdgeCacheSize Generated from Dropwizard metric import (metric=Master.EdgeCacheSize, type=alluxio.master.metastore.caching.Cache$$Lambda$112/1248281086)
# TYPE Master_EdgeCacheSize gauge
Master_EdgeCacheSize 5.0
# HELP Master_AbsentCacheHits Generated from Dropwizard metric import (metric=Master.AbsentCacheHits, type=alluxio.master.file.meta.AsyncUfsAbsentPathCache$$Lambda$126/2019708974)
# TYPE Master_AbsentCacheHits gauge
Master_AbsentCacheHits 0.0
# HELP heap_used Generated from Dropwizard metric import (metric=heap.used, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$44/1776957250)
# TYPE heap_used gauge
heap_used 1.31025808E8
# HELP pools_Metaspace_committed Generated from Dropwizard metric import (metric=pools.Metaspace.committed, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$53/280884709)
# TYPE pools_Metaspace_committed gauge
pools_Metaspace_committed 6.4790528E7
# HELP Cluster_Workers Generated from Dropwizard metric import (metric=Cluster.Workers, type=alluxio.master.block.DefaultBlockMaster$Metrics$4)
# TYPE Cluster_Workers gauge
Cluster_Workers 0.0
# HELP pools_PS_Old_Gen_max Generated from Dropwizard metric import (metric=pools.PS-Old-Gen.max, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$51/343965883)
# TYPE pools_PS_Old_Gen_max gauge
pools_PS_Old_Gen_max 2.863661056E9
# HELP Cluster_CapacityUsed Generated from Dropwizard metric import (metric=Cluster.CapacityUsed, type=alluxio.master.block.DefaultBlockMaster$Metrics$$Lambda$91/1723439123)
# TYPE Cluster_CapacityUsed gauge
Cluster_CapacityUsed 0.0
# HELP Cluster_BytesReadRemoteThroughput Generated from Dropwizard metric import (metric=Cluster.BytesReadRemoteThroughput, type=alluxio.master.metrics.DefaultMetricsMaster$2)
# TYPE Cluster_BytesReadRemoteThroughput gauge
Cluster_BytesReadRemoteThroughput 0.0
# HELP Master_CreateDirectoryOps Generated from Dropwizard metric import (metric=Master.CreateDirectoryOps, type=com.codahale.metrics.Counter)
# TYPE Master_CreateDirectoryOps gauge
Master_CreateDirectoryOps 0.0
# HELP pools_Metaspace_max Generated from Dropwizard metric import (metric=pools.Metaspace.max, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$51/343965883)
# TYPE pools_Metaspace_max gauge
pools_Metaspace_max -1.0
# HELP Master_EdgeLockPoolSize Generated from Dropwizard metric import (metric=Master.EdgeLockPoolSize, type=alluxio.master.file.meta.InodeLockManager$$Lambda$110/1339151743)
# TYPE Master_EdgeLockPoolSize gauge
Master_EdgeLockPoolSize 3.0
# HELP Master_PathsRenamed Generated from Dropwizard metric import (metric=Master.PathsRenamed, type=com.codahale.metrics.Counter)
# TYPE Master_PathsRenamed gauge
Master_PathsRenamed 0.0
# HELP Cluster_BytesReadUfsThroughput Generated from Dropwizard metric import (metric=Cluster.BytesReadUfsThroughput, type=alluxio.master.metrics.DefaultMetricsMaster$2)
# TYPE Cluster_BytesReadUfsThroughput gauge
Cluster_BytesReadUfsThroughput 0.0
# HELP Cluster_RootUfsCapacityUsed Generated from Dropwizard metric import (metric=Cluster.RootUfsCapacityUsed, type=alluxio.master.file.DefaultFileSystemMaster$Metrics$$Lambda$136/1486785900)
# TYPE Cluster_RootUfsCapacityUsed gauge
Cluster_RootUfsCapacityUsed 4.21391036416E11
# HELP terminated_count Generated from Dropwizard metric import (metric=terminated.count, type=com.codahale.metrics.jvm.ThreadStatesGaugeSet$$Lambda$58/1875308878)
# TYPE terminated_count gauge
terminated_count 0.0
# HELP Master_ListingCacheLoadTimes Generated from Dropwizard metric import (metric=Master.ListingCacheLoadTimes, type=com.codahale.metrics.Counter)
# TYPE Master_ListingCacheLoadTimes gauge
Master_ListingCacheLoadTimes 0.0
# HELP Cluster_BytesWrittenDomainThroughput Generated from Dropwizard metric import (metric=Cluster.BytesWrittenDomainThroughput, type=alluxio.master.metrics.DefaultMetricsMaster$2)
# TYPE Cluster_BytesWrittenDomainThroughput gauge
Cluster_BytesWrittenDomainThroughput 0.0
# HELP pools_PS_Old_Gen_committed Generated from Dropwizard metric import (metric=pools.PS-Old-Gen.committed, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$53/280884709)
# TYPE pools_PS_Old_Gen_committed gauge
pools_PS_Old_Gen_committed 2.24395264E8
# HELP Cluster_BytesWrittenLocal Generated from Dropwizard metric import (metric=Cluster.BytesWrittenLocal, type=com.codahale.metrics.Counter)
# TYPE Cluster_BytesWrittenLocal gauge
Cluster_BytesWrittenLocal 0.0
# HELP Master_CompleteFileOps Generated from Dropwizard metric import (metric=Master.CompleteFileOps, type=com.codahale.metrics.Counter)
# TYPE Master_CompleteFileOps gauge
Master_CompleteFileOps 0.0
# HELP Master_UfsSessionCount_Ufs:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage Generated from Dropwizard metric import (metric=Master.UfsSessionCount-Ufs:%2FUsers%2Fmbl%2Fprojects%2Fgithub%2Falluxio-2%2FunderFSStorage, type=com.codahale.metrics.Counter)
# TYPE Master_UfsSessionCount_Ufs:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage gauge
Master_UfsSessionCount_Ufs:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage 0.0
# HELP Cluster_BytesReadRemote Generated from Dropwizard metric import (metric=Cluster.BytesReadRemote, type=com.codahale.metrics.Counter)
# TYPE Cluster_BytesReadRemote gauge
Cluster_BytesReadRemote 0.0
# HELP Master_InodeCacheHitRatio Generated from Dropwizard metric import (metric=Master.InodeCacheHitRatio, type=alluxio.master.metastore.caching.StatsCounter$$Lambda$111/858075954)
# TYPE Master_InodeCacheHitRatio gauge
Master_InodeCacheHitRatio 6.0
# HELP non_heap_max Generated from Dropwizard metric import (metric=non-heap.max, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$49/1344645519)
# TYPE non_heap_max gauge
non_heap_max -1.0
# HELP Master_FilesFreed Generated from Dropwizard metric import (metric=Master.FilesFreed, type=com.codahale.metrics.Counter)
# TYPE Master_FilesFreed gauge
Master_FilesFreed 0.0
# HELP heap_committed Generated from Dropwizard metric import (metric=heap.committed, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$46/827966648)
# TYPE heap_committed gauge
heap_committed 5.05413632E8
# HELP Cluster_ActiveRpcReadCount Generated from Dropwizard metric import (metric=Cluster.ActiveRpcReadCount, type=com.codahale.metrics.Counter)
# TYPE Cluster_ActiveRpcReadCount gauge
Cluster_ActiveRpcReadCount 0.0
# HELP Cluster_BytesReadDirectThroughput Generated from Dropwizard metric import (metric=Cluster.BytesReadDirectThroughput, type=alluxio.master.metrics.DefaultMetricsMaster$2)
# TYPE Cluster_BytesReadDirectThroughput gauge
Cluster_BytesReadDirectThroughput 0.0
# HELP total_committed Generated from Dropwizard metric import (metric=total.committed, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$42/633070006)
# TYPE total_committed gauge
total_committed 5.89185024E8
# HELP Master_FreeFileOps Generated from Dropwizard metric import (metric=Master.FreeFileOps, type=com.codahale.metrics.Counter)
# TYPE Master_FreeFileOps gauge
Master_FreeFileOps 0.0
# HELP non_heap_committed Generated from Dropwizard metric import (metric=non-heap.committed, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$50/1234776885)
# TYPE non_heap_committed gauge
non_heap_committed 8.3771392E7
# HELP pools_PS_Eden_Space_used Generated from Dropwizard metric import (metric=pools.PS-Eden-Space.used, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$52/230835489)
# TYPE pools_PS_Eden_Space_used gauge
pools_PS_Eden_Space_used 8.8277696E7
# HELP Cluster_ActiveRpcWriteCount Generated from Dropwizard metric import (metric=Cluster.ActiveRpcWriteCount, type=com.codahale.metrics.Counter)
# TYPE Cluster_ActiveRpcWriteCount gauge
Cluster_ActiveRpcWriteCount 0.0
# HELP Master_FilesToBePersisted Generated from Dropwizard metric import (metric=Master.FilesToBePersisted, type=alluxio.master.file.DefaultFileSystemMaster$Metrics$$Lambda$132/811735475)
# TYPE Master_FilesToBePersisted gauge
Master_FilesToBePersisted 4.0
# HELP PS_Scavenge_time Generated from Dropwizard metric import (metric=PS-Scavenge.time, type=com.codahale.metrics.jvm.GarbageCollectorMetricSet$$Lambda$38/1555690610)
# TYPE PS_Scavenge_time gauge
PS_Scavenge_time 76.0
# HELP Master_RenamePathOps Generated from Dropwizard metric import (metric=Master.RenamePathOps, type=com.codahale.metrics.Counter)
# TYPE Master_RenamePathOps gauge
Master_RenamePathOps 0.0
# HELP pools_PS_Eden_Space_committed Generated from Dropwizard metric import (metric=pools.PS-Eden-Space.committed, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$53/280884709)
# TYPE pools_PS_Eden_Space_committed gauge
pools_PS_Eden_Space_committed 2.63716864E8
# HELP pools_Compressed_Class_Space_init Generated from Dropwizard metric import (metric=pools.Compressed-Class-Space.init, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$54/1847509784)
# TYPE pools_Compressed_Class_Space_init gauge
pools_Compressed_Class_Space_init 0.0
# HELP Master_AbsentCacheSize Generated from Dropwizard metric import (metric=Master.AbsentCacheSize, type=alluxio.master.file.meta.AsyncUfsAbsentPathCache$$Lambda$124/1800125485)
# TYPE Master_AbsentCacheSize gauge
Master_AbsentCacheSize 0.0
# HELP total_max Generated from Dropwizard metric import (metric=total.max, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$41/267760927)
# TYPE total_max gauge
total_max 3.817865215E9
# HELP pools_PS_Old_Gen_used_after_gc Generated from Dropwizard metric import (metric=pools.PS-Old-Gen.used-after-gc, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$55/2114650936)
# TYPE pools_PS_Old_Gen_used_after_gc gauge
pools_PS_Old_Gen_used_after_gc 4.288068E7
# HELP non_heap_used Generated from Dropwizard metric import (metric=non-heap.used, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$48/764577347)
# TYPE non_heap_used gauge
non_heap_used 7.8969672E7
# HELP Master_Run_User:mbl Generated from Dropwizard metric import (metric=Master.Run.User:mbl, type=com.codahale.metrics.Timer)
# TYPE Master_Run_User:mbl summary
Master_Run_User:mbl{quantile="0.5",} 0.0
Master_Run_User:mbl{quantile="0.75",} 0.0
Master_Run_User:mbl{quantile="0.95",} 0.0
Master_Run_User:mbl{quantile="0.98",} 0.0
Master_Run_User:mbl{quantile="0.99",} 0.0
Master_Run_User:mbl{quantile="0.999",} 0.0
Master_Run_User:mbl_count 0.0
# HELP Cluster_CapacityTotalTierMEM Generated from Dropwizard metric import (metric=Cluster.CapacityTotalTierMEM, type=alluxio.master.block.DefaultBlockMaster$Metrics$1)
# TYPE Cluster_CapacityTotalTierMEM gauge
Cluster_CapacityTotalTierMEM 0.0
# HELP PS_MarkSweep_time Generated from Dropwizard metric import (metric=PS-MarkSweep.time, type=com.codahale.metrics.jvm.GarbageCollectorMetricSet$$Lambda$38/1555690610)
# TYPE PS_MarkSweep_time gauge
PS_MarkSweep_time 155.0
# HELP Cluster_CacheHitRate Generated from Dropwizard metric import (metric=Cluster.CacheHitRate, type=alluxio.master.metrics.MetricsStore$$Lambda$638/1129944640)
# TYPE Cluster_CacheHitRate gauge
Cluster_CacheHitRate 0.0
# HELP Cluster_BytesReadUfsAll Generated from Dropwizard metric import (metric=Cluster.BytesReadUfsAll, type=com.codahale.metrics.Counter)
# TYPE Cluster_BytesReadUfsAll gauge
Cluster_BytesReadUfsAll 0.0
# HELP pools_PS_Survivor_Space_usage Generated from Dropwizard metric import (metric=pools.PS-Survivor-Space.usage, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$3)
# TYPE pools_PS_Survivor_Space_usage gauge
pools_PS_Survivor_Space_usage 0.0
# HELP Master_ListingCacheMisses Generated from Dropwizard metric import (metric=Master.ListingCacheMisses, type=com.codahale.metrics.Counter)
# TYPE Master_ListingCacheMisses gauge
Master_ListingCacheMisses 0.0
# HELP pools_Code_Cache_usage Generated from Dropwizard metric import (metric=pools.Code-Cache.usage, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$3)
# TYPE pools_Code_Cache_usage gauge
pools_Code_Cache_usage 0.040077463785807295
# HELP Master_ConnectFromMaster_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local Generated from Dropwizard metric import (metric=Master.ConnectFromMaster.UFS:%2FUsers%2Fmbl%2Fprojects%2Fgithub%2Falluxio-2%2FunderFSStorage.UFS_TYPE:local, type=com.codahale.metrics.Timer)
# TYPE Master_ConnectFromMaster_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local summary
Master_ConnectFromMaster_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.5",} 0.0
Master_ConnectFromMaster_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.75",} 0.0
Master_ConnectFromMaster_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.95",} 0.0
Master_ConnectFromMaster_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.98",} 0.0
Master_ConnectFromMaster_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.99",} 0.0
Master_ConnectFromMaster_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.999",} 0.0
Master_ConnectFromMaster_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local_count 0.0
# HELP Cluster_CapacityTotalTierSSD Generated from Dropwizard metric import (metric=Cluster.CapacityTotalTierSSD, type=alluxio.master.block.DefaultBlockMaster$Metrics$1)
# TYPE Cluster_CapacityTotalTierSSD gauge
Cluster_CapacityTotalTierSSD 0.0
# HELP Cluster_BytesReadDirect Generated from Dropwizard metric import (metric=Cluster.BytesReadDirect, type=com.codahale.metrics.Counter)
# TYPE Cluster_BytesReadDirect gauge
Cluster_BytesReadDirect 0.0
# HELP pools_Metaspace_used Generated from Dropwizard metric import (metric=pools.Metaspace.used, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$52/230835489)
# TYPE pools_Metaspace_used gauge
pools_Metaspace_used 6.1153584E7
# HELP Master_DeletePathOps Generated from Dropwizard metric import (metric=Master.DeletePathOps, type=com.codahale.metrics.Counter)
# TYPE Master_DeletePathOps gauge
Master_DeletePathOps 0.0
# HELP loaded Generated from Dropwizard metric import (metric=loaded, type=com.codahale.metrics.jvm.ClassLoadingGaugeSet$$Lambda$56/540585569)
# TYPE loaded gauge
loaded 10835.0
# HELP Master_LastBackupRestoreCount Generated from Dropwizard metric import (metric=Master.LastBackupRestoreCount, type=alluxio.master.BackupManager$$Lambda$69/1050349584)
# TYPE Master_LastBackupRestoreCount gauge
Master_LastBackupRestoreCount -1.0
# HELP Master_FilesPinned Generated from Dropwizard metric import (metric=Master.FilesPinned, type=alluxio.master.file.DefaultFileSystemMaster$Metrics$$Lambda$131/412892790)
# TYPE Master_FilesPinned gauge
Master_FilesPinned 0.0
# HELP pools_PS_Old_Gen_init Generated from Dropwizard metric import (metric=pools.PS-Old-Gen.init, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$54/1847509784)
# TYPE pools_PS_Old_Gen_init gauge
pools_PS_Old_Gen_init 1.79306496E8
# HELP Cluster_CapacityTotalTierHDD Generated from Dropwizard metric import (metric=Cluster.CapacityTotalTierHDD, type=alluxio.master.block.DefaultBlockMaster$Metrics$1)
# TYPE Cluster_CapacityTotalTierHDD gauge
Cluster_CapacityTotalTierHDD 0.0
# HELP PS_Scavenge_count Generated from Dropwizard metric import (metric=PS-Scavenge.count, type=com.codahale.metrics.jvm.GarbageCollectorMetricSet$$Lambda$37/1846896625)
# TYPE PS_Scavenge_count gauge
PS_Scavenge_count 8.0
# HELP log_info_count Generated from Dropwizard metric import (metric=log.info.count, type=alluxio.metrics.LogStateCounterSet$$Lambda$65/1795799895)
# TYPE log_info_count gauge
log_info_count 303.0
# HELP PS_MarkSweep_count Generated from Dropwizard metric import (metric=PS-MarkSweep.count, type=com.codahale.metrics.jvm.GarbageCollectorMetricSet$$Lambda$37/1846896625)
# TYPE PS_MarkSweep_count gauge
PS_MarkSweep_count 3.0
# HELP Master_TotalBlocks Generated from Dropwizard metric import (metric=Master.TotalBlocks, type=com.codahale.metrics.Counter)
# TYPE Master_TotalBlocks gauge
Master_TotalBlocks 0.0
# HELP Master_EmbeddedJournalSnapshotLastIndex Generated from Dropwizard metric import (metric=Master.EmbeddedJournalSnapshotLastIndex, type=alluxio.master.journal.raft.JournalStateMachine$$Lambda$149/289639718)
# TYPE Master_EmbeddedJournalSnapshotLastIndex gauge
Master_EmbeddedJournalSnapshotLastIndex -1.0
# HELP count Generated from Dropwizard metric import (metric=count, type=com.codahale.metrics.jvm.ThreadStatesGaugeSet$$Lambda$59/1522311648)
# TYPE count gauge
count 89.0
# HELP Master_PathsUnmounted Generated from Dropwizard metric import (metric=Master.PathsUnmounted, type=com.codahale.metrics.Counter)
# TYPE Master_PathsUnmounted gauge
Master_PathsUnmounted 0.0
# HELP Master_ListingCacheEvictions Generated from Dropwizard metric import (metric=Master.ListingCacheEvictions, type=com.codahale.metrics.Counter)
# TYPE Master_ListingCacheEvictions gauge
Master_ListingCacheEvictions 0.0
# HELP pools_Code_Cache_committed Generated from Dropwizard metric import (metric=pools.Code-Cache.committed, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$53/280884709)
# TYPE pools_Code_Cache_committed gauge
pools_Code_Cache_committed 1.0551296E7
# HELP Master_FilesCompleted Generated from Dropwizard metric import (metric=Master.FilesCompleted, type=com.codahale.metrics.Counter)
# TYPE Master_FilesCompleted gauge
Master_FilesCompleted 0.0
# HELP runnable_count Generated from Dropwizard metric import (metric=runnable.count, type=com.codahale.metrics.jvm.ThreadStatesGaugeSet$$Lambda$58/1875308878)
# TYPE runnable_count gauge
runnable_count 20.0
# HELP unloaded Generated from Dropwizard metric import (metric=unloaded, type=com.codahale.metrics.jvm.ClassLoadingGaugeSet$$Lambda$57/1007653873)
# TYPE unloaded gauge
unloaded 24.0
# HELP non_heap_usage Generated from Dropwizard metric import (metric=non-heap.usage, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$2)
# TYPE non_heap_usage gauge
non_heap_usage -7.8969608E7
# HELP Master_GetSpace_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local Generated from Dropwizard metric import (metric=Master.GetSpace.UFS:%2FUsers%2Fmbl%2Fprojects%2Fgithub%2Falluxio-2%2FunderFSStorage.UFS_TYPE:local, type=com.codahale.metrics.Timer)
# TYPE Master_GetSpace_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local summary
Master_GetSpace_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.5",} 4.9368000000000006E-5
Master_GetSpace_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.75",} 8.971200000000001E-5
Master_GetSpace_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.95",} 8.971200000000001E-5
Master_GetSpace_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.98",} 8.971200000000001E-5
Master_GetSpace_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.99",} 8.971200000000001E-5
Master_GetSpace_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local{quantile="0.999",} 8.971200000000001E-5
Master_GetSpace_UFS:_2FUsers_2Fmbl_2Fprojects_2Fgithub_2Falluxio_2_2FunderFSStorage_UFS_TYPE:local_count 3.0
# HELP new_count Generated from Dropwizard metric import (metric=new.count, type=com.codahale.metrics.jvm.ThreadStatesGaugeSet$$Lambda$58/1875308878)
# TYPE new_count gauge
new_count 0.0
# HELP Master_ListingCacheHits Generated from Dropwizard metric import (metric=Master.ListingCacheHits, type=com.codahale.metrics.Counter)
# TYPE Master_ListingCacheHits gauge
Master_ListingCacheHits 0.0
# HELP pools_Compressed_Class_Space_usage Generated from Dropwizard metric import (metric=pools.Compressed-Class-Space.usage, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$3)
# TYPE pools_Compressed_Class_Space_usage gauge
pools_Compressed_Class_Space_usage 0.007205970585346222
# HELP Master_SetAttributeOps Generated from Dropwizard metric import (metric=Master.SetAttributeOps, type=com.codahale.metrics.Counter)
# TYPE Master_SetAttributeOps gauge
Master_SetAttributeOps 0.0
# HELP heap_max Generated from Dropwizard metric import (metric=heap.max, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$45/1268066861)
# TYPE heap_max gauge
heap_max 3.817865216E9
# HELP Cluster_BytesReadLocalThroughput Generated from Dropwizard metric import (metric=Cluster.BytesReadLocalThroughput, type=alluxio.master.metrics.DefaultMetricsMaster$2)
# TYPE Cluster_BytesReadLocalThroughput gauge
Cluster_BytesReadLocalThroughput 0.0
# HELP pools_Code_Cache_used Generated from Dropwizard metric import (metric=pools.Code-Cache.used, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$52/230835489)
# TYPE pools_Code_Cache_used gauge
pools_Code_Cache_used 1.0085824E7
# HELP pools_Compressed_Class_Space_used Generated from Dropwizard metric import (metric=pools.Compressed-Class-Space.used, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$52/230835489)
# TYPE pools_Compressed_Class_Space_used gauge
pools_Compressed_Class_Space_used 7737352.0
# HELP total_started_count Generated from Dropwizard metric import (metric=total_started.count, type=com.codahale.metrics.jvm.ThreadStatesGaugeSet$$Lambda$62/1836797772)
# TYPE total_started_count gauge
total_started_count 424.0
# HELP Master_NewBlocksGot Generated from Dropwizard metric import (metric=Master.NewBlocksGot, type=com.codahale.metrics.Counter)
# TYPE Master_NewBlocksGot gauge
Master_NewBlocksGot 0.0
# HELP Cluster_BytesWrittenUfsThroughput Generated from Dropwizard metric import (metric=Cluster.BytesWrittenUfsThroughput, type=alluxio.master.metrics.DefaultMetricsMaster$2)
# TYPE Cluster_BytesWrittenUfsThroughput gauge
Cluster_BytesWrittenUfsThroughput 0.0
# HELP Master_InodeLockPoolSize Generated from Dropwizard metric import (metric=Master.InodeLockPoolSize, type=alluxio.master.file.meta.InodeLockManager$$Lambda$109/611381722)
# TYPE Master_InodeLockPoolSize gauge
Master_InodeLockPoolSize 3.0
# HELP total_init Generated from Dropwizard metric import (metric=total.init, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$39/1164371389)
# TYPE total_init gauge
total_init 2.7099136E8
# HELP Master_EdgeCacheLoadTimes Generated from Dropwizard metric import (metric=Master.EdgeCacheLoadTimes, type=com.codahale.metrics.Counter)
# TYPE Master_EdgeCacheLoadTimes gauge
Master_EdgeCacheLoadTimes 63036.0
# HELP Master_FilesCreated Generated from Dropwizard metric import (metric=Master.FilesCreated, type=com.codahale.metrics.Counter)
# TYPE Master_FilesCreated gauge
Master_FilesCreated 0.0
# HELP Master_getConfigurationInProgress Generated from Dropwizard metric import (metric=Master.getConfigurationInProgress, type=com.codahale.metrics.Counter)
# TYPE Master_getConfigurationInProgress gauge
Master_getConfigurationInProgress 0.0
# HELP Master_InodeCacheSize Generated from Dropwizard metric import (metric=Master.InodeCacheSize, type=alluxio.master.metastore.caching.Cache$$Lambda$112/1248281086)
# TYPE Master_InodeCacheSize gauge
Master_InodeCacheSize 12.0
# HELP Master_JournalLastCheckPointTime Generated from Dropwizard metric import (metric=Master.JournalLastCheckPointTime, type=alluxio.master.journal.raft.JournalStateMachine$$Lambda$151/2048834776)
# TYPE Master_JournalLastCheckPointTime gauge
Master_JournalLastCheckPointTime -1.0
# HELP Cluster_CapacityTotal Generated from Dropwizard metric import (metric=Cluster.CapacityTotal, type=alluxio.master.block.DefaultBlockMaster$Metrics$$Lambda$90/201924323)
# TYPE Cluster_CapacityTotal gauge
Cluster_CapacityTotal 0.0
# HELP Cluster_LostWorkers Generated from Dropwizard metric import (metric=Cluster.LostWorkers, type=alluxio.master.block.DefaultBlockMaster$Metrics$5)
# TYPE Cluster_LostWorkers gauge
Cluster_LostWorkers 0.0
# HELP Cluster_RootUfsCapacityTotal Generated from Dropwizard metric import (metric=Cluster.RootUfsCapacityTotal, type=alluxio.master.file.DefaultFileSystemMaster$Metrics$$Lambda$135/1763695690)
# TYPE Cluster_RootUfsCapacityTotal gauge
Cluster_RootUfsCapacityTotal 4.99963174912E11
# HELP pools_Compressed_Class_Space_committed Generated from Dropwizard metric import (metric=pools.Compressed-Class-Space.committed, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$53/280884709)
# TYPE pools_Compressed_Class_Space_committed gauge
pools_Compressed_Class_Space_committed 8429568.0
# HELP pools_Compressed_Class_Space_max Generated from Dropwizard metric import (metric=pools.Compressed-Class-Space.max, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$51/343965883)
# TYPE pools_Compressed_Class_Space_max gauge
pools_Compressed_Class_Space_max 1.073741824E9
# HELP pools_PS_Survivor_Space_init Generated from Dropwizard metric import (metric=pools.PS-Survivor-Space.init, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$54/1847509784)
# TYPE pools_PS_Survivor_Space_init gauge
pools_PS_Survivor_Space_init 1.1010048E7
# HELP Master_GetFileInfoOps Generated from Dropwizard metric import (metric=Master.GetFileInfoOps, type=com.codahale.metrics.Counter)
# TYPE Master_GetFileInfoOps gauge
Master_GetFileInfoOps 0.0
# HELP non_heap_init Generated from Dropwizard metric import (metric=non-heap.init, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$47/112061925)
# TYPE non_heap_init gauge
non_heap_init 2555904.0
# HELP Cluster_CapacityFreeTierSSD Generated from Dropwizard metric import (metric=Cluster.CapacityFreeTierSSD, type=alluxio.master.block.DefaultBlockMaster$Metrics$3)
# TYPE Cluster_CapacityFreeTierSSD gauge
Cluster_CapacityFreeTierSSD 0.0
# HELP Cluster_BytesWrittenRemoteThroughput Generated from Dropwizard metric import (metric=Cluster.BytesWrittenRemoteThroughput, type=alluxio.master.metrics.DefaultMetricsMaster$2)
# TYPE Cluster_BytesWrittenRemoteThroughput gauge
Cluster_BytesWrittenRemoteThroughput 0.0
# HELP Master_FilesPersisted Generated from Dropwizard metric import (metric=Master.FilesPersisted, type=com.codahale.metrics.Counter)
# TYPE Master_FilesPersisted gauge
Master_FilesPersisted 0.0
# HELP peak_count Generated from Dropwizard metric import (metric=peak.count, type=com.codahale.metrics.jvm.ThreadStatesGaugeSet$$Lambda$61/1318822808)
# TYPE peak_count gauge
peak_count 237.0
# HELP pools_Metaspace_init Generated from Dropwizard metric import (metric=pools.Metaspace.init, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$54/1847509784)
# TYPE pools_Metaspace_init gauge
pools_Metaspace_init 0.0
# HELP Master_FileInfosGot Generated from Dropwizard metric import (metric=Master.FileInfosGot, type=com.codahale.metrics.Counter)
# TYPE Master_FileInfosGot gauge
Master_FileInfosGot 0.0
# HELP pools_Code_Cache_init Generated from Dropwizard metric import (metric=pools.Code-Cache.init, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$54/1847509784)
# TYPE pools_Code_Cache_init gauge
pools_Code_Cache_init 2555904.0
# HELP Cluster_BytesWrittenLocalThroughput Generated from Dropwizard metric import (metric=Cluster.BytesWrittenLocalThroughput, type=alluxio.master.metrics.DefaultMetricsMaster$2)
# TYPE Cluster_BytesWrittenLocalThroughput gauge
Cluster_BytesWrittenLocalThroughput 0.0
# HELP pools_Metaspace_usage Generated from Dropwizard metric import (metric=pools.Metaspace.usage, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$3)
# TYPE pools_Metaspace_usage gauge
pools_Metaspace_usage 0.9438661157383993
# HELP Master_PathsDeleted Generated from Dropwizard metric import (metric=Master.PathsDeleted, type=com.codahale.metrics.Counter)
# TYPE Master_PathsDeleted gauge
Master_PathsDeleted 0.0
# HELP Master_EdgeCacheHits Generated from Dropwizard metric import (metric=Master.EdgeCacheHits, type=com.codahale.metrics.Counter)
# TYPE Master_EdgeCacheHits gauge
Master_EdgeCacheHits 3.0
# HELP Cluster_CapacityUsedTierMEM Generated from Dropwizard metric import (metric=Cluster.CapacityUsedTierMEM, type=alluxio.master.block.DefaultBlockMaster$Metrics$2)
# TYPE Cluster_CapacityUsedTierMEM gauge
Cluster_CapacityUsedTierMEM 0.0
# HELP pools_PS_Eden_Space_max Generated from Dropwizard metric import (metric=pools.PS-Eden-Space.max, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$51/343965883)
# TYPE pools_PS_Eden_Space_max gauge
pools_PS_Eden_Space_max 1.391460352E9
# HELP timed_waiting_count Generated from Dropwizard metric import (metric=timed_waiting.count, type=com.codahale.metrics.jvm.ThreadStatesGaugeSet$$Lambda$58/1875308878)
# TYPE timed_waiting_count gauge
timed_waiting_count 54.0
# HELP daemon_count Generated from Dropwizard metric import (metric=daemon.count, type=com.codahale.metrics.jvm.ThreadStatesGaugeSet$$Lambda$60/36202360)
# TYPE daemon_count gauge
daemon_count 73.0
# HELP heap_init Generated from Dropwizard metric import (metric=heap.init, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$$Lambda$43/1459794865)
# TYPE heap_init gauge
heap_init 2.68435456E8
# HELP Master_EdgeCacheEvictions Generated from Dropwizard metric import (metric=Master.EdgeCacheEvictions, type=com.codahale.metrics.Counter)
# TYPE Master_EdgeCacheEvictions gauge
Master_EdgeCacheEvictions 0.0
# HELP deadlock_count Generated from Dropwizard metric import (metric=deadlock.count, type=com.codahale.metrics.jvm.ThreadStatesGaugeSet$$Lambda$63/1383547042)
# TYPE deadlock_count gauge
deadlock_count 0.0
# HELP Cluster_BytesWrittenRemote Generated from Dropwizard metric import (metric=Cluster.BytesWrittenRemote, type=com.codahale.metrics.Counter)
# TYPE Cluster_BytesWrittenRemote gauge
Cluster_BytesWrittenRemote 0.0
# HELP Master_UnmountOps Generated from Dropwizard metric import (metric=Master.UnmountOps, type=com.codahale.metrics.Counter)
# TYPE Master_UnmountOps gauge
Master_UnmountOps 0.0
# HELP uptime Generated from Dropwizard metric import (metric=uptime, type=com.codahale.metrics.jvm.JvmAttributeGaugeSet$$Lambda$36/667026744)
# TYPE uptime gauge
uptime 26723.0
# HELP Master_PathsMounted Generated from Dropwizard metric import (metric=Master.PathsMounted, type=com.codahale.metrics.Counter)
# TYPE Master_PathsMounted gauge
Master_PathsMounted 0.0
# HELP pools_PS_Eden_Space_usage Generated from Dropwizard metric import (metric=pools.PS-Eden-Space.usage, type=com.codahale.metrics.jvm.MemoryUsageGaugeSet$3)
# TYPE pools_PS_Eden_Space_usage gauge
pools_PS_Eden_Space_usage 0.0634424803215665
# HELP Master_InodeCacheEvictions Generated from Dropwizard metric import (metric=Master.InodeCacheEvictions, type=com.codahale.metrics.Counter)
# TYPE Master_InodeCacheEvictions gauge
Master_InodeCacheEvictions 0.0
# HELP Master_ListingCacheSize Generated from Dropwizard metric import (metric=Master.ListingCacheSize, type=alluxio.master.metastore.caching.CachingInodeStore$ListingCache$$Lambda$114/1980731812)
# TYPE Master_ListingCacheSize gauge
Master_ListingCacheSize 1.0
# HELP Master_FileBlockInfosGot Generated from Dropwizard metric import (metric=Master.FileBlockInfosGot, type=com.codahale.metrics.Counter)
# TYPE Master_FileBlockInfosGot gauge
Master_FileBlockInfosGot 0.0
# HELP Master_DirectoriesCreated Generated from Dropwizard metric import (metric=Master.DirectoriesCreated, type=com.codahale.metrics.Counter)
# TYPE Master_DirectoriesCreated gauge
Master_DirectoriesCreated 0.0
# HELP Master_LastBackupRestoreTimeMs Generated from Dropwizard metric import (metric=Master.LastBackupRestoreTimeMs, type=alluxio.master.BackupManager$$Lambda$70/1815546035)
# TYPE Master_LastBackupRestoreTimeMs gauge
Master_LastBackupRestoreTimeMs -1.0
# HELP ratis_log_worker_flushTime Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.flushTime, type=com.codahale.metrics.Timer)
# TYPE ratis_log_worker_flushTime summary
ratis_log_worker_flushTime{quantile="0.5",instance="localhost_19200",group="group-ABB3109A44C1",} 2.4402E-4
ratis_log_worker_flushTime{quantile="0.75",instance="localhost_19200",group="group-ABB3109A44C1",} 2.4402E-4
ratis_log_worker_flushTime{quantile="0.95",instance="localhost_19200",group="group-ABB3109A44C1",} 4.12825E-4
ratis_log_worker_flushTime{quantile="0.98",instance="localhost_19200",group="group-ABB3109A44C1",} 4.12825E-4
ratis_log_worker_flushTime{quantile="0.99",instance="localhost_19200",group="group-ABB3109A44C1",} 4.12825E-4
ratis_log_worker_flushTime{quantile="0.999",instance="localhost_19200",group="group-ABB3109A44C1",} 4.12825E-4
ratis_log_worker_flushTime_count{instance="localhost_19200",group="group-ABB3109A44C1",} 4.0
# HELP ratis_log_worker_flushCount Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.flushCount, type=com.codahale.metrics.Counter)
# TYPE ratis_log_worker_flushCount gauge
ratis_log_worker_flushCount{instance="localhost_19200",group="group-ABB3109A44C1",} 4.0
# HELP ratis_log_worker_stateMachineLogEntryCount Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.stateMachineLogEntryCount, type=com.codahale.metrics.Counter)
# TYPE ratis_log_worker_stateMachineLogEntryCount gauge
ratis_log_worker_stateMachineLogEntryCount{instance="localhost_19200",group="group-ABB3109A44C1",} 1.0
# HELP ratis_log_worker_writelogExecutionTime Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.writelogExecutionTime, type=com.codahale.metrics.Timer)
# TYPE ratis_log_worker_writelogExecutionTime summary
ratis_log_worker_writelogExecutionTime{quantile="0.5",instance="localhost_19200",group="group-ABB3109A44C1",} 3.51172E-4
ratis_log_worker_writelogExecutionTime{quantile="0.75",instance="localhost_19200",group="group-ABB3109A44C1",} 3.51172E-4
ratis_log_worker_writelogExecutionTime{quantile="0.95",instance="localhost_19200",group="group-ABB3109A44C1",} 9.509340000000001E-4
ratis_log_worker_writelogExecutionTime{quantile="0.98",instance="localhost_19200",group="group-ABB3109A44C1",} 9.509340000000001E-4
ratis_log_worker_writelogExecutionTime{quantile="0.99",instance="localhost_19200",group="group-ABB3109A44C1",} 9.509340000000001E-4
ratis_log_worker_writelogExecutionTime{quantile="0.999",instance="localhost_19200",group="group-ABB3109A44C1",} 9.509340000000001E-4
ratis_log_worker_writelogExecutionTime_count{instance="localhost_19200",group="group-ABB3109A44C1",} 4.0
# HELP ratis_log_worker_syncBatchSize Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.syncBatchSize, type=org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogWorker$$Lambda$290/1215166819)
# TYPE ratis_log_worker_syncBatchSize gauge
ratis_log_worker_syncBatchSize{instance="localhost_19200",group="group-ABB3109A44C1",} 1.0
# HELP ratis_log_worker_closedSegmentsSizeInBytes Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.closedSegmentsSizeInBytes, type=org.apache.ratis.server.metrics.SegmentedRaftLogMetrics$$Lambda$270/310090530)
# TYPE ratis_log_worker_closedSegmentsSizeInBytes gauge
ratis_log_worker_closedSegmentsSizeInBytes{instance="localhost_19200",group="group-ABB3109A44C1",} 18732.0
# HELP ratis_log_worker_queueingDelay Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.queueingDelay, type=com.codahale.metrics.Timer)
# TYPE ratis_log_worker_queueingDelay summary
ratis_log_worker_queueingDelay{quantile="0.5",instance="localhost_19200",group="group-ABB3109A44C1",} 2.3916000000000003E-5
ratis_log_worker_queueingDelay{quantile="0.75",instance="localhost_19200",group="group-ABB3109A44C1",} 3.5398300000000004E-4
ratis_log_worker_queueingDelay{quantile="0.95",instance="localhost_19200",group="group-ABB3109A44C1",} 6.87938E-4
ratis_log_worker_queueingDelay{quantile="0.98",instance="localhost_19200",group="group-ABB3109A44C1",} 6.87938E-4
ratis_log_worker_queueingDelay{quantile="0.99",instance="localhost_19200",group="group-ABB3109A44C1",} 6.87938E-4
ratis_log_worker_queueingDelay{quantile="0.999",instance="localhost_19200",group="group-ABB3109A44C1",} 6.87938E-4
ratis_log_worker_queueingDelay_count{instance="localhost_19200",group="group-ABB3109A44C1",} 6.0
# HELP ratis_log_worker_appendEntryLatency Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.appendEntryLatency, type=com.codahale.metrics.Timer)
# TYPE ratis_log_worker_appendEntryLatency summary
ratis_log_worker_appendEntryLatency{quantile="0.5",instance="localhost_19200",group="group-ABB3109A44C1",} 1.2939E-4
ratis_log_worker_appendEntryLatency{quantile="0.75",instance="localhost_19200",group="group-ABB3109A44C1",} 3.23125E-4
ratis_log_worker_appendEntryLatency{quantile="0.95",instance="localhost_19200",group="group-ABB3109A44C1",} 0.0039696620000000005
ratis_log_worker_appendEntryLatency{quantile="0.98",instance="localhost_19200",group="group-ABB3109A44C1",} 0.0039696620000000005
ratis_log_worker_appendEntryLatency{quantile="0.99",instance="localhost_19200",group="group-ABB3109A44C1",} 0.0039696620000000005
ratis_log_worker_appendEntryLatency{quantile="0.999",instance="localhost_19200",group="group-ABB3109A44C1",} 0.0039696620000000005
ratis_log_worker_appendEntryLatency_count{instance="localhost_19200",group="group-ABB3109A44C1",} 4.0
# HELP ratis_log_worker_configLogEntryCount Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.configLogEntryCount, type=com.codahale.metrics.Counter)
# TYPE ratis_log_worker_configLogEntryCount gauge
ratis_log_worker_configLogEntryCount{instance="localhost_19200",group="group-ABB3109A44C1",} 1.0
# HELP ratis_log_worker_cacheHitCount Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.cacheHitCount, type=com.codahale.metrics.Counter)
# TYPE ratis_log_worker_cacheHitCount gauge
ratis_log_worker_cacheHitCount{instance="localhost_19200",group="group-ABB3109A44C1",} 65.0
# HELP ratis_log_worker_enqueuedTime Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.enqueuedTime, type=com.codahale.metrics.Timer)
# TYPE ratis_log_worker_enqueuedTime summary
ratis_log_worker_enqueuedTime{quantile="0.5",instance="localhost_19200",group="group-ABB3109A44C1",} 4.6143E-5
ratis_log_worker_enqueuedTime{quantile="0.75",instance="localhost_19200",group="group-ABB3109A44C1",} 0.0035845010000000004
ratis_log_worker_enqueuedTime{quantile="0.95",instance="localhost_19200",group="group-ABB3109A44C1",} 0.008875492
ratis_log_worker_enqueuedTime{quantile="0.98",instance="localhost_19200",group="group-ABB3109A44C1",} 0.008875492
ratis_log_worker_enqueuedTime{quantile="0.99",instance="localhost_19200",group="group-ABB3109A44C1",} 0.008875492
ratis_log_worker_enqueuedTime{quantile="0.999",instance="localhost_19200",group="group-ABB3109A44C1",} 0.008875492
ratis_log_worker_enqueuedTime_count{instance="localhost_19200",group="group-ABB3109A44C1",} 6.0
# HELP ratis_log_worker_readEntryLatency Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.readEntryLatency, type=com.codahale.metrics.Timer)
# TYPE ratis_log_worker_readEntryLatency summary
ratis_log_worker_readEntryLatency{quantile="0.5",instance="localhost_19200",group="group-ABB3109A44C1",} 1.2816E-5
ratis_log_worker_readEntryLatency{quantile="0.75",instance="localhost_19200",group="group-ABB3109A44C1",} 1.8235E-5
ratis_log_worker_readEntryLatency{quantile="0.95",instance="localhost_19200",group="group-ABB3109A44C1",} 3.4808E-5
ratis_log_worker_readEntryLatency{quantile="0.98",instance="localhost_19200",group="group-ABB3109A44C1",} 5.3962E-5
ratis_log_worker_readEntryLatency{quantile="0.99",instance="localhost_19200",group="group-ABB3109A44C1",} 6.0271000000000006E-5
ratis_log_worker_readEntryLatency{quantile="0.999",instance="localhost_19200",group="group-ABB3109A44C1",} 0.004183213
ratis_log_worker_readEntryLatency_count{instance="localhost_19200",group="group-ABB3109A44C1",} 514.0
# HELP ratis_log_worker_closedSegmentsNum Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.closedSegmentsNum, type=org.apache.ratis.server.metrics.SegmentedRaftLogMetrics$$Lambda$268/1175781635)
# TYPE ratis_log_worker_closedSegmentsNum gauge
ratis_log_worker_closedSegmentsNum{instance="localhost_19200",group="group-ABB3109A44C1",} 0.0
# HELP ratis_log_worker_dataQueueSize Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.dataQueueSize, type=org.apache.ratis.server.metrics.SegmentedRaftLogMetrics$$Lambda$286/1393271257)
# TYPE ratis_log_worker_dataQueueSize gauge
ratis_log_worker_dataQueueSize{instance="localhost_19200",group="group-ABB3109A44C1",} 0.0
# HELP ratis_log_worker_syncTime Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.syncTime, type=com.codahale.metrics.Timer)
# TYPE ratis_log_worker_syncTime summary
ratis_log_worker_syncTime{quantile="0.5",instance="localhost_19200",group="group-ABB3109A44C1",} 1.72914E-4
ratis_log_worker_syncTime{quantile="0.75",instance="localhost_19200",group="group-ABB3109A44C1",} 2.31856E-4
ratis_log_worker_syncTime{quantile="0.95",instance="localhost_19200",group="group-ABB3109A44C1",} 2.31856E-4
ratis_log_worker_syncTime{quantile="0.98",instance="localhost_19200",group="group-ABB3109A44C1",} 2.31856E-4
ratis_log_worker_syncTime{quantile="0.99",instance="localhost_19200",group="group-ABB3109A44C1",} 2.31856E-4
ratis_log_worker_syncTime{quantile="0.999",instance="localhost_19200",group="group-ABB3109A44C1",} 2.31856E-4
ratis_log_worker_syncTime_count{instance="localhost_19200",group="group-ABB3109A44C1",} 4.0
# HELP ratis_log_worker_appendEntryCount Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.appendEntryCount, type=com.codahale.metrics.Counter)
# TYPE ratis_log_worker_appendEntryCount gauge
ratis_log_worker_appendEntryCount{instance="localhost_19200",group="group-ABB3109A44C1",} 4.0
# HELP ratis_log_worker_finalizelogsegmentExecutionTime Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.finalizelogsegmentExecutionTime, type=com.codahale.metrics.Timer)
# TYPE ratis_log_worker_finalizelogsegmentExecutionTime summary
ratis_log_worker_finalizelogsegmentExecutionTime{quantile="0.5",instance="localhost_19200",group="group-ABB3109A44C1",} 0.003328197
ratis_log_worker_finalizelogsegmentExecutionTime{quantile="0.75",instance="localhost_19200",group="group-ABB3109A44C1",} 0.003328197
ratis_log_worker_finalizelogsegmentExecutionTime{quantile="0.95",instance="localhost_19200",group="group-ABB3109A44C1",} 0.003328197
ratis_log_worker_finalizelogsegmentExecutionTime{quantile="0.98",instance="localhost_19200",group="group-ABB3109A44C1",} 0.003328197
ratis_log_worker_finalizelogsegmentExecutionTime{quantile="0.99",instance="localhost_19200",group="group-ABB3109A44C1",} 0.003328197
ratis_log_worker_finalizelogsegmentExecutionTime{quantile="0.999",instance="localhost_19200",group="group-ABB3109A44C1",} 0.003328197
ratis_log_worker_finalizelogsegmentExecutionTime_count{instance="localhost_19200",group="group-ABB3109A44C1",} 1.0
# HELP ratis_log_worker_startlogsegmentExecutionTime Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.startlogsegmentExecutionTime, type=com.codahale.metrics.Timer)
# TYPE ratis_log_worker_startlogsegmentExecutionTime summary
ratis_log_worker_startlogsegmentExecutionTime{quantile="0.5",instance="localhost_19200",group="group-ABB3109A44C1",} 0.008214741000000001
ratis_log_worker_startlogsegmentExecutionTime{quantile="0.75",instance="localhost_19200",group="group-ABB3109A44C1",} 0.008214741000000001
ratis_log_worker_startlogsegmentExecutionTime{quantile="0.95",instance="localhost_19200",group="group-ABB3109A44C1",} 0.008214741000000001
ratis_log_worker_startlogsegmentExecutionTime{quantile="0.98",instance="localhost_19200",group="group-ABB3109A44C1",} 0.008214741000000001
ratis_log_worker_startlogsegmentExecutionTime{quantile="0.99",instance="localhost_19200",group="group-ABB3109A44C1",} 0.008214741000000001
ratis_log_worker_startlogsegmentExecutionTime{quantile="0.999",instance="localhost_19200",group="group-ABB3109A44C1",} 0.008214741000000001
ratis_log_worker_startlogsegmentExecutionTime_count{instance="localhost_19200",group="group-ABB3109A44C1",} 1.0
# HELP ratis_log_worker_openSegmentSizeInBytes Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.openSegmentSizeInBytes, type=org.apache.ratis.server.metrics.SegmentedRaftLogMetrics$$Lambda$272/1273256345)
# TYPE ratis_log_worker_openSegmentSizeInBytes gauge
ratis_log_worker_openSegmentSizeInBytes{instance="localhost_19200",group="group-ABB3109A44C1",} 131.0
# HELP ratis_log_worker_segmentLoadLatency Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.segmentLoadLatency, type=com.codahale.metrics.Timer)
# TYPE ratis_log_worker_segmentLoadLatency summary
ratis_log_worker_segmentLoadLatency{quantile="0.5",instance="localhost_19200",group="group-ABB3109A44C1",} 0.001278307
ratis_log_worker_segmentLoadLatency{quantile="0.75",instance="localhost_19200",group="group-ABB3109A44C1",} 0.001727273
ratis_log_worker_segmentLoadLatency{quantile="0.95",instance="localhost_19200",group="group-ABB3109A44C1",} 0.002564006
ratis_log_worker_segmentLoadLatency{quantile="0.98",instance="localhost_19200",group="group-ABB3109A44C1",} 0.003004937
ratis_log_worker_segmentLoadLatency{quantile="0.99",instance="localhost_19200",group="group-ABB3109A44C1",} 0.024872756000000003
ratis_log_worker_segmentLoadLatency{quantile="0.999",instance="localhost_19200",group="group-ABB3109A44C1",} 0.024872756000000003
ratis_log_worker_segmentLoadLatency_count{instance="localhost_19200",group="group-ABB3109A44C1",} 62.0
# HELP ratis_log_worker_workerQueueSize Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.workerQueueSize, type=org.apache.ratis.server.metrics.SegmentedRaftLogMetrics$$Lambda$288/842979141)
# TYPE ratis_log_worker_workerQueueSize gauge
ratis_log_worker_workerQueueSize{instance="localhost_19200",group="group-ABB3109A44C1",} 0.0
# HELP ratis_log_worker_cacheMissCount Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.cacheMissCount, type=com.codahale.metrics.Counter)
# TYPE ratis_log_worker_cacheMissCount gauge
ratis_log_worker_cacheMissCount{instance="localhost_19200",group="group-ABB3109A44C1",} 3.0
# HELP ratis_log_worker_metadataLogEntryCount Generated from Dropwizard metric import (metric=ratis.log_worker.localhost_19200@group-ABB3109A44C1.metadataLogEntryCount, type=com.codahale.metrics.Counter)
# TYPE ratis_log_worker_metadataLogEntryCount gauge
ratis_log_worker_metadataLogEntryCount{instance="localhost_19200",group="group-ABB3109A44C1",} 3.0
# HELP ratis_server_retryCacheEntryCount Generated from Dropwizard metric import (metric=ratis.server.localhost_19200@group-ABB3109A44C1.retryCacheEntryCount, type=org.apache.ratis.server.metrics.RaftServerMetricsImpl$$Lambda$344/494860246)
# TYPE ratis_server_retryCacheEntryCount gauge
ratis_server_retryCacheEntryCount{instance="localhost_19200",group="group-ABB3109A44C1",} 24.0
# HELP ratis_server_numPendingRequestByteSize Generated from Dropwizard metric import (metric=ratis.server.localhost_19200@group-ABB3109A44C1.numPendingRequestByteSize, type=org.apache.ratis.server.impl.PendingRequests$RequestMap$$Lambda$545/1607021689)
# TYPE ratis_server_numPendingRequestByteSize gauge
ratis_server_numPendingRequestByteSize{instance="localhost_19200",group="group-ABB3109A44C1",} 0.0
# HELP ratis_server_retryCacheMissCount Generated from Dropwizard metric import (metric=ratis.server.localhost_19200@group-ABB3109A44C1.retryCacheMissCount, type=org.apache.ratis.server.metrics.RaftServerMetricsImpl$$Lambda$350/1947557088)
# TYPE ratis_server_retryCacheMissCount gauge
ratis_server_retryCacheMissCount{instance="localhost_19200",group="group-ABB3109A44C1",} 25.0
# HELP ratis_server_retryCacheMissRate Generated from Dropwizard metric import (metric=ratis.server.localhost_19200@group-ABB3109A44C1.retryCacheMissRate, type=org.apache.ratis.server.metrics.RaftServerMetricsImpl$$Lambda$352/1246525155)
# TYPE ratis_server_retryCacheMissRate gauge
ratis_server_retryCacheMissRate{instance="localhost_19200",group="group-ABB3109A44C1",} 0.9615384615384616
# HELP ratis_server_clientWatchRequest Generated from Dropwizard metric import (metric=ratis.server.localhost_19200@group-ABB3109A44C1.clientWatchRequest, type=com.codahale.metrics.Timer)
# TYPE ratis_server_clientWatchRequest summary
ratis_server_clientWatchRequest{quantile="0.5",instance="localhost_19200",group="group-ABB3109A44C1",} 1.56376E-4
ratis_server_clientWatchRequest{quantile="0.75",instance="localhost_19200",group="group-ABB3109A44C1",} 1.56376E-4
ratis_server_clientWatchRequest{quantile="0.95",instance="localhost_19200",group="group-ABB3109A44C1",} 1.56376E-4
ratis_server_clientWatchRequest{quantile="0.98",instance="localhost_19200",group="group-ABB3109A44C1",} 1.56376E-4
ratis_server_clientWatchRequest{quantile="0.99",instance="localhost_19200",group="group-ABB3109A44C1",} 1.56376E-4
ratis_server_clientWatchRequest{quantile="0.999",instance="localhost_19200",group="group-ABB3109A44C1",} 1.56376E-4
ratis_server_clientWatchRequest_count{instance="localhost_19200",group="group-ABB3109A44C1",} 1.0
# HELP ratis_server_clientWriteRequest Generated from Dropwizard metric import (metric=ratis.server.localhost_19200@group-ABB3109A44C1.clientWriteRequest, type=com.codahale.metrics.Timer)
# TYPE ratis_server_clientWriteRequest summary
ratis_server_clientWriteRequest{quantile="0.5",instance="localhost_19200",group="group-ABB3109A44C1",} 4.93E-7
ratis_server_clientWriteRequest{quantile="0.75",instance="localhost_19200",group="group-ABB3109A44C1",} 4.93E-7
ratis_server_clientWriteRequest{quantile="0.95",instance="localhost_19200",group="group-ABB3109A44C1",} 4.93E-7
ratis_server_clientWriteRequest{quantile="0.98",instance="localhost_19200",group="group-ABB3109A44C1",} 4.93E-7
ratis_server_clientWriteRequest{quantile="0.99",instance="localhost_19200",group="group-ABB3109A44C1",} 4.93E-7
ratis_server_clientWriteRequest{quantile="0.999",instance="localhost_19200",group="group-ABB3109A44C1",} 4.93E-7
ratis_server_clientWriteRequest_count{instance="localhost_19200",group="group-ABB3109A44C1",} 1.0
# HELP ratis_server_numPendingRequestInQueue Generated from Dropwizard metric import (metric=ratis.server.localhost_19200@group-ABB3109A44C1.numPendingRequestInQueue, type=org.apache.ratis.server.impl.PendingRequests$RequestMap$$Lambda$543/768168562)
# TYPE ratis_server_numPendingRequestInQueue gauge
ratis_server_numPendingRequestInQueue{instance="localhost_19200",group="group-ABB3109A44C1",} 0.0
# HELP ratis_server_clientReadRequest Generated from Dropwizard metric import (metric=ratis.server.localhost_19200@group-ABB3109A44C1.clientReadRequest, type=com.codahale.metrics.Timer)
# TYPE ratis_server_clientReadRequest summary
ratis_server_clientReadRequest{quantile="0.5",instance="localhost_19200",group="group-ABB3109A44C1",} 8.140000000000001E-7
ratis_server_clientReadRequest{quantile="0.75",instance="localhost_19200",group="group-ABB3109A44C1",} 8.140000000000001E-7
ratis_server_clientReadRequest{quantile="0.95",instance="localhost_19200",group="group-ABB3109A44C1",} 8.140000000000001E-7
ratis_server_clientReadRequest{quantile="0.98",instance="localhost_19200",group="group-ABB3109A44C1",} 8.140000000000001E-7
ratis_server_clientReadRequest{quantile="0.99",instance="localhost_19200",group="group-ABB3109A44C1",} 8.140000000000001E-7
ratis_server_clientReadRequest{quantile="0.999",instance="localhost_19200",group="group-ABB3109A44C1",} 8.140000000000001E-7
ratis_server_clientReadRequest_count{instance="localhost_19200",group="group-ABB3109A44C1",} 1.0
# HELP ratis_server_localhost_19200_peerCommitIndex Generated from Dropwizard metric import (metric=ratis.server.localhost_19200@group-ABB3109A44C1.localhost_19200_peerCommitIndex, type=org.apache.ratis.server.metrics.RaftServerMetricsImpl$$Lambda$342/1674528524)
# TYPE ratis_server_localhost_19200_peerCommitIndex gauge
ratis_server_localhost_19200_peerCommitIndex{instance="localhost_19200",group="group-ABB3109A44C1",} 416.0
# HELP ratis_server_retryCacheHitRate Generated from Dropwizard metric import (metric=ratis.server.localhost_19200@group-ABB3109A44C1.retryCacheHitRate, type=org.apache.ratis.server.metrics.RaftServerMetricsImpl$$Lambda$348/468207268)
# TYPE ratis_server_retryCacheHitRate gauge
ratis_server_retryCacheHitRate{instance="localhost_19200",group="group-ABB3109A44C1",} 0.038461538461538464
# HELP ratis_server_retryCacheHitCount Generated from Dropwizard metric import (metric=ratis.server.localhost_19200@group-ABB3109A44C1.retryCacheHitCount, type=org.apache.ratis.server.metrics.RaftServerMetricsImpl$$Lambda$346/1693362259)
# TYPE ratis_server_retryCacheHitCount gauge
ratis_server_retryCacheHitCount{instance="localhost_19200",group="group-ABB3109A44C1",} 1.0
```