### PR TITLE
Alluxio preferentially move block to a lower tier when freeing space

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/GreedyAllocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/GreedyAllocator.java
@@ -46,7 +46,7 @@ public final class GreedyAllocator implements Allocator {
   }
 
   @Override
-  public StorageDirView allocateBlockWithView(long sessionId, long blockSize,
+  public synchronized StorageDirView allocateBlockWithView(long sessionId, long blockSize,
       BlockStoreLocation location, BlockMetadataView metadataView, boolean skipReview) {
     mMetadataView = Preconditions.checkNotNull(metadataView, "view");
     return allocateBlock(sessionId, blockSize, location, skipReview);

--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/MaxFreeAllocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/MaxFreeAllocator.java
@@ -45,7 +45,7 @@ public final class MaxFreeAllocator implements Allocator {
   }
 
   @Override
-  public StorageDirView allocateBlockWithView(long sessionId, long blockSize,
+  public synchronized StorageDirView allocateBlockWithView(long sessionId, long blockSize,
       BlockStoreLocation location, BlockMetadataView metadataView, boolean skipReview) {
     mMetadataView = Preconditions.checkNotNull(metadataView, "view");
     return allocateBlock(sessionId, blockSize, location, skipReview);

--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/RoundRobinAllocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/RoundRobinAllocator.java
@@ -57,7 +57,7 @@ public final class RoundRobinAllocator implements Allocator {
   }
 
   @Override
-  public StorageDirView allocateBlockWithView(long sessionId, long blockSize,
+  public synchronized StorageDirView allocateBlockWithView(long sessionId, long blockSize,
       BlockStoreLocation location, BlockMetadataView metadataView, boolean skipReview) {
     mMetadataView = Preconditions.checkNotNull(metadataView, "view");
     return allocateBlock(sessionId, blockSize, location, skipReview);


### PR DESCRIPTION
pr-link: Alluxio/alluxio#14518

### What changes are proposed in this pull request?
We want to modify this implementation so that when the space needs to be freed, the block that needs to be evicted will moved to the lower tier first. If it fails, we remove the block.

### Why are the changes needed?
Currently alluxio will directly remove blocks when freeing space. When the available space in MEM is used up，the evictable block is removed directly. The next time the data is read, it is reload from the UFS. In some cases, it will impose additional performance overhead.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
