### PR TITLE
Fix wrong format of s3 bucket creationDate

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListAllMyBucketsResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListAllMyBucketsResult.java
@@ -37,8 +37,7 @@ public class ListAllMyBucketsResult {
   public ListAllMyBucketsResult(List<URIStatus> names) {
     mBuckets =
         names.stream().map((uriStatus) -> new Bucket(uriStatus.getName(),
-            LocalDateTime.ofEpochSecond(
-                uriStatus.getCreationTimeMs() / 1000L, 0, ZoneOffset.UTC).toString()))
+            S3RestUtils.toS3Date(uriStatus.getCreationTimeMs())))
             .collect(Collectors.toList());
   }
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListAllMyBucketsResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListAllMyBucketsResult.java
@@ -17,8 +17,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix wrong format of s3 bucket creationDate.

### Why are the changes needed?

When I use the AWS S3Client JAVA SDK to call listBuckets on AlluxioProxy, the request fails as it is unable to parse the time. The exception information is as follows:

```Exception in thread "main" software.amazon.awssdk.core.exception.SdkClientException: Unable to unmarshall response (Text '2022-03-04T10:10:44' could not be parsed at index 19)```

### Does this PR introduce any user facing changes?
no
