### PR TITLE
Add worker startup timeout property key

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3123,7 +3123,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey WORKER_STARTUP_TIMEOUT =
       new Builder(Name.WORKER_STARTUP_TIMEOUT)
-          .setDefaultValue("60sec")
+          .setDefaultValue("10min")
           .setDescription("Maximum time to wait for worker startup.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.ALL)
@@ -6785,8 +6785,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String WORKER_RPC_EXECUTOR_FJP_ASYNC =
         "alluxio.worker.rpc.executor.fjp.async";
     public static final String WORKER_SESSION_TIMEOUT_MS = "alluxio.worker.session.timeout";
-    public static final String WORKER_STARTUP_TIMEOUT =
-        "alluxio.worker.startup.timeout";
+    public static final String WORKER_STARTUP_TIMEOUT = "alluxio.worker.startup.timeout";
     public static final String WORKER_STORAGE_CHECKER_ENABLED =
         "alluxio.worker.storage.checker.enabled";
     public static final String WORKER_TIERED_STORE_BLOCK_LOCK_READERS =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3121,6 +3121,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
+  public static final PropertyKey WORKER_STARTUP_TIMEOUT =
+      new Builder(Name.WORKER_STARTUP_TIMEOUT)
+          .setDefaultValue("60sec")
+          .setDescription("Maximum time to wait for worker startup.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.ALL)
+          .build();
   public static final PropertyKey WORKER_MANAGEMENT_BACKOFF_STRATEGY =
       new Builder(Name.WORKER_MANAGEMENT_BACKOFF_STRATEGY)
           .setDefaultValue("ANY")
@@ -6778,6 +6785,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String WORKER_RPC_EXECUTOR_FJP_ASYNC =
         "alluxio.worker.rpc.executor.fjp.async";
     public static final String WORKER_SESSION_TIMEOUT_MS = "alluxio.worker.session.timeout";
+    public static final String WORKER_STARTUP_TIMEOUT =
+        "alluxio.worker.startup.timeout";
     public static final String WORKER_STORAGE_CHECKER_ENABLED =
         "alluxio.worker.storage.checker.enabled";
     public static final String WORKER_TIERED_STORE_BLOCK_LOCK_READERS =

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -94,7 +94,6 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
     try {
       mStartTimeMs = System.currentTimeMillis();
       mUfsManager = new WorkerUfsManager();
-      
       mRegistry = new WorkerRegistry();
       List<Callable<Void>> callables = new ArrayList<>();
       for (final WorkerFactory factory : ServiceLoader.load(WorkerFactory.class,
@@ -107,8 +106,8 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
         });
       }
       // In the worst case, each worker factory is blocked waiting for the dependent servers to be
-      // registered at worker registry, so the maximum timeout here is set to the multiply of
-      // the number of factories by the default timeout of getting a worker from the registry.
+      // registered at worker registry. The maximum timeout here is set by configuration
+      // alluxio.worker.startup.timeout
       CommonUtils.invokeAll(callables,
           (long) callables.size() * ServerConfiguration.getMs(PropertyKey.WORKER_STARTUP_TIMEOUT));
 

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker;
 
-import alluxio.Constants;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.metrics.MetricKey;
@@ -95,6 +94,7 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
     try {
       mStartTimeMs = System.currentTimeMillis();
       mUfsManager = new WorkerUfsManager();
+      
       mRegistry = new WorkerRegistry();
       List<Callable<Void>> callables = new ArrayList<>();
       for (final WorkerFactory factory : ServiceLoader.load(WorkerFactory.class,
@@ -110,7 +110,7 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
       // registered at worker registry, so the maximum timeout here is set to the multiply of
       // the number of factories by the default timeout of getting a worker from the registry.
       CommonUtils.invokeAll(callables,
-          (long) callables.size() * 10 * Constants.DEFAULT_REGISTRY_GET_TIMEOUT_MS);
+          (long) callables.size() * ServerConfiguration.getMs(PropertyKey.WORKER_STARTUP_TIMEOUT));
 
       // Setup web server
       mWebServer =


### PR DESCRIPTION
### What changes are proposed in this pull request?
Add worker registry timeout property key to make the timeout adjustable.

### Why are the changes needed?

As a temporary plan to serve https://github.com/Alluxio/alluxio/issues/14503

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. addition of property key `alluxio.worker.startup.timeout`
