### PR TITLE
Add timing information to Raft failover process

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -878,6 +878,12 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("Total number of lost workers inside the cluster")
           .setMetricType(MetricType.GAUGE)
           .build();
+  public static final MetricKey CLUSTER_RAFT_FAILOVER_DURATION =
+      new Builder("Cluster.RaftFailoverDuration")
+          .setDescription("The time taken during the last failover operation when using the "
+              + "Embedded Journal")
+          .setMetricType(MetricType.GAUGE)
+          .build();
 
   // Server metrics shared by Master, Worker and other Alluxio servers
   public static final MetricKey TOTAL_EXTRA_TIME =

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -690,6 +690,20 @@ public class JournalStateMachine extends BaseStateMachine {
   }
 
   /**
+   * This function is triggered when the state machine becomes CANDIDATE.
+   */
+  @Override
+  public void notifyExtendedNoLeader(RaftProtos.RoleInfoProto roleInfoProto) {
+    long lastLeaderElapsedTimeMs = roleInfoProto.getCandidateInfo().getLastLeaderElapsedTimeMs();
+    if (roleInfoProto.getRole() == RaftProtos.RaftPeerRole.CANDIDATE) {
+      LOG.info("Transitioned to CANDIDATE, last leader was {}ms ago", lastLeaderElapsedTimeMs);
+      mJournalSystem.setLastLeaderTime(System.currentTimeMillis() - lastLeaderElapsedTimeMs);
+    } else {
+      LOG.warn("Triggered notifyExtendedNoLeader when role is {}", roleInfoProto.getRole());
+    }
+  }
+
+  /**
    * @return the snapshot replication manager
    */
   public SnapshotReplicationManager getSnapshotReplicationManager() {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -682,6 +682,9 @@ public class JournalStateMachine extends BaseStateMachine {
   public void notifyLeaderChanged(RaftGroupMemberId groupMemberId, RaftPeerId raftPeerId) {
     if (mRaftGroupId == groupMemberId.getGroupId()) {
       mIsLeader = groupMemberId.getPeerId() == raftPeerId;
+      if (!mIsLeader) {
+        mJournalSystem.setLastLeaderTime(System.currentTimeMillis());
+      }
       mJournalSystem.notifyLeadershipStateChanged(mIsLeader);
     } else {
       LOG.warn("Received notification for unrecognized group {}, current group is {}",

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -683,6 +683,9 @@ public class JournalStateMachine extends BaseStateMachine {
     if (mRaftGroupId == groupMemberId.getGroupId()) {
       mIsLeader = groupMemberId.getPeerId() == raftPeerId;
       if (!mIsLeader) {
+        // If this state machine wins an election right after starting or right after losing
+        // another election, it will not trigger notifyExtendedNoLeader. This is therefore the
+        // last point of contact with another leader.
         mJournalSystem.setLastLeaderTime(System.currentTimeMillis());
       }
       mJournalSystem.notifyLeadershipStateChanged(mIsLeader);
@@ -693,7 +696,9 @@ public class JournalStateMachine extends BaseStateMachine {
   }
 
   /**
-   * This function is triggered when the state machine becomes CANDIDATE.
+   * This function is triggered when the state machine becomes CANDIDATE. This function's
+   * activation is regulated by the RaftServerConfigKeys.Notification.setNoLeaderTimeout() call
+   * in RaftJournalSystem.
    */
   @Override
   public void notifyExtendedNoLeader(RaftProtos.RoleInfoProto roleInfoProto) {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -394,7 +394,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
      *  for a leader election.
      */
     RaftServerConfigKeys.Notification.setNoLeaderTimeout(properties,
-        TimeDuration.valueOf(1, TimeUnit.NANOSECONDS));
+        TimeDuration.valueOf(1, TimeUnit.MILLISECONDS));
 
     long messageSize = ServerConfiguration.global().getBytes(
         PropertyKey.MASTER_EMBEDDED_JOURNAL_TRANSPORT_MAX_INBOUND_MESSAGE_SIZE);

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -389,7 +389,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     RaftServerConfigKeys.LeaderElection.setLeaderStepDownWaitTime(properties,
         TimeDuration.valueOf(Long.MAX_VALUE, TimeUnit.MILLISECONDS));
 
-    /* Setting this TimeDuration to 0 notifies the state machine every time the state machine
+    /* Setting this TimeDuration to 1ms notifies the state machine every time the state machine
      * transitions from FOLLOWER to CANDIDATE. We can then measure the totality of the time taken
      *  for a leader election.
      */
@@ -507,12 +507,8 @@ public class RaftJournalSystem extends AbstractJournalSystem {
         .set(new AsyncJournalWriter(mRaftJournalWriter, () -> getJournalSinks(null)));
     mTransferLeaderAllowed.set(true);
 
-    if (getLastLeaderTime() == -1) {
-      LOG.info("Gained primacy at cluster launch.");
-    } else {
-      LOG.info("Gained primacy after {}ms long election.",
-          System.currentTimeMillis() - getLastLeaderTime());
-    }
+    LOG.info("Gained primacy after {}ms long election.",
+        System.currentTimeMillis() - getLastLeaderTime());
     setLastLeaderTime(-1);
   }
 

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-//    o.sync();
+    o.sync();
     //#else
     o.hflush();
     //#endif

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-    o.sync();
+//    o.sync();
     //#else
     o.hflush();
     //#endif


### PR DESCRIPTION
Adding timing information to the Raft failover process in the form of a log message and a metric