### PR TITLE
Fix journal dumper not work

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
@@ -151,10 +151,9 @@ public class RaftJournalDumper extends AbstractJournalDumper {
       return;
     }
     Preconditions.checkState(
-        entry.getAllFields().size() <= 1
-            || (entry.getAllFields().size() == 2 && entry.hasSequenceNumber()),
+        entry.toBuilder().clearOperationId().clearSequenceNumber().getAllFields().size() <= 1,
         "Raft journal entries should never set multiple fields in addition to sequence "
-            + "number, but found %s",
+            + "number, but found\n%s",
         entry);
     if (entry.getJournalEntriesCount() > 0) {
       // This entry aggregates multiple entries.


### PR DESCRIPTION
### What changes are proposed in this pull request?

fix journal dumper not work.

### Why are the changes needed?

when use command `./bin/alluxio readJournal` will face error like:
```
java.lang.RuntimeException: java.lang.IllegalStateException: Raft journal entries should never set multiple fields in addition to sequence number, but found sequence_number: 6
update_inode {
  id: 0
  last_modification_time_ms: 1641571923648
  last_access_time_ms: 1641571923648
}
operationId {
  mostSignificantBits: 3407999256801922785
  leastSignificantBits: -4799816901488576434
}

        at alluxio.master.journal.tool.RaftJournalDumper.lambda$readRatisLogFromDir$0(RaftJournalDumper.java:99)
        at org.apache.ratis.server.raftlog.segmented.LogSegment.readSegmentFile(LogSegment.java:141)
        at org.apache.ratis.server.raftlog.segmented.LogSegment.readSegmentFile(LogSegment.java:125)
        at alluxio.master.journal.tool.RaftJournalDumper.readRatisLogFromDir(RaftJournalDumper.java:90)
        at alluxio.master.journal.tool.RaftJournalDumper.readFromDir(RaftJournalDumper.java:79)
        at alluxio.master.journal.tool.RaftJournalDumper.dumpJournal(RaftJournalDumper.java:69)
        at alluxio.master.journal.tool.JournalTool.dumpJournal(JournalTool.java:121)
        at alluxio.master.journal.tool.JournalTool.main(JournalTool.java:95)
Caused by: java.lang.IllegalStateException: Raft journal entries should never set multiple fields in addition to sequence number, but found sequence_number: 6
update_inode {
  id: 0
  last_modification_time_ms: 1641571923648
  last_access_time_ms: 1641571923648
}
operationId {
  mostSignificantBits: 3407999256801922785
  leastSignificantBits: -4799816901488576434
}

        at com.google.common.base.Preconditions.checkState(Preconditions.java:589)
        at alluxio.master.journal.tool.RaftJournalDumper.writeSelected(RaftJournalDumper.java:153)
        at alluxio.master.journal.tool.RaftJournalDumper.writeSelected(RaftJournalDumper.java:162)
        at alluxio.master.journal.tool.RaftJournalDumper.lambda$readRatisLogFromDir$0(RaftJournalDumper.java:97)
        ... 7 more
```

### Does this PR introduce any user facing changes?

No user facing changes.
