### PR TITLE
Fix RaftJournalSystem / AlluxioMaster shutdown hook deadlock

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -380,6 +380,10 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     RaftServerConfigKeys.Log.Appender.setInstallSnapshotEnabled(
         properties, false);
 
+    // if left enabled, the System.exit() called by Ratis can deadlock with the AlluxioMaster
+    // process shutdown hook
+    org.apache.ratis.util.ExitUtils.disableSystemExit();
+
     /*
      * Soft disable RPC level safety.
      *

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -381,7 +381,16 @@ public class RaftJournalSystem extends AbstractJournalSystem {
         properties, false);
 
     // if left enabled, the System.exit() called by Ratis can deadlock with the AlluxioMaster
-    // process shutdown hook
+    // process shutdown hook. Description:
+    // * The AlluxioMaster starts the RaftJournalSystem using RaftJournalSystem.startInternal().
+    //   It now holds a synchronized lock on RaftJournalSystem.
+    // * startInternal calls mServer.start() and fails for any reason, calling System.exit(int) -->
+    //   Runtime.getRuntime().exit(int) in Ratis.
+    // * Runtime.getRuntime().exit(int) calls the shutdown hooks, including the {@link ProcessUtils)
+    //   --> process.stop() --> RaftJournalSystem.stopInternal(), which cannot proceed because of
+    //   the synchronized lock on RaftJournalSystem.
+    // This line disables the System.exit(int) call in Ratis internally in favor of an
+    // Exception being thrown. This prevents the deadlock.
     org.apache.ratis.util.ExitUtils.disableSystemExit();
 
     /*


### PR DESCRIPTION
### Description of bug
 - The `AlluxioMaster` starts the `RaftJournalSystem` using `RaftJournalSystem#startInternal`. It now holds a `synchronized` lock on `RaftJournalSystem`.
https://github.com/Alluxio/alluxio/blob/dea6a46d67640f54d133744a9b318849fad9ae5c/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java#L748

- `startInternal` gets to
https://github.com/Alluxio/alluxio/blob/dea6a46d67640f54d133744a9b318849fad9ae5c/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java#L768
This action fails, for whatever reason, causing `System.exit(int)` --> `Runtime.getRuntime().exit(int)` internally in [Ratis](https://github.com/apache/ratis/blob/96db7f6801738c1c1036f205d925be02e219426c/ratis-common/src/main/java/org/apache/ratis/util/ExitUtils.java#L138). 

- `Runtime.getRuntime().exit(int)` calls the shotdown hooks, including: 
https://github.com/Alluxio/alluxio/blob/dea6a46d67640f54d133744a9b318849fad9ae5c/core/server/common/src/main/java/alluxio/ProcessUtils.java#L96-L98
`process.stop()` calls `RaftJournalSystem.stopInternal()`, which cannot proceed because of the `synchronized` lock on `RaftJournalSystem.startInternal()`.

### Result
Deadlock.

### Fix
This one line disables the `System.exit(int)` call in Ratis internally in favor of an Exception being thrown. This prevents the deadlock.

