### PR TITLE
Fix incorrect directory when mounting & formatting master journal volume

### DIFF
--- a/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
+++ b/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
@@ -160,11 +160,32 @@ master:
   count: 1 # For multiMaster mode increase this to >1
 
 journal:
-  type: "UFS"
+  # [ Required values ]
+  type: "UFS" # One of "UFS" or "EMBEDDED"
+  folder: "/journal" # Master journal directory or equivalent storage path
+  #
+  # [ Conditionally required values ]
+  #
+  ## [ UFS-backed journal options ]
+  ## - required when using a UFS-type journal (journal.type="UFS")
+  ##
+  ## ufsType is one of "local" or "HDFS"
+  ## - "local" results in a PV being allocated to each Master Pod as the journal
+  ## - "HDFS" results in no PV allocation, it is up to you to ensure you have
+  ##   properly configured the required Alluxio properties for Alluxio to access
+  ##   the HDFS URI designated as the journal folder
   ufsType: "local"
-  folder: "/journal"
+  #
+  ## [ K8s volume options ]
+  ## - required when using an EMBEDDED journal (journal.type="EMBEDDED")
+  ## - required when using a local UFS journal (journal.type="UFS" and journal.ufsType="local")
+  ##
+  ## volumeType controls the type of journal volume.
+  volumeType: persistentVolumeClaim # One of "persistentVolumeClaim" or "emptyDir"
+  ## size sets the requested storage capacity for a persistentVolumeClaim,
+  ## or the sizeLimit on an emptyDir PV.
   size: 1Gi
-  volumeType: persistentVolumeClaim
+  ### Unique attributes to use when the journal is persistentVolumeClaim
   storageClass: "standard"
   accessModes:
     - ReadWriteOnce
@@ -180,11 +201,32 @@ master:
   count: 1 # For multiMaster mode increase this to >1
 
 journal:
-  type: "UFS"
+  # [ Required values ]
+  type: "UFS" # One of "UFS" or "EMBEDDED"
+  folder: "/journal" # Master journal directory or equivalent storage path
+  #
+  # [ Conditionally required values ]
+  #
+  ## [ UFS-backed journal options ]
+  ## - required when using a UFS-type journal (journal.type="UFS")
+  ##
+  ## ufsType is one of "local" or "HDFS"
+  ## - "local" results in a PV being allocated to each Master Pod as the journal
+  ## - "HDFS" results in no PV allocation, it is up to you to ensure you have
+  ##   properly configured the required Alluxio properties for Alluxio to access
+  ##   the HDFS URI designated as the journal folder
   ufsType: "local"
-  folder: "/journal"
+  #
+  ## [ K8s volume options ]
+  ## - required when using an EMBEDDED journal (journal.type="EMBEDDED")
+  ## - required when using a local UFS journal (journal.type="UFS" and journal.ufsType="local")
+  ##
+  ## volumeType controls the type of journal volume.
+  volumeType: emptyDir # One of "persistentVolumeClaim" or "emptyDir"
+  ## size sets the requested storage capacity for a persistentVolumeClaim,
+  ## or the sizeLimit on an emptyDir PV.
   size: 1Gi
-  volumeType: emptyDir
+  ### Unique attributes to use when the journal is emptyDir
   medium: ""
 ```
 
@@ -205,12 +247,24 @@ $ kubectl create secret generic alluxio-hdfs-config --from-file=${HADOOP_CONF_DI
 
 ```properties
 journal:
-  type: "UFS"
-  ufsType: "non-local"
-  folder: "hdfs://{$hostname}:{$hostport}/journal"
+  # [ Required values ]
+  type: "UFS" # One of "UFS" or "EMBEDDED"
+  folder: "hdfs://{$hostname}:{$hostport}/journal" # Master journal directory or equivalent storage path
+  #
+  # [ Conditionally required values ]
+  #
+  ## [ UFS-backed journal options ]
+  ## - required when using a UFS-type journal (journal.type="UFS")
+  ##
+  ## ufsType is one of "local" or "HDFS"
+  ## - "local" results in a PV being allocated to each Master Pod as the journal
+  ## - "HDFS" results in no PV allocation, it is up to you to ensure you have
+  ##   properly configured the required Alluxio properties for Alluxio to access
+  ##   the HDFS URI designated as the journal folder
+  ufsType: "HDFS"
 
 properties:
