### PR TITLE
Use user-defined Hub cluster ID

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5913,8 +5913,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey HUB_CLUSTER_ID =
           new Builder(Name.HUB_CLUSTER_ID)
                   .setDescription("A user-defined id for the Hub cluster. Must be unique from "
-                          + "other Hub clusters connecting to the same Hosted Hub. Must be a "
-                          + "4-character alphanumeric string.")
+                          + "other Hub clusters connecting to the same Hosted Hub tenant. Must be "
+                          + "a 4-character alphanumeric string.")
                   .build();
   public static final PropertyKey HUB_CLUSTER_LABEL =
           new Builder(Name.HUB_CLUSTER_LABEL)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5910,6 +5910,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
                   .setDescription("The secret key of Hub Manager.")
                   .setDisplayType(DisplayType.CREDENTIALS)
                   .build();
+  public static final PropertyKey HUB_CLUSTER_ID =
+          new Builder(Name.HUB_CLUSTER_ID)
+                  .setDescription("A user-defined id for the Hub cluster. Must be unique from "
+                          + "other Hub clusters connecting to the same Hosted Hub. Must be a "
+                          + "4-character alphanumeric string.")
+                  .build();
   public static final PropertyKey HUB_CLUSTER_LABEL =
           new Builder(Name.HUB_CLUSTER_LABEL)
                   .setDefaultValue("Alluxio Hub")
@@ -7206,6 +7212,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String HUB_AUTHENTICATION_API_KEY = "alluxio.hub.authentication.apiKey";
     public static final String HUB_AUTHENTICATION_SECRET_KEY =
             "alluxio.hub.authentication.secretKey";
+    public static final String HUB_CLUSTER_ID =
+            "alluxio.hub.cluster.id";
     public static final String HUB_CLUSTER_LABEL =
             "alluxio.hub.cluster.label";
     public static final String HUB_MANAGER_AGENT_LOST_THRESHOLD_TIME =


### PR DESCRIPTION
### What changes are proposed in this pull request?

Previously we were using the Alluxio cluster id to unique identify a Hub cluster. This PR introduces a new property key that users must set to uniquely identify. their Hub cluster. This allows the Hub Manager to register with the Hosted Hub immediately, instead of depending on retrieving the Alluxio cluster id from the Meta Master before registering.

### Why are the changes needed?

This change is Hub-related and allows users to uniquely identify their Hub clusters.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
Added property key `alluxio.hub.cluster.id` - a 4-character, alphanumeric string
