### PR TITLE
Reset fs context in `MultiProcessCluster`

### DIFF
--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -272,6 +272,7 @@ public final class MultiProcessCluster {
     for (int i = 0; i < count; i++) {
       createMaster(startIndex + i).start();
     }
+    mFilesystemContext = null;
   }
 
   /**


### PR DESCRIPTION
Reset the file system context to null after a new master has been added. This allows a new fs client to be instantiated and take into account the new master.