### PR TITLE
Create MaxFile stressbench

### DIFF
--- a/docs/en/operation/StressBench.md
+++ b/docs/en/operation/StressBench.md
@@ -22,6 +22,7 @@ The following benchmark suites are currently supported:
 * `StressMasterBench` - A benchmark tool measuring the master performance of Alluxio.
 * `StressWorkerBench` - A benchmark tool measuring the IO performance of reading from Alluxio Worker.
 * `UfsIOBench` - A benchmark tool measuring the IO throughput between the Alluxio cluster and the UFS.
+* `MaxFileBench` - A benchmark tool measuring the maximum number of empty files in Alluxio metastore. 
 
 ## Examples
 ### Basic Examples
@@ -720,6 +721,76 @@ The cluster testing is similar to single node testing except that
 
 ### Limitations
 - Worker Stress Bench only supports testing self-generated test files.
+
+
+## Max File Stress Bench
+
+The Max File Stress Bench is designed to measure the maximum number of empty files that can be held in Alluxio metastore.
+
+### Parameters
+Unlike other stress benches, the Max File Stress Bench has only a limited number of configurable options:
+
+<table class="table table-striped">
+    <tr>
+        <th>Parameter</th>
+        <th>Default Value</th>
+        <th>Description</th>
+    </tr>
+    <tr>
+        <td>base</td>
+        <td>alluxio://localhost:19998/stress-master-base</td>
+        <td>The base directory path URI to perform operations in. </td>
+    </tr>
+    <tr>
+        <td>base-alias</td>
+        <td></td>
+        <td>The alias for the base path, unused if empty</td>
+    </tr>
+    <tr>
+        <td>clients</td>
+        <td>1</td>
+        <td>The number of fs client instances to use</td>
+    </tr>
+    <tr>
+        <td>conf</td>
+        <td>{}</td>
+        <td>Any HDFS client configuration key=value. Can repeat to provide multiple configuration values.</td>
+    </tr>
+    <tr>
+        <td>create-file-size</td>
+        <td>0</td>
+        <td>The size of a file for the Create op, allowed to be 0. (0, 1m, 2k, 8k, etc.)</td>
+    </tr>
+    <tr>
+        <td>threads</td>
+        <td>256</td>
+        <td>The number of concurrent threads to use</td>
+    </tr>
+</table>
+
+### Single node testing
+#### Prerequisite
+A running Alluxio cluster with one master and one worker.
+
+#### Single test
+```console
+$ bin/alluxio runClass alluxio.stress.cli.MaxFileBench ...
+```
+### Cluster testing
+This is only useful if the throughput provided by running this stress bench on the master node directly is insufficient.
+
+#### Prerequisite
+A running Alluxio cluster. Each worker node contains one worker, one job worker.
+
+#### Testing
+Use the `--cluster` flag. 
+
+### Expected runtime and ending condition
+Because this stress bench creates file until the master metastore is full, it takes a long time to run. Expect several hours of runtime depending 
+on which metastore you have configured and how much heap space / disk space is available to said metastore. 
+
+The stress bench ends after many create operations fail successively. Each failure is followed by an increasingly long timeout. This means that if
+your network is particularly slow, this stress bench could end prematurely. 
 
 ## UFS IO Bench
 

