### PR TITLE
Display unescape the ufs URI

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -1010,12 +1010,12 @@ public final class AlluxioMasterRestServiceHandler {
         if (metricName.contains(MetricKey.CLUSTER_BYTES_READ_UFS.getName())) {
           String ufs = alluxio.metrics.Metric.getTagUfsValueFromFullName(metricName);
           if (ufs != null && isMounted(ufs)) {
-            ufsReadSizeMap.put(ufs, FormatUtils.getSizeFromBytes(value));
+            ufsReadSizeMap.put(MetricsSystem.unescape(ufs), FormatUtils.getSizeFromBytes(value));
           }
         } else if (metricName.contains(MetricKey.CLUSTER_BYTES_WRITTEN_UFS.getName())) {
           String ufs = alluxio.metrics.Metric.getTagUfsValueFromFullName(metricName);
           if (ufs != null && isMounted(ufs)) {
-            ufsWriteSizeMap.put(ufs, FormatUtils.getSizeFromBytes(value));
+            ufsWriteSizeMap.put(MetricsSystem.unescape(ufs), FormatUtils.getSizeFromBytes(value));
           }
         } else if (metricName.endsWith("Ops")) {
           rpcInvocations


### PR DESCRIPTION
### What changes are proposed in this pull request?

Display unescape the ufs URI.

### Why are the changes needed?

Display unescape the ufs URI

### Does this PR introduce any user facing changes?

original:
![1637051193(1)](https://user-images.githubusercontent.com/3060835/141948394-a08edecd-a7fc-48ad-b932-875dbc5fc0c3.png)
now:
![1637051263(1)](https://user-images.githubusercontent.com/3060835/141948585-4d747f2f-b350-4d8a-82af-4463a376c24e.png)