### PR TITLE
Fix metrics Worker.ActiveClients counter error

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -638,6 +638,13 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
           // the sessionId.
           LOG.debug("Invalid worker state while committing block.", e);
         }
+      } else {
+        // When getTempBlockMeta() return null, such as a block readType NO_CACHE writeType THROUGH.
+        // Counter will not be decrement in the commitblock().
+        // So we should decrement counter here.
+        if (mUnderFileSystemBlockStore.isNoCache(sessionId, blockId)) {
+          Metrics.WORKER_ACTIVE_CLIENTS.dec();
+        }
       }
     } finally {
       mUnderFileSystemBlockStore.releaseAccess(sessionId, blockId);

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
@@ -248,6 +248,18 @@ public final class UnderFileSystemBlockStore implements SessionCleanable {
   }
 
   /**
+   * @param sessionId the session ID
+   * @param blockId the block ID
+   * @return true if mNoCache is set
+   */
+  public boolean isNoCache(long sessionId, long blockId) {
+    Key key = new Key(sessionId, blockId);
+    BlockInfo blockInfo = mBlocks.get(key);
+    UnderFileSystemBlockMeta mMeta = blockInfo.getMeta();
+    return mMeta.isNoCache();
+  }
+
+  /**
    * Gets the {@link UnderFileSystemBlockMeta} for a session ID and block ID pair.
    *
    * @param sessionId the session ID


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix metrics Worker.ActiveClients counter error

### Why are the changes needed?
When executing end-to-end test: allxuio runTest --readType NO_CACHE --writeType THROUGH. the counter metric Worker.ActiveClients.xxx will change to 2 instead of 0.

### Does this PR introduce any user facing changes?
No