### PR TITLE
Request all followers for snapshot instead of a single follower

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1858,19 +1858,18 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
-  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_SNAPSHOT_DATA_REQUEST_TIMEOUT =
-      new Builder(Name.MASTER_EMBEDDED_JOURNAL_SNAPSHOT_DATA_REQUEST_TIMEOUT)
-          .setDefaultValue("35sec")
-          .setDescription("Duration after which the primary master will ask another secondary "
-              + "master for snapshot data, after it has determined that it needs a snapshot.")
+  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT =
+      new Builder(Name.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT)
+          .setDefaultValue("60sec")
+          .setDescription("Time after which calls made through the Raft client timeout.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
-  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_SNAPSHOT_DATA_REQUEST_INTERVAL =
-      new Builder(Name.MASTER_EMBEDDED_JOURNAL_SNAPSHOT_DATA_REQUEST_INTERVAL)
-          .setDefaultValue("500ms")
-          .setDescription("Interval at which the primary master requests snapshot data from a "
-              + "secondary master, after it has determined that it needs a snapshot.")
+  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_INTERVAL =
+      new Builder(Name.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_INTERVAL)
+          .setDefaultValue("100ms")
+          .setDescription("Base interval for retrying Raft client calls. The retry policy is "
+              + "ExponentialBackoffRetry")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
@@ -6452,10 +6451,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.embedded.journal.write.timeout";
     public static final String MASTER_EMBEDDED_JOURNAL_SNAPSHOT_REPLICATION_CHUNK_SIZE =
         "alluxio.master.embedded.journal.snapshot.replication.chunk.size";
-    public static final String MASTER_EMBEDDED_JOURNAL_SNAPSHOT_DATA_REQUEST_TIMEOUT =
-        "alluxio.master.embedded.journal.snapshot.data.request.timeout";
-    public static final String MASTER_EMBEDDED_JOURNAL_SNAPSHOT_DATA_REQUEST_INTERVAL =
-        "alluxio.master.embedded.journal.snapshot.data.request.interval";
+    public static final String MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT =
+        "alluxio.master.embedded.journal.raft.client.request.timeout";
+    public static final String MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_INTERVAL =
+        "alluxio.master.embedded.journal.raft.client.request.interval";
     public static final String MASTER_EMBEDDED_JOURNAL_TRANSPORT_REQUEST_TIMEOUT_MS =
         "alluxio.master.embedded.journal.transport.request.timeout.ms";
     public static final String MASTER_EMBEDDED_JOURNAL_TRANSPORT_MAX_INBOUND_MESSAGE_SIZE =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1858,6 +1858,22 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_SNAPSHOT_DATA_REQUEST_TIMEOUT =
+      new Builder(Name.MASTER_EMBEDDED_JOURNAL_SNAPSHOT_DATA_REQUEST_TIMEOUT)
+          .setDefaultValue("35sec")
+          .setDescription("Duration after which the primary master will ask another secondary "
+              + "master for snapshot data, after it has determined that it needs a snapshot.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_SNAPSHOT_DATA_REQUEST_INTERVAL =
+      new Builder(Name.MASTER_EMBEDDED_JOURNAL_SNAPSHOT_DATA_REQUEST_INTERVAL)
+          .setDefaultValue("500ms")
+          .setDescription("Interval at which the primary master requests snapshot data from a "
+              + "secondary master, after it has determined that it needs a snapshot.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_TRANSPORT_REQUEST_TIMEOUT_MS =
       new Builder(Name.MASTER_EMBEDDED_JOURNAL_TRANSPORT_REQUEST_TIMEOUT_MS)
           .setDefaultValue("5sec")
@@ -6436,6 +6452,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.embedded.journal.write.timeout";
     public static final String MASTER_EMBEDDED_JOURNAL_SNAPSHOT_REPLICATION_CHUNK_SIZE =
         "alluxio.master.embedded.journal.snapshot.replication.chunk.size";
+    public static final String MASTER_EMBEDDED_JOURNAL_SNAPSHOT_DATA_REQUEST_TIMEOUT =
+        "alluxio.master.embedded.journal.snapshot.data.request.timeout";
+    public static final String MASTER_EMBEDDED_JOURNAL_SNAPSHOT_DATA_REQUEST_INTERVAL =
+        "alluxio.master.embedded.journal.snapshot.data.request.interval";
     public static final String MASTER_EMBEDDED_JOURNAL_TRANSPORT_REQUEST_TIMEOUT_MS =
         "alluxio.master.embedded.journal.transport.request.timeout.ms";
     public static final String MASTER_EMBEDDED_JOURNAL_TRANSPORT_MAX_INBOUND_MESSAGE_SIZE =

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -291,7 +291,6 @@ public class JournalStateMachine extends BaseStateMachine {
 
   @Override
   public void close() {
-    mSnapshotManager.close();
     mClosed = true;
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -882,8 +882,12 @@ public class RaftJournalSystem extends AbstractJournalSystem {
    */
   public synchronized CompletableFuture<RaftClientReply> sendMessageAsync(
       RaftPeerId server, Message message) {
-    RaftClient client = createClient(TimeDuration.valueOf(35, TimeUnit.SECONDS),
-        RetryPolicies.retryForeverWithSleep(TimeDuration.valueOf(500, TimeUnit.MILLISECONDS)));
+    long timeoutMs = ServerConfiguration.getMs(
+        PropertyKey.MASTER_EMBEDDED_JOURNAL_SNAPSHOT_DATA_REQUEST_TIMEOUT);
+    long retryMs = ServerConfiguration.getMs(
+        PropertyKey.MASTER_EMBEDDED_JOURNAL_SNAPSHOT_DATA_REQUEST_INTERVAL);
+    RaftClient client = createClient(TimeDuration.valueOf(timeoutMs, TimeUnit.MILLISECONDS),
+        RetryPolicies.retryForeverWithSleep(TimeDuration.valueOf(retryMs, TimeUnit.MILLISECONDS)));
     RaftClientRequest request = RaftClientRequest.newBuilder()
             .setClientId(mRawClientId)
             .setServerId(server)

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
@@ -473,10 +473,10 @@ public class SnapshotReplicationManager {
           }
           JournalQueryResponse response = JournalQueryResponse.parseFrom(
               reply.getMessage().getContent().asReadOnlyByteBuffer());
-          LOG.debug("Received snapshot info from follower {} - {}", peerId, response);
           if (!response.hasSnapshotInfoResponse()) {
             throw new IOException("Invalid response for GetSnapshotInfoRequest " + response);
           }
+          LOG.debug("Received snapshot info from follower {} - {}", peerId, response);
           SnapshotMetadata latest = response.getSnapshotInfoResponse().getLatest();
           if (snapshotMetadata == null
               || (latest.getSnapshotTerm() >= snapshotMetadata.getSnapshotTerm())

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
@@ -378,6 +378,7 @@ public class SnapshotReplicationManager {
           expected, update, mDownloadState.get());
       return false;
     }
+    LOG.info("Successfully transitioned from {} to {}", expected, update);
     return true;
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotUploader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotUploader.java
@@ -151,6 +151,9 @@ public class SnapshotUploader<S, R>
   @Override
   public void onError(Throwable t) {
     LOG.error("Error sending snapshot {} at {}", mSnapshotFile, mOffset, t);
+    // propagates error to SnapshpotReplicationManager#receiveSnapshotFromFollower ->
+    // observer.getFuture().exceptionally(). This allows leader to request other followers for a
+    // snapshot.
     mStream.onError(t);
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotUploader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotUploader.java
@@ -151,6 +151,7 @@ public class SnapshotUploader<S, R>
   @Override
   public void onError(Throwable t) {
     LOG.error("Error sending snapshot {} at {}", mSnapshotFile, mOffset, t);
+    mStream.onError(t);
   }
 
   @Override

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -20,6 +20,8 @@ import alluxio.grpc.JournalQueryRequest;
 import alluxio.grpc.NetAddress;
 import alluxio.grpc.QuorumServerInfo;
 import alluxio.grpc.RaftJournalServiceGrpc;
+import alluxio.grpc.UploadSnapshotPRequest;
+import alluxio.grpc.UploadSnapshotPResponse;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.BufferUtils;
@@ -45,12 +47,19 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(SnapshotDownloader.class)
 public class SnapshotReplicationManagerTest {
   private static final int SNAPSHOT_SIZE = 100000;
 
@@ -62,13 +71,14 @@ public class SnapshotReplicationManagerTest {
       new ConfigurationRule(PropertyKey.MASTER_EMBEDDED_JOURNAL_SNAPSHOT_REPLICATION_CHUNK_SIZE,
           "32KB", ServerConfiguration.global());
 
-  private WaitForOptions mWaitOptions = WaitForOptions.defaults().setTimeoutMs(30000);
+  private final WaitForOptions mWaitOptions = WaitForOptions.defaults().setTimeoutMs(30000);
   private SnapshotReplicationManager mLeaderSnapshotManager;
   private SnapshotReplicationManager mFollowerSnapshotManager;
   private RaftJournalSystem mLeader;
   private RaftJournalSystem mFollower;
   private SimpleStateMachineStorage mLeaderStore;
   private SimpleStateMachineStorage mFollowerStore;
+  private RaftJournalServiceClient mClient;
   private Server mServer;
 
   @Before
@@ -80,17 +90,17 @@ public class SnapshotReplicationManagerTest {
         Collections.singletonList(QuorumServerInfo.newBuilder()
             .setServerAddress(NetAddress.newBuilder()
                 .setHost("follower").setRpcPort(12345)).build()));
-    Mockito.when(mLeader.sendMessageAsync(any(), any())).thenAnswer((args) -> {
-      Message message = args.getArgument(1, Message.class);
-      JournalQueryRequest queryRequest = JournalQueryRequest.parseFrom(
-          message.getContent().asReadOnlyByteBuffer());
-      Message response = mFollowerSnapshotManager.handleRequest(queryRequest);
-      RaftClientReply reply = Mockito.mock(RaftClientReply.class);
-      Mockito.when(reply.getMessage()).thenReturn(response);
-      return CompletableFuture.completedFuture(reply);
-    });
+//    Mockito.when(mLeader.sendMessageAsync(any(), any())).thenAnswer((args) -> {
+//      Message message = args.getArgument(1, Message.class);
+//      JournalQueryRequest queryRequest = JournalQueryRequest.parseFrom(
+//          message.getContent().asReadOnlyByteBuffer());
+//      Message response = mFollowerSnapshotManager.handleRequest(queryRequest);
+//      RaftClientReply reply = Mockito.mock(RaftClientReply.class);
+//      Mockito.when(reply.getMessage()).thenReturn(response);
+//      return CompletableFuture.completedFuture(reply);
+//    });
     mLeaderStore = getSimpleStateMachineStorage();
-    mLeaderSnapshotManager = new SnapshotReplicationManager(mLeader, mLeaderStore);
+    mLeaderSnapshotManager = Mockito.spy(new SnapshotReplicationManager(mLeader, mLeaderStore));
 
     String serverName = InProcessServerBuilder.generateName();
     mServer = InProcessServerBuilder.forName(serverName)
@@ -99,35 +109,40 @@ public class SnapshotReplicationManagerTest {
     mServer.start();
     ManagedChannel channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
     RaftJournalServiceGrpc.RaftJournalServiceStub stub = RaftJournalServiceGrpc.newStub(channel);
-    RaftJournalServiceClient client = Mockito.mock(RaftJournalServiceClient.class);
+    mClient = Mockito.mock(RaftJournalServiceClient.class);
 
     // download rpc mock
-    Mockito.when(client.downloadSnapshot(any())).thenAnswer((args) -> {
+    Mockito.when(mClient.downloadSnapshot(any())).thenAnswer((args) -> {
       StreamObserver responseObserver = args.getArgument(0, StreamObserver.class);
       return stub.downloadSnapshot(responseObserver);
     });
 
     // upload rpc mock
-    Mockito.when(client.uploadSnapshot(any())).thenAnswer((args) -> {
+    Mockito.when(mClient.uploadSnapshot(any())).thenAnswer((args) -> {
       StreamObserver responseObserver = args.getArgument(0, StreamObserver.class);
       return stub.uploadSnapshot(responseObserver);
     });
 
     mFollowerStore = getSimpleStateMachineStorage();
     mFollower = Mockito.mock(RaftJournalSystem.class);
-    mFollowerSnapshotManager = new SnapshotReplicationManager(mFollower, mFollowerStore, client);
+    mFollowerSnapshotManager = new SnapshotReplicationManager(mFollower, mFollowerStore, mClient);
   }
 
   private SimpleStateMachineStorage getSimpleStateMachineStorage() throws IOException {
     RaftStorage rs = new RaftStorageImpl(mFolder.newFolder(CommonUtils.randomAlphaNumString(6)),
-            RaftServerConfigKeys.Log.CorruptionPolicy.getDefault());
+        RaftServerConfigKeys.Log.CorruptionPolicy.getDefault());
     SimpleStateMachineStorage snapshotStore = new SimpleStateMachineStorage();
     snapshotStore.init(rs);
     return snapshotStore;
   }
 
   private void createSnapshotFile(SimpleStateMachineStorage storage) throws IOException {
-    java.io.File file = storage.getSnapshotFile(0, 1);
+    createSnapshotFile(storage, 0, 1);
+  }
+
+  private void createSnapshotFile(SimpleStateMachineStorage storage, long term, long index)
+      throws IOException {
+    java.io.File file = storage.getSnapshotFile(term, index);
     FileUtils.writeByteArrayToFile(file, BufferUtils.getIncreasingByteArray(SNAPSHOT_SIZE));
     storage.loadLatestSnapshot();
   }
@@ -170,5 +185,77 @@ public class SnapshotReplicationManagerTest {
     CommonUtils.waitFor("follower snapshot to complete",
         () -> mFollowerStore.getLatestSnapshot() != null, mWaitOptions);
     validateSnapshotFile(mFollowerStore);
+  }
+
+  private RaftPeerId peerIdFrom(String id, int port) {
+    return RaftPeerId.valueOf(String.format("%s_%d", id, port));
+  }
+
+  @Test
+  public void selectDifferentFollowerForSnapshot() throws Exception {
+    SimpleStateMachineStorage secondFollowerStore = getSimpleStateMachineStorage();
+    RaftJournalSystem secondFollower = Mockito.mock(RaftJournalSystem.class);
+    SnapshotReplicationManager secondFollowerReplicationManager =
+        new SnapshotReplicationManager(secondFollower, secondFollowerStore, mClient);
+
+    createSnapshotFile(mFollowerStore);
+    createSnapshotFile(secondFollowerStore, 0, 2); // preferable to the default 0, 1 snapshot
+
+    SnapshotUploader<UploadSnapshotPRequest, UploadSnapshotPResponse> spy =
+        PowerMockito.spy(SnapshotUploader.forFollower(secondFollowerStore,
+            secondFollowerStore.getLatestSnapshot()));
+    Mockito.doNothing().when(spy).onCompleted();
+
+    Mockito.when(mLeaderSnapshotManager.receiveSnapshotFromFollower(spy))
+        .thenAnswer(mock -> {
+          StreamObserver<UploadSnapshotPResponse> streamObserver =
+              mock.getArgument(0, StreamObserver.class);
+          SnapshotDownloader<UploadSnapshotPResponse, UploadSnapshotPRequest> dummy =
+              PowerMockito.spy(
+                  SnapshotDownloader.forLeader(mLeaderStore, streamObserver, "dummy"));
+          PowerMockito.doThrow(new IOException("download failed")).when(dummy, "onNextInternal",
+              any());
+          return dummy;
+        })
+        .thenCallRealMethod();
+
+    ArrayList<QuorumServerInfo> l = new ArrayList<>();
+    String idFollower1 = "follower1";
+    String idFollower2 = "follower2";
+    int rpcPort1 = 12345;
+    int rpcPort2 = 23456;
+    l.add(QuorumServerInfo.newBuilder()
+        .setServerAddress(NetAddress.newBuilder()
+            .setHost(idFollower1).setRpcPort(rpcPort1)).build());
+    l.add(QuorumServerInfo.newBuilder()
+        .setServerAddress(NetAddress.newBuilder()
+            .setHost(idFollower2).setRpcPort(rpcPort2)).build());
+
+    Mockito.when(mLeader.getQuorumServerInfoList()).thenReturn(l);
+
+    Mockito.when(mLeader.sendMessageAsync(any(), any())).thenAnswer((args) -> {
+      RaftPeerId peerId = args.getArgument(0, RaftPeerId.class);
+      Message message = args.getArgument(1, Message.class);
+      JournalQueryRequest queryRequest = JournalQueryRequest.parseFrom(
+          message.getContent().asReadOnlyByteBuffer());
+      Message response;
+      if (peerId.equals(peerIdFrom(idFollower1, rpcPort1))) {
+        response = mFollowerSnapshotManager.handleRequest(queryRequest);
+      } else {
+        response = secondFollowerReplicationManager.handleRequest(queryRequest);
+      }
+      RaftClientReply reply = Mockito.mock(RaftClientReply.class);
+      Mockito.when(reply.getMessage()).thenReturn(response);
+      return CompletableFuture.completedFuture(reply);
+    });
+
+    mLeaderSnapshotManager.maybeCopySnapshotFromFollower();
+
+    try {
+      CommonUtils.waitFor("leader snapshot to complete",
+          () -> mLeaderSnapshotManager.maybeCopySnapshotFromFollower() != -1, mWaitOptions);
+    } finally {
+      validateSnapshotFile(mLeaderStore);
+    }
   }
 }

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-//    o.sync();
+    o.sync();
     //#else
     o.hflush();
     //#endif

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-    o.sync();
+//    o.sync();
     //#else
     o.hflush();
     //#endif


### PR DESCRIPTION
Modifies the behavior of the `SnapshotReplicationManager` to allow the leading master to request a snapshot from all followers sequentially, from most recent to least recent snapshot. It also importantly recreates a new `RaftJournalServiceClient` for each new communication between leader and follower.
This addresses the issue where the leader would repeatedly request a snapshot from one flaky follower, and therefore the leader would never receive a snapshot.
The `SnapshotReplicationManager` state machine has been modified as follows:
old:
<img src="https://user-images.githubusercontent.com/23088925/152085603-74af7249-98e0-4aef-bca4-459776c3d364.png" alt="old" width="200"/>

new:
<img src="https://user-images.githubusercontent.com/23088925/152236611-f4a5c456-fe0f-4b8d-9e7c-1cb95d9587a3.png" alt="new" width="200"/>

`STREAM_DATA` now goes back to `REQUEST_DATA` instead of `IDLE` to request data from other followers.
`REQUEST_DATA` only goes back to `IDLE` after requesting snapshots from all followers that have a more recent snapshot than the leader's.