### PR TITLE
Remove fuse default_permission

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5407,20 +5407,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "other value to use libfuse2 first, libfuse3 if libfuse2 failed")
           .setScope(Scope.ALL)
           .build();
-  public static final PropertyKey FUSE_PERMISSION_CHECK_ENABLED =
-      new Builder(Name.FUSE_PERMISSION_CHECK_ENABLED)
-          .setDefaultValue(true)
-          .setDescription("Whether to add -o default_permissions fuse mount option by default. "
-              + "When this option is enabled, kernel will perform its own permission check "
-              + "instead of deferring all permission checking to Alluxio. "
-              + "Alluxio Fuse does all the permission check "
-              + "with user that launches the Fuse application instead of "
-              + "the user running the Fuse operations. Please do not set this value to false "
-              + "unless permission check is not important in your workloads.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
-          .setScope(Scope.CLIENT)
-          .setIsHidden(true)
-          .build();
   public static final PropertyKey FUSE_SHARED_CACHING_READER_ENABLED =
       new Builder(Name.FUSE_SHARED_CACHING_READER_ENABLED)
           .setDefaultValue(false)
@@ -7202,8 +7188,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String FUSE_DEBUG_ENABLED = "alluxio.fuse.debug.enabled";
     public static final String FUSE_FS_NAME = "alluxio.fuse.fs.name";
     public static final String FUSE_JNIFUSE_ENABLED = "alluxio.fuse.jnifuse.enabled";
-    public static final String FUSE_PERMISSION_CHECK_ENABLED
-        = "alluxio.fuse.permission.check.enabled";
     public static final String FUSE_SHARED_CACHING_READER_ENABLED
         = "alluxio.fuse.shared.caching.reader.enabled";
     public static final String FUSE_LOGGING_THRESHOLD = "alluxio.fuse.logging.threshold";

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -295,10 +295,6 @@ public final class AlluxioFuse {
       res.add(String.format("-omax_write=%d", maxWrite));
     }
 
-    if (alluxioConf.getBoolean(PropertyKey.FUSE_PERMISSION_CHECK_ENABLED)) {
-      // double same fuse mount options will not error out
-      res.add("-odefault_permissions");
-    }
     return res;
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove default_permission mount option.

### Why are the changes needed?

Alluxio fuse needs comprehensive security story. Before that story come out, it does not make sense to enable default_permissions

### Does this PR introduce any user facing changes?
NA
