### PR TITLE
Revert "Support read(Bytebuffer buf) method in LocalCacheFileInStream" won't merge

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -165,6 +165,17 @@ public class AlluxioFileInStream extends FileInStream {
   }
 
   @Override
+  public int read(byte[] b) throws IOException {
+    return read(b, 0, b.length);
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    Preconditions.checkArgument(b != null, PreconditionMessage.ERR_READ_BUFFER_NULL);
+    return read(ByteBuffer.wrap(b), off, len);
+  }
+
+  @Override
   public int read(ByteBuffer byteBuffer, int off, int len) throws IOException {
     Preconditions.checkArgument(off >= 0 && len >= 0 && len + off <= byteBuffer.capacity(),
         PreconditionMessage.ERR_BUFFER_STATE.toString(), byteBuffer.capacity(), off, len);

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -14,10 +14,6 @@ package alluxio.client.file;
 import alluxio.Seekable;
 import alluxio.client.BoundedStream;
 import alluxio.client.PositionedReadable;
-import alluxio.exception.PreconditionMessage;
-import alluxio.util.io.BufferUtils;
-
-import com.google.common.base.Preconditions;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,51 +24,8 @@ import java.nio.ByteBuffer;
  * collection of {@link #read} methods to access this stream of bytes. In addition, one can seek
  * into a given offset of the stream to read.
  */
-public abstract class FileInStream extends InputStream
-    implements BoundedStream, PositionedReadable, Seekable {
-  private final byte[] mSingleByte = new byte[1];
-
-  @Override
-  public int read() throws IOException {
-    int bytesRead = read(mSingleByte);
-    if (bytesRead == -1) {
-      return -1;
-    }
-    Preconditions.checkState(bytesRead == 1);
-    return BufferUtils.byteToInt(mSingleByte[0]);
-  }
-
-  @Override
-  public int read(byte[] b) throws IOException {
-    return read(b, 0, b.length);
-  }
-
-  @Override
-  public int read(byte[] b, int off, int len) throws IOException {
-    Preconditions.checkNotNull(b, PreconditionMessage.ERR_READ_BUFFER_NULL);
-    return read(ByteBuffer.wrap(b), off, len);
-  }
-
-  /**
-   * Reads up to buf.remaining() bytes into buf. Callers should use
-   * buf.limit(..) to control the size of the desired read.
-   * <p>
-   * After a successful call, buf.position() will be advanced by the number
-   * of bytes read and buf.limit() should be unchanged.
-   * <p>
-   * In the case of an exception, the values of buf.position() and buf.limit()
-   * are undefined, and callers should be prepared to recover from this eventually.
-   * <p>
-   * Implementations should treat 0-length requests as legitimate, and must not
-   * signal an error upon their receipt.
-   *
-   * @param buf the ByteBuffer to receive the results of the read operation
-   * @return the number of bytes read, possibly zero, or -1 if reach end-of-stream
-   */
-  public int read(ByteBuffer buf) throws IOException {
-    return read(buf, buf.position(), buf.remaining());
-  }
-
+public abstract class FileInStream extends InputStream implements BoundedStream, PositionedReadable,
+    Seekable {
   /**
    * Reads up to len bytes of data from the input stream into the byte buffer.
    *

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -19,6 +19,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
+import alluxio.util.io.BufferUtils;
 
 import com.codahale.metrics.Meter;
 import com.google.common.annotations.VisibleForTesting;
@@ -30,8 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
+
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -45,6 +46,7 @@ public class LocalCacheFileInStream extends FileInStream {
   /** Page size in bytes. */
   protected final long mPageSize;
 
+  private final byte[] mSingleByte = new byte[1];
   private final Closer mCloser = Closer.create();
 
   /** Local store to store pages. */
@@ -110,41 +112,37 @@ public class LocalCacheFileInStream extends FileInStream {
   }
 
   @Override
-  public int read(byte[] b, int off, int len) throws IOException {
-    return readInternal(b, off, len, ReadType.READ_INTO_BYTE_ARRAY, mPosition, false);
+  public int read() throws IOException {
+    int bytesRead = read(mSingleByte);
+    if (bytesRead == -1) {
+      return -1;
+    }
+    Preconditions.checkState(bytesRead == 1);
+    return BufferUtils.byteToInt(mSingleByte[0]);
   }
 
   @Override
-  public int read(ByteBuffer buf, int off, int len) throws IOException {
-    byte[] b = new byte[buf.remaining()];
-    int totalBytesRead =
-        readInternal(b, off, len, ReadType.READ_INTO_BYTE_BUFFER, mPosition, false);
-    if (totalBytesRead == -1) {
-      return -1;
-    }
-    buf.put(b, off, totalBytesRead);
-    return totalBytesRead;
+
+  public int read(byte[] b) throws IOException {
+    return read(b, 0, b.length);
   }
 
-  // TODO(binfan): take ByteBuffer once CacheManager takes ByteBuffer to avoid extra mem copy
-  private int readInternal(byte[] b, int off, int len, ReadType readType, long pos,
-      boolean isPositionedRead) throws IOException {
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
     Preconditions.checkArgument(len >= 0, "length should be non-negative");
     Preconditions.checkArgument(off >= 0, "offset should be non-negative");
-    Preconditions.checkArgument(pos >= 0, "position should be non-negative");
     if (len == 0) {
       return 0;
     }
-    if (pos >= mStatus.getLength()) { // at end of file
+    if (mPosition >= mStatus.getLength()) { // at end of file
       return -1;
     }
     int totalBytesRead = 0;
-    long currentPosition = pos;
-    long lengthToRead = Math.min(len, mStatus.getLength() - pos);
+    long lengthToRead = Math.min(len, mStatus.getLength() - mPosition);
     // for each page, check if it is available in the cache
     while (totalBytesRead < lengthToRead) {
-      long currentPage = currentPosition / mPageSize;
-      int currentPageOffset = (int) (currentPosition % mPageSize);
+      long currentPage = mPosition / mPageSize;
+      int currentPageOffset = (int) (mPosition % mPageSize);
       int bytesLeftInPage =
           (int) Math.min(mPageSize - currentPageOffset, lengthToRead - totalBytesRead);
       PageId pageId;
@@ -161,7 +159,7 @@ public class LocalCacheFileInStream extends FileInStream {
       mStopwatch.stop();
       if (bytesRead > 0) {
         totalBytesRead += bytesRead;
-        currentPosition += bytesRead;
+        mPosition += bytesRead;
         Metrics.BYTES_READ_CACHE.mark(bytesRead);
         if (cacheContext != null) {
           cacheContext
@@ -173,13 +171,14 @@ public class LocalCacheFileInStream extends FileInStream {
       } else {
         // on local cache miss, read a complete page from external storage. This will always make
         // progress or throw an exception
+
         mStopwatch.reset().start();
-        byte[] page = readExternalPage(currentPosition, readType);
+        byte[] page = readExternalPage(mPosition);
         mStopwatch.stop();
         if (page.length > 0) {
           System.arraycopy(page, currentPageOffset, b, off + totalBytesRead, bytesLeftInPage);
           totalBytesRead += bytesLeftInPage;
-          currentPosition += bytesLeftInPage;
+          mPosition += bytesLeftInPage;
           Metrics.BYTES_REQUESTED_EXTERNAL.mark(bytesLeftInPage);
           if (cacheContext != null) {
             cacheContext.incrementCounter(
@@ -192,11 +191,8 @@ public class LocalCacheFileInStream extends FileInStream {
           mCacheManager.put(pageId, page, mCacheContext);
         }
       }
-      if (!isPositionedRead) {
-        mPosition = currentPosition;
-      }
     }
-    if (totalBytesRead > len || (totalBytesRead < len && currentPosition < mStatus.getLength())) {
+    if (totalBytesRead > len || (totalBytesRead < len && remaining() > 0)) {
       throw new IOException(String.format("Invalid number of bytes read - "
           + "bytes to read = %d, actual bytes read = %d, bytes remains in file %d",
           len, totalBytesRead, remaining()));
@@ -227,7 +223,58 @@ public class LocalCacheFileInStream extends FileInStream {
 
   @Override
   public int positionedRead(long pos, byte[] b, int off, int len) throws IOException {
-    return readInternal(b, off, len, ReadType.READ_INTO_BYTE_ARRAY, pos, true);
+    Preconditions.checkArgument(len >= 0, "length should be non-negative");
+    Preconditions.checkArgument(off >= 0, "offset should be non-negative");
+    Preconditions.checkArgument(pos >= 0, "position should be non-negative");
+    if (len == 0) {
+      return 0;
+    }
+    if (pos < 0 || pos >= mStatus.getLength()) { // at end of file
+      return -1;
+    }
+    int totalBytesRead = 0;
+    long currentPosition = pos;
+    long lengthToRead = Math.min(len, mStatus.getLength() - pos);
+    // for each page, check if it is available in the cache
+    while (totalBytesRead < lengthToRead) {
+      long currentPage = currentPosition / mPageSize;
+      int currentPageOffset = (int) (currentPosition % mPageSize);
+      int bytesLeftInPage =
+          (int) Math.min(mPageSize - currentPageOffset, lengthToRead - totalBytesRead);
+      CacheContext cacheContext = mStatus.getCacheContext();
+      PageId pageId;
+      if (cacheContext != null && cacheContext.getCacheIdentifier() != null) {
+        pageId = new PageId(cacheContext.getCacheIdentifier(), currentPage);
+      } else {
+        pageId = new PageId(Long.toString(mStatus.getFileId()), currentPage);
+      }
+      int bytesRead =
+          mCacheManager.get(pageId, currentPageOffset, bytesLeftInPage, b, off + totalBytesRead);
+      if (bytesRead > 0) {
+        totalBytesRead += bytesRead;
+        currentPosition += bytesRead;
+        Metrics.BYTES_READ_CACHE.mark(bytesRead);
+      } else {
+        // on local cache miss, read a complete page from external storage. This will always make
+        // progress or throw an exception
+        byte[] page = readExternalPage(currentPosition);
+        if (page.length > 0) {
+          System.arraycopy(page, currentPageOffset, b, off + totalBytesRead, bytesLeftInPage);
+          totalBytesRead += bytesLeftInPage;
+          currentPosition += bytesLeftInPage;
+          Metrics.BYTES_REQUESTED_EXTERNAL.mark(bytesLeftInPage);
+          mCacheManager.put(pageId, page, mCacheContext);
+        }
+      }
+    }
+    if (totalBytesRead > len || (totalBytesRead < len && currentPosition < mStatus.getLength())) {
+      throw new IOException(String.format(
+          "Invalid number of bytes positionread - read from position = %d, "
+              + "bytes to read = %d, actual bytes read = %d, bytes remains in file %d",
+          pos, len, totalBytesRead, mStatus.getLength() - currentPosition)
+      );
+    }
+    return totalBytesRead;
   }
 
   @Override
@@ -260,7 +307,7 @@ public class LocalCacheFileInStream extends FileInStream {
 
   /**
    * Convenience method to get external file reader with lazy init.
-   * <p>
+   *
    * // TODO(calvin): Evaluate if using positioned read to allow for more concurrency is worthwhile
    *
    * @param pos position to set the external stream to
@@ -284,37 +331,26 @@ public class LocalCacheFileInStream extends FileInStream {
   /**
    * Reads a page from external storage which contains the position specified. Note that this makes
    * a copy of the page.
-   * <p>
+   *
    * This method is synchronized to ensure thread safety for positioned reads. Only a single thread
    * should call this method at a time because the underlying state (mExternalFileInStream) is
    * shared. Another way would be to use positioned reads instead of seek and read, but that assumes
    * the underlying FileInStream implements thread safe positioned reads which are not much more
    * expensive than seek and read.
-   * <p>
+   *
    * TODO(calvin): Consider a more efficient API which does not require a data copy.
    *
    * @param pos the position which the page will contain
    * @return a byte array of the page data
    */
-  private synchronized byte[] readExternalPage(long pos, ReadType readType) throws IOException {
+  private synchronized byte[] readExternalPage(long pos) throws IOException {
     long pageStart = pos - (pos % mPageSize);
     FileInStream stream = getExternalFileInStream(pageStart);
     int pageSize = (int) Math.min(mPageSize, mStatus.getLength() - pageStart);
     byte[] page = new byte[pageSize];
-    ByteBuffer buffer = readType == ReadType.READ_INTO_BYTE_BUFFER ? ByteBuffer.wrap(page) : null;
     int totalBytesRead = 0;
     while (totalBytesRead < pageSize) {
-      int bytesRead;
-      switch (readType) {
-        case READ_INTO_BYTE_ARRAY:
-          bytesRead = stream.read(page, totalBytesRead, pageSize - totalBytesRead);
-          break;
-        case READ_INTO_BYTE_BUFFER:
-          bytesRead = stream.read(buffer);
-          break;
-        default:
-          throw new IOException("unsupported read type = " + readType);
-      }
+      int bytesRead = stream.read(page, totalBytesRead, pageSize - totalBytesRead);
       if (bytesRead <= 0) {
         break;
       }
@@ -353,16 +389,5 @@ public class LocalCacheFileInStream extends FileInStream {
             return 0;
           });
     }
-  }
-
-  enum ReadType {
-    /**
-     * read some number of bytes from the input stream and stores them into the buffer array.
-     */
-    READ_INTO_BYTE_ARRAY,
-    /**
-     * read some number of bytes from the input stream and stores them into the ByteBuffer.
-     */
-    READ_INTO_BYTE_BUFFER
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/file/MockFileInStream.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/MockFileInStream.java
@@ -62,13 +62,11 @@ public final class MockFileInStream extends FileInStream {
     mStream.skip(n);
   }
 
-  @Override
-  public long getPos() throws IOException {
+  @Override public long getPos() throws IOException {
     return mLength - remaining();
   }
 
-  @Override
-  public int positionedRead(long position, byte[] buffer, int offset, int length)
+  @Override public int positionedRead(long position, byte[] buffer, int offset, int length)
       throws IOException {
     throw new UnsupportedOperationException("positionedRead not implemented for mock FileInStream");
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -103,27 +103,11 @@ public class LocalCacheFileInStreamTest {
   }
 
   @Test
-  public void readFullPageThroughReadByteBufferMethod() throws Exception {
-    int fileSize = PAGE_SIZE;
-    int bufferSize = fileSize;
-    int pages = 1;
-    verifyReadFullFileThroughReadByteBufferMethod(fileSize, bufferSize, pages);
-  }
-
-  @Test
   public void readSmallPage() throws Exception {
     int fileSize = PAGE_SIZE / 5;
     int bufferSize = fileSize;
     int pages = 1;
     verifyReadFullFile(fileSize, bufferSize, pages);
-  }
-
-  @Test
-  public void readSmallPageThroughReadByteBufferMethod() throws Exception {
-    int fileSize = PAGE_SIZE / 5;
-    int bufferSize = fileSize;
-    int pages = 1;
-    verifyReadFullFileThroughReadByteBufferMethod(fileSize, bufferSize, pages);
   }
 
   @Test
@@ -181,47 +165,11 @@ public class LocalCacheFileInStreamTest {
   }
 
   @Test
-  public void readPartialPageThroughReadByteBufferMethod() throws Exception {
-    int fileSize = PAGE_SIZE;
-    byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
-    ByteArrayCacheManager manager = new ByteArrayCacheManager();
-    LocalCacheFileInStream stream = setupWithSingleFile(testData, manager);
-
-    int partialReadSize = fileSize / 5;
-    int offset = fileSize / 5;
-
-    // cache miss
-    ByteBuffer cacheMissBuffer = ByteBuffer.wrap(new byte[partialReadSize]);
-    stream.seek(offset);
-    Assert.assertEquals(partialReadSize, stream.read(cacheMissBuffer));
-    Assert.assertArrayEquals(
-        Arrays.copyOfRange(testData, offset, offset + partialReadSize), cacheMissBuffer.array());
-    Assert.assertEquals(0, manager.mPagesServed);
-    Assert.assertEquals(1, manager.mPagesCached);
-
-    // cache hit
-    ByteBuffer cacheHitBuffer = ByteBuffer.wrap(new byte[partialReadSize]);
-    stream.seek(offset);
-    Assert.assertEquals(partialReadSize, stream.read(cacheHitBuffer));
-    Assert.assertArrayEquals(
-        Arrays.copyOfRange(testData, offset, offset + partialReadSize), cacheHitBuffer.array());
-    Assert.assertEquals(1, manager.mPagesServed);
-  }
-
-  @Test
   public void readMultiPage() throws Exception {
     int pages = 2;
     int fileSize = PAGE_SIZE + 10;
     int bufferSize = fileSize;
     verifyReadFullFile(fileSize, bufferSize, pages);
-  }
-
-  @Test
-  public void readMultiPageThroughReadByteBufferMethod() throws Exception {
-    int pages = 2;
-    int fileSize = PAGE_SIZE + 10;
-    int bufferSize = fileSize;
-    verifyReadFullFileThroughReadByteBufferMethod(fileSize, bufferSize, pages);
   }
 
   @Test
@@ -254,35 +202,6 @@ public class LocalCacheFileInStreamTest {
   }
 
   @Test
-  public void readMultiPageMixedThroughReadByteBufferMethod() throws Exception {
-    int pages = 10;
-    int fileSize = PAGE_SIZE * pages;
-    byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
-    ByteArrayCacheManager manager = new ByteArrayCacheManager();
-    LocalCacheFileInStream stream = setupWithSingleFile(testData, manager);
-
-    // populate cache
-    int pagesCached = 0;
-    for (int i = 0; i < pages; i++) {
-      stream.seek(PAGE_SIZE * i);
-      if (ThreadLocalRandom.current().nextBoolean()) {
-        Assert.assertEquals(testData[(i * PAGE_SIZE)], stream.read());
-        pagesCached++;
-      }
-    }
-
-    Assert.assertEquals(0, manager.mPagesServed);
-    Assert.assertEquals(pagesCached, manager.mPagesCached);
-
-    // sequential read
-    stream.seek(0);
-    ByteBuffer fullReadBuf = ByteBuffer.wrap(new byte[fileSize]);
-    Assert.assertEquals(fileSize, stream.read(fullReadBuf));
-    Assert.assertArrayEquals(testData, fullReadBuf.array());
-    Assert.assertEquals(pagesCached, manager.mPagesServed);
-  }
-
-  @Test
   public void readOversizedBuffer() throws Exception {
     int pages = 1;
     int fileSize = PAGE_SIZE;
@@ -291,27 +210,11 @@ public class LocalCacheFileInStreamTest {
   }
 
   @Test
-  public void readOversizedBufferThroughReadByteBufferMethod() throws Exception {
-    int pages = 1;
-    int fileSize = PAGE_SIZE;
-    int bufferSize = fileSize * 2;
-    verifyReadFullFileThroughReadByteBufferMethod(fileSize, bufferSize, pages);
-  }
-
-  @Test
   public void readSmallPageOversizedBuffer() throws Exception {
     int pages = 1;
     int fileSize = PAGE_SIZE / 3;
     int bufferSize = fileSize * 2;
     verifyReadFullFile(fileSize, bufferSize, pages);
-  }
-
-  @Test
-  public void readSmallPageOversizedBufferThroughReadByteBufferMethod() throws Exception {
-    int pages = 1;
-    int fileSize = PAGE_SIZE / 3;
-    int bufferSize = fileSize * 2;
-    verifyReadFullFileThroughReadByteBufferMethod(fileSize, bufferSize, pages);
   }
 
   @Test
@@ -425,35 +328,6 @@ public class LocalCacheFileInStreamTest {
   }
 
   @Test
-  public void externalStoreMultiReadThroughReadByteBufferMethod() throws Exception {
-    int fileSize = PAGE_SIZE;
-    byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
-    ByteArrayCacheManager manager = new ByteArrayCacheManager();
-    Map<AlluxioURI, byte[]> files = new HashMap<>();
-    AlluxioURI testFilename = new AlluxioURI("/test");
-    files.put(testFilename, testData);
-
-    ByteArrayFileSystem fs = new MultiReadByteArrayFileSystem(files);
-
-    LocalCacheFileInStream stream = new LocalCacheFileInStream(fs.getStatus(testFilename),
-        (status) -> fs.openFile(status, OpenFilePOptions.getDefaultInstance()), manager, sConf);
-
-    // cache miss
-    ByteBuffer cacheMissBuf = ByteBuffer.wrap(new byte[fileSize]);
-    Assert.assertEquals(fileSize, stream.read(cacheMissBuf));
-    Assert.assertArrayEquals(testData, cacheMissBuf.array());
-    Assert.assertEquals(0, manager.mPagesServed);
-    Assert.assertEquals(1, manager.mPagesCached);
-
-    // cache hit
-    stream.seek(0);
-    ByteBuffer cacheHitBuf = ByteBuffer.wrap(new byte[fileSize]);
-    Assert.assertEquals(fileSize, stream.read(cacheHitBuf));
-    Assert.assertArrayEquals(testData, cacheHitBuf.array());
-    Assert.assertEquals(1, manager.mPagesServed);
-  }
-
-  @Test
   public void readMultipleFiles() throws Exception {
     Random random = new Random();
     ByteArrayCacheManager manager = new ByteArrayCacheManager();
@@ -507,7 +381,7 @@ public class LocalCacheFileInStreamTest {
         (status) -> fs.openFile(status, OpenFilePOptions.getDefaultInstance()), manager, sConf);
   }
 
-  private Map<AlluxioURI, LocalCacheFileInStream> setupWithMultipleFiles(Map<String, byte[]> files,
+  private  Map<AlluxioURI, LocalCacheFileInStream> setupWithMultipleFiles(Map<String, byte[]> files,
       CacheManager manager) {
     Map<AlluxioURI, byte[]> fileMap = files.entrySet().stream()
         .collect(Collectors.toMap(entry -> new AlluxioURI(entry.getKey()), Map.Entry::getValue));
@@ -551,29 +425,6 @@ public class LocalCacheFileInStreamTest {
     stream.seek(0);
     byte[] cacheHit = new byte[bufferSize];
     Assert.assertEquals(fileSize, stream.read(cacheHit));
-    Assert.assertArrayEquals(testData, Arrays.copyOfRange(cacheHit, 0, fileSize));
-    Assert.assertEquals(pages, manager.mPagesServed);
-  }
-
-  private void verifyReadFullFileThroughReadByteBufferMethod(int fileSize, int bufferSize,
-      int pages) throws Exception {
-    byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
-    ByteArrayCacheManager manager = new ByteArrayCacheManager();
-    LocalCacheFileInStream stream = setupWithSingleFile(testData, manager);
-
-    // cache miss
-    byte[] cacheMiss = new byte[bufferSize];
-    ByteBuffer cacheMissBuffer = ByteBuffer.wrap(cacheMiss);
-    Assert.assertEquals(fileSize, stream.read(cacheMissBuffer));
-    Assert.assertArrayEquals(testData, Arrays.copyOfRange(cacheMiss, 0, fileSize));
-    Assert.assertEquals(0, manager.mPagesServed);
-    Assert.assertEquals(pages, manager.mPagesCached);
-
-    // cache hit
-    stream.seek(0);
-    byte[] cacheHit = new byte[bufferSize];
-    ByteBuffer cacheHitBuffer = ByteBuffer.wrap(cacheHit);
-    Assert.assertEquals(fileSize, stream.read(cacheHitBuffer));
     Assert.assertArrayEquals(testData, Arrays.copyOfRange(cacheHit, 0, fileSize));
     Assert.assertEquals(pages, manager.mPagesServed);
   }
@@ -926,12 +777,6 @@ public class LocalCacheFileInStreamTest {
     }
 
     @Override
-    public int read(ByteBuffer byteBuffer, int off, int len) throws IOException {
-      mTicker.advance(StepTicker.Type.CACHE_MISS);
-      return mDelegate.read(byteBuffer, off, len);
-    }
-
-    @Override
     public long getPos() throws IOException {
       return mDelegate.getPos();
     }
@@ -951,6 +796,11 @@ public class LocalCacheFileInStreamTest {
         throws IOException {
       mTicker.advance(StepTicker.Type.CACHE_MISS);
       return mDelegate.positionedRead(position, buffer, offset, length);
+    }
+
+    @Override
+    public int read() throws IOException {
+      return 0;
     }
   }
 
@@ -1004,11 +854,6 @@ public class LocalCacheFileInStreamTest {
     public int read(byte[] b, int off, int len) throws IOException {
       int toRead = len > 1 ? ThreadLocalRandom.current().nextInt(1, len) : len;
       return mIn.read(b, off, toRead);
-    }
-
-    @Override
-    public int read(ByteBuffer buf) throws IOException {
-      return mIn.read(buf);
     }
 
     @Override

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsInputStream.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsInputStream.java
@@ -17,7 +17,6 @@ import com.google.common.base.Preconditions;
 import org.apache.hadoop.fs.FSDataInputStream;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 /**
  * A wrapper class to translate Hadoop FileSystem FSDataInputStream to Alluxio FileSystem
@@ -46,11 +45,6 @@ public class AlluxioHdfsInputStream extends FileInStream {
   @Override
   public int read() throws IOException {
     return mInput.read();
-  }
-
-  @Override
-  public int read(ByteBuffer buf) throws IOException {
-    return mInput.read(buf);
   }
 
   @Override

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HdfsFileInputStream.java
@@ -18,11 +18,9 @@ import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileDoesNotExistException;
 
-import org.apache.hadoop.fs.ByteBufferReadable;
 import org.apache.hadoop.fs.FileSystem.Statistics;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +28,7 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
+
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -38,8 +36,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * {@link FileInStream} with additional statistics gathering in a {@link Statistics} object.
  */
 @NotThreadSafe
-public class HdfsFileInputStream extends InputStream implements Seekable, PositionedReadable,
-    ByteBufferReadable {
+public class HdfsFileInputStream extends InputStream implements Seekable, PositionedReadable {
   private static final Logger LOG = LoggerFactory.getLogger(HdfsFileInputStream.class);
 
   private final Statistics mStatistics;
@@ -127,18 +124,6 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
     }
 
     int bytesRead = mInputStream.read(buffer, offset, length);
-    if (bytesRead != -1 && mStatistics != null) {
-      mStatistics.incrementBytesRead(bytesRead);
-    }
-    return bytesRead;
-  }
-
-  @Override
-  public int read(ByteBuffer buf) throws IOException {
-    if (mClosed) {
-      throw new IOException(ExceptionMessage.READ_CLOSED_STREAM.getMessage());
-    }
-    int bytesRead = mInputStream.read(buf);
     if (bytesRead != -1 && mStatistics != null) {
       mStatistics.incrementBytesRead(bytesRead);
     }

--- a/tests/src/test/java/alluxio/client/hadoop/HdfsFileInputStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/HdfsFileInputStreamIntegrationTest.java
@@ -40,14 +40,12 @@ import org.junit.rules.ExpectedException;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 /**
  * Integration tests for {@link HdfsFileInputStream}.
  */
 public final class HdfsFileInputStreamIntegrationTest extends BaseIntegrationTest {
-
   private static final int FILE_LEN = 255;
   private static final int BUFFER_SIZE = 50;
   private static final String IN_MEMORY_FILE = "/inMemoryFile";
@@ -217,32 +215,6 @@ public final class HdfsFileInputStreamIntegrationTest extends BaseIntegrationTes
     length = mInMemInputStream.read(FILE_LEN, buf, 0, FILE_LEN);
     Assert.assertEquals(-1, length);
     length = mUfsInputStream.read(FILE_LEN, buf, 0, FILE_LEN);
-    Assert.assertEquals(-1, length);
-  }
-
-  /**
-   * Tests {@link HdfsFileInputStream#read(java.nio.ByteBuffer buf)}.
-   */
-  @Test
-  public void readTest5() throws Exception {
-    byte[] data = new byte[FILE_LEN];
-    ByteBuffer buf = ByteBuffer.wrap(data);
-    int length = mInMemInputStream.read(buf);
-    Assert.assertEquals(FILE_LEN, length);
-    Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(0, FILE_LEN, buf));
-
-    createUfsInStream(ReadType.NO_CACHE);
-    buf.rewind();
-    buf.clear();
-    length = mUfsInputStream.read(buf);
-    Assert.assertEquals(FILE_LEN, length);
-    Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(0, FILE_LEN, buf));
-
-    buf.rewind();
-    buf.clear();
-    length = mInMemInputStream.read(buf);
-    Assert.assertEquals(-1, length);
-    length = mUfsInputStream.read(buf);
     Assert.assertEquals(-1, length);
   }
 


### PR DESCRIPTION
This reverts commit 62e06ed79d09aaac54ec9b1be6d2e75536e26616.

### What changes are proposed in this pull request?

revert a commit which might cause the performance regression

### Why are the changes needed?


### Does this PR introduce any user facing changes?
N/A