### PR TITLE
Save one list copy in rm

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1920,8 +1920,12 @@ public class DefaultFileSystemMaster extends CoreMaster
     }
 
     // Inodes for which deletion will be attempted
-    List<Pair<AlluxioURI, LockedInodePath>> inodesToDelete =
-        new ArrayList<>((int) inode.asDirectory().getChildCount());
+    List<Pair<AlluxioURI, LockedInodePath>> inodesToDelete;
+    if (inode.isDirectory()) {
+      inodesToDelete = new ArrayList<>((int) inode.asDirectory().getChildCount());
+    } else {
+      inodesToDelete = new ArrayList<>(1);
+    }
 
     // Add root of sub-tree to delete
     inodesToDelete.add(new Pair<>(inodePath.getUri(), inodePath));
@@ -2000,8 +2004,9 @@ public class DefaultFileSystemMaster extends CoreMaster
         mSyncManager.stopSyncAndJournal(RpcContext.NOOP, inodePath.getUri());
       }
 
-      // Delete Inodes
-      for (Pair<AlluxioURI, LockedInodePath> delInodePair : inodesToDelete) {
+      // Delete Inodes from children to parents
+      for (int i = inodesToDelete.size() - 1; i >= 0; i--) {
+        Pair<AlluxioURI, LockedInodePath> delInodePair = inodesToDelete.get(i);
         // The entry is null because an error is met from the pre-processing
         if (delInodePair == null) {
           continue;

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1920,7 +1920,8 @@ public class DefaultFileSystemMaster extends CoreMaster
     }
 
     // Inodes for which deletion will be attempted
-    List<Pair<AlluxioURI, LockedInodePath>> inodesToDelete = new ArrayList<>();
+    List<Pair<AlluxioURI, LockedInodePath>> inodesToDelete =
+        new ArrayList<>((int) inode.asDirectory().getChildCount());
 
     // Add root of sub-tree to delete
     inodesToDelete.add(new Pair<>(inodePath.getUri(), inodePath));


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. Refactor the rm to avoid one list copy
2. Better init sizing to avoid some copy from ArrayList auto-sizing
3. Setting unused positions to `null` will help GC

### Why are the changes needed?

See above

### Does this PR introduce any user facing changes?

NA

### Memory saves
If there are `n` inodes to process, the save will be:
1. An `ArrayList` of size `n`, so `8 byte * n`
2. One `Pair<>` per inode, so `32 byte * n`
3. Some `ArrayList` resizing internally by initializing with the final size. So the save is bounded by `8 byte * n`.

The total save is `<(8+32+8) byte * n`. But these are temporary variables so the cost can be less significant than long-held ones. The CPU save could be a more significant benefit, subject to our observation from micro benchmark.
