### PR TITLE
Change generate tarball command

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -104,7 +104,7 @@ func chdir(path string) {
 }
 
 func getCommonMvnArgs(hadoopVersion version) []string {
-	args := []string{"-T", "1", "-am", "clean", "install", "-DskipTests", "-Dfindbugs.skip", "-Dmaven.javadoc.skip", "-Dcheckstyle.skip", "-Pno-webui-linter", "-Prelease"}
+	args := []string{"-am", "clean", "install", "-DskipTests", "-Dfindbugs.skip", "-Dmaven.javadoc.skip", "-Dcheckstyle.skip", "-Pno-webui-linter", "-Prelease"}
 	if mvnArgsFlag != "" {
 		for _, arg := range strings.Split(mvnArgsFlag, ",") {
 			args = append(args, arg)
@@ -115,6 +115,11 @@ func getCommonMvnArgs(hadoopVersion version) []string {
 	if includeYarnIntegration(hadoopVersion) {
 		args = append(args, "-Pyarn")
 	}
+
+	// Ensure that the "-T" parameter passed from "-mvn_args" can take effect,
+	// because only the first -T parameter in "mvn" command will take effect.
+	// If the -T parameter is not given in "-mvn_args", this configuration will take effect.
+	args = append(args, "-T", "1");
 	return args
 }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Changed the default command when generating tarball.
The default command to generate a tarball is `mvn -T 1 -am .....` the first parameter `-T 1` means only a thread to be used when compiling. If you want to increase the number of compiled threads, you can pass in the -T parameter through `-mvn-args` for example `-mvn-args "-T,1C" ` which can increase the speed of compilation.
After testing, if the mvn command has multiple -T given, only the first one will take effect, for example, `mvn -T 1 -T 1C` which is equivalent to `mvn -T 1 `, to ensure that the "-T" parameter passed from "-mvn_args" can take effect, need to put the default `-T 1` parameter after the `-T X` parameter given by `-mvn-args`

Tested on my Linux (16 cores), if the -mvn-args "-T,1C" parameter is given, the generate a tarball time can be shortened from about 9 min to about 3 minutes

### Why are the changes needed?

Provide a way to increase the speed of tarball generation

### Does this PR introduce any user facing changes?
no
