### PR TITLE
Make recursive options consistent in the filesystem shell

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/ChgrpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/ChgrpCommand.java
@@ -99,12 +99,12 @@ public final class ChgrpCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "chgrp [-R --recursive] <group> <path>";
+    return "chgrp [-R/--recursive] <group> <path>";
   }
 
   @Override
   public String getDescription() {
     return "Changes the group of a file or directory specified by args."
-        + " Specify -R(--recursive) to change the group recursively.";
+        + " Specify -R/--recursive to change the group recursively.";
   }
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/ChgrpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/ChgrpCommand.java
@@ -34,7 +34,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class ChgrpCommand extends AbstractFileSystemCommand {
 
   private static final Option RECURSIVE_OPTION =
-      Option.builder("R")
+      Option.builder("R").longOpt("recursive")
           .required(false)
           .hasArg(false)
           .desc("change group recursively")
@@ -84,7 +84,7 @@ public final class ChgrpCommand extends AbstractFileSystemCommand {
   @Override
   protected void runPlainPath(AlluxioURI path, CommandLine cl)
       throws IOException, AlluxioException {
-    chgrp(path, mGroup, cl.hasOption("R"));
+    chgrp(path, mGroup, cl.hasOption(RECURSIVE_OPTION.getOpt()));
   }
 
   @Override
@@ -99,12 +99,12 @@ public final class ChgrpCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "chgrp [-R] <group> <path>";
+    return "chgrp [-R --recursive] <group> <path>";
   }
 
   @Override
   public String getDescription() {
     return "Changes the group of a file or directory specified by args."
-        + " Specify -R to change the group recursively.";
+        + " Specify -R(--recursive) to change the group recursively.";
   }
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/ChmodCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/ChmodCommand.java
@@ -36,7 +36,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class ChmodCommand extends AbstractFileSystemCommand {
 
   private static final Option RECURSIVE_OPTION =
-      Option.builder("R")
+      Option.builder("R").longOpt("recursive")
           .required(false)
           .hasArg(false)
           .desc("change mode recursively")
@@ -56,7 +56,7 @@ public final class ChmodCommand extends AbstractFileSystemCommand {
   @Override
   protected void runPlainPath(AlluxioURI plainPath, CommandLine cl)
       throws AlluxioException, IOException {
-    chmod(plainPath, mModeString, cl.hasOption("R"));
+    chmod(plainPath, mModeString, cl.hasOption(RECURSIVE_OPTION.getOpt()));
   }
 
   @Override
@@ -103,12 +103,12 @@ public final class ChmodCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "chmod [-R] <mode> <path>";
+    return "chmod [-R(--recursive)] <mode> <path>";
   }
 
   @Override
   public String getDescription() {
     return "Changes the permission of a file or directory specified by args."
-        + " Specify -R to change the permission recursively.";
+        + " Specify -R(--recursive) to change the permission recursively.";
   }
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/ChmodCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/ChmodCommand.java
@@ -103,12 +103,12 @@ public final class ChmodCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "chmod [-R(--recursive)] <mode> <path>";
+    return "chmod [-R/--recursive] <mode> <path>";
   }
 
   @Override
   public String getDescription() {
     return "Changes the permission of a file or directory specified by args."
-        + " Specify -R(--recursive) to change the permission recursively.";
+        + " Specify -R/--recursive to change the permission recursively.";
   }
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/ChownCommand.java
@@ -135,12 +135,12 @@ public final class ChownCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "chown [-R --recursive] <owner>[:<group>] <path>";
+    return "chown [-R/--recursive] <owner>[:<group>] <path>";
   }
 
   @Override
   public String getDescription() {
     return "Changes the owner of a file or directory specified by args."
-        + " Specify -R(--recursive) to change the owner recursively.";
+        + " Specify -R/--recursive to change the owner recursively.";
   }
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/ChownCommand.java
@@ -36,7 +36,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class ChownCommand extends AbstractFileSystemCommand {
 
   private static final Option RECURSIVE_OPTION =
-      Option.builder("R")
+      Option.builder("R").longOpt("recursive")
           .required(false)
           .hasArg(false)
           .desc("change owner recursively")
@@ -58,9 +58,9 @@ public final class ChownCommand extends AbstractFileSystemCommand {
   protected void runPlainPath(AlluxioURI path, CommandLine cl)
       throws AlluxioException, IOException {
     if (mGroup == null) {
-      chown(path, mOwner, cl.hasOption("R"));
+      chown(path, mOwner, cl.hasOption(RECURSIVE_OPTION.getOpt()));
     } else {
-      chown(path, mOwner, mGroup, cl.hasOption("R"));
+      chown(path, mOwner, mGroup, cl.hasOption(RECURSIVE_OPTION.getOpt()));
     }
   }
 
@@ -135,12 +135,12 @@ public final class ChownCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "chown [-R] <owner>[:<group>] <path>";
+    return "chown [-R --recursive] <owner>[:<group>] <path>";
   }
 
   @Override
   public String getDescription() {
     return "Changes the owner of a file or directory specified by args."
-        + " Specify -R to change the owner recursively.";
+        + " Specify -R(--recursive) to change the owner recursively.";
   }
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
@@ -76,11 +76,17 @@ public final class CpCommand extends AbstractFileSystemCommand {
   private static final int COPY_TO_LOCAL_BUFFER_SIZE_DEFAULT = 64 * Constants.MB;
 
   private static final Option RECURSIVE_OPTION =
-      Option.builder("R")
+      Option.builder("R").longOpt("recursive")
           .required(false)
           .hasArg(false)
           .desc("copy files in subdirectories recursively")
           .build();
+  private static final Option ANOTHER_RECURSIVE_OPTION =
+      Option.builder("r")
+              .required(false)
+              .hasArg(false)
+              .desc("copy files in subdirectories recursively")
+              .build();
   public static final Option THREAD_OPTION =
       Option.builder()
           .longOpt("thread")
@@ -340,6 +346,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
   @Override
   public Options getOptions() {
     return new Options().addOption(RECURSIVE_OPTION)
+        .addOption(ANOTHER_RECURSIVE_OPTION)
         .addOption(THREAD_OPTION)
         .addOption(PRESERVE_OPTION);
   }
@@ -412,10 +419,11 @@ public final class CpCommand extends AbstractFileSystemCommand {
         throw new FileDoesNotExistException(
             ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(srcPath.getPath()));
       }
+      boolean recursive = cl.hasOption(RECURSIVE_OPTION.getOpt()) || cl.hasOption(ANOTHER_RECURSIVE_OPTION.getOpt());
       if (srcPath.containsWildcard()) {
-        copyWildcard(srcPaths, dstPath, cl.hasOption(RECURSIVE_OPTION.getOpt()));
+        copyWildcard(srcPaths, dstPath, recursive);
       } else {
-        copy(srcPath, dstPath, cl.hasOption(RECURSIVE_OPTION.getOpt()));
+        copy(srcPath, dstPath, recursive);
       }
     } else {
       throw new InvalidPathException(
@@ -488,7 +496,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
     } else {
       if (!recursive) {
         throw new IOException(
-            srcPath.getPath() + " is a directory, to copy it please use \"cp -R <src> <dst>\"");
+            srcPath.getPath() + " is a directory, to copy it please use \"cp -R(-r,--recursive) <src> <dst>\"");
       }
 
       List<URIStatus> statuses;
@@ -793,7 +801,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
   @Override
   public String getUsage() {
     return "cp "
-        + "[-R] "
+        + "[-R -r --recursive] "
         + "[--buffersize <bytes>] "
         + "<src> <dst>";
   }
@@ -801,7 +809,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
   @Override
   public String getDescription() {
     return "Copies a file or a directory in the Alluxio filesystem or between local filesystem "
-        + "and Alluxio filesystem. The -R flag is needed to copy directories in the Alluxio "
+        + "and Alluxio filesystem. The -R(-r or --recursive) flags are needed to copy directories in the Alluxio "
         + "filesystem. Local Path with schema \"file\".";
   }
 

--- a/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
@@ -420,7 +420,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
             ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(srcPath.getPath()));
       }
       boolean recursive = cl.hasOption(RECURSIVE_OPTION.getOpt())
