### PR TITLE
Fix byte buffer not reset after read in client IO bench

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
@@ -355,6 +355,7 @@ public class StressClientIOBench extends Benchmark<ClientIOTaskResult> {
       mBuffer = new byte[(int) FormatUtils.parseSpaceSize(mParameters.mBufferSize)];
       Arrays.fill(mBuffer, (byte) 'A');
       mByteBuffer = ByteBuffer.wrap(mBuffer);
+      mByteBuffer.mark();
 
       mFileSize = FormatUtils.parseSpaceSize(mParameters.mFileSize);
       mCurrentOffset = mFileSize;
@@ -463,6 +464,7 @@ public class StressClientIOBench extends Benchmark<ClientIOTaskResult> {
         }
         case READ_BYTE_BUFFER: {
           int bytesRead = mInStream.read(mByteBuffer);
+          mByteBuffer.reset();
           if (bytesRead < 0) {
             closeInStream();
             mInStream = mFs.open(mFilePath);
@@ -559,6 +561,7 @@ public class StressClientIOBench extends Benchmark<ClientIOTaskResult> {
         }
         case READ_BYTE_BUFFER: {
           int bytesRead = mInStream.read(mByteBuffer);
+          mByteBuffer.reset();
           if (bytesRead < 0) {
             closeInStream();
             mInStream = mFs.openFile(new AlluxioURI(mFilePath.toString()));


### PR DESCRIPTION
Mark the byte buffer after creation and reset it after read is done.
If it is not reset after read, the position of the byte buffer is at its limit, and following read will always write 0 bytes into the buffer.

Reference: https://docs.oracle.com/javase/8/docs/api/java/nio/Buffer.html#reset-- 
