### PR TITLE
Add listFiles operation to Fuse IO bench

### DIFF
--- a/stress/common/src/main/java/alluxio/stress/fuse/FuseIOOperation.java
+++ b/stress/common/src/main/java/alluxio/stress/fuse/FuseIOOperation.java
@@ -17,6 +17,8 @@ package alluxio.stress.fuse;
 public enum FuseIOOperation {
   /** Write operation to test the write throughput or prepare data for reading. */
   WRITE("Write"),
+  /** List the files to cache metadata on client side, separating metadata and data performance. */
+  LISTFILE("ListFile"),
 
   /** Now only streaming reading is supported, that is, sequentially read the written files. */
   READ("Read"),

--- a/stress/common/src/main/java/alluxio/stress/fuse/FuseIOOperation.java
+++ b/stress/common/src/main/java/alluxio/stress/fuse/FuseIOOperation.java
@@ -18,7 +18,7 @@ public enum FuseIOOperation {
   /** Write operation to test the write throughput or prepare data for reading. */
   WRITE("Write"),
   /** List the files to cache metadata on client side, separating metadata and data performance. */
-  LISTFILE("ListFile"),
+  LIST_FILE("ListFile"),
 
   /** Now only streaming reading is supported, that is, sequentially read the written files. */
   READ("Read"),

--- a/stress/common/src/main/java/alluxio/stress/fuse/FuseIOParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/fuse/FuseIOParameters.java
@@ -25,7 +25,8 @@ public final class FuseIOParameters extends Parameters {
   public static final String FIELD_READ_RANDOM = "mReadRandom";
 
   @Parameter(names = {"--operation"},
-      description = "the operation to perform. Options are [Read]",
+      description = "The operation to perform. Options are [Read, Write, ListFile], where "
+          + "\"Write\" and \"ListFile\" are for testing read performance, not individual tests.",
       converter = FuseIOOperationConverter.class,
       required = true)
   public FuseIOOperation mOperation;
@@ -38,11 +39,11 @@ public final class FuseIOParameters extends Parameters {
   public String mLocalPath = "/mnt/alluxio-fuse/fuse-io-bench";
 
   @Parameter(names = {"--file-size"},
-          description = "The files size for IO operations. (100k, 1m, 1g, etc.)")
+      description = "The files size for IO operations. (100k, 1m, 1g, etc.)")
   public String mFileSize = "100k";
 
   @Parameter(names = {"--buffer-size"},
-          description = "The buffer size for IO operations. (1k, 16k, etc.)")
+      description = "The buffer size for IO operations. (1k, 16k, etc.)")
   public String mBufferSize = "64k";
 
   @Parameter(names = {"--num-files-per-dir"},

--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -306,11 +306,11 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
       CommonUtils.sleepMs(waitMs);
       mStartBarrierPassed = true;
 
-      if (mParameters.mOperation == FuseIOOperation.LISTFILE) {
+      if (mParameters.mOperation == FuseIOOperation.LIST_FILE) {
         for (int dirId = mThreadId; dirId < mParameters.mNumDirs; dirId += mParameters.mThreads) {
           String dirPath = String.format("%s/%d", mParameters.mLocalPath, dirId);
           File dir = new File(dirPath);
-          dir.listFiles().toString();
+          dir.listFiles();
         }
         return;
       }


### PR DESCRIPTION
If FuseIOBench has operation ListFile, we call File.listFiles() to cache the metadata of the files so that the data and metadata operations are separated, improving reading throughput in the case of lots of small files.
