### PR TITLE
Increase timeout for FreeAndDeleteIntegrationTest.deleteDir test

### DIFF
--- a/tests/src/test/java/alluxio/client/fs/FreeAndDeleteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FreeAndDeleteIntegrationTest.java
@@ -136,7 +136,7 @@ public final class FreeAndDeleteIntegrationTest extends BaseIntegrationTest {
    * Tests that deleting a directory with number of files larger than maximum lock cache size will
    * not be blocked.
    */
-  @Test(timeout = 3000)
+  @Test(timeout = 10000)
   public void deleteDir() throws Exception {
     String uniqPath = PathUtils.uniqPath();
     for (int file = 0; file < 2 * LOCK_POOL_HIGH_WATERMARK; file++) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix flaky test
```
Error: 6.142 [ERROR] alluxio.client.fs.FreeAndDeleteIntegrationTest.deleteDir  Time elapsed: 5.849 s  <<< ERROR!
org.junit.runners.model.TestTimedOutException: test timed out after 3000 milliseconds
	at java.base@11.0.10/jdk.internal.misc.Unsafe.park(Native Method)
	at java.base@11.0.10/java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)
	at app//io.grpc.stub.ClientCalls$ThreadlessExecutor.waitAndDrain(ClientCalls.java:731)
	at app//io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:149)
	at app//alluxio.grpc.FileSystemMasterClientServiceGrpc$FileSystemMasterClientServiceBlockingStub.completeFile(FileSystemMasterClientServiceGrpc.java:1672)
	at app//alluxio.client.file.RetryHandlingFileSystemMasterClient.lambda$completeFile$4(RetryHandlingFileSystemMasterClient.java:172)
	at app//alluxio.client.file.RetryHandlingFileSystemMasterClient$$Lambda$608/0x00000008406b7840.call(Unknown Source)
	at app//alluxio.AbstractClient.retryRPCInternal(AbstractClient.java:407)
	at app//alluxio.AbstractClient.retryRPC(AbstractClient.java:373)
	at app//alluxio.AbstractClient.retryRPC(AbstractClient.java:362)
	at app//alluxio.client.file.RetryHandlingFileSystemMasterClient.completeFile(RetryHandlingFileSystemMasterClient.java:172)
	at app//alluxio.client.file.AlluxioFileOutStream.close(AlluxioFileOutStream.java:203)
	at app//alluxio.client.fs.FreeAndDeleteIntegrationTest.deleteDir(FreeAndDeleteIntegrationTest.java:145)
	at java.base@11.0.10/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base@11.0.10/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base@11.0.10/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base@11.0.10/java.lang.reflect.Method.invoke(Method.java:566)
	at app//org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at app//org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at app//org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at app//org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at app//org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:288)
	at app//org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:282)
	at java.base@11.0.10/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base@11.0.10/java.lang.Thread.run(Thread.java:834)
```