### PR TITLE
Fix argument in alluxio-fuse unmount when argument has trailing slash

### DIFF
--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -82,7 +82,7 @@ mount_fuse() {
 }
 
 umount_fuse() {
-  local mount_point=$1
+  local mount_point=${1%/}
   local fuse_pid=$(fuse_stat | awk '{print $1,$2}' | grep -w ${mount_point} | awk '{print $1}')
   if [[ -z ${fuse_pid} ]]; then
     echo "${mount_point} not mounted" >&2


### PR DESCRIPTION
Previously
  integration/fuse/bin/alluxio-fuse unmount /path/to/mount/point
will work, but
  integration/fuse/bin/alluxio-fuse unmount /path/to/mount/point/
will give error "/path/to/mount/point/ not mounted". Strip the trailing
slash so both would work.

Fixes #11203