### PR TITLE
Make jvm pause monitor display gc info correctly

### DIFF
--- a/core/common/src/main/java/alluxio/util/JvmPauseMonitor.java
+++ b/core/common/src/main/java/alluxio/util/JvmPauseMonitor.java
@@ -180,6 +180,8 @@ public class JvmPauseMonitor {
     List<GarbageCollectorMXBean> gcBeanList = ManagementFactory.getGarbageCollectorMXBeans();
     Map<String, GarbageCollectorMXBean> gcBeanMap = new HashMap<>();
     for (GarbageCollectorMXBean gcBean : gcBeanList) {
+      // #getGarbageCollectorMXBeans will return the same gc bean
+      // so we need to clone a new gc bean.
       gcBeanMap.put(gcBean.getName(), new GarbageCollectorMXBeanView(gcBean));
     }
     return gcBeanMap;

--- a/core/common/src/main/java/alluxio/util/JvmPauseMonitor.java
+++ b/core/common/src/main/java/alluxio/util/JvmPauseMonitor.java
@@ -245,13 +245,17 @@ public class JvmPauseMonitor {
     private final String[] mMemoryPoolNames;
     private final ObjectName mObjectName;
 
+    /**
+     * Creates a new instance of {@link GarbageCollectorMXBeanView}.
+     * @param gcBean which the unmodifiable view should be constructed from
+     */
     public GarbageCollectorMXBeanView(GarbageCollectorMXBean gcBean) {
-      mCollectionCount=gcBean.getCollectionCount();
-      mCollectionTime=gcBean.getCollectionTime();
-      mName=gcBean.getName();
-      mValid=gcBean.isValid();
-      mMemoryPoolNames=gcBean.getMemoryPoolNames();
-      mObjectName=gcBean.getObjectName();
+      mCollectionCount = gcBean.getCollectionCount();
+      mCollectionTime = gcBean.getCollectionTime();
+      mName = gcBean.getName();
+      mValid = gcBean.isValid();
+      mMemoryPoolNames = gcBean.getMemoryPoolNames();
+      mObjectName = gcBean.getObjectName();
     }
 
     @Override

--- a/core/common/src/main/java/alluxio/util/JvmPauseMonitor.java
+++ b/core/common/src/main/java/alluxio/util/JvmPauseMonitor.java
@@ -151,15 +151,15 @@ public class JvmPauseMonitor {
       oldBean = gcMXBeanMapBeforeSleep.get(name);
       newBean = gcMXBeanMapAfterSleep.get(name);
       if (oldBean == null) {
-        beanDiffs.add("new GCBean created name= '" + newBean.getName() + "' count="
-            + newBean.getCollectionCount() + " time=" + newBean.getCollectionTime() + "ms");
+        beanDiffs.add(String.format("new GCBean created name='%s' count=%d time=%dms",
+            newBean.getName(), newBean.getCollectionCount(), newBean.getCollectionTime()));
       } else if (newBean == null) {
-        beanDiffs.add("old GCBean canceled name= '" + oldBean.getName() + "' count="
-            + oldBean.getCollectionCount() + " time=" + oldBean.getCollectionTime() + "ms");
+        beanDiffs.add(String.format("old GCBean canceled name= '%s' count=%d time=%dms",
+            oldBean.getName(), oldBean.getCollectionCount(), oldBean.getCollectionTime()));
       } else {
         if (oldBean.getCollectionTime() != newBean.getCollectionTime()
             || oldBean.getCollectionCount() != newBean.getCollectionCount()) {
-          beanDiffs.add(String.format("GC name ='%s' count=%d time=%dms", newBean.getName(),
+          beanDiffs.add(String.format("GC name='%s' count=%d time=%dms", newBean.getName(),
               newBean.getCollectionCount() - oldBean.getCollectionCount(),
               newBean.getCollectionTime() - oldBean.getCollectionTime()));
         }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Make jvm pause monitor to display gc info correctly.

### Why are the changes needed?

I found that the jvm pause monitor could not display gc info correctly and always print `No GCs detected` even after gc. This PR fixes this issue.

### Does this PR introduce any user facing changes?

No user facing changes.