### PR TITLE
Fix isSetByUser reports incorrect config source

### DIFF
--- a/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
+++ b/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
@@ -191,7 +191,8 @@ public class AlluxioProperties {
   public boolean isSetByUser(PropertyKey key) {
     if (mUserProps.containsKey(key)) {
       Optional<String> val = mUserProps.get(key);
-      return val.isPresent();
+      // Sources larger than Source.CLUSTER_DEFAULT are considered to be set by the user
+      return val.isPresent() && (getSource(key).compareTo(Source.CLUSTER_DEFAULT) > 0);
     }
     return false;
   }

--- a/core/common/src/test/java/alluxio/conf/AlluxioPropertiesTest.java
+++ b/core/common/src/test/java/alluxio/conf/AlluxioPropertiesTest.java
@@ -101,6 +101,23 @@ public class AlluxioPropertiesTest {
   }
 
   @Test
+  public void isSetByUser() {
+    assertFalse(mProperties.isSetByUser(mKeyWithValue));
+    assertFalse(mProperties.isSetByUser(mKeyWithoutValue));
+    mProperties.put(mKeyWithValue, "value", Source.CLUSTER_DEFAULT);
+    mProperties.put(mKeyWithoutValue, "value", Source.CLUSTER_DEFAULT);
+    assertFalse(mProperties.isSetByUser(mKeyWithValue));
+    assertFalse(mProperties.isSetByUser(mKeyWithoutValue));
+    // Sources larger than Source.CLUSTER_DEFAULT are considered to be set by the user
+    mProperties.put(mKeyWithValue, "value", Source.SYSTEM_PROPERTY);
+    mProperties.put(mKeyWithoutValue, "value", Source.SYSTEM_PROPERTY);
+    assertTrue(mProperties.isSetByUser(mKeyWithValue));
+    assertTrue(mProperties.isSetByUser(mKeyWithoutValue));
+    mProperties.remove(mKeyWithValue);
+    assertFalse(mProperties.isSetByUser(mKeyWithValue));
+  }
+
+  @Test
   public void entrySet() {
     Set<Map.Entry<? extends PropertyKey, String>> expected =
         PropertyKey.defaultKeys().stream()


### PR DESCRIPTION
### What changes are proposed in this pull request?
isSetByUser() returns inaccurate results

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
[isSetByUser() returns inaccurate results](https://github.com/Alluxio/alluxio/issues/14879)


### Does this PR introduce any user facing changes?
NO

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
