### PR TITLE
Enable Zookeeper 3.4 compatibility mode for `ZKMasterInquireClient`

### DIFF
--- a/core/common/src/main/java/alluxio/master/ZkMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/ZkMasterInquireClient.java
@@ -114,6 +114,7 @@ public final class ZkMasterInquireClient implements MasterInquireClient, Closeab
     curatorBuilder.connectString(connectDetails.getZkAddress());
     curatorBuilder.retryPolicy(new ExponentialBackoffRetry(Constants.SECOND_MS, 3));
     curatorBuilder.zookeeperFactory(new AlluxioZookeeperFactory(authEnabled));
+    curatorBuilder.zk34CompatibilityMode(true);
     mClient = curatorBuilder.build();
 
     mInquireRetryCount = inquireRetryCount;


### PR DESCRIPTION
Both `PrimarySelectorClient` and `ZKMasterInquireClient` communicate with ZK servers, but only `PrimarySelectorClient` has the ZK 3.4 compatibility flag enabled. This brings both in line with each other. 