### PR TITLE
Use increment-by-count instead of iteration for fail & cancel counters

### DIFF
--- a/tests/src/test/java/alluxio/client/cli/job/DistributedCmdTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/DistributedCmdTest.java
@@ -1,0 +1,140 @@
+package alluxio.client.cli.job;
+
+import static org.junit.Assert.assertEquals;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.URIStatus;
+import alluxio.job.plan.NoopPlanConfig;
+import alluxio.job.plan.load.LoadConfig;
+import alluxio.job.plan.migrate.MigrateConfig;
+import alluxio.job.plan.persist.PersistConfig;
+import alluxio.master.job.metrics.DistributedCmdMetrics;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
+import alluxio.retry.CountingRetry;
+import alluxio.retry.RetryPolicy;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+public class DistributedCmdTest {
+  private static final String LOAD = "/load";
+  private static final String MIGRATE = "/migrate";
+  private static final String PERSIST = "/persist";
+  private static final String NOOP_PLAN = "/compact";
+
+  private static final long LOAD_FILE_LENGTH = 1;
+  private static final long MIGRATE_FILE_LENGTH = 2;
+  private static final long PERSIST_FILE_LENGTH = 3;
+  private static final long NOOP_PLAN_FILE_LENGTH = 4;
+  private static final long DEFAULT_ZERO_LENGTH = 0;
+
+  private LoadConfig mLoadJobConfig;
+  private MigrateConfig mMigrateJobConfig;
+  private PersistConfig mPersistJobConfig;
+  private NoopPlanConfig mNoopPlanConfig;
+  private FileSystem mFileSystem;
+  private RetryPolicy mRetryPolicy;
+
+  private URIStatus mLoadURIStatus;
+  private URIStatus mMigrateURIStatus;
+  private URIStatus mPersistURIStatus;
+  private URIStatus mNoopPlanURIStatus;
+
+  @Rule
+  public ExpectedException mException = ExpectedException.none();
+
+  @Before
+  public void before() {
+    mLoadJobConfig = Mockito.mock(LoadConfig.class);
+    mMigrateJobConfig = Mockito.mock(MigrateConfig.class);
+    mPersistJobConfig = Mockito.mock(PersistConfig.class);
+    mNoopPlanConfig = Mockito.mock(NoopPlanConfig.class);
+    mFileSystem = Mockito.mock(FileSystem.class);
+    mRetryPolicy = new CountingRetry(5);
+
+    mLoadURIStatus = Mockito.mock(URIStatus.class);
+    mMigrateURIStatus = Mockito.mock(URIStatus.class);
+    mPersistURIStatus = Mockito.mock(URIStatus.class);
+    mNoopPlanURIStatus = Mockito.mock(URIStatus.class);
+  }
+
+  private void runJob() throws Exception {
+  //  expectException(IOException.class, ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage("No such path"));
+    Mockito.when(mLoadURIStatus.getLength()).thenReturn(LOAD_FILE_LENGTH);
+
+    Mockito.when(mLoadJobConfig.getFilePath()).thenReturn(LOAD);
+    Mockito.when(mMigrateJobConfig.getSource()).thenReturn(MIGRATE);
+    Mockito.when(mPersistJobConfig.getFilePath()).thenReturn(PERSIST);
+
+    Mockito.when(mFileSystem.getStatus(new AlluxioURI(LOAD))).thenReturn(mLoadURIStatus);
+    Mockito.when(mFileSystem.getStatus(new AlluxioURI(LOAD)).getLength())
+            .thenReturn(LOAD_FILE_LENGTH);
+
+    Mockito.when(mFileSystem.getStatus(new AlluxioURI(MIGRATE))).thenReturn(mMigrateURIStatus);
+    Mockito.when(mFileSystem.getStatus(new AlluxioURI(MIGRATE)).getLength())
+            .thenReturn(MIGRATE_FILE_LENGTH);
+
+    Mockito.when(mFileSystem.getStatus(new AlluxioURI(PERSIST))).thenReturn(mPersistURIStatus);
+    Mockito.when(mFileSystem.getStatus(new AlluxioURI(PERSIST)).getLength())
+            .thenReturn(PERSIST_FILE_LENGTH);
+
+    Mockito.when(mFileSystem.getStatus(new AlluxioURI(NOOP_PLAN))).thenReturn(mNoopPlanURIStatus);
+    Mockito.when(mFileSystem.getStatus(new AlluxioURI(NOOP_PLAN)).getLength())
+            .thenReturn(NOOP_PLAN_FILE_LENGTH);
+  }
+
+  private void expectException(Class<? extends Throwable> cls, String msg) {
+    mException.expect(cls);
+    mException.expectMessage(msg);
+  }
+
+  @Test
+  public void testSupportedConfigForCompleteStatus() throws Exception {
+    runJob();
+    //Run for supported configs.
+    DistributedCmdMetrics.incrementForCompleteStatusWithRetry(
+            mLoadJobConfig, mFileSystem, mRetryPolicy);
+    DistributedCmdMetrics.incrementForCompleteStatusWithRetry(
+            mMigrateJobConfig, mFileSystem, mRetryPolicy);
+    DistributedCmdMetrics.incrementForCompleteStatusWithRetry(
+            mPersistJobConfig, mFileSystem, mRetryPolicy);
+
+    ////should expect function calls to fileSystem.getStatus(new AlluxioURI(filePath)).getLength(),
+    // and cooresponding file sizes obtained.
+    double loadFileSize = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_FILE_SIZE.getName()).getValue();
+    double migrateFileSize = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_MIGRATE_JOB_FILE_SIZE.getName()).getValue();
+    double persistFileSize = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_ASYNC_PERSIST_FILE_SIZE.getName()).getValue();
+
+    assertEquals(loadFileSize, LOAD_FILE_LENGTH, 0);
+    assertEquals(migrateFileSize, MIGRATE_FILE_LENGTH, 0);
+    assertEquals(persistFileSize, PERSIST_FILE_LENGTH, 0);
+  }
+
+  @Test
+  public void testUnSupportedConfigForCompleteStatus() throws Exception {
+    MetricsSystem.resetAllMetrics();
+    //Run for an unsupported config NoopPlanConfig.
+    DistributedCmdMetrics.incrementForCompleteStatusWithRetry(
+            mNoopPlanConfig, mFileSystem, mRetryPolicy);
+
+    double loadFileSize = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_FILE_SIZE.getName()).getValue();
+    double migrateFileSize = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_MIGRATE_JOB_FILE_SIZE.getName()).getValue();
+    double persistFileSize = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_ASYNC_PERSIST_FILE_SIZE.getName()).getValue();
+
+    //should expect no call to fileSystem.getStatus(new AlluxioURI(filePath)).getLength().
+    assertEquals(loadFileSize, DEFAULT_ZERO_LENGTH, 0);
+    assertEquals(migrateFileSize, DEFAULT_ZERO_LENGTH, 0);
+    assertEquals(persistFileSize, DEFAULT_ZERO_LENGTH, 0);
+  }
+}

