### PR TITLE
Issue #12704 - Exclude ratis-thirdparty-misc for alluxio-hub-server

### DIFF
--- a/hub/server/pom.xml
+++ b/hub/server/pom.xml
@@ -34,6 +34,12 @@
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-server-common</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.ratis</groupId>
+          <artifactId>ratis-thirdparty-misc</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Excludes `ratis-thirdparty-misc` as a transitive dependency in `alluxio-hub-server` module.

### Why are the changes needed?

ratis-thirdparty-misc brings old versions of netty-tcnative-boringssl-static that breaks the **ProcessMonitorTest's

### Does this PR introduce any user facing changes?

No user facing changes!
