### PR TITLE
Add timeout for waitForJobStatus in DistributedCommandsCancelStatsTest

### DIFF
--- a/tests/src/test/java/alluxio/client/cli/job/DistributedCommandsCancelStatsTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/DistributedCommandsCancelStatsTest.java
@@ -43,6 +43,8 @@ import java.util.Collections;
  * The tests compare the job statuses (CANCEL or not) and stat counter values for each status.
  */
 public class DistributedCommandsCancelStatsTest extends JobShellTest {
+  static final int TEST_TIMEOUT = 45;
+
   @ClassRule
   public static LocalAlluxioClusterResource sResource =
       new LocalAlluxioClusterResource.Builder()
@@ -80,7 +82,7 @@ public class DistributedCommandsCancelStatsTest extends JobShellTest {
     sJobShell.run("cancel", Long.toString(jobId));
 
     JobTestUtils
-        .waitForJobStatus(sJobMaster, jobId, Sets.newHashSet(Status.CANCELED), 45);
+        .waitForJobStatus(sJobMaster, jobId, Sets.newHashSet(Status.CANCELED), TEST_TIMEOUT);
 
     sJobShell.run("stat", "-v", Long.toString(jobId));
 
@@ -125,7 +127,7 @@ public class DistributedCommandsCancelStatsTest extends JobShellTest {
     sJobShell.run("cancel", Long.toString(jobId));
 
     JobTestUtils
-            .waitForJobStatus(sJobMaster, jobId, Sets.newHashSet(Status.CANCELED), 45);
+            .waitForJobStatus(sJobMaster, jobId, Sets.newHashSet(Status.CANCELED), TEST_TIMEOUT);
 
     sJobShell.run("stat", "-v", Long.toString(jobId));
 
@@ -167,7 +169,7 @@ public class DistributedCommandsCancelStatsTest extends JobShellTest {
     sJobShell.run("cancel", Long.toString(jobId));
 
     JobTestUtils
-            .waitForJobStatus(sJobMaster, jobId, Sets.newHashSet(Status.CANCELED), 45);
+            .waitForJobStatus(sJobMaster, jobId, Sets.newHashSet(Status.CANCELED), TEST_TIMEOUT);
 
     sJobShell.run("stat", "-v", Long.toString(jobId));
 

--- a/tests/src/test/java/alluxio/client/cli/job/DistributedCommandsCancelStatsTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/DistributedCommandsCancelStatsTest.java
@@ -80,7 +80,7 @@ public class DistributedCommandsCancelStatsTest extends JobShellTest {
     sJobShell.run("cancel", Long.toString(jobId));
 
     JobTestUtils
-        .waitForJobStatus(sJobMaster, jobId, Sets.newHashSet(Status.CANCELED));
+        .waitForJobStatus(sJobMaster, jobId, Sets.newHashSet(Status.CANCELED), 45);
 
     sJobShell.run("stat", "-v", Long.toString(jobId));
 
@@ -125,7 +125,7 @@ public class DistributedCommandsCancelStatsTest extends JobShellTest {
     sJobShell.run("cancel", Long.toString(jobId));
 
     JobTestUtils
-            .waitForJobStatus(sJobMaster, jobId, Sets.newHashSet(Status.CANCELED));
+            .waitForJobStatus(sJobMaster, jobId, Sets.newHashSet(Status.CANCELED), 45);
 
     sJobShell.run("stat", "-v", Long.toString(jobId));
 
@@ -167,7 +167,7 @@ public class DistributedCommandsCancelStatsTest extends JobShellTest {
     sJobShell.run("cancel", Long.toString(jobId));
 
     JobTestUtils
-            .waitForJobStatus(sJobMaster, jobId, Sets.newHashSet(Status.CANCELED));
+            .waitForJobStatus(sJobMaster, jobId, Sets.newHashSet(Status.CANCELED), 45);
 
     sJobShell.run("stat", "-v", Long.toString(jobId));
 


### PR DESCRIPTION
### What changes are proposed in this pull request?
Add timeout for waitForJobStatus in DistributedCommandsCancelStatsTest

### Why are the changes needed?
Add adjustable timeout for the test, some test jobs need to have longer timeouts.

