### PR TITLE
Use tini-static in Dockerfile for new alphine docker image

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -55,7 +55,7 @@ ARG ENABLE_DYNAMIC_USER=true
 # Add Tini for Alluxio helm charts (https://github.com/Alluxio/alluxio/pull/12233)
 # - https://github.com/krallin/tini
 ENV TINI_VERSION v0.18.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/local/bin/tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /usr/local/bin/tini
 RUN chmod +x /usr/local/bin/tini
 
 RUN apk add --no-cache openjdk8 openjdk8-jre-lib unzip vim


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fixes https://github.com/Alluxio/alluxio/issues/14079
change to install tini-static which includes all its dependencies

### Why are the changes needed?
alphine doesn't have tini dependencies

### Does this PR introduce any user facing changes?
It supports tini -- entrypoint.sh to continue working in kube scripts
