### PR TITLE
Fix Flaky AlluxioMasterProcessTest.stopAfterStandbyTransition

### DIFF
--- a/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
+++ b/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
@@ -202,10 +202,10 @@ public final class AlluxioMasterProcessTest {
     assertTrue(isBound(mRpcPort));
     assertTrue(isBound(mWebPort));
     primarySelector.setState(PrimarySelector.State.STANDBY);
-    t.join(10000);
+    t.join(30000);
     // make these two lines flake less
-    //assertFalse(isBound(mRpcPort));
-    //assertFalse(isBound(mWebPort));
+    assertFalse(isBound(mRpcPort));
+    assertFalse(isBound(mWebPort));
     assertFalse(master.isRunning());
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix Flaky alluxio.master.AlluxioMasterProcessTest.stopAfterStandbyTransition

### Why are the changes needed?

The test itself is simple, it tries to simulate the process when the master sets to a standby state.
And this test will check if the master cleans up as follows:
1. clean up RPC port.
2. clean up web port.
3. master switch to not running state.

However, it sleeps 10 seconds to wait for all cleanings to happen :(

In this pr, I just increase the sleep time to make this test less flaky and we should avoid this test pattern in the future.

### Does this PR introduce any user facing changes?

no
