### PR TITLE
Fix UI Worker page table header issue

### DIFF
--- a/webui/master/src/containers/pages/Workers/Workers.test.tsx
+++ b/webui/master/src/containers/pages/Workers/Workers.test.tsx
@@ -54,6 +54,7 @@ describe('Workers', () => {
 
     it('Renders without crashing', () => {
       expect(shallowWrapper.length).toEqual(1);
+      expect(shallowWrapper.find('#id-nodename')).toHaveLength(1);
     });
 
     it('Matches snapshot', () => {
@@ -62,18 +63,26 @@ describe('Workers', () => {
 
     it('Hostname in Kubernetes environment', () => {
       shallowWrapper.setProps({
-        workersData: { ...props.workersData, normalNodeInfos: [{ host: 'hostIp (podIp)', workerId: 1 }] },
+        workersData: {
+          ...props.workersData,
+          normalNodeInfos: [{ host: 'hostIp1 (podIp)', workerId: 1 }, { host: 'hostIp2 (podIp)', workerId: 2 }],
+        },
       });
-      expect(shallowWrapper.find('#id-1').props().children).toEqual('Node Name(Container Host)');
-      expect(shallowWrapper.find('#id-1-link').prop('href')).toEqual(`//hostIp:${props.initData.workerPort}`);
+      expect(shallowWrapper.find('#id-nodename').props().children).toEqual('Node Name(Container Host)');
+      expect(shallowWrapper.find('#id-1-link').prop('href')).toEqual(`//hostIp1:${props.initData.workerPort}`);
+      expect(shallowWrapper.find('#id-2-link').prop('href')).toEqual(`//hostIp2:${props.initData.workerPort}`);
     });
 
     it('Hostname in bare-metal environment', () => {
       shallowWrapper.setProps({
-        workersData: { ...props.workersData, normalNodeInfos: [{ host: 'hostIp', workerId: 1 }] },
+        workersData: {
+          ...props.workersData,
+          normalNodeInfos: [{ host: 'hostIp1', workerId: 1 }, { host: 'hostIp2', workerId: 2 }],
+        },
       });
-      expect(shallowWrapper.find('#id-1').props().children).toEqual('Node Name');
-      expect(shallowWrapper.find('#id-1-link').prop('href')).toEqual(`//hostIp:${props.initData.workerPort}`);
+      expect(shallowWrapper.find('#id-nodename').props().children).toEqual('Node Name');
+      expect(shallowWrapper.find('#id-1-link').prop('href')).toEqual(`//hostIp1:${props.initData.workerPort}`);
+      expect(shallowWrapper.find('#id-2-link').prop('href')).toEqual(`//hostIp2:${props.initData.workerPort}`);
     });
   });
 });

--- a/webui/master/src/containers/pages/Workers/Workers.tsx
+++ b/webui/master/src/containers/pages/Workers/Workers.tsx
@@ -47,13 +47,13 @@ export class WorkersPresenter extends React.Component<AllProps> {
               <Table hover={true}>
                 <thead>
                   <tr>
-                    {workersData.normalNodeInfos.map((nodeInfo: INodeInfo) => (
-                      <th key={nodeInfo.workerId} id={`id-${nodeInfo.workerId}`}>
-                        {/*When workers start with kubernetes. `nodeInfo.host` is `hostIp (podIp)`,
-                            So it should be displayed as Node Name(Container Host).*/}
-                        {nodeInfo.host.includes('(') ? 'Node Name(Container Host)' : 'Node Name'}
-                      </th>
-                    ))}
+                    <th id="id-nodename">
+                      {/* When workers start with kubernetes. `nodeInfo.host` is `hostIp (podIp)`,
+                          So it should be displayed as Node Name(Container Host). */}
+                      {workersData.normalNodeInfos.some((nodeInfo: INodeInfo) => nodeInfo.host.includes('('))
+                        ? 'Node Name(Container Host)'
+                        : 'Node Name'}
+                    </th>
                     {initData.debug && (
                       <React.Fragment>
                         <th>[D]Worker Id</th>

--- a/webui/master/src/containers/pages/Workers/__snapshots__/Workers.test.tsx.snap
+++ b/webui/master/src/containers/pages/Workers/__snapshots__/Workers.test.tsx.snap
@@ -23,6 +23,11 @@ exports[`Workers Shallow component Matches snapshot 1`] = `
         >
           <thead>
             <tr>
+              <th
+                id="id-nodename"
+              >
+                Node Name
+              </th>
               <th>
                 Last Heartbeat
               </th>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fixed an issue where `Node Name` header in Worker page was rendering per worker

Note: Replacing https://github.com/Alluxio/alluxio/pull/14898 with proper fix

### Why are the changes needed?

See above
![image](https://user-images.githubusercontent.com/6509369/151632979-e0928cd5-a047-413a-a66f-12241511e742.png)


### Does this PR introduce any user facing changes?

Yes, web UI Worker page table is fixed to prevent repeat `Node Name` headers from rendering.