### PR TITLE
Extract mountOptions from VolumeContext as a second backup source

### DIFF
--- a/integration/docker/csi/alluxio/nodeserver.go
+++ b/integration/docker/csi/alluxio/nodeserver.go
@@ -50,6 +50,12 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 
 	mountOptions := req.GetVolumeCapability().GetMount().GetMountFlags()
+    if len(mountOptions) == 0 {
+        if opts, ok := req.GetVolumeContext()["mountOptions"]; ok {
+            mountOptions = strings.Split(opts, ",")
+        }
+    }
+
 	if req.GetReadonly() {
 		mountOptions = append(mountOptions, "ro")
 	}

--- a/integration/kubernetes/CSI_README.md
+++ b/integration/kubernetes/CSI_README.md
@@ -88,3 +88,31 @@ spec:
     - entry_timeout=36000
     - attr_timeout=36000
 ```
+
+If you use inline volume provisioning, you can customize these options in `VolumeSource.csi.volumeAttributes`
+
+An example of creating POD using Alluxio inline volume Spec:
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alluxio-nginx
+spec:
+  containers:
+  - image: nginx:latest
+    name: nginx
+    ports:
+    - containerPort: 80
+      protocol: TCP
+    volumeMounts:
+      - mountPath: /data
+        name: alluxio-inline-volume
+  volumes:
+  - name: alluxio-inline-volume
+    csi:
+      driver: alluxio
+      volumeAttributes:
+        alluxioPath: "/data"
+        javaOptions: "-Dalluxio.master.hostname=bar.com"
+        mountOptions: "kernel_cache,allow_otheri,entry_timeout=36000,attr_timeout=36000"
+```


### PR DESCRIPTION
### What changes are proposed in this pull request?

support config mountOptions from volumeAttributes when using csi inline volume

### Why are the changes needed?

CSI inline volume doesn't have option to set mountOptions separately, support it by setting the mountOptions inside volumeAttributes.

### Does this PR introduce any user facing changes?

No

Fixes https://github.com/Alluxio/alluxio/issues/14389