### PR TITLE
[SMALLFIX] Correct the property name in the helm charts

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -227,3 +227,5 @@
 0.6.33
 
 - Fix CSI typo. Upgrade CSI driver and provisioner. Improve CSI static pvc template.
+- Fix typo in specifying fuse mount options.
+

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.32
+version: 0.6.33
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -87,7 +87,7 @@
   {{- $workerJavaOpts = print "-Dalluxio.worker.fuse.mount.alluxio.path=/" | append $workerJavaOpts }}
   {{- $workerJavaOpts = printf "-Dalluxio.worker.fuse.mount.point=%v" .Values.fuse.mountPath | append $workerJavaOpts }}
   {{- if .Values.fuse.mountOptions }}
-  {{- $workerJavaOpts = printf "-Dalluxiuo.worker.fuse.mount.options=%v" .Values.fuse.mountOptions | append $workerJavaOpts }}
+  {{- $workerJavaOpts = printf "-Dalluxio.worker.fuse.mount.options=%v" .Values.fuse.mountOptions | append $workerJavaOpts }}
   {{- end }}
   {{- $workerJavaOpts = print "-Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME}" | append $workerJavaOpts }}
   {{- if .Values.fuse.jvmOptions }}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fixes a typo in alluxio helm charts.

### Why are the changes needed?

The typo prevents us from passing custom mount options (e.g, `allow_other`) to alluxio's helm charts.

### Does this PR introduce any user facing changes?

None.