### PR TITLE
Fix UFS version check in hdfs supportsPath

### DIFF
--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
@@ -78,7 +78,7 @@ public class HdfsUnderFileSystemFactory implements UnderFileSystemFactory {
       // are supported this is not an option and we have to continue to use this method.
       for (final String prefix : alluxioConf.getList(PropertyKey.UNDERFS_HDFS_PREFIXES, ",")) {
         if (path.startsWith(prefix)) {
-          if (!conf.isSet(PropertyKey.UNDERFS_VERSION)
+          if (!conf.isSetByUser(PropertyKey.UNDERFS_VERSION)
               || HdfsVersion.matches(conf.get(PropertyKey.UNDERFS_VERSION), getVersion())) {
             return true;
           }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix Hdfs supportsPath function bug

### Why are the changes needed?
Only when the user manually sets PropertyKey `UNDERFS_VERSION`, the value of `UNDERFS_VERSION`  should be compared with `getVersion()`, so we should use `IsSetByUser()`  instead of `isSet()`.

This is similar to [Fix ozone supportspath #14833](https://github.com/Alluxio/alluxio/pull/14833)

Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
