### PR TITLE
Use traverseOrClose instead of traverse

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -377,7 +377,7 @@ public class LockedInodePath implements Closeable {
 
     LockedInodePath newPath =
         new LockedInodePath(mUri, this, mPathComponents, LockPattern.WRITE_EDGE, mUseTryLock);
-    newPath.traverse();
+    newPath.traverseOrClose();
     return newPath;
   }
 


### PR DESCRIPTION
Currently `LockedInodePath#lockFinalEdgeWrite()` is only used in two locations:

- [InodeSyncStream.java#L926](https://github.com/Alluxio/alluxio/blob/7f30116efd9f789d80902498a8b404aaa560e260/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java#L926)
- [InodeSyncStream.java#L1017](https://github.com/Alluxio/alluxio/blob/7f30116efd9f789d80902498a8b404aaa560e260/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java#L1017)

Both of the objects returned by this method are wrapped in try-with-resources blocks, so they will be `close()`ed. However, internal to `lockFinalEdgeWrite()` there is a possibility that the `traverse()` call will fail and hence the object in the try-with-resources block will not be initialized.
```
public LockedInodePath lockFinalEdgeWrite() throws InvalidPathException {
    Preconditions.checkState(!fullPathExists());

    LockedInodePath newPath =
        new LockedInodePath(mUri, this, mPathComponents, LockPattern.WRITE_EDGE, mUseTryLock);
    newPath.traverse();
    return newPath;
  }
```

This PR just swaps the usage of `newPath.traverse();` to `newPath.traverseOrClose();` to safeguard this scenario.

