### PR TITLE
Bump alluxio-maven img to 0.07

### DIFF
--- a/.github/workflows/java11_integration_tests.yml
+++ b/.github/workflows/java11_integration_tests.yml
@@ -56,7 +56,7 @@ jobs:
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
           ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server,!table/server/underdb/glue,!underfs/hdfs,!underfs/ozone,!underfs/adl,!underfs/abfs,!underfs/cosn,!underfs/wasb,!underfs/cos,!underfs/kodo,!underfs/oss,!underfs/swift \
-          ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.6-jdk11 \
+          ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.7-jdk11 \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60
 

--- a/.github/workflows/java11_integration_tests_webui.yml
+++ b/.github/workflows/java11_integration_tests_webui.yml
@@ -40,7 +40,7 @@ jobs:
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
           ALLUXIO_DOCKER_MVN_PROJECT_LIST=!shaded/client,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server \
-          ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.6-jdk11 \
+          ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.7-jdk11 \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60
 

--- a/.github/workflows/java11_unit_tests.yml
+++ b/.github/workflows/java11_unit_tests.yml
@@ -45,7 +45,7 @@ jobs:
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
           ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!assembly/client,!assembly/server \
-          ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.6-jdk11 \
+          ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.7-jdk11 \
           dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl '!tests,!webui,!hub,!hub/server,!hub/transport'
         timeout-minutes: 60
 

--- a/dev/github/run_docker.sh
+++ b/dev/github/run_docker.sh
@@ -23,7 +23,7 @@ function main {
   fi
   if [ -z "${ALLUXIO_DOCKER_IMAGE}" ]
   then
-    ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.0.6-jdk8"
+    ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.0.7-jdk8"
   fi
 
   local run_args="--rm"

--- a/dev/jenkins/run_docker.sh
+++ b/dev/jenkins/run_docker.sh
@@ -23,7 +23,7 @@ function main {
   fi
   if [ -z "${ALLUXIO_DOCKER_IMAGE}" ]
   then
-    ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.0.6-jdk8"
+    ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.0.7-jdk8"
   fi
 
   local run_args="--rm"


### PR DESCRIPTION
Applies the change introduced by https://github.com/Alluxio/alluxio/pull/15150 by building the docker image and updating its references to the newly tagged version