### PR TITLE
Fix flaky ReplicateDefinitionTest

### DIFF
--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -117,6 +117,8 @@ public final class ReplicateDefinitionTest {
     mMockFileSystemContext = PowerMockito.mock(FileSystemContext.class);
     when(mMockFileSystemContext.getClientContext())
         .thenReturn(ClientContext.create(ServerConfiguration.global()));
+    when(mMockFileSystemContext.getClusterConf())
+        .thenReturn(ServerConfiguration.global());
     mMockBlockStore = PowerMockito.mock(AlluxioBlockStore.class);
     mMockFileSystem = mock(FileSystem.class);
     mMockUfsManager = mock(UfsManager.class);
@@ -175,7 +177,7 @@ public final class ReplicateDefinitionTest {
         .thenReturn(mTestBlockInfo
             .setLocations(Lists.newArrayList(new BlockLocation().setWorkerAddress(ADDRESS_1))));
     PowerMockito.mockStatic(AlluxioBlockStore.class);
-    when(AlluxioBlockStore.create(mMockFileSystemContext)).thenReturn(mMockBlockStore);
+    when(AlluxioBlockStore.create(any(FileSystemContext.class))).thenReturn(mMockBlockStore);
 
     ReplicateConfig config = new ReplicateConfig(TEST_PATH, TEST_BLOCK_ID, 1 /* value not used */);
     ReplicateDefinition definition = new ReplicateDefinition();


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix broken unit tests in ReplicateDefinitionTest.

```
Error: 0.379 [ERROR] alluxio.job.plan.replicate.ReplicateDefinitionTest.runTaskLocalBlockWorkerDifferentFileStatus  Time elapsed: 0.688 s  <<< ERROR!
java.lang.NullPointerException
	at alluxio.job.util.JobUtils.loadBlock(JobUtils.java:147)
	at alluxio.job.plan.replicate.ReplicateDefinition.runTask(ReplicateDefinition.java:106)
	at alluxio.job.plan.replicate.ReplicateDefinitionTest.runTaskReplicateTestHelper(ReplicateDefinitionTest.java:182)
	at alluxio.job.plan.replicate.ReplicateDefinitionTest.runTaskLocalBlockWorkerDifferentFileStatus(ReplicateDefinitionTest.java:290)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

### Why are the changes needed?

Due to the recent changes to `JobUtils` in PR #14317  , the way `blockStore` is created was changed. 
Previously it was created directly from the `FileSystemContext` object that was passed in as an argument, after the changes, it was created from a new context that is created from `FileSystemContext.create(config)`. This makes the mock `when(AlluxioBlockStore.create(mMockFileSystemContext).thenReturn(mMockBlockStore);` no longer triggered, since the context object is different.

The fix is simply to expect any `FileSystemContext` when creating a block store.

Also add mock for the method `FileSystemContext.getClusterConf` which is now called to get the configuration, to prevent NPEs.

### Does this PR introduce any user facing changes?

No.
