### PR TITLE
Change a collection from ConcurrentHashSet to HashSet in sync

### DIFF
--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -28,6 +28,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -109,7 +111,7 @@ public class UfsStatusCache {
    */
   @Nullable
   public Collection<UfsStatus> addChildren(AlluxioURI path, Collection<UfsStatus> children) {
-    ConcurrentHashSet<UfsStatus> set = new ConcurrentHashSet<>();
+    Set<UfsStatus> set = new HashSet<>();
     children.forEach(child -> {
       AlluxioURI childPath = path.joinUnsafe(child.getName());
       addStatus(childPath, child);

--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -28,6 +28,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -117,7 +118,7 @@ public class UfsStatusCache {
       addStatus(childPath, child);
       set.add(child);
     });
-    return mChildren.put(path, set);
+    return mChildren.put(path, Collections.unmodifiableSet(set));
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -12,7 +12,6 @@
 package alluxio.underfs;
 
 import alluxio.AlluxioURI;
-import alluxio.collections.ConcurrentHashSet;
 import alluxio.exception.InvalidPathException;
 import alluxio.master.file.RpcContext;
 import alluxio.master.file.meta.MountTable;


### PR DESCRIPTION
### What changes are proposed in this pull request?

Change a ConcurrentHashSet to HashSet to reduce cost in metadata sync.

### Why are the changes needed?

The collection is only locally used for reading and can be changed to HashSet for lower cost.

### Does this PR introduce any user facing changes?

NA
