### PR TITLE
Fix Load command

### DIFF
--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -556,6 +556,17 @@ public final class NetworkAddressUtils {
   }
 
   /**
+   * @param targetAddress the target address, hostname or IP
+   * @param timeoutMs Timeout in milliseconds to use for checking that a possible local host is
+   *        reachable
+   * @return  true if the target address is the local address, false otherwise
+   */
+  public static boolean isLocalAddress(String targetAddress, int timeoutMs) {
+    return getLocalHostName(timeoutMs).equals(targetAddress)
+        || getLocalIpAddress(timeoutMs).equals(targetAddress);
+  }
+
+  /**
    * Tests if the address is externally resolvable. Address must not be wildcard, link local,
    * loopback address, non-IPv4, or other unreachable addresses.
    *

--- a/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
@@ -73,6 +73,31 @@ public class NetworkAddressUtilsTest {
     assertFalse(NetworkAddressUtils.containsLocalIp(clusterAddresses, mConfiguration));
   }
 
+  @Test
+  public void TestisLocalAddress() {
+    int resolveTimeout = (int) mConfiguration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS);
+    String localHostName = NetworkAddressUtils.getLocalHostName(resolveTimeout);
+    String localIp = NetworkAddressUtils.getLocalIpAddress(resolveTimeout);
+
+    assertTrue(NetworkAddressUtils.isLocalAddress(localHostName, resolveTimeout));
+    assertTrue(NetworkAddressUtils.isLocalAddress(localIp, resolveTimeout));
+
+    assertFalse(NetworkAddressUtils.isLocalAddress(localHostName + "false", resolveTimeout));
+    assertFalse(NetworkAddressUtils.isLocalAddress(localIp + "false", resolveTimeout));
+  }
+
+  @Test
+  public void TestisNotLocalAddress() {
+    List<InetSocketAddress> clusterAddresses = new ArrayList<>();
+    InetSocketAddress raftNodeAddress1 = new InetSocketAddress("host1", 10);
+    InetSocketAddress raftNodeAddress2 = new InetSocketAddress("host2", 20);
+    InetSocketAddress raftNodeAddress3 = new InetSocketAddress("host3", 30);
+    clusterAddresses.add(raftNodeAddress1);
+    clusterAddresses.add(raftNodeAddress2);
+    clusterAddresses.add(raftNodeAddress3);
+    assertFalse(NetworkAddressUtils.containsLocalIp(clusterAddresses, mConfiguration));
+  }
+
   /**
    * Tests the
    * {@link NetworkAddressUtils#getConnectAddress(ServiceType, alluxio.conf.AlluxioConfiguration)}

--- a/core/server/worker/src/main/java/alluxio/worker/block/CacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/CacheRequestManager.java
@@ -63,7 +63,7 @@ public class CacheRequestManager {
   /** The block worker. */
   private final BlockWorker mBlockWorker;
   private final ConcurrentHashMap<Long, CacheRequest> mActiveCacheRequests;
-  private final String mLocalWorkerHostname;
+  private final int mNetWorkHostResolutionTimeoutMs;
   private final FileSystemContext mFsContext;
   /** Keeps track of the number of rejected cache requests. */
   private final AtomicLong mNumRejected = new AtomicLong(0);
@@ -79,8 +79,8 @@ public class CacheRequestManager {
     mBlockWorker = blockWorker;
     mFsContext = fsContext;
     mActiveCacheRequests = new ConcurrentHashMap<>();
-    mLocalWorkerHostname = NetworkAddressUtils.getLocalHostName(
-        (int) ServerConfiguration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
+    mNetWorkHostResolutionTimeoutMs =
+        (int) ServerConfiguration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS);
   }
 
   /**
@@ -225,7 +225,8 @@ public class CacheRequestManager {
 
   private boolean cacheBlock(CacheRequest request) throws IOException, AlluxioException {
     boolean result;
-    boolean isSourceLocal = mLocalWorkerHostname.equals(request.getSourceHost());
+    boolean isSourceLocal = NetworkAddressUtils.isLocalAddress(request.getSourceHost(),
+        mNetWorkHostResolutionTimeoutMs);
     long blockId = request.getBlockId();
     long blockLength = request.getLength();
     // Check if the block has already been cached on this worker


### PR DESCRIPTION
### What changes are proposed in this pull request?

In some scenarios `cacheBlock` is Unable to correctly determine that the request is a local data source when running the `load command` if `alluxio.network.ip.address.used=true`

### Why are the changes needed?
Describe the bug
```properties
alluxio.network.ip.address.used=true
```
running `load` command
```bash
bin/allxuio fs load /
```
cacheBlock will always execute the `cacheBlockFromRemoteWorker` branch
<img width="1466" alt="image" src="https://user-images.githubusercontent.com/32928346/156492912-bdc383b4-ae18-430d-b06f-46b721126867.png">
---
Reason:
the `mLocalWorkerHostname` always hostname
https://github.com/Alluxio/alluxio/blob/f4ace8f14c1f96a85d1c441fb2acc4f6259c4403/core/server/worker/src/main/java/alluxio/worker/block/CacheRequestManager.java#L76-L84

but  the `request.getSourceHost()` maybe IP address, Because if `alluxio.network.ip.address.used` is true, worker will use IP as workerAddress instead of hostname, So `isSourceLocal ` will always be false.
https://github.com/Alluxio/alluxio/blob/f4ace8f14c1f96a85d1c441fb2acc4f6259c4403/core/server/worker/src/main/java/alluxio/worker/block/CacheRequestManager.java#L226-L250

worker use IP as workerAddress instead of hostname to build `CacheRequest`
![image](https://user-images.githubusercontent.com/32928346/156499622-1584e6a8-0556-4775-ab5e-62c476fd1416.png)

<img width="697" alt="image" src="https://user-images.githubusercontent.com/32928346/156499940-ab75a409-e413-4fbb-aae1-2dafd2bc312b.png">

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
