### PR TITLE
Improve exception message in block list merger function

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -178,8 +178,8 @@ public final class BlockMasterWorkerServiceHandler extends
               String entryReport = entries.stream().map((e) -> e.getKey().toString())
                       .collect(Collectors.joining(","));
               throw new AssertionError(
-                  String.format("Duplicate locations found for worker %s with LocationBlockIdListEntry "
-                      + "objects %s", workerId, entryReport));
+                String.format("Duplicate locations found for worker %s "
+                    + "with LocationBlockIdListEntry objects %s", workerId, entryReport));
             }));
   }
 }


### PR DESCRIPTION
The `(e1, e2)` from the merger function are two lists where the 2nd one should be merged with the 1st one. In the current implementation we print the two lists which are simply blockIDs, this is not very informative. This PR changes the message to printing the received entry locations so we can better tell what entries are not merged at the worker side.
