### PR TITLE
[DOCFIX] Add readme to csi driver

### DIFF
--- a/integration/docker/csi/README.md
+++ b/integration/docker/csi/README.md
@@ -6,4 +6,5 @@ To see how to use Alluxio CSI Driver, please check out:
 https://docs.alluxio.io/os/user/stable/en/deploy/Running-Alluxio-On-Kubernetes.html#csi
 
 or,
+
 https://github.com/Alluxio/alluxio/blob/master/integration/kubernetes/CSI_README.md

--- a/integration/docker/csi/README.md
+++ b/integration/docker/csi/README.md
@@ -1,0 +1,9 @@
+## Alluxio CSI Driver
+
+This module implements container storage interface(https://github.com/container-storage-interface/spec) for Alluxio.
+
+To see how to use Alluxio CSI Driver, please check out:
+https://docs.alluxio.io/os/user/stable/en/deploy/Running-Alluxio-On-Kubernetes.html#csi
+
+or,
+https://github.com/Alluxio/alluxio/blob/master/integration/kubernetes/CSI_README.md


### PR DESCRIPTION
The CSI driver directory is lacking a README. We are trying to add Alluxio CSI driver into kuberbetes csi drivers list documentation, and the hyperlink to Alluxio CSI driver directory will be included. However currently there is no explanation of anything in that directory. This PR adds a README that points to our CSI documentation.