### PR TITLE
Fix BlockMasterRegisterStreamIntegrationTest

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -37,6 +37,7 @@ import alluxio.wire.WorkerNetAddress;
 import com.google.common.annotations.VisibleForTesting;
 
 import java.util.Collection;
+import java.time.Clock;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -334,4 +335,12 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
    * @param context the stream context to be closed
    */
   void workerRegisterFinish(WorkerRegisterContext context);
+
+  /**
+   * Returns the BlockMaster's clock so other components can align with
+   * the BlockMaster's time.
+   *
+   * @return the current clock
+   */
+  Clock getClock();
 }

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -108,6 +108,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -431,28 +432,36 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
     @Override
     public void heartbeat() {
+      AtomicInteger removedSessions = new AtomicInteger(0);
       mActiveRegisterContexts.entrySet().removeIf((entry) -> {
         WorkerRegisterContext context = entry.getValue();
-        final long lastUpdate = mClock.millis() - context.getLastActivityTimeMs();
-        if (lastUpdate < mTimeout) {
+        final long clockTime = mClock.millis();
+        final long lastActivityTime = context.getLastActivityTimeMs();
+        final long staleTime = clockTime - lastActivityTime;
+        if (staleTime < mTimeout) {
           return false;
         }
         String msg = String.format(
-            "Worker register stream hanging for more than %sms for worker %d!"
+            "ClockTime: %d, LastActivityTime: %d. Worker %d register stream hanging for %sms!"
                 + " Tune up %s if this is undesired.",
-            mTimeout, context.mWorker.getId(),
-            PropertyKey.MASTER_WORKER_REGISTER_STREAM_RESPONSE_TIMEOUT.toString());
+            clockTime, lastActivityTime, context.mWorker.getId(), staleTime,
+            PropertyKey.MASTER_WORKER_REGISTER_STREAM_RESPONSE_TIMEOUT);
         Exception e = new TimeoutException(msg);
         try {
           context.closeWithError(e);
         } catch (Throwable t) {
+          t.addSuppressed(e);
           LOG.error("Failed to close an open register stream for worker {}. "
-              + "The stream has been open for {}ms.", context.getWorkerId(), lastUpdate, t);
+              + "The stream has been open for {}ms.", context.getWorkerId(), staleTime, t);
           // Do not remove the entry so this will be retried
           return false;
         }
+        removedSessions.getAndDecrement();
         return true;
       });
+      if (removedSessions.get() > 0) {
+        LOG.info("Removed {} stale worker registration streams", removedSessions.get());
+      }
     }
 
     @Override
@@ -1240,6 +1249,11 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     Preconditions.checkNotNull(workerCommand, "Worker heartbeat response command is null!");
 
     return workerCommand;
+  }
+
+  @Override
+  public Clock getClock() {
+    return mClock;
   }
 
   private void processWorkerMetrics(String hostname, List<Metric> metrics) {

--- a/core/server/master/src/main/java/alluxio/master/block/WorkerRegisterContext.java
+++ b/core/server/master/src/main/java/alluxio/master/block/WorkerRegisterContext.java
@@ -21,7 +21,6 @@ import io.grpc.stub.StreamObserver;
 
 import java.io.Closeable;
 import java.time.Clock;
-import java.time.Instant;
 import java.util.EnumSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/core/server/master/src/main/java/alluxio/master/block/WorkerRegisterContext.java
+++ b/core/server/master/src/main/java/alluxio/master/block/WorkerRegisterContext.java
@@ -20,6 +20,7 @@ import alluxio.resource.LockResource;
 import io.grpc.stub.StreamObserver;
 
 import java.io.Closeable;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.EnumSet;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -37,9 +38,10 @@ public class WorkerRegisterContext implements Closeable {
    * Locks on the worker's metadata sections. The locks will be held throughout the
    * stream and will be unlocked at the end.
    */
-  private LockResource mWorkerLock;
-  private AtomicBoolean mOpen;
-  private StreamObserver<RegisterWorkerPRequest> mWorkerRequestObserver;
+  private final LockResource mWorkerLock;
+  private final AtomicBoolean mOpen;
+  private final StreamObserver<RegisterWorkerPRequest> mWorkerRequestObserver;
+  private final Clock mClock;
 
   /**
    * Keeps track of the last activity time on this stream.
@@ -50,7 +52,8 @@ public class WorkerRegisterContext implements Closeable {
 
   private WorkerRegisterContext(
       MasterWorkerInfo info,
-      StreamObserver<RegisterWorkerPRequest> workerRequestObserver) {
+      StreamObserver<RegisterWorkerPRequest> workerRequestObserver,
+      Clock clock) {
     mWorker = info;
     mWorkerRequestObserver = workerRequestObserver;
     mWorkerLock = info.lockWorkerMeta(EnumSet.of(
@@ -58,6 +61,8 @@ public class WorkerRegisterContext implements Closeable {
         WorkerMetaLockSection.USAGE,
         WorkerMetaLockSection.BLOCKS), false);
     mOpen = new AtomicBoolean(true);
+    mClock = clock;
+    mLastActivityTimeMs = mClock.millis();
   }
 
   /**
@@ -81,7 +86,7 @@ public class WorkerRegisterContext implements Closeable {
   }
 
   void updateTs() {
-    mLastActivityTimeMs = Instant.now().toEpochMilli();
+    mLastActivityTimeMs = mClock.millis();
   }
 
   long getLastActivityTimeMs() {
@@ -115,6 +120,6 @@ public class WorkerRegisterContext implements Closeable {
       BlockMaster blockMaster, long workerId,
       StreamObserver<RegisterWorkerPRequest> workerRequestObserver) throws NotFoundException {
     MasterWorkerInfo info = blockMaster.getWorker(workerId);
-    return new WorkerRegisterContext(info, workerRequestObserver);
+    return new WorkerRegisterContext(info, workerRequestObserver, blockMaster.getClock());
   }
 }

--- a/tests/src/test/java/alluxio/client/fs/BlockMasterRegisterStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/BlockMasterRegisterStreamIntegrationTest.java
@@ -857,7 +857,7 @@ public class BlockMasterRegisterStreamIntegrationTest {
     sendStreamToMaster(requestChunks,
         RegisterStreamTestUtils.getErrorCapturingResponseObserver(errorQueue));
 
-    assertEquals(0, errorQueue.size());
+    assertEquals(errorQueue.toString(), 0, errorQueue.size());
     MasterWorkerInfo worker = mBlockMaster.getWorker(workerId);
     assertEquals(expectedBlockCount, worker.getBlockCount());
     assertEquals(0, worker.getToRemoveBlockCount());


### PR DESCRIPTION
### What changes are proposed in this pull request?

The `WorkerRegisterContext` should have the same clock from the BlockMaster. 

### Why are the changes needed?

This change fixes the flaky test `BlockMasterRegisterStreamIntegrationTest.hangingWorkerSessionRecycled()`.

The only change in behavior is now in the tests, the `WorkerRegisterContext` will have the same manually controlled clock as other tests, so the behavior is correctly validated by tests. Before this change, `WorkerRegisterContext` relies on the system clock, which defeats all clock-based test logics.

In real use cases all classes use the JVM internal system clock so there's no behavior change at all.

### Does this PR introduce any user facing changes?

NA
