### PR TITLE
Add some information and break loop when a task failed incomplete

### DIFF
--- a/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
+++ b/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
@@ -224,8 +224,10 @@ public final class PlanCoordinator {
         }
         taskInfo.setStatus(Status.FAILED);
         taskInfo.setErrorType("JobWorkerLost");
-        taskInfo.setErrorMessage("Job worker was lost before the task could complete");
+        taskInfo.setErrorMessage(String.format("Job worker(%s) was lost before"
+                + "the task(%d) could complete", taskInfo.getWorkerHost(), taskId));
         statusChanged = true;
+        break;
       }
       if (statusChanged) {
         updateStatus();

--- a/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
+++ b/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
@@ -224,7 +224,7 @@ public final class PlanCoordinator {
         }
         taskInfo.setStatus(Status.FAILED);
         taskInfo.setErrorType("JobWorkerLost");
-        taskInfo.setErrorMessage(String.format("Job worker(%s) was lost before"
+        taskInfo.setErrorMessage(String.format("Job worker(%s) was lost before "
                 + "the task(%d) could complete", taskInfo.getWorkerHost(), taskId));
         statusChanged = true;
         break;


### PR DESCRIPTION
### What changes are proposed in this pull request?
Add more information and break the taskId check loop when a task failed.   

### Why are the changes needed?
Not enough information for us to know which task failed , no need to check other taskId in the loop, just break.  
Please clarify why the changes are needed. For instance,
Get more information when task failed, skip useless loop.

### Does this PR introduce any user facing changes?
No
Please list the user-facing changes introduced by your change, including
No
