### PR TITLE
Fix how to attach to Alluxio process using remote debugger

### DIFF
--- a/bin/alluxio
+++ b/bin/alluxio
@@ -164,17 +164,22 @@ function copyDir {
 
 function runJavaClass {
   CLASS_ARGS=()
+  local debug=false
   for arg in "$@"; do
       case "${arg}" in
           -debug)
-              ALLUXIO_USER_JAVA_OPTS+=" ${ALLUXIO_USER_DEBUG_JAVA_OPTS}" ;;
+              debug=true ;;
           -D* | -X* | -agentlib* | -javaagent*)
               ALLUXIO_SHELL_JAVA_OPTS+=" ${arg}" ;;
           *)
               CLASS_ARGS+=("${arg}")
       esac
   done
-  "${JAVA}" -cp ${CLASSPATH} ${ALLUXIO_USER_JAVA_OPTS} ${ALLUXIO_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} "${CLASS_ARGS[@]}"
+  if $debug; then
+    "${JAVA}" ${ALLUXIO_USER_ATTACH_OPTS} -cp ${CLASSPATH} ${ALLUXIO_USER_JAVA_OPTS} ${ALLUXIO_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} "${CLASS_ARGS[@]}"
+  else
+    "${JAVA}" -cp ${CLASSPATH} ${ALLUXIO_USER_JAVA_OPTS} ${ALLUXIO_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} "${CLASS_ARGS[@]}"
+  fi
 }
 
 function formatJournal {

--- a/bin/alluxio
+++ b/bin/alluxio
@@ -164,22 +164,18 @@ function copyDir {
 
 function runJavaClass {
   CLASS_ARGS=()
-  local debug=false
+  local debug_opts=""
   for arg in "$@"; do
       case "${arg}" in
           -debug)
-              debug=true ;;
+              debug_opts+="${ALLUXIO_USER_ATTACH_OPTS}" ;;
           -D* | -X* | -agentlib* | -javaagent*)
               ALLUXIO_SHELL_JAVA_OPTS+=" ${arg}" ;;
           *)
               CLASS_ARGS+=("${arg}")
       esac
   done
