### PR TITLE
Add three types of read and cluster mode in Fuse Stress Bench

### DIFF
--- a/stress/common/src/main/java/alluxio/stress/fuse/FuseIOOperation.java
+++ b/stress/common/src/main/java/alluxio/stress/fuse/FuseIOOperation.java
@@ -25,8 +25,18 @@ public enum FuseIOOperation {
   LIST_FILE("ListFile"),
 
   /** Now only streaming reading is supported, that is, sequentially read the written files. */
-  READ("Read"),
-  // TODO(Shawn): Support other types of read
+  /**
+   * Read data stored in local worker via local Fuse mount point.
+   */
+  LOCAL_READ("LocalRead"),
+  /**
+   * Read data stored in other worker nodes via local Fuse mount point.
+   */
+  REMOTE_READ("RemoteRead"),
+  /**
+   * Read <numAllFiles>/<numWorker> files evenly from all workers through local Fuse mount point.
+   */
+  CLUSTER_READ("ClusterRead")
   ;
 
   /**
@@ -35,7 +45,9 @@ public enum FuseIOOperation {
    */
   public static boolean isRead(FuseIOOperation operation) {
     switch (operation) {
-      case READ:
+      case LOCAL_READ:
+      case REMOTE_READ:
+      case CLUSTER_READ:
         return true;
       default:
         return false;

--- a/stress/common/src/main/java/alluxio/stress/fuse/FuseIOParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/fuse/FuseIOParameters.java
@@ -22,8 +22,9 @@ import com.beust.jcommander.Parameter;
  */
 public final class FuseIOParameters extends Parameters {
   @Parameter(names = {"--operation"},
-      description = "The operation to perform. Options are [Read, Write, ListFile], where "
-          + "\"Write\" and \"ListFile\" are for testing read performance, not individual tests.",
+      description = "The operation to perform. Options are [LocalRead, RemoteRead, ClusterRead, "
+          + "Write, ListFile], where \"Write\" and \"ListFile\" are for testing read performance, "
+          + "not individual tests.",
       converter = FuseIOOperationConverter.class,
       required = true)
   public FuseIOOperation mOperation;

--- a/stress/common/src/main/java/alluxio/stress/fuse/FuseIOSummary.java
+++ b/stress/common/src/main/java/alluxio/stress/fuse/FuseIOSummary.java
@@ -1,0 +1,193 @@
+package alluxio.stress.fuse;
+
+import alluxio.stress.BaseParameters;
+import alluxio.stress.GraphGenerator;
+import alluxio.stress.Summary;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The summary for Fuse IO stress bench.
+ */
+public class FuseIOSummary implements Summary {
+  private Map<String, Float> mIndividualThroughput;
+  private List<String> mNodes;
+  private Map<String, List<String>> mErrors;
+  private FuseIOParameters mParameters;
+  private BaseParameters mBaseParameters;
+  private long mRecordStartMs;
+  private long mEndMs;
+  private long mIOBytes;
+  private float mIOMBps;
+
+  /**
+   * Creates an instance.
+   */
+  public FuseIOSummary() {
+    // Default constructor required for json deserialization
+    mNodes = new ArrayList<>();
+    mErrors = new HashMap<>();
+    mIndividualThroughput = new HashMap<>();
+  }
+
+  /**
+   * Creates an instance.
+   *
+   * @param parameters the parameters for the Fuse IO stress bench
+   * @param baseParameters the base parameters for the Fuse IO stress bench
+   * @param nodes the unique ids of all workers
+   * @param errors all errors reported by workers
+   * @param recordStartMs the timestamp starting counting bytes
+   * @param endMs the timestamp that the test ends
+   * @param ioBytes total number of bytes processed by workers
+   * @param ioMBps aggregated throughput data
+   * @param individualThroughput the throughput data of each worker
+   */
+  public FuseIOSummary(FuseIOParameters parameters, BaseParameters baseParameters,
+      List<String> nodes, Map<String, List<String>> errors, long recordStartMs, long endMs,
+      long ioBytes, float ioMBps, Map<String, Float> individualThroughput) {
+    mIndividualThroughput = individualThroughput;
+    mNodes = nodes;
+    mErrors = errors;
+    mParameters = parameters;
+    mBaseParameters = baseParameters;
+    mRecordStartMs = recordStartMs;
+    mEndMs = endMs;
+    mIOBytes = ioBytes;
+    mIOMBps = ioMBps;
+  }
+
+  @Override
+  public GraphGenerator graphGenerator() {
+    return null;
+  }
+
+  /**
+   * @return a map mapping worker unique id to its throughput
+   */
+  public Map<String, Float> getIndividualThroughput() {
+    return mIndividualThroughput;
+  }
+
+  /**
+   * @param individualThroughput the map mapping worker unique id to its throughput
+   */
+  public void setIndividualThroughput(Map<String, Float> individualThroughput) {
+    mIndividualThroughput = individualThroughput;
+  }
+
+  /**
+   * @return the list of the unique ids of workers
+   */
+  public List<String> getNodes() {
+    return mNodes;
+  }
+
+  /**
+   * @param nodes the list of the unique ids of workers
+   */
+  public void setNodes(List<String> nodes) {
+    mNodes = nodes;
+  }
+
+  /**
+   * @return the list of errors
+   */
+  public Map<String, List<String>> getErrors() {
+    return mErrors;
+  }
+
+  /**
+   * @param errors  the list of errors
+   */
+  public void setErrors(Map<String, List<String>> errors) {
+    mErrors = errors;
+  }
+
+  /**
+   * @return Fuse IO stress bench parameters
+   */
+  public FuseIOParameters getParameters() {
+    return mParameters;
+  }
+
+  /**
+   * @param parameters Fuse IO stress bench parameters
+   */
+  public void setParameters(FuseIOParameters parameters) {
+    mParameters = parameters;
+  }
+
+  /**
+   * @return the base parameters
+   */
+  public BaseParameters getBaseParameters() {
+    return mBaseParameters;
+  }
+
+  /**
+   * @param baseParameters the base parameters
+   */
+  public void setBaseParameters(BaseParameters baseParameters) {
+    mBaseParameters = baseParameters;
+  }
+
+  /**
+   * @return the timestamp starting counting bytes (in ms)
+   */
+  public long getRecordStartMs() {
+    return mRecordStartMs;
+  }
+
+  /**
+   * @param recordStartMs the timestamp starting counting bytes (in ms)
+   */
+  public void setRecordStartMs(long recordStartMs) {
+    mRecordStartMs = recordStartMs;
+  }
+
+  /**
+   * @return the timestamp that test ends (in ms)
+   */
+  public long getEndMs() {
+    return mEndMs;
+  }
+
+  /**
+   * @param endMs the timestamp that test ends (in ms)
+   */
+  public void setEndMs(long endMs) {
+    mEndMs = endMs;
+  }
+
+  /**
+   * @return total number of bytes processed during test time
+   */
+  public long getIOBytes() {
+    return mIOBytes;
+  }
+
+  /**
+   * @param ioBytes total number of bytes processed during test time
+   */
+  public void setIOBytes(long ioBytes) {
+    mIOBytes = ioBytes;
+  }
+
+  /**
+   * @return overall throughput (in MB / s)
+   */
+  public float getIOMBps() {
+    return mIOMBps;
+  }
+
+  /**
+   * @param ioMBps overall throughput (in MB / s)
+   */
+  public void setIOMBps(float ioMBps) {
+    mIOMBps = ioMBps;
+  }
+}

--- a/stress/common/src/main/java/alluxio/stress/fuse/FuseIOTaskResult.java
+++ b/stress/common/src/main/java/alluxio/stress/fuse/FuseIOTaskResult.java
@@ -12,47 +12,81 @@
 package alluxio.stress.fuse;
 
 import alluxio.Constants;
-import alluxio.collections.Pair;
-
 import alluxio.stress.BaseParameters;
-import alluxio.stress.Parameters;
-import alluxio.stress.Summary;
 import alluxio.stress.TaskResult;
-import alluxio.stress.common.SummaryStatistics;
-import alluxio.stress.graph.Graph;
-import alluxio.stress.graph.LineGraph;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.base.Splitter;
 
-import java.io.IOException;
-import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * The task result for the Fuse IO stress tests.
  */
-public final class FuseIOTaskResult implements TaskResult, Summary {
+public final class FuseIOTaskResult implements TaskResult {
   private long mRecordStartMs;
   private long mEndMs;
-  private Map<Integer, ThreadCountResult> mThreadCountResults;
+  private long mIOBytes;
+  private List<String> mErrors;
   private BaseParameters mBaseParameters;
   private FuseIOParameters mParameters;
-
-  private Map<Integer, Map<String, SummaryStatistics>> mTimeToFirstByte;
 
   /**
    * Creates an instance.
    */
   public FuseIOTaskResult() {
-    // Default constructor required for json deserialization
-    mThreadCountResults = new HashMap<>();
-    mTimeToFirstByte = new HashMap<>();
+    mErrors = new ArrayList<>();
+  }
+
+  @Override
+  public TaskResult.Aggregator aggregator() {
+    return new Aggregator();
+  }
+
+  private static final class Aggregator implements TaskResult.Aggregator<FuseIOTaskResult> {
+    @Override
+    public FuseIOSummary aggregate(Iterable<FuseIOTaskResult> results) throws Exception {
+      long recordStartMs = 0;
+      long endMs = 0;
+      long ioBytes = 0;
+      FuseIOParameters fuseIOParameters = null;
+      BaseParameters baseParameters = null;
+      List<String> nodes = new ArrayList<>();
+      Map<String, List<String>> errors = new HashMap<>();
+      Map<String, Float> individualThroughput = new HashMap<>();
+
+      for (FuseIOTaskResult taskResult: results) {
+        recordStartMs = taskResult.getRecordStartMs();
+        endMs = Math.max(endMs, taskResult.getEndMs());
+        ioBytes += taskResult.getIOBytes();
+        fuseIOParameters = taskResult.getParameters();
+        baseParameters = taskResult.getBaseParameters();
+
+        String workerUniqueId = taskResult.getBaseParameters().mId;
+        nodes.add(workerUniqueId);
+        individualThroughput.put(workerUniqueId, taskResult.getIOMBps());
+        errors.put(workerUniqueId, taskResult.getErrors());
+      }
+
+      float ioMBps = (float) ioBytes / (endMs - recordStartMs) * 1000.0f / Constants.MB;
+
+      return new FuseIOSummary(fuseIOParameters, baseParameters, nodes, errors, recordStartMs,
+          endMs, ioBytes, ioMBps, individualThroughput);
+    }
+  }
+
+  /**
+   * Merges this thread result into the Fuse IO task result.
+   *
+   * @param result  the result to merge
+   */
+  public void merge(FuseIOTaskResult result) {
+    mRecordStartMs = Math.min(mRecordStartMs, result.mRecordStartMs);
+    mEndMs = Math.max(mEndMs, result.mEndMs);
+    mIOBytes += result.mIOBytes;
+    mErrors.addAll(result.mErrors);
   }
 
   /**
@@ -70,17 +104,55 @@ public final class FuseIOTaskResult implements TaskResult, Summary {
   }
 
   /**
-   * @return the Fuse IO parameters
+   * @return the Fuse IO Stress Bench parameters
    */
   public FuseIOParameters getParameters() {
     return mParameters;
   }
 
   /**
-   * @param parameters the Fuse IO parameters
+   * @param parameters the Fuse IO Stress Bench parameters
    */
   public void setParameters(FuseIOParameters parameters) {
     mParameters = parameters;
+  }
+
+  /**
+   * @return the duration (in ms)
+   */
+  public long getDurationMs() {
+    return mEndMs - mRecordStartMs;
+  }
+
+  /**
+   * @param durationMs the duration (in ms)
+   */
+  @JsonIgnore
+  public void setDurationMs(long durationMs) {
+    // ignore
+  }
+
+  /**
+   * @return bytes of IO
+   */
+  public long getIOBytes() {
+    return mIOBytes;
+  }
+
+  /**
+   * Increments the bytes of IO an amount.
+   *
+   * @param ioBytes the amount to increment by
+   */
+  public void incrementIOBytes(long ioBytes) {
+    mIOBytes += ioBytes;
+  }
+
+  /**
+   * @param ioBytes bytes of IO
+   */
+  public void setIOBytes(long ioBytes) {
+    mIOBytes = ioBytes;
   }
 
   /**
@@ -98,30 +170,6 @@ public final class FuseIOTaskResult implements TaskResult, Summary {
   }
 
   /**
-   * @return client IO statistics per method
-   */
-  public Map<Integer, Map<String, SummaryStatistics>> getTimeToFirstBytePerThread() {
-    return mTimeToFirstByte;
-  }
-
-  /**
-   * @param timeToFirstByte time to first statistics
-   */
-  public void setTimeToFirstBytePerThread(Map<Integer, Map<String,
-      SummaryStatistics>> timeToFirstByte) {
-    mTimeToFirstByte = timeToFirstByte;
-  }
-
-  /**
-   * @param numThreads thread count
-   * @param statistics FuseIOTaskResultStatistics
-   */
-  public void putTimeToFirstBytePerThread(Integer numThreads,
-      Map<String, SummaryStatistics> statistics) {
-    mTimeToFirstByte.put(numThreads, statistics);
-  }
-
-  /**
    * @return the end time (in ms)
    */
   public long getEndMs() {
@@ -136,303 +184,37 @@ public final class FuseIOTaskResult implements TaskResult, Summary {
   }
 
   /**
-   * @return the map of thread counts to results
+   * @return the list of errors
    */
-  public Map<Integer, ThreadCountResult> getThreadCountResults() {
-    return mThreadCountResults;
+  public List<String> getErrors() {
+    return mErrors;
   }
 
   /**
-   * @param threadCountResults the map of thread counts to results
+   * @param errors the list of errors
    */
-  public void setThreadCountResults(Map<Integer, ThreadCountResult> threadCountResults) {
-    mThreadCountResults = threadCountResults;
+  public void setErrors(List<String> errors) {
+    mErrors = errors;
   }
 
   /**
-   * @param threadCount the thread count of the results
-   * @param threadCountResult the results to add
+   * @param errMessage the error message to add
    */
-  public void addThreadCountResults(int threadCount, ThreadCountResult threadCountResult) {
-    mThreadCountResults.put(threadCount, threadCountResult);
-  }
-
-  private long computeLastEndMs() {
-    long endMs = 0;
-    for (ThreadCountResult result : mThreadCountResults.values()) {
-      endMs = Math.max(endMs, result.getEndMs());
-    }
-    return endMs;
-  }
-
-  private LineGraph.Data getThroughputData() {
-    LineGraph.Data data = new LineGraph.Data();
-    for (Map.Entry<Integer, ThreadCountResult> entry : mThreadCountResults.entrySet()) {
-      data.addData(entry.getKey(), entry.getValue().getIOMBps());
-    }
-    return data;
-  }
-
-  private void getNumSuccessData(String series, LineGraph lineGraph) {
-    Map<String, LineGraph.Data> data = new HashMap<>();
-
-    for (Map.Entry<Integer, Map<String, SummaryStatistics>> threadEntry :
-        mTimeToFirstByte.entrySet()) {
-      for (Map.Entry<String, SummaryStatistics> methodEntry :
-          threadEntry.getValue().entrySet()) {
-        String prefix = series + ", method: " + methodEntry.getKey();
-        LineGraph.Data currentData = data.getOrDefault(prefix, new LineGraph.Data());
-        currentData.addData(threadEntry.getKey(), methodEntry.getValue().mNumSuccess);
-        data.put(prefix, currentData);
-      }
-    }
-
-    for (Map.Entry<String, LineGraph.Data> entry : data.entrySet()) {
-      lineGraph.addDataSeries(entry.getKey(), entry.getValue());
-    }
-  }
-
-  private void getTimeToFistByteData(String series, LineGraph lineGraph) {
-    for (Map.Entry<Integer, Map<String, SummaryStatistics>> threadEntry :
-        mTimeToFirstByte.entrySet()) {
-      for (Map.Entry<String, SummaryStatistics> methodEntry :
-          threadEntry.getValue().entrySet()) {
-        lineGraph.addDataSeries(series
-            + ", method: " + methodEntry.getKey()
-            + ", thread: " + threadEntry.getKey(), methodEntry.getValue().computeTimeData());
-      }
-    }
-  }
-
-  private List<String> collectErrors() {
-    List<String> errors = new ArrayList<>();
-    for (Map.Entry<Integer, ThreadCountResult> entry : mThreadCountResults.entrySet()) {
-      // add all the errors for this thread count, with the thread count appended to prefix
-      errors.addAll(
-          entry.getValue().getErrors().stream().map(err -> entry.getKey().toString() + ": " + err)
-              .collect(Collectors.toList()));
-    }
-    return errors;
-  }
-
-  @Override
-  public TaskResult.Aggregator aggregator() {
-    return new Aggregator();
-  }
-
-  private static final class Aggregator implements TaskResult.Aggregator<FuseIOTaskResult> {
-    @Override
-    public FuseIOTaskResult aggregate(Iterable<FuseIOTaskResult> results) throws Exception {
-      Iterator<FuseIOTaskResult> it = results.iterator();
-      if (it.hasNext()) {
-        FuseIOTaskResult taskResult = it.next();
-        if (it.hasNext()) {
-          throw new IOException(
-              "FuseIO is a single node test, so multiple task results cannot be aggregated.");
-        }
-        return taskResult;
-      }
-      return new FuseIOTaskResult();
-    }
-  }
-
-  @Override
-  public alluxio.stress.GraphGenerator graphGenerator() {
-    return new GraphGenerator();
+  public void addErrorMessage(String errMessage) {
+    mErrors.add(errMessage);
   }
 
   /**
-   * The graph generator for this summary.
+   * @return the throughput (MB/s)
    */
-  public static final class GraphGenerator extends alluxio.stress.GraphGenerator {
-    @Override
-    public List<Graph> generate(List<? extends Summary> results) {
-      List<Graph> graphs = new ArrayList<>();
-      // expecting FuseIOTaskResult, or will throw ClassCastException
-      List<FuseIOTaskResult> summaries =
-          results.stream().map(x -> (FuseIOTaskResult) x).collect(Collectors.toList());
-
-      // Iterate over all operations
-      for (FuseIOOperation operation : FuseIOOperation.values()) {
-        List<FuseIOTaskResult> opSummaries =
-            summaries.stream().filter(x -> x.mParameters.mOperation == operation)
-                .collect(Collectors.toList());
-
-        if (!opSummaries.isEmpty()) {
-          // first() is the list of common field names, second() is the list of unique field names
-          Pair<List<String>, List<String>> fieldNames = Parameters.partitionFieldNames(
-              opSummaries.stream().map(x -> x.mParameters).collect(Collectors.toList()));
-
-          // Split up common description into 100 character chunks, for the sub title
-          List<String> subTitle = new ArrayList<>(Splitter.fixedLength(100).splitToList(
-              opSummaries.get(0).mParameters.getDescription(fieldNames.getFirst())));
-
-          for (FuseIOTaskResult summary : opSummaries) {
-            String series = summary.mParameters.getDescription(fieldNames.getSecond());
-            subTitle.add(series + ": " + DateFormat.getDateTimeInstance()
-                .format(summary.computeLastEndMs()));
-          }
-
-          LineGraph responseTimeGraph = new LineGraph(String
-              .format("%s - Throughput"),
-              subTitle, "# Threads", "Throughput (MB/s)");
-
-          LineGraph numSuccessGraph = new LineGraph(String
-              .format("%s - API calls", operation),
-              subTitle, "# Threads", "# API calls");
-
-          LineGraph timeToFirstByteGraph = new LineGraph(String
-              .format("%s - Time To First Byte"),
-              subTitle, "# Threads", "Time To First Byte (Ms)");
-
-          for (FuseIOTaskResult summary : opSummaries) {
-            String series = summary.mParameters.getDescription(fieldNames.getSecond());
-            responseTimeGraph.addDataSeries(series, summary.getThroughputData());
-            responseTimeGraph.setErrors(series, summary.collectErrors());
-
-            summary.getNumSuccessData(series, numSuccessGraph);
-
-            summary.getTimeToFistByteData(series, timeToFirstByteGraph);
-          }
-          graphs.add(responseTimeGraph);
-          graphs.add(numSuccessGraph);
-          graphs.add(timeToFirstByteGraph);
-        }
-      }
-
-      return graphs;
-    }
+  public float getIOMBps() {
+    return ((float) mIOBytes / getDurationMs()) * 1000.0f / Constants.MB;
   }
 
   /**
-   * A result for a single thread count test.
+   * @param ioMBps the throughput (MB / s)
    */
-  public static final class ThreadCountResult {
-    private long mRecordStartMs;
-    private long mEndMs;
-    private long mIOBytes;
-    private List<String> mErrors;
-
-    /**
-     * Creates an instance.
-     */
-    public ThreadCountResult() {
-      // Default constructor required for json deserialization
-      mErrors = new ArrayList<>();
-    }
-
-    /**
-     * Merges (updates) a result with this result.
-     *
-     * @param result  the result to merge
-     */
-    public void merge(FuseIOTaskResult.ThreadCountResult result) {
-      mRecordStartMs = Math.min(mRecordStartMs, result.mRecordStartMs);
-      mEndMs = Math.max(mEndMs, result.mEndMs);
-      mIOBytes += result.mIOBytes;
-      mErrors.addAll(result.mErrors);
-    }
-
-    /**
-     * @return the duration (in ms)
-     */
-    public long getDurationMs() {
-      return mEndMs - mRecordStartMs;
-    }
-
-    /**
-     * @param durationMs the duration (in ms)
-     */
-    @JsonIgnore
-    public void setDurationMs(long durationMs) {
-      // ignore
-    }
-
-    /**
-     * @return bytes of IO
-     */
-    public long getIOBytes() {
-      return mIOBytes;
-    }
-
-    /**
-     * Increments the bytes of IO an amount.
-     *
-     * @param ioBytes the amount to increment by
-     */
-    public void incrementIOBytes(long ioBytes) {
-      mIOBytes += ioBytes;
-    }
-
-    /**
-     * @param ioBytes bytes of IO
-     */
-    public void setIOBytes(long ioBytes) {
-      mIOBytes = ioBytes;
-    }
-
-    /**
-     * @return the start time (in ms)
-     */
-    public long getRecordStartMs() {
-      return mRecordStartMs;
-    }
-
-    /**
-     * @param recordStartMs the start time (in ms)
-     */
-    public void setRecordStartMs(long recordStartMs) {
-      mRecordStartMs = recordStartMs;
-    }
-
-    /**
-     * @return the end time (in ms)
-     */
-    public long getEndMs() {
-      return mEndMs;
-    }
-
-    /**
-     * @param endMs the end time (in ms)
-     */
-    public void setEndMs(long endMs) {
-      mEndMs = endMs;
-    }
-
-    /**
-     * @return the list of errors
-     */
-    public List<String> getErrors() {
-      return mErrors;
-    }
-
-    /**
-     * @param errors the list of errors
-     */
-    public void setErrors(List<String> errors) {
-      mErrors = errors;
-    }
-
-    /**
-     * @param errMessage the error message to add
-     */
-    public void addErrorMessage(String errMessage) {
-      mErrors.add(errMessage);
-    }
-
-    /**
-     * @return the throughput (MB/s)
-     */
-    public float getIOMBps() {
-      return ((float) mIOBytes / getDurationMs()) * 1000.0f / Constants.MB;
-    }
-
-    /**
-     * @param ioMBps the throughput (MB / s)
-     */
-    @JsonIgnore
-    public void setIOMBps(float ioMBps) {
-      // ignore
-    }
+  public void setIOMBps(float ioMBps) {
+    // ignore
   }
 }

--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -11,7 +11,10 @@
 
 package alluxio.stress.cli.fuse;
 
+import alluxio.ClientContext;
 import alluxio.Constants;
+import alluxio.client.job.JobMasterClient;
+import alluxio.conf.InstancedConfiguration;
 import alluxio.stress.BaseParameters;
 import alluxio.stress.StressConstants;
 import alluxio.stress.cli.Benchmark;
@@ -20,8 +23,10 @@ import alluxio.stress.fuse.FuseIOOperation;
 import alluxio.stress.fuse.FuseIOParameters;
 import alluxio.stress.fuse.FuseIOTaskResult;
 import alluxio.util.CommonUtils;
+import alluxio.util.ConfigurationUtils;
 import alluxio.util.FormatUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
+import alluxio.worker.job.JobMasterClientContext;
 
 import com.beust.jcommander.ParametersDelegate;
 import com.google.common.collect.ImmutableList;
@@ -37,13 +42,13 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Single node stress test.
@@ -54,6 +59,10 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
   @ParametersDelegate
   private FuseIOParameters mParameters = new FuseIOParameters();
 
+  /** Names of the directories created by workers for the test, also unique ids of the workers. */
+  private List<String> mWorkerDirNames;
+  /** 0-based id of this worker/job worker. */
+  private int mWorkerZeroBasedId;
   /** Set to true after the first barrier is passed. */
   private volatile boolean mStartBarrierPassed = false;
 
@@ -75,68 +84,108 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
     return String.join("\n", ImmutableList.of(
         "A stress bench for testing the reading throughput of Fuse-based POSIX API.",
         "To run the test, data must be written first by executing \"Write\" operation, then "
-            + "run \"Read\" operation to test the reading throughput. Optionally one can set "
-            + "alluxio.user.metadata.cache.enabled=true when mounting Alluxio Fuse and run "
-            + "\"ListFile\" before \"Read\" to cache the metadata of the test files and eliminate "
-            + "the effect of metadata operations while getting the reading throughput data.",
-        "Note that \"--operation\" is required, and \"--local-path\" can be a local filesystem "
-            + "path or a mounted Fuse path.",
+            + "run \"Read\" operation to test the reading throughput. The three different options "
+            + "of read are: ",
+        "LocalRead: Read data stored only in local worker via local Fuse mount point",
+        "RemoteRead: Read data stored in other worker nodes evenly via local Fuse mount point.",
+        "ClusterRead: Read <numAllFiles>/<numWorker> number of files evenly from all workers via "
+            + "local Fuse mount point.",
+        "Optionally one can set alluxio.user.metadata.cache.enabled=true when mounting Alluxio "
+            + "Fuse and run \"ListFile\" before \"Read\" to cache the metadata of the test files "
+            + "and eliminate the effect of metadata operations while getting the reading "
+            + "throughput data.",
+        "Note that \"--operation\" is required, \"--local-path\" can be a local filesystem "
+            + "path or a mounted Fuse path, and non-cluster mode only supports local read.",
         "",
         "Example:",
+        "# The test will be run in cluster mode using job service",
         "# The test data will be written to /mnt/alluxio-fuse/FuseIOTest",
         "# Files will be evenly distributed into 32 directories, each contains 10 files of "
-            + "size 100 MB",
+            + "size 100 MB. 32 threads of each worker will be used to generate the files",
         "# Metadata of the test files will be cached",
-        "# 32 threads will be used for writing the data, and 16 threads will be used for "
-            + "testing the reading throughput",
+        "# 16 threads of each worker will be used for testing the reading throughput with "
+            + "ClusterRead.",
         "# 5 seconds of warmup time and 30 seconds of actual reading test time",
         "$ bin/alluxio runClass alluxio.stress.cli.fuse.fuseIOBench --operation Write \\",
         "--local-path /mnt/alluxio-fuse/FuseIOTest --num-dirs 32 --num-files-per-dir 10 \\",
-        "--file-size 100m --threads 32",
+        "--file-size 100m --threads 32 --cluster",
         "$ bin/alluxio runClass alluxio.stress.cli.fuse.fuseIOBench --operation ListFile \\",
         "--local-path /mnt/alluxio-fuse/FuseIOTest",
         "$ bin/alluxio runClass alluxio.stress.cli.fuse.fuseIOBench --operation Read \\",
         "--local-path /mnt/alluxio-fuse/FuseIOTest --num-dirs 32 --num-files-per-dir 10 \\",
-        "--file-size 100m --threads 16 --warmup 5s --duration 30s",
+        "--file-size 100m --threads 16 --warmup 5s --duration 30s --cluster",
         ""
     ));
   }
 
   @Override
   public void prepare() throws Exception {
+    if (mBaseParameters.mCluster) {
+      // For cluster mode, this function is called once before the job is submitted to the job
+      // service. Nothing should be done, otherwise the bench will break.
+      return;
+    }
     if (mParameters.mThreads > mParameters.mNumDirs) {
       throw new IllegalArgumentException(String.format(
           "Some of the threads are not being used. Please set the number of directories to "
               + "be at least the number of threads, preferably a multiple of it."
       ));
     }
+    File localPath = new File(mParameters.mLocalPath);
+
     if (mParameters.mOperation == FuseIOOperation.WRITE) {
       LOG.warn("Cannot write repeatedly, so warmup is not possible. Setting warmup to 0s.");
       mParameters.mWarmup = "0s";
       for (int i = 0; i < mParameters.mNumDirs; i++) {
-        Files.createDirectories(Paths.get(mParameters.mLocalPath + "/" + i));
+        Files.createDirectories(Paths.get(String.format(
+            "%s/%s/dir-%d", mParameters.mLocalPath, mBaseParameters.mId, i)));
+      }
+    } else {
+      if ((mParameters.mOperation == FuseIOOperation.REMOTE_READ
+          || mParameters.mOperation == FuseIOOperation.CLUSTER_READ)
+          && !mBaseParameters.mDistributed) {
+        throw new IllegalArgumentException(String.format(
+            "Single-node Fuse IO stress bench doesn't support RemoteRead or ClusterRead."
+        ));
+      }
+      // Find 0-based id, and make sure dirs and workers are 1-to-1.
+      File[] workerDirs = localPath.listFiles();
+      int numWorkers;
+      try (JobMasterClient client = JobMasterClient.Factory.create(
+          JobMasterClientContext.newBuilder(ClientContext.create(new InstancedConfiguration(
+              ConfigurationUtils.defaults()))).build())) {
+        numWorkers = client.getAllWorkerHealth().size();
+      }
+      if (numWorkers != workerDirs.length) {
+        throw new IllegalStateException("Some worker crashed or joined after data are written."
+                + "The test is stopped.");
+      }
+      mWorkerDirNames = Arrays.asList(workerDirs).stream()
+              .map(file -> file.getName())
+              .collect(Collectors.toList());
+      try {
+        mWorkerZeroBasedId = mWorkerDirNames.indexOf(mBaseParameters.mId);
+      } catch (Exception e) {
+        throw new IllegalStateException(String.format(
+            "Directory %s is not found. Please use this bench to generate test files. If this is "
+                + "the case, some worker crashed or joined after data is written. The test is "
+                + "stopped.", mBaseParameters.mId));
       }
     }
   }
 
   @Override
   public FuseIOTaskResult runLocal() throws Exception {
-    List<Integer> threadCounts = new ArrayList<>(mParameters.mThreads);
-    threadCounts.sort(Comparator.comparingInt(i -> i));
-
-    FuseIOTaskResult taskResult = new FuseIOTaskResult();
+    FuseIOTaskResult taskResult = runFuseBench();
     taskResult.setBaseParameters(mBaseParameters);
     taskResult.setParameters(mParameters);
-    FuseIOTaskResult.ThreadCountResult threadCountResult = runForThreadCount(mParameters.mThreads);
-    taskResult.addThreadCountResults(mParameters.mThreads, threadCountResult);
 
     return taskResult;
   }
 
-  private FuseIOTaskResult.ThreadCountResult runForThreadCount(int numThreads) throws Exception {
-    LOG.info("Running benchmark for thread count: " + numThreads);
+  private FuseIOTaskResult runFuseBench() throws Exception {
     ExecutorService service =
-        ExecutorServiceFactories.fixedThreadPool("bench-thread", numThreads).create();
+        ExecutorServiceFactories.fixedThreadPool("bench-thread", mParameters.mThreads).create();
     long durationMs = FormatUtils.parseTimeSize(mParameters.mDuration);
     long warmupMs = FormatUtils.parseTimeSize(mParameters.mWarmup);
     long startMs = mBaseParameters.mStartMs;
@@ -147,9 +196,9 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
     long endMs = startMs + warmupMs + durationMs;
     BenchContext context = new BenchContext(startMs, endMs);
 
-    List<Callable<Void>> callables = new ArrayList<>(numThreads);
-    for (int i = 0; i < numThreads; i++) {
-      callables.add(new BenchThread(context, i, numThreads));
+    List<Callable<Void>> callables = new ArrayList<>(mParameters.mThreads);
+    for (int i = 0; i < mParameters.mThreads; i++) {
+      callables.add(new BenchThread(context, i));
     }
     service.invokeAll(callables, FormatUtils.parseTimeSize(mBaseParameters.mBenchTimeout),
         TimeUnit.MILLISECONDS);
@@ -157,10 +206,10 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
     service.shutdownNow();
     service.awaitTermination(30, TimeUnit.SECONDS);
 
-    FuseIOTaskResult.ThreadCountResult result = context.getResult();
+    FuseIOTaskResult result = context.getResult();
 
-    LOG.info(String.format("thread count: %d, errors: %d, IO throughput (MB/s): %f", numThreads,
-        result.getErrors().size(), result.getIOMBps()));
+    LOG.info(String.format("worker id: %s, errors: %d, IO throughput (MB/s): %f",
+        mBaseParameters.mId, result.getErrors().size(), result.getIOMBps()));
 
     return result;
   }
@@ -230,7 +279,7 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
     private final long mEndMs;
 
     /** The results. Access must be synchronized for thread safety. */
-    private FuseIOTaskResult.ThreadCountResult mThreadCountResult;
+    private FuseIOTaskResult mFuseIOTaskResult;
 
     public BenchContext(long startMs, long endMs) {
       mStartMs = startMs;
@@ -245,20 +294,20 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
       return mEndMs;
     }
 
-    public synchronized void mergeThreadResult(FuseIOTaskResult.ThreadCountResult threadResult) {
-      if (mThreadCountResult == null) {
-        mThreadCountResult = threadResult;
+    public synchronized void mergeThreadResult(FuseIOTaskResult threadResult) {
+      if (mFuseIOTaskResult == null) {
+        mFuseIOTaskResult = threadResult;
       } else {
         try {
-          mThreadCountResult.merge(threadResult);
+          mFuseIOTaskResult.merge(threadResult);
         } catch (Exception e) {
-          mThreadCountResult.addErrorMessage(e.getMessage());
+          mFuseIOTaskResult.addErrorMessage(e.getMessage());
         }
       }
     }
 
-    public synchronized FuseIOTaskResult.ThreadCountResult getResult() {
-      return mThreadCountResult;
+    public synchronized FuseIOTaskResult getResult() {
+      return mFuseIOTaskResult;
     }
   }
 
@@ -271,11 +320,11 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
     private FileInputStream mInStream = null;
     private FileOutputStream mOutStream = null;
     private long mCurrentOffset;
+    private long mRecordMs;
 
-    private final FuseIOTaskResult.ThreadCountResult mThreadCountResult =
-        new FuseIOTaskResult.ThreadCountResult();
+    private final FuseIOTaskResult mFuseIOTaskResult = new FuseIOTaskResult();
 
-    private BenchThread(BenchContext context, int threadId, int numThreads) {
+    private BenchThread(BenchContext context, int threadId) {
       mContext = context;
       mThreadId = threadId;
 
@@ -283,6 +332,8 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
       Arrays.fill(mBuffer, (byte) 'A');
 
       mFileSize = FormatUtils.parseSpaceSize(mParameters.mFileSize);
+      // Actual time to start measurement
+      mRecordMs = mContext.getStartMs() + FormatUtils.parseTimeSize(mParameters.mWarmup);
     }
 
     @Override
@@ -291,23 +342,21 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
         runInternal();
       } catch (Exception e) {
         LOG.error(Thread.currentThread().getName() + ": failed", e);
-        mThreadCountResult.addErrorMessage(e.getMessage());
+        mFuseIOTaskResult.addErrorMessage(e.getMessage());
       } finally {
         closeInStream();
         closeOutStream();
       }
 
-      // Update thread count result
-      mThreadCountResult.setEndMs(CommonUtils.getCurrentMs());
-      mContext.mergeThreadResult(mThreadCountResult);
+      // Update bench result by merging in individual thread result
+      mFuseIOTaskResult.setEndMs(CommonUtils.getCurrentMs());
+      mContext.mergeThreadResult(mFuseIOTaskResult);
 
       return null;
     }
 
     private void runInternal() throws Exception {
-      // When to start recording measurements
-      long recordMs = mContext.getStartMs() + FormatUtils.parseTimeSize(mParameters.mWarmup);
-      mThreadCountResult.setRecordStartMs(recordMs);
+      mFuseIOTaskResult.setRecordStartMs(mRecordMs);
       boolean isRead = FuseIOOperation.isRead(mParameters.mOperation);
 
       long waitMs = mContext.getStartMs() - CommonUtils.getCurrentMs();
@@ -320,32 +369,38 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
       mStartBarrierPassed = true;
 
       if (mParameters.mOperation == FuseIOOperation.LIST_FILE) {
-        for (int dirId = mThreadId; dirId < mParameters.mNumDirs; dirId += mParameters.mThreads) {
-          String dirPath = String.format("%s/%d", mParameters.mLocalPath, dirId);
-          File dir = new File(dirPath);
-          dir.listFiles();
+        for (String workerDirNames: mWorkerDirNames) {
+          for (int dirId = mThreadId; dirId < mParameters.mNumDirs; dirId += mParameters.mThreads) {
+            String dirPath = String.format("%s/%s/dir-%d", mParameters.mLocalPath,
+                workerDirNames, dirId);
+            File dir = new File(dirPath);
+            dir.listFiles();
+          }
         }
-        return;
-      }
-
-      for (int dirId = mThreadId; dirId < mParameters.mNumDirs; dirId += mParameters.mThreads) {
-        for (int fileId = 0; fileId < mParameters.mNumFilesPerDir; fileId++) {
-          mCurrentOffset = 0;
-          String filePath = String.format("%s/%d/%d", mParameters.mLocalPath, dirId, fileId);
-          while (!Thread.currentThread().isInterrupted()) {
-            if (isRead && CommonUtils.getCurrentMs() > mContext.getEndMs()) {
-              closeInStream();
-              return;
-            }
-            long ioBytes = applyOperation(filePath);
-
-            // Done reading/writing one file
-            if (ioBytes <= 0) {
-              break;
-            }
-            // Start recording after the warmup
-            if (CommonUtils.getCurrentMs() > recordMs) {
-              mThreadCountResult.incrementIOBytes(ioBytes);
+      } else if (mParameters.mOperation == FuseIOOperation.WRITE
+          || mParameters.mOperation == FuseIOOperation.LOCAL_READ) {
+        for (int dirId = mThreadId; dirId < mParameters.mNumDirs; dirId += mParameters.mThreads) {
+          for (int fileId = 0; fileId < mParameters.mNumFilesPerDir; fileId++) {
+            String filePath = String.format("%s/%s/dir-%d/file-%d", mParameters.mLocalPath,
+                mBaseParameters.mId, dirId, fileId);
+            processFile(filePath, isRead);
+          }
+        }
+      } else {
+        for (int dirRead = 0; dirRead < mWorkerDirNames.size(); dirRead++) {
+          int indexCurrentDir = (dirRead + mWorkerZeroBasedId) % mWorkerDirNames.size();
+          // Skip itself if the operation is remote read.
+          if (indexCurrentDir == mWorkerZeroBasedId
+              && mParameters.mOperation == FuseIOOperation.REMOTE_READ) {
+            indexCurrentDir++;
+          }
+          String nameCurrentDir = mWorkerDirNames.get(indexCurrentDir);
+          for (int dirId = mThreadId; dirId < mParameters.mNumDirs; dirId += mParameters.mThreads) {
+            for (int fileId = mWorkerZeroBasedId; fileId < mParameters.mNumFilesPerDir;
+                fileId += mWorkerDirNames.size()) {
+              String filePath = String.format("%s/%s/dir-%d/file-%d", mParameters.mLocalPath,
+                  nameCurrentDir, dirId, fileId);
+              processFile(filePath, isRead);
             }
           }
         }
@@ -358,12 +413,37 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
       }
     }
 
+    private void processFile(String filePath, boolean isRead) throws IOException {
+      mCurrentOffset = 0;
+      while (!Thread.currentThread().isInterrupted()) {
+        if (isRead && CommonUtils.getCurrentMs() > mContext.getEndMs()) {
+          closeInStream();
+          return;
+        }
+        long ioBytes = applyOperation(filePath);
+
+        // Done reading/writing one file
+        if (ioBytes <= 0) {
+          break;
+        }
+        // Start recording after the warmup
+        if (CommonUtils.getCurrentMs() > mFuseIOTaskResult.getRecordStartMs()) {
+          mFuseIOTaskResult.incrementIOBytes(ioBytes);
+        }
+      }
+    }
+
     private long applyOperation(String filePath) throws IOException {
       if (FuseIOOperation.isRead(mParameters.mOperation) && mInStream == null) {
         mInStream = new FileInputStream(filePath);
       }
       switch (mParameters.mOperation) {
-        case READ: {
+        case LOCAL_READ:
+        case REMOTE_READ:
+        case CLUSTER_READ: {
+          if (mInStream == null) {
+            mInStream = new FileInputStream(filePath);
+          }
           int bytesRead = mInStream.read(mBuffer);
           if (bytesRead < 0) {
             closeInStream();
@@ -394,7 +474,7 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
           mInStream.close();
         }
       } catch (IOException e) {
-        mThreadCountResult.addErrorMessage(e.getMessage());
+        mFuseIOTaskResult.addErrorMessage(e.getMessage());
       } finally {
         mInStream = null;
       }
@@ -406,7 +486,7 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
           mOutStream.close();
         }
       } catch (IOException e) {
-        mThreadCountResult.addErrorMessage(e.getMessage());
+        mFuseIOTaskResult.addErrorMessage(e.getMessage());
       } finally {
         mOutStream = null;
       }


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. Implement [`LocalRead`, `RemoteRead`, `ClusterRead`] in cluster mode in Fuse IO Stress Bench.
2. Create FuseIOSummary class for aggregated results of all workers in the cluster.
3. Remove ThreadCount class under FuseIOTaskResult class to simplify the logic.

### Why are the changes needed?

1. [design doc](https://docs.google.com/document/d/1kmrOh6blvm1fEIILnIvG-a_GbFkqwYsAkVei2GiJ6fg/edit#heading=h.tkbrhe1f6jlp)
2. Using the new FuseIOSummary class we can show the aggregated results better and more concisely. This is also adopted by master stress bench etc. where multiple nodes are used.
3. The original ThreadCount class is adopted from clientIOStressBench, where one run of the bench can test different number of threads, and each ThreadCount object is the result of one particular number of threads. FuseIOStressBench doesn't support testing multiple number of threads, so we can get rid of ThreadCount class to simplify the design.

### Does this PR introduce any user facing changes?

Users could run FuseIOStressBench in a cluster with job service. `Read` operation also expands to [`LocalRead`, `RemoteRead`, `ClusterRead`]
