### PR TITLE
Add a default hasSubCommand in Command

### DIFF
--- a/core/common/src/main/java/alluxio/cli/Command.java
+++ b/core/common/src/main/java/alluxio/cli/Command.java
@@ -51,7 +51,7 @@ public interface Command extends Closeable {
    * @return whether this command has sub-commands
    */
   default boolean hasSubCommand() {
-    return false;
+    return !getSubCommands().isEmpty();
   }
 
   /**

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectConfigCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectConfigCommand.java
@@ -53,11 +53,6 @@ public class CollectConfigCommand extends AbstractCollectInfoCommand {
   }
 
   @Override
-  public boolean hasSubCommand() {
-    return false;
-  }
-
-  @Override
   public int run(CommandLine cl) throws AlluxioException, IOException {
     mWorkingDirPath = getWorkingDirectory(cl);
     String confDirPath = mFsContext.getClusterConf().get(PropertyKey.CONF_DIR);

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectEnvCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectEnvCommand.java
@@ -73,11 +73,6 @@ public class CollectEnvCommand extends ExecuteShellCollectInfoCommand {
   }
 
   @Override
-  public boolean hasSubCommand() {
-    return false;
-  }
-
-  @Override
   public String getUsage() {
     return "collectEnv <outputPath>";
   }

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
@@ -175,11 +175,6 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
   }
 
   @Override
-  public boolean hasSubCommand() {
-    return false;
-  }
-
-  @Override
   public int run(CommandLine cl) throws AlluxioException, IOException {
     // Determine the working dir path
     mWorkingDirPath = getWorkingDirectory(cl);

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectMetricsCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectMetricsCommand.java
@@ -55,11 +55,6 @@ public class CollectMetricsCommand extends AbstractCollectInfoCommand {
   }
 
   @Override
-  public boolean hasSubCommand() {
-    return false;
-  }
-
-  @Override
   public int run(CommandLine cl) throws AlluxioException, IOException {
     // Determine the working dir path
     mWorkingDirPath = getWorkingDirectory(cl);

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/JournalCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/JournalCommand.java
@@ -60,11 +60,6 @@ public class JournalCommand extends AbstractFsAdminCommand {
   }
 
   @Override
-  public boolean hasSubCommand() {
-    return true;
-  }
-
-  @Override
   public Map<String, Command> getSubCommands() {
     return mSubCommands;
   }

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/MetricsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/MetricsCommand.java
@@ -58,11 +58,6 @@ public class MetricsCommand extends AbstractFsAdminCommand {
   }
 
   @Override
-  public boolean hasSubCommand() {
-    return true;
-  }
-
-  @Override
   public Map<String, Command> getSubCommands() {
     return mSubCommands;
   }

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/PathConfCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/PathConfCommand.java
@@ -54,11 +54,6 @@ public final class PathConfCommand extends AbstractFsAdminCommand {
   }
 
   @Override
-  public boolean hasSubCommand() {
-    return true;
-  }
-
-  @Override
   public Map<String, Command> getSubCommands() {
     return mSubCommands;
   }

--- a/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/journal/QuorumCommand.java
@@ -62,11 +62,6 @@ public class QuorumCommand extends AbstractFsAdminCommand {
   }
 
   @Override
-  public boolean hasSubCommand() {
-    return true;
-  }
-
-  @Override
   public Map<String, Command> getSubCommands() {
     return mSubCommands;
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add a default hasSubCommand in Command to simplify the command implementations. 

### Why are the changes needed?

- Add a default hasSubCommand in Command
- Remove useless implementations from all class implemented from command.

### Does this PR introduce any user facing changes?

No 
