### PR TITLE
[DOCFIX] Update obsolete default WriteType value

### DIFF
--- a/docs/_data/table/cn/WriteType.yml
+++ b/docs/_data/table/cn/WriteType.yml
@@ -1,8 +1,8 @@
 CACHE_THROUGH:
   数据被同步地写入到Alluxio的Worker和底层存储系统。
 MUST_CACHE:
-  数据被同步地写入到Alluxio的Worker。但不会被写入到底层存储系统。这是默认写类型。
+  数据被同步地写入到Alluxio的Worker。但不会被写入到底层存储系统。
 THROUGH:
   数据被同步地写入到底层存储系统。但不会被写入到Alluxio的Worker。
 ASYNC_THROUGH:
-  数据被同步地写入到Alluxio的Worker，并异步地写入到底层存储系统。处于实验阶段。
+  数据被同步地写入到Alluxio的Worker，并异步地写入到底层存储系统。这是默认写类型。

--- a/docs/_data/table/en/WriteType.yml
+++ b/docs/_data/table/en/WriteType.yml
@@ -2,9 +2,9 @@ CACHE_THROUGH:
   Data is written synchronously to a Alluxio worker and the under storage system.
 MUST_CACHE:
   Data is written synchronously to a Alluxio worker. No data will be written to the under
-  storage. This is the default write type.
+  storage.
 THROUGH:
   Data is written synchronously to the under storage. No data will be written to Alluxio.
 ASYNC_THROUGH:
   Data is written synchronously to a Alluxio worker and asynchronously to the under storage
-  system. Experimental.
+  system. This is the default write type.


### PR DESCRIPTION
### What changes are proposed in this pull request?

Update FS-API document regarding default write type.

### Why are the changes needed?

commit 35ea6fc6aa066a40d732430f948b452caff78a5b updated the default write type value from MUST_CACHE to ASYNC_THROUGH. 
FS-API did not update accrodingly. This PR fixes this issue  both in English and Chinese version.

### Does this PR introduce any user facing changes?

No.
