### PR TITLE
Fix DistribtuedLoad CLI Output and dump failed files to local csv

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
@@ -19,10 +19,8 @@ import alluxio.job.wire.Status;
 import alluxio.util.CommonUtils;
 import alluxio.worker.job.JobMasterClientContext;
 
-import com.beust.jcommander.internal.Sets;
 import com.google.common.collect.Lists;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
@@ -94,7 +94,6 @@ public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCo
 
   /**
    * Gets the number of failed jobs.
-   * 
    * @return number of failed jobs
    */
   public int getFailedCount() {
@@ -103,7 +102,6 @@ public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCo
 
   /**
    * Gets the number of completed jobs.
-   * 
    * @return the number of completed job
    */
   public int getCompletedCount() {

--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
@@ -19,8 +19,11 @@ import alluxio.job.wire.Status;
 import alluxio.util.CommonUtils;
 import alluxio.worker.job.JobMasterClientContext;
 
+import com.beust.jcommander.internal.Sets;
 import com.google.common.collect.Lists;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -49,6 +52,7 @@ public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCo
     mActiveJobs = DEFAULT_ACTIVE_JOBS;
     mFailedCount = 0;
     mCompletedCount = 0;
+    mFailedFiles = new HashSet<>();
   }
 
   protected void drain() {

--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
@@ -41,7 +41,7 @@ public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCo
   protected final JobMasterClient mClient;
   private int mFailedCount;
   private int mCompletedCount;
-  protected Set<String> mFailedFiles;
+  private Set<String> mFailedFiles;
 
   protected AbstractDistributedJobCommand(FileSystemContext fsContext) {
     super(fsContext);
@@ -110,5 +110,13 @@ public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCo
    */
   public int getCompletedCount() {
     return mCompletedCount;
+  }
+
+  /**
+   * Gets failed files.
+   * @return failed files
+   */
+  public Set<String> getFailedFiles() {
+    return mFailedFiles;
   }
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
@@ -44,9 +44,11 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -261,8 +263,21 @@ public class DistributedCpCommand extends AbstractDistributedJobCommand {
     }
 
     @Override
-    protected JobConfig getJobConfig() {
+    public JobConfig getJobConfig() {
       return mJobConfig;
+    }
+
+    @Override
+    public int getSize() {
+      return 1;
+    }
+
+    @Override
+    public Set<String> getFailedFiles() {
+      if (getFailedTasks().isEmpty()) {
+        return Collections.singleton(mJobConfig.getSource());
+      }
+      return Collections.EMPTY_SET;
     }
 
     @Override
@@ -299,8 +314,23 @@ public class DistributedCpCommand extends AbstractDistributedJobCommand {
     }
 
     @Override
-    protected JobConfig getJobConfig() {
+    public JobConfig getJobConfig() {
       return mJobConfig;
+    }
+
+    @Override
+    public int getSize() {
+      return mJobConfig.getJobConfigs().size();
+    }
+
+    @Override
+    public Set<String> getFailedFiles() {
+      List<JobInfo> tasks = getFailedTasks();
+      Set<String> files = new HashSet<>();
+      for (JobInfo task : tasks) {
+        files.add(task.getDescription());
+      }
+      return files;
     }
 
     @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
@@ -48,7 +48,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedCpCommand.java
@@ -273,11 +273,10 @@ public class DistributedCpCommand extends AbstractDistributedJobCommand {
     }
 
     @Override
-    public Set<String> getFailedFiles() {
-      if (getFailedTasks().isEmpty()) {
-        return Collections.singleton(mJobConfig.getSource());
+    public void setFailedFiles() {
+      if (!mFailedTasks.isEmpty()) {
+        mFailedFiles = Collections.singleton(mJobConfig.getSource());
       }
-      return Collections.EMPTY_SET;
     }
 
     @Override
@@ -324,13 +323,12 @@ public class DistributedCpCommand extends AbstractDistributedJobCommand {
     }
 
     @Override
-    public Set<String> getFailedFiles() {
-      List<JobInfo> tasks = getFailedTasks();
-      Set<String> files = new HashSet<>();
-      for (JobInfo task : tasks) {
-        files.add(task.getDescription());
+    public void setFailedFiles() {
+      if (!mFailedTasks.isEmpty()) {
+        for (JobInfo task : mFailedTasks) {
+          mFailedFiles.add(StringUtils.substringBetween(task.getDescription(), "Source=", ","));
+        }
       }
-      return files;
     }
 
     @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -48,7 +48,8 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class DistributedLoadCommand extends AbstractDistributedJobCommand {
   private static final int DEFAULT_REPLICATION = 1;
   private static final int DEFAULT_FAILURE_LIMIT = 1;
-  private static final String DEFAULT_FAILURE_FILE_PATH = "logs/user/%s_failures.csv";
+  private static final String DEFAULT_FAILURE_FILE_PATH =
+      "logs/user/distributedLoad_%s_failures.csv";
   private static final Option REPLICATION_OPTION =
       Option.builder()
           .longOpt("replication")

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -22,18 +22,23 @@ import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
 
+import com.beust.jcommander.internal.Sets;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.concurrent.ThreadSafe;
@@ -314,7 +319,30 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
 
     System.out.println(String.format("Completed count is %d,Failed count is %d.",
         getCompletedCount(), getFailedCount()));
+    if (mFailedFiles.size()>0){
+      StringBuilder output = new StringBuilder();
+      output.append("Here's recent failed files: \n");
+      String dumpPath = "test.txt";
 
+
+      Iterator<String> iterator=mFailedFiles.iterator();
+      for (int i = 0; i < Math.min(20, mFailedFiles.size()); i++) {
+        String failure = iterator.next();
+        output.append(failure);
+        output.append(",\n");
+      }
+      try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(dumpPath))) {
+        for (String failure:
+            mFailedFiles) {
+          writer.write(String.format("%s%n", failure));
+        }
+
+      }
+
+
+      output.append(String.format("Check out %s for full list of failed files", dumpPath));
+      System.out.print(output.toString());
+    }
     return 0;
   }
 
@@ -341,5 +369,36 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
   @Override
   public void close() throws IOException {
     mClient.close();
+  }
+
+  public static void main(String[] args) throws IOException {
+    Set<String> mFailedFiles = Sets.newHashSet();
+    mFailedFiles.add("/test/s");
+    mFailedFiles.add("/test/a");
+    mFailedFiles.add("/test/c");
+    if (mFailedFiles.size()>0){
+      StringBuilder output = new StringBuilder();
+      output.append("Here's recent failed files: \n");
+      String dumpPath = "test.txt";
+
+
+        Iterator<String> iterator=mFailedFiles.iterator();
+        for (int i = 0; i < Math.min(20, mFailedFiles.size()); i++) {
+          String failure = iterator.next();
+          output.append(failure);
+          output.append(",\n");
+        }
+      try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(dumpPath))) {
+        for (String failure:
+        mFailedFiles) {
+          writer.write(String.format("%s%n", failure));
+        }
+
+      }
+
+
+      output.append(String.format("Check out %s for full list of failed files", dumpPath));
+      System.out.print(output.toString());
+    }
   }
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -316,30 +316,23 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
         }
       }
     }
-
     System.out.println(String.format("Completed count is %d,Failed count is %d.",
         getCompletedCount(), getFailedCount()));
-    if (mFailedFiles.size()>0){
+    if (mFailedFiles.size() > 0) {
       StringBuilder output = new StringBuilder();
       output.append("Here's recent failed files: \n");
-      String dumpPath = "test.txt";
-
-
-      Iterator<String> iterator=mFailedFiles.iterator();
+      String dumpPath = "/logs/user/distributedLoad_failures.txt";
+      Iterator<String> iterator = mFailedFiles.iterator();
       for (int i = 0; i < Math.min(20, mFailedFiles.size()); i++) {
         String failure = iterator.next();
         output.append(failure);
         output.append(",\n");
       }
       try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(dumpPath))) {
-        for (String failure:
-            mFailedFiles) {
+        for (String failure : mFailedFiles) {
           writer.write(String.format("%s%n", failure));
         }
-
       }
-
-
       output.append(String.format("Check out %s for full list of failed files", dumpPath));
       System.out.print(output.toString());
     }
@@ -369,36 +362,5 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
   @Override
   public void close() throws IOException {
     mClient.close();
-  }
-
-  public static void main(String[] args) throws IOException {
-    Set<String> mFailedFiles = Sets.newHashSet();
-    mFailedFiles.add("/test/s");
-    mFailedFiles.add("/test/a");
-    mFailedFiles.add("/test/c");
-    if (mFailedFiles.size()>0){
-      StringBuilder output = new StringBuilder();
-      output.append("Here's recent failed files: \n");
-      String dumpPath = "test.txt";
-
-
-        Iterator<String> iterator=mFailedFiles.iterator();
-        for (int i = 0; i < Math.min(20, mFailedFiles.size()); i++) {
-          String failure = iterator.next();
-          output.append(failure);
-          output.append(",\n");
-        }
-      try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(dumpPath))) {
-        for (String failure:
-        mFailedFiles) {
-          writer.write(String.format("%s%n", failure));
-        }
-
-      }
-
-
-      output.append(String.format("Check out %s for full list of failed files", dumpPath));
-      System.out.print(output.toString());
-    }
   }
 }

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -320,25 +320,29 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
         getCompletedCount(), getFailedCount()));
     Set<String> failures = getFailedFiles();
     if (failures.size() > 0) {
-      String path = String.join("_", StringUtils.split(args[0], "/"));
-      String failurePath = String.format(DEFAULT_FAILURE_FILE_PATH, path);
-      StringBuilder output = new StringBuilder();
-      output.append("Here are recent failed files: \n");
-      Iterator<String> iterator = failures.iterator();
-      for (int i = 0; i < Math.min(DEFAULT_FAILURE_LIMIT, failures.size()); i++) {
-        String failure = iterator.next();
-        output.append(failure);
-        output.append(",\n");
-      }
-      try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(failurePath))) {
-        for (String failure : failures) {
-          writer.write(String.format("%s%n", failure));
-        }
-      }
-      output.append(String.format("Check out %s for full list of failed files.", failurePath));
-      System.out.print(output);
+      processFailures(args[0], failures);
     }
     return 0;
