### PR TITLE
Add metadata cache metric

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCachingBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCachingBaseFileSystem.java
@@ -25,6 +25,8 @@ import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.RenamePOptions;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.util.FileSystemOptions;
 import alluxio.util.ThreadUtils;
 import alluxio.wire.FileInfo;
@@ -78,6 +80,9 @@ public class MetadataCachingBaseFileSystem extends BaseFileSystem {
     // asynchronously update access time.
     mAccessTimeUpdater = new ThreadPoolExecutor(0, masterClientThreads, THREAD_KEEPALIVE_SECOND,
         TimeUnit.SECONDS, new SynchronousQueue<>());
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricsSystem.getMetricName(MetricKey.CLIENT_META_DATA_CACHE_SIZE.getName()),
+        mMetadataCache::size);
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1452,6 +1452,13 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_META_DATA_CACHE_SIZE =
+      new Builder("Client.MetadataCacheSize")
+          .setDescription("Size of cached metadata. Only valid if the filesystem is"
+              + "alluxio.client.file.MetadataCachingBaseFileSystem.")
+          .setMetricType(MetricType.GAUGE)
+          .setIsClusterAggregated(false)
+          .build();
 
   // Fuse operation timer and failure counter metrics are added dynamically.
   // Other Fuse related metrics are added here


### PR DESCRIPTION
### What changes are proposed in this pull request?
Add meta data cache size gauge metric.  
Add a new metric key called CLIENT_META_DATA_CACHE_SIZE
Register the new key to metric system in MetadataCachingBaseFileSystem.
### Why are the changes needed?
Get client metadata cache size info, let us know how the meta cache size grows under specific workload, it will help us to adjust parameters to the load.

### Does this PR introduce any user facing changes?
No
Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  No
  2. addition or removal of property keys
  No
  3. webui
  No
