### PR TITLE
[SMALLFIX] Make rm throw early

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1837,12 +1837,12 @@ public final class DefaultFileSystemMaster extends CoreMaster
               LockPattern.WRITE_EDGE);
       try (LockedInodePath inodePath = mInodeTree
               .lockInodePath(lockingScheme)) {
+        mPermissionChecker.checkParentPermission(Mode.Bits.WRITE, inodePath);
         mMountTable.checkUnderWritableMountPoint(path);
         if (!inodePath.fullPathExists()) {
           throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST
               .getMessage(path));
         }
-        mPermissionChecker.checkParentPermission(Mode.Bits.WRITE, inodePath);
 
         if (context.getOptions().getRecursive()) {
           List<String> failedChildren = new ArrayList<>();

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1837,7 +1837,13 @@ public final class DefaultFileSystemMaster extends CoreMaster
               LockPattern.WRITE_EDGE);
       try (LockedInodePath inodePath = mInodeTree
               .lockInodePath(lockingScheme)) {
+        mMountTable.checkUnderWritableMountPoint(path);
+        if (!inodePath.fullPathExists()) {
+          throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST
+              .getMessage(path));
+        }
         mPermissionChecker.checkParentPermission(Mode.Bits.WRITE, inodePath);
+
         if (context.getOptions().getRecursive()) {
           List<String> failedChildren = new ArrayList<>();
           try (LockedInodePathList descendants = mInodeTree.getDescendants(inodePath)) {
@@ -1859,12 +1865,6 @@ public final class DefaultFileSystemMaster extends CoreMaster
             auditContext.setAllowed(false);
             throw e;
           }
-        }
-        mMountTable.checkUnderWritableMountPoint(path);
-
-        if (!inodePath.fullPathExists()) {
-          throw new FileDoesNotExistException(ExceptionMessage.PATH_DOES_NOT_EXIST
-              .getMessage(path));
         }
 
         deleteInternal(rpcContext, inodePath, context);


### PR DESCRIPTION
### What changes are proposed in this pull request?

RM should throw early before traversing children paths. The traversal is costly.

### Why are the changes needed?

See above

### Does this PR introduce any user facing changes?

NA