### PR TITLE
Fix race condition in StressMasterBench

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
@@ -386,12 +386,25 @@ public class StressMasterBench extends Benchmark<MasterBenchTaskResult> {
       }
       CommonUtils.sleepMs(waitMs);
 
-      while (!Thread.currentThread().isInterrupted()
-          && ((!useStopCount && CommonUtils.getCurrentMs() < mContext.getEndMs())
-              || (useStopCount && mContext.mCounter.get() < mParameters.mStopCount))) {
+      long localCounter = 0;
+      while (true) {
+        if (Thread.currentThread().isInterrupted()) {
+          break;
+        }
+        if (!useStopCount) {
+          if (CommonUtils.getCurrentMs() >= mContext.getEndMs()) {
+            break;
+          }
+        } else {
+          localCounter = mContext.getCounter().getAndIncrement();
+          if (localCounter >= mParameters.mStopCount) {
+            break;
+          }
+        }
+
         mContext.getRateLimiter().acquire();
         long startNs = System.nanoTime();
-        applyOperation();
+        applyOperation(localCounter);
         long endNs = System.nanoTime();
 
         long currentMs = CommonUtils.getCurrentMs();
@@ -414,9 +427,7 @@ public class StressMasterBench extends Benchmark<MasterBenchTaskResult> {
       }
     }
 
-    private void applyOperation() throws IOException {
-      long counter = mContext.getCounter().getAndIncrement();
-
+    private void applyOperation(long counter) throws IOException {
       Path path;
       switch (mParameters.mOperation) {
         case CREATE_DIR:

--- a/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
@@ -394,8 +394,8 @@ public class StressMasterBench extends Benchmark<MasterBenchTaskResult> {
         if (!useStopCount && CommonUtils.getCurrentMs() >= mContext.getEndMs()) {
           break;
         }
-        if (useStopCount
-            && (localCounter = mContext.getCounter().getAndIncrement()) >= mParameters.mStopCount) {
+        localCounter = mContext.getCounter().getAndIncrement();
+        if (useStopCount && localCounter >= mParameters.mStopCount) {
           break;
         }
 

--- a/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
@@ -391,15 +391,12 @@ public class StressMasterBench extends Benchmark<MasterBenchTaskResult> {
         if (Thread.currentThread().isInterrupted()) {
           break;
         }
-        if (!useStopCount) {
-          if (CommonUtils.getCurrentMs() >= mContext.getEndMs()) {
-            break;
-          }
-        } else {
-          localCounter = mContext.getCounter().getAndIncrement();
-          if (localCounter >= mParameters.mStopCount) {
-            break;
-          }
+        if (!useStopCount && CommonUtils.getCurrentMs() >= mContext.getEndMs()) {
+          break;
+        }
+        if (useStopCount
+            && (localCounter = mContext.getCounter().getAndIncrement()) >= mParameters.mStopCount) {
+          break;
         }
 
         mContext.getRateLimiter().acquire();


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix a race condition in StressMasterBench. The current code does not atomically get, compare and increment a concurrent counter, and causes the number of runs to be incorrect.

### Why are the changes needed?

#### Background

I was using the stress master benchmark tool to create test files on the master, when I found the number of created files does not match what I specified in the arguments:

```console
bin/alluxio runClass alluxio.stress.cli.StressMasterBench --fixed-count 10000 --stop-count 10000  
--operation CreateFile --warmup 0s --cluster --cluster-limit 3 
--base 'alluxio://AlluxioSandbox-bowen-fix-masters-1:19998/stress-master-base'
```

This command uses three job workers to create 10000 files each on the master, and stops the job as soon as the `--stop-count` has been reached. Therefore, the expected total number of files is 30000. However, running this command on a 3-worker cluster produces 30752 files, and that number fluctuates around 30700. This indicates that there's a race condition.

The default number of concurrent threads to create files is `256`. Reducing this number decreases the chance of getting extra runs.

#### Root cause

The current code retrieves the concurrent counter, and compares it with the parameters:

https://github.com/Alluxio/alluxio/blob/28c5c4f2b3557b2888ea230c95c33dad60d59103/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java#L391

Then tries to atomically increment it afterwards:

https://github.com/Alluxio/alluxio/blob/28c5c4f2b3557b2888ea230c95c33dad60d59103/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java#L418

The comparison and increment are not done atomically. When the counter is getting near the stop count, before the counter is incremented in one thread, some other thread can enter the loop, and causes extra runs.

#### Fix

The fix is simple: just do the comparison and increment atomically.

Beyond that, I took the liberty of simplifying the conditions of the while loop.

### Does this PR introduce any user facing changes?
No.
