### PR TITLE
Avoid creating new empty sets in MutableInode

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1601,6 +1601,8 @@ public class DefaultFileSystemMaster extends CoreMaster
         .setLastModificationTimeMs(opTimeMs)
         .setLastAccessTimeMs(opTimeMs)
         .setOverwriteModificationTime(true)
+        .setPinned(inode.isPinned())
+        .addAllMediumType(inode.getMediumTypes())
         .build());
     mInodeTree.updateInodeFile(rpcContext, entry.build());
 
@@ -3700,11 +3702,14 @@ public class DefaultFileSystemMaster extends CoreMaster
       throws FileDoesNotExistException, InvalidPathException, AccessControlException {
     Inode inode = inodePath.getInode();
     SetAttributePOptions.Builder protoOptions = context.getOptions();
+    UpdateInodeEntry.Builder entry = UpdateInodeEntry.newBuilder().setId(inode.getId());
     if (protoOptions.hasPinned()) {
       mInodeTree.setPinned(rpcContext, inodePath, context.getOptions().getPinned(),
           context.getOptions().getPinnedMediaList(), opTimeMs);
+      entry.setPinned(protoOptions.getPinned());
+      entry.addAllMediumType(protoOptions.getPinnedMediaList());
     }
-    UpdateInodeEntry.Builder entry = UpdateInodeEntry.newBuilder().setId(inode.getId());
+
     if (protoOptions.hasReplicationMax() || protoOptions.hasReplicationMin()) {
       Integer replicationMax =
           protoOptions.hasReplicationMax() ? protoOptions.getReplicationMax() : null;

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1601,8 +1601,6 @@ public class DefaultFileSystemMaster extends CoreMaster
         .setLastModificationTimeMs(opTimeMs)
         .setLastAccessTimeMs(opTimeMs)
         .setOverwriteModificationTime(true)
-        .setPinned(inode.isPinned())
-        .addAllMediumType(inode.getMediumTypes())
         .build());
     mInodeTree.updateInodeFile(rpcContext, entry.build());
 
@@ -3702,14 +3700,11 @@ public class DefaultFileSystemMaster extends CoreMaster
       throws FileDoesNotExistException, InvalidPathException, AccessControlException {
     Inode inode = inodePath.getInode();
     SetAttributePOptions.Builder protoOptions = context.getOptions();
-    UpdateInodeEntry.Builder entry = UpdateInodeEntry.newBuilder().setId(inode.getId());
     if (protoOptions.hasPinned()) {
       mInodeTree.setPinned(rpcContext, inodePath, context.getOptions().getPinned(),
           context.getOptions().getPinnedMediaList(), opTimeMs);
-      entry.setPinned(protoOptions.getPinned());
-      entry.addAllMediumType(protoOptions.getPinnedMediaList());
     }
-
+    UpdateInodeEntry.Builder entry = UpdateInodeEntry.newBuilder().setId(inode.getId());
     if (protoOptions.hasReplicationMax() || protoOptions.hasReplicationMin()) {
       Integer replicationMax =
           protoOptions.hasReplicationMax() ? protoOptions.getReplicationMax() : null;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
@@ -21,10 +21,10 @@ import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.wire.FileInfo;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -144,7 +144,7 @@ public abstract class Inode implements InodeView {
   }
 
   @Override
-  public Set<String> getMediumTypes() {
+  public ImmutableSet<String> getMediumTypes() {
     return mDelegate.getMediumTypes();
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -781,6 +781,8 @@ public class InodeTree implements DelegatingJournaled {
           if (context.getXAttr() != null) {
             updateInodeEntry.putAllXAttr(CommonUtils.convertToByteString(context.getXAttr()));
           }
+          updateInodeEntry.setPinned(currentInodeDirectory.isPinned());
+          updateInodeEntry.addAllMediumType(currentInodeDirectory.getMediumTypes());
           mState.applyAndJournal(rpcContext, updateInodeEntry.build());
         }
       }
@@ -808,9 +810,7 @@ public class InodeTree implements DelegatingJournaled {
           currentInodeDirectory.getId(), pathComponents[k], missingDirContext);
       if (currentInodeDirectory.isPinned() && !newDir.isPinned()) {
         newDir.setPinned(true);
-        if (!currentInodeDirectory.getMediumTypes().isEmpty()) {
-          newDir.setMediumTypes(ImmutableSet.copyOf(currentInodeDirectory.getMediumTypes()));
-        }
+        newDir.setMediumTypes(currentInodeDirectory.getMediumTypes());
       }
       inheritOwnerAndGroupIfEmpty(newDir, currentInodeDirectory);
 
@@ -916,9 +916,7 @@ public class InodeTree implements DelegatingJournaled {
     }
     if (currentInodeDirectory.isPinned() && !newInode.isPinned()) {
       newInode.setPinned(true);
-      if (!currentInodeDirectory.getMediumTypes().isEmpty()) {
-        newInode.setMediumTypes(ImmutableSet.copyOf(currentInodeDirectory.getMediumTypes()));
-      }
+      newInode.setMediumTypes(currentInodeDirectory.getMediumTypes());
     }
 
     mState.applyAndJournal(rpcContext, newInode,

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -809,6 +809,8 @@ public class InodeTree implements DelegatingJournaled {
         newDir.setPinned(true);
         if (!currentInodeDirectory.getMediumTypes().isEmpty()) {
           newDir.setMediumTypes(new HashSet<>(currentInodeDirectory.getMediumTypes()));
+        } else {
+          newDir.setMediumTypes(Collections.emptySet());
         }
       }
       inheritOwnerAndGroupIfEmpty(newDir, currentInodeDirectory);
@@ -917,6 +919,8 @@ public class InodeTree implements DelegatingJournaled {
       newInode.setPinned(true);
       if (!currentInodeDirectory.getMediumTypes().isEmpty()) {
         newInode.setMediumTypes(new HashSet<>(currentInodeDirectory.getMediumTypes()));
+      } else {
+        newInode.setMediumTypes(Collections.emptySet());
       }
     }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -807,7 +807,9 @@ public class InodeTree implements DelegatingJournaled {
           currentInodeDirectory.getId(), pathComponents[k], missingDirContext);
       if (currentInodeDirectory.isPinned() && !newDir.isPinned()) {
         newDir.setPinned(true);
-        newDir.setMediumTypes(new HashSet<>(currentInodeDirectory.getMediumTypes()));
+        if (!currentInodeDirectory.getMediumTypes().isEmpty()) {
+          newDir.setMediumTypes(new HashSet<>(currentInodeDirectory.getMediumTypes()));
+        }
       }
       inheritOwnerAndGroupIfEmpty(newDir, currentInodeDirectory);
 
@@ -913,7 +915,9 @@ public class InodeTree implements DelegatingJournaled {
     }
     if (currentInodeDirectory.isPinned() && !newInode.isPinned()) {
       newInode.setPinned(true);
-      newInode.setMediumTypes(new HashSet<>(currentInodeDirectory.getMediumTypes()));
+      if (!currentInodeDirectory.getMediumTypes().isEmpty()) {
+        newInode.setMediumTypes(new HashSet<>(currentInodeDirectory.getMediumTypes()));
+      }
     }
 
     mState.applyAndJournal(rpcContext, newInode,

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -781,8 +781,6 @@ public class InodeTree implements DelegatingJournaled {
           if (context.getXAttr() != null) {
             updateInodeEntry.putAllXAttr(CommonUtils.convertToByteString(context.getXAttr()));
           }
-          updateInodeEntry.setPinned(currentInodeDirectory.isPinned());
-          updateInodeEntry.addAllMediumType(currentInodeDirectory.getMediumTypes());
           mState.applyAndJournal(rpcContext, updateInodeEntry.build());
         }
       }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -59,6 +59,7 @@ import alluxio.util.interfaces.Scoped;
 import alluxio.wire.OperationId;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -808,9 +809,7 @@ public class InodeTree implements DelegatingJournaled {
       if (currentInodeDirectory.isPinned() && !newDir.isPinned()) {
         newDir.setPinned(true);
         if (!currentInodeDirectory.getMediumTypes().isEmpty()) {
-          newDir.setMediumTypes(new HashSet<>(currentInodeDirectory.getMediumTypes()));
-        } else {
-          newDir.setMediumTypes(Collections.emptySet());
+          newDir.setMediumTypes(ImmutableSet.copyOf(currentInodeDirectory.getMediumTypes()));
         }
       }
       inheritOwnerAndGroupIfEmpty(newDir, currentInodeDirectory);
@@ -918,9 +917,7 @@ public class InodeTree implements DelegatingJournaled {
     if (currentInodeDirectory.isPinned() && !newInode.isPinned()) {
       newInode.setPinned(true);
       if (!currentInodeDirectory.getMediumTypes().isEmpty()) {
-        newInode.setMediumTypes(new HashSet<>(currentInodeDirectory.getMediumTypes()));
-      } else {
-        newInode.setMediumTypes(Collections.emptySet());
+        newInode.setMediumTypes(ImmutableSet.copyOf(currentInodeDirectory.getMediumTypes()));
       }
     }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -59,7 +59,6 @@ import alluxio.util.interfaces.Scoped;
 import alluxio.wire.OperationId;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeView.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeView.java
@@ -20,9 +20,10 @@ import alluxio.security.authorization.AclActions;
 import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.wire.FileInfo;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -124,7 +125,7 @@ public interface InodeView extends JournalEntryRepresentable, Comparable<InodeVi
   /**
    * @return the pinned medium types set
    */
-  Set<String> getMediumTypes();
+  ImmutableSet<String> getMediumTypes();
 
   /**
    * @return the UFS fingerprint

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInode.java
@@ -63,6 +63,7 @@ public abstract class MutableInode<T extends MutableInode> implements InodeView 
   private long mParentId;
   private PersistenceState mPersistenceState;
   private boolean mPinned;
+  // TODO(jiacheng): figure out what this does
   private Set<String> mMediumTypes;
   protected AccessControlList mAcl;
   private String mUfsFingerprint;
@@ -81,7 +82,7 @@ public abstract class MutableInode<T extends MutableInode> implements InodeView 
     mParentId = InodeTree.NO_PARENT;
     mPersistenceState = PersistenceState.NOT_PERSISTED;
     mPinned = false;
-    mMediumTypes = new HashSet<>();
+    mMediumTypes = Collections.emptySet();
     mAcl = new AccessControlList();
     mUfsFingerprint = Constants.INVALID_UFS_FINGERPRINT;
     mXAttr = null;
@@ -610,12 +611,14 @@ public abstract class MutableInode<T extends MutableInode> implements InodeView 
     if (entry.hasPinned()) {
       // pinning status has changed, therefore we change the medium list with it.
       if (entry.getPinned()) {
+        // TODO(jiacheng): get rid of this
         List<String> mediaList = ServerConfiguration.getList(
             PropertyKey.MASTER_TIERED_STORE_GLOBAL_MEDIUMTYPE);
-        setMediumTypes(entry.getMediumTypeList().stream()
-            .filter(mediaList::contains).collect(Collectors.toSet()));
-      } else {
-        setMediumTypes(Collections.emptySet());
+        Set<String> validMediums = entry.getMediumTypeList().stream()
+            .filter(mediaList::contains).collect(Collectors.toSet());
+        if (!validMediums.isEmpty()) {
+          setMediumTypes(validMediums);
+        }
       }
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInode.java
@@ -36,12 +36,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -54,9 +50,9 @@ import javax.annotation.concurrent.NotThreadSafe;
 public abstract class MutableInode<T extends MutableInode> implements InodeView {
   private static final Logger LOG = LoggerFactory.getLogger(MutableInode.class);
 
-  public static final Set<String> EMPTY_MEDIUMS = ImmutableSet.of();
-  private static final Set<String> MEDIUMS = Collections.unmodifiableSet(new HashSet<>(
-      ServerConfiguration.getList(PropertyKey.MASTER_TIERED_STORE_GLOBAL_MEDIUMTYPE)));
+  public static final ImmutableSet<String> NO_MEDIUM = ImmutableSet.of();
+  private static final ImmutableSet<String> MEDIUMS = ImmutableSet.copyOf(
+      ServerConfiguration.getList(PropertyKey.MASTER_TIERED_STORE_GLOBAL_MEDIUMTYPE));
   protected long mCreationTimeMs;
   private boolean mDeleted;
   protected final boolean mDirectory;
@@ -69,7 +65,7 @@ public abstract class MutableInode<T extends MutableInode> implements InodeView 
   private long mParentId;
   private PersistenceState mPersistenceState;
   private boolean mPinned;
-  private Set<String> mMediumTypes;
+  private ImmutableSet<String> mMediumTypes;
   protected AccessControlList mAcl;
   private String mUfsFingerprint;
   private Map<String, byte[]> mXAttr;
@@ -87,7 +83,7 @@ public abstract class MutableInode<T extends MutableInode> implements InodeView 
     mParentId = InodeTree.NO_PARENT;
     mPersistenceState = PersistenceState.NOT_PERSISTED;
     mPinned = false;
-    mMediumTypes = EMPTY_MEDIUMS;
+    mMediumTypes = NO_MEDIUM;
     mAcl = new AccessControlList();
     mUfsFingerprint = Constants.INVALID_UFS_FINGERPRINT;
     mXAttr = null;
@@ -195,8 +191,7 @@ public abstract class MutableInode<T extends MutableInode> implements InodeView 
   }
 
   @Override
-  // TODO(jiacheng): Make this interface immutable
-  public Set<String> getMediumTypes() {
+  public ImmutableSet<String> getMediumTypes() {
     return mMediumTypes;
   }
 
@@ -504,7 +499,7 @@ public abstract class MutableInode<T extends MutableInode> implements InodeView 
    * @param mediumTypes the medium types to pin to
    * @return the updated object
    */
-  public T setMediumTypes(Set<String> mediumTypes) {
+  public T setMediumTypes(ImmutableSet<String> mediumTypes) {
     mMediumTypes = mediumTypes;
     return getThis();
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInode.java
@@ -581,6 +581,8 @@ public abstract class MutableInode<T extends MutableInode> implements InodeView 
     }
     if (entry.getMediumTypeCount() != 0) {
       setMediumTypes(ImmutableSet.copyOf(entry.getMediumTypeList()));
+    } else {
+      setMediumTypes(MutableInode.NO_MEDIUM);
     }
     if (entry.hasName()) {
       setName(entry.getName());
@@ -628,7 +630,11 @@ public abstract class MutableInode<T extends MutableInode> implements InodeView 
               }
             }
             setMediumTypes(ImmutableSet.copyOf(validMediums));
+          } else {
+            setMediumTypes(NO_MEDIUM);
           }
+        } else {
+          setMediumTypes(NO_MEDIUM);
         }
       }
     }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInode.java
@@ -581,8 +581,6 @@ public abstract class MutableInode<T extends MutableInode> implements InodeView 
     }
     if (entry.getMediumTypeCount() != 0) {
       setMediumTypes(ImmutableSet.copyOf(entry.getMediumTypeList()));
-    } else {
-      setMediumTypes(MutableInode.NO_MEDIUM);
     }
     if (entry.hasName()) {
       setName(entry.getName());
@@ -636,6 +634,8 @@ public abstract class MutableInode<T extends MutableInode> implements InodeView 
         } else {
           setMediumTypes(NO_MEDIUM);
         }
+      } else {
+        setMediumTypes(NO_MEDIUM);
       }
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInode.java
@@ -63,7 +63,6 @@ public abstract class MutableInode<T extends MutableInode> implements InodeView 
   private long mParentId;
   private PersistenceState mPersistenceState;
   private boolean mPinned;
-  // TODO(jiacheng): figure out what this does
   private Set<String> mMediumTypes;
   protected AccessControlList mAcl;
   private String mUfsFingerprint;
@@ -618,7 +617,11 @@ public abstract class MutableInode<T extends MutableInode> implements InodeView 
             .filter(mediaList::contains).collect(Collectors.toSet());
         if (!validMediums.isEmpty()) {
           setMediumTypes(validMediums);
+        } else {
+          setMediumTypes(Collections.emptySet());
         }
+      } else {
+        setMediumTypes(Collections.emptySet());
       }
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeDirectory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeDirectory.java
@@ -24,6 +24,7 @@ import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.util.CommonUtils;
 import alluxio.util.proto.ProtoUtils;
 import alluxio.wire.FileInfo;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -211,9 +212,7 @@ public final class MutableInodeDirectory extends MutableInode<MutableInodeDirect
       ret.mDefaultAcl = new DefaultAccessControlList();
     }
     if (!entry.getMediumTypeList().isEmpty()) {
-      ret.setMediumTypes(new HashSet<>(entry.getMediumTypeList()));
-    } else {
-      ret.setMediumTypes(Collections.emptySet());
+      ret.setMediumTypes(ImmutableSet.copyOf(entry.getMediumTypeList()));
     }
     if (entry.getXAttrCount() > 0) {
       ret.setXAttr(CommonUtils.convertFromByteString(entry.getXAttrMap()));
@@ -310,9 +309,7 @@ public final class MutableInodeDirectory extends MutableInode<MutableInodeDirect
         .setChildCount(inode.getChildCount())
         .setDefaultACL((DefaultAccessControlList) ProtoUtils.fromProto(inode.getDefaultAcl()));
     if (!inode.getMediumTypeList().isEmpty()) {
-      d.setMediumTypes(new HashSet<>(inode.getMediumTypeList()));
-    } else {
-      d.setMediumTypes(Collections.emptySet());
+      d.setMediumTypes(ImmutableSet.copyOf(inode.getMediumTypeList()));
     }
     if (inode.getXAttrCount() > 0) {
       d.setXAttr(CommonUtils.convertFromByteString(inode.getXAttrMap()));

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeDirectory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeDirectory.java
@@ -209,7 +209,9 @@ public final class MutableInodeDirectory extends MutableInode<MutableInodeDirect
     } else {
       ret.mDefaultAcl = new DefaultAccessControlList();
     }
-    ret.setMediumTypes(new HashSet<>(entry.getMediumTypeList()));
+    if (!entry.getMediumTypeList().isEmpty()) {
+      ret.setMediumTypes(new HashSet<>(entry.getMediumTypeList()));
+    }
     if (entry.getXAttrCount() > 0) {
       ret.setXAttr(CommonUtils.convertFromByteString(entry.getXAttrMap()));
     }
@@ -303,8 +305,10 @@ public final class MutableInodeDirectory extends MutableInode<MutableInodeDirect
         .setMountPoint(inode.getIsMountPoint())
         .setDirectChildrenLoaded(inode.getHasDirectChildrenLoaded())
         .setChildCount(inode.getChildCount())
-        .setDefaultACL((DefaultAccessControlList) ProtoUtils.fromProto(inode.getDefaultAcl()))
-        .setMediumTypes(new HashSet<>(inode.getMediumTypeList()));
+        .setDefaultACL((DefaultAccessControlList) ProtoUtils.fromProto(inode.getDefaultAcl()));
+    if (!inode.getMediumTypeList().isEmpty()) {
+      d.setMediumTypes(new HashSet<>(inode.getMediumTypeList()));
+    }
     if (inode.getXAttrCount() > 0) {
       d.setXAttr(CommonUtils.convertFromByteString(inode.getXAttrMap()));
     }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeDirectory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeDirectory.java
@@ -25,6 +25,7 @@ import alluxio.util.CommonUtils;
 import alluxio.util.proto.ProtoUtils;
 import alluxio.wire.FileInfo;
 
+import java.util.Collections;
 import java.util.HashSet;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -211,6 +212,8 @@ public final class MutableInodeDirectory extends MutableInode<MutableInodeDirect
     }
     if (!entry.getMediumTypeList().isEmpty()) {
       ret.setMediumTypes(new HashSet<>(entry.getMediumTypeList()));
+    } else {
+      ret.setMediumTypes(Collections.emptySet());
     }
     if (entry.getXAttrCount() > 0) {
       ret.setXAttr(CommonUtils.convertFromByteString(entry.getXAttrMap()));
@@ -308,6 +311,8 @@ public final class MutableInodeDirectory extends MutableInode<MutableInodeDirect
         .setDefaultACL((DefaultAccessControlList) ProtoUtils.fromProto(inode.getDefaultAcl()));
     if (!inode.getMediumTypeList().isEmpty()) {
       d.setMediumTypes(new HashSet<>(inode.getMediumTypeList()));
+    } else {
+      d.setMediumTypes(Collections.emptySet());
     }
     if (inode.getXAttrCount() > 0) {
       d.setXAttr(CommonUtils.convertFromByteString(inode.getXAttrMap()));

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeDirectory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeDirectory.java
@@ -24,10 +24,9 @@ import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.util.CommonUtils;
 import alluxio.util.proto.ProtoUtils;
 import alluxio.wire.FileInfo;
+
 import com.google.common.collect.ImmutableSet;
 
-import java.util.Collections;
-import java.util.HashSet;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeFile.java
@@ -31,6 +31,7 @@ import alluxio.wire.FileInfo;
 import com.google.common.base.Preconditions;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -419,6 +420,8 @@ public final class MutableInodeFile extends MutableInode<MutableInodeFile>
 
     if (!entry.getMediumTypeList().isEmpty()) {
       ret.setMediumTypes(new HashSet<>(entry.getMediumTypeList()));
+    } else {
+      ret.setMediumTypes(Collections.emptySet());
     }
     return ret;
   }
@@ -547,6 +550,8 @@ public final class MutableInodeFile extends MutableInode<MutableInodeFile>
         .setTempUfsPath(inode.getPersistJobTempUfsPath());
     if (!inode.getMediumTypeList().isEmpty()) {
       f.setMediumTypes(new HashSet<>(inode.getMediumTypeList()));
+    } else {
+      f.setMediumTypes(Collections.emptySet());
     }
     if (inode.getXAttrCount() > 0) {
       f.setXAttr(CommonUtils.convertFromByteString(inode.getXAttrMap()));

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeFile.java
@@ -417,7 +417,9 @@ public final class MutableInodeFile extends MutableInode<MutableInodeFile>
       ret.setXAttr(CommonUtils.convertFromByteString(entry.getXAttrMap()));
     }
 
-    ret.setMediumTypes(new HashSet<>(entry.getMediumTypeList()));
+    if (!entry.getMediumTypeList().isEmpty()) {
+      ret.setMediumTypes(new HashSet<>(entry.getMediumTypeList()));
+    }
     return ret;
   }
 
