### PR TITLE
[DOCFIX] Fix wrong file name in k8s doc

### DIFF
--- a/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
+++ b/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
@@ -1485,7 +1485,7 @@ Now you can put the PVC name in your application pod spec to use the Alluxio Fil
 The template `alluxio-nginx-pod.yaml.template` shows how to use PVC in the pod. You can also deploy
 it by running 
 ```console
-$ mv alluxio-nginx-pod.yaml.templte alluxio-nginx-pod.yaml
+$ mv alluxio-nginx-pod.yaml.template alluxio-nginx-pod.yaml
 $ kubectl apply -f alluxio-nginx-pod.yaml
 ```
 to validate that CSI has been deployed, and you can successfully access the data stored in Alluxio. 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix wrong file name in docs, e.g. [https://docs.alluxio.io/os/user/stable/en/deploy/Running-Alluxio-On-Kubernetes.html#posix-api](https://docs.alluxio.io/os/user/stable/en/deploy/Running-Alluxio-On-Kubernetes.html#posix-api). The file name in command should be alluxio-nginx-pod.yaml.template.

![image](https://user-images.githubusercontent.com/13930429/147519660-529a016d-d7b1-47af-a8e0-d4030dcc20a0.png)

