### PR TITLE
[SMALLFIX] Fix the logging message in BackupWorkerRole

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
@@ -375,7 +375,7 @@ public class BackupWorkerRole extends AbstractBackupRole {
 
         leaderAddress = inquireClient.getPrimaryRpcAddress();
       } catch (Throwable t) {
-        LOG.warn("Failed to get backup-leader address. {}. Error:{}. Attempt:{}", t.toString(),
+        LOG.warn("Failed to get backup-leader address. Error:{}. Attempt:{}", t.toString(),
             infiniteRetryPolicy.getAttemptCount());
         continue;
       }


### PR DESCRIPTION
What changes are proposed in this pull request?
Fix https://github.com/Alluxio/new-contributor-tasks/issues/630
Fix the logging message in BackupWorkerRole when failed to get backup-leader address.

Why are the changes needed?
Improve logging format.

Does this PR introduce any user facing changes?
No.