### PR TITLE
Make sure ufs to only once load a native shared library

### DIFF
--- a/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
+++ b/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
@@ -200,6 +200,7 @@ public class ExtensionFactoryRegistry<T extends ExtensionFactory<?, S>,
           LOG.debug("Discovered a factory implementation {} - {} in jar {}", factory.getClass(),
               factory, jarPath);
           register(factory, factories);
+          register(factory);
         }
       } catch (Throwable t) {
         LOG.warn("Failed to load jar {}: {}", jar, t.toString());

--- a/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
+++ b/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
@@ -278,8 +278,8 @@ public class ExtensionFactoryRegistry<T extends ExtensionFactory<?, S>,
    * @param factories list of factories
    * @return list of factories that support the given path which may be an empty list
    */
-  public List<T> select(String path, S conf, List<T> factories) {
-    Preconditions.checkArgument(path != null, "path may not be null");
+  private List<T> select(String path, S conf, List<T> factories) {
+    Preconditions.checkNotNull(path, "path may not be null");
 
     List<T> eligibleFactories = new ArrayList<>();
     for (T factory : factories) {

--- a/underfs/cephfs/pom.xml
+++ b/underfs/cephfs/pom.xml
@@ -31,7 +31,6 @@
       <groupId>io.github.opendataio</groupId>
       <artifactId>libcephfs</artifactId>
       <version>0.0.1</version>
-      <scope>provided</scope>
     </dependency>
 
     <!-- Internal dependencies -->


### PR DESCRIPTION
Make sure ufs to only once load a native shared library(.so) at runtime, through making sure the same classloader for the same 
 ufs

Signed-off-by: Xue Yantao xueyantao2114@163.com

### What changes are proposed in this pull request?

Please outline the changes and how this PR fixes the issue.

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
