### PR TITLE
Remove fall-back logic from journal appending

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1807,14 +1807,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
-  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_WRITE_LOCAL_FIRST_ENABLED =
-      new Builder(Name.MASTER_EMBEDDED_JOURNAL_WRITE_LOCAL_FIRST_ENABLED)
-          .setDefaultValue(true)
-          .setDescription("Whether the journal writer will attempt to write entry locally before "
-              + "falling back to a full remote raft client.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.MASTER)
-          .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED)
           .setDefaultValue(false)

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -451,7 +451,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   @Override
   public synchronized void gainPrimacy() {
     mSnapshotAllowed.set(false);
-    LocalFirstRaftClient client = new LocalFirstRaftClient(mServer, this::createClient,
+    RaftJournalAppender client = new RaftJournalAppender(mServer, this::createClient,
         mRawClientId, ServerConfiguration.global());
 
     Runnable closeClient = () -> {
@@ -578,7 +578,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   public synchronized void checkpoint() throws IOException {
     // TODO(feng): consider removing this once we can automatically propagate
     //             snapshots from secondary master
-    try (LocalFirstRaftClient client = new LocalFirstRaftClient(mServer, this::createClient,
+    try (RaftJournalAppender client = new RaftJournalAppender(mServer, this::createClient,
         mRawClientId, ServerConfiguration.global())) {
       mSnapshotAllowed.set(true);
       catchUp(mStateMachine, client);
@@ -611,7 +611,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
    *
    * The caller is responsible for detecting and responding to leadership changes.
    */
-  private void catchUp(JournalStateMachine stateMachine, LocalFirstRaftClient client)
+  private void catchUp(JournalStateMachine stateMachine, RaftJournalAppender client)
       throws TimeoutException, InterruptedException {
     long startTime = System.currentTimeMillis();
     long waitBeforeRetry = ServerConfiguration.global()

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
@@ -49,7 +49,7 @@ public class RaftJournalWriter implements JournalWriter {
   private final AtomicLong mLastSubmittedSequenceNumber;
   private final AtomicLong mLastCommittedSequenceNumber;
 
-  private final LocalFirstRaftClient mClient;
+  private final RaftJournalAppender mClient;
 
   private volatile boolean mClosed;
   private JournalEntry.Builder mJournalEntryBuilder;
@@ -61,7 +61,7 @@ public class RaftJournalWriter implements JournalWriter {
    *               this client and is responsible for closing it
    */
   public RaftJournalWriter(long nextSequenceNumberToWrite,
-      LocalFirstRaftClient client) {
+      RaftJournalAppender client) {
     LOG.debug("Journal writer created starting at SN#{}", nextSequenceNumberToWrite);
     mNextSequenceNumberToWrite = new AtomicLong(nextSequenceNumberToWrite);
     mLastSubmittedSequenceNumber = new AtomicLong(-1);

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalWriterTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalWriterTest.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
  * Unit tests for {@link RaftJournalWriter}.
  */
 public class RaftJournalWriterTest {
-  private LocalFirstRaftClient mClient;
+  private RaftJournalAppender mClient;
   private RaftJournalWriter mRaftJournalWriter;
 
   @After
@@ -51,7 +51,7 @@ public class RaftJournalWriterTest {
   }
 
   private void setupRaftJournalWriter() throws IOException  {
-    mClient = mock(LocalFirstRaftClient.class);
+    mClient = mock(RaftJournalAppender.class);
     RaftClientReply reply = RaftClientReply.newBuilder()
             .setClientId(ClientId.randomId())
             .setServerId(


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fallback logic of (writing via remote when local fails) seem to be wrapped over a bug in test, and not of intention.
Removing the logic and simplifying the code/properties little bit.