### PR TITLE
fix: helm format for jobMaster.env

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -294,8 +294,8 @@ spec:
                 fieldPath: status.podIP
           {{- end }}
           {{- range $key, $value := .Values.jobMaster.env }}
-            - name: "{{ $key }}"
-              value: "{{ $value }}"
+          - name: "{{ $key }}"
+            value: "{{ $value }}"
           {{- end }}
           envFrom:
           - configMapRef:


### PR DESCRIPTION
### What changes are proposed in this pull request?

The jobMaster.env format in helm-chart has the wrong indent (more indent then needed)

```
      env:
          - name: ALLUXIO_MASTER_HOSTNAME
            ......
          {{- range $key, $value := .Values.jobMaster.env }}
            - name: "{{ $key }}"
              value: "{{ $value }}"
          {{- end }}
          envFrom:
          - ......
```

### Why are the changes needed?

If jobMaster.env is set, the wrong indent can cause helm apply error:

```
error converting YAML to JSON: yaml: line 150: did not find expected key
```

### Does this PR introduce any user facing changes?

Enable helm apply with jobMaster.env set.