--- a/tests/src/test/java/alluxio/client/cli/job/DistributedCmdTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/DistributedCmdTest.java
@@ -12,6 +12,7 @@
 package alluxio.client.cli.job;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
 
 import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;
@@ -36,7 +37,7 @@ public class DistributedCmdTest {
   private static final String LOAD = "/load";
   private static final String MIGRATE = "/migrate";
   private static final String PERSIST = "/persist";
-  private static final String NOOP_PLAN = "/compact";
+  private static final String NOOP_PLAN = "/noop";
 
   private static final long LOAD_FILE_LENGTH = 1;
   private static final long MIGRATE_FILE_LENGTH = 2;
@@ -99,6 +100,8 @@ public class DistributedCmdTest {
     Mockito.when(mFileSystem.getStatus(new AlluxioURI(NOOP_PLAN))).thenReturn(mNoopPlanURIStatus);
     Mockito.when(mFileSystem.getStatus(new AlluxioURI(NOOP_PLAN)).getLength())
             .thenReturn(NOOP_PLAN_FILE_LENGTH);
+
+    Mockito.clearInvocations(mFileSystem);
   }
 
   @Test
@@ -119,6 +122,9 @@ public class DistributedCmdTest {
     assertEquals(loadFileSize, LOAD_FILE_LENGTH, 0); // should equal LOAD_FILE_LENGTH
     assertEquals(migrateFileSize, DEFAULT_ZERO_LENGTH, 0); // should equal DEFAULT_ZERO_LENGTH
     assertEquals(persistFileSize, DEFAULT_ZERO_LENGTH, 0); // should equal DEFAULT_ZERO_LENGTH
+
+    //should expect one call to .getStatus
+    Mockito.verify(mFileSystem).getStatus(new AlluxioURI(LOAD));
   }
 
   @Test
@@ -139,6 +145,9 @@ public class DistributedCmdTest {
     assertEquals(loadFileSize, DEFAULT_ZERO_LENGTH, 0); // should equal DEFAULT_ZERO_LENGTH
     assertEquals(migrateFileSize, MIGRATE_FILE_LENGTH, 0); // should equal MIGRATE_FILE_LENGTH
     assertEquals(persistFileSize, DEFAULT_ZERO_LENGTH, 0); // should equal DEFAULT_ZERO_LENGTH
+
+    //should expect one call to .getStatus
+    Mockito.verify(mFileSystem).getStatus(new AlluxioURI(MIGRATE));
   }
 
   @Test
@@ -159,6 +168,9 @@ public class DistributedCmdTest {
     assertEquals(loadFileSize, DEFAULT_ZERO_LENGTH, 0); // should equal DEFAULT_ZERO_LENGTH
     assertEquals(migrateFileSize, DEFAULT_ZERO_LENGTH, 0); // should equal DEFAULT_ZERO_LENGTH
     assertEquals(persistFileSize, PERSIST_FILE_LENGTH, 0); // should equal PERSIST_FILE_LENGTH
+
+    //should expect one call to .getStatus
+    Mockito.verify(mFileSystem).getStatus(new AlluxioURI(PERSIST));
   }
 
   @Test
@@ -178,5 +190,8 @@ public class DistributedCmdTest {
     assertEquals(loadFileSize, DEFAULT_ZERO_LENGTH, 0); // should equal DEFAULT_ZERO_LENGTH
     assertEquals(migrateFileSize, DEFAULT_ZERO_LENGTH, 0); // should equal DEFAULT_ZERO_LENGTH
     assertEquals(persistFileSize, DEFAULT_ZERO_LENGTH, 0); // should equal DEFAULT_ZERO_LENGTH
+
+    // should expect no call to .getStatus
+    Mockito.verify(mFileSystem, never()).getStatus(new AlluxioURI(NOOP_PLAN));
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/job/DistributedCmdTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/DistributedCmdTest.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.client.cli.job;
 
 import static org.junit.Assert.assertEquals;

--- a/tests/src/test/java/alluxio/client/cli/job/DistributedCmdTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/DistributedCmdTest.java
@@ -63,8 +63,7 @@ public class DistributedCmdTest {
     mNoopPlanURIStatus = Mockito.mock(URIStatus.class);
   }
 
-  private void runJob() throws Exception {
-  //  expectException(IOException.class, ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage("No such path"));
+  private void initialize() throws Exception {
     Mockito.when(mLoadURIStatus.getLength()).thenReturn(LOAD_FILE_LENGTH);
 
     Mockito.when(mLoadJobConfig.getFilePath()).thenReturn(LOAD);
@@ -88,14 +87,9 @@ public class DistributedCmdTest {
             .thenReturn(NOOP_PLAN_FILE_LENGTH);
   }
 
-  private void expectException(Class<? extends Throwable> cls, String msg) {
-    mException.expect(cls);
-    mException.expectMessage(msg);
-  }
-
   @Test
   public void testSupportedConfigForCompleteStatus() throws Exception {
-    runJob();
+    initialize();
     //Run for supported configs.
     DistributedCmdMetrics.incrementForCompleteStatusWithRetry(
             mLoadJobConfig, mFileSystem, mRetryPolicy);

--- a/tests/src/test/java/alluxio/client/cli/job/DistributedCommandsStatsTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/DistributedCommandsStatsTest.java
@@ -79,10 +79,6 @@ public class DistributedCommandsStatsTest extends JobShellTest {
     assertTrue(output[5].contains("\tWorker: "));
     assertEquals("\tStatus: COMPLETED", output[7]);
 
-    double cancelledCount = MetricsSystem.getMetricValue(
-            MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_CANCEL.getName()).getValue();
-    double failedCount = MetricsSystem.getMetricValue(
-            MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_FAIL.getName()).getValue();
     double completedCount = MetricsSystem.getMetricValue(
             MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_SUCCESS.getName()).getValue();
     double fileCount = MetricsSystem.getMetricValue(
@@ -90,13 +86,15 @@ public class DistributedCommandsStatsTest extends JobShellTest {
     double fileSize = MetricsSystem.getMetricValue(
             MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_FILE_SIZE.getName()).getValue();
 
-    //Metrics for other job types
+    //Metrics for Migrate job type
     double completedMigrateCount = MetricsSystem.getMetricValue(
             MetricKey.MASTER_MIGRATE_JOB_SUCCESS.getName()).getValue();
     double completedMigrateFileCount = MetricsSystem.getMetricValue(
             MetricKey.MASTER_MIGRATE_JOB_FILE_COUNT.getName()).getValue();
     double completedMigrateFileSize = MetricsSystem.getMetricValue(
             MetricKey.MASTER_MIGRATE_JOB_FILE_SIZE.getName()).getValue();
+
+    //Metrics for Persist job type
     double completedPersistCount = MetricsSystem.getMetricValue(
             MetricKey.MASTER_ASYNC_PERSIST_SUCCESS.getName()).getValue();
     double completedPersistFileCount = MetricsSystem.getMetricValue(
@@ -104,8 +102,7 @@ public class DistributedCommandsStatsTest extends JobShellTest {
     double completedPersistFileSize = MetricsSystem.getMetricValue(
             MetricKey.MASTER_ASYNC_PERSIST_FILE_SIZE.getName()).getValue();
 
-    assertEquals(cancelledCount, 0, 0);
-    assertEquals(failedCount, 0, 0);
+    //test counters for distributed load on Complete status.
     assertEquals(completedCount, 1, 0); //distributedLoad operation count equals 1.
     assertEquals(fileCount, 1, 0); // file count equals 1.
     assertEquals(fileSize, length, 0); // file size equals $length.
@@ -147,23 +144,8 @@ public class DistributedCommandsStatsTest extends JobShellTest {
 
     double cancelledCount = MetricsSystem.getMetricValue(
             MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_CANCEL.getName()).getValue();
-    double failedCount = MetricsSystem.getMetricValue(
-            MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_FAIL.getName()).getValue();
-    double completedCount = MetricsSystem.getMetricValue(
-            MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_SUCCESS.getName()).getValue();
-    double fileCount = MetricsSystem.getMetricValue(
-            MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_FILE_COUNT.getName()).getValue();
-    double fileSize = MetricsSystem.getMetricValue(
-            MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_FILE_SIZE.getName()).getValue();
-    double loadRate = MetricsSystem.getMetricValue(
-            MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_RATE.getName()).getValue();
 
     assertEquals(cancelledCount, 1, 0);
-    assertEquals(failedCount, 0, 0);
-    assertEquals(completedCount, 0, 0);
-    assertEquals(fileCount, 0, 0);
-    assertEquals(fileSize, 0, 0);
-    assertEquals(loadRate, 0, 0);
   }
 
   @Test
@@ -197,16 +179,10 @@ public class DistributedCommandsStatsTest extends JobShellTest {
             MetricKey.MASTER_MIGRATE_JOB_FAIL.getName()).getValue();
     double completedCount = MetricsSystem.getMetricValue(
             MetricKey.MASTER_MIGRATE_JOB_SUCCESS.getName()).getValue();
-    double fileCount = MetricsSystem.getMetricValue(
-            MetricKey.MASTER_MIGRATE_JOB_FILE_COUNT.getName()).getValue();
-    double fileSize = MetricsSystem.getMetricValue(
-            MetricKey.MASTER_MIGRATE_JOB_FILE_SIZE.getName()).getValue();
 
     assertEquals(cancelledCount, 1, 0);
     assertEquals(failedCount, 0, 0);
     assertEquals(completedCount, 0, 0);
-    assertEquals(fileCount, 0, 0);
-    assertEquals(fileSize, 0, 0);
   }
 
   @Test
@@ -238,15 +214,9 @@ public class DistributedCommandsStatsTest extends JobShellTest {
             MetricKey.MASTER_ASYNC_PERSIST_FAIL.getName()).getValue();
     double completedCount = MetricsSystem.getMetricValue(
             MetricKey.MASTER_ASYNC_PERSIST_SUCCESS.getName()).getValue();
-    double fileCount = MetricsSystem.getMetricValue(
-            MetricKey.MASTER_ASYNC_PERSIST_FILE_COUNT.getName()).getValue();
-    double fileSize = MetricsSystem.getMetricValue(
-            MetricKey.MASTER_ASYNC_PERSIST_FILE_SIZE.getName()).getValue();
 
     assertEquals(cancelledCount, 1, 0);
     assertEquals(failedCount, 0, 0);
     assertEquals(completedCount, 0, 0);
-    assertEquals(fileCount, 0, 0);
-    assertEquals(fileSize, 0, 0);
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/job/DistributedCommandsStatsTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/DistributedCommandsStatsTest.java
@@ -40,7 +40,7 @@ import java.util.Collections;
  * If the job completes fast enough before the CANCEL operations runs,then the test would fail.
  * The tests compare the job statuses (CANCEL or not) and stat counter values for each status.
  */
-public class DistributedCommandsCancelStatsTest extends JobShellTest {
+public class DistributedCommandsStatsTest extends JobShellTest {
   private static final long SLEEP_MS = Constants.SECOND_MS * 15;
   private static final int TEST_TIMEOUT = 45;
 
@@ -55,6 +55,71 @@ public class DistributedCommandsCancelStatsTest extends JobShellTest {
                 .setListStatusWithOptionsMs(SLEEP_MS)
                 .setExistsMs(SLEEP_MS)
                 .setMkdirsMs(SLEEP_MS)));
+
+  @Test
+  public void testCompleteStats() throws Exception {
+    final int length = 10;
+    FileSystemTestUtils.createByteFile(sFileSystem, "/test", WritePType.THROUGH, length);
+
+    long jobId = sJobMaster.run(new LoadConfig("/test", 1, Collections.EMPTY_SET,
+            Collections.EMPTY_SET, Collections.EMPTY_SET, Collections.EMPTY_SET, false));
+
+    JobTestUtils
+            .waitForJobStatus(sJobMaster, jobId, Sets.newHashSet(Status.COMPLETED), TEST_TIMEOUT);
+
+    sJobShell.run("stat", "-v", Long.toString(jobId));
+
+    String[] output = mOutput.toString().split("\n");
+    assertEquals(String.format("ID: %s", jobId), output[0]);
+    assertEquals(String.format("Name: Load"), output[1]);
+    assertTrue(output[2].contains("Description: LoadConfig"));
+    assertTrue(output[2].contains("/test"));
+    assertEquals("Status: COMPLETED", output[3]);
+    assertEquals("Task 0", output[4]);
+    assertTrue(output[5].contains("\tWorker: "));
+    assertEquals("\tStatus: COMPLETED", output[7]);
+
+    double cancelledCount = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_CANCEL.getName()).getValue();
+    double failedCount = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_FAIL.getName()).getValue();
+    double completedCount = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_SUCCESS.getName()).getValue();
+    double fileCount = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_FILE_COUNT.getName()).getValue();
+    double fileSize = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_JOB_DISTRIBUTED_LOAD_FILE_SIZE.getName()).getValue();
+
+    //Metrics for other job types
+    double completedMigrateCount = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_MIGRATE_JOB_SUCCESS.getName()).getValue();
+    double completedMigrateFileCount = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_MIGRATE_JOB_FILE_COUNT.getName()).getValue();
+    double completedMigrateFileSize = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_MIGRATE_JOB_FILE_SIZE.getName()).getValue();
+    double completedPersistCount = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_ASYNC_PERSIST_SUCCESS.getName()).getValue();
+    double completedPersistFileCount = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_ASYNC_PERSIST_FILE_COUNT.getName()).getValue();
+    double completedPersistFileSize = MetricsSystem.getMetricValue(
+            MetricKey.MASTER_ASYNC_PERSIST_FILE_SIZE.getName()).getValue();
+
+    assertEquals(cancelledCount, 0, 0);
+    assertEquals(failedCount, 0, 0);
+    assertEquals(completedCount, 1, 0); //distributedLoad operation count equals 1.
+    assertEquals(fileCount, 1, 0); // file count equals 1.
+    assertEquals(fileSize, length, 0); // file size equals $length.
+
+    //test for other job types. Migrate counters, should all be 0.
+    assertEquals(completedMigrateCount, 0, 0);
+    assertEquals(completedMigrateFileCount, 0, 0);
+    assertEquals(completedMigrateFileSize, 0, 0);
+
+    //test AsyncPersist counters, should all be 0.
+    assertEquals(completedPersistCount, 0, 0);
+    assertEquals(completedPersistFileCount, 0, 0);
+    assertEquals(completedPersistFileSize, 0, 0);
+  }
 
   @Test
   public void testDistributedLoadCancelStats() throws Exception {


### PR DESCRIPTION
### What changes are proposed in this pull request?
1. Use increment-by-counts instead of iteration for fail and cancel stat counters
2. Refactor DistributedMetrics to skip for other non-supported job types.

Please outline the changes and how this PR fixes the issue.
1. Previously there is a performance drop, which may be caused by the PR https://github.com/Alluxio/alluxio/pull/14989. Inspecting the PR, code changes for incrementing failure counters are added. 
When the code runs for batch config, if the folder has lots of files and the batch size is huge,  incrementing failure counters in the iteration will be slow. 
Changing the iteration to adding the increment values directly will avoid the long-running loop, and thus speed up the code to run.
2. Refactored the code to skip unsupported job types, so that the code looks cleaner and would run without further going through the remaining code body.
3. Added a unit test to test Complete status, removed some unnecessary tests.
