### PR TITLE
[WIP] Add k8s Job definition for journal format

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -241,3 +241,7 @@
 0.6.36
 
 - Fix volumeMounts indentations in master statefulset
+
+0.6.37
+
+- Define Jobs and initContainers to wait for journal formatting

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.36
+version: 0.6.37
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
+++ b/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
@@ -357,3 +357,30 @@ imagePullSecrets:
   - name: {{ $name }}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Flag indicating whether or not the Alluxio Master journal format requires a k8s Job.
+Since this function returns a templated output, the boolean output is returned as
+the strings "true" and "false".
+*/}}
+{{- define "alluxio.master.needsJournalFormatJob" -}}
+{{ and .Values.journal.format.runFormat (ne .Values.journal.volumeType "emptyDir") }}
+{{- end -}}
+
+{{/*
+String suffix of the Alluxio Master journal format Job name.
+*/}}
+{{- define "alluxio.master.journalFormatJobNameSuffix" -}}
+{{- $chart := include "alluxio.chart" . -}}
+{{- printf "journal-format-job-%s-%s" $chart .Release.Name }}
+{{- end -}}
+
+{{/*
+String name of the Alluxio Master Statefulset. Its Pods will use
+this name as the prefix, with "-[0-9]+" as the suffix.
+*/}}
+{{- define "alluxio.master.statefulsetName" -}}
+{{- $fullName := include "alluxio.fullname" . -}}
+{{- printf "%s-master" $fullName }}
+{{- end -}}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/job-reader-sa.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/job-reader-sa.yaml
@@ -1,0 +1,64 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+{{- $name := include "alluxio.name" . }}
+{{- $fullName := include "alluxio.fullname" . }}
+{{- $chart := include "alluxio.chart" . }}
+{{- $namespace := .Release.Namespace }}
+{{- $needsJournalFormatJob := (eq "true" (include "alluxio.master.needsJournalFormatJob" .)) }}
+{{- $needsNewSA := not (or .Values.master.serviceAccount .Values.serviceAccount) }}
+
+{{- if $needsJournalFormatJob }}
+{{- if $needsNewSA }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: job-reader-sa
+  namespace: {{ $namespace }}
+# explicitly mount K8s API credentials (this is the default behaviour)
+automountServiceAccountToken: true
+---
+{{- end }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: job-reader-role
+  namespace: {{ $namespace }}
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: job-reader-role-binding
+  namespace: {{ $namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: job-reader-role
+subjects:
+- kind: ServiceAccount
+  {{- if $needsNewSA }}
+  name: job-reader-sa
+  {{- else if .Values.master.serviceAccount }}
+  name: {{ .Values.master.serviceAccount }}
+  {{- else }}
+  name: .Values.serviceAccount
+  {{- end }}
+  namespace: {{ $namespace }}
+{{- end }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/journal-format-job.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/journal-format-job.yaml
@@ -1,0 +1,90 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+
+{{- $name := include "alluxio.name" . }}
+{{- $fullName := include "alluxio.fullname" . }}
+{{- $chart := include "alluxio.chart" . }}
+{{- $needsJournalFormatJob := (eq "true" (include "alluxio.master.needsJournalFormatJob" .)) }}
+{{- $journalFormatJobNameSuffix := include "alluxio.master.journalFormatJobNameSuffix" . }}
+{{- $statefulsetName := include "alluxio.master.statefulsetName" . }}
+
+{{/* The following variables are defined because the "." scope is overridden in a range loop */}}
+{{- $release := .Release }}
+{{- $values  := .Values }}
+
+{{- if $needsJournalFormatJob }}
+{{- $count := int (ternary .Values.master.count 1 (eq .Values.journal.type "EMBEDDED")) }}
+{{ range $i, $e := until $count }}
+{{- $journalFormatJobName := printf "%s-%d-%s" $statefulsetName $i $journalFormatJobNameSuffix }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $journalFormatJobName }}
+  labels:
+    name: {{ $journalFormatJobName }}
+    app: {{ $name }}
+    chart: {{ $chart }}
+    release: {{ $release.Name }}
+    heritage: {{ $release.Service }}
+    role: alluxio-master
+  annotations:
+  {{- if (eq $values.journal.format.frequency "always") }}
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- else }}
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
+  ownerReferences:
+  - apiVersion: v1
+    kind: StatefulSet
+    name: {{ $statefulsetName }}
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  activeDeadlineSeconds: 30
+  # do NOT specify a 'ttlSecondsAfterFinished' because we need
+  # the job to persist in order for the master initContainers
+  # to determine that the journal has been formatted
+  template:
+    spec:
+      securityContext:
+        runAsUser: {{ $values.user }}
+        runAsGroup: {{ $values.group }}
+        fsGroup: {{ $values.fsGroup }}
+      containers:
+      - name: journal-format
+        image: {{ $values.image }}:{{ $values.imageTag }}
+        imagePullPolicy: {{ $values.imagePullPolicy }}
+        command: ["alluxio","formatJournal"]
+        env:
+          - name: ALLUXIO_MASTER_HOSTNAME
+            value: {{ $statefulsetName }}-{{ $i }}
+        envFrom:
+          - configMapRef:
+              name: {{ $fullName }}-config
+        volumeMounts:
+          {{- if (eq $values.journal.volumeType "persistentVolumeClaim") }}
+          - name: alluxio-journal
+            mountPath: {{ $values.journal.folder }}
+          {{- end }}
+      restartPolicy: Never
+      volumes:
+      {{- if (eq $values.journal.volumeType "persistentVolumeClaim") }}
+      - name: alluxio-journal
+        persistentVolumeClaim:
+          # claimName is determined by the volumeClaimTemplates in the StatefulSet
+          claimName: alluxio-journal-{{ $statefulsetName }}-{{ $i }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -22,13 +22,16 @@
 {{- $name := include "alluxio.name" . }}
 {{- $fullName := include "alluxio.fullname" . }}
 {{- $chart := include "alluxio.chart" . }}
+{{- $needsJournalFormatJob := (eq "true" (include "alluxio.master.needsJournalFormatJob" .)) }}
+{{- $journalFormatJobNameSuffix := include "alluxio.master.journalFormatJobNameSuffix" . }}
+{{- $statefulsetName := include "alluxio.master.statefulsetName" . }}
 
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ $fullName }}-master
+  name: {{ $statefulsetName }}
   labels:
-    name: {{ $fullName }}-master
+    name: {{ $statefulsetName }}
     app: {{ $name }}
     chart: {{ $chart }}
     release: {{ .Release.Name }}
@@ -39,14 +42,14 @@ spec:
     matchLabels:
       app: {{ $name }}
       role: alluxio-master
-      name: {{ $fullName }}-master
-  serviceName: {{ $fullName }}-master
+      name: {{ $statefulsetName }}
+  serviceName: {{ $statefulsetName }}
   podManagementPolicy: Parallel
   replicas: {{ $masterCount }}
   template:
     metadata:
       labels:
-        name: {{ $fullName }}-master
+        name: {{ $statefulsetName }}
         app: {{ $name }}
         chart: {{ $chart }}
         release: {{ .Release.Name }}
@@ -91,20 +94,26 @@ spec:
       serviceAccountName: {{ .Values.master.serviceAccount }}
     {{- else if .Values.serviceAccount }}
       serviceAccountName: {{ .Values.serviceAccount }}
+    {{- else if $needsJournalFormatJob }}
+      serviceAccountName: job-reader-sa
     {{- end }}
       {{- if .Values.imagePullSecrets }}
 {{ include "alluxio.imagePullSecrets" . | indent 6 }}
       {{- end}}
       initContainers:
-      {{- if .Values.journal.format.runFormat}}
-      - name: journal-format
-        image: {{ .Values.image }}:{{ .Values.imageTag }}
-        imagePullPolicy: {{ .Values.imagePullPolicy }}
-        command: ["alluxio","formatJournal"]
-        volumeMounts:
-          - name: alluxio-journal
-            mountPath: /journal
-      {{- end}}
+      {{- if $needsJournalFormatJob }}
+      - name: wait-for-journal-format
+        image: groundnuty/k8s-wait-for:latest
+        imagePullPolicy: IfNotPresent
+        env:
+          # POD_NAME is the StatefulSet name with the indexed suffix
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        # manually override entrypoint command in order to evaluate POD_NAME
+        command: ['sh', '-c', 'wait_for.sh "job" "${POD_NAME}-{{ $journalFormatJobNameSuffix }}"']
+      {{- end }}
       {{ if .Values.hub.enabled -}}
       shareProcessNamespace: true
       {{- end }}

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -216,6 +216,7 @@ journal:
   # Configuration for journal formatting job
   format:
     runFormat: false # Change to true to format journal
+    frequency: "once" # one of "once" or "always"
 
 
 # You can enable metastore to use ROCKS DB instead of Heap


### PR DESCRIPTION
### What changes are proposed in this pull request?

### Why are the changes needed?

Currently in order to perform journal formatting through the Helm chart, you must set the value `journal.format.runFormat=true`. This defines an `initContainer` inside the Alluxio master StatefulSet Pods which runs `alluxio format`. This means that any time the pods are restarted, the journal will be reformatted.

The only way to stop this behaviour is to `helm upgrade` the chart release with value `journal.format.runFormat=false`.

This change defines a k8s Job which performs the `alluxio format` outside of the lifecycle scope of the Pod by using [Helm hooks](https://helm.sh/docs/topics/charts_hooks/). The end-user can modify the lifecycle of the journal format job in a limited way through the usage of the new value `journal.format.frequency=("once"|"always").
- `journal.format.frequency="once"` will run `alluxio format` exactly once per Helm release (i.e: during `helm install`)
- `journal.format.frequency="always"` will run `alluxio format` on any change to the Helm release (i.e: `helm install`, `helm upgrade`, `helm rollback`)

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. A new Helm chart value `journal.format.frequency`

---
### Design choice explanation

The goal in this design was to decouple Pod lifecycles with the journal format lifecycle. Unfortunately in doing so, there was no way to guarantee that the Pods could wait for the format Job to actually run to completion before starting without the usage of an `initContainer`.
- Sometimes I observed the Master pod would start and identify a pre-existing journal before the Job could complete formatting it; this despite the fact that the Job would get defined and deployed in k8s _before_ the Master StatefulSet due to the `"helm.sh/hook": pre-install` annotation.

There appears to be some demand in the K8s community about asking for this type of feature, however in the meantime I found the following workaround: https://github.com/kubernetes/kubernetes/issues/106802#issuecomment-988530288
- This workaround involves passing the namespace's `default` ServiceAccount credentials to the `initContainer` with additional Role permissions in order to allow the container to query the k8s API for the Job list & status

Note that because of this `initContainer` implementation any time that `journal.format.runFormat` is true, the corresponding k8s Job(s) _must_ be `Completed` and present in the k8s system. A consequence of that fact is that we must explicitly avoid deletion of completed/terminated Jobs. In the [k8s Job docs](https://kubernetes.io/docs/concepts/workloads/controllers/job/#ttl-mechanism-for-finished-jobs) they state that:
> If the field [.spec.ttkSecondsAfterFinished] is unset, this Job won't be cleaned up by the TTL controller after it finishes.
> ...
> Even though the [control plane](https://kubernetes.io/docs/reference/glossary/?all=true#term-control-plane) eventually [garbage collects](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection) the Pods from a deleted Job after they either fail or complete...

So what this means is that even if we define that we do not wish for completed Jobs to be cleaned up, their corresponding pods may still get garbage collected regardless. I don't _believe_ this affects the Job resource whatsoever, however I was unable to find a concrete answer. The only thing I found in [the docs](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/) was for the aforementioned TTL mechanism.

---
### Test scenarios
- DONE: test journal formatting with local PVs and PVCs
- DONE: test journal formatting (or lack thereof) with emptyDir journal
- TODO: test journal formatting with HDFS journal
- TODO: test journal formatting with multiple masters
- TODO (bugfix?): test loading blocks from workers after master restart (no journal format)
  - Successfully identified and loaded Alluxio fs from prior journal, however the blocks which should have been in cache were no longer accessible. Reading `PERSISTED` files resulted in reads from UFS, and any `NOT_PERSISTED` files prior to restart were unable to be read.