### PR TITLE
Upgrade Ratis version to 2.2.0

### DIFF
--- a/core/server/common/pom.xml
+++ b/core/server/common/pom.xml
@@ -26,7 +26,7 @@
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.parent.basedir}/build</build.path>
-    <alluxio.ratis.version>2.0.0</alluxio.ratis.version>
+    <alluxio.ratis.version>2.2.0</alluxio.ratis.version>
   </properties>
 
   <dependencies>

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -62,7 +62,7 @@ public class SnapshotReplicationManagerTest {
       new ConfigurationRule(PropertyKey.MASTER_EMBEDDED_JOURNAL_SNAPSHOT_REPLICATION_CHUNK_SIZE,
           "32KB", ServerConfiguration.global());
 
-  private WaitForOptions mWaitOptions = WaitForOptions.defaults().setTimeoutMs(30000);
+  private final WaitForOptions mWaitOptions = WaitForOptions.defaults().setTimeoutMs(30000);
   private SnapshotReplicationManager mLeaderSnapshotManager;
   private SnapshotReplicationManager mFollowerSnapshotManager;
   private RaftJournalSystem mLeader;
@@ -120,7 +120,8 @@ public class SnapshotReplicationManagerTest {
 
   private SimpleStateMachineStorage getSimpleStateMachineStorage() throws IOException {
     RaftStorage rs = new RaftStorageImpl(mFolder.newFolder(CommonUtils.randomAlphaNumString(6)),
-            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault());
+        RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
+        RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize());
     SimpleStateMachineStorage snapshotStore = new SimpleStateMachineStorage();
     snapshotStore.init(rs);
     return snapshotStore;

--- a/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
@@ -84,7 +84,8 @@ public class RaftJournalDumper extends AbstractJournalDumper {
         PrintStream out =
             new PrintStream(new BufferedOutputStream(new FileOutputStream(mJournalEntryFile)));
         RaftStorage storage = new RaftStorageImpl(getJournalDir(),
-                RaftServerConfigKeys.Log.CorruptionPolicy.getDefault())) {
+            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
+            RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize())) {
       List<LogSegmentPath> paths = LogSegmentPath.getLogSegmentPaths(storage);
       for (LogSegmentPath path : paths) {
         final int entryCount = LogSegment.readSegmentFile(path.getPath().toFile(),
@@ -114,7 +115,8 @@ public class RaftJournalDumper extends AbstractJournalDumper {
 
   private void readRatisSnapshotFromDir() throws IOException {
     try (RaftStorage storage = new RaftStorageImpl(getJournalDir(),
-            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault())) {
+            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
+            RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize())) {
       SimpleStateMachineStorage stateMachineStorage = new SimpleStateMachineStorage();
       stateMachineStorage.init(storage);
       SingleFileSnapshotInfo currentSnapshot = stateMachineStorage.getLatestSnapshot();

--- a/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
+++ b/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
@@ -221,7 +221,8 @@ public class JournalToolTest extends BaseIntegrationTest {
     try (RaftStorage storage = new RaftStorageImpl(
         new File(RaftJournalUtils.getRaftJournalDir(new File(journalFolder)),
             RaftJournalSystem.RAFT_GROUP_UUID.toString()),
-            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault())) {
+            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
+            RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize())) {
       SimpleStateMachineStorage stateMachineStorage = new SimpleStateMachineStorage();
       stateMachineStorage.init(storage);
       SingleFileSnapshotInfo snapshot = stateMachineStorage.getLatestSnapshot();

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
@@ -101,7 +101,8 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
 
     SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
     storage.init(new RaftStorageImpl(raftDir,
-        RaftServerConfigKeys.Log.CorruptionPolicy.getDefault()));
+        RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
+        RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize()));
     SingleFileSnapshotInfo snapshot = storage.findLatestSnapshot();
     assertNotNull(snapshot);
     mCluster.notifySuccess();
@@ -144,7 +145,8 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
     mCluster.stopMaster(catchUpMasterIndex);
     SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
     storage.init(new RaftStorageImpl(raftDir,
-        RaftServerConfigKeys.Log.CorruptionPolicy.getDefault()));
+        RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
+        RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize()));
     SingleFileSnapshotInfo snapshot = storage.findLatestSnapshot();
     assertNotNull(snapshot);
     mCluster.notifySuccess();


### PR DESCRIPTION
From [this code comparison](https://github.com/apache/ratis/compare/ratis-2.0.0...ratis-2.2.0) it appears that Ratis 2.2.0 brings some fixes to the snapshotting logic. This draft PR serves to see if a version bump would break significant portions of the code. 