### PR TITLE
Add profile in pom for module alluxio-shade-ozone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -562,11 +562,6 @@
         <version>${ozone.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-ozone-filesystem</artifactId>
-        <version>${ozone.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.qcloud.cos</groupId>
         <artifactId>hadoop-cos</artifactId>
         <version>${hadoop-cos.version}</version>

--- a/shaded/ozone/pom.xml
+++ b/shaded/ozone/pom.xml
@@ -51,24 +51,33 @@
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-ozone-client</artifactId>
+      <version>${ufs.ozone.version}</version>
+    </dependency>
   </dependencies>
 
   <profiles>
-    <!-- Profile to build this UFS module connecting to ozone 1 -->
     <profile>
-      <id>ufs-ozone-1</id>
+      <id>ufs-hadoop-2</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-ozone-filesystem-hadoop2</artifactId>
+          <version>${ufs.ozone.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>ufs-hadoop-3</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
       <dependencies>
         <dependency>
           <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-ozone-filesystem</artifactId>
-          <version>${ufs.ozone.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-ozone-client</artifactId>
+          <artifactId>hadoop-ozone-filesystem-hadoop3</artifactId>
           <version>${ufs.ozone.version}</version>
         </dependency>
       </dependencies>


### PR DESCRIPTION

### What changes are proposed in this pull request?

make dependency artifact "hadoop-ozone-filesystem-hadoop" of pom.xml file in module alluxio-shade-ozone is consistent with hadoop version.

Please outline the changes and how this PR fixes the issue.

add profile in alluxio-shade-ozone pom to build jar with a consistent version with hadoop.

### Why are the changes needed?

Using alluxio-2.6.2 doesn't work when setting ozone to be the under-filesystem and my hadoop version is 2.10.1 not 3.3.  While I change the dependency jar "hadoop-ozone-filesystem-hadoop" to "hadoop-ozone-filesystem-hadoop2", it works.

### Does this PR introduce any user facing changes?
NO