### PR TITLE
Register journal sequence number metric

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/AbstractJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AbstractJournalSystem.java
@@ -51,6 +51,7 @@ public abstract class AbstractJournalSystem implements JournalSystem {
     Preconditions.checkState(!mRunning, "Journal is already running");
     startInternal();
     mRunning = true;
+    registerMetrics();
   }
 
   @Override

--- a/core/server/common/src/main/java/alluxio/master/journal/AbstractJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AbstractJournalSystem.java
@@ -51,7 +51,6 @@ public abstract class AbstractJournalSystem implements JournalSystem {
     Preconditions.checkState(!mRunning, "Journal is already running");
     startInternal();
     mRunning = true;
-    registerMetrics();
   }
 
   @Override

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -235,7 +235,11 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     mSnapshotAllowed = new AtomicBoolean(true);
     mPrimarySelector = new RaftPrimarySelector();
     mAsyncJournalWriter = new AtomicReference<>();
-    super.registerMetrics();
+    try {
+      super.registerMetrics();
+    } catch (RuntimeException e){
+      return;
+    }
   }
 
   private void maybeMigrateOldJournal() {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -237,7 +237,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     mAsyncJournalWriter = new AtomicReference<>();
     try {
       super.registerMetrics();
-    } catch (RuntimeException e){
+    } catch (RuntimeException e) {
       return;
     }
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -235,6 +235,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     mSnapshotAllowed = new AtomicBoolean(true);
     mPrimarySelector = new RaftPrimarySelector();
     mAsyncJournalWriter = new AtomicReference<>();
+    super.registerMetrics();
   }
 
   private void maybeMigrateOldJournal() {

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
@@ -75,6 +75,7 @@ public class UfsJournalSystem extends AbstractJournalSystem {
     MetricsSystem.registerGaugeIfAbsent(
         MetricKey.MASTER_UFS_JOURNAL_INITIAL_REPLAY_TIME_MS.getName(),
         () -> mInitialCatchupTimeMs);
+    super.registerMetrics();
   }
 
   @Override

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
@@ -77,7 +77,7 @@ public class UfsJournalSystem extends AbstractJournalSystem {
         () -> mInitialCatchupTimeMs);
     try {
       super.registerMetrics();
-    } catch (RuntimeException e){
+    } catch (RuntimeException e) {
       return;
     }
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
@@ -75,7 +75,11 @@ public class UfsJournalSystem extends AbstractJournalSystem {
     MetricsSystem.registerGaugeIfAbsent(
         MetricKey.MASTER_UFS_JOURNAL_INITIAL_REPLAY_TIME_MS.getName(),
         () -> mInitialCatchupTimeMs);
-    super.registerMetrics();
+    try {
+      super.registerMetrics();
+    } catch (RuntimeException e){
+      return;
+    }
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

We need the sequence number information of log to monitor the cluster status. The corresponding metrickey is provided in the source code, but it is not registered to the metric system.

Please outline the changes and how this PR fixes the issue.

Register the metric key related to the sequence number to the metric system

### Does this PR introduce any user facing changes?
No

