### PR TITLE
Fix ozone supportspath

### DIFF
--- a/underfs/ozone/src/main/java/alluxio/underfs/ozone/OzoneUnderFileSystemFactory.java
+++ b/underfs/ozone/src/main/java/alluxio/underfs/ozone/OzoneUnderFileSystemFactory.java
@@ -36,7 +36,7 @@ public class OzoneUnderFileSystemFactory extends HdfsUnderFileSystemFactory {
   @Override
   public boolean supportsPath(String path, UnderFileSystemConfiguration conf) {
     if (supportsPath(path)) {
-      if (!conf.isSet(PropertyKey.UNDERFS_VERSION)
+      if (!conf.isSetByUser(PropertyKey.UNDERFS_VERSION)
           || conf.get(PropertyKey.UNDERFS_VERSION).equals(getVersion())) {
         return true;
       }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix ozone `supportsPath` function bug

### Why are the changes needed?

PropertyKey `UNDERFS_VERSION` has a default value of `3.3` which makes `conf.isSet(PropertyKey.UNDERFS_VERSION)` always `true`, This causes  to ozone `supportsPath` function return the wrong value (The default value of `3.3` is not equal to the version of ozone. So the result of `conf.get(PropertyKey.UNDERFS_VERSION).equals(getVersion())` is false)

### Does this PR introduce any user facing changes?
No
