### PR TITLE
Supplement the documentation description of sudo password-free login

### DIFF
--- a/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
+++ b/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
@@ -32,6 +32,7 @@ To deploy Alluxio in production, we highly recommend running Alluxio masters in
 * Enable SSH login without password from the master node to worker nodes and from the master node to itself.
   You can add a public SSH key for the host into `~/.ssh/authorized_keys`.
   See [this tutorial](http://www.linuxproblem.org/art_9.html) for more details.
+* Enable sudo command can be used without inputting the password, or it will always fall into the wait state.
 * TCP traffic across all nodes is allowed.
   For basic functionality, make sure RPC port (default:19998) is open on all nodes.
 * Allow `sudo` privilege for the OS user that Alluxio will be running as.

--- a/docs/en/ufs/HDFS.md
+++ b/docs/en/ufs/HDFS.md
@@ -115,6 +115,8 @@ to verify the files and directories created by Alluxio exist. For this test, you
 files named like: `/default_tests_files/BASIC_CACHE_THROUGH` at
 [http://localhost:50070/explorer.html](http://localhost:50070/explorer.html)
 
+(the default port of HDFS web UI is 9870 over version 3.0.0)
+
 Stop Alluxio by running:
 
 ```console


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add a statement, that is "Enable sudo command can be used without inputting the password, or it will always fall into the wait state."

### Why are the changes needed?

If not, some nodes will wait for inputting password but nobody can do it.

### Does this PR introduce any user facing changes?

No.
