### PR TITLE
Support workaround fuse operation

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5408,6 +5408,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "will drop the metadata cache of path '/mnt/alluxio-fuse/path/to/be/cleaned/'")
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey FUSE_WORKAROUND_LIST =
+      new Builder(Name.FUSE_WORKAROUND_LIST)
+          .setDefaultValue(false)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   //
   // Standalone FUSE process related properties
   //
@@ -7134,6 +7140,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.fuse.user.group.translation.enabled";
     public static final String FUSE_SPECIAL_COMMAND_ENABLED =
         "alluxio.fuse.special.command.enabled";
+    public static final String FUSE_WORKAROUND_LIST =
+        "alluxio.fuse.workaround.list";
     //
     // Standalone FUSE process related properties
     //

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -567,7 +567,8 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
 
     FileOutStream os = ce.getOut();
     long bytesWritten = os.getBytesWritten();
-    if (offset != bytesWritten && offset + sz > bytesWritten) {
+    if (!mWorkAroundSet.contains("write")
+        && offset != bytesWritten && offset + sz > bytesWritten) {
       LOG.error("Only sequential write is supported. Cannot write bytes of size {} to offset {} "
           + "when {} bytes have written to path {}", size, offset, bytesWritten, path);
       return -ErrorCodes.EIO();

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -64,6 +64,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -121,6 +122,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
       = new IndexedSet<>(ID_INDEX, PATH_INDEX);
   private final boolean mIsUserGroupTranslation;
   private final AuthPolicy mAuthPolicy;
+  private final List<String> mWorkAroundList;
 
   // Map for holding the async releasing entries for proper umount
   private final Map<Long, FileInStream> mReleasingReadEntries = new ConcurrentHashMap<>();
@@ -192,6 +194,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
     mIsUserGroupTranslation = conf.getBoolean(PropertyKey.FUSE_USER_GROUP_TRANSLATION_ENABLED);
     mMaxUmountWaitTime = (int) conf.getMs(PropertyKey.FUSE_UMOUNT_TIMEOUT);
     mAuthPolicy = AuthPolicyFactory.create(mFileSystem, conf, this);
+    mWorkAroundList = mConf.getList(PropertyKey.FUSE_WORKAROUND_LIST, ",");
     if (opts.isDebug()) {
       try {
         LogUtils.setLogLevel(this.getClass().getName(), org.slf4j.event.Level.DEBUG.toString());
@@ -393,14 +396,15 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
       return -ErrorCodes.EIO();
     }
 
-    if (status != null && !status.isCompleted()) {
-      // Cannot open incomplete file for read or write
-      // wait for file to complete in read or read_write mode
-      if (!AlluxioFuseUtils.waitForFileCompleted(mFileSystem, uri)) {
-        LOG.error(String.format("Cannot open incomplete file %s. "
-            + "Failed to wait for file completed with flag 0x%x",
-            path, flags));
-        return -ErrorCodes.EIO();
+    if (!mWorkAroundList.contains("open")) {
+      if (status != null && !status.isCompleted()) {
+        // Cannot open incomplete file for read or write
+        // wait for file to complete in read or read_write mode
+        if (!AlluxioFuseUtils.waitForFileCompleted(mFileSystem, uri)) {
+          LOG.error(String.format("Cannot open incomplete file %s. " + "Failed to wait for file completed with flag 0x%x",
+              path, flags));
+          return -ErrorCodes.EIO();
+        }
       }
     }
 
@@ -765,6 +769,9 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
   }
 
   private int chmodInternal(String path, long mode) {
+    if (mWorkAroundList.contains("chmod")) {
+      return 0;
+    }
     AlluxioURI uri = mPathResolverCache.getUnchecked(path);
 
     SetAttributePOptions options = SetAttributePOptions.newBuilder()
@@ -785,6 +792,9 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
   }
 
   private int chownInternal(String path, long uid, long gid) {
+    if (mWorkAroundList.contains("chown")) {
+      return 0;
+    }
     if (!mIsUserGroupTranslation) {
       LOG.info("Cannot change the owner/group of path {}. Please set {} to be true to enable "
               + "user group translation in Alluxio-FUSE.",
@@ -856,6 +866,9 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
   }
 
   private int truncateInternal(String path, long size) {
+    if (mWorkAroundList.contains("truncate")) {
+      return 0;
+    }
     // Truncate scenarios:
     // 1. Truncate size = 0, file does not exist => no-op
     // 2. Truncate size = 0, file exists and completed


### PR DESCRIPTION
### What changes are proposed in this pull request?

For pass some benchmark tools like `fio`, I purpose to add a workaround list to pass some specific fuse operation.

### Why are the changes needed?

Add a configure key contains fuse operation list separated by comma, return `0` for these method.

### Does this PR introduce any user facing changes?

No
