### PR TITLE
Test Log4j old log deletion and cleanup

### DIFF
--- a/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
@@ -157,5 +157,33 @@ public final class ConfigurationTestUtils {
     return conf;
   }
 
+  /**
+   * Provides the default Log4J configuration as found in conf/log4j.properties.
+   * @return a map of properties and their values
+   */
+  public static Map<String, String> testLog4jDefaults() {
+    Map<String, String> log4jConf = new HashMap<>();
+    // root logger
+    log4jConf.put("log4j.rootLogger", "INFO, ${alluxio.logger.type}, ${alluxio.remote.logger"
+        + ".type}");
+    // master logger
+    log4jConf.put("log4j.appender.MASTER_LOGGER", "org.apache.log4j.RollingFileAppender");
+    log4jConf.put("log4j.appender.MASTER_LOGGER.File", "${alluxio.logs.dir}/master.log");
+    log4jConf.put("log4j.appender.MASTER_LOGGER.MaxFileSize", "10MB");
+    log4jConf.put("log4j.appender.MASTER_LOGGER.MaxBackupIndex", "100");
+    log4jConf.put("log4j.appender.MASTER_LOGGER.layout", "org.apache.log4j.PatternLayout");
+    log4jConf.put("log4j.appender.MASTER_LOGGER.layout.ConversionPattern", "%d{ISO8601} %-5p "
+        + "%c{1} - %m%n");
+    // worker logger
+    log4jConf.put("log4j.appender.WORKER_LOGGER", "org.apache.log4j.RollingFileAppender");
+    log4jConf.put("log4j.appender.WORKER_LOGGER.File", "${alluxio.logs.dir}/worker.log");
+    log4jConf.put("log4j.appender.WORKER_LOGGER.MaxFileSize", "10MB");
+    log4jConf.put("log4j.appender.WORKER_LOGGER.MaxBackupIndex", "100");
+    log4jConf.put("log4j.appender.WORKER_LOGGER.layout", "org.apache.log4j.PatternLayout");
+    log4jConf.put("log4j.appender.WORKER_LOGGER.layout.ConversionPattern", "%d{ISO8601} %-5p "
+        + "%c{1} - %m%n");
+    return log4jConf;
+  }
+
   private ConfigurationTestUtils() {} // prevent instantiation
 }

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -8,16 +8,6 @@
  *
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
-/*
- * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
- * (the "License"). You may not use this work except in compliance with the License, which is
- * available at www.apache.org/licenses/LICENSE-2.0
- *
- * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied, as more fully set forth in the License.
- *
- * See the NOTICE file distributed with this work for information regarding copyright ownership.
- */
 
 package alluxio.multi.process;
 

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -259,7 +259,7 @@ public final class MultiProcessCluster {
       default:
         throw new IllegalStateException("Unknown deploy mode: " + mDeployMode);
     }