@@ -542,8 +544,10 @@ public final class MutableInodeFile extends MutableInode<MutableInodeFile>
         .setReplicationMin(inode.getReplicationMin())
         .setPersistJobId(inode.getPersistJobId())
         .setShouldPersistTime(inode.getShouldPersistTime())
-        .setTempUfsPath(inode.getPersistJobTempUfsPath())
-        .setMediumTypes(new HashSet<>(inode.getMediumTypeList()));
+        .setTempUfsPath(inode.getPersistJobTempUfsPath());
+    if (!inode.getMediumTypeList().isEmpty()) {
+      f.setMediumTypes(new HashSet<>(inode.getMediumTypeList()));
+    }
     if (inode.getXAttrCount() > 0) {
       f.setXAttr(CommonUtils.convertFromByteString(inode.getXAttrMap()));
     }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeFile.java
@@ -32,8 +32,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import javax.annotation.concurrent.NotThreadSafe;
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeFile.java
@@ -29,6 +29,7 @@ import alluxio.util.proto.ProtoUtils;
 import alluxio.wire.FileInfo;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -419,9 +420,7 @@ public final class MutableInodeFile extends MutableInode<MutableInodeFile>
     }
 
     if (!entry.getMediumTypeList().isEmpty()) {
-      ret.setMediumTypes(new HashSet<>(entry.getMediumTypeList()));
-    } else {
-      ret.setMediumTypes(Collections.emptySet());
+      ret.setMediumTypes(ImmutableSet.copyOf(entry.getMediumTypeList()));
     }
     return ret;
   }
