### PR TITLE
Fix for alluxio.logs.dir

### DIFF
--- a/docs/_data/table/en/common-configuration.yml
+++ b/docs/_data/table/en/common-configuration.yml
@@ -159,7 +159,7 @@ alluxio.locality.rack:
 alluxio.locality.script:
   'A script to determine tiered identity for locality checking'
 alluxio.logs.dir:
-  'The path under Alluxio home directory to store log files. It has a corresponding environment variable $ALLUXIO_LOGS_DIR. Note: overwriting this property will not work when it is passed as a JVM system property (e.g., appending &quot;-Dalluxio.logs.dir&quot;=&lt;NEW_VALUE&gt;&quot; to $ALLUXIO_JAVA_OPTS). Setting it in alluxio-site.properties will not work.'
+  'The path under Alluxio home directory to store log files. It has a corresponding environment variable $ALLUXIO_LOGS_DIR. Note: overwriting this property will only work when it is passed as a JVM system property (e.g., appending &quot;-Dalluxio.logs.dir&quot;=&lt;NEW_VALUE&gt;&quot; to $ALLUXIO_JAVA_OPTS). Setting it in alluxio-site.properties will not work.'
 alluxio.logserver.hostname:
   'The hostname of Alluxio logserver. Note: overwriting this property will only work when it is passed as a JVM system property (e.g., appending &quot;-Dalluxio.logserver.hostname&quot;=&lt;NEW_VALUE&gt;&quot; to $ALLUXIO_JAVA_OPTS). Setting it in alluxio-site.properties will not work.'
 alluxio.logserver.logs.dir:

--- a/docs/_data/table/en/common-configuration.yml
+++ b/docs/_data/table/en/common-configuration.yml
@@ -159,7 +159,7 @@ alluxio.locality.rack:
 alluxio.locality.script:
   'A script to determine tiered identity for locality checking'
 alluxio.logs.dir:
-  'The path under Alluxio home directory to store log files. It has a corresponding environment variable $ALLUXIO_LOGS_DIR. Note: overwriting this property will only work when it is passed as a JVM system property (e.g., appending &quot;-Dalluxio.logs.dir&quot;=&lt;NEW_VALUE&gt;&quot; to $ALLUXIO_JAVA_OPTS). Setting it in alluxio-site.properties will not work.'
+  'The path under Alluxio home directory to store log files. It has a corresponding environment variable $ALLUXIO_LOGS_DIR. Note: overwriting this property will not work when it is passed as a JVM system property (e.g., appending &quot;-Dalluxio.logs.dir&quot;=&lt;NEW_VALUE&gt;&quot; to $ALLUXIO_JAVA_OPTS). Setting it in alluxio-site.properties will not work.'
 alluxio.logserver.hostname:
   'The hostname of Alluxio logserver. Note: overwriting this property will only work when it is passed as a JVM system property (e.g., appending &quot;-Dalluxio.logserver.hostname&quot;=&lt;NEW_VALUE&gt;&quot; to $ALLUXIO_JAVA_OPTS). Setting it in alluxio-site.properties will not work.'
 alluxio.logserver.logs.dir:

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -37,16 +37,27 @@ if [[ -e "${ALLUXIO_CONF_DIR}/alluxio-env.sh" ]]; then
   . "${ALLUXIO_CONF_DIR}/alluxio-env.sh"
 fi
 
+# This will set the value of ALLUXIO_LOGS_DIR based in the user configuration.
+# the environment variable ${ALLUXIO_LOGS_DIR} will be firstly consider.
 ALLUXIO_LOGS_DIR_JAVA_OPT_PRE="-Dalluxio.logs.dir="
 if [[  -n "${ALLUXIO_LOGS_DIR}" ]]; then
+  # If user set ALLUXIO_LOGS_DIR, use this.
   ALLUXIO_LOGS_DIR="${ALLUXIO_LOGS_DIR}"
 elif [[ ${ALLUXIO_JAVA_OPTS} == *${ALLUXIO_LOGS_DIR_JAVA_OPT_PRE}* ]]; then
+  # If user set alluxio.logs.dir in ALLUXIO_JAVA_OPTS, use this.
+  # Extract "XXX -Dalluxio.logs.dir=<value> XXX".
+  # First get "<value> XXX".
   ALLUXIO_LOGS_DIR_TMP=${ALLUXIO_JAVA_OPTS#*${ALLUXIO_LOGS_DIR_JAVA_OPT_PRE}}
+  # Then get "<value>".
   ALLUXIO_LOGS_DIR=$(echo "${ALLUXIO_LOGS_DIR_TMP}"|awk '{print $1}')
+  # Set ALLUXIO_LOGS_DIR_FROM_ALLUXIO_JAVA_OPTS_TAG to true is let ALLUXIO_JAVA_OPTS
+  # not append -Dalluxio.user.logs.dir=<value> later, since it already have.
   ALLUXIO_LOGS_DIR_FROM_ALLUXIO_JAVA_OPTS_TAG="true"
 else
+  # Else set ALLUXIO_LOGS_DIR to default value.
   ALLUXIO_LOGS_DIR="${ALLUXIO_HOME}/logs"
 fi
+
 ALLUXIO_USER_LOGS_DIR="${ALLUXIO_USER_LOGS_DIR:-${ALLUXIO_LOGS_DIR}/user}"
 
 # Check if java is found


### PR DESCRIPTION
### What changes are proposed in this pull request?
 After I append `"-Dalluxio.logs.dir"=<NEW_VALUE>"` to $ALLUXIO_JAVA_OPTS in alluxio-en.sh, found it is not work.
After set `export ALLUXIO_LOGS_DIR='<NEW_VALUE>'` ,it will work.
The reason is that in alluxio-config.sh,
````
ALLUXIO_LOGS_DIR="${ALLUXIO_LOGS_DIR:-${ALLUXIO_HOME}/logs}"
..
ALLUXIO_JAVA_OPTS+=" -Dalluxio.conf.dir=${ALLUXIO_CONF_DIR} -Dalluxio.logs.dir=${ALLUXIO_LOGS_DIR} -Dalluxio.user.logs.dir=${ALLUXIO_USER_LOGS_DIR}"

````
if you donnot set ALLUXIO_LOGS_DIR ,then the value of ALLUXIO_LOGS_DIR  is ${ALLUXIO_HOME}/logs and will overwrite alluxio.user.logs.dir.
So even if you definite  `-Dalluxio.logs.dir"=<NEW_VALUE>` in ALLUXIO_JAVA_OPTS , it will overwrite to default value and cannot work.



### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  It actually not work.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
no
