### PR TITLE
Change `JournalStateMachine`'s executor service

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -65,12 +65,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ForkJoinPool;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -148,9 +146,7 @@ public class JournalStateMachine extends BaseStateMachine {
    */
   public JournalStateMachine(Map<String, RaftJournal> journals, RaftJournalSystem journalSystem,
                              Integer maxConcurrencyPoolSize) {
-    ArrayBlockingQueue<Runnable> boundedQ = new ArrayBlockingQueue<>(maxConcurrencyPoolSize * 2);
-    mJournalPool = new ThreadPoolExecutor(maxConcurrencyPoolSize / 2, maxConcurrencyPoolSize, 0L,
-        TimeUnit.MILLISECONDS, boundedQ);
+    mJournalPool = new ForkJoinPool(maxConcurrencyPoolSize);
     LOG.info("Ihe max concurrency for notifyTermIndexUpdated is loading with max threads {}",
         maxConcurrencyPoolSize);
     mJournals = journals;


### PR DESCRIPTION
### What changes are proposed in this pull request?
Switch the `ExecutorService` that `JournalStateMachine` uses from `ThreadPoolExecutor` to `ForkJoinPool`.

### Why are the changes needed?
This PR is an update after #14559. Combined, these two PRs remove the `JournalStateMachine`'s reliance on the `ForkJoinPool.commonPool()`. This reliance is undesirable as explained in [this article](https://dzone.com/articles/be-aware-of-forkjoinpoolcommonpool).

### Does this PR introduce any user facing changes?
No.