### PR TITLE
Move transferleader logic from master to client-side

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -714,6 +714,11 @@
         <version>${ratis.version}</version>
       </dependency>
       <dependency>
+        <artifactId>ratis-client</artifactId>
+        <groupId>org.apache.ratis</groupId>
+        <version>${ratis.version}</version>
+      </dependency>
+      <dependency>
         <artifactId>ratis-grpc</artifactId>
         <groupId>org.apache.ratis</groupId>
         <version>${ratis.version}</version>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -67,6 +67,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
     </dependency>
+    <dependency>
+      <artifactId>ratis-client</artifactId>
+      <groupId>org.apache.ratis</groupId>
+    </dependency>
 
     <!-- Internal dependencies -->
     <dependency>
@@ -97,6 +101,12 @@
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-server-common</artifactId>
+      <version>2.7.0-SNAPSHOT</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -93,6 +93,11 @@
       <artifactId>alluxio-job-client</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-core-server-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
       <!-- Test dependencies -->
     <dependency>
@@ -101,12 +106,6 @@
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-core-server-common</artifactId>
-      <version>2.7.0-SNAPSHOT</version>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumElectCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumElectCommand.java
@@ -15,7 +15,6 @@ import static alluxio.master.journal.raft.RaftJournalSystem.RAFT_GROUP_ID;
 
 import alluxio.cli.fsadmin.command.AbstractFsAdminCommand;
 import alluxio.cli.fsadmin.command.Context;
