### PR TITLE
Add gitignore for intermediate go binaries

### DIFF
--- a/dev/scripts/.gitignore
+++ b/dev/scripts/.gitignore
@@ -1,0 +1,3 @@
+src/alluxio.org/buildDistribution
+src/alluxio.org/checkdocs
+


### PR DESCRIPTION
running the generate-tarball and check-docs commands builds an intermediate go binary
these binaries are usually invoked and then removed as part of successfully completing the script execution
when the script terminates unexpectedly and does not reach the cleanup step, the intermediate binaries are leftover and pollutes the git workspace
adding the intermediate binaries to gitignore to keep a more pristine workspace in the failure scenario for these scripts