### PR TITLE
Extend cluster change notice timeout

### DIFF
--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestBase.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestBase.java
@@ -55,7 +55,7 @@ public class EmbeddedJournalIntegrationTestBase extends BaseIntegrationTest {
 
   protected void waitForQuorumPropertySize(Predicate<? super QuorumServerInfo> pred, int size)
       throws InterruptedException, TimeoutException {
-    final int TIMEOUT_1MIN = 60 * 1000; // in ms
+    final int TIMEOUT_1MIN30SEC = 90 * 1000; // in ms
     CommonUtils.waitFor("quorum property", () -> {
       try {
         return mCluster.getJournalMasterClientForMaster().getQuorumInfo().getServerInfoList()
@@ -63,6 +63,6 @@ public class EmbeddedJournalIntegrationTestBase extends BaseIntegrationTest {
       } catch (AlluxioStatusException e) {
         return false;
       }
-    }, WaitForOptions.defaults().setTimeoutMs(TIMEOUT_1MIN));
+    }, WaitForOptions.defaults().setTimeoutMs(TIMEOUT_1MIN30SEC));
   }
 }


### PR DESCRIPTION
Extend the timeout that the cluster has to notice changes to the quorum for EmbeddedJournal integration tests. This reduces flakiness.