### PR TITLE
Handle Fuse open flags

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseOpenUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseOpenUtils.java
@@ -1,0 +1,121 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.fuse;
+
+
+import jnr.constants.platform.OpenFlags;
+
+public final class AlluxioFuseOpenUtils {
+  // TODO(lu) change to bit operation to speed up
+  // FUSE open flags accordance to open flags on Linux:
+  
+  // r Open file for reading. An exception occurs if the file does not exist.
+  // (Decimal): 32768 (Octal): 00000100000 (Hexadecimal): 00008000
+  // (Binary ): 00000000000000001000000000000000
+  private static final int READ =  32768;
+  // r+/w+ Open file for reading and writing. An exception occurs if the file
+  // does not exist. If open for writing, the file is created (if it does not
+  // exist) or truncated (if it exists).
+  // (Decimal): 32770 (Octal): 00000100002 (Hexadecimal): 00008002
+  // (Binary ): 00000000000000001000000000000010
+  private static final int R_OR_W_PLUS =  32770;
+  // rs Open file for reading in synchronous mode. Instructs the operating
+  // system to bypass the local file system cache. This is primarily useful
+  // for opening files on NFS mounts as it allows you to skip the
+  // potentially stale local cache. It has a very real impact on I/O 
+  // performance so don't use this flag unless you need it. Note that this
+  // doesn't turn fs.open() into a synchronous blocking call. If that's
+  // what you want then you should be using fs.openSync().
+  // (Decimal): 36864 (Octal): 00000110000 (Hexadecimal): 00009000
+  // (Binary ): 00000000000000001001000000000000
+  private static final int READ_SYNC =  36864;
+  // rs+ Open file for reading and writing, telling the OS to open it
+  // synchronously. See notes for 'rs' about using this with caution.
+  //(Decimal): 36866 (Octal): 00000110002 (Hexadecimal): 00009002
+  // (Binary ): 00000000000000001001000000000010
+  private static final int RS_PLUS =  36866;
+  // w Open file for writing. The file is created (if it does not exist) or
+  // truncated (if it exists).
+  // (Decimal): 32769 (Octal): 00000100001 (Hexadecimal): 00008001
+  // (Binary ): 00000000000000001000000000000001
+  private static final int WRITE =  32769;
+  // wx  FUSE.open() is never called
+  // a Open file for appending. The file is created if it does not exist.
+  // (Decimal): 33793 (Octal): 00000102001 (Hexadecimal): 00008401
+  // (Binary ): 00000000000000001000010000000001
+  private static final int APPEND = 33793;
+  // ax  FUSE.open() is never called
+  // a+  # Open file for reading and appending. The file is created if it
+  // does not exist.
+  // (Decimal): 33794 (Octal): 00000102002 (Hexadecimal): 00008402
+  // (Binary ): 00000000000000001000010000000010
+  private static final int APPEND_PLUS = 33794;
+  // ax+ FUSE.open() is never called
+
+  public static OpenType getOpenType(int flag) {
+    OpenFlags openFlags = OpenFlags.valueOf(flag);
+    switch (openFlags) {
+      case O_RDONLY:
+      case O_NONBLOCK:
+      case O_EVTONLY:
+        return OpenType.READ_ONLY;
+      case O_WRONLY:
+      // If file exists, error out with EEXIST
+      case O_CREAT:
+      // Truncate to length 0
+      case O_TRUNC:
+      // If file exists, error out with EEXIST
+      case O_EXCL: 
+      case O_SYNC:
+        return OpenType.WRITE_ONLY;
+      case O_RDWR:
+        return OpenType.READ_WRITE;
+      case O_APPEND:
+      // Use readdir() to read directory
+      case O_DIRECTORY:
+        return OpenType.NOT_SUPPORTED;
+      default:
+        return getSpecialOpenType(flag);
+    }
+  }
+  
+  private static OpenType getSpecialOpenType(int flag) {
+    switch (flag) {
+      case READ:
+      case READ_SYNC:
+        return OpenType.READ_ONLY;
+      case R_OR_W_PLUS:
+      case RS_PLUS:
+        return OpenType.READ_WRITE;
+      case WRITE:
+        return OpenType.WRITE_ONLY;
+      case APPEND:
+      case APPEND_PLUS:
+        return OpenType.NOT_SUPPORTED;
+      default:
+        return OpenType.UNKNOWN;
+    }
+  }
+
+  public enum OpenType {
+    READ_ONLY,
+    WRITE_ONLY,
+    // TODO(maobaolong): Add an option to decide whether reject rw flag
+    // Alluxio does not support open a file for reading and writing concurrently.
+    // Read or write behavior is decided in the first read() or write()
+    // if read then write or write then read, we error out
+    READ_WRITE,
+    NOT_SUPPORTED,
+    UNKNOWN,
+    ;
+  }
+}

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseOpenUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseOpenUtils.java
@@ -19,7 +19,8 @@ import jnr.constants.platform.OpenFlags;
  */
 public final class AlluxioFuseOpenUtils {
   // TODO(lu) change to bit operation to speed up
-  // FUSE open flags accordance to open flags on Linux:
+  // Extra commonly used Fuse open flags other than defined in
+  // {@link jnr.constants.Constant.OpenFlags}
 
   // r Open file for reading. An exception occurs if the file does not exist.
   // (Decimal): 32768 (Octal): 00000100000 (Hexadecimal): 00008000
@@ -93,27 +94,27 @@ public final class AlluxioFuseOpenUtils {
       case O_DIRECTORY:
         return OpenAction.NOT_SUPPORTED;
       default:
-        return getExtraOpenAction(flag);
+        return getOpenActionFromExtraOpenFlags(flag);
     }
   }
 
   /**
-   * Gets Fuse open action based on open flag
-   * constants defined in this class.
+   * Gets Fuse open action based on extra open flags
+   * defined in this class.
    *
    * @param flag the open flag
    * @return the open action
    */
