### PR TITLE
[DOCFIX] Tweak FUSE metric and property descriptions

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5129,7 +5129,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey FUSE_CACHED_PATHS_MAX =
       new Builder(Name.FUSE_CACHED_PATHS_MAX)
           .setDefaultValue(500)
-          .setDescription("Maximum number of Alluxio paths to cache for FUSE conversion.")
+          .setDescription("Maximum number of FUSE-to-Alluxio path mappings to cache "
+              + "for FUSE conversion.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)
           .build();

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1613,7 +1613,7 @@ public final class MetricKey implements Comparable<MetricKey> {
   public static final MetricKey FUSE_CACHED_PATH_COUNT =
       new Builder("Fuse.CachedPathCount")
           .setDescription(String
-              .format("Total number of Alluxio paths to cache for FUSE conversion. "
+              .format("Total number of FUSE-to-Alluxio path mappings being cached. "
                       + "This value will be smaller or equal to %s",
               PropertyKey.FUSE_CACHED_PATHS_MAX.getName()))
           .setMetricType(MetricType.GAUGE)


### PR DESCRIPTION
Minor tweaks to metric descriptions to the metric `FUSE_CACHED_PATH_COUNT`.
