### PR TITLE
Add property to skip listing broken symlinks on local UFS

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -779,6 +779,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_LOCAL_SKIP_BROKEN_SYMLINKS =
+      new Builder(Name.UNDERFS_LOCAL_SKIP_BROKEN_SYMLINKS)
+          .setDefaultValue(false)
+          .setDescription("When set to true, any time the local underfs lists a broken "
+              + "symlink, it will treat the entry as if it didn't exist at all."
+              + "")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_WEB_HEADER_LAST_MODIFIED =
       new Builder(Name.UNDERFS_WEB_HEADER_LAST_MODIFIED)
           .setDefaultValue("EEE, dd MMM yyyy HH:mm:ss zzz")
@@ -5445,6 +5454,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_HDFS_IMPL = "alluxio.underfs.hdfs.impl";
     public static final String UNDERFS_HDFS_PREFIXES = "alluxio.underfs.hdfs.prefixes";
     public static final String UNDERFS_HDFS_REMOTE = "alluxio.underfs.hdfs.remote";
+    public static final String UNDERFS_LOCAL_SKIP_BROKEN_SYMLINKS =
+        "alluxio.underfs.local.skip.broken.symlinks";
     public static final String UNDERFS_WEB_HEADER_LAST_MODIFIED =
         "alluxio.underfs.web.header.last.modified";
     public static final String UNDERFS_WEB_CONNECTION_TIMEOUT =

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -50,8 +50,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.util.ArrayList;

--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -50,6 +50,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.util.ArrayList;
@@ -72,6 +74,8 @@ public class LocalUnderFileSystem extends ConsistentUnderFileSystem
     implements AtomicFileOutputStreamCallback {
   private static final Logger LOG = LoggerFactory.getLogger(LocalUnderFileSystem.class);
 
+  private final boolean mSkipBrokenSymlinks;
+
   /**
    * Constructs a new {@link LocalUnderFileSystem}.
    *
@@ -80,6 +84,7 @@ public class LocalUnderFileSystem extends ConsistentUnderFileSystem
    */
   public LocalUnderFileSystem(AlluxioURI uri, UnderFileSystemConfiguration ufsConf) {
     super(uri, ufsConf);
+    mSkipBrokenSymlinks = ufsConf.getBoolean(PropertyKey.UNDERFS_LOCAL_SKIP_BROKEN_SYMLINKS);
   }
 
   @Override
@@ -283,7 +288,9 @@ public class LocalUnderFileSystem extends ConsistentUnderFileSystem
   public UfsStatus[] listStatus(String path) throws IOException {
     path = stripPath(path);
     File file = new File(path);
-    File[] files = file.listFiles();
+    // By default, exists follows symlinks. If the symlink is invalid .exists() returns false
+    File[] files = mSkipBrokenSymlinks ? file.listFiles(File::exists) : file.listFiles();
+
     if (files != null) {
       UfsStatus[] rtn = new UfsStatus[files.length];
       int i = 0;

--- a/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemTest.java
+++ b/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemTest.java
@@ -289,6 +289,10 @@ public class LocalUnderFileSystemTest {
 
   @Test
   public void testSymlinkNonSkip() throws IOException {
+    InstancedConfiguration c = new InstancedConfiguration(sConf.copyProperties());
+    c.set(PropertyKey.UNDERFS_LOCAL_SKIP_BROKEN_SYMLINKS, false);
+    mLocalUfs =
+        UnderFileSystem.Factory.create(mLocalUfsRoot, UnderFileSystemConfiguration.defaults(c));
     Path linkPath = createNonExistentSymlink();
     assertTrue(Files.exists(linkPath, LinkOption.NOFOLLOW_LINKS));
     assertFalse(Files.exists(linkPath));


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add a property to skip broken symlinks when calling listStatus with the LocalUnderFileSystem


### Why are the changes needed?

When a broken symlink appears when using a local UFS, all listings will fail because of the additional call to `#readProperties` in `LocalUndeFileSystem#listStatus`. This behavior can help alert users to broken symlinks, but also breaks functionality until the symlink is removed, which may be undesirable.

### Does this PR introduce any user facing changes?

A new option that can be used with a local UFS mount.