### PR TITLE
Make ufs cephfs seekable

### DIFF
--- a/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephFSUnderFileSystem.java
+++ b/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephFSUnderFileSystem.java
@@ -552,7 +552,7 @@ public class CephFSUnderFileSystem extends ConsistentUnderFileSystem
           inputStream.close();
           throw e;
         }
-        return inputStream;
+        return new CephSeekableInputStream(inputStream);
       } catch (IOException e) {
         LOG.warn("{} try to open {} : {}", retryPolicy.getAttemptCount(), path, e.toString());
         te = e;
@@ -736,6 +736,11 @@ public class CephFSUnderFileSystem extends ConsistentUnderFileSystem
 
   private void statfs(String path, CephStatVFS stat) throws IOException {
     mMount.statfs(path, stat);
+  }
+
+  @Override
+  public boolean isSeekable() {
+    return true;
   }
 }
 

--- a/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephSeekableInputStream.java
+++ b/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephSeekableInputStream.java
@@ -1,0 +1,37 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.cephfs;
+
+import alluxio.underfs.SeekableUnderFileInputStream;
+
+import java.io.IOException;
+
+/**
+ * The input stream of CEPHFS as under filesystem. This input stream supports seeking and can be
+ * cached for reuse.
+ */
+public class CephSeekableInputStream extends SeekableUnderFileInputStream {
+
+  CephSeekableInputStream(CephInputStream in) {
+    super(in);
+  }
+
+  @Override
+  public void seek(long position) throws IOException {
+    ((CephInputStream) in).seek(position);
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return ((CephInputStream) in).getPos();
+  }
+}


### PR DESCRIPTION
The input stream of CEPHFS as under filesystem. This input stream supports seeking and can be
 cached for reuse.

Signed-off-by: Xue Yantao <xueyantao2114@163.com>

### What changes are proposed in this pull request?

Please outline the changes and how this PR fixes the issue.

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
