### PR TITLE
Add metric to monitor checkpoint

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -667,6 +667,14 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("The last raft log index which was applied to the state machine")
           .setMetricType(MetricType.GAUGE)
           .build();
+  public static final MetricKey MASTER_JOURNAL_CHECKPOINT_WARN =
+          new Builder("Master.JournalCheckpointWarn")
+         .setDescription("If the raft log index exceeds "
+                  + "MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, and the last checkpoint "
+                  + "exceeds MASTER_WEB_JOURNAL_CHECKPOINT_WARNING_THRESHOLD_TIME,"
+                  + " it returns 1 to indicate that a warning is required, otherwise it returns 0")
+          .setMetricType(MetricType.GAUGE)
+          .build();
 
   public static final MetricKey MASTER_JOURNAL_GAIN_PRIMACY_TIMER =
       new Builder("Master.JournalGainPrimacyTimer")

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -668,14 +668,14 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_JOURNAL_CHECKPOINT_WARN =
-          new Builder("Master.JournalCheckpointWarn")
-         .setDescription("If the raft log index exceeds "
-                  + "MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, and the last checkpoint "
-                  + "exceeds MASTER_WEB_JOURNAL_CHECKPOINT_WARNING_THRESHOLD_TIME,"
-                  + " it returns 1 to indicate that a warning is required, otherwise it returns 0")
-          .setMetricType(MetricType.GAUGE)
-          .build();
-
+      new Builder("Master.JournalCheckpointWarn")
+          .setDescription(String.format("If the raft log index exceeds %s, and the "
+              + "last checkpoint exceeds %s, it returns 1 to indicate that a warning"
+              + " is required, otherwise it returns 0",
+              PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES.getName(),
+              PropertyKey.MASTER_WEB_JOURNAL_CHECKPOINT_WARNING_THRESHOLD_TIME.getName()))
+         .setMetricType(MetricType.GAUGE)
+         .build();
   public static final MetricKey MASTER_JOURNAL_GAIN_PRIMACY_TIMER =
       new Builder("Master.JournalGainPrimacyTimer")
           .setDescription("The timer statistics of journal gain primacy")

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -161,6 +161,13 @@ public class JournalStateMachine extends BaseStateMachine {
     MetricsSystem.registerGaugeIfAbsent(
         MetricKey.MASTER_JOURNAL_LAST_APPLIED_COMMIT_INDEX.getName(),
         () -> mLastAppliedCommitIndex);
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_JOURNAL_CHECKPOINT_WARN.getName(),
+        () -> getLastAppliedTermIndex().getIndex() - mSnapshotLastIndex
+              > ServerConfiguration.getLong(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES)
+              && System.currentTimeMillis() - mLastCheckPointTime > ServerConfiguration.getMs(
+              PropertyKey.MASTER_WEB_JOURNAL_CHECKPOINT_WARNING_THRESHOLD_TIME) ? 1 : 0
+    );
   }
 
   @Override

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -164,9 +164,9 @@ public class JournalStateMachine extends BaseStateMachine {
     MetricsSystem.registerGaugeIfAbsent(
         MetricKey.MASTER_JOURNAL_CHECKPOINT_WARN.getName(),
         () -> getLastAppliedTermIndex().getIndex() - mSnapshotLastIndex
-              > ServerConfiguration.getLong(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES)
-              && System.currentTimeMillis() - mLastCheckPointTime > ServerConfiguration.getMs(
-              PropertyKey.MASTER_WEB_JOURNAL_CHECKPOINT_WARNING_THRESHOLD_TIME) ? 1 : 0
+                > ServerConfiguration.getLong(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES)
+                && System.currentTimeMillis() - mLastCheckPointTime > ServerConfiguration.getMs(
+                PropertyKey.MASTER_WEB_JOURNAL_CHECKPOINT_WARNING_THRESHOLD_TIME)
     );
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add metric to monitor checkpoint

### Why are the changes needed?

Refer to the implementation of AlluxioMasterRestServiceHandler#getWebUIOverview. Although there will be an alert on the web page when the checkpoint is abnormal, we want to use a third-party operation and maintenance system to monitor this situation, so we hope to expose this metric. When it is 1, the monitoring system is triggered to send an alarm message .

### Does this PR introduce any user facing changes?
No
