### PR TITLE
Support start container id from current timestamp

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2675,6 +2675,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey
+      MASTER_BLOCK_CONTAINER_ID_START_FROM_TIMESTAMP =
+      new Builder(Name.MASTER_BLOCK_CONTAINER_ID_START_FROM_TIMESTAMP)
+          .setDescription("If enabled, the first container id is current timestamp")
+          .setScope(Scope.MASTER)
+          .setDefaultValue(false)
+          .build();
 
   //
   // Secondary master related properties
@@ -5834,6 +5841,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.journal.gc.threshold";
     public static final String MASTER_JOURNAL_TEMPORARY_FILE_GC_THRESHOLD_MS =
         "alluxio.master.journal.temporary.file.gc.threshold";
+    public static final String MASTER_BLOCK_CONTAINER_ID_START_FROM_TIMESTAMP =
+        "alluxio.master.block.container.id.start.from.timestamp";
 
     //
     // File system master related properties

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -355,7 +355,13 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
   public void resetState() {
     mBlockStore.clear();
     mJournaledNextContainerId = 0;
-    mBlockContainerIdGenerator.setNextContainerId(0);
+    long startContainerId = 0L;
+    if (ServerConfiguration.getBoolean(
+        PropertyKey.MASTER_BLOCK_CONTAINER_ID_START_FROM_TIMESTAMP)) {
+      startContainerId = System.currentTimeMillis() / 1000;
+    }
+    LOG.info("The start container id is {}", startContainerId);
+    mBlockContainerIdGenerator.setNextContainerId(startContainerId);
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -233,8 +233,9 @@ public class InodeTree implements DelegatingJournaled {
   public void initializeRoot(String owner, String group, Mode mode, JournalContext context)
       throws UnavailableException {
     if (mState.getRoot() == null) {
+      long directoryId = mDirectoryIdGenerator.getNewDirectoryId(context);
       MutableInodeDirectory root = MutableInodeDirectory.create(
-          mDirectoryIdGenerator.getNewDirectoryId(context), NO_PARENT, ROOT_INODE_NAME,
+          0, NO_PARENT, ROOT_INODE_NAME,
           CreateDirectoryContext
               .mergeFrom(CreateDirectoryPOptions.newBuilder().setMode(mode.toProto()))
               .setOwner(owner).setGroup(group));


### PR DESCRIPTION
### What changes are proposed in this pull request?

Without this PR, alluxio master will generate block container id from `0`, after master format and restart without worker format, the old worker will report its block to alluxio master, not sure the master will accept the block by accident.

So this PR aimed to supply configure key to enable start block container id from current timestamp, so that the blockContainer Id will never possible to be the same value in a long period.

### Does this PR introduce any user facing changes?

NO


### How to test

- start a alluxio cluster with the config key `alluxio.master.block.container.id.start.from.timestamp=true`

- I can see the following log
2021-08-31 18:56:56,708 INFO  DefaultBlockMaster - The start container id is 1630407414