### PR TITLE
Add a skip-prepare parameter for MaxThroughput

### DIFF
--- a/stress/common/src/main/java/alluxio/stress/master/MasterBenchParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/master/MasterBenchParameters.java
@@ -96,6 +96,10 @@ public final class MasterBenchParameters extends Parameters {
 
   public Map<String, String> mConf = new HashMap<>();
 
+  @Parameter(names = {"--skip-prepare"},
+      description = "If true, skip the prepare.")
+  public boolean mSkipPrepare = false;
+
   /**
    * Converts from String to Operation instance.
    */

--- a/stress/shell/src/main/java/alluxio/stress/cli/suite/MaxThroughput.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/suite/MaxThroughput.java
@@ -73,7 +73,9 @@ public class MaxThroughput extends Suite<MaxThroughputSummary> {
 
     List<String> baseArgs = new ArrayList<>(Arrays.asList(args));
 
-    prepareBeforeAllTests(baseArgs);
+    if (mParameters.mSkipPrepare) {
+      prepareBeforeAllTests(baseArgs);
+    }
 
     int lower = 0;
     int upper = Integer.MAX_VALUE;

--- a/stress/shell/src/main/java/alluxio/stress/cli/suite/MaxThroughput.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/suite/MaxThroughput.java
@@ -73,7 +73,7 @@ public class MaxThroughput extends Suite<MaxThroughputSummary> {
 
     List<String> baseArgs = new ArrayList<>(Arrays.asList(args));
 
-    if (mParameters.mSkipPrepare) {
+    if (!mParameters.mSkipPrepare) {
       prepareBeforeAllTests(baseArgs);
     }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

We'll do a same maxThroughput test many time, so we don't want to change basedir or create&delete a lots of file before test.

### Why are the changes needed?

Add a parameter to supply a way to skip prepare step.

### Does this PR introduce any user facing changes?

Add a new parameter `--skip-prepare`
