### PR TITLE
Ignore errors while closing the UFS journal log writer's internal stream

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
@@ -307,7 +307,7 @@ public class UfsJournal implements Journal {
    *
    * This must be called after {@link #signalLosePrimacy()} to finish the transition from primary.
    */
-  public synchronized void awaitLosePrimacy() throws IOException {
+  public synchronized void awaitLosePrimacy() {
     Preconditions.checkState(mState.get() == State.STANDBY,
         "Should already be set to STANDBY state. unexpected state: " + mState.get());
     Preconditions.checkState(mWriter != null, "writer thread must not be null in primary mode");
@@ -628,7 +628,7 @@ public class UfsJournal implements Journal {
   }
 
   @Override
-  public synchronized void close() throws IOException {
+  public synchronized void close() {
     if (mAsyncWriter != null) {
       mAsyncWriter.close();
       mAsyncWriter = null;

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
@@ -393,7 +393,7 @@ final class UfsJournalLogWriter implements JournalWriter {
   }
 
   @Override
-  public synchronized void close() throws IOException {
+  public synchronized void close() {
     if (mClosed) {
       return;
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
@@ -116,12 +116,8 @@ public class UfsJournalSystem extends AbstractJournalSystem {
     }
 
     // Wait for all journals to transition to standby
-    try {
-      for (UfsJournal journal : mJournals.values()) {
-        journal.awaitLosePrimacy();
-      }
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to downgrade journal to standby", e);
+    for (UfsJournal journal : mJournals.values()) {
+      journal.awaitLosePrimacy();
     }
   }
 


### PR DESCRIPTION
When master process is paused (via sigkill) for a long time, the internal hdfs-client can get confused about the data-node states and throw runtime exception. In an FT cluster, this currently means if a master encounters this during losePrimacy time, it'll never come back up. 

Overall, it's OK to ignore internal streaming errors during `close()`. Because the next time it'll either be a read stream or a new write stream.