### PR TITLE
Fix Fuse open flags 0b11

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -32,6 +32,7 @@ import alluxio.util.OSUtils;
 import alluxio.util.ShellUtils;
 import alluxio.util.WaitForOptions;
 
+import jnr.constants.platform.OpenFlags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ru.serce.jnrfuse.ErrorCodes;
@@ -51,7 +52,45 @@ public final class AlluxioFuseUtils {
       .getMs(PropertyKey.FUSE_LOGGING_THRESHOLD);
   private static final int MAX_ASYNC_RELEASE_WAITTIME_MS = 5000;
 
+  // Open flags
+  // TODO(maobaolong): Add an option to decide whether reject rw flag
+  //  or fallback to truncate
+  // TODO(lu) improve open flag handling https://github.com/mafintosh/fuse-bindings/issues/25
+  // 0x8001 stand for 'w' which means open file for writing
+  private static final int OPEN_WRITE = 32769;
+  // 0x8002 stand for 'r+' which means Open file for reading and writing
+  private static final int OPEN_READ_WRITE = 32770;
+
   private AlluxioFuseUtils() {}
+
+  /**
+   * Detects if open file for overwriting.
+   *
+   * @param flags the open flags
+   * @return true if open a file for overwriting, false otherwise
+   */
+  public static boolean isOpenOverwrite(int flags) {
+    boolean overwrite = OpenFlags.valueOf(flags) == OpenFlags.O_WRONLY
+        || flags == OPEN_WRITE;
+    return overwrite;
+  }
+
+  /**
+   * Detects if open file for reading and writing.
+   *
+   * @param flags the open flags
+   * @return true if open a file for reading and writing, false otherwise
+   */
+  public static boolean isOpenReadWrite(int flags) {
+    if (flags == OPEN_READ_WRITE) {
+      LOG.warn(String.format("Open file with flags 0x%x for reading and writing. "
+          + "Alluxio does not support reading and writing a file concurrently. "
+          + "Treat as read first. Close input stream, "
+          + "delete file, and create a new file when detected first write.", flags));
+      return true;
+    }
+    return false;
+  }
 
   /**
    * Retrieves the uid of the given user.

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -83,7 +83,7 @@ public final class AlluxioFuseUtils {
    */
   public static boolean isOpenReadWrite(int flags) {
     if (flags == OPEN_READ_WRITE) {
-      LOG.warn(String.format("Open file with flags 0x%x for reading and writing. "
+      LOG.debug(String.format("Open file with flags 0x%x for reading and writing. "
           + "Alluxio does not support reading and writing a file concurrently. "
           + "Treat as read first. Close input stream, "
           + "delete file, and create a new file when detected first write.", flags));

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -345,7 +345,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
     final AlluxioURI uri = mPathResolverCache.getUnchecked(path);
     try {
       if (overwrite) {
-        LOG.warn(String.format("Open path %s with flags 0x%x for overwriting. "
+        LOG.debug(String.format("Open path %s with flags 0x%x for overwriting. "
                 + "Alluxio will delete the old file and create a new file for writing",
             path, flags));
         if (mFileSystem.exists(uri)) {
@@ -436,7 +436,8 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
     CreateFileEntry<FileOutStream> ce = mCreateFileEntries.getFirstByField(ID_INDEX, fd);
     if (ce == null) {
       // error out or
-      // if readOrWrite flag detected, close the inputstream, delete file and create file for overwrite
+      // if readOrWrite flag detected, close the inputstream,
+      // delete file and create file for overwrite
       final int flags = fi.flags.get();
       FileInStream is = mOpenFileEntries.get(fd);
       if (is == null || !AlluxioFuseUtils.isOpenReadWrite(flags)) {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -45,7 +45,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import jnr.constants.platform.OpenFlags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -336,22 +335,19 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
   @Override
   public int open(String path, FuseFileInfo fi) {
     final int flags = fi.flags.get();
-    // TODO(maobaolong): Add an option to decide whether reject rw flag
-    //  or fallback to truncate
-    // 0b11 here aimed to handle both 0x8001 and 0x8002
-    // 0x8001 stand for 'w' which means open file for writing.
-    // 0x8002 stand for 'r+' which means Open file for reading and writing.
-    boolean overwrite = OpenFlags.valueOf(flags) == OpenFlags.O_WRONLY
-        || (flags & 0b11) != 0;
-    String methodName = overwrite ? "Fuse.OpenOverwrite" : "Fuse.Open";
-    return AlluxioFuseUtils.call(LOG, () -> openInternal(path, fi, overwrite),
-        methodName, "path=%s,flags=0x%x", path, flags);
+    return AlluxioFuseUtils.call(LOG, () -> openInternal(path, fi),
+        "Fuse.open", "path=%s,flags=0x%x", path, flags);
   }
 
-  private int openInternal(String path, FuseFileInfo fi, boolean overwrite) {
+  private int openInternal(String path, FuseFileInfo fi) {
+    final int flags = fi.flags.get();
+    boolean overwrite = AlluxioFuseUtils.isOpenOverwrite(flags);
     final AlluxioURI uri = mPathResolverCache.getUnchecked(path);
     try {
       if (overwrite) {
+        LOG.warn(String.format("Open path %s with flags 0x%x for overwriting. "
+                + "Alluxio will delete the old file and create a new file for writing",
+            path, flags));
         if (mFileSystem.exists(uri)) {
           mFileSystem.delete(uri);
         }
@@ -439,8 +435,41 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
     final long fd = fi.fh.get();
     CreateFileEntry<FileOutStream> ce = mCreateFileEntries.getFirstByField(ID_INDEX, fd);
     if (ce == null) {
-      LOG.error("Cannot find fd for {} in table", path);
-      return -ErrorCodes.EBADFD();
+      // error out or
+      // if readOrWrite flag detected, close the inputstream, delete file and create file for overwrite
+      final int flags = fi.flags.get();
+      FileInStream is = mOpenFileEntries.get(fd);
+      if (is == null || !AlluxioFuseUtils.isOpenReadWrite(flags)) {
+        LOG.error("Cannot find fd for {} in table", path);
+        return -ErrorCodes.EBADFD();
+      }
+      if (offset != 0) {
+        LOG.error(String.format("Cannot overwrite file {} with offset {}. "
+            + "File is opened with flags 0x%x", path, offset, fi.flags.get()));
+        return -ErrorCodes.EIO();
+      }
+      try {
+        mReleasingReadEntries.put(fd, is);
+        try {
+          synchronized (is) {
+            is.close();
+          }
+        } finally {
+          mReleasingReadEntries.remove(fd);
+        }
+        final AlluxioURI uri = mPathResolverCache.getUnchecked(path);
+        if (mFileSystem.exists(uri)) {
+          mFileSystem.delete(uri);
+        }
+        // TODO(lu) will multiple threads read()/write() concurrently?
+        FileOutStream os = mFileSystem.createFile(uri);
+        ce = new CreateFileEntry(fd, path, os);
+        mCreateFileEntries.add(ce);
+        mAuthPolicy.setUserGroupIfNeeded(uri);
+      } catch (Exception e) {
+        LOG.error("IOException while overwriting file {}.", path, e);
+        return -ErrorCodes.EIO();
+      }
     }
     FileOutStream os = ce.getOut();
     if (offset != os.getBytesWritten()) {


### PR DESCRIPTION
### What changes are proposed in this pull request?
Explicitly catch 0x8001 open for write cases. 
Don't use (flags & 0b11) != 0 to detect overwrite since 0X8002， 0xc002 open for read is included.
### Why are the changes needed?
To avoid detect 0xc002 open for read as open for overwriting
To support 0x8002 for open for read or open for write
### Does this PR introduce any user facing changes?
Fix read failures
