### PR TITLE
Improve locking in LostWorkerDetectionHeartbeatExecutor

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1455,13 +1455,13 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     public void heartbeat() {
       long masterWorkerTimeoutMs = ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_TIMEOUT_MS);
       for (MasterWorkerInfo worker : mWorkers) {
-        try (LockResource r = worker.lockWorkerMeta(
-            EnumSet.of(WorkerMetaLockSection.BLOCKS), false)) {
-          // This is not locking because the field is atomic
-          final long lastUpdate = mClock.millis() - worker.getLastUpdatedTimeMs();
-          if (lastUpdate > masterWorkerTimeoutMs) {
-            LOG.error("The worker {}({}) timed out after {}ms without a heartbeat!", worker.getId(),
-                worker.getWorkerAddress(), lastUpdate);
+        // This is not locking because the field is atomic
+        final long lastUpdate = mClock.millis() - worker.getLastUpdatedTimeMs();
+        if (lastUpdate > masterWorkerTimeoutMs) {
+          try (LockResource r = worker.lockWorkerMeta(
+              EnumSet.of(WorkerMetaLockSection.BLOCKS), false)) {
+            LOG.error("The worker {}({}) timed out after {}ms without a heartbeat!",
+                worker.getId(), worker.getWorkerAddress(), lastUpdate);
             processLostWorker(worker);
           }
         }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Move the locked section to only when the worker is lost and removed

### Why are the changes needed?

When the worker is not lost, no need to take the lock.

### Does this PR introduce any user facing changes?

NA
