### PR TITLE
Update protolock plugin

### DIFF
--- a/core/transport/pom.xml
+++ b/core/transport/pom.xml
@@ -138,7 +138,7 @@
         <groupId>com.salesforce.servicelibs</groupId>
         <artifactId>proto-backwards-compatibility</artifactId>
         <configuration>
-          <protoSourceRoot>${basedir}/target/classes/</protoSourceRoot>
+          <protoSourceRoot>${basedir}/src/main/proto</protoSourceRoot>
         </configuration>
         <executions>
           <execution>

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -1,0 +1,9519 @@
+{
+  "definitions": [
+    {
+      "protopath": "grpc:/:block_master.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "BlockMasterInfoField",
+            "enum_fields": [
+              {
+                "name": "CAPACITY_BYTES",
+                "integer": 1
+              },
+              {
+                "name": "CAPACITY_BYTES_ON_TIERS",
+                "integer": 2
+              },
+              {
+                "name": "FREE_BYTES",
+                "integer": 3
+              },
+              {
+                "name": "LIVE_WORKER_NUM",
+                "integer": 4
+              },
+              {
+                "name": "LOST_WORKER_NUM",
+                "integer": 5
+              },
+              {
+                "name": "USED_BYTES",
+                "integer": 6
+              },
+              {
+                "name": "USED_BYTES_ON_TIERS",
+                "integer": 7
+              }
+            ]
+          },
+          {
+            "name": "WorkerRange",
+            "enum_fields": [
+              {
+                "name": "ALL",
+                "integer": 1
+              },
+              {
+                "name": "LIVE",
+                "integer": 2
+              },
+              {
+                "name": "LOST",
+                "integer": 3
+              },
+              {
+                "name": "SPECIFIED",
+                "integer": 4
+              }
+            ]
+          },
+          {
+            "name": "WorkerInfoField",
+            "enum_fields": [
+              {
+                "name": "ADDRESS",
+                "integer": 1
+              },
+              {
+                "name": "WORKER_CAPACITY_BYTES",
+                "integer": 2
+              },
+              {
+                "name": "WORKER_CAPACITY_BYTES_ON_TIERS",
+                "integer": 3
+              },
+              {
+                "name": "ID",
+                "integer": 4
+              },
+              {
+                "name": "LAST_CONTACT_SEC",
+                "integer": 5
+              },
+              {
+                "name": "START_TIME_MS",
+                "integer": 6
+              },
+              {
+                "name": "STATE",
+                "integer": 7
+              },
+              {
+                "name": "WORKER_USED_BYTES",
+                "integer": 8
+              },
+              {
+                "name": "WORKER_USED_BYTES_ON_TIERS",
+                "integer": 9
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "BlockMasterInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "capacityBytes",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "freeBytes",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "liveWorkerNum",
+                "type": "int32"
+              },
+              {
+                "id": 5,
+                "name": "lostWorkerNum",
+                "type": "int32"
+              },
+              {
+                "id": 6,
+                "name": "usedBytes",
+                "type": "int64"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "capacityBytesOnTiers",
+                  "type": "int64"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 7,
+                  "name": "usedBytesOnTiers",
+                  "type": "int64"
+                }
+              }
+            ]
+          },
+          {
+            "name": "GetBlockInfoPOptions"
+          },
+          {
+            "name": "GetBlockInfoPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "GetBlockInfoPOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetBlockInfoPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockInfo",
+                "type": "grpc.BlockInfo"
+              }
+            ]
+          },
+          {
+            "name": "GetCapacityBytesPOptions"
+          },
+          {
+            "name": "GetCapacityBytesPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "bytes",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "GetBlockMasterInfoPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "filters",
+                "type": "BlockMasterInfoField",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "GetBlockMasterInfoPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockMasterInfo",
+                "type": "BlockMasterInfo"
+              }
+            ]
+          },
+          {
+            "name": "GetUsedBytesPOptions"
+          },
+          {
+            "name": "GetUsedBytesPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "bytes",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "WorkerInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "address",
+                "type": "grpc.WorkerNetAddress"
+              },
+              {
+                "id": 3,
+                "name": "lastContactSec",
+                "type": "int32"
+              },
+              {
+                "id": 4,
+                "name": "state",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "capacityBytes",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "usedBytes",
+                "type": "int64"
+              },
+              {
+                "id": 7,
+                "name": "startTimeMs",
+                "type": "int64"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 8,
+                  "name": "capacityBytesOnTiers",
+                  "type": "int64"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 9,
+                  "name": "usedBytesOnTiers",
+                  "type": "int64"
+                }
+              }
+            ]
+          },
+          {
+            "name": "GetWorkerReportPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "addresses",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "fieldRanges",
+                "type": "WorkerInfoField",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "workerRange",
+                "type": "WorkerRange"
+              }
+            ]
+          },
+          {
+            "name": "GetWorkerInfoListPOptions"
+          },
+          {
+            "name": "GetWorkerInfoListPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerInfos",
+                "type": "WorkerInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "WorkerLostStorageInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "address",
+                "type": "grpc.WorkerNetAddress"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "lostStorage",
+                  "type": "StorageList"
+                }
+              }
+            ]
+          },
+          {
+            "name": "GetWorkerLostStoragePOptions"
+          },
+          {
+            "name": "GetWorkerLostStoragePResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerLostStorageInfo",
+                "type": "WorkerLostStorageInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "TierList",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tiers",
+                "type": "int64",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "BlockIdList",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockId",
+                "type": "int64",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "StorageList",
+            "fields": [
+              {
+                "id": 1,
+                "name": "storage",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "BlockHeartbeatPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "metrics",
+                "type": "grpc.Metric",
+                "is_repeated": true
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "capacityBytesOnTiers",
+                  "type": "int64"
+                }
+              }
+            ]
+          },
+          {
+            "name": "LocationBlockIdListEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "key",
+                "type": "BlockStoreLocationProto"
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "BlockIdList"
+              }
+            ]
+          },
+          {
+            "name": "BlockHeartbeatPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerId",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "removedBlockIds",
+                "type": "int64",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "options",
+                "type": "BlockHeartbeatPOptions"
+              },
+              {
+                "id": 7,
+                "name": "addedBlocks",
+                "type": "LocationBlockIdListEntry",
+                "is_repeated": true
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "usedBytesOnTiers",
+                  "type": "int64"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 4,
+                  "name": "addedBlocksOnTiers",
+                  "type": "TierList"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 6,
+                  "name": "lostStorage",
+                  "type": "StorageList"
+                }
+              }
+            ]
+          },
+          {
+            "name": "BlockHeartbeatPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "command",
+                "type": "grpc.Command"
+              }
+            ]
+          },
+          {
+            "name": "CommitBlockPResponse"
+          },
+          {
+            "name": "CommitBlockPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "usedBytesOnTier",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "tierAlias",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "blockId",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "length",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "options",
+                "type": "CommitBlockPOptions"
+              },
+              {
+                "id": 7,
+                "name": "mediumType",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "CommitBlockPOptions"
+          },
+          {
+            "name": "CommitBlockInUfsPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "length",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "options",
+                "type": "CommitBlockInUfsPOptions"
+              }
+            ]
+          },
+          {
+            "name": "CommitBlockInUfsPOptions"
+          },
+          {
+            "name": "CommitBlockInUfsPResponse"
+          },
+          {
+            "name": "GetWorkerIdPOptions"
+          },
+          {
+            "name": "GetWorkerIdPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerNetAddress",
+                "type": "grpc.WorkerNetAddress"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "GetWorkerIdPOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetWorkerIdPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerId",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "GetRegisterLeasePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "blockCount",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "GetRegisterLeasePOptions"
+          },
+          {
+            "name": "GetRegisterLeasePResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "allowed",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "expiryMs",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "options",
+                "type": "GetRegisterLeasePOptions"
+              }
+            ]
+          },
+          {
+            "name": "RegisterWorkerPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "configs",
+                "type": "grpc.ConfigProperty",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "RegisterWorkerPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "storageTiers",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "options",
+                "type": "RegisterWorkerPOptions"
+              },
+              {
+                "id": 8,
+                "name": "currentBlocks",
+                "type": "LocationBlockIdListEntry",
+                "is_repeated": true
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 3,
+                  "name": "totalBytesOnTiers",
+                  "type": "int64"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 4,
+                  "name": "usedBytesOnTiers",
+                  "type": "int64"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 5,
+                  "name": "currentBlocksOnTiers",
+                  "type": "TierList"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 7,
+                  "name": "lostStorage",
+                  "type": "StorageList"
+                }
+              }
+            ]
+          },
+          {
+            "name": "RegisterWorkerPResponse"
+          }
+        ],
+        "services": [
+          {
+            "name": "BlockMasterClientService",
+            "rpcs": [
+              {
+                "name": "GetBlockInfo",
+                "in_type": "GetBlockInfoPRequest",
+                "out_type": "GetBlockInfoPResponse"
+              },
+              {
+                "name": "GetBlockMasterInfo",
+                "in_type": "GetBlockMasterInfoPOptions",
+                "out_type": "GetBlockMasterInfoPResponse"
+              },
+              {
+                "name": "GetCapacityBytes",
+                "in_type": "GetCapacityBytesPOptions",
+                "out_type": "GetCapacityBytesPResponse"
+              },
+              {
+                "name": "GetUsedBytes",
+                "in_type": "GetUsedBytesPOptions",
+                "out_type": "GetUsedBytesPResponse"
+              },
+              {
+                "name": "GetWorkerInfoList",
+                "in_type": "GetWorkerInfoListPOptions",
+                "out_type": "GetWorkerInfoListPResponse"
+              },
+              {
+                "name": "GetWorkerReport",
+                "in_type": "GetWorkerReportPOptions",
+                "out_type": "GetWorkerInfoListPResponse"
+              },
+              {
+                "name": "GetWorkerLostStorage",
+                "in_type": "GetWorkerLostStoragePOptions",
+                "out_type": "GetWorkerLostStoragePResponse"
+              }
+            ]
+          },
+          {
+            "name": "BlockMasterWorkerService",
+            "rpcs": [
+              {
+                "name": "BlockHeartbeat",
+                "in_type": "BlockHeartbeatPRequest",
+                "out_type": "BlockHeartbeatPResponse"
+              },
+              {
+                "name": "CommitBlock",
+                "in_type": "CommitBlockPRequest",
+                "out_type": "CommitBlockPResponse"
+              },
+              {
+                "name": "CommitBlockInUfs",
+                "in_type": "CommitBlockInUfsPRequest",
+                "out_type": "CommitBlockInUfsPResponse"
+              },
+              {
+                "name": "GetWorkerId",
+                "in_type": "GetWorkerIdPRequest",
+                "out_type": "GetWorkerIdPResponse"
+              },
+              {
+                "name": "RegisterWorker",
+                "in_type": "RegisterWorkerPRequest",
+                "out_type": "RegisterWorkerPResponse"
+              },
+              {
+                "name": "RegisterWorkerStream",
+                "in_type": "RegisterWorkerPRequest",
+                "out_type": "RegisterWorkerPResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              },
+              {
+                "name": "RequestRegisterLease",
+                "in_type": "GetRegisterLeasePRequest",
+                "out_type": "GetRegisterLeasePResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "grpc/common.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc.block"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "BlockMasterProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "grpc:/:block_worker.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "RequestType",
+            "enum_fields": [
+              {
+                "name": "ALLUXIO_BLOCK"
+              },
+              {
+                "name": "UFS_FILE",
+                "integer": 1
+              },
+              {
+                "name": "UFS_FALLBACK_BLOCK",
+                "integer": 2
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "CheckRequest"
+          },
+          {
+            "name": "CheckResponse"
+          },
+          {
+            "name": "Chunk",
+            "fields": [
+              {
+                "id": 1,
+                "name": "data",
+                "type": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "ReadRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "block_id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "offset",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "length",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "promote",
+                "type": "bool"
+              },
+              {
+                "id": 5,
+                "name": "chunk_size",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "open_ufs_block_options",
+                "type": "alluxio.proto.dataserver.OpenUfsBlockOptions"
+              },
+              {
+                "id": 7,
+                "name": "offset_received",
+                "type": "int64"
+              },
+              {
+                "id": 8,
+                "name": "position_short",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "ReadResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "chunk",
+                "type": "Chunk"
+              }
+            ]
+          },
+          {
+            "name": "WriteRequestCommand",
+            "fields": [
+              {
+                "id": 1,
+                "name": "type",
+                "type": "RequestType"
+              },
+              {
+                "id": 2,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "offset",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "tier",
+                "type": "int32"
+              },
+              {
+                "id": 5,
+                "name": "flush",
+                "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "create_ufs_file_options",
+                "type": "alluxio.proto.dataserver.CreateUfsFileOptions"
+              },
+              {
+                "id": 7,
+                "name": "create_ufs_block_options",
+                "type": "alluxio.proto.dataserver.CreateUfsBlockOptions"
+              },
+              {
+                "id": 8,
+                "name": "medium_type",
+                "type": "string"
+              },
+              {
+                "id": 9,
+                "name": "pin_on_create",
+                "type": "bool"
+              },
+              {
+                "id": 10,
+                "name": "space_to_reserve",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "WriteRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "command",
+                "type": "WriteRequestCommand"
+              },
+              {
+                "id": 2,
+                "name": "chunk",
+                "type": "Chunk"
+              }
+            ]
+          },
+          {
+            "name": "WriteResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "offset",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "AsyncCacheRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "block_id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "source_host",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "source_port",
+                "type": "int32"
+              },
+              {
+                "id": 4,
+                "name": "open_ufs_block_options",
+                "type": "alluxio.proto.dataserver.OpenUfsBlockOptions"
+              },
+              {
+                "id": 5,
+                "name": "length",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "CacheRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "block_id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "source_host",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "source_port",
+                "type": "int32"
+              },
+              {
+                "id": 4,
+                "name": "open_ufs_block_options",
+                "type": "alluxio.proto.dataserver.OpenUfsBlockOptions"
+              },
+              {
+                "id": 5,
+                "name": "length",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "async",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "AsyncCacheResponse"
+          },
+          {
+            "name": "CacheResponse"
+          },
+          {
+            "name": "OpenLocalBlockRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "block_id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "promote",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "OpenLocalBlockResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "CreateLocalBlockRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "block_id",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "tier",
+                "type": "int32"
+              },
+              {
+                "id": 4,
+                "name": "space_to_reserve",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "only_reserve_space",
+                "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "cleanup_on_failure",
+                "type": "bool"
+              },
+              {
+                "id": 7,
+                "name": "medium_type",
+                "type": "string"
+              },
+              {
+                "id": 8,
+                "name": "pin_on_create",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "CreateLocalBlockResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "RemoveBlockRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "block_id",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "RemoveBlockResponse"
+          },
+          {
+            "name": "MoveBlockRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "block_id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "medium_type",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "MoveBlockResponse"
+          },
+          {
+            "name": "ClearMetricsRequest"
+          },
+          {
+            "name": "ClearMetricsResponse"
+          }
+        ],
+        "services": [
+          {
+            "name": "BlockWorker",
+            "rpcs": [
+              {
+                "name": "ReadBlock",
+                "in_type": "ReadRequest",
+                "out_type": "ReadResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              },
+              {
+                "name": "WriteBlock",
+                "in_type": "WriteRequest",
+                "out_type": "WriteResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              },
+              {
+                "name": "OpenLocalBlock",
+                "in_type": "OpenLocalBlockRequest",
+                "out_type": "OpenLocalBlockResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              },
+              {
+                "name": "CreateLocalBlock",
+                "in_type": "CreateLocalBlockRequest",
+                "out_type": "CreateLocalBlockResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              },
+              {
+                "name": "AsyncCache",
+                "in_type": "AsyncCacheRequest",
+                "out_type": "AsyncCacheResponse"
+              },
+              {
+                "name": "Cache",
+                "in_type": "CacheRequest",
+                "out_type": "CacheResponse"
+              },
+              {
+                "name": "RemoveBlock",
+                "in_type": "RemoveBlockRequest",
+                "out_type": "RemoveBlockResponse"
+              },
+              {
+                "name": "MoveBlock",
+                "in_type": "MoveBlockRequest",
+                "out_type": "MoveBlockResponse"
+              },
+              {
+                "name": "ClearMetrics",
+                "in_type": "ClearMetricsRequest",
+                "out_type": "ClearMetricsResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "proto/dataserver/protocol.proto"
+          },
+          {
+            "path": "grpc/common.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc.block"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "BlockWorkerProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "grpc:/:common.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "Bits",
+            "enum_fields": [
+              {
+                "name": "NONE",
+                "integer": 1
+              },
+              {
+                "name": "EXECUTE",
+                "integer": 2
+              },
+              {
+                "name": "WRITE",
+                "integer": 3
+              },
+              {
+                "name": "WRITE_EXECUTE",
+                "integer": 4
+              },
+              {
+                "name": "READ",
+                "integer": 5
+              },
+              {
+                "name": "READ_EXECUTE",
+                "integer": 6
+              },
+              {
+                "name": "READ_WRITE",
+                "integer": 7
+              },
+              {
+                "name": "ALL",
+                "integer": 8
+              }
+            ]
+          },
+          {
+            "name": "MetricType",
+            "enum_fields": [
+              {
+                "name": "GAUGE"
+              },
+              {
+                "name": "COUNTER",
+                "integer": 1
+              },
+              {
+                "name": "METER",
+                "integer": 2
+              },
+              {
+                "name": "TIMER",
+                "integer": 3
+              }
+            ]
+          },
+          {
+            "name": "CommandType",
+            "enum_fields": [
+              {
+                "name": "Unknown"
+              },
+              {
+                "name": "Nothing",
+                "integer": 1
+              },
+              {
+                "name": "Register",
+                "integer": 2
+              },
+              {
+                "name": "Free",
+                "integer": 3
+              },
+              {
+                "name": "Delete",
+                "integer": 4
+              },
+              {
+                "name": "Persist",
+                "integer": 5
+              }
+            ]
+          },
+          {
+            "name": "TtlAction",
+            "enum_fields": [
+              {
+                "name": "DELETE"
+              },
+              {
+                "name": "FREE",
+                "integer": 1
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "PMode",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ownerBits",
+                "type": "Bits"
+              },
+              {
+                "id": 2,
+                "name": "groupBits",
+                "type": "Bits"
+              },
+              {
+                "id": 3,
+                "name": "otherBits",
+                "type": "Bits"
+              }
+            ]
+          },
+          {
+            "name": "BlockInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "length",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "locations",
+                "type": "BlockLocation",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "BlockLocation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "workerAddress",
+                "type": "WorkerNetAddress"
+              },
+              {
+                "id": 3,
+                "name": "tierAlias",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "mediumType",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Metric",
+            "fields": [
+              {
+                "id": 1,
+                "name": "instance",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "source",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "value",
+                "type": "double"
+              },
+              {
+                "id": 5,
+                "name": "metricType",
+                "type": "MetricType"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 6,
+                  "name": "tags",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "ConfigProperty",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "source",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Command",
+            "fields": [
+              {
+                "id": 1,
+                "name": "commandType",
+                "type": "CommandType"
+              },
+              {
+                "id": 2,
+                "name": "data",
+                "type": "int64",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "LocalityTier",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tierName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "TieredIdentity",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tiers",
+                "type": "LocalityTier",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "NetAddress",
+            "fields": [
+              {
+                "id": 1,
+                "name": "host",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "rpcPort",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "WorkerNetAddress",
+            "fields": [
+              {
+                "id": 1,
+                "name": "host",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "rpcPort",
+                "type": "int32"
+              },
+              {
+                "id": 3,
+                "name": "dataPort",
+                "type": "int32"
+              },
+              {
+                "id": 4,
+                "name": "webPort",
+                "type": "int32"
+              },
+              {
+                "id": 5,
+                "name": "domainSocketPath",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "tieredIdentity",
+                "type": "TieredIdentity"
+              },
+              {
+                "id": 7,
+                "name": "containerHost",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "BlockStoreLocationProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tierAlias",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "mediumType",
+                "type": "string"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "CommonProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "grpc:/:file_system_master.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "WritePType",
+            "enum_fields": [
+              {
+                "name": "MUST_CACHE",
+                "integer": 1
+              },
+              {
+                "name": "TRY_CACHE",
+                "integer": 2
+              },
+              {
+                "name": "CACHE_THROUGH",
+                "integer": 3
+              },
+              {
+                "name": "THROUGH",
+                "integer": 4
+              },
+              {
+                "name": "ASYNC_THROUGH",
+                "integer": 5
+              },
+              {
+                "name": "NONE",
+                "integer": 6
+              }
+            ]
+          },
+          {
+            "name": "ReadPType",
+            "enum_fields": [
+              {
+                "name": "NO_CACHE",
+                "integer": 1
+              },
+              {
+                "name": "CACHE",
+                "integer": 2
+              },
+              {
+                "name": "CACHE_PROMOTE",
+                "integer": 3
+              }
+            ]
+          },
+          {
+            "name": "LoadMetadataPType",
+            "enum_fields": [
+              {
+                "name": "NEVER"
+              },
+              {
+                "name": "ONCE",
+                "integer": 1
+              },
+              {
+                "name": "ALWAYS",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "SyncPointStatus",
+            "enum_fields": [
+              {
+                "name": "Not_Initially_Synced"
+              },
+              {
+                "name": "Syncing",
+                "integer": 1
+              },
+              {
+                "name": "Initially_Synced",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "PAclEntryType",
+            "enum_fields": [
+              {
+                "name": "Owner"
+              },
+              {
+                "name": "NamedUser",
+                "integer": 1
+              },
+              {
+                "name": "OwningGroup",
+                "integer": 2
+              },
+              {
+                "name": "NamedGroup",
+                "integer": 3
+              },
+              {
+                "name": "Mask",
+                "integer": 4
+              },
+              {
+                "name": "Other",
+                "integer": 5
+              }
+            ]
+          },
+          {
+            "name": "PAclAction",
+            "enum_fields": [
+              {
+                "name": "Read"
+              },
+              {
+                "name": "Write",
+                "integer": 1
+              },
+              {
+                "name": "Execute",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "SetAclAction",
+            "enum_fields": [
+              {
+                "name": "REPLACE"
+              },
+              {
+                "name": "MODIFY",
+                "integer": 1
+              },
+              {
+                "name": "REMOVE",
+                "integer": 2
+              },
+              {
+                "name": "REMOVE_ALL",
+                "integer": 3
+              },
+              {
+                "name": "REMOVE_DEFAULT",
+                "integer": 4
+              }
+            ]
+          },
+          {
+            "name": "UfsPMode",
+            "enum_fields": [
+              {
+                "name": "NO_ACCESS",
+                "integer": 1
+              },
+              {
+                "name": "READ_ONLY",
+                "integer": 2
+              },
+              {
+                "name": "READ_WRITE",
+                "integer": 3
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "FsOpPId",
+            "fields": [
+              {
+                "id": 1,
+                "name": "mostSignificantBits",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "leastSignificantBits",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "FileSystemMasterCommonPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "syncIntervalMs",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "ttl",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "ttlAction",
+                "type": "grpc.TtlAction"
+              },
+              {
+                "id": 4,
+                "name": "operationId",
+                "type": "FsOpPId"
+              }
+            ]
+          },
+          {
+            "name": "CheckAccessPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "CheckAccessPOptions"
+              }
+            ]
+          },
+          {
+            "name": "CheckAccessPResponse"
+          },
+          {
+            "name": "CheckAccessPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "bits",
+                "type": "Bits"
+              },
+              {
+                "id": 2,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              }
+            ]
+          },
+          {
+            "name": "CheckConsistencyPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "inconsistentPaths",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "CheckConsistencyPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              }
+            ]
+          },
+          {
+            "name": "CheckConsistencyPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "CheckConsistencyPOptions"
+              }
+            ]
+          },
+          {
+            "name": "CompleteFilePResponse"
+          },
+          {
+            "name": "CompleteFilePOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ufsLength",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "asyncPersistOptions",
+                "type": "ScheduleAsyncPersistencePOptions"
+              },
+              {
+                "id": 3,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              }
+            ]
+          },
+          {
+            "name": "CompleteFilePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "CompleteFilePOptions"
+              }
+            ]
+          },
+          {
+            "name": "OpenFilePOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "readType",
+                "type": "ReadPType"
+              },
+              {
+                "id": 2,
+                "name": "maxUfsReadConcurrency",
+                "type": "int32"
+              },
+              {
+                "id": 3,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              },
+              {
+                "id": 4,
+                "name": "updateLastAccessTime",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "true"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "CreateDirectoryPResponse"
+          },
+          {
+            "name": "CreateDirectoryPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "recursive",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "allowExists",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "mode",
+                "type": "PMode"
+              },
+              {
+                "id": 4,
+                "name": "writeType",
+                "type": "WritePType"
+              },
+              {
+                "id": 5,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              }
+            ]
+          },
+          {
+            "name": "CreateDirectoryPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "CreateDirectoryPOptions"
+              }
+            ]
+          },
+          {
+            "name": "CreateFilePResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "fileInfo",
+                "type": "FileInfo"
+              }
+            ]
+          },
+          {
+            "name": "CreateFilePOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockSizeBytes",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "recursive",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "mode",
+                "type": "PMode"
+              },
+              {
+                "id": 4,
+                "name": "replicationMax",
+                "type": "int32"
+              },
+              {
+                "id": 5,
+                "name": "replicationMin",
+                "type": "int32"
+              },
+              {
+                "id": 6,
+                "name": "replicationDurable",
+                "type": "int32"
+              },
+              {
+                "id": 7,
+                "name": "writeTier",
+                "type": "int32"
+              },
+              {
+                "id": 8,
+                "name": "writeType",
+                "type": "WritePType"
+              },
+              {
+                "id": 9,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              },
+              {
+                "id": 10,
+                "name": "persistenceWaitTime",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "CreateFilePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "CreateFilePOptions"
+              }
+            ]
+          },
+          {
+            "name": "DeletePResponse"
+          },
+          {
+            "name": "DeletePOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "recursive",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "alluxioOnly",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "unchecked",
+                "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              }
+            ]
+          },
+          {
+            "name": "DeletePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "DeletePOptions"
+              }
+            ]
+          },
+          {
+            "name": "FreePResponse"
+          },
+          {
+            "name": "FreePOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "recursive",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "forced",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              }
+            ]
+          },
+          {
+            "name": "FreePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "FreePOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetNewBlockIdForFilePResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "GetNewBlockIdForFilePOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetNewBlockIdForFilePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "GetNewBlockIdForFilePOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetStatusPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "fileInfo",
+                "type": "FileInfo"
+              }
+            ]
+          },
+          {
+            "name": "GetStatusPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "loadMetadataType",
+                "type": "LoadMetadataPType"
+              },
+              {
+                "id": 2,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              },
+              {
+                "id": 3,
+                "name": "accessMode",
+                "type": "Bits"
+              },
+              {
+                "id": 4,
+                "name": "updateTimestamps",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "true"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "GetStatusPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "GetStatusPOptions"
+              }
+            ]
+          },
+          {
+            "name": "ExistsPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "loadMetadataType",
+                "type": "LoadMetadataPType"
+              },
+              {
+                "id": 2,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              }
+            ]
+          },
+          {
+            "name": "SyncPointInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "syncPointUri",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "syncStatus",
+                "type": "SyncPointStatus"
+              }
+            ]
+          },
+          {
+            "name": "GetSyncPathListPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "syncPaths",
+                "type": "SyncPointInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "GetSyncPathListPRequest"
+          },
+          {
+            "name": "ListStatusPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "fileInfos",
+                "type": "FileInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ListStatusPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "loadDirectChildren",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "loadMetadataType",
+                "type": "LoadMetadataPType"
+              },
+              {
+                "id": 3,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              },
+              {
+                "id": 4,
+                "name": "recursive",
+                "type": "bool"
+              },
+              {
+                "id": 5,
+                "name": "loadMetadataOnly",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "ListStatusPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "ListStatusPOptions"
+              }
+            ]
+          },
+          {
+            "name": "LoadMetadataPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "recursive",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "createAncestors",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "loadDescendantType",
+                "type": "fscommon.LoadDescendantPType"
+              },
+              {
+                "id": 4,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              },
+              {
+                "id": 5,
+                "name": "loadType",
+                "type": "LoadMetadataPType"
+              }
+            ]
+          },
+          {
+            "name": "PAclEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "type",
+                "type": "PAclEntryType"
+              },
+              {
+                "id": 2,
+                "name": "subject",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "actions",
+                "type": "PAclAction",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "isDefault",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "PAcl",
+            "fields": [
+              {
+                "id": 1,
+                "name": "owner",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "owningGroup",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "entries",
+                "type": "PAclEntry",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "mode",
+                "type": "int32"
+              },
+              {
+                "id": 5,
+                "name": "isDefault",
+                "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "isDefaultEmpty",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "FileBlockInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockInfo",
+                "type": "grpc.BlockInfo"
+              },
+              {
+                "id": 2,
+                "name": "offset",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "ufsLocations",
+                "type": "grpc.WorkerNetAddress",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "ufsStringLocations",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "FileInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "fileId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "ufsPath",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "length",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "blockSizeBytes",
+                "type": "int64"
+              },
+              {
+                "id": 7,
+                "name": "creationTimeMs",
+                "type": "int64"
+              },
+              {
+                "id": 8,
+                "name": "completed",
+                "type": "bool"
+              },
+              {
+                "id": 9,
+                "name": "folder",
+                "type": "bool"
+              },
+              {
+                "id": 10,
+                "name": "pinned",
+                "type": "bool"
+              },
+              {
+                "id": 11,
+                "name": "cacheable",
+                "type": "bool"
+              },
+              {
+                "id": 12,
+                "name": "persisted",
+                "type": "bool"
+              },
+              {
+                "id": 13,
+                "name": "blockIds",
+                "type": "int64",
+                "is_repeated": true
+              },
+              {
+                "id": 14,
+                "name": "lastModificationTimeMs",
+                "type": "int64"
+              },
+              {
+                "id": 15,
+                "name": "ttl",
+                "type": "int64"
+              },
+              {
+                "id": 16,
+                "name": "owner",
+                "type": "string"
+              },
+              {
+                "id": 17,
+                "name": "group",
+                "type": "string"
+              },
+              {
+                "id": 18,
+                "name": "mode",
+                "type": "int32"
+              },
+              {
+                "id": 19,
+                "name": "persistenceState",
+                "type": "string"
+              },
+              {
+                "id": 20,
+                "name": "mountPoint",
+                "type": "bool"
+              },
+              {
+                "id": 21,
+                "name": "fileBlockInfos",
+                "type": "FileBlockInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 22,
+                "name": "ttlAction",
+                "type": "grpc.TtlAction"
+              },
+              {
+                "id": 23,
+                "name": "mountId",
+                "type": "int64"
+              },
+              {
+                "id": 24,
+                "name": "inAlluxioPercentage",
+                "type": "int32"
+              },
+              {
+                "id": 25,
+                "name": "inMemoryPercentage",
+                "type": "int32"
+              },
+              {
+                "id": 26,
+                "name": "ufsFingerprint",
+                "type": "string"
+              },
+              {
+                "id": 27,
+                "name": "acl",
+                "type": "PAcl"
+              },
+              {
+                "id": 28,
+                "name": "defaultAcl",
+                "type": "PAcl"
+              },
+              {
+                "id": 29,
+                "name": "replicationMax",
+                "type": "int32"
+              },
+              {
+                "id": 30,
+                "name": "replicationMin",
+                "type": "int32"
+              },
+              {
+                "id": 31,
+                "name": "lastAccessTimeMs",
+                "type": "int64"
+              },
+              {
+                "id": 33,
+                "name": "mediumType",
+                "type": "string",
+                "is_repeated": true
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 32,
+                  "name": "xattr",
+                  "type": "bytes"
+                }
+              }
+            ]
+          },
+          {
+            "name": "GetFilePathPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetFilePathPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "fileId",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "MountPResponse"
+          },
+          {
+            "name": "MountPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "readOnly",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "shared",
+                "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "properties",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "MountPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "alluxioPath",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "ufsPath",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "options",
+                "type": "MountPOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetMountTablePResponse",
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 1,
+                  "name": "mountPoints",
+                  "type": "MountPointInfo"
+                }
+              }
+            ]
+          },
+          {
+            "name": "GetMountTablePRequest"
+          },
+          {
+            "name": "MountPointInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ufsUri",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "ufsType",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "ufsCapacityBytes",
+                "type": "int64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "-1"
+                  }
+                ]
+              },
+              {
+                "id": 4,
+                "name": "ufsUsedBytes",
+                "type": "int64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "-1"
+                  }
+                ]
+              },
+              {
+                "id": 5,
+                "name": "readOnly",
+                "type": "bool"
+              },
+              {
+                "id": 7,
+                "name": "shared",
+                "type": "bool"
+              },
+              {
+                "id": 8,
+                "name": "mountId",
+                "type": "int64"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 6,
+                  "name": "properties",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "FileSystemCommandOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "persistOptions",
+                "type": "PersistCommandOptions"
+              }
+            ]
+          },
+          {
+            "name": "PersistCommandOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "persistFiles",
+                "type": "PersistFile",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "PersistFile",
+            "fields": [
+              {
+                "id": 1,
+                "name": "fileId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "blockIds",
+                "type": "int64",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "FileSystemCommand",
+            "fields": [
+              {
+                "id": 1,
+                "name": "commandType",
+                "type": "grpc.CommandType"
+              },
+              {
+                "id": 2,
+                "name": "commandOptions",
+                "type": "FileSystemCommandOptions"
+              }
+            ]
+          },
+          {
+            "name": "RenamePResponse"
+          },
+          {
+            "name": "RenamePOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              },
+              {
+                "id": 2,
+                "name": "persist",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "RenamePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "dstPath",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "options",
+                "type": "RenamePOptions"
+              }
+            ]
+          },
+          {
+            "name": "ReverseResolvePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ufsUri",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ReverseResolvePResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "alluxioPath",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SetAttributePResponse"
+          },
+          {
+            "name": "SetAttributePOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pinned",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "persisted",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "owner",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "group",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "mode",
+                "type": "PMode"
+              },
+              {
+                "id": 6,
+                "name": "recursive",
+                "type": "bool"
+              },
+              {
+                "id": 7,
+                "name": "replicationMax",
+                "type": "int32"
+              },
+              {
+                "id": 8,
+                "name": "replicationMin",
+                "type": "int32"
+              },
+              {
+                "id": 9,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              },
+              {
+                "id": 10,
+                "name": "pinnedMedia",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "SetAttributePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "SetAttributePOptions"
+              }
+            ]
+          },
+          {
+            "name": "SetAclPResponse"
+          },
+          {
+            "name": "SetAclPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              },
+              {
+                "id": 2,
+                "name": "recursive",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "SetAclPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "action",
+                "type": "SetAclAction"
+              },
+              {
+                "id": 3,
+                "name": "entries",
+                "type": "PAclEntry",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "options",
+                "type": "SetAclPOptions"
+              }
+            ]
+          },
+          {
+            "name": "ScheduleAsyncPersistencePResponse"
+          },
+          {
+            "name": "ScheduleAsyncPersistencePOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              },
+              {
+                "id": 2,
+                "name": "persistenceWaitTime",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "ScheduleAsyncPersistencePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "ScheduleAsyncPersistencePOptions"
+              }
+            ]
+          },
+          {
+            "name": "StartSyncPResponse"
+          },
+          {
+            "name": "StartSyncPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              }
+            ]
+          },
+          {
+            "name": "StartSyncPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "StartSyncPOptions"
+              }
+            ]
+          },
+          {
+            "name": "StopSyncPResponse"
+          },
+          {
+            "name": "StopSyncPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              }
+            ]
+          },
+          {
+            "name": "StopSyncPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "StopSyncPOptions"
+              }
+            ]
+          },
+          {
+            "name": "UnmountPResponse"
+          },
+          {
+            "name": "UnmountPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "commonOptions",
+                "type": "FileSystemMasterCommonPOptions"
+              }
+            ]
+          },
+          {
+            "name": "UnmountPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "alluxioPath",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "UnmountPOptions"
+              }
+            ]
+          },
+          {
+            "name": "UfsInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "uri",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "properties",
+                "type": "MountPOptions"
+              }
+            ]
+          },
+          {
+            "name": "UpdateMountPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "alluxioPath",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "options",
+                "type": "MountPOptions"
+              }
+            ]
+          },
+          {
+            "name": "UpdateMountPResponse"
+          },
+          {
+            "name": "UpdateUfsModePResponse"
+          },
+          {
+            "name": "UpdateUfsModePOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ufsMode",
+                "type": "UfsPMode"
+              }
+            ]
+          },
+          {
+            "name": "UpdateUfsModePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ufsPath",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "UpdateUfsModePOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetStateLockHoldersPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "threads",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "GetStateLockHoldersPOptions"
+          },
+          {
+            "name": "GetStateLockHoldersPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "GetStateLockHoldersPOptions"
+              }
+            ]
+          },
+          {
+            "name": "FileSystemHeartbeatPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "command",
+                "type": "FileSystemCommand"
+              }
+            ]
+          },
+          {
+            "name": "FileSystemHeartbeatPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "persistedFileFingerprints",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "FileSystemHeartbeatPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "persistedFiles",
+                "type": "int64",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "options",
+                "type": "FileSystemHeartbeatPOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetFileInfoPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "fileInfo",
+                "type": "FileInfo"
+              }
+            ]
+          },
+          {
+            "name": "GetFileInfoPOptions"
+          },
+          {
+            "name": "GetFileInfoPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "fileId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "GetFileInfoPOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetPinnedFileIdsPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pinnedFileIds",
+                "type": "int64",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "GetPinnedFileIdsPOptions"
+          },
+          {
+            "name": "GetPinnedFileIdsPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "GetPinnedFileIdsPOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetUfsInfoPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ufsInfo",
+                "type": "UfsInfo"
+              }
+            ]
+          },
+          {
+            "name": "GetUfsInfoPOptions"
+          },
+          {
+            "name": "GetUfsInfoPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "mountId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "GetUfsInfoPOptions"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "FileSystemMasterClientService",
+            "rpcs": [
+              {
+                "name": "CheckAccess",
+                "in_type": "CheckAccessPRequest",
+                "out_type": "CheckAccessPResponse"
+              },
+              {
+                "name": "CheckConsistency",
+                "in_type": "CheckConsistencyPRequest",
+                "out_type": "CheckConsistencyPResponse"
+              },
+              {
+                "name": "CompleteFile",
+                "in_type": "CompleteFilePRequest",
+                "out_type": "CompleteFilePResponse"
+              },
+              {
+                "name": "CreateDirectory",
+                "in_type": "CreateDirectoryPRequest",
+                "out_type": "CreateDirectoryPResponse"
+              },
+              {
+                "name": "CreateFile",
+                "in_type": "CreateFilePRequest",
+                "out_type": "CreateFilePResponse"
+              },
+              {
+                "name": "Free",
+                "in_type": "FreePRequest",
+                "out_type": "FreePResponse"
+              },
+              {
+                "name": "GetFilePath",
+                "in_type": "GetFilePathPRequest",
+                "out_type": "GetFilePathPResponse"
+              },
+              {
+                "name": "GetMountTable",
+                "in_type": "GetMountTablePRequest",
+                "out_type": "GetMountTablePResponse"
+              },
+              {
+                "name": "GetSyncPathList",
+                "in_type": "GetSyncPathListPRequest",
+                "out_type": "GetSyncPathListPResponse"
+              },
+              {
+                "name": "GetNewBlockIdForFile",
+                "in_type": "GetNewBlockIdForFilePRequest",
+                "out_type": "GetNewBlockIdForFilePResponse"
+              },
+              {
+                "name": "GetStatus",
+                "in_type": "GetStatusPRequest",
+                "out_type": "GetStatusPResponse"
+              },
+              {
+                "name": "ListStatus",
+                "in_type": "ListStatusPRequest",
+                "out_type": "ListStatusPResponse",
+                "out_streamed": true
+              },
+              {
+                "name": "Mount",
+                "in_type": "MountPRequest",
+                "out_type": "MountPResponse"
+              },
+              {
+                "name": "Remove",
+                "in_type": "DeletePRequest",
+                "out_type": "DeletePResponse"
+              },
+              {
+                "name": "Rename",
+                "in_type": "RenamePRequest",
+                "out_type": "RenamePResponse"
+              },
+              {
+                "name": "ReverseResolve",
+                "in_type": "ReverseResolvePRequest",
+                "out_type": "ReverseResolvePResponse"
+              },
+              {
+                "name": "ScheduleAsyncPersistence",
+                "in_type": "ScheduleAsyncPersistencePRequest",
+                "out_type": "ScheduleAsyncPersistencePResponse"
+              },
+              {
+                "name": "SetAcl",
+                "in_type": "SetAclPRequest",
+                "out_type": "SetAclPResponse"
+              },
+              {
+                "name": "SetAttribute",
+                "in_type": "SetAttributePRequest",
+                "out_type": "SetAttributePResponse"
+              },
+              {
+                "name": "StartSync",
+                "in_type": "StartSyncPRequest",
+                "out_type": "StartSyncPResponse"
+              },
+              {
+                "name": "StopSync",
+                "in_type": "StopSyncPRequest",
+                "out_type": "StopSyncPResponse"
+              },
+              {
+                "name": "Unmount",
+                "in_type": "UnmountPRequest",
+                "out_type": "UnmountPResponse"
+              },
+              {
+                "name": "UpdateMount",
+                "in_type": "UpdateMountPRequest",
+                "out_type": "UpdateMountPResponse"
+              },
+              {
+                "name": "UpdateUfsMode",
+                "in_type": "UpdateUfsModePRequest",
+                "out_type": "UpdateUfsModePResponse"
+              },
+              {
+                "name": "GetStateLockHolders",
+                "in_type": "GetStateLockHoldersPRequest",
+                "out_type": "GetStateLockHoldersPResponse"
+              }
+            ]
+          },
+          {
+            "name": "FileSystemMasterWorkerService",
+            "rpcs": [
+              {
+                "name": "FileSystemHeartbeat",
+                "in_type": "FileSystemHeartbeatPRequest",
+                "out_type": "FileSystemHeartbeatPResponse"
+              },
+              {
+                "name": "GetFileInfo",
+                "in_type": "GetFileInfoPRequest",
+                "out_type": "GetFileInfoPResponse"
+              },
+              {
+                "name": "GetPinnedFileIds",
+                "in_type": "GetPinnedFileIdsPRequest",
+                "out_type": "GetPinnedFileIdsPResponse"
+              },
+              {
+                "name": "GetUfsInfo",
+                "in_type": "GetUfsInfoPRequest",
+                "out_type": "GetUfsInfoPResponse"
+              }
+            ]
+          },
+          {
+            "name": "FileSystemMasterJobService",
+            "rpcs": [
+              {
+                "name": "GetFileInfo",
+                "in_type": "GetFileInfoPRequest",
+                "out_type": "GetFileInfoPResponse"
+              },
+              {
+                "name": "GetUfsInfo",
+                "in_type": "GetUfsInfoPRequest",
+                "out_type": "GetUfsInfoPResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "grpc/common.proto"
+          },
+          {
+            "path": "grpc/fscommon.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc.file"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "FileSystemMasterProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "grpc:/:fscommon.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "LoadDescendantPType",
+            "enum_fields": [
+              {
+                "name": "NONE"
+              },
+              {
+                "name": "ONE",
+                "integer": 1
+              },
+              {
+                "name": "ALL",
+                "integer": 2
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc.fscommon"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "FsCommonProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "grpc:/:job_master.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "Status",
+            "enum_fields": [
+              {
+                "name": "UNKNOWN"
+              },
+              {
+                "name": "CREATED",
+                "integer": 1
+              },
+              {
+                "name": "CANCELED",
+                "integer": 2
+              },
+              {
+                "name": "FAILED",
+                "integer": 3
+              },
+              {
+                "name": "RUNNING",
+                "integer": 4
+              },
+              {
+                "name": "COMPLETED",
+                "integer": 5
+              }
+            ]
+          },
+          {
+            "name": "JobType",
+            "enum_fields": [
+              {
+                "name": "PLAN",
+                "integer": 1
+              },
+              {
+                "name": "TASK",
+                "integer": 2
+              },
+              {
+                "name": "WORKFLOW",
+                "integer": 3
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "JobUnused"
+          },
+          {
+            "name": "JobInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "errorMessage",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "status",
+                "type": "Status"
+              },
+              {
+                "id": 6,
+                "name": "lastUpdated",
+                "type": "int64"
+              },
+              {
+                "id": 8,
+                "name": "type",
+                "type": "JobType"
+              },
+              {
+                "id": 9,
+                "name": "result",
+                "type": "bytes"
+              },
+              {
+                "id": 15,
+                "name": "errorType",
+                "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 10,
+                "name": "parentId",
+                "type": "int64"
+              },
+              {
+                "id": 11,
+                "name": "children",
+                "type": "JobInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 12,
+                "name": "workerHost",
+                "type": "string"
+              },
+              {
+                "id": 13,
+                "name": "description",
+                "type": "string"
+              },
+              {
+                "id": 14,
+                "name": "affectedPaths",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "unused0",
+                "type": "JobUnused",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "unused1",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "StatusSummary",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "Status"
+              },
+              {
+                "id": 2,
+                "name": "count",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "JobServiceSummary",
+            "fields": [
+              {
+                "id": 1,
+                "name": "summaryPerStatus",
+                "type": "StatusSummary",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "recentActivities",
+                "type": "JobInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "recentFailures",
+                "type": "JobInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "longestRunning",
+                "type": "JobInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "JobWorkerHealth",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "loadAverage",
+                "type": "double",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "lastUpdated",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "hostname",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "taskPoolSize",
+                "type": "int32"
+              },
+              {
+                "id": 6,
+                "name": "numActiveTasks",
+                "type": "int32"
+              },
+              {
+                "id": 7,
+                "name": "unfinishedTasks",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "JobCommand",
+            "fields": [
+              {
+                "id": 1,
+                "name": "runTaskCommand",
+                "type": "RunTaskCommand"
+              },
+              {
+                "id": 2,
+                "name": "cancelTaskCommand",
+                "type": "CancelTaskCommand"
+              },
+              {
+                "id": 3,
+                "name": "registerCommand",
+                "type": "RegisterCommand"
+              },
+              {
+                "id": 4,
+                "name": "setTaskPoolSizeCommand",
+                "type": "SetTaskPoolSizeCommand"
+              }
+            ]
+          },
+          {
+            "name": "RunTaskCommand",
+            "fields": [
+              {
+                "id": 1,
+                "name": "jobId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "taskId",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "jobConfig",
+                "type": "bytes"
+              },
+              {
+                "id": 4,
+                "name": "taskArgs",
+                "type": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "RegisterCommand"
+          },
+          {
+            "name": "SetTaskPoolSizeCommand",
+            "fields": [
+              {
+                "id": 1,
+                "name": "taskPoolSize",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "CancelTaskCommand",
+            "fields": [
+              {
+                "id": 1,
+                "name": "jobId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "taskId",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "CancelPOptions"
+          },
+          {
+            "name": "CancelPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "jobId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "CancelPOptions"
+              }
+            ]
+          },
+          {
+            "name": "CancelPResponse"
+          },
+          {
+            "name": "GetJobStatusPOptions"
+          },
+          {
+            "name": "GetJobStatusPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "jobId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "GetJobStatusPOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetJobStatusPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "jobInfo",
+                "type": "JobInfo"
+              }
+            ]
+          },
+          {
+            "name": "GetJobStatusDetailedPOptions"
+          },
+          {
+            "name": "GetJobStatusDetailedPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "jobId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "GetJobStatusDetailedPOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetJobStatusDetailedPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "jobInfo",
+                "type": "JobInfo"
+              }
+            ]
+          },
+          {
+            "name": "ListAllPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "Status",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "jobIdOnly",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "ListAllPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "ListAllPOptions"
+              }
+            ]
+          },
+          {
+            "name": "ListAllPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "jobIds",
+                "type": "int64",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "jobInfos",
+                "type": "JobInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "RunPOptions"
+          },
+          {
+            "name": "RunPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "jobConfig",
+                "type": "bytes"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "RunPOptions"
+              }
+            ]
+          },
+          {
+            "name": "RunPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "jobId",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "GetJobServiceSummaryPOptions"
+          },
+          {
+            "name": "GetJobServiceSummaryPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "GetJobServiceSummaryPOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetJobServiceSummaryPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "summary",
+                "type": "JobServiceSummary"
+              }
+            ]
+          },
+          {
+            "name": "GetAllWorkerHealthPOptions"
+          },
+          {
+            "name": "GetAllWorkerHealthPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "GetAllWorkerHealthPOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetAllWorkerHealthPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerHealths",
+                "type": "JobWorkerHealth",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "JobHeartbeatPOptions"
+          },
+          {
+            "name": "JobHeartbeatPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "jobWorkerHealth",
+                "type": "JobWorkerHealth"
+              },
+              {
+                "id": 2,
+                "name": "taskInfos",
+                "type": "JobInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "options",
+                "type": "JobHeartbeatPOptions"
+              }
+            ]
+          },
+          {
+            "name": "JobHeartbeatPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "commands",
+                "type": "JobCommand",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "RegisterJobWorkerPOptions"
+          },
+          {
+            "name": "RegisterJobWorkerPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerNetAddress",
+                "type": "grpc.WorkerNetAddress"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "RegisterJobWorkerPOptions"
+              }
+            ]
+          },
+          {
+            "name": "RegisterJobWorkerPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "JobMasterClientService",
+            "rpcs": [
+              {
+                "name": "Cancel",
+                "in_type": "CancelPRequest",
+                "out_type": "CancelPResponse"
+              },
+              {
+                "name": "GetJobStatus",
+                "in_type": "GetJobStatusPRequest",
+                "out_type": "GetJobStatusPResponse"
+              },
+              {
+                "name": "GetJobStatusDetailed",
+                "in_type": "GetJobStatusDetailedPRequest",
+                "out_type": "GetJobStatusDetailedPResponse"
+              },
+              {
+                "name": "GetJobServiceSummary",
+                "in_type": "GetJobServiceSummaryPRequest",
+                "out_type": "GetJobServiceSummaryPResponse"
+              },
+              {
+                "name": "ListAll",
+                "in_type": "ListAllPRequest",
+                "out_type": "ListAllPResponse"
+              },
+              {
+                "name": "Run",
+                "in_type": "RunPRequest",
+                "out_type": "RunPResponse"
+              },
+              {
+                "name": "GetAllWorkerHealth",
+                "in_type": "GetAllWorkerHealthPRequest",
+                "out_type": "GetAllWorkerHealthPResponse"
+              }
+            ]
+          },
+          {
+            "name": "JobMasterWorkerService",
+            "rpcs": [
+              {
+                "name": "Heartbeat",
+                "in_type": "JobHeartbeatPRequest",
+                "out_type": "JobHeartbeatPResponse"
+              },
+              {
+                "name": "RegisterJobWorker",
+                "in_type": "RegisterJobWorkerPRequest",
+                "out_type": "RegisterJobWorkerPResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "grpc/common.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc.job"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "JobMasterProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "grpc:/:journal_master.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "QuorumServerState",
+            "enum_fields": [
+              {
+                "name": "AVAILABLE",
+                "integer": 1
+              },
+              {
+                "name": "UNAVAILABLE",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "JournalDomain",
+            "enum_fields": [
+              {
+                "name": "MASTER",
+                "integer": 1
+              },
+              {
+                "name": "JOB_MASTER",
+                "integer": 2
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "QuorumServerInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "serverAddress",
+                "type": "NetAddress"
+              },
+              {
+                "id": 2,
+                "name": "serverState",
+                "type": "QuorumServerState"
+              },
+              {
+                "id": 3,
+                "name": "isLeader",
+                "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "priority",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "GetQuorumInfoPOptions"
+          },
+          {
+            "name": "GetQuorumInfoPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "GetQuorumInfoPOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetQuorumInfoPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "domain",
+                "type": "JournalDomain"
+              },
+              {
+                "id": 2,
+                "name": "serverInfo",
+                "type": "QuorumServerInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "RemoveQuorumServerPOptions"
+          },
+          {
+            "name": "RemoveQuorumServerPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "RemoveQuorumServerPOptions"
+              },
+              {
+                "id": 2,
+                "name": "serverAddress",
+                "type": "NetAddress"
+              }
+            ]
+          },
+          {
+            "name": "RemoveQuorumServerPResponse"
+          },
+          {
+            "name": "TransferLeadershipPOptions"
+          },
+          {
+            "name": "TransferLeadershipPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "TransferLeadershipPOptions"
+              },
+              {
+                "id": 2,
+                "name": "serverAddress",
+                "type": "NetAddress"
+              }
+            ]
+          },
+          {
+            "name": "TransferLeadershipPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "transferId",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ResetPrioritiesPOptions"
+          },
+          {
+            "name": "ResetPrioritiesPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "ResetPrioritiesPOptions"
+              }
+            ]
+          },
+          {
+            "name": "ResetPrioritiesPResponse"
+          },
+          {
+            "name": "TransferLeaderMessage",
+            "fields": [
+              {
+                "id": 1,
+                "name": "msg",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetTransferLeaderMessageOptions"
+          },
+          {
+            "name": "GetTransferLeaderMessagePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "transferId",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetTransferLeaderMessagePResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "transMsg",
+                "type": "TransferLeaderMessage"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "JournalMasterClientService",
+            "rpcs": [
+              {
+                "name": "GetQuorumInfo",
+                "in_type": "GetQuorumInfoPRequest",
+                "out_type": "GetQuorumInfoPResponse"
+              },
+              {
+                "name": "RemoveQuorumServer",
+                "in_type": "RemoveQuorumServerPRequest",
+                "out_type": "RemoveQuorumServerPResponse"
+              },
+              {
+                "name": "TransferLeadership",
+                "in_type": "TransferLeadershipPRequest",
+                "out_type": "TransferLeadershipPResponse"
+              },
+              {
+                "name": "ResetPriorities",
+                "in_type": "ResetPrioritiesPRequest",
+                "out_type": "ResetPrioritiesPResponse"
+              },
+              {
+                "name": "GetTransferLeaderMessage",
+                "in_type": "GetTransferLeaderMessagePRequest",
+                "out_type": "GetTransferLeaderMessagePResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "grpc/common.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc.journal"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "JournalMasterProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "grpc:/:messaging_transport.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "MessagingRequestHeader",
+            "fields": [
+              {
+                "id": 1,
+                "name": "requestId",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "MessagingResponseHeader",
+            "fields": [
+              {
+                "id": 1,
+                "name": "requestId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "isThrowable",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "TransportMessage",
+            "fields": [
+              {
+                "id": 1,
+                "name": "requestHeader",
+                "type": "MessagingRequestHeader"
+              },
+              {
+                "id": 2,
+                "name": "responseHeader",
+                "type": "MessagingResponseHeader"
+              },
+              {
+                "id": 3,
+                "name": "message",
+                "type": "bytes"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "MessagingService",
+            "rpcs": [
+              {
+                "name": "connect",
+                "in_type": "TransportMessage",
+                "out_type": "TransportMessage",
+                "in_streamed": true,
+                "out_streamed": true
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc.messaging"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "MessagingTransportProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "grpc:/:meta_master.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "ConfigStatus",
+            "enum_fields": [
+              {
+                "name": "PASSED",
+                "integer": 1
+              },
+              {
+                "name": "WARN",
+                "integer": 2
+              },
+              {
+                "name": "FAILED",
+                "integer": 3
+              }
+            ]
+          },
+          {
+            "name": "Scope",
+            "enum_fields": [
+              {
+                "name": "MASTER",
+                "integer": 1
+              },
+              {
+                "name": "WORKER",
+                "integer": 2
+              },
+              {
+                "name": "CLIENT",
+                "integer": 4
+              },
+              {
+                "name": "SERVER",
+                "integer": 3
+              },
+              {
+                "name": "ALL",
+                "integer": 7
+              },
+              {
+                "name": "NONE"
+              }
+            ]
+          },
+          {
+            "name": "MasterInfoField",
+            "enum_fields": [
+              {
+                "name": "LEADER_MASTER_ADDRESS"
+              },
+              {
+                "name": "MASTER_ADDRESSES",
+                "integer": 1
+              },
+              {
+                "name": "RPC_PORT",
+                "integer": 2
+              },
+              {
+                "name": "SAFE_MODE",
+                "integer": 3
+              },
+              {
+                "name": "START_TIME_MS",
+                "integer": 4
+              },
+              {
+                "name": "UP_TIME_MS",
+                "integer": 5
+              },
+              {
+                "name": "VERSION",
+                "integer": 6
+              },
+              {
+                "name": "WEB_PORT",
+                "integer": 7
+              },
+              {
+                "name": "WORKER_ADDRESSES",
+                "integer": 8
+              },
+              {
+                "name": "ZOOKEEPER_ADDRESSES",
+                "integer": 9
+              },
+              {
+                "name": "CLUSTER_ID",
+                "integer": 10
+              }
+            ]
+          },
+          {
+            "name": "BackupState",
+            "enum_fields": [
+              {
+                "name": "None",
+                "integer": 1
+              },
+              {
+                "name": "Initiating",
+                "integer": 2
+              },
+              {
+                "name": "Transitioning",
+                "integer": 3
+              },
+              {
+                "name": "Running",
+                "integer": 4
+              },
+              {
+                "name": "Completed",
+                "integer": 5
+              },
+              {
+                "name": "Failed",
+                "integer": 6
+              }
+            ]
+          },
+          {
+            "name": "MetaCommand",
+            "enum_fields": [
+              {
+                "name": "MetaCommand_Unknown"
+              },
+              {
+                "name": "MetaCommand_Nothing",
+                "integer": 1
+              },
+              {
+                "name": "MetaCommand_Register",
+                "integer": 2
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "ConfigProperties",
+            "fields": [
+              {
+                "id": 1,
+                "name": "properties",
+                "type": "ConfigProperty",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "GetConfigurationPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "rawValue",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "ignoreClusterConf",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "ignorePathConf",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "GetConfigurationPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "clusterConfigs",
+                "type": "ConfigProperty",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "clusterConfigHash",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "pathConfigHash",
+                "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "pathConfigs",
+                  "type": "ConfigProperties"
+                }
+              }
+            ]
+          },
+          {
+            "name": "InconsistentPropertyValues",
+            "fields": [
+              {
+                "id": 1,
+                "name": "values",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "InconsistentProperty",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "values",
+                  "type": "InconsistentPropertyValues"
+                }
+              }
+            ]
+          },
+          {
+            "name": "InconsistentProperties",
+            "fields": [
+              {
+                "id": 1,
+                "name": "properties",
+                "type": "InconsistentProperty",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ConfigCheckReport",
+            "fields": [
+              {
+                "id": 3,
+                "name": "status",
+                "type": "ConfigStatus"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 1,
+                  "name": "errors",
+                  "type": "InconsistentProperties"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "warns",
+                  "type": "InconsistentProperties"
+                }
+              }
+            ]
+          },
+          {
+            "name": "GetConfigReportPOptions"
+          },
+          {
+            "name": "GetConfigReportPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "report",
+                "type": "ConfigCheckReport"
+              }
+            ]
+          },
+          {
+            "name": "MasterInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "leaderMasterAddress",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "masterAddresses",
+                "type": "grpc.NetAddress",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "rpcPort",
+                "type": "int32"
+              },
+              {
+                "id": 4,
+                "name": "safeMode",
+                "type": "bool"
+              },
+              {
+                "id": 5,
+                "name": "startTimeMs",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "upTimeMs",
+                "type": "int64"
+              },
+              {
+                "id": 7,
+                "name": "version",
+                "type": "string"
+              },
+              {
+                "id": 8,
+                "name": "webPort",
+                "type": "int32"
+              },
+              {
+                "id": 9,
+                "name": "workerAddresses",
+                "type": "grpc.NetAddress",
+                "is_repeated": true
+              },
+              {
+                "id": 10,
+                "name": "zookeeperAddresses",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 11,
+                "name": "clusterId",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetMasterInfoPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "filter",
+                "type": "MasterInfoField",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "GetMasterInfoPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "masterInfo",
+                "type": "MasterInfo"
+              }
+            ]
+          },
+          {
+            "name": "CheckpointPOptions"
+          },
+          {
+            "name": "CheckpointPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "masterHostname",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "BackupPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "BackupPOptions"
+              },
+              {
+                "id": 2,
+                "name": "targetDirectory",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "BackupPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "localFileSystem",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "runAsync",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "allowLeader",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "BackupPStatus",
+            "fields": [
+              {
+                "id": 1,
+                "name": "backupId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "backupState",
+                "type": "BackupState"
+              },
+              {
+                "id": 3,
+                "name": "backupHost",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "backupUri",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "entryCount",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "backupError",
+                "type": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "BackupStatusPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "backupId",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SetPathConfigurationPOptions"
+          },
+          {
+            "name": "SetPathConfigurationPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "options",
+                "type": "SetPathConfigurationPOptions"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "properties",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "SetPathConfigurationPResponse"
+          },
+          {
+            "name": "RemovePathConfigurationPOptions"
+          },
+          {
+            "name": "RemovePathConfigurationPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "keys",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "options",
+                "type": "RemovePathConfigurationPOptions"
+              }
+            ]
+          },
+          {
+            "name": "RemovePathConfigurationPResponse"
+          },
+          {
+            "name": "GetConfigHashPOptions"
+          },
+          {
+            "name": "GetConfigHashPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "clusterConfigHash",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "pathConfigHash",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetMasterIdPOptions"
+          },
+          {
+            "name": "GetMasterIdPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "masterAddress",
+                "type": "grpc.NetAddress"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "GetMasterIdPOptions"
+              }
+            ]
+          },
+          {
+            "name": "GetMasterIdPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "masterId",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "RegisterMasterPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "configs",
+                "type": "grpc.ConfigProperty",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "RegisterMasterPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "masterId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "RegisterMasterPOptions"
+              }
+            ]
+          },
+          {
+            "name": "RegisterMasterPResponse"
+          },
+          {
+            "name": "MasterHeartbeatPOptions"
+          },
+          {
+            "name": "MasterHeartbeatPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "masterId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "options",
+                "type": "MasterHeartbeatPOptions"
+              }
+            ]
+          },
+          {
+            "name": "MasterHeartbeatPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "command",
+                "type": "MetaCommand"
+              }
+            ]
+          },
+          {
+            "name": "UpdateConfigurationPRequest",
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 1,
+                  "name": "properties",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "UpdateConfigurationPResponse",
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 1,
+                  "name": "status",
+                  "type": "bool"
+                }
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "MetaMasterClientService",
+            "rpcs": [
+              {
+                "name": "Backup",
+                "in_type": "BackupPRequest",
+                "out_type": "BackupPStatus"
+              },
+              {
+                "name": "GetBackupStatus",
+                "in_type": "BackupStatusPRequest",
+                "out_type": "BackupPStatus"
+              },
+              {
+                "name": "GetConfigReport",
+                "in_type": "GetConfigReportPOptions",
+                "out_type": "GetConfigReportPResponse"
+              },
+              {
+                "name": "GetMasterInfo",
+                "in_type": "GetMasterInfoPOptions",
+                "out_type": "GetMasterInfoPResponse"
+              },
+              {
+                "name": "Checkpoint",
+                "in_type": "CheckpointPOptions",
+                "out_type": "CheckpointPResponse"
+              }
+            ]
+          },
+          {
+            "name": "MetaMasterConfigurationService",
+            "rpcs": [
+              {
+                "name": "GetConfiguration",
+                "in_type": "GetConfigurationPOptions",
+                "out_type": "GetConfigurationPResponse"
+              },
+              {
+                "name": "SetPathConfiguration",
+                "in_type": "SetPathConfigurationPRequest",
+                "out_type": "SetPathConfigurationPResponse"
+              },
+              {
+                "name": "RemovePathConfiguration",
+                "in_type": "RemovePathConfigurationPRequest",
+                "out_type": "RemovePathConfigurationPResponse"
+              },
+              {
+                "name": "GetConfigHash",
+                "in_type": "GetConfigHashPOptions",
+                "out_type": "GetConfigHashPResponse"
+              },
+              {
+                "name": "UpdateConfiguration",
+                "in_type": "UpdateConfigurationPRequest",
+                "out_type": "UpdateConfigurationPResponse"
+              }
+            ]
+          },
+          {
+            "name": "MetaMasterMasterService",
+            "rpcs": [
+              {
+                "name": "GetMasterId",
+                "in_type": "GetMasterIdPRequest",
+                "out_type": "GetMasterIdPResponse"
+              },
+              {
+                "name": "RegisterMaster",
+                "in_type": "RegisterMasterPRequest",
+                "out_type": "RegisterMasterPResponse"
+              },
+              {
+                "name": "MasterHeartbeat",
+                "in_type": "MasterHeartbeatPRequest",
+                "out_type": "MasterHeartbeatPResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "grpc/common.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc.meta"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "MetaMasterProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "grpc:/:metric_master.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "ClearMetricsPRequest"
+          },
+          {
+            "name": "ClearMetricsPResponse"
+          },
+          {
+            "name": "MetricsHeartbeatPOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "clientMetrics",
+                "type": "ClientMetrics",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ClientMetrics",
+            "fields": [
+              {
+                "id": 1,
+                "name": "source",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "metrics",
+                "type": "grpc.Metric",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "MetricsHeartbeatPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "MetricsHeartbeatPOptions"
+              }
+            ]
+          },
+          {
+            "name": "MetricsHeartbeatPResponse"
+          },
+          {
+            "name": "MetricValue",
+            "fields": [
+              {
+                "id": 1,
+                "name": "doubleValue",
+                "type": "double"
+              },
+              {
+                "id": 2,
+                "name": "stringValue",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "metricType",
+                "type": "grpc.MetricType"
+              }
+            ]
+          },
+          {
+            "name": "GetMetricsPOptions"
+          },
+          {
+            "name": "GetMetricsPResponse",
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 1,
+                  "name": "metrics",
+                  "type": "MetricValue"
+                }
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "MetricsMasterClientService",
+            "rpcs": [
+              {
+                "name": "ClearMetrics",
+                "in_type": "ClearMetricsPRequest",
+                "out_type": "ClearMetricsPResponse"
+              },
+              {
+                "name": "MetricsHeartbeat",
+                "in_type": "MetricsHeartbeatPRequest",
+                "out_type": "MetricsHeartbeatPResponse"
+              },
+              {
+                "name": "GetMetrics",
+                "in_type": "GetMetricsPOptions",
+                "out_type": "GetMetricsPResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "grpc/common.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc.metric"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "MetricMasterProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "grpc:/:raft_journal.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "JournalQueryRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "snapshotInfoRequest",
+                "type": "GetSnapshotInfoRequest"
+              },
+              {
+                "id": 2,
+                "name": "snapshotRequest",
+                "type": "GetSnapshotRequest"
+              },
+              {
+                "id": 3,
+                "name": "addQuorumServerRequest",
+                "type": "AddQuorumServerRequest"
+              }
+            ]
+          },
+          {
+            "name": "JournalQueryResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "snapshotInfoResponse",
+                "type": "GetSnapshotInfoResponse"
+              }
+            ]
+          },
+          {
+            "name": "AddQuorumServerRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "serverAddress",
+                "type": "NetAddress"
+              }
+            ]
+          },
+          {
+            "name": "GetSnapshotInfoRequest"
+          },
+          {
+            "name": "GetSnapshotInfoResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "latest",
+                "type": "SnapshotMetadata"
+              }
+            ]
+          },
+          {
+            "name": "GetSnapshotRequest"
+          },
+          {
+            "name": "SnapshotMetadata",
+            "fields": [
+              {
+                "id": 1,
+                "name": "snapshotTerm",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "snapshotIndex",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "SnapshotData",
+            "fields": [
+              {
+                "id": 1,
+                "name": "snapshotTerm",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "snapshotIndex",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "chunk",
+                "type": "bytes"
+              },
+              {
+                "id": 4,
+                "name": "offset",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "eof",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "UploadSnapshotPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "data",
+                "type": "SnapshotData"
+              }
+            ]
+          },
+          {
+            "name": "UploadSnapshotPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "offsetReceived",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "DownloadSnapshotPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "offsetReceived",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "DownloadSnapshotPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "data",
+                "type": "SnapshotData"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "RaftJournalService",
+            "rpcs": [
+              {
+                "name": "UploadSnapshot",
+                "in_type": "UploadSnapshotPRequest",
+                "out_type": "UploadSnapshotPResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              },
+              {
+                "name": "DownloadSnapshot",
+                "in_type": "DownloadSnapshotPRequest",
+                "out_type": "DownloadSnapshotPResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "grpc/common.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc.meta"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "RaftJournalProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "grpc:/:sasl_server.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "SaslMessageType",
+            "enum_fields": [
+              {
+                "name": "CHALLENGE"
+              },
+              {
+                "name": "SUCCESS",
+                "integer": 1
+              }
+            ]
+          },
+          {
+            "name": "ChannelAuthenticationScheme",
+            "enum_fields": [
+              {
+                "name": "NOSASL"
+              },
+              {
+                "name": "SIMPLE",
+                "integer": 1
+              },
+              {
+                "name": "CUSTOM",
+                "integer": 2
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "SaslMessage",
+            "fields": [
+              {
+                "id": 1,
+                "name": "messageType",
+                "type": "SaslMessageType"
+              },
+              {
+                "id": 2,
+                "name": "message",
+                "type": "bytes"
+              },
+              {
+                "id": 3,
+                "name": "clientId",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "authenticationScheme",
+                "type": "ChannelAuthenticationScheme"
+              },
+              {
+                "id": 5,
+                "name": "channelRef",
+                "type": "string"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "SaslAuthenticationService",
+            "rpcs": [
+              {
+                "name": "authenticate",
+                "in_type": "SaslMessage",
+                "out_type": "SaslMessage",
+                "in_streamed": true,
+                "out_streamed": true
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc.sasl"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "AuthenticationServerProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "grpc:/:table:/:layout:/:hive:/:hive.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "SortingColumn.SortingOrder",
+            "enum_fields": [
+              {
+                "name": "ASCENDING"
+              },
+              {
+                "name": "DESCENDING",
+                "integer": 1
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "StorageFormat",
+            "fields": [
+              {
+                "id": 1,
+                "name": "serde",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "input_format",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "output_format",
+                "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 4,
+                  "name": "serdelib_parameters",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "HiveBucketProperty",
+            "fields": [
+              {
+                "id": 1,
+                "name": "bucketed_by",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "bucket_count",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "sorted_by",
+                "type": "SortingColumn",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "SortingColumn",
+            "fields": [
+              {
+                "id": 1,
+                "name": "column_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "order",
+                "type": "SortingOrder"
+              }
+            ]
+          },
+          {
+            "name": "Storage",
+            "fields": [
+              {
+                "id": 1,
+                "name": "storage_format",
+                "type": "StorageFormat"
+              },
+              {
+                "id": 2,
+                "name": "location",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "bucket_property",
+                "type": "HiveBucketProperty"
+              },
+              {
+                "id": 4,
+                "name": "skewed",
+                "type": "bool"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 5,
+                  "name": "serde_parameters",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "PartitionInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "values",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "partition_name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "table_name",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "storage",
+                "type": "Storage"
+              },
+              {
+                "id": 6,
+                "name": "data_cols",
+                "type": "FieldSchema",
+                "is_repeated": true
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 7,
+                  "name": "parameters",
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "grpc/common.proto"
+          },
+          {
+            "path": "grpc/table/table_master.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc.table.layout"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc.table.layout.hive"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "HiveLayoutProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "grpc:/:table:/:table_master.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "PrincipalType",
+            "enum_fields": [
+              {
+                "name": "USER"
+              },
+              {
+                "name": "ROLE",
+                "integer": 1
+              }
+            ]
+          },
+          {
+            "name": "TableInfo.TableType",
+            "enum_fields": [
+              {
+                "name": "NATIVE"
+              },
+              {
+                "name": "IMPORTED",
+                "integer": 1
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "FieldSchema",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "uint32"
+              },
+              {
+                "id": 2,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "type",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "comment",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Schema",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cols",
+                "type": "FieldSchema",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "Database",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "description",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "location",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "owner_name",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "owner_type",
+                "type": "PrincipalType"
+              },
+              {
+                "id": 7,
+                "name": "comment",
+                "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 4,
+                  "name": "parameter",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "TableInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "table_name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "type",
+                "type": "TableType"
+              },
+              {
+                "id": 4,
+                "name": "owner",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "schema",
+                "type": "Schema"
+              },
+              {
+                "id": 6,
+                "name": "layout",
+                "type": "Layout"
+              },
+              {
+                "id": 8,
+                "name": "partition_cols",
+                "type": "FieldSchema",
+                "is_repeated": true
+              },
+              {
+                "id": 9,
+                "name": "previous_version",
+                "type": "int64"
+              },
+              {
+                "id": 10,
+                "name": "version",
+                "type": "int64"
+              },
+              {
+                "id": 11,
+                "name": "version_creation_time",
+                "type": "int64"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 7,
+                  "name": "parameters",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "LayoutSpec",
+            "fields": [
+              {
+                "id": 1,
+                "name": "spec",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "PartitionSpec",
+            "fields": [
+              {
+                "id": 1,
+                "name": "spec",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Layout",
+            "fields": [
+              {
+                "id": 1,
+                "name": "layout_type",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "layout_spec",
+                "type": "LayoutSpec"
+              },
+              {
+                "id": 3,
+                "name": "layout_data",
+                "type": "bytes"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 4,
+                  "name": "stats",
+                  "type": "ColumnStatisticsInfo"
+                }
+              }
+            ]
+          },
+          {
+            "name": "Transformation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "layout",
+                "type": "Layout"
+              },
+              {
+                "id": 2,
+                "name": "definition",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Partition",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partition_spec",
+                "type": "PartitionSpec"
+              },
+              {
+                "id": 2,
+                "name": "base_layout",
+                "type": "Layout"
+              },
+              {
+                "id": 3,
+                "name": "transformations",
+                "type": "Transformation",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "version",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "version_creation_time",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "ColumnStatisticsInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "col_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "col_type",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "data",
+                "type": "ColumnStatisticsData"
+              }
+            ]
+          },
+          {
+            "name": "ColumnStatisticsData",
+            "fields": [
+              {
+                "id": 1,
+                "name": "boolean_stats",
+                "type": "BooleanColumnStatsData"
+              },
+              {
+                "id": 2,
+                "name": "long_stats",
+                "type": "LongColumnStatsData"
+              },
+              {
+                "id": 3,
+                "name": "double_stats",
+                "type": "DoubleColumnStatsData"
+              },
+              {
+                "id": 4,
+                "name": "string_stats",
+                "type": "StringColumnStatsData"
+              },
+              {
+                "id": 5,
+                "name": "binary_stats",
+                "type": "BinaryColumnStatsData"
+              },
+              {
+                "id": 6,
+                "name": "decimal_stats",
+                "type": "DecimalColumnStatsData"
+              },
+              {
+                "id": 7,
+                "name": "date_stats",
+                "type": "DateColumnStatsData"
+              }
+            ]
+          },
+          {
+            "name": "BooleanColumnStatsData",
+            "fields": [
+              {
+                "id": 1,
+                "name": "num_trues",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "num_falses",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "num_nulls",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "bit_vectors",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "LongColumnStatsData",
+            "fields": [
+              {
+                "id": 1,
+                "name": "low_value",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "high_value",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "num_nulls",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "num_distincts",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "bit_vectors",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "DoubleColumnStatsData",
+            "fields": [
+              {
+                "id": 1,
+                "name": "low_value",
+                "type": "double"
+              },
+              {
+                "id": 2,
+                "name": "high_value",
+                "type": "double"
+              },
+              {
+                "id": 3,
+                "name": "num_nulls",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "num_distincts",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "bit_vectors",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Decimal",
+            "fields": [
+              {
+                "id": 1,
+                "name": "scale",
+                "type": "int32"
+              },
+              {
+                "id": 2,
+                "name": "unscaled",
+                "type": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "DecimalColumnStatsData",
+            "fields": [
+              {
+                "id": 1,
+                "name": "low_value",
+                "type": "Decimal"
+              },
+              {
+                "id": 2,
+                "name": "high_value",
+                "type": "Decimal"
+              },
+              {
+                "id": 3,
+                "name": "num_nulls",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "num_distincts",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "bit_vectors",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "StringColumnStatsData",
+            "fields": [
+              {
+                "id": 1,
+                "name": "max_col_len",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "avg_col_len",
+                "type": "double"
+              },
+              {
+                "id": 3,
+                "name": "num_nulls",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "num_distincts",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "bit_vectors",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "BinaryColumnStatsData",
+            "fields": [
+              {
+                "id": 1,
+                "name": "max_col_len",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "avg_col_len",
+                "type": "double"
+              },
+              {
+                "id": 3,
+                "name": "num_nulls",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "bit_vectors",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Date",
+            "fields": [
+              {
+                "id": 1,
+                "name": "days_since_epoch",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "DateColumnStatsData",
+            "fields": [
+              {
+                "id": 1,
+                "name": "low_value",
+                "type": "Date"
+              },
+              {
+                "id": 2,
+                "name": "high_value",
+                "type": "Date"
+              },
+              {
+                "id": 3,
+                "name": "num_nulls",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "num_distincts",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "bit_vectors",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SyncStatus",
+            "fields": [
+              {
+                "id": 2,
+                "name": "tables_ignored",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "tables_unchanged",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "tables_updated",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "tables_removed",
+                "type": "string",
+                "is_repeated": true
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 1,
+                  "name": "tables_errors",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "GetAllDatabasesPRequest"
+          },
+          {
+            "name": "GetAllDatabasesPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "database",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "GetAllTablesPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "database",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetAllTablesPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "table",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "GetDatabasePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetDatabasePResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db",
+                "type": "Database"
+              }
+            ]
+          },
+          {
+            "name": "GetTablePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "table_name",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetTablePResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "table_info",
+                "type": "TableInfo"
+              }
+            ]
+          },
+          {
+            "name": "AttachDatabasePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "udb_type",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "udb_connection_uri",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "udb_db_name",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "ignore_sync_errors",
+                "type": "bool"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 5,
+                  "name": "options",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "AttachDatabasePResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "success",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "sync_status",
+                "type": "SyncStatus"
+              }
+            ]
+          },
+          {
+            "name": "DetachDatabasePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "DetachDatabasePResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "success",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "SyncDatabasePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SyncDatabasePResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "success",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "status",
+                "type": "SyncStatus"
+              }
+            ]
+          },
+          {
+            "name": "FileStatistics",
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 1,
+                  "name": "column",
+                  "type": "ColumnStatisticsInfo"
+                }
+              }
+            ]
+          },
+          {
+            "name": "GetTableColumnStatisticsPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "table_name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "col_names",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "GetPartitionColumnStatisticsPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "table_name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "col_names",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "part_names",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "GetTableColumnStatisticsPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "statistics",
+                "type": "ColumnStatisticsInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ColumnStatisticsList",
+            "fields": [
+              {
+                "id": 1,
+                "name": "statistics",
+                "type": "ColumnStatisticsInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "GetPartitionColumnStatisticsPResponse",
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 1,
+                  "name": "partition_statistics",
+                  "type": "ColumnStatisticsList"
+                }
+              }
+            ]
+          },
+          {
+            "name": "Value",
+            "fields": [
+              {
+                "id": 1,
+                "name": "long_type",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "double_type",
+                "type": "double"
+              },
+              {
+                "id": 3,
+                "name": "string_type",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "boolean_type",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "Range",
+            "fields": [
+              {
+                "id": 1,
+                "name": "low",
+                "type": "Value"
+              },
+              {
+                "id": 2,
+                "name": "high",
+                "type": "Value"
+              }
+            ]
+          },
+          {
+            "name": "RangeSet",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ranges",
+                "type": "Range",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "EquatableValueSet",
+            "fields": [
+              {
+                "id": 1,
+                "name": "candidates",
+                "type": "Value",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "white_list",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "AllOrNoneSet",
+            "fields": [
+              {
+                "id": 1,
+                "name": "all",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "Domain",
+            "fields": [
+              {
+                "id": 1,
+                "name": "range",
+                "type": "RangeSet"
+              },
+              {
+                "id": 2,
+                "name": "equatable",
+                "type": "EquatableValueSet"
+              },
+              {
+                "id": 3,
+                "name": "all_or_none",
+                "type": "AllOrNoneSet"
+              }
+            ]
+          },
+          {
+            "name": "Constraint",
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 1,
+                  "name": "column_constraints",
+                  "type": "Domain"
+                }
+              }
+            ]
+          },
+          {
+            "name": "ReadTablePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "table_name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "constraint",
+                "type": "Constraint"
+              }
+            ]
+          },
+          {
+            "name": "ReadTablePResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partitions",
+                "type": "Partition",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "TransformTablePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "table_name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "definition",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "TransformTablePResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "job_id",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "GetTransformJobInfoPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "job_id",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "TransformJobInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "table_name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "definition",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "job_id",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "job_status",
+                "type": "alluxio.grpc.job.Status"
+              },
+              {
+                "id": 6,
+                "name": "job_error",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetTransformJobInfoPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "info",
+                "type": "TransformJobInfo",
+                "is_repeated": true
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "TableMasterClientService",
+            "rpcs": [
+              {
+                "name": "GetAllDatabases",
+                "in_type": "GetAllDatabasesPRequest",
+                "out_type": "GetAllDatabasesPResponse"
+              },
+              {
+                "name": "GetAllTables",
+                "in_type": "GetAllTablesPRequest",
+                "out_type": "GetAllTablesPResponse"
+              },
+              {
+                "name": "GetDatabase",
+                "in_type": "GetDatabasePRequest",
+                "out_type": "GetDatabasePResponse"
+              },
+              {
+                "name": "GetTable",
+                "in_type": "GetTablePRequest",
+                "out_type": "GetTablePResponse"
+              },
+              {
+                "name": "AttachDatabase",
+                "in_type": "AttachDatabasePRequest",
+                "out_type": "AttachDatabasePResponse"
+              },
+              {
+                "name": "DetachDatabase",
+                "in_type": "DetachDatabasePRequest",
+                "out_type": "DetachDatabasePResponse"
+              },
+              {
+                "name": "SyncDatabase",
+                "in_type": "SyncDatabasePRequest",
+                "out_type": "SyncDatabasePResponse"
+              },
+              {
+                "name": "GetTableColumnStatistics",
+                "in_type": "GetTableColumnStatisticsPRequest",
+                "out_type": "GetTableColumnStatisticsPResponse"
+              },
+              {
+                "name": "GetPartitionColumnStatistics",
+                "in_type": "GetPartitionColumnStatisticsPRequest",
+                "out_type": "GetPartitionColumnStatisticsPResponse"
+              },
+              {
+                "name": "ReadTable",
+                "in_type": "ReadTablePRequest",
+                "out_type": "ReadTablePResponse"
+              },
+              {
+                "name": "TransformTable",
+                "in_type": "TransformTablePRequest",
+                "out_type": "TransformTablePResponse"
+              },
+              {
+                "name": "GetTransformJobInfo",
+                "in_type": "GetTransformJobInfoPRequest",
+                "out_type": "GetTransformJobInfoPResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "grpc/common.proto"
+          },
+          {
+            "path": "grpc/job_master.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc.table"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc.table"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "TableMasterProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "grpc:/:version.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "ServiceType",
+            "enum_fields": [
+              {
+                "name": "UNKNOWN_SERVICE"
+              },
+              {
+                "name": "FILE_SYSTEM_MASTER_CLIENT_SERVICE",
+                "integer": 1
+              },
+              {
+                "name": "FILE_SYSTEM_MASTER_WORKER_SERVICE",
+                "integer": 2
+              },
+              {
+                "name": "FILE_SYSTEM_MASTER_JOB_SERVICE",
+                "integer": 3
+              },
+              {
+                "name": "BLOCK_MASTER_CLIENT_SERVICE",
+                "integer": 4
+              },
+              {
+                "name": "BLOCK_MASTER_WORKER_SERVICE",
+                "integer": 5
+              },
+              {
+                "name": "META_MASTER_CONFIG_SERVICE",
+                "integer": 6
+              },
+              {
+                "name": "META_MASTER_CLIENT_SERVICE",
+                "integer": 7
+              },
+              {
+                "name": "META_MASTER_MASTER_SERVICE",
+                "integer": 8
+              },
+              {
+                "name": "METRICS_MASTER_CLIENT_SERVICE",
+                "integer": 9
+              },
+              {
+                "name": "JOB_MASTER_CLIENT_SERVICE",
+                "integer": 10
+              },
+              {
+                "name": "JOB_MASTER_WORKER_SERVICE",
+                "integer": 11
+              },
+              {
+                "name": "FILE_SYSTEM_WORKER_WORKER_SERVICE",
+                "integer": 12
+              },
+              {
+                "name": "JOURNAL_MASTER_CLIENT_SERVICE",
+                "integer": 13
+              },
+              {
+                "name": "TABLE_MASTER_CLIENT_SERVICE",
+                "integer": 14
+              },
+              {
+                "name": "META_MASTER_BACKUP_MESSAGING_SERVICE",
+                "integer": 15
+              },
+              {
+                "name": "RAFT_JOURNAL_SERVICE",
+                "integer": 16
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "GetServiceVersionPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "serviceType",
+                "type": "ServiceType"
+              }
+            ]
+          },
+          {
+            "name": "GetServiceVersionPResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "version",
+                "type": "int64"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "ServiceVersionClientService",
+            "rpcs": [
+              {
+                "name": "getServiceVersion",
+                "in_type": "GetServiceVersionPRequest",
+                "out_type": "GetServiceVersionPResponse"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "alluxio.grpc.version"
+        },
+        "options": [
+          {
+            "name": "java_multiple_files",
+            "value": "true"
+          },
+          {
+            "name": "java_package",
+            "value": "alluxio.grpc"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "VersionProto"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "proto:/:client:/:cache.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "PPageStoreCommonOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pageSize",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "cacheSize",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "alluxioVersion",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "PRocksPageStoreOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "commonOptions",
+                "type": "PPageStoreCommonOptions"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "alluxio.proto.client"
+        }
+      }
+    },
+    {
+      "protopath": "proto:/:dataserver:/:protocol.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "OpenUfsBlockOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ufs_path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "offset_in_file",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "block_size",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "maxUfsReadConcurrency",
+                "type": "int32"
+              },
+              {
+                "id": 5,
+                "name": "mountId",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "no_cache",
+                "type": "bool"
+              },
+              {
+                "id": 7,
+                "name": "user",
+                "type": "string"
+              },
+              {
+                "id": 8,
+                "name": "block_in_ufs_tier",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "CreateUfsFileOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ufs_path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "owner",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "group",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "mode",
+                "type": "int32"
+              },
+              {
+                "id": 5,
+                "name": "mount_id",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "acl",
+                "type": "alluxio.proto.shared.AccessControlList"
+              }
+            ]
+          },
+          {
+            "name": "CreateUfsBlockOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "bytes_in_block_store",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "mount_id",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "fallback",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "Response",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "status.PStatus"
+              },
+              {
+                "id": 2,
+                "name": "message",
+                "type": "string"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "proto/dataserver/status.proto"
+          },
+          {
+            "path": "proto/shared/acl.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.proto.dataserver"
+        }
+      }
+    },
+    {
+      "protopath": "proto:/:dataserver:/:status.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "PStatus",
+            "enum_fields": [
+              {
+                "name": "OK"
+              },
+              {
+                "name": "CANCELED",
+                "integer": 1
+              },
+              {
+                "name": "UNKNOWN",
+                "integer": 2
+              },
+              {
+                "name": "INVALID_ARGUMENT",
+                "integer": 3
+              },
+              {
+                "name": "DEADLINE_EXCEEDED",
+                "integer": 4
+              },
+              {
+                "name": "NOT_FOUND",
+                "integer": 5
+              },
+              {
+                "name": "ALREADY_EXISTS",
+                "integer": 6
+              },
+              {
+                "name": "PERMISSION_DENIED",
+                "integer": 7
+              },
+              {
+                "name": "UNAUTHENTICATED",
+                "integer": 16
+              },
+              {
+                "name": "RESOURCE_EXHAUSTED",
+                "integer": 8
+              },
+              {
+                "name": "FAILED_PRECONDITION",
+                "integer": 9
+              },
+              {
+                "name": "ABORTED",
+                "integer": 10
+              },
+              {
+                "name": "OUT_OF_RANGE",
+                "integer": 11
+              },
+              {
+                "name": "UNIMPLEMENTED",
+                "integer": 12
+              },
+              {
+                "name": "INTERNAL",
+                "integer": 13
+              },
+              {
+                "name": "UNAVAILABLE",
+                "integer": 14
+              },
+              {
+                "name": "DATA_LOSS",
+                "integer": 15
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "alluxio.proto.status"
+        }
+      }
+    },
+    {
+      "protopath": "proto:/:journal:/:block.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "BlockContainerIdGeneratorEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "next_container_id",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "BlockInfoEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "block_id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "length",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "DeleteBlockEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "block_id",
+                "type": "int64"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "alluxio.proto.journal"
+        }
+      }
+    },
+    {
+      "protopath": "proto:/:journal:/:file.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "PTtlAction",
+            "enum_fields": [
+              {
+                "name": "DELETE"
+              },
+              {
+                "name": "FREE",
+                "integer": 1
+              }
+            ]
+          },
+          {
+            "name": "PSetAclAction",
+            "enum_fields": [
+              {
+                "name": "REPLACE"
+              },
+              {
+                "name": "MODIFY",
+                "integer": 1
+              },
+              {
+                "name": "REMOVE",
+                "integer": 2
+              },
+              {
+                "name": "REMOVE_ALL",
+                "integer": 3
+              },
+              {
+                "name": "REMOVE_DEFAULT",
+                "integer": 4
+              }
+            ]
+          },
+          {
+            "name": "UfsMode",
+            "enum_fields": [
+              {
+                "name": "NO_ACCESS"
+              },
+              {
+                "name": "READ_ONLY",
+                "integer": 1
+              },
+              {
+                "name": "READ_WRITE",
+                "integer": 2
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "StringPairEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "key",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ActiveSyncTxIdEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "mount_id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "tx_id",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "AddSyncPointEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "syncpoint_path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "mount_id",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "RemoveSyncPointEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "syncpoint_path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "mount_id",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "AddMountPointEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "alluxio_path",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "ufs_path",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "readOnly",
+                "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "properties",
+                "type": "StringPairEntry",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "shared",
+                "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "mount_id",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "AsyncPersistRequestEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "file_id",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "CompleteFileEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "block_ids",
+                "type": "int64",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "length",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "op_time_ms",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "ufs_fingerprint",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "DeleteFileEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "recursive",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "op_time_ms",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "alluxioOnly",
+                "type": "bool"
+              },
+              {
+                "id": 5,
+                "name": "path",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "DeleteMountPointEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "alluxio_path",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "NewBlockEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "UpdateInodeEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "parent_id",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "persistence_state",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "pinned",
+                "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "creation_time_ms",
+                "type": "int64"
+              },
+              {
+                "id": 7,
+                "name": "last_modification_time_ms",
+                "type": "int64"
+              },
+              {
+                "id": 8,
+                "name": "overwrite_modification_time",
+                "type": "bool"
+              },
+              {
+                "id": 9,
+                "name": "owner",
+                "type": "string"
+              },
+              {
+                "id": 10,
+                "name": "group",
+                "type": "string"
+              },
+              {
+                "id": 11,
+                "name": "mode",
+                "type": "int32"
+              },
+              {
+                "id": 12,
+                "name": "ttl",
+                "type": "int64"
+              },
+              {
+                "id": 13,
+                "name": "ttlAction",
+                "type": "PTtlAction",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "DELETE"
+                  }
+                ]
+              },
+              {
+                "id": 14,
+                "name": "acl",
+                "type": "alluxio.proto.shared.AccessControlList"
+              },
+              {
+                "id": 15,
+                "name": "ufs_fingerprint",
+                "type": "string"
+              },
+              {
+                "id": 16,
+                "name": "medium_type",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 18,
+                "name": "last_access_time_ms",
+                "type": "int64"
+              },
+              {
+                "id": 19,
+                "name": "overwrite_access_time",
+                "type": "bool"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 17,
+                  "name": "xAttr",
+                  "type": "bytes"
+                }
+              }
+            ]
+          },
+          {
+            "name": "UpdateInodeDirectoryEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "mount_point",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "direct_children_loaded",
+                "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "defaultAcl",
+                "type": "alluxio.proto.shared.AccessControlList"
+              }
+            ]
+          },
+          {
+            "name": "UpdateInodeFileEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "block_size_bytes",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "length",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "completed",
+                "type": "bool"
+              },
+              {
+                "id": 5,
+                "name": "cacheable",
+                "type": "bool"
+              },
+              {
+                "id": 7,
+                "name": "set_blocks",
+                "type": "int64",
+                "is_repeated": true
+              },
+              {
+                "id": 8,
+                "name": "replication_max",
+                "type": "int32"
+              },
+              {
+                "id": 9,
+                "name": "replication_min",
+                "type": "int32"
+              },
+              {
+                "id": 10,
+                "name": "persist_job_id",
+                "type": "int64"
+              },
+              {
+                "id": 11,
+                "name": "temp_ufs_path",
+                "type": "string"
+              },
+              {
+                "id": 12,
+                "name": "path",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "InodeDirectoryEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "parent_id",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "persistence_state",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "pinned",
+                "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "creation_time_ms",
+                "type": "int64"
+              },
+              {
+                "id": 7,
+                "name": "last_modification_time_ms",
+                "type": "int64"
+              },
+              {
+                "id": 8,
+                "name": "owner",
+                "type": "string"
+              },
+              {
+                "id": 9,
+                "name": "group",
+                "type": "string"
+              },
+              {
+                "id": 10,
+                "name": "mode",
+                "type": "int32"
+              },
+              {
+                "id": 11,
+                "name": "mount_point",
+                "type": "bool"
+              },
+              {
+                "id": 12,
+                "name": "direct_children_loaded",
+                "type": "bool"
+              },
+              {
+                "id": 13,
+                "name": "ttl",
+                "type": "int64"
+              },
+              {
+                "id": 14,
+                "name": "ttlAction",
+                "type": "PTtlAction",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "DELETE"
+                  }
+                ]
+              },
+              {
+                "id": 15,
+                "name": "acl",
+                "type": "alluxio.proto.shared.AccessControlList"
+              },
+              {
+                "id": 16,
+                "name": "defaultAcl",
+                "type": "alluxio.proto.shared.AccessControlList"
+              },
+              {
+                "id": 17,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 18,
+                "name": "medium_type",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 20,
+                "name": "last_access_time_ms",
+                "type": "int64"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 19,
+                  "name": "xAttr",
+                  "type": "bytes"
+                }
+              }
+            ]
+          },
+          {
+            "name": "InodeDirectoryIdGeneratorEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "container_id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "sequence_number",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "InodeFileEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "parent_id",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "persistence_state",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "pinned",
+                "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "creation_time_ms",
+                "type": "int64"
+              },
+              {
+                "id": 7,
+                "name": "last_modification_time_ms",
+                "type": "int64"
+              },
+              {
+                "id": 8,
+                "name": "block_size_bytes",
+                "type": "int64"
+              },
+              {
+                "id": 9,
+                "name": "length",
+                "type": "int64"
+              },
+              {
+                "id": 10,
+                "name": "completed",
+                "type": "bool"
+              },
+              {
+                "id": 11,
+                "name": "cacheable",
+                "type": "bool"
+              },
+              {
+                "id": 12,
+                "name": "blocks",
+                "type": "int64",
+                "is_repeated": true
+              },
+              {
+                "id": 13,
+                "name": "ttl",
+                "type": "int64"
+              },
+              {
+                "id": 14,
+                "name": "owner",
+                "type": "string"
+              },
+              {
+                "id": 15,
+                "name": "group",
+                "type": "string"
+              },
+              {
+                "id": 16,
+                "name": "mode",
+                "type": "int32"
+              },
+              {
+                "id": 17,
+                "name": "ttlAction",
+                "type": "PTtlAction",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "DELETE"
+                  }
+                ]
+              },
+              {
+                "id": 18,
+                "name": "ufs_fingerprint",
+                "type": "string"
+              },
+              {
+                "id": 19,
+                "name": "acl",
+                "type": "alluxio.proto.shared.AccessControlList"
+              },
+              {
+                "id": 20,
+                "name": "replication_max",
+                "type": "int32"
+              },
+              {
+                "id": 21,
+                "name": "replication_min",
+                "type": "int32"
+              },
+              {
+                "id": 22,
+                "name": "persist_job_id",
+                "type": "int64"
+              },
+              {
+                "id": 23,
+                "name": "temp_ufs_path",
+                "type": "string"
+              },
+              {
+                "id": 24,
+                "name": "replication_durable",
+                "type": "int32"
+              },
+              {
+                "id": 25,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 26,
+                "name": "medium_type",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 27,
+                "name": "should_persist_time",
+                "type": "int64"
+              },
+              {
+                "id": 29,
+                "name": "last_access_time_ms",
+                "type": "int64"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 28,
+                  "name": "xAttr",
+                  "type": "bytes"
+                }
+              }
+            ]
+          },
+          {
+            "name": "InodeLastModificationTimeEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "last_modification_time_ms",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "PersistDirectoryEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "PersistFileEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "length",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "op_time_ms",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "RenameEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "dst_path",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "op_time_ms",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "new_parent_id",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "new_name",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "path",
+                "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "new_path",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SetAclEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "op_time_ms",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "action",
+                "type": "PSetAclAction"
+              },
+              {
+                "id": 4,
+                "name": "entries",
+                "type": "alluxio.proto.shared.AclEntry",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "recursive",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "SetAttributeEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "op_time_ms",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "pinned",
+                "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "ttl",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "persisted",
+                "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "owner",
+                "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "group",
+                "type": "string"
+              },
+              {
+                "id": 8,
+                "name": "permission",
+                "type": "int32"
+              },
+              {
+                "id": 9,
+                "name": "ttlAction",
+                "type": "PTtlAction",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "DELETE"
+                  }
+                ]
+              },
+              {
+                "id": 10,
+                "name": "ufs_fingerprint",
+                "type": "string"
+              },
+              {
+                "id": 11,
+                "name": "persistJobId",
+                "type": "int64"
+              },
+              {
+                "id": 12,
+                "name": "tempUfsPath",
+                "type": "string"
+              },
+              {
+                "id": 13,
+                "name": "replication_max",
+                "type": "int32"
+              },
+              {
+                "id": 14,
+                "name": "replication_min",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "UpdateUfsModeEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ufsPath",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "ufsMode",
+                "type": "UfsMode",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "READ_WRITE"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "grpc/common.proto"
+          },
+          {
+            "path": "proto/shared/acl.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.proto.journal"
+        }
+      }
+    },
+    {
+      "protopath": "proto:/:journal:/:journal.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "JournalOpPId",
+            "fields": [
+              {
+                "id": 1,
+                "name": "mostSignificantBits",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "leastSignificantBits",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "JournalEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "sequence_number",
+                "type": "int64"
+              },
+              {
+                "id": 52,
+                "name": "operationId",
+                "type": "JournalOpPId"
+              },
+              {
+                "id": 34,
+                "name": "active_sync_tx_id",
+                "type": "ActiveSyncTxIdEntry"
+              },
+              {
+                "id": 43,
+                "name": "add_table",
+                "type": "AddTableEntry"
+              },
+              {
+                "id": 51,
+                "name": "add_table_partitions",
+                "type": "AddTablePartitionsEntry"
+              },
+              {
+                "id": 32,
+                "name": "add_sync_point",
+                "type": "AddSyncPointEntry"
+              },
+              {
+                "id": 2,
+                "name": "add_mount_point",
+                "type": "AddMountPointEntry"
+              },
+              {
+                "id": 16,
+                "name": "async_persist_request",
+                "type": "AsyncPersistRequestEntry"
+              },
+              {
+                "id": 44,
+                "name": "attach_db",
+                "type": "AttachDbEntry"
+              },
+              {
+                "id": 3,
+                "name": "block_container_id_generator",
+                "type": "BlockContainerIdGeneratorEntry"
+              },
+              {
+                "id": 4,
+                "name": "block_info",
+                "type": "BlockInfoEntry"
+              },
+              {
+                "id": 42,
+                "name": "cluster_info",
+                "type": "ClusterInfoEntry"
+              },
+              {
+                "id": 5,
+                "name": "complete_file",
+                "type": "CompleteFileEntry"
+              },
+              {
+                "id": 29,
+                "name": "delete_block",
+                "type": "DeleteBlockEntry"
+              },
+              {
+                "id": 6,
+                "name": "delete_file",
+                "type": "DeleteFileEntry"
+              },
+              {
+                "id": 8,
+                "name": "delete_mount_point",
+                "type": "DeleteMountPointEntry"
+              },
+              {
+                "id": 45,
+                "name": "detach_db",
+                "type": "DetachDbEntry"
+              },
+              {
+                "id": 9,
+                "name": "inode_directory",
+                "type": "InodeDirectoryEntry"
+              },
+              {
+                "id": 10,
+                "name": "inode_directory_id_generator",
+                "type": "InodeDirectoryIdGeneratorEntry"
+              },
+              {
+                "id": 11,
+                "name": "inode_file",
+                "type": "InodeFileEntry"
+              },
+              {
+                "id": 12,
+                "name": "inode_last_modification_time",
+                "type": "InodeLastModificationTimeEntry"
+              },
+              {
+                "id": 38,
+                "name": "new_block",
+                "type": "NewBlockEntry"
+              },
+              {
+                "id": 40,
+                "name": "path_properties",
+                "type": "PathPropertiesEntry"
+              },
+              {
+                "id": 15,
+                "name": "persist_directory",
+                "type": "PersistDirectoryEntry"
+              },
+              {
+                "id": 41,
+                "name": "remove_path_properties",
+                "type": "RemovePathPropertiesEntry"
+              },
+              {
+                "id": 50,
+                "name": "remove_table",
+                "type": "RemoveTableEntry"
+              },
+              {
+                "id": 47,
+                "name": "remove_transform_job_info",
+                "type": "RemoveTransformJobInfoEntry"
+              },
+              {
+                "id": 33,
+                "name": "remove_sync_point",
+                "type": "RemoveSyncPointEntry"
+              },
+              {
+                "id": 19,
+                "name": "rename",
+                "type": "RenameEntry"
+              },
+              {
+                "id": 31,
+                "name": "set_acl",
+                "type": "SetAclEntry"
+              },
+              {
+                "id": 27,
+                "name": "set_attribute",
+                "type": "SetAttributeEntry"
+              },
+              {
+                "id": 46,
+                "name": "add_transform_job_info",
+                "type": "AddTransformJobInfoEntry"
+              },
+              {
+                "id": 48,
+                "name": "complete_transform_table",
+                "type": "CompleteTransformTableEntry"
+              },
+              {
+                "id": 49,
+                "name": "update_database_info",
+                "type": "UpdateDatabaseInfoEntry"
+              },
+              {
+                "id": 30,
+                "name": "update_ufs_mode",
+                "type": "UpdateUfsModeEntry"
+              },
+              {
+                "id": 35,
+                "name": "update_inode",
+                "type": "UpdateInodeEntry"
+              },
+              {
+                "id": 36,
+                "name": "update_inode_directory",
+                "type": "UpdateInodeDirectoryEntry"
+              },
+              {
+                "id": 37,
+                "name": "update_inode_file",
+                "type": "UpdateInodeFileEntry"
+              },
+              {
+                "id": 39,
+                "name": "journal_entries",
+                "type": "JournalEntry",
+                "is_repeated": true
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "proto/journal/block.proto"
+          },
+          {
+            "path": "proto/journal/file.proto"
+          },
+          {
+            "path": "proto/journal/meta.proto"
+          },
+          {
+            "path": "proto/journal/table.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.proto.journal"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "alluxio.proto.journal"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "proto:/:journal:/:meta.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "PathPropertiesEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "properties",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "RemovePathPropertiesEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ClusterInfoEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cluster_id",
+                "type": "string"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "alluxio.proto.journal"
+        }
+      }
+    },
+    {
+      "protopath": "proto:/:journal:/:table.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "AttachDbEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "udb_type",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "udb_connection_uri",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "udb_db_name",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "db_name",
+                "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 5,
+                  "name": "config",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "DetachDbEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "AddTableEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "table_name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "owner",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "schema",
+                "type": "alluxio.grpc.table.Schema"
+              },
+              {
+                "id": 5,
+                "name": "layout",
+                "type": "alluxio.grpc.table.Layout"
+              },
+              {
+                "id": 6,
+                "name": "table_stats",
+                "type": "alluxio.grpc.table.ColumnStatisticsInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 8,
+                "name": "partition_cols",
+                "type": "alluxio.grpc.table.FieldSchema",
+                "is_repeated": true
+              },
+              {
+                "id": 9,
+                "name": "partitions",
+                "type": "alluxio.grpc.table.Partition",
+                "is_repeated": true
+              },
+              {
+                "id": 10,
+                "name": "previous_version",
+                "type": "int64"
+              },
+              {
+                "id": 11,
+                "name": "version",
+                "type": "int64"
+              },
+              {
+                "id": 12,
+                "name": "version_creation_time",
+                "type": "int64"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 7,
+                  "name": "parameters",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "AddTablePartitionsEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "table_name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "version",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "partitions",
+                "type": "alluxio.grpc.table.Partition",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "RemoveTableEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "table_name",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "version",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "CompleteTransformTableEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "table_name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "definition",
+                "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 4,
+                  "name": "transformed_layouts",
+                  "type": "alluxio.grpc.table.Layout"
+                }
+              }
+            ]
+          },
+          {
+            "name": "AddTransformJobInfoEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "table_name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "definition",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "job_id",
+                "type": "int64"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 5,
+                  "name": "transformed_layouts",
+                  "type": "alluxio.grpc.table.Layout"
+                }
+              }
+            ]
+          },
+          {
+            "name": "RemoveTransformJobInfoEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "table_name",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "UpdateDatabaseInfoEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "db_name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "location",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "owner_name",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "owner_type",
+                "type": "alluxio.grpc.table.PrincipalType"
+              },
+              {
+                "id": 6,
+                "name": "comment",
+                "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 3,
+                  "name": "parameter",
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "grpc/table/table_master.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.proto.journal"
+        }
+      }
+    },
+    {
+      "protopath": "proto:/:meta:/:block.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "BlockMeta",
+            "fields": [
+              {
+                "id": 1,
+                "name": "length",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "BlockLocation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "worker_id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "tier",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "mediumType",
+                "type": "string"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "alluxio.proto.meta"
+        }
+      }
+    },
+    {
+      "protopath": "proto:/:meta:/:inode_meta.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Inode",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "creation_time_ms",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "is_directory",
+                "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "ttl",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "ttl_action",
+                "type": "grpc.TtlAction"
+              },
+              {
+                "id": 25,
+                "name": "last_modified_ms",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "parent_id",
+                "type": "int64"
+              },
+              {
+                "id": 8,
+                "name": "persistence_state",
+                "type": "string"
+              },
+              {
+                "id": 9,
+                "name": "is_pinned",
+                "type": "bool"
+              },
+              {
+                "id": 10,
+                "name": "access_acl",
+                "type": "alluxio.proto.shared.AccessControlList"
+              },
+              {
+                "id": 11,
+                "name": "ufs_fingerprint",
+                "type": "string"
+              },
+              {
+                "id": 27,
+                "name": "medium_type",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 30,
+                "name": "last_accessed_ms",
+                "type": "int64"
+              },
+              {
+                "id": 12,
+                "name": "is_mount_point",
+                "type": "bool"
+              },
+              {
+                "id": 13,
+                "name": "has_direct_children_loaded",
+                "type": "bool"
+              },
+              {
+                "id": 26,
+                "name": "child_count",
+                "type": "int64"
+              },
+              {
+                "id": 14,
+                "name": "default_acl",
+                "type": "alluxio.proto.shared.AccessControlList"
+              },
+              {
+                "id": 15,
+                "name": "block_size_bytes",
+                "type": "int64"
+              },
+              {
+                "id": 16,
+                "name": "blocks",
+                "type": "int64",
+                "is_repeated": true
+              },
+              {
+                "id": 17,
+                "name": "is_cacheable",
+                "type": "bool"
+              },
+              {
+                "id": 18,
+                "name": "is_completed",
+                "type": "bool"
+              },
+              {
+                "id": 19,
+                "name": "length",
+                "type": "int64"
+              },
+              {
+                "id": 20,
+                "name": "replication_durable",
+                "type": "int32"
+              },
+              {
+                "id": 21,
+                "name": "replication_max",
+                "type": "int32"
+              },
+              {
+                "id": 22,
+                "name": "replication_min",
+                "type": "int32"
+              },
+              {
+                "id": 28,
+                "name": "should_persist_time",
+                "type": "int64"
+              },
+              {
+                "id": 23,
+                "name": "persist_job_id",
+                "type": "int64"
+              },
+              {
+                "id": 24,
+                "name": "persist_job_temp_ufs_path",
+                "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 29,
+                  "name": "xAttr",
+                  "type": "bytes"
+                }
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "grpc/common.proto"
+          },
+          {
+            "path": "proto/shared/acl.proto"
+          }
+        ],
+        "package": {
+          "name": "alluxio.proto.meta"
+        }
+      }
+    },
+    {
+      "protopath": "proto:/:shared:/:acl.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "AclAction",
+            "enum_fields": [
+              {
+                "name": "READ"
+              },
+              {
+                "name": "WRITE",
+                "integer": 1
+              },
+              {
+                "name": "EXECUTE",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "AclEntryType",
+            "enum_fields": [
+              {
+                "name": "OWNER"
+              },
+              {
+                "name": "NAMED_USER",
+                "integer": 1
+              },
+              {
+                "name": "OWNING_GROUP",
+                "integer": 2
+              },
+              {
+                "name": "NAMED_GROUP",
+                "integer": 3
+              },
+              {
+                "name": "MASK",
+                "integer": 4
+              },
+              {
+                "name": "OTHER",
+                "integer": 5
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "AclActions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "actions",
+                "type": "AclAction",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "AclEntry",
+            "fields": [
+              {
+                "id": 1,
+                "name": "type",
+                "type": "AclEntryType"
+              },
+              {
+                "id": 2,
+                "name": "subject",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "actions",
+                "type": "AclAction",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "isDefault",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "NamedAclActions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "actions",
+                "type": "AclActions"
+              }
+            ]
+          },
+          {
+            "name": "AccessControlList",
+            "fields": [
+              {
+                "id": 1,
+                "name": "owningUser",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "owningGroup",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "userActions",
+                "type": "NamedAclActions",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "groupActions",
+                "type": "NamedAclActions",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "maskActions",
+                "type": "AclActions"
+              },
+              {
+                "id": 6,
+                "name": "otherActions",
+                "type": "AclActions"
+              },
+              {
+                "id": 7,
+                "name": "isDefault",
+                "type": "bool"
+              },
+              {
+                "id": 8,
+                "name": "isEmpty",
+                "type": "bool"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "alluxio.proto.shared"
+        }
+      }
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
       <dependency>
         <groupId>com.salesforce.servicelibs</groupId>
         <artifactId>proto-backwards-compatibility</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Protolock prevents incompatible protobuf changes such as removing a field from a proto , but we are not using it correctly so far. 

https://github.com/salesforce/proto-backwards-compat-maven-plugin


### Why are the changes needed?
Better backwards compatibility 
