### PR TITLE
Fix url address of the alive workers  when workers start with kubernetes

### DIFF
--- a/webui/master/src/containers/pages/Workers/Workers.tsx
+++ b/webui/master/src/containers/pages/Workers/Workers.tsx
@@ -66,7 +66,18 @@ export class WorkersPresenter extends React.Component<AllProps> {
                   {workersData.normalNodeInfos.map((nodeInfo: INodeInfo) => (
                     <tr key={nodeInfo.workerId}>
                       <td>
-                        <a href={`//${nodeInfo.host}:${initData.workerPort}`} rel="noopener noreferrer" target="_blank">
+                        <a
+                          href={
+                            // When workers start with kubernetes. `nodeInfo.host` is `hostIp (podIp)`
+                            nodeInfo.host.includes('(')
+                              ? `//${nodeInfo.host.substring(0, nodeInfo.host.indexOf('(')).trim()}:${
+                                  initData.workerPort
+                                }`
+                              : `//${nodeInfo.host}:${initData.workerPort}`
+                          }
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
                           {nodeInfo.host}
                         </a>
                       </td>


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix url address of the alive workers when workers start with kubernetes.

### Why are the changes needed?
When services start with kubernetes. The address of alive workers is wrong. 

### Does this PR introduce any user facing changes?
Fix url address of the alive workers when workers start with kubernetes.