+  }
+
+  private void processFailures(String arg, Set<String> failures) throws IOException {
+    String path = String.join("_", StringUtils.split(arg, "/"));
+    String failurePath = String.format(DEFAULT_FAILURE_FILE_PATH, path);
+    StringBuilder output = new StringBuilder();
+    output.append("Here are recent failed files: \n");
+    Iterator<String> iterator = failures.iterator();
+    for (int i = 0; i < Math.min(DEFAULT_FAILURE_LIMIT, failures.size()); i++) {
+      String failure = iterator.next();
+      output.append(failure);
+      output.append(",\n");
+    }
+    try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(failurePath))) {
+      for (String failure : failures) {
+        writer.write(String.format("%s%n", failure));
+      }
+    }
+    output.append(String.format("Check out %s for full list of failed files.", failurePath));
+    System.out.print(output);
   }
 
   private void readItemsFromOptionString(Set<String> localityIds, String argOption) {

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -319,9 +319,9 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
     System.out.println(String.format("Completed count is %d,Failed count is %d.",
         getCompletedCount(), getFailedCount()));
     Set<String> failures = getFailedFiles();
-    String path = String.join("_", StringUtils.split(args[0], "/"));
-    String failurePath = String.format(DEFAULT_FAILURE_FILE_PATH, path);
     if (failures.size() > 0) {
+      String path = String.join("_", StringUtils.split(args[0], "/"));
+      String failurePath = String.format(DEFAULT_FAILURE_FILE_PATH, path);
       StringBuilder output = new StringBuilder();
       output.append("Here are recent failed files: \n");
       Iterator<String> iterator = failures.iterator();

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -28,8 +28,10 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.BufferedReader;
+import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -309,8 +311,10 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
         }
       }
     }
