### PR TITLE
Support RocksDB inode/block store to different disk paths

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2342,14 +2342,20 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey MASTER_METASTORE_DIR_INODE =
       stringBuilder(Name.MASTER_METASTORE_DIR_INODE)
           .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
-          .setDescription("If the metastore is ROCKS, this property controls where the RocksDB stores inode metadata. This property defaults to " + Name.MASTER_METASTORE_DIR + ". And it can be used to change inode metadata storage path to a different disk to improve RocksDB performance.")
+          .setDescription("If the metastore is ROCKS, this property controls where the RocksDB "
+              + "stores inode metadata. This property defaults to " + Name.MASTER_METASTORE_DIR
+              + ". And it can be used to change inode metadata storage path to a different disk "
+              + "to improve RocksDB performance.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_METASTORE_DIR_BLOCK =
       stringBuilder(Name.MASTER_METASTORE_DIR_BLOCK)
           .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
-          .setDescription("If the metastore is ROCKS, this property controls where the RocksDB stores block metadata. This property defaults to " + Name.MASTER_METASTORE_DIR + ". And it can be used to change block metadata storage path to a different disk to improve RocksDB performance.")
+          .setDescription("If the metastore is ROCKS, this property controls where the RocksDB "
+              + "stores block metadata. This property defaults to " + Name.MASTER_METASTORE_DIR
+              + ". And it can be used to change block metadata storage path to a different disk "
+              + "to improve RocksDB performance.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2364,6 +2364,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
         .setScope(Scope.MASTER)
         .build();
+  public static final PropertyKey MASTER_METASTORE_BLOCK_STORE_DIR =
+      stringBuilder(Name.MASTER_METASTORE_BLOCK_STORE_DIR)
+        .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
+        .setDescription("The block store metastore work directory. "
+            + "Only some metastores need disk.")
+        .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+        .setScope(Scope.MASTER)
+        .build();
   public static final PropertyKey MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE =
       intBuilder(Name.MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE)
           // TODO(andrew): benchmark different batch sizes to improve the default and provide a
@@ -7567,6 +7575,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metastore.rocks.parallel.backup.compression.level";
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_THREADS =
         "alluxio.master.metastore.rocks.parallel.backup.threads";
+    public static final String MASTER_METASTORE_BLOCK_STORE_DIR =
+        "alluxio.master.metastore.block.store.dir";
     public static final String MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE =
         "alluxio.master.metastore.inode.cache.evict.batch.size";
     public static final String MASTER_METASTORE_INODE_CACHE_HIGH_WATER_MARK_RATIO =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2349,8 +2349,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey MASTER_METASTORE_DIR_BLOCK =
       stringBuilder(Name.MASTER_METASTORE_DIR_BLOCK)
           .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
-          .setDescription("The block metastore work directory. "
-              + "Only some metastores need disk.")
+          .setDescription("If the metastore is ROCKS, this property controls where the RocksDB stores block metadata. This property defaults to " + Name.MASTER_METASTORE_DIR + ". And it can be used to change block metadata storage path to a different disk to improve RocksDB performance.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2342,8 +2342,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey MASTER_METASTORE_DIR_INODE =
       stringBuilder(Name.MASTER_METASTORE_DIR_INODE)
           .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
-          .setDescription("The inode metastore work directory. "
-              + "Only some metastores need disk.")
+          .setDescription("If the metastore is ROCKS, this property controls where the RocksDB stores inode metadata. This property defaults to " + Name.MASTER_METASTORE_DIR + ". And it can be used to change inode metadata storage path to a different disk to improve RocksDB performance.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2339,6 +2339,22 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_METASTORE_DIR_INODE =
+      stringBuilder(Name.MASTER_METASTORE_DIR_INODE)
+          .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
+          .setDescription("The inode metastore work directory. "
+              + "Only some metastores need disk.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_METASTORE_DIR_BLOCK =
+      stringBuilder(Name.MASTER_METASTORE_DIR_BLOCK)
+          .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
+          .setDescription("The block metastore work directory. "
+              + "Only some metastores need disk.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_METASTORE_ROCKS_PARALLEL_BACKUP =
       booleanBuilder(Name.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP)
         .setDefaultValue(false)
@@ -2361,14 +2377,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
             Math.max(1, Runtime.getRuntime().availableProcessors() / 2)),
             "The default number of threads used by backing up rocksdb in parallel.")
         .setDescription("The number of threads used by backing up rocksdb in parallel.")
-        .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-        .setScope(Scope.MASTER)
-        .build();
-  public static final PropertyKey MASTER_METASTORE_BLOCK_STORE_DIR =
-      stringBuilder(Name.MASTER_METASTORE_BLOCK_STORE_DIR)
-        .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
-        .setDescription("The block store metastore work directory. "
-            + "Only some metastores need disk.")
         .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
         .setScope(Scope.MASTER)
         .build();
@@ -7569,14 +7577,16 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_METASTORE_INODE = "alluxio.master.metastore.inode";
     public static final String MASTER_METASTORE_BLOCK = "alluxio.master.metastore.block";
     public static final String MASTER_METASTORE_DIR = "alluxio.master.metastore.dir";
+    public static final String MASTER_METASTORE_DIR_INODE =
+        "alluxio.master.metastore.dir.block";
+    public static final String MASTER_METASTORE_DIR_BLOCK =
+        "alluxio.master.metastore.dir.block";
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP =
         "alluxio.master.metastore.rocks.parallel.backup";
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_COMPRESSION_LEVEL =
         "alluxio.master.metastore.rocks.parallel.backup.compression.level";
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_THREADS =
         "alluxio.master.metastore.rocks.parallel.backup.threads";
-    public static final String MASTER_METASTORE_BLOCK_STORE_DIR =
-        "alluxio.master.metastore.block.store.dir";
     public static final String MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE =
         "alluxio.master.metastore.inode.cache.evict.batch.size";
     public static final String MASTER_METASTORE_INODE_CACHE_HIGH_WATER_MARK_RATIO =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -7582,7 +7582,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_METASTORE_BLOCK = "alluxio.master.metastore.block";
     public static final String MASTER_METASTORE_DIR = "alluxio.master.metastore.dir";
     public static final String MASTER_METASTORE_DIR_INODE =
-        "alluxio.master.metastore.dir.block";
+        "alluxio.master.metastore.dir.inode";
     public static final String MASTER_METASTORE_DIR_BLOCK =
         "alluxio.master.metastore.dir.block";
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP =

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -119,11 +119,13 @@ public class AlluxioMasterProcess extends MasterProcess {
     }
     // Create masters.
     String baseDir = Configuration.getString(PropertyKey.MASTER_METASTORE_DIR);
+    String blockStoreBaseDir =
+        Configuration.getString(PropertyKey.MASTER_METASTORE_BLOCK_STORE_DIR);
     mContext = CoreMasterContext.newBuilder()
         .setJournalSystem(mJournalSystem)
         .setSafeModeManager(mSafeModeManager)
         .setBackupManager(mBackupManager)
-        .setBlockStoreFactory(MasterUtils.getBlockStoreFactory(baseDir))
+        .setBlockStoreFactory(MasterUtils.getBlockStoreFactory(blockStoreBaseDir))
         .setInodeStoreFactory(MasterUtils.getInodeStoreFactory(baseDir))
         .setStartTimeMs(mStartTimeMs)
         .setPort(NetworkAddressUtils

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -118,15 +118,14 @@ public class AlluxioMasterProcess extends MasterProcess {
           String.format("Journal %s has not been formatted!", mJournalSystem));
     }
     // Create masters.
-    String baseDir = Configuration.getString(PropertyKey.MASTER_METASTORE_DIR);
-    String blockStoreBaseDir =
-        Configuration.getString(PropertyKey.MASTER_METASTORE_BLOCK_STORE_DIR);
+    String inodeStoreBaseDir = Configuration.getString(PropertyKey.MASTER_METASTORE_DIR_INODE);
+    String blockStoreBaseDir = Configuration.getString(PropertyKey.MASTER_METASTORE_DIR_BLOCK);
     mContext = CoreMasterContext.newBuilder()
         .setJournalSystem(mJournalSystem)
         .setSafeModeManager(mSafeModeManager)
         .setBackupManager(mBackupManager)
         .setBlockStoreFactory(MasterUtils.getBlockStoreFactory(blockStoreBaseDir))
-        .setInodeStoreFactory(MasterUtils.getInodeStoreFactory(baseDir))
+        .setInodeStoreFactory(MasterUtils.getInodeStoreFactory(inodeStoreBaseDir))
         .setStartTimeMs(mStartTimeMs)
         .setPort(NetworkAddressUtils
             .getPort(ServiceType.MASTER_RPC, Configuration.global()))


### PR DESCRIPTION
### What changes are proposed in this pull request?

With this PR, we can configure block store and inode store into different disk, so that the performance can be improved leverage this PR.

### Does this PR introduce any user facing changes?

Add a new propertykey `alluxio.master.metastore.block.store.dir` which default to be same with `alluxio.master.metastore.dir`