### PR TITLE
Release Bytebuf in workerFuse to fix leak

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataWriter.java
@@ -102,6 +102,7 @@ public final class BlockWorkerDataWriter implements DataWriter {
       }
     }
     long append = mBlockWriter.append(buf);
+    buf.release();
     MetricsSystem.counter(MetricKey.WORKER_BYTES_WRITTEN_DIRECT.getName()).inc(append);
     MetricsSystem.meter(MetricKey.WORKER_BYTES_WRITTEN_DIRECT_THROUGHPUT.getName()).mark(append);
   }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataWriter.java
@@ -92,19 +92,22 @@ public final class BlockWorkerDataWriter implements DataWriter {
 
   @Override
   public void writeChunk(final ByteBuf buf) throws IOException {
-    if (mReservedBytes < pos() + buf.readableBytes()) {
-      try {
-        long bytesToReserve = Math.max(mBufferSize, pos() + buf.readableBytes() - mReservedBytes);
-        // Allocate enough space in the existing temporary block for the write.
-        mBlockWorker.requestSpace(mSessionId, mBlockId, bytesToReserve);
-      } catch (Exception e) {
-        throw new IOException(e);
+    try {
+      if (mReservedBytes < pos() + buf.readableBytes()) {
+        try {
+          long bytesToReserve = Math.max(mBufferSize, pos() + buf.readableBytes() - mReservedBytes);
+          // Allocate enough space in the existing temporary block for the write.
+          mBlockWorker.requestSpace(mSessionId, mBlockId, bytesToReserve);
+        } catch (Exception e) {
+          throw new IOException(e);
+        }
       }
+      long append = mBlockWriter.append(buf);
+      MetricsSystem.counter(MetricKey.WORKER_BYTES_WRITTEN_DIRECT.getName()).inc(append);
+      MetricsSystem.meter(MetricKey.WORKER_BYTES_WRITTEN_DIRECT_THROUGHPUT.getName()).mark(append);   
+    } finally {
+      buf.release();
     }
-    long append = mBlockWriter.append(buf);
-    buf.release();
-    MetricsSystem.counter(MetricKey.WORKER_BYTES_WRITTEN_DIRECT.getName()).inc(append);
-    MetricsSystem.meter(MetricKey.WORKER_BYTES_WRITTEN_DIRECT_THROUGHPUT.getName()).mark(append);
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataWriter.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerDataWriter.java
@@ -95,7 +95,8 @@ public final class BlockWorkerDataWriter implements DataWriter {
     try {
       if (mReservedBytes < pos() + buf.readableBytes()) {
         try {
-          long bytesToReserve = Math.max(mBufferSize, pos() + buf.readableBytes() - mReservedBytes);
+          long bytesToReserve = Math.max(mBufferSize, pos() + buf.readableBytes()
+              - mReservedBytes);
           // Allocate enough space in the existing temporary block for the write.
           mBlockWorker.requestSpace(mSessionId, mBlockId, bytesToReserve);
         } catch (Exception e) {


### PR DESCRIPTION
The ByteBuf is never released in workerFuse writing process. This brings memory leak (out of direct memory)

Partly solve https://github.com/Alluxio/alluxio/issues/14620