### PR TITLE
Disable jvm dns cache in java11 in dockerfile-dev

### DIFF
--- a/integration/docker/Dockerfile-dev
+++ b/integration/docker/Dockerfile-dev
@@ -86,8 +86,9 @@ RUN wget -qO /tmp/async-profiler-1.8.3-linux-x64.tar.gz "https://github.com/jvm-
 
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk
 
-# Disable JVM DNS cache
-RUN echo "networkaddress.cache.ttl=0" >> ${JAVA_HOME}/jre/lib/security/java.security
+# Disable JVM DNS cache in both java8 and java11
+RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/java.security
+RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-11-openjdk/conf/security/java.security
 
 # Add the following for native libraries needed by rocksdb
 ENV LD_LIBRARY_PATH /lib64:${LD_LIBRARY_PATH}


### PR DESCRIPTION
We install java11 in dev image but didn't disable jvm dns cache for it. This PR fixes this.
