### PR TITLE
Support register.lease.enabled can be updated

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -51,9 +51,6 @@ public final class BlockMasterWorkerServiceHandler extends
     BlockMasterWorkerServiceGrpc.BlockMasterWorkerServiceImplBase {
   private static final Logger LOG = LoggerFactory.getLogger(BlockMasterWorkerServiceHandler.class);
 
-  private final boolean mRegisterLeaseOn =
-      ServerConfiguration.getBoolean(PropertyKey.MASTER_WORKER_REGISTER_LEASE_ENABLED);
-
   private final BlockMaster mBlockMaster;
 
   /**
@@ -157,7 +154,8 @@ public final class BlockMasterWorkerServiceHandler extends
     RpcUtils.call(LOG,
         (RpcUtils.RpcCallableThrowsIOException<RegisterWorkerPResponse>) () -> {
           // The exception will be propagated to the worker side and the worker should retry.
-          if (mRegisterLeaseOn && !mBlockMaster.hasRegisterLease(workerId)) {
+          if (ServerConfiguration.getBoolean(PropertyKey.MASTER_WORKER_REGISTER_LEASE_ENABLED)
+              && !mBlockMaster.hasRegisterLease(workerId)) {
             String errorMsg = String.format("Worker %s does not have a lease or the lease "
                 + "has expired. The worker should acquire a new lease and retry to register.",
                 workerId);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Now the `alluxio.master.worker.register.lease.enabled` is read once the `BlockMasterWorkerServiceHandler` object init instance, but cannot be updated after that.

### Why are the changes needed?

Read the propertykey from `ServerConfiguration` each time for worker register, never mind the performance down, since the register request for each worker have only one time, and get a value from `ServerConfiguration` have no io operation.

### Does this PR introduce any user facing changes?

NO
