### PR TITLE
Update dependencies to resolve some CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     <jacoco.version>0.8.5</jacoco.version>
     <java.version>1.8</java.version>
     <jaxb.version>2.3.3</jaxb.version>
-    <jersey.version>2.29.1</jersey.version>
+    <jersey.version>2.34</jersey.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
     <junit.version>4.13</junit.version>
     <log4j.version>2.17.1</log4j.version>
@@ -146,9 +146,9 @@
     <oshi.version>5.3.5</oshi.version>
     <powermock.version>2.0.7</powermock.version>
     <prometheus.version>0.8.0</prometheus.version>
-    <guava.version>29.0-jre</guava.version>
+    <guava.version>30.0-jre</guava.version>
     <parquet.version>1.11.0</parquet.version>
-    <protobuf.version>3.12.4</protobuf.version>
+    <protobuf.version>3.19.2</protobuf.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <ratis.version>2.0.0</ratis.version>
     <slf4j.version>1.7.30</slf4j.version>
@@ -214,12 +214,12 @@
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-client</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2</version>
       </dependency>
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-model</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2</version>
       </dependency>
       <dependency>
         <groupId>com.beust</groupId>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Update 5 dependencies to resolve some CVEs reported in #14769.

### Why are the changes needed?

Some reported CVEs are from outdated dependencies. This PR updates some of them.

The original report can be obtained by running `trivy image --offline-scan alluxio/alluxio:2.7.2`. We need to scan the built image and get a updated report after this upgrade.

### Does this PR introduce any user facing changes?

No.
