### PR TITLE
Fix wrong method call to get username and wrong parameter assignment

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/auth/CustomAuthPolicy.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/auth/CustomAuthPolicy.java
@@ -50,8 +50,8 @@ public class CustomAuthPolicy implements AuthPolicy {
       return;
     }
     SetAttributePOptions attributeOptions = SetAttributePOptions.newBuilder()
-        .setGroup(mUname)
-        .setOwner(mGname)
+        .setGroup(mGname)
+        .setOwner(mUname)
         .build();
     mFileSystem.setAttribute(uri, attributeOptions);
     LOG.debug("Set attributes of path {} to {}", uri, attributeOptions);

--- a/integration/fuse/src/main/java/alluxio/fuse/auth/SystemUserGroupAuthPolicy.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/auth/SystemUserGroupAuthPolicy.java
@@ -61,7 +61,7 @@ public final class SystemUserGroupAuthPolicy implements AuthPolicy {
           @Override
           public String load(Long uid) {
             try {
-              String userName = AlluxioFuseUtils.getGroupName(uid);
+              String userName = AlluxioFuseUtils.getUserName(uid);
               return userName.isEmpty() ? DEFAULT_USER_NAME : userName;
             } catch (IOException e) {
               // This should never be reached since input uid is always valid


### PR DESCRIPTION
### What changes are proposed in this pull request?

 1. Use the correct method to get the username for cache.
 2. Correct assignment to Group and Owner.

### Why are the changes needed?

  1. Currently, using the getGroupName method to get the username, the getUserName method should be used.
  2. The option parameter assignment is reversed.

### Does this PR introduce any user facing changes?

no
