### PR TITLE
Preserve config changes made by Hub on pod restarts

### DIFF
--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -61,18 +61,26 @@ function printUsage {
 
 function writeConf {
   local IFS=$'\n' # split by line instead of space
-  for keyvaluepair in $(env); do
-    # split around the first "="
-    key=$(echo ${keyvaluepair} | cut -d= -f1)
-    value=$(echo ${keyvaluepair} | cut -d= -f2-)
-    if [[ -n "${ALLUXIO_ENV_MAP[${key}]}" ]]; then
-      echo "export ${key}=\"${value}\"" >> conf/alluxio-env.sh
-    fi
-  done
+  if [ ! -f "conf/alluxio-env.sh" ]; then
+    for keyvaluepair in $(env); do
+      # split around the first "="
+      key=$(echo ${keyvaluepair} | cut -d= -f1)
+      value=$(echo ${keyvaluepair} | cut -d= -f2-)
+      if [[ -n "${ALLUXIO_ENV_MAP[${key}]}" ]]; then
+        echo "export ${key}=\"${value}\"" >> conf/alluxio-env.sh
+      fi
+    done
+  fi
   LOG4J_FILE_TEMPLATE="/tmp/log4j.properties"
   LOG4J_FILE="conf/log4j.properties"
   if [ -f "$LOG4J_FILE_TEMPLATE" ] && [ ! -f "$LOG4J_FILE" ]; then
     cp $LOG4J_FILE_TEMPLATE $LOG4J_FILE
+  fi
+  if [[ ! -z "${ALLUXIO_LOG4J_PROPERTIES}" ]]; then
+    echo "${ALLUXIO_LOG4J_PROPERTIES}" > $LOG4J_FILE
+  fi
+  if [[ ! -z "${ALLUXIO_SITE_PROPERTIES}" ]]; then
+    echo "${ALLUXIO_SITE_PROPERTIES}" > conf/alluxio-site.properties
   fi
 }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?
 
Populate both log4 and site-properties files if the environment variables are set (due to making changes via Hub). Previous [PR](https://github.com/Alluxio/alluxio/pull/14913) was only populating log4j properties, so config changes were lost on Hub Manager pod restarts 

This change allows the following logic to work properly:
- The Hub manager persists changes to the K8s API server, communicating using the fabric8.io library. This is the same library used by Spark on K8s and is considerably less verbose than the official K8s java binding.
-  Hub manager writes env, site, and log4j properties to the K8s configMap as environment variables 
- The docker entrypoint populates these files if the environment variables are set

### Why are the changes needed?

Explained above

### Does this PR introduce any user facing changes?

no
