### PR TITLE
Disable invalid ZK test

### DIFF
--- a/tests/src/test/java/alluxio/server/ft/ZookeeperFailureIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/ZookeeperFailureIntegrationTest.java
@@ -33,6 +33,7 @@ import alluxio.grpc.GrpcChannelBuilder;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -107,6 +108,7 @@ public class ZookeeperFailureIntegrationTest extends BaseIntegrationTest {
     mCluster.notifySuccess();
   }
 
+  @Ignore // cannot guarantee `assertNotEquals(leaderIdx, leaderIdx2);`
   @Test
   public void zkConnectionPolicy_Standard() throws Exception {
     mCluster = MultiProcessCluster.newBuilder(PortCoordination.ZOOKEEPER_CONNECTION_POLICY_STANDARD)


### PR DESCRIPTION
Disables one zk test because the assertion it relies on cannot be guaranteed