### PR TITLE
[DOCFIX] Remove alluxio-fuse image reference

### DIFF
--- a/docs/en/api/POSIX-API.md
+++ b/docs/en/api/POSIX-API.md
@@ -293,7 +293,7 @@ $ ${ALLUXIO_HOME}/integration/fuse/bin/alluxio-fuse mount \
 A special mount option is the `max_idle_threads=N` which defines the maximum number of idle fuse daemon threads allowed.
 If the value is too small, FUSE may frequently create and destroy threads which will introduce extra performance overhead.
 Note that, libfuse introduce this mount option in 3.2 while JNI-Fuse supports 2.9.X during experimental stage.
-The Alluxio Fuse docker image [alluxio/{{site.ALLUXIO_DOCKER_IMAGE}}-fuse](https://hub.docker.com/r/alluxio/{{site.ALLUXIO_DOCKER_IMAGE}}-fuse/)
+The Alluxio docker image [alluxio/{{site.ALLUXIO_DOCKER_IMAGE}}](https://hub.docker.com/r/alluxio/{{site.ALLUXIO_DOCKER_IMAGE}}/)
 enables this property by modifying the [libfuse source code](https://github.com/cheyang/libfuse/tree/fuse_2_9_5_customize_multi_threads_v2).
 
 If you are using alluxio fuse docker image, set the `MAX_IDLE_THREADS` via environment variable:
@@ -301,7 +301,7 @@ If you are using alluxio fuse docker image, set the `MAX_IDLE_THREADS` via envir
 $ docker run -d --rm \
     ...
     --env MAX_IDLE_THREADS=64 \
-    alluxio/{{site.ALLUXIO_DOCKER_IMAGE}}-fuse fuse
+    alluxio/{{site.ALLUXIO_DOCKER_IMAGE}} fuse
 ```
   {% endcollapsible %}
 {% endaccordion %}


### PR DESCRIPTION
Remove the last few of the references to alluxio/alluxio-fuse image.

@LuQQiu 