### PR TITLE
Fix FormatUtils.getSizeFromBytes should supports EB

### DIFF
--- a/core/common/src/main/java/alluxio/util/FormatUtils.java
+++ b/core/common/src/main/java/alluxio/util/FormatUtils.java
@@ -153,7 +153,12 @@ public final class FormatUtils {
       return String.format(Locale.ENGLISH, "%.2fTB", ret);
     }
     ret /= 1024;
-    return String.format(Locale.ENGLISH, "%.2fPB", ret);
+    if (ret <= 1024 * 5) {
+      return String.format(Locale.ENGLISH, "%.2fPB", ret);
+    }
+    ret /= 1024;
+    //Long.MAX_VALUE bytes approximately equals to 8EB.
+    return String.format(Locale.ENGLISH, "%.2fEB", ret);
   }
 
   /**


### PR DESCRIPTION
What changes are proposed in this pull request?
add EB in FormatUtils.getSizeFromBytes.

Why are the changes needed?
While ufs is very very large, it can display as xxxxEB.