### PR TITLE
Fix BlockMasterIntegrityIntegrationTest for worker stream register

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1295,6 +1295,9 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
             mLostBlocks.remove(blockId);
           } else {
             invalidBlockCount++;
+            // The block is not recognized and should therefore be purged from the worker
+            // The file may have been removed when the worker was lost
+            workerInfo.scheduleRemoveFromWorker(blockId);
             LOG.debug("Invalid block: {} from worker {}.", blockId,
                 workerInfo.getWorkerAddress().getHost());
           }


### PR DESCRIPTION
This test fails when worker registers with a stream, due to how the operation are rearranged for the streaming registration.

Although this is on the same codepath for unary RPC register, this does not affect the correctness.