### PR TITLE
Add a second constructor in PrometheusMetricsServlet #13165

### DIFF
--- a/core/server/common/src/main/java/alluxio/metrics/sink/PrometheusMetricsServlet.java
+++ b/core/server/common/src/main/java/alluxio/metrics/sink/PrometheusMetricsServlet.java
@@ -18,6 +18,8 @@ import io.prometheus.client.exporter.MetricsServlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
+import java.util.Properties;
+
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -40,6 +42,17 @@ public class PrometheusMetricsServlet implements Sink {
   public PrometheusMetricsServlet(MetricRegistry registry) {
     mCollectorRegistry = CollectorRegistry.defaultRegistry;
     mCollectorRegistry.register(new DropwizardExports(registry));
+  }
+
+  /**
+   * Creates a new {@link alluxio.metrics.sink.PrometheusMetricsServlet} with a
+   * {@link MetricRegistry}.
+   *
+   * @param properties the properties, not used for now
+   * @param registry the metric registry to register
+   */
+  public PrometheusMetricsServlet(Properties properties, MetricRegistry registry) {
+    this(registry);
   }
 
   /**


### PR DESCRIPTION
* favor MetricsSystem.startSinksFromConfig to get the constructor by
  reflection with parameters (Properties, MetricRegistry)

### What changes are proposed in this pull request?

Fixes https://github.com/Alluxio/alluxio/issues/13165, be able to load PrometheusMetricsServlet when configured by metrics.properties

### Why are the changes needed?

BUGFIX, MetricsSystem.startSinksFromConfig requires the constructor of the Sink with two parameters (Properties, MetricRegistry), PrometheusMetricsServlet doesn't provide such constructor.

### Does this PR introduce any user facing changes?

 None