### PR TITLE
Fix Hub + k8s issues due to bad formatting and missing log4j.properties

### DIFF
--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -69,6 +69,11 @@ function writeConf {
       echo "export ${key}=\"${value}\"" >> conf/alluxio-env.sh
     fi
   done
+  LOG4J_FILE_TEMPLATE="/tmp/log4j.properties"
+  LOG4J_FILE="conf/log4j.properties"
+  if [ -f "$LOG4J_FILE_TEMPLATE" ] && [ ! -f "$LOG4J_FILE" ]; then
+    cp $LOG4J_FILE_TEMPLATE $LOG4J_FILE
+  fi
 }
 
 function formatMasterIfSpecified {

--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -22,7 +22,9 @@
 {{- /*         ALLUXIO_JAVA_OPTS             */}}
 {{- /* ===================================== */}}
 {{- $alluxioJavaOpts := list }}
-{{- $alluxioJavaOpts = print "-Dalluxio.hub.agent.rpc.hostname=${ALLUXIO_HUB_AGENT_RPC_HOSTNAME}" | append $alluxioJavaOpts }}
+{{- if .Values.hub.enabled }}
+  {{- $alluxioJavaOpts = print "-Dalluxio.hub.agent.rpc.hostname=${ALLUXIO_HUB_AGENT_RPC_HOSTNAME}" | append $alluxioJavaOpts }}
+{{- end }}
 {{- /* Specify master hostname if single master */}}
 {{- if $isSingleMaster }}
   {{- $alluxioJavaOpts = printf "-Dalluxio.master.hostname=%v-%v" $fullName $defaultMasterName | append $alluxioJavaOpts }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -116,16 +116,16 @@ spec:
           {{- if .Values.hub.resources }}
 {{ include "alluxio.hub.resources" . | indent 10 }}
           {{- end }}
-        command: [ "tini", "--", "/entrypoint.sh" ]
+          command: [ "tini", "--", "/entrypoint.sh" ]
           {{- if .Values.hub.agent.args }}
-        args:
+          args:
 {{ toYaml .Values.hub.agent.args | trim | indent 12 }}
           {{- end }}
-        env:
+          env:
           {{- range $key, $value := .Values.hub.env }}
           - name: "{{ $key }}"
             value: "{{ $value }}"
-            {{- end }}
+          {{- end }}
           - name: ALLUXIO_HUB_AGENT_RPC_HOSTNAME
             valueFrom:
               fieldRef:
@@ -134,17 +134,17 @@ spec:
             value: "{{ .Values.user }}"
           - name: ALLUXIO_HUB_NO_START
             value: "true"
-        envFrom:
+          envFrom:
           - configMapRef:
               name: {{ $fullName }}-config
-        ports:
-            - containerPort: { { .Values.hub.agent.ports.rpc } }
-              name: agent-rpc
-        volumeMounts:
+          ports:
+          - containerPort: {{ .Values.hub.agent.ports.rpc }}
+            name: agent-rpc
+          volumeMounts:
           - name: conf-volume
             mountPath: /opt/alluxio/conf
             readOnly: false
-          {{- end }}
+        {{- end }}
         - name: alluxio-master
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
@@ -293,9 +293,9 @@ spec:
             name: job-web
           volumeMounts:
             {{- if .Values.hub.enabled }}
-              - name: conf-volume
-                mountPath: /opt/alluxio/conf
-                readOnly: false
+            - name: conf-volume
+              mountPath: /opt/alluxio/conf
+              readOnly: false
             {{- end }}
             {{- if .Values.metrics.enabled }}
             - name: {{ $fullName }}-metrics-volume


### PR DESCRIPTION
### What changes are proposed in this pull request?

- copy over `log4j.properties` in `docker/entrypoint.sh` in order for Alluxio cluster + Hub in k8s env to properly start
- fix formatting issues in (hub) helm chart yaml files

### Why are the changes needed?

These changes are required for the Hub to be properly launched via kubernetes.

### Does this PR introduce any user facing changes?

no
