### PR TITLE
Avoid creating the empty object for S3 root

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -944,7 +944,8 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     String dir = stripPrefixIfPresent(path);
     ObjectListingChunk objs = getObjectListingChunk(dir, recursive);
     // If there are, this is a folder and we can create the necessary metadata
-    if (objs != null && ((objs.getObjectStatuses() != null && objs.getObjectStatuses().length > 0)
+    if (objs != null && !isRoot(dir)
+        && ((objs.getObjectStatuses() != null && objs.getObjectStatuses().length > 0)
         || (objs.getCommonPrefixes() != null && objs.getCommonPrefixes().length > 0))) {
       // Do not recreate the breadcrumb if it already exists
       String folderName = convertToFolderName(dir);

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -400,15 +400,8 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
           new PutObjectRequest(mBucketName, key, new ByteArrayInputStream(new byte[0]), meta));
       return true;
     } catch (AmazonClientException e) {
-      if (key.equals("/")) {
-        // Ignore the error since it's root
-        LOG.info("Ignore the error of failing to create the root object {} since it's not needed",
-            e.getMessage());
-        return true;
-      } else {
-        LOG.error("Failed to create object: {}", key, e);
-        return false;
-      }
+      LOG.error("Failed to create object: {}", key, e);
+      return false;
     }
   }
 

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -400,8 +400,15 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
           new PutObjectRequest(mBucketName, key, new ByteArrayInputStream(new byte[0]), meta));
       return true;
     } catch (AmazonClientException e) {
-      LOG.error("Failed to create object: {}", key, e);
-      return false;
+      if (key.equals("/")) {
+        // Ignore the error since it's root
+        LOG.info("Ignore the error of failing to create the root object {} since it's not needed",
+            e.getMessage());
+        return true;
+      } else {
+        LOG.error("Failed to create object: {}", key, e);
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?
Avoid creating the empty object for root
### Why are the changes needed?
To avoid some customized S3 object storage error.
### Does this PR introduce any user facing changes?