### PR TITLE
Fix flaky FileOutStreamIntegrationTest#cancelWrite

### DIFF
--- a/tests/src/test/java/alluxio/client/fs/io/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileOutStreamIntegrationTest.java
@@ -229,7 +229,8 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
    * resources.
    */
   @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL, "250ms"})
+      confParams = {PropertyKey.Name.MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL, "250ms",
+          PropertyKey.Name.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "250ms"})
   @Test
   public void cancelWrite() throws Exception {
     AlluxioURI path = new AlluxioURI(PathUtils.uniqPath());
@@ -239,7 +240,7 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
       os.cancel();
     }
     long gracePeriod = ServerConfiguration
-        .getMs(PropertyKey.MASTER_LOST_WORKER_DETECTION_INTERVAL) * 2;
+        .getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS) * 2;
     CommonUtils.sleepMs(gracePeriod);
     List<WorkerInfo> workers =
         mLocalAlluxioClusterResource.get().getLocalAlluxioMaster().getMasterProcess()


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix an integration test of FileOutStreamIntegrationTest#cancelWrite

### Why are the changes needed?

Original test setup intended to customize worker-master heartbeat interval to speed up the test.
However,  a bug was introduced in https://github.com/Alluxio/alluxio/pull/10588/
which customized the wrong property key.
As a result, the grace period is only 0.5s as supposed to be 2s, introducing flakiness due to lack of time 
for block information to be propagated from worker to master.

### Does this PR introduce any user facing changes?

No
