### PR TITLE
Update alluxio-maven to use go1.12 + update cacerts

### DIFF
--- a/dev/jenkins/Dockerfile-jdk11
+++ b/dev/jenkins/Dockerfile-jdk11
@@ -104,8 +104,17 @@ RUN mkdir -p /home/jenkins && \
     mkdir -p /.config && \
     chmod -R 777 /.config && \
     apt-get update -y && \
-    apt-get install -y golang-go ruby ruby-dev make build-essential fuse && \
-    gem install jekyll bundler
+    apt-get upgrade -y ca-certificates && \
+    apt-get install -y build-essential fuse make ruby ruby-dev
+# jekyll for documentation
+RUN gem install jekyll bundler
+# golang for tooling
+RUN wget https://dl.google.com/go/go1.12.linux-amd64.tar.gz && \
+    tar -xvf go1.12.linux-amd64.tar.gz && \
+    mv go /usr/local
+ENV GOROOT=/usr/local/go
+ENV PATH=$GOROOT/bin:$PATH
+# terraform for deployment scripts
 RUN wget --quiet https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_linux_amd64.zip && \
     unzip -o ./terraform_0.12.24_linux_amd64.zip -d /usr/local/bin/ && \
     rm terraform_0.12.24_linux_amd64.zip

--- a/dev/jenkins/Dockerfile-jdk8
+++ b/dev/jenkins/Dockerfile-jdk8
@@ -20,8 +20,17 @@ RUN mkdir -p /home/jenkins && \
     mkdir -p /.config && \
     chmod -R 777 /.config && \
     apt-get update -y && \
-    apt-get install -y golang-go ruby ruby-dev make build-essential fuse && \
-    gem install jekyll bundler
+    apt-get upgrade -y ca-certificates && \
+    apt-get install -y build-essential fuse make ruby ruby-dev
+# jekyll for documentation
+RUN gem install jekyll bundler
+# golang for tooling
+RUN wget https://dl.google.com/go/go1.12.linux-amd64.tar.gz && \
+    tar -xvf go1.12.linux-amd64.tar.gz && \
+    mv go /usr/local
+ENV GOROOT=/usr/local/go
+ENV PATH=$GOROOT/bin:$PATH
+# terraform for deployment scripts
 RUN wget --quiet https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_linux_amd64.zip && \
     unzip -o ./terraform_0.12.24_linux_amd64.zip -d /usr/local/bin/ && \
     rm terraform_0.12.24_linux_amd64.zip


### PR DESCRIPTION
### What changes are proposed in this pull request and why are they needed?

The alluxio-maven image is used to verify PR builds. Currently it is installing go1.11 but the generate tarball go code uses strings.ReplaceAll which is only available starting go1.12.

In addition, some commands that depend on curl/wget are failing due to client certificates being out of date. This is fixed by upgrading the ca-certificates package.

### Does this PR introduce any user facing changes?

They better not...
