### PR TITLE
Close the existing S3 http stream when we're creating a new one

### DIFF
--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AInputStream.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AInputStream.java
@@ -147,6 +147,7 @@ public class S3AInputStream extends InputStream {
     String errorMessage = String.format("Failed to open key: %s bucket: %s", mKey, mBucketName);
     while (mRetryPolicy.attempt()) {
       try {
+        closeStream();
         mIn = mClient.getObject(getReq).getObjectContent();
         return;
       } catch (AmazonS3Exception e) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Close the existing S3 http stream when we're creating a new one

### Why are the changes needed?

We need to close the stream if it's not in use.  this one might fix or improve https://github.com/Alluxio/alluxio/issues/14215

### Does this PR introduce any user facing changes?

No.
