### PR TITLE
Refactor `RaftJournalAppender`

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalAppender.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalAppender.java
@@ -20,7 +20,6 @@ import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftClientRequest;
-import org.apache.ratis.protocol.exceptions.AlreadyClosedException;
 import org.apache.ratis.server.RaftServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,10 +99,6 @@ public class RaftJournalAppender {
       if (t != null) {
         // Handle and rethrow exception.
         LOG.trace("Received remote exception", t);
-        if (t instanceof AlreadyClosedException || t.getCause() instanceof AlreadyClosedException) {
-          // create a new client if the current client is already closed
-          LOG.warn("Connection is closed.");
-        }
         throw new CompletionException(t.getCause());
       }
     });

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -94,7 +94,6 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
@@ -885,7 +884,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
               try {
                 client.close();
               } catch (IOException e) {
-                throw new CompletionException(e);
+                LogUtils.warnWithException(LOG, "Exception occurred closing raft client", e);
               }
             });
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
@@ -21,7 +21,6 @@ import alluxio.util.FormatUtils;
 import com.google.common.base.Preconditions;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
-import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,12 +118,12 @@ public class RaftJournalWriter implements JournalWriter {
         mLastSubmittedSequenceNumber.set(flushSN);
         LOG.trace("Flushing entry {} ({})", entry, message);
         RaftClientReply reply = mClient
-            .sendAsync(message, TimeDuration.valueOf(mWriteTimeoutMs, TimeUnit.MILLISECONDS))
+            .sendAsync(message)
             .get(mWriteTimeoutMs, TimeUnit.MILLISECONDS);
-        mLastCommittedSequenceNumber.set(flushSN);
         if (reply.getException() != null) {
           throw reply.getException();
         }
+        mLastCommittedSequenceNumber.set(flushSN);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new IOException(e);
@@ -148,7 +147,6 @@ public class RaftJournalWriter implements JournalWriter {
     LOG.info("Closing journal writer. Last sequence numbers written/submitted/committed: {}/{}/{}",
         mNextSequenceNumberToWrite.get() - 1, mLastSubmittedSequenceNumber.get(),
         mLastCommittedSequenceNumber.get());
-    closeClient();
   }
 
   /**
@@ -156,13 +154,5 @@ public class RaftJournalWriter implements JournalWriter {
    */
   public long getNextSequenceNumberToWrite() {
     return mNextSequenceNumberToWrite.get();
-  }
-
-  private void closeClient() {
-    try {
-      mClient.close();
-    } catch (IOException e) {
-      LOG.warn("Failed to close raft client: {}", e.toString());
-    }
   }
 }

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalWriterTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalWriterTest.java
@@ -91,7 +91,7 @@ public class RaftJournalWriterTest {
         return reply;
       }
     };
-    when(mClient.sendAsync(any(), any())).thenReturn(future);
+    when(mClient.sendAsync(any())).thenReturn(future);
 
     mRaftJournalWriter = new RaftJournalWriter(1, mClient);
   }
@@ -107,16 +107,16 @@ public class RaftJournalWriterTest {
               .setAlluxioPath(alluxioMountPoint)
               .setUfsPath(ufsPath).build()).build());
     }
-    verify(mClient, never()).sendAsync(any(), any());
+    verify(mClient, never()).sendAsync(any());
 
     mRaftJournalWriter.flush();
-    verify(mClient, times(1)).sendAsync(any(), any());
+    verify(mClient, times(1)).sendAsync(any());
     mRaftJournalWriter.flush();
-    verify(mClient, times(1)).sendAsync(any(), any());
+    verify(mClient, times(1)).sendAsync(any());
 
     mRaftJournalWriter.write(Journal.JournalEntry.getDefaultInstance());
     mRaftJournalWriter.flush();
-    verify(mClient, times(2)).sendAsync(any(), any());
+    verify(mClient, times(2)).sendAsync(any());
   }
 
   @Test
@@ -137,6 +137,6 @@ public class RaftJournalWriterTest {
               .setUfsPath(ufsPath).build()).build());
     }
     mRaftJournalWriter.write(Journal.JournalEntry.getDefaultInstance());
-    verify(mClient, atLeast(totalMessageBytes / flushBatchSize)).sendAsync(any(), any());
+    verify(mClient, atLeast(totalMessageBytes / flushBatchSize)).sendAsync(any());
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?
Refactoring `RaftJournalAppender` to only use try-with-resource blocks when creating and using `RaftClient`s, or close said clients in `whenComplete` blocks when dealing with async client calls.

### Why are the changes needed?
Improperly creating / not creating or closing / not closing clients can lead to uncertain behavior. This causes a lot of headaches for debugging and makes the code harder to read.

Moving the `RaftClient`s to try-with-resource blocks allowed me to refactor many other parts of the code. Many functions (such as `RaftJournalAppender#close`) became obsolete and were removed. In the case of clients make async calls and return futures, I made sure to include `client.close()` in the `whenComplete` blocks of futures.
Moreover, `RaftJournalAppender#sendLocalRequest` made no use of its `timeout` parameter, so it was removed. 
