### PR TITLE
Add timeout logic to local block reading/writing

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3064,11 +3064,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
-  public static final PropertyKey WORKER_CACHE_IO_TIMEOUT_THREADS =
-      new Builder(Name.WORKER_CACHE_IO_TIMEOUT_THREADS)
-          .setDefaultValue("32")
+  public static final PropertyKey WORKER_CACHE_IO_TIMEOUT_THREADS_MAX =
+      new Builder(Name.WORKER_CACHE_IO_TIMEOUT_THREADS_MAX)
+          .setDefaultValue("1024")
           .setDescription("The number of threads to handle cache I/O operation timeout, "
-              + "when " + Name.WORKER_CACHE_IO_TIMEOUT_DURATION + " is positive.")
+              + "when " + Name.WORKER_CACHE_IO_TIMEOUT_DURATION + " is positive. "
+              + "Suggest setting this value to the maximum of "
+              + Name.WORKER_NETWORK_BLOCK_READER_THREADS_MAX
+              + " and " + Name.WORKER_NETWORK_BLOCK_WRITER_THREADS_MAX)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
@@ -6738,8 +6741,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.block.heartbeat.timeout";
     public static final String WORKER_CACHE_IO_TIMEOUT_DURATION =
         "alluxio.worker.cache.io.timeout.duration";
-    public static final String WORKER_CACHE_IO_TIMEOUT_THREADS =
-        "alluxio.worker.cache.io.timeout.threads";
+    public static final String WORKER_CACHE_IO_TIMEOUT_THREADS_MAX =
+        "alluxio.worker.cache.io.timeout.threads.max";
     public static final String WORKER_CONTAINER_HOSTNAME =
         "alluxio.worker.container.hostname";
     public static final String WORKER_DATA_FOLDER = "alluxio.worker.data.folder";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3053,6 +3053,25 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
