### PR TITLE
Install libfuse3 separately in two docker images

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN if [ ${ENABLE_DYNAMIC_USER} = "true" ] ; then \
 
 ADD dockerfile-common.sh /
 
-# The following libfuse setup is modified from cheyang/fuse2:ubuntu1604-customize to be applied on alpine
+# Install libfuse2 and libfuse3. Libfuse2 setup is modified from cheyang/fuse2:ubuntu1604-customize to be applied on alpine
 WORKDIR /
 
 ENV MAX_IDLE_THREADS "64"
@@ -49,8 +49,9 @@ RUN \
   apk add --no-cache ca-certificates wget bash && \
   apk add --no-cache --virtual .build-deps \
   build-base pkgconfig eudev git gcc make cmake gettext-dev libtool autoconf automake && \
-  ./dockerfile-common.sh install-libfuse && \
+  ./dockerfile-common.sh install-libfuse2 && \
   rm -rf libfuse && \
+  apk add fuse3=3.2.6-r1 && \
   apk del --no-cache .build-deps
 
 ENV LD_LIBRARY_PATH "/usr/local/lib:${LD_LIBRARY_PATH}"

--- a/integration/docker/Dockerfile-dev
+++ b/integration/docker/Dockerfile-dev
@@ -39,7 +39,7 @@ RUN if [ ${ENABLE_DYNAMIC_USER} = "true" ] ; then \
 
 ADD dockerfile-common.sh /
 
-# The following libfuse setup is modified from cheyang/fuse2:ubuntu1604-customize to be applied on centOS
+# Install libfuse2 and libfuse3. Libfuse2 setup is modified from cheyang/fuse2:ubuntu1604-customize to be applied on centOS
 WORKDIR /
 
 ENV MAX_IDLE_THREADS "64"
@@ -49,7 +49,8 @@ RUN \
     yum install -y ca-certificates pkgconfig wget udev git && \
     yum install -y gcc gcc-c++ make cmake gettext-devel libtool autoconf && \
     yum clean all && \
-    ./dockerfile-common.sh install-libfuse
+    ./dockerfile-common.sh install-libfuse2 && \
+    yum install -y fuse3-libs
 
 ENV LD_LIBRARY_PATH "/usr/local/lib:${LD_LIBRARY_PATH}"
 

--- a/integration/docker/dockerfile-common.sh
+++ b/integration/docker/dockerfile-common.sh
@@ -13,11 +13,11 @@
 # Shared chunk of commands used both in Dockerfile and Dockerfile-dev.
 
 #######################################
-# Install libfuse with MAX_IDLE_THREAD able to be configured and libfuse3.
+# Install libfuse with MAX_IDLE_THREAD able to be configured.
 # Arguments:
 #   None
 #######################################
-function installLibfuse {
+function installLibfuse2 {
   # libfuse2
   git clone https://github.com/Alluxio/libfuse.git
   cd libfuse
@@ -27,10 +27,6 @@ function installLibfuse {
   make -j8
   make install
   cd ..
-
-  # libfuse3
-  apk add fuse3=3.2.6-r1
-
 }
 
 #######################################
@@ -99,8 +95,8 @@ function main {
   command=$1
   shift
   case $command in
-    "install-libfuse")
-      installLibfuse 
+    "install-libfuse2")
+      installLibfuse2
       ;;
     "user-operation")
       userOperation "$@"


### PR DESCRIPTION
Dockerfile-dev uses CentOS and uses `yum` to install packages. Dockerfile uses Alpine and uses `apk` to install packages. Using `apk add` to install libfuse3 in Dockerfile-dev will break the build.