### PR TITLE
Correct CSI Driver apiVersion and rbac namespace

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -252,4 +252,5 @@
 
 0.6.39
 
-- Fix csi controller rbac rule not specifying namespace.
+- Fix CSI controller rbac rule not specifying namespace.
+- Fix CSI driver compatibility issue under kubernetes 18+ version.

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -249,3 +249,7 @@
 0.6.38
 
 - Fix MOUNT_POINT env in fuse daemonset
+
+0.6.39
+
+- Fix csi controller rbac rule not specifying namespace.

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.38
+version: 0.6.39
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/csi/controller-rbac.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/csi/controller-rbac.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: csi-controller-sa
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 ---
 
 kind: ClusterRole
@@ -51,7 +51,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: csi-controller-sa
-    namespace: default
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: alluxio-external-provisioner-role

--- a/integration/kubernetes/helm-chart/alluxio/templates/csi/driver.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/csi/driver.yaml
@@ -10,7 +10,7 @@
 #
 
 {{ if .Values.csi.enabled -}}
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: {{ ternary "storage.k8s.io/v1" "storage.k8s.io/v1beta1" (semverCompare ">=1.18.0-0" .Capabilities.KubeVersion.Version) }}
 kind: CSIDriver
 metadata:
   name: alluxio


### PR DESCRIPTION
### What changes are proposed in this pull request?

Correct CSI Driver apiVersion and rbac namespace.

### Why are the changes needed?

* CSI controller rbac is currently only created under the default namespace.
* `storage.k8s.io/v1beta1/CSIDriver` is replaced by `storage.k8s.io/v1/CSIDriver` in kubernetes 18+ version.

### Does this PR introduce any user facing changes?

No user facing changes.
