### PR TITLE
Revert "Bump internal netty version to 4.1.55.Final"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
     <grpc.version>1.37.0</grpc.version>
     <gson.version>2.8.6</gson.version>
-    <netty.version>4.1.55.Final</netty.version>
+    <netty.version>4.1.52.Final</netty.version>
     <rocksdb.version>6.15.2</rocksdb.version>
     <hadoop.version>3.3.0</hadoop.version>
     <jacoco.version>0.8.5</jacoco.version>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Revert netty version change to use a netty version with better compatibility