+
     System.out.println(String.format("Completed count is %d,Failed count is %d.",
         getCompletedCount(), getFailedCount()));
+
     return 0;
   }
 

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -48,7 +48,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class DistributedLoadCommand extends AbstractDistributedJobCommand {
   private static final int DEFAULT_REPLICATION = 1;
   private static final int DEFAULT_FAILURE_LIMIT = 1;
-  private static final String DEFAULT_FAILURE_FILE_PATH = "logs/user/distributedLoad_failures.csv";
+  private static final String DEFAULT_FAILURE_FILE_PATH_Pattern = "logs/user/%s_failures.csv";
   private static final Option REPLICATION_OPTION =
       Option.builder()
           .longOpt("replication")
@@ -317,23 +317,23 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
     }
     System.out.println(String.format("Completed count is %d,Failed count is %d.",
         getCompletedCount(), getFailedCount()));
+    String failurePath = String.format(DEFAULT_FAILURE_FILE_PATH_Pattern, args[0]);
     Set<String> failures = getFailedFiles();
     if (failures.size() > 0) {
       StringBuilder output = new StringBuilder();
-      output.append("Here's recent failed files: \n");
+      output.append("Here are recent failed files: \n");
       Iterator<String> iterator = failures.iterator();
       for (int i = 0; i < Math.min(DEFAULT_FAILURE_LIMIT, failures.size()); i++) {
         String failure = iterator.next();
         output.append(failure);
         output.append(",\n");
       }
-      try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(DEFAULT_FAILURE_FILE_PATH))) {
+      try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(failurePath))) {
         for (String failure : failures) {
           writer.write(String.format("%s%n", failure));
         }
       }
