### PR TITLE
[DOCFIX] Add distributedLoad command to the caching docs

### DIFF
--- a/docs/en/core-services/Caching.md
+++ b/docs/en/core-services/Caching.md
@@ -423,6 +423,9 @@ If the data is already in a UFS, use
 $ ./bin/alluxio fs load ${PATH_TO_FILE}
 ```
 
+To speed up the loading process for files or directories, use the [distributedLoad command]({{ '/en/operation/User-CLI.html#distributedLoad' | relativize_url }})
+instead of load command.
+
 To load data from the local file system, use the command
 [`alluxio fs copyFromLocal`]({{ '/en/operation/User-CLI.html#copyfromlocal' | relativize_url
 }}).


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add distribtuedLoad command to the caching docs

### Why are the changes needed?

Otherwise people don't know distributedLoad command can be used to accelerate the data loading speed

### Does this PR introduce any user facing changes?

change docs