### PR TITLE
Add examples for Hub Manager/Agent to alluxio-env.sh

### DIFF
--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -56,7 +56,7 @@
 # E.g. "-Dalluxio.worker.rpc.port=49999" to set worker port, "-Xms2048M -Xmx2048M" to limit the heap size of worker.
 # ALLUXIO_WORKER_JAVA_OPTS
 
-# Config properties set for Alluxio worker daemon. (Default: "")
+# Config properties set for Alluxio job worker daemon. (Default: "")
 # E.g. " -javaagent:./jmx_prometheus_javaagent-0.16.0.jar=18080:./config.yaml "
 # ALLUXIO_JOB_WORKER_JAVA_OPTS
 
@@ -67,6 +67,17 @@
 # Config properties set for Alluxio log server daemon. (Default: "")
 # E.g. "-Xms2048M -Xmx2048M" to limit the heap size of log server.
 # ALLUXIO_LOGSERVER_JAVA_OPTS
+
+# Config properties set for Alluxio Hub Manager daemon. (Default: "")
+# E.g. "-Dalluxio.hub.hosted.rpc.hostname=<hub_url> to connect to Hosted Hub.
+#       -Dalluxio.hub.authentication.apiKey=<apiKey> to authenticate with Hosted Hub.
+#       -Dalluxio.hub.authentication.secretKey=<secretKey> to authenticate with Hosted Hub.
+#       -Dalluxio.hub.cluster.id=abcd" to uniquely identify the associated Alluxio cluster.
+# ALLUXIO_HUB_MANAGER_JAVA_OPTS
+
+# Config properties set for Alluxio Hub Agent daemon. (Default: "")
+# E.g. "-Dalluxio.hub.manager.rpc.hostname=<hub_manager_host>" to connect to Hub Manager.
+# ALLUXIO_HUB_AGENT_JAVA_OPTS
 
 # Config properties set for Alluxio shell. (Default: "")
 # E.g. "-Dalluxio.user.file.writetype.default=CACHE_THROUGH"
@@ -99,6 +110,14 @@
 # Configuring remote debugging for Alluxio log server process. (Default: "")
 # E.g. "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60006"
 # ALLUXIO_LOGSERVER_ATTACH_OPTS
+
+# Configuring remote debugging for Alluxio Hub Manager. (Default: "")
+# E.g. "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60007"
+# ALLUXIO_HUB_MANAGER_ATTACH_OPTS
+
+# Configuring remote debugging for Alluxio Hub Agent. (Default: "")
+# E.g. "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60008"
+# ALLUXIO_HUB_AGENT_ATTACH_OPTS
 
 # Configuring remote debugging for Alluxio shell. (Default: "")
 # E.g. "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=60000"


### PR DESCRIPTION
### What changes are proposed in this pull request?

Follow-up to https://github.com/Alluxio/alluxio/pull/14991. Adding env examples for Hub Manager/Agent.

### Why are the changes needed?

Adding missing examples for Hub manager and agent.

### Does this PR introduce any user facing changes?

No
