### PR TITLE
[SMALLFIX] Remove alluxio.user.hostname from REMOVED_KEYS

### DIFF
--- a/core/common/src/main/java/alluxio/conf/RemovedKey.java
+++ b/core/common/src/main/java/alluxio/conf/RemovedKey.java
@@ -108,8 +108,6 @@ public final class RemovedKey {
       put("alluxio.user.file.write.location.policy.class",
           replacedSince(V2_0_0, PropertyKey.USER_BLOCK_WRITE_LOCATION_POLICY.getName()));
       put("alluxio.user.heartbeat.interval", removedSince(V2_0_0));
-      put("alluxio.user.hostname",
-          replacedSince(V2_0_0, PropertyKey.LOCALITY_TIER_NODE.getName()));
       put("alluxio.user.lineage.enabled", removedSince(V2_0_0));
       put("alluxio.user.lineage.master.client.threads", removedSince(V2_0_0));
       put("alluxio.user.local.reader.packet.size.bytes", removedSince(V2_0_0));


### PR DESCRIPTION
Fix Alluxio/new-contributor-tasks#610

alluxio.user.hostname is not deprecated and is still used. 
So remove it from REMOVED_KEYS of alluxio.conf.RemovedKey.