-
+    // adding default alluxio properties
     for (Entry<PropertyKey, String> entry :
         ConfigurationTestUtils.testConfigurationDefaults(ServerConfiguration.global(),
         NetworkAddressUtils.getLocalHostName(
@@ -278,6 +278,12 @@ public final class MultiProcessCluster {
     mProperties.put(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS,
         PathUtils.concatPath(mWorkDir, "underFSStorage"));
     new File(mProperties.get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS)).mkdirs();
+    // adding default log4j properties
+    for (Entry<String, String> entry : ConfigurationTestUtils.testLog4jDefaults().entrySet()) {
+      if (!mLog4jProperties.containsKey(entry.getKey())) {
+        mLog4jProperties.put(entry.getKey(), entry.getValue());
+      }
+    }
     if (format) {
       formatJournal();
     }
@@ -700,8 +706,8 @@ public final class MultiProcessCluster {
     conf.put(PropertyKey.MASTER_WEB_PORT, Integer.toString(address.getWebPort()));
     conf.put(PropertyKey.MASTER_EMBEDDED_JOURNAL_PORT,
         Integer.toString(address.getEmbeddedJournalPort()));
-    conf.put(PropertyKey.getOrBuildCustom("log4j.configurationFile"),
-        new File(confDir, "log4j.properties").getAbsolutePath());
+    conf.put(PropertyKey.getOrBuildCustom("log4j.configuration"),
+        "file:" + new File(confDir, "log4j.properties").getAbsolutePath());
     if (mDeployMode.equals(DeployMode.EMBEDDED)) {
       File journalDir = new File(mWorkDir, "journal" + extension);
       journalDir.mkdirs();
@@ -737,8 +743,8 @@ public final class MultiProcessCluster {
     conf.put(PropertyKey.LOGS_DIR, logsDir.getAbsolutePath());
     conf.put(PropertyKey.WORKER_RPC_PORT, Integer.toString(rpcPort));
     conf.put(PropertyKey.WORKER_WEB_PORT, Integer.toString(webPort));
-    conf.put(PropertyKey.getOrBuildCustom("log4j.configurationFile"),
-        new File(confDir, "log4j.properties").getAbsolutePath());
+    conf.put(PropertyKey.getOrBuildCustom("log4j.configuration"),
+        "file:" + new File(confDir, "log4j.properties").getAbsolutePath());
 
     Worker worker = mCloser.register(new Worker(logsDir, conf));
     mWorkers.add(worker);

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -8,6 +8,16 @@
  *
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
 
 package alluxio.multi.process;
 
@@ -690,6 +700,8 @@ public final class MultiProcessCluster {
     conf.put(PropertyKey.MASTER_WEB_PORT, Integer.toString(address.getWebPort()));
     conf.put(PropertyKey.MASTER_EMBEDDED_JOURNAL_PORT,
         Integer.toString(address.getEmbeddedJournalPort()));
+    conf.put(PropertyKey.getOrBuildCustom("log4j.configurationFile"),
+        new File(confDir, "log4j.properties").getAbsolutePath());
     if (mDeployMode.equals(DeployMode.EMBEDDED)) {
       File journalDir = new File(mWorkDir, "journal" + extension);
       journalDir.mkdirs();
@@ -725,6 +737,8 @@ public final class MultiProcessCluster {
     conf.put(PropertyKey.LOGS_DIR, logsDir.getAbsolutePath());
     conf.put(PropertyKey.WORKER_RPC_PORT, Integer.toString(rpcPort));
     conf.put(PropertyKey.WORKER_WEB_PORT, Integer.toString(webPort));
+    conf.put(PropertyKey.getOrBuildCustom("log4j.configurationFile"),
+        new File(confDir, "log4j.properties").getAbsolutePath());
 
     Worker worker = mCloser.register(new Worker(logsDir, conf));
     mWorkers.add(worker);
@@ -828,6 +842,9 @@ public final class MultiProcessCluster {
   private Map<String, String> convertPropMap(Map<PropertyKey, String> properties) {
     // Generates the full set of properties to write
     Map<String, String> map = new HashMap<>();
+    for (Map.Entry<PropertyKey, String> entry : mProperties.entrySet()) {
+      map.put(entry.getKey().toString(), entry.getValue());
+    }
     for (Map.Entry<PropertyKey, String> entry : properties.entrySet()) {
       map.put(entry.getKey().toString(), entry.getValue());
     }

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -94,6 +94,8 @@ public class PortCoordination {
   public static final List<ReservedPort> QUORUM_SHELL_INFO = allocate(3, 0);
   public static final List<ReservedPort> QUORUM_SHELL_REMOVE = allocate(5, 0);
 
+  public static final List<ReservedPort> WORKER_LOG4J_STRESS = allocate(1, 2);
+
   private static synchronized List<ReservedPort> allocate(int numMasters, int numWorkers) {
     int needed = numMasters * MultiProcessCluster.PORTS_PER_MASTER
         + numWorkers * MultiProcessCluster.PORTS_PER_WORKER;

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
@@ -11,7 +11,6 @@
 
 package alluxio.server.ft.journal.raft;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -29,7 +28,6 @@ import alluxio.multi.process.PortCoordination;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 
-import net.bytebuddy.utility.RandomString;
 import org.apache.commons.io.FileUtils;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.storage.RaftStorageImpl;
@@ -69,36 +67,6 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
     fs.createDirectory(testDir);
     mCluster.waitForAndKillPrimaryMaster(MASTER_INDEX_WAIT_TIME);
     assertTrue(fs.exists(testDir));
-    mCluster.notifySuccess();
-  }
-
-  @Test
-  public void ouee() throws Exception {
-    mCluster = MultiProcessCluster.newBuilder(PortCoordination.EMBEDDED_JOURNAL_FAILOVER)
-        .setClusterName("EmbeddedJournalFaultTolerance_failover")
-        .setNumMasters(1)
-        .setNumWorkers(2)
-        .addLog4jProperty("log4j.rootLogger", "DEBUG, ${alluxio.logger.type}, ${alluxio.remote"
-            + ".logger.type}")
-        .addLog4jProperty("log4j.appender.WORKER_LOGGER.MaxFileSize", "10KB")
-        .addLog4jProperty("log4j.appender.WORKER_LOGGER.MaxBackupIndex", "2")
-        .addLog4jProperty("log4j.appender.WORKER_LOGGER", "org.apache.log4j.RollingFileAppender")
-        .addLog4jProperty("log4j.appender.WORKER_LOGGER.File", "${alluxio.logs.dir}/worker.bruh")
-        .addLog4jProperty("log4j.appender.WORKER_LOGGER.layout", "org.apache.log4j.PatternLayout")
-        .addLog4jProperty("log4j.appender.WORKER_LOGGER.layout.ConversionPattern", "%d{ISO8601} "
-        + "%-5p %c{1} - %m%n")
-        .build();
-    mCluster.start();
-
-    for (int i = 0; i < 100; i++) {
-      AlluxioURI path = new AlluxioURI("/" + RandomString.make());
-      mCluster.getFileSystemClient().createDirectory(path);
-      boolean exists = mCluster.getFileSystemClient().exists(path);
-      assertTrue(exists);
-      mCluster.getFileSystemClient().delete(path);
-      exists = mCluster.getFileSystemClient().exists(path);
-      assertFalse(exists);
-    }
     mCluster.notifySuccess();
   }
 

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
@@ -11,6 +11,7 @@
 
 package alluxio.server.ft.journal.raft;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -28,6 +29,7 @@ import alluxio.multi.process.PortCoordination;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 
+import net.bytebuddy.utility.RandomString;
 import org.apache.commons.io.FileUtils;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.storage.RaftStorageImpl;
@@ -67,6 +69,36 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
     fs.createDirectory(testDir);
     mCluster.waitForAndKillPrimaryMaster(MASTER_INDEX_WAIT_TIME);
     assertTrue(fs.exists(testDir));
+    mCluster.notifySuccess();
+  }
+
+  @Test
+  public void ouee() throws Exception {
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.EMBEDDED_JOURNAL_FAILOVER)
+        .setClusterName("EmbeddedJournalFaultTolerance_failover")
+        .setNumMasters(1)
+        .setNumWorkers(2)
+        .addLog4jProperty("log4j.rootLogger", "DEBUG, ${alluxio.logger.type}, ${alluxio.remote"
+            + ".logger.type}")
+        .addLog4jProperty("log4j.appender.WORKER_LOGGER.MaxFileSize", "10KB")
+        .addLog4jProperty("log4j.appender.WORKER_LOGGER.MaxBackupIndex", "2")
+        .addLog4jProperty("log4j.appender.WORKER_LOGGER", "org.apache.log4j.RollingFileAppender")
+        .addLog4jProperty("log4j.appender.WORKER_LOGGER.File", "${alluxio.logs.dir}/worker.bruh")
+        .addLog4jProperty("log4j.appender.WORKER_LOGGER.layout", "org.apache.log4j.PatternLayout")
+        .addLog4jProperty("log4j.appender.WORKER_LOGGER.layout.ConversionPattern", "%d{ISO8601} "
+        + "%-5p %c{1} - %m%n")
+        .build();
+    mCluster.start();
+
+    for (int i = 0; i < 100; i++) {
+      AlluxioURI path = new AlluxioURI("/" + RandomString.make());
+      mCluster.getFileSystemClient().createDirectory(path);
+      boolean exists = mCluster.getFileSystemClient().exists(path);
+      assertTrue(exists);
+      mCluster.getFileSystemClient().delete(path);
+      exists = mCluster.getFileSystemClient().exists(path);
+      assertFalse(exists);
+    }
     mCluster.notifySuccess();
   }
 

--- a/tests/src/test/java/alluxio/server/worker/WorkerLoggingIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/worker/WorkerLoggingIntegrationTest.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.server.worker;
 
 import static org.junit.Assert.assertFalse;

--- a/tests/src/test/java/alluxio/server/worker/WorkerLoggingIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/worker/WorkerLoggingIntegrationTest.java
@@ -1,0 +1,68 @@
+package alluxio.server.worker;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import alluxio.AlluxioURI;
+import alluxio.multi.process.MultiProcessCluster;
+import alluxio.multi.process.PortCoordination;
+
+import net.bytebuddy.utility.RandomString;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class WorkerLoggingIntegrationTest {
+
+  /**
+   * This test makes ensures log4j does not hold onto old logging files that have been deleted.
+   */
+  @Test
+  public void workerLog4jStressTest() throws Exception {
+    MultiProcessCluster mCluster =
+        MultiProcessCluster.newBuilder(PortCoordination.WORKER_LOG4J_STRESS)
+            .setClusterName("workerLog4jStressTest")
+            .setNumMasters(1)
+            .setNumWorkers(2)
+            .addLog4jProperty("log4j.rootLogger", "DEBUG, ${alluxio.logger.type}, ${alluxio.remote"
+                + ".logger.type}")
+            // changing the name from the default log file name to avoid collisions
+            .addLog4jProperty("log4j.appender.WORKER_LOGGER.File", "${alluxio.logs.dir}/worker"
+                + ".testlog")
+            .addLog4jProperty("log4j.appender.WORKER_LOGGER.MaxFileSize", "1MB")
+            .addLog4jProperty("log4j.appender.WORKER_LOGGER.MaxBackupIndex", "2")
+            .build();
+    mCluster.start();
+
+    for (int i = 0; i < 100; i++) {
+      AlluxioURI path = new AlluxioURI("/" + RandomString.make());
+      mCluster.getFileSystemClient().createDirectory(path);
+      boolean exists = mCluster.getFileSystemClient().exists(path);
+      assertTrue(exists);
+      mCluster.getFileSystemClient().delete(path);
+      exists = mCluster.getFileSystemClient().exists(path);
+      assertFalse(exists);
+    }
+
+    ProcessBuilder builder = new ProcessBuilder("sh", "-c", "lsof -c java | grep \"worker"
+        + ".testlog\"");
+    builder.inheritIO().redirectOutput(ProcessBuilder.Redirect.PIPE);
+    Process process = builder.start();
+    // wait for lsof to complete
+    process.waitFor();
+    String out;
+    try (BufferedReader reader = new BufferedReader(
+        new InputStreamReader(process.getInputStream()))) {
+      // iterates over all open files with "worker.testlog" as a prefix
+      while ((out = reader.readLine()) != null) {
+        if (out.contains("(deleted)")) {
+          // log4j is holding onto deleted files and the test must fail
+          Assert.fail();
+        }
+      }
+    }
+    mCluster.notifySuccess();
+  }
+}


### PR DESCRIPTION
Introduces a new integration test that makes sure that old log files produced by log4j are not being held onto.