### PR TITLE
[DOCFIX] Update Flink documentation

### DIFF
--- a/docs/cn/compute/Flink.md
+++ b/docs/cn/compute/Flink.md
@@ -73,7 +73,7 @@ $ export HADOOP_CLASSPATH={{site.ALLUXIO_CLIENT_JAR_PATH}}
 ```yaml
 env.java.opts: -Dalluxio.user.file.writetype.default=CACHE_THROUGH
 ```
-
+注意：如果有正在运行的Flink集群，需要将该集群停止并重新运行以应用更改后的配置。
 ## 在Flink中使用Alluxio
 
 Flink中使用Alluxio，指定路径时使用`alluxio://`前缀。

--- a/docs/en/compute/Flink.md
+++ b/docs/en/compute/Flink.md
@@ -16,7 +16,7 @@ that you can easily work with files stored in Alluxio.
 
 * Setup Java for Java 8 Update 161 or higher (8u161+), 64-bit.
 * Alluxio has been set up and is running.
-* Flink has been set up and is running.
+* Flink has been installed and set up.
 
 ## Configuration
 

--- a/docs/en/compute/Flink.md
+++ b/docs/en/compute/Flink.md
@@ -88,6 +88,7 @@ the write type, you should add the following to `{FLINK_HOME}/conf/flink-conf.ya
 ```yaml
 env.java.opts: -Dalluxio.user.file.writetype.default=CACHE_THROUGH
 ```
+Note: If there are running flink clusters, stop the flink clusters and restart them to apply the changes to the configuration.
 
 ## Using Alluxio with Flink
 


### PR DESCRIPTION
In the english version of the flink doc, in the prerequisite section it says `Flink has been set up and is running.` which sounds like there should be a running cluster started by the Flink's `bin/start-cluster.sh` command. However, after the changes are made to the configuration of hadoop and flink, running the example in the doc won't work unless the running flink cluster is stopped.