### PR TITLE
Add jobStatus metrics

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -652,6 +652,37 @@ public final class MetricKey implements Comparable<MetricKey> {
               + "Use this metric to monitor when your master boot-up time is high。")
           .setMetricType(MetricType.GAUGE)
           .build();
+  // Job metrics
+  public static final MetricKey MASTER_JOB_CANCELED =
+      new Builder("Master.JobCanceled")
+          .setDescription("The number of canceled status job")
+          .setMetricType(MetricType.COUNTER)
+          .build();
+  public static final MetricKey MASTER_JOB_COMPLETED =
+      new Builder("Master.JobCompleted")
+          .setDescription("The number of completed status job")
+          .setMetricType(MetricType.COUNTER)
+          .build();
+  public static final MetricKey MASTER_JOB_COUNT =
+      new Builder("Master.JobCount")
+          .setDescription("The number of all status job")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_JOB_CREATED =
+      new Builder("Master.JobCreated")
+          .setDescription("The number of created status job")
+          .setMetricType(MetricType.COUNTER)
+          .build();
+  public static final MetricKey MASTER_JOB_FAILED =
+      new Builder("Master.JobFailed")
+          .setDescription("The number of failed status job")
+          .setMetricType(MetricType.COUNTER)
+          .build();
+  public static final MetricKey MASTER_JOB_RUNNING =
+      new Builder("Master.JobRunning")
+          .setDescription("The number of running status job")
+          .setMetricType(MetricType.COUNTER)
+          .build();
 
   // Cluster metrics
   public static final MetricKey CLUSTER_ACTIVE_RPC_READ_COUNT =

--- a/job/common/src/main/java/alluxio/job/plan/meta/PlanInfo.java
+++ b/job/common/src/main/java/alluxio/job/plan/meta/PlanInfo.java
@@ -14,9 +14,12 @@ package alluxio.job.plan.meta;
 import alluxio.job.JobConfig;
 import alluxio.job.wire.Status;
 import alluxio.job.wire.TaskInfo;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.util.CommonUtils;
 import alluxio.wire.WorkerInfo;
 
+import com.codahale.metrics.Counter;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -57,6 +60,7 @@ public final class PlanInfo implements Comparable<PlanInfo> {
     mErrorType = "";
     mErrorMessage = "";
     mStatus = Status.CREATED;
+    Metrics.JOB_CREATED.inc();
     mStatusChangeCallback = statusChangeCallback;
   }
 
@@ -194,6 +198,8 @@ public final class PlanInfo implements Comparable<PlanInfo> {
         if (mStatusChangeCallback != null) {
           mStatusChangeCallback.accept(this);
         }
+        Metrics.counter(oldStatus).dec();
+        Metrics.counter(status).inc();
       }
     }
   }
@@ -243,5 +249,36 @@ public final class PlanInfo implements Comparable<PlanInfo> {
   @Override
   public int hashCode() {
     return Objects.hashCode(mId);
+  }
+
+  @ThreadSafe
+  private static final class Metrics {
+    private static final Counter JOB_CANCELED =
+        MetricsSystem.counter(MetricKey.MASTER_JOB_CANCELED.getName());
+    private static final Counter JOB_COMPLETED =
+        MetricsSystem.counter(MetricKey.MASTER_JOB_COMPLETED.getName());
+    private static final Counter JOB_CREATED =
+        MetricsSystem.counter(MetricKey.MASTER_JOB_CREATED.getName());
+    private static final Counter JOB_FAILED =
+        MetricsSystem.counter(MetricKey.MASTER_JOB_FAILED.getName());
+    private static final Counter JOB_RUNNING =
+        MetricsSystem.counter(MetricKey.MASTER_JOB_RUNNING.getName());
+
+    private Metrics() {} // prevent instantiation
+
+    private static Counter counter(Status status) {
+      switch (status) {
+        case CREATED:
+          return JOB_CREATED;
+        case CANCELED:
+          return JOB_CANCELED;
+        case FAILED:
+          return JOB_FAILED;
+        case RUNNING:
+          return JOB_RUNNING;
+        default:
+          return JOB_COMPLETED;
+      }
+    }
   }
 }

--- a/job/server/src/main/java/alluxio/job/workflow/WorkflowExecution.java
+++ b/job/server/src/main/java/alluxio/job/workflow/WorkflowExecution.java
@@ -13,11 +13,16 @@ package alluxio.job.workflow;
 
 import alluxio.job.JobConfig;
 import alluxio.job.wire.Status;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.util.CommonUtils;
 
+import com.codahale.metrics.Counter;
 import com.google.common.base.Preconditions;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
 import java.util.Set;
 
 /**
@@ -105,6 +110,12 @@ public abstract class WorkflowExecution {
   }
 
   private void setStatus(Status status) {
+    if (mStatus != status) {
+      if (mStatus != null) {
+        Metrics.counter(mStatus).dec();
+      }
+      Metrics.counter(status).inc();
+    }
     mStatus = status;
     mLastUpdated = CommonUtils.getCurrentMs();
   }
@@ -115,4 +126,35 @@ public abstract class WorkflowExecution {
    * @return list of {@link JobConfig} to execute next, empty when there is no more work
    */
   protected abstract Set<JobConfig> nextJobs();
