### PR TITLE
Fix printout bug for load command

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/CacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/CacheRequestManager.java
@@ -24,6 +24,7 @@ import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.util.CommonUtils;
+import alluxio.util.WaitForOptions;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.logging.SamplingLogger;
 import alluxio.util.network.NetworkAddressUtils;
@@ -100,7 +101,8 @@ public class CacheRequestManager {
       } else {
         try {
           CommonUtils.waitFor("block to be loaded",
-              () -> mActiveCacheRequests.containsKey(blockId));
+              () -> !mActiveCacheRequests.containsKey(blockId),
+              WaitForOptions.defaults().setTimeoutMs(30 * Constants.SECOND_MS));
         } catch (InterruptedException e) {
           throw new CancelledException("Fail to finish cache request synchronously. "
               + "Interrupted while waiting for block to be loaded by another request.", e);

--- a/shell/src/main/java/alluxio/cli/fs/command/LoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LoadCommand.java
@@ -120,8 +120,8 @@ public final class LoadCommand extends AbstractFileSystemCommand {
         return;
       }
       runLoadTask(filePath, status, local);
-      System.out.println(filePath + " loaded");
     }
+    System.out.println(filePath + " loaded");
   }
 
   private void runLoadTask(AlluxioURI filePath, URIStatus status, boolean local)


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix load command printout bug, keep the behavior the same as before(print out directory level information instead of file-level)
Also, add wait option to cache request manager when waiting for the request to be complete.
### Why are the changes needed?
Keep the load command the same behavior as before, print out directory level information instead of file level

### Does this PR introduce any user facing changes?
