### PR TITLE
Load ozone class using extension class loader

### DIFF
--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -80,7 +80,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
     implements AtomicFileOutputStreamCallback {
   private static final Logger LOG = LoggerFactory.getLogger(HdfsUnderFileSystem.class);
-  private static final int MAX_TRY = 5;
+  protected static final int MAX_TRY = 5;
   private static final String HDFS_USER = "";
   /** Name of the class for the HDFS Acl provider. */
   private static final String HDFS_ACL_PROVIDER_CLASS =
@@ -825,7 +825,7 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
   /**
    * @return the underlying HDFS {@link FileSystem} object
    */
-  private FileSystem getFs() throws IOException {
+  protected FileSystem getFs() throws IOException {
     try {
       // TODO(gpang): handle different users
       return mUserFs.get(HDFS_USER);

--- a/underfs/ozone/src/main/java/alluxio/underfs/ozone/OzoneUnderFileOutputStream.java
+++ b/underfs/ozone/src/main/java/alluxio/underfs/ozone/OzoneUnderFileOutputStream.java
@@ -1,0 +1,89 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.ozone;
+
+import alluxio.underfs.hdfs.HdfsUnderFileOutputStream;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+
+import java.io.IOException;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Output stream implementation for {@link OzoneUnderFileOutputStream}.
+ */
+@NotThreadSafe
+public class OzoneUnderFileOutputStream extends HdfsUnderFileOutputStream {
+  /**
+   * Basic constructor.
+   *
+   * @param out underlying stream to wrap
+   */
+  public OzoneUnderFileOutputStream(FSDataOutputStream out) {
+    super(out);
+  }
+
+  @Override
+  public void close() throws IOException {
+    ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+      super.close();
+    } finally {
+      Thread.currentThread().setContextClassLoader(previousClassLoader);
+    }
+  }
+
+  @Override
+  public void flush() throws IOException {
+    ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+      super.flush();
+    } finally {
+      Thread.currentThread().setContextClassLoader(previousClassLoader);
+    }
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+      super.write(b);
+    } finally {
+      Thread.currentThread().setContextClassLoader(previousClassLoader);
+    }
+  }
+
+  @Override
+  public void write(byte[] b) throws IOException {
+    ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+      super.write(b);
+    } finally {
+      Thread.currentThread().setContextClassLoader(previousClassLoader);
+    }
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+      super.write(b, off, len);
+    } finally {
+      Thread.currentThread().setContextClassLoader(previousClassLoader);
+    }
+  }
+}

--- a/underfs/ozone/src/main/java/alluxio/underfs/ozone/OzoneUnderFileSystem.java
+++ b/underfs/ozone/src/main/java/alluxio/underfs/ozone/OzoneUnderFileSystem.java
@@ -1,0 +1,86 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.ozone;
+
+import alluxio.AlluxioURI;
+import alluxio.retry.CountingRetry;
+import alluxio.retry.RetryPolicy;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.hdfs.HdfsUnderFileSystem;
+import alluxio.underfs.options.CreateOptions;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Ozone {@link UnderFileSystem} implementation.
+ */
+@ThreadSafe
+public class OzoneUnderFileSystem extends HdfsUnderFileSystem {
+  private static final Logger LOG = LoggerFactory.getLogger(OzoneUnderFileSystem.class);
+
+  /**
+   * Factory method to constructs a new HDFS {@link UnderFileSystem} instance.
+   *
+   * @param ufsUri the {@link AlluxioURI} for this UFS
+   * @param conf the configuration for Hadoop
+   * @return a new HDFS {@link UnderFileSystem} instance
+   */
+  public static OzoneUnderFileSystem createInstance(AlluxioURI ufsUri,
+      UnderFileSystemConfiguration conf) {
+    Configuration hdfsConf = createConfiguration(conf);
+    return new OzoneUnderFileSystem(ufsUri, conf, hdfsConf);
+  }
+
+  /**
+   * Constructs a new Ozone {@link UnderFileSystem}.
+   *  @param ufsUri the {@link AlluxioURI} for this UFS
+   * @param conf the configuration for this UFS
+   * @param hdfsConf the configuration for HDFS
+   */
+  public OzoneUnderFileSystem(AlluxioURI ufsUri, UnderFileSystemConfiguration conf,
+      Configuration hdfsConf) {
+    super(ufsUri, conf, hdfsConf);
+  }
+
+  @Override
+  public OutputStream createDirect(String path, CreateOptions options) throws IOException {
+    IOException te = null;
+    FileSystem hdfs = getFs();
+    RetryPolicy retryPolicy = new CountingRetry(MAX_TRY);
+    while (retryPolicy.attempt()) {
+      try {
+        // TODO(chaomin): support creating HDFS files with specified block size and replication.
+        OutputStream outputStream = new OzoneUnderFileOutputStream(
+            FileSystem.create(hdfs, new Path(path),
+              new FsPermission(options.getMode().toShort())));
+        if (options.getAcl() != null) {
+          setAclEntries(path, options.getAcl().getEntries());
+        }
+        return outputStream;
+      } catch (IOException e) {
+        LOG.warn("Attempt count {} : {} ", retryPolicy.getAttemptCount(), e.toString());
+        te = e;
+      }
+    }
+    throw te;
+  }
+}

