### PR TITLE
Support auto abort multiupload after timeout

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3710,14 +3710,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_COUNT =
       new Builder(Name.PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_COUNT)
           .setDefaultValue(3)
-          .setDescription("The retry count when abort multipart upload failed.")
+          .setDescription("The retry count when aborting a multipart upload fails.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_DELAY =
       new Builder(Name.PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_DELAY)
           .setDefaultValue("10sec")
-          .setDescription("The retry delay time when abort multipart upload failed.")
+          .setDescription("The retry delay time when aborting a multipart upload fails.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3700,6 +3700,34 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey PROXY_S3_MULTIPART_UPLOAD_TIMEOUT =
+      new Builder(Name.PROXY_S3_MULTIPART_UPLOAD_TIMEOUT)
+          .setDefaultValue("10min")
+          .setDescription("The timeout for aborting proxy s3 multipart upload automatically.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_COUNT =
+      new Builder(Name.PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_COUNT)
+          .setDefaultValue(3)
+          .setDescription("The retry count when abort multipart upload failed.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_DELAY =
+      new Builder(Name.PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_DELAY)
+          .setDefaultValue("10sec")
+          .setDescription("The retry delay time when abort multipart upload failed.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey PROXY_S3_MULTIPART_UPLOAD_CLEANER_POOL_SIZE =
+      new Builder(Name.PROXY_S3_MULTIPART_UPLOAD_CLEANER_POOL_SIZE)
+          .setDefaultValue(1)
+          .setDescription("The abort multipart upload cleaner pool size.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey PROXY_STREAM_CACHE_TIMEOUT_MS =
       new Builder(Name.PROXY_STREAM_CACHE_TIMEOUT_MS)
           .setAlias("alluxio.proxy.stream.cache.timeout.ms")
@@ -6242,6 +6270,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String PROXY_S3_DELETE_TYPE = "alluxio.proxy.s3.deletetype";
     public static final String PROXY_S3_MULTIPART_TEMPORARY_DIR_SUFFIX =
         "alluxio.proxy.s3.multipart.temporary.dir.suffix";
+    public static final String PROXY_S3_MULTIPART_UPLOAD_TIMEOUT =
+        "alluxio.proxy.s3.multipart.upload.timeout";
+    public static final String PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_COUNT =
+        "alluxio.proxy.s3.multipart.upload.cleaner.retry.count";
+    public static final String PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_DELAY =
+        "alluxio.proxy.s3.multipart.upload.cleaner.retry.delay";
+    public static final String PROXY_S3_MULTIPART_UPLOAD_CLEANER_POOL_SIZE =
+        "alluxio.proxy.s3.multipart.upload.cleaner.pool.size";
     public static final String PROXY_STREAM_CACHE_TIMEOUT_MS =
         "alluxio.proxy.stream.cache.timeout";
     public static final String PROXY_WEB_BIND_HOST = "alluxio.proxy.web.bind.host";

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/MultipartUploadCleaner.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/MultipartUploadCleaner.java
@@ -18,7 +18,6 @@ import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;
-import alluxio.exception.InvalidPathException;
 import alluxio.grpc.DeletePOptions;
 
 import org.slf4j.Logger;
@@ -259,8 +258,8 @@ public class MultipartUploadCleaner {
         }
       } catch (IOException | AlluxioException e) {
         mRetryCount++;
-        LOG.error("Failed abort multipart upload {} in bucket {} with uploadId {} after {} retries with error {}.",
-            mObject, mBucket, mUploadId, mRetryCount, e);
+        LOG.error("Failed abort multipart upload {} in bucket {} with uploadId {} "
+                + "after {} retries with error {}.", mObject, mBucket, mUploadId, mRetryCount, e);
         e.printStackTrace();
         if (canRetry(this)) {
           apply(this, mRetryDelay);

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/MultipartUploadCleaner.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/MultipartUploadCleaner.java
@@ -1,0 +1,288 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.URIStatus;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.FileDoesNotExistException;
+import alluxio.exception.InvalidPathException;
+import alluxio.grpc.DeletePOptions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A lazy method (not scan the whole fileSystem to find tmp directory) to
+ * support automatic abortion s3 multipartUpload after a timeout.
+ */
+public class MultipartUploadCleaner {
+  private static final Logger LOG = LoggerFactory.getLogger(MultipartUploadCleaner.class);
+
+  private final long mTimeout;
+  private final int mRetry;
+  private final long mRetryDelay;
+  private final FileSystem mFs;
+  private final ScheduledThreadPoolExecutor mExecutor;
+  private final ConcurrentHashMap<AbortTask, ScheduledFuture<?>> mTasks =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Creates a new instance of {@link MultipartUploadCleaner}.
+   *
+   * @param fs the {@link FileSystem} instance
+   */
+  public MultipartUploadCleaner(FileSystem fs) {
+    mTimeout =
+        ServerConfiguration.getMs(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_TIMEOUT);
+    mRetry =
+        ServerConfiguration.getInt(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_COUNT);
+    mRetryDelay =
+        ServerConfiguration.getMs(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_DELAY);
+    mExecutor = new ScheduledThreadPoolExecutor(
+        ServerConfiguration.getInt(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_CLEANER_POOL_SIZE));
+
+    mFs = fs;
+  }
+
+  /**
+   * Schedule a task to clean multipart upload.
+   *
+   * @param bucket bucket name
+   * @param object object name
+   * @return true if add a abort task
+   */
+  public boolean apply(String bucket, String object)
+      throws IOException, AlluxioException {
+    // Use schedule pool do everyThing.
+    long delay = tryAbortMultipartUpload(bucket, object, null);
+    if (delay > 0) {
+      long uploadId = getMultipartUploadId(bucket, object);
+      return apply(new AbortTask(bucket, object, uploadId), 0);
+    }
+    return false;
+  }
+
+  /**
+   * Schedule a task to clean multipart upload.
+   *
+   * @param bucket bucket name
+   * @param object object name
+   * @param uploadId multipart upload tmp directory fileId
+   * @return true if add a abort task
+   */
+  public boolean apply(String bucket, String object, Long uploadId)
+      throws IOException, AlluxioException {
+    // Use schedule pool do everyThing.
+    if (uploadId == null) {
+      uploadId = getMultipartUploadId(bucket, object);
+    }
+    return apply(new AbortTask(bucket, object, uploadId), 0);
+  }
+
+  /**
+   * Schedule a task to clean multipart upload.
+   *
+   * @param task abort multipart upload task
+   * @param delay delay time
+   * @return true if add a abort task
+   */
+  private boolean apply(AbortTask task, long delay) {
+    final ScheduledFuture<?> f = mExecutor.schedule(task, delay, TimeUnit.MILLISECONDS);
+    mTasks.put(task, f);
+    return true;
+  }
+
+  /**
+   * Cancel schedule task.
+   *
+   * @param bucket bucket name
+   * @param object object name
+   * @param uploadId multipart upload tmp directory fileId
+   */
+  public void cancelAbort(String bucket, String object, Long uploadId) {
+    AbortTask task = new AbortTask(bucket, object, uploadId);
+    if (mTasks.containsKey(task)) {
+      ScheduledFuture<?> f = mTasks.remove(task);
+      if (f != null) {
+        f.cancel(false);
+      }
+    }
+  }
+
+  /**
+   * Remove finished task.
+   */
+  private void removeTaskRecord(AbortTask task) {
+    mTasks.remove(task);
+  }
+
+  /**
+   * Detect if abort task can retry.
+   *
+   * @param task abort task
+   * @return if task can retry
+   */
+  private boolean canRetry(AbortTask task) {
+    return task.mRetryCount < mRetry;
+  }
+
+  /**
+   * Try to abort a multipart upload if it was timeout.
+   *
+   * @param bucket the bucket name
+   * @param object the object name
+   * @param uploadId multipart upload tmp directory fileId
+   * @return delay time
+   */
+  public long tryAbortMultipartUpload(String bucket, String object, Long uploadId)
+      throws IOException, AlluxioException {
+    long delay = 0;
+    final String bucketPath = AlluxioURI.SEPARATOR  + bucket;
+    final String multipartTemporaryDir =
+        S3RestUtils.getMultipartTemporaryDirForObject(bucketPath, object);
+    final String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
+    AlluxioURI tmpUri = new AlluxioURI(multipartTemporaryDir);
+    try {
+      URIStatus status = mFs.getStatus(tmpUri);
+      if ((uploadId == null || uploadId == status.getFileId()) && status.isFolder()) {
+        final long curTime = System.currentTimeMillis();
+        long lastModificationTimeMs = status.getLastModificationTimeMs();
+        delay = lastModificationTimeMs + mTimeout - curTime;
+        if (delay <= 0) {
+          // check object, when merge multipart upload, it may be timeout
+          try {
+            AlluxioURI uri = new AlluxioURI(objectPath);
+            status = mFs.getStatus(uri);
+            lastModificationTimeMs = status.getLastModificationTimeMs();
+            delay = lastModificationTimeMs + mTimeout - curTime;
+            if (delay <= 0) {
+              mFs.delete(tmpUri, DeletePOptions.newBuilder().setRecursive(true).build());
+              LOG.info("Abort multipart upload {} in bucket {} with uploadId {}.",
+                  object, bucket, uploadId);
+            }
+          } catch (FileDoesNotExistException e) {
+            mFs.delete(tmpUri, DeletePOptions.newBuilder().setRecursive(true).build());
+            LOG.info("Abort multipart upload {} in bucket {} with uploadId {}.",
+                object, bucket, uploadId);
+          }
+        }
+      }
+    } catch (FileDoesNotExistException ignored) {
+      return delay;
+    }
+    return delay;
+  }
+
+  /**
+   * Get multipart uploadId.
+   *
+   * @param bucket the bucket name
+   * @param object the object name
+   */
+  private Long getMultipartUploadId(String bucket, String object)
+      throws IOException, AlluxioException {
+    final String bucketPath = AlluxioURI.SEPARATOR  + bucket;
+    String multipartTemporaryDir =
+        S3RestUtils.getMultipartTemporaryDirForObject(bucketPath, object);
+    try {
+      URIStatus status = mFs.getStatus(new AlluxioURI(multipartTemporaryDir));
+      return status.getFileId();
+    } catch (FileDoesNotExistException | InvalidPathException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Abort Multipart upload task.
+   */
+  public class AbortTask implements Runnable {
+    private final String mBucket;
+    private final String mObject;
+    private final Long mUploadId;
+    private int mRetryCount;
+
+    /**
+     * Creates a new instance of {@link AbortTask}.
+     *
+     * @param bucket the bucket name
+     * @param object the object name
+     * @param uploadId multipart upload tmp directory fileId
+     */
+    public AbortTask(String bucket, String object,
+                     Long uploadId) {
+      mBucket = bucket;
+      mObject = object;
+      mUploadId = uploadId;
+      mRetryCount = 0;
+    }
+
+    @Override
+    public void run() {
+      try {
+        long delay = tryAbortMultipartUpload(mBucket, mObject, mUploadId);
+        if (delay > 0) {
+          apply(this, delay);
+        } else {
+          removeTaskRecord(this);
+        }
+      } catch (IOException | AlluxioException e) {
+        mRetryCount++;
+        LOG.error("Failed abort multipart upload {} in bucket {} with uploadId {} with error {}"
+            + " after retry {} count.", mObject, mBucket, mUploadId, e, mRetryCount);
+        e.printStackTrace();
+        if (canRetry(this)) {
+          apply(this, mRetryDelay);
+        }
+      }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      AbortTask abortTask = (AbortTask) o;
+      return mBucket.equals(abortTask.mBucket)
+          && mObject.equals(abortTask.mObject)
+          && mUploadId.equals(abortTask.mUploadId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(mBucket, mObject, mUploadId);
+    }
+
+    @Override
+    public String toString() {
+      return "AbortTask{"
+          + "mBucket='" + mBucket + '\''
+          + ", mObject='" + mObject + '\''
+          + ", mUploadId=" + mUploadId
+          + ", mRetryCount=" + mRetryCount
+          + '}';
+    }
+  }
+}

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ErrorCode.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ErrorCode.java
@@ -32,6 +32,7 @@ public class S3ErrorCode {
     public static final String NO_SUCH_UPLOAD = "NoSuchUpload";
     public static final String PRECONDITION_FAILED = "PreconditionFailed";
     public static final String INVALID_CONTINUATION_TOKEN = "InvalidContinuationToken";
+    public static final String UPLOAD_ALREADY_EXISTS = "UploadAlreadyExists";
 
     private Name() {
     } // prevents instantiation
@@ -82,6 +83,10 @@ public class S3ErrorCode {
       Name.INVALID_CONTINUATION_TOKEN,
       "The continuation token provided is incorrect",
       Response.Status.BAD_REQUEST);
+  public static final S3ErrorCode UPLOAD_ALREADY_EXISTS = new S3ErrorCode(
+      Name.UPLOAD_ALREADY_EXISTS,
+      "The specified multipart upload already exits",
+      Response.Status.CONFLICT);
 
   //
   // Customized error codes.


### PR DESCRIPTION
### What changes are proposed in this pull request?

 #14257

### Does this PR introduce any user facing changes?

Add these PropertyKey:
1. `alluxio.proxy.s3.multipart.upload.timeout` 
2. `alluxio.proxy.s3.multipart.upload.cleaner.retry.count`
3. `alluxio.proxy.s3.multipart.upload.cleaner.retry.delay`
4. `alluxio.proxy.s3.multipart.upload.cleaner.pool.size`
