### PR TITLE
Add APPLICATION_FORM_URLENCODED to S3RestServiceHandler

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -74,7 +74,8 @@ import javax.ws.rs.core.Response;
 @NotThreadSafe
 @Path(S3RestServiceHandler.SERVICE_PREFIX)
 @Produces(MediaType.APPLICATION_XML)
-@Consumes({ MediaType.TEXT_XML, MediaType.APPLICATION_XML, MediaType.APPLICATION_OCTET_STREAM })
+@Consumes({ MediaType.TEXT_XML, MediaType.APPLICATION_XML,
+    MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_FORM_URLENCODED })
 public final class S3RestServiceHandler {
   private static final Logger LOG = LoggerFactory.getLogger(S3RestServiceHandler.class);
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Without this MediaType, hadoop s3a cannot works with alluxio s3 proxy.

The aws-java-sdk-s3 which hadoop s3a dependent add a `Content-Type` `application/x-www-form-urlencoded` default, 

![image](https://user-images.githubusercontent.com/17329931/147131096-b4f78f19-afd3-46b0-a333-f81de1756da6.png)

And if Alluxio s3 proxy don't add the `APPLICATION_FORM_URLENCODED` consumer, Alluxio proxy will throw an `NotSupportedException`.

![image](https://user-images.githubusercontent.com/17329931/147131542-416fb58d-9449-4a13-9a1d-4494ea44029a.png)

```Console
 bin/hdfs dfs -ls s3a://test/
21/12/23 00:53:19 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
21/12/23 00:53:19 INFO security.UserGroupInformation: Hadoop UGI authentication : SIMPLE
21/12/23 01:03:40 WARN s3a.S3AFileSystem: Client: Amazon S3 error 415: 415 Unsupported Media Type; Unsupported Media Type (retryable)

com.amazonaws.services.s3.model.AmazonS3Exception: Unsupported Media Type (Service: Amazon S3; Status Code: 415; Error Code: 415 Unsupported Media Type; Request ID: null), S3 Extended Request ID: null
	at com.amazonaws.http.AmazonHttpClient.handleErrorResponse(AmazonHttpClient.java:1182)
	at com.amazonaws.http.AmazonHttpClient.executeOneRequest(AmazonHttpClient.java:770)
	at com.amazonaws.http.AmazonHttpClient.executeHelper(AmazonHttpClient.java:489)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:310)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:3785)
	at com.amazonaws.services.s3.AmazonS3Client.headBucket(AmazonS3Client.java:1107)
	at com.amazonaws.services.s3.AmazonS3Client.doesBucketExist(AmazonS3Client.java:1070)
	at org.apache.hadoop.fs.s3a.S3AFileSystem.verifyBucketExists(S3AFileSystem.java:276)
	at org.apache.hadoop.fs.s3a.S3AFileSystem.initialize(S3AFileSystem.java:236)
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2836)
	at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:101)
	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2873)
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2855)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:390)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:356)
	at org.apache.hadoop.fs.shell.PathData.expandAsGlob(PathData.java:325)
	at org.apache.hadoop.fs.shell.Command.expandArgument(Command.java:245)
	at org.apache.hadoop.fs.shell.Command.expandArguments(Command.java:228)
	at org.apache.hadoop.fs.shell.FsCommand.processRawArguments(FsCommand.java:103)
	at org.apache.hadoop.fs.shell.Command.run(Command.java:175)
	at org.apache.hadoop.fs.FsShell.run(FsShell.java:317)
	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:76)
	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:90)
	at org.apache.hadoop.fs.FsShell.main(FsShell.java:380)
```

After patching this PR.

```
 bin/hdfs dfs -ls s3a://test/

Found 11 items
-rw-rw-rw-   1 mbl mbl       1366 2021-12-22 16:43 s3a://test/1.txt
-rw-rw-rw-   1 mbl mbl       1366 2021-12-22 16:46 s3a://test/2.txt
-rw-rw-rw-   1 mbl mbl       1366 2021-12-22 16:50 s3a://test/3.txt
-rw-rw-rw-   1 mbl mbl       1366 2021-12-22 16:52 s3a://test/4.txt
-rw-rw-rw-   1 mbl mbl       1366 2021-12-22 17:19 s3a://test/5.txt
-rw-rw-rw-   1 mbl mbl       1366 2021-12-22 17:27 s3a://test/6.txt
-rw-rw-rw-   1 mbl mbl       1366 2021-12-22 17:28 s3a://test/7.txt
-rw-rw-rw-   1 mbl mbl       1366 2021-12-22 17:29 s3a://test/8.txt
-rw-rw-rw-   1 mbl mbl       1366 2021-12-22 17:31 s3a://test/9.txt
-rw-rw-rw-   1 mbl mbl       1366 2021-12-04 06:08 s3a://test/README.txt
drwxrwxrwx   - mbl mbl          0 2021-12-23 01:16 s3a://test/tmp
 
 bin/hdfs dfs -cat s3a://test/1.txt

For the latest information about Hadoop, please visit our website at:

   http://hadoop.apache.org/core/
...
```

### Why are the changes needed?

Without this PR, hadoop s3a cannot work.

### Does this PR introduce any user facing changes?

No.