### PR TITLE
Close RocksDB objects that are AutoCloseable

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
@@ -98,7 +98,8 @@ public class RocksPageStore implements PageStore {
       Options dbOptions) {
     mPageStoreOptions = pageStoreOptions;
     mDbOptions = dbOptions;
-    mCapacity = (long) (pageStoreOptions.getCacheSize() / (1 + pageStoreOptions.getOverheadRatio()));
+    mCapacity =
+        (long) (pageStoreOptions.getCacheSize() / (1 + pageStoreOptions.getOverheadRatio()));
     mDb = rocksDB;
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
@@ -40,6 +40,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * A page store implementation which utilizes rocksDB to persist the data. This implementation
  * will not be included to client jar by default to reduce client jar size.
  */
+// TODO(jiacheng): lord gimme strength to fix this too
 @NotThreadSafe
 public class RocksPageStore implements PageStore {
   private static final Logger LOG = LoggerFactory.getLogger(RocksPageStore.class);

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
@@ -47,7 +47,7 @@ public class RocksPageStore implements PageStore {
 
   private final long mCapacity;
   private final RocksDB mDb;
-  private final RocksPageStoreOptions mPsOptions;
+  private final RocksPageStoreOptions mPageStoreOptions;
   private final Options mDbOptions;
 
   /**
@@ -90,12 +90,15 @@ public class RocksPageStore implements PageStore {
   /**
    * Creates a new instance of {@link PageStore} backed by RocksDB.
    *
-   * @param psOptions options for the rocks page store
+   * @param pageStoreOptions options for the rocks page store
+   * @param rocksDB RocksDB instance
+   * @param dbOptions the RocksDB options
    */
-  private RocksPageStore(RocksPageStoreOptions psOptions, RocksDB rocksDB, Options dbOptions) {
-    mPsOptions = psOptions;
+  private RocksPageStore(RocksPageStoreOptions pageStoreOptions, RocksDB rocksDB,
+      Options dbOptions) {
+    mPageStoreOptions = pageStoreOptions;
     mDbOptions = dbOptions;
-    mCapacity = (long) (psOptions.getCacheSize() / (1 + psOptions.getOverheadRatio()));
+    mCapacity = (long) (pageStoreOptions.getCacheSize() / (1 + pageStoreOptions.getOverheadRatio()));
     mDb = rocksDB;
   }
 
@@ -157,8 +160,10 @@ public class RocksPageStore implements PageStore {
 
   @Override
   public void close() {
+    LOG.info("Closing RocksPageStore and recycling all RocksDB JNI objects");
     mDb.close();
     mDbOptions.close();
+    LOG.info("RocksPageStore closed");
   }
 
   private static byte[] getKeyFromPageId(PageId pageId) {

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStoreOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStoreOptions.java
@@ -21,7 +21,6 @@ import org.rocksdb.CompressionType;
 /**
  * Options used to instantiate {@link RocksPageStore}.
  */
-// TODO(jiacheng): lord gimme strength to fix this too
 public class RocksPageStoreOptions extends PageStoreOptions {
   // TODO(feng): consider making the overhead ratio configurable
   // We assume 20% overhead using Rocksdb as a page store, i.e., with 1GB space allocated, we

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStoreOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStoreOptions.java
@@ -21,6 +21,7 @@ import org.rocksdb.CompressionType;
 /**
  * Options used to instantiate {@link RocksPageStore}.
  */
+// TODO(jiacheng): lord gimme strength to fix this too
 public class RocksPageStoreOptions extends PageStoreOptions {
   // TODO(feng): consider making the overhead ratio configurable
   // We assume 20% overhead using Rocksdb as a page store, i.e., with 1GB space allocated, we

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -24,7 +24,6 @@ import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.CompressionType;
-import org.rocksdb.DBOptions;
 import org.rocksdb.HashLinkedListMemTableConfig;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
@@ -79,21 +78,21 @@ public class RocksBlockStore implements BlockStore {
     mCfOpts = new ColumnFamilyOptions()
             .setMemTableConfig(new HashLinkedListMemTableConfig())
             .setCompressionType(CompressionType.NO_COMPRESSION);
-      List<ColumnFamilyDescriptor> columns =
-              Arrays.asList(new ColumnFamilyDescriptor(BLOCK_META_COLUMN.getBytes(), mCfOpts),
-                      new ColumnFamilyDescriptor(BLOCK_LOCATIONS_COLUMN.getBytes(), mCfOpts));
-      String dbPath = PathUtils.concatPath(baseDir, BLOCKS_DB_NAME);
-      String backupPath = PathUtils.concatPath(baseDir, BLOCKS_DB_NAME + "-backups");
-      // Create block store db path if it does not exist.
-      if (!FileUtils.exists(dbPath)) {
-        try {
-          FileUtils.createDir(dbPath);
-        } catch (IOException e) {
-          LOG.warn("Failed to create nonexistent db path at: {}. Error:{}", dbPath, e);
-        }
+    List<ColumnFamilyDescriptor> columns =
+        Arrays.asList(new ColumnFamilyDescriptor(BLOCK_META_COLUMN.getBytes(), mCfOpts),
+            new ColumnFamilyDescriptor(BLOCK_LOCATIONS_COLUMN.getBytes(), mCfOpts));
+    String dbPath = PathUtils.concatPath(baseDir, BLOCKS_DB_NAME);
+    String backupPath = PathUtils.concatPath(baseDir, BLOCKS_DB_NAME + "-backups");
+    // Create block store db path if it does not exist.
+    if (!FileUtils.exists(dbPath)) {
+      try {
+        FileUtils.createDir(dbPath);
+      } catch (IOException e) {
+        LOG.warn("Failed to create nonexistent db path at: {}. Error:{}", dbPath, e);
       }
-      mRocksStore = new RocksStore("BlockStore", dbPath, backupPath, columns,
-              Arrays.asList(mBlockMetaColumn, mBlockLocationsColumn));
+    }
+    mRocksStore = new RocksStore("BlockStore", dbPath, backupPath, columns,
+        Arrays.asList(mBlockMetaColumn, mBlockLocationsColumn));
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -244,7 +244,7 @@ public class RocksInodeStore implements InodeStore {
    * @return an iterator over stored inodes
    */
   public Iterator<InodeView> iterator() {
-    // TODO(jiacheng): where is this iterator closed?
+    // TODO(jiacheng): close the iterator when we iterate the BlockStore for backup
     return RocksUtils.createIterator(db().newIterator(mInodesColumn.get(), mIteratorOption),
         (iter) -> getMutable(Longs.fromByteArray(iter.key()), ReadOption.defaults()).get());
   }
@@ -343,8 +343,7 @@ public class RocksInodeStore implements InodeStore {
    */
   public String toStringEntries() {
     StringBuilder sb = new StringBuilder();
-    try (
-        ReadOptions readOptions = new ReadOptions().setTotalOrderSeek(true);
+    try (ReadOptions readOptions = new ReadOptions().setTotalOrderSeek(true);
         RocksIterator inodeIter = db().newIterator(mInodesColumn.get(), readOptions)) {
       inodeIter.seekToFirst();
       while (inodeIter.isValid()) {

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -30,7 +30,6 @@ import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.CompressionType;
-import org.rocksdb.DBOptions;
 import org.rocksdb.HashLinkedListMemTableConfig;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
@@ -128,13 +128,11 @@ public final class RocksStore implements Closeable {
         });
         mDb.close();
         mCheckpoint.close();
-        mDbOpts.close();
       } catch (Throwable t) {
         LOG.error("Failed to close rocks database", t);
       }
       mDb = null;
       mCheckpoint = null;
-      mDbOpts = null;
     }
   }
 
@@ -227,6 +225,8 @@ public final class RocksStore implements Closeable {
   @Override
   public synchronized void close() {
     stopDb();
+    mDbOpts.close();
+    mDbOpts = null;
     LOG.info("Closed store at {}", mDbPath);
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
@@ -54,7 +54,7 @@ public final class RocksStore implements Closeable {
   private final String mDbPath;
   private final String mDbCheckpointPath;
   private final Collection<ColumnFamilyDescriptor> mColumnFamilyDescriptors;
-  private DBOptions mDbOpts;
+  private final DBOptions mDbOpts;
 
   private RocksDB mDb;
   private Checkpoint mCheckpoint;
@@ -227,7 +227,6 @@ public final class RocksStore implements Closeable {
   public synchronized void close() {
     stopDb();
     mDbOpts.close();
-    mDbOpts = null;
     LOG.info("Closed store at {}", mDbPath);
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
@@ -62,6 +62,7 @@ public final class RocksStore implements Closeable {
   private List<AtomicReference<ColumnFamilyHandle>> mColumnHandles;
 
   /**
+   * @param name a name to distinguish what store this is
    * @param dbPath a path for the rocks database
    * @param checkpointPath a path for taking database checkpoints
    * @param columnFamilyDescriptors columns to create within the rocks database

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksUtils.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksUtils.java
@@ -118,6 +118,7 @@ public final class RocksUtils {
       }
 
       @Override
+      // TODO(jiacheng): close this iterator properly on finish
       public T next() {
         try {
           return parser.next(rocksIterator);

--- a/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksStoreTest.java
@@ -23,7 +23,6 @@ import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.CompressionType;
-import org.rocksdb.DBOptions;
 import org.rocksdb.HashLinkedListMemTableConfig;
 import org.rocksdb.RocksDB;
 import org.rocksdb.WriteOptions;
@@ -63,7 +62,8 @@ public class RocksStoreTest {
 
     String newBbDir = mFolder.newFolder("rocks-new").getAbsolutePath();
     store =
-        new RocksStore("test-new", newBbDir, backupsDir, columnDescriptors, Arrays.asList(testColumn));
+        new RocksStore("test-new", newBbDir, backupsDir, columnDescriptors,
+            Arrays.asList(testColumn));
     store.restoreFromCheckpoint(
         new CheckpointInputStream(new ByteArrayInputStream(baos.toByteArray())));
     db = store.getDb();

--- a/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/rocks/RocksStoreTest.java
@@ -44,12 +44,6 @@ public class RocksStoreTest {
         .setMemTableConfig(new HashLinkedListMemTableConfig())
         .setCompressionType(CompressionType.NO_COMPRESSION)
         .useFixedLengthPrefixExtractor(Longs.BYTES); // We always search using the initial long key
-    DBOptions dbOpts = new DBOptions()
-        // Concurrent memtable write is not supported for hash linked list memtable
-        .setAllowConcurrentMemtableWrite(false)
-        .setMaxOpenFiles(-1)
-        .setCreateIfMissing(true)
-        .setCreateMissingColumnFamilies(true);
 
     List<ColumnFamilyDescriptor> columnDescriptors =
         Arrays.asList(new ColumnFamilyDescriptor("test".getBytes(), cfOpts));
@@ -57,7 +51,7 @@ public class RocksStoreTest {
     String backupsDir = mFolder.newFolder("rocks-backups").getAbsolutePath();
     AtomicReference<ColumnFamilyHandle> testColumn = new AtomicReference<>();
     RocksStore store =
-        new RocksStore(dbDir, backupsDir, columnDescriptors, dbOpts, Arrays.asList(testColumn));
+        new RocksStore("test", dbDir, backupsDir, columnDescriptors, Arrays.asList(testColumn));
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     RocksDB db = store.getDb();
     int count = 10;
@@ -69,7 +63,7 @@ public class RocksStoreTest {
 
     String newBbDir = mFolder.newFolder("rocks-new").getAbsolutePath();
     store =
-        new RocksStore(newBbDir, backupsDir, columnDescriptors, dbOpts, Arrays.asList(testColumn));
+        new RocksStore("test-new", newBbDir, backupsDir, columnDescriptors, Arrays.asList(testColumn));
     store.restoreFromCheckpoint(
         new CheckpointInputStream(new ByteArrayInputStream(baos.toByteArray())));
     db = store.getDb();


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fixes https://github.com/facebook/rocksdb/issues/9378
The `orgs.rocksdb.RocksObject` extends `AutoCloseable` so they should be closed properly to avoid leaks. 

### Why are the changes needed?

According to the [RocksDB documentation](https://github.com/facebook/rocksdb/wiki/RocksJava-Basics#memory-management) and a sample [PR discussion](https://github.com/facebook/rocksdb/pull/7608#discussion_r515159270), the objects need to be closed or wrapped in a try-with-resource block.

### Does this PR introduce any user facing changes?

NA
