### PR TITLE
Revert "Upgrade zookeeper from 3.5.5 to 3.5.8"

### DIFF
--- a/core/common/pom.xml
+++ b/core/common/pom.xml
@@ -88,10 +88,6 @@
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -608,14 +608,7 @@
       <dependency>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
-        <version>3.5.8</version>
-        <!-- conflicts with netty-all -->
-        <exclusions>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
+        <version>3.5.5</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
This reverts commit 71f76a1803bc57f196601578b5d16862faf47875.

For backwards compatibility reasons. 