### PR TITLE
Include missing Javadoc comments on public methods and classes

### DIFF
--- a/build/checkstyle/alluxio_checks.xml
+++ b/build/checkstyle/alluxio_checks.xml
@@ -225,12 +225,16 @@
     </module>
     <module name="EqualsHashCode"/>
 
+    <!-- Checks the Javadoc of a public method or constructor exists. -->
+    <module name="MissingJavadocMethod" />
     <!-- Checks the Javadoc of a public method or constructor. Only applies to production code. -->
     <module name="JavadocMethod">
       <property name="id" value="ProductionScope"/>
       <property name="accessModifiers" value="public"/>
       <property name="validateThrows" value="false"/>
     </module>
+    <!-- Checks the Javadoc of a public class or interface exists. -->
+    <module name="MissingJavadocType" />
     <!-- Checks Javadoc comments for public class and interface definitions. Only applies to
          production code -->
     <module name="JavadocType">

--- a/build/checkstyle/suppressions.xml
+++ b/build/checkstyle/suppressions.xml
@@ -10,4 +10,7 @@
     <suppress files="[\\/]src[\\/]main[\\/].*|[\\/]generated-sources[\\/].*" id="TestScope" />
     <!--  Suppress specific file  -->
     <suppress files="hub/server/src/main/java/alluxio/hub/manager/process/ManagerProcessContext.java" checks="Indentation" />
+    <!-- Excludes test files from having Javadocs for classes and methods (a lot do not have those) -->
+    <suppress files="[\\/]*[\\/]test[\\/].*" checks="MissingJavadocMethod" />
+    <suppress files="[\\/]*[\\/]test[\\/].*" checks="MissingJavadocType" />
 </suppressions>

--- a/build/checkstyle/suppressions.xml
+++ b/build/checkstyle/suppressions.xml
@@ -13,4 +13,6 @@
     <!-- Excludes test files from having Javadocs for classes and methods (a lot do not have those) -->
     <suppress files="[\\/]*[\\/]test[\\/].*" checks="MissingJavadocMethod" />
     <suppress files="[\\/]*[\\/]test[\\/].*" checks="MissingJavadocType" />
+    <suppress files="[\\/]src[\\/]test[\\/].*|[\\/]generated-test-sources[\\/].*" checks="MissingJavadocMethod" />
+    <suppress files="[\\/]src[\\/]test[\\/].*|[\\/]generated-test-sources[\\/].*" checks="MissingJavadocType" />
 </suppressions>

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -108,6 +108,12 @@ public interface FileSystem extends Closeable {
       return get(subject, new InstancedConfiguration(ConfigurationUtils.defaults()));
     }
 
