### PR TITLE
Fix flaky BlockMasterMetricsTest.testSize

### DIFF
--- a/core/server/master/src/test/java/alluxio/master/block/BlockMasterMetricsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/BlockMasterMetricsTest.java
@@ -18,7 +18,6 @@ import alluxio.Constants;
 import alluxio.MasterStorageTierAssoc;
 import alluxio.StorageTierAssoc;
 import alluxio.master.block.DefaultBlockMaster.Metrics;
-import alluxio.master.metastore.BlockStore;
 import alluxio.metrics.MetricInfo;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
@@ -26,7 +25,6 @@ import alluxio.metrics.MetricsSystem;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix flaky `BlockMasterMetricsTest.testSize`, e.g. https://github.com/Alluxio/alluxio/runs/4037547872?check_suite_focus=true

```console
Error: 9.386 [ERROR] alluxio.master.block.BlockMasterMetricsTest.testSize  Time elapsed: 0.002 s  <<< FAILURE!
java.lang.AssertionError: expected:<100> but was:<0>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at alluxio.master.block.BlockMasterMetricsTest.testSize(BlockMasterMetricsTest.java:83)
```

### Does this PR introduce any user facing changes?

No.