### PR TITLE
Count the number of successful and failed job

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
@@ -35,6 +35,8 @@ public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCo
   protected List<JobAttempt> mSubmittedJobAttempts;
   protected int mActiveJobs;
   protected final JobMasterClient mClient;
+  private int mFailedCount;
+  private int mCompletedCount;
 
   protected AbstractDistributedJobCommand(FileSystemContext fsContext) {
     super(fsContext);
@@ -43,6 +45,8 @@ public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCo
     mClient = JobMasterClient.Factory.create(
         JobMasterClientContext.newBuilder(clientContext).build());
     mActiveJobs = DEFAULT_ACTIVE_JOBS;
+    mFailedCount = 0;
+    mCompletedCount = 0;
   }
 
   protected void drain() {
@@ -65,9 +69,11 @@ public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCo
             return true;
           case CANCELED:
           case COMPLETED:
+            mCompletedCount++;
             removed.set(true);
             return false;
           case FAILED:
+            mFailedCount++;
             removed.set(true);
             return false;
           default:
@@ -79,5 +85,19 @@ public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCo
       }
       CommonUtils.sleepMs(5);
     }
+  }
+
+  /**
+   * Gets the number of failed job.
+   */
+  protected int getFailedCount() {
+    return mFailedCount;
+  }
+
+  /**
+   * Gets the number of completed job.
+   */
+  protected int getCompletedCount() {
+    return mCompletedCount;
   }
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
@@ -57,6 +57,8 @@ public final class DistributedLoadUtils {
         localityIds, excludedLocalityIds);
     // Wait remaining jobs to complete.
     command.drain();
+    System.out.println(String.format("Completed count is %d,Failed count is %d.",
+            command.getCompletedCount(), command.getFailedCount()));
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

For distributedjobcommand, now it just prints the information to the console, this change can intuitively obtain statistical information.

### Why are the changes needed?
We want to visually obtain the number of successful and failed jobs for each distributedLoad operation.

### Does this PR introduce any user facing changes?
No
