### PR TITLE
Retry the eviction on delete page file failures

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -419,6 +419,10 @@ public class LocalCacheManager implements CacheManager {
           // Failed to evict page, remove new page from metastore as there will not be enough space
           undoAddPage(pageId);
         }
+        if (e instanceof PageNotFoundException) {
+          //The victim page got deleted by other thread, likely due to a benign racing. Will retry.
+          return PutResult.BENIGN_RACING;
+        }
         LOG.error("Failed to delete page {} from pageStore", pageId, e);
         Metrics.PUT_STORE_DELETE_ERRORS.inc();
         return PutResult.OTHER;

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -799,11 +799,19 @@ public final class LocalCacheManagerTest {
     mConf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, PAGE_SIZE_BYTES);
     FaultyPageStore pageStore = new FaultyPageStore();
     mCacheManager = createLocalCacheManager(mConf, mMetaStore, pageStore);
-    pageStore.setDeleteFaulty(true);
     // first put should be ok
     assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
     // trigger a failed eviction
+    pageStore.setPutFaulty(true);
+    // put operation failed because we do not retry for the IO exception from put
     assertFalse(mCacheManager.put(PAGE_ID2, PAGE2));
+    //clear put faulty and set delete faulty to true
+    pageStore.setPutFaulty(false);
+    pageStore.setDeleteFaulty(true);
+    // put operation succeeded after retry
+    assertTrue(mCacheManager.put(PAGE_ID2, PAGE2));
+    assertEquals(PAGE_SIZE_BYTES, mCacheManager.get(PAGE_ID2, PAGE2.length, mBuf, 0));
+    assertArrayEquals(PAGE2, mBuf);
     // restore page store to function
     pageStore.setDeleteFaulty(false);
     // trigger another eviction, this should work


### PR DESCRIPTION
### What changes are proposed in this pull request?

Retry the eviction when the deletion of the victim page file failed (it has been deleted by others)

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  As FB team shared with us, we might see a spike of page put failures if we delete all the page files on the disk.  I think this one might also occur when there is a race on delete the same page file.   So add a retry might help the put operation get through in case the victim file has been deleted by some one else.

### Does this PR introduce any user facing changes?

No
