### PR TITLE
Handle the interrupted exception to make the higher level exit

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/TimeBoundPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/TimeBoundPageStore.java
@@ -64,8 +64,10 @@ public class TimeBoundPageStore implements PageStore {
     try {
       mTimeLimter.callWithTimeout(callable, mTimeoutMs, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
+      // Task got cancelled by others, interrupt the current thread
+      // and then throw a runtime ex to make the higher level stop.
       Thread.currentThread().interrupt();
-      throw new IOException(e);
+      throw new RuntimeException(e);
     } catch (TimeoutException e) {
       Metrics.STORE_PUT_TIMEOUT.inc();
       throw new IOException(e);
@@ -90,8 +92,10 @@ public class TimeBoundPageStore implements PageStore {
     try {
       return mTimeLimter.callWithTimeout(callable, mTimeoutMs, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
+      // Task got cancelled by others, interrupt the current thread
+      // and then throw a runtime ex to make the higher level stop.
       Thread.currentThread().interrupt();
-      throw new IOException(e);
+      throw new RuntimeException(e);
     } catch (TimeoutException e) {
       Metrics.STORE_GET_TIMEOUT.inc();
       throw new IOException(e);
@@ -113,8 +117,10 @@ public class TimeBoundPageStore implements PageStore {
     try {
       mTimeLimter.callWithTimeout(callable, mTimeoutMs, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
+      // Task got cancelled by others, interrupt the current thread
+      // and then throw a runtime ex to make the higher level stop.
       Thread.currentThread().interrupt();
-      throw new IOException(e);
+      throw new RuntimeException(e);
     } catch (TimeoutException e) {
       Metrics.STORE_DELETE_TIMEOUT.inc();
       throw new IOException(e);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Handle the interrupted exception in local cache's time bounded manager.  This change will make the higher level exit when the task got cancelled by the task owner or other threads.

### Why are the changes needed?

Now we wrapped the interrupted exception as an IO exception.  The IO exception will be logged and swallowed in local cache's code which means the higher level caller will continue running.  We should make the higher level interrupted and exit as soon as possible  

### Does this PR introduce any user facing changes?

No
