### PR TITLE
Fix flaky JobMasterIntegrationTest

### DIFF
--- a/tests/src/test/java/alluxio/job/master/JobMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/master/JobMasterIntegrationTest.java
@@ -50,8 +50,8 @@ import java.util.concurrent.atomic.AtomicReference;
  * Integration tests for the job master.
  */
 public final class JobMasterIntegrationTest extends BaseIntegrationTest {
-  private static final long WORKER_TIMEOUT_MS = 500;
-  private static final long LOST_WORKER_INTERVAL_MS = 500;
+  private static final long WORKER_TIMEOUT_MS = 2000;
+  private static final long LOST_WORKER_INTERVAL_MS = 2000;
   private JobMaster mJobMaster;
   private JobWorkerProcess mJobWorker;
   private LocalAlluxioJobCluster mLocalAlluxioJobCluster;

--- a/tests/src/test/java/alluxio/job/util/JobTestUtils.java
+++ b/tests/src/test/java/alluxio/job/util/JobTestUtils.java
@@ -22,9 +22,7 @@ import alluxio.util.WaitForOptions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -58,26 +56,26 @@ public final class JobTestUtils {
   public static JobInfo waitForJobStatus(final JobMaster jobMaster, final long jobId,
       final Set<Status> statuses) throws InterruptedException, TimeoutException {
     final AtomicReference<JobInfo> singleton = new AtomicReference<>();
-    List<String> jobStatus = new ArrayList<>();
-    jobStatus.add("");
+    final AtomicReference<String> jobStatus = new AtomicReference<>();
     try {
       CommonUtils.waitFor(
-          String.format("job %d to be one of status %s", jobId, Arrays.toString(statuses.toArray())),
+          String.format("job %d to be one of status %s", jobId,
+              Arrays.toString(statuses.toArray())),
           () -> {
             JobInfo info;
             try {
               info = jobMaster.getStatus(jobId);
+              jobStatus.set(info.toString());
               if (statuses.contains(info.getStatus())) {
                 singleton.set(info);
               }
-              jobStatus.set(0, info.toString());
               return statuses.contains(info.getStatus());
             } catch (JobDoesNotExistException e) {
               throw Throwables.propagate(e);
             }
           }, WaitForOptions.defaults().setTimeoutMs(30 * Constants.SECOND_MS));
     } catch (TimeoutException e) {
-      throw new TimeoutException(String.format("%s, %s", e.getMessage(), jobStatus.get(0)));
+      throw new TimeoutException(String.format("%s, %s", e.getMessage(), jobStatus.toString()));
     }
 
     return singleton.get();

--- a/tests/src/test/java/alluxio/job/util/JobTestUtils.java
+++ b/tests/src/test/java/alluxio/job/util/JobTestUtils.java
@@ -22,7 +22,9 @@ import alluxio.util.WaitForOptions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -56,21 +58,28 @@ public final class JobTestUtils {
   public static JobInfo waitForJobStatus(final JobMaster jobMaster, final long jobId,
       final Set<Status> statuses) throws InterruptedException, TimeoutException {
     final AtomicReference<JobInfo> singleton = new AtomicReference<>();
-    CommonUtils.waitFor(
-        String.format("job %d to be one of status %s", jobId, Arrays.toString(statuses.toArray())),
-        () -> {
-          JobInfo info;
-          try {
-            info = jobMaster.getStatus(jobId);
-            System.out.println(info.toString());
-            if (statuses.contains(info.getStatus())) {
-              singleton.set(info);
+    List<String> jobStatus = new ArrayList<>();
+    jobStatus.add("");
+    try {
+      CommonUtils.waitFor(
+          String.format("job %d to be one of status %s", jobId, Arrays.toString(statuses.toArray())),
+          () -> {
+            JobInfo info;
+            try {
+              info = jobMaster.getStatus(jobId);
+              if (statuses.contains(info.getStatus())) {
+                singleton.set(info);
+              }
+              jobStatus.set(0, info.toString());
+              return statuses.contains(info.getStatus());
+            } catch (JobDoesNotExistException e) {
+              throw Throwables.propagate(e);
             }
-            return statuses.contains(info.getStatus());
-          } catch (JobDoesNotExistException e) {
-            throw Throwables.propagate(e);
-          }
-        }, WaitForOptions.defaults().setTimeoutMs(30 * Constants.SECOND_MS));
+          }, WaitForOptions.defaults().setTimeoutMs(30 * Constants.SECOND_MS));
+    } catch (TimeoutException e) {
+      throw new TimeoutException(String.format("%s, %s", e.getMessage(), jobStatus.get(0)));
+    }
+
     return singleton.get();
   }
 

--- a/tests/src/test/java/alluxio/job/util/JobTestUtils.java
+++ b/tests/src/test/java/alluxio/job/util/JobTestUtils.java
@@ -62,6 +62,7 @@ public final class JobTestUtils {
           JobInfo info;
           try {
             info = jobMaster.getStatus(jobId);
+            System.out.println(info.toString());
             if (statuses.contains(info.getStatus())) {
               singleton.set(info);
             }


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Fix flaky JobMasterIntegrationTest, add more log info to guard future test flaky

**Why are the changes needed?**
This integration test uses small `JOB_MASTER_WORKER_HEARTBEAT_INTERVAL`, `JOB_MASTER_WORKER_TIMEOUT`, and `JOB_MASTER_LOST_WORKER_INTERVAL` to accelerate the integration test. This setting is totally fine when we do tests at a local machine or Jenkins. However, the `JOB_MASTER_WORKER_HEARTBEAT_INTERVAL` can take a much longer time in GitHub action, which results in a list of flaky tests. The error message is as follows:

```
Error: 3.474 [ERROR] alluxio.job.master.JobMasterIntegrationTest.throttleJobWorkerTasks  Time elapsed: 32.855 s  <<< ERROR!
java.util.concurrent.TimeoutException: Timed out waiting for job 1643913746839 to be one of status [RUNNING, COMPLETED] options: WaitForOptions{interval=20, timeout=30000} last value: false, PlanInfo{id=1643913746839, errorType=JobWorkerLost, errorMessage=Task execution failed: Job worker(bbf508a040fc) was lost before the task(0) could complete, childPlanInfoList=[TaskInfo{jobId=1643913746839, taskId=0, status=COMPLETED, errorMessage=, result=null, lastUpdated=1643913737647, workerHost=bbf508a040fc, description=}], status=FAILED, result=, lastUpdated=1643913737650, name=Sleep, description=SleepJobConfig{timeMs=1}, affectedPaths=[]}
	at alluxio.job.util.JobTestUtils.waitForJobStatus(JobTestUtils.java:80)
	at alluxio.job.master.JobMasterIntegrationTest.throttleJobWorkerTasks(JobMasterIntegrationTest.java:197)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at alluxio.job.plan.PlanDefinitionRegistryRule$1.evaluate(PlanDefinitionRegistryRule.java:49)
	at alluxio.testutils.LocalAlluxioClusterResource$1.evaluate(LocalAlluxioClusterResource.java:198)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:288)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:282)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```

This pr change should partially eliminate the test flaky because of job worker lost.

**Does this PR introduce any user facing changes?**
No