### PR TITLE
[DOCFIX] Update k8s doc

### DIFF
--- a/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
+++ b/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
@@ -793,7 +793,7 @@ matching PersistentVolumes. See "(Optional) Provision a Persistent Volume" in
 
 Once ready, access the Alluxio CLI from the master Pod and run basic I/O tests.
 ```console
-$ kubectl exec -ti alluxio-master-0 /bin/bash
+$ kubectl exec -ti alluxio-master-0 -- /bin/bash
 ```
 
 From the master Pod, execute the following:
@@ -1232,7 +1232,7 @@ capture the updated environment variables and send logs to the remote log server
 You can go into the log server pod and verify the logs exist.
 
 ```console
-$ kubectl exec -it <logserver-pod-name> bash
+$ kubectl exec -it <logserver-pod-name> -- bash
 # In the logserver pod
 bash-4.4$ pwd
 /opt/alluxio
@@ -1792,7 +1792,7 @@ follows:
 
 Access the Alluxio CLI from the master Pod.
 ```console
-$ kubectl exec -ti alluxio-master-0 /bin/bash
+$ kubectl exec -ti alluxio-master-0 -- /bin/bash
 ```
 
 From the master Pod, execute the following:


### PR DESCRIPTION
A minor update to add `--` in the `kubectl` command in the doc.

We can still run the command as expected if we don't put the `--` before the command, but we would get a warning `kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead. `