### PR TITLE
Fix flaky test EmbeddedJournalIntegrationTestResizing.growCluster

### DIFF
--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestResizing.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestResizing.java
@@ -133,6 +133,9 @@ public class EmbeddedJournalIntegrationTestResizing extends EmbeddedJournalInteg
     // Wait until cluster registers unavailability of the shut down master.
     waitForQuorumPropertySize(info -> info.getServerState() == QuorumServerState.UNAVAILABLE, 1);
 
+    // Reacquire FS client after master re-election.
+    fs = mCluster.getFileSystemClient();
+
     // Verify cluster is still operational.
     assertTrue(fs.exists(testDir));
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix flaky test `EmbeddedJournalIntegrationTestResizing.growCluster` which fails randomly.

e.g. 

```
alluxio.exception.status.UnavailableException: Failed to connect to master (06883b23f40e:11068) after 1 attempts.Please check if Alluxio master is currently running on "06883b23f40e:11068". Service="FileSystemMasterClient"
	at alluxio.AbstractClient.connect(AbstractClient.java:280)
	at alluxio.AbstractClient.retryRPCInternal(AbstractClient.java:405)
	at alluxio.AbstractClient.retryRPC(AbstractClient.java:373)
	at alluxio.AbstractClient.retryRPC(AbstractClient.java:362)
	at alluxio.client.file.RetryHandlingFileSystemMasterClient.getStatus(RetryHandlingFileSystemMasterClient.java:202)
	at alluxio.client.file.BaseFileSystem.lambda$exists$4(BaseFileSystem.java:207)
	at alluxio.client.file.BaseFileSystem.rpc(BaseFileSystem.java:574)
	at alluxio.client.file.BaseFileSystem.exists(BaseFileSystem.java:203)
	at alluxio.client.file.FileSystem.exists(FileSystem.java:270)
	at alluxio.server.ft.journal.raft.EmbeddedJournalIntegrationTestResizing.growCluster(EmbeddedJournalIntegrationTestResizing.java:137)
```

The fix is to reacquire a client after the master re-election, since the master RPC address might have changed after the master switch. I'm not familiar with HA and Raft, but from my experiments and observations, without the fix, the test fails 1 out of 8 runs, and after applying the fix, it does not fail for a consecutive 20 runs.

@jiacheliu3 @yuzhu Please check if this fix makes sense, and if so, I think there are more bugs of such kind in this test class that needs fixing.