### PR TITLE
Fix metric web ui can't resolve large number datapoints

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/TimeSeries.java
+++ b/core/common/src/main/java/alluxio/metrics/TimeSeries.java
@@ -11,15 +11,14 @@
 
 package alluxio.metrics;
 
-import java.util.LinkedList;
-import java.util.List;
+import com.google.common.collect.EvictingQueue;
 
 /**
  * Represents a time series which can be graphed in the UI.
  */
 public class TimeSeries {
   private final String mName;
-  private final List<DataPoint> mDataPoints;
+  private final EvictingQueue<DataPoint> mDataPoints;
 
   /**
    * Create a new time series with the given name and no data.
@@ -27,7 +26,7 @@ public class TimeSeries {
    */
   public TimeSeries(String name) {
     mName = name;
-    mDataPoints = new LinkedList<>();
+    mDataPoints = EvictingQueue.create(20);
   }
 
   /**
@@ -48,7 +47,7 @@ public class TimeSeries {
   /**
    * @return the data of the time series
    */
-  public List<DataPoint> getDataPoints() {
+  public EvictingQueue<DataPoint> getDataPoints() {
     return mDataPoints;
   }
 

--- a/core/common/src/main/java/alluxio/wire/MasterWebUIMetrics.java
+++ b/core/common/src/main/java/alluxio/wire/MasterWebUIMetrics.java
@@ -680,7 +680,7 @@ public final class MasterWebUIMetrics implements Serializable {
    * @return the updated masterWebUIMetrics object
    */
   public MasterWebUIMetrics setTimeSeriesMetrics(List<TimeSeries> timeSeries) {
-    mTimeSeriesMetrics = timeSeries.subList(Math.max(timeSeries.size() - 20, 0), timeSeries.size());
+    mTimeSeriesMetrics = timeSeries;
     return this;
   }
 

--- a/core/server/master/src/test/java/alluxio/master/metrics/TimeSeriesStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metrics/TimeSeriesStoreTest.java
@@ -73,7 +73,7 @@ public class TimeSeriesStoreTest {
     store.record(metric1, value1);
     CommonUtils.sleepMs(10); // To prevent the two records from being placed in the same ms.
     store.record(metric1, value2);
-    assertEquals(value1, store.getTimeSeries().get(0).getDataPoints().element().getValue(), 0);
-    assertEquals(value2, store.getTimeSeries().get(0).getDataPoints().element().getValue(), 0);
+    assertEquals(value1, store.getTimeSeries().get(0).getDataPoints().poll().getValue(), 0);
+    assertEquals(value2, store.getTimeSeries().get(0).getDataPoints().poll().getValue(), 0);
   }
 }

--- a/core/server/master/src/test/java/alluxio/master/metrics/TimeSeriesStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metrics/TimeSeriesStoreTest.java
@@ -60,8 +60,8 @@ public class TimeSeriesStoreTest {
     }
     assertNotNull(ts1);
     assertNotNull(ts2);
-    assertEquals(value1, ts1.getDataPoints().get(0).getValue(), 0);
-    assertEquals(value2, ts2.getDataPoints().get(0).getValue(), 0);
+    assertEquals(value1, ts1.getDataPoints().element().getValue(), 0);
+    assertEquals(value2, ts2.getDataPoints().element().getValue(), 0);
   }
 
   @Test
@@ -73,7 +73,7 @@ public class TimeSeriesStoreTest {
     store.record(metric1, value1);
     CommonUtils.sleepMs(10); // To prevent the two records from being placed in the same ms.
     store.record(metric1, value2);
-    assertEquals(value1, store.getTimeSeries().get(0).getDataPoints().get(0).getValue(), 0);
-    assertEquals(value2, store.getTimeSeries().get(0).getDataPoints().get(1).getValue(), 0);
+    assertEquals(value1, store.getTimeSeries().get(0).getDataPoints().element().getValue(), 0);
+    assertEquals(value2, store.getTimeSeries().get(0).getDataPoints().element().getValue(), 0);
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix metric web ui will block when data points number too large to process

### Why are the changes needed?
This is a bug. metric web ui can't show pages, when there are too many data points. 

### Does this PR introduce any user facing changes?
No
Please list the user-facing changes introduced by your change, including
webui
