### PR TITLE
Fix stop logic in FuseIntegrationTest

### DIFF
--- a/tests/src/test/java/alluxio/client/fuse/AbstractFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/AbstractFuseIntegrationTest.java
@@ -83,11 +83,14 @@ public abstract class AbstractFuseIntegrationTest {
   public abstract void mountFuse(FileSystem fileSystem, String mountPoint, String alluxioRoot);
 
   /**
-   * Umounts the given fuse mount point.
-   *
-   * @param mountPoint the Fuse mount point
+   * Run before cluster stops.
    */
-  public abstract void umountFuse(String mountPoint) throws Exception;
+  public abstract void beforeStop() throws Exception;
+
+  /**
+   * Run after cluster stops.
+   */
+  public abstract void afterStop() throws Exception;
 
   @BeforeClass
   public static void beforeClass() {
@@ -116,7 +119,9 @@ public abstract class AbstractFuseIntegrationTest {
 
   @After
   public void after() throws Exception {
+    beforeStop();
     stop();
+    afterStop();
   }
 
   protected void umountFromShellIfMounted() throws IOException {
@@ -126,13 +131,6 @@ public abstract class AbstractFuseIntegrationTest {
   }
 
   private void stop() throws Exception {
-    if (fuseMounted()) {
-      try {
-        umountFuse(mMountPoint);
-      } catch (Exception e) {
-        // The Fuse application may be unmounted by the cluster stop
-      }
-    }
     try {
       mAlluxioCluster.stop();
     } finally {

--- a/tests/src/test/java/alluxio/client/fuse/AbstractFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/AbstractFuseIntegrationTest.java
@@ -119,15 +119,18 @@ public abstract class AbstractFuseIntegrationTest {
     stop();
   }
 
+  protected void umountFromShellIfMounted() throws IOException {
+    if (fuseMounted()) {
+      ShellUtils.execCommand("umount", mMountPoint);
+    }
+  }
+
   private void stop() throws Exception {
     if (fuseMounted()) {
       try {
         umountFuse(mMountPoint);
       } catch (Exception e) {
         // The Fuse application may be unmounted by the cluster stop
-      }
-      if (fuseMounted()) {
-        ShellUtils.execCommand("umount", mMountPoint);
       }
     }
     try {

--- a/tests/src/test/java/alluxio/client/fuse/AbstractFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/AbstractFuseIntegrationTest.java
@@ -120,11 +120,6 @@ public abstract class AbstractFuseIntegrationTest {
   }
 
   private void stop() throws Exception {
-    try {
-      mAlluxioCluster.stop();
-    } finally {
-      IntegrationTestUtils.releaseMasterPorts();
-    }
     if (fuseMounted()) {
       try {
         umountFuse(mMountPoint);
@@ -134,6 +129,11 @@ public abstract class AbstractFuseIntegrationTest {
       if (fuseMounted()) {
         ShellUtils.execCommand("umount", mMountPoint);
       }
+    }
+    try {
+      mAlluxioCluster.stop();
+    } finally {
+      IntegrationTestUtils.releaseMasterPorts();
     }
   }
 

--- a/tests/src/test/java/alluxio/client/fuse/JNIFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNIFuseIntegrationTest.java
@@ -48,7 +48,6 @@ public class JNIFuseIntegrationTest extends AbstractFuseIntegrationTest {
       // will try umounting from shell
     }
     umountFromShellIfMounted();
-
   }
 
   @Override

--- a/tests/src/test/java/alluxio/client/fuse/JNIFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNIFuseIntegrationTest.java
@@ -17,6 +17,7 @@ import alluxio.conf.ServerConfiguration;
 import alluxio.fuse.AlluxioJniFuseFileSystem;
 import alluxio.fuse.FuseMountOptions;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 /**
@@ -40,8 +41,18 @@ public class JNIFuseIntegrationTest extends AbstractFuseIntegrationTest {
   }
 
   @Override
-  public void umountFuse(String mountPath) throws Exception {
-    mFuseFileSystem.umount(true);
+  public void beforeStop() throws IOException {
+    try {
+      mFuseFileSystem.umount(true);
+    } catch (Exception e) {
+      // will try umounting from shell
+    }
     umountFromShellIfMounted();
+
+  }
+
+  @Override
+  public void afterStop() {
+    // noop
   }
 }

--- a/tests/src/test/java/alluxio/client/fuse/JNIFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNIFuseIntegrationTest.java
@@ -42,5 +42,6 @@ public class JNIFuseIntegrationTest extends AbstractFuseIntegrationTest {
   @Override
   public void umountFuse(String mountPath) throws Exception {
     mFuseFileSystem.umount(true);
+    umountFromShellIfMounted();
   }
 }

--- a/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
@@ -40,8 +40,17 @@ public class JNRFuseIntegrationTest extends AbstractFuseIntegrationTest {
   }
 
   @Override
-  public void umountFuse(String mountPath) throws Exception {
-    mFuseFileSystem.umount();
+  public void beforeStop() throws Exception {
+    try {
+      mFuseFileSystem.umount();
+    } catch (Exception e) {
+      // will try umounting from shell
+    }
     umountFromShellIfMounted();
+  }
+
+  @Override
+  public void afterStop() throws Exception {
+    // noop
   }
 }

--- a/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
@@ -42,5 +42,6 @@ public class JNRFuseIntegrationTest extends AbstractFuseIntegrationTest {
   @Override
   public void umountFuse(String mountPath) throws Exception {
     mFuseFileSystem.umount();
+    umountFromShellIfMounted();
   }
 }

--- a/tests/src/test/java/alluxio/server/worker/WorkerFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/worker/WorkerFuseIntegrationTest.java
@@ -33,7 +33,14 @@ public class WorkerFuseIntegrationTest extends AbstractFuseIntegrationTest {
   }
 
   @Override
-  public void umountFuse(String mountPath) throws Exception {
+  public void beforeStop() throws Exception {
     // Fuse application is unmounted automatically when stopping the worker
   }
+
+  @Override
+  public void afterStop() throws Exception {
+    // umount the mountpoint
+    umountFromShellIfMounted();
+  }
+
 }

--- a/tests/src/test/java/alluxio/server/worker/WorkerFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/worker/WorkerFuseIntegrationTest.java
@@ -42,5 +42,4 @@ public class WorkerFuseIntegrationTest extends AbstractFuseIntegrationTest {
     // umount the mountpoint
     umountFromShellIfMounted();
   }
-
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix the `stop()` logic in FuseIntegrationTest so umounting will work for JNI, JNR and WorkerFuseIntegrationTest.

- For JNI and JNR, umount will happen before cluster stops
- For WorkFuseIntegrationTest, umount will happen after cluster stops

### Why are the changes needed?

This PR fixes the following bug: 

The `stop()` in FuseIntegrationTest currently umounts fuse mountpoint after cluster stops. This works for WorkerIntegrationTest, but for JNI and JNR, umounting will fail with `Input/output error`, since the cluster has already stopped. In JNI and JNR's situations, umount should run before cluster stops.

### Does this PR introduce any user facing changes?

No
