### PR TITLE
Add Dockerfile-dev to the alluxio tarball

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -195,6 +195,7 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 		"integration/docker/conf/alluxio-env.sh.template",
 		"integration/docker/conf/alluxio-site.properties.template",
 		"integration/docker/Dockerfile",
+		"integration/docker/Dockerfile-dev",
 		"integration/docker/dockerfile-common.sh",
 		"integration/docker/entrypoint.sh",
 		"integration/fuse/bin/alluxio-fuse",


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add Dockerfile-dev to the generated alluxio tarball so that we can build docker image from that tarball directly

### Why are the changes needed?

Otherwise we cannot build the alluxio-dev docker image

### Does this PR introduce any user facing changes?

NA
