### PR TITLE
Update Hub elasticsearch field names and add dev flag for scripts

### DIFF
--- a/hub/transport/src/main/proto/grpc/rest.proto
+++ b/hub/transport/src/main/proto/grpc/rest.proto
@@ -215,11 +215,12 @@ message SpeedTestParameter {
 message ElasticsearchInfo {
   optional ElasticsearchEnvironmentVariables env_variables = 1;
   optional ElasticsearchDashboards dashboards = 2;
+  optional string host = 3;
 }
 
 message ElasticsearchEnvironmentVariables {
-  optional string hub_es_cluster_endpoint = 1;
-  optional string hub_es_cluster_port = 2;
+  optional string hub_es_endpoint = 1;
+  optional string hub_es_port = 2;
   optional string hub_es_username = 3;
   optional string hub_es_password = 4;
   optional string hub_cluster_id = 5;

--- a/integration/hub-elastic/README.md
+++ b/integration/hub-elastic/README.md
@@ -6,7 +6,7 @@
 - Requires access to Alluxio master and workers at `<hostname>:<webport>/metrics/prometheus` endpoint
 - Requires environment variables to be set in `./metricbeat/env`
 - Run `./metricbeat/metricbeat-start.sh /path/to/metricbeat`
-
+  - Use `-d` flag to connect to Elasticsearch without ssl certificate verification (for development environments)
 
 ## Logstash
 - [Logstash OSS 7.12.1](https://www.elastic.co/downloads/past-releases/logstash-oss-7-12-1) must be used
@@ -14,6 +14,7 @@
 - Uses port `5044`
 - Requires environment variables to be set in `./logstash/env`
 - Run `./logstash/logstash-start.sh /path/to/logstash`
+  - Use `-d` flag to connect to Elasticsearch without ssl certificate verification (for development environments)
 
 ## Filebeat
 - [Filebeat OSS 7.12.1](https://www.elastic.co/downloads/past-releases/filebeat-oss-7-12-1) must be used

--- a/integration/hub-elastic/logstash/logstash-start.sh
+++ b/integration/hub-elastic/logstash/logstash-start.sh
@@ -10,7 +10,7 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
-# This script assumes the following: 
+# This script assumes the following:
 # - Logstash OSS 7.12.1 is being used
 # - Clean installation
 # - Downloads available here: https://www.elastic.co/downloads/past-releases/logstash-oss-7-12-1
@@ -29,27 +29,41 @@ SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 cd "${SCRIPTPATH}/../../.." > /dev/null 2>&1
 
 HELP=$(cat <<EOF
-Usage: logstash-start.sh [-s] /path/to/logstash
+Usage: logstash-start.sh [-d] /path/to/logstash
 
+    -d                   Set to disable verifying Elasticsearch ssl certificate. This is primarily used in
+                         development/testing environments to connect to locally launched Elasticsearch clusters.
     /path/to/logstash    Path to logstash directory
 
 EOF
 )
-  
-if [[ "$#" -ne 1 ]]; then
+
+if [[ "$#" -eq 0 ]]; then
   echo "Arguments /path/to/logstash' must be provided."
   echo "${HELP}"
   exit 1
 fi
 
+USE_DEV="false"
+while getopts "d" o; do
+  case "${o}" in
+    d)
+      USE_DEV="true"
+      shift
+      ;;
+    *)
+      ;;
+  esac
+done
+
 LOGSTASH_DIR="${1}"
 
-if [[ ! -d ${LOGSTASH_DIR} ]]; then 
+if [[ ! -d ${LOGSTASH_DIR} ]]; then
   echo "Directory ${LOGSTASH_DIR} DOES NOT exists."
   exit 1
 fi
 
-if [[ ! -f ${SCRIPTPATH}/env ]]; then 
+if [[ ! -f ${SCRIPTPATH}/env ]]; then
   echo "env DOES NOT exists."
   exit 1
 fi
@@ -68,6 +82,9 @@ set +a
 
 # copy logstash configuration file to logstash installation directory
 cp -f ${SCRIPTPATH}/logstash.conf ${LOGSTASH_DIR}/logstash.conf
+if [[ "${USE_DEV}" == "true" ]]; then
+  sed -i '' -e "s/# ssl_certificate_verification/ssl_certificate_verification/" ${LOGSTASH_DIR}/logstash.conf
+fi
 
 cd ${LOGSTASH_DIR}
 

--- a/integration/hub-elastic/logstash/logstash.conf
+++ b/integration/hub-elastic/logstash/logstash.conf
@@ -14,7 +14,7 @@ input {
     port => 5044
   }
 }
-  
+
 filter {
   grok {
     match => { "message" => "%{TIMESTAMP_ISO8601:timestamp} %{LOGLEVEL:log-level}(\s+)%{JAVACLASS:class}(?<method>.*)? - (?m)%{GREEDYDATA:msg}" }
@@ -25,7 +25,7 @@ filter {
     remove_field => ["timestamp"]
   }
 }
-  
+
 output {
   elasticsearch {
     hosts => ["https://${HUB_ES_ENDPOINT}:${HUB_ES_PORT}"]
@@ -33,6 +33,7 @@ output {
     password => "${HUB_ES_PASSWORD}"
     index => "logstash-7.12.1-${HUB_CLUSTER_ID}"
     ilm_enabled => false
+    # ssl_certificate_verification => false # Does not verify server's certificate. Do not use in a production environment
   }
 }
 

--- a/integration/hub-elastic/metricbeat/metricbeat.yml
+++ b/integration/hub-elastic/metricbeat/metricbeat.yml
@@ -40,6 +40,7 @@ output.elasticsearch:
   username: "${HUB_ES_USERNAME:?HUB_ES_USERNAME env var is not set}"
   password: "${HUB_ES_PASSWORD:?HUB_ES_PASSWORD env var is not set}"
   index: "metricbeat-%{[agent.version]}-${HUB_CLUSTER_ID}"
+  # ssl.verification_mode: none # Does not verify server's certificate. Do not use in a production environment
 
 # ================================= Processors =================================
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

- Renamed proto message fields introduced in https://github.com/Alluxio/alluxio/pull/14951
  - **NOTE:** renaming fields break back-compat but OK in this case since the fields (and Hub in general) aren't being used yet
  - keep naming convention consistent with other related fields
- added `host` field to `ElasticsearchInfo` proto def
- added `-d` dev flag for metricbeat/logstash scripts to allow for connecting to a locally launched Elasticsearch cluster (for dev purposes)

### Why are the changes needed?

see section above

### Does this PR introduce any user facing changes?

no
