### PR TITLE
[SMALLFIX] Change the default base directory path of StressBench

### DIFF
--- a/stress/common/src/main/java/alluxio/stress/client/ClientIOParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/client/ClientIOParameters.java
@@ -49,7 +49,7 @@ public final class ClientIOParameters extends FileSystemParameters {
   @Parameter(names = {"--base"},
       description = "The base directory path URI to perform operations in")
   @Parameters.PathDescription(aliasFieldName = "mBaseAlias")
-  public String mBasePath = "alluxio://localhost:19998/stress-client-io-base";
+  public String mBasePath = "alluxio:///stress-client-io-base";
 
   @Parameter(names = {"--base-alias"}, description = "The alias for the base path, unused if empty")
   @Parameters.KeylessDescription

--- a/stress/common/src/main/java/alluxio/stress/jobservice/JobServiceBenchParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/jobservice/JobServiceBenchParameters.java
@@ -35,7 +35,7 @@ public final class JobServiceBenchParameters extends GeneralParameters {
 
   @Parameter(names = {"--base"},
       description = "The base directory path URI to perform operations in")
-  public String mBasePath = "alluxio://localhost:19998/stress-job-service-base";
+  public String mBasePath = "alluxio:///stress-job-service-base";
 
   @Parameter(names = {"--file-size"},
       description = "The size of a file for the Create op, allowed to be 0. (0, 1m, 2k, 8k, etc.)")

--- a/stress/common/src/main/java/alluxio/stress/master/MasterBenchParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/master/MasterBenchParameters.java
@@ -49,7 +49,7 @@ public final class MasterBenchParameters extends FileSystemParameters {
   @Parameter(names = {"--base"},
       description = "The base directory path URI to perform operations in")
   @Parameters.PathDescription(aliasFieldName = "mBaseAlias")
-  public String mBasePath = "alluxio://localhost:19998/stress-master-base";
+  public String mBasePath = "alluxio:///stress-master-base";
 
   @Parameter(names = {"--base-alias"}, description = "The alias for the base path, unused if empty")
   @Parameters.KeylessDescription

--- a/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
@@ -28,7 +28,7 @@ public final class WorkerBenchParameters extends FileSystemParameters {
   @Parameter(names = {"--base"},
       description = "The base directory path URI to perform operations in")
   @Parameters.PathDescription(aliasFieldName = "mBaseAlias")
-  public String mBasePath = "alluxio://localhost:19998/stress-worker-base";
+  public String mBasePath = "alluxio:///stress-worker-base";
 
   @Parameter(names = {"--base-alias"}, description = "The alias for the base path, unused if empty")
   @Parameters.KeylessDescription


### PR DESCRIPTION
### What changes are proposed in this pull request?

I changed the default baes directory of StressBench from "alluxio://localhost:19998/" into "alluxio:///" .

### Why are the changes needed?

The former default base directory is localhost:19998, but we may not use the port 19998 in some case. So the directory "alluxio:///" is more reasonable.

### Does this PR introduce any user facing changes?

The default base directory is changed, but the user don't need care of this since the former directory is included in the new directory
