### PR TITLE
Remove one extra copy in block deletion

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -36,6 +36,7 @@ import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -120,7 +121,7 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
    * @param blockIds a list of block ids to remove from Alluxio space
    * @param delete whether to delete blocks' metadata in Master
    */
-  void removeBlocks(List<Long> blockIds, boolean delete) throws UnavailableException;
+  void removeBlocks(Collection<Long> blockIds, boolean delete) throws UnavailableException;
 
   /**
    * Validates the integrity of blocks with respect to the validator. A warning will be printed if

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -674,7 +674,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
   }
 
   @Override
-  public void removeBlocks(List<Long> blockIds, boolean delete) throws UnavailableException {
+  public void removeBlocks(Collection<Long> blockIds, boolean delete) throws UnavailableException {
     try (JournalContext journalContext = createJournalContext()) {
       for (long blockId : blockIds) {
         Set<Long> workerIds;

--- a/core/server/master/src/main/java/alluxio/master/file/BlockDeletionContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/BlockDeletionContext.java
@@ -14,7 +14,6 @@ package alluxio.master.file;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.List;
 
 /**
  * Interface for a class which gathers block deletion requests, then handles them during close.

--- a/core/server/master/src/main/java/alluxio/master/file/BlockDeletionContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/BlockDeletionContext.java
@@ -42,6 +42,6 @@ public interface BlockDeletionContext extends Closeable {
      *
      * @param blocks the deleted blocks
      */
-    void process(List<Long> blocks) throws IOException;
+    void process(Collection<Long> blocks) throws IOException;
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultBlockDeletionContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultBlockDeletionContext.java
@@ -48,10 +48,10 @@ public final class DefaultBlockDeletionContext implements BlockDeletionContext {
 
   @Override
   public void close() throws IOException {
-    // Make sure every listener gets called, even if some throw exceptions.
-    Throwable thrown = null;
     // Prevent accidental modification from the listeners
     Collection<Long> viewOnlyBlocks = Collections.unmodifiableCollection(mBlocks);
+    // Make sure every listener gets called, even if some throw exceptions.
+    Throwable thrown = null;
     for (BlockDeletionListener listener : mListeners) {
       try {
         listener.process(viewOnlyBlocks);

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultBlockDeletionContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultBlockDeletionContext.java
@@ -12,7 +12,6 @@
 package alluxio.master.file;
 
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4757,7 +4757,7 @@ public final class DefaultFileSystemMaster extends CoreMaster
         blocks -> blocks.forEach(mUfsBlockLocationCache::invalidate));
   }
 
-  private void removeBlocks(List<Long> blocks) throws IOException {
+  private void removeBlocks(Collection<Long> blocks) throws IOException {
     if (blocks.isEmpty()) {
       return;
     }


### PR DESCRIPTION
### What changes are proposed in this pull request?

One copy over the block list is avoided in `DefaultBlockDeletionContext`.

### Why are the changes needed?

The copy in `DefaultBlockDeletionContext.close()` guards two things:
1. A copy creates a view over the `mBlocks`, so the listeners all see the same list of blocks.
2. A copy attempts to provide better thread-safety (although it's not a reliable guarantee)

Point 1 is actually not so meaningful. On `close()`, the context really should have all block IDs ready and no one is updating the list.
Point 2 has been addressed by https://github.com/Alluxio/alluxio/pull/12715

AFAIS the copy is unnecessary now.

### Does this PR introduce any user facing changes?

No.