### PR TITLE
Improve UfsIOBench and RpcBench command descriptions

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/GetPinnedFileIdsBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/GetPinnedFileIdsBench.java
@@ -72,10 +72,10 @@ public class GetPinnedFileIdsBench extends RpcBench<GetPinnedFileIdsParameters> 
         "Example:",
         "# 2 job workers will be chosen to run the benchmark",
         "# Each job worker runs 3 simulated clients",
-        "# Each client keeps requesting a total number of 100k pinned files for "
-            + "a total of 5 seconds",
+        "# Each client keeps requesting a total number of 10k pinned files for "
+            + "a total of 100 milliseconds",
         "$ bin/alluxio runClass alluxio.stress.cli.GetPinnedFileIdsBench --concurrency 3 \\",
-        "--cluster --cluster-limit 2 --num-files 100000 --duration 5s",
+        "--cluster --cluster-limit 2 --num-files 10000 --duration 100ms",
         ""
     ));
   }

--- a/stress/shell/src/main/java/alluxio/stress/cli/GetPinnedFileIdsBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/GetPinnedFileIdsBench.java
@@ -67,13 +67,15 @@ public class GetPinnedFileIdsBench extends RpcBench<GetPinnedFileIdsParameters> 
         "A benchmarking tool for the GetPinnedFileIds RPC.",
         "The test will generate a specified number of test files and pin them. "
             + "Then it will keep calling the GetPinnedFileIds RPC by the specified load until the "
-            + "specified duration has elapsed.",
+            + "specified duration has elapsed. The test files will be cleaned up in the end.",
         "",
         "Example:",
-        "4 simulated workers running on 2 job workers, requesting a total number of 100k pinned "
-            + "files for a total of 5 seconds:",
-        "$ bin/alluxio runClass alluxio.stress.cli.GetPinnedFileIdsBench --concurrency 2 "
-            + "--cluster-limit 2 --num-files 100000 --duration 5s",
+        "# 2 job workers will be chosen to run the benchmark",
+        "# Each job worker runs 3 simulated clients",
+        "# Each client keeps requesting a total number of 100k pinned files for "
+            + "a total of 5 seconds",
+        "$ bin/alluxio runClass alluxio.stress.cli.GetPinnedFileIdsBench --concurrency 3 \\",
+        "--cluster --cluster-limit 2 --num-files 100000 --duration 5s",
         ""
     ));
   }

--- a/stress/shell/src/main/java/alluxio/stress/cli/RegisterWorkerBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/RegisterWorkerBench.java
@@ -71,10 +71,12 @@ public class RegisterWorkerBench extends RpcBench<BlockMasterBenchParameters> {
             + "the controlled stress on the master side.",
         "",
         "Example:",
-        "Each job worker runs 2 simulated workers, each having 3000 blocks on tier 0 and 10000 "
-            + "blocks on tier 1:",
-        "$ bin/alluxio runClass alluxio.stress.cli.RegisterWorkerBench --concurrency 2 "
-            + "--cluster-limit 1 --tiers \"1000,1000,1000;5000,5000\"",
+        "# 2 job workers will be chosen to run the benchmark",
+        "# Each job worker runs 3 simulated workers",
+        "# Each simulated worker has 3000 blocks on tier 0 and 10000 on tier 1",
+        "# Each simulated worker sends the register RPC once",
+        "$ bin/alluxio runClass alluxio.stress.cli.RegisterWorkerBench --concurrency 3 \\",
+        "--cluster --cluster-limit 2 --tiers \"1000,1000,1000;5000,5000\"",
         ""
     ));
   }

--- a/stress/shell/src/main/java/alluxio/stress/cli/UfsIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/UfsIOBench.java
@@ -23,6 +23,7 @@ import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.util.io.PathUtils;
 
 import com.beust.jcommander.ParametersDelegate;
