### PR TITLE
Put all Fuse Stressbench operations in a new dir

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -138,6 +138,8 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
               + "be at least the number of threads, preferably a multiple of it."
       ));
     }
+    // All test operations happen in mLocalpath/fuseIOStressBench
+    mParameters.mLocalPath = mParameters.mLocalPath + "/fuseIOStressBench";
     File localPath = new File(mParameters.mLocalPath);
 
     if (mParameters.mOperation == FuseIOOperation.WRITE) {

--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -139,7 +139,7 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
       ));
     }
     // All test operations happen in mLocalpath/fuseIOStressBench
-    mParameters.mLocalPath = mParameters.mLocalPath + "/fuseIOStressBench";
+    mParameters.mLocalPath = Paths.get(mParameters.mLocalPath, "fuseIOStressBench").toString();
     File localPath = new File(mParameters.mLocalPath);
 
     if (mParameters.mOperation == FuseIOOperation.WRITE) {


### PR DESCRIPTION
We create a new dir `fuseIOStressBench` inside `localPath` and all files will be written and read inside this new directory. We can then avoid the case that the test files interfere with other files in Alluxio space.