### PR TITLE
Fix job service error message

### DIFF
--- a/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
+++ b/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
@@ -119,9 +119,9 @@ public final class PlanCoordinator {
       definition = PlanDefinitionRegistry.INSTANCE.getJobDefinition(mPlanInfo.getJobConfig());
     } catch (JobDoesNotExistException e) {
       LOG.info("Exception when getting jobDefinition from jobConfig: ", e);
-      mPlanInfo.setStatus(Status.FAILED);
       mPlanInfo.setErrorType(ErrorUtils.getErrorType(e));
       mPlanInfo.setErrorMessage(e.getMessage());
+      mPlanInfo.setStatus(Status.FAILED);
       throw e;
     }
     SelectExecutorsContext context =
@@ -212,9 +212,9 @@ public final class PlanCoordinator {
    */
   public synchronized void setJobAsFailed(String errorType, String errorMessage) {
     if (!mPlanInfo.getStatus().isFinished()) {
-      mPlanInfo.setStatus(Status.FAILED);
       mPlanInfo.setErrorType(errorType);
       mPlanInfo.setErrorMessage(errorMessage);
+      mPlanInfo.setStatus(Status.FAILED);
     }
     mWorkersInfoList = null;
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?
Make job service output correct error message when set job status to failure

### Why are the changes needed?

Before this change we would always get `Job set to failed without given an error type or message` because we set error message after we set job status to failure.

### Does this PR introduce any user facing changes?
NA