### PR TITLE
[SMALLFIX] Fix logging for OpenLocalBlock RPC

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
@@ -115,7 +115,7 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
         mResponseObserver.onError(GrpcExceptionUtils.fromThrowable(e));
       }
     }, "OpenBlock", true, false, mResponseObserver, "Session=%d, Request=%s",
-        mSessionId, mRequest);
+        mSessionId, request);
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
@@ -116,6 +116,7 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
       }
     }, "OpenBlock", true, false, mResponseObserver, "Session=%d, Request=%s",
         mSessionId, request);
+  // Must use request object directly for this log as mRequest is only set in the Callable
   }
 
   @Override


### PR DESCRIPTION
The existing log is 
```
2021-12-31 17:15:20,810 DEBUG ShortCircuitBlockReadHandler - Enter(stream): OpenBlock: Session=0, Request=null
```
Because the `mRequest` is set only in the lambda.