### PR TITLE
[SMALLFIX] Remove noisy log in UfsStatusCache

### DIFF
--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -80,7 +80,6 @@ public class UfsStatusCache {
     mPrefetchExecutor = prefetchExecutor;
     mUfsFetchTimeout =
         ServerConfiguration.getMs(PropertyKey.MASTER_METADATA_SYNC_UFS_PREFETCH_TIMEOUT);
-    LOG.info("UFS fetch timeout set to {}ms", mUfsFetchTimeout);
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove a log message on UfsStatusCache creation.

### Why are the changes needed?

https://github.com/Alluxio/alluxio/pull/15065 added a log message in `UfsStatusCache`. At that moment I didn't realize this `UfsStatusCache` is created on every sync request. Having a log message on every sync request will be too noisy and may even hurt performance.

### Does this PR introduce any user facing changes?

NA