### PR TITLE
Fix incorrect available bytes when change space in StorageDir

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageDir.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageDir.java
@@ -382,18 +382,23 @@ public final class DefaultStorageDir implements StorageDir {
   }
 
   private void reclaimSpace(long size, boolean committed) {
-    Preconditions.checkState(mCapacityBytes >= mAvailableBytes.get() + size,
-        "Available bytes should always be less than total capacity bytes");
-    mAvailableBytes.addAndGet(size);
+    mAvailableBytes.getAndUpdate(oldAvailableBytes -> {
+      long newAvailableBytes = oldAvailableBytes + size;
+      Preconditions.checkState(mCapacityBytes >= newAvailableBytes,
+              "Available bytes should always be less than total capacity bytes");
+      return newAvailableBytes;
+    });
     if (committed) {
       mCommittedBytes.addAndGet(-size);
     }
   }
 
   private void reserveSpace(long size, boolean committed) {
-    Preconditions.checkState(size <= mAvailableBytes.get() + mReservedBytes.get(),
-        "Available bytes should always be non-negative");
-    mAvailableBytes.getAndSet(Math.max(0, mAvailableBytes.get() - size));
+    mAvailableBytes.getAndUpdate(oldAvailableBytes -> {
+      Preconditions.checkState(size <= oldAvailableBytes + getReservedBytes(),
+              "Available bytes should always be non-negative");
+      return Math.max(0, oldAvailableBytes - size);
+    });
     if (committed) {
       mCommittedBytes.addAndGet(size);
     }

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageDir.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageDir.java
@@ -397,7 +397,7 @@ public final class DefaultStorageDir implements StorageDir {
     mAvailableBytes.getAndUpdate(oldAvailableBytes -> {
       Preconditions.checkState(size <= oldAvailableBytes + getReservedBytes(),
               "Available bytes should always be non-negative");
-      return Math.max(0, oldAvailableBytes - size);
+      return oldAvailableBytes - size;
     });
     if (committed) {
       mCommittedBytes.addAndGet(size);

--- a/core/server/worker/src/test/java/alluxio/worker/block/meta/DefaultStorageDirTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/meta/DefaultStorageDirTest.java
@@ -13,6 +13,7 @@ package alluxio.worker.block.meta;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.Constants;
@@ -27,7 +28,6 @@ import alluxio.worker.block.TieredBlockStoreTestUtils;
 
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -53,6 +53,7 @@ public final class DefaultStorageDirTest {
   private static final int TEST_TIER_ORDINAL = 0;
   private static final int TEST_DIR_INDEX = 1;
   private static final long TEST_DIR_CAPACITY = 1000;
+  private static final long TEST_REVERSED_BYTES = TEST_DIR_CAPACITY / 4;
   private String mTestDirPath;
   private StorageTier mTier;
   private StorageDir mDir;
@@ -82,8 +83,8 @@ public final class DefaultStorageDirTest {
         testDirPaths, testDirCapacity, testDirMediumType, null);
 
     mTier = DefaultStorageTier.newStorageTier(Constants.MEDIUM_MEM, false);
-    mDir = DefaultStorageDir.newStorageDir(
-        mTier, TEST_DIR_INDEX, TEST_DIR_CAPACITY, 0, mTestDirPath, Constants.MEDIUM_MEM);
+    mDir = DefaultStorageDir.newStorageDir(mTier, TEST_DIR_INDEX, TEST_DIR_CAPACITY,
+        TEST_REVERSED_BYTES, mTestDirPath, Constants.MEDIUM_MEM);
     mBlockMeta = new DefaultBlockMeta(TEST_BLOCK_ID, TEST_BLOCK_SIZE, mDir);
     mTempBlockMeta =
         new DefaultTempBlockMeta(TEST_SESSION_ID, TEST_TEMP_BLOCK_ID, TEST_TEMP_BLOCK_SIZE, mDir);
@@ -224,32 +225,34 @@ public final class DefaultStorageDirTest {
   public void getBytes() throws Exception {
     // Initial state
     assertEquals(TEST_DIR_CAPACITY, mDir.getCapacityBytes());
-    assertEquals(TEST_DIR_CAPACITY, mDir.getAvailableBytes());
+    assertEquals(TEST_DIR_CAPACITY - TEST_REVERSED_BYTES, mDir.getAvailableBytes());
     assertEquals(0, mDir.getCommittedBytes());
 
     // Add a temp block
     mDir.addTempBlockMeta(mTempBlockMeta);
     assertEquals(TEST_DIR_CAPACITY, mDir.getCapacityBytes());
-    assertEquals(TEST_DIR_CAPACITY - TEST_TEMP_BLOCK_SIZE, mDir.getAvailableBytes());
+    assertEquals(TEST_DIR_CAPACITY - TEST_REVERSED_BYTES - TEST_TEMP_BLOCK_SIZE,
+        mDir.getAvailableBytes());
     assertEquals(0, mDir.getCommittedBytes());
 
     // Add a committed block
     mDir.addBlockMeta(mBlockMeta);
     assertEquals(TEST_DIR_CAPACITY, mDir.getCapacityBytes());
-    assertEquals(TEST_DIR_CAPACITY - TEST_BLOCK_SIZE - TEST_TEMP_BLOCK_SIZE,
+    assertEquals(TEST_DIR_CAPACITY - TEST_REVERSED_BYTES - TEST_BLOCK_SIZE - TEST_TEMP_BLOCK_SIZE,
         mDir.getAvailableBytes());
     assertEquals(TEST_BLOCK_SIZE, mDir.getCommittedBytes());
 
     // Remove the temp block added
     mDir.removeTempBlockMeta(mTempBlockMeta);
     assertEquals(TEST_DIR_CAPACITY, mDir.getCapacityBytes());
-    assertEquals(TEST_DIR_CAPACITY - TEST_BLOCK_SIZE, mDir.getAvailableBytes());
+    assertEquals(TEST_DIR_CAPACITY - TEST_REVERSED_BYTES - TEST_BLOCK_SIZE,
+        mDir.getAvailableBytes());
     assertEquals(TEST_BLOCK_SIZE, mDir.getCommittedBytes());
 
     // Remove the committed block added
     mDir.removeBlockMeta(mBlockMeta);
     assertEquals(TEST_DIR_CAPACITY, mDir.getCapacityBytes());
-    assertEquals(TEST_DIR_CAPACITY, mDir.getAvailableBytes());
+    assertEquals(TEST_DIR_CAPACITY - TEST_REVERSED_BYTES, mDir.getAvailableBytes());
     assertEquals(0, mDir.getCommittedBytes());
   }
 
@@ -321,7 +324,7 @@ public final class DefaultStorageDirTest {
     String alias = bigBlockMeta.getBlockLocation().tierAlias();
     mThrown.expect(WorkerOutOfSpaceException.class);
     mThrown.expectMessage(ExceptionMessage.NO_SPACE_FOR_BLOCK_META.getMessage(TEST_BLOCK_ID,
-        bigBlockSize, TEST_DIR_CAPACITY, alias));
+        bigBlockSize, TEST_DIR_CAPACITY - TEST_REVERSED_BYTES, alias));
     mDir.addBlockMeta(bigBlockMeta);
   }
 
@@ -372,7 +375,7 @@ public final class DefaultStorageDirTest {
     String alias = bigTempBlockMeta.getBlockLocation().tierAlias();
     mThrown.expect(WorkerOutOfSpaceException.class);
     mThrown.expectMessage(ExceptionMessage.NO_SPACE_FOR_BLOCK_META.getMessage(TEST_TEMP_BLOCK_ID,
-        bigBlockSize, TEST_DIR_CAPACITY, alias));
+        bigBlockSize, TEST_DIR_CAPACITY - TEST_REVERSED_BYTES, alias));
     mDir.addTempBlockMeta(bigTempBlockMeta);
   }
 
@@ -438,16 +441,17 @@ public final class DefaultStorageDirTest {
   @Test
   public void blockMeta() throws Exception {
     assertFalse(mDir.hasBlockMeta(TEST_BLOCK_ID));
-    assertEquals(TEST_DIR_CAPACITY, mDir.getAvailableBytes());
+    assertEquals(TEST_DIR_CAPACITY - TEST_REVERSED_BYTES, mDir.getAvailableBytes());
 
     mDir.addBlockMeta(mBlockMeta);
     assertTrue(mDir.hasBlockMeta(TEST_BLOCK_ID));
     assertEquals(mBlockMeta, mDir.getBlockMeta(TEST_BLOCK_ID));
-    assertEquals(TEST_DIR_CAPACITY - TEST_BLOCK_SIZE, mDir.getAvailableBytes());
+    assertEquals(TEST_DIR_CAPACITY - TEST_REVERSED_BYTES - TEST_BLOCK_SIZE,
+        mDir.getAvailableBytes());
 
     mDir.removeBlockMeta(mBlockMeta);
     assertFalse(mDir.hasBlockMeta(TEST_BLOCK_ID));
-    assertEquals(TEST_DIR_CAPACITY, mDir.getAvailableBytes());
+    assertEquals(TEST_DIR_CAPACITY - TEST_REVERSED_BYTES, mDir.getAvailableBytes());
   }
 
   /**
@@ -457,16 +461,17 @@ public final class DefaultStorageDirTest {
   @Test
   public void tempBlockMeta() throws Exception {
     assertFalse(mDir.hasTempBlockMeta(TEST_TEMP_BLOCK_ID));
-    assertEquals(TEST_DIR_CAPACITY, mDir.getAvailableBytes());
+    assertEquals(TEST_DIR_CAPACITY - TEST_REVERSED_BYTES, mDir.getAvailableBytes());
 
     mDir.addTempBlockMeta(mTempBlockMeta);
     assertTrue(mDir.hasTempBlockMeta(TEST_TEMP_BLOCK_ID));
     assertEquals(mTempBlockMeta, mDir.getTempBlockMeta(TEST_TEMP_BLOCK_ID));
-    assertEquals(TEST_DIR_CAPACITY - TEST_TEMP_BLOCK_SIZE, mDir.getAvailableBytes());
+    assertEquals(TEST_DIR_CAPACITY - TEST_REVERSED_BYTES - TEST_TEMP_BLOCK_SIZE,
+        mDir.getAvailableBytes());
 
     mDir.removeTempBlockMeta(mTempBlockMeta);
     assertFalse(mDir.hasTempBlockMeta(TEST_TEMP_BLOCK_ID));
-    assertEquals(TEST_DIR_CAPACITY, mDir.getAvailableBytes());
+    assertEquals(TEST_DIR_CAPACITY - TEST_REVERSED_BYTES, mDir.getAvailableBytes());
   }
 
   /**
@@ -475,10 +480,11 @@ public final class DefaultStorageDirTest {
   @Test
   public void resizeTempBlockMeta() throws Exception {
     mDir.addTempBlockMeta(mTempBlockMeta);
-    assertEquals(TEST_DIR_CAPACITY - TEST_TEMP_BLOCK_SIZE, mDir.getAvailableBytes());
+    assertEquals(TEST_DIR_CAPACITY - TEST_REVERSED_BYTES - TEST_TEMP_BLOCK_SIZE,
+        mDir.getAvailableBytes());
     final long newSize = TEST_TEMP_BLOCK_SIZE + 10;
     mDir.resizeTempBlockMeta(mTempBlockMeta, newSize);
-    assertEquals(TEST_DIR_CAPACITY - newSize, mDir.getAvailableBytes());
+    assertEquals(TEST_DIR_CAPACITY - TEST_REVERSED_BYTES - newSize, mDir.getAvailableBytes());
   }
 
   /**
@@ -489,15 +495,9 @@ public final class DefaultStorageDirTest {
   public void resizeTempBlockMetaInvalidStateException() throws Exception {
     mDir.addTempBlockMeta(mTempBlockMeta);
     final long newSize = TEST_TEMP_BLOCK_SIZE - 10;
-    try {
-      mDir.resizeTempBlockMeta(mTempBlockMeta, newSize);
-      Assert.fail("Should throw an Exception when newSize is smaller than oldSize");
-    } catch (Exception e) {
-      assertTrue(e instanceof InvalidWorkerStateException);
-      Assert.assertThat(e.getMessage(),
-          CoreMatchers.equalTo("Shrinking block, not supported!"));
-      assertEquals(TEST_TEMP_BLOCK_SIZE, mTempBlockMeta.getBlockSize());
-    }
+    assertThrows("Shrinking block, not supported!", InvalidWorkerStateException.class,
+        () -> mDir.resizeTempBlockMeta(mTempBlockMeta, newSize));
+    assertEquals(TEST_TEMP_BLOCK_SIZE, mTempBlockMeta.getBlockSize());
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix incorrect available bytes when change space in StorageDir.

### Why are the changes needed?

Otherwise the value of available bytes will greater than real available bytes And also make it thread-safe.

### Does this PR introduce any user facing changes?

No user facing changes.
