### PR TITLE
Make the stopwatch thread-safe in readInternal

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -132,6 +132,7 @@ public class LocalCacheFileInStream extends FileInStream {
     int totalBytesRead = 0;
     long currentPosition = pos;
     long lengthToRead = Math.min(len, mStatus.getLength() - pos);
+    // used in positionedRead, so make stopwatch a local variable rather than class member 
     Stopwatch stopwatch = createUnstartedStopwatch();
     // for each page, check if it is available in the cache
     while (totalBytesRead < lengthToRead) {

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -132,7 +132,7 @@ public class LocalCacheFileInStream extends FileInStream {
     int totalBytesRead = 0;
     long currentPosition = pos;
     long lengthToRead = Math.min(len, mStatus.getLength() - pos);
-    // used in positionedRead, so make stopwatch a local variable rather than class member 
+    // used in positionedRead, so make stopwatch a local variable rather than class member
     Stopwatch stopwatch = createUnstartedStopwatch();
     // for each page, check if it is available in the cache
     while (totalBytesRead < lengthToRead) {

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -132,6 +132,7 @@ public class LocalCacheFileInStream extends FileInStream {
     int totalBytesRead = 0;
     long currentPosition = pos;
     long lengthToRead = Math.min(len, mStatus.getLength() - pos);
+    Stopwatch stopwatch = createUnstartedStopwatch();
     // for each page, check if it is available in the cache
     while (totalBytesRead < lengthToRead) {
       long currentPage = currentPosition / mPageSize;
@@ -145,8 +146,7 @@ public class LocalCacheFileInStream extends FileInStream {
       } else {
         pageId = new PageId(Long.toString(mStatus.getFileId()), currentPage);
       }
-      Stopwatch stopwatch = createUnstartedStopwatch();
-      stopwatch.start();
+      stopwatch.reset().start();
       int bytesRead =
           mCacheManager.get(pageId, currentPageOffset, bytesLeftInPage, b, off + totalBytesRead,
               mCacheContext);

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -483,8 +483,13 @@ public class LocalCacheFileInStreamTest {
     );
     LocalCacheFileInStream stream =
         new LocalCacheFileInStream(fs.getStatus(testFileName),
-            (status) -> fs.openFile(status, OpenFilePOptions.getDefaultInstance()), manager, sConf,
-            Stopwatch.createUnstarted(timeSource));
+            (status) -> fs.openFile(status, OpenFilePOptions.getDefaultInstance()), manager,
+            sConf) {
+          @Override
+          protected Stopwatch createUnstartedStopwatch() {
+            return Stopwatch.createUnstarted(timeSource);
+          }
+        };
 
     Assert.assertArrayEquals(testData, ByteStreams.toByteArray(stream));
     long timeReadCache = recordedMetrics.get(


### PR DESCRIPTION
### What changes are proposed in this pull request?

 Make the stopwatch in readInternal as a local var to avoid potential race condition

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. The current usage stopwatch in readInternal might cause race condition
  2. readInternal is called by positionedRead which should be thread-safe
 

### Does this PR introduce any user facing changes?

N/A
