### PR TITLE
Remove one constraint for listfile in FuseIOStressBench

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -129,7 +129,8 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
       // service. Nothing should be done, otherwise the bench will break.
       return;
     }
-    if (mParameters.mThreads > mParameters.mNumDirs) {
+    if (mParameters.mThreads > mParameters.mNumDirs
+        && mParameters.mOperation != FuseIOOperation.LIST_FILE) {
       throw new IllegalArgumentException(String.format(
           "Some of the threads are not being used. Please set the number of directories to "
               + "be at least the number of threads, preferably a multiple of it."


### PR DESCRIPTION
In FuseIOStressBench, num-dirs is not needed for running ListFile operation, but the logic compares number of threads and number of directories, and throw error if the number of threads is larger than number of directories. This constraint should not apply to ListFile operation. This PR fixes this problem.