### PR TITLE
Fix unescape the ufs url of alluxio fsadmin report metrics result

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -821,7 +821,7 @@ public final class MetricsSystem {
             entry.getKey(), metric.getClass().getName());
         continue;
       }
-      metricsMap.put(entry.getKey(), valueBuilder.build());
+      metricsMap.put(unescape(entry.getKey()), valueBuilder.build());
     }
     return metricsMap;
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

when type bin/alluxio fsadmin report metrics, the ufs url excaped.

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
 1.Unescape all names.
 2.The  unescape function  is `return uri.replace("%2F", "/").replace("%2E", ".").replace("%25", "%");`. We have not any metrics name is  %2F,%2E or %25, so it is will be safe.


### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
 no
