### PR TITLE
Make the call to transferLeadership asynchronous

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/journal/JournalMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/journal/JournalMasterClient.java
@@ -37,10 +37,17 @@ public interface JournalMasterClient extends Closeable {
   void removeQuorumServer(NetAddress serverAddress) throws AlluxioStatusException;
 
   /**
-   * Changes the leading master of the quorum.
+   * Initiates changing the leading master of the quorum.
    *
-   * @param newLeaderNetAddress server address of the new leader
+   * @param newLeaderNetAddress server address of the prospective new leader
    * @throws AlluxioStatusException
    */
   void transferLeadership(NetAddress newLeaderNetAddress) throws AlluxioStatusException;
+
+  /**
+   * Resets RaftPeer priorities.
+   *
+   * @throws AlluxioStatusException
+   */
+  void resetPriorities() throws AlluxioStatusException;
 }

--- a/core/client/fs/src/main/java/alluxio/client/journal/RetryHandlingJournalMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/journal/RetryHandlingJournalMasterClient.java
@@ -19,6 +19,7 @@ import alluxio.grpc.GetQuorumInfoPResponse;
 import alluxio.grpc.JournalMasterClientServiceGrpc;
 import alluxio.grpc.NetAddress;
 import alluxio.grpc.RemoveQuorumServerPRequest;
+import alluxio.grpc.ResetPrioritiesPRequest;
 import alluxio.grpc.ServiceType;
 import alluxio.grpc.TransferLeadershipPRequest;
 import alluxio.master.MasterClientContext;
@@ -81,5 +82,11 @@ public class RetryHandlingJournalMasterClient extends AbstractMasterClient
     retryRPC(() -> mClient.transferLeadership(
         TransferLeadershipPRequest.newBuilder().setServerAddress(newLeaderNetAddress).build()),
         RPC_LOG, "TransferLeadership", "serverAddress=%s", newLeaderNetAddress);
+  }
+
+  @Override
+  public void resetPriorities() throws AlluxioStatusException {
+    retryRPC(() -> mClient.resetPriorities(ResetPrioritiesPRequest.getDefaultInstance()),
+            RPC_LOG, "ResetPriorities", "");
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/DefaultJournalMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/DefaultJournalMaster.java
@@ -65,4 +65,10 @@ public class DefaultJournalMaster implements JournalMaster {
     checkQuorumOpSupported();
     ((RaftJournalSystem) mJournalSystem).transferLeadership(newLeaderAddress);
   }
+
+  @Override
+  public void resetPriorities() throws IOException {
+    checkQuorumOpSupported();
+    ((RaftJournalSystem) mJournalSystem).resetPriorities();
+  }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalMaster.java
@@ -46,4 +46,11 @@ public interface JournalMaster {
    * @throws IOException if error occurs while performing the operation
    */
   void transferLeadership(NetAddress newLeaderAddress) throws IOException;
+
+  /**
+   * Resets RaftPeer priorities.
+   *
+   * @throws IOException if error occurs while performing the operation
+   */
+  void resetPriorities() throws IOException;
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalMasterClientServiceHandler.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalMasterClientServiceHandler.java
@@ -12,11 +12,14 @@
 package alluxio.master.journal;
 
 import alluxio.RpcUtils;
+
 import alluxio.grpc.GetQuorumInfoPRequest;
 import alluxio.grpc.GetQuorumInfoPResponse;
 import alluxio.grpc.JournalMasterClientServiceGrpc;
 import alluxio.grpc.RemoveQuorumServerPRequest;
 import alluxio.grpc.RemoveQuorumServerPResponse;
+import alluxio.grpc.ResetPrioritiesPRequest;
+import alluxio.grpc.ResetPrioritiesPResponse;
 import alluxio.grpc.TransferLeadershipPRequest;
 import alluxio.grpc.TransferLeadershipPResponse;
 
@@ -66,5 +69,14 @@ public class JournalMasterClientServiceHandler
       mJournalMaster.transferLeadership(request.getServerAddress());
       return TransferLeadershipPResponse.getDefaultInstance();
     }, "transferLeadership", "request=%s", responseObserver, request);
+  }
+
+  @Override
+  public void resetPriorities(ResetPrioritiesPRequest request,
+      StreamObserver<ResetPrioritiesPResponse> responseObserver) {
+    RpcUtils.call(LOG, () -> {
+      mJournalMaster.resetPriorities();
+      return ResetPrioritiesPResponse.getDefaultInstance();
+    }, "resetPriorities", "request=%s", responseObserver, request);
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -928,18 +928,19 @@ public class RaftJournalSystem extends AbstractJournalSystem {
               serverAddress, newLeaderPeerId);
       // fire and forget: need to immediately return as the master will shut down its RPC servers
       // once the TransferLeadershipRequest is initiated.
-      Thread.sleep(3_000);
+      final int sleepTimeMs = 3_000;
       new Thread(() -> {
         try {
+          Thread.sleep(sleepTimeMs);
           client.admin().transferLeadership(newLeaderPeerId, TRANSFER_LEADER_WAIT_MS);
         } catch(Throwable t){
           LOG.error("caught an error: {}", t.getMessage());
           /* checking the transfer happens in {@link QuorumElectCommand} */
         }
       }).start();
-      LOG.info("TransferLeadershipRequest sent");
+      LOG.info("Transferring leadership initiated");
     } catch (Throwable t) {
-      LOG.error(t.getMessage());
+      throw new IOException(t);
     }
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -912,41 +912,34 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     // --- end of updating priorities ---
     final int TRANSFER_LEADER_WAIT_MS = 30_000;
     try (RaftClient client = createClient()) {
-      LOG.info("Applying new peer state before transferring leadership: {}",
-              peersToString(peersWithNewPriorities));
+      String stringPeers = "[" + peersWithNewPriorities.stream().map(RaftPeer::toString)
+                      .collect(Collectors.joining(", ")) + "]";
+      LOG.info("Applying new peer state before transferring leadership: {}", stringPeers);
       // set peers to have new priorities
       RaftClientReply reply = client.admin().setConfiguration(peersWithNewPriorities);
-      processReply(reply);
+      if (!reply.isSuccess()) {
+        throw reply.getException() != null
+                ? reply.getException()
+                : new IOException(String.format("reply <%s> failed", reply));
+      }
       // transfer leadership
-      LOG.info("Transferring leadership to master with address <{}> and with RaftPeerId <{}>",
+      LOG.info("Transferring leadership to master with address <{}> and with RaftPeerId " +
+                      "<{}>",
               serverAddress, newLeaderPeerId);
-      reply = client.admin().transferLeadership(newLeaderPeerId, TRANSFER_LEADER_WAIT_MS);
-      processReply(reply);
-      // reset the peers to have the old priorities
-      LOG.info("Resetting peer state to before transfer: {}", peersToString(oldPeers));
-      reply = client.admin().setConfiguration(oldPeers);
-      processReply(reply);
-      LOG.info("Successfully reset peer state");
-    }
-  }
-
-  /**
-   * @param peers to be printed into a string
-   * @return the peers as a comma delimited list
-   */
-  private String peersToString(List<RaftPeer> peers) {
-    return "[" + peers.stream().map(RaftPeer::toString).collect(Collectors.joining(", ")) + "]";
-  }
-
-  /**
-   * @param reply from the ratis operation
-   * @throws IOException
-   */
-  private void processReply(RaftClientReply reply) throws IOException {
-    if (!reply.isSuccess()) {
-      throw reply.getException() != null
-              ? reply.getException()
-              : new IOException(String.format("reply <%s> failed", reply));
+      // fire and forget: need to immediately return as the master will shut down its RPC servers
+      // once the TransferLeadershipRequest is initiated.
+      Thread.sleep(3_000);
+      new Thread(() -> {
+        try {
+          client.admin().transferLeadership(newLeaderPeerId, TRANSFER_LEADER_WAIT_MS);
+        } catch(Throwable t){
+          LOG.error("caught an error: {}", t.getMessage());
+          /* checking the transfer happens in {@link QuorumElectCommand} */
+        }
+      }).start();
+      LOG.info("TransferLeadershipRequest sent");
+    } catch (Throwable t) {
+      LOG.error(t.getMessage());
     }
   }
 

--- a/core/transport/src/main/proto/grpc/journal_master.proto
+++ b/core/transport/src/main/proto/grpc/journal_master.proto
@@ -49,6 +49,13 @@ message TransferLeadershipPRequest {
 }
 message TransferLeadershipPResponse {}
 
