### PR TITLE
Fix the semantic ambiguity of LoadMetadataCommand

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/LoadMetadataCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LoadMetadataCommand.java
@@ -17,6 +17,7 @@ import alluxio.cli.CommandUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
+import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.ListStatusPOptions;
 
 import org.apache.commons.cli.CommandLine;
@@ -42,6 +43,13 @@ public class LoadMetadataCommand extends AbstractFileSystemCommand {
           .desc("load metadata subdirectories recursively")
           .build();
 
+  private static final Option FORCE_OPTION =
+      Option.builder("F")
+          .required(false)
+          .hasArg(false)
+          .desc("update the metadata of the existing sub file forcibly")
+          .build();
+
   /**
    * Constructs a new instance to load metadata for the given Alluxio path from UFS.
    *
@@ -58,13 +66,16 @@ public class LoadMetadataCommand extends AbstractFileSystemCommand {
 
   @Override
   public Options getOptions() {
-    return new Options().addOption(RECURSIVE_OPTION);
+    return new Options()
+        .addOption(RECURSIVE_OPTION)
+        .addOption(FORCE_OPTION);
   }
 
   @Override
   protected void runPlainPath(AlluxioURI plainPath, CommandLine cl)
       throws AlluxioException, IOException {
-    loadMetadata(plainPath, cl.hasOption(RECURSIVE_OPTION.getOpt()));
+    loadMetadata(plainPath, cl.hasOption(RECURSIVE_OPTION.getOpt()),
+        cl.hasOption(FORCE_OPTION.getOpt()));
   }
 
   @Override
@@ -76,10 +87,18 @@ public class LoadMetadataCommand extends AbstractFileSystemCommand {
     return 0;
   }
 
-  private void loadMetadata(AlluxioURI path, boolean recursive) throws IOException {
+  private void loadMetadata(AlluxioURI path, boolean recursive, boolean force) throws IOException {
     try {
-      ListStatusPOptions options = ListStatusPOptions.newBuilder()
-          .setRecursive(recursive).build();
+      ListStatusPOptions options;
+      if (force) {
+        options = ListStatusPOptions.newBuilder()
+            .setRecursive(recursive)
+            .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
+                .setSyncIntervalMs(0).build())
+            .build();
+      } else {
+        options = ListStatusPOptions.newBuilder().setRecursive(recursive).build();
+      }
       mFileSystem.loadMetadata(path, options);
     } catch (AlluxioException e) {
       throw new IOException(e.getMessage());
@@ -88,7 +107,7 @@ public class LoadMetadataCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "loadMetadata [-R] <path>";
+    return "loadMetadata [-R] [-F] <path>";
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

Resolve issue #14183.

### Why are the changes needed?

Provide users with an option to synchronize metadata of subfiles of a directory.

### Does this PR introduce any user-facing changes?

The force option is added to the `loadMetadata` command in the CLI：

<img width="1107" alt="截屏2021-09-30 上午2 31 11" src="https://user-images.githubusercontent.com/4209464/135328059-c4523196-0a9a-41f0-8c34-1f69471c4e53.png">