--- a/stress/common/src/main/java/alluxio/stress/common/FileSystemParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/common/FileSystemParameters.java
@@ -23,23 +23,23 @@ import com.beust.jcommander.Parameter;
  * FileSystem common parameters.
  */
 public class FileSystemParameters extends Parameters {
-  public static final String CLIENT_TYPE = "--client-type";
-  public static final String READ_TYPE = "--read-type";
-  public static final String WRITE_TYPE = "--write-type";
+  public static final String CLIENT_TYPE_OPTION_NAME = "--client-type";
+  public static final String READ_TYPE_FLAG_OPTION_NAME = "--read-type";
+  public static final String WRITE_TYPE_OPTION_NAME = "--write-type";
 
-  @Parameter(names = {CLIENT_TYPE},
+  @Parameter(names = {CLIENT_TYPE_OPTION_NAME},
       description = "the client API type. Alluxio native or hadoop compatible client,"
           + " default is AlluxioHDFS",
       converter = FileSystemParameters.FileSystemParametersClientTypeConverter.class)
   public FileSystemClientType mClientType = FileSystemClientType.ALLUXIO_HDFS;
 
-  @Parameter(names = {READ_TYPE},
+  @Parameter(names = {READ_TYPE_FLAG_OPTION_NAME},
       description = "the cache mechanism during read. Options are [NO_CACHE, CACHE, CACHE_PROMOTE]"
           + " default is CACHE",
       converter = FileSystemParameters.FileSystemParametersReadTypeConverter.class)
   public ReadType mReadType = ReadType.CACHE;
 
-  @Parameter(names = {WRITE_TYPE},
+  @Parameter(names = {WRITE_TYPE_OPTION_NAME},
       description = "The write type to use when creating files. Options are [MUST_CACHE, "
           + "CACHE_THROUGH, THROUGH, ASYNC_THROUGH, ALL]",
       converter = FileSystemParameters.FileSystemParametersWriteTypeConverter.class)

--- a/stress/common/src/main/java/alluxio/stress/common/FileSystemParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/common/FileSystemParameters.java
@@ -23,19 +23,23 @@ import com.beust.jcommander.Parameter;
  * FileSystem common parameters.
  */
 public class FileSystemParameters extends Parameters {
-  @Parameter(names = {"--client-type"},
+  public static final String CLIENT_TYPE = "--client-type";
+  public static final String READ_TYPE = "--read-type";
+  public static final String WRITE_TYPE = "--write-type";
+
+  @Parameter(names = {CLIENT_TYPE},
       description = "the client API type. Alluxio native or hadoop compatible client,"
           + " default is AlluxioHDFS",
       converter = FileSystemParameters.FileSystemParametersClientTypeConverter.class)
   public FileSystemClientType mClientType = FileSystemClientType.ALLUXIO_HDFS;
 
-  @Parameter(names = {"--read-type"},
+  @Parameter(names = {READ_TYPE},
       description = "the cache mechanism during read. Options are [NO_CACHE, CACHE, CACHE_PROMOTE]"
           + " default is CACHE",
       converter = FileSystemParameters.FileSystemParametersReadTypeConverter.class)
   public ReadType mReadType = ReadType.CACHE;
 
-  @Parameter(names = {"--write-type"},
+  @Parameter(names = {WRITE_TYPE},
       description = "The write type to use when creating files. Options are [MUST_CACHE, "
           + "CACHE_THROUGH, THROUGH, ASYNC_THROUGH, ALL]",
       converter = FileSystemParameters.FileSystemParametersWriteTypeConverter.class)

--- a/stress/common/src/main/java/alluxio/stress/master/MasterBenchBaseParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/master/MasterBenchBaseParameters.java
@@ -20,26 +20,33 @@ import com.beust.jcommander.Parameter;
  * This holds all the parameters shared by the MasterBench and MasterBatchTask.
  */
 public class MasterBenchBaseParameters extends FileSystemParameters {
+  public static final String CLIENT_NUM = "--clients";
+  public static final String THREADS = "--threads";
+  public static final String WARMUP = "--warmup";
+  public static final String BASE = "--base";
+  public static final String STOP_COUNT = "--stop-count";
+  public static final String CREATE_FILE_SIZE = "--create-file-size";
+
   /** The stop count value that is invalid. */
   public static final int STOP_COUNT_INVALID = -1;
 
-  @Parameter(names = {"--clients"}, description = "the number of fs client instances to use")
+  @Parameter(names = {CLIENT_NUM}, description = "the number of fs client instances to use")
   public int mClients = 1;
 
-  @Parameter(names = {"--threads"}, description = "the number of concurrent threads to use")
+  @Parameter(names = {THREADS}, description = "the number of concurrent threads to use")
   public int mThreads = 256;
 
-  @Parameter(names = {"--warmup"},
+  @Parameter(names = {WARMUP},
       description = "The length of time to warmup before recording measurements. (1m, 10m, 60s, "
           + "10000ms, etc.)")
   public String mWarmup = "30s";
 
-  @Parameter(names = {"--base"},
+  @Parameter(names = {BASE},
       description = "The base directory path URI to perform operations in")
   @Parameters.PathDescription(aliasFieldName = "mBaseAlias")
   public String mBasePath = "alluxio:///stress-master-base";
 
-  @Parameter(names = {"--stop-count"},
+  @Parameter(names = {STOP_COUNT},
       description = "The benchmark will stop after this number of paths. If -1, it is not used and "
           + "the benchmark will stop after the duration. If this is used, duration will be "
           + "ignored. This is typically used for creating files in preparation for another "
@@ -47,7 +54,7 @@ public class MasterBenchBaseParameters extends FileSystemParameters {
           + "termination condition.")
   public int mStopCount = STOP_COUNT_INVALID;
 
-  @Parameter(names = {"--create-file-size"},
+  @Parameter(names = {CREATE_FILE_SIZE},
       description = "The size of a file for the Create op, allowed to be 0. (0, 1m, 2k, 8k, etc.)")
   public String mCreateFileSize = "0";
 }

--- a/stress/common/src/main/java/alluxio/stress/master/MasterBenchBaseParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/master/MasterBenchBaseParameters.java
@@ -20,33 +20,34 @@ import com.beust.jcommander.Parameter;
  * This holds all the parameters shared by the MasterBench and MasterBatchTask.
  */
 public class MasterBenchBaseParameters extends FileSystemParameters {
-  public static final String CLIENT_NUM = "--clients";
-  public static final String THREADS = "--threads";
-  public static final String WARMUP = "--warmup";
-  public static final String BASE = "--base";
-  public static final String STOP_COUNT = "--stop-count";
-  public static final String CREATE_FILE_SIZE = "--create-file-size";
+  public static final String CLIENT_NUM_OPTION_NAME = "--clients";
+  public static final String THREADS_OPTION_NAME = "--threads";
+  public static final String WARMUP_OPTION_NAME = "--warmup";
+  public static final String BASE_OPTION_NAME = "--base";
+  public static final String STOP_COUNT_OPTION_NAME = "--stop-count";
+  public static final String CREATE_FILE_SIZE_OPTION_NAME = "--create-file-size";
 
   /** The stop count value that is invalid. */
   public static final int STOP_COUNT_INVALID = -1;
 
-  @Parameter(names = {CLIENT_NUM}, description = "the number of fs client instances to use")
+  @Parameter(names = {CLIENT_NUM_OPTION_NAME},
+      description = "the number of fs client instances to use")
   public int mClients = 1;
 
-  @Parameter(names = {THREADS}, description = "the number of concurrent threads to use")
+  @Parameter(names = {THREADS_OPTION_NAME}, description = "the number of concurrent threads to use")
   public int mThreads = 256;
 
-  @Parameter(names = {WARMUP},
+  @Parameter(names = {WARMUP_OPTION_NAME},
       description = "The length of time to warmup before recording measurements. (1m, 10m, 60s, "
           + "10000ms, etc.)")
   public String mWarmup = "30s";
 
-  @Parameter(names = {BASE},
+  @Parameter(names = {BASE_OPTION_NAME},
       description = "The base directory path URI to perform operations in")
   @Parameters.PathDescription(aliasFieldName = "mBaseAlias")
   public String mBasePath = "alluxio:///stress-master-base";
 
-  @Parameter(names = {STOP_COUNT},
+  @Parameter(names = {STOP_COUNT_OPTION_NAME},
       description = "The benchmark will stop after this number of paths. If -1, it is not used and "
           + "the benchmark will stop after the duration. If this is used, duration will be "
           + "ignored. This is typically used for creating files in preparation for another "
@@ -54,7 +55,7 @@ public class MasterBenchBaseParameters extends FileSystemParameters {
           + "termination condition.")
   public int mStopCount = STOP_COUNT_INVALID;
 
-  @Parameter(names = {CREATE_FILE_SIZE},
+  @Parameter(names = {CREATE_FILE_SIZE_OPTION_NAME},
       description = "The size of a file for the Create op, allowed to be 0. (0, 1m, 2k, 8k, etc.)")
   public String mCreateFileSize = "0";
 }

--- a/stress/common/src/main/java/alluxio/stress/master/MasterBenchParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/master/MasterBenchParameters.java
@@ -25,39 +25,41 @@ import java.util.Map;
  * getters and setters.
  */
 public final class MasterBenchParameters extends MasterBenchBaseParameters {
-  public static final String OPERATION = "--operation";
-  public static final String TARGET_THROUGHPUT = "--target-throughput";
-  public static final String BASE_ALIAS = "--base-alias";
-  public static final String TAG = "--tag";
-  public static final String DURATION = "--duration";
-  public static final String FIXED_COUNT = "--fixed-count";
-  public static final String CONF = "--conf";
-  public static final String SKIP_PREPARE = "--skip-prepare";
+  public static final String OPERATION_OPTION_NAME = "--operation";
+  public static final String TARGET_THROUGHPUT_OPTION_NAME = "--target-throughput";
+  public static final String BASE_ALIAS_OPTION_NAME = "--base-alias";
+  public static final String TAG_OPTION_NAME = "--tag";
+  public static final String DURATION_OPTION_NAME = "--duration";
+  public static final String FIXED_COUNT_OPTION_NAME = "--fixed-count";
+  public static final String CONF_OPTION_NAME = "--conf";
+  public static final String SKIP_PREPARE_OPTION_NAME = "--skip-prepare";
 
-  @Parameter(names = {OPERATION},
+  @Parameter(names = {OPERATION_OPTION_NAME},
       description = "the operation to perform. Options are [CreateFile, GetBlockLocations, "
           + "GetFileStatus, OpenFile, CreateDir, ListDir, ListDirLocated, RenameFile, DeleteFile]",
       converter = OperationConverter.class,
       required = true)
   public Operation mOperation;
 
-  @Parameter(names = {TARGET_THROUGHPUT},
+  @Parameter(names = {TARGET_THROUGHPUT_OPTION_NAME},
       description = "the target throughput to issue operations. (ops / s)")
   public int mTargetThroughput = 1000;
 
-  @Parameter(names = {BASE_ALIAS}, description = "The alias for the base path, unused if empty")
+  @Parameter(names = {BASE_ALIAS_OPTION_NAME},
+      description = "The alias for the base path, unused if empty")
   @Parameters.KeylessDescription
   public String mBaseAlias = "";
 
-  @Parameter(names = {TAG}, description = "optional human-readable string to identify this run")
+  @Parameter(names = {TAG_OPTION_NAME},
+      description = "optional human-readable string to identify this run")
   @Parameters.KeylessDescription
   public String mTag = "";
 
-  @Parameter(names = {DURATION},
+  @Parameter(names = {DURATION_OPTION_NAME},
       description = "The length of time to run the benchmark. (1m, 10m, 60s, 10000ms, etc.)")
   public String mDuration = "30s";
 
-  @Parameter(names = {FIXED_COUNT},
+  @Parameter(names = {FIXED_COUNT_OPTION_NAME},
       description = "The number of paths in the fixed portion. Must be greater than 0. The first "
           + "'fixed-count' paths are in the fixed portion of the namespace. This means all tasks "
           + "are guaranteed to have the same number of paths in the fixed portion. This is "
@@ -69,13 +71,13 @@ public final class MasterBenchParameters extends MasterBenchBaseParameters {
           + "1000 files so that the task will not end before the desired duration time.")
   public int mFixedCount = 100;
 
-  @DynamicParameter(names = CONF,
+  @DynamicParameter(names = CONF_OPTION_NAME,
       description = "Any HDFS client configuration key=value. Can repeat to provide multiple "
           + "configuration values.")
 
   public Map<String, String> mConf = new HashMap<>();
 
-  @Parameter(names = {SKIP_PREPARE},
+  @Parameter(names = {SKIP_PREPARE_OPTION_NAME},
       description = "If true, skip the prepare.")
   public boolean mSkipPrepare = false;
 

--- a/stress/common/src/main/java/alluxio/stress/master/MasterBenchParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/master/MasterBenchParameters.java
@@ -25,31 +25,39 @@ import java.util.Map;
  * getters and setters.
  */
 public final class MasterBenchParameters extends MasterBenchBaseParameters {
+  public static final String OPERATION = "--operation";
+  public static final String TARGET_THROUGHPUT = "--target-throughput";
+  public static final String BASE_ALIAS = "--base-alias";
+  public static final String TAG = "--tag";
+  public static final String DURATION = "--duration";
+  public static final String FIXED_COUNT = "--fixed-count";
+  public static final String CONF = "--conf";
+  public static final String SKIP_PREPARE = "--skip-prepare";
 
-  @Parameter(names = {"--operation"},
+  @Parameter(names = {OPERATION},
       description = "the operation to perform. Options are [CreateFile, GetBlockLocations, "
           + "GetFileStatus, OpenFile, CreateDir, ListDir, ListDirLocated, RenameFile, DeleteFile]",
       converter = OperationConverter.class,
       required = true)
   public Operation mOperation;
 
-  @Parameter(names = {"--target-throughput"},
+  @Parameter(names = {TARGET_THROUGHPUT},
       description = "the target throughput to issue operations. (ops / s)")
   public int mTargetThroughput = 1000;
 
-  @Parameter(names = {"--base-alias"}, description = "The alias for the base path, unused if empty")
+  @Parameter(names = {BASE_ALIAS}, description = "The alias for the base path, unused if empty")
   @Parameters.KeylessDescription
   public String mBaseAlias = "";
 
-  @Parameter(names = {"--tag"}, description = "optional human-readable string to identify this run")
+  @Parameter(names = {TAG}, description = "optional human-readable string to identify this run")
   @Parameters.KeylessDescription
   public String mTag = "";
 
-  @Parameter(names = {"--duration"},
+  @Parameter(names = {DURATION},
       description = "The length of time to run the benchmark. (1m, 10m, 60s, 10000ms, etc.)")
   public String mDuration = "30s";
 
-  @Parameter(names = {"--fixed-count"},
+  @Parameter(names = {FIXED_COUNT},
       description = "The number of paths in the fixed portion. Must be greater than 0. The first "
           + "'fixed-count' paths are in the fixed portion of the namespace. This means all tasks "
           + "are guaranteed to have the same number of paths in the fixed portion. This is "
@@ -61,13 +69,13 @@ public final class MasterBenchParameters extends MasterBenchBaseParameters {
           + "1000 files so that the task will not end before the desired duration time.")
   public int mFixedCount = 100;
 
-  @DynamicParameter(names = "--conf",
+  @DynamicParameter(names = CONF,
       description = "Any HDFS client configuration key=value. Can repeat to provide multiple "
           + "configuration values.")
 
   public Map<String, String> mConf = new HashMap<>();
 
-  @Parameter(names = {"--skip-prepare"},
+  @Parameter(names = {SKIP_PREPARE},
       description = "If true, skip the prepare.")
   public boolean mSkipPrepare = false;
 

--- a/stress/shell/src/main/java/alluxio/stress/cli/MaxFileBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/MaxFileBench.java
@@ -17,7 +17,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
-import alluxio.retry.ExponentialBackoffRetry;
+import alluxio.retry.CountingRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.stress.BaseParameters;
 import alluxio.stress.common.FileSystemClientType;
@@ -135,7 +135,7 @@ public class MaxFileBench extends StressMasterBench {
   }
 
   private final class AlluxioNativeMaxFileThread implements Callable<Void> {
-    private static final int OPERATION_TIMEOUT_MS = 2_000;
+    private static final int OPERATION_TIMEOUT_MS = 2 * 60 * 1_000;
 
     private RetryPolicy mRetryPolicy = createPolicy();
     private final ExecutorService mExecutor = Executors.newSingleThreadExecutor();
@@ -155,10 +155,8 @@ public class MaxFileBench extends StressMasterBench {
     }
 
     private RetryPolicy createPolicy() {
-      final int initWaitTimeMs = 100;
-      final int maxWaitTimeMs = 15_000;
-      final int numAttempts = 8;
-      return new ExponentialBackoffRetry(initWaitTimeMs, maxWaitTimeMs, numAttempts);
+      final int numAttempts = 3;
+      return new CountingRetry(numAttempts);
     }
 
     @Override

--- a/stress/shell/src/main/java/alluxio/stress/cli/MaxFileBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/MaxFileBench.java
@@ -1,0 +1,146 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.stress.cli;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileSystem;
+import alluxio.exception.AlluxioException;
+import alluxio.grpc.CreateDirectoryPOptions;
+import alluxio.stress.master.MasterBenchTaskResult;
+import alluxio.util.CommonUtils;
+import alluxio.util.FormatUtils;
+import alluxio.util.executor.ExecutorServiceFactories;
+import alluxio.util.io.PathUtils;
+
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * MaxFile StressBench class.
+ */
+public class MaxFileBench extends StressMasterBench {
+  static AtomicBoolean sFinish = new AtomicBoolean(false);
+  private final MasterBenchTaskResult mTotalResults = new MasterBenchTaskResult();
+
+  /**
+   * @param args command-line arguments
+   */
+  public static void main(String[] args) {
+    mainInternal(args, new MaxFileBench());
+  }
+
+  @Override
+  public String getBenchDescription() {
+    return "MaxFile stress bench";
+  }
+
+  @Override
+  public MasterBenchTaskResult runLocal() throws Exception {
+    ExecutorService service = ExecutorServiceFactories.fixedThreadPool("maxfile-bench-thread",
+        mParameters.mThreads).create();
+
+    List<Callable<Void>> callables = new ArrayList<>(mParameters.mThreads);
+    for (int i = 0; i < mParameters.mThreads; i++) {
+      callables.add(new AlluxioNativeMaxFileThread(i, mCachedNativeFs[i % mCachedNativeFs.length]));
+    }
+    System.out.printf("Starting %d bench threads\n", callables.size());
+    service.invokeAll(callables, FormatUtils.parseTimeSize(mBaseParameters.mBenchTimeout),
+        TimeUnit.MILLISECONDS);
+    System.out.println("Bench threads finished");
+
+    service.shutdownNow();
+    service.awaitTermination(30, TimeUnit.SECONDS);
+
+    return mTotalResults;
+  }
+
+  private final class AlluxioNativeMaxFileThread implements Callable<Void> {
+    private final int mId;
+
+    private final int mInitWaitTimeMs = 100;
+    private final int mMaxWaitTimeMs = 15_000;
+    private int mWaitTimeMs = mInitWaitTimeMs;
+
+    private final MasterBenchTaskResult mResult = new MasterBenchTaskResult();
+    private final FileSystem mFs;
+    private final Path mBasePath;
+    private final Path mFixedBasePath;
+
+    AlluxioNativeMaxFileThread(int id, FileSystem fs) {
+      mId = id;
+      mFs = fs;
+      mBasePath =
+          new Path(PathUtils.concatPath(mParameters.mBasePath, "dirs", mBaseParameters.mId));
+      mFixedBasePath = new Path(mBasePath, "fixed");
+    }
+
+    @Override
+    public Void call() throws Exception {
+      mResult.setRecordStartMs(CommonUtils.getCurrentMs());
+      AtomicLong localCounter = new AtomicLong();
+      while (!sFinish.get()) {
+        if (Thread.currentThread().isInterrupted()) {
+          break;
+        }
+        long increment = localCounter.getAndIncrement();
+        if (increment % 50_000 == 0) {
+          System.out.printf("[%d] Created %d files\n", mId, increment);
+        }
+        try {
+          applyOperation(increment);
+        } catch (Exception e) {
+          if (mWaitTimeMs > mMaxWaitTimeMs) {
+            System.out.printf("[%d] Waiting timeout, ending\n", mId);
+            sFinish.set(true);
+            break;
+          } else {
+            System.out.printf("[%d] Failed, sleeping for %d\n", mId, mWaitTimeMs);
+            Thread.sleep(mWaitTimeMs);
+            mWaitTimeMs *= 2;
+            continue;
+          }
+        }
+        mResult.incrementNumSuccess(1);
+        mWaitTimeMs = mInitWaitTimeMs;
+      }
+
+      // record local results
+      mResult.setEndMs(CommonUtils.getCurrentMs());
+      mResult.setParameters(mParameters);
+      mResult.setBaseParameters(mBaseParameters);
+
+      // merging total results
+      mTotalResults.merge(mResult);
+      return null;
+    }
+
+    private void applyOperation(long counter) throws IOException, AlluxioException {
+      Path path;
+      if (counter < mParameters.mFixedCount) {
+        path = new Path(mFixedBasePath, Long.toString(counter));
+      } else {
+        path = new Path(mBasePath, Long.toString(counter));
+      }
+
+      mFs.createDirectory(new AlluxioURI(path.toString()),
+          CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    }
+  }
+}

--- a/stress/shell/src/main/java/alluxio/stress/cli/MaxFileBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/MaxFileBench.java
@@ -12,6 +12,7 @@
 package alluxio.stress.cli;
 
 import alluxio.AlluxioURI;
+import alluxio.annotation.SuppressFBWarnings;
 import alluxio.client.file.FileSystem;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;
@@ -48,6 +49,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * MaxFile StressBench class.
  */
+@SuppressFBWarnings("BC_UNCONFIRMED_CAST")
 public class MaxFileBench extends StressMasterBench {
   private static final Logger LOG = LoggerFactory.getLogger(MaxFileBench.class);
 

--- a/stress/shell/src/main/java/alluxio/stress/cli/MaxFileBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/MaxFileBench.java
@@ -14,19 +14,29 @@ package alluxio.stress.cli;
 import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;
 import alluxio.exception.AlluxioException;
-import alluxio.grpc.CreateDirectoryPOptions;
+import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.WritePType;
+import alluxio.stress.BaseParameters;
+import alluxio.stress.common.FileSystemClientType;
+import alluxio.stress.common.FileSystemParameters;
+import alluxio.stress.master.MasterBenchBaseParameters;
+import alluxio.stress.master.MasterBenchParameters;
 import alluxio.stress.master.MasterBenchTaskResult;
+import alluxio.stress.master.Operation;
 import alluxio.util.CommonUtils;
 import alluxio.util.FormatUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.util.io.PathUtils;
 
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Strings;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -43,6 +53,17 @@ public class MaxFileBench extends StressMasterBench {
 
   static AtomicBoolean sFinish = new AtomicBoolean(false);
   private final MasterBenchTaskResult mTotalResults = new MasterBenchTaskResult();
+  private final List<String> mDefaultParams = Arrays.asList(
+      BaseParameters.BENCH_TIMEOUT, String.format("%ds", Integer.MAX_VALUE),
+      FileSystemParameters.CLIENT_TYPE, FileSystemClientType.ALLUXIO_NATIVE.toString(),
+      BaseParameters.CLUSTER_START_DELAY_FLAG, "0s",
+      MasterBenchParameters.DURATION, String.format("%ds", Integer.MAX_VALUE),
+      MasterBenchParameters.OPERATION, Operation.CREATE_FILE.toString(),
+      MasterBenchBaseParameters.STOP_COUNT, Integer.toString(
+          MasterBenchBaseParameters.STOP_COUNT_INVALID),
+      MasterBenchBaseParameters.WARMUP, "0s",
+      FileSystemParameters.WRITE_TYPE, WritePType.MUST_CACHE.toString()
+  );
 
   /**
    * @param args command-line arguments
@@ -50,18 +71,43 @@ public class MaxFileBench extends StressMasterBench {
   public static void main(String[] args) {
     // TODO(jenoudet): run MaxThroughput beforehand
 
-    // TODO(jenoudet): integrate --operation --client-type into args automatically
-    // bin/alluxio runClass alluxio.stress.cli.MaxFileBench --operation CreateDir \
-    // --write-type MUST_CACHE --client-type AlluxioNative --threads 8 --in-process
     mainInternal(args, new MaxFileBench());
   }
 
   @Override
   public String getBenchDescription() {
-    return "MaxFile stress bench";
+    List<String> descLines = new ArrayList<>(Arrays.asList(
+        "MaxFile. This stressbench runs CreateFile until the master becomes unresponsive.",
+        "This stressbench ignore the following options and sets its own values as follows:"
+    ));
+    for (int i = 0; i < mDefaultParams.size(); i += 2) {
+      descLines.add(String.format("%s=%s", mDefaultParams.get(i), mDefaultParams.get(i + 1)));
+    }
+    return Strings.join("\n\t", descLines);
   }
 
-  // TODO(jenoudet): override JCommander description for MaxFile
+  @Override
+  protected void parseParameters(String[] args) {
+    List<String> argsList = new ArrayList<>(Arrays.asList(args));
+    argsList.addAll(mDefaultParams);
+
+    JCommander jc = new JCommander(this);
+    jc.setAllowParameterOverwriting(true);
+    jc.setProgramName(this.getClass().getSimpleName());
+    try {
+      jc.parse(argsList.toArray(new String[0]));
+      if (mBaseParameters.mHelp) {
+        System.out.println(getBenchDescription());
+        jc.usage();
+        System.exit(0);
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to parse command: ", e);
+      System.out.println(getBenchDescription());
+      jc.usage();
+      throw e;
+    }
+  }
 
   @Override
   public MasterBenchTaskResult runLocal() throws Exception {
@@ -164,8 +210,8 @@ public class MaxFileBench extends StressMasterBench {
         path = new Path(mBasePath, Long.toString(counter));
       }
 
-      mFs.createDirectory(new AlluxioURI(path.toString()),
-          CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+      mFs.createFile(new AlluxioURI(path.toString()),
+          CreateFilePOptions.newBuilder().setRecursive(true).build());
     }
   }
 }

--- a/stress/shell/src/main/java/alluxio/stress/cli/MaxFileBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/MaxFileBench.java
@@ -58,29 +58,27 @@ public class MaxFileBench extends StressMasterBench {
 
   private final List<String> mDefaultParams = Arrays.asList(
       BaseParameters.BENCH_TIMEOUT, String.format("%ds", Integer.MAX_VALUE),
-      FileSystemParameters.CLIENT_TYPE, FileSystemClientType.ALLUXIO_NATIVE.toString(),
+      FileSystemParameters.CLIENT_TYPE_OPTION_NAME, FileSystemClientType.ALLUXIO_NATIVE.toString(),
       BaseParameters.CLUSTER_START_DELAY_FLAG, "0s",
-      MasterBenchParameters.DURATION, String.format("%ds", Integer.MAX_VALUE),
-      MasterBenchParameters.OPERATION, Operation.CREATE_FILE.toString(),
-      MasterBenchBaseParameters.STOP_COUNT, Integer.toString(
+      MasterBenchParameters.DURATION_OPTION_NAME, String.format("%ds", Integer.MAX_VALUE),
+      MasterBenchParameters.OPERATION_OPTION_NAME, Operation.CREATE_FILE.toString(),
+      MasterBenchBaseParameters.STOP_COUNT_OPTION_NAME, Integer.toString(
           MasterBenchBaseParameters.STOP_COUNT_INVALID),
-      MasterBenchBaseParameters.WARMUP, "0s",
-      FileSystemParameters.WRITE_TYPE, WritePType.MUST_CACHE.toString()
+      MasterBenchBaseParameters.WARMUP_OPTION_NAME, "0s",
+      FileSystemParameters.WRITE_TYPE_OPTION_NAME, WritePType.MUST_CACHE.toString()
   );
 
   /**
    * @param args command-line arguments
    */
   public static void main(String[] args) {
-    // TODO(jenoudet): run MaxThroughput beforehand
-
     mainInternal(args, new MaxFileBench());
   }
 
   @Override
   public String getBenchDescription() {
     List<String> descLines = new ArrayList<>(Arrays.asList(
-        "MaxFile. This stressbench runs CreateFile until the master becomes unresponsive.",
+        "MaxFile. Creates files until no more files can be created.",
         "This stressbench ignore the following options and sets its own values as follows:"
     ));
     for (int i = 0; i < mDefaultParams.size(); i += 2) {

--- a/stress/shell/src/main/java/alluxio/stress/cli/MaxFileBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/MaxFileBench.java
@@ -149,9 +149,8 @@ public class MaxFileBench extends StressMasterBench {
     AlluxioNativeMaxFileThread(int id, FileSystem fs) {
       mId = id;
       mFs = fs;
-      mBasePath =
-          new Path(PathUtils.concatPath(mParameters.mBasePath, "files", mId));
-      mFixedBasePath = new Path(mBasePath, "fixed");
+      mBasePath = new Path(PathUtils.concatPath(mParameters.mBasePath, mFilesDir, mId));
+      mFixedBasePath = new Path(mBasePath, mFixedDir);
       LOG.info("[{}]: basePath: {}, fixedBasePath: {}", mId, mBasePath, mFixedBasePath);
     }
 

--- a/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
@@ -72,7 +72,7 @@ public class StressMasterBench extends AbstractStressBench<MasterBenchTaskResult
   private FileSystem[] mCachedFs;
 
   /** In case the Alluxio Native API is used,  use the following instead. */
-  private alluxio.client.file.FileSystem[] mCachedNativeFs;
+  protected alluxio.client.file.FileSystem[] mCachedNativeFs;
 
   /**
    * Creates instance.

--- a/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
@@ -73,6 +73,10 @@ public class StressMasterBench extends AbstractStressBench<MasterBenchTaskResult
 
   /** In case the Alluxio Native API is used,  use the following instead. */
   protected alluxio.client.file.FileSystem[] mCachedNativeFs;
+  /* Directories where the stress bench creates files depending on the --operation chosen. */
+  protected final String mDirsDir = "dirs";
+  protected final String mFilesDir = "files";
+  protected final String mFixedDir = "fixed";
 
   /**
    * Creates instance.
@@ -327,12 +331,12 @@ public class StressMasterBench extends AbstractStressBench<MasterBenchTaskResult
       mCounter = new AtomicLong();
       if (mParameters.mOperation == Operation.CREATE_DIR) {
         mBasePath =
-            new Path(PathUtils.concatPath(mParameters.mBasePath, "dirs", mBaseParameters.mId));
+            new Path(PathUtils.concatPath(mParameters.mBasePath, mDirsDir, mBaseParameters.mId));
       } else {
         mBasePath =
-            new Path(PathUtils.concatPath(mParameters.mBasePath, "files", mBaseParameters.mId));
+            new Path(PathUtils.concatPath(mParameters.mBasePath, mFilesDir, mBaseParameters.mId));
       }
-      mFixedBasePath = new Path(mBasePath, "fixed");
+      mFixedBasePath = new Path(mBasePath, mFixedDir);
       LOG.info("BenchContext: basePath: {}, fixedBasePath: {}", mBasePath, mFixedBasePath);
     }
 


### PR DESCRIPTION
This PR introduces a new stressbench test called MaxFileBench.
MaxFileBench creates 0-byte files until the master becomes unresponsive. To ensure we are pushing the master to its limits, we pause between a failure and another attempt at creating a file. This pause doubles in length on successive failure, and gets reset when a new success occurs. If the pause gets too large the test ends. This ensures that the master has actually become unavailable rather than flaky. 