-      output.append(
-          String.format("Check out %s for full list of failed files", DEFAULT_FAILURE_FILE_PATH));
+      output.append(String.format("Check out %s for full list of failed files", failurePath));
       System.out.print(output);
     }
     return 0;

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -326,8 +326,7 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
     return 0;
   }
 
-  private void processFailures(String arg, Set<String> failures) throws IOException {
-    ;
+  private void processFailures(String arg, Set<String> failures) {
     String path = String.join("_", StringUtils.split(arg, "/"));
     String failurePath = String.format(DEFAULT_FAILURE_FILE_PATH, path);
     StringBuilder output = new StringBuilder();

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -22,7 +22,6 @@ import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.InvalidArgumentException;
 
-import com.beust.jcommander.internal.Sets;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
@@ -30,10 +29,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -318,18 +318,19 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
     }
     System.out.println(String.format("Completed count is %d,Failed count is %d.",
         getCompletedCount(), getFailedCount()));
-    if (mFailedFiles.size() > 0) {
+    Set<String> failures = getFailedFiles();
+    if (failures.size() >= 0) {
       StringBuilder output = new StringBuilder();
       output.append("Here's recent failed files: \n");
-      String dumpPath = "/logs/user/distributedLoad_failures.txt";
-      Iterator<String> iterator = mFailedFiles.iterator();
-      for (int i = 0; i < Math.min(20, mFailedFiles.size()); i++) {
+      String dumpPath = "logs/user/distributedLoad_failures.txt";
+      Iterator<String> iterator = failures.iterator();
+      for (int i = 0; i < Math.min(20, failures.size()); i++) {
         String failure = iterator.next();
         output.append(failure);
         output.append(",\n");
       }
       try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(dumpPath))) {
-        for (String failure : mFailedFiles) {
+        for (String failure : failures) {
           writer.write(String.format("%s%n", failure));
         }
       }

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -335,7 +335,7 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
           writer.write(String.format("%s%n", failure));
         }
       }
-      output.append(String.format("Check out %s for full list of failed files", failurePath));
+      output.append(String.format("Check out %s for full list of failed files.", failurePath));
       System.out.print(output);
     }
     return 0;

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -48,7 +48,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class DistributedLoadCommand extends AbstractDistributedJobCommand {
   private static final int DEFAULT_REPLICATION = 1;
   private static final int DEFAULT_FAILURE_LIMIT = 1;
-  private static final String DEFAULT_FAILURE_FILE_PATH_Pattern = "logs/user/%s_failures.csv";
+  private static final String DEFAULT_FAILURE_FILE_PATH = "logs/user/%s_failures.csv";
   private static final Option REPLICATION_OPTION =
       Option.builder()
           .longOpt("replication")
@@ -317,8 +317,9 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
     }
     System.out.println(String.format("Completed count is %d,Failed count is %d.",
         getCompletedCount(), getFailedCount()));
-    String failurePath = String.format(DEFAULT_FAILURE_FILE_PATH_Pattern, args[0]);
     Set<String> failures = getFailedFiles();
