### PR TITLE
Remove permission check from Sync in InodeSyncStream

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -314,16 +314,7 @@ public class InodeSyncStream {
       if (mAuditContext != null && mAuditContextSrcInodeFunc != null) {
         mAuditContext.setSrcInode(mAuditContextSrcInodeFunc.apply(path));
       }
-      try {
-        if (mPermissionCheckOperation != null) {
-          mPermissionCheckOperation.accept(path, mFsMaster.getPermissionChecker());
-        }
-      } catch (AccessControlException e) {
-        if (mAuditContext != null) {
-          mAuditContext.setAllowed(false);
-        }
-        throw e;
-      }
+
       syncInodeMetadata(path);
       syncPathCount++;
       if (mDescendantType == DescendantType.ONE) {


### PR DESCRIPTION
Remove permission check from Sync in InodeSyncStream. Sync is the server behavior, should not be checked permission against the client user.
