### PR TITLE
Move prepare stage to local in stress bench

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
@@ -74,9 +74,6 @@ public abstract class Benchmark<T extends TaskResult> {
   /**
    * Prepares to run the test.
    */
-  // TODO(bowen): When the test runs in cluster mode, the prepare step will execute
-  //  both in the command side and on each job worker side. We should separate the logic
-  //  into two different calls instead of relying on the same prepare().
   public abstract void prepare() throws Exception;
 
   /**
@@ -144,9 +141,6 @@ public abstract class Benchmark<T extends TaskResult> {
       throw e;
     }
 
-    // prepare the benchmark.
-    prepare();
-
     if (!mBaseParameters.mProfileAgent.isEmpty()) {
       mBaseParameters.mJavaOpts.add("-javaagent:" + mBaseParameters.mProfileAgent
           + "=" + BaseParameters.AGENT_OUTPUT_PATH);
@@ -164,6 +158,8 @@ public abstract class Benchmark<T extends TaskResult> {
     }
 
     // run locally
+    // prepare the benchmark.
+    prepare();
     if (mBaseParameters.mInProcess) {
       // run in process
       T result = runLocal();


### PR DESCRIPTION
Currently in stress bench, prepare() is called before the job is distributed to job service if cluster flag is turned on. Therefore the node that runs the command will run prepare() once independently from the actual job unnecessarily. This could mess up the stress bench test. 
This PR makes the call to prepare() to a later stage where the commands are only ran locally. 

@dbw9580 Is this what you mean? This problem is messing up my test so I need to fix it now.
@yuzhu PTAL, thanks!