### PR TITLE
Change the thread pool for `CompletableFuture.runAsync`

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2277,6 +2277,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_JOURNAL_LOG_CONCURRENCY_MAX =
+          new Builder(Name.MASTER_JOURNAL_LOG_CONCURRENCY_MAX)
+                  .setDefaultValue(256)
+                  .setDescription("Max concurrency for notifyTermIndexUpdated method, be sure it's "
+                          + "enough")
+                  .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+                  .setScope(Scope.MASTER)
+                  .build();
   public static final PropertyKey MASTER_JOURNAL_SPACE_MONITOR_INTERVAL =
       new Builder(Name.MASTER_JOURNAL_SPACE_MONITOR_INTERVAL)
       .setDefaultValue("10min")
@@ -6219,6 +6227,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_JOURNAL_TYPE = "alluxio.master.journal.type";
     public static final String MASTER_JOURNAL_LOG_SIZE_BYTES_MAX =
         "alluxio.master.journal.log.size.bytes.max";
+    public static final String MASTER_JOURNAL_LOG_CONCURRENCY_MAX =
+        "alluxio.master.journal.log.concurrency.max";
     public static final String MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS =
         "alluxio.master.journal.tailer.shutdown.quiet.wait.time";
     public static final String MASTER_JOURNAL_TAILER_SLEEP_TIME_MS =

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -65,9 +65,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -107,6 +110,8 @@ public class JournalStateMachine extends BaseStateMachine {
   private volatile boolean mSnapshotting = false;
   private volatile boolean mIsLeader = false;
 
+  private final ExecutorService mJournalPool;
+
   /**
    * This callback is used for interrupting someone who suspends the journal applier to work on
    * the states. It helps prevent dirty read/write of the states when the journal is reloading.
@@ -139,8 +144,15 @@ public class JournalStateMachine extends BaseStateMachine {
    * @param journals      master journals; these journals are still owned by the caller, not by the
    *                      journal state machine
    * @param journalSystem the raft journal system
+   * @param maxConcurrencyPoolSize the maximum concurrency for notifyTermIndexUpdated
    */
-  public JournalStateMachine(Map<String, RaftJournal> journals, RaftJournalSystem journalSystem) {
+  public JournalStateMachine(Map<String, RaftJournal> journals, RaftJournalSystem journalSystem,
+                             Integer maxConcurrencyPoolSize) {
+    ArrayBlockingQueue<Runnable> boundedQ = new ArrayBlockingQueue<>(maxConcurrencyPoolSize * 2);
+    mJournalPool = new ThreadPoolExecutor(maxConcurrencyPoolSize / 2, maxConcurrencyPoolSize, 0L,
+        TimeUnit.MILLISECONDS, boundedQ);
+    LOG.info("Ihe max concurrency for notifyTermIndexUpdated is loading with max threads {}",
+        maxConcurrencyPoolSize);
     mJournals = journals;
     mJournalApplier = new BufferedJournalApplier(journals,
         () -> journalSystem.getJournalSinks(null));
@@ -303,7 +315,7 @@ public class JournalStateMachine extends BaseStateMachine {
   @Override
   public void notifyTermIndexUpdated(long term, long index) {
     super.notifyTermIndexUpdated(term, index);
-    CompletableFuture.runAsync(mJournalSystem::updateGroup);
+    CompletableFuture.runAsync(mJournalSystem::updateGroup, mJournalPool);
   }
 
   private long getNextIndex() {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalConfiguration.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalConfiguration.java
@@ -34,6 +34,7 @@ public class RaftJournalConfiguration {
   private InetSocketAddress mLocalAddress;
   private long mMaxLogSize;
   private File mPath;
+  private Integer mMaxConcurrencyPoolSize;
 
   /**
    * @param serviceType either master raft service or job master raft service
@@ -50,7 +51,9 @@ public class RaftJournalConfiguration {
         .setLocalAddress(NetworkAddressUtils.getConnectAddress(serviceType,
             ServerConfiguration.global()))
         .setMaxLogSize(ServerConfiguration.getBytes(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX))
-        .setPath(new File(JournalUtils.getJournalLocation().getPath()));
+        .setPath(new File(JournalUtils.getJournalLocation().getPath()))
+        .setMaxConcurrencyPoolSize(
+            ServerConfiguration.getInt(PropertyKey.MASTER_JOURNAL_LOG_CONCURRENCY_MAX));
   }
 
   /**
@@ -175,6 +178,22 @@ public class RaftJournalConfiguration {
    */
   public RaftJournalConfiguration setPath(File path) {
     mPath = path;
+    return this;
+  }
+
+  /**
+   * @return the maxConcurrencyPoolSize
+   */
+  public Integer getMaxConcurrencyPoolSize() {
+    return mMaxConcurrencyPoolSize;
+  }
+
+  /**
+   * @param maxConcurrencyPoolSize max thread size for notifyTermIndexUpdated method
+   * @return the updated configuration
+   */
+  public RaftJournalConfiguration setMaxConcurrencyPoolSize(Integer maxConcurrencyPoolSize) {
+    mMaxConcurrencyPoolSize = maxConcurrencyPoolSize;
     return this;
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -302,7 +302,8 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     if (mStateMachine != null) {
       mStateMachine.close();
     }
-    mStateMachine = new JournalStateMachine(mJournals, this);
+    mStateMachine = new JournalStateMachine(mJournals, this,
+        mConf.getMaxConcurrencyPoolSize());
 
     RaftProperties properties = new RaftProperties();
     Parameters parameters = new Parameters();


### PR DESCRIPTION
Redo of PR #14553 by @lilyzhoupeijie.

Change the thread pool used by `CompletableFuture.runAsync` from the
common pool to a separate `ForkJoinPool`. This is because of the
concerns raised in [this
article](https://dzone.com/articles/be-aware-of-forkjoinpoolcommonpool)
about the common pool.

pr-link: Alluxio/alluxio#14559
change-id: cid-deffcf1dae7c6bf74b3d9363d83b5c3a4c009d0b