### PR TITLE
Replace PowerMock with Mockito in LogLevelTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -877,6 +877,13 @@
       <groupId>com.thoughtworks.xstream</groupId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <!-- version needs to be >= 3.4.0 -->
+      <version>3.5.13</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -818,11 +818,6 @@
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -846,6 +841,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
     <log4j.version>2.17.1</log4j.version>
     <maven.version>3.3.9</maven.version>
     <metrics.version>4.1.11</metrics.version>
+    <mockito.version>3.5.13</mockito.version>
     <orc.version>1.6.3</orc.version>
     <oshi.version>5.3.5</oshi.version>
     <powermock.version>2.0.7</powermock.version>
@@ -837,6 +838,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <!-- version needs to be >= 3.4.0 -->
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito2</artifactId>
       <scope>test</scope>
@@ -875,13 +883,6 @@
     <dependency>
       <artifactId>xstream</artifactId>
       <groupId>com.thoughtworks.xstream</groupId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <!-- version needs to be >= 3.4.0 -->
-      <version>3.5.13</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -844,11 +844,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito2</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <log4j.version>2.17.1</log4j.version>
     <maven.version>3.3.9</maven.version>
     <metrics.version>4.1.11</metrics.version>
-    <mockito.version>3.5.13</mockito.version>
+    <mockito.version>3.4.4</mockito.version>
     <orc.version>1.6.3</orc.version>
     <oshi.version>5.3.5</oshi.version>
     <powermock.version>2.0.7</powermock.version>
@@ -747,7 +747,13 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>3.4.4</version>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
+        <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -835,13 +841,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <!-- version needs to be >= 3.4.0 -->
-      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -814,12 +814,17 @@
       <artifactId>log4j-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <!-- Dependencies in the test scope. -->

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -98,5 +98,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>3.4.4</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -101,7 +101,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>3.4.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -98,5 +98,12 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <!-- version needs to be >= 3.4.0 -->
+      <version>3.5.13</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -98,12 +98,5 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <!-- version needs to be >= 3.4.0 -->
-      <version>3.5.13</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/shell/src/test/java/alluxio/cli/LogLevelTest.java
+++ b/shell/src/test/java/alluxio/cli/LogLevelTest.java
@@ -26,7 +26,6 @@ import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.job.wire.JobWorkerHealth;
 import alluxio.master.MasterInquireClient;
-
 import alluxio.uri.MultiMasterAuthority;
 import alluxio.uri.ZookeeperAuthority;
 import alluxio.wire.WorkerNetAddress;
