### PR TITLE
Make metadata cache global

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
@@ -32,6 +32,21 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class MetadataCache {
   private static final Logger LOG = LoggerFactory.getLogger(MetadataCache.class);
 
+
+  private static volatile MetadataCache metadataCache = null;
+
+  public static MetadataCache getInstance(int maxSize, long expirationTimeMs) {
+    if (metadataCache == null) {
+      synchronized (MetadataCache.class) {
+        if (metadataCache == null) {
+          LOG.info("Create MetadataCache.");
+          metadataCache = new MetadataCache(maxSize, expirationTimeMs);
+        }
+      }
+    }
+    return metadataCache;
+  }
+
   private class CachedItem {
     private URIStatus mStatus = null;
     private List<URIStatus> mDirStatuses = null;

--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCachingBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCachingBaseFileSystem.java
@@ -57,7 +57,7 @@ public class MetadataCachingBaseFileSystem extends BaseFileSystem {
   private static final URIStatus NOT_FOUND_STATUS = new URIStatus(
       new FileInfo().setCompleted(true));
 
-  private final MetadataCache mMetadataCache;
+  protected static MetadataCache mMetadataCache;
   private final ExecutorService mAccessTimeUpdater;
   private final boolean mDisableUpdateFileAccessTime;
 
@@ -70,7 +70,7 @@ public class MetadataCachingBaseFileSystem extends BaseFileSystem {
     int maxSize = mFsContext.getClusterConf().getInt(PropertyKey.USER_METADATA_CACHE_MAX_SIZE);
     long expirationTimeMs = mFsContext.getClusterConf()
         .getMs(PropertyKey.USER_METADATA_CACHE_EXPIRATION_TIME);
-    mMetadataCache = new MetadataCache(maxSize, expirationTimeMs);
+    mMetadataCache = MetadataCache.getInstance(maxSize, expirationTimeMs);
     int masterClientThreads = mFsContext.getClusterConf()
         .getInt(PropertyKey.USER_FILE_MASTER_CLIENT_POOL_SIZE_MAX);
     mDisableUpdateFileAccessTime = mFsContext.getClusterConf()


### PR DESCRIPTION
We can globalize metadata cache so that compute nodes like `Presto Worker` can share the metadata cache, improving access efficiency and saving memory.