### PR TITLE
Change the thread pool for `CompletableFuture.runAsync`

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2276,6 +2276,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_JOURNAL_LOG_CONCURRENCY_MAX =
+          new Builder(Name.MASTER_JOURNAL_LOG_CONCURRENCY_MAX)
+                  .setDefaultValue(256)
+                  .setDescription("Max concurrency for notifyTermIndexUpdated method, be sure it's "
+                          + "enough")
+                  .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+                  .setScope(Scope.MASTER)
+                  .build();
   public static final PropertyKey MASTER_JOURNAL_SPACE_MONITOR_INTERVAL =
       new Builder(Name.MASTER_JOURNAL_SPACE_MONITOR_INTERVAL)
       .setDefaultValue("10min")
@@ -6218,6 +6226,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_JOURNAL_TYPE = "alluxio.master.journal.type";
     public static final String MASTER_JOURNAL_LOG_SIZE_BYTES_MAX =
         "alluxio.master.journal.log.size.bytes.max";
+    public static final String MASTER_JOURNAL_LOG_CONCURRENCY_MAX =
+        "alluxio.master.journal.log.concurrency.max";
     public static final String MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS =
         "alluxio.master.journal.tailer.shutdown.quiet.wait.time";
     public static final String MASTER_JOURNAL_TAILER_SLEEP_TIME_MS =

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -67,6 +67,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -106,6 +108,8 @@ public class JournalStateMachine extends BaseStateMachine {
   private volatile boolean mSnapshotting = false;
   private volatile boolean mIsLeader = false;
 
+  private final ExecutorService mJournalPool;
+
   /**
    * This callback is used for interrupting someone who suspends the journal applier to work on
    * the states. It helps prevent dirty read/write of the states when the journal is reloading.
@@ -138,8 +142,13 @@ public class JournalStateMachine extends BaseStateMachine {
    * @param journals      master journals; these journals are still owned by the caller, not by the
    *                      journal state machine
    * @param journalSystem the raft journal system
+   * @param maxConcurrencyPoolSize the maximum concurrency for notifyTermIndexUpdated
    */
-  public JournalStateMachine(Map<String, RaftJournal> journals, RaftJournalSystem journalSystem) {
+  public JournalStateMachine(Map<String, RaftJournal> journals, RaftJournalSystem journalSystem,
+                             Integer maxConcurrencyPoolSize) {
+    mJournalPool = Executors.newFixedThreadPool(maxConcurrencyPoolSize);
+    LOG.info("Ihe max concurrency for notifyTermIndexUpdated is loading with max threads {}",
+        maxConcurrencyPoolSize);
     mJournals = journals;
     mJournalApplier = new BufferedJournalApplier(journals,
         () -> journalSystem.getJournalSinks(null));
@@ -302,7 +311,7 @@ public class JournalStateMachine extends BaseStateMachine {
   @Override
   public void notifyTermIndexUpdated(long term, long index) {
     super.notifyTermIndexUpdated(term, index);
-    CompletableFuture.runAsync(mJournalSystem::updateGroup);
+    CompletableFuture.runAsync(mJournalSystem::updateGroup, mJournalPool);
   }
 
   private long getNextIndex() {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalConfiguration.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalConfiguration.java
@@ -34,6 +34,7 @@ public class RaftJournalConfiguration {
   private InetSocketAddress mLocalAddress;
   private long mMaxLogSize;
   private File mPath;
+  private Integer mMaxConcurrencyPoolSize;
 
   /**
    * @param serviceType either master raft service or job master raft service
@@ -50,7 +51,9 @@ public class RaftJournalConfiguration {
         .setLocalAddress(NetworkAddressUtils.getConnectAddress(serviceType,
             ServerConfiguration.global()))
         .setMaxLogSize(ServerConfiguration.getBytes(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX))
-        .setPath(new File(JournalUtils.getJournalLocation().getPath()));
+        .setPath(new File(JournalUtils.getJournalLocation().getPath()))
+        .setMaxConcurrencyPoolSize(
+            ServerConfiguration.getInt(PropertyKey.MASTER_JOURNAL_LOG_CONCURRENCY_MAX));
   }
 
   /**
@@ -175,6 +178,19 @@ public class RaftJournalConfiguration {
    */
   public RaftJournalConfiguration setPath(File path) {
     mPath = path;
+    return this;
+  }
+
+  public Integer getMaxConcurrencyPoolSize() {
+    return mMaxConcurrencyPoolSize;
+  }
+
+  /**
+   * @param maxConcurrencyPoolSize max thread size for notifyTermIndexUpdated method
+   * @return the updated configuration
+   */
+  public RaftJournalConfiguration setMaxConcurrencyPoolSize(Integer maxConcurrencyPoolSize) {
+    mMaxConcurrencyPoolSize = maxConcurrencyPoolSize;
     return this;
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalConfiguration.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalConfiguration.java
@@ -181,6 +181,9 @@ public class RaftJournalConfiguration {
     return this;
   }
 
+  /**
+   * @return the maxConcurrencyPoolSize
+   */
   public Integer getMaxConcurrencyPoolSize() {
     return mMaxConcurrencyPoolSize;
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -301,7 +301,8 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     if (mStateMachine != null) {
       mStateMachine.close();
     }
-    mStateMachine = new JournalStateMachine(mJournals, this);
+    mStateMachine = new JournalStateMachine(mJournals, this,
+        mConf.getMaxConcurrencyPoolSize());
 
     RaftProperties properties = new RaftProperties();
     Parameters parameters = new Parameters();

--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -246,9 +246,6 @@ public final class ReplicationChecker implements HeartbeatExecutor {
       }
       try (LockedInodePath inodePath = mInodeTree.lockFullInodePath(inodeId, LockPattern.READ)) {
         InodeFile file = inodePath.getInodeFile();
-        if (!file.isCompleted()) {
-          return;
-        }
         for (long blockId : file.getBlockIds()) {
           BlockInfo blockInfo = null;
           try {
@@ -307,9 +304,6 @@ public final class ReplicationChecker implements HeartbeatExecutor {
       // locking the entire path but just the inode file since this access is read-only.
       try (LockedInodePath inodePath = mInodeTree.lockFullInodePath(inodeId, LockPattern.READ)) {
         InodeFile file = inodePath.getInodeFile();
-        if (!file.isCompleted()) {
-          continue;
-        }
         for (long blockId : file.getBlockIds()) {
           BlockInfo blockInfo = null;
           try {

--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -246,6 +246,9 @@ public final class ReplicationChecker implements HeartbeatExecutor {
       }
       try (LockedInodePath inodePath = mInodeTree.lockFullInodePath(inodeId, LockPattern.READ)) {
         InodeFile file = inodePath.getInodeFile();
+        if (!file.isCompleted()) {
+          return;
+        }
         for (long blockId : file.getBlockIds()) {
           BlockInfo blockInfo = null;
           try {
@@ -304,6 +307,9 @@ public final class ReplicationChecker implements HeartbeatExecutor {
       // locking the entire path but just the inode file since this access is read-only.
       try (LockedInodePath inodePath = mInodeTree.lockFullInodePath(inodeId, LockPattern.READ)) {
         InodeFile file = inodePath.getInodeFile();
+        if (!file.isCompleted()) {
+          continue;
+        }
         for (long blockId : file.getBlockIds()) {
           BlockInfo blockInfo = null;
           try {


### PR DESCRIPTION
Redo of PR #14553 by @lilyzhoupeijie. 

Change the thread pool used by `CompletableFuture.runAsync` from the common pool to a separate `ForkJoinPool`. This is because of the concerns raised in [this article](https://dzone.com/articles/be-aware-of-forkjoinpoolcommonpool) about the common pool.