--- a/underfs/ozone/src/main/java/alluxio/underfs/ozone/OzoneUnderFileSystemFactory.java
+++ b/underfs/ozone/src/main/java/alluxio/underfs/ozone/OzoneUnderFileSystemFactory.java
@@ -11,22 +11,31 @@
 
 package alluxio.underfs.ozone;
 
+import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.OzoneUfsConstants;
 import alluxio.conf.PropertyKey;
+import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
-import alluxio.underfs.hdfs.HdfsUnderFileSystem;
 import alluxio.underfs.hdfs.HdfsUnderFileSystemFactory;
+
+import com.google.common.base.Preconditions;
 
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * Factory for creating {@link HdfsUnderFileSystem}.
+ * Factory for creating {@link OzoneUnderFileSystem}.
  *
- * It caches created {@link HdfsUnderFileSystem}s, using the scheme and authority pair as the key.
+ * It caches created {@link OzoneUnderFileSystem}s, using the scheme and authority pair as the key.
  */
 @ThreadSafe
 public class OzoneUnderFileSystemFactory extends HdfsUnderFileSystemFactory {
+
+  @Override
+  public UnderFileSystem create(String path, UnderFileSystemConfiguration conf) {
+    Preconditions.checkNotNull(path, "path");
+    return OzoneUnderFileSystem.createInstance(new AlluxioURI(path), conf);
+  }
 
   @Override
   public boolean supportsPath(String path) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

We found that the present master branch cannot write ufs when mount an ozone ufs. The following is the `worker.log`

```
2022-01-19 01:27:33,897 ERROR AbstractWriteHandler - Failed to write data for request UfsFileWriteRequest{id=-1, sessionId=4241132740562180823, ufsPath=o3fs://bucket1.vol1/f40, createUfsFileOptions=ufs_path: "o3fs://bucket1.vol1/f40"
owner: "mbl"
group: "staff"
mode: 420
mount_id: 7992182030805134325
acl {
  owningUser: "mbl"
  owningGroup: "staff"
  userActions {
    name: ""
    actions {
      actions: READ
      actions: WRITE
    }
  }
  groupActions {
    name: ""
    actions {
      actions: READ
    }
  }
  otherActions {
    actions: READ
  }
  isDefault: false
  isEmpty: false
}
}
java.io.IOException: java.io.IOException: Exception getting XceiverClient: alluxio.shaded.hdfs.com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Failed to get class org.apache.ratis.grpc.GrpcFactory as a subclass of interface org.apache.ratis.rpc.RpcFactory
        at org.apache.hadoop.ozone.client.io.KeyOutputStream.handleWrite(KeyOutputStream.java:250)
        at org.apache.hadoop.ozone.client.io.KeyOutputStream.write(KeyOutputStream.java:220)
        at org.apache.hadoop.fs.ozone.OzoneFSOutputStream.write(OzoneFSOutputStream.java:46)
        at org.apache.hadoop.fs.FSDataOutputStream$PositionCache.write(FSDataOutputStream.java:62)
        at java.io.DataOutputStream.write(DataOutputStream.java:107)
        at alluxio.underfs.hdfs.HdfsUnderFileOutputStream.write(HdfsUnderFileOutputStream.java:69)
        at io.netty.buffer.UnsafeByteBufUtil.getBytes(UnsafeByteBufUtil.java:608)
        at io.netty.buffer.UnsafeByteBufUtil.getBytes(UnsafeByteBufUtil.java:595)
        at io.netty.buffer.PooledUnsafeDirectByteBuf.getBytes(PooledUnsafeDirectByteBuf.java:142)
        at io.netty.buffer.CompositeByteBuf.getBytes(CompositeByteBuf.java:1161)
        at io.netty.buffer.CompositeByteBuf.getBytes(CompositeByteBuf.java:49)
        at io.netty.buffer.AbstractByteBuf.readBytes(AbstractByteBuf.java:965)
        at io.netty.buffer.CompositeByteBuf.readBytes(CompositeByteBuf.java:2097)
        at io.netty.buffer.CompositeByteBuf.readBytes(CompositeByteBuf.java:49)
        at alluxio.network.protocol.databuffer.NettyDataBuffer.readBytes(NettyDataBuffer.java:64)
        at alluxio.worker.grpc.UfsFileWriteHandler.writeBuf(UfsFileWriteHandler.java:141)
        at alluxio.worker.grpc.UfsFileWriteHandler.writeBuf(UfsFileWriteHandler.java:49)
        at alluxio.worker.grpc.AbstractWriteHandler.writeData(AbstractWriteHandler.java:281)
        at alluxio.worker.grpc.AbstractWriteHandler.lambda$writeDataMessage$1(AbstractWriteHandler.java:179)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
        at alluxio.worker.grpc.GrpcExecutors$ImpersonateThreadPoolExecutor.lambda$execute$0(GrpcExecutors.java:125)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.IOException: Exception getting XceiverClient: alluxio.shaded.hdfs.com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Failed to get class org.apache.ratis.grpc.GrpcFactory as a subclass of interface org.apache.ratis.rpc.RpcFactory
        at org.apache.hadoop.hdds.scm.XceiverClientManager.getClient(XceiverClientManager.java:243)
        at org.apache.hadoop.hdds.scm.XceiverClientManager.acquireClient(XceiverClientManager.java:165)
        at org.apache.hadoop.hdds.scm.XceiverClientManager.acquireClient(XceiverClientManager.java:138)
        at org.apache.hadoop.hdds.scm.storage.BlockOutputStream.<init>(BlockOutputStream.java:147)
        at org.apache.hadoop.hdds.scm.storage.RatisBlockOutputStream.<init>(RatisBlockOutputStream.java:79)
        at org.apache.hadoop.ozone.client.io.BlockOutputStreamEntry.checkStream(BlockOutputStreamEntry.java:99)
        at org.apache.hadoop.ozone.client.io.BlockOutputStreamEntry.cleanup(BlockOutputStreamEntry.java:178)
        at org.apache.hadoop.ozone.client.io.KeyOutputStream.handleException(KeyOutputStream.java:344)
        at org.apache.hadoop.ozone.client.io.KeyOutputStream.writeToOutputStream(KeyOutputStream.java:282)
        at org.apache.hadoop.ozone.client.io.KeyOutputStream.handleWrite(KeyOutputStream.java:240)
        ... 23 more
Caused by: alluxio.shaded.hdfs.com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Failed to get class org.apache.ratis.grpc.GrpcFactory as a subclass of interface org.apache.ratis.rpc.RpcFactory
        at alluxio.shaded.hdfs.com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2055)
        at alluxio.shaded.hdfs.com.google.common.cache.LocalCache.get(LocalCache.java:3966)
        at alluxio.shaded.hdfs.com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4863)
        at org.apache.hadoop.hdds.scm.XceiverClientManager.getClient(XceiverClientManager.java:221)
        ... 32 more
Caused by: java.lang.IllegalArgumentException: Failed to get class org.apache.ratis.grpc.GrpcFactory as a subclass of interface org.apache.ratis.rpc.RpcFactory
        at org.apache.ratis.util.ReflectionUtils.getClass(ReflectionUtils.java:215)
        at org.apache.ratis.rpc.SupportedRpcType.newFactory(SupportedRpcType.java:44)
        at org.apache.ratis.client.RaftClient$Builder.build(RaftClient.java:98)
        at org.apache.hadoop.hdds.ratis.RatisHelper.newRaftClient(RatisHelper.java:234)
        at org.apache.hadoop.hdds.ratis.RatisHelper.newRaftClient(RatisHelper.java:173)
        at org.apache.hadoop.hdds.scm.XceiverClientRatis.connect(XceiverClientRatis.java:170)
        at org.apache.hadoop.hdds.scm.XceiverClientManager$2.call(XceiverClientManager.java:237)
        at org.apache.hadoop.hdds.scm.XceiverClientManager$2.call(XceiverClientManager.java:221)
        at alluxio.shaded.hdfs.com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4868)
        at alluxio.shaded.hdfs.com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3533)
        at alluxio.shaded.hdfs.com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2282)
        at alluxio.shaded.hdfs.com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2159)
        at alluxio.shaded.hdfs.com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2049)
        ... 35 more
Caused by: java.lang.ClassNotFoundException: Class org.apache.ratis.grpc.GrpcFactory not found
        at org.apache.ratis.util.ReflectionUtils.getClassByName(ReflectionUtils.java:144)
        at org.apache.ratis.util.ReflectionUtils.getClass(ReflectionUtils.java:213)
        ... 47 more
```

### Why are the changes needed?

Root cause is `org.apache.ratis.util.ReflectionUtils$Classes#CLASS_LOADER`

```
    private static final ClassLoader CLASS_LOADER = Optional.ofNullable(
            Thread.currentThread().getContextClassLoader()).orElseGet(ReflectionUtils.class::getClassLoader);
```

and `ReflectionUtils` load class by `CLASS_LOADER`, which is `appClassLoader`, it cannot load the class within the extension jar.

Using extension loader while write and close within output stream.

### Does this PR introduce any user facing changes?

No

### How to test

- start master
- start worker
- start ozone & create volume & create bucket
- mount ozone
```
bin/alluxio fs mount --option alluxio.underfs.version=1.2.1 --option alluxio.underfs.hdfs.configuration=/Users/mbl/projects/tencent/hadoop-ozone/hadoop-ozone/dev-support/intellij/ozone-site.xml /ozone o3fs://bucket1.vol1/
```
- write a file into ozone through alluxio
```shell
bin/alluxio fs -Dalluxio.user.file.writetype.default=CACHE_THROUGH  copyFromLocal LICENSE /ozone/f37
bin/alluxio fs cat  /ozone/f37
```
