### PR TITLE
Fix the stuck situation when distributedLoad incompleted file

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
@@ -94,7 +94,7 @@ public final class DistributedLoadUtils {
       if (!uriStatus.isFolder()) {
         if (!uriStatus.isCompleted()) {
           incompleteCount.getAndIncrement();
-          System.out.printf("Attempt load failed because: %s is in incomplete status",
+          System.out.printf("Ignored load because: %s is in incomplete status",
                   uriStatus.getPath());
           return;
         }
@@ -114,8 +114,10 @@ public final class DistributedLoadUtils {
         }
       }
     });
-    System.out.printf("%d paths load failed because they are in incomplete status",
-            incompleteCount.get());
+    if (incompleteCount.get() > 0) {
+      System.out.printf("Ignore load %d paths because they are in incomplete status",
+              incompleteCount.get());
+    }
 
     // add all the jobs left in the pool
     if (pool.size() > 0) {

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
@@ -90,6 +90,9 @@ public final class DistributedLoadUtils {
     ListStatusPOptions options = ListStatusPOptions.newBuilder().setRecursive(true).build();
     command.mFileSystem.iterateStatus(filePath, options, uriStatus -> {
       if (!uriStatus.isFolder()) {
+        if(!uriStatus.isCompleted()) {
+          return;
+        }
         AlluxioURI fileURI = new AlluxioURI(uriStatus.getPath());
         if (uriStatus.getInAlluxioPercentage() == 100 && replication == 1) {
           // The file has already been fully loaded into Alluxio.

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
@@ -90,7 +90,7 @@ public final class DistributedLoadUtils {
     ListStatusPOptions options = ListStatusPOptions.newBuilder().setRecursive(true).build();
     command.mFileSystem.iterateStatus(filePath, options, uriStatus -> {
       if (!uriStatus.isFolder()) {
-        if(!uriStatus.isCompleted()) {
+        if (!uriStatus.isCompleted()) {
           return;
         }
         AlluxioURI fileURI = new AlluxioURI(uriStatus.getPath());

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
@@ -35,7 +35,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 
 /**
@@ -89,11 +89,11 @@ public final class DistributedLoadUtils {
       Set<String> excludedWorkerSet, Set<String> localityIds, Set<String> excludedLocalityIds,
       boolean printOut) throws IOException, AlluxioException {
     ListStatusPOptions options = ListStatusPOptions.newBuilder().setRecursive(true).build();
-    AtomicInteger incompleteCount = new AtomicInteger();
+    LongAdder incompleteCount = new LongAdder();
     command.mFileSystem.iterateStatus(filePath, options, uriStatus -> {
       if (!uriStatus.isFolder()) {
         if (!uriStatus.isCompleted()) {
-          incompleteCount.getAndIncrement();
+          incompleteCount.increment();
           System.out.printf("Ignored load because: %s is in incomplete status",
                   uriStatus.getPath());
           return;
@@ -114,9 +114,9 @@ public final class DistributedLoadUtils {
         }
       }
     });
-    if (incompleteCount.get() > 0) {
+    if (incompleteCount.longValue() > 0) {
       System.out.printf("Ignore load %d paths because they are in incomplete status",
-              incompleteCount.get());
+              incompleteCount.longValue());
     }
 
     // add all the jobs left in the pool


### PR DESCRIPTION
### What changes are proposed in this pull request?
When distributingload the file, if the file status is incompleted, skip this file

### Why are the changes needed?
When distributeload files, if the file status is incompleted, the command will get stuck.

### Does this PR introduce any user facing changes?
No
