### PR TITLE
Fix copyFromLocal command

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
@@ -376,7 +376,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
           srcPaths.add(srcPath);
         }
       }
-      if (srcPaths.size() == 1) {
+      if (srcPaths.size() == 1 && !(new File(srcPaths.get(0).getPath())).isDirectory()) {
         copyFromLocalFile(srcPaths.get(0), dstPath);
       } else {
         CopyThreadPoolExecutor pool = new CopyThreadPoolExecutor(mThread, System.out, System.err,

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
@@ -393,6 +393,15 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
     Assert.assertNotNull(sFileSystem.getStatus(dstURI1));
     Assert.assertNotNull(sFileSystem.getStatus(dstURI2));
     Assert.assertNotNull(sFileSystem.getStatus(dstURI3));
+
+    File srcDeepDir = new File(sLocalAlluxioCluster.getAlluxioHome() + "/srcDir0/srcDir1");
+    srcDeepDir.mkdirs();
+    generateFileContent("/srcDir0/srcDir1/srcFile3", BufferUtils.getIncreasingByteArray(10));
+    String srcDeepDirStr = "file://" + sLocalAlluxioCluster.getAlluxioHome() + "/srcDir0/";
+    ret = sFsShell.run("cp", srcDeepDirStr, "/dstDir");
+    Assert.assertEquals(0, ret);
+    AlluxioURI dstURI4 = new AlluxioURI("/dstDir/srcDir1/srcFile3");
+    Assert.assertNotNull(sFileSystem.getStatus(dstURI4));
   }
 
   @Test


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix copyFromLocal command

### Why are the changes needed?

Can not copy local dir which has only a subdir to alluxio via "copyFromLocal" command.
e.g. Copy a local ”dir0“ like:

>     dir0
>       |
>        — dir1
>             |
>             — file0  

alluxio will throw "Source /dir0/dir1 is not a file."

### Does this PR introduce any user facing changes?
No
