### PR TITLE
Upgrade netty to the stable version to fix the existing CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
     <grpc.version>1.37.0</grpc.version>
     <gson.version>2.8.6</gson.version>
-    <netty.version>4.1.52.Final</netty.version>
+    <netty.version>4.1.65.Final</netty.version>
     <rocksdb.version>6.15.2</rocksdb.version>
     <hadoop.version>3.3.0</hadoop.version>
     <jacoco.version>0.8.5</jacoco.version>


### PR DESCRIPTION
### What changes are proposed in this pull request?

I modified the netty version in the pom.xml file. Upgrade netty to the stable version (netty-4.1.65.Final) to fix the existing [CVE](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=Flink). 

### Why are the changes needed?
None.

### Does this PR introduce any user facing changes?
None.