@@ -549,9 +548,7 @@ public final class MutableInodeFile extends MutableInode<MutableInodeFile>
         .setShouldPersistTime(inode.getShouldPersistTime())
         .setTempUfsPath(inode.getPersistJobTempUfsPath());
     if (!inode.getMediumTypeList().isEmpty()) {
-      f.setMediumTypes(new HashSet<>(inode.getMediumTypeList()));
-    } else {
-      f.setMediumTypes(Collections.emptySet());
+      f.setMediumTypes(ImmutableSet.copyOf(inode.getMediumTypeList()));
     }
     if (inode.getXAttrCount() > 0) {
       f.setXAttr(CommonUtils.convertFromByteString(inode.getXAttrMap()));


### PR DESCRIPTION
### What changes are proposed in this pull request?

The `MutableInode` uses a Set to store mediums that the file/dir is pinned in. By default this is an empty HashSet. This PR changes empty sets to `Collection.emptySet()` which is a singleton, in order to avoid creation of empty HashSets.

### Why are the changes needed?

The main intention is to reduce memory waste on empty collections. 

Before: 
54.5MB total
342B in a `MutableInodeFile.mMediumTypes` where we have a pin medium specified
<img width="1496" alt="Screen Shot 2022-03-29 at 6 31 10 PM" src="https://user-images.githubusercontent.com/14806853/160592702-80383c3b-0a16-4a65-9766-cda69ee1ef14.png">

After
46.6MB total
82B in a `MutableInodeFile.mMediumTypes` where we have a pin medium specified
![image](https://user-images.githubusercontent.com/14806853/160814714-9be1d157-b43a-4fd5-9c6e-80d89991614a.png)

When there's no value, the save is one empty `HashSet` per MutableInode, < 100B.
When there's value, the save is 342B -> 82B per MutableInode.

### Does this PR introduce any user facing changes?

NA
