### PR TITLE
Fix S3 API ListStatus return value

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -176,9 +176,10 @@ public class ListBucketResult {
     mContents = new ArrayList<>();
     for (URIStatus status : objectsList) {
       mContents.add(new Content(
-          status.getPath().substring(prefix.length()),
+          status.isFolder() ? status.getPath().substring(prefix.length())
+              + AlluxioURI.SEPARATOR : status.getPath().substring(prefix.length()),
           S3RestUtils.toS3Date(status.getLastModificationTimeMs()),
-          String.valueOf(status.getLength())
+          status.isFolder() ? "0" : String.valueOf(status.getLength())
       ));
     }
 

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -308,7 +308,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
         HttpMethod.GET, expected,
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
 
-    assertEquals("folder0", expected.getContents().get(0).getKey());
+    assertEquals("folder0/", expected.getContents().get(0).getKey());
     assertEquals(0, expected.getCommonPrefixes().size());
 
     //parameters with list-type=2 and max-key=1
@@ -356,7 +356,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
         HttpMethod.GET, expected,
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
 
-    assertEquals("folder0", expected.getContents().get(0).getKey());
+    assertEquals("folder0/", expected.getContents().get(0).getKey());
     assertEquals(0, expected.getCommonPrefixes().size());
   }
 

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -183,10 +183,10 @@ public final class S3ClientRestApiTest extends RestApiTest {
     assertEquals(6, expected.getContents().size());
     assertEquals("file0", expected.getContents().get(0).getKey());
     assertEquals("file1", expected.getContents().get(1).getKey());
-    assertEquals("folder0", expected.getContents().get(2).getKey());
+    assertEquals("folder0/", expected.getContents().get(2).getKey());
     assertEquals("folder0/file0", expected.getContents().get(3).getKey());
     assertEquals("folder0/file1", expected.getContents().get(4).getKey());
-    assertEquals("folder1", expected.getContents().get(5).getKey());
+    assertEquals("folder1/", expected.getContents().get(5).getKey());
     assertEquals(0, expected.getCommonPrefixes().size());
 
     //parameters with delimiter="/"
@@ -223,7 +223,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE)).run();
 
     assertEquals(3, expected.getContents().size());
-    assertEquals("folder0", expected.getContents().get(0).getKey());
+    assertEquals("folder0/", expected.getContents().get(0).getKey());
     assertEquals("folder0/file0", expected.getContents().get(1).getKey());
     assertEquals("folder0/file1", expected.getContents().get(2).getKey());
     assertEquals(0, expected.getCommonPrefixes().size());
@@ -244,10 +244,10 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
     assertEquals(5, expected.getContents().size());
     assertEquals("file1", expected.getContents().get(0).getKey());
-    assertEquals("folder0", expected.getContents().get(1).getKey());
+    assertEquals("folder0/", expected.getContents().get(1).getKey());
     assertEquals("folder0/file0", expected.getContents().get(2).getKey());
     assertEquals("folder0/file1", expected.getContents().get(3).getKey());
-    assertEquals("folder1", expected.getContents().get(4).getKey());
+    assertEquals("folder1/", expected.getContents().get(4).getKey());
     assertEquals(0, expected.getCommonPrefixes().size());
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

S3 doesn't have dir concept so it will return size 0 for all non-object content with delimiter /.

### Why are the changes needed?

make return value correct, tested as follows:
```
aws s3api list-objects-v2 --bucket shouwei-test
{
    "Contents": [
        {
            "LastModified": "2021-11-04T01:33:07.000Z", 
            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"", 
            "StorageClass": "STANDARD", 
            "Key": "alluxio/", 
            "Size": 0
        }, 
        {
            "LastModified": "2021-11-04T01:33:08.000Z", 
            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"", 
            "StorageClass": "STANDARD", 
            "Key": "alluxio/special_backups/", 
            "Size": 0
        }, 
        {
            "LastModified": "2021-11-04T01:33:08.000Z", 
            "ETag": "\"4a6b70de44d18dffbd94860a7d60f9e2\"", 
            "StorageClass": "STANDARD", 
            "Key": "alluxio/special_backups/alluxio-backup-2021-11-04-1635989588831.gz", 
            "Size": 190
        }
    ]
}
aws s3api list-objects-v2 --endpoint-url http://localhost:39999/api/v1/s3 --bucket shouwei-test
{
    "Contents": [
        {
            "LastModified": "2021-11-18T20:04:04.068Z", 
            "Key": "alluxio/", 
            "Size": 0
        }, 
        {
            "LastModified": "2021-11-18T20:04:04.068Z", 
            "Key": "alluxio/special_backups/", 
            "Size": 0
        }, 
        {
            "LastModified": "2021-11-03T18:33:08.000Z", 
            "Key": "alluxio/special_backups/alluxio-backup-2021-11-04-1635989588831.gz", 
            "Size": 190
        }
    ]
}
```

### Does this PR introduce any user facing changes?

s3 API change.
