### PR TITLE
Make all BlockStore iterations use CloseableIterator

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -379,8 +379,8 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
   @Override
   public CloseableIterator<JournalEntry> getJournalEntryIterator() {
-    Iterator<Block> blockStoreIterator = mBlockStore.iterator();
-    Iterator<JournalEntry> blockIterator = new Iterator<JournalEntry>() {
+    CloseableIterator<Block> blockStoreIterator = mBlockStore.getCloseableIterator();
+    Iterator<JournalEntry> journalIterator = new Iterator<JournalEntry>() {
       @Override
       public boolean hasNext() {
         return blockStoreIterator.hasNext();
@@ -404,20 +404,13 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
       }
     };
 
-    CloseableIterator<JournalEntry> closeableIterator =
-        CloseableIterator.create(blockIterator, (whatever) -> {
-          if (blockStoreIterator instanceof CloseableIterator) {
-            final CloseableIterator<Block> c = (CloseableIterator<Block>) blockStoreIterator;
-            c.close();
-          } else {
-            // no op
-          }
-        });
+    CloseableIterator<JournalEntry> journalCloseableIterator =
+        CloseableIterator.create(journalIterator, (whatever) -> blockStoreIterator.close());
 
     return CloseableIterator.concat(
         CloseableIterator.noopCloseable(
             CommonUtils.singleElementIterator(getContainerIdJournalEntry())),
-        closeableIterator);
+        journalCloseableIterator);
   }
 
   /**
@@ -726,10 +719,12 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
   public void validateBlocks(Function<Long, Boolean> validator, boolean repair)
       throws UnavailableException {
     List<Long> invalidBlocks = new ArrayList<>();
-    for (Iterator<Block> iter = mBlockStore.iterator(); iter.hasNext(); ) {
-      long id = iter.next().getId();
-      if (!validator.apply(id)) {
-        invalidBlocks.add(id);
+    try (CloseableIterator<Block> iter = mBlockStore.getCloseableIterator()) {
+      for (; iter.hasNext(); ) {
+        long id = iter.next().getId();
+        if (!validator.apply(id)) {
+          invalidBlocks.add(id);
+        }
       }
     }
     if (!invalidBlocks.isEmpty()) {

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -720,7 +720,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
       throws UnavailableException {
     List<Long> invalidBlocks = new ArrayList<>();
     try (CloseableIterator<Block> iter = mBlockStore.getCloseableIterator()) {
-      for (; iter.hasNext(); ) {
+      while (iter.hasNext()) {
         long id = iter.next().getId();
         if (!validator.apply(id)) {
           invalidBlocks.add(id);

--- a/core/server/master/src/main/java/alluxio/master/metastore/BlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/BlockStore.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.metastore;
 
-import alluxio.master.metastore.BlockStore.Block;
 import alluxio.proto.meta.Block.BlockLocation;
 import alluxio.proto.meta.Block.BlockMeta;
 import alluxio.resource.CloseableIterator;
@@ -88,6 +87,25 @@ public interface BlockStore {
    */
   long size();
 
