### PR TITLE
Add webui information in kubernetes environment

### DIFF
--- a/webui/master/src/containers/pages/Workers/Workers.test.tsx
+++ b/webui/master/src/containers/pages/Workers/Workers.test.tsx
@@ -59,5 +59,21 @@ describe('Workers', () => {
     it('Matches snapshot', () => {
       expect(shallowWrapper).toMatchSnapshot();
     });
+
+    it('Hostname in Kubernetes environment', () => {
+      shallowWrapper.setProps({
+        workersData: { ...props.workersData, normalNodeInfos: [{ host: 'hostIp (podIp)', workerId: 1 }] },
+      });
+      expect(shallowWrapper.find('#id-1').props().children).toEqual('Node Name(Container Host)');
+      expect(shallowWrapper.find('#id-1-link').prop('href')).toEqual(`//hostIp:${props.initData.workerPort}`);
+    });
+
+    it('Hostname in bare-metal environment', () => {
+      shallowWrapper.setProps({
+        workersData: { ...props.workersData, normalNodeInfos: [{ host: 'hostIp', workerId: 1 }] },
+      });
+      expect(shallowWrapper.find('#id-1').props().children).toEqual('Node Name');
+      expect(shallowWrapper.find('#id-1-link').prop('href')).toEqual(`//hostIp:${props.initData.workerPort}`);
+    });
   });
 });

--- a/webui/master/src/containers/pages/Workers/Workers.tsx
+++ b/webui/master/src/containers/pages/Workers/Workers.tsx
@@ -49,6 +49,8 @@ export class WorkersPresenter extends React.Component<AllProps> {
                   <tr>
                     {workersData.normalNodeInfos.map((nodeInfo: INodeInfo) => (
                       <th key={nodeInfo.workerId}>
+                        {/*When workers start with kubernetes. `nodeInfo.host` is `hostIp (podIp)`,
+                            So it should be displayed as Node Name(Container Host).*/}
                         {nodeInfo.host.includes('(') ? 'Node Name(Container Host)' : 'Node Name'}
                       </th>
                     ))}

--- a/webui/master/src/containers/pages/Workers/Workers.tsx
+++ b/webui/master/src/containers/pages/Workers/Workers.tsx
@@ -48,7 +48,7 @@ export class WorkersPresenter extends React.Component<AllProps> {
                 <thead>
                   <tr>
                     {workersData.normalNodeInfos.map((nodeInfo: INodeInfo) => (
-                      <th key={nodeInfo.workerId}>
+                      <th key={nodeInfo.workerId} id={`id-${nodeInfo.workerId}`}>
                         {/*When workers start with kubernetes. `nodeInfo.host` is `hostIp (podIp)`,
                             So it should be displayed as Node Name(Container Host).*/}
                         {nodeInfo.host.includes('(') ? 'Node Name(Container Host)' : 'Node Name'}
@@ -73,6 +73,7 @@ export class WorkersPresenter extends React.Component<AllProps> {
                     <tr key={nodeInfo.workerId}>
                       <td>
                         <a
+                          id={`id-${nodeInfo.workerId}-link`}
                           href={
                             // When workers start with kubernetes. `nodeInfo.host` is `hostIp (podIp)`
                             nodeInfo.host.includes('(')

--- a/webui/master/src/containers/pages/Workers/Workers.tsx
+++ b/webui/master/src/containers/pages/Workers/Workers.tsx
@@ -47,7 +47,11 @@ export class WorkersPresenter extends React.Component<AllProps> {
               <Table hover={true}>
                 <thead>
                   <tr>
-                    <th>Node Name</th>
+                    {workersData.normalNodeInfos.map((nodeInfo: INodeInfo) => (
+                      <th key={nodeInfo.workerId}>
+                        {nodeInfo.host.includes('(') ? 'Node Name(Container Host)' : 'Node Name'}
+                      </th>
+                    ))}
                     {initData.debug && (
                       <React.Fragment>
                         <th>[D]Worker Id</th>

--- a/webui/master/src/containers/pages/Workers/__snapshots__/Workers.test.tsx.snap
+++ b/webui/master/src/containers/pages/Workers/__snapshots__/Workers.test.tsx.snap
@@ -24,9 +24,6 @@ exports[`Workers Shallow component Matches snapshot 1`] = `
           <thead>
             <tr>
               <th>
-                Node Name
-              </th>
-              <th>
                 Last Heartbeat
               </th>
               <th>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add the header information of the worker page in the kubernetes environment.

### Why are the changes needed?

When Alluxio is used in the k8s environment, two ips will be displayed on the worker page, namely hostip (podip), but the header is marked as Node Name, which is now modified to display as Node Name (Container Host) 
<img width="1774" alt="111" src="https://user-images.githubusercontent.com/26144703/138483824-36ff1943-8344-4641-8def-f3059c86ec0e.png">

### Does this PR introduce any user facing changes?
yes