### PR TITLE
Add authentication logic for Hub Manager

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5613,6 +5613,16 @@ public final class PropertyKey implements Comparable<PropertyKey> {
                   .setDefaultValue("30075")
                   .setDescription("The port that the hub agent's RPC port should bind to")
                   .build();
+  public static final PropertyKey HUB_AUTHENTICATION_API_KEY =
+          new Builder(Name.HUB_AUTHENTICATION_API_KEY)
+                  .setDescription("The API key of Hub manager.")
+                  .setDisplayType(DisplayType.CREDENTIALS)
+                  .build();
+  public static final PropertyKey HUB_AUTHENTICATION_SECRET_KEY =
+          new Builder(Name.HUB_AUTHENTICATION_SECRET_KEY)
+                  .setDescription("The secret key of Hub Manager.")
+                  .setDisplayType(DisplayType.CREDENTIALS)
+                  .build();
   public static final PropertyKey HUB_CLUSTER_LABEL =
           new Builder(Name.HUB_CLUSTER_LABEL)
                   .setDefaultValue("Alluxio Hub")
@@ -6848,6 +6858,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     ///
     /// Alluxio Hub Manager Properties
     ///
+    public static final String HUB_AUTHENTICATION_API_KEY = "alluxio.hub.authentication.apiKey";
+    public static final String HUB_AUTHENTICATION_SECRET_KEY =
+            "alluxio.hub.authentication.secretKey";
     public static final String HUB_CLUSTER_LABEL =
             "alluxio.hub.cluster.label";
     public static final String HUB_MANAGER_AGENT_LOST_THRESHOLD_TIME =

--- a/hub/server/src/main/java/alluxio/hub/manager/rpc/interceptor/HubAuthenticationInterceptor.java
+++ b/hub/server/src/main/java/alluxio/hub/manager/rpc/interceptor/HubAuthenticationInterceptor.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.hub.manager.rpc.interceptor;
 
 import alluxio.hub.proto.HubAuthentication;

--- a/hub/server/src/main/java/alluxio/hub/manager/rpc/interceptor/HubAuthenticationInterceptor.java
+++ b/hub/server/src/main/java/alluxio/hub/manager/rpc/interceptor/HubAuthenticationInterceptor.java
@@ -1,0 +1,62 @@
+package alluxio.hub.manager.rpc.interceptor;
+
+import alluxio.hub.proto.HubAuthentication;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Client side interceptor that is used to augment outgoing metadata with the API and secret keys
+ * for the channel that the RPC is being called on.
+ */
+@ThreadSafe
+public class HubAuthenticationInterceptor implements ClientInterceptor {
+
+  /** Metadata key for the API key. */
+  public static final Metadata.Key<String> METADATA_API_KEY =
+      Metadata.Key.of("hub-api-key", Metadata.ASCII_STRING_MARSHALLER);
+
+  /** Metadata key for the Secret key. */
+  public static final Metadata.Key<String> METADATA_SECRET_KEY =
+      Metadata.Key.of("hub-secret-key", Metadata.ASCII_STRING_MARSHALLER);
+
+  private final HubAuthentication mHubAuthentication;
+
+  /**
+   * Creates the client-side interceptor that augments outgoing metadata with API and secret keys
+   * for authentication.
+   * @param hubAuthentication API and secret keys used by the Hub Manager for authentication
+   */
+  public HubAuthenticationInterceptor(HubAuthentication hubAuthentication) {
+    mHubAuthentication = hubAuthentication;
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+      CallOptions callOptions, Channel next) {
+    return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+            next.newCall(method, callOptions)) {
+      @Override
+      public void start(Listener<RespT> responseListener, Metadata headers) {
+        // Put API and secret keys in header.
+        headers.put(METADATA_API_KEY, mHubAuthentication.getApiKey());
+        headers.put(METADATA_SECRET_KEY, mHubAuthentication.getSecretKey());
+        super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(
+                responseListener) {
+          @Override
+          public void onHeaders(Metadata headers) {
+            super.onHeaders(headers);
+          }
+        }, headers);
+      }
+    };
+  }
+}

--- a/hub/server/src/main/java/alluxio/hub/manager/rpc/observer/RequestStreamObserver.java
+++ b/hub/server/src/main/java/alluxio/hub/manager/rpc/observer/RequestStreamObserver.java
@@ -46,7 +46,7 @@ public abstract class RequestStreamObserver<ReqT, ResT> implements StreamObserve
    */
   @Override
   public void onError(Throwable t) {
-    LOG.error("Async listener error:", t);
+    handleError("Async listener error", t);
     LOG.info("Async listener connection canceled. Attempting to reconnect...");
     restart();
   }
@@ -82,4 +82,12 @@ public abstract class RequestStreamObserver<ReqT, ResT> implements StreamObserve
    * Handles restarting the request stream observer.
    */
   public abstract void restart();
+
+  /**
+   * Handles errors depending on the type.
+   *
+   * @param message message to log
+   * @param t Throwable object
+   */
+  public abstract void handleError(String message, Throwable t);
 }

--- a/hub/transport/src/main/proto/grpc/agent.proto
+++ b/hub/transport/src/main/proto/grpc/agent.proto
@@ -19,6 +19,7 @@ service AgentManagerService {
   rpc ListCatalogs(AgentListCatalogRequest) returns (AgentListCatalogResponse);
   rpc SetPrestoConfDir(AgentSetPrestoConfRequest) returns (AgentSetPrestoConfResponse);
   rpc ValidatePrestoConfDir(AgentValidatePrestoConfRequest) returns (AgentValidatePrestoConfResponse);
+  rpc Shutdown(AgentShutdownRequest) returns (AgentShutdownResponse);
 }
 
 message AgentFileUploadRequest {
@@ -138,3 +139,10 @@ message AgentValidatePrestoConfRequest {
 message AgentValidatePrestoConfResponse {
   optional ValidationResult result = 1;
 }
+
+message AgentShutdownRequest {
+  optional string log_message = 1;
+  optional int32 exit_code = 2;
+}
+
+message AgentShutdownResponse {}

--- a/hub/transport/src/main/proto/grpc/rest.proto
+++ b/hub/transport/src/main/proto/grpc/rest.proto
@@ -7,6 +7,10 @@ option java_outer_classname = "RestProto";
 package alluxio.hub.proto;
 
 // Messages used in request/responses to the Hub Manager API
+message HubAuthentication {
+  optional string api_key = 1;
+  optional string secret_key = 2;
+}
 
 message Status {
   optional string uptime = 1;


### PR DESCRIPTION
### What changes are proposed in this pull request?

- Hub Manager is required to send authentication keys (API and secret keys) for all gRPC calls.
- Keys must be set via new properties in `alluxio-site.properties`
- If a Hub Manager is unauthenticated, it will attempt to shutdown all Hub Agents and itself, logging an error stating that it was unauthenticated.

### Why are the changes needed?

This change allows the Hub Manager to use API and secret keys to prove its authentication.

### Does this PR introduce any user facing changes?

New property keys
`alluxio.hub.authentication.apiKey`
`alluxio.hub.authentication.secretKey`