### PR TITLE
Introduce client-side keep-alive monitoring for channels of RPC network

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4573,7 +4573,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey USER_NETWORK_RPC_KEEPALIVE_TIME =
       new Builder(Name.USER_NETWORK_RPC_KEEPALIVE_TIME)
-          .setDefaultValue(Long.MAX_VALUE)
+          .setDefaultValue("30sec")
           .setDescription("The amount of time for a rpc client "
               + "to wait for a response before pinging the server to see if it is still alive.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)


### PR DESCRIPTION
This will avoid clients being stuck on target RPC servers under various network faults.