### PR TITLE
Update register stream timestamp more often

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/RegisterStreamObserver.java
+++ b/core/server/master/src/main/java/alluxio/master/block/RegisterStreamObserver.java
@@ -154,6 +154,9 @@ public class RegisterStreamObserver implements StreamObserver<RegisterWorkerPReq
                 + "Probably %s was exceeded!",
             PropertyKey.MASTER_WORKER_REGISTER_STREAM_RESPONSE_TIMEOUT.toString());
 
+        // Update the TS before and after processing the request, so that when a message
+        // takes long to process, the stream does not time out.
+        mContext.updateTs();
         mBlockMaster.workerRegisterFinish(mContext);
         mContext.updateTs();
 

--- a/core/server/master/src/main/java/alluxio/master/block/RegisterStreamObserver.java
+++ b/core/server/master/src/main/java/alluxio/master/block/RegisterStreamObserver.java
@@ -94,6 +94,9 @@ public class RegisterStreamObserver implements StreamObserver<RegisterWorkerPReq
                 + "Probably %s was exceeded!",
             PropertyKey.MASTER_WORKER_REGISTER_STREAM_RESPONSE_TIMEOUT.toString());
 
+        // Update the TS before and after processing the request, so that when a message
+        // takes long to process, the stream does not time out.
+        mContext.updateTs();
         mBlockMaster.workerRegisterStream(mContext, chunk, isHead);
         mContext.updateTs();
         // Return an ACK to the worker so it sends the next batch


### PR DESCRIPTION
### What changes are proposed in this pull request?

During a worker registration stream, we identify stale stream and `DefaultBlockMaster$WorkerRegisterStreamGCExecutor` recycles them based on the last-message-received timestamp. This change updates the timestamp more often.

### Why are the changes needed?

There will be fewer false positives for stale streams. The false positives are expensive.

### Does this PR introduce any user facing changes?

NA
