### PR TITLE
Fix Fuse write

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -482,8 +482,8 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
     if (offset + sz <= bytesWritten) {
       LOG.warn("Skip writting to file {} offset={} size={} when {} bytes has written to file",
           path, offset, sz, bytesWritten);
-      // TODO(lu) validate if it works? do i need to return sz?
-      return 0;
+      // To fulfill vim :wq
+      return sz;
     }
 
     try {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix incorrect result in linux vim ：wq
modify file.

### Why are the changes needed?

vim modify file will have many same write requests
it will write(offset=0,size=4096)
and then write(offset=0,size=4096) again.
The changes are validated.

### Does this PR introduce any user facing changes?
correct the vim modify file results.
