### PR TITLE
Support free all blocks from specified worker

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
@@ -26,6 +26,10 @@ import alluxio.grpc.ReadRequest;
 import alluxio.grpc.ReadResponse;
 import alluxio.grpc.RemoveBlockRequest;
 import alluxio.grpc.RemoveBlockResponse;
+import alluxio.grpc.RemoveAllBlockRequest;
+import alluxio.grpc.RemoveAllBlockResponse;
+import alluxio.grpc.TryRemoveAllBlockRequest;
+import alluxio.grpc.TryRemoveAllBlockResponse;
 import alluxio.grpc.WriteRequest;
 import alluxio.grpc.WriteResponse;
 import alluxio.security.user.UserState;
@@ -125,6 +129,24 @@ public interface BlockWorkerClient extends Closeable {
    * @throws StatusRuntimeException if any error occurs
    */
   RemoveBlockResponse removeBlock(RemoveBlockRequest request);
+
+  /**
+   * Removes all blocks from worker.
+   * Will remove all blocks that can be found in worker, whether persistent or not
+   * @param request the Frees block request
+   * @return the response from server
+   * @throws StatusRuntimeException if any error occurs
+   */
+  RemoveAllBlockResponse removeAllBlock(RemoveAllBlockRequest request);
+
+  /**
+   * Try removes all blocks from worker.
+   * only free the block that block Evictable ( not pined or not locked or not marked in tier ).
+   * @param request the remove block request
+   * @return the response from server
+   * @throws StatusRuntimeException if any error occurs
+   */
+  TryRemoveAllBlockResponse tryRemoveAllBlock(TryRemoveAllBlockRequest request);
 
   /**
    * Move a block from worker.

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
@@ -36,6 +36,10 @@ import alluxio.grpc.ReadRequest;
 import alluxio.grpc.ReadResponse;
 import alluxio.grpc.RemoveBlockRequest;
 import alluxio.grpc.RemoveBlockResponse;
+import alluxio.grpc.RemoveAllBlockRequest;
+import alluxio.grpc.RemoveAllBlockResponse;
+import alluxio.grpc.TryRemoveAllBlockRequest;
+import alluxio.grpc.TryRemoveAllBlockResponse;
 import alluxio.grpc.WriteRequest;
 import alluxio.grpc.WriteResponse;
 import alluxio.retry.RetryPolicy;
@@ -198,6 +202,18 @@ public class DefaultBlockWorkerClient implements BlockWorkerClient {
   public RemoveBlockResponse removeBlock(final RemoveBlockRequest request) {
     return mRpcBlockingStub.withDeadlineAfter(mRpcTimeoutMs, TimeUnit.MILLISECONDS)
         .removeBlock(request);
+  }
+
+  @Override
+  public RemoveAllBlockResponse removeAllBlock(final RemoveAllBlockRequest request) {
+    return mRpcBlockingStub.withDeadlineAfter(mRpcTimeoutMs, TimeUnit.MILLISECONDS)
+            .removeAllBlock(request);
+  }
+
+  @Override
+  public TryRemoveAllBlockResponse tryRemoveAllBlock(final TryRemoveAllBlockRequest request) {
+    return mRpcBlockingStub.withDeadlineAfter(mRpcTimeoutMs, TimeUnit.MILLISECONDS)
+        .tryRemoveAllBlock(request);
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -286,6 +286,26 @@ public interface BlockWorker extends Worker, SessionCleanable {
       throws InvalidWorkerStateException, BlockDoesNotExistException, IOException;
 
   /**
+   * Frees all block from Alluxio managed space.
+   * Will remove all blocks that can be found in tiers, whether persistent or not
+   *
+   * @param sessionId the id of the client
+   * @throws InvalidWorkerStateException if blockId has not been committed
+   */
+  void removeAllBlock(long sessionId)
+      throws InvalidWorkerStateException, IOException;
+
+  /**
+   * Try to frees all block from Alluxio managed space.
+   * Will free up as much space as possible,
+   * only free the block that block Evictable ( not pined or not locked or not marked in tier ).
+   * The Evictable: {@link BlockMetadataEvictorView#isBlockEvictable(long)}.
+   *
+   * @param sessionId the id of the client
+   */
+  void tryRemoveAllBlock(long sessionId) throws IOException;
+
+  /**
    * Request an amount of space for a block in its storage directory. The block must be a temporary
    * block.
    *

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockStore.java
@@ -292,6 +292,14 @@ public interface BlockStore extends SessionCleanable, Closeable {
       IOException;
 
   /**
+   * a wrap of {@link TieredBlockStore#freeSpace(long, long, long, BlockStoreLocation)} method,
+   * will free up as much space as possible.
+   * @param sessionId the id of the session to move a block
+   * @throws IOException
+   */
+  void tryFreeAllSpace(long sessionId) throws IOException;
+
+  /**
    * Notifies the block store that a block was accessed so the block store could update accordingly
    * the registered listeners such as evictor and allocator on block access.
    *

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -71,6 +71,7 @@ import java.net.InetSocketAddress;
 import java.nio.channels.FileChannel;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -535,6 +536,26 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   public void removeBlock(long sessionId, long blockId)
       throws InvalidWorkerStateException, BlockDoesNotExistException, IOException {
     mLocalBlockStore.removeBlock(sessionId, blockId);
+  }
+
+  @Override
+  public void removeAllBlock(long sessionId)
+      throws InvalidWorkerStateException, IOException {
+    BlockStoreMeta mBlockStoreMeta = getStoreMetaFull();
+    for (List<Long> mBlockIds : mBlockStoreMeta.getBlockList().values()) {
+      for (long mBlockId: mBlockIds) {
+        try {
+          mLocalBlockStore.removeBlock(sessionId, mBlockId);
+        } catch (BlockDoesNotExistException e) {
+          LOG.info("No such block id: " + mBlockId);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void tryRemoveAllBlock(long sessionId) throws IOException {
+    mLocalBlockStore.tryFreeAllSpace(sessionId);
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -837,6 +837,19 @@ public class TieredBlockStore implements BlockStore {
     }
   }
 
+  @Override
+  public void tryFreeAllSpace(long sessionId) throws IOException {
+    BlockStoreLocation location = BlockStoreLocation.anyTier();
+    try {
+      LOG.debug("tryFreeAllSpace, sessionId={}, ", sessionId);
+      freeSpace(sessionId, 0, getBlockStoreMeta().getCapacityBytes(), location);
+    } catch (WorkerOutOfSpaceException e) {
+      // WorkerOutOfSpaceException is within the expected,
+      // because we are trying to free all space in all tiers
+      LOG.info("Not all space free");
+    }
+  }
+
   /**
    * Gets the most updated view with most recent information on pinned inodes, and currently locked
    * blocks.

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerClientServiceHandler.java
@@ -33,6 +33,10 @@ import alluxio.grpc.ReadRequest;
 import alluxio.grpc.ReadResponse;
 import alluxio.grpc.ReadResponseMarshaller;
 import alluxio.grpc.RemoveBlockRequest;
+import alluxio.grpc.RemoveAllBlockRequest;
+import alluxio.grpc.RemoveAllBlockResponse;
+import alluxio.grpc.TryRemoveAllBlockRequest;
+import alluxio.grpc.TryRemoveAllBlockResponse;
 import alluxio.grpc.RemoveBlockResponse;
 import alluxio.grpc.WriteRequestMarshaller;
 import alluxio.grpc.WriteResponse;
@@ -173,6 +177,26 @@ public class BlockWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorker
       mBlockWorker.removeBlock(sessionId, request.getBlockId());
       return RemoveBlockResponse.getDefaultInstance();
     }, "removeBlock", "request=%s", responseObserver, request);
+  }
+
+  @Override
+  public void removeAllBlock(RemoveAllBlockRequest request,
+                             StreamObserver<RemoveAllBlockResponse> responseObserver) {
+    long sessionId = IdUtils.createSessionId();
+    RpcUtils.call(LOG, () -> {
+      mBlockWorker.removeAllBlock(sessionId);
+      return RemoveAllBlockResponse.getDefaultInstance();
+    }, "removeAllBlock", "request=%s", responseObserver, request);
+  }
+
+  @Override
+  public void tryRemoveAllBlock(TryRemoveAllBlockRequest request,
+                                StreamObserver<TryRemoveAllBlockResponse> responseObserver) {
+    long sessionId = IdUtils.createSessionId();
+    RpcUtils.call(LOG, () -> {
+      mBlockWorker.tryRemoveAllBlock(sessionId);
+      return TryRemoveAllBlockResponse.getDefaultInstance();
+    }, "tryRemoveAllBlock", "request=%s", responseObserver, request);
   }
 
   @Override

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
@@ -330,6 +330,18 @@ public class DefaultBlockWorkerTest {
   }
 
   @Test
+  public void removeALLBlock() throws Exception {
+    long sessionId = mRandom.nextLong();
+    for (long blockId = 0L; blockId < 1024L; blockId++) {
+      mBlockWorker.createBlock(sessionId, blockId, 1, "", 1);
+      mBlockWorker.commitBlock(sessionId, blockId, true);
+    }
+    mBlockWorker.removeAllBlock(sessionId);
+    long num = mBlockWorker.getStoreMeta().getUsedBytes();
+    assertEquals(0, mBlockWorker.getStoreMetaFull().getNumberOfBlocks());
+  }
+
+  @Test
   public void requestSpace() throws Exception {
     long blockId = mRandom.nextLong();
     long sessionId = mRandom.nextLong();

--- a/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
@@ -153,6 +153,17 @@ public class NoopBlockWorker implements BlockWorker {
   }
 
   @Override
+  public void removeAllBlock(long sessionId)
+          throws InvalidWorkerStateException, IOException {
+    // noop
+  }
+
+  @Override
+  public void tryRemoveAllBlock(long sessionId) throws IOException {
+    // noop
+  }
+
+  @Override
   public void requestSpace(long sessionId, long blockId, long additionalBytes)
       throws BlockDoesNotExistException, WorkerOutOfSpaceException, IOException {
     // noop

--- a/core/transport/src/main/proto/grpc/block_worker.proto
+++ b/core/transport/src/main/proto/grpc/block_worker.proto
@@ -22,6 +22,8 @@ service BlockWorker {
   rpc AsyncCache (AsyncCacheRequest) returns (AsyncCacheResponse);
   rpc Cache (CacheRequest) returns (CacheResponse);
   rpc RemoveBlock (RemoveBlockRequest) returns (RemoveBlockResponse);
+  rpc RemoveAllBlock (RemoveAllBlockRequest) returns (RemoveAllBlockResponse);
+  rpc tryRemoveAllBlock (TryRemoveAllBlockRequest) returns (TryRemoveAllBlockResponse);
   rpc MoveBlock (MoveBlockRequest) returns (MoveBlockResponse);
 
   // TODO(lu) Move to metrics worker
@@ -171,6 +173,14 @@ message RemoveBlockRequest {
 }
 
 message RemoveBlockResponse {}
+
+message RemoveAllBlockRequest {}
+
+message RemoveAllBlockResponse {}
+
+message TryRemoveAllBlockRequest {}
+
+message TryRemoveAllBlockResponse {}
 
 message MoveBlockRequest {
   optional int64 block_id = 1;

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,1 +1,0 @@
-This directory contains Alluxio logs

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/FreeWorkerTierCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/FreeWorkerTierCommand.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.cli.fsadmin.command;
 
 import alluxio.annotation.PublicApi;

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/FreeWorkerTierCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/FreeWorkerTierCommand.java
@@ -1,0 +1,204 @@
+package alluxio.cli.fsadmin.command;
+
+import alluxio.annotation.PublicApi;
+import alluxio.client.block.stream.BlockWorkerClient;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.client.block.BlockWorkerInfo;
+import alluxio.client.file.FileSystemContext;
+import alluxio.grpc.RemoveAllBlockRequest;
+import alluxio.grpc.TryRemoveAllBlockRequest;
+import alluxio.resource.CloseableResource;
+import alluxio.wire.WorkerNetAddress;
+import alluxio.exception.AlluxioException;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.SynchronousQueue;
+import java.util.stream.Collectors;
+
+/**
+ * Command for free all worker managed cache space.
+ */
+@PublicApi
+public class FreeWorkerTierCommand extends AbstractFsAdminCommand {
+  /**
+   * @param context     fsadmin command context
+   * @param alluxioConf Alluxio configuration
+   */
+  public FreeWorkerTierCommand(Context context, AlluxioConfiguration alluxioConf) {
+    super(context);
+    mAlluxioConf = alluxioConf;
+  }
+
+  private static final Option HELP_OPTION =
+      Option.builder("h")
+          .longOpt("help")
+          .required(false)
+          .hasArg(false)
+          .desc("help")
+          .build();
+
+  private static final Option WORKERS_OPTION =
+      Option.builder("w")
+          .longOpt("workers")
+          .required(false)
+          .hasArg(true)
+          .desc("If given, free blocks from specified workers. "
+              + "Pass in the worker hostnames separated by comma")
+          .build();
+
+  private static final Option FORCE_OPTION =
+      Option.builder("f")
+          .longOpt("force")
+          .required(false)
+          .hasArg(false)
+          .desc("If given, "
+              + "will remove all blocks that can be found in worker, whether persistent or not")
+          .build();
+
+  @Override
+  public String getDescription() {
+    return String.format("free(evict) all blocks from all worker \nusage: %s\n"
+            + "Options:\n"
+            + " -%s, --%s\t%s\n"
+            + " -%s, --%s\t%s",
+        getUsage(),
+        FORCE_OPTION.getOpt(), FORCE_OPTION.getLongOpt(), FORCE_OPTION.getDescription(),
+        WORKERS_OPTION.getOpt(), WORKERS_OPTION.getLongOpt(), WORKERS_OPTION.getDescription());
+  }
+
+  @Override
+  public String getUsage() {
+    return getCommandName() + " [--force] [--workers <worker_hostname>]";
+  }
+
+  @Override
+  public Options getOptions() {
+    return new Options()
+        .addOption(WORKERS_OPTION)
+        .addOption(FORCE_OPTION)
+        .addOption(HELP_OPTION);
+  }
+
+  private final AlluxioConfiguration mAlluxioConf;
+
+  @Override
+  public String getCommandName() {
+    return "freeWorkerTier";
+  }
+
+  /**
+   * Thread that free the block from a specific worker.
+   */
+  private class RemoveWorkerCallable implements Callable<Void> {
+    private final WorkerNetAddress mWorker;
+    private final FileSystemContext mContext;
+    private final boolean mForce;
+
+    RemoveWorkerCallable(WorkerNetAddress worker, FileSystemContext context, boolean force) {
+      mWorker = worker;
+      mContext = context;
+      mForce = force;
+    }
+
+    @Override
+    public Void call() throws Exception {
+      try (CloseableResource<BlockWorkerClient> blockWorkerClient =
+               mContext.acquireBlockWorkerClient(mWorker)) {
+        if (mForce) {
+          blockWorkerClient.get().removeAllBlock(RemoveAllBlockRequest.newBuilder().build());
+        } else {
+          blockWorkerClient.get().tryRemoveAllBlock(TryRemoveAllBlockRequest.newBuilder().build());
+        }
+      }
+      System.out.printf("Successfully Free blocks of worker %s.%n", mWorker.getHost());
+      return null;
+    }
+  }
+
+  /**
+   * Free all block of a list of workers.
+   *
+   * @param workers the workers to clear blocks of
+   * @param context FileSystemContext
+   * @param force   Whether to force all free block form worker,
+   *                if true all blocks will be freed even if it is not persistent
+   */
+  private void freeWorkers(List<WorkerNetAddress> workers,
+                           FileSystemContext context, boolean force) throws IOException {
+    if (workers.isEmpty()) {
+      return;
+    }
+    List<Future<Void>> futures = new ArrayList<>();
+    ExecutorService service = new ThreadPoolExecutor(0, 32,
+        0L, TimeUnit.MILLISECONDS, new SynchronousQueue<>());
+    for (WorkerNetAddress worker : workers) {
+      futures.add(service.submit(new RemoveWorkerCallable(worker, context, force)));
+    }
+    try {
+      for (Future<Void> future : futures) {
+        future.get();
+      }
+    } catch (ExecutionException e) {
+      System.out.println("Fatal error: " + e);
+    } catch (InterruptedException e) {
+      System.out.println("interrupted, exiting.");
+    } finally {
+      service.shutdownNow();
+    }
+  }
+
+  @Override
+  public int run(CommandLine cl) throws AlluxioException, IOException {
+    if (cl.hasOption(HELP_OPTION.getOpt())) {
+      System.out.println(getDescription());
+      return 0;
+    }
+
+    try (FileSystemContext context = FileSystemContext.create(mAlluxioConf)) {
+      List<WorkerNetAddress> workersToClear = new ArrayList<>();
+      List<WorkerNetAddress> allWorkersList = context.getCachedWorkers().stream()
+          .map(BlockWorkerInfo::getNetAddress).collect(Collectors.toList());
+
+      if (cl.hasOption(WORKERS_OPTION.getOpt())) {
+        // get valid worker address and invalid worker address from command line
+        String workersValue = cl.getOptionValue(WORKERS_OPTION.getOpt());
+        Set<String> workersRequired = new HashSet<>(Arrays.asList(workersValue.split(",")));
+        for (WorkerNetAddress worker : allWorkersList) {
+          if (workersRequired.contains(worker.getHost())) {
+            workersToClear.add(worker);
+            workersRequired.remove(worker.getHost());
+          }
+        }
+        if (!workersRequired.isEmpty()) {
+          System.out.println("Wrong worker hostname ");
+          System.out.println(" Invalid worker: " + String.join(", ", workersRequired));
+          System.out.println(" Valid worker: " + workersToClear.stream().map(
+              WorkerNetAddress::getHost).collect(Collectors.joining(", ")));
+          System.out.println("Nothing to do");
+          return -1;
+        }
+      } else {
+        workersToClear = allWorkersList;
+      }
+
+      freeWorkers(workersToClear, context, cl.hasOption(FORCE_OPTION.getOpt()));
+
+      return 0;
+    }
+  }
+}

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/FreeWorkerTierCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/FreeWorkerTierCommand.java
@@ -83,9 +83,9 @@ public class FreeWorkerTierCommand extends AbstractFsAdminCommand {
 
   @Override
   public String getDescription() {
-    return String.format("free(evict) all blocks from all worker \nusage: %s\n"
-            + "Options:\n"
-            + " -%s, --%s\t%s\n"
+    return String.format("free(evict) all blocks from all worker %nusage: %s%n"
+            + "Options:%n"
+            + " -%s, --%s\t%s%n"
             + " -%s, --%s\t%s",
         getUsage(),
         FORCE_OPTION.getOpt(), FORCE_OPTION.getLongOpt(), FORCE_OPTION.getDescription(),

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/FreeWorkerTierCommandIntergrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/FreeWorkerTierCommandIntergrationTest.java
@@ -1,0 +1,92 @@
+package alluxio.client.cli.fsadmin.command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import alluxio.AlluxioURI;
+import alluxio.client.cli.fsadmin.AbstractFsAdminShellTest;
+import alluxio.grpc.CreateFilePOptions;
+import alluxio.client.file.FileSystemTestUtils;
+import alluxio.exception.AlluxioException;
+import alluxio.grpc.WritePType;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class FreeWorkerTierCommandIntergrationTest extends AbstractFsAdminShellTest {
+  final String mCOMMAND = "freeWorkerTier";
+  final String mFILE1 = "/foobar1";
+
+  public void reset() throws Exception {
+    if (!mLocalAlluxioCluster.isStartedWorkers()){
+      mLocalAlluxioCluster.startWorkers();
+    }
+    if (mLocalAlluxioCluster.getClient().exists(new AlluxioURI(mFILE1))) {
+      mLocalAlluxioCluster.getClient().delete(new AlluxioURI(mFILE1));
+    }
+  }
+
+  @Test
+  public void normal() {
+    int ret;
+    ret = mFsAdminShell.run(mCOMMAND);
+    assertEquals(0, ret);
+    ret = mFsAdminShell.run(mCOMMAND, "force");
+    assertEquals(0, ret);
+    ret = mFsAdminShell.run(mCOMMAND, "f");
+    assertEquals(0, ret);
+  }
+
+  @Test
+  public void wrongParameter() {
+    int ret;
+    ret = mFsAdminShell.run(mCOMMAND, "workers", "-1");
+    assertEquals(-1, ret);
+  }
+
+  @Test
+  public void freeToBePersistedBlock() throws Exception {
+    reset();
+    // The block that persisted block will not be removed from worker tier
+    FileSystemTestUtils.createByteFile(mLocalAlluxioCluster.getClient(), new AlluxioURI(mFILE1),
+        CreateFilePOptions.newBuilder().setRecursive(true)
+            .setWriteType(WritePType.ASYNC_THROUGH).setPersistenceWaitTime(
+            Integer.MAX_VALUE).build(), 10);
+    assertEquals(0, mFsAdminShell.run(mCOMMAND));
+    assertTrue(isInMemoryTest(mFILE1));
+  }
+
+  @Test
+  public void freePersistedBlock() throws Exception {
+    reset();
+    // The block that persisted block will be removed from worker tier
+    if (mLocalAlluxioCluster.isStartedWorkers()){
+      FileSystemTestUtils.createByteFile(mLocalAlluxioCluster.getClient(),
+          mFILE1, WritePType.CACHE_THROUGH, 10);
+      assertEquals(0, mFsAdminShell.run(mCOMMAND));
+      assertFalse(isInMemoryTest(mFILE1));
+    }
+  }
+
+  @Test
+  public void freeWithFormattedMaster() throws Exception {
+    // The block that persisted block will be removed from worker tier without master metadata
+    reset();
+    FileSystemTestUtils.createByteFile(mLocalAlluxioCluster.getClient(),
+        mFILE1, WritePType.CACHE_THROUGH, 10);
+    mLocalAlluxioCluster.formatAndRestartMasters();
+    assertEquals(0, mFsAdminShell.run(mCOMMAND));
+    assertFalse(isInMemoryTest(mFILE1));
+  }
+
+  /**
+   * @param path a file path
+   * @return whether the file is in memory
+   */
+  protected boolean isInMemoryTest(String path) throws IOException, AlluxioException {
+    return (mLocalAlluxioCluster.getClient().getStatus(
+        new AlluxioURI(path)).getInMemoryPercentage() == 100);
+  }
+}

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/FreeWorkerTierCommandIntergrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/FreeWorkerTierCommandIntergrationTest.java
@@ -31,7 +31,7 @@ public class FreeWorkerTierCommandIntergrationTest extends AbstractFsAdminShellT
   final String mFILE1 = "/foobar1";
 
   public void reset() throws Exception {
-    if (!mLocalAlluxioCluster.isStartedWorkers()){
+    if (!mLocalAlluxioCluster.isStartedWorkers()) {
       mLocalAlluxioCluster.startWorkers();
     }
     if (mLocalAlluxioCluster.getClient().exists(new AlluxioURI(mFILE1))) {
@@ -73,7 +73,7 @@ public class FreeWorkerTierCommandIntergrationTest extends AbstractFsAdminShellT
   public void freePersistedBlock() throws Exception {
     reset();
     // The block that persisted block will be removed from worker tier
-    if (mLocalAlluxioCluster.isStartedWorkers()){
+    if (mLocalAlluxioCluster.isStartedWorkers()) {
       FileSystemTestUtils.createByteFile(mLocalAlluxioCluster.getClient(),
           mFILE1, WritePType.CACHE_THROUGH, 10);
       assertEquals(0, mFsAdminShell.run(mCOMMAND));

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/FreeWorkerTierCommandIntergrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/FreeWorkerTierCommandIntergrationTest.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.client.cli.fsadmin.command;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
### What changes are proposed in this pull request?
Add fsadmin command "freeWorkerTier"
```
$ .bin/alluxio fsadmin freeWorkerTier --help
free(evict) all blocks from all worker 
usage: freeWorkerTier [--force] [--workers <worker_hostname>]
Options:
 -f, --force    If given, will remove all blocks that can be found in worker, whether persistent or not
 -w, --workers  If given, free blocks from specified workers. Pass in the worker hostnames separated by comma
```
### Why are the changes needed?
This command is similar alluxio fs free, but It can free all blocks of a specified worker node rather than a directory. It doesn‘t depend on the metadata of the master node. So you can use it when all master nodes are destroyed.
The worker cache in the tier will be invalid when all master nodes are destroyed, because all block metadata was lost. In this case, you should use this command to free all workers block to reset cluster.
This command will free the MUST_CACHE block, which is another difference with "alluxio fs free". Same with "alluxio fs free" Any pinned/un persisted files cannot be freed unless -f option is specified.

### Does this PR introduce any user facing changes?
no
