### PR TITLE
Check secondary master unsupported journal type EMBEDDED

### DIFF
--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -102,6 +102,7 @@ public enum ExceptionMessage {
   JOURNAL_WRITE_AFTER_CLOSE("Cannot write entry after closing the stream"),
   JOURNAL_WRITE_FAILURE("Failed to write to journal file ({0}): {1}"),
   JOURNAL_FLUSH_FAILURE("Failed to flush journal file ({0}): {1}"),
+  JOURNAL_TYPE_UNSUPPORTED("Secondary master unsupported journal type EMBEDDED"),
 
   // Raft journal
   FAILED_RAFT_BOOTSTRAP("Failed to bootstrap raft cluster with addresses {0}: {1}"),

--- a/core/common/src/main/java/alluxio/exception/UnsupportedJournalTypeException.java
+++ b/core/common/src/main/java/alluxio/exception/UnsupportedJournalTypeException.java
@@ -1,0 +1,46 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.exception;
+
+/**
+ * The exception thrown when an AlluxioSecondaryMaster start with EMBEDDED JournalType.
+ */
+public class UnsupportedJournalTypeException extends AlluxioException {
+  private static final long serialVersionUID = 964881830415517869L;
+
+  /**
+   * Constructs a new exception with the cause.
+   *
+   * @param cause the cause
+   */
+  protected UnsupportedJournalTypeException(Throwable cause) {
+    super(cause);
+  }
+
+  /**
+   * Constructs a new exception with the specified exception message.
+   *
+   * @param message the exception message
+   */
+  public UnsupportedJournalTypeException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new exception with the specified exception message.
+   *
+   * @param message the exception message
+   */
+  public UnsupportedJournalTypeException(ExceptionMessage message) {
+      this(message.getMessage());
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/AlluxioSecondaryMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioSecondaryMaster.java
@@ -16,7 +16,10 @@ import alluxio.ProcessUtils;
 import alluxio.RuntimeConstants;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
+import alluxio.exception.ExceptionMessage;
+import alluxio.exception.UnsupportedJournalTypeException;
 import alluxio.master.journal.JournalSystem;
+import alluxio.master.journal.JournalType;
 import alluxio.master.journal.JournalUtils;
 import alluxio.underfs.MasterUfsManager;
 import alluxio.util.CommonUtils;
@@ -55,6 +58,11 @@ public final class AlluxioSecondaryMaster implements Process {
   AlluxioSecondaryMaster() {
     try {
       URI journalLocation = JournalUtils.getJournalLocation();
+      JournalType journalType =
+              ServerConfiguration.getEnum(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.class);
+      if (journalType == JournalType.EMBEDDED) {
+        throw new UnsupportedJournalTypeException(ExceptionMessage.JOURNAL_TYPE_UNSUPPORTED);
+      }
       mJournalSystem = new JournalSystem.Builder()
           .setLocation(journalLocation).build(ProcessType.MASTER);
       mRegistry = new MasterRegistry();
@@ -80,7 +88,7 @@ public final class AlluxioSecondaryMaster implements Process {
             String.format("Journal %s has not been formatted!", journalLocation));
       }
       mLatch = new CountDownLatch(1);
-    } catch (IOException e) {
+    } catch (IOException | UnsupportedJournalTypeException e) {
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?
If secondary master sets journal type EMBEDDED. First check journal type.

### Why are the changes needed?
If secondary master sets journal type EMBEDDED. The secondary master can start. But secondary master unsupported journal type EMBEDDED.

### Does this PR introduce any user facing changes?
None
