### PR TITLE
Enable UFS to return Fingerprint

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/BaseUnderFileSystem.java
@@ -48,6 +48,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public abstract class BaseUnderFileSystem implements UnderFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(BaseUnderFileSystem.class);
+  public static final Pair<AccessControlList, DefaultAccessControlList> EMPTY_ACL =
+      new Pair<>(null, null);
 
   /** The UFS {@link AlluxioURI} used to create this {@link BaseUnderFileSystem}. */
   protected final AlluxioURI mUri;
@@ -84,7 +86,7 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
   @Override
   public Pair<AccessControlList, DefaultAccessControlList> getAclPair(String path)
       throws IOException {
-    return new Pair<>(null, null);
+    return EMPTY_ACL;
   }
 
   @Override
@@ -113,6 +115,22 @@ public abstract class BaseUnderFileSystem implements UnderFileSystem {
       // In certain scenarios, it is expected that the UFS path does not exist.
       LOG.debug("Failed fingerprint. path: {} error: {}", path, e.toString());
       return Constants.INVALID_UFS_FINGERPRINT;
+    }
+  }
+
+  @Override
+  public Fingerprint getParsedFingerprint(String path) {
+    try {
+      UfsStatus status = getStatus(path);
+      Pair<AccessControlList, DefaultAccessControlList> aclPair = getAclPair(path);
+
+      if (aclPair == null || aclPair.getFirst() == null || !aclPair.getFirst().hasExtended()) {
+        return Fingerprint.create(getUnderFSType(), status);
+      } else {
+        return Fingerprint.create(getUnderFSType(), status, aclPair.getFirst());
+      }
+    } catch (IOException e) {
+      return Fingerprint.INVALID_FINGERPRINT;
     }
   }
 

--- a/core/common/src/main/java/alluxio/underfs/Fingerprint.java
+++ b/core/common/src/main/java/alluxio/underfs/Fingerprint.java
@@ -38,6 +38,8 @@ public final class Fingerprint {
   /** These tags are all the content tags in the fingerprints. */
   private static final Tag[] CONTENT_TAGS = {Tag.TYPE, Tag.UFS, Tag.CONTENT_HASH};
 
+  public static final Fingerprint INVALID_FINGERPRINT = new Fingerprint(Collections.emptyMap());
+
   private static final char KVDELIMTER = '|';
   private static final char TAGDELIMTER = ' ';
 

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -560,28 +560,35 @@ public class InodeSyncStream {
       AlluxioURI ufsUri = resolution.getUri();
       try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
         UnderFileSystem ufs = ufsResource.get();
-        String ufsFingerprint;
+//        String ufsFingerprint;
         Fingerprint ufsFpParsed;
+
+        // TODO(jiacheng): work on this
         // When the status is not cached and it was not due to file not found, we retry
         if (fileNotFound) {
-          ufsFingerprint = Constants.INVALID_UFS_FINGERPRINT;
-          ufsFpParsed = Fingerprint.parse(ufsFingerprint);
+//          ufsFingerprint = Constants.INVALID_UFS_FINGERPRINT;
+          ufsFpParsed = Fingerprint.INVALID_FINGERPRINT;
         } else if (cachedStatus == null) {
           // TODO(david): change the interface so that getFingerprint returns a parsed fingerprint
-          ufsFingerprint = (String) getFromUfs(() -> ufs.getFingerprint(ufsUri.toString()));
-          ufsFpParsed = Fingerprint.parse(ufsFingerprint);
+//          ufsFingerprint = (String) getFromUfs(() -> ufs.getFingerprint(ufsUri.toString()));
+//          ufsFpParsed = Fingerprint.parse(ufsFingerprint);
+          ufsFpParsed = ufs.getParsedFingerprint(ufsUri.toString());
         } else {
           // When the status is cached
-          Pair<AccessControlList, DefaultAccessControlList> aclPair =
-              (Pair<AccessControlList, DefaultAccessControlList>)
-                  getFromUfs(() -> ufs.getAclPair(ufsUri.toString()));
-          if (aclPair == null || aclPair.getFirst() == null || !aclPair.getFirst().hasExtended()) {
+          if (!mFsMaster.isAclEnabled()) {
             ufsFpParsed = Fingerprint.create(ufs.getUnderFSType(), cachedStatus);
           } else {
-            ufsFpParsed = Fingerprint.create(ufs.getUnderFSType(), cachedStatus,
-                aclPair.getFirst());
+            Pair<AccessControlList, DefaultAccessControlList> aclPair =
+                    (Pair<AccessControlList, DefaultAccessControlList>)
+                            getFromUfs(() -> ufs.getAclPair(ufsUri.toString()));
+            if (aclPair == null || aclPair.getFirst() == null || !aclPair.getFirst().hasExtended()) {
+              ufsFpParsed = Fingerprint.create(ufs.getUnderFSType(), cachedStatus);
+            } else {
+              ufsFpParsed = Fingerprint.create(ufs.getUnderFSType(), cachedStatus,
+                      aclPair.getFirst());
+            }
           }
-          ufsFingerprint = ufsFpParsed.serialize();
+//          ufsFingerprint = ufsFpParsed.serialize();
         }
         boolean containsMountPoint = mMountTable.containsMountPoint(inodePath.getUri(), true);
 
@@ -606,8 +613,10 @@ public class InodeSyncStream {
               // Only set group if not empty
               builder.setGroup(group);
             }
+//            SetAttributeContext ctx = SetAttributeContext.mergeFrom(builder)
+//                .setUfsFingerprint(ufsFingerprint);
             SetAttributeContext ctx = SetAttributeContext.mergeFrom(builder)
-                .setUfsFingerprint(ufsFingerprint);
+                    .setUfsFingerprint(ufsFpParsed.serialize());
             mFsMaster.setAttributeSingleFile(mRpcContext, inodePath, false, opTimeMs, ctx);
           }
         }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncUtils.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncUtils.java
@@ -34,6 +34,8 @@ public final class UfsSyncUtils {
    */
   public static SyncPlan computeSyncPlan(Inode inode, Fingerprint ufsFingerprint,
       boolean containsMountPoint) {
+    // TODO(jiacheng): We still store a string in the inode instead of a Fingerprint obj.
+    //  This parse is unavoidable until we change it.
     Fingerprint inodeFingerprint =  Fingerprint.parse(inode.getUfsFingerprint());
     boolean isContentSynced = inodeUfsIsContentSynced(inode, inodeFingerprint, ufsFingerprint);
     boolean isMetadataSynced = inodeUfsIsMetadataSynced(inode, inodeFingerprint, ufsFingerprint);


### PR DESCRIPTION
### What changes are proposed in this pull request?

This change adds a method for UFS to directly return a Fingerprint object, so we don't need to concat a string first then parse it.

### Why are the changes needed?

Save the intermedia cost of String creation and parsing.

### Does this PR introduce any user facing changes?

There's one more method added to UnderFileSystem interface but it has a default implementation. So NA.
