### PR TITLE
Fix the StressBench summary bug

### DIFF
--- a/stress/common/src/main/java/alluxio/stress/jobservice/JobServiceBenchTaskResult.java
+++ b/stress/common/src/main/java/alluxio/stress/jobservice/JobServiceBenchTaskResult.java
@@ -13,6 +13,7 @@ package alluxio.stress.jobservice;
 
 import alluxio.stress.BaseParameters;
 import alluxio.stress.TaskResult;
+import alluxio.util.JsonSerializable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -240,7 +241,8 @@ public final class JobServiceBenchTaskResult implements TaskResult {
         nodes.put(result.getBaseParameters().mId, result);
 
         if (mergingTaskResult == null) {
-          mergingTaskResult = result;
+          String jsonResult = result.toJson();
+          mergingTaskResult = (JobServiceBenchTaskResult) JsonSerializable.fromJson(jsonResult);
           continue;
         }
         mergingTaskResult.aggregateByWorker(result);

--- a/stress/common/src/main/java/alluxio/stress/master/MasterBenchTaskResult.java
+++ b/stress/common/src/main/java/alluxio/stress/master/MasterBenchTaskResult.java
@@ -13,6 +13,7 @@ package alluxio.stress.master;
 
 import alluxio.stress.BaseParameters;
 import alluxio.stress.TaskResult;
+import alluxio.util.JsonSerializable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -258,7 +259,9 @@ public final class MasterBenchTaskResult implements TaskResult {
         nodes.put(result.getBaseParameters().mId, result);
 
         if (mergingTaskResult == null) {
-          mergingTaskResult = result;
+          // make a deep copy from the first task result
+          String jsonResult = result.toJson();
+          mergingTaskResult = (MasterBenchTaskResult) JsonSerializable.fromJson(jsonResult);
           continue;
         }
         mergingTaskResult.aggregateByWorker(result);


### PR DESCRIPTION
### What changes are proposed in this pull request?

This change aim to solve the bug in the StressMasterBench and StressJobServiceBench. The outputs of these bench contain task information about all nodes, but the first node's information is an aggregated information which contains information about other nodes. Now the output will correctly output the information about all nodes.

### Why are the changes needed?

The StressMasterBench and StressJobServiceBench will now correctly output the result information about all nodes.

### Does this PR introduce any user facing changes?

There is no changes.
