### PR TITLE
Avoid printing too many blocks on logging

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -32,6 +32,7 @@ import alluxio.metrics.MetricInfo;
 import alluxio.metrics.MetricsSystem;
 import alluxio.retry.RetryPolicy;
 import alluxio.retry.RetryUtils;
+import alluxio.util.CommonUtils;
 import alluxio.util.SecurityUtils;
 
 import com.codahale.metrics.Timer;
@@ -376,8 +377,8 @@ public abstract class AbstractClient implements Client {
       long duration = System.currentTimeMillis() - startMs;
       logger.debug("Exit (OK): {}({}) in {} ms", rpcName, debugDesc, duration);
       if (duration >= mRpcThreshold) {
-        logger.warn("{}({}) returned {} in {} ms (>={} ms)",
-            rpcName, String.format(description, args), ret, duration, mRpcThreshold);
+        logger.warn("{}({}) returned in {} ms (>={} ms)",
+            rpcName, String.format(description, args), duration, mRpcThreshold);
       }
       return ret;
     } catch (Exception e) {

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -377,8 +377,9 @@ public abstract class AbstractClient implements Client {
       long duration = System.currentTimeMillis() - startMs;
       logger.debug("Exit (OK): {}({}) in {} ms", rpcName, debugDesc, duration);
       if (duration >= mRpcThreshold) {
-        logger.warn("{}({}) returned in {} ms (>={} ms)",
-            rpcName, String.format(description, args), duration, mRpcThreshold);
+        logger.warn("{}({}) returned {} in {} ms (>={} ms)",
+            rpcName, String.format(description, args),
+            CommonUtils.summarizeCollection(ret), duration, mRpcThreshold);
       }
       return ret;
     } catch (Exception e) {

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -46,6 +46,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -64,6 +65,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -881,6 +883,29 @@ public final class CommonUtils {
       }
     }
     return Integer.parseInt(version);
+  }
+
+  /**
+   * @param obj a Java object
+   * @return if this object is an collection
+   */
+  public static boolean isCollection(Object obj) {
+    return obj instanceof Collection || obj instanceof Map;
+  }
+
+  /**
+   * @param obj a Java object
+   * @param limit number of entries
+   * @return a truncated string if this object is a collection larger than limit
+   */
+  public static String summarizeCollection(Object obj, int limit) {
+    if (obj instanceof Collection && ((Collection<?>) obj).size() > limit) {
+      return String.format(
+          "%s{%d entries}", obj.getClass().getSimpleName(), ((Collection<?>) obj).size());
+    } else if (obj instanceof Map && ((Map<?, ?>) obj).size() > limit) {
+      return String.format("Map{%d entries}", ((Map<?, ?>) obj).size());
+    }
+    return obj.toString();
   }
 
   private CommonUtils() {} // prevent instantiation

--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -54,6 +54,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Random;
 import java.util.StringTokenizer;
 import java.util.concurrent.Callable;
