### PR TITLE
Make the checkConsistency command check more cases

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1295,7 +1295,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
           throw e;
         }
         checkConsistencyRecursive(parent, inconsistentUris, false,
-            syncStatus != OK);
+            syncStatus == OK);
 
         auditContext.setSucceeded(true);
       }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1327,14 +1327,17 @@ public final class DefaultFileSystemMaster extends CoreMaster
         try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
           UnderFileSystem ufs = ufsResource.get();
           String ufsPath = resolution.getUri().getPath();
-          Arrays.stream(ufs.listStatus(ufsPath)).forEach(status -> {
-            for (Inode child : children) {
-              if (child.getName().equals(status.getName())) {
-                return;
+          UfsStatus[] statuses = ufs.listStatus(ufsPath);
+          if (statuses != null) {
+            Arrays.stream(statuses).forEach(status -> {
+              for (Inode child : children) {
+                if (child.getName().equals(status.getName())) {
+                  return;
+                }
               }
-            }
-            inconsistentUris.add(inodePath.getUri().join(status.getName()));
-          });
+              inconsistentUris.add(inodePath.getUri().join(status.getName()));
+            });
+          }
         }
       }
     } catch (InvalidPathException e) {

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CheckConsistencyCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CheckConsistencyCommandIntegrationTest.java
@@ -117,9 +117,9 @@ public class CheckConsistencyCommandIntegrationTest extends AbstractFileSystemSh
 
     sFsShell.run("checkConsistency", "-r", "/testRoot");
     res = mOutput.toString();
-    assertTrue(res.contains("/testRoot has: 1 inconsistent files") &&
-        res.contains("repairing path: /testRoot/testFileA") &&
-        res.contains("/testRoot/testFileA repaired"));
+    assertTrue(res.contains("/testRoot has: 1 inconsistent files")
+        && res.contains("repairing path: /testRoot/testFileA")
+        && res.contains("/testRoot/testFileA repaired"));
     assertFalse(sFileSystem.exists(new AlluxioURI("/testRoot/testFileA")));
   }
 

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CheckConsistencyCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CheckConsistencyCommandIntegrationTest.java
@@ -101,6 +101,28 @@ public class CheckConsistencyCommandIntegrationTest extends AbstractFileSystemSh
         .getLength());
   }
 
+  @Test
+  public void testExistInAlluxioButNotInUfs() throws Exception {
+    FileSystemTestUtils
+        .createByteFile(sFileSystem, "/testRoot/testFileA", WritePType.CACHE_THROUGH, 10);
+    String ufsPath = sFileSystem.getStatus(new AlluxioURI("/testRoot")).getUfsPath();
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
+    ufs.deleteFile(sFileSystem.getStatus(new AlluxioURI("/testRoot/testFileA")).getUfsPath());
+
+    sFsShell.run("checkConsistency", "/testRoot");
+    String res = mOutput.toString();
+    assertTrue(res.contains("The following files are inconsistent")
+        && res.contains("/testRoot/testFileA"));
+    mOutput.reset();
+
+    sFsShell.run("checkConsistency", "-r", "/testRoot");
+    res = mOutput.toString();
+    assertTrue(res.contains("/testRoot has: 1 inconsistent files") &&
+        res.contains("repairing path: /testRoot/testFileA") &&
+        res.contains("/testRoot/testFileA repaired"));
+    assertFalse(sFileSystem.exists(new AlluxioURI("/testRoot/testFileA")));
+  }
+
   /**
    * Tests the check consistency shell command correctly identifies a consistent subtree.
    */

--- a/tests/src/test/java/alluxio/client/fs/CheckConsistencyIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/CheckConsistencyIntegrationTest.java
@@ -180,6 +180,19 @@ public class CheckConsistencyIntegrationTest extends BaseIntegrationTest {
     Assert.assertEquals(expected, result);
   }
 
+  @Test
+  public void existsInUfsButNotAlluxio() throws Exception {
+    String ufsDirectory = mFileSystem.getStatus(DIRECTORY).getUfsPath();
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsDirectory,
+        ServerConfiguration.global());
+    String filename = "ufs_exists";
+    String newPath = ufsDirectory + AlluxioURI.SEPARATOR + filename;
+    ufs.mkdirs(newPath);
+    List<AlluxioURI> expected = Lists.newArrayList(DIRECTORY.join(filename));
+    Assert.assertEquals(expected, mFileSystemMaster.checkConsistency(DIRECTORY,
+        CheckConsistencyContext.defaults()));
+  }
+
   /**
    * Tests the {@link FileSystemMaster#checkConsistency(AlluxioURI, CheckConsistencyContext)} method
    * when a file does not exist as a file in the under storage.


### PR DESCRIPTION
### What changes are proposed in this pull request?

Check consistency should check case that exist in UFS but not exist in alluxio

### Why are the changes needed?

Now if a file exists in UFS but not in alluxio, then the `checkConsistency` command will not return any consistency information. This PR fixes this issue. 

### Does this PR introduce any user facing changes?