-  alluxio.master.mount.table.root.ufs: "hdfs://<ns>"
+  alluxio.master.mount.table.root.ufs: "hdfs://{$hostname}:{$hostport}/alluxio"
   alluxio.master.journal.ufs.option.alluxio.underfs.hdfs.configuration: "/secrets/hdfsConfig/core-site.xml:/secrets/hdfsConfig/hdfs-site.xml"
 
 secrets:
@@ -226,14 +280,22 @@ secrets:
 master:
   count: 3
 
-journal:
-  type: "EMBEDDED"
-  folder: "/journal"
-  # volumeType controls the type of journal volume.
-  # It can be "persistentVolumeClaim" or "emptyDir"
-  volumeType: persistentVolumeClaim
+  # [ Required values ]
+  type: "EMBEDDED" # One of "UFS" or "EMBEDDED"
+  folder: "/journal" # Master journal directory or equivalent storage path
+  #
+  # [ Conditionally required values ]
+  #
+  ## [ K8s volume options ]
+  ## - required when using an EMBEDDED journal (journal.type="EMBEDDED")
+  ## - required when using a local UFS journal (journal.type="UFS" and journal.ufsType="local")
+  ##
+  ## volumeType controls the type of journal volume.
+  volumeType: persistentVolumeClaim # One of "persistentVolumeClaim" or "emptyDir"
+  ## size sets the requested storage capacity for a persistentVolumeClaim,
+  ## or the sizeLimit on an emptyDir PV.
   size: 1Gi
-  # Attributes to use when the journal is persistentVolumeClaim
+  ### Unique attributes to use when the journal is persistentVolumeClaim
   storageClass: "standard"
   accessModes:
     - ReadWriteOnce
@@ -246,11 +308,22 @@ master:
   count: 3
 
 journal:
-  type: "UFS"
-  ufsType: "local"
-  folder: "/journal"
+  # [ Required values ]
+  type: "EMBEDDED" # One of "UFS" or "EMBEDDED"
+  folder: "/journal" # Master journal directory or equivalent storage path
+  #
+  # [ Conditionally required values ]
+  #
+  ## [ K8s volume options ]
+  ## - required when using an EMBEDDED journal (journal.type="EMBEDDED")
+  ## - required when using a local UFS journal (journal.type="UFS" and journal.ufsType="local")
+  ##
+  ## volumeType controls the type of journal volume.
+  volumeType: emptyDir # One of "persistentVolumeClaim" or "emptyDir"
+  ## size sets the requested storage capacity for a persistentVolumeClaim,
+  ## or the sizeLimit on an emptyDir PV.
   size: 1Gi
-  volumeType: emptyDir
+  ### Unique attributes to use when the journal is emptyDir
   medium: ""
 ```
 

--- a/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
+++ b/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
@@ -164,10 +164,7 @@ journal:
   ufsType: "local"
   folder: "/journal"
   size: 1Gi
-  # volumeType controls the type of journal volume.
-  # It can be "persistentVolumeClaim" or "emptyDir"
   volumeType: persistentVolumeClaim
-  # Attributes to use when the journal is persistentVolumeClaim
   storageClass: "standard"
   accessModes:
     - ReadWriteOnce
@@ -187,10 +184,7 @@ journal:
   ufsType: "local"
   folder: "/journal"
   size: 1Gi
-  # volumeType controls the type of journal volume.
-  # It can be "persistentVolumeClaim" or "emptyDir"
   volumeType: emptyDir
-  # Attributes to use when the journal is emptyDir
   medium: ""
 ```
 