+  /**
+   * Gets a {@link CloseableIterator} over the blocks.
+   * The iterator must be closed properly.
+   * One option is to follow the below idiom:
+   * <pre>{@code
+   *   try (CloseableIterator<Block> iter =
+   *       mBlockStore.getCloseableIterator()) {
+   *     for (; iter.hasNext(); ) {
+   *       // take the element and perform operations
+   *     }
+   *   }
+   * }</pre>
+   *
+   * If the iterator must be passed to other methods,
+   * it must be closed at the end of operation or on exceptions.
+   * Otherwise there can be a leak!
+   *
+   * @return a {@link CloseableIterator} over the blocks
+   * */
   CloseableIterator<Block> getCloseableIterator();
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/metastore/BlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/BlockStore.java
@@ -94,7 +94,7 @@ public interface BlockStore {
    * <pre>{@code
    *   try (CloseableIterator<Block> iter =
    *       mBlockStore.getCloseableIterator()) {
-   *     for (; iter.hasNext(); ) {
+   *     while (iter.hasNext()) {
    *       // take the element and perform operations
    *     }
    *   }

--- a/core/server/master/src/main/java/alluxio/master/metastore/BlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/BlockStore.java
@@ -14,6 +14,7 @@ package alluxio.master.metastore;
 import alluxio.master.metastore.BlockStore.Block;
 import alluxio.proto.meta.Block.BlockLocation;
 import alluxio.proto.meta.Block.BlockMeta;
+import alluxio.resource.CloseableIterator;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,7 +25,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * The block store keeps track of block sizes and block locations.
  */
 @ThreadSafe
-public interface BlockStore extends Iterable<Block> {
+public interface BlockStore {
   /**
    * @param id a block id
    * @return the block's metadata, or empty if the block does not exist
@@ -86,6 +87,8 @@ public interface BlockStore extends Iterable<Block> {
    * @return size of the block store
    */
   long size();
+
+  CloseableIterator<Block> getCloseableIterator();
 
   /**
    * Block metadata.

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapBlockStore.java
@@ -19,6 +19,7 @@ import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.proto.meta.Block.BlockLocation;
 import alluxio.proto.meta.Block.BlockMeta;
+import alluxio.resource.CloseableIterator;
 import alluxio.util.ObjectSizeCalculator;
 
 import com.google.common.collect.ImmutableSet;
@@ -75,9 +76,9 @@ public class HeapBlockStore implements BlockStore {
   }
 
   @Override
-  public Iterator<Block> iterator() {
+  public CloseableIterator<Block> getCloseableIterator() {
     Iterator<Entry<Long, BlockMeta>> it = mBlocks.entrySet().iterator();
-    return new Iterator<Block>() {
+    return CloseableIterator.noopCloseable(new Iterator<Block>() {
       @Override
       public boolean hasNext() {
         return it.hasNext();
@@ -88,7 +89,7 @@ public class HeapBlockStore implements BlockStore {
         Entry<Long, BlockMeta> entry = it.next();
         return new Block(entry.getKey(), entry.getValue());
       }
-    };
+    });
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -16,6 +16,7 @@ import alluxio.conf.ServerConfiguration;
 import alluxio.master.metastore.BlockStore;
 import alluxio.proto.meta.Block.BlockLocation;
 import alluxio.proto.meta.Block.BlockMeta;
+import alluxio.resource.CloseableIterator;
 import alluxio.util.io.FileUtils;
 import alluxio.util.io.PathUtils;
 
@@ -214,7 +215,7 @@ public class RocksBlockStore implements BlockStore {
   }
 
   @Override
-  public Iterator<Block> iterator() {
+  public CloseableIterator<Block> getCloseableIterator() {
     RocksIterator iterator = db().newIterator(mBlockMetaColumn.get(), mIteratorOption);
     return RocksUtils.createCloseableIterator(iterator,
         (iter) -> new Block(Longs.fromByteArray(iter.key()), BlockMeta.parseFrom(iter.value())));

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;

--- a/core/server/master/src/test/java/alluxio/master/BackupManagerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/BackupManagerTest.java
@@ -120,7 +120,7 @@ public class BackupManagerTest {
     CloseableIterator<BlockStore.Block> testBlockIter =
         CloseableIterator.create(blocks.iterator(), (whatever) -> blockIteratorClosed.set(true));
     RocksBlockStore mockBlockStore = mock(RocksBlockStore.class);
-    when(mockBlockStore.iterator()).thenReturn(testBlockIter);
+    when(mockBlockStore.getCloseableIterator()).thenReturn(testBlockIter);
 
     // Prepare the BlockMaster for the backup operation
     CoreMasterContext masterContext = MasterTestUtils.testMasterContext(

--- a/core/server/master/src/test/java/alluxio/master/metastore/BlockStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/BlockStoreTest.java
@@ -19,6 +19,7 @@ import alluxio.master.metastore.heap.HeapBlockStore;
 import alluxio.master.metastore.rocks.RocksBlockStore;
 import alluxio.proto.meta.Block;
 
+import alluxio.resource.CloseableIterator;
 import com.google.common.io.Files;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,14 +64,15 @@ public class BlockStoreTest {
       mBlockStore.putBlock(i, Block.BlockMeta.newBuilder().setLength(i).build());
     }
 
-    Iterator<BlockStore.Block> iter = mBlockStore.iterator();
-    for (int i = 0; i < blockCount; i++) {
-      assertTrue(iter.hasNext());
-      BlockStore.Block block = iter.next();
-      assertEquals(i, block.getId());
-      assertEquals(i, block.getMeta().getLength());
+    try (CloseableIterator<BlockStore.Block> iter = mBlockStore.getCloseableIterator()) {
+      for (int i = 0; i < blockCount; i++) {
+        assertTrue(iter.hasNext());
+        BlockStore.Block block = iter.next();
+        assertEquals(i, block.getId());
+        assertEquals(i, block.getMeta().getLength());
+      }
+      assertFalse(iter.hasNext());
     }
-    assertFalse(iter.hasNext());
     mBlockStore.clear();
   }
 

--- a/core/server/master/src/test/java/alluxio/master/metastore/BlockStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/BlockStoreTest.java
@@ -18,8 +18,8 @@ import static org.junit.Assert.assertTrue;
 import alluxio.master.metastore.heap.HeapBlockStore;
 import alluxio.master.metastore.rocks.RocksBlockStore;
 import alluxio.proto.meta.Block;
-
 import alluxio.resource.CloseableIterator;
+
 import com.google.common.io.Files;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,7 +27,6 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 @RunWith(Parameterized.class)


### PR DESCRIPTION
### What changes are proposed in this pull request?

For all callers of BlockStore iterators, force them to get a CloseableIterator and use try-with-resource pattern.

### Why are the changes needed?

Even after https://github.com/Alluxio/alluxio/pull/14964/files, there are still operation that directly iterate the BlockStore without using the CloseableIterator and try-with-resource pattern. This change is to address newly found ones.

The root cause is `BlockStore extends Iterable` which gives `Iterator` to callers. Callers are not aware that the iterators are essentially `CloseableIterator` and do not close them. It's not easy to close either, the caller must first do a checked cast to `CloseableIterator`, and the whole process just does not support try-with-resource pattern.

So this change totally removed interface of `Iterator<Block> iterator()` and provides a replacement `CloseableIterator<Block> getCloseableIterator()`, so the callers can directly use try-with-resource pattern.

### Does this PR introduce any user facing changes?

NA