### PR TITLE
Update CSI-related usage

### DIFF
--- a/integration/kubernetes/CSI_README.md
+++ b/integration/kubernetes/CSI_README.md
@@ -11,12 +11,11 @@ Kubernetes 1.14 or higher, RBAC enabled in API server(https://kubernetes.io/docs
 
 ### Docker image
 
-The `alluxio/alluxio` docker image now supports CSI. You can build the docker image yourself following the instructions in
-`${ALLUXIO_HOME}/integration/docker/README.md`, section `Building docker image for production` or `Building docker image
-for development` depending on your needs. If you don't build the image locally, Kubernetes will use the latest published `alluxio/alluxio`
-image on Dockerhub.
+The official `alluxio/alluxio` docker image now supports CSI. By default Kubernetes will pull the latest published `alluxio/alluxio` image on Dockerhub.
 
-
+Alternatively you can build the docker image yourself following the instructions in `${ALLUXIO_HOME}/integration/docker/README.md`,
+section `Building docker image for production` or `Building docker image for development` depending on your needs. Make sure you refer to your
+built image in the deploying yaml files.
 
 ### Deploy
 

--- a/integration/kubernetes/CSI_README.md
+++ b/integration/kubernetes/CSI_README.md
@@ -1,6 +1,7 @@
 # Alluxio CSI
 
 This module implement container storage interface(https://github.com/container-storage-interface/spec) for Alluxio.
+The related source code is at `${ALLUXIO_HOME}/integration/docker/csi`.
 
 ## Requirements
 

--- a/integration/kubernetes/CSI_README.md
+++ b/integration/kubernetes/CSI_README.md
@@ -9,21 +9,25 @@ Kubernetes 1.14 or higher, RBAC enabled in API server(https://kubernetes.io/docs
 ## Usage
 
 
-### Build docker image
+### Docker image
 
-Please run `docker build . -t alluxio/alluxio-csi:<version_tag>` to build CSI docker image. Alluxio doesn't provide official CSI docker image currently.
-You need to build the image by yourself.
+The `alluxio/alluxio` docker image now supports CSI. You can build the docker image yourself following the instructions in
+`${ALLUXIO_HOME}/integration/docker/README.md`, section `Building docker image for production` or `Building docker image
+for development` depending on your needs. If you don't build the image locally, Kubernetes will use the latest published `alluxio/alluxio`
+image on Dockerhub.
+
+
 
 ### Deploy
 
-Please use `helm-generate.sh` to generate related templates. All CSI related templates should under `integration/kubernetes/<deploy-mode>/csi` folder.
+Please use `helm-generate.sh` to generate related templates. All CSI related templates will be under `integration/kubernetes/<deploy-mode>/csi` folder.
 
-You need to deploy `alluxio-csi-controller`, `alluxio-csi-nodeplugin`, `alluxio-csi-driver` before mount volume via CSI.
+You need to deploy `alluxio-csi-controller`, `alluxio-csi-nodeplugin`, `alluxio-csi-driver` before mounting volume via CSI.
 
-We provide two types of provisioning methods. For static provisioning, you need to create `PersistentVolume` and `PersistentVolumeClaim` first.
-For dynamic provisioning, you need to create `StorageClass` and  `PersistentVolumeClaim`.
+We provide two types of provisioning methods. For static provisioning, you need to deploy `alluxio-pv.yaml` and `alluxio-pvc-static.yaml` first.
+For dynamic provisioning, you need to deploy `alluxio-storage-class.yaml` and  `alluxio-pvc.yaml` first.
 
-All these examples will be generated after running `helm-generate.sh`.
+To deploy any service, run `kubectl apply -f /file/path`
 
 ### Configuration
 

--- a/integration/kubernetes/CSI_README.md
+++ b/integration/kubernetes/CSI_README.md
@@ -14,17 +14,17 @@ Kubernetes 1.14 or higher, RBAC enabled in API server(https://kubernetes.io/docs
 The official `alluxio/alluxio` docker image now supports CSI. By default Kubernetes will pull the latest published `alluxio/alluxio` image on Dockerhub.
 
 Alternatively you can build the docker image yourself following the instructions in `${ALLUXIO_HOME}/integration/docker/README.md`,
-section `Building docker image for production` or `Building docker image for development` depending on your needs. Make sure you refer to your
-built image in the deploying yaml files.
+section `Building docker image for production` or `Building docker image for development` depending on your needs. Make sure you refer to the
+built image in the CSI deploying yaml files.
 
 ### Deploy
 
-Please use `helm-generate.sh` to generate related templates. All CSI related templates will be under `integration/kubernetes/<deploy-mode>/csi` folder.
+Please use `helm-generate.sh` to generate related templates. All CSI related templates will be under `${ALLUXIO_HOME}/integration/kubernetes/<deploy-mode>/csi` folder.
 
 You need to deploy `alluxio-csi-controller`, `alluxio-csi-nodeplugin`, `alluxio-csi-driver` before mounting volume via CSI.
 
-We provide two types of provisioning methods. For static provisioning, you need to deploy `alluxio-pv.yaml` and `alluxio-pvc-static.yaml` first.
-For dynamic provisioning, you need to deploy `alluxio-storage-class.yaml` and  `alluxio-pvc.yaml` first.
+The generated templates provide two types of provisioning methods. For static provisioning, you need to deploy `alluxio-pv.yaml` (a persistent volume) and 
+`alluxio-pvc-static.yaml` (a persistent volume claim) first. For dynamic provisioning, you need to deploy `alluxio-storage-class.yaml` and  `alluxio-pvc.yaml` first.
 
 To deploy any service, run `kubectl apply -f /file/path`
 

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -190,10 +190,13 @@
 - Fix Alluxio CSI `nodeplugin.yaml` indentation
 
 0.6.25
-- Fix Alluxio CSI `nodeplugin.yaml` indentation, add support for dns plocy & change CSI log level
+- Fix Alluxio CSI `nodeplugin.yaml` indentation, add support for dns policy & change CSI log level
 
 0.6.26
 - Add livenessProbe and readinessProbe to values.yaml to allow for overriding
 
 0.6.27
 - Enable Fuse process embedded in worker process
+
+0.6.28
+- Fix Alluxio CSI docker image reference. Move CSI REAEME.md instructions here

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -199,4 +199,4 @@
 - Enable Fuse process embedded in worker process
 
 0.6.28
-- Fix Alluxio CSI docker image reference. Move CSI REAEME.md instructions here
+- Fix Alluxio CSI docker image reference. Add CSI README.md instructions.

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -537,7 +537,7 @@ logserver:
 # kubernetes CSI plugin
 csi:
   enabled: false
-  image: alluxio/alluxio-csi
+  image: alluxio/alluxio
   imageTag: 2.7.0-SNAPSHOT
   imagePullPolicy: IfNotPresent
   controllerPlugin:


### PR DESCRIPTION
CSI docker-related files are moved to the Docker dir and the original CSI dir only contains a README.md. Since CSI depends on Kubernetes, now move the readme into the Kubernetes dir. Update information and values accordingly.