### PR TITLE
Update Helm chart metadata for recent changes

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -191,3 +191,6 @@
 
 0.6.25
 - Fix Alluxio CSI `nodeplugin.yaml` indentation, add support for dns plocy & change CSI log level
+
+0.6.26
+- Add livenessProbe and readinessProbe to values.yaml to allow for overriding

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,11 +12,13 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.25
+version: 0.6.26
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan
   email: adit@alluxio.com
+- name: Chris Zhu
+  email: czhu@alluxio.com
 - name: Jiacheng Liu
   email: jiacheng@alluxio.com
 - name: Yang Che


### PR DESCRIPTION
This PR is made as a follow-up to the additions added in PR #13945, which added the functionality to override `livenessProbe` and `readinessProbe` in our Helm chart.

This PR just updates `Chart.yaml` and `CHANGELOG.md` to reflect these changes.