### PR TITLE
Support extend a custom auth type

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5419,7 +5419,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.ALL)
           .build();
-  public static final PropertyKey SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_HANDLER_CLASS =
+  public static final PropertyKey SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_CLASS =
       new Builder(Name.SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_HANDLER_CLASS)
           .setDescription(
               "The class to provide a custom security authentication sasl client handler.")

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5421,11 +5421,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_HANDLER_CLASS =
       new Builder(Name.SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_HANDLER_CLASS)
+          .setDescription(
+              "The class to provide a custom security authentication sasl client handler.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_HANDLER_CLASS =
       new Builder(Name.SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_HANDLER_CLASS)
+          .setDescription(
+              "The class to provide a custom security authentication sasl server handler.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5420,14 +5420,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.ALL)
           .build();
   public static final PropertyKey SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_CLASS =
-      new Builder(Name.SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_HANDLER_CLASS)
+      new Builder(Name.SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_CLASS)
           .setDescription(
               "The class to provide a custom security authentication sasl client handler.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_CLASS =
-      new Builder(Name.SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_HANDLER_CLASS)
+      new Builder(Name.SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_CLASS)
           .setDescription(
               "The class to provide a custom security authentication sasl server handler.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
@@ -7127,10 +7127,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     //
     public static final String SECURITY_AUTHENTICATION_CUSTOM_PROVIDER_CLASS =
         "alluxio.security.authentication.custom.provider.class";
-    public static final String SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_HANDLER_CLASS =
-        "alluxio.security.authentication.custom.sasl.client.handler.class";
-    public static final String SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_HANDLER_CLASS =
-        "alluxio.security.authentication.custom.sasl.server.handler.class";
+    public static final String SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_CLASS =
+        "alluxio.security.authentication.custom.sasl.client.class";
+    public static final String SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_CLASS =
+        "alluxio.security.authentication.custom.sasl.server.class";
     public static final String SECURITY_AUTHENTICATION_TYPE =
         "alluxio.security.authentication.type";
     public static final String SECURITY_AUTHORIZATION_PERMISSION_ENABLED =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5422,14 +5422,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_CLASS =
       new Builder(Name.SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_CLASS)
           .setDescription(
-              "The class to provide a custom security authentication sasl client handler.")
+              "The class to provide a custom security authentication sasl client.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_CLASS =
       new Builder(Name.SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_CLASS)
           .setDescription(
-              "The class to provide a custom security authentication sasl server handler.")
+              "The class to provide a custom security authentication sasl server.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5419,6 +5419,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.ALL)
           .build();
+  public static final PropertyKey SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_HANDLER_CLASS =
+      new Builder(Name.SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_HANDLER_CLASS)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_HANDLER_CLASS =
+      new Builder(Name.SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_HANDLER_CLASS)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+
   public static final PropertyKey SECURITY_AUTHENTICATION_TYPE =
       new Builder(Name.SECURITY_AUTHENTICATION_TYPE)
           .setDefaultValue("SIMPLE")
@@ -7112,6 +7123,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     //
     public static final String SECURITY_AUTHENTICATION_CUSTOM_PROVIDER_CLASS =
         "alluxio.security.authentication.custom.provider.class";
+    public static final String SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_HANDLER_CLASS =
+        "alluxio.security.authentication.custom.sasl.client.handler.class";
+    public static final String SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_HANDLER_CLASS =
+        "alluxio.security.authentication.custom.sasl.server.handler.class";
     public static final String SECURITY_AUTHENTICATION_TYPE =
         "alluxio.security.authentication.type";
     public static final String SECURITY_AUTHORIZATION_PERMISSION_ENABLED =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5426,7 +5426,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
-  public static final PropertyKey SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_HANDLER_CLASS =
+  public static final PropertyKey SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_CLASS =
       new Builder(Name.SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_HANDLER_CLASS)
           .setDescription(
               "The class to provide a custom security authentication sasl server handler.")

--- a/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
@@ -167,6 +167,11 @@ public class ChannelAuthenticator {
         return new alluxio.security.authentication.plain.SaslClientHandlerPlain(mParentSubject,
             mConfiguration);
       case CUSTOM:
+        if (!mConfiguration.isSetByUser(
+            PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_HANDLER_CLASS)) {
+          return new alluxio.security.authentication.plain.SaslClientHandlerPlain(mParentSubject,
+              mConfiguration);
+        }
         Class clazz = mConfiguration.getClass(
             PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_HANDLER_CLASS);
         try {

--- a/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
@@ -168,19 +168,19 @@ public class ChannelAuthenticator {
             mConfiguration);
       case CUSTOM:
         if (!mConfiguration.isSetByUser(
-            PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_HANDLER_CLASS)) {
+            PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_CLASS)) {
           return new alluxio.security.authentication.plain.SaslClientHandlerPlain(mParentSubject,
               mConfiguration);
         }
         Class clazz = mConfiguration.getClass(
-            PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_HANDLER_CLASS);
+            PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_CLASS);
         try {
           return (SaslClientHandler) clazz.getConstructor(
                   new Class[] {Subject.class, AlluxioConfiguration.class})
               .newInstance(mParentSubject, mConfiguration);
         } catch (ReflectiveOperationException e) {
           throw new IllegalStateException(
-              PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_HANDLER_CLASS.getName()
+              PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_CLIENT_CLASS.getName()
                   + " configured to invalid class "
                   + clazz + ". Cannot create SaslClientHandler.", e);
         }

--- a/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
+++ b/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
@@ -130,6 +130,10 @@ public class DefaultAuthenticationServer
       case SIMPLE:
         return new SaslServerHandlerPlain(mHostName, mConfiguration, mImpersonationAuthenticator);
       case CUSTOM:
+        if (!mConfiguration.isSetByUser(
+            PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_HANDLER_CLASS)) {
+          return new SaslServerHandlerPlain(mHostName, mConfiguration, mImpersonationAuthenticator);
+        }
         Class clazz = mConfiguration.getClass(
             PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_HANDLER_CLASS);
         try {

--- a/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
+++ b/core/common/src/main/java/alluxio/security/authentication/DefaultAuthenticationServer.java
@@ -131,11 +131,11 @@ public class DefaultAuthenticationServer
         return new SaslServerHandlerPlain(mHostName, mConfiguration, mImpersonationAuthenticator);
       case CUSTOM:
         if (!mConfiguration.isSetByUser(
-            PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_HANDLER_CLASS)) {
+            PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_CLASS)) {
           return new SaslServerHandlerPlain(mHostName, mConfiguration, mImpersonationAuthenticator);
         }
         Class clazz = mConfiguration.getClass(
-            PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_HANDLER_CLASS);
+            PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_CLASS);
         try {
           return (SaslServerHandler) clazz.getConstructor(
                   new Class[] {String.class, AlluxioConfiguration.class,
@@ -143,7 +143,7 @@ public class DefaultAuthenticationServer
               .newInstance(mHostName, mConfiguration, mImpersonationAuthenticator);
         } catch (ReflectiveOperationException e) {
           throw new IllegalStateException(
-              PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_HANDLER_CLASS.getName()
+              PropertyKey.SECURITY_AUTHENTICATION_CUSTOM_SASL_SERVER_CLASS.getName()
                   + " configured to invalid class "
                   + clazz + ". Cannot create SaslServerHandler.", e);
         }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support extend a custom auth type.

### Why are the changes needed?

With this PR, we can use custom auth type for a new auth implementation, otherwise, we have to add a new auth type to the AuthType enum and proto. 

### Does this PR introduce any user facing changes?

```
alluxio.security.authentication.custom.provider.class=
alluxio.security.authentication.custom.sasl.client.handler.class=
alluxio.security.authentication.custom.sasl.server.handler.class=
```