@@ -35,6 +34,7 @@ import org.apache.commons.cli.CommandLine;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.List;
 
 public class LogLevelTest {
+
   // Configure the web port to use special numbers to make sure the config is taking effect
   private static final int MASTER_WEB_PORT = 45699;
   private static final int WORKER_WEB_PORT = 50099;
@@ -102,7 +103,8 @@ public class LogLevelTest {
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
     when(mockCommandLine.hasOption(LogLevel.TARGET_OPTION_NAME)).thenReturn(true);
     when(mockCommandLine.getOptionValue(LogLevel.TARGET_OPTION_NAME)).thenReturn(mockArgs[1]);
-    try (MockedStatic<MasterInquireClient.Factory> mockFactory = mockStatic(MasterInquireClient.Factory.class)) {
+    try (MockedStatic<MasterInquireClient.Factory> mockFactory =
+        mockStatic(MasterInquireClient.Factory.class)) {
       MasterInquireClient mockInquireClient = mock(MasterInquireClient.class);
       when(mockInquireClient.getPrimaryRpcAddress()).thenReturn(
           new InetSocketAddress("masters-1", mConf.getInt(PropertyKey.MASTER_RPC_PORT)));
@@ -128,7 +130,8 @@ public class LogLevelTest {
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
     when(mockCommandLine.hasOption(LogLevel.TARGET_OPTION_NAME)).thenReturn(true);
     when(mockCommandLine.getOptionValue(LogLevel.TARGET_OPTION_NAME)).thenReturn(mockArgs[1]);
-    try (MockedStatic<MasterInquireClient.Factory> mockFactory = mockStatic(MasterInquireClient.Factory.class)) {
+    try (MockedStatic<MasterInquireClient.Factory> mockFactory =
+        mockStatic(MasterInquireClient.Factory.class)) {
       MasterInquireClient mockInquireClient = mock(MasterInquireClient.class);
       when(mockInquireClient.getPrimaryRpcAddress()).thenReturn(new InetSocketAddress("masters-1",
           mConf.getInt(PropertyKey.MASTER_RPC_PORT)));
@@ -153,7 +156,8 @@ public class LogLevelTest {
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
     when(mockCommandLine.hasOption(LogLevel.TARGET_OPTION_NAME)).thenReturn(true);
     when(mockCommandLine.getOptionValue(LogLevel.TARGET_OPTION_NAME)).thenReturn(mockArgs[1]);
-    try (MockedStatic<JobMasterClient.Factory> mockFactory = mockStatic(JobMasterClient.Factory.class)) {
+    try (MockedStatic<JobMasterClient.Factory> mockFactory =
+        mockStatic(JobMasterClient.Factory.class)) {
       JobMasterClient mockJobClient = mock(JobMasterClient.class);
       when(mockJobClient.getAddress()).thenReturn(new InetSocketAddress("masters-2",
           mConf.getInt(PropertyKey.JOB_MASTER_RPC_PORT)));
@@ -175,7 +179,8 @@ public class LogLevelTest {
     when(mockCommandLine.getArgs()).thenReturn(mockArgs);
     when(mockCommandLine.hasOption(LogLevel.TARGET_OPTION_NAME)).thenReturn(true);
     when(mockCommandLine.getOptionValue(LogLevel.TARGET_OPTION_NAME)).thenReturn(mockArgs[1]);
-    try (MockedStatic<JobMasterClient.Factory> mockFactory = mockStatic(JobMasterClient.Factory.class)) {
+    try (MockedStatic<JobMasterClient.Factory> mockFactory =
+        mockStatic(JobMasterClient.Factory.class)) {
       JobMasterClient mockJobClient = mock(JobMasterClient.class);
       when(mockJobClient.getAddress()).thenReturn(new InetSocketAddress("masters-2",
           mConf.getInt(PropertyKey.JOB_MASTER_RPC_PORT)));
@@ -228,7 +233,8 @@ public class LogLevelTest {
     List<JobWorkerHealth> jobWorkers = new ArrayList<>();
     jobWorkers.add(new JobWorkerHealth(0, new ArrayList<>(), 10, 0, 0, "workers-1"));
     jobWorkers.add(new JobWorkerHealth(1, new ArrayList<>(), 10, 0, 0, "workers-2"));
-    try (MockedStatic<JobMasterClient.Factory> mockFactory = mockStatic(JobMasterClient.Factory.class)) {
+    try (MockedStatic<JobMasterClient.Factory> mockFactory =
+        mockStatic(JobMasterClient.Factory.class)) {
       JobMasterClient mockJobClient = mock(JobMasterClient.class);
       when(mockJobClient.getAllWorkerHealth()).thenReturn(jobWorkers);
       mockFactory.when(() -> JobMasterClient.Factory.create(any())).thenReturn(mockJobClient);

--- a/shell/src/test/java/alluxio/cli/LogLevelTest.java
+++ b/shell/src/test/java/alluxio/cli/LogLevelTest.java
@@ -43,7 +43,6 @@ import java.util.HashSet;
 import java.util.List;
 
 public class LogLevelTest {
-
   // Configure the web port to use special numbers to make sure the config is taking effect
   private static final int MASTER_WEB_PORT = 45699;
   private static final int WORKER_WEB_PORT = 50099;

--- a/shell/src/test/java/alluxio/cli/LogLevelTest.java
+++ b/shell/src/test/java/alluxio/cli/LogLevelTest.java
@@ -212,6 +212,7 @@ public class LogLevelTest {
       when(mockFsContext.getCachedWorkers()).thenReturn(workers);
       mockFactory.when(() -> FileSystemContext.create(any(ClientContext.class)))
           .thenReturn(mockFsContext);
+
       List<LogLevel.TargetInfo> targets = LogLevel.parseOptTarget(mockCommandLine, mConf);
       assertEquals(2, targets.size());
       assertEquals(new LogLevel.TargetInfo("workers-1", WORKER_WEB_PORT, "worker"),

--- a/shell/src/test/java/alluxio/cli/LogLevelTest.java
+++ b/shell/src/test/java/alluxio/cli/LogLevelTest.java
@@ -139,6 +139,7 @@ public class LogLevelTest {
           .thenReturn(() -> new MultiMasterAuthority(masterAddresses));
       mockFactory.when(() -> MasterInquireClient.Factory.create(any(), any()))
           .thenReturn(mockInquireClient);
+
       List<LogLevel.TargetInfo> targets = LogLevel.parseOptTarget(mockCommandLine, mConf);
       assertEquals(1, targets.size());
       assertEquals(new LogLevel.TargetInfo("masters-1", MASTER_WEB_PORT, "master"),


### PR DESCRIPTION
### What changes are proposed in this pull request?

Replace PowerMock with Mockito in LogLevelTest.

### Why are the changes needed?

Part of #15003. 

This PR intentionally limits the scope of change to a single low-impact test, so that we can first add needed dependencies and see if it works, then proceed to replace more PowerMock in other tests.

### Does this PR introduce any user facing changes?

No.

### Why not set mockito-inline in all child-projects but only apply this dependency to the `shell` project?

`powermock` is still used in other child projects. If the `mockito-inline` dependency is enabled for all child projects in root pom, because of https://github.com/powermock/powermock/issues/992, there will be conflicts between powermock and mockito-inline.

The plan is to progressively replace powermock module-by-module, then remove powermock from root pom and enable mockito-inline there.