### PR TITLE
Fix null pointer exception for AuditLog

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -685,7 +685,8 @@ public final class DefaultFileSystemMaster extends CoreMaster
         mAsyncAuditLogWriter.start();
         MetricsSystem.registerGaugeIfAbsent(
             MetricKey.MASTER_AUDIT_LOG_ENTRIES_SIZE.getName(),
-            () -> mAsyncAuditLogWriter.getAuditLogEntriesSize());
+            () -> mAsyncAuditLogWriter != null
+                    ? mAsyncAuditLogWriter.getAuditLogEntriesSize() : -1);
       }
       if (ServerConfiguration.getBoolean(PropertyKey.UNDERFS_CLEANUP_ENABLED)) {
         getExecutorService().submit(


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix a null pointer exception problem when registering AuditLog metric in #14131

### Why are the changes needed?

When registering `MASTER_AUDIT_LOG_ENTRIES_SIZE` metric, if manually transferLeader , `mAsyncAuditLogWriter` will be set to null , and a null pointer exception will occur at this time.

### Does this PR introduce any user facing changes?
No
