### PR TITLE
Improve error message when read permission denied

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -20,6 +20,7 @@ import alluxio.collections.IndexDefinition;
 import alluxio.collections.IndexedSet;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.AccessControlException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.FileIncompleteException;
 import alluxio.fuse.auth.AuthPolicy;
@@ -298,6 +299,9 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
     } catch (FileDoesNotExistException | InvalidPathException e) {
       LOG.debug("Failed to get info of {}, path does not exist or is invalid", path);
       return -ErrorCodes.ENOENT();
+    } catch (AccessControlException e) {
+      LOG.error("Permission denied when getattr {}: ", path, e);
+      return -ErrorCodes.EACCES();
     } catch (Throwable e) {
       LOG.error("Failed to getattr {}: ", path, e);
       return -ErrorCodes.EIO();


### PR DESCRIPTION
### What changes are proposed in this pull request?

When open file is permission denied, give correct error code in Fuse to show that the error is permission denied instead of general I/O errors

### Why are the changes needed?

clear user info when permission denied

### Does this PR introduce any user facing changes?
Fuse read will give clear permission denied message
