### PR TITLE
Make method getCanonicalServiceName return null

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -275,6 +275,11 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
         .getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);
   }
 
+  @Override
+  public String getCanonicalServiceName() {
+    return null;
+  }
+
   @Nullable
   @Override
   public BlockLocation[] getFileBlockLocations(FileStatus file, long start, long len)


### PR DESCRIPTION
### What changes are proposed in this pull request?

make method getCanonicalServiceName return null value.

### Why are the changes needed?

According to the hadoop [javadoc](https://hadoop.apache.org/docs/stable/api/index.html), method `getCanonicalServiceName` should return null directly if the filesystem does not implement tokens.

### Does this PR introduce any user facing changes?

no user facing changes.
