### PR TITLE
Fix success count in job service stressbench

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/StressJobServiceBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/StressJobServiceBench.java
@@ -316,7 +316,7 @@ public class StressJobServiceBench extends Benchmark<JobServiceBenchTaskResult> 
             new AlluxioURI(dirPath), numReplication, new HashSet<>(), new HashSet<>(),
             new HashSet<>(), new HashSet<>(), false, false);
       } finally {
-        mResult.incrementNumSuccess((long) cmd.getCompletedCount() * mParameters.mBatchSize);
+        mResult.incrementNumSuccess(cmd.getCompletedCount());
       }
     }
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix count number in stressbench since we now use file count in distributedLoad command instead of operation count.

### Why are the changes needed?

we now use file count in distributedLoad command instead of operation count after #https://github.com/Alluxio/alluxio/pull/15106

### Does this PR introduce any user facing changes?

na