### PR TITLE
Return directly when an exception is thrown during transfer leader

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/journal/JournalMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/journal/JournalMasterClient.java
@@ -13,6 +13,7 @@ package alluxio.client.journal;
 
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.grpc.GetQuorumInfoPResponse;
+import alluxio.grpc.GetTransferLeaderMessagePResponse;
 import alluxio.grpc.NetAddress;
 
 import java.io.Closeable;
@@ -50,4 +51,11 @@ public interface JournalMasterClient extends Closeable {
    * @throws AlluxioStatusException
    */
   void resetPriorities() throws AlluxioStatusException;
+
+  /**
+   * Resets RaftPeer priorities.
+   *
+   * @return list of exception message throwing when transfer leader.
+   */
+  GetTransferLeaderMessagePResponse getTransferLeaderMessage() throws AlluxioStatusException;
 }

--- a/core/client/fs/src/main/java/alluxio/client/journal/RetryHandlingJournalMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/journal/RetryHandlingJournalMasterClient.java
@@ -16,6 +16,8 @@ import alluxio.Constants;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.grpc.GetQuorumInfoPRequest;
 import alluxio.grpc.GetQuorumInfoPResponse;
+import alluxio.grpc.GetTransferLeaderMessagePRequest;
+import alluxio.grpc.GetTransferLeaderMessagePResponse;
 import alluxio.grpc.JournalMasterClientServiceGrpc;
 import alluxio.grpc.NetAddress;
 import alluxio.grpc.RemoveQuorumServerPRequest;
@@ -88,5 +90,11 @@ public class RetryHandlingJournalMasterClient extends AbstractMasterClient
   public void resetPriorities() throws AlluxioStatusException {
     retryRPC(() -> mClient.resetPriorities(ResetPrioritiesPRequest.getDefaultInstance()),
             RPC_LOG, "ResetPriorities", "");
+  }
+
+  @Override
+  public GetTransferLeaderMessagePResponse getTransferLeaderMessage() throws AlluxioStatusException {
+    return retryRPC(() -> mClient.getTransferLeaderMessage(GetTransferLeaderMessagePRequest.getDefaultInstance()),
+            RPC_LOG, "GetTransferLeaderMessage",  "");
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/DefaultJournalMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/DefaultJournalMaster.java
@@ -71,4 +71,10 @@ public class DefaultJournalMaster implements JournalMaster {
     checkQuorumOpSupported();
     ((RaftJournalSystem) mJournalSystem).resetPriorities();
   }
+
+  @Override
+  public void getTransferLeaderMessage() {
+    checkQuorumOpSupported();
+    ((RaftJournalSystem) mJournalSystem).getTransferLeaderMessage();
+  }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalMaster.java
@@ -53,4 +53,9 @@ public interface JournalMaster {
    * @throws IOException if error occurs while performing the operation
    */
   void resetPriorities() throws IOException;
+
+  /**
+   * Gets list of exception message throwing when transfer leader.
+   */
+  void getTransferLeaderMessage();
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalMasterClientServiceHandler.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalMasterClientServiceHandler.java
@@ -15,6 +15,8 @@ import alluxio.RpcUtils;
 
 import alluxio.grpc.GetQuorumInfoPRequest;
 import alluxio.grpc.GetQuorumInfoPResponse;
+import alluxio.grpc.GetTransferLeaderMessagePRequest;
+import alluxio.grpc.GetTransferLeaderMessagePResponse;
 import alluxio.grpc.JournalMasterClientServiceGrpc;
 import alluxio.grpc.RemoveQuorumServerPRequest;
 import alluxio.grpc.RemoveQuorumServerPResponse;
@@ -78,5 +80,14 @@ public class JournalMasterClientServiceHandler
       mJournalMaster.resetPriorities();
       return ResetPrioritiesPResponse.getDefaultInstance();
     }, "resetPriorities", "request=%s", responseObserver, request);
+  }
+
+  @Override
+  public void getTransferLeaderMessage(GetTransferLeaderMessagePRequest request,
+                                       StreamObserver<GetTransferLeaderMessagePResponse> responseObserver) {
+    RpcUtils.call(LOG, () -> {
+      mJournalMaster.getTransferLeaderMessage();
+      return GetTransferLeaderMessagePResponse.getDefaultInstance();
+    }, "GetTransferLeaderMessage", "request=%s", responseObserver, request);
   }
 }

--- a/core/transport/src/main/proto/grpc/journal_master.proto
+++ b/core/transport/src/main/proto/grpc/journal_master.proto
@@ -58,6 +58,17 @@ message ResetPrioritiesPRequest {
 }
 message ResetPrioritiesPResponse {}
 
+message TransferLeaderMessage {
+    optional string msg = 1;
+    optional bool isException = 2;
+}
+// GetTransferLeaderMessage API
+message GetTransferLeaderMessageOptions {}
+message GetTransferLeaderMessagePRequest {}
+message GetTransferLeaderMessagePResponse{
+    repeated TransferLeaderMessage transMsg = 1;
+}
+
 /**
   * This interface contains journal master service endpoints for Alluxio clients.
   */
@@ -82,4 +93,9 @@ service JournalMasterClientService {
      * Reset all the RaftPeer priorities.
      */
     rpc ResetPriorities(ResetPrioritiesPRequest) returns (ResetPrioritiesPResponse);
+
+    /**
+     * Gets list of exception message throwing when transfer leader.
+     */
+    rpc GetTransferLeaderMessage(GetTransferLeaderMessagePRequest) returns (GetTransferLeaderMessagePResponse);
 }

--- a/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumElectCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumElectCommand.java
@@ -19,8 +19,10 @@ import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.grpc.GetQuorumInfoPResponse;
+import alluxio.grpc.GetTransferLeaderMessagePResponse;
 import alluxio.grpc.NetAddress;
 import alluxio.grpc.QuorumServerInfo;
+import alluxio.grpc.TransferLeaderMessage;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 
@@ -69,6 +71,15 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
       final int TIMEOUT_3MIN = 3 * 60 * 1000; // in milliseconds
       CommonUtils.waitFor("Waiting for election to finalize", () -> {
         try {
+          GetTransferLeaderMessagePResponse transferMsg = jmClient.getTransferLeaderMessage();
+          Optional<TransferLeaderMessage>
+                  exceptionMsgOpt = transferMsg.getTransMsgList().stream()
+                  .filter(TransferLeaderMessage::getIsException).findAny();
+          String msg = exceptionMsgOpt.isPresent() ? exceptionMsgOpt.get().getMsg() : null;
+          if (msg != null) {
+            System.out.println(msg);
+            return false;
+          }
           GetQuorumInfoPResponse quorumInfo = jmClient.getQuorumInfo();
 
           Optional<QuorumServerInfo>


### PR DESCRIPTION
### What changes are proposed in this pull request?

According to #14029 ,while master report timeout exception,return directly.

### Why are the changes needed?
Now we can't perceive when throwing an exception, and there may be wrong results.

### Does this PR introduce any user facing changes?
No
