### PR TITLE
Fix alluxio fuse atime unable to display problem

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -268,9 +268,13 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
       stat.st_blocks.set((int) Math.ceil((double) size / 512));
 
       final long ctime_sec = status.getLastModificationTimeMs() / 1000;
+      final long atime_sec = status.getLastAccessTimeMs() / 1000;
       // Keeps only the "residual" nanoseconds not caputred in citme_sec
       final long ctime_nsec = (status.getLastModificationTimeMs() % 1000) * 1_000_000L;
+      final long atime_nsec = (status.getLastAccessTimeMs() % 1000) * 1_000_000L;
 
+      stat.st_atim.tv_sec.set(atime_sec);
+      stat.st_atim.tv_nsec.set(atime_nsec);
       stat.st_ctim.tv_sec.set(ctime_sec);
       stat.st_ctim.tv_nsec.set(ctime_nsec);
       stat.st_mtim.tv_sec.set(ctime_sec);

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
@@ -215,6 +215,7 @@ public class AlluxioJniFuseFileSystemTest {
     // set up status
     FileInfo info = new FileInfo();
     info.setLength(4 * Constants.KB + 1);
+    info.setLastAccessTimeMs(1000);
     info.setLastModificationTimeMs(1000);
     String userName = System.getProperty("user.name");
     info.setOwner(userName);
@@ -231,6 +232,9 @@ public class AlluxioJniFuseFileSystemTest {
     assertEquals(0, mFuseFs.getattr("/foo", stat));
     assertEquals(status.getLength(), stat.st_size.longValue());
     assertEquals(9, stat.st_blocks.intValue());
+    assertEquals(status.getLastAccessTimeMs() / 1000, stat.st_atim.tv_sec.get());
+    assertEquals((status.getLastAccessTimeMs() % 1000) * 1000,
+            stat.st_atim.tv_nsec.longValue());
     assertEquals(status.getLastModificationTimeMs() / 1000, stat.st_ctim.tv_sec.get());
     assertEquals((status.getLastModificationTimeMs() % 1000) * 1000,
         stat.st_ctim.tv_nsec.longValue());


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix alluxio fuse don't display atime problem
### Why are the changes needed?
When exec stat file command in alluxio fuse mount point, the result can't show atime.
### Does this PR introduce any user facing changes?
No