+    /**
+     * Get a FileSystem from the cache with a given subject.
+     * @param subject The subject to use for security-related client operations
+     * @param conf the Alluxio configuration
+     * @return a FileSystem from the cache, creating a new one if it doesn't yet exist
+     */
     public static FileSystem get(Subject subject, AlluxioConfiguration conf) {
       Preconditions.checkNotNull(subject, "subject");
       // TODO(gpang): should this key use the UserState instead of subject?

--- a/core/common/src/main/java/alluxio/master/MasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/MasterInquireClient.java
@@ -63,8 +63,10 @@ public interface MasterInquireClient {
      */
     Authority toAuthority();
 
+    @Override
     boolean equals(Object obj);
 
+    @Override
     int hashCode();
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsAbsentPathCache.java
@@ -70,6 +70,10 @@ public interface UfsAbsentPathCache {
 
     private Factory() {} // prevent instantiation
 
+    /**
+     * @param mountTable the mount table
+     * @return {@link UfsAbsentPathCache}
+     */
     public static UfsAbsentPathCache create(MountTable mountTable) {
       int numThreads = ServerConfiguration.getInt(PropertyKey.MASTER_UFS_PATH_CACHE_THREADS);
       if (numThreads <= 0) {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsBlockLocationCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsBlockLocationCache.java
@@ -50,6 +50,10 @@ public interface UfsBlockLocationCache {
   final class Factory {
     private Factory() {} // prevent instantiation
 
+    /**
+     * @param mountTable the mount table
+     * @return {@link UfsBlockLocationCache}
+     */
     public static UfsBlockLocationCache create(MountTable mountTable) {
       return new LazyUfsBlockLocationCache(mountTable);
     }

--- a/core/server/master/src/main/java/alluxio/master/metastore/BlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/BlockStore.java
@@ -94,15 +94,25 @@ public interface BlockStore extends Iterable<Block> {
     private final long mId;
     private final BlockMeta mMeta;
 
+    /**
+     * @param id the block id
+     * @param meta the block meta
+     */
     public Block(long id, BlockMeta meta) {
       mId = id;
       mMeta = meta;
     }
 
+    /**
+     * @return id
+     */
     public long getId() {
       return mId;
     }
 
+    /**
+     * @return block meta
+     */
     public BlockMeta getMeta() {
       return mMeta;
     }

--- a/integration/fuse/src/main/java/alluxio/cli/command/AbstractFuseShellCommand.java
+++ b/integration/fuse/src/main/java/alluxio/cli/command/AbstractFuseShellCommand.java
@@ -30,6 +30,11 @@ public abstract class AbstractFuseShellCommand implements FuseCommand {
   protected final FileSystem mFileSystem;
   protected final String mParentCommandName;
 
+  /**
+   * @param fileSystem the file system the command takes effect on
+   * @param alluxioConfiguration the Alluxio configuration
+   * @param commandName the parent command name
+   */
   public AbstractFuseShellCommand(FileSystem fileSystem,
       AlluxioConfiguration alluxioConfiguration, String commandName) {
     mFileSystem = fileSystem;

--- a/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/AbstractMetadataCacheSubCommand.java
+++ b/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/AbstractMetadataCacheSubCommand.java
@@ -20,8 +20,16 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.InvalidArgumentException;
 
+/**
+ * Metadata cache sub command.
+ */
 public abstract class AbstractMetadataCacheSubCommand extends AbstractFuseShellCommand {
 
+  /**
+   * @param fileSystem the file system the command takes effect on
+   * @param alluxioConfiguration the Alluxio configuration
+   * @param commandName the parent command name
+   */
   public AbstractMetadataCacheSubCommand(FileSystem fileSystem,
       AlluxioConfiguration alluxioConfiguration, String commandName) {
     super(fileSystem, alluxioConfiguration, commandName);

--- a/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/DropAllCommand.java
+++ b/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/DropAllCommand.java
@@ -19,7 +19,16 @@ import alluxio.client.file.URIStatus;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.wire.FileInfo;
 
+/**
+ * The metadata cache 'dropAll' subcommand.
+ */
 public final class DropAllCommand extends AbstractMetadataCacheSubCommand {
+
+  /**
+   * @param fs the file system the command takes effect on
+   * @param conf the Alluxio configuration
+   * @param parentCommandName the parent command name
+   */
   public DropAllCommand(FileSystem fs, AlluxioConfiguration conf, String parentCommandName) {
     super(fs, conf, parentCommandName);
   }

--- a/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/DropCommand.java
+++ b/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/DropCommand.java
@@ -19,7 +19,16 @@ import alluxio.client.file.URIStatus;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.wire.FileInfo;
 
+/**
+ * The metadata cache 'drop' subcommand.
+ */
 public final class DropCommand extends AbstractMetadataCacheSubCommand {
+
+  /**
+   * @param fs the file system the command takes effect on
+   * @param conf the Alluxio configuration
+   * @param parentCommandName the parent command name
+   */
   public DropCommand(FileSystem fs, AlluxioConfiguration conf, String parentCommandName) {
     super(fs, conf, parentCommandName);
   }

--- a/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/SizeCommand.java
+++ b/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/SizeCommand.java
@@ -19,7 +19,16 @@ import alluxio.client.file.URIStatus;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.wire.FileInfo;
 
+/**
+ * The metadata cache 'size' subcommand.
+ */
 public final class SizeCommand extends AbstractMetadataCacheSubCommand {
+
+  /**
+   * @param fs the file system the command takes effect on
+   * @param conf the Alluxio configuration
+   * @param parentCommandName the parent command name
+   */
   public SizeCommand(FileSystem fs, AlluxioConfiguration conf, String parentCommandName) {
     super(fs, conf, parentCommandName);
   }


### PR DESCRIPTION
The issue is that the Checkstyle Javadoc rules previously (before #14537) checked both the existence and the format of Javadocs. When they were updated, the Javadoc rules only regarded the format of Javadocs, no longer their existence. This rectifies this oversight.