### PR TITLE
Update log4j configuration for performance

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -41,7 +41,7 @@ log4j.appender.JOB_MASTER_LOGGER.File=${alluxio.logs.dir}/job_master.log
 log4j.appender.JOB_MASTER_LOGGER.MaxFileSize=10MB
 log4j.appender.JOB_MASTER_LOGGER.MaxBackupIndex=100
 log4j.appender.JOB_MASTER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.JOB_MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+log4j.appender.JOB_MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
 
 # Appender for Job Workers
 log4j.appender.JOB_WORKER_LOGGER=org.apache.log4j.RollingFileAppender
@@ -49,7 +49,7 @@ log4j.appender.JOB_WORKER_LOGGER.File=${alluxio.logs.dir}/job_worker.log
 log4j.appender.JOB_WORKER_LOGGER.MaxFileSize=10MB
 log4j.appender.JOB_WORKER_LOGGER.MaxBackupIndex=100
 log4j.appender.JOB_WORKER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.JOB_WORKER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+log4j.appender.JOB_WORKER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
 
 # Appender for Master
 log4j.appender.MASTER_LOGGER=org.apache.log4j.RollingFileAppender
@@ -73,7 +73,7 @@ log4j.appender.MASTER_AUDIT_LOGGER.File=${alluxio.logs.dir}/master_audit.log
 log4j.appender.MASTER_AUDIT_LOGGER.MaxFileSize=10MB
 log4j.appender.MASTER_AUDIT_LOGGER.MaxBackupIndex=100
 log4j.appender.MASTER_AUDIT_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.MASTER_AUDIT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+log4j.appender.MASTER_AUDIT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
 
 # Appender for Job Master audit
 log4j.appender.JOB_MASTER_AUDIT_LOGGER=org.apache.log4j.RollingFileAppender
@@ -81,7 +81,7 @@ log4j.appender.JOB_MASTER_AUDIT_LOGGER.File=${alluxio.logs.dir}/job_master_audit
 log4j.appender.JOB_MASTER_AUDIT_LOGGER.MaxFileSize=10MB
 log4j.appender.JOB_MASTER_AUDIT_LOGGER.MaxBackupIndex=100
 log4j.appender.JOB_MASTER_AUDIT_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.JOB_MASTER_AUDIT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+log4j.appender.JOB_MASTER_AUDIT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
 
 # Appender for Hub Agent
 log4j.appender.HUB_AGENT_LOGGER=org.apache.log4j.RollingFileAppender

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -620,8 +620,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
         throw new InvalidArgumentException("Unrecognized worker range: " + workerRange);
     }
 
-    List<WorkerInfo> workerInfoList = new ArrayList<>(
-        selectedLiveWorkers.size() + selectedLostWorkers.size());
+    List<WorkerInfo> workerInfoList = new ArrayList<>();
     for (MasterWorkerInfo worker : selectedLiveWorkers) {
       // extractWorkerInfo handles the locking internally
       workerInfoList.add(extractWorkerInfo(worker, options.getFieldRange(), true));

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -620,7 +620,8 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
         throw new InvalidArgumentException("Unrecognized worker range: " + workerRange);
     }
 
-    List<WorkerInfo> workerInfoList = new ArrayList<>();
+    List<WorkerInfo> workerInfoList = new ArrayList<>(
+        selectedLiveWorkers.size() + selectedLostWorkers.size());
     for (MasterWorkerInfo worker : selectedLiveWorkers) {
       // extractWorkerInfo handles the locking internally
       workerInfoList.add(extractWorkerInfo(worker, options.getFieldRange(), true));


### PR DESCRIPTION
### What changes are proposed in this pull request?

Change the log format to improve performance. This impacts job master/worker log and audit log.

### Why are the changes needed?
`%F` is the file that log event is from (java file)
`%M` is the method
Example log looks like this
```
2021-12-14 17:26:32,763 INFO master.AbstractMaster (AbstractMaster.java:stop) - JobMaster: Stopping primary master.
2021-12-14 17:26:32,764 INFO master.AbstractMaster (AbstractMaster.java:stop) - JobMaster: Stopped primary master.
```

As log4j document specifies, using `%F` and `%M` will hurt performance. We have `%c{1}` which outputs the class name anyways so these info are not necessary.
https://logging.apache.org/log4j/2.x/manual/layouts.html#PatternFile in sections for `%F` and `%M`

### Does this PR introduce any user facing changes?

The log will look different. I don't think anyone is parsing those anyways so the impact should be small enough. We are just changing job master/worker log format to be the same as master/worker.