### PR TITLE
Disable worker register lease by default

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2860,7 +2860,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_WORKER_REGISTER_LEASE_ENABLED =
       new Builder(Name.MASTER_WORKER_REGISTER_LEASE_ENABLED)
-          .setDefaultValue("true")
+          .setDefaultValue(false)
           .setDescription("Whether workers request for leases before they register. "
               + "The RegisterLease is used by the master to control the concurrency of workers"
               + " that are actively registering.")


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix #14618

Disable worker register lease by default.

### Why are the changes needed?

To keep backward compatible. Now, the 2.6 and older than 2.7 user cannot upgrade the alluxio master to 2.7 while keep workers in old version, no worker can be registered to alluxio master.

So I submit this PR to make MASTER_WORKER_REGISTER_LEASE_ENABLED default to false to keep backward compatible. People who like use this feature, just enable it manually.

If we recommend to use this feature strongly, we can announce to enable it in next release and make sure most of users have accept this change.

### Does this PR introduce any user facing changes?

No