### PR TITLE
Change the equal method of Authority Object

### DIFF
--- a/core/common/src/main/java/alluxio/uri/MultiMasterAuthority.java
+++ b/core/common/src/main/java/alluxio/uri/MultiMasterAuthority.java
@@ -13,6 +13,10 @@ package alluxio.uri;
 
 import com.google.common.base.Objects;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * A multi-master authority implementation.
  */
@@ -54,7 +58,11 @@ public class MultiMasterAuthority implements Authority {
       return false;
     }
     MultiMasterAuthority that = (MultiMasterAuthority) o;
-    return toString().equals(that.toString());
+
+    Set<String> firstAuthority = new HashSet<>(Arrays.asList(toString().split(",")));
+    Set<String> secondAuthority = new HashSet<>(Arrays.asList(that.toString().split(",")));
+
+    return firstAuthority.equals(secondAuthority);
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/uri/ZookeeperAuthority.java
+++ b/core/common/src/main/java/alluxio/uri/ZookeeperAuthority.java
@@ -13,6 +13,10 @@ package alluxio.uri;
 
 import com.google.common.base.Objects;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * {@link ZookeeperAuthority} supports authority containing Zookeeper addresses.
  */
@@ -44,7 +48,11 @@ public final class ZookeeperAuthority implements Authority {
       return false;
     }
     ZookeeperAuthority that = (ZookeeperAuthority) o;
-    return toString().equals(that.toString());
+
+    Set<String> firstAuthority = new HashSet<>(Arrays.asList(mZkAddress.split(",")));
+    Set<String> secondAuthority = new HashSet<>(Arrays.asList(that.mZkAddress.split(",")));
+
+    return firstAuthority.equals(secondAuthority);
   }
 
   @Override

--- a/core/common/src/test/java/alluxio/uri/AuthorityTest.java
+++ b/core/common/src/test/java/alluxio/uri/AuthorityTest.java
@@ -143,4 +143,39 @@ public class AuthorityTest {
           ((ZookeeperAuthority) Authority.fromString(test)).getZookeeperAddress());
     }
   }
+
+  @Test
+  public void authorityEqualTest() {
+    //test the authority in random order, inorder and then test the different authorities.
+    //Zookeepers
+    assertTrue(Authority.fromString("zk@host1:2181;host2:2181;host3:2181").equals(
+        Authority.fromString("zk@host1:2181;host3:2181;host2:2181")));
+    assertTrue(Authority.fromString("zk@host1:2181;host2:2181;host3:2181").equals(
+        Authority.fromString("zk@host1:2181;host2:2181;host3:2181")));
+    assertFalse(Authority.fromString("zk@host1:2181;host2:2181;host4:2181").equals(
+        Authority.fromString("zk@host1:2181;host2:2181;host3:2181")));
+
+    //multiMasters
+    assertTrue(Authority.fromString("host1:19998,host2:19998,host3:19998").equals(
+        Authority.fromString("host1:19998,host3:19998,host2:19998")));
+    assertTrue(Authority.fromString("host1:19998,host2:19998,host3:19998").equals(
+        Authority.fromString("host1:19998,host2:19998,host3:19998")));
+    assertTrue(Authority.fromString("host1:19998,host2:19998,host3:19998").equals(
+        Authority.fromString("host1:19998,host2:19998,host3:19998")));
+
+    //singleMaster
+    assertTrue(Authority.fromString("host1:19998").equals(Authority.fromString("host1:19998")));
+    assertFalse(Authority.fromString("host1:19998").equals(Authority.fromString("host2:19998")));
+
+    //noAuthority
+    assertTrue(Authority.fromString("").equals(Authority.fromString(null)));
+
+    //embeddedLogical
+    assertTrue(Authority.fromString("ebj@logical").equals(Authority.fromString("ebj@logical")));
+    assertFalse(Authority.fromString("ebj@logical1").equals(Authority.fromString("ebj@logical2")));
+
+    //zookeeperLogical
+    assertTrue(Authority.fromString("zk@logical").equals(Authority.fromString("zk@logical")));
+    assertFalse(Authority.fromString("zk@logical1").equals(Authority.fromString("zk@logical2")));
+  }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

The equal() function of Authority object is changed. Previously, it will check whether the whole string output of Authority is the same. So if there is multiple Masters or Zookeepers, like "host1,host2,host3" , the two Authority file should follow the same order and then they are equal. Now the order doesn't matter and "host1, host2" is equal to "host2, host1".

### Why are the changes needed?

In the StressBench, we previously need to input the Master's address in the same order with the alluxio-site.property. Now, there is no need to in the same order.

### Does this PR introduce any user facing changes?

When using stressbench, now the input of Master's address can be in any order.
