### PR TITLE
Fix FUSE umount logic under Linux

### DIFF
--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/AbstractFuseFileSystem.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/AbstractFuseFileSystem.java
@@ -149,20 +149,12 @@ public abstract class AbstractFuseFileSystem implements FuseFileSystem {
       }
     } else {
       try {
-        exitCode = new ProcessBuilder("fusermount", "-u", "-z", mountPath).start().waitFor();
-      } catch (Exception e) {
-        if (e instanceof InterruptedException) {
-          Thread.currentThread().interrupt();
-        }
-        try {
-          exitCode = new ProcessBuilder("umount", mountPath).start().waitFor();
-        } catch (InterruptedException ie) {
-          Thread.currentThread().interrupt();
-          throw new FuseException("Unable to umount FS", e);
-        } catch (IOException ioe) {
-          ioe.addSuppressed(e);
-          throw new FuseException("Unable to umount FS", ioe);
-        }
+        exitCode = new ProcessBuilder("umount", mountPath).start().waitFor();
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        throw new FuseException("Unable to umount FS", ie);
+      } catch (IOException ioe) {
+        throw new FuseException("Unable to umount FS", ioe);
       }
     }
     if (exitCode != 0) {

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/AbstractFuseFileSystem.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/AbstractFuseFileSystem.java
@@ -150,6 +150,9 @@ public abstract class AbstractFuseFileSystem implements FuseFileSystem {
     } else {
       try {
         exitCode = new ProcessBuilder("fusermount", "-u", "-z", mountPath).start().waitFor();
+        if (exitCode != 0) { 
+          throw new Exception(String.format("fusermount returns %d", exitCode));
+        }
       } catch (Exception e) {
         if (e instanceof InterruptedException) {
           Thread.currentThread().interrupt();

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/AbstractFuseFileSystem.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/AbstractFuseFileSystem.java
@@ -149,12 +149,20 @@ public abstract class AbstractFuseFileSystem implements FuseFileSystem {
       }
     } else {
       try {
-        exitCode = new ProcessBuilder("umount", mountPath).start().waitFor();
-      } catch (InterruptedException ie) {
-        Thread.currentThread().interrupt();
-        throw new FuseException("Unable to umount FS", ie);
-      } catch (IOException ioe) {
-        throw new FuseException("Unable to umount FS", ioe);
+        exitCode = new ProcessBuilder("fusermount", "-u", "-z", mountPath).start().waitFor();
+      } catch (Exception e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
+        try {
+          exitCode = new ProcessBuilder("umount", mountPath).start().waitFor();
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          throw new FuseException("Unable to umount FS", e);
+        } catch (IOException ioe) {
+          ioe.addSuppressed(e);
+          throw new FuseException("Unable to umount FS", ioe);
+        }
       }
     }
     if (exitCode != 0) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix FUSE umount logic under Linux by falling back to `umount` if `fusermount` returns non-zero code.

Tested under Debian 11 using libfuse2 and libfuse3. CI tests umount logic on alpine:3.10.2. Need more tests on other distros.

### Why are the changes needed?

Previously under Linux, alluxio-fuse uses `fusermount` to umount FUSE mountpoint, and if the call to `fusermount` process throws exception, use `umount` to umount instead. 

However, in some distros (like Debian 11), `fusermount` requires root privileges to umount, and **returns code 1** (not throwing exception) if not. The error message of running `fusermount -u` without root is `fusermount: failed to open /etc/mtab: No such file or directory`. But in Debian 11, `umount` can run without root privilege.

The requirement of root privileges differs in different distros. In the table, `Yes` means root is required to run a command on a distro. Tests on more distros are required.

| Distro | `fusermount -u` | `umount` |
| -- | -- | -- |
| Debian 11 | Yes | No |
| alpine:3.10.2 (docker image) | No | Yes |
| CentOS 7.9.2009 | No | Yes |

### Does this PR introduce any user facing changes?

No