### PR TITLE
Add dir-start-index fuseStressBench

### DIFF
--- a/stress/common/src/main/java/alluxio/stress/fuse/FuseIOParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/fuse/FuseIOParameters.java
@@ -62,6 +62,11 @@ public final class FuseIOParameters extends Parameters {
           + "10000ms, etc.)")
   public String mWarmup = "15s";
 
+  @Parameter(names = {"--dir-start-index"},
+      description = "The first index of the generated dirs. Used for generating "
+          + "test files in multiple batches.")
+  public int mDirStartIndex = 0;
+
   /**
    * Converts from String to FuseIOOperation instance.
    *

--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -146,7 +146,8 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
     File localPath = new File(mParameters.mLocalPath);
 
     if (mParameters.mOperation == FuseIOOperation.WRITE) {
-      for (int i = 0; i < mParameters.mNumDirs; i++) {
+      int startIndex = mParameters.mDirStartIndex;
+      for (int i = startIndex; i < startIndex + mParameters.mNumDirs; i++) {
         Files.createDirectories(Paths.get(String.format(
             TEST_DIR_STRING_FORMAT, mParameters.mLocalPath, mBaseParameters.mId, i)));
       }
@@ -417,7 +418,8 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
     }
 
     private void writeOrLocalRead() throws Exception {
-      for (int testDirId = mThreadId; testDirId < mParameters.mNumDirs;
+      int startIndex = mParameters.mDirStartIndex;
+      for (int testDirId = startIndex + mThreadId; testDirId < startIndex + mParameters.mNumDirs;
           testDirId += mParameters.mThreads) {
         for (int testFileId = 0; testFileId < mParameters.mNumFilesPerDir; testFileId++) {
           String filePath = String.format(TEST_FILE_STRING_FORMAT,


### PR DESCRIPTION
When generating data in fuse stressbench, user can choose the directory names to start from a certain index. 

With this change, user is able to generate all test data in different batches. For example, for the first batch we set `--num-dirs 10` and `--dir-start-index 0`, and for the second batch we set `--num-dirs 10` and `--dir-start-index 10`, we are able to generate 20-dirs test files that is recognizable by reading stress bench.