### PR TITLE
Use jobMasterRpcAddresses to judge ServiceType

### DIFF
--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -29,9 +29,10 @@ import alluxio.retry.RetryUtils;
 import alluxio.security.user.UserState;
 import alluxio.uri.Authority;
 import alluxio.uri.MultiMasterAuthority;
-
 import alluxio.util.ConfigurationUtils;
+
 import io.grpc.StatusRuntimeException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -30,6 +30,7 @@ import alluxio.security.user.UserState;
 import alluxio.uri.Authority;
 import alluxio.uri.MultiMasterAuthority;
 
+import alluxio.util.ConfigurationUtils;
 import io.grpc.StatusRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -148,8 +149,8 @@ public class PollingMasterInquireClient implements MasterInquireClient {
         ServiceVersionClientServiceGrpc.newBlockingStub(channel)
             .withDeadlineAfter(mConfiguration.getMs(PropertyKey.USER_MASTER_POLLING_TIMEOUT),
                 TimeUnit.MILLISECONDS);
-    ServiceType serviceType
-        = address.getPort() == mConfiguration.getInt(PropertyKey.JOB_MASTER_RPC_PORT)
+    List<InetSocketAddress> addresses = ConfigurationUtils.getJobMasterRpcAddresses(mConfiguration);
+    ServiceType serviceType = addresses.contains(address)
         ? ServiceType.JOB_MASTER_CLIENT_SERVICE : ServiceType.META_MASTER_CLIENT_SERVICE;
     try {
       versionClient.getServiceVersion(GetServiceVersionPRequest.newBuilder()


### PR DESCRIPTION
### What changes are proposed in this pull request?

We cannot run job service related command line tools when we start 3 job master in same machine with different port while the leader is not the default job master rpc port.

### Why are the changes needed?

After fix this, we can use the following command to start 3 job master and execute job service related command line tools successfully while the leader it not the default job master rpc port

```bash
ALLUXIO_JOB_MASTER_JAVA_OPTS="-Dalluxio.job.master.rpc.port=20001 -Dalluxio.job.master.web.port=20002 -Dalluxio.job.master.embedded.journal.port=20003 -Dalluxio.work.dir=/tmp/alluxio-tmp/alluxio-0 -Xbootclasspath/a:/Users/mbl/projects/github/alluxio-2/conf  -Dalluxio.logger.type=Console" bin/alluxio-start.sh -N job_master
ALLUXIO_JOB_MASTER_JAVA_OPTS="-Dalluxio.job.master.rpc.port=20011 -Dalluxio.job.master.web.port=20012 -Dalluxio.job.master.embedded.journal.port=20013 -Dalluxio.work.dir=/tmp/alluxio-tmp/alluxio-1 -Xbootclasspath/a:/Users/mbl/projects/github/alluxio-2/conf  -Dalluxio.logger.type=Console" bin/alluxio-start.sh -N job_master 
ALLUXIO_JOB_MASTER_JAVA_OPTS="-Dalluxio.job.master.rpc.port=20021 -Dalluxio.job.master.web.port=20022 -Dalluxio.job.master.embedded.journal.port=20023 -Dalluxio.work.dir=/tmp/alluxio-tmp/alluxio-2 -Xbootclasspath/a:/Users/mbl/projects/github/alluxio-2/conf  -Dalluxio.logger.type=Console" bin/alluxio-start.sh -N job_master


```

### Does this PR introduce any user facing changes?

No
