### PR TITLE
Update evictor(LRU) reference when get a page in LocalCacheManager

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -466,13 +466,11 @@ public class LocalCacheManager implements CacheManager {
       Metrics.GET_ERRORS.inc();
       return -1;
     }
-    boolean hasPage;
     ReadWriteLock pageLock = getPageLock(pageId);
     try (LockResource r = new LockResource(pageLock.readLock())) {
       try (LockResource r2 = new LockResource(mMetaLock.readLock())) {
-        hasPage = mMetaStore.hasPage(pageId);
-      }
-      if (!hasPage) {
+        mMetaStore.getPageInfo(pageId); //check if page exists and refresh LRU items
+      } catch (PageNotFoundException e) {
         LOG.debug("get({},pageOffset={}) fails due to page not found", pageId, pageOffset);
         return 0;
       }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Update evictor(LRU) reference by calling getPageInfo when get a page in LocalCacheManager

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. The LRU evictor won't work properly without this change, because read(get) a page won't update the LRU reference which might cause the active pages got evicted earlier.

### Does this PR introduce any user facing changes?
N/A
