### PR TITLE
Update ozone from 1.1.0 to 1.2.1

### DIFF
--- a/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -120,7 +120,7 @@ public class SnapshotReplicationManagerTest {
 
   private SimpleStateMachineStorage getSimpleStateMachineStorage() throws IOException {
     RaftStorage rs = new RaftStorageImpl(mFolder.newFolder(CommonUtils.randomAlphaNumString(6)),
-            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault());
+            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(), 0);
     SimpleStateMachineStorage snapshotStore = new SimpleStateMachineStorage();
     snapshotStore.init(rs);
     return snapshotStore;

--- a/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
@@ -84,7 +84,7 @@ public class RaftJournalDumper extends AbstractJournalDumper {
         PrintStream out =
             new PrintStream(new BufferedOutputStream(new FileOutputStream(mJournalEntryFile)));
         RaftStorage storage = new RaftStorageImpl(getJournalDir(),
-                RaftServerConfigKeys.Log.CorruptionPolicy.getDefault())) {
+                RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(), 0)) {
       List<LogSegmentPath> paths = LogSegmentPath.getLogSegmentPaths(storage);
       for (LogSegmentPath path : paths) {
         final int entryCount = LogSegment.readSegmentFile(path.getPath().toFile(),
@@ -114,7 +114,7 @@ public class RaftJournalDumper extends AbstractJournalDumper {
 
   private void readRatisSnapshotFromDir() throws IOException {
     try (RaftStorage storage = new RaftStorageImpl(getJournalDir(),
-            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault())) {
+            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(), 0)) {
       SimpleStateMachineStorage stateMachineStorage = new SimpleStateMachineStorage();
       stateMachineStorage.init(storage);
       SingleFileSnapshotInfo currentSnapshot = stateMachineStorage.getLatestSnapshot();

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     <ratis.version>2.2.0</ratis.version>
     <slf4j.version>1.7.30</slf4j.version>
     <jackson.version>2.11.1</jackson.version>
-    <ozone.version>1.2.0</ozone.version>
+    <ozone.version>1.2.1</ozone.version>
     <hadoop-cos.version>3.1.0-5.8.5</hadoop-cos.version>
     <cos_api.version>5.6.19</cos_api.version>
     <surefire.forkCount>2</surefire.forkCount>

--- a/pom.xml
+++ b/pom.xml
@@ -150,10 +150,10 @@
     <parquet.version>1.11.0</parquet.version>
     <protobuf.version>3.12.4</protobuf.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <ratis.version>2.0.0</ratis.version>
+    <ratis.version>2.2.0</ratis.version>
     <slf4j.version>1.7.30</slf4j.version>
     <jackson.version>2.11.1</jackson.version>
-    <ozone.version>1.1.0</ozone.version>
+    <ozone.version>1.2.0</ozone.version>
     <hadoop-cos.version>3.1.0-5.8.5</hadoop-cos.version>
     <cos_api.version>5.6.19</cos_api.version>
     <surefire.forkCount>2</surefire.forkCount>

--- a/shaded/ozone/pom.xml
+++ b/shaded/ozone/pom.xml
@@ -26,8 +26,9 @@
     <!-- The build path need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>
-    <ufs.ozone.version>1.1.0</ufs.ozone.version>
+    <ufs.ozone.version>1.2.0</ufs.ozone.version>
     <shading.prefix>alluxio.shaded.ozone</shading.prefix>
+    <ozone.metrics.version>3.2.5</ozone.metrics.version>
   </properties>
 
   <dependencies>
@@ -62,14 +63,25 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-ozone-filesystem</artifactId>
+          <groupId>org.apache.ozone</groupId>
+          <artifactId>ozone-filesystem</artifactId>
+          <version>${ufs.ozone.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>io.dropwizard.metrics</groupId>
+              <artifactId>metrics-core</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.ozone</groupId>
+          <artifactId>ozone-client</artifactId>
           <version>${ufs.ozone.version}</version>
         </dependency>
         <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-ozone-client</artifactId>
-          <version>${ufs.ozone.version}</version>
+          <groupId>io.dropwizard.metrics</groupId>
+          <artifactId>metrics-core</artifactId>
+          <version>${ozone.metrics.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -135,6 +147,10 @@
                   <pattern>org.codehaus.jackson</pattern>
                   <shadedPattern>${shading.prefix}.org.codehaus.jackson</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>com.codahale.metrics</pattern>
+                  <shadedPattern>${shading.prefix}.com.codahale.metrics</shadedPattern>
+                </relocation>
               </relocations>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
@@ -155,6 +171,9 @@
                   <include>org.apache.httpcomponents:*</include>
                   <include>commons-httpclient:commons-httpclient</include>
                   <include>org.codehaus.jackson:*</include>
+                  <include>org.apache.ozone:*</include>
+                  <include>org.apache.ratis:*</include>
+                  <include>io.dropwizard.metrics:metrics-core</include>
                 </includes>
                 <excludes>
                   <exclude>org.slf4j:*</exclude>

--- a/shaded/ozone/pom.xml
+++ b/shaded/ozone/pom.xml
@@ -26,7 +26,7 @@
     <!-- The build path need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.basedir}/build</build.path>
-    <ufs.ozone.version>1.2.0</ufs.ozone.version>
+    <ufs.ozone.version>1.2.1</ufs.ozone.version>
     <shading.prefix>alluxio.shaded.ozone</shading.prefix>
     <ozone.metrics.version>3.2.5</ozone.metrics.version>
   </properties>

--- a/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
+++ b/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
@@ -221,7 +221,7 @@ public class JournalToolTest extends BaseIntegrationTest {
     try (RaftStorage storage = new RaftStorageImpl(
         new File(RaftJournalUtils.getRaftJournalDir(new File(journalFolder)),
             RaftJournalSystem.RAFT_GROUP_UUID.toString()),
-            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault())) {
+            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(), 0)) {
       SimpleStateMachineStorage stateMachineStorage = new SimpleStateMachineStorage();
       stateMachineStorage.init(storage);
       SingleFileSnapshotInfo snapshot = stateMachineStorage.getLatestSnapshot();

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
@@ -101,7 +101,7 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
 
     SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
     storage.init(new RaftStorageImpl(raftDir,
-        RaftServerConfigKeys.Log.CorruptionPolicy.getDefault()));
+        RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(), 0));
     SingleFileSnapshotInfo snapshot = storage.findLatestSnapshot();
     assertNotNull(snapshot);
     mCluster.notifySuccess();
@@ -144,7 +144,7 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
     mCluster.stopMaster(catchUpMasterIndex);
     SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
     storage.init(new RaftStorageImpl(raftDir,
-        RaftServerConfigKeys.Log.CorruptionPolicy.getDefault()));
+        RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(), 0));
     SingleFileSnapshotInfo snapshot = storage.findLatestSnapshot();
     assertNotNull(snapshot);
     mCluster.notifySuccess();


### PR DESCRIPTION
### What changes are proposed in this pull request?

update the ozone version from 1.1.0 to 1.2.1

### Why are the changes needed?
when update ozone from 1.1.0 to 1.2.1, some classes of ozone can not find classes of protobuf if relocation for protobuf, so ozone needs to be included for protobuf shade. Also add a shade to metrics for ratis otherwise JmxReporter.class cannot be found in the metrics-core-4.1.1.jar currently used by alluxio.
