### PR TITLE
Fix helm add env for fuse daemonset

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -245,3 +245,7 @@
 0.6.37
 
 - Fix jobMaster.env indentations in master statefulset
+
+0.6.38
+
+- Fix MOUNT_POINT env in fuse daemonset

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.37
+version: 0.6.38
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
@@ -111,6 +111,8 @@ spec:
                 fieldPath: status.hostIP
           - name: FUSE_ALLUXIO_PATH
             value: {{ .Values.fuse.alluxioPath }}
+          - name: MOUNT_POINT
+            value: {{ .Values.fuse.mountPath }}
           {{- range $key, $value := .Values.fuse.env }}
           - name: "{{ $key }}"
             value: "{{ $value }}"


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add `MOUNT_POINT` env for fuse daemonset.

```
          env:
          ...
          - name: MOUNT_POINT
            value: {{ .Values.fuse.mountPath }}
          ...
```

### Why are the changes needed?

`MOUNT_POINT` env is required in `entrypoint.sh` for fuse argument:

```
MOUNT_POINT="${MOUNT_POINT:-/mnt/alluxio-fuse}"
...
function mountAlluxioRootFSWithFuseOption {
...
  exec integration/fuse/bin/alluxio-fuse mount -n ${fuseOptions} ${MOUNT_POINT} ${ALLUXIO_PATH}
}
```

But `MOUNT_POINT` is not set in fuse daemonset through env. So if the `.Values.fuse.mountPath` is set other than default `/mnt/alluxio-fuse`, the entrypoint will fuse to a wrong mount point.

### Does this PR introduce any user facing changes?

Fix wrong mount point path if user set their own `Values.fuse.mountPath` in helm chart.
