### PR TITLE
Fix RPC benchmarks extra preparation and low concurrency

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/GetPinnedFileIdsBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/GetPinnedFileIdsBench.java
@@ -86,8 +86,8 @@ public class GetPinnedFileIdsBench extends RpcBench<GetPinnedFileIdsParameters> 
     // So including that in the log can help associate the log to the run
     LOG.info("Task ID is {}", mBaseParameters.mId);
 
-    // the preparation is done by the invoking client
-    // so skip preparation when running in job worker
+    // The preparation is done by the invoking shell process to ensure the preparation is only
+    // done once, so skip preparation when running in job worker
     if (mBaseParameters.mDistributed) {
       LOG.info("Skipping preparation in distributed execution");
       return;

--- a/stress/shell/src/main/java/alluxio/stress/cli/RegisterWorkerBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/RegisterWorkerBench.java
@@ -106,10 +106,14 @@ public class RegisterWorkerBench extends RpcBench<BlockMasterBenchParameters> {
     }
     mBlockCount = blockCount;
 
-    // Prepare these block IDs concurrently
-    LOG.info("Preparing blocks at the master");
-    RpcBenchPreparationUtils.prepareBlocksInMaster(blockMap, getPool(), mParameters.mConcurrency);
-    LOG.info("Created all blocks at the master");
+    // the preparation is done by the invoking client
+    // so skip preparation when running in job worker
+    if (!mBaseParameters.mDistributed) {
+      // Prepare these block IDs concurrently
+      LOG.info("Preparing blocks at the master");
+      RpcBenchPreparationUtils.prepareBlocksInMaster(blockMap);
+      LOG.info("Created all blocks at the master");
+    }
 
     // Prepare worker IDs
     int numWorkers = mParameters.mConcurrency;

--- a/stress/shell/src/main/java/alluxio/stress/cli/RegisterWorkerBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/RegisterWorkerBench.java
@@ -106,8 +106,8 @@ public class RegisterWorkerBench extends RpcBench<BlockMasterBenchParameters> {
     }
     mBlockCount = blockCount;
 
-    // the preparation is done by the invoking client
-    // so skip preparation when running in job worker
+    // The preparation is done by the invoking shell process to ensure the preparation is only
+    // done once, so skip preparation when running in job worker
     if (!mBaseParameters.mDistributed) {
       // Prepare these block IDs concurrently
       LOG.info("Preparing blocks at the master");

--- a/stress/shell/src/main/java/alluxio/stress/cli/RpcBenchPreparationUtils.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/RpcBenchPreparationUtils.java
@@ -67,7 +67,8 @@ public class RpcBenchPreparationUtils {
    *
    * @param locToBlocks a map from block location to block IDs
    */
-  public static void prepareBlocksInMaster(Map<BlockStoreLocation, List<Long>> locToBlocks) throws InterruptedException {
+  public static void prepareBlocksInMaster(Map<BlockStoreLocation, List<Long>> locToBlocks)
+      throws InterruptedException {
     // Partition the wanted block IDs to smaller jobs in order to utilize concurrency
     int concurrency = Runtime.getRuntime().availableProcessors() * 4;
     List<List<Long>> jobs = new ArrayList<>();

--- a/stress/shell/src/main/java/alluxio/stress/cli/StreamRegisterWorkerBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/StreamRegisterWorkerBench.java
@@ -99,8 +99,8 @@ public class StreamRegisterWorkerBench extends RpcBench<BlockMasterBenchParamete
                     .build());
     mBlockMap = blockMap;
 
-    // the preparation is done by the invoking client
-    // so skip preparation when running in job worker
+    // The preparation is done by the invoking shell process to ensure the preparation is only
+    // done once, so skip preparation when running in job worker
     if (!mBaseParameters.mDistributed) {
       // Prepare these block IDs concurrently
       LOG.info("Preparing blocks at the master");

--- a/stress/shell/src/main/java/alluxio/stress/cli/StreamRegisterWorkerBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/StreamRegisterWorkerBench.java
@@ -99,10 +99,14 @@ public class StreamRegisterWorkerBench extends RpcBench<BlockMasterBenchParamete
                     .build());
     mBlockMap = blockMap;
 
-    // Prepare these block IDs concurrently
-    LOG.info("Preparing blocks at the master");
-    RpcBenchPreparationUtils.prepareBlocksInMaster(blockMap, getPool(), mParameters.mConcurrency);
-    LOG.info("Created all blocks at the master");
+    // the preparation is done by the invoking client
+    // so skip preparation when running in job worker
+    if (!mBaseParameters.mDistributed) {
+      // Prepare these block IDs concurrently
+      LOG.info("Preparing blocks at the master");
+      RpcBenchPreparationUtils.prepareBlocksInMaster(blockMap);
+      LOG.info("Created all blocks at the master");
+    }
 
     // Prepare worker IDs
     int numWorkers = mParameters.mConcurrency;

--- a/stress/shell/src/main/java/alluxio/stress/cli/WorkerHeartbeatBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/WorkerHeartbeatBench.java
@@ -170,8 +170,8 @@ public class WorkerHeartbeatBench extends RpcBench<BlockMasterBenchParameters> {
                     .build());
     mLocationBlockIdList = client.convertBlockListMapToProto(blockMap);
 
-    // the preparation is done by the invoking client
-    // so skip preparation when running in job worker
+    // The preparation is done by the invoking shell process to ensure the preparation is only
+    // done once, so skip preparation when running in job worker
     if (!mBaseParameters.mDistributed) {
       // Prepare these block IDs concurrently
       LOG.info("Preparing block IDs at the master");

--- a/stress/shell/src/main/java/alluxio/stress/cli/WorkerHeartbeatBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/WorkerHeartbeatBench.java
@@ -170,9 +170,14 @@ public class WorkerHeartbeatBench extends RpcBench<BlockMasterBenchParameters> {
                     .build());
     mLocationBlockIdList = client.convertBlockListMapToProto(blockMap);
 
-    // Prepare these block IDs concurrently
-    LOG.info("Preparing block IDs at the master");
-    RpcBenchPreparationUtils.prepareBlocksInMaster(blockMap, getPool(), mParameters.mConcurrency);
+    // the preparation is done by the invoking client
+    // so skip preparation when running in job worker
+    if (!mBaseParameters.mDistributed) {
+      // Prepare these block IDs concurrently
+      LOG.info("Preparing block IDs at the master");
+      RpcBenchPreparationUtils.prepareBlocksInMaster(blockMap);
+      LOG.info("Created all blocks at the master");
+    }
 
     // Prepare simulated workers
     int numWorkers = mParameters.mConcurrency;


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix extra preparations in `RegisterWorkerBench` and `WorkerHeartbeatBench`.
Increase concurrency for both benchmarks, to accelerate benchmarking.

