### PR TITLE
Preload metadata in the same directory

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCachingBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCachingBaseFileSystem.java
@@ -123,6 +123,9 @@ public class MetadataCachingBaseFileSystem extends BaseFileSystem {
   public URIStatus getStatus(AlluxioURI path, GetStatusPOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException {
     checkUri(path);
+    if (mMetadataCache.get(path) == null) {
+      this.listStatus(path.getParent());
+    }
     URIStatus status = mMetadataCache.get(path);
     if (status == null || !status.isCompleted()) {
       try {


### PR DESCRIPTION
If the current file or directory is not in the cache, we can load the metadata of all files and dirs in the parent directory in advance to avoid multiple metadata loading.