### PR TITLE
Resolve lock leak during recursive delete

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -431,7 +431,12 @@ public class InodeTree implements DelegatingJournaled {
       throws InvalidPathException {
     LockedInodePath inodePath =
         new LockedInodePath(uri, mInodeStore, mInodeLockManager, getRoot(), lockPattern, tryLock);
-    inodePath.traverseOrClose();
+    try {
+      inodePath.traverse();
+    } catch (Throwable t) {
+      inodePath.close();
+      throw t;
+    }
     return inodePath;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -972,7 +972,7 @@ public class InodeTree implements DelegatingJournaled {
       }
       try {
         descendants.add(childPath);
-      } catch (OutOfMemoryError e) {
+      } catch (Error e) {
         // If adding to descendants fails due to OOM, this object
         // will not be tracked so we must close it manually
         childPath.close();

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -964,8 +964,8 @@ public class InodeTree implements DelegatingJournaled {
     }
     for (Inode child : mInodeStore.getChildren(inode.asDirectory())) {
       LockedInodePath childPath;
-      try {
-        childPath = inodePath.lockChild(child, LockPattern.WRITE_EDGE);
+      try (LockedInodePath childPathRef = inodePath.lockChild(child, LockPattern.WRITE_EDGE)) {
+        childPath = childPathRef;
       } catch (InvalidPathException e) {
         // Child does not exist.
         continue;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -969,9 +969,6 @@ public class InodeTree implements DelegatingJournaled {
       } catch (InvalidPathException e) {
         // Child does not exist.
         continue;
-      } catch (Exception e) {
-        childPath.close();
-        throw e;
       }
       descendants.add(childPath);
       gatherDescendants(childPath, descendants);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -430,8 +430,8 @@ public class InodeTree implements DelegatingJournaled {
   public LockedInodePath lockInodePath(AlluxioURI uri, LockPattern lockPattern, boolean tryLock)
       throws InvalidPathException {
     LockedInodePath inodePath =
-        new LockedInodePath(uri, mInodeStore, mInodeLockManager, getRoot(), lockPattern, tryLock)
-          .traverseOrClose();
+        new LockedInodePath(uri, mInodeStore, mInodeLockManager, getRoot(), lockPattern, tryLock);
+    inodePath.traverseOrClose();
     return inodePath;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -430,13 +430,8 @@ public class InodeTree implements DelegatingJournaled {
   public LockedInodePath lockInodePath(AlluxioURI uri, LockPattern lockPattern, boolean tryLock)
       throws InvalidPathException {
     LockedInodePath inodePath =
-        new LockedInodePath(uri, mInodeStore, mInodeLockManager, getRoot(), lockPattern, tryLock);
-    try {
-      inodePath.traverse();
-    } catch (Throwable t) {
-      inodePath.close();
-      throw t;
-    }
+        new LockedInodePath(uri, mInodeStore, mInodeLockManager, getRoot(), lockPattern, tryLock)
+          .traverseOrClose();
     return inodePath;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -965,7 +965,14 @@ public class InodeTree implements DelegatingJournaled {
         // Child does not exist.
         continue;
       }
-      descendants.add(childPath);
+      try {
+        descendants.add(childPath);
+      } catch (OutOfMemoryError e) {
+        // If adding to descendants fails due to OOM, this object
+        // will not be tracked so we must close it manually
+        childPath.close();
+        throw e;
+      }
       gatherDescendants(childPath, descendants);
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -964,11 +964,14 @@ public class InodeTree implements DelegatingJournaled {
     }
     for (Inode child : mInodeStore.getChildren(inode.asDirectory())) {
       LockedInodePath childPath;
-      try (LockedInodePath childPathRef = inodePath.lockChild(child, LockPattern.WRITE_EDGE)) {
-        childPath = childPathRef;
+      try {
+        childPath = inodePath.lockChild(child, LockPattern.WRITE_EDGE);
       } catch (InvalidPathException e) {
         // Child does not exist.
         continue;
+      } catch (Exception e) {
+        childPath.close();
+        throw e;
       }
       descendants.add(childPath);
       gatherDescendants(childPath, descendants);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -377,7 +377,7 @@ public class LockedInodePath implements Closeable {
 
     LockedInodePath newPath =
         new LockedInodePath(mUri, this, mPathComponents, LockPattern.WRITE_EDGE, mUseTryLock);
-    newPath.traverse();
+    newPath.traverseOrClose();
     return newPath;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -377,7 +377,7 @@ public class LockedInodePath implements Closeable {
 
     LockedInodePath newPath =
         new LockedInodePath(mUri, this, mPathComponents, LockPattern.WRITE_EDGE, mUseTryLock);
-    newPath.traverseOrClose();
+    newPath.traverse();
     return newPath;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
@@ -208,8 +208,12 @@ public class SimpleInodeLockList implements InodeLockList {
   }
 
   private void lockAndAddInode(Inode inode, LockMode mode) {
-    try (RWLockResource lock = mInodeLockManager.lockInode(inode, mode, mUseTryLock)) {
+    RWLockResource lock = mInodeLockManager.lockInode(inode, mode, mUseTryLock);
+    try {
       addInodeLock(inode, mode, lock);
+    } catch (Throwable t) {
+      lock.close();
+      throw t;
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
@@ -208,7 +208,9 @@ public class SimpleInodeLockList implements InodeLockList {
   }
 
   private void lockAndAddInode(Inode inode, LockMode mode) {
-    addInodeLock(inode, mode, mInodeLockManager.lockInode(inode, mode, mUseTryLock));
+    try (RWLockResource lock = mInodeLockManager.lockInode(inode, mode, mUseTryLock)) {
+      addInodeLock(inode, mode, lock);
+    }
   }
 
   private void addEdgeLock(Edge edge, LockMode mode, RWLockResource lock) {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
@@ -200,7 +200,7 @@ public class SimpleInodeLockList implements InodeLockList {
     }
     try {
       mLocks.add(lock);
-    } catch (OutOfMemoryError e) {
+    } catch (Error e) {
       // If adding to mLocks fails due to OOM, this lock
       // will not be tracked so we must close it manually
       lock.close();

--- a/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
@@ -223,7 +223,13 @@ public class SimpleInodeLockList implements InodeLockList {
   }
 
   private void lockAndAddEdge(Edge edge, LockMode mode) {
-    addEdgeLock(edge, mode, mInodeLockManager.lockEdge(edge, mode, mUseTryLock));
+    RWLockResource lock = mInodeLockManager.lockEdge(edge, mode, mUseTryLock);
+    try {
+      addEdgeLock(edge, mode, lock);
+    } catch (Throwable t) {
+      lock.close();
+      throw t;
+    }
   }
 
   /**


### PR DESCRIPTION
These changes are being made to address the following leak message:
```
2021-10-23 18:17:29,940 ERROR AlluxioResourceLeakDetector - LEAK: LockResource.close() was not called before resource is garbage-collected. See https://docs.alluxio.io/os/user/stable/en/operation/Troubleshooting.html#resource-leak-detection for more information about this message.
Recent access records: 
Created at:
	alluxio.resource.LockResource.<init>(LockResource.java:46)
	alluxio.resource.LockResource.<init>(LockResource.java:70)
	alluxio.resource.RWLockResource.<init>(RWLockResource.java:39)
	alluxio.resource.RefCountLockResource.<init>(RefCountLockResource.java:54)
	alluxio.collections.LockPool.get(LockPool.java:210)
	alluxio.master.file.meta.InodeLockManager.lockInode(InodeLockManager.java:169)
	alluxio.master.file.meta.SimpleInodeLockList.lockAndAddInode(SimpleInodeLockList.java:211)
	alluxio.master.file.meta.SimpleInodeLockList.lockInode(SimpleInodeLockList.java:95)
	alluxio.master.file.meta.CompositeInodeLockList.lockInode(CompositeInodeLockList.java:63)
	alluxio.master.file.meta.LockedInodePath.traverse(LockedInodePath.java:448)
	alluxio.master.file.meta.LockedInodePath.traverseOrClose(LockedInodePath.java:386)
	alluxio.master.file.meta.LockedInodePath.lockChild(LockedInodePath.java:358)
	alluxio.master.file.meta.LockedInodePath.lockChild(LockedInodePath.java:342)
	alluxio.master.file.meta.InodeTree.gatherDescendants(InodeTree.java:984)
	alluxio.master.file.meta.InodeTree.gatherDescendants(InodeTree.java:990)
	alluxio.master.file.meta.InodeTree.getDescendants(InodeTree.java:968)
	alluxio.master.file.DefaultFileSystemMaster.delete(DefaultFileSystemMaster.java:1823)
	alluxio.master.file.PrivilegedFileSystemMaster.delete(PrivilegedFileSystemMaster.java:356)
	alluxio.master.file.FileSystemMasterClientServiceHandler.lambda$remove$17(FileSystemMasterClientServiceHandler.java:359)
	alluxio.RpcUtils.callAndReturn(RpcUtils.java:121)
	alluxio.RpcUtils.call(RpcUtils.java:83)
	alluxio.RpcUtils.call(RpcUtils.java:58)
	alluxio.master.file.FileSystemMasterClientServiceHandler.remove(FileSystemMasterClientServiceHandler.java:357)
	alluxio.grpc.FileSystemMasterClientServiceGrpc$MethodHandlers.invoke(FileSystemMasterClientServiceGrpc.java:2578)
	io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
	io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
	io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
	io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
	alluxio.security.authentication.ClientIpAddressInjector$1.onHalfClose(ClientIpAddressInjector.java:57)
	io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
	io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
	io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
	alluxio.security.authentication.AuthenticatedUserInjector$1.onHalfClose(AuthenticatedUserInjector.java:67)
	io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:331)
	io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:797)
	io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
	alluxio.concurrent.jsr.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1378)
	alluxio.concurrent.jsr.ForkJoinTask.doExec(ForkJoinTask.java:609)
	alluxio.concurrent.jsr.ForkJoinPool.runWorker(ForkJoinPool.java:1356)
	alluxio.concurrent.jsr.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:131)
2021-10-23 18:17:29,941 ERROR AlluxioResourceLeakDetector - Leak detected when alluxio.leak.detector.exit.on.leak set to true. Shutting down the JVM
```