### PR TITLE
Create the test dir earlier in Fuse stressbench cluster mode

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -58,6 +58,9 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
   private static final String TEST_DIR_STRING_FORMAT = "%s/%s/dir-%d";
   private static final String TEST_FILE_STRING_FORMAT = "%s/%s/dir-%d/file-%d";
 
+  /** All test operations happen in a designated test directory mLocalpath/fuseIOStressBench. */
+  private static final String TEST_DIR = "fuseIOStressBench";
+
   @ParametersDelegate
   private FuseIOParameters mParameters = new FuseIOParameters();
 
@@ -127,8 +130,8 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
   @Override
   public void prepare() throws Exception {
     if (mBaseParameters.mCluster) {
-      // Create test directory /fuseIOStressBench before job submitted to job service.
-      Files.createDirectories(Paths.get(mParameters.mLocalPath, "fuseIOStressBench"));
+      // Create the designated test directory before job submitted to job service.
+      Files.createDirectories(Paths.get(mParameters.mLocalPath, TEST_DIR));
       return;
     }
     if (mParameters.mThreads > mParameters.mNumDirs
@@ -138,8 +141,8 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
               + "be at least the number of threads, preferably a multiple of it."
       ));
     }
-    // All test operations happen in mLocalpath/fuseIOStressBench
-    mParameters.mLocalPath = Paths.get(mParameters.mLocalPath, "fuseIOStressBench").toString();
+    // Update mLocalPath to always include the designated test directory.
+    mParameters.mLocalPath = Paths.get(mParameters.mLocalPath, TEST_DIR).toString();
     File localPath = new File(mParameters.mLocalPath);
 
     if (mParameters.mOperation == FuseIOOperation.WRITE) {

--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -127,8 +127,8 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
   @Override
   public void prepare() throws Exception {
     if (mBaseParameters.mCluster) {
-      // For cluster mode, this function is called once before the job is submitted to the job
-      // service. Nothing should be done, otherwise the bench will break.
+      // Create test directory /fuseIOStressBench before job submitted to job service.
+      Files.createDirectories(Paths.get(mParameters.mLocalPath, "fuseIOStressBench"));
       return;
     }
     if (mParameters.mThreads > mParameters.mNumDirs


### PR DESCRIPTION
We create a directory `fuseIOStressBench` in `mParameters.mLocalPath` for the stressbench. The whole process should be, first `getattr()`, find out it doesn't exist, then `create()`.

In cluster mode, job worker 1 may `getattr()` first and find out it doesn't exist. Before job worker 1 calls `create()`, job worker 2 calls `create()` first, and thus now the path `/fuseIOStressBench` exists, which makes worker1 `create()` fail.

With this fix, the node that issues the stressbench command will create `/fuseIOStressBench` before job service sends the distributed job to job workers, so that by the time the job worker starts the stressbench, the path already exists and they won't race on creating this path.

This requires that the node starting the stressbench command also needs the fuse process just as all other workers, especially if this node is not a worker node. But we should make sure the correctness first.