### PR TITLE
Support bypassing backup delegation via shell switch

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/backup/BackupLeaderRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupLeaderRole.java
@@ -164,10 +164,16 @@ public class BackupLeaderRole extends AbstractBackupRole {
       // Whether to attempt to delegate backup to a backup worker.
       delegateBackup = ServerConfiguration.getBoolean(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED)
           && ConfigurationUtils.isHaMode(ServerConfiguration.global());
+      // Check if backup-delegation is suppressed by back-up client.
+      if (delegateBackup && request.getOptions().getBypassDelegation()) {
+        LOG.info("Back-up delegation is suppressed by back-up client.");
+        delegateBackup = false;
+      }
       // Fail, if in HA mode and no masters available to delegate,
       // unless `AllowLeader` flag in the backup request is set.
       if (delegateBackup && mBackupWorkerHostNames.size() == 0) {
         if (request.getOptions().getAllowLeader()) {
+          LOG.info("Back-up delegation is deactivated for cluster with no followers.");
           delegateBackup = false;
         } else {
           throw new BackupDelegationException("No master found to delegate backup.");

--- a/core/transport/src/main/proto/grpc/meta_master.proto
+++ b/core/transport/src/main/proto/grpc/meta_master.proto
@@ -121,6 +121,7 @@ message BackupPOptions {
     optional bool localFileSystem = 1;
     optional bool runAsync = 2;
     optional bool allowLeader = 3;
+    optional bool bypassDelegation = 4;
 }
 message BackupPStatus {
     optional string backupId = 1;

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -5021,6 +5021,11 @@
                 "id": 3,
                 "name": "allowLeader",
                 "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "bypassDelegation",
+                "type": "bool"
               }
             ]
           },

--- a/docs/en/operation/Journal.md
+++ b/docs/en/operation/Journal.md
@@ -217,7 +217,10 @@ Since it is uncertain which host will take the backup, it is suggested to use sh
 
 A backup attempt will fail if delegation fails to find a standby master, thus favoring service availability.
 For manual backups, you can pass `--allow-leader` option to allow the leading master to take a backup when there are no standby masters to delegate the backup.
-This will cause temporary service unavailability while the leading master is writing a backup.
+
+You can also pass `--bypass-delegation` flag to disable delegation all together.
+
+Disabling backup delegation using above flags will revert backup behavior to local and will cause temporary service unavailability while the leading master is writing a backup.
 
 ### Restoring from a backup
 

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/BackupCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/BackupCommand.java
@@ -49,7 +49,15 @@ public class BackupCommand extends AbstractFsAdminCommand {
           .required(false)
           .hasArg(false)
           .desc("whether to allow leader to take the backup when"
-              + " HA cluster has no standby master.")
+              + " backup delegation is enabled and HA cluster has no standby master.")
+          .build();
+  private static final Option BYPASS_DELEGATION_OPTION =
+      Option.builder()
+          .longOpt("bypass-delegation")
+          .required(false)
+          .hasArg(false)
+          .desc("when specified, the leading master will by-pass backup delegation,"
+              + " if it was enabled by configuration.")
           .build();
 
   /**
@@ -83,7 +91,8 @@ public class BackupCommand extends AbstractFsAdminCommand {
         BackupPOptions.newBuilder()
             .setRunAsync(true)
             .setLocalFileSystem(cl.hasOption(LOCAL_OPTION.getLongOpt()))
-            .setAllowLeader(cl.hasOption(ALLOW_LEADER_OPTION.getLongOpt())));
+            .setAllowLeader(cl.hasOption(ALLOW_LEADER_OPTION.getLongOpt()))
+            .setBypassDelegation(cl.hasOption(BYPASS_DELEGATION_OPTION.getLongOpt())));
     // Take backup in async mode.
     BackupStatus status = mMetaClient.backup(opts.build());
     UUID backupId = status.getBackupId();


### PR DESCRIPTION
### What changes are proposed in this pull request?

Introducing a new flag `--bypass-delegation` to backup command for safely by-passing backup delegation.
Passing this flag will revert leading master to taking backups locally.

### Why are the changes needed?

This new flag provides a fail-safe switch for backup delegation problems.

### Does this PR introduce any user facing changes?
1- fsadmin backup command is given an additional flag.
