### PR TITLE
[DOCFIX] Add fs.AbstractFileSystem.alluxio.impl to Hadoop docs

### DIFF
--- a/docs/en/compute/Hadoop-MapReduce.md
+++ b/docs/en/compute/Hadoop-MapReduce.md
@@ -32,13 +32,18 @@ For example, if you are using Hadoop 2.7 download this
 
 > **This step is only required for Hadoop 1.x and can be skipped by users of Hadoop 2.x or later**.
 
-Add the following property to the `core-site.xml` of your Hadoop installation:
+Add the following properties to the `core-site.xml` of your Hadoop installation:
 
 ```xml
 <property>
   <name>fs.alluxio.impl</name>
   <value>alluxio.hadoop.FileSystem</value>
-  <description>The Alluxio FileSystem</description>
+  <description>The Alluxio FileSystem (Hadoop 1.x and 2.x)</description>
+</property>
+<property>
+  <name>fs.AbstractFileSystem.alluxio.impl</name>
+  <value>alluxio.hadoop.AlluxioFileSystem</value>
+  <description>The Alluxio AbstractFileSystem (Hadoop 2.x)</description>
 </property>
 ```
 


### PR DESCRIPTION
These changes add an XML property which we suggested in the [Alluxio Hadoop CN docs](https://docs.alluxio.io/os/user/stable/cn/compute/Hadoop-MapReduce.html?q=AlluxioFileSystem#%E9%85%8D%E7%BD%AEhadoop) but which are not present in the [Alluxio Hadoop EN docs](https://docs.alluxio.io/os/user/stable/en/compute/Hadoop-MapReduce.html#configuring-hadoop-core-site-properties).

Similarly, I noticed in the CN docs there is no mention of these properties being skippable for Hadoop >= 2.x. Not sure which of the two docs are correct on that.