### PR TITLE
Add a reading buffer to local cache for tiny read

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -53,9 +53,9 @@ public class LocalCacheFileInStream extends FileInStream {
   /** File info, fetched from external FS. */
   private final URIStatus mStatus;
   private final FileInStreamOpener mExternalFileInStreamOpener;
+  private final int mBufferSize;
 
   private byte[] mBuffer = null;
-  private final int mBufferSize;
   private long mBufferStartOffset;
   private long mBufferEndOffset;
 
@@ -110,6 +110,7 @@ public class LocalCacheFileInStream extends FileInStream {
     Metrics.registerGauges();
 
     mBufferSize = (int) conf.getBytes(PropertyKey.USER_CLIENT_CACHE_IN_STREAM_BUFFER_SIZE);
+    Preconditions.checkArgument(mBufferSize >= 0, "Buffer size cannot be negative. %s", mPageSize);
     if (mBufferSize > 0) {
       mBuffer = new byte[mBufferSize];
     }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -54,7 +54,7 @@ public class LocalCacheFileInStream extends FileInStream {
   private final URIStatus mStatus;
   private final FileInStreamOpener mExternalFileInStreamOpener;
 
-  private final byte[] mBuffer;
+  private byte[] mBuffer = null;
   private final int mBufferSize;
   private long mBufferStartOffset;
   private long mBufferEndOffset;
@@ -109,10 +109,10 @@ public class LocalCacheFileInStream extends FileInStream {
     }
     Metrics.registerGauges();
 
-    mBufferSize = 8192;
-    mBuffer = new byte[mBufferSize];
-    mBufferStartOffset = -1;
-    mBufferEndOffset = -1;
+    mBufferSize = (int) conf.getBytes(PropertyKey.USER_CLIENT_CACHE_IN_STREAM_BUFFER_SIZE);
+    if (mBufferSize > 0) {
+      mBuffer = new byte[mBufferSize];
+    }
   }
 
   @Override
@@ -213,7 +213,6 @@ public class LocalCacheFileInStream extends FileInStream {
   // TODO(binfan): take ByteBuffer once CacheManager takes ByteBuffer to avoid extra mem copy
   private int readInternal(byte[] b, int off, int len, ReadType readType, long pos,
       boolean isPositionedRead) throws IOException {
-
     Preconditions.checkArgument(len >= 0, "length should be non-negative");
     Preconditions.checkArgument(off >= 0, "offset should be non-negative");
     Preconditions.checkArgument(pos >= 0, "position should be non-negative");
@@ -226,7 +225,6 @@ public class LocalCacheFileInStream extends FileInStream {
     int totalBytesRead = 0;
     long currentPosition = pos;
     long lengthToRead = Math.min(len, mStatus.getLength() - pos);
-
     // used in positionedRead, so make stopwatch a local variable rather than class member
     Stopwatch stopwatch = createUnstartedStopwatch();
     // for each page, check if it is available in the cache

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -146,12 +146,14 @@ public class LocalCacheFileInStream extends FileInStream {
         // Skip load to the in stream buffer if the data piece is larger than buffer size
         return localCachedRead(b, off, len, readType, pos, stopwatch);
       } else {
-        int bytesToRead = (int) Math.min(mBufferSize, mStatus.getLength() - pos);
-        int bytesRead = localCachedRead(mBuffer, 0, bytesToRead, readType, pos, stopwatch);
+        int bytesLoadToBuffer = (int) Math.min(mBufferSize, mStatus.getLength() - pos);
+        int bytesRead = localCachedRead(mBuffer, 0, bytesLoadToBuffer, readType, pos, stopwatch);
         mBufferStartOffset = pos;
         mBufferEndOffset = pos + bytesRead;
         int dataReadFromBuffer = Math.min(bytesRead, len);
         System.arraycopy(mBuffer, 0, b, off, dataReadFromBuffer);
+        MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_READ_IN_STREAM_BUFFER.getName())
+            .mark(dataReadFromBuffer);
         return dataReadFromBuffer;
       }
     }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -118,7 +118,8 @@ public class LocalCacheFileInStream extends FileInStream {
 
   @Override
   public int read(byte[] bytesBuffer, int offset, int length) throws IOException {
-    return readInternal(bytesBuffer, offset, length, ReadType.READ_INTO_BYTE_ARRAY, mPosition, false);
+    return readInternal(bytesBuffer, offset, length, ReadType.READ_INTO_BYTE_ARRAY, mPosition,
+        false);
   }
 
   @Override
@@ -133,8 +134,8 @@ public class LocalCacheFileInStream extends FileInStream {
     return totalBytesRead;
   }
 
-  private int bufferedRead(byte[] bytesBuffer, int offset, int length, ReadType readType, long position,
-                           Stopwatch stopwatch) throws IOException {
+  private int bufferedRead(byte[] bytesBuffer, int offset, int length, ReadType readType,
+                           long position, Stopwatch stopwatch) throws IOException {
     if (mBuffer == null) { //buffer is disabled, read data from local cache directly.
       return localCachedRead(bytesBuffer, offset, length, readType, position, stopwatch);
     }
@@ -151,7 +152,8 @@ public class LocalCacheFileInStream extends FileInStream {
         return localCachedRead(bytesBuffer, offset, length, readType, position, stopwatch);
       } else {
         int bytesLoadToBuffer = (int) Math.min(mBufferSize, mStatus.getLength() - position);
-        int bytesRead = localCachedRead(mBuffer, 0, bytesLoadToBuffer, readType, position, stopwatch);
+        int bytesRead =
+            localCachedRead(mBuffer, 0, bytesLoadToBuffer, readType, position, stopwatch);
         mBufferStartOffset = position;
         mBufferEndOffset = position + bytesRead;
         int dataReadFromBuffer = Math.min(bytesRead, length);
@@ -163,9 +165,8 @@ public class LocalCacheFileInStream extends FileInStream {
     }
   }
 
-  private int localCachedRead(byte[] bytesBuffer, int offset, int length, ReadType readType, long position,
-                              Stopwatch stopwatch)
-      throws IOException {
+  private int localCachedRead(byte[] bytesBuffer, int offset, int length, ReadType readType,
+                              long position, Stopwatch stopwatch) throws IOException {
     long currentPage = position / mPageSize;
     PageId pageId;
     CacheContext cacheContext = mStatus.getCacheContext();
@@ -178,8 +179,9 @@ public class LocalCacheFileInStream extends FileInStream {
     int bytesLeftInPage = (int) (mPageSize - currentPageOffset);
     int bytesToReadInPage = Math.min(bytesLeftInPage, length);
     stopwatch.reset().start();
-    int bytesRead = mCacheManager.get(pageId, currentPageOffset, bytesToReadInPage, bytesBuffer, offset,
-        mCacheContext);
+    int bytesRead =
+        mCacheManager.get(pageId, currentPageOffset, bytesToReadInPage, bytesBuffer, offset,
+            mCacheContext);
     stopwatch.stop();
     if (bytesRead > 0) {
       MetricsSystem.meter(MetricKey.CLIENT_CACHE_BYTES_READ_CACHE.getName()).mark(bytesRead);
@@ -217,8 +219,8 @@ public class LocalCacheFileInStream extends FileInStream {
   }
 
   // TODO(binfan): take ByteBuffer once CacheManager takes ByteBuffer to avoid extra mem copy
-  private int readInternal(byte[] bytesBuffer, int offset, int length, ReadType readType, long position,
-      boolean isPositionedRead) throws IOException {
+  private int readInternal(byte[] bytesBuffer, int offset, int length, ReadType readType,
+                           long position, boolean isPositionedRead) throws IOException {
     Preconditions.checkArgument(length >= 0, "length should be non-negative");
     Preconditions.checkArgument(offset >= 0, "offset should be non-negative");
     Preconditions.checkArgument(position >= 0, "position should be non-negative");
@@ -243,7 +245,8 @@ public class LocalCacheFileInStream extends FileInStream {
         mPosition = currentPosition;
       }
     }
-    if (totalBytesRead > length || (totalBytesRead < length && currentPosition < mStatus.getLength())) {
+    if (totalBytesRead > length
+        || (totalBytesRead < length && currentPosition < mStatus.getLength())) {
       throw new IOException(String.format("Invalid number of bytes read - "
           + "bytes to read = %d, actual bytes read = %d, bytes remains in file %d",
           length, totalBytesRead, remaining()));
@@ -348,7 +351,8 @@ public class LocalCacheFileInStream extends FileInStream {
    * @param position the position which the page will contain
    * @return a byte array of the page data
    */
-  private synchronized byte[] readExternalPage(long position, ReadType readType) throws IOException {
+  private synchronized byte[] readExternalPage(long position, ReadType readType)
+      throws IOException {
     long pageStart = position - (position % mPageSize);
     FileInStream stream = getExternalFileInStream(pageStart);
     int pageSize = (int) Math.min(mPageSize, mStatus.getLength() - pageStart);

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -12,6 +12,7 @@
 package alluxio.client.file.cache;
 
 import alluxio.AlluxioURI;
+import alluxio.Constants;
 import alluxio.client.file.CacheContext;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
@@ -63,12 +64,17 @@ import com.google.common.io.ByteStreams;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,20 +89,34 @@ import java.util.stream.IntStream;
 /**
  * Unit tests for {@link LocalCacheFileInStream}.
  */
+@RunWith(Parameterized.class)
 public class LocalCacheFileInStreamTest {
-  private static AlluxioConfiguration sConf = new InstancedConfiguration(
+  private static InstancedConfiguration sConf = new InstancedConfiguration(
       ConfigurationUtils.defaults());
-  private static final int PAGE_SIZE =
-      (int) sConf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE);
+
+  @Parameters(name = "{index}: page_size({0}), in_stream_buffer_size({1})")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        { Constants.MB, 0 }, { Constants.MB, 8 * Constants.KB }
+    });
+  }
+
+  @Parameter(0)
+  public int mPageSize;
+
+  @Parameter(1)
+  public int mBufferSize;
 
   @Before
   public void before() {
     MetricsSystem.clearAllMetrics();
+    sConf.set(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE, mPageSize);
+    sConf.set(PropertyKey.USER_CLIENT_CACHE_IN_STREAM_BUFFER_SIZE, mBufferSize);
   }
 
   @Test
   public void readFullPage() throws Exception {
-    int fileSize = PAGE_SIZE;
+    int fileSize = mPageSize;
     int bufferSize = fileSize;
     int pages = 1;
     verifyReadFullFile(fileSize, bufferSize, pages);
@@ -104,7 +124,7 @@ public class LocalCacheFileInStreamTest {
 
   @Test
   public void readFullPageThroughReadByteBufferMethod() throws Exception {
-    int fileSize = PAGE_SIZE;
+    int fileSize = mPageSize;
     int bufferSize = fileSize;
     int pages = 1;
     verifyReadFullFileThroughReadByteBufferMethod(fileSize, bufferSize, pages);
@@ -112,7 +132,7 @@ public class LocalCacheFileInStreamTest {
 
   @Test
   public void readSmallPage() throws Exception {
-    int fileSize = PAGE_SIZE / 5;
+    int fileSize = mPageSize / 5;
     int bufferSize = fileSize;
     int pages = 1;
     verifyReadFullFile(fileSize, bufferSize, pages);
@@ -120,7 +140,7 @@ public class LocalCacheFileInStreamTest {
 
   @Test
   public void readSmallPageThroughReadByteBufferMethod() throws Exception {
-    int fileSize = PAGE_SIZE / 5;
+    int fileSize = mPageSize / 5;
     int bufferSize = fileSize;
     int pages = 1;
     verifyReadFullFileThroughReadByteBufferMethod(fileSize, bufferSize, pages);
@@ -154,7 +174,7 @@ public class LocalCacheFileInStreamTest {
 
   @Test
   public void readPartialPage() throws Exception {
-    int fileSize = PAGE_SIZE;
+    int fileSize = mPageSize;
     byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
     ByteArrayCacheManager manager = new ByteArrayCacheManager();
     LocalCacheFileInStream stream = setupWithSingleFile(testData, manager);
@@ -182,7 +202,7 @@ public class LocalCacheFileInStreamTest {
 
   @Test
   public void readPartialPageThroughReadByteBufferMethod() throws Exception {
-    int fileSize = PAGE_SIZE;
+    int fileSize = mPageSize;
     byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
     ByteArrayCacheManager manager = new ByteArrayCacheManager();
     LocalCacheFileInStream stream = setupWithSingleFile(testData, manager);
@@ -211,7 +231,7 @@ public class LocalCacheFileInStreamTest {
   @Test
   public void readMultiPage() throws Exception {
     int pages = 2;
-    int fileSize = PAGE_SIZE + 10;
+    int fileSize = mPageSize + 10;
     int bufferSize = fileSize;
     verifyReadFullFile(fileSize, bufferSize, pages);
   }
@@ -219,7 +239,7 @@ public class LocalCacheFileInStreamTest {
   @Test
   public void readMultiPageThroughReadByteBufferMethod() throws Exception {
     int pages = 2;
-    int fileSize = PAGE_SIZE + 10;
+    int fileSize = mPageSize + 10;
     int bufferSize = fileSize;
     verifyReadFullFileThroughReadByteBufferMethod(fileSize, bufferSize, pages);
   }
@@ -227,7 +247,7 @@ public class LocalCacheFileInStreamTest {
   @Test
   public void readMultiPageMixed() throws Exception {
     int pages = 10;
-    int fileSize = PAGE_SIZE * pages;
+    int fileSize = mPageSize * pages;
     byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
     ByteArrayCacheManager manager = new ByteArrayCacheManager();
     LocalCacheFileInStream stream = setupWithSingleFile(testData, manager);
@@ -235,9 +255,9 @@ public class LocalCacheFileInStreamTest {
     // populate cache
     int pagesCached = 0;
     for (int i = 0; i < pages; i++) {
-      stream.seek(PAGE_SIZE * i);
+      stream.seek(mPageSize * i);
       if (ThreadLocalRandom.current().nextBoolean()) {
-        Assert.assertEquals(testData[(i * PAGE_SIZE)], stream.read());
+        Assert.assertEquals(testData[(i * mPageSize)], stream.read());
         pagesCached++;
       }
     }
@@ -256,7 +276,7 @@ public class LocalCacheFileInStreamTest {
   @Test
   public void readMultiPageMixedThroughReadByteBufferMethod() throws Exception {
     int pages = 10;
-    int fileSize = PAGE_SIZE * pages;
+    int fileSize = mPageSize * pages;
     byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
     ByteArrayCacheManager manager = new ByteArrayCacheManager();
     LocalCacheFileInStream stream = setupWithSingleFile(testData, manager);
@@ -264,9 +284,9 @@ public class LocalCacheFileInStreamTest {
     // populate cache
     int pagesCached = 0;
     for (int i = 0; i < pages; i++) {
-      stream.seek(PAGE_SIZE * i);
+      stream.seek(mPageSize * i);
       if (ThreadLocalRandom.current().nextBoolean()) {
-        Assert.assertEquals(testData[(i * PAGE_SIZE)], stream.read());
+        Assert.assertEquals(testData[(i * mPageSize)], stream.read());
         pagesCached++;
       }
     }
@@ -285,7 +305,7 @@ public class LocalCacheFileInStreamTest {
   @Test
   public void readOversizedBuffer() throws Exception {
     int pages = 1;
-    int fileSize = PAGE_SIZE;
+    int fileSize = mPageSize;
     int bufferSize = fileSize * 2;
     verifyReadFullFile(fileSize, bufferSize, pages);
   }
@@ -293,7 +313,7 @@ public class LocalCacheFileInStreamTest {
   @Test
   public void readOversizedBufferThroughReadByteBufferMethod() throws Exception {
     int pages = 1;
-    int fileSize = PAGE_SIZE;
+    int fileSize = mPageSize;
     int bufferSize = fileSize * 2;
     verifyReadFullFileThroughReadByteBufferMethod(fileSize, bufferSize, pages);
   }
@@ -301,7 +321,7 @@ public class LocalCacheFileInStreamTest {
   @Test
   public void readSmallPageOversizedBuffer() throws Exception {
     int pages = 1;
-    int fileSize = PAGE_SIZE / 3;
+    int fileSize = mPageSize / 3;
     int bufferSize = fileSize * 2;
     verifyReadFullFile(fileSize, bufferSize, pages);
   }
@@ -309,14 +329,14 @@ public class LocalCacheFileInStreamTest {
   @Test
   public void readSmallPageOversizedBufferThroughReadByteBufferMethod() throws Exception {
     int pages = 1;
-    int fileSize = PAGE_SIZE / 3;
+    int fileSize = mPageSize / 3;
     int bufferSize = fileSize * 2;
     verifyReadFullFileThroughReadByteBufferMethod(fileSize, bufferSize, pages);
   }
 
   @Test
   public void positionedReadPartialPage() throws Exception {
-    int fileSize = PAGE_SIZE;
+    int fileSize = mPageSize;
     byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
     ByteArrayCacheManager manager = new ByteArrayCacheManager();
     LocalCacheFileInStream stream = setupWithSingleFile(testData, manager);
@@ -344,7 +364,7 @@ public class LocalCacheFileInStreamTest {
 
   @Test
   public void positionReadOversizedBuffer() throws Exception {
-    int fileSize = PAGE_SIZE;
+    int fileSize = mPageSize;
     byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
     ByteArrayCacheManager manager = new ByteArrayCacheManager();
     LocalCacheFileInStream stream = setupWithSingleFile(testData, manager);
@@ -369,7 +389,7 @@ public class LocalCacheFileInStreamTest {
 
   @Test
   public void readPagesMetrics() throws Exception {
-    int fileSize = PAGE_SIZE * 5;
+    int fileSize = mPageSize * 5;
     byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
     ByteArrayCacheManager manager = new ByteArrayCacheManager();
     LocalCacheFileInStream stream = setupWithSingleFile(testData, manager);
@@ -397,7 +417,7 @@ public class LocalCacheFileInStreamTest {
 
   @Test
   public void externalStoreMultiRead() throws Exception {
-    int fileSize = PAGE_SIZE;
+    int fileSize = mPageSize;
     byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
     ByteArrayCacheManager manager = new ByteArrayCacheManager();
     Map<AlluxioURI, byte[]> files = new HashMap<>();
@@ -426,7 +446,7 @@ public class LocalCacheFileInStreamTest {
 
   @Test
   public void externalStoreMultiReadThroughReadByteBufferMethod() throws Exception {
-    int fileSize = PAGE_SIZE;
+    int fileSize = mPageSize;
     byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
     ByteArrayCacheManager manager = new ByteArrayCacheManager();
     Map<AlluxioURI, byte[]> files = new HashMap<>();
@@ -470,7 +490,7 @@ public class LocalCacheFileInStreamTest {
 
   @Test
   public void cacheMetricCacheHitReadTime() throws Exception {
-    byte[] testData = BufferUtils.getIncreasingByteArray(PAGE_SIZE);
+    byte[] testData = BufferUtils.getIncreasingByteArray(mPageSize);
     AlluxioURI testFileName = new AlluxioURI("/test");
     Map<AlluxioURI, byte[]> files = ImmutableMap.of(testFileName, testData);
     StepTicker timeSource = new StepTicker();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4929,8 +4929,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_CLIENT_CACHE_IN_STREAM_BUFFER_SIZE =
-      new Builder(Name.USER_CLIENT_CACHE_IN_STREAM_BUFFER_SIZE)
-          .setDefaultValue("0")
+      dataSizeBuilder(Name.USER_CLIENT_CACHE_IN_STREAM_BUFFER_SIZE)
+          .setDefaultValue("0B")
           .setDescription("Size of the reading buffer for tiny read.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4928,6 +4928,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_CLIENT_CACHE_IN_STREAM_BUFFER_SIZE =
+      new Builder(Name.USER_CLIENT_CACHE_IN_STREAM_BUFFER_SIZE)
+          .setDefaultValue("0")
+          .setDescription("Size of the reading buffer for tiny read.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_FILE_WRITE_TYPE_DEFAULT =
       enumBuilder(Name.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class)
           .setDefaultValue(WriteType.ASYNC_THROUGH)
@@ -7138,6 +7145,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.client.cache.dir";
     public static final String USER_CLIENT_CACHE_LOCAL_STORE_FILE_BUCKETS =
         "alluxio.user.client.cache.local.store.file.buckets";
+    public static final String USER_CLIENT_CACHE_IN_STREAM_BUFFER_SIZE =
+        "alluxio.user.client.cache.instream_buffer_size";
     public static final String USER_CLIENT_CACHE_PAGE_SIZE =
         "alluxio.user.client.cache.page.size";
     public static final String USER_CLIENT_CACHE_QUOTA_ENABLED =

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1635,6 +1635,12 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.METER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_CACHE_BYTES_READ_IN_STREAM_BUFFER =
+      new Builder("Client.CacheBytesReadInStreamBuffer")
+          .setDescription("Total number of bytes read from the client cache's in stream buffer.")
+          .setMetricType(MetricType.METER)
+          .setIsClusterAggregated(false)
+          .build();
   public static final MetricKey CLIENT_CACHE_BYTES_READ_EXTERNAL =
       new Builder("Client.CacheBytesReadExternal")
           .setDescription("Total number of bytes read from external storage due to a cache miss "

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -137,7 +137,7 @@ public final class MetricKey implements Comparable<MetricKey> {
   /**
    * @return the name of the Metric without instance prefix
    */
-  public String getMetricsName() {
+  public String getMetricName() {
     return mMetricsName;
   }
 
@@ -239,7 +239,7 @@ public final class MetricKey implements Comparable<MetricKey> {
   // Master metrics
   // Absent cache stats
   public static final MetricKey MASTER_ABSENT_CACHE_HITS =
-      new Builder("Master.AbsentCacheHits")
+      new Builder("Master.AbsentCacheHits")F
           .setDescription("Number of cache hits on the absent cache")
           .setMetricType(MetricType.GAUGE)
           .build();

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -45,6 +45,8 @@ public final class MetricKey implements Comparable<MetricKey> {
 
   /** Metric name. */
   private final String mName;
+  /** Metrics name without instance prefix. */
+  private final String mMetricsName
 
   /** Metric key description. */
   private final String mDescription;
@@ -67,6 +69,7 @@ public final class MetricKey implements Comparable<MetricKey> {
     mDescription = Strings.isNullOrEmpty(description) ? "N/A" : description;
     mMetricType = metricType;
     mIsClusterAggregated = isClusterAggregated;
+    mMetricsName = extractMetricName();
   }
 
   /**
@@ -134,7 +137,11 @@ public final class MetricKey implements Comparable<MetricKey> {
   /**
    * @return the name of the Metric without instance prefix
    */
-  public String getMetricName() {
+  public String getMetricsName() {
+    return mMetricsName;
+  }
+
+  private String extractMetricName() {
     String[] pieces = mName.split("\\.");
     if (pieces.length <= 1) {
       return mName;

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -46,7 +46,7 @@ public final class MetricKey implements Comparable<MetricKey> {
   /** Metric name. */
   private final String mName;
   /** Metrics name without instance prefix. */
-  private final String mMetricsName
+  private final String mMetricName;
 
   /** Metric key description. */
   private final String mDescription;
@@ -69,7 +69,7 @@ public final class MetricKey implements Comparable<MetricKey> {
     mDescription = Strings.isNullOrEmpty(description) ? "N/A" : description;
     mMetricType = metricType;
     mIsClusterAggregated = isClusterAggregated;
-    mMetricsName = extractMetricName();
+    mMetricName = extractMetricName();
   }
 
   /**
@@ -138,7 +138,7 @@ public final class MetricKey implements Comparable<MetricKey> {
    * @return the name of the Metric without instance prefix
    */
   public String getMetricName() {
-    return mMetricsName;
+    return mMetricName;
   }
 
   private String extractMetricName() {

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -239,7 +239,7 @@ public final class MetricKey implements Comparable<MetricKey> {
   // Master metrics
   // Absent cache stats
   public static final MetricKey MASTER_ABSENT_CACHE_HITS =
-      new Builder("Master.AbsentCacheHits")F
+      new Builder("Master.AbsentCacheHits")
           .setDescription("Number of cache hits on the absent cache")
           .setMetricType(MetricType.GAUGE)
           .build();


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add a reading buffer to local cache for tiny read

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. we're seeing performance degradation when presto keep reading tiny pieces (1~10 bytes) from local cache on some encrypted parquet format.

### Does this PR introduce any user facing changes?
no
