### PR TITLE
Add another open for read flag

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseOpenUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseOpenUtils.java
@@ -65,6 +65,10 @@ public final class AlluxioFuseOpenUtils {
   private static final int APPEND_PLUS = 0x8402;
   // ax+ FUSE.open() is never called
 
+  // Fuse flags found in actual workloads
+  // used by filebench to read file
+  private static final int READ_TWO = 0xc002;
+
   /**
    * Gets Alluxio Fuse open action based on open flag.
    *
@@ -108,6 +112,7 @@ public final class AlluxioFuseOpenUtils {
   private static OpenAction getOpenActionFromExtraOpenFlags(int flag) {
     switch (flag) {
       case READ:
+      case READ_TWO:
       case READ_SYNC:
         return OpenAction.READ_ONLY;
       case WRITE:


### PR DESCRIPTION
### What changes are proposed in this pull request?
Filebench will use 0xc002 open flag to open the file for reading.
### Why are the changes needed?
Support using 0xc002 to open file for reading
### Does this PR introduce any user facing changes?
NA