### PR TITLE
Fix #14822 change rocksdbjni maven dependency to runtime

### DIFF
--- a/shaded/client/pom.xml
+++ b/shaded/client/pom.xml
@@ -39,11 +39,11 @@
       <artifactId>hadoop-client</artifactId>
       <scope>provided</scope>
     </dependency>
-    <!-- Have RocksDB dependency in provided scope by default to reduce client jar size -->
+    <!-- Have RocksDB dependency in runtime scope by default -->
     <dependency>
       <groupId>org.rocksdb</groupId>
       <artifactId>rocksdbjni</artifactId>
-      <scope>provided</scope>
+      <scope>runtime</scope>
     </dependency>
     <!-- Runtime logging dependencies -->
     <dependency>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix #14822

### Why are the changes needed?
Alluxio clients like Presto cache will miss the rocksdbjni dependency when using Alluxio local cache based on ROCKS.

### Does this PR introduce any user facing changes?
Nope.
