### PR TITLE
Update default ZK path for jobmaster

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5203,9 +5203,11 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
 
   public static final PropertyKey ZOOKEEPER_JOB_ELECTION_PATH =
-      new Builder(Name.ZOOKEEPER_JOB_ELECTION_PATH).setDefaultValue("/alluxio/job_election").build();
+      new Builder(Name.ZOOKEEPER_JOB_ELECTION_PATH)
+          .setDefaultValue("/alluxio/job_election").build();
   public static final PropertyKey ZOOKEEPER_JOB_LEADER_PATH =
-      new Builder(Name.ZOOKEEPER_JOB_LEADER_PATH).setDefaultValue("/alluxio/job_leader").build();
+      new Builder(Name.ZOOKEEPER_JOB_LEADER_PATH)
+          .setDefaultValue("/alluxio/job_leader").build();
 
   //
   // JVM Monitor related properties

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5203,9 +5203,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
 
   public static final PropertyKey ZOOKEEPER_JOB_ELECTION_PATH =
-      new Builder(Name.ZOOKEEPER_JOB_ELECTION_PATH).setDefaultValue("/job_election").build();
+      new Builder(Name.ZOOKEEPER_JOB_ELECTION_PATH).setDefaultValue("/alluxio/job_election").build();
   public static final PropertyKey ZOOKEEPER_JOB_LEADER_PATH =
-      new Builder(Name.ZOOKEEPER_JOB_LEADER_PATH).setDefaultValue("/job_leader").build();
+      new Builder(Name.ZOOKEEPER_JOB_LEADER_PATH).setDefaultValue("/alluxio/job_leader").build();
 
   //
   // JVM Monitor related properties


### PR DESCRIPTION
IMO, "/job_election" and "/job_leader" should not be created in the root directory. So I updated default ZK path for jobmaster, and added prefix "/alluxio". 

![image](https://user-images.githubusercontent.com/55134131/129672335-0f174783-6263-4e3f-8e85-929e61d1f4da.png)