-  private static OpenAction getExtraOpenAction(int flag) {
+  private static OpenAction getOpenActionFromExtraOpenFlags(int flag) {
     switch (flag) {
       case READ:
       case READ_SYNC:
         return OpenAction.READ_ONLY;
+      case WRITE:
+        return OpenAction.WRITE_ONLY;
       case R_OR_W_PLUS:
       case RS_PLUS:
         return OpenAction.READ_WRITE;
-      case WRITE:
-        return OpenAction.WRITE_ONLY;
       case APPEND:
       case APPEND_PLUS:
         return OpenAction.NOT_SUPPORTED;

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseOpenUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseOpenUtils.java
@@ -25,13 +25,13 @@ public final class AlluxioFuseOpenUtils {
   // r Open file for reading. An exception occurs if the file does not exist.
   // (Decimal): 32768 (Octal): 00000100000 (Hexadecimal): 00008000
   // (Binary ): 00000000000000001000000000000000
-  private static final int READ =  32768;
+  private static final int READ = 0x8000;
   // r+/w+ Open file for reading and writing. An exception occurs if the file
   // does not exist. If open for writing, the file is created (if it does not
   // exist) or truncated (if it exists).
   // (Decimal): 32770 (Octal): 00000100002 (Hexadecimal): 00008002
   // (Binary ): 00000000000000001000000000000010
-  private static final int R_OR_W_PLUS =  32770;
+  private static final int R_OR_W_PLUS = 0x8002;
   // rs Open file for reading in synchronous mode. Instructs the operating
   // system to bypass the local file system cache. This is primarily useful
   // for opening files on NFS mounts as it allows you to skip the
@@ -41,28 +41,28 @@ public final class AlluxioFuseOpenUtils {
   // what you want then you should be using fs.openSync().
   // (Decimal): 36864 (Octal): 00000110000 (Hexadecimal): 00009000
   // (Binary ): 00000000000000001001000000000000
-  private static final int READ_SYNC =  36864;
+  private static final int READ_SYNC = 0x9000;
   // rs+ Open file for reading and writing, telling the OS to open it
   // synchronously. See notes for 'rs' about using this with caution.
   //(Decimal): 36866 (Octal): 00000110002 (Hexadecimal): 00009002
   // (Binary ): 00000000000000001001000000000010
-  private static final int RS_PLUS =  36866;
+  private static final int RS_PLUS = 0x9002;
   // w Open file for writing. The file is created (if it does not exist) or
   // truncated (if it exists).
   // (Decimal): 32769 (Octal): 00000100001 (Hexadecimal): 00008001
   // (Binary ): 00000000000000001000000000000001
-  private static final int WRITE =  32769;
+  private static final int WRITE = 0x8001;
   // wx  FUSE.open() is never called
   // a Open file for appending. The file is created if it does not exist.
   // (Decimal): 33793 (Octal): 00000102001 (Hexadecimal): 00008401
   // (Binary ): 00000000000000001000010000000001
-  private static final int APPEND = 33793;
+  private static final int APPEND = 0x8401;
   // ax  FUSE.open() is never called
   // a+  # Open file for reading and appending. The file is created if it
   // does not exist.
   // (Decimal): 33794 (Octal): 00000102002 (Hexadecimal): 00008402
   // (Binary ): 00000000000000001000010000000010
-  private static final int APPEND_PLUS = 33794;
+  private static final int APPEND_PLUS = 0x8402;
   // ax+ FUSE.open() is never called
 
   /**

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -32,7 +32,6 @@ import alluxio.util.OSUtils;
 import alluxio.util.ShellUtils;
 import alluxio.util.WaitForOptions;
 
-import jnr.constants.platform.OpenFlags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ru.serce.jnrfuse.ErrorCodes;
@@ -52,45 +51,7 @@ public final class AlluxioFuseUtils {
       .getMs(PropertyKey.FUSE_LOGGING_THRESHOLD);
   private static final int MAX_ASYNC_RELEASE_WAITTIME_MS = 5000;
 
-  // Open flags
-  // TODO(maobaolong): Add an option to decide whether reject rw flag
-  //  or fallback to truncate
-  // TODO(lu) improve open flag handling https://github.com/mafintosh/fuse-bindings/issues/25
-  // 0x8001 stand for 'w' which means open file for writing
-  private static final int OPEN_WRITE = 32769;
-  // 0x8002 stand for 'r+' which means Open file for reading and writing
-  private static final int OPEN_READ_WRITE = 32770;
-
   private AlluxioFuseUtils() {}
-
-  /**
-   * Detects if open file for overwriting.
-   *
-   * @param flags the open flags
-   * @return true if open a file for overwriting, false otherwise
-   */
-  public static boolean isOpenOverwrite(int flags) {
-    boolean overwrite = OpenFlags.valueOf(flags) == OpenFlags.O_WRONLY
-        || flags == OPEN_WRITE;
-    return overwrite;
-  }
-
-  /**
-   * Detects if open file for reading and writing.
-   *
-   * @param flags the open flags
-   * @return true if open a file for reading and writing, false otherwise
-   */
-  public static boolean isOpenReadWrite(int flags) {
-    if (flags == OPEN_READ_WRITE) {
-      LOG.debug(String.format("Open file with flags 0x%x for reading and writing. "
-          + "Alluxio does not support reading and writing a file concurrently. "
-          + "Treat as read first. Close input stream, "
-          + "delete file, and create a new file when detected first write.", flags));
-      return true;
-    }
-    return false;
-  }
 
   /**
    * Retrieves the uid of the given user.

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -363,6 +363,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
     }
     long fid = mNextOpenFileId.getAndIncrement();
     try {
+      // TODO(lu) how to deal with concurrent open() for read/write or write/write
       if (openAction == OpenAction.WRITE_ONLY) {
         if (mFileSystem.exists(uri)) {
           OpenFlags openFlags = OpenFlags.valueOf(flags);

--- a/integration/fuse/src/test/java/alluxio/jnifuse/struct/FuseFileInfoTest.java
+++ b/integration/fuse/src/test/java/alluxio/jnifuse/struct/FuseFileInfoTest.java
@@ -13,11 +13,13 @@ package alluxio.jnifuse.struct;
 
 import static org.junit.Assert.assertEquals;
 
+import jnr.constants.platform.OpenFlags;
 import jnr.ffi.Pointer;
 import jnr.ffi.Runtime;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 public class FuseFileInfoTest {
   @Test

--- a/integration/fuse/src/test/java/alluxio/jnifuse/struct/FuseFileInfoTest.java
+++ b/integration/fuse/src/test/java/alluxio/jnifuse/struct/FuseFileInfoTest.java
@@ -13,13 +13,11 @@ package alluxio.jnifuse.struct;
 
 import static org.junit.Assert.assertEquals;
 
-import jnr.constants.platform.OpenFlags;
 import jnr.ffi.Pointer;
 import jnr.ffi.Runtime;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 
 public class FuseFileInfoTest {
   @Test


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fixes https://github.com/Alluxio/alluxio/issues/14740

### Why are the changes needed?
Fuse open with different flags has different interpretations.
Fuse can open file for read/write/read and write/ append .....
we need to handle them correspondingly.

### Does this PR introduce any user facing changes?
Fuse open() behaviors
