### PR TITLE
Fix alluxio-fuse inaccurate parse ps output

### DIFF
--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -116,12 +116,12 @@ fuse_stat() {
   local fuse_info=$(ps aux | grep [A]lluxioFuse)
   if [[ -n ${fuse_info} ]]; then
     echo -e "pid\tmount_point\talluxio_path"
-    echo -e "$(ps aux | grep [A]lluxioFuse | awk -F' ' '{print $2 "\t" $(NF-2) "\t" $NF}')"
+    echo -e "$(ps ax -o pid,args | grep [A]lluxioFuse | awk -F' ' '{print $1 "\t" $(NF-2) "\t" $NF}')"
     return 0
   fi
-  fuse_info=$(ps aux | grep [A]lluxioWorker | grep alluxio\.worker\.fuse\.enabled=true)
+  fuse_info=$(ps ax -o pid,args | grep [A]lluxioWorker | grep alluxio\.worker\.fuse\.enabled=true)
   if [[ -n ${fuse_info} ]]; then
-    fuse_worker_pid="$(echo ${fuse_info} | awk '{print $2}')"
+    fuse_worker_pid="$(echo ${fuse_info} | awk '{print $1}')"
     fuse_mount_point="$(echo ${fuse_info} | grep -Po '(?<=alluxio\.worker\.fuse\.mount\.point=)\S+(?=\s)')"
     fuse_alluxio_path="$(echo ${fuse_info} | grep -Po '(?<=alluxio\.worker\.fuse\.mount\.alluxio\.path=)\S+(?=\s)')"
     echo -e "pid\tmount_point\talluxio_path"
@@ -131,7 +131,7 @@ fuse_stat() {
   fuse_info=$(ps aux | grep [S]tackMain)
   if [[ -n ${fuse_info} ]]; then
     echo -e "pid\tmount_point\tsource_path"
-    echo -e "$(ps aux | grep [S]tackMain | awk -F' ' '{print $2 "\t" $(NF-2) "\t" $(NF-1)}')"
+    echo -e "$(ps ax -o pid,args | grep [S]tackMain | awk -F' ' '{print $1 "\t" $(NF-2) "\t" $(NF-1)}')"
     return 0
   fi
   echo "No mount point found. AlluxioFuse process is not running."


### PR DESCRIPTION
* explicitly set required field by '-o' option to eliminate ambiguous
  output column order

### What changes are proposed in this pull request?

explicit set '-o' option to eliminate different version of ps command ambiguous output format

### Why are the changes needed?

ps command in alpine image is from busybox, which pid is the first column by default.

### Does this PR introduce any user facing changes?

No

Fixes https://github.com/Alluxio/alluxio/issues/14379