@@ -65,7 +66,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -895,17 +895,16 @@ public final class CommonUtils {
 
   /**
    * @param obj a Java object
-   * @param limit number of entries
-   * @return a truncated string if this object is a collection larger than limit
+   * @return a string to summarize the object if this is a collection or a map
    */
-  public static String summarizeCollection(Object obj, int limit) {
-    if (obj instanceof Collection && ((Collection<?>) obj).size() > limit) {
+  public static String summarizeCollection(Object obj) {
+    if (obj instanceof Collection) {
       return String.format(
           "%s{%d entries}", obj.getClass().getSimpleName(), ((Collection<?>) obj).size());
-    } else if (obj instanceof Map && ((Map<?, ?>) obj).size() > limit) {
+    } else if (obj instanceof Map) {
       return String.format("Map{%d entries}", ((Map<?, ?>) obj).size());
     }
-    return obj.toString();
+    return Objects.toString(obj);
   }
 
   private CommonUtils() {} // prevent instantiation

--- a/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
@@ -12,6 +12,7 @@
 package alluxio.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
@@ -24,7 +25,10 @@ import alluxio.conf.InstancedConfiguration;
 import alluxio.security.group.CachedGroupMapping;
 import alluxio.security.group.GroupMappingService;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -41,6 +45,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -210,6 +215,26 @@ public class CommonUtilsTest {
           testCase.mCtorArgs);
       assertEquals(o.toString(), testCase.mExpected);
     }
+  }
+
+  @Test
+  public void isCollection() {
+    assertTrue(CommonUtils.isCollection(Sets.newHashSet()));
+    assertTrue(CommonUtils.isCollection(Maps.newHashMap()));
+    assertTrue(CommonUtils.isCollection(Lists.newArrayList()));
+    assertFalse(CommonUtils.isCollection(null));
+    assertFalse(CommonUtils.isCollection(1));
+  }
+
+  @Test
+  public void summarizeCollection() {
+    Set<Integer> set = Sets.newHashSet(1, 2);
+    assertEquals(set.toString(), CommonUtils.summarizeCollection(set, 2));
+    assertEquals("HashSet{2 entries}", CommonUtils.summarizeCollection(set, 1));
+
+    Map<Integer, Long> map = ImmutableMap.of(0, 3L, 1, 1L);
+    assertEquals(map.toString(), CommonUtils.summarizeCollection(map, 2));
+    assertEquals("Map{2 entries}", CommonUtils.summarizeCollection(map, 1));
   }
 
   static class TestClassA {

--- a/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
@@ -229,12 +229,14 @@ public class CommonUtilsTest {
   @Test
   public void summarizeCollection() {
     Set<Integer> set = Sets.newHashSet(1, 2);
-    assertEquals(set.toString(), CommonUtils.summarizeCollection(set, 2));
-    assertEquals("HashSet{2 entries}", CommonUtils.summarizeCollection(set, 1));
+    assertEquals("HashSet{2 entries}", CommonUtils.summarizeCollection(set));
 
     Map<Integer, Long> map = ImmutableMap.of(0, 3L, 1, 1L);
-    assertEquals(map.toString(), CommonUtils.summarizeCollection(map, 2));
-    assertEquals("Map{2 entries}", CommonUtils.summarizeCollection(map, 1));
+    assertEquals("Map{2 entries}", CommonUtils.summarizeCollection(map));
+
+    TestClassA a = new TestClassA();
+    assertEquals(a.toString(), CommonUtils.summarizeCollection(a));
+    assertEquals("null", CommonUtils.summarizeCollection(null));
   }
 
   static class TestClassA {

--- a/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
+++ b/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -38,7 +37,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -501,13 +499,6 @@ public final class MasterWorkerInfo {
   @Override
   // TODO(jiacheng): Read lock on the conversion
   public String toString() {
-    Collection<Long> blocks = mBlocks;
-    String blockFieldName = "blocks";
-    // We truncate the list of block IDs to print, unless it is for DEBUG logs
-    if (!LOG.isDebugEnabled() && mBlocks.size() > BLOCK_SIZE_LIMIT) {
-      blockFieldName = "blocks-truncated";
-      blocks = mBlocks.stream().limit(BLOCK_SIZE_LIMIT).collect(Collectors.toList());
-    }
     return MoreObjects.toStringHelper(this)
         .add("id", mMeta.mId)
         .add("workerAddress", mMeta.mWorkerAddress)
@@ -515,7 +506,9 @@ public final class MasterWorkerInfo {
         .add("usedBytes", mUsage.mUsedBytes)
         .add("lastUpdatedTimeMs", mLastUpdatedTimeMs.get())
         .add("blockCount", mBlocks.size())
-        .add(blockFieldName, blocks)
+        // We truncate the list of block IDs to print, unless it is for DEBUG logs
+        .add("blocks", LOG.isDebugEnabled() ? mBlocks :
+            CommonUtils.summarizeCollection(mBlocks, BLOCK_SIZE_LIMIT))
         .add("lostStorage", mUsage.mLostStorage).toString();
   }
 

--- a/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
+++ b/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
@@ -92,7 +92,6 @@ public final class MasterWorkerInfo {
   private static final Logger LOG = LoggerFactory.getLogger(MasterWorkerInfo.class);
   private static final String LIVE_WORKER_STATE = "In Service";
   private static final String LOST_WORKER_STATE = "Out of Service";
-  private static final int BLOCK_SIZE_LIMIT = 100;
 
   /** Worker's last updated time in ms. */
   private final AtomicLong mLastUpdatedTimeMs;
@@ -505,10 +504,8 @@ public final class MasterWorkerInfo {
         .add("capacityBytes", mUsage.mCapacityBytes)
         .add("usedBytes", mUsage.mUsedBytes)
         .add("lastUpdatedTimeMs", mLastUpdatedTimeMs.get())
-        .add("blockCount", mBlocks.size())
-        // We truncate the list of block IDs to print, unless it is for DEBUG logs
-        .add("blocks", LOG.isDebugEnabled() ? mBlocks :
-            CommonUtils.summarizeCollection(mBlocks, BLOCK_SIZE_LIMIT))
+        // We only show the number of blocks unless it is for DEBUG logs
+        .add("blocks", LOG.isDebugEnabled() ? mBlocks : CommonUtils.summarizeCollection(mBlocks))
         .add("lostStorage", mUsage.mLostStorage).toString();
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Instead of showing 

```
2021-09-28 05:03:00,999 WARN  FileSystemMasterClient - GetPinList() returned [12884901887, 10737418239, 15032385535, ... 4000 others ]] in 2312 ms (>=1000 ms)
```

printing in logs

```
2021-09-28 05:03:00,999 WARN  FileSystemMasterClient - GetPinList() returned in 2312 ms (>=1000 ms)
```


### Why are the changes needed?

- Worker logs can be spammed by the warning log printing all blocks
- Can be slow down

### Does this PR introduce any user facing changes?

No