### PR TITLE
Register local cache read metrics

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -75,6 +75,13 @@ public class LocalCacheFileInStream extends FileInStream {
   }
 
   /**
+   * Registers metrics.
+   */
+  public static void registerMetrics() {
+    Metrics.registerGauges();
+  }
+
+  /**
    * Constructor when the {@link URIStatus} is already available.
    *
    * @param status file status

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/LocalCacheFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/LocalCacheFileSystem.java
@@ -102,6 +102,7 @@ public class LocalCacheFileSystem extends org.apache.hadoop.fs.FileSystem {
     }
     MetricsSystem.startSinksFromConfig(new MetricsConfig(metricsProperties));
     mCacheManager = CacheManager.Factory.get(mAlluxioConf);
+    LocalCacheFileInStream.registerMetrics();
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

Some of the local cache read metrics like bytes read, hit rate ect
are registered only when a LocalCacheFileInStream object is created.
In client systems where there are coordinators and workers, file read
might only happen on workers, while metrics are only exposed from
coordinators (e.g. Presto), resulting the metrics not being registered.
Always register the metrics when initializing LocalCacheFileSystem.

### Why are the changes needed?

Fixes https://github.com/Alluxio/alluxio/issues/14200