### PR TITLE
Fix the bug which load metadata failed when the path is special

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -113,10 +113,10 @@ import javax.annotation.Nullable;
  * while performing a sync for a large tree. Additionally, by using a prefetch mechanism we can
  * concurrently process other inodes while waiting for UFS RPCs to complete.
  *
- * With regards to locking, this class expects to be able to take a write lock on any inode, and
+ * With regard to locking, this class expects to be able to take a write lock on any inode, and
  * then subsequently downgrades or unlocks after the sync is finished. Even though we use
  * {@link java.util.concurrent.locks.ReentrantReadWriteLock}, because we concurrently process
- * inodes on separate threads, we cannot utilize the reetrnant behavior. The implications of
+ * inodes on separate threads, we cannot utilize the reentrant behavior. The implications of
  * that mean the caller of this class must not hold a write while calling {@link #sync()}.
  *
  * A user of this class is expected to create a new instance for each path that they would like
@@ -211,7 +211,7 @@ public class InodeSyncStream {
    * {@link LockPattern#READ}.
    *
    * It is an error to initiate sync without a WRITE_EDGE lock when loadOnly is {@code false}.
-   * If loadOnly is set to {@code true}, then the the root path may have a read lock.
+   * If loadOnly is set to {@code true}, then the root path may have a read lock.
    *
    * @param rootPath The root path to begin syncing
    * @param fsMaster the {@link FileSystemMaster} calling this method
@@ -291,7 +291,7 @@ public class InodeSyncStream {
   }
 
   /**
-   * Sync the metadata according the the root path the stream was created with.
+   * Sync the metadata according the root path the stream was created with.
    *
    * @return SyncStatus object
    */
@@ -734,6 +734,7 @@ public class InodeSyncStream {
       FileDoesNotExistException, InvalidFileSizeException, InvalidPathException, IOException {
     AlluxioURI path = inodePath.getUri();
     MountTable.Resolution resolution = mMountTable.resolve(path);
+    int failedSync = 0;
     try {
       if (context.getUfsStatus() == null) {
         // uri does not exist in ufs
@@ -787,8 +788,15 @@ public class InodeSyncStream {
               loadMetadata(descendant, loadMetadataContext);
             } catch (FileNotFoundException e) {
               LOG.debug("Failed to loadMetadata because file is not in ufs:"
-                      + " inodePath={}, options={}.",
+                  + " inodePath={}, options={}.",
                   childURI, loadMetadataContext, e);
+            } catch (BlockInfoException | FileAlreadyCompletedException
+                | FileDoesNotExistException | InvalidFileSizeException
+                | IOException e) {
+              LOG.debug("Failed to loadMetadata because the ufs file or directory"
+                  + " is {}, options={}.",
+                  childStatus, loadMetadataContext, e);
+              failedSync++;
             }
           }
           mInodeTree.setDirectChildrenLoaded(mRpcContext, inodePath.getInode().asDirectory());
@@ -798,6 +806,10 @@ public class InodeSyncStream {
       LOG.debug("Failed to loadMetadata: inodePath={}, context={}.", inodePath.getUri(), context,
           e);
       throw new IOException(e);
+    }
+    if (failedSync > 0) {
+      throw new IOException(String.format("Failed to load metadata of %s files or directories "
+          + "under %s", failedSync, path));
     }
   }
 
@@ -840,7 +852,7 @@ public class InodeSyncStream {
       }
     }
     for (Pair<Integer, MutableInodeFile> pair : fileEntryMap.values()) {
-      // Replace the old entry place holder with the new entry,
+      // Replace the old entry placeholder with the new entry,
       // to create the file in the same place in the journal
       newEntries.set(pair.getFirst(),
           pair.getSecond().toJournalEntry());


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix the bug which load metadata failed when the path is special.

### Why are the changes needed?
For example, there are some files whose names are like `tmp\flinkxdata\.data\2c64b72a51458ea04db1b9e25c1cd834_0_0`. Alluxio will transfer the file names into a path like `tmp/flinkxdata/.data/2c64b72a51458ea04db1b9e25c1cd834_0_0`. When loading metadata from ufs will failed every times, leaded to unable to refresh some new metadata which is at the back of special files.
Before:
![image](https://user-images.githubusercontent.com/3060835/147059670-800e59f0-1445-4401-a4c6-9a82ddda27a0.png)
![1640161292(1)](https://user-images.githubusercontent.com/3060835/147059791-c0885a7c-ee94-4ed4-8761-4b580a1a9576.png)
After:
![1640161431(1)](https://user-images.githubusercontent.com/3060835/147060177-09367762-d2d5-4554-ab22-614174322970.png)

### Does this PR introduce any user facing changes?
None
