### PR TITLE
Add deplay when launching multiple masters in `MultiProcessCluster`

### DIFF
--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -269,8 +269,10 @@ public final class MultiProcessCluster {
     writeConf();
     ServerConfiguration.merge(mProperties, Source.RUNTIME);
 
+    final int MASTER_START_DELAY_MS = 500; // in ms
     for (int i = 0; i < count; i++) {
       createMaster(startIndex + i).start();
+      wait(MASTER_START_DELAY_MS);
     }
     mFilesystemContext = null;
   }


### PR DESCRIPTION
Adding a delay between launching each master in `MultiProcessCluster` significantly decreases the flakiness at startup. When all the masters are launched at the same time, Ratis can have some difficulties selecting a leading master