### PR TITLE
Make short-cirtcuit can fall back to grpc when path notfound

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataReader.java
@@ -151,7 +151,7 @@ public final class LocalFileDataReader implements DataReader {
         OpenLocalBlockResponse response = mStream.receive(mDataTimeoutMs);
         Preconditions.checkState(response.hasPath());
         mPath = response.getPath();
-        if (Files.notExists(Paths.get(mPath))) {
+        if (!Files.exists(Paths.get(mPath))) {
           throw new NotFoundException(String.format(
                   "LocalFileDataReader can not find the path:%s", mPath));
         }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataReader.java
@@ -16,6 +16,7 @@ import alluxio.client.ReadType;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.options.InStreamOptions;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.OpenLocalBlockRequest;
 import alluxio.grpc.OpenLocalBlockResponse;
 import alluxio.metrics.MetricKey;
@@ -31,6 +32,7 @@ import com.google.common.base.Preconditions;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -149,6 +151,10 @@ public final class LocalFileDataReader implements DataReader {
         OpenLocalBlockResponse response = mStream.receive(mDataTimeoutMs);
         Preconditions.checkState(response.hasPath());
         mPath = response.getPath();
+        if (Files.notExists(Paths.get(mPath))) {
+          throw new NotFoundException(String.format(
+                  "LocalFileDataReader can not find the path:%s", mPath));
+        }
       } catch (Exception e) {
         mBlockWorker.close();
         throw e;

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/LocalFileDataReader.java
@@ -151,13 +151,16 @@ public final class LocalFileDataReader implements DataReader {
         OpenLocalBlockResponse response = mStream.receive(mDataTimeoutMs);
         Preconditions.checkState(response.hasPath());
         mPath = response.getPath();
-        if (!Files.exists(Paths.get(mPath))) {
-          throw new NotFoundException(String.format(
-                  "LocalFileDataReader can not find the path:%s", mPath));
-        }
       } catch (Exception e) {
         mBlockWorker.close();
         throw e;
+      }
+
+      if (!Files.exists(Paths.get(mPath))) {
+        mStream.close();
+        mBlockWorker.close();
+        throw new NotFoundException(String.format(
+            "LocalFileDataReader can not find the path:%s", mPath));
       }
     }
 


### PR DESCRIPTION
             LocalFileDataReader should check the path from the local worker,
            if the path can not be found, so falling back to the network transfer.
            The case may happen on the K8S, such as, client and worker in two diffrent containers

### What changes are proposed in this pull request?

Please outline the changes and how this PR fixes the issue.
core/client:LocalFileDataReader Factory check the path from the local worker
### Why are the changes needed?

Please clarify why the changes are needed. For instance,
                 LocalFileDataReader should check the path from the local worker,
                if the path can not be found, so can falling back to the network transfer.
                The case may happen on the K8S, such as, client and worker in two diffrent containers，
                client can not see the  worker data path.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
