### PR TITLE
Support store client cache to multidisk

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -567,7 +566,15 @@ public class LocalCacheManager implements CacheManager {
     if (options.getType() == PageStoreType.MEM) {
       return true;
     }
-    Path rootDir = Paths.get(options.getRootDir());
+    for (Path rootDir : options.getRootDirs()) {
+      if (!restoreInternal(rootDir, options)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean restoreInternal(Path rootDir, PageStoreOptions options) {
     if (!Files.exists(rootDir)) {
       LOG.error("Failed to restore PageStore: Directory {} does not exist", rootDir);
       return false;

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -29,6 +29,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -43,7 +44,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class LocalPageStore implements PageStore {
   private static final Logger LOG = LoggerFactory.getLogger(LocalPageStore.class);
   private static final String ERROR_NO_SPACE_LEFT = "No space left on device";
-  private final String mRoot;
+  private final List<Path> mRoots;
   private final long mPageSize;
   private final long mCapacity;
   private final int mFileBuckets;
@@ -55,15 +56,16 @@ public class LocalPageStore implements PageStore {
    * @param options options for the local page store
    */
   public LocalPageStore(LocalPageStoreOptions options) {
-    mRoot = options.getRootDir();
+    mRoots = options.getRootDirs();
     mPageSize = options.getPageSize();
     mCapacity = (long) (options.getCacheSize() / (1 + options.getOverheadRatio()));
     mFileBuckets = options.getFileBuckets();
-    // normalize the path to deal with trailing slash
-    Path rootDir = Paths.get(mRoot);
-    // pattern encoding root_path/page_size(ulong)/bucket(uint)/file_id(str)/page_idx(ulong)/
+    // pattern encoding root_path/page_size(ulong)/bucket(uint)/file_id(str)/page_idx(ulong)
     mPagePattern = Pattern.compile(
-        String.format("%s/%d/(\\d+)/([^/]+)/(\\d+)", Pattern.quote(rootDir.toString()), mPageSize));
+        String.format("%s/%d/(\\d+)/([^/]+)/(\\d+)", "("
+                + mRoots.stream().map(path -> path.toString()).reduce((a, b) -> a + "|" + b).get()
+                + ")",
+            mPageSize));
   }
 
   @Override
@@ -84,7 +86,7 @@ public class LocalPageStore implements PageStore {
       Files.deleteIfExists(p);
       if (e.getMessage().contains(ERROR_NO_SPACE_LEFT)) {
         throw new ResourceExhaustedException(
-            String.format("%s is full, configured with %d bytes", mRoot, mCapacity), e);
+            String.format("%s is full, configured with %d bytes", getRoot(pageId), mCapacity), e);
       }
       throw new IOException("Failed to write file " + p + " for page " + pageId);
     }
@@ -159,8 +161,16 @@ public class LocalPageStore implements PageStore {
   @VisibleForTesting
   public Path getFilePath(PageId pageId) {
     // TODO(feng): encode fileId with URLEncoder to escape invalid characters for file name
-    return Paths.get(mRoot, Long.toString(mPageSize), getFileBucket(pageId.getFileId()),
-        pageId.getFileId(), Long.toString(pageId.getPageIndex()));
+    return Paths.get(getRoot(pageId).toString(), Long.toString(mPageSize),
+        getFileBucket(pageId.getFileId()), pageId.getFileId(),
+        Long.toString(pageId.getPageIndex()));
+  }
+
+  private Path getRoot(PageId pageId) {
+    // TODO(maobaolong): Refactor to support choose volume policy
+    int index = pageId.hashCode() % mRoots.size();
+    index = index < 0 ? index + mRoots.size() : index;
+    return mRoots.get(index);
   }
 
   private String getFileBucket(String fileId) {
@@ -178,12 +188,12 @@ public class LocalPageStore implements PageStore {
       return null;
     }
     try {
-      String fileBucket = Preconditions.checkNotNull(matcher.group(1));
-      String fileId = Preconditions.checkNotNull(matcher.group(2));
+      String fileBucket = Preconditions.checkNotNull(matcher.group(2));
+      String fileId = Preconditions.checkNotNull(matcher.group(3));
       if (!fileBucket.equals(getFileBucket(fileId))) {
         return null;
       }
-      String fileName = Preconditions.checkNotNull(matcher.group(3));
+      String fileName = Preconditions.checkNotNull(matcher.group(4));
       long pageIndex = Long.parseLong(fileName);
       return new PageId(fileId, pageIndex);
     } catch (NumberFormatException e) {
@@ -219,8 +229,11 @@ public class LocalPageStore implements PageStore {
 
   @Override
   public Stream<PageInfo> getPages() throws IOException {
-    Path rootDir = Paths.get(mRoot);
-    return Files.walk(rootDir).filter(Files::isRegularFile).map(this::getPageInfo);
+    Stream<Path> stream = Stream.empty();
+    for (Path root : mRoots) {
+      stream = Stream.concat(stream, Files.walk(root));
+    }
+    return stream.filter(Files::isRegularFile).map(this::getPageInfo);
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStoreOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStoreOptions.java
@@ -65,7 +65,7 @@ public class LocalPageStoreOptions extends PageStoreOptions {
         .add("FileBuckets", mFileBuckets)
         .add("OverheadRatio", mOverheadRatio)
         .add("PageSize", mPageSize)
-        .add("RootDir", mRootDir)
+        .add("RootDirs", mRootDirs)
         .add("TimeoutDuration", mTimeoutDuration)
         .add("TimeoutThreads", mTimeoutThreads)
         .toString();

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/PageStoreOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/PageStoreOptions.java
@@ -16,6 +16,7 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * Options used to instantiate a {@link alluxio.client.file.cache.PageStore}.
@@ -32,18 +33,12 @@ public abstract class PageStoreOptions {
         PropertyKey.USER_CLIENT_CACHE_STORE_TYPE, PageStoreType.class);
     switch (storeType) {
       case LOCAL: {
-        Path rootDir = PageStore.getStorePath(storeType,
-            conf.get(PropertyKey.USER_CLIENT_CACHE_DIR));
         options = new LocalPageStoreOptions()
-            .setFileBuckets(conf.getInt(PropertyKey.USER_CLIENT_CACHE_LOCAL_STORE_FILE_BUCKETS))
-            .setRootDir(rootDir.toString());
+            .setFileBuckets(conf.getInt(PropertyKey.USER_CLIENT_CACHE_LOCAL_STORE_FILE_BUCKETS));
         break;
       }
       case ROCKS: {
-        Path rootDir = PageStore.getStorePath(storeType,
-                conf.get(PropertyKey.USER_CLIENT_CACHE_DIR));
         options = new RocksPageStoreOptions();
-        options.setRootDir(rootDir.toString());
         break;
       }
       case MEM:
@@ -53,8 +48,10 @@ public abstract class PageStoreOptions {
         throw new IllegalArgumentException(String.format("Unrecognized store type %s",
             storeType.name()));
     }
-
-    options.setPageSize(conf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE))
+    List<Path> rootDir = PageStore.getStorePath(
+        storeType, conf.get(PropertyKey.USER_CLIENT_CACHE_DIR));
+    options.setRootDirs(rootDir)
+        .setPageSize(conf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE))
         .setCacheSize(conf.getBytes(PropertyKey.USER_CLIENT_CACHE_SIZE))
         .setAlluxioVersion(conf.get(PropertyKey.VERSION))
         .setTimeoutDuration(conf.getMs(PropertyKey.USER_CLIENT_CACHE_TIMEOUT_DURATION))
@@ -82,7 +79,7 @@ public abstract class PageStoreOptions {
   /**
    * Root directory where the data is stored.
    */
-  protected String mRootDir;
+  protected List<Path> mRootDirs;
 
   /**
    * Page size for the data.
@@ -117,19 +114,19 @@ public abstract class PageStoreOptions {
   protected double mOverheadRatio;
 
   /**
-   * @param rootDir the root directory where pages are stored
+   * @param rootDirs the root directories where pages are stored
    * @return the updated options
    */
-  public PageStoreOptions setRootDir(String rootDir) {
-    mRootDir = rootDir;
+  public PageStoreOptions setRootDirs(List<Path> rootDirs) {
+    mRootDirs = rootDirs;
     return this;
   }
 
   /**
-   * @return the root directory where pages are stored
+   * @return the root directories where pages are stored
    */
-  public String getRootDir() {
-    return mRootDir;
+  public List<Path> getRootDirs() {
+    return mRootDirs;
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
@@ -65,7 +65,8 @@ public class RocksPageStore implements PageStore {
         .setCompressionType(pageStoreOptions.getCompressionType());
     RocksDB db = null;
     try {
-      db = RocksDB.open(rocksOptions, pageStoreOptions.getRootDir());
+      // TODO(maobaolong): rocksdb support only one root for now.
+      db = RocksDB.open(rocksOptions, pageStoreOptions.getRootDirs().get(0).toString());
       byte[] confData = db.get(CONF_KEY);
       Cache.PRocksPageStoreOptions pOptions = pageStoreOptions.toProto();
       if (confData != null) {

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStoreOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStoreOptions.java
@@ -18,6 +18,8 @@ import alluxio.proto.client.Cache.PRocksPageStoreOptions;
 import com.google.common.base.MoreObjects;
 import org.rocksdb.CompressionType;
 
+import java.util.ArrayList;
+
 /**
  * Options used to instantiate {@link RocksPageStore}.
  */
@@ -43,7 +45,7 @@ public class RocksPageStoreOptions extends PageStoreOptions {
    * Creates a new instance of {@link RocksPageStoreOptions}.
    */
   public RocksPageStoreOptions() {
-    mRootDir = "";
+    mRootDirs = new ArrayList<>();
     mMaxPageSize = Constants.MB;
     mWriteBufferSize = 64 * Constants.MB;
     mMaxBufferPoolSize = 32;
@@ -143,7 +145,7 @@ public class RocksPageStoreOptions extends PageStoreOptions {
         .add("MaxPageSize", mMaxPageSize)
         .add("OverheadRatio", mOverheadRatio)
         .add("PageSize", mPageSize)
-        .add("RootDir", mRootDir)
+        .add("RootDirs", mRootDirs)
         .add("TimeoutDuration", mTimeoutDuration)
         .add("TimeoutThreads", mTimeoutThreads)
         .add("WriteBufferSize", mWriteBufferSize)

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -620,7 +620,7 @@ public final class LocalCacheManagerTest {
     PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
     mPageStore.put(PAGE_ID1, PAGE1);
     mPageStore.put(pageUuid, PAGE2);
-    String rootDir = mPageStoreOptions.getRootDir();
+    String rootDir = mPageStoreOptions.getRootDirs().get(0).toString();
     FileUtils.createFile(Paths.get(rootDir, "invalidPageFile").toString());
     mCacheManager = LocalCacheManager.create(mConf, mMetaStore, mPageStore);
     assertEquals(CacheManager.State.READ_WRITE, mCacheManager.state());
@@ -636,7 +636,7 @@ public final class LocalCacheManagerTest {
     PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
     mPageStore.put(PAGE_ID1, PAGE1);
     mPageStore.put(pageUuid, PAGE2);
-    String rootDir = mPageStoreOptions.getRootDir();
+    String rootDir = mPageStoreOptions.getRootDirs().get(0).toString();
     FileUtils.createFile(Paths.get(rootDir, "invalidPageFile").toString());
     mCacheManager = createLocalCacheManager(mConf, mMetaStore, mPageStore);
     assertEquals(0, mCacheManager.get(PAGE_ID1, PAGE1.length, mBuf, 0));
@@ -651,7 +651,7 @@ public final class LocalCacheManagerTest {
     PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
     mPageStore.put(PAGE_ID1, PAGE1);
     mPageStore.put(pageUuid, PAGE2);
-    String rootDir = mPageStoreOptions.getRootDir();
+    String rootDir = mPageStoreOptions.getRootDirs().get(0).toString();
     FileUtils.deletePathRecursively(rootDir);
     File rootParent = new File(rootDir).getParentFile();
     try {
@@ -671,7 +671,7 @@ public final class LocalCacheManagerTest {
     PageId pageUuid = new PageId(UUID.randomUUID().toString(), 0);
     mPageStore.put(PAGE_ID1, PAGE1);
     mPageStore.put(pageUuid, PAGE2);
-    String rootDir = mPageStoreOptions.getRootDir();
+    String rootDir = mPageStoreOptions.getRootDirs().get(0).toString();
     FileUtils.deletePathRecursively(rootDir);
     File rootParent = new File(rootDir).getParentFile();
     rootParent.setWritable(false);

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/store/PageStoreTest.java
@@ -24,6 +24,7 @@ import alluxio.client.file.cache.PageStore;
 import alluxio.exception.PageNotFoundException;
 import alluxio.util.io.BufferUtils;
 
+import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -34,6 +35,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -69,7 +71,7 @@ public class PageStoreTest {
     mOptions.setPageSize(1024);
     mOptions.setCacheSize(65536);
     mOptions.setAlluxioVersion(ProjectConstants.VERSION);
-    mOptions.setRootDir(mTemp.getRoot().getAbsolutePath());
+    mOptions.setRootDirs(Lists.newArrayList(Paths.get(mTemp.getRoot().getAbsolutePath())));
     mPageStore = PageStore.create(mOptions);
   }
 

--- a/tests/src/test/java/alluxio/client/fs/LocalCacheManagerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LocalCacheManagerIntegrationTest.java
@@ -212,7 +212,7 @@ public final class LocalCacheManagerIntegrationTest extends BaseIntegrationTest 
     mCacheManager.close();
     // creates with an invalid page file stored
     String rootDir = PageStore.getStorePath(PageStoreType.LOCAL,
-        mConf.get(PropertyKey.USER_CLIENT_CACHE_DIR)).toString();
+        mConf.get(PropertyKey.USER_CLIENT_CACHE_DIR)).get(0).toString();
     FileUtils.createFile(Paths.get(rootDir, "invalidPageFile").toString());
     mCacheManager = LocalCacheManager.create(mConf);
     assertEquals(0, mCacheManager.get(PAGE_ID, PAGE_SIZE_BYTES, mBuffer, 0));


### PR DESCRIPTION
### What changes are proposed in this pull request?

In some of our scenarios, we have to use multi-disk to be our cache storage.
- There are no enough space if we just store cache data into one disk
- There are no enough bandwidth if we just store cache data into one disk.

### Why are the changes needed?

Store the cache data into multi-disk by hash & mod

### Does this PR introduce any user facing changes?

User can config `alluxio.user.client.cache.dir=rootdir1,rootdir2,rootdir3`.

Meanwhile, this change support keep consistent to the original usage `alluxio.user.client.cache.dir=rootdir1`