### PR TITLE
 Improve javadoc in core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java #620 

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -287,7 +287,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     }
 
     /**
-     * Get the combined result from all batches.
+     * Gets the combined result from all batches.
      *
      * @return a list of inputs for successful operations
      * @throws IOException if a non-Alluxio error occurs


### PR DESCRIPTION
### What changes are proposed in this pull request?
In https://github.com/Alluxio/alluxio/blob/95d69b2e7f0651f2c5fb01dca3fe54bde861c993/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java#L290,

change it to "Gets the combined result from all batches."

### Why are the changes needed?

Improve javadoc.

### Does this PR introduce any user facing changes?
change L290 javadoc  
from:
* Get the combined result from all batches.
to:
* Gets the combined result from all batches.
