### PR TITLE
Allow higher keep-alive frequency for worker data server

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3196,7 +3196,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey WORKER_NETWORK_PERMIT_KEEPALIVE_TIME_MS =
       new Builder(
           Name.WORKER_NETWORK_PERMIT_KEEPALIVE_TIME_MS)
-          .setDefaultValue("5m")
+          .setDefaultValue("30s")
           .setDescription(
               "Specify the most aggressive keep-alive time clients are permitted to configure. "
                   + "The server will try to detect clients exceeding this rate and when detected "


### PR DESCRIPTION
RPC channels that are opened to worker are configured to send keep-alive pings every 30sec. This change increases worker server's tolerance to that default.