### PR TITLE
Use virtual functions instead of AmazonS3 for temp token refresh

### DIFF
--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AInputStream.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AInputStream.java
@@ -33,14 +33,14 @@ public class S3AInputStream extends InputStream {
   private static final Logger LOG = LoggerFactory.getLogger(S3AInputStream.class);
 
   /** Client for operations with s3. */
-  private final AmazonS3 mClient;
+  protected AmazonS3 mClient;
   /** Name of the bucket the object resides in. */
   private final String mBucketName;
   /** The path of the object to read. */
   private final String mKey;
 
   /** The backing input stream from s3. */
-  private S3ObjectInputStream mIn;
+  protected S3ObjectInputStream mIn;
   /** The current position of the stream. */
   private long mPos;
 
@@ -146,7 +146,7 @@ public class S3AInputStream extends InputStream {
     String errorMessage = String.format("Failed to open key: %s bucket: %s", mKey, mBucketName);
     while (mRetryPolicy.attempt()) {
       try {
-        mIn = mClient.getObject(getReq).getObjectContent();
+        mIn = getClient().getObject(getReq).getObjectContent();
         return;
       } catch (AmazonS3Exception e) {
         errorMessage = String
@@ -161,6 +161,13 @@ public class S3AInputStream extends InputStream {
     }
     // Failed after retrying key does not exist
     throw new IOException(errorMessage, lastException);
+  }
+
+  /**
+   * @return the client
+   */
+  protected AmazonS3 getClient() {
+    return mClient;
   }
 
   /**

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AOutputStream.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AOutputStream.java
@@ -68,7 +68,7 @@ public class S3AOutputStream extends OutputStream {
    * to upload file larger than 100MB using Multipart Uploads.
    */
   // TODO(calvin): Investigate if the lower level API can be more efficient.
-  private final TransferManager mManager;
+  protected TransferManager mManager;
 
   /** The output stream to a local file where the file will be buffered until closed. */
   private OutputStream mLocalOutputStream;
@@ -147,7 +147,7 @@ public class S3AOutputStream extends OutputStream {
 
       // Generate the put request and wait for the transfer manager to complete the upload
       PutObjectRequest putReq = new PutObjectRequest(mBucketName, path, mFile).withMetadata(meta);
-      mManager.upload(putReq).waitForUploadResult();
+      getTransferManager().upload(putReq).waitForUploadResult();
     } catch (Exception e) {
       LOG.error("Failed to upload {}", path, e);
       throw new IOException(e);
@@ -167,5 +167,12 @@ public class S3AOutputStream extends OutputStream {
    */
   protected String getUploadPath() {
     return mKey;
+  }
+
+  /**
+   * @return return the transfer manager
+   */
+  protected TransferManager getTransferManager() {
+    return mManager;
   }
 }


### PR DESCRIPTION
Use virtual functions instead of AmazonS3 for temp token refresh. 
