### PR TITLE
[DOCFIX] Fix docker doc

### DIFF
--- a/docs/en/deploy/Running-Alluxio-On-Docker.md
+++ b/docs/en/deploy/Running-Alluxio-On-Docker.md
@@ -39,6 +39,8 @@ To set up Docker after provisioning the instance, which will be referred as the 
 
 ```console
 $ sudo yum install -y docker
+# Create docker group
+$ sudo groupadd docker
 # Add the current user to the docker group
 $ sudo usermod -a -G docker $(id -u -n)
 # Start docker service

--- a/docs/en/deploy/Running-Alluxio-On-Docker.md
+++ b/docs/en/deploy/Running-Alluxio-On-Docker.md
@@ -39,9 +39,10 @@ To set up Docker after provisioning the instance, which will be referred as the 
 
 ```console
 $ sudo yum install -y docker
-$ sudo service docker start
 # Add the current user to the docker group
 $ sudo usermod -a -G docker $(id -u -n)
+# Start docker service
+$ sudo service docker start
 # Log out and log back in again to pick up the group changes
 $ exit
 ```


### PR DESCRIPTION
Tested on CentOS7.

The docker group is not automatically created after installing docker via yum, so create it manually.

Other than log out and log back in, the docker service has to restart to pick up the group change, otherwise there's permission denied error. Move the command after done with adding user to group so no need to restart docker service.