### PR TITLE
Improve deletion error message

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2010,24 +2010,28 @@ public class DefaultFileSystemMaster extends CoreMaster
       }
 
       if (!failedUris.isEmpty()) {
-        StringBuilder errorReport = new StringBuilder(
-            ExceptionMessage.DELETE_FAILED_UFS.getMessage(failedUris.size() + " paths: "));
-        boolean trim = failedUris.size() > 20;
-        for (int i = 0; i < (trim ? 20 : failedUris.size()); i++) {
-          if (i > 0) {
-            errorReport.append(", ");
-          }
-          Pair<String, String> pathAndError = failedUris.get(i);
-          errorReport.append(String.format("%s (%s)",
-              pathAndError.getFirst(), pathAndError.getSecond()));
-        }
-        if (trim) {
-          errorReport.append("...(only 20 errors shown)");
-        }
-        throw new FailedPreconditionException(errorReport.toString());
+        throw new FailedPreconditionException(buildDeleteFailureMessage(failedUris));
       }
     }
     Metrics.PATHS_DELETED.inc(inodesToDelete.size());
+  }
+
+  private String buildDeleteFailureMessage(List<Pair<String, String>> failedUris) {
+    StringBuilder errorReport = new StringBuilder(
+        ExceptionMessage.DELETE_FAILED_UFS.getMessage(failedUris.size() + " paths: "));
+    boolean trim = !LOG.isDebugEnabled() && failedUris.size() > 20;
+    for (int i = 0; i < (trim ? 20 : failedUris.size()); i++) {
+      if (i > 0) {
+        errorReport.append(", ");
+      }
+      Pair<String, String> pathAndError = failedUris.get(i);
+      errorReport.append(String.format("%s (%s)",
+          pathAndError.getFirst(), pathAndError.getSecond()));
+    }
+    if (trim) {
+      errorReport.append("...(only 20 errors shown)");
+    }
+    return errorReport.toString();
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2010,11 +2010,21 @@ public class DefaultFileSystemMaster extends CoreMaster
       }
 
       if (!failedUris.isEmpty()) {
-        Collection<String> messages = failedUris.stream()
-            .map(pair -> String.format("%s (%s)", pair.getFirst(), pair.getSecond()))
-            .collect(Collectors.toList());
-        throw new FailedPreconditionException(
-            ExceptionMessage.DELETE_FAILED_UFS.getMessage(StringUtils.join(messages, ", ")));
+        StringBuilder errorReport = new StringBuilder(
+            ExceptionMessage.DELETE_FAILED_UFS.getMessage(failedUris.size() + " paths: "));
+        boolean trim = failedUris.size() > 20;
+        for (int i = 0; i < (trim ? 20 : failedUris.size()) ; i++) {
+          if (i > 0) {
+            errorReport.append(", ");
+          }
+          Pair<String, String> pathAndError = failedUris.get(i);
+          errorReport.append(String.format("%s (%s)",
+              pathAndError.getFirst(), pathAndError.getSecond()));
+        }
+        if (trim) {
+          errorReport.append("...(only 20 errors shown)");
+        }
+        throw new FailedPreconditionException(errorReport.toString());
       }
     }
     Metrics.PATHS_DELETED.inc(inodesToDelete.size());

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2013,7 +2013,7 @@ public class DefaultFileSystemMaster extends CoreMaster
         StringBuilder errorReport = new StringBuilder(
             ExceptionMessage.DELETE_FAILED_UFS.getMessage(failedUris.size() + " paths: "));
         boolean trim = failedUris.size() > 20;
-        for (int i = 0; i < (trim ? 20 : failedUris.size()) ; i++) {
+        for (int i = 0; i < (trim ? 20 : failedUris.size()); i++) {
           if (i > 0) {
             errorReport.append(", ");
           }


### PR DESCRIPTION
### What changes are proposed in this pull request?

This change trims the deletions message for large deletion failures

### Why are the changes needed?

When many inodes fail to be deleted, the error msg will be too long for the log message and generate too many side product strings.

### Does this PR introduce any user facing changes?

The error msg users see will be different. Although the message itself is trimmed, I don't think the user will need the full list of all failure messages in one go. My estimation is the first batch of error messages will be representative enough and if not, after fixing the first batch, the next try will reveal the left batch of failures and eventually all failures can be fixed.