### PR TITLE
Replace guava's Files.createTempDir()

### DIFF
--- a/core/common/src/main/java/alluxio/util/io/FileUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/FileUtils.java
@@ -344,6 +344,18 @@ public final class FileUtils {
   }
 
   /**
+   * Creates a temporary directory like guava's Files.createTempDir().
+   *
+   * @return the created temporary directory
+   */
+  public static File createTempDir() throws IOException {
+    File tempDirBase =
+         new File(System.getProperty("java.io.tmpdir"));
+    return Files.createTempDirectory(
+         tempDirBase.toPath(), System.currentTimeMillis() + "-").toFile();
+  }
+
+  /**
    * Checks if a path exists.
    *
    * @param path the given path

--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -320,10 +319,7 @@ public class CollectInfo extends AbstractShell {
     }
 
     // Collect tarballs from where the SSH command completed
-    File tempDirBase =
-             new File(System.getProperty("java.io.tmpdir"));
-    File tempDir = Files.createTempDirectory(
-                 tempDirBase.toPath(), System.currentTimeMillis() + "-").toFile();
+    File tempDir = FileUtils.createTempDir();
     List<File> filesFromHosts = new ArrayList<>();
     List<CompletableFuture<CommandReturn>> scpFutures =
             new ArrayList<>(allHosts.size());


### PR DESCRIPTION
see https://www.cvedetails.com/cve/CVE-2020-8908/

A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.