-              || cl.hasOption(RECURSIVE_ALIAS_OPTION.getOpt());
+          || cl.hasOption(RECURSIVE_ALIAS_OPTION.getOpt());
       if (srcPath.containsWildcard()) {
         copyWildcard(srcPaths, dstPath, recursive);
       } else {
@@ -496,9 +496,8 @@ public final class CpCommand extends AbstractFileSystemCommand {
       copyFile(srcPath, dstPath);
     } else {
       if (!recursive) {
-        throw new IOException(
-            srcPath.getPath() + " is a directory,"
-                    + " to copy it please use \"cp -R(-r,--recursive) <src> <dst>\"");
+        throw new IOException(srcPath.getPath() + " is a directory,"
+            + " to copy it please use \"cp -R/-r/--recursive <src> <dst>\"");
       }
 
       List<URIStatus> statuses;
@@ -803,7 +802,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
   @Override
   public String getUsage() {
     return "cp "
-        + "[-R -r --recursive] "
+        + "[-R/-r/--recursive] "
         + "[--buffersize <bytes>] "
         + "<src> <dst>";
   }
@@ -811,7 +810,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
   @Override
   public String getDescription() {
     return "Copies a file or a directory in the Alluxio filesystem or between local filesystem "
-        + "and Alluxio filesystem. The -R(-r or --recursive) flags are needed to copy"
+        + "and Alluxio filesystem. The -R/-r/--recursive flags are needed to copy"
         + "directories in the Alluxio filesystem. Local Path with schema \"file\".";
   }
 

--- a/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CpCommand.java
@@ -81,12 +81,12 @@ public final class CpCommand extends AbstractFileSystemCommand {
           .hasArg(false)
           .desc("copy files in subdirectories recursively")
           .build();
-  private static final Option ANOTHER_RECURSIVE_OPTION =
+  private static final Option RECURSIVE_ALIAS_OPTION =
       Option.builder("r")
-              .required(false)
-              .hasArg(false)
-              .desc("copy files in subdirectories recursively")
-              .build();
+          .required(false)
+          .hasArg(false)
+          .desc("copy files in subdirectories recursively")
+          .build();
   public static final Option THREAD_OPTION =
       Option.builder()
           .longOpt("thread")
@@ -346,7 +346,7 @@ public final class CpCommand extends AbstractFileSystemCommand {
   @Override
   public Options getOptions() {
     return new Options().addOption(RECURSIVE_OPTION)
-        .addOption(ANOTHER_RECURSIVE_OPTION)
+        .addOption(RECURSIVE_ALIAS_OPTION)
         .addOption(THREAD_OPTION)
         .addOption(PRESERVE_OPTION);
   }
@@ -419,7 +419,8 @@ public final class CpCommand extends AbstractFileSystemCommand {
         throw new FileDoesNotExistException(
             ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(srcPath.getPath()));
       }
-      boolean recursive = cl.hasOption(RECURSIVE_OPTION.getOpt()) || cl.hasOption(ANOTHER_RECURSIVE_OPTION.getOpt());
+      boolean recursive = cl.hasOption(RECURSIVE_OPTION.getOpt())
+              || cl.hasOption(RECURSIVE_ALIAS_OPTION.getOpt());
       if (srcPath.containsWildcard()) {
         copyWildcard(srcPaths, dstPath, recursive);
       } else {
@@ -496,7 +497,8 @@ public final class CpCommand extends AbstractFileSystemCommand {
     } else {
       if (!recursive) {
         throw new IOException(
-            srcPath.getPath() + " is a directory, to copy it please use \"cp -R(-r,--recursive) <src> <dst>\"");
+            srcPath.getPath() + " is a directory,"
+                    + " to copy it please use \"cp -R(-r,--recursive) <src> <dst>\"");
       }
 
       List<URIStatus> statuses;
@@ -809,8 +811,8 @@ public final class CpCommand extends AbstractFileSystemCommand {
   @Override
   public String getDescription() {
     return "Copies a file or a directory in the Alluxio filesystem or between local filesystem "
-        + "and Alluxio filesystem. The -R(-r or --recursive) flags are needed to copy directories in the Alluxio "
-        + "filesystem. Local Path with schema \"file\".";
+        + "and Alluxio filesystem. The -R(-r or --recursive) flags are needed to copy"
+        + "directories in the Alluxio filesystem. Local Path with schema \"file\".";
   }
 
   private static boolean isAlluxio(String scheme) {

--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -136,19 +136,19 @@ public final class LsCommand extends AbstractFileSystemCommand {
 
   private static final Option REVERSE_SORT_OPTION =
       Option.builder("r")
-              .required(false)
-              .hasArg(false)
-              .desc("reverse order while sorting")
-              .build();
+         .required(false)
+         .hasArg(false)
+         .desc("reverse order while sorting")
+         .build();
 
   private static final Option TIMESTAMP_OPTION =
       Option.builder()
-          .required(false)
-          .longOpt("timestamp")
-          .hasArg(true)
-          .desc("display specific timestamp(default is last modification time) {"
+         .required(false)
+         .longOpt("timestamp")
+         .hasArg(true)
+         .desc("display specific timestamp(default is last modification time) {"
               + String.join("|", TIMESTAMP_FIELDS.keySet()) + "}")
-          .build();
+         .build();
 
   /**
    * Formats the ls result string.
@@ -300,9 +300,10 @@ public final class LsCommand extends AbstractFileSystemCommand {
   @Override
   protected void runPlainPath(AlluxioURI path, CommandLine cl)
       throws AlluxioException, IOException {
-    ls(path, cl.hasOption(RECURSIVE_OPTION.getOpt()), cl.hasOption("f"), cl.hasOption("d"), cl.hasOption("h"),
-        cl.hasOption("p"), cl.getOptionValue("sort", null), cl.hasOption("r"),
-        cl.getOptionValue("timestamp", "lastModificationTime"));
+    ls(path, cl.hasOption(RECURSIVE_OPTION.getOpt()), cl.hasOption("f"),
+            cl.hasOption("d"), cl.hasOption("h"), cl.hasOption("p"),
+            cl.getOptionValue("sort", null), cl.hasOption("r"),
+            cl.getOptionValue("timestamp", "lastModificationTime"));
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -118,7 +118,7 @@ public final class LsCommand extends AbstractFileSystemCommand {
           .build();
 
   private static final Option RECURSIVE_OPTION =
-      Option.builder("R")
+      Option.builder("R").longOpt("recursive")
           .required(false)
           .hasArg(false)
           .desc("list subdirectories recursively")
@@ -300,7 +300,7 @@ public final class LsCommand extends AbstractFileSystemCommand {
   @Override
   protected void runPlainPath(AlluxioURI path, CommandLine cl)
       throws AlluxioException, IOException {
-    ls(path, cl.hasOption("R"), cl.hasOption("f"), cl.hasOption("d"), cl.hasOption("h"),
+    ls(path, cl.hasOption(RECURSIVE_OPTION.getOpt()), cl.hasOption("f"), cl.hasOption("d"), cl.hasOption("h"),
         cl.hasOption("p"), cl.getOptionValue("sort", null), cl.hasOption("r"),
         cl.getOptionValue("timestamp", "lastModificationTime"));
   }
@@ -317,7 +317,7 @@ public final class LsCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "ls [-d|-f|-p|-R|-h|--sort=option|--timestamp=option|-r] <path> ...";
+    return "ls [-d|-f|-p|-R(--recursive)|-h|--sort=option|--timestamp=option|-r] <path> ...";
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -301,9 +301,9 @@ public final class LsCommand extends AbstractFileSystemCommand {
   protected void runPlainPath(AlluxioURI path, CommandLine cl)
       throws AlluxioException, IOException {
     ls(path, cl.hasOption(RECURSIVE_OPTION.getOpt()), cl.hasOption("f"),
-            cl.hasOption("d"), cl.hasOption("h"), cl.hasOption("p"),
-            cl.getOptionValue("sort", null), cl.hasOption("r"),
-            cl.getOptionValue("timestamp", "lastModificationTime"));
+        cl.hasOption("d"), cl.hasOption("h"), cl.hasOption("p"),
+        cl.getOptionValue("sort", null), cl.hasOption("r"),
+        cl.getOptionValue("timestamp", "lastModificationTime"));
   }
 
   @Override
@@ -318,7 +318,7 @@ public final class LsCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "ls [-d|-f|-p|-R(--recursive)|-h|--sort=option|--timestamp=option|-r] <path> ...";
+    return "ls [-d|-f|-p|-R/--recursive|-h|--sort=option|--timestamp=option|-r] <path> ...";
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
@@ -36,11 +36,17 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class RmCommand extends AbstractFileSystemCommand {
 
   private static final Option RECURSIVE_OPTION =
-      Option.builder("R")
+      Option.builder("R").longOpt("recursive")
           .required(false)
           .hasArg(false)
           .desc("delete files and subdirectories recursively")
           .build();
+  private static final Option ANOTHER_RECURSIVE_OPTION =
+          Option.builder("r")
+                  .required(false)
+                  .hasArg(false)
+                  .desc("copy files in subdirectories recursively")
+                  .build();
 
   private static final String REMOVE_UNCHECKED_OPTION_CHAR = "U";
   private static final Option REMOVE_UNCHECKED_OPTION =
@@ -74,6 +80,7 @@ public final class RmCommand extends AbstractFileSystemCommand {
   public Options getOptions() {
     return new Options()
         .addOption(RECURSIVE_OPTION)
+        .addOption(ANOTHER_RECURSIVE_OPTION)
         .addOption(REMOVE_UNCHECKED_OPTION)
         .addOption(REMOVE_ALLUXIO_ONLY);
   }
@@ -82,13 +89,13 @@ public final class RmCommand extends AbstractFileSystemCommand {
   protected void runPlainPath(AlluxioURI path, CommandLine cl)
       throws AlluxioException, IOException {
     // TODO(calvin): Remove explicit state checking.
-    boolean recursive = cl.hasOption("R");
+    boolean recursive = cl.hasOption(RECURSIVE_OPTION.getOpt()) || cl.hasOption(ANOTHER_RECURSIVE_OPTION.getOpt());
     if (!mFileSystem.exists(path)) {
       throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
     }
     if (!recursive && mFileSystem.getStatus(path).isFolder()) {
       throw new IOException(
-          path.getPath() + " is a directory, to remove it, please use \"rm -R <path>\"");
+          path.getPath() + " is a directory, to remove it, please use \"rm -R(-r or --recursive) <path>\"");
     }
     boolean isAlluxioOnly = cl.hasOption(REMOVE_ALLUXIO_ONLY.getLongOpt());
     DeletePOptions options =
@@ -114,12 +121,12 @@ public final class RmCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "rm [-R] [-U] [--alluxioOnly] <path>";
+    return "rm [-R --recursive -r] [-U] [--alluxioOnly] <path>";
   }
 
   @Override
   public String getDescription() {
-    return "Removes the specified file. Specify -R to remove file or directory recursively."
+    return "Removes the specified file. Specify -R(-r or --recursive) to remove file or directory recursively."
         + " Specify -U to remove directories without checking UFS contents are in sync."
         + " Specify -alluxioOnly to remove data and metadata from alluxio space only.";
   }

--- a/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
@@ -41,12 +41,12 @@ public final class RmCommand extends AbstractFileSystemCommand {
           .hasArg(false)
           .desc("delete files and subdirectories recursively")
           .build();
-  private static final Option ANOTHER_RECURSIVE_OPTION =
-          Option.builder("r")
-                  .required(false)
-                  .hasArg(false)
-                  .desc("copy files in subdirectories recursively")
-                  .build();
+  private static final Option RECURSIVE_ALIAS_OPTION =
+      Option.builder("r")
+          .required(false)
+          .hasArg(false)
+          .desc("copy files in subdirectories recursively")
+          .build();
 
   private static final String REMOVE_UNCHECKED_OPTION_CHAR = "U";
   private static final Option REMOVE_UNCHECKED_OPTION =
@@ -80,7 +80,7 @@ public final class RmCommand extends AbstractFileSystemCommand {
   public Options getOptions() {
     return new Options()
         .addOption(RECURSIVE_OPTION)
-        .addOption(ANOTHER_RECURSIVE_OPTION)
+        .addOption(RECURSIVE_ALIAS_OPTION)
         .addOption(REMOVE_UNCHECKED_OPTION)
         .addOption(REMOVE_ALLUXIO_ONLY);
   }
@@ -89,13 +89,15 @@ public final class RmCommand extends AbstractFileSystemCommand {
   protected void runPlainPath(AlluxioURI path, CommandLine cl)
       throws AlluxioException, IOException {
     // TODO(calvin): Remove explicit state checking.
-    boolean recursive = cl.hasOption(RECURSIVE_OPTION.getOpt()) || cl.hasOption(ANOTHER_RECURSIVE_OPTION.getOpt());
+    boolean recursive = cl.hasOption(RECURSIVE_OPTION.getOpt())
+            || cl.hasOption(RECURSIVE_ALIAS_OPTION.getOpt());
     if (!mFileSystem.exists(path)) {
       throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
     }
     if (!recursive && mFileSystem.getStatus(path).isFolder()) {
       throw new IOException(
-          path.getPath() + " is a directory, to remove it, please use \"rm -R(-r or --recursive) <path>\"");
+          path.getPath() + " is a directory, to remove it,"
+                  + " please use \"rm -R(-r or --recursive) <path>\"");
     }
     boolean isAlluxioOnly = cl.hasOption(REMOVE_ALLUXIO_ONLY.getLongOpt());
     DeletePOptions options =
@@ -126,9 +128,10 @@ public final class RmCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getDescription() {
-    return "Removes the specified file. Specify -R(-r or --recursive) to remove file or directory recursively."
-        + " Specify -U to remove directories without checking UFS contents are in sync."
-        + " Specify -alluxioOnly to remove data and metadata from alluxio space only.";
+    return "Removes the specified file. Specify -R(-r or --recursive) to remove file"
+            + " or directory recursively. Specify -U to remove directories without checking "
+            + " UFS contents are in sync. Specify -alluxioOnly to remove data and metadata from"
+            + " alluxio space only.";
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
@@ -122,7 +122,7 @@ public final class RmCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "rm [-R/--recursive/-r] [-U] [--alluxioOnly] <path>";
+    return "rm [-R/-r/--recursive] [-U] [--alluxioOnly] <path>";
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
@@ -90,14 +90,13 @@ public final class RmCommand extends AbstractFileSystemCommand {
       throws AlluxioException, IOException {
     // TODO(calvin): Remove explicit state checking.
     boolean recursive = cl.hasOption(RECURSIVE_OPTION.getOpt())
-            || cl.hasOption(RECURSIVE_ALIAS_OPTION.getOpt());
+        || cl.hasOption(RECURSIVE_ALIAS_OPTION.getOpt());
     if (!mFileSystem.exists(path)) {
       throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
     }
     if (!recursive && mFileSystem.getStatus(path).isFolder()) {
-      throw new IOException(
-          path.getPath() + " is a directory, to remove it,"
-                  + " please use \"rm -R(-r or --recursive) <path>\"");
+      throw new IOException(path.getPath() + " is a directory, to remove it,"
+          + " please use \"rm -R/-r/--recursive <path>\"");
     }
     boolean isAlluxioOnly = cl.hasOption(REMOVE_ALLUXIO_ONLY.getLongOpt());
     DeletePOptions options =
@@ -123,15 +122,15 @@ public final class RmCommand extends AbstractFileSystemCommand {
 
   @Override
   public String getUsage() {
-    return "rm [-R --recursive -r] [-U] [--alluxioOnly] <path>";
+    return "rm [-R/--recursive/-r] [-U] [--alluxioOnly] <path>";
   }
 
   @Override
   public String getDescription() {
-    return "Removes the specified file. Specify -R(-r or --recursive) to remove file"
-            + " or directory recursively. Specify -U to remove directories without checking "
-            + " UFS contents are in sync. Specify -alluxioOnly to remove data and metadata from"
-            + " alluxio space only.";
+    return "Removes the specified file. Specify -R/-r/--recursive to remove file"
+        + " or directory recursively. Specify -U to remove directories without checking "
+        + " UFS contents are in sync. Specify -alluxioOnly to remove data and metadata from"
+        + " alluxio space only.";
   }
 
   @Override

--- a/tests/src/test/java/alluxio/client/cli/fs/command/RmCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/RmCommandIntegrationTest.java
@@ -32,7 +32,7 @@ public final class RmCommandIntegrationTest extends AbstractFileSystemShellTest 
     sFsShell.run("mkdir", "/testFolder");
     toCompare.append(getCommandOutput(new String[] {"mkdir", "/testFolder"}));
     sFsShell.run("rm", "/testFolder");
-    toCompare.append("/testFolder is a directory, to remove it, please use \"rm -R <path>\"\n");
+    toCompare.append("/testFolder is a directory, to remove it, please use \"rm -R/-r/--recursive <path>\"\n");
     Assert.assertEquals(toCompare.toString(), mOutput.toString());
   }
 

--- a/tests/src/test/java/alluxio/client/cli/fs/command/RmCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/RmCommandIntegrationTest.java
@@ -32,7 +32,8 @@ public final class RmCommandIntegrationTest extends AbstractFileSystemShellTest 
     sFsShell.run("mkdir", "/testFolder");
     toCompare.append(getCommandOutput(new String[] {"mkdir", "/testFolder"}));
     sFsShell.run("rm", "/testFolder");
-    toCompare.append("/testFolder is a directory, to remove it, please use \"rm -R/-r/--recursive <path>\"\n");
+    toCompare.append("/testFolder is a directory, to remove it,"
+        + " please use \"rm -R/-r/--recursive <path>\"\n");
     Assert.assertEquals(toCompare.toString(), mOutput.toString());
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix #8498 

In this patch, I tried to use a method similar to Option.alias(), but
org.apache.commons.cli.Option does not provide a similar function, so I chose to add an ANOTHER_RECURSIVE_OPTION. If there is a better implementation, please suggest it and I will change the code.

### Why are the changes needed?
make the option consistent with fs shell

### Does this PR introduce any user facing changes?
No