### PR TITLE
Remove kernel-devel package from Dockerfile-dev

### DIFF
--- a/integration/docker/Dockerfile-dev
+++ b/integration/docker/Dockerfile-dev
@@ -46,7 +46,7 @@ ENV MAX_IDLE_THREADS "64"
 
 RUN \
     yum update -y && yum upgrade -y && \
-    yum install -y kernel-devel ca-certificates pkgconfig wget udev git && \
+    yum install -y ca-certificates pkgconfig wget udev git && \
     yum install -y gcc gcc-c++ make cmake gettext-devel libtool autoconf && \
     yum clean all && \
     ./dockerfile-common.sh install-libfuse


### PR DESCRIPTION
Installing package `kernel-devel` introduces a few HIGH (2nd highest level severity) vulnerabilities scanned by Trivy.

Removing it doesn't break the installation of other packages or Alluxio.

Related issue: #14264 