### PR TITLE
Add worker and client metrics size to log info

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -673,8 +673,8 @@ public final class MetricsSystem {
   public static List<alluxio.grpc.Metric> reportWorkerMetrics() {
     long start = System.currentTimeMillis();
     List<alluxio.grpc.Metric> metricsList = reportMetrics(InstanceType.WORKER);
-    LOG.debug("Get the worker metrics list to report to leading master in {}ms",
-        System.currentTimeMillis() - start);
+    LOG.debug("Get the worker metrics list contains {} metrics to report to leading master in {}ms",
+        metricsList.size(), System.currentTimeMillis() - start);
     return metricsList;
   }
 
@@ -684,8 +684,8 @@ public final class MetricsSystem {
   public static List<alluxio.grpc.Metric> reportClientMetrics() {
     long start = System.currentTimeMillis();
     List<alluxio.grpc.Metric> metricsList = reportMetrics(InstanceType.CLIENT);
-    LOG.debug("Get the client metrics list to report to leading master in {}ms",
-        System.currentTimeMillis() - start);
+    LOG.debug("Get the client metrics list contains {} metrics to report to leading master in {}ms",
+        metricsList.size(), System.currentTimeMillis() - start);
     return metricsList;
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?
Add helpful information, this is inspired by pr #14277
Please clarify why the changes are needed. For instance,
 Developers can get metrics debug information directly in log.
### Does this PR introduce any user facing changes?
No
