### PR TITLE
Implement simple random write in AlluxioJniFuse

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5348,7 +5348,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey FUSE_TMP_FOLDER =
       new Builder(Name.FUSE_TMP_FOLDER)
-          .setDefaultValue("/tmp/alluxio-fuse")
+          .setDefaultValue("")
           .setDescription("A temporary folder for writing files through fuse. Files are first "
               + "written to this folder, then written to Alluxio upon finish writing the file")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5328,6 +5328,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey FUSE_TMP_FOLDER =
+      new Builder(Name.FUSE_TMP_FOLDER)
+          .setDefaultValue("/tmp/alluxio-fuse")
+          .setDescription("A temporary folder for writing files through fuse. Files are first "
+              + "written to this folder, then written to Alluxio upon finish writing the file")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey FUSE_UMOUNT_TIMEOUT =
       new Builder(Name.FUSE_UMOUNT_TIMEOUT)
           .setDefaultValue("1min")
@@ -7073,6 +7081,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         = "alluxio.fuse.shared.caching.reader.enabled";
     public static final String FUSE_LOGGING_THRESHOLD = "alluxio.fuse.logging.threshold";
     public static final String FUSE_MAXWRITE_BYTES = "alluxio.fuse.maxwrite.bytes";
+    public static final String FUSE_TMP_FOLDER = "alluxio.fuse.tmp.folder";
     public static final String FUSE_UMOUNT_TIMEOUT =
         "alluxio.fuse.umount.timeout";
     public static final String FUSE_USER_GROUP_TRANSLATION_ENABLED =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5346,11 +5346,21 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)
           .build();
-  public static final PropertyKey FUSE_TMP_FOLDER =
-      new Builder(Name.FUSE_TMP_FOLDER)
-          .setDefaultValue("")
-          .setDescription("A temporary folder for writing files through fuse. Files are first "
-              + "written to this folder, then written to Alluxio upon finish writing the file")
+  public static final PropertyKey FUSE_RANDOM_WRITE_ENABLED =
+      new Builder(Name.FUSE_RANDOM_WRITE_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("Whether to enable random write when writing through POSIX API. "
+              + "By setting this value to true, the files written through POSIX API are first "
+              + "written to a temporary directory, then written to Alluxio upon finishing. "
+              + "This local-then-Alluxio way of writing supports random write.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey FUSE_TMP_DIR =
+      new Builder(Name.FUSE_TMP_DIR)
+          .setDefaultValue("/tmp/alluxio-fuse")
+          .setDescription("The temporary directory for writing files through POSIX API when "
+              + "alluxio.fuse.random.write.enabled is set to true.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)
           .build();
@@ -7101,7 +7111,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         = "alluxio.fuse.shared.caching.reader.enabled";
     public static final String FUSE_LOGGING_THRESHOLD = "alluxio.fuse.logging.threshold";
     public static final String FUSE_MAXWRITE_BYTES = "alluxio.fuse.maxwrite.bytes";
-    public static final String FUSE_TMP_FOLDER = "alluxio.fuse.tmp.folder";
+    public static final String FUSE_RANDOM_WRITE_ENABLED = "alluxio.fuse.random.write.enabled";
+    public static final String FUSE_TMP_DIR = "alluxio.fuse.tmp.dir";
     public static final String FUSE_UMOUNT_TIMEOUT =
         "alluxio.fuse.umount.timeout";
     public static final String FUSE_USER_GROUP_TRANSLATION_ENABLED =

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -89,6 +89,10 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
   private final AtomicLong mNextOpenFileId = new AtomicLong(0);
 
   private final Map<Long, FileInStream> mOpenFileEntries = new ConcurrentHashMap<>();
+  // Map contains the locks for file opened for reading or writing (OpenAction = READ_WRITE)
+  // This is to guarantee open() - concurrent reads()/writes will
+  // only create one FileInStream/FileOutStream
+  private final Map<Long, Object> mOpenReadWriteLocks = new ConcurrentHashMap<>();
   private final FuseShell mFuseShell;
   private static final IndexDefinition<CreateFileEntry<FileOutStream>, Long>
       ID_INDEX =
@@ -365,7 +369,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
           flags, path));
       return -ErrorCodes.EINVAL();
     }
-    long fid = mNextOpenFileId.getAndIncrement();
+    long fd = mNextOpenFileId.getAndIncrement();
     try {
       // TODO(lu) how to deal with concurrent open() for read/write or write/write
       if (openAction == OpenAction.WRITE_ONLY) {
@@ -377,7 +381,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
           mFileSystem.delete(uri);
         }
         FileOutStream os = mFileSystem.createFile(uri);
-        mCreateFileEntries.add(new CreateFileEntry(fid, path, os));
+        mCreateFileEntries.add(new CreateFileEntry(fd, path, os));
         mAuthPolicy.setUserGroupIfNeeded(uri);
         LOG.debug(String.format("Open path %s with flags 0x%x for overwriting. "
                 + "Alluxio deleted the old file and created a new file for writing",
@@ -393,10 +397,14 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
             throw e;
           }
         }
-        mOpenFileEntries.put(fid, is);
+        mOpenFileEntries.put(fd, is);
+      } else {
+        // For OpenAction.READ_WRITE, we defer to the first read() or write()
+        // to open or create file.
+        Object lock = new Object();
+        mOpenReadWriteLocks.put(fd, lock);
       }