+  public static final PropertyKey WORKER_CACHE_IO_TIMEOUT_DURATION =
+      new Builder(Name.WORKER_CACHE_IO_TIMEOUT_DURATION)
+          .setDefaultValue("-1")
+          .setDescription("The timeout duration for worker cache I/O operations ("
+              + "reading/writing). When this property is a positive value,"
+              + "worker cache operations after timing out will fail and fallback to external "
+              + "file system but transparent to applications; "
+              + "when this property is a negative value, this feature is disabled.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey WORKER_CACHE_IO_TIMEOUT_THREADS =
+      new Builder(Name.WORKER_CACHE_IO_TIMEOUT_THREADS)
+          .setDefaultValue("32")
+          .setDescription("The number of threads to handle cache I/O operation timeout, "
+              + "when " + Name.WORKER_CACHE_IO_TIMEOUT_DURATION + " is positive.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey WORKER_CONTAINER_HOSTNAME =
       new Builder(Name.WORKER_CONTAINER_HOSTNAME)
           .setDescription("The container hostname if worker is running in a container.")
@@ -6717,6 +6736,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.block.heartbeat.interval";
     public static final String WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS =
         "alluxio.worker.block.heartbeat.timeout";
+    public static final String WORKER_CACHE_IO_TIMEOUT_DURATION =
+        "alluxio.worker.cache.io.timeout.duration";
+    public static final String WORKER_CACHE_IO_TIMEOUT_THREADS =
+        "alluxio.worker.cache.io.timeout.threads";
     public static final String WORKER_CONTAINER_HOSTNAME =
         "alluxio.worker.container.hostname";
     public static final String WORKER_DATA_FOLDER = "alluxio.worker.data.folder";

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1312,6 +1312,32 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey WORKER_CACHE_READ_TIMEOUT =
+      new Builder("Worker.CacheReadTimeout")
+          .setDescription("Number of timeouts when writing to worker storage.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey WORKER_CACHE_READ_THREADS_REJECTED =
+      new Builder("Worker.CacheReadThreadsRejected")
+          .setDescription("Number of rejection of I/O threads on submitting tasks to thread pool, "
+              + "likely due to unresponsive local file system.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey WORKER_CACHE_WRITE_TIMEOUT =
+      new Builder("Worker.CacheWriteTimeout")
+          .setDescription("Number of timeouts when writing to worker storage.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey WORKER_CACHE_WRITE_THREADS_REJECTED =
+      new Builder("Worker.CacheWriteThreadsRejected")
+          .setDescription("Number of rejection of I/O threads on submitting tasks to thread pool, "
+              + "likely due to unresponsive local file system.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey WORKER_CACHE_BLOCKS_SIZE =
       new Builder("Worker.CacheBlocksSize")
           .setDescription("Total number of bytes that being cached through cache requests")

--- a/core/common/src/main/java/alluxio/worker/block/io/TimeBoundBlockReader.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/TimeBoundBlockReader.java
@@ -1,0 +1,120 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block.io;
+
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
+
+import com.codahale.metrics.Counter;
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.SimpleTimeLimiter;
+import com.google.common.util.concurrent.TimeLimiter;
+import io.netty.buffer.ByteBuf;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A wrapper class on {@link BlockReader} with timeout.
+ * Note that, this reader will not queue any request.
+ */
+public class TimeBoundBlockReader extends BlockReader {
+  private final BlockReader mBlockReader;
+  private final long mTimeoutMs;
+  private TimeLimiter mTimeLimter = null;
+  private ExecutorService mExecutorService = null;
+
+  /**
+   * Creates new time bounded block reader.
+   *
+   * @param blockReader the block reader
+   * @param timeoutMs timeout in milliseconds
+   * @param timeoutThreads threads to execute operation and timeout
+   */
+  public TimeBoundBlockReader(BlockReader blockReader, long timeoutMs, int timeoutThreads)
+      throws IOException {
+    mBlockReader = blockReader;
+    mTimeoutMs = timeoutMs;
+    mExecutorService = new ThreadPoolExecutor(timeoutThreads,
+        timeoutThreads, 0L, TimeUnit.MILLISECONDS, new SynchronousQueue<>());
+    mTimeLimter = SimpleTimeLimiter.create(mExecutorService);
+  }
+
+  @Override
+  public ByteBuffer read(long offset, long length) throws IOException {
+    return callWithTimeout(() -> mBlockReader.read(offset, length));
+  }
+
+  @Override
+  public int transferTo(ByteBuf buf) throws IOException {
+    return callWithTimeout(() -> mBlockReader.transferTo(buf));
+  }
+
+  @Override
+  public void close() throws IOException {
+    mExecutorService.shutdown();
+    mBlockReader.close();
+  }
+
+  @Override
+  public long getLength() {
+    return mBlockReader.getLength();
+  }
+
+  @Override
+  public ReadableByteChannel getChannel() {
+    return mBlockReader.getChannel();
+  }
+
+  @Override
+  public boolean isClosed() {
+    return mBlockReader.isClosed();
+  }
+
+  @Override
+  public String getLocation() {
+    return mBlockReader.getLocation();
+  }
+
+  private <T> T callWithTimeout(Callable<T> callable) throws IOException {
+    try {
+      return mTimeLimter.callWithTimeout(callable, mTimeoutMs, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException(e);
+    } catch (TimeoutException e) {
+      Metrics.READ_TIMEOUT.inc();
+      throw new IOException(e);
+    } catch (RejectedExecutionException e) {
+      Metrics.READ_THREAD_REJECTED.inc();
+      throw new IOException(e);
+    } catch (Throwable t) {
+      Throwables.propagateIfPossible(t, IOException.class);
+      throw new IOException(t);
+    }
+  }
+
+  private static final class Metrics {
+    private static final Counter READ_TIMEOUT =
+        MetricsSystem.counter(MetricKey.WORKER_CACHE_READ_TIMEOUT.getName());
+    private static final Counter READ_THREAD_REJECTED =
+        MetricsSystem.counter(MetricKey.WORKER_CACHE_READ_THREADS_REJECTED.getName());
+  }
+}

--- a/core/common/src/main/java/alluxio/worker/block/io/TimeBoundBlockWriter.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/TimeBoundBlockWriter.java
@@ -1,0 +1,116 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block.io;
+
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
+import alluxio.network.protocol.databuffer.DataBuffer;
+
+import com.codahale.metrics.Counter;
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.SimpleTimeLimiter;
+import com.google.common.util.concurrent.TimeLimiter;
+import io.netty.buffer.ByteBuf;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A wrapper class on {@link BlockWriter} with timeout.
+ * Note that, this reader will not queue any request.
+ */
+public class TimeBoundBlockWriter extends BlockWriter {
+  private final BlockWriter mBlockWriter;
+  private final long mTimeoutMs;
+  private final TimeLimiter mTimeLimter;
+  private final ExecutorService mExecutorService;
+
+  /**
+   * Creates new time bounded block writer.
+   *
+   * @param blockWriter the block writer
+   * @param timeoutMs timeout in milliseconds
+   * @param timeoutThreads threads to execute read operations and timeout
+   */
+  public TimeBoundBlockWriter(BlockWriter blockWriter, long timeoutMs, int timeoutThreads)
+      throws IOException {
+    mBlockWriter = blockWriter;
+    mTimeoutMs = timeoutMs;
+    mExecutorService = new ThreadPoolExecutor(timeoutThreads,
+        timeoutThreads, 0L, TimeUnit.MILLISECONDS, new SynchronousQueue<>());
+    mTimeLimter = SimpleTimeLimiter.create(mExecutorService);
+  }
+
+  @Override
+  public long append(ByteBuffer inputBuf) throws IOException {
+    return callWithTimeout(() -> mBlockWriter.append(inputBuf));
+  }
+
+  @Override
+  public long append(ByteBuf buf) throws IOException {
+    return callWithTimeout(() -> mBlockWriter.append(buf));
+  }
+
+  @Override
+  public long append(DataBuffer buffer) throws IOException {
+    return callWithTimeout(() -> mBlockWriter.append(buffer));
+  }
+
+  @Override
+  public long getPosition() {
+    return mBlockWriter.getPosition();
+  }
+
+  @Override
+  public WritableByteChannel getChannel() {
+    return mBlockWriter.getChannel();
+  }
+
+  @Override
+  public void close() throws IOException {
+    mExecutorService.shutdown();
+    mBlockWriter.close();
+  }
+
+  private <T> T callWithTimeout(Callable<T> callable) throws IOException {
+    try {
+      return mTimeLimter.callWithTimeout(callable, mTimeoutMs, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException(e);
+    } catch (TimeoutException e) {
+      Metrics.WRITE_TIMEOUT.inc();
+      throw new IOException(e);
+    } catch (RejectedExecutionException e) {
+      Metrics.WRITE_THREAD_REJECTED.inc();
+      throw new IOException(e);
+    } catch (Throwable t) {
+      Throwables.propagateIfPossible(t, IOException.class);
+      throw new IOException(t);
+    }
+  }
+
+  private static final class Metrics {
+    private static final Counter WRITE_TIMEOUT =
+        MetricsSystem.counter(MetricKey.WORKER_CACHE_WRITE_TIMEOUT.getName());
+    private static final Counter WRITE_THREAD_REJECTED =
+        MetricsSystem.counter(MetricKey.WORKER_CACHE_WRITE_THREADS_REJECTED.getName());
+  }
+}

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -215,7 +215,7 @@ public class TieredBlockStore implements BlockStore {
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       checkTempBlockOwnedBySession(sessionId, blockId);
       TempBlockMeta tempBlockMeta = mMetaManager.getTempBlockMeta(blockId);
-      BlockWriter writer = new StoreBlockWriter(tempBlockMeta, TIMEOUT_DURATION, TIMEOUT_THREADS);
+      BlockWriter writer = new StoreBlockWriter(tempBlockMeta);
       if (TIMEOUT_DURATION > 0) {
         return new TimeBoundBlockWriter(writer, TIMEOUT_DURATION, TIMEOUT_THREADS);
       }

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -29,6 +29,8 @@ import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
 import alluxio.worker.block.io.StoreBlockReader;
 import alluxio.worker.block.io.StoreBlockWriter;
+import alluxio.worker.block.io.TimeBoundBlockReader;
+import alluxio.worker.block.io.TimeBoundBlockWriter;
 import alluxio.worker.block.management.DefaultStoreLoadTracker;
 import alluxio.worker.block.management.ManagementTaskCoordinator;
 import alluxio.worker.block.meta.BlockMeta;
@@ -90,6 +92,11 @@ public class TieredBlockStore implements BlockStore {
   private static final long REMOVE_BLOCK_TIMEOUT_MS = 60_000;
   private static final long FREE_AHEAD_BYTETS =
       ServerConfiguration.getBytes(PropertyKey.WORKER_TIERED_STORE_FREE_AHEAD_BYTES);
+  private static final long TIMEOUT_DURATION =
+      ServerConfiguration.getMs(PropertyKey.WORKER_CACHE_IO_TIMEOUT_DURATION);
+  private static final int TIMEOUT_THREADS =
+      ServerConfiguration.getInt(PropertyKey.WORKER_CACHE_IO_TIMEOUT_THREADS);
+
   private final BlockMetadataManager mMetaManager;
   private final BlockLockManager mLockManager;
   private final Allocator mAllocator;
@@ -208,7 +215,11 @@ public class TieredBlockStore implements BlockStore {
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       checkTempBlockOwnedBySession(sessionId, blockId);
       TempBlockMeta tempBlockMeta = mMetaManager.getTempBlockMeta(blockId);
-      return new StoreBlockWriter(tempBlockMeta);
+      BlockWriter writer = new StoreBlockWriter(tempBlockMeta, TIMEOUT_DURATION, TIMEOUT_THREADS);
+      if (TIMEOUT_DURATION > 0) {
+        return new TimeBoundBlockWriter(writer, TIMEOUT_DURATION, TIMEOUT_THREADS);
+      }
+      return writer;
     }
   }
 
@@ -219,7 +230,11 @@ public class TieredBlockStore implements BlockStore {
     mLockManager.validateLock(sessionId, blockId, lockId);
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       BlockMeta blockMeta = mMetaManager.getBlockMeta(blockId);
-      return new StoreBlockReader(sessionId, blockMeta);
+      BlockReader reader = new StoreBlockReader(sessionId, blockMeta);
+      if (TIMEOUT_DURATION > 0) {
+        return new TimeBoundBlockReader(reader, TIMEOUT_DURATION, TIMEOUT_THREADS);
+      }
+      return reader;
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -94,8 +94,8 @@ public class TieredBlockStore implements BlockStore {
       ServerConfiguration.getBytes(PropertyKey.WORKER_TIERED_STORE_FREE_AHEAD_BYTES);
   private static final long TIMEOUT_DURATION =
       ServerConfiguration.getMs(PropertyKey.WORKER_CACHE_IO_TIMEOUT_DURATION);
-  private static final int TIMEOUT_THREADS =
-      ServerConfiguration.getInt(PropertyKey.WORKER_CACHE_IO_TIMEOUT_THREADS);
+  private static final int TIMEOUT_THREADS_MAX =
+      ServerConfiguration.getInt(PropertyKey.WORKER_CACHE_IO_TIMEOUT_THREADS_MAX);
 
   private final BlockMetadataManager mMetaManager;
   private final BlockLockManager mLockManager;
@@ -217,7 +217,7 @@ public class TieredBlockStore implements BlockStore {
       TempBlockMeta tempBlockMeta = mMetaManager.getTempBlockMeta(blockId);
       BlockWriter writer = new StoreBlockWriter(tempBlockMeta);
       if (TIMEOUT_DURATION > 0) {
-        return new TimeBoundBlockWriter(writer, TIMEOUT_DURATION, TIMEOUT_THREADS);
+        return new TimeBoundBlockWriter(writer, TIMEOUT_DURATION, TIMEOUT_THREADS_MAX);
       }
       return writer;
     }
@@ -232,7 +232,7 @@ public class TieredBlockStore implements BlockStore {
       BlockMeta blockMeta = mMetaManager.getBlockMeta(blockId);
       BlockReader reader = new StoreBlockReader(sessionId, blockMeta);
       if (TIMEOUT_DURATION > 0) {
-        return new TimeBoundBlockReader(reader, TIMEOUT_DURATION, TIMEOUT_THREADS);
+        return new TimeBoundBlockReader(reader, TIMEOUT_DURATION, TIMEOUT_THREADS_MAX);
       }
       return reader;
     }


### PR DESCRIPTION
One of the fix for https://github.com/Alluxio/alluxio/issues/15019

### What changes are proposed in this pull request?
When read/write from/to local block, timeout when taking too long.
### Why are the changes needed?
Sometimes read/write to disk will hang and cannot be recovered.
### Does this PR introduce any user facing changes?
When read/write takes too long, a timeout exception is thrown