### PR TITLE
Add additional logging to log linkage errors

### DIFF
--- a/core/server/common/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/common/src/main/java/alluxio/RpcUtils.java
@@ -145,6 +145,8 @@ public final class RpcUtils {
       }
       throw AlluxioStatusException.fromIOException(e).toGrpcStatusException();
     } catch (RuntimeException | LinkageError e) {
+      // Linkage error can happen when ufs libraries are improperly included or classloaded,
+      // right now those simply fail silently.
       logger.error("Exit (Error): {}: {}", methodName,
           String.format(description, processObjects(logger, args)), e);
       MetricsSystem.counter(getQualifiedFailureMetricName(methodName)).inc();

--- a/core/server/common/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/common/src/main/java/alluxio/RpcUtils.java
@@ -144,7 +144,7 @@ public final class RpcUtils {
         }
       }
       throw AlluxioStatusException.fromIOException(e).toGrpcStatusException();
-    } catch (RuntimeException e) {
+    } catch (RuntimeException | LinkageError e) {
       logger.error("Exit (Error): {}: {}", methodName,
           String.format(description, processObjects(logger, args)), e);
       MetricsSystem.counter(getQualifiedFailureMetricName(methodName)).inc();


### PR DESCRIPTION
### What changes are proposed in this pull request?
Log linkage errors in GRPC calls

### Why are the changes needed?

These errors get masked otherwise. This surfaces them.
