### PR TITLE
Remove extra leak detector in RefCountLockResource

### DIFF
--- a/core/common/src/main/java/alluxio/resource/LockResource.java
+++ b/core/common/src/main/java/alluxio/resource/LockResource.java
@@ -30,6 +30,9 @@ import javax.annotation.Nullable;
  *     ...
  *   }
  * </pre>
+ *
+ * The subclasses will be tracked by the leak detector.
+ * The subclasses should call super.close() in their close(), otherwise a leak will be reported.
  */
 // extends Closeable instead of AutoCloseable to enable usage with Guava's Closer.
 public class LockResource implements Closeable {

--- a/core/common/src/main/java/alluxio/resource/RWLockResource.java
+++ b/core/common/src/main/java/alluxio/resource/RWLockResource.java
@@ -59,13 +59,4 @@ public class RWLockResource extends LockResource {
     mLock = mRwLock.readLock();
     return true;
   }
-
-  /**
-   * This dummy implementation is just to make sure when a subclass of {@link RWLockResource}
-   * calls {@code super.close()}, {@link LockResource#close()} is called.
-   */
-  @Override
-  public void close() {
-    super.close();
-  }
 }

--- a/core/common/src/main/java/alluxio/resource/RWLockResource.java
+++ b/core/common/src/main/java/alluxio/resource/RWLockResource.java
@@ -59,4 +59,13 @@ public class RWLockResource extends LockResource {
     mLock = mRwLock.readLock();
     return true;
   }
+
+  /**
+   * This dummy implementation is just to make sure when a subclass of {@link RWLockResource}
+   * calls {@code super.close()}, {@link LockResource#close()} is called.
+   */
+  @Override
+  public void close() {
+    super.close();
+  }
 }

--- a/core/common/src/main/java/alluxio/resource/RefCountLockResource.java
+++ b/core/common/src/main/java/alluxio/resource/RefCountLockResource.java
@@ -14,13 +14,10 @@ package alluxio.resource;
 import alluxio.concurrent.LockMode;
 
 import com.google.common.base.Preconditions;
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakTracker;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import javax.annotation.Nullable;
 
 /**
  * Reference counted Lock resource, automatically unlocks and decrements the reference count.
@@ -28,15 +25,7 @@ import javax.annotation.Nullable;
  * the lock reference count and unlocking when the resource is closed.
  */
 public class RefCountLockResource extends RWLockResource {
-
-  private static final ResourceLeakDetector<RefCountLockResource> DETECTOR =
-      AlluxioResourceLeakDetectorFactory.instance()
-          .newResourceLeakDetector(RefCountLockResource.class);
-
   private final AtomicInteger mRefCount;
-
-  @Nullable
-  private final ResourceLeakTracker<RefCountLockResource> mTracker = DETECTOR.track(this);
 
   /**
    * Creates a new instance of {@link LockResource} using the given lock and reference counter. The
@@ -63,9 +52,6 @@ public class RefCountLockResource extends RWLockResource {
   @Override
   public void close() {
     super.close();
-    if (mTracker != null) {
-      mTracker.close(this);
-    }
     mRefCount.decrementAndGet();
   }
 }

--- a/core/common/src/main/java/alluxio/resource/RefCountLockResource.java
+++ b/core/common/src/main/java/alluxio/resource/RefCountLockResource.java
@@ -51,6 +51,7 @@ public class RefCountLockResource extends RWLockResource {
    */
   @Override
   public void close() {
+    // Make sure all super classes are properly closed
     super.close();
     mRefCount.decrementAndGet();
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

The `RefCountLockResource#mTracker` field is removed.

### Why are the changes needed?

`RefCountLockResource` extends `LockResource`, so `RefCountLockResource` is already leak tracked. 

In the current implementation, `RefCountLockResource` has two `mTracker` fields, one declared in its own class, the other from `LockResource`. This doubles the memory footprint for leak detection. Each `DefaultResourceLeak` object retains 1.4KB heap, which is a big cost.
![image](https://user-images.githubusercontent.com/14806853/155050131-1721854a-d33a-42d4-bba2-68fcfbced567.png)

### Does this PR introduce any user facing changes?

NA