### PR TITLE
Remove hardcoded indentation for Helm secret volumeMounts

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -241,3 +241,7 @@
 0.6.36
 
 - Fix volumeMounts indentations in master statefulset
+
+0.6.37
+
+- Remove hardcoded indentation for secret volumeMounts

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.36
+version: 0.6.37
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
+++ b/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
@@ -165,25 +165,25 @@ resources:
 
 {{- define "alluxio.master.secretVolumeMounts" -}}
   {{- range $key, $val := .Values.secrets.master }}
-            - name: secret-{{ $key }}-volume
-              mountPath: /secrets/{{ $val }}
-              readOnly: true
+- name: secret-{{ $key }}-volume
+  mountPath: /secrets/{{ $val }}
+  readOnly: true
   {{- end }}
 {{- end -}}
 
 {{- define "alluxio.worker.secretVolumeMounts" -}}
   {{- range $key, $val := .Values.secrets.worker }}
-            - name: secret-{{ $key }}-volume
-              mountPath: /secrets/{{ $val }}
-              readOnly: true
+- name: secret-{{ $key }}-volume
+  mountPath: /secrets/{{ $val }}
+  readOnly: true
   {{- end -}}
 {{- end -}}
 
 {{- define "alluxio.logserver.secretVolumeMounts" -}}
   {{- range $key, $val := .Values.secrets.logserver }}
-          - name: secret-{{ $key }}-volume
-            mountPath: /secrets/{{ $val }}
-            readOnly: true
+- name: secret-{{ $key }}-volume
+  mountPath: /secrets/{{ $val }}
+  readOnly: true
   {{- end -}}
 {{- end -}}
 

--- a/integration/kubernetes/helm-chart/alluxio/templates/logserver/deployment.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/logserver/deployment.yaml
@@ -88,7 +88,7 @@ spec:
             {{- end }}
             {{- if .Values.secrets }}
               {{- if .Values.secrets.logserver }}
-            {{- include "alluxio.logserver.secretVolumeMounts" . }}
+{{- include "alluxio.logserver.secretVolumeMounts" . | indent 10 }}
               {{- end }}
             {{- end }}
             {{- if .Values.mounts }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -260,7 +260,7 @@ spec:
             {{- end }}
             {{- if .Values.secrets }}
               {{- if .Values.secrets.master }}
-{{- include "alluxio.master.secretVolumeMounts" . }}
+{{- include "alluxio.master.secretVolumeMounts" . | indent 12 }}
               {{- end }}
             {{- end }}
             {{- if .Values.mounts }}
@@ -349,7 +349,7 @@ spec:
           {{- end }}
           {{- if .Values.secrets }}
             {{- if .Values.secrets.master }}
-{{- include "alluxio.master.secretVolumeMounts" . }}
+{{- include "alluxio.master.secretVolumeMounts" . | indent 12 }}
             {{- end }}
           {{- end }}
           {{- if .Values.mounts }}

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
@@ -245,7 +245,7 @@ spec:
             {{- end }}
             {{- if .Values.secrets -}}
               {{- if .Values.secrets.worker -}}
-{{- include "alluxio.worker.secretVolumeMounts" . }}
+{{- include "alluxio.worker.secretVolumeMounts" . | indent 12 }}
               {{- end -}}
             {{- end -}}
             {{- if .Values.tieredstore -}}
@@ -340,7 +340,7 @@ spec:
             {{- end }}
             {{- if .Values.secrets }}
               {{- if .Values.secrets.worker }}
-{{- include "alluxio.worker.secretVolumeMounts" . }}
+{{- include "alluxio.worker.secretVolumeMounts" . | indent 12 }}
               {{- end -}}
             {{- end }}
             {{- if .Values.tieredstore }}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Adjust Helm chart template indentation level for `Secret` `volumeMounts` to use the `indent` pipe as opposed to hard-coding whitespaces.

### Why are the changes needed?

Thanks to #15029 the indentation mismatch is already fixed, but this change will just discourage similar indentation mismatches in the future.

### Does this PR introduce any user facing changes?

No user-facing changes.
