### PR TITLE
Remove the in alluxio check for distributedload

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
@@ -91,7 +91,7 @@ public final class DistributedLoadUtils {
       URIStatus status, int replication, Set<String> workerSet, Set<String> excludedWorkerSet,
       Set<String> localityIds, Set<String> excludedLocalityIds) {
     AlluxioURI filePath = new AlluxioURI(status.getPath());
-    if (status.getInAlluxioPercentage() == 100) {
+    if (status.getInAlluxioPercentage() == 100 && replication == 1) {
       // The file has already been fully loaded into Alluxio.
       System.out.println(filePath + " is already fully loaded in Alluxio");
       return;


### PR DESCRIPTION
### What changes are proposed in this pull request?

Address suggestion in https://github.com/Alluxio/alluxio/pull/13967, remove the alluxio check for distributedload.

### Why are the changes needed?

With this PR, we can re-load the file to a new specific replicas, something like from 1 replica to 3 replica

### Does this PR introduce any user facing changes?

No