### PR TITLE
Fix Alluxio/new-contributor-tasks#613

### DIFF
--- a/integration/metrics/docker-compose-master.yaml
+++ b/integration/metrics/docker-compose-master.yaml
@@ -21,7 +21,7 @@ services:
 
   # Collector
   otel-collector:
-    image: otel/opentelemetry-collector-dev:latest
+    image: otel/opentelemetry-collector-dev:b24db545eb56e2ee7dcf6a8f3740ce49bb80608b
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
@@ -37,7 +37,7 @@ services:
 
   # Agent
   otel-agent:
-    image: otel/opentelemetry-collector-dev:latest
+    image: otel/opentelemetry-collector-dev:b24db545eb56e2ee7dcf6a8f3740ce49bb80608b
     command: ["--config=/etc/otel-agent-config.yaml"]
     volumes:
       - ./otel-agent-config.yaml:/etc/otel-agent-config.yaml

--- a/integration/metrics/docker-compose-worker.yaml
+++ b/integration/metrics/docker-compose-worker.yaml
@@ -13,7 +13,7 @@ version: "2"
 services:
   # Agent
   otel-agent:
-    image: otel/opentelemetry-collector-dev:latest
+    image: otel/opentelemetry-collector-dev:b24db545eb56e2ee7dcf6a8f3740ce49bb80608b
     environment:
       MASTER_IP: "${MASTER_IP}"
     command: ["--config=/etc/otel-agent-config-worker.yaml"]


### PR DESCRIPTION
update otel/opentelemetry-collector-dev:latest to otel/opentelemetry-collector-dev:b24db545eb56e2ee7dcf6a8f3740ce49bb80608b

### What changes are proposed in this pull request?

Files under alluxio/integration/metrics use "otel/opentelemetry-collector-dev:latest" which is not backward compatible.
Changed to "otel/opentelemetry-collector-dev:b24db545eb56e2ee7dcf6a8f3740ce49bb80608b".
