### PR TITLE
Add a pattern to verify locks are held in MasterWorkerInfo

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1036,6 +1036,9 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
    */
   private void processWorkerRemovedBlocks(MasterWorkerInfo workerInfo,
       Collection<Long> removedBlockIds) {
+    Preconditions.checkState(workerInfo.checkLocks(EnumSet.of(
+        WorkerMetaLockSection.BLOCKS), false));
+
     for (long removedBlockId : removedBlockIds) {
       try (LockResource r = lockBlock(removedBlockId)) {
         Optional<BlockMeta> block = mBlockStore.getBlock(removedBlockId);
@@ -1064,6 +1067,9 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
    */
   private void processWorkerAddedBlocks(MasterWorkerInfo workerInfo,
       Map<BlockLocation, List<Long>> addedBlockIds) {
+    Preconditions.checkState(workerInfo.checkLocks(EnumSet.of(
+        WorkerMetaLockSection.BLOCKS), false));
+
     long invalidBlockCount = 0;
     for (Map.Entry<BlockLocation, List<Long>> entry : addedBlockIds.entrySet()) {
       for (long blockId : entry.getValue()) {
@@ -1102,6 +1108,9 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
    * @param workerInfo The worker metadata object
    */
   private void processWorkerOrphanedBlocks(MasterWorkerInfo workerInfo) {
+    Preconditions.checkState(workerInfo.checkLocks(EnumSet.of(
+        WorkerMetaLockSection.USAGE), true));
+
     long orphanedBlockCount = 0;
     for (long block : workerInfo.getBlocks()) {
       if (!mBlockStore.getBlock(block).isPresent()) {
@@ -1243,6 +1252,9 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
    * @param worker the worker metadata
    */
   private void processLostWorker(MasterWorkerInfo worker) {
+    Preconditions.checkState(worker.checkLocks(EnumSet.of(
+        WorkerMetaLockSection.BLOCKS), false));
+
     mLostWorkers.add(worker);
     mWorkers.remove(worker);
     WorkerNetAddress workerAddress = worker.getWorkerAddress();

--- a/core/server/master/src/main/java/alluxio/master/block/meta/LockType.java
+++ b/core/server/master/src/main/java/alluxio/master/block/meta/LockType.java
@@ -1,0 +1,6 @@
+package alluxio.master.block.meta;
+
+public enum LockType {
+  SHARED,
+  EXCLUSIVE
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add a syntax to double check certain locks are held, within methods that require external locking.
The idea is from HDFS

https://github.com/apache/hadoop/blob/cb2b7970ee190edca3b1a33427e629e32acf0ad7/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/ProvidedStorageMap.java#L147

### Why are the changes needed?

It's easier to enforce locking mechanism from methods that need external locking. Without checking, we can only advise people to follow the locking pattern in the comment.
