### PR TITLE
Use Powermock annotation to support javax.crypto

### DIFF
--- a/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
+++ b/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
@@ -39,6 +39,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
@@ -56,6 +57,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 @RunWith(PowerMockRunner.class) // annotations for `startMastersThrowsUnavailableException`
 @PrepareForTest({FaultTolerantAlluxioMasterProcess.class})
+@PowerMockIgnore({"javax.crypto.*"}) // https://stackoverflow.com/questions/7442875/generating-hmacsha256-signature-in-junit
 public final class AlluxioMasterProcessTest {
 
   @Rule


### PR DESCRIPTION
This change fixes the failing tests in `AlluxioMasterProcessTest`. See [this SO post](https://stackoverflow.com/questions/7442875/generating-hmacsha256-signature-in-junit) for details about the solution.