### PR TITLE
Remove hadoop AbstractFileSystem default port

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioFileSystem.java
@@ -12,7 +12,6 @@
 package alluxio.hadoop;
 
 import alluxio.Constants;
-import alluxio.conf.PropertyKey;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.DelegateToFileSystem;
@@ -38,7 +37,7 @@ import java.net.URISyntaxException;
 public class AlluxioFileSystem extends DelegateToFileSystem {
   /**
    * This constructor has the signature needed by
-   * {@link AbstractFileSystem#createFileSystem(URI, Configuration)}
+   * {@link org.apache.hadoop.fs.AbstractFileSystem#createFileSystem(URI, Configuration)}
    * in Hadoop 2.x.
    *
    * @param uri the uri for this Alluxio filesystem
@@ -48,10 +47,5 @@ public class AlluxioFileSystem extends DelegateToFileSystem {
   AlluxioFileSystem(final URI uri, final Configuration conf)
       throws IOException, URISyntaxException {
     super(uri, new FileSystem(), conf, Constants.SCHEME, false);
-  }
-
-  @Override
-  public int getUriDefaultPort() {
-    return (Integer) PropertyKey.MASTER_RPC_PORT.getDefaultValue();
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove hadoop AbstractFileSystem default port to fix errors when use logical address.

### Why are the changes needed?

Currently throw an exception when using logical address.
fixes #14648 

### Does this PR introduce any user facing changes?

method `alluxio.hadoop.AbstactFileSystem.getUriDefaultPort` will return 0.