### PR TITLE
[DOCFIX] Fix the HDFS document

### DIFF
--- a/docs/en/ufs/HDFS.md
+++ b/docs/en/ufs/HDFS.md
@@ -115,6 +115,8 @@ to verify the files and directories created by Alluxio exist. For this test, you
 files named like: `/default_tests_files/BASIC_CACHE_THROUGH` at
 [http://localhost:50070/explorer.html](http://localhost:50070/explorer.html)
 
+(The default port of HDFS web UI is 9870 in the version over 3.0.0)
+
 Stop Alluxio by running:
 
 ```console

--- a/docs/en/ufs/HDFS.md
+++ b/docs/en/ufs/HDFS.md
@@ -115,7 +115,7 @@ to verify the files and directories created by Alluxio exist. For this test, you
 files named like: `/default_tests_files/BASIC_CACHE_THROUGH` at
 [http://localhost:50070/explorer.html](http://localhost:50070/explorer.html)
 
-(The default port of HDFS web UI is 9870 in the version over 3.0.0)
+(The default port of HDFS web UI is 9870 in the version over 3.0.0. See [this tutorial](https://hadoop.apache.org/docs/r3.2.0/hadoop-project-dist/hadoop-common/ClusterSetup.html) for more details.)
 
 Stop Alluxio by running:
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

The default port of HDFS web UI is 9870 in the version over 3.0.0

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. If not, the User will think that he configured the HDFS incorrectly.

### Does this PR introduce any user facing changes?

   no
