### PR TITLE
Upgrade log4j 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <jersey.version>2.29.1</jersey.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
     <junit.version>4.13</junit.version>
-    <log4j.version>2.16.0</log4j.version>
+    <log4j.version>2.17.0</log4j.version>
     <maven.version>3.3.9</maven.version>
     <metrics.version>4.1.11</metrics.version>
     <orc.version>1.6.3</orc.version>


### PR DESCRIPTION
Ref https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45105