-      // For OpenAction.READ_WRITE, we defer to the first read() or write() to open or create file.
-      fi.fh.set(fid);
+      fi.fh.set(fd);
       return 0;
     } catch (Throwable e) {
       LOG.error("Failed to open path={},openAction={}: ", path, openAction, e);
@@ -415,28 +423,40 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
     final int sz = (int) size;
     int nread = 0;
     int rd = 0;
-    Long fd = fi.fh.get();
-    final int flags = fi.flags.get();
+    final long fd = fi.fh.get();
     try {
       FileInStream is = mOpenFileEntries.get(fd);
-      if (is == null && AlluxioFuseOpenUtils.getOpenAction(flags) != OpenAction.READ_WRITE) {
-        LOG.error("Cannot find fd for {} in table", path);
-        return -ErrorCodes.EBADFD();
-      }
       if (is == null) {
-        // Fuse open() file with open flags for reading and writing concurrently.
-        // If the first read(), we open file for reading only.
-        // If opened for write() already, error out.
-        // Alluxio supports read only or write only.
-        CreateFileEntry<FileOutStream> ce = mCreateFileEntries.getFirstByField(ID_INDEX, fd);
-        if (ce != null) {
-          LOG.error(String.format("Cannot open file %s with flags 0x%x "
-              + "for reading and writing concurrently", path, flags));
-          return -ErrorCodes.EIO();
+        // Could be first read in open(READ_WRITE)
+        Object lock = mOpenReadWriteLocks.get(fd);
+        if (lock == null) {
+          // The FileInStream can be created by other
+          // concurrent read() operations
+          is = mOpenFileEntries.get(fd);
+          if (is == null) {
+            LOG.error("Cannot find fd for {} in table", path);
+            return -ErrorCodes.EBADFD();
+          }
         }
-        final AlluxioURI uri = mPathResolverCache.getUnchecked(path);
-        is = mFileSystem.openFile(uri);
-        mOpenFileEntries.put(fd, is);
+        if (is == null) {
+          synchronized (lock) {
+            is = mOpenFileEntries.get(fd);
+            CreateFileEntry<FileOutStream> ce = mCreateFileEntries.getFirstByField(ID_INDEX, fd);
+            if (ce != null) {
+              LOG.error("Cannot open file {} for concurrent read and write", path);
+              return -ErrorCodes.EOPNOTSUPP();
+            }
+            if (is == null) {
+              try {
+                final AlluxioURI uri = mPathResolverCache.getUnchecked(path);
+                is = mFileSystem.openFile(uri);
+                mOpenFileEntries.put(fd, is);
+              } finally {
+                mOpenReadWriteLocks.remove(fd);
+              }
+            }
+          }
+        }
       }
 
       // FileInStream is not thread safe
@@ -478,34 +498,56 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
     final long fd = fi.fh.get();
     final int flags = fi.flags.get();
     CreateFileEntry<FileOutStream> ce = mCreateFileEntries.getFirstByField(ID_INDEX, fd);
-    if (ce == null && AlluxioFuseOpenUtils.getOpenAction(flags) != OpenAction.READ_WRITE) {
-      LOG.error("Cannot find fd for {} in table", path);
-      return -ErrorCodes.EBADFD();
-    }
-    FileInStream is = mOpenFileEntries.get(fd);
-    if (is != null) {
-      LOG.error(String.format("Cannot open file %s with flags 0x%x "
-          + "for reading and writing concurrently", path, flags));
-      return -ErrorCodes.EIO();
-    }
     if (ce == null) {
-      try {
-        final AlluxioURI uri = mPathResolverCache.getUnchecked(path);
-        if (mFileSystem.exists(uri)) {
-          mFileSystem.delete(uri);
+      // Check if file is opened for OpenAction=READ_WRITE.
+      // The file is opened for either read or write.
+      // Read or write depends on the first operation
+      Object lock = mOpenReadWriteLocks.get(fd);
+      if (lock == null) {
+        // Write is usually sequential
+        // Used to prevent concurrent write in the future
+        ce = mCreateFileEntries.getFirstByField(ID_INDEX, fd);
+        if (ce == null) {
+          LOG.error("Cannot find fd for {} in table", path);
+          return -ErrorCodes.EBADFD();
         }
-        FileOutStream os = mFileSystem.createFile(uri);
-        ce = new CreateFileEntry(fd, path, os);
-        mCreateFileEntries.add(ce);
-        mAuthPolicy.setUserGroupIfNeeded(uri);
-        LOG.debug(String.format("Open path %s with flags 0x%x for reading and writing. "
-            + "Treat as write only and error out if detecting reading behavior. "
-            + "Alluxio deleted the old file and created a new file for writing",
-            path, flags));
-      } catch (Throwable e) {
-        LOG.error(String.format("Failed to write path: %s size: %s offset: %s flags: 0x%x",
-            path, size, offset, flags), e);
-        return -ErrorCodes.EIO();
+      }
+      if (ce == null) {
+        if (offset != 0) {
+          LOG.error(String.format("Cannot overwrite file %s with offset %s. "
+              + "File is opened with flags 0x%x", path, offset, fi.flags.get()));
+          return -ErrorCodes.EIO();
+        }
+        synchronized (lock) {
+          ce = mCreateFileEntries.getFirstByField(ID_INDEX, fd);
+          FileInStream is = mOpenFileEntries.get(fd);
+          if (is != null) {
+            LOG.error("Cannot open file {} for concurrent read and write", path);
+            return -ErrorCodes.EOPNOTSUPP();
+          }
+          if (ce == null) {
+            try {
+              final AlluxioURI uri = mPathResolverCache.getUnchecked(path);
+              if (mFileSystem.exists(uri)) {
+                mFileSystem.delete(uri);
+              }
+              FileOutStream os = mFileSystem.createFile(uri);
+              ce = new CreateFileEntry(fd, path, os);
+              mCreateFileEntries.add(ce);
+              mAuthPolicy.setUserGroupIfNeeded(uri);
+              LOG.debug(String.format("Open path %s with flags 0x%x for reading and writing. "
+                      + "Treat as write only and error out if detecting reading behavior. "
+                      + "Alluxio deleted the old file and created a new file for writing",
+                  path, flags));
+            } catch (Throwable e) {
+              LOG.error(String.format("Failed to write path: %s size: %s offset: %s flags: 0x%x",
+                  path, size, offset, flags), e);
+              return -ErrorCodes.EIO();
+            } finally {
+              mOpenReadWriteLocks.remove(fd);
+            }
+          }
+        }
       }
     }
 
@@ -574,6 +616,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
   private int releaseInternal(String path, FuseFileInfo fi) {
     long fd = fi.fh.get();
     try {
+      mOpenReadWriteLocks.remove(fd);
       FileInStream is = mOpenFileEntries.remove(fd);
       CreateFileEntry<FileOutStream> ce = mCreateFileEntries.getFirstByField(ID_INDEX, fd);
       if (is == null && ce == null) {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -251,7 +251,9 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
       }
       long size = status.getLength();
       if (!status.isCompleted()) {
-        if (mCreateFileEntries.contains(PATH_INDEX, path)) {
+        if (mRandomWriteEnabled) {
+          size = (int) new File(Paths.get(mTmpDir, path).toString()).length();
+        } else if (mCreateFileEntries.contains(PATH_INDEX, path)) {
           // Alluxio master will not update file length until file is completed
           // get file length from the current output stream
           CreateFileEntry<FileOutStream> ce = mCreateFileEntries.getFirstByField(PATH_INDEX, path);
@@ -269,11 +271,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
           size = status.getLength();
         }
       }
-      if (mRandomWriteEnabled) {
-        stat.st_size.set((int) new File(Paths.get(mTmpDir, path).toString()).length());
-      } else {
-        stat.st_size.set(size);
-      }
+      stat.st_size.set(size);
 
       // Sets block number to fulfill du command needs
       // `st_blksize` is ignored in `getattr` according to

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -51,7 +51,11 @@ import jnr.constants.platform.OpenFlags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -556,7 +560,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
     RandomAccessFile tmpFile;
     try {
       File tmpFolder = new File(mTmpFolder);
-      if (!tmpFolder.exists()){
+      if (!tmpFolder.exists()) {
         tmpFolder.mkdirs();
       }
       tmpFile = new RandomAccessFile(Paths.get(mTmpFolder, path).toString(), "rw");

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -50,10 +50,7 @@ import jnr.constants.platform.OpenFlags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -272,7 +269,11 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
           size = status.getLength();
         }
       }
-      stat.st_size.set(size);
+      if (mRandomWriteEnabled) {
+        stat.st_size.set((int) new File(Paths.get(mTmpDir, path).toString()).length());
+      } else {
+        stat.st_size.set(size);
+      }
 
       // Sets block number to fulfill du command needs
       // `st_blksize` is ignored in `getattr` according to


### PR DESCRIPTION
A very simple implementation of random write in AlluxioJniFuse.

Use `RandomAccessFile` to write into a tmp file with `seek()` and `write()`. Upon finish writing and `release()` is called, create a `FileInputStream` to read from the tmp file, then write into Alluxio with `FileOutStream`, 64KB at a time (use the default value of `alluxio.user.local.writer.chunk.size.bytes`).

The script provided in #14708 could run successfully and have expected outcome.