### PR TITLE
Fix last snapshot index in delegated backup

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -216,6 +216,7 @@ public class JournalStateMachine extends BaseStateMachine {
         SAMPLING_LOG.warn("Failed to get raft group info: {}", e.getMessage());
       }
       long index = mSnapshotManager.maybeCopySnapshotFromFollower();
+      mSnapshotLastIndex = index;
       mLastCheckPointTime = System.currentTimeMillis();
       return index;
     } else {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -216,7 +216,9 @@ public class JournalStateMachine extends BaseStateMachine {
         SAMPLING_LOG.warn("Failed to get raft group info: {}", e.getMessage());
       }
       long index = mSnapshotManager.maybeCopySnapshotFromFollower();
-      mSnapshotLastIndex = index;
+      if (index != RaftLog.INVALID_LOG_INDEX) {
+        mSnapshotLastIndex = index;
+      }
       mLastCheckPointTime = System.currentTimeMillis();
       return index;
     } else {


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fixes #13932
Fix the last snapshot related metrics 

### Why are the changes needed?
When delegation backup is implemented, the leader master will download the snapshot from standby master and use it as its own snapshot, but in this process, we didn't update the last snapshot related metrics of the leader master.

### Does this PR introduce any user facing changes?
Fix last snapshot metrics