@@ -212,7 +206,7 @@ $ kubectl create secret generic alluxio-hdfs-config --from-file=${HADOOP_CONF_DI
 ```properties
 journal:
   type: "UFS"
-  ufsType: "HDFS"
+  ufsType: "non-local"
   folder: "hdfs://{$hostname}:{$hostport}/journal"
 
 properties:
@@ -256,10 +250,7 @@ journal:
   ufsType: "local"
   folder: "/journal"
   size: 1Gi
-  # volumeType controls the type of journal volume.
-  # It can be "persistentVolumeClaim" or "emptyDir"
   volumeType: emptyDir
-  # Attributes to use when the journal is emptyDir
   medium: ""
 ```
 
@@ -660,6 +651,9 @@ This `initContainer` will run `alluxio formatJournal` when the Pod is created an
   securityContext:
     runAsUser: 1000
   command: ["alluxio","formatJournal"]
+  envFrom:
+    - configMapRef:
+      name: alluxio-config
   volumeMounts:
     - name: alluxio-journal
       mountPath: /journal

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -254,3 +254,7 @@
 
 - Fix CSI controller rbac rule not specifying namespace.
 - Fix CSI driver compatibility issue under kubernetes 18+ version.
+
+0.6.40
+
+- Fix incorrect directory when mounting & formatting master journal volume

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.39
+version: 0.6.40
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -101,9 +101,12 @@ spec:
         image: {{ .Values.image }}:{{ .Values.imageTag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["alluxio","formatJournal"]
+        envFrom:
+          - configMapRef:
+              name: {{ $fullName }}-config
         volumeMounts:
           - name: alluxio-journal
-            mountPath: /journal
+            mountPath: {{ .Values.journal.folder }}
       {{- end}}
       {{ if .Values.hub.enabled -}}
       shareProcessNamespace: true
@@ -252,7 +255,7 @@ spec:
             {{- end }}
             {{- if $needJournalVolume }}
             - name: alluxio-journal
-              mountPath: /journal
+              mountPath: {{ .Values.journal.folder }}
             {{- end }}
             {{- if .Values.metastore }}
             - name: alluxio-metastore

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -194,18 +194,27 @@ jobMaster:
 # UFS journal with HDFS example
 # journal:
 #   type: "UFS"
+#   ufsType: "non-local"
 #   folder: "hdfs://{$hostname}:{$hostport}/journal"
 # EMBEDDED journal to /journal example
 # journal:
 #   type: "EMBEDDED"
 #   folder: "/journal"
 journal:
-  type: "UFS" # "UFS" or "EMBEDDED"
-  ufsType: "local" # Ignored if type is "EMBEDDED". "local" or "HDFS"
-  folder: "/journal" # Master journal folder
+  # [ Required arguments ]
+  type: "UFS" # One of "UFS" or "EMBEDDED"
+  folder: "/journal" # Master journal directory or equivalent storage path
+  # [ Conditionally required arguments ]
+  #
+  # [[ UFS-backed journal options (journal.type="UFS") ]]
+  ufsType: "local" # One of "local" or "non-local"
+  #
+  # [[ K8s volume options ]]
+  # - required when using an EMBEDDED journal (journal.type="EMBEDDED")
+  # - required when using a local UFS journal (journal.type="UFS" and journal.ufsType="local")
+  #
   # volumeType controls the type of journal volume.
-  # It can be "persistentVolumeClaim" or "emptyDir"
-  volumeType: persistentVolumeClaim
+  volumeType: persistentVolumeClaim # One of "persistentVolumeClaim" or "emptyDir"
   size: 1Gi
   # Attributes to use when the journal is persistentVolumeClaim
   storageClass: "standard"
@@ -213,6 +222,7 @@ journal:
     - ReadWriteOnce
   # Attributes to use when the journal is emptyDir
   medium: ""
+  # [ Optional arguments ]
   # Configuration for journal formatting job
   format:
     runFormat: false # Change to true to format journal

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -194,37 +194,47 @@ jobMaster:
 # UFS journal with HDFS example
 # journal:
 #   type: "UFS"
-#   ufsType: "non-local"
+#   ufsType: "HDFS"
 #   folder: "hdfs://{$hostname}:{$hostport}/journal"
 # EMBEDDED journal to /journal example
 # journal:
 #   type: "EMBEDDED"
 #   folder: "/journal"
 journal:
-  # [ Required arguments ]
+  # [ Required values ]
   type: "UFS" # One of "UFS" or "EMBEDDED"
   folder: "/journal" # Master journal directory or equivalent storage path
-  # [ Conditionally required arguments ]
   #
-  # [[ UFS-backed journal options (journal.type="UFS") ]]
-  ufsType: "local" # One of "local" or "non-local"
+  # [ Conditionally required values ]
   #
-  # [[ K8s volume options ]]
-  # - required when using an EMBEDDED journal (journal.type="EMBEDDED")
-  # - required when using a local UFS journal (journal.type="UFS" and journal.ufsType="local")
+  ## [ UFS-backed journal options ]
+  ## - required when using a UFS-type journal (journal.type="UFS")
+  ##
+  ## ufsType is one of "local" or "HDFS"
+  ## - "local" results in a PV being allocated to each Master Pod as the journal
+  ## - "HDFS" results in no PV allocation, it is up to you to ensure you have
+  ##   properly configured the required Alluxio properties for Alluxio to access
+  ##   the HDFS URI designated as the journal folder
+  ufsType: "local"
   #
-  # volumeType controls the type of journal volume.
+  ## [ K8s volume options ]
+  ## - required when using an EMBEDDED journal (journal.type="EMBEDDED")
+  ## - required when using a local UFS journal (journal.type="UFS" and journal.ufsType="local")
+  ##
+  ## volumeType controls the type of journal volume.
   volumeType: persistentVolumeClaim # One of "persistentVolumeClaim" or "emptyDir"
+  ## size sets the requested storage capacity for a persistentVolumeClaim,
+  ## or the sizeLimit on an emptyDir PV.
   size: 1Gi
-  # Attributes to use when the journal is persistentVolumeClaim
+  ### Unique attributes to use when the journal is persistentVolumeClaim
   storageClass: "standard"
   accessModes:
     - ReadWriteOnce
-  # Attributes to use when the journal is emptyDir
+  ### Unique attributes to use when the journal is emptyDir
   medium: ""
-  # [ Optional arguments ]
-  # Configuration for journal formatting job
-  format:
+  #
+  # [ Optional values ]
+  format: # Configuration for journal formatting job
     runFormat: false # Change to true to format journal
 
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR simply adds the `alluxio-config` ConfigMap to the `initContainer` which is launched to format the master journal. Furthermore, it also uses the value set in `.Values.journal.folder` as the mount directory for journal PVs.

### Why are the changes needed?

Without these changes, the PV intended as the Alluxio master journal would always be mounted under `/journal`. This would be completely ignored if the user changed `.Values.journal.folder` to anything other than `/journal`.

Furthermore, attempting to use the `initContainer` to run the journal format job would cause the journal to be mounted to the [Alluxio default value](https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html?q=alluxio.master.journal.folder) `alluxio.master.journal.folder=${alluxio.work.dir}/journal`.

For example with the following journal values:
```
journal:
  type: "EMBEDDED"
  folder: "/tmp/journal"
  format:
    runFormat: true
```

Before:
```
$ kubectl logs -f alluxio-master-0 -c journal-format
Formatting Alluxio Master @ alluxio-master-0.alluxio-master.default.svc.cluster.local
2022-02-23 19:25:10,778 INFO  Format - Formatting master journal: /opt/alluxio-2.8.0-SNAPSHOT/journal/
2022-02-23 19:25:10,841 INFO  Format - Formatting complete

$ kubectl logs -f alluxio-master-0 -c alluxio-master
2022-02-23 19:31:10,679 ERROR AlluxioMaster - Fatal error: Failed to create master process
java.lang.RuntimeException: java.lang.RuntimeException: Journal alluxio.master.journal.raft.RaftJournalSystem@1810399e has not been formatted!
	at alluxio.master.AlluxioMasterProcess.<init>(AlluxioMasterProcess.java:122)
	at alluxio.master.FaultTolerantAlluxioMasterProcess.<init>(FaultTolerantAlluxioMasterProcess.java:61)
	at alluxio.master.AlluxioMasterProcess$Factory.create(AlluxioMasterProcess.java:467)
	at alluxio.master.AlluxioMaster.main(AlluxioMaster.java:45)
Caused by: java.lang.RuntimeException: Journal alluxio.master.journal.raft.RaftJournalSystem@1810399e has not been formatted!
	at alluxio.master.AlluxioMasterProcess.<init>(AlluxioMasterProcess.java:101)
	... 3 more
```

After:
```
$ kubectl logs -f alluxio-master-0 -c journal-format
Formatting Alluxio Master @ alluxio-master-0.alluxio-master.default.svc.cluster.local
2022-02-23 19:38:55,662 INFO  Format - Formatting master journal: /tmp/journal/
2022-02-23 19:38:55,716 INFO  Format - Formatting complete

$ kubectl logs -f alluxio-master-0 -c alluxio-master
...
2022-02-23 19:39:15,778 INFO  FaultTolerantAlluxioMasterProcess - Primary started
2022-02-23 19:39:15,778 INFO  DefaultSafeModeManager - Rpc server started, waiting 5000ms for workers to register
2022-02-23 19:39:15,778 INFO  AlluxioMasterProcess - gRPC server listening on: 0.0.0.0:19998
2022-02-23 19:39:15,779 INFO  AlluxioMasterProcess - Alluxio master version 2.8.0-SNAPSHOT started (gained leadership). bindAddress=0.0.0.0/0.0.0.0:19998, connectAddress=10.244.1.11:19998, webAddress=/0.0.0.0:19999
```

### Does this PR introduce any user facing changes?

One user-facing value changes:
- `journal.ufsType` option "HDFS" was semantically changed to `"non-local"`
  - The prior value of "HDFS" will still be accepted and behave as expected. This value change is purely for clarity and posterity.
- The k8s docs were updated to reflect this

Some comments were added to the entirety of the `journal` section of `values.yaml` for clarity.