### PR TITLE
Fix runClass FuseIOBench help command typo

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -110,12 +110,12 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
         "# 16 threads of each worker will be used for testing the reading throughput with "
             + "ClusterRead.",
         "# 5 seconds of warmup time and 30 seconds of actual reading test time",
-        "$ bin/alluxio runClass alluxio.stress.cli.fuse.fuseIOBench --operation Write \\",
+        "$ bin/alluxio runClass alluxio.stress.cli.fuse.FuseIOBench --operation Write \\",
         "--local-path /mnt/alluxio-fuse/FuseIOTest --num-dirs 32 --num-files-per-dir 10 \\",
         "--file-size 100m --threads 32 --cluster",
-        "$ bin/alluxio runClass alluxio.stress.cli.fuse.fuseIOBench --operation ListFile \\",
+        "$ bin/alluxio runClass alluxio.stress.cli.fuse.FuseIOBench --operation ListFile \\",
         "--local-path /mnt/alluxio-fuse/FuseIOTest",
-        "$ bin/alluxio runClass alluxio.stress.cli.fuse.fuseIOBench --operation ClusterRead \\",
+        "$ bin/alluxio runClass alluxio.stress.cli.fuse.FuseIOBench --operation ClusterRead \\",
         "--local-path /mnt/alluxio-fuse/FuseIOTest --num-dirs 32 --num-files-per-dir 10 \\",
         "--file-size 100m --threads 16 --warmup 5s --duration 30s --cluster",
         ""


### PR DESCRIPTION
### What changes are proposed in this pull request?
fix FuseIOBench help command output typo

### Why are the changes needed?
In the command ". /bin/alluxio runClass alluxio.stress.cli.fuse.FuseIOBench --help" output example, the class name is lowercase (xxx runClass alluxio.stress.cli.fuse.fuseIOBench xxx). Use it cloud not load class FuseIOBench, so it needs to be modified 

### Does this PR introduce any user facing changes?
no 