+    String path = String.join("_", StringUtils.split(args[0], "/"));
+    String failurePath = String.format(DEFAULT_FAILURE_FILE_PATH, path);
     if (failures.size() > 0) {
       StringBuilder output = new StringBuilder();
       output.append("Here are recent failed files: \n");

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -319,10 +319,10 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
     System.out.println(String.format("Completed count is %d,Failed count is %d.",
         getCompletedCount(), getFailedCount()));
     Set<String> failures = getFailedFiles();
-    if (failures.size() >= 0) {
+    if (failures.size() > 0) {
       StringBuilder output = new StringBuilder();
       output.append("Here's recent failed files: \n");
-      String dumpPath = "logs/user/distributedLoad_failures.txt";
+      String dumpPath = "logs/user/distributedLoad_failures.csv";
       Iterator<String> iterator = failures.iterator();
       for (int i = 0; i < Math.min(20, failures.size()); i++) {
         String failure = iterator.next();
@@ -335,7 +335,7 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
         }
       }
       output.append(String.format("Check out %s for full list of failed files", dumpPath));
-      System.out.print(output.toString());
+      System.out.print(output);
     }
     return 0;
   }

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -47,7 +47,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @PublicApi
 public final class DistributedLoadCommand extends AbstractDistributedJobCommand {
   private static final int DEFAULT_REPLICATION = 1;
-  private static final int DEFAULT_FAILURE_LIMIT = 1;
+  private static final int DEFAULT_FAILURE_LIMIT = 20;
   private static final String DEFAULT_FAILURE_FILE_PATH =
       "logs/user/distributedLoad_%s_failures.csv";
   private static final Option REPLICATION_OPTION =

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -47,6 +47,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @PublicApi
 public final class DistributedLoadCommand extends AbstractDistributedJobCommand {
   private static final int DEFAULT_REPLICATION = 1;
+  private static final int DEFAULT_FAILURE_LIMIT = 1;
+  private static final String DEFAULT_FAILURE_FILE_PATH = "logs/user/distributedLoad_failures.csv";
   private static final Option REPLICATION_OPTION =
       Option.builder()
           .longOpt("replication")
@@ -319,19 +321,19 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
     if (failures.size() > 0) {
       StringBuilder output = new StringBuilder();
       output.append("Here's recent failed files: \n");
-      String dumpPath = "logs/user/distributedLoad_failures.csv";
       Iterator<String> iterator = failures.iterator();
-      for (int i = 0; i < Math.min(20, failures.size()); i++) {
+      for (int i = 0; i < Math.min(DEFAULT_FAILURE_LIMIT, failures.size()); i++) {
         String failure = iterator.next();
         output.append(failure);
         output.append(",\n");
       }
-      try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(dumpPath))) {
+      try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(DEFAULT_FAILURE_FILE_PATH))) {
         for (String failure : failures) {
           writer.write(String.format("%s%n", failure));
         }
       }
-      output.append(String.format("Check out %s for full list of failed files", dumpPath));
+      output.append(
+          String.format("Check out %s for full list of failed files", DEFAULT_FAILURE_FILE_PATH));
       System.out.print(output);
     }
     return 0;

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -50,7 +49,6 @@ public final class DistributedLoadUtils {
 
   /**
    * Distributed loads a file or directory in Alluxio space, makes it resident in memory.
-   * 
    * @param command The command to execute loading
    * @param pool The pool for batched jobs
    * @param batchSize size for batched jobs
@@ -144,11 +142,10 @@ public final class DistributedLoadUtils {
 
   /**
    * Creates a new job to load a file in Alluxio space, makes it resident in memory.
-   * 
    * @param command The command to execute loading
    * @param filePath The {@link AlluxioURI} path to load into Alluxio memory
    * @param replication The replication of file to load into Alluxio memory
-   * @param directCache
+   * @param directCache use direct cache or passive cache
    * @param printOut whether print out progress in console
    */
   private static JobAttempt newJob(AbstractDistributedJobCommand command, List<URIStatus> filePath,
@@ -340,7 +337,6 @@ public final class DistributedLoadUtils {
   public static class LoadJobAttemptFactory {
     /**
      * Loads a file or directory in Alluxio space, makes it resident in memory.
-     * 
      * @param command The command to execute loading
      * @param filePath The {@link AlluxioURI} path to load into Alluxio memory
      * @param replication Number of block replicas of each loaded file

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
@@ -177,11 +177,10 @@ public final class DistributedLoadUtils {
     }
 
     @Override
-    public Set<String> getFailedFiles() {
-      if (getFailedTasks().isEmpty()) {
-        return Collections.singleton(mJobConfig.getFilePath());
+    public void setFailedFiles() {
+      if (!mFailedTasks.isEmpty()) {
+        mFailedFiles = Collections.singleton(mJobConfig.getFilePath());
       }
-      return Collections.EMPTY_SET;
     }
 
     @Override
@@ -222,11 +221,10 @@ public final class DistributedLoadUtils {
     }
 
     @Override
-    public Set<String> getFailedFiles() {
-      if (getFailedTasks().isEmpty()) {
-        return Collections.singleton(mJobConfig.getFilePath());
+    public void setFailedFiles() {
+      if (!mFailedTasks.isEmpty()) {
+        mFailedFiles = Collections.singleton(mJobConfig.getFilePath());
       }
-      return Collections.EMPTY_SET;
     }
 
     @Override
@@ -264,13 +262,12 @@ public final class DistributedLoadUtils {
     }
 
     @Override
-    public Set<String> getFailedFiles() {
-      List<JobInfo> tasks = getFailedTasks();
-      Set<String> files = new HashSet<>();
-      for (JobInfo task : tasks) {
-        files.add(task.getDescription());
+    public void setFailedFiles() {
+      if (!mFailedTasks.isEmpty()) {
+        for (JobInfo task : mFailedTasks) {
+          mFailedFiles.add(StringUtils.substringBetween(task.getDescription(), "FilePath=", ","));
+        }
       }
-      return files;
     }
 
     @Override
@@ -312,13 +309,12 @@ public final class DistributedLoadUtils {
     }
 
     @Override
-    public Set<String> getFailedFiles() {
-      List<JobInfo> tasks = getFailedTasks();
-      Set<String> files = new HashSet<>();
-      for (JobInfo task : tasks) {
-        files.add(StringUtils.substringBetween(task.getDescription(), "FilePath=", ","));
+    public void setFailedFiles() {
+      if (!mFailedTasks.isEmpty()) {
+        for (JobInfo task : mFailedTasks) {
+          mFailedFiles.add(StringUtils.substringBetween(task.getDescription(), "FilePath=", ","));
+        }
       }
-      return files;
     }
 
     @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadUtils.java
@@ -71,7 +71,7 @@ public final class DistributedLoadUtils {
         excludedLocalityIds, directCache, printOut);
     // add all the jobs left in the pool
     if (pool.size() > 0) {
-      addJob(command, pool, batchSize, replication, workerSet, excludedWorkerSet, localityIds,
+      addJob(command, pool, replication, workerSet, excludedWorkerSet, localityIds,
           excludedLocalityIds, directCache, printOut);
       pool.clear();
     }
@@ -118,7 +118,7 @@ public final class DistributedLoadUtils {
         }
         pool.add(uriStatus);
         if (pool.size() == batchSize) {
-          addJob(command, pool, batchSize, replication, workerSet, excludedWorkerSet, localityIds,
+          addJob(command, pool, replication, workerSet, excludedWorkerSet, localityIds,
               excludedLocalityIds, directCache, printOut);
           pool.clear();
         }
@@ -131,14 +131,14 @@ public final class DistributedLoadUtils {
   }
 
   private static void addJob(AbstractDistributedJobCommand command, List<URIStatus> statuses,
-      int batchSize, int replication, Set<String> workerSet, Set<String> excludedWorkerSet,
+      int replication, Set<String> workerSet, Set<String> excludedWorkerSet,
       Set<String> localityIds, Set<String> excludedLocalityIds, boolean directCache,
       boolean printOut) {
     if (command.mSubmittedJobAttempts.size() >= command.mActiveJobs) {
       // Wait one job to complete.
       command.waitJob();
     }
-    command.mSubmittedJobAttempts.add(newJob(command, statuses, batchSize, replication, workerSet,
+    command.mSubmittedJobAttempts.add(newJob(command, statuses, replication, workerSet,
         excludedWorkerSet, localityIds, excludedLocalityIds, directCache, printOut));
   }
 
@@ -147,16 +147,15 @@ public final class DistributedLoadUtils {
    * 
    * @param command The command to execute loading
    * @param filePath The {@link AlluxioURI} path to load into Alluxio memory
-   * @param batchSize
    * @param replication The replication of file to load into Alluxio memory
    * @param directCache
    * @param printOut whether print out progress in console
    */
   private static JobAttempt newJob(AbstractDistributedJobCommand command, List<URIStatus> filePath,
-      int batchSize, int replication, Set<String> workerSet, Set<String> excludedWorkerSet,
+      int replication, Set<String> workerSet, Set<String> excludedWorkerSet,
       Set<String> localityIds, Set<String> excludedLocalityIds, boolean directCache,
       boolean printOut) {
-    JobAttempt jobAttempt = LoadJobAttemptFactory.create(command, filePath, batchSize, replication,
+    JobAttempt jobAttempt = LoadJobAttemptFactory.create(command, filePath, replication,
         workerSet, excludedWorkerSet, localityIds, excludedLocalityIds, directCache, printOut);
     jobAttempt.run();
     return jobAttempt;
@@ -344,7 +343,6 @@ public final class DistributedLoadUtils {
      * 
      * @param command The command to execute loading
      * @param filePath The {@link AlluxioURI} path to load into Alluxio memory
-     * @param batchSize
      * @param replication Number of block replicas of each loaded file
      * @param workerSet A set of worker hosts to load data
      * @param excludedWorkerSet A set of worker hosts can not to load data
@@ -355,11 +353,11 @@ public final class DistributedLoadUtils {
      * @return specific load job attempt
      **/
     public static JobAttempt create(AbstractDistributedJobCommand command, List<URIStatus> filePath,
-        int batchSize, int replication, Set<String> workerSet, Set<String> excludedWorkerSet,
+        int replication, Set<String> workerSet, Set<String> excludedWorkerSet,
         Set<String> localityIds, Set<String> excludedLocalityIds, boolean directCache,
         boolean printOut) {
       JobAttempt jobAttempt;
-      if (batchSize <= 1) {
+      if (filePath.size() == 1) {
         LoadConfig config = new LoadConfig(filePath.iterator().next().getPath(), replication,
             workerSet, excludedWorkerSet, localityIds, excludedLocalityIds, directCache);
         if (printOut) {

--- a/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
@@ -288,6 +288,6 @@ public final class DistributedLoadCommandTest extends AbstractFileSystemShellTes
     Assert.assertTrue(mOutput.toString().contains(
         String.format("Completed count is %s,Failed count is %s.\n", fileSize / 2, fileSize / 2)));
     Assert.assertTrue(mOutput.toString().contains(
-        "Check out ./logs/user/distributedLoad_testFailure_failures.csv for full list of failed files."));
+        "./logs/user/distributedLoad_testFailure_failures.csv for full list of failed files."));
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
@@ -250,6 +250,7 @@ public final class DistributedLoadCommandTest extends AbstractFileSystemShellTes
       Assert.assertEquals(100, status.getInMemoryPercentage());
     }
   }
+
   @Test
   public void loadDirWithCorrectCount() throws IOException, AlluxioException {
     FileSystemShell fsShell = new FileSystemShell(ServerConfiguration.global());
@@ -267,6 +268,7 @@ public final class DistributedLoadCommandTest extends AbstractFileSystemShellTes
     }
     fsShell.run("distributedLoad", "/testCount", "--batch-size", "3");
     String[] output = mOutput.toString().split("\n");
-    Assert.assertEquals(String.format("Completed count is %s,Failed count is 0.",fileSize), output[output.length-1]);
+    Assert.assertEquals(String.format("Completed count is %s,Failed count is 0.", fileSize),
+        output[output.length - 1]);
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
@@ -285,7 +285,8 @@ public final class DistributedLoadCommandTest extends AbstractFileSystemShellTes
       }
     }
     fsShell.run("distributedLoad", "/testFailure");
-    Assert.assertTrue(mOutput.toString().contains("Completed count is 10,Failed count is 10.\n"));
+    Assert.assertTrue(mOutput.toString().contains(
+        String.format("Completed count is %s,Failed count is %s.\n", fileSize / 2, fileSize / 2)));
     Assert.assertTrue(mOutput.toString().contains(
         "Check out ./logs/user/distributedLoad_testFailure_failures.csv for full list of failed files."));
   }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
@@ -290,8 +290,10 @@ public final class DistributedLoadCommandTest extends AbstractFileSystemShellTes
     Assert.assertTrue(result);
 
     fsShell.run("distributedLoad", "/testCount");
-    String[] output = mOutput.toString().split("\n");
-    Assert.assertTrue(
-        mOutput.toString().contains("Completed count is 0,Failed count is 1."));
+
+    Assert.assertTrue(mOutput.toString().contains("Completed count is 0,Failed count is 1.\n"
+        + "Here are recent failed files: \n" + "/testCount/testBatchFile,\n"
+        + "Check out ./logs/user/distributedLoad_testCount_failures.csv for full list of failed files."));
+
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -256,15 +255,10 @@ public final class DistributedLoadCommandTest extends AbstractFileSystemShellTes
     FileSystemShell fsShell = new FileSystemShell(ServerConfiguration.global());
     FileSystem fs = sResource.get().getClient();
     int fileSize = 66;
-    List<AlluxioURI> uris = new ArrayList<>(fileSize);
     for (int i = 0; i < fileSize; i++) {
       FileSystemTestUtils.createByteFile(fs, "/testCount/testBatchFile" + i, WritePType.THROUGH,
           10);
-
       AlluxioURI uri = new AlluxioURI("/testCount/testBatchFile" + i);
-
-
-      uris.add(uri);
       URIStatus status = fs.getStatus(uri);
       Assert.assertNotEquals(100, status.getInMemoryPercentage());
     }
@@ -275,34 +269,24 @@ public final class DistributedLoadCommandTest extends AbstractFileSystemShellTes
   }
 
   @Test
-  public void loadDirWithFailure() throws IOException, AlluxioException, InterruptedException {
+  public void loadDirWithFailure() throws IOException, AlluxioException {
     FileSystemShell fsShell = new FileSystemShell(ServerConfiguration.global());
     FileSystem fs = sResource.get().getClient();
-
     int fileSize = 20;
     for (int i = 0; i < fileSize; i++) {
       FileSystemTestUtils.createByteFile(fs, "/testFailure/testBatchFile" + i, WritePType.THROUGH,
           10);
-
-
-      if (i% 2 == 0) {
+      if (i % 2 == 0) {
         AlluxioURI uri = new AlluxioURI("/testFailure/testBatchFile" + i);
         URIStatus fileInfo = fs.getStatus(uri);
         String path = fileInfo.getFileInfo().getUfsPath();
         boolean result = new File(path).delete();
         Assert.assertTrue(result);
       }
-
     }
     fsShell.run("distributedLoad", "/testFailure");
-Thread.sleep(5000);
-    fsShell.run("ls", "/testFailure");
-
-    Assert.assertEquals(mOutput,"");
     Assert.assertTrue(mOutput.toString().contains("Completed count is 10,Failed count is 10.\n"));
-    Assert.assertTrue(mOutput.toString().contains("Check out ./logs/user/distributedLoad_testFailure_failures.csv for full list of failed files."));
-
-
-
+    Assert.assertTrue(mOutput.toString().contains(
+        "Check out ./logs/user/distributedLoad_testFailure_failures.csv for full list of failed files."));
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
@@ -250,4 +250,23 @@ public final class DistributedLoadCommandTest extends AbstractFileSystemShellTes
       Assert.assertEquals(100, status.getInMemoryPercentage());
     }
   }
+  @Test
+  public void loadDirWithCorrectCount() throws IOException, AlluxioException {
+    FileSystemShell fsShell = new FileSystemShell(ServerConfiguration.global());
+    FileSystem fs = sResource.get().getClient();
+    int fileSize = 99;
+    List<AlluxioURI> uris = new ArrayList<>(fileSize);
+    for (int i = 0; i < fileSize; i++) {
+      FileSystemTestUtils.createByteFile(fs, "/testCount/testBatchFile" + i, WritePType.THROUGH,
+          10);
+
+      AlluxioURI uri = new AlluxioURI("/testCount/testBatchFile" + i);
+      uris.add(uri);
+      URIStatus status = fs.getStatus(uri);
+      Assert.assertNotEquals(100, status.getInMemoryPercentage());
+    }
+    fsShell.run("distributedLoad", "/testCount", "--batch-size", "3");
+    String[] output = mOutput.toString().split("\n");
+    Assert.assertEquals(String.format("Completed count is %s,Failed count is 0.",fileSize), output[output.length-1]);
+  }
 }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
@@ -15,7 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.cli.fs.FileSystemShell;
 import alluxio.cli.fs.command.DistributedLoadCommand;
 import alluxio.client.cli.fs.AbstractFileSystemShellTest;
-import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
@@ -36,14 +35,11 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 
 /**

--- a/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
@@ -254,7 +254,7 @@ public final class DistributedLoadCommandTest extends AbstractFileSystemShellTes
   public void loadDirWithCorrectCount() throws IOException, AlluxioException {
     FileSystemShell fsShell = new FileSystemShell(ServerConfiguration.global());
     FileSystem fs = sResource.get().getClient();
-    int fileSize = 99;
+    int fileSize = 66;
     List<AlluxioURI> uris = new ArrayList<>(fileSize);
     for (int i = 0; i < fileSize; i++) {
       FileSystemTestUtils.createByteFile(fs, "/testCount/testBatchFile" + i, WritePType.THROUGH,


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix the CLI output of distributedLoad command 
### Why are the changes needed?

With batch, the output of distributedLoad command output is having wrong file count. And there's no way for user to parse the output and get failures. S

### Does this PR introduce any user facing changes?

  1. change in user-facing CLI
If there's failure in the execution, there would be additional output as the following:
Here are recent failed files:
/a/b/c,
/a/b/d,
Check out logs/user/distributedLoad_`PATH`_failures.csv for full list of failed files 
(PATH here would be the underscore separated path of distributedLoad command, for example if path is /a/b/c, then the failure file would be in logs/user/distributedLoad_a_b_c_failures.csv)
Output file format would be one failure file name per line without header:
/a/b/c
/c/b/a