### PR TITLE
Add a configuration to set ufs fetch timeout

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2815,7 +2815,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       new Builder(Name.MASTER_METADATA_SYNC_UFS_PREFETCH_TIMEOUT)
           .setDefaultValue("100ms")
           .setDescription("The timeout for a metadata fetch operation from the UFSes. "
-              + "Adjust this timeout according to the expected UFS worse-case response time.")
+              + "Adjust this timeout according to the expected UFS worst-case response time.")
           .setScope(Scope.MASTER)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2811,6 +2811,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.MASTER)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
+  public static final PropertyKey MASTER_METADATA_SYNC_UFS_PREFETCH_TIMEOUT =
+      new Builder(Name.MASTER_METADATA_SYNC_UFS_PREFETCH_TIMEOUT)
+          .setDefaultValue("100ms")
+          .setDescription("The timeout for a metadata fetch operation from the UFSes. "
+              + "Adjust this timeout according to the expected UFS worse-case response time.")
+          .setScope(Scope.MASTER)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .build();
   public static final PropertyKey MASTER_RPC_EXECUTOR_TYPE =
       new Builder(Name.MASTER_RPC_EXECUTOR_TYPE)
           .setDefaultValue("TPE")
@@ -6501,6 +6509,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metadata.sync.report.failure";
     public static final String MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE =
         "alluxio.master.metadata.sync.ufs.prefetch.pool.size";
+    public static final String MASTER_METADATA_SYNC_UFS_PREFETCH_TIMEOUT =
+        "alluxio.master.metadata.sync.ufs.prefetch.timeout";
     public static final String MASTER_METASTORE = "alluxio.master.metastore";
     public static final String MASTER_METASTORE_DIR = "alluxio.master.metastore.dir";
     public static final String MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE =

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -643,7 +643,8 @@ public class InodeSyncStream {
           syncChildren && mRootScheme.getPath().equals(inodePath.getUri());
     }
 
-    Map<String, Inode> inodeChildren = new HashMap<>();
+    int childCount = inode.isDirectory() ? (int) inode.asDirectory().getChildCount() : 0;
+    Map<String, Inode> inodeChildren = new HashMap<>(childCount);
     if (syncChildren) {
       // maps children name to inode
       mInodeStore.getChildren(inode.asDirectory())


### PR DESCRIPTION
### What changes are proposed in this pull request?

This change makes the UFS fetch operation timeout configurable.

Also a minor change which uses the sized constructor for HashMap.

### Why are the changes needed?

Some UFSes can be bad in worst response time so the fetch operation can timeout easily when the timeout is just 100ms. This might be most useful in the development stage, where the user is accessing a remote UFS like S3 from a random location, so the response time can be randomly bad.

### Does this PR introduce any user facing changes?

This adds a new property key for the user to configure if really needs to.