### PR TITLE
Disable noisy info log from ratis

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -210,4 +210,6 @@ log4j.logger.io.grpc.netty.NettyServerHandler=OFF
 log4j.logger.org.apache.ratis.grpc.server.GrpcLogAppender=ERROR
 log4j.logger.org.apache.ratis.grpc.server.GrpcServerProtocolService=WARN
 log4j.logger.org.apache.ratis.server.impl.FollowerInfo=WARN
+log4j.logger.org.apache.ratis.server.leader.FollowerInfo=WARN
 log4j.logger.org.apache.ratis.server.impl.RaftServerImpl=WARN
+log4j.logger.org.apache.ratis.server.RaftServer$Division=WARN


### PR DESCRIPTION
fixes #15173

### What changes are proposed in this pull request?

Correctly set `FollowerInfo` and `RaftServer$Division` logger to WARN level

### Why are the changes needed?

Avoid overwhelm leader and follower logs

### Does this PR introduce any user facing changes?

No