### PR TITLE
Fix RetryHandlingJournalMasterClient

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/journal/RetryHandlingJournalMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/journal/RetryHandlingJournalMasterClient.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A wrapper for the gRPC client to interact with the journal master, used by alluxio clients.
+ * It would talk to both JobMaster and Master, so it should inherit AbstractJobMasterClient
  */
 public class RetryHandlingJournalMasterClient extends AbstractJobMasterClient
     implements JournalMasterClient {


### PR DESCRIPTION
This client would also read the JobMaster, so it should inherit the AbstractJobMasterClient

Issue: https://github.com/Alluxio/alluxio/issues/14211

I have verified in my own environment:

[ec2-user@FaultToleranceScaleRestartEmbeddedJournal-master-0 alluxio]$ ./bin/alluxio fsadmin journal quorum info -domain JOB_MASTER
CLASSPATH: /opt/alluxio-2.7.0-SNAPSHOT/conf/::/opt/alluxio-2.7.0-SNAPSHOT/assembly/alluxio-client-2.7.0-SNAPSHOT.jar:/opt/alluxio-2.7.0-SNAPSHOT/lib/alluxio-integration-tools-validation-2.7.0-SNAPSHOT.jar
Journal domain	: JOB_MASTER
Quorum size	: 5
Quorum leader	: FaultToleranceScaleRestartEmbeddedJournal-master-1:20003

STATE       | PRIORITY | SERVER ADDRESS
AVAILABLE   | 0        | FaultToleranceScaleRestartEmbeddedJournal-master-0:20003
AVAILABLE   | 0        | FaultToleranceScaleRestartEmbeddedJournal-master-1:20003
AVAILABLE   | 0        | FaultToleranceScaleRestartEmbeddedJournal-master-2:20003
AVAILABLE   | 0        | FaultToleranceScaleRestartEmbeddedJournal-master-3:20003
AVAILABLE   | 0        | FaultToleranceScaleRestartEmbeddedJournal-master-4:20003