### PR TITLE
Remove usage of Helm hooks in Helm chart

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -234,3 +234,7 @@
 - Enable mounting a specific directory in Alluxio through Fuse
 - Fixes a typo in rendering the fuse mount directory.
 
+0.6.35
+
+- Remove usage of Helm hook annotations in Charts
+

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.33
+version: 0.6.34
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.34
+version: 0.6.35
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/config/alluxio-conf.yaml
@@ -182,9 +182,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": before-hook-creation
   name: {{ $fullName }}-config
   labels:
     name: {{ $fullName }}-config

--- a/integration/kubernetes/operator/alluxio/charts/alluxio-repo/alluxio/templates/config/alluxio-conf.yaml
+++ b/integration/kubernetes/operator/alluxio/charts/alluxio-repo/alluxio/templates/config/alluxio-conf.yaml
@@ -12,9 +12,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": before-hook-creation
   name: {{ template "alluxio.fullname" . }}-config
   labels:
     name: {{ template "alluxio.fullname" . }}-config

--- a/integration/kubernetes/operator/alluxio/charts/alluxio-repo/alluxio/templates/config/alluxio-fuse-conf.yaml
+++ b/integration/kubernetes/operator/alluxio/charts/alluxio-repo/alluxio/templates/config/alluxio-fuse-conf.yaml
@@ -13,9 +13,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "alluxio.fullname" . }}-fuse-config
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     name: {{ template "alluxio.fullname" . }}-fuse-config
     app: {{ template "alluxio.name" . }}

--- a/integration/kubernetes/operator/alluxio/charts/alluxio-repo/alluxio/templates/format/master.yaml
+++ b/integration/kubernetes/operator/alluxio/charts/alluxio-repo/alluxio/templates/format/master.yaml
@@ -13,9 +13,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "alluxio.fullname" . }}-format-script
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     name: {{ template "alluxio.fullname" . }}-format-script
     app: {{ template "alluxio.name" . }}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Removal of the Helm hook annotations in our Helm chart.

### Why are the changes needed?

The usage of Helm hooks for `ConfigMap` resources means that they cannot be `helm upgrade`-ed. We _could_ add the `"helm.sh/hook": "pre-upgrade"` annotation to address that, but I actually think these resources should not be hooks in the first place.

From the [Helm hooks documentation](https://helm.sh/docs/topics/charts_hooks/):
> **Hook resources are not managed with corresponding releases**
>
> The resources that a hook creates are currently not tracked or managed as part of the release. Once Helm verifies that the hook has reached its ready state, it will leave the hook resource alone. Garbage collection of hook resources when the corresponding release is deleted may be added to Helm 3 in the future, so any hook resources that must never be deleted should be annotated with [helm.sh/resource-policy:](http://helm.sh/resource-policy:) keep.

`ConfigMap` resources are definitely something that are coupled with individual Helm releases, and it doesn't make sense to have to manage their lifecycles independently of releases. Hooks would make sense for one-time jobs or bootstrapping services, but not the currently affected `ConfigMap`s.

### Does this PR introduce any user facing changes?

No user-facing changes.
