### PR TITLE
Catch errors during explicit cache cleanup

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/UnderFileSystemBlockMeta.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/UnderFileSystemBlockMeta.java
@@ -35,7 +35,7 @@ public final class UnderFileSystemBlockMeta {
    *
    * @param sessionId the session ID
    * @param blockId the block ID
-   * @param options the {@link Protocol.OpenUfsBlockOptions}
+   * @param options the {@link Protocol.OpenUfsBlUfsInputStreamCacheTestockOptions}
    */
   public UnderFileSystemBlockMeta(long sessionId, long blockId,
       Protocol.OpenUfsBlockOptions options) {


### PR DESCRIPTION
It's been verified that this explicit `cleanUp` call causes assertions from guava cache.