-import alluxio.client.journal.JournalMasterClient;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.AlluxioStatusException;
@@ -99,7 +98,6 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
 
   @Override
   public int run(CommandLine cl) throws IOException {
-    JournalMasterClient jmClient = mMasterJournalMasterClient;
     String strAddr = cl.getOptionValue(ADDRESS_OPTION_NAME);
     NetAddress address = QuorumCommand.stringToAddress(strAddr);
     InetSocketAddress serverAddress = InetSocketAddress
@@ -136,7 +134,7 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
       // fire and forget: need to immediately return as the master will shut down its RPC servers
       // once the TransferLeadershipRequest is initiated.
       final int SLEEP_TIME_MS = 3_000;
-      final int TRANSFER_LEADER_WAIT_MS = 30_000;
+      final int TRANSFER_LEADER_WAIT_MS = 60_000;
       try {
         Thread.sleep(SLEEP_TIME_MS);
         RaftClientReply reply1 = client.admin().transferLeadership(newLeaderPeerId,
@@ -156,7 +154,7 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
       final int TIMEOUT_3MIN = 3 * 60 * 1000; // in milliseconds
       CommonUtils.waitFor("Waiting for election to finalize", () -> {
         try {
-          GetQuorumInfoPResponse quorumInfo = jmClient.getQuorumInfo();
+          GetQuorumInfoPResponse quorumInfo = mMasterJournalMasterClient.getQuorumInfo();
 
           Optional<QuorumServerInfo>
               leadingMasterInfoOpt = quorumInfo.getServerInfoList().stream()

--- a/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumElectCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumElectCommand.java
@@ -124,12 +124,12 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
       String stringPeers = "[" + peersWithNewPriorities.stream().map(RaftPeer::toString)
           .collect(Collectors.joining(", ")) + "]";
       mPrintStream.printf(
-          "Applying new peer state before transferring leadership: %s\n", stringPeers);
+          "Applying new peer state before transferring leadership: %s%n", stringPeers);
       RaftClientReply reply = client.admin().setConfiguration(peersWithNewPriorities);
       processReply(reply, "failed to set master priorities before initiating election");
       /* transfer leadership */
       mPrintStream.printf(
-          "Transferring leadership to master with address <%s> and with RaftPeerId <%s>\n",
+          "Transferring leadership to master with address <%s> and with RaftPeerId <%s>%n",
           serverAddress, newLeaderPeerId);
       // fire and forget: need to immediately return as the master will shut down its RPC servers
       // once the TransferLeadershipRequest is initiated.
@@ -141,7 +141,7 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
             TRANSFER_LEADER_WAIT_MS);
         processReply(reply1, "election failed");
       } catch (Throwable t) {
-        mPrintStream.printf("caught an error when executing transfer: %s\n", t.getMessage());
+        mPrintStream.printf("caught an error when executing transfer: %s%n", t.getMessage());
         return -1;
       }
       mPrintStream.println("Transferring leadership initiated");
@@ -235,7 +235,7 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
       IOException ioe = reply.getException() != null
           ? reply.getException()
           : new IOException(String.format("reply <%s> failed", reply));
-      mPrintStream.printf("%s. Error: %s\n", msgToUser, ioe);
+      mPrintStream.printf("%s. Error: %s%n", msgToUser, ioe);
       throw new IOException(msgToUser);
     }
   }

--- a/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumElectCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumElectCommand.java
@@ -11,6 +11,8 @@
 
 package alluxio.cli.fsadmin.journal;
 
+import static alluxio.master.journal.raft.RaftJournalSystem.RAFT_GROUP_ID;
+
 import alluxio.cli.fsadmin.command.AbstractFsAdminCommand;
 import alluxio.cli.fsadmin.command.Context;
 import alluxio.client.journal.JournalMasterClient;
@@ -21,16 +23,37 @@ import alluxio.exception.status.InvalidArgumentException;
 import alluxio.grpc.GetQuorumInfoPResponse;
 import alluxio.grpc.NetAddress;
 import alluxio.grpc.QuorumServerInfo;
+import alluxio.master.journal.raft.RaftJournalConfiguration;
+import alluxio.master.journal.raft.RaftJournalUtils;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
+import alluxio.util.network.NetworkAddressUtils;
 
 import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.client.RaftClientConfigKeys;
+import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.retry.ExponentialBackoffRetry;
+import org.apache.ratis.util.TimeDuration;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 /**
  * Command for transferring the leadership to another master within a quorum.
@@ -42,12 +65,28 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
   public static final String TRANSFER_SUCCESS = "Successfully elected %s as the new leader";
   public static final String TRANSFER_FAILED = "Failed to elect %s as the new leader: %s";
 
+  private final ClientId mRawClientId = ClientId.randomId();
+  private final RaftJournalConfiguration mRaftJournalConf;
+  private final RaftGroup mRaftGroup;
+
   /**
    * @param context fsadmin command context
    * @param alluxioConf Alluxio configuration
    */
   public QuorumElectCommand(Context context, AlluxioConfiguration alluxioConf) {
     super(context);
+    mRaftJournalConf =
+        RaftJournalConfiguration.defaults(
+            NetworkAddressUtils.ServiceType.MASTER_RAFT);
+    List<InetSocketAddress> addresses = mRaftJournalConf.getClusterAddresses();
+    Set<RaftPeer> peers = addresses.stream()
+        .map(addr -> RaftPeer.newBuilder()
+            .setId(RaftJournalUtils.getPeerId(addr))
+            .setAddress(addr)
+            .build()
+        )
+        .collect(Collectors.toSet());
+    mRaftGroup = RaftGroup.valueOf(RAFT_GROUP_ID, peers);
   }
 
   /**
@@ -61,10 +100,58 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
   @Override
   public int run(CommandLine cl) throws IOException {
     JournalMasterClient jmClient = mMasterJournalMasterClient;
-    String serverAddress = cl.getOptionValue(ADDRESS_OPTION_NAME);
-    NetAddress address = QuorumCommand.stringToAddress(serverAddress);
+    String strAddr = cl.getOptionValue(ADDRESS_OPTION_NAME);
+    NetAddress address = QuorumCommand.stringToAddress(strAddr);
+    InetSocketAddress serverAddress = InetSocketAddress
+        .createUnresolved(address.getHost(), address.getRpcPort());
+    List<RaftPeer> oldPeers = new ArrayList<>(mRaftGroup.getPeers());
+    // if you cannot find the address in the quorum, throw exception.
+    if (oldPeers.stream().map(RaftPeer::getAddress).noneMatch(addr -> addr.equals(strAddr))) {
+      throw new IOException(String.format("<%s> is not part of the quorum <%s>.",
+          strAddr, oldPeers.stream().map(RaftPeer::getAddress).collect(Collectors.toList())));
+    }
+
+    RaftPeerId newLeaderPeerId =
+        RaftJournalUtils.getPeerId(address.getHost(), address.getRpcPort());
+    /* update priorities to enable transfer */
+    List<RaftPeer> peersWithNewPriorities = new ArrayList<>();
+    for (RaftPeer peer : oldPeers) {
+      peersWithNewPriorities.add(
+          RaftPeer.newBuilder(peer)
+              .setPriority(peer.getId().equals(newLeaderPeerId) ? 2 : 1)
+              .build()
+      );
+    }
+    try (RaftClient client = createClient()) {
+      String stringPeers = "[" + peersWithNewPriorities.stream().map(RaftPeer::toString)
+          .collect(Collectors.joining(", ")) + "]";
+      mPrintStream.printf(
+          "Applying new peer state before transferring leadership: %s\n", stringPeers);
+      RaftClientReply reply = client.admin().setConfiguration(peersWithNewPriorities);
+      processReply(reply, "failed to set master priorities before initiating election");
+      /* transfer leadership */
+      mPrintStream.printf(
+          "Transferring leadership to master with address <%s> and with RaftPeerId <%s>\n",
+          serverAddress, newLeaderPeerId);
+      // fire and forget: need to immediately return as the master will shut down its RPC servers
+      // once the TransferLeadershipRequest is initiated.
+      final int SLEEP_TIME_MS = 3_000;
+      final int TRANSFER_LEADER_WAIT_MS = 30_000;
+      try {
+        Thread.sleep(SLEEP_TIME_MS);
+        RaftClientReply reply1 = client.admin().transferLeadership(newLeaderPeerId,
+            TRANSFER_LEADER_WAIT_MS);
+        processReply(reply1, "election failed");
+      } catch (Throwable t) {
+        mPrintStream.printf("caught an error when executing transfer: %s\n", t.getMessage());
+        return -1;
+      }
+      mPrintStream.println("Transferring leadership initiated");
+    } catch (Throwable t) {
+      throw new IOException(t);
+    }
+
     try {
-      jmClient.transferLeadership(address);
       // wait for confirmation of leadership transfer
       final int TIMEOUT_3MIN = 3 * 60 * 1000; // in milliseconds
       CommonUtils.waitFor("Waiting for election to finalize", () -> {
@@ -84,8 +171,6 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
 
       mPrintStream.println(String.format(TRANSFER_SUCCESS, serverAddress));
       return 0;
-    } catch (AlluxioStatusException e) {
-      mPrintStream.println(String.format(TRANSFER_FAILED, serverAddress, e.getMessage()));
     } catch (InterruptedException | TimeoutException e) {
       mPrintStream.println(String.format(TRANSFER_FAILED, serverAddress, "the election was "
               + "initiated but never completed"));
@@ -120,5 +205,40 @@ public class QuorumElectCommand extends AbstractFsAdminCommand {
   public Options getOptions() {
     return new Options().addOption(ADDRESS_OPTION_NAME, true,
             "Server address that will take over as leader");
+  }
+
+  private RaftClient createClient() {
+    RaftProperties properties = new RaftProperties();
+    Parameters parameters = new Parameters();
+    RaftClientConfigKeys.Rpc.setRequestTimeout(properties,
+        TimeDuration.valueOf(15, TimeUnit.SECONDS));
+    ExponentialBackoffRetry retryPolicy = ExponentialBackoffRetry.newBuilder()
+        .setBaseSleepTime(TimeDuration.valueOf(100, TimeUnit.MILLISECONDS))
+        .setMaxAttempts(10)
+        .setMaxSleepTime(
+            TimeDuration.valueOf(100000, TimeUnit.MILLISECONDS))
+        .build();
+    return RaftClient.newBuilder()
+        .setRaftGroup(mRaftGroup)
+        .setClientId(mRawClientId)
+        .setLeaderId(null)
+        .setProperties(properties)
+        .setParameters(parameters)
+        .setRetryPolicy(retryPolicy)
+        .build();
+  }
+
+  /**
+   * @param reply from the ratis operation
+   * @throws IOException
+   */
+  private void processReply(RaftClientReply reply, String msgToUser) throws IOException {
+    if (!reply.isSuccess()) {
+      IOException ioe = reply.getException() != null
+          ? reply.getException()
+          : new IOException(String.format("reply <%s> failed", reply));
+      mPrintStream.printf("%s. Error: %s\n", msgToUser, ioe);
+      throw new IOException(msgToUser);
+    }
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/QuorumCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/QuorumCommandIntegrationTest.java
@@ -206,7 +206,7 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
 
       mOutput.reset();
       shell.run("journal", "quorum", "elect", "-address" , newLeaderAddr);
-      String output = mOutput.toString().trim();
+      String output = lastLine(mOutput.toString().trim());
       String expected = String.format(QuorumElectCommand.TRANSFER_SUCCESS, newLeaderAddr);
       Assert.assertEquals(expected, output);
     }

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-//    o.sync();
+    o.sync();
     //#else
     o.hflush();
     //#endif

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-    o.sync();
+//    o.sync();
     //#else
     o.hflush();
     //#endif


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix #14068

### Why are the changes needed?

Make it easy to handle the whole transferleader transaction.

### Does this PR introduce any user facing changes?

```
bin/alluxio fsadmin journal quorum elect -address localhost:19200
Applying new peer state before transferring leadership: [localhost_19202|rpc:localhost:19202|priority:1, localhost_19201|rpc:localhost:19201|priority:1, localhost_19200|rpc:localhost:19200|priority:2]
Transferring leadership to master with address <localhost:19200> and with RaftPeerId <localhost_19200>
Transferring leadership initiated
Successfully elected localhost:19200 as the new leader
```