### PR TITLE
Handle temp directories correctly for multiple test jvm

### DIFF
--- a/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
+++ b/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.UUID;
 
 /**
@@ -28,8 +27,6 @@ import java.util.UUID;
  */
 public final class AlluxioTestDirectory {
   private static final Logger LOG = LoggerFactory.getLogger(AlluxioTestDirectory.class);
-
-  private static final int MAX_FILE_AGE_HOURS = 1;
 
   /**
    * This directory should be used over the system temp directory for creating temporary files
@@ -60,7 +57,6 @@ public final class AlluxioTestDirectory {
       throw new RuntimeException("Failed to create directory " + file.getAbsolutePath());
     }
 
-    Runtime.getRuntime().addShutdownHook(new Thread(() -> delete(file)));
     return file;
   }
 
@@ -70,29 +66,18 @@ public final class AlluxioTestDirectory {
    * @return the testing directory
    */
   private static File createTestingDirectory() {
-    final File tmpDir = new File(System.getProperty("java.io.tmpdir"), "alluxio-tests");
-    if (tmpDir.exists()) {
-      cleanUpOldFiles(tmpDir);
-    }
+    final File tmpDir = new File(System.getProperty("java.io.tmpdir"),
+        "alluxio-tests" + "-" + UUID.randomUUID());
     if (!tmpDir.exists()) {
       if (!tmpDir.mkdir()) {
         throw new RuntimeException(
             "Failed to create testing directory " + tmpDir.getAbsolutePath());
       }
     }
-    return tmpDir;
-  }
 
-  /**
-   * Deletes files in the given directory which are older than 2 hours.
-   *
-   * @param dir the directory to clean up
-   */
-  private static void cleanUpOldFiles(File dir) {
-    long cutoffTimestamp = System.currentTimeMillis() - (MAX_FILE_AGE_HOURS * Constants.HOUR_MS);
-    Arrays.asList(dir.listFiles()).stream()
-        .filter(file -> !FileUtils.isFileNewer(file, cutoffTimestamp))
-        .forEach(AlluxioTestDirectory::delete);
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> delete(tmpDir)));
+
+    return tmpDir;
   }
 
   private static void delete(File file) {

--- a/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
+++ b/core/common/src/test/java/alluxio/AlluxioTestDirectory.java
@@ -51,7 +51,7 @@ public final class AlluxioTestDirectory {
    * @param prefix a prefix to use in naming the temporary directory
    * @return the created directory
    */
-  public static File createTemporaryDirectory(File parent, String prefix) {
+  private static File createTemporaryDirectory(File parent, String prefix) {
     final File file = new File(parent, prefix + "-" + UUID.randomUUID());
     if (!file.mkdirs()) {
       throw new RuntimeException("Failed to create directory " + file.getAbsolutePath());

--- a/tests/src/test/java/alluxio/master/table/TableIntegrationTest.java
+++ b/tests/src/test/java/alluxio/master/table/TableIntegrationTest.java
@@ -56,7 +56,7 @@ public final class TableIntegrationTest extends BaseIntegrationTest {
   private static final String DB_NAME = "test";
   private static final String DB_NAME_ERRORS = "test_ERRORS";
   private static final File WAREHOUSE_DIR = AlluxioTestDirectory
-      .createTemporaryDirectory(new File("/tmp/alluxio-tests"), "TableIntegrationTest");
+      .createTemporaryDirectory("TableIntegrationTest");
   /** The docker image name and tag. */
   private static final String HMS_IMAGE = "<REPLACE WITH DOCKER IMAGE/TAG OF HMS>";
   private static final String TEST_TABLE = "test_table";


### PR DESCRIPTION
### What changes are proposed in this pull request?
Change temp dir creation to be unique and delete upon jvm exit. 

### Why are the changes needed?
When github runs test with multiple jvms, the two jvms can try to create temp dir at the same time and cause the following error. 

```
Error: 5.534 [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.85 s <<< FAILURE! - in alluxio.client.cli.fsadmin.BackupCommandIntegrationTest
Error: 5.542 [ERROR] alluxio.client.cli.fsadmin.BackupCommandIntegrationTest  Time elapsed: 0.762 s  <<< ERROR!
java.lang.ExceptionInInitializerError
	at alluxio.master.AbstractLocalAlluxioCluster.setAlluxioWorkDirectory(AbstractLocalAlluxioCluster.java:362)
	at alluxio.master.LocalAlluxioCluster.initConfiguration(LocalAlluxioCluster.java:128)
	at alluxio.testutils.LocalAlluxioClusterResource.start(LocalAlluxioClusterResource.java:150)
	at alluxio.testutils.LocalAlluxioClusterResource$1.evaluate(LocalAlluxioClusterResource.java:192)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:364)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:272)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:237)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:158)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:428)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:562)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:548)
Caused by: java.lang.RuntimeException: Failed to create testing directory /tmp/alluxio-tests
	at alluxio.AlluxioTestDirectory.createTestingDirectory(AlluxioTestDirectory.java:80)
	at alluxio.AlluxioTestDirectory.<clinit>(AlluxioTestDirectory.java:38)
	... 15 more


```
