### PR TITLE
Create directory recursively in Fuse

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -545,6 +545,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
     try {
       mFileSystem.createDirectory(uri,
           CreateDirectoryPOptions.newBuilder()
+              .setRecursive(true)
               .setMode(new Mode((short) mode).toProto())
               .build());
       mAuthPolicy.setUserGroupIfNeeded(uri);


### PR DESCRIPTION
Recursively create directories in JniFuse. 

If some code, for example Fuse stressbench, wants to create directories recursively in the mount point, Alluxio will recursively create those directories as well and won't error out.

Directly using command `mkdir` in the mount point won't create the directories recursively.