### PR TITLE
[DOCFIX] Update tensorflow doc example

### DIFF
--- a/docs/en/compute/Tensorflow.md
+++ b/docs/en/compute/Tensorflow.md
@@ -23,7 +23,9 @@ on top of Alluxio POSIX API.
 
 * Setup Java for Java 8 Update 60 or higher (8u60+), 64-bit.
 * Alluxio has been set up and is running.
-* [Tensorflow](https://www.tensorflow.org/install/pip) installed. This guide uses Tensorflow **v1.15**.
+* [Python3](https://www.python.org/downloads/) installed.
+* [Numpy](https://numpy.org/install/) installed. This guide uses numpy **1.19.5**.
+* [Tensorflow](https://www.tensorflow.org/install/pip) installed. This guide uses Tensorflow **2.6.2**.
 
 ## Setting up Alluxio POSIX API
 
@@ -75,18 +77,18 @@ $ ./integration/fuse/bin/alluxio-fuse stat
 The mounted folder `/mnt/fuse` is ready for the deep learning frameworks to use, which would treat the Alluxio storage as a local folder. 
 This folder will be used for the Tensorflow training in the next section.
 
-## Examples: Image Recognition
+## Example: Image Recognition
 
 ### Preparing training data
 
 If the training data is already in a remote data storage, you can mount it as a folder under the Alluxio `/training-data` directory. 
 Those data will be visible to the applications running on local `/mnt/fuse/`.
 
-Suppose the ImageNet data is stored in a S3 bucket `s3://alluxio-tensorflow-imagenet/`.
-Run the following command to mount this S3 bucket to Alluxio path `/training-data/imagenet`:
+Suppose the MNIST data is stored in a S3 bucket `s3://alluxio-tensorflow-mnist/`.
+Run the following command to mount this S3 bucket to Alluxio path `/training-data/mnist`:
 
 ```console
-$ ./bin/alluxio fs mount /training-data/imagenet/ s3://alluxio-tensorflow-imagenet/ \
+$ ./bin/alluxio fs mount /training-data/mnist/ s3://alluxio-tensorflow-mnist/ \
   --option aws.accessKeyID=<ACCESS_KEY_ID> --option aws.secretKey=<SECRET_KEY>
 ```
 
@@ -96,61 +98,44 @@ These credentials are associated with the mounting point so that the future acce
 If the data is not in a remote data storage, you can copy it to Alluxio namespace:
 
 ```console
-$ wget http://download.tensorflow.org/models/image/imagenet/inception-2015-12-05.tgz
-$ ./bin/alluxio fs mkdir /training-data/imagenet 
-$ ./bin/alluxio fs copyFromLocal inception-2015-12-05.tgz /training-data/imagenet 
+$ wget https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz
+$ ./bin/alluxio fs mkdir /training-data/mnist 
+$ ./bin/alluxio fs copyFromLocal mnitt.npz /training-data/mnist 
 ```
 
-Suppose the ImageNet data is stored in an S3 bucket `s3://alluxio-tensorflow-imagenet/`, 
+Suppose the MNIST data is stored in an S3 bucket `s3://alluxio-tensorflow-mnist/`, 
 the following three commands will show the exact same data after the two mount processes:
 
 ```
-aws s3 ls s3://alluxio-tensorflow-imagenet/
-# 2019-02-07 03:51:15          0 
-# 2019-02-07 03:56:09   88931400 inception-2015-12-05.tgz
-bin/alluxio fs ls /training-data/imagenet/
-# -rwx---rwx ec2-user       ec2-user              88931400       PERSISTED 02-07-2019 03:56:09:000   0% /training-data/imagenet/inception-2015-12-05.tgz
-ls -l /mnt/fuse/imagenet/
+aws s3 ls s3://alluxio-tensorflow-mnist/
+# 2021-11-04 17:43:58    11490434 mnist.npz
+bin/alluxio fs ls /training-data/mnist/
+# -rwx---rwx ec2-user       ec2-user              11490434       PERSISTED 11-04-2021 17:45:41:000   0% mnist.npz
+ls -l /mnt/fuse/mnist/
 # total 0
-# -rwx---rwx 0 ec2-user ec2-user 88931400 Feb  7 03:56 inception-2015-12-05.tgz
+# -rwx---rwx 0 ec2-user ec2-user 11490434 Nov  4 17:45 mnist.npz
 ```
 
 ### Run image recognition test
 
-Download the [image recognition script](https://raw.githubusercontent.com/tensorflow/models/v1.11/tutorials/image/imagenet/classify_image.py)
-and run it with the local folder which holds the training data.
+Download the [image recognition script](https://github.com/ssz1997/AlluxioFuseTensorflowExample/blob/main/mnist_test.py)
+and run it with the training data `/mnt/fuse/mnist.npz`.
 
 ```console
-$ curl -o classify_image.py -L https://raw.githubusercontent.com/tensorflow/models/v1.11/tutorials/image/imagenet/classify_image.py
-$ python classify_image.py --model_dir /mnt/fuse/imagenet/
+$ curl -o mnist_test.py -L https://github.com/ssz1997/AlluxioFuseTensorflowExample/blob/main/mnist_test.py
+$ python3 mnist_test.py /mnt/fuse/mnist.npz
 ```
 
-This will use the input data in `/mnt/fuse/imagenet/inception-2015-12-05.tgz` to recognize images,  write some intermediate data to `/mnt/fuse/imagenet` 
-and if everything works you will see in your command prompt:
+This will use the input data in `/mnt/fuse/mnist.npz` to recognize images, 
+and if everything works you will see something like this in your command prompt:
 
 ```
-giant panda, panda, panda bear, coon bear, Ailuropoda melanoleuca (score = 0.89107)
-indri, indris, Indri indri, Indri brevicaudatus (score = 0.00779)
-lesser panda, red panda, panda, bear cat, cat bear, Ailurus fulgens (score = 0.00296)
-custard apple (score = 0.00147)
-earthstar (score = 0.00117)
+Epoch 1, Loss: 0.1307114064693451, Accuracy: 96.0566635131836, Test Loss: 0.07885940372943878, Test Accuracy: 97.29000091552734
+Epoch 2, Loss: 0.03961360827088356, Accuracy: 98.71500396728516, Test Loss: 0.06348009407520294, Test Accuracy: 97.87999725341797
+Epoch 3, Loss: 0.0206863172352314, Accuracy: 99.33999633789062, Test Loss: 0.060054901987314224, Test Accuracy: 98.20999908447266
+Epoch 4, Loss: 0.011528069153428078, Accuracy: 99.61166381835938, Test Loss: 0.05984818935394287, Test Accuracy: 98.3699951171875
+Epoch 5, Loss: 0.008437666110694408, Accuracy: 99.71666717529297, Test Loss: 0.060016192495822906, Test Accuracy: 98.5199966430664
 ```
-
-## Examples: Tensorflow benchmark
-
-Mount the ImageNet data stored in an S3 bucket into path `/training-data/imagenet`,
-assuming the data is at the S3 path `s3://alluxio-tensorflow-imagenet/`.
-
-```console
-$ ./bin/alluxio fs mount /training-data/imagenet/ \
-  s3://alluxio-tensorflow-imagenet/ \
-  --option aws.accessKeyID=<ACCESS_KEY_ID> \
-  --option aws.secretKey=<SECRET_KEY>
-```
-
-To access the training data in S3 via Alluxio, with the Alluxio POSIX API,
-we can pass the path `/mnt/fuse/imagenet` to the parameter `data_dir` of the benchmark
-script [tf_cnn_benchmarsk.py](https://github.com/tensorflow/benchmarks/blob/master/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py).
 
 ## Tips
 


### PR DESCRIPTION
Provide a new example in tensorflow documentation. 

MNIST dataset is another well-known image recognition dataset that classifies hand-writing digits. 

The python script is slightly modified from https://www.tensorflow.org/tutorials/quickstart/advanced.

The original second example uses `tf_cnn_benchmarsk.py`, which is more suitable for tensorflow1 whereas the new example is using tensorflow2, and is no longer under maintained. Therefore remove it. 