### PR TITLE
Make distributed tasks delay time configurable

### DIFF
--- a/stress/common/src/main/java/alluxio/stress/BaseParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/BaseParameters.java
@@ -34,6 +34,7 @@ public final class BaseParameters {
   public static final long UNDEFINED_START_MS = -1;
   public static final String AGENT_OUTPUT_PATH = "/tmp/stress_client.log";
   public static final String DEFAULT_TASK_ID = "local-task-0";
+  public static final String START_DELAY_MS = "--start-delay";
 
   // Public flags
   @Parameter(names = {CLUSTER_FLAG},
@@ -86,4 +87,8 @@ public final class BaseParameters {
 
   @Parameter(names = {"-h", HELP_FLAG}, help = true)
   public boolean mHelp = false;
+
+  @Parameter(names = {START_DELAY_MS},
+          description = "The start delay for the distributed tasks, in ms.")
+  public long mStartDelay = 10000;
 }

--- a/stress/common/src/main/java/alluxio/stress/BaseParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/BaseParameters.java
@@ -50,7 +50,8 @@ public final class BaseParameters {
 
   @Parameter(names = {CLUSTER_START_DELAY_FLAG},
       description = "The start delay for the jobs to wait before starting the benchmark, "
-          + "used to synchronize the jobs")
+          + "used to synchronize the jobs. For example, --start-delay 10000ms,"
+              + "--start-delay 15s, --start-delay 2m")
   public String mClusterStartDelay = "10s";
 
   @Parameter(names = {JAVA_OPT_FLAG},

--- a/stress/common/src/main/java/alluxio/stress/BaseParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/BaseParameters.java
@@ -23,6 +23,7 @@ import java.util.List;
 public final class BaseParameters {
   public static final String CLUSTER_FLAG = "--cluster";
   public static final String CLUSTER_LIMIT_FLAG = "--cluster-limit";
+  public static final String CLUSTER_START_DELAY_FLAG = "--cluster-start-delay";
   public static final String DISTRIBUTED_FLAG = "--distributed";
   public static final String ID_FLAG = "--id";
   public static final String IN_PROCESS_FLAG = "--in-process";
@@ -34,7 +35,6 @@ public final class BaseParameters {
   public static final long UNDEFINED_START_MS = -1;
   public static final String AGENT_OUTPUT_PATH = "/tmp/stress_client.log";
   public static final String DEFAULT_TASK_ID = "local-task-0";
-  public static final String START_DELAY_MS = "--start-delay";
 
   // Public flags
   @Parameter(names = {CLUSTER_FLAG},
@@ -47,6 +47,11 @@ public final class BaseParameters {
           + " will run on all available cluster workers. If < 0, will run on the workers from the"
           + " end of the worker list. This flag is only used if " + CLUSTER_FLAG + " is enabled.")
   public int mClusterLimit = 0;
+
+  @Parameter(names = {CLUSTER_START_DELAY_FLAG},
+      description = "The start delay for the jobs to wait before starting the benchmark, "
+          + "used to synchronize the jobs")
+  public String mClusterStartDelay = "10s";
 
   @Parameter(names = {JAVA_OPT_FLAG},
       description = "The java options to add to the command line to for the task. This can be "
@@ -87,8 +92,4 @@ public final class BaseParameters {
 
   @Parameter(names = {"-h", HELP_FLAG}, help = true)
   public boolean mHelp = false;
-
-  @Parameter(names = {START_DELAY_MS},
-          description = "The start delay for the distributed tasks, in ms.")
-  public String mStartDelay = "10000ms";
 }

--- a/stress/common/src/main/java/alluxio/stress/BaseParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/BaseParameters.java
@@ -90,5 +90,5 @@ public final class BaseParameters {
 
   @Parameter(names = {START_DELAY_MS},
           description = "The start delay for the distributed tasks, in ms.")
-  public long mStartDelay = 10000;
+  public String mStartDelay = "10000ms";
 }

--- a/stress/common/src/main/java/alluxio/stress/BaseParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/BaseParameters.java
@@ -50,8 +50,8 @@ public final class BaseParameters {
 
   @Parameter(names = {CLUSTER_START_DELAY_FLAG},
       description = "The start delay for the jobs to wait before starting the benchmark, "
-          + "used to synchronize the jobs. For example, --start-delay 10000ms,"
-              + "--start-delay 15s, --start-delay 2m")
+          + "used to synchronize the jobs. For example, --cluster-start-delay 10000ms,"
+              + "--cluster-start-delay 15s, --cluster-start-delay 2m")
   public String mClusterStartDelay = "10s";
 
   @Parameter(names = {JAVA_OPT_FLAG},

--- a/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
@@ -118,7 +118,7 @@ public abstract class Benchmark<T extends TaskResult> {
     commandArgs.addAll(mBaseParameters.mJavaOpts.stream().map(String::trim)
         .collect(Collectors.toList()));
     String className = this.getClass().getCanonicalName();
-    return new StressBenchConfig(className, commandArgs, 10000, mBaseParameters.mClusterLimit);
+    return new StressBenchConfig(className, commandArgs, mBaseParameters.mStartDelay, mBaseParameters.mClusterLimit);
   }
 
   /**

--- a/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
@@ -118,7 +118,8 @@ public abstract class Benchmark<T extends TaskResult> {
     commandArgs.addAll(mBaseParameters.mJavaOpts.stream().map(String::trim)
         .collect(Collectors.toList()));
     String className = this.getClass().getCanonicalName();
-    return new StressBenchConfig(className, commandArgs, mBaseParameters.mStartDelay, mBaseParameters.mClusterLimit);
+    return new StressBenchConfig(className, commandArgs,
+            mBaseParameters.mStartDelay, mBaseParameters.mClusterLimit);
   }
 
   /**

--- a/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
@@ -22,6 +22,7 @@ import alluxio.stress.StressConstants;
 import alluxio.stress.TaskResult;
 import alluxio.stress.job.StressBenchConfig;
 import alluxio.util.ConfigurationUtils;
+import alluxio.util.FormatUtils;
 import alluxio.util.ShellUtils;
 
 import com.beust.jcommander.JCommander;
@@ -118,8 +119,9 @@ public abstract class Benchmark<T extends TaskResult> {
     commandArgs.addAll(mBaseParameters.mJavaOpts.stream().map(String::trim)
         .collect(Collectors.toList()));
     String className = this.getClass().getCanonicalName();
+    long mStartDelay = FormatUtils.parseTimeSize(mBaseParameters.mStartDelay);
     return new StressBenchConfig(className, commandArgs,
-            mBaseParameters.mStartDelay, mBaseParameters.mClusterLimit);
+            mStartDelay, mBaseParameters.mClusterLimit);
   }
 
   /**

--- a/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
@@ -119,9 +119,8 @@ public abstract class Benchmark<T extends TaskResult> {
     commandArgs.addAll(mBaseParameters.mJavaOpts.stream().map(String::trim)
         .collect(Collectors.toList()));
     String className = this.getClass().getCanonicalName();
-    long mStartDelay = FormatUtils.parseTimeSize(mBaseParameters.mStartDelay);
-    return new StressBenchConfig(className, commandArgs,
-            mStartDelay, mBaseParameters.mClusterLimit);
+    long startDelay = FormatUtils.parseTimeSize(mBaseParameters.mClusterStartDelay);
+    return new StressBenchConfig(className, commandArgs, startDelay, mBaseParameters.mClusterLimit);
   }
 
   /**

--- a/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
@@ -381,7 +381,7 @@ public class StressMasterBench extends Benchmark<MasterBenchTaskResult> {
       long waitMs = mContext.getStartMs() - CommonUtils.getCurrentMs();
       if (waitMs < 0) {
         throw new IllegalStateException(String.format(
-            "Thread missed barrier. Set the start time to a later time. start: %d current: %d",
+            "Thread missed barrier. Increase the start delay. start: %d current: %d",
             mContext.getStartMs(), CommonUtils.getCurrentMs()));
       }
       CommonUtils.sleepMs(waitMs);

--- a/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
@@ -357,7 +357,7 @@ public class StressClientIOBench extends Benchmark<ClientIOTaskResult> {
       long waitMs = mContext.getStartMs() - CommonUtils.getCurrentMs();
       if (waitMs < 0) {
         throw new IllegalStateException(String.format(
-            "Thread missed barrier. Set the start time to a later time. start: %d current: %d",
+            "Thread missed barrier. Increase the start delay. start: %d current: %d",
             mContext.getStartMs(), CommonUtils.getCurrentMs()));
       }
       CommonUtils.sleepMs(waitMs);

--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -313,7 +313,7 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
       long waitMs = mContext.getStartMs() - CommonUtils.getCurrentMs();
       if (waitMs < 0) {
         throw new IllegalStateException(String.format(
-            "Thread missed barrier. Set the start time to a later time. start: %d current: %d",
+            "Thread missed barrier. Increase the start delay. start: %d current: %d",
             mContext.getStartMs(), CommonUtils.getCurrentMs()));
       }
       CommonUtils.sleepMs(waitMs);

--- a/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -249,7 +249,7 @@ public class StressWorkerBench extends Benchmark<WorkerBenchTaskResult> {
       long waitMs = mContext.getStartMs() - CommonUtils.getCurrentMs();
       if (waitMs < 0) {
         throw new IllegalStateException(String.format(
-            "Thread missed barrier. Set the start time to a later time. start: %d current: %d",
+            "Thread missed barrier. Increase the start delay. start: %d current: %d",
             mContext.getStartMs(), CommonUtils.getCurrentMs()));
       }
       CommonUtils.sleepMs(waitMs);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Make distributed tasks delay time configurable.

### Why are the changes needed?

When the number of nodes in the cluster is large, the delay time of 10s may cause incomplete task scheduling. The delay time should be flexibly configured as required

### Does this PR introduce any user facing changes?
No
