### PR TITLE
Stop journal before masters during shut-down

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -161,8 +161,8 @@ public class AlluxioMasterProcess extends MasterProcess {
     if (isServing()) {
       stopServing();
     }
-    closeMasters();
     mJournalSystem.stop();
+    closeMasters();
     LOG.info("Stopped.");
   }
 

--- a/job/server/src/main/java/alluxio/master/AlluxioJobMasterProcess.java
+++ b/job/server/src/main/java/alluxio/master/AlluxioJobMasterProcess.java
@@ -153,8 +153,8 @@ public class AlluxioJobMasterProcess extends MasterProcess {
     if (isServing()) {
       stopServing();
     }
-    stopMaster();
     mJournalSystem.stop();
+    stopMaster();
   }
 
   protected void startMaster(boolean isLeader) {


### PR DESCRIPTION
Before this change, journal-system was still active, during shut-down, after masters were closed.
This causes `NullPointerException`s for `BlockMaster` as the block-store was closed but the journal system was still pushing entries. 