### PR TITLE
Add application/octet-stream to consumed content types in S3 Handler

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -76,7 +76,7 @@ import javax.ws.rs.core.Response;
 @NotThreadSafe
 @Path(S3RestServiceHandler.SERVICE_PREFIX)
 @Produces(MediaType.APPLICATION_XML)
-@Consumes({ MediaType.TEXT_XML, MediaType.APPLICATION_XML })
+@Consumes({ MediaType.TEXT_XML, MediaType.APPLICATION_XML, MediaType.APPLICATION_OCTET_STREAM })
 public final class S3RestServiceHandler {
   private static final Logger LOG = LoggerFactory.getLogger(S3RestServiceHandler.class);
 


### PR DESCRIPTION
The AWS Java client uses this content type in its requests. Also, the
body content type is only consumed in a single method anyways, and is
treated the same regardless of its type.

### What changes are proposed in this pull request?

Add `application/octet-stream` to the default mime types which are allowed

### Why are the changes needed?

Some S3 clients (e.g. Java AWS SDK) use the `application/octet-stream` by default for the request content type. We only ever consume a byte stream in the handlers anyways, so adding `application/octet-stream` to the types should be harmless and increase support.

### Does this PR introduce any user facing changes?

No