### PR TITLE
Fix redundant free when inAlluxio percentage is 0

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/FreeCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/FreeCommand.java
@@ -85,10 +85,12 @@ public final class FreeCommand extends AbstractFileSystemCommand {
             // but 'free' on an empty file should be a no-op
             return true;
           }
-          if (fileStatus.getInAlluxioPercentage() >= 0) {
+          if (fileStatus.getInAlluxioPercentage() > 0) {
             mFileSystem.free(path, options);
+            return fileStatus.getInAlluxioPercentage() == 0;
+          } else {
+            return true;
           }
-          return fileStatus.getInAlluxioPercentage() == 0;
         } catch (Exception e) {
           Throwables.propagateIfPossible(e);
           throw new RuntimeException(e);


### PR DESCRIPTION
### What changes are proposed in this pull request?
When the file in Alluxio percentage  is zero or the path is a directory, the logic in  waitFor will free again.    

### Why are the changes needed?
The logic may cause  redundant free call to master.
### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
No
