### PR TITLE
Print stack trace from ProcessUtils.fatalError()

### DIFF
--- a/core/server/common/src/main/java/alluxio/ProcessUtils.java
+++ b/core/server/common/src/main/java/alluxio/ProcessUtils.java
@@ -60,7 +60,7 @@ public final class ProcessUtils {
    * @param args args for the format string
    */
   public static void fatalError(Logger logger, String format, Object... args) {
-    fatalError(logger, null, format, args);
+    fatalError(logger, new Throwable(), format, args);
   }
 
   /**


### PR DESCRIPTION

### What changes are proposed in this pull request?

Currently when ProcessUtils.fatalError() is called without a Throwable object no stack trace is printed.
In this change, a new Throwable object is created which is used to print the stack trace.

### Why are the changes needed?

Fixes #10432

### Does this PR introduce any user facing changes?

No
