### PR TITLE
Enable additional keep-alive configuration on gRPC servers

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2013,6 +2013,40 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("The maximum size of a message that can be sent to the Alluxio master")
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_NETWORK_FLOWCONTROL_WINDOW =
+        new Builder(Name.MASTER_NETWORK_FLOWCONTROL_WINDOW)
+          .setDefaultValue("2MB")
+          .setDescription("The HTTP2 flow control window used by worker gRPC connections. Larger "
+              + "value will allow more data to be buffered but will use more memory.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_NETWORK_KEEPALIVE_TIME_MS =
+      new Builder(Name.MASTER_NETWORK_KEEPALIVE_TIME_MS)
+          .setDefaultValue("2h")
+          .setDescription("The amount of time for data server (for block reads and block writes) "
+              + "to wait for a response before pinging the client to see if it is still alive.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_NETWORK_KEEPALIVE_TIMEOUT_MS =
+      new Builder(Name.MASTER_NETWORK_KEEPALIVE_TIMEOUT_MS)
+          .setDefaultValue("30sec")
+          .setDescription("The maximum time for a data server (for block reads and block writes) "
+              + "to wait for a keepalive response before closing the connection.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_NETWORK_PERMIT_KEEPALIVE_TIME_MS =
+      new Builder(Name.MASTER_NETWORK_PERMIT_KEEPALIVE_TIME_MS)
+          .setDefaultValue("30sec")
+          .setDescription(
+              "Specify the most aggressive keep-alive time clients are permitted to configure. "
+                  + "The server will try to detect clients exceeding this rate and when detected "
+                  + "will forcefully close the connection.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL =
       new Builder(Name.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL)
           .setDefaultValue("5min")
@@ -3133,6 +3167,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue("30sec")
           .setDescription("The maximum time for a data server (for block reads and block writes) "
               + "to wait for a keepalive response before closing the connection.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.WORKER)
+          .build();
+  public static final PropertyKey WORKER_NETWORK_PERMIT_KEEPALIVE_TIME_MS =
+      new Builder(
+          Name.WORKER_NETWORK_PERMIT_KEEPALIVE_TIME_MS)
+          .setDefaultValue("5m")
+          .setDescription(
+              "Specify the most aggressive keep-alive time clients are permitted to configure. "
+                  + "The server will try to detect clients exceeding this rate and when detected "
+                  + "will forcefully close the connection.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
@@ -5796,6 +5841,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metrics.file.size.distribution.buckets";
     public static final String MASTER_NETWORK_MAX_INBOUND_MESSAGE_SIZE =
         "alluxio.master.network.max.inbound.message.size";
+    public static final String MASTER_NETWORK_FLOWCONTROL_WINDOW =
+        "alluxio.master.network.flowcontrol.window";
+    public static final String MASTER_NETWORK_KEEPALIVE_TIME_MS =
+        "alluxio.master.network.keepalive.time";
+    public static final String MASTER_NETWORK_KEEPALIVE_TIMEOUT_MS =
+        "alluxio.master.network.keepalive.timeout";
+    public static final String MASTER_NETWORK_PERMIT_KEEPALIVE_TIME_MS =
+        "alluxio.master.network.permit.keepalive.time";
     public static final String MASTER_PERSISTENCE_INITIAL_INTERVAL_MS =
         "alluxio.master.persistence.initial.interval";
     public static final String MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS =
@@ -5990,6 +6043,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.network.keepalive.time";
     public static final String WORKER_NETWORK_KEEPALIVE_TIMEOUT_MS =
         "alluxio.worker.network.keepalive.timeout";
+    public static final String WORKER_NETWORK_PERMIT_KEEPALIVE_TIME_MS =
+            "alluxio.worker.network.permit,.keepalive.time";
     public static final String WORKER_NETWORK_MAX_INBOUND_MESSAGE_SIZE =
         "alluxio.worker.network.max.inbound.message.size";
     public static final String WORKER_NETWORK_NETTY_BOSS_THREADS =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2016,15 +2016,16 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey MASTER_NETWORK_FLOWCONTROL_WINDOW =
         new Builder(Name.MASTER_NETWORK_FLOWCONTROL_WINDOW)
           .setDefaultValue("2MB")
-          .setDescription("The HTTP2 flow control window used by worker gRPC connections. Larger "
-              + "value will allow more data to be buffered but will use more memory.")
+          .setDescription(
+              "The HTTP2 flow control window used by Alluxio master gRPC connections. Larger "
+                  + "value will allow more data to be buffered but will use more memory.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_NETWORK_KEEPALIVE_TIME_MS =
       new Builder(Name.MASTER_NETWORK_KEEPALIVE_TIME_MS)
           .setDefaultValue("2h")
-          .setDescription("The amount of time for data server (for block reads and block writes) "
+          .setDescription("The amount of time for Alluxio master gRPC server "
               + "to wait for a response before pinging the client to see if it is still alive.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
@@ -2032,7 +2033,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey MASTER_NETWORK_KEEPALIVE_TIMEOUT_MS =
       new Builder(Name.MASTER_NETWORK_KEEPALIVE_TIMEOUT_MS)
           .setDefaultValue("30sec")
-          .setDescription("The maximum time for a data server (for block reads and block writes) "
+          .setDescription("The maximum time for Alluxio master gRPC server "
               + "to wait for a keepalive response before closing the connection.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
@@ -6044,7 +6045,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String WORKER_NETWORK_KEEPALIVE_TIMEOUT_MS =
         "alluxio.worker.network.keepalive.timeout";
     public static final String WORKER_NETWORK_PERMIT_KEEPALIVE_TIME_MS =
-            "alluxio.worker.network.permit,.keepalive.time";
+            "alluxio.worker.network.permit.keepalive.time";
     public static final String WORKER_NETWORK_MAX_INBOUND_MESSAGE_SIZE =
         "alluxio.worker.network.max.inbound.message.size";
     public static final String WORKER_NETWORK_NETTY_BOSS_THREADS =

--- a/core/common/src/main/java/alluxio/grpc/GrpcServerBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcServerBuilder.java
@@ -129,7 +129,7 @@ public final class GrpcServerBuilder {
   }
 
   /**
-   * Sets the keep alive time.
+   * Sets the server keep-alive time.
    *
    * @param keepAliveTime the time to wait after idle before pinging client
    * @param timeUnit unit of the time
@@ -141,7 +141,7 @@ public final class GrpcServerBuilder {
   }
 
   /**
-   * Sets the keep alive timeout.
+   * Sets the server keep-alive timeout.
    *
    * @param keepAliveTimeout time to wait after pinging client before closing the connection
    * @param timeUnit unit of the timeout
@@ -149,6 +149,19 @@ public final class GrpcServerBuilder {
    */
   public GrpcServerBuilder keepAliveTimeout(long keepAliveTimeout, TimeUnit timeUnit) {
     mNettyServerBuilder = mNettyServerBuilder.keepAliveTimeout(keepAliveTimeout, timeUnit);
+    return this;
+  }
+
+  /**
+   * Sets the high-bar for client-side keep-alive frequency.
+   * Clients pushing this bar will be held back by closing their connections.
+   *
+   * @param permitKeepAlive permitted client-side keep-alive time
+   * @param timeUnit unit of the timeout
+   * @return an updated instance of this {@link GrpcServerBuilder}
+   */
+  public GrpcServerBuilder permitKeepAlive(long permitKeepAlive, TimeUnit timeUnit) {
+    mNettyServerBuilder = mNettyServerBuilder.permitKeepAliveTime(permitKeepAlive, timeUnit);
     return this;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -18,6 +18,7 @@ import alluxio.RuntimeConstants;
 import alluxio.concurrent.jsr.ForkJoinPool;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
+import alluxio.grpc.GrpcServer;
 import alluxio.grpc.GrpcServerAddress;
 import alluxio.grpc.GrpcServerBuilder;
 import alluxio.grpc.GrpcService;
@@ -299,44 +300,62 @@ public class AlluxioMasterProcess extends MasterProcess {
    * {@link Master}s and meta services.
    */
   protected void startServingRPCServer() {
+    stopRejectingRpcServer();
+
+    LOG.info("Starting gRPC server on address:{}", mRpcBindAddress);
+    mGrpcServer = createRPCServer();
+
+    LOG.info("gRPC serving...");
     try {
-      stopRejectingRpcServer();
-      LOG.info("Starting Alluxio master gRPC server on address {}", mRpcBindAddress);
-      GrpcServerBuilder serverBuilder = GrpcServerBuilder.forAddress(
-          GrpcServerAddress.create(mRpcConnectAddress.getHostName(), mRpcBindAddress),
-          ServerConfiguration.global(), ServerUserState.global());
-      mRPCExecutor = new ForkJoinPool(
-          ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM),
-          ThreadFactoryUtils.buildFjp("master-rpc-pool-thread-%d", true),
-          null,
-          true,
-          ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_CORE_POOL_SIZE),
-          ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_MAX_POOL_SIZE),
-          ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_MIN_RUNNABLE),
-          null,
-          ServerConfiguration.getMs(PropertyKey.MASTER_RPC_EXECUTOR_KEEPALIVE),
-          TimeUnit.MILLISECONDS);
-
-      serverBuilder.executor(mRPCExecutor);
-      MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_RPC_QUEUE_LENGTH.getName(),
-              mRPCExecutor::getQueuedSubmissionCount);
-
-      for (Master master : mRegistry.getServers()) {
-        registerServices(serverBuilder, master.getServices());
-      }
-
-      // Add journal master client service.
-      serverBuilder.addService(alluxio.grpc.ServiceType.JOURNAL_MASTER_CLIENT_SERVICE,
-          new GrpcService(new JournalMasterClientServiceHandler(
-              new DefaultJournalMaster(JournalDomain.MASTER, mJournalSystem))));
-      serverBuilder.maxInboundMessageSize(
-          (int) ServerConfiguration.getBytes(PropertyKey.MASTER_NETWORK_MAX_INBOUND_MESSAGE_SIZE));
-      mGrpcServer = serverBuilder.build().start();
+      mGrpcServer.start();
       mSafeModeManager.notifyRpcServerStarted();
-      LOG.info("Started Alluxio master gRPC server on address {}", mRpcConnectAddress);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      LOG.error("gRPC serving failed.", e);
+      throw new RuntimeException("gRPC serving failed");
     }
+  }
+
+  private GrpcServer createRPCServer() {
+    // Create an executor for Master RPC server.
+    mRPCExecutor =
+        new ForkJoinPool(ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_PARALLELISM),
+            ThreadFactoryUtils.buildFjp("master-rpc-pool-thread-%d", true), null, true,
+            ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_CORE_POOL_SIZE),
+            ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_MAX_POOL_SIZE),
+            ServerConfiguration.getInt(PropertyKey.MASTER_RPC_EXECUTOR_MIN_RUNNABLE), null,
+            ServerConfiguration.getMs(PropertyKey.MASTER_RPC_EXECUTOR_KEEPALIVE),
+            TimeUnit.MILLISECONDS);
+    MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_RPC_QUEUE_LENGTH.getName(),
+            mRPCExecutor::getQueuedSubmissionCount);
+    // Create underlying gRPC server.
+    GrpcServerBuilder builder = GrpcServerBuilder
+        .forAddress(GrpcServerAddress.create(mRpcConnectAddress.getHostName(), mRpcBindAddress),
+            ServerConfiguration.global(), ServerUserState.global())
+        .executor(mRPCExecutor)
+        .flowControlWindow(
+            (int) ServerConfiguration.getBytes(PropertyKey.MASTER_NETWORK_FLOWCONTROL_WINDOW))
+        .keepAliveTime(
+            ServerConfiguration.getMs(PropertyKey.MASTER_NETWORK_KEEPALIVE_TIME_MS),
+            TimeUnit.MILLISECONDS)
+        .keepAliveTimeout(
+            ServerConfiguration.getMs(PropertyKey.MASTER_NETWORK_KEEPALIVE_TIMEOUT_MS),
+            TimeUnit.MILLISECONDS)
+        .permitKeepAlive(
+            ServerConfiguration.getMs(PropertyKey.MASTER_NETWORK_PERMIT_KEEPALIVE_TIME_MS),
+            TimeUnit.MILLISECONDS)
+        .maxInboundMessageSize((int) ServerConfiguration.getBytes(
+            PropertyKey.MASTER_NETWORK_MAX_INBOUND_MESSAGE_SIZE));
+    // Bind manifests of each Alluxio master to RPC server.
+    for (Master master : mRegistry.getServers()) {
+      registerServices(builder, master.getServices());
+    }
+    // Bind manifest of Alluxio JournalMaster service.
+    // TODO(ggezer) Merge this with registerServices() logic.
+    builder.addService(alluxio.grpc.ServiceType.JOURNAL_MASTER_CLIENT_SERVICE,
+        new GrpcService(new JournalMasterClientServiceHandler(
+            new DefaultJournalMaster(JournalDomain.MASTER, mJournalSystem))));
+    // Builds a server that is not started yet.
+    return builder.build();
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -305,10 +305,14 @@ public class AlluxioMasterProcess extends MasterProcess {
     LOG.info("Starting gRPC server on address:{}", mRpcBindAddress);
     mGrpcServer = createRPCServer();
 
-    LOG.info("gRPC serving...");
     try {
+      // Start serving.
       mGrpcServer.start();
       mSafeModeManager.notifyRpcServerStarted();
+      // Acquire and log bind port from newly started server.
+      InetSocketAddress listeningAddress = InetSocketAddress
+          .createUnresolved(mRpcBindAddress.getHostName(), mGrpcServer.getBindPort());
+      LOG.info("gRPC server listening on: {}", listeningAddress);
     } catch (IOException e) {
       LOG.error("gRPC serving failed.", e);
       throw new RuntimeException("gRPC serving failed");

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
@@ -58,6 +58,8 @@ public final class GrpcDataServer implements DataServer {
       ServerConfiguration.getMs(PropertyKey.WORKER_NETWORK_KEEPALIVE_TIME_MS);
   private final long mKeepAliveTimeoutMs =
       ServerConfiguration.getMs(PropertyKey.WORKER_NETWORK_KEEPALIVE_TIMEOUT_MS);
+  private final long mPermitKeepAliveTimeMs =
+      ServerConfiguration.getMs(PropertyKey.WORKER_NETWORK_PERMIT_KEEPALIVE_TIME_MS);
   private final long mFlowControlWindow =
       ServerConfiguration.getBytes(PropertyKey.WORKER_NETWORK_FLOWCONTROL_WINDOW);
   private final long mMaxInboundMessageSize =
@@ -103,6 +105,7 @@ public final class GrpcDataServer implements DataServer {
           .flowControlWindow((int) mFlowControlWindow)
           .keepAliveTime(mKeepAliveTimeMs, TimeUnit.MILLISECONDS)
           .keepAliveTimeout(mKeepAliveTimeoutMs, TimeUnit.MILLISECONDS)
+          .permitKeepAlive(mPermitKeepAliveTimeMs, TimeUnit.MILLISECONDS)
           .maxInboundMessageSize((int) mMaxInboundMessageSize)
           .build()
           .start();


### PR DESCRIPTION
### What changes are proposed in this pull request?
This setting controls tolerance of gRPC servers against clients' keep-alive frequency.

### Why are the changes needed?
Earlier change to enable client-side keep-alive to 30secs required a server-side change to tolerate such frequency beyond what's default (5mins) 
