### PR TITLE
Fix resource leak due to Files.walk

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -221,7 +221,9 @@ public class LocalPageStore implements PageStore {
   @Override
   public Stream<PageInfo> getPages() throws IOException {
     Path rootDir = Paths.get(mRoot);
-    return Files.walk(rootDir).filter(Files::isRegularFile).map(this::getPageInfo);
+    try (Stream<Path> stream = Files.walk(rootDir)) {
+      return stream.filter(Files::isRegularFile).map(this::getPageInfo);
+    }
   }
 
   @Override


### PR DESCRIPTION
Files.walk will open stream, we should close it.

 

see jdk: 
the {try} -with-resources construct should be used to ensure that the
stream's

{[@link|https://github.com/link] Stream#close close}
method is invoked after the stream
operations are completed.