### PR TITLE
Add ElasticsearchInfo to Hub rest.proto

### DIFF
--- a/hub/transport/src/main/proto/grpc/hosted.proto
+++ b/hub/transport/src/main/proto/grpc/hosted.proto
@@ -64,6 +64,24 @@ message HubManagerObjects {
     map<string, HubManagerObject> hub_managers = 1;
 }
 
+message ElasticsearchInfo {
+    optional ElasticsearchEnvironmentVariables env_variables = 1;
+    optional ElasticsearchDashboards dashboards = 2;
+
+}
+
+message ElasticsearchEnvironmentVariables {
+    optional string es_domain_endpoint = 1;
+    optional string es_cluster_port = 2;
+    optional string es_username = 3;
+    optional string es_password = 4;
+}
+
+message ElasticsearchDashboards {
+    optional string logs_dashboard_id = 1;
+    optional string metrics_dashboard_id = 2;
+}
+
 message BaseMessage {
     optional HubMetadata hub_metadata = 1;
 }

--- a/hub/transport/src/main/proto/grpc/hosted.proto
+++ b/hub/transport/src/main/proto/grpc/hosted.proto
@@ -64,24 +64,6 @@ message HubManagerObjects {
     map<string, HubManagerObject> hub_managers = 1;
 }
 
-message ElasticsearchInfo {
-    optional ElasticsearchEnvironmentVariables env_variables = 1;
-    optional ElasticsearchDashboards dashboards = 2;
-
-}
-
-message ElasticsearchEnvironmentVariables {
-    optional string es_domain_endpoint = 1;
-    optional string es_cluster_port = 2;
-    optional string es_username = 3;
-    optional string es_password = 4;
-}
-
-message ElasticsearchDashboards {
-    optional string logs_dashboard_id = 1;
-    optional string metrics_dashboard_id = 2;
-}
-
 message BaseMessage {
     optional HubMetadata hub_metadata = 1;
 }

--- a/hub/transport/src/main/proto/grpc/rest.proto
+++ b/hub/transport/src/main/proto/grpc/rest.proto
@@ -215,7 +215,6 @@ message SpeedTestParameter {
 message ElasticsearchInfo {
   optional ElasticsearchEnvironmentVariables env_variables = 1;
   optional ElasticsearchDashboards dashboards = 2;
-  map<string, string> errors = 3;
 }
 
 message ElasticsearchEnvironmentVariables {

--- a/hub/transport/src/main/proto/grpc/rest.proto
+++ b/hub/transport/src/main/proto/grpc/rest.proto
@@ -219,10 +219,11 @@ message ElasticsearchInfo {
 }
 
 message ElasticsearchEnvironmentVariables {
-  optional string hub_es_domain_endpoint = 1;
+  optional string hub_es_cluster_endpoint = 1;
   optional string hub_es_cluster_port = 2;
   optional string hub_es_username = 3;
   optional string hub_es_password = 4;
+  optional string hub_cluster_id = 5;
 }
 
 message ElasticsearchDashboards {

--- a/hub/transport/src/main/proto/grpc/rest.proto
+++ b/hub/transport/src/main/proto/grpc/rest.proto
@@ -215,7 +215,7 @@ message SpeedTestParameter {
 message ElasticsearchInfo {
   optional ElasticsearchEnvironmentVariables env_variables = 1;
   optional ElasticsearchDashboards dashboards = 2;
-
+  map<string, string> errors = 3;
 }
 
 message ElasticsearchEnvironmentVariables {
@@ -226,7 +226,6 @@ message ElasticsearchEnvironmentVariables {
 }
 
 message ElasticsearchDashboards {
-  optional string logs_dashboard_id = 1;
-  optional string metrics_dashboard_id = 2;
+  map<string, string> dashboard_ids = 1;
 }
 

--- a/hub/transport/src/main/proto/grpc/rest.proto
+++ b/hub/transport/src/main/proto/grpc/rest.proto
@@ -210,3 +210,23 @@ message SpeedTestParameter {
   optional string path = 3;
   map<string, string> properties = 4;
 }
+
+// Elasticsearch specific messages
+message ElasticsearchInfo {
+  optional ElasticsearchEnvironmentVariables env_variables = 1;
+  optional ElasticsearchDashboards dashboards = 2;
+
+}
+
+message ElasticsearchEnvironmentVariables {
+  optional string hub_es_domain_endpoint = 1;
+  optional string hub_es_cluster_port = 2;
+  optional string hub_es_username = 3;
+  optional string hub_es_password = 4;
+}
+
+message ElasticsearchDashboards {
+  optional string logs_dashboard_id = 1;
+  optional string metrics_dashboard_id = 2;
+}
+


### PR DESCRIPTION
### What changes are proposed in this pull request?
Add Elasticsearch specific grpc messages to hosted.proto

Please outline the changes and how this PR fixes the issue.

### Why are the changes needed?
These changes are needed for the Hub UI to retrieve elasticsearch env variables and dashboard id's and embed Kibana dashboards. 
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
