### PR TITLE
Upgrade netty to the stable version to fix the existing CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
     <gmetric4j.version>1.0.7</gmetric4j.version>
     <grpc.version>1.17.1</grpc.version>
-    <netty.version>4.1.30.Final</netty.version>
+    <netty.version>4.1.65.Final</netty.version>
     <hadoop.version>2.2.0</hadoop.version>
     <hadoop-openstack.version>2.6.0</hadoop-openstack.version>
     <java.version>1.8</java.version>


### PR DESCRIPTION
### What changes are proposed in this pull request?

I modified the netty version in the pom.xml file. Upgrade netty to the stable version (netty-4.1.65.Final) to fix the existing [CVE](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=Flink). 

### Why are the changes needed?
None.

### Does this PR introduce any user facing changes?
None.
