### PR TITLE
Remove unnecessary jvm opts when starting worker

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -330,8 +330,7 @@ start_worker() {
   fi
 
   echo "Starting worker @ $(hostname -f). Logging to ${ALLUXIO_LOGS_DIR}"
-  (ALLUXIO_WORKER_JAVA_OPTS=${ALLUXIO_WORKER_JAVA_OPTS} \
-     nohup ${BIN}/launch-process worker > ${ALLUXIO_LOGS_DIR}/worker.out 2>&1 ) &
+  (nohup ${BIN}/launch-process worker > ${ALLUXIO_LOGS_DIR}/worker.out 2>&1 ) &
 }
 
 start_workers() {
@@ -343,10 +342,6 @@ start_workers() {
 }
 
 restart_worker() {
-  if [[ -z ${ALLUXIO_WORKER_JAVA_OPTS} ]]; then
-    ALLUXIO_WORKER_JAVA_OPTS=${ALLUXIO_JAVA_OPTS}
-  fi
-
   RUN=$(ps -ef | grep "alluxio.worker.AlluxioWorker" | grep "java" | wc | awk '{ print $1; }')
   if [[ ${RUN} -eq 0 ]]; then
     echo "Restarting worker @ $(hostname -f). Logging to ${ALLUXIO_LOGS_DIR}"


### PR DESCRIPTION
### What changes are proposed in this pull request?

fix https://github.com/Alluxio/alluxio/issues/14994

### Why are the changes needed?
Remove redundent JVM options for worker.
See https://github.com/Alluxio/alluxio/blob/master/bin/launch-process#L77
When running launch-process script, it had initialized the config. It is unnecessary to pass the worker JVM opts in alluxio-start.sh

### Does this PR introduce any user facing changes?
No
