### PR TITLE
Skip computation if all stressbench RPC tests failed

### DIFF
--- a/stress/common/src/main/java/alluxio/stress/rpc/RpcTaskSummary.java
+++ b/stress/common/src/main/java/alluxio/stress/rpc/RpcTaskSummary.java
@@ -61,6 +61,9 @@ public class RpcTaskSummary implements Summary {
   }
 
   private void calculate() {
+    if (mPoints.isEmpty()) {
+      return;
+    }
     for (RpcTaskResult.Point p : mPoints) {
       mTotalDurationMs += p.mDurationMs;
     }
@@ -80,6 +83,9 @@ public class RpcTaskSummary implements Summary {
 
   @Override
   public String toString() {
+    if (mPoints.isEmpty()) {
+      return String.format("RpcTaskSummary:%nNo data points%nErrors: %s%n", mErrors);
+    }
     return String.format("RpcTaskSummary: Data points: %d, Errors: %d%n"
         + "Total: %.3e, Average: %.3e, Median: %.3e%n"
         + "5 Percentile: %.3e%n25 Percentile: %.3e%n75 Percentile: %.3e%n95 Percentile: %.3e%n",


### PR DESCRIPTION
### Why are the changes needed?

If all RPC tests failed, the `mPoints` will be empty and `getPercentiles()` in the computation will throw an exception complaining no percentiles can be calculated. The stressbench command will then fail.