+// ResetPriorities API
+message ResetPrioritiesPOptions {}
+message ResetPrioritiesPRequest {
+    optional ResetPrioritiesPOptions options = 1;
+}
+message ResetPrioritiesPResponse {}
+
 /**
   * This interface contains journal master service endpoints for Alluxio clients.
   */
@@ -68,4 +75,9 @@ service JournalMasterClientService {
      * Transfers the leadership from the current leader to another designated leader.
      */
     rpc TransferLeadership(TransferLeadershipPRequest) returns (TransferLeadershipPResponse);
+
+    /**
+     * Reset all the RaftPeer priorities.
+     */
+    rpc ResetPriorities(ResetPrioritiesPRequest) returns (ResetPrioritiesPResponse);
 }

--- a/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumElectCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumElectCommand.java
@@ -71,6 +71,7 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
 
     MasterInquireClient inquireClient = MasterInquireClient.Factory
             .create(mConf, FileSystemContext.create(mConf).getClientContext().getUserState());
+    boolean success = true;
     // wait for confirmation of leadership transfer
     try {
       CommonUtils.waitFor("Waiting for leadership transfer to finalize", () -> {
@@ -84,6 +85,7 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
       });
       mPrintStream.println(String.format(TRANSFER_SUCCESS, serverAddress));
     } catch (Exception e) {
+      success = false;
       mPrintStream.println(String.format(TRANSFER_FAILED, serverAddress, e));
     }
     // Resetting RaftPeer priorities using a separate RPC because the old leader has shut down
@@ -93,9 +95,10 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
       jmClient.resetPriorities();
       mPrintStream.println(RESET_SUCCESS);
     } catch (Exception e) {
+      success = false;
       mPrintStream.println(String.format(RESET_FAILED, e));
     }
-    return 0;
+    return success ? 0 : -1;
   }
 
   @Override

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/QuorumCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/QuorumCommandIntegrationTest.java
@@ -183,11 +183,11 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void transferLeader() throws Exception {
+  public void elect() throws Exception {
     final int MASTER_INDEX_WAIT_TIME = 5_000;
     int numMasters = 3;
     mCluster = MultiProcessCluster.newBuilder(PortCoordination.QUORUM_SHELL_REMOVE)
-            .setClusterName("QuorumShellTransferLeader").setNumMasters(numMasters).setNumWorkers(0)
+            .setClusterName("QuorumShellElect").setNumMasters(numMasters).setNumWorkers(0)
             .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.EMBEDDED.toString())
             .addProperty(PropertyKey.MASTER_JOURNAL_FLUSH_TIMEOUT_MS, "5min")
             // To make the test run faster.
@@ -206,8 +206,9 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
       mOutput.reset();
       shell.run("journal", "quorum", "elect", "-address" , newLeaderAddr);
       output = mOutput.toString().trim();
-      Assert.assertEquals(String.format(QuorumElectCommand.OUTPUT_SUCCESS, newLeaderAddr),
-              output);
+      String expected = String.format(QuorumElectCommand.TRANSFER_SUCCESS + "\n"
+              + QuorumElectCommand.RESET_SUCCESS, newLeaderAddr);
+      Assert.assertEquals(expected, output);
     }
     mCluster.notifySuccess();
   }

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTest.java
@@ -293,6 +293,26 @@ public final class EmbeddedJournalIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test
+  public void resetPriorities() throws Exception {
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.EMBEDDED_JOURNAL_FAILOVER)
+            .setClusterName("TransferLeadership")
+            .setNumMasters(NUM_MASTERS)
+            .setNumWorkers(0)
+            .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.EMBEDDED.toString())
+            .addProperty(PropertyKey.MASTER_JOURNAL_FLUSH_TIMEOUT_MS, "5min")
+            .addProperty(PropertyKey.MASTER_EMBEDDED_JOURNAL_ELECTION_TIMEOUT, "750ms")
+            .build();
+    mCluster.start();
+
+    try {
+      mCluster.getJournalMasterClientForMaster().resetPriorities();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    mCluster.notifySuccess();
+  }
+
+  @Test
   public void transferLeadershipOutsideCluster() throws Exception {
     mCluster = MultiProcessCluster.newBuilder(PortCoordination.EMBEDDED_JOURNAL_FAILOVER)
             .setClusterName("TransferLeadership")


### PR DESCRIPTION
### Why are the changes needed?
To avoid the `quorum elect` command from hanging indefinitely