+import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,8 +56,22 @@ public class UfsIOBench extends Benchmark<IOTaskResult> {
 
   @Override
   public String getBenchDescription() {
-    // TODO(Jiacheng) Fill in description
-    return "";
+    return String.join("\n", ImmutableList.of(
+        "A benchmarking tool for the I/O between Alluxio and UFS.",
+        "This test will measure the I/O throughput between Alluxio workers and "
+            + "the specified UFS path. Each worker will create concurrent clients to "
+            + "first generate test files of the specified size then read those files. "
+            + "The write/read I/O throughput will be measured in the process.",
+        "",
+        "Example:",
+        "# This invokes the I/O benchmark to HDFS in the Alluxio cluster",
+        "# 2 workers will be used",
+        "# 2 concurrent clients will be created on each worker",
+        "# Each thread is writing then reading 512m of data",
+        "$ bin/alluxio runUfsIOTest --path hdfs://<hdfs-address> --cluster --cluster-limit 2 \\",
+        " --io-size 512m --threads 2",
+        ""
+    ));
   }
 
   @Override

--- a/stress/shell/src/main/java/alluxio/stress/cli/WorkerHeartbeatBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/WorkerHeartbeatBench.java
@@ -144,10 +144,12 @@ public class WorkerHeartbeatBench extends RpcBench<BlockMasterBenchParameters> {
             + "heartbeats to the master nonstop, until the specified time has elapsed.",
         "",
         "Example:",
-        "Each job worker runs 2 simulated workers, each having 3000 blocks on tier 0 and 10000 "
-            + "blocks on tier 1. Keep sending heartbeats for 30s:",
-        "$ bin/alluxio runClass alluxio.stress.cli.WorkerHeartbeatBench --concurrency 2 "
-            + "--cluster-limit 1 --tiers \"1000,1000,1000;5000,5000\" --duration 30s",
+        "# 2 job workers will be chosen to run the benchmark",
+        "# Each job worker runs 3 threads each simulating one worker",
+        "# Each worker will have 3000 blocks on tier 0 and 10000 blocks on tier 1",
+        "# Keep sending heartbeats for 30s",
+        "$ bin/alluxio runClass alluxio.stress.cli.WorkerHeartbeatBench --concurrency 3 \\",
+        "--cluster --cluster-limit 2 --tiers \"1000,1000,1000;5000,5000\" --duration 30s",
         ""
     ));
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

This change implements the missing description for `UfsIOBench` command and improves descriptions in `RpcBench` children, conforming to the same format.

Below is an example from `WorkerHeartbeatBench`. The rough structure is description -> example -> options -> parse exception.

```
$ bin/alluxio runClass alluxio.stress.cli.WorkerHeartbeatBench foofoofoo
A benchmarking tool for the WorkerHeartbeat RPC.
The test will generate a specified number of blocks in the master (without associated files). The test will also register the simulated workers with the master. Then it will keep generating heartbeats with the specified load and sending heartbeats to the master nonstop, until the specified time has elapsed.

Example:
# 2 job workers will be chosen to run the benchmark
# Each job worker runs 3 threads each simulating one worker
# Each worker will have 3000 blocks on tier 0 and 10000 blocks on tier 1
# Keep sending heartbeats for 30s
$ bin/alluxio runClass alluxio.stress.cli.WorkerHeartbeatBench --concurrency 3 \
--cluster --cluster-limit 2 --tiers "1000,1000,1000;5000,5000" --duration 30s

Usage: WorkerHeartbeatBench [options]
  Options:
    --bench-timeout
      The length of time to wait when finishing the benchmark. (10m 600s, 
      etc.) 
      Default: 20m
    --cluster
      If true, runs the benchmark via the job service cluster. Otherwise, runs 
      locally. 
      Default: false
    --cluster-limit
      If greater than 0, it will only run on that number of workers. If 0, 
      will run on all available cluster workers. If < 0, will run on the 
      workers from the end of the worker list. This flag is only used if 
      --cluster is enabled.
      Default: 0
    --concurrency
      simulate this many clients/workers on one machine
      Default: 2
    --duration
      The length of time to run the benchmark. (1m, 10m, 60s, 10000ms, etc.)
      Default: 5s
    -h, --help

    --java-opt
      The java options to add to the command line to for the task. This can be 
      repeated. The options must be quoted and prefixed with a space, to avoid 
      getting passed to the JVM. For example: --java-opt " -Xmx4g" --java-opt 
      " -Xms2g"
      Default: []
    --profile-agent
      The path to the profile agent if one is available. Providing this will 
      enable a more detailed output.
      Default: <empty string>
    --tiers
      The number of blocks in each storage dir and tier. List tiers in the 
      order of MEM, SSD and HDD separated by semicolon, list dirs inside each 
      tier separated by comma. Example: "100,200,300;1000,1500;2000"

com.beust.jcommander.ParameterException: Was passed main parameter 'foofoofoo' but no main parameter was defined in your arg class
	at com.beust.jcommander.JCommander.initMainParameterValue(JCommander.java:954)
	at com.beust.jcommander.JCommander.parseValues(JCommander.java:755)
	at com.beust.jcommander.JCommander.parse(JCommander.java:356)
	at com.beust.jcommander.JCommander.parse(JCommander.java:335)
	at alluxio.stress.cli.Benchmark.run(Benchmark.java:134)
	at alluxio.stress.cli.Benchmark.mainInternal(Benchmark.java:90)
	at alluxio.stress.cli.WorkerHeartbeatBench.main(WorkerHeartbeatBench.java:192)
```

### Why are the changes needed?

See above

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. Command output
