### PR TITLE
Add fuse log to collectLog command

### DIFF
--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
@@ -58,6 +58,8 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
       "worker.out",
       "job_worker.log",
       "job_worker.out",
+      "fuse.log",
+      "fuse.out",
       "proxy.log",
       "proxy.out",
       "task.log",


### PR DESCRIPTION
`CollectLog` cli command doesn't collect fuse-related logs. Include them in the included logs.