### PR TITLE
Simplify the worker start-up timeout logic

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -105,11 +105,8 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
           return null;
         });
       }
-      // In the worst case, each worker factory is blocked waiting for the dependent servers to be
-      // registered at worker registry. The maximum timeout here is set by configuration
-      // alluxio.worker.startup.timeout
       CommonUtils.invokeAll(callables,
-          (long) callables.size() * ServerConfiguration.getMs(PropertyKey.WORKER_STARTUP_TIMEOUT));
+          ServerConfiguration.getMs(PropertyKey.WORKER_STARTUP_TIMEOUT));
 
       // Setup web server
       mWebServer =


### PR DESCRIPTION
### What changes are proposed in this pull request?

As @jiacheliu3 suggested in https://github.com/Alluxio/alluxio/pull/14918, it would be better to remove "callables.size() * " in the worker startup timeout caluculation.  

### Why are the changes needed?

Make the timeout config more straight forward and easy to read.

### Does this PR introduce any user facing changes?
N/A