### PR TITLE
Fix warning on failed dir deletion after running a Spark job

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -261,7 +261,7 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
       mFileSystem.delete(uri, options);
       return true;
     } catch (InvalidPathException | FileDoesNotExistException e) {
-      LOG.warn("delete failed: {}", e.toString());
+      LOG.debug("delete failed: {}", e.toString());
       return false;
     } catch (AlluxioException e) {
       throw new IOException(e);


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix #10365

Before:
![1f9d93c15336b6aa6826da417d83fcc](https://user-images.githubusercontent.com/3060835/149722770-f6a6a575-98bd-465a-908e-d3ff965ff8c9.png)
After:
![e3794c7f2893bf3d41119d04c58e2bb](https://user-images.githubusercontent.com/3060835/149722809-fbd6c6f4-9f06-4bd6-b05f-d6301acf9bd6.png)
And I find that staging path also didn't exist with writing directly to hdfs.

### Why are the changes needed?
See #10365 

### Does this PR introduce any user facing changes?
No