+
+  @ThreadSafe
+  private static final class Metrics {
+    private static final Counter JOB_CANCELED =
+        MetricsSystem.counter(MetricKey.MASTER_JOB_CANCELED.getName());
+    private static final Counter JOB_COMPLETED =
+        MetricsSystem.counter(MetricKey.MASTER_JOB_COMPLETED.getName());
+    private static final Counter JOB_CREATED =
+        MetricsSystem.counter(MetricKey.MASTER_JOB_CREATED.getName());
+    private static final Counter JOB_FAILED =
+        MetricsSystem.counter(MetricKey.MASTER_JOB_FAILED.getName());
+    private static final Counter JOB_RUNNING =
+        MetricsSystem.counter(MetricKey.MASTER_JOB_RUNNING.getName());
+
+    private Metrics() {} // prevent instantiation
+
+    private static Counter counter(Status status) {
+      switch (status) {
+        case CANCELED:
+          return JOB_CANCELED;
+        case COMPLETED:
+          return JOB_COMPLETED;
+        case CREATED:
+          return JOB_CREATED;
+        case FAILED:
+          return JOB_FAILED;
+        default:
+          return JOB_RUNNING;
+      }
+    }
+  }
 }

--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -49,6 +49,8 @@ import alluxio.master.job.workflow.WorkflowTracker;
 import alluxio.master.journal.NoopJournaled;
 import alluxio.master.job.plan.PlanCoordinator;
 import alluxio.master.job.plan.PlanTracker;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.resource.LockResource;
 import alluxio.underfs.UfsManager;
 import alluxio.util.CommonUtils;
@@ -171,6 +173,14 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
         mWorkflowTracker);
 
     mWorkerHealth = new ConcurrentHashMap<>();
+
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_JOB_COUNT.getName(),
+        () -> MetricsSystem.counter(MetricKey.MASTER_JOB_CANCELED.getName()).getCount()
+            + MetricsSystem.counter(MetricKey.MASTER_JOB_COMPLETED.getName()).getCount()
+            + MetricsSystem.counter(MetricKey.MASTER_JOB_CREATED.getName()).getCount()
+            + MetricsSystem.counter(MetricKey.MASTER_JOB_FAILED.getName()).getCount()
+            + MetricsSystem.counter(MetricKey.MASTER_JOB_RUNNING.getName()).getCount());
   }
 
   /**

--- a/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
+++ b/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
@@ -39,6 +39,8 @@ import alluxio.master.MasterContext;
 import alluxio.master.job.command.CommandManager;
 import alluxio.master.journal.noop.NoopJournalSystem;
 import alluxio.master.job.plan.PlanCoordinator;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.underfs.UfsManager;
 
 import com.google.common.collect.Lists;
@@ -108,12 +110,17 @@ public final class JobMasterTest {
 
     JobInfo status = mJobMaster.getStatus(jobId);
 
+    Assert.assertEquals(2,
+        MetricsSystem.counter(MetricKey.MASTER_JOB_CREATED.getName()).getCount());
+    Assert.assertEquals(2, MetricsSystem.counter(MetricKey.MASTER_JOB_COUNT.getName()).getCount());
     Assert.assertEquals(Status.FAILED, status.getStatus());
     List<JobInfo> children = status.getChildren();
     Assert.assertEquals(1, children.size());
     JobInfo child = children.get(0);
     Assert.assertEquals(Status.FAILED, child.getStatus());
     Assert.assertEquals(0, child.getChildren().size());
+    Assert.assertEquals(2, MetricsSystem.counter(MetricKey.MASTER_JOB_FAILED.getName()).getCount());
+    Assert.assertEquals(2, MetricsSystem.counter(MetricKey.MASTER_JOB_COUNT.getName()).getCount());
   }
 
   @Test
@@ -129,6 +136,8 @@ public final class JobMasterTest {
     for (long i = 0; i < TEST_JOB_MASTER_JOB_CAPACITY; i++) {
       jobIdList.add(mJobMaster.run(jobConfig));
     }
+    Assert.assertEquals(TEST_JOB_MASTER_JOB_CAPACITY,
+        MetricsSystem.counter(MetricKey.MASTER_JOB_RUNNING.getName()).getCount());
     final List<Long> list = mJobMaster.list(ListAllPOptions.getDefaultInstance());
     Assert.assertEquals(jobIdList, list);
     Assert.assertEquals(TEST_JOB_MASTER_JOB_CAPACITY,
@@ -198,6 +207,8 @@ public final class JobMasterTest {
     long jobId = mJobMaster.run(config);
     mJobMaster.cancel(jobId);
     verify(coordinator).cancel();
+    Assert.assertEquals(1,
+        MetricsSystem.counter(MetricKey.MASTER_JOB_CANCELED.getName()).getCount());
   }
 
   private static class DummyPlanConfig implements PlanConfig {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add metrics for Job service master to monitor the size of each status of job

### Why are the changes needed?

Please clarify why the changes are needed. For instance,

Sometime, job master didn't works as expected, sometime it even didn't work at all, so add some metrics to measure how busy job master is.

### Does this PR introduce any user facing changes?

Users can get job status metrics in webui

fix #13894