### PR TITLE
[SMALLFIX] Fix complete file error message

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1488,7 +1488,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
 
     InodeFile inode = inodePath.getInodeFile();
     if (inode.isCompleted() && inode.getLength() != Constants.UNKNOWN_SIZE) {
-      throw new FileAlreadyCompletedException("File " + getName() + " has already been completed.");
+      throw new FileAlreadyCompletedException("File " + inode.getName() + " has already been completed.");
     }
     if (length < 0 && length != Constants.UNKNOWN_SIZE) {
       throw new InvalidFileSizeException(

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1488,7 +1488,8 @@ public final class DefaultFileSystemMaster extends CoreMaster
 
     InodeFile inode = inodePath.getInodeFile();
     if (inode.isCompleted() && inode.getLength() != Constants.UNKNOWN_SIZE) {
-      throw new FileAlreadyCompletedException("File " + inode.getName() + " has already been completed.");
+      throw new FileAlreadyCompletedException(String
+          .format("File %s has already been completed.", inode.getName()));
     }
     if (length < 0 && length != Constants.UNKNOWN_SIZE) {
       throw new InvalidFileSizeException(


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix typo in code to show correct error message

### Why are the changes needed?

2021-12-19 22:52:13,523 ERROR AlluxioJniFuseFileSystem - Failed closing /animals_12101333.h5
alluxio.exception.status.AlreadyExistsException: File FileSystemMaster has already been completed.
	at alluxio.exception.status.AlluxioStatusException.from(AlluxioStatusException.java:138)
	at alluxio.exception.status.AlluxioStatusException.fromStatusRuntimeException(AlluxioStatusException.java:224)
	at alluxio.AbstractClient.retryRPCInternal(AbstractClient.java:408)
	at alluxio.AbstractClient.retryRPC(AbstractClient.java:372)
	at alluxio.AbstractClient.retryRPC(AbstractClient.java:361)
	at alluxio.client.file.RetryHandlingFileSystemMasterClient.completeFile(RetryHandlingFileSystemMasterClient.java:171)
	at alluxio.client.file.AlluxioFileOutStream.close(AlluxioFileOutStream.java:202)
	at alluxio.fuse.CreateFileEntry.close(CreateFileEntry.java:89)
	at alluxio.fuse.AlluxioJniFuseFileSystem.releaseInternal(AlluxioJniFuseFileSystem.java:512)

### Does this PR introduce any user facing changes?
correct error message
