### PR TITLE
[SMALLFIX] Correct the configuration rendering for alluxioPath

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -232,4 +232,5 @@
 0.6.34
 
 - Enable mounting a specific directory in Alluxio through Fuse
+- Fixes a typo in rendering the fuse mount directory.
 

--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -84,7 +84,7 @@
 {{- /* Worker Fuse configurations */}}
 {{- if eq .Values.worker.fuseEnabled true}}
   {{- $workerJavaOpts = print "-Dalluxio.worker.fuse.enabled=true" | append $workerJavaOpts }}
-  {{- $workerJavaOpts = print "-Dalluxio.worker.fuse.mount.alluxio.path=%v" .Values.fuse.alluxioPath | append $workerJavaOpts }}
+  {{- $workerJavaOpts = printf "-Dalluxio.worker.fuse.mount.alluxio.path=%v" .Values.fuse.alluxioPath | append $workerJavaOpts }}
   {{- $workerJavaOpts = printf "-Dalluxio.worker.fuse.mount.point=%v" .Values.fuse.mountPath | append $workerJavaOpts }}
   {{- if .Values.fuse.mountOptions }}
   {{- $workerJavaOpts = printf "-Dalluxio.worker.fuse.mount.options=%v" .Values.fuse.mountOptions | append $workerJavaOpts }}


### PR DESCRIPTION

### What changes are proposed in this pull request?

Fixes a typo in the helm charts. I haven't tried, but I believe it should be `printf` otherwise the `alluxioPath` will be rendered as `%v/` which shouldn't work.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs: None
  2. addition or removal of property keys: None
  3. webui: None
