### PR TITLE
Add worker fuse thread pool

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataReader.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataReader.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -62,7 +63,7 @@ public final class BlockWorkerDataReader implements DataReader {
    * @param chunkSize the chunk size
    */
   private BlockWorkerDataReader(ExecutorService executor, BlockReader reader,
-        long offset, long len, long chunkSize) {
+      long offset, long len, long chunkSize) {
     mReader = reader;
     Preconditions.checkArgument(chunkSize > 0);
     mPos = offset;
@@ -82,7 +83,8 @@ public final class BlockWorkerDataReader implements DataReader {
     try {
       buffer = readResult.get();
     } catch (Exception e) {
-      LOG.debug(e.toString());
+      LOG.error("Failed to read with Fuse in worker.", e);
+      throw new IOException("Failed to read with Fuse in worker.");
     }
     DataBuffer dataBuffer = new NioDataBuffer(buffer, buffer.remaining());
     mPos += dataBuffer.getLength();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3104,6 +3104,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
+  public static final PropertyKey WORKER_FUSE_READ_EXECUTOR_POOL_SIZE =
+      new Builder(Name.WORKER_FUSE_READ_EXECUTOR_POOL_SIZE)
+          .setDefaultValue(2048)
+          .setDescription("The size of the fixed-thread pool for reading used "
+              + "by Fuse embedded in worker process.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.WORKER)
+          .build();
   public static final PropertyKey WORKER_MANAGEMENT_BACKOFF_STRATEGY =
       new Builder(Name.WORKER_MANAGEMENT_BACKOFF_STRATEGY)
           .setDefaultValue("ANY")
@@ -6479,6 +6487,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.fuse.mount.options";
     public static final String WORKER_FUSE_MOUNT_POINT =
         "alluxio.worker.fuse.mount.point";
+    public static final String WORKER_FUSE_READ_EXECUTOR_POOL_SIZE =
+        "alluxio.worker.fuse.read.executor.pool.size";
     public static final String WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES =
         "alluxio.worker.management.tier.align.reserved.bytes";
     public static final String WORKER_MANAGEMENT_BACKOFF_STRATEGY =

--- a/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -33,6 +33,7 @@ import alluxio.worker.block.meta.TempBlockMeta;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
@@ -356,4 +357,12 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @return the white list
    */
   List<String> getWhiteList();
+
+  /**
+   * Gets the workerFuse executor service given the operation.
+   *
+   * @param operation the operation for the executor service
+   * @return the corresponding workerFuse executor service
+   */
+  ExecutorService getWorkerFuseExecutorService(String operation);
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -79,6 +79,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -274,7 +275,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
                   ServerConfiguration.global(), ServerUserState.global()));
     }
 
-    // Mounts the embedded Fuse application
+    // Mounts the embedded Fuse application and starts workerFuse thread executor
     if (ServerConfiguration.getBoolean(PropertyKey.WORKER_FUSE_ENABLED)) {
       mFuseManager.start();
     }
@@ -689,6 +690,11 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
     }
     throw new UnavailableException(ExceptionMessage.UFS_BLOCK_ACCESS_TOKEN_UNAVAILABLE
         .getMessage(request.getId(), request.getOpenUfsBlockOptions().getUfsPath()));
+  }
+
+  @Override
+  public ExecutorService getWorkerFuseExecutorService(String operation) {
+    return mFuseManager.getWorkerFuseExecutorService(operation);
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/FuseManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/FuseManager.java
@@ -114,7 +114,9 @@ public class FuseManager implements Closeable {
 
   @Override
   public void close() throws IOException {
-    mWorkerFuseReadExecutorService.shutdownNow();
+    if (mWorkerFuseReadExecutorService != null) {
+      mWorkerFuseReadExecutorService.shutdownNow();
+    }
     if (mFuseUmountable != null) {
       try {
         mFuseUmountable.umount(true);

--- a/core/server/worker/src/main/java/alluxio/worker/block/FuseManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/FuseManager.java
@@ -20,9 +20,7 @@ import alluxio.fuse.AlluxioFuse;
 import alluxio.fuse.FuseMountOptions;
 import alluxio.fuse.FuseUmountable;
 
-import alluxio.master.AlluxioExecutorService;
 import alluxio.util.ThreadFactoryUtils;
-import alluxio.util.executor.ExecutorServiceFactories;
 import com.google.common.io.Closer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +57,7 @@ public class FuseManager implements Closeable {
   }
 
   /**
-   * Starts mounting the internal Fuse applications and create workerFuse executor service.
+   * Starts mounting the internal Fuse applications and creates workerFuse executor services.
    */
   public void start() {
     AlluxioConfiguration conf = ServerConfiguration.global();
@@ -109,8 +107,8 @@ public class FuseManager implements Closeable {
     if (operation.equals("read")) {
       return mWorkerFuseReadExecutorService;
     } else {
-      LOG.error("Fail to obtain {} executor service in workerFuse.", operation);
-      return null;
+      throw new IllegalArgumentException(
+          String.format("Unknown workerFuse executor service %s.", operation));
     }
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
@@ -203,6 +204,11 @@ public class NoopBlockWorker implements BlockWorker {
 
   @Override
   public List<String> getWhiteList() {
+    return null;
+  }
+
+  @Override
+  public ExecutorService getWorkerFuseExecutorService(String operation) {
     return null;
   }
 


### PR DESCRIPTION
In workerFuse, reading goes through internal method calls instead of gRPC. This brings some problems, for example, issue #14276 .

This PR adds a configurable fixed-size thread pool for reading to put a resource constraint.