### PR TITLE
Remove erroneous whitespace deletion in Helm Chart

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/domain-socket-pvc.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/domain-socket-pvc.yaml
@@ -9,7 +9,7 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
-{{- if not (eq .Values.worker.enabled false) -}}
+{{ if not (eq .Values.worker.enabled false) -}}
 
 {{ $shortCircuitEnabled := .Values.shortCircuit.enabled -}}
 {{ $needDomainSocketVolume := and (and $shortCircuitEnabled (eq .Values.shortCircuit.policy "uuid")) (eq .Values.shortCircuit.volumeType "persistentVolumeClaim") -}}


### PR DESCRIPTION
Whiteout this change, the resulting Helm template would be:

```
# Source: alluxio/templates/worker/domain-socket-pvc.yaml
#
# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
# (the "License"). You may not use this work except in compliance with the License, which is
# available at www.apache.org/licenses/LICENSE-2.0
#
# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
# either express or implied, as more fully set forth in the License.
#
# See the NOTICE file distributed with this work for information regarding copyright ownership.
#apiVersion: v1
```

Now it will be

```
# Source: alluxio/templates/worker/domain-socket-pvc.yaml
#
# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
# (the "License"). You may not use this work except in compliance with the License, which is
# available at www.apache.org/licenses/LICENSE-2.0
#
# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
# either express or implied, as more fully set forth in the License.
#
# See the NOTICE file distributed with this work for information regarding copyright ownership.

apiVersion: v1
```