### PR TITLE
Merge mount Alluxio path in k8s & resolve conflict

### DIFF
--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -16,6 +16,7 @@ ALLUXIO_HOME="/opt/alluxio"
 NO_FORMAT='--no-format'
 FUSE_OPTS='--fuse-opts'
 MOUNT_POINT="${MOUNT_POINT:-/mnt/alluxio-fuse}"
+ALLUXIO_PATH="${FUSE_ALLUXIO_PATH:-/}"
 ALLUXIO_USERNAME="${ALLUXIO_USERNAME:-root}"
 ALLUXIO_GROUP="${ALLUXIO_GROUP:-root}"
 ALLUXIO_UID="${ALLUXIO_UID:-0}"
@@ -104,7 +105,7 @@ function mountAlluxioRootFSWithFuseOption {
   ! mkdir -p ${MOUNT_POINT}
   ! umount ${MOUNT_POINT}
   #! integration/fuse/bin/alluxio-fuse unmount ${MOUNT_POINT}
-  exec integration/fuse/bin/alluxio-fuse mount -n ${fuseOptions} ${MOUNT_POINT} /
+  exec integration/fuse/bin/alluxio-fuse mount -n ${fuseOptions} ${MOUNT_POINT} ${ALLUXIO_PATH}
 }
 
 function startCsiServer {

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -223,3 +223,7 @@
 0.6.32
 
 - Add toggles to disable master/worker resource deployment
+
+0.6.33
+
+- Enable mounting a specific directory in Alluxio through Fuse

--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -84,7 +84,7 @@
 {{- /* Worker Fuse configurations */}}
 {{- if eq .Values.worker.fuseEnabled true}}
   {{- $workerJavaOpts = print "-Dalluxio.worker.fuse.enabled=true" | append $workerJavaOpts }}
-  {{- $workerJavaOpts = print "-Dalluxio.worker.fuse.mount.alluxio.path=/" | append $workerJavaOpts }}
+  {{- $workerJavaOpts = print "-Dalluxio.worker.fuse.mount.alluxio.path=%v" .Values.fuse.alluxioPath | append $workerJavaOpts }}
   {{- $workerJavaOpts = printf "-Dalluxio.worker.fuse.mount.point=%v" .Values.fuse.mountPath | append $workerJavaOpts }}
   {{- if .Values.fuse.mountOptions }}
   {{- $workerJavaOpts = printf "-Dalluxiuo.worker.fuse.mount.options=%v" .Values.fuse.mountOptions | append $workerJavaOpts }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
@@ -109,6 +109,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
+          - name: FUSE_ALLUXIO_PATH
+            value: {{ .Values.fuse.alluxioPath }}
           {{- range $key, $value := .Values.fuse.env }}
           - name: "{{ $key }}"
             value: "{{ $value }}"

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -428,6 +428,8 @@ fuse:
   mountOptions: allow_other
   # Mount path in the host
   mountPath: /mnt/alluxio-fuse
+  # The path in Alluxio being mounted
+  alluxioPath: /
   resources:
     requests:
       cpu: "0.5"


### PR DESCRIPTION
Previously using helm chart we can only mount the whole Alluxio storage.
Now by specifying `FUSE_ALLUXIO_PATH` in the helm chart, we are able to
mount one specific directory in Alluxio, both for standalone Fuse and
workerFuse.

pr-link: #14599
change-id: cid-89a283a3246d855f2d00f9fa516f4855f082911a