-  if $debug; then
-    "${JAVA}" ${ALLUXIO_USER_ATTACH_OPTS} -cp ${CLASSPATH} ${ALLUXIO_USER_JAVA_OPTS} ${ALLUXIO_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} "${CLASS_ARGS[@]}"
-  else
-    "${JAVA}" -cp ${CLASSPATH} ${ALLUXIO_USER_JAVA_OPTS} ${ALLUXIO_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} "${CLASS_ARGS[@]}"
-  fi
+  "${JAVA}" ${debug_opts} -cp ${CLASSPATH} ${ALLUXIO_USER_JAVA_OPTS} ${ALLUXIO_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} "${CLASS_ARGS[@]}"
 }
 
 function formatJournal {

--- a/bin/alluxio-monitor.sh
+++ b/bin/alluxio-monitor.sh
@@ -53,6 +53,13 @@ get_env() {
   . ${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh
   CLASSPATH=${ALLUXIO_CLIENT_CLASSPATH}
   ALLUXIO_TASK_LOG="${ALLUXIO_LOGS_DIR}/task.log"
+
+  # Remove the remote debug configuration to avoid the error: "transport error 20: bind failed: Address already in use."
+  # See https://github.com/Alluxio/alluxio/issues/10958
+  ALLUXIO_MASTER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_MASTER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')
+  ALLUXIO_WORKER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_WORKER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')
+  ALLUXIO_JOB_MASTER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_JOB_MASTER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')
+  ALLUXIO_JOB_WORKER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_JOB_WORKER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')
 }
 
 prepare_monitor() {

--- a/bin/alluxio-monitor.sh
+++ b/bin/alluxio-monitor.sh
@@ -53,13 +53,6 @@ get_env() {
   . ${ALLUXIO_LIBEXEC_DIR}/alluxio-config.sh
   CLASSPATH=${ALLUXIO_CLIENT_CLASSPATH}
   ALLUXIO_TASK_LOG="${ALLUXIO_LOGS_DIR}/task.log"
-
-  # Remove the remote debug configuration to avoid the error: "transport error 20: bind failed: Address already in use." 
-  # See https://github.com/Alluxio/alluxio/issues/10958
-  ALLUXIO_MASTER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_MASTER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')
-  ALLUXIO_WORKER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_WORKER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')
-  ALLUXIO_JOB_MASTER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_JOB_MASTER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')
-  ALLUXIO_JOB_WORKER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_JOB_WORKER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//')
 }
 
 prepare_monitor() {

--- a/bin/launch-process
+++ b/bin/launch-process
@@ -99,13 +99,15 @@ print_help() {
 #         2: the main class to launch
 #         3.... Additional arguments to the java program
 launch_process() {
+  local attach_opts
   local java_opts
   local main_class
 
-  java_opts=${1}
-  main_class=${2}
+  attach_opts=${1}
+  java_opts=${2}
+  main_class=${3}
 
-  exec ${JAVA} -cp ${ALLUXIO_SERVER_CLASSPATH} ${java_opts} "${main_class}" ${@:3}
+  exec ${JAVA} ${attach_opts} -cp ${ALLUXIO_SERVER_CLASSPATH} ${java_opts} "${main_class}" ${@:4}
 }
 
 # Launch a master process
@@ -130,7 +132,8 @@ launch_master() {
     ALLUXIO_MASTER_JAVA_OPTS+=" -XX:MetaspaceSize=256M "
   fi
 
-  launch_process "${ALLUXIO_MASTER_JAVA_OPTS}" \
+  launch_process "${ALLUXIO_MASTER_ATTACH_OPTS}" \
+                 "${ALLUXIO_MASTER_JAVA_OPTS}" \
                  "alluxio.master.AlluxioMaster"
 }
 
@@ -141,13 +144,15 @@ launch_secondary_master() {
   if [[ "${res}" -eq "0" ]]; then
     ALLUXIO_SECONDARY_MASTER_JAVA_OPTS+=" -Xmx8g "
   fi
-  launch_process "${ALLUXIO_SECONDARY_MASTER_JAVA_OPTS}" \
+  launch_process "${ALLUXIO_SECONDARY_MASTER_ATTACH_OPTS}" \
+                 "${ALLUXIO_SECONDARY_MASTER_JAVA_OPTS}" \
                  "alluxio.master.AlluxioSecondaryMaster"
 }
 
 # Launch a job master process
 launch_job_master() {
-  launch_process "${ALLUXIO_JOB_MASTER_JAVA_OPTS}" \
+  launch_process "${ALLUXIO_JOB_MASTER_ATTACH_OPTS}" \
+                 "${ALLUXIO_JOB_MASTER_JAVA_OPTS}" \
                  "alluxio.master.AlluxioJobMaster"
 }
 
@@ -165,31 +170,36 @@ launch_worker() {
     ALLUXIO_WORKER_JAVA_OPTS+=" -XX:MaxDirectMemorySize=4g "
   fi
 
-  launch_process "${ALLUXIO_WORKER_JAVA_OPTS}" \
+  launch_process "${ALLUXIO_WORKER_ATTACH_OPTS}" \
+                 "${ALLUXIO_WORKER_JAVA_OPTS}" \
                  "alluxio.worker.AlluxioWorker"
 }
 
 # Launch a job worker process
 launch_job_worker() {
-  launch_process "${ALLUXIO_JOB_WORKER_JAVA_OPTS}" \
+  launch_process "${ALLUXIO_JOB_WORKER_ATTACH_OPTS}" \
+                 "${ALLUXIO_JOB_WORKER_JAVA_OPTS}" \
                  "alluxio.worker.AlluxioJobWorker"
 }
 
 # Launch the hub agent process
 launch_hub_agent() {
-   launch_process "${ALLUXIO_HUB_AGENT_JAVA_OPTS}" \
+  launch_process "${ALLUXIO_HUB_AGENT_ATTACH_OPTS}" \
+                 "${ALLUXIO_HUB_AGENT_JAVA_OPTS}" \
                  "alluxio.hub.agent.process.AgentProcess"
 }
 
 # Launch the hub manager process
 launch_hub_manager() {
-   launch_process "${ALLUXIO_HUB_MANAGER_JAVA_OPTS}" \
+  launch_process "${ALLUXIO_HUB_MANAGER_ATTACH_OPTS}" \
+                 "${ALLUXIO_HUB_MANAGER_JAVA_OPTS}" \
                  "alluxio.hub.manager.process.ManagerProcess"
 }
 
 # Launch a proxy process
 launch_proxy() {
-  launch_process "${ALLUXIO_PROXY_JAVA_OPTS}" \
+  launch_process "${ALLUXIO_PROXY_ATTACH_OPTS}" \
+                 "${ALLUXIO_PROXY_JAVA_OPTS}" \
                  "alluxio.proxy.AlluxioProxy"
 }
 
@@ -200,7 +210,8 @@ launch_proxy() {
 #                                 directory where the logserver will
 #                                 store logs.
 launch_logserver() {
-  launch_process "${ALLUXIO_LOGSERVER_JAVA_OPTS}" \
+  launch_process "${ALLUXIO_LOGSERVER_ATTACH_OPTS}" \
+                 "${ALLUXIO_LOGSERVER_JAVA_OPTS}" \
                  "alluxio.logserver.AlluxioLogServer" \
                  "${ALLUXIO_LOGSERVER_LOGS_DIR}"
 }

--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -22,6 +22,9 @@
 # (https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html),
 # and is respected by both external jobs and Alluxio servers (or shell).
 
+# This file also allows you to configure Alluxio remote debugging as outlined here:
+# https://docs.alluxio.io/os/user/stable/en/operation/Troubleshooting.html#alluxio-remote-debug
+
 # JVM is required to run Alluxio.
 # If its path is not set in Shell, please specify either of following environment variables
 # JAVA_HOME
@@ -68,3 +71,7 @@
 # Additional classpath entries for Alluxio processes. (Default: "")
 # E.g. "/path/to/library1/:/path/to/library2/"
 # ALLUXIO_CLASSPATH
+
+# Configuring remote debugging for Alluxio master process
+# E.g. "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60001"
+# ALLUXIO_MASTER_ATTACH_OPTS

--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -64,6 +64,10 @@
 # E.g. "-Xms2048M -Xmx2048M" to limit the heap size of proxy.
 # ALLUXIO_PROXY_JAVA_OPTS
 
+# Config properties set for Alluxio log server daemon. (Default: "")
+# E.g. "-Xms2048M -Xmx2048M" to limit the heap size of log server.
+# ALLUXIO_LOGSERVER_JAVA_OPTS
+
 # Config properties set for Alluxio shell. (Default: "")
 # E.g. "-Dalluxio.user.file.writetype.default=CACHE_THROUGH"
 # ALLUXIO_USER_JAVA_OPTS
@@ -72,6 +76,30 @@
 # E.g. "/path/to/library1/:/path/to/library2/"
 # ALLUXIO_CLASSPATH
 
-# Configuring remote debugging for Alluxio master process
+# Configuring remote debugging for Alluxio master process. (Default: "")
 # E.g. "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60001"
 # ALLUXIO_MASTER_ATTACH_OPTS
+
+# Configuring remote debugging for Alluxio job master process. (Default: "")
+# E.g. "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60002"
+# ALLUXIO_JOB_MASTER_ATTACH_OPTS
+
+# Configuring remote debugging for Alluxio worker process. (Default: "")
+# E.g. "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60003"
+# ALLUXIO_WORKER_ATTACH_OPTS
+
+# Configuring remote debugging for Alluxio job worker process. (Default: "")
+# E.g. "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60004"
+# ALLUXIO_JOB_WORKER_ATTACH_OPTS
+
+# Configuring remote debugging for Alluxio proxy process. (Default: "")
+# E.g. "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60005"
+# ALLUXIO_PROXY_ATTACH_OPTS
+
+# Configuring remote debugging for Alluxio log server process. (Default: "")
+# E.g. "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60006"
+# ALLUXIO_LOGSERVER_ATTACH_OPTS
+
+# Configuring remote debugging for Alluxio shell. (Default: "")
+# E.g. "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60000"
+# ALLUXIO_USER_ATTACH_OPTS

--- a/docs/en/operation/Troubleshooting.md
+++ b/docs/en/operation/Troubleshooting.md
@@ -75,9 +75,9 @@ If you want to debug shell commands (e.g. `bin/alluxio fs ls /`), you can set th
 
 ```shell
 # Java 5 through 8
-export ALLUXIO_USER_ATTACH_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=66009"
+export ALLUXIO_USER_ATTACH_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60000"
 # Java 9 and up
-export ALLUXIO_USER_ATTACH_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:66009"
+export ALLUXIO_USER_ATTACH_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:60000"
 ```
 
 After setting this parameter, you can add the `-debug` flag to start a debug server such as `bin/alluxio fs -debug ls /`.

--- a/docs/en/operation/Troubleshooting.md
+++ b/docs/en/operation/Troubleshooting.md
@@ -63,14 +63,14 @@ In general, you can use `ALLUXIO_<PROCESS>_ATTACH_OPTS` to specify how an Alluxi
 
 `suspend={y | n}` will decide whether the JVM process waits until the debugger connects or not.
 
-`address` determines which port the Alluxio process will use to be attached to by a debugger. If left blank, it will 
+`address` determines which port the Alluxio process will use to be attached to by a debugger. If left blank, it will
 choose an open port by itself.
 
 After completing this setup, learn how [to attach](#to-attach).
 
 ### Debugging shell commands
 
-If you want to debug shell commands (e.g. `bin/alluxio fs ls /`), you can set the `ALLUXIO_USER_DEBUG_JAVA_OPTS` in 
+If you want to debug shell commands (e.g. `bin/alluxio fs ls /`), you can set the `ALLUXIO_USER_DEBUG_JAVA_OPTS` in
 `conf/alluxio-env.sh` as above:
 
 ```shell
@@ -90,7 +90,7 @@ There exists a [comprehensive tutorial on how to attach to and debug a Java proc
 
 Start the process or shell command of interest, then create a new java remote configuration,
 set the debug server's host and port, and start the debug session. If you set a breakpoint which can be reached, the IDE
-will enter debug mode. Yand you can inspect the current context's variables, call stack, thread list, and expression
+will enter debug mode. You can inspect the current context's variables, call stack, thread list, and expression
 evaluation.
 
 ## Alluxio collectInfo command

--- a/docs/en/operation/Troubleshooting.md
+++ b/docs/en/operation/Troubleshooting.md
@@ -44,25 +44,53 @@ For more information about logging, please check out
 
 ## Alluxio remote debug
 
-Java remote debugging makes it easier to debug Alluxio at the source level without modifying any code. You
-will need to append the JVM remote debugging parameters and start a debugging server. There are several ways to append
-the remote debugging parameters; you can export the following configuration properties in shell or `alluxio-env.sh`:
+### Debugging Alluxio processes
 
-```bash
-export ALLUXIO_WORKER_JAVA_OPTS="$ALLUXIO_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=6606"
-export ALLUXIO_MASTER_JAVA_OPTS="$ALLUXIO_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=6607"
-export ALLUXIO_USER_DEBUG_JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=6609"
+Java remote debugging makes it easier to debug Alluxio at the source level without modifying any code. You
+will need to set the JVM remote debugging parameters before starting the process. There are several ways to add
+the remote debugging parameters; you can export the following configuration properties in shell or `conf/alluxio-env.sh`:
+
+```shell
+# Java 5 through 8
+export ALLUXIO_MASTER_ATTACH_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60001"
+export ALLUXIO_WORKER_ATTACH_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60002"
+# Java 9 and up
+export ALLUXIO_MASTER_ATTACH_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:60001"
+export ALLUXIO_WORKER_ATTACH_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:60002"
 ```
 
-If you want to debug shell commands, you can add the `-debug` flag to start a debug server with the JVM debug
-parameters `ALLUXIO_USER_DEBUG_JAVA_OPTS`, such as `alluxio fs -debug ls /`.
+In general, you can use `ALLUXIO_<PROCESS>_ATTACH_OPTS` to specify how an Alluxio process should be attached to.
 
-`suspend = y/n` will decide whether the JVM process wait until the debugger connects. If you want to debug with the
-shell command, set the `suspend = y`. Otherwise, you can set `suspend = n` to avoid unnecessary waiting time.
+`suspend={y | n}` will decide whether the JVM process waits until the debugger connects or not.
 
-After starting the master or worker, use Eclipse, IntelliJ IDEA, or another java IDE, create a new java remote configuration,
+`address` determines which port the Alluxio process will use to be attached to by a debugger. If left blank, it will 
+choose an open port by itself.
+
+After completing this setup, learn how [to attach](#to-attach).
+
+### Debugging shell commands
+
+If you want to debug shell commands (e.g. `bin/alluxio fs ls /`), you can set the `ALLUXIO_USER_DEBUG_JAVA_OPTS` in 
+`conf/alluxio-env.sh` as above:
+
+```shell
+# Java 5 through 8
+export ALLUXIO_USER_ATTACH_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=66009"
+# Java 9 and up
+export ALLUXIO_USER_ATTACH_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:66009"
+```
+
+After setting this parameter, you can add the `-debug` flag to start a debug server such as `bin/alluxio fs -debug ls /`.
+
+After completing this setup, learn how [to attach](#to-attach).
+
+### To attach
+
+There exists a [comprehensive tutorial on how to attach to and debug a Java process in IntelliJ](https://www.jetbrains.com/help/idea/attaching-to-local-process.html).
+
+Start the process or shell command of interest, then create a new java remote configuration,
 set the debug server's host and port, and start the debug session. If you set a breakpoint which can be reached, the IDE
-will enter debug mode and you can inspect the current context's variables, call stack, thread list, and expression
+will enter debug mode. Yand you can inspect the current context's variables, call stack, thread list, and expression
 evaluation.
 
 ## Alluxio collectInfo command
@@ -313,7 +341,7 @@ See [Spark on Alluxio]({{ '/en/compute/Spark.html' | relativize_url }}) for more
 
 Alternatively, add the following lines to `spark/conf/spark-defaults.conf`:
 
-```properties
+```
 spark.driver.extraClassPath {{site.ALLUXIO_CLIENT_JAR_PATH}}
 spark.executor.extraClassPath {{site.ALLUXIO_CLIENT_JAR_PATH}}
 ```


### PR DESCRIPTION
Attaching a debugger to an Alluxio process was broken. This was due to the fact that the `-agentlib` parameter was passed alongside the `ALLUXIO_JAVA_OPTS`.
For example, when trying the attach to an Alluxio master process using `suspend=y`, the `-agentlib` argument would be passed to `alluxio.cli.GetConf` and would hang until a debugger is attached to it, preventing the master from launching. 
When setting `suspend=n` but assigning a port through the `address` parameter, both `alluxio.cli.GetConf` and `alluxio.master.AlluxioMaster` would both try to set up debug servers using the same port.
This PR decouples the `-agentlib` parameter into its own configurable parameter to prevent this issue.