### PR TITLE
Implement an unmodifiable List for array

### DIFF
--- a/core/common/src/main/java/alluxio/collections/UnmodifiableArrayList.java
+++ b/core/common/src/main/java/alluxio/collections/UnmodifiableArrayList.java
@@ -1,0 +1,269 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.collections;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterators;
+
+import java.util.Collection;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * This class provides an unmodifiable List proxy for an underlying array.
+ * In other words, this helps you use the array like a List, but not being able to modify it.
+ *
+ * The difference to {@code Collections.unmodifiableList(Arrays.asList(array))} is,
+ * in some Java implementations like adoptjdk, Arrays.asList() copies the array with
+ * {@code new ArrayList<>(array)} so it is not performant.
+ *
+ * Use this when you just want to return an unmodifiable view of the array.
+ *
+ * Create an instance with the constructor and get the underlying array with {@link #toArray()}.
+ */
+public class UnmodifiableArrayList<T> implements List<T> {
+  T[] mElements;
+
+  /**
+   * @param elements the underlying array
+   */
+  public UnmodifiableArrayList(T[] elements) {
+    Preconditions.checkNotNull(elements);
+    mElements = elements;
+  }
+
+  @Override
+  public int size() {
+    return mElements.length;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return mElements == null || mElements.length == 0;
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    return indexOf(o) >= 0;
+  }
+
+  @Override
+  public Iterator<T> iterator() {
+    return Iterators.forArray(mElements);
+  }
+
+  @Override
+  public Object[] toArray() {
+    return mElements;
+  }
+
+  @Override
+  public <T1> T1[] toArray(T1[] a) {
+    // An exception will be thrown if the target type is not convertible
+    return (T1[]) mElements;
+  }
+
+  @Override
+  public boolean add(T t) {
+    throw new UnsupportedOperationException(
+        "modification is not supported in UnmodifiableArrayList");
+  }
+
+  @Override
+  public boolean remove(Object o) {
+    throw new UnsupportedOperationException(
+        "modification is not supported in UnmodifiableArrayList");
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> c) {
+    return false;
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends T> c) {
+    throw new UnsupportedOperationException(
+        "modification is not supported in UnmodifiableArrayList");
+  }
+
+  @Override
+  public boolean addAll(int index, Collection<? extends T> c) {
+    throw new UnsupportedOperationException(
+        "modification is not supported in UnmodifiableArrayList");
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> c) {
+    throw new UnsupportedOperationException(
+        "modification is not supported in UnmodifiableArrayList");
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> c) {
+    throw new UnsupportedOperationException(
+        "modification is not supported in UnmodifiableArrayList");
+  }
+
+  @Override
+  public void clear() {
+    throw new UnsupportedOperationException(
+        "modification is not supported in UnmodifiableArrayList");
+  }
+
+  @Override
+  public T get(int index) {
+    return mElements[index];
+  }
+
+  @Override
+  public T set(int index, T element) {
+    throw new UnsupportedOperationException(
+        "modification is not supported in UnmodifiableArrayList");
+  }
+
+  @Override
+  public void add(int index, T element) {
+    throw new UnsupportedOperationException(
+        "modification is not supported in UnmodifiableArrayList");
+  }
+
+  @Override
+  public T remove(int index) {
+    throw new UnsupportedOperationException(
+        "modification is not supported in UnmodifiableArrayList");
+  }
+
+  @Override
+  public int lastIndexOf(Object o) {
+    return 0;
+  }
+
+  @Override
+  public ListIterator<T> listIterator() {
+    return new ListItr(0);
+  }
+
+  @Override
+  public ListIterator<T> listIterator(int index) {
+    if (index < 0 || index > mElements.length)
+      throw new IndexOutOfBoundsException("Index: "+index);
+    return new ListItr(index);
+  }
+
+  @Override
+  public List<T> subList(int fromIndex, int toIndex) {
+    throw new UnsupportedOperationException(
+        "subList is not supported in UnmodifiableArrayList, use the underlying array instead");
+  }
+
+  @Override
+  public int indexOf(Object o) {
+    if (o == null) {
+      for (int i = 0; i < mElements.length; i++)
+        if (mElements[i]==null) {
+          return i;
+        }
+    } else {
+      for (int i = 0; i < mElements.length; i++)
+        if (o.equals(mElements[i])) {
+          return i;
+        }
+    }
+    return -1;
+  }
+
+  private class Itr implements Iterator<T> {
+    int cursor;       // index of next element to return
+    int lastRet = -1; // index of last element returned; -1 if no such
+
+    Itr() {}
+
+    public boolean hasNext() {
+      return cursor != mElements.length;
+    }
+
+    @Override
+    public T next() {
+      int i = cursor;
+      if (i >= mElements.length)
+        throw new NoSuchElementException();
+      cursor = i + 1;
+      return mElements[lastRet = i];
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException(
+          "modification is not supported in UnmodifiableArrayList");
+    }
+
+    @Override
+    public void forEachRemaining(Consumer<? super T> consumer) {
+      Objects.requireNonNull(consumer);
+      final int size = mElements.length;
+      int i = cursor;
+      if (i >= size) {
+        return;
+      }
+      while (i != size) {
+        consumer.accept(mElements[i++]);
+      }
+      // update once at end of iteration to reduce heap write traffic
+      cursor = i;
+      lastRet = i - 1;
+    }
+  }
+
+  private class ListItr extends Itr implements ListIterator<T> {
+    ListItr(int index) {
+      super();
+      cursor = index;
+    }
+
+    public boolean hasPrevious() {
+      return cursor != 0;
+    }
+
+    public int nextIndex() {
+      return cursor;
+    }
+
+    public int previousIndex() {
+      return cursor - 1;
+    }
+
+    public T previous() {
+      int i = cursor - 1;
+      if (i < 0)
+        throw new NoSuchElementException();
+      if (i >= mElements.length)
+        throw new ConcurrentModificationException();
+      cursor = i;
+      return mElements[lastRet = i];
+    }
+
+    public void set(T e) {
+      throw new UnsupportedOperationException(
+          "modification is not supported in UnmodifiableArrayList");
+    }
+
+    public void add(T e) {
+      throw new UnsupportedOperationException(
+          "modification is not supported in UnmodifiableArrayList");
+    }
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -78,7 +78,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.LinkedList;

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -652,7 +652,7 @@ public class InodeSyncStream {
 
       // Fetch and populate children into the cache
       mStatusCache.prefetchChildren(inodePath.getUri(), mMountTable);
-      Collection<UfsStatus> listStatus = mStatusCache
+      UfsStatus[] listStatus = mStatusCache
           .fetchChildrenIfAbsent(mRpcContext, inodePath.getUri(), mMountTable);
       // Iterate over UFS listings and process UFS children.
       if (listStatus != null) {
@@ -749,7 +749,7 @@ public class InodeSyncStream {
         // now load all children if required
         LoadDescendantPType type = context.getOptions().getLoadDescendantType();
         if (type != LoadDescendantPType.NONE) {
-          Collection<UfsStatus> children = mStatusCache.fetchChildrenIfAbsent(mRpcContext,
+          UfsStatus[] children = mStatusCache.fetchChildrenIfAbsent(mRpcContext,
               inodePath.getUri(), mMountTable);
           if (children == null) {
             LOG.debug("fetching children for {} returned null", inodePath.getUri());

--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -113,13 +113,10 @@ public class UfsStatusCache {
    */
   @Nullable
   public UfsStatus[] addChildren(AlluxioURI path, UfsStatus[] children) {
-//    List<UfsStatus> list = new ArrayList<>(children.length);
-//    UfsStatus[] arr = new UfsStatus[children.length];
     for (int i = 0; i < children.length; i++) {
       UfsStatus child = children[i];
       AlluxioURI childPath = path.joinUnsafe(child.getName());
       addStatus(childPath, child);
-//      list.add(child);
     }
     return mChildren.put(path, children);
   }
@@ -220,7 +217,7 @@ public class UfsStatusCache {
    */
   @Nullable
   public UfsStatus[] fetchChildrenIfAbsent(RpcContext rpcContext, AlluxioURI path,
-                                                     MountTable mountTable, boolean useFallback)
+       MountTable mountTable, boolean useFallback)
       throws InterruptedException, InvalidPathException {
     Future<UfsStatus[]> prefetchJob = mActivePrefetchJobs.get(path);
     if (prefetchJob != null) {
@@ -305,7 +302,6 @@ public class UfsStatusCache {
         mAbsentCache.addSinglePath(path);
         return null;
       }
-//      children = Arrays.asList(statuses);
       children = statuses;
       addChildren(path, statuses);
     } catch (IllegalArgumentException | IOException e) {

--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -27,11 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -116,14 +112,15 @@ public class UfsStatusCache {
    * @return the previous set of children if the mapping existed, null otherwise
    */
   @Nullable
-  public Collection<UfsStatus> addChildren(AlluxioURI path, Collection<UfsStatus> children) {
-    Set<UfsStatus> set = new HashSet<>(children.size());
-    children.forEach(child -> {
+  public Collection<UfsStatus> addChildren(AlluxioURI path, UfsStatus[] children) {
+    List<UfsStatus> list = new ArrayList<>(children.length);
+    for (int i = 0; i < children.length; i++) {
+      UfsStatus child = children[i];
       AlluxioURI childPath = path.joinUnsafe(child.getName());
       addStatus(childPath, child);
-      set.add(child);
-    });
-    return mChildren.put(path, Collections.unmodifiableSet(set));
+      list.add(child);
+    }
+    return mChildren.put(path, Collections.unmodifiableList(list));
   }
 
   /**
@@ -308,7 +305,7 @@ public class UfsStatusCache {
         return null;
       }
       children = Arrays.asList(statuses);
-      addChildren(path, children);
+      addChildren(path, statuses);
     } catch (IllegalArgumentException | IOException e) {
       LOG.debug("Failed to add status to cache {}", path, e);
     }

--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -266,7 +265,7 @@ public class UfsStatusCache {
    */
   @Nullable
   public UfsStatus[] fetchChildrenIfAbsent(RpcContext rpcContext, AlluxioURI path,
-                                                     MountTable mountTable)
+       MountTable mountTable)
       throws InterruptedException, InvalidPathException {
     return fetchChildrenIfAbsent(rpcContext, path, mountTable, true);
   }

--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -50,8 +50,8 @@ public class UfsStatusCache {
   private static final Logger LOG = LoggerFactory.getLogger(UfsStatusCache.class);
 
   private final ConcurrentHashMap<AlluxioURI, UfsStatus> mStatuses;
-  private final ConcurrentHashMap<AlluxioURI, Future<Collection<UfsStatus>>> mActivePrefetchJobs;
-  private final ConcurrentHashMap<AlluxioURI, Collection<UfsStatus>> mChildren;
+  private final ConcurrentHashMap<AlluxioURI, Future<UfsStatus[]>> mActivePrefetchJobs;
+  private final ConcurrentHashMap<AlluxioURI, UfsStatus[]> mChildren;
   private final UfsAbsentPathCache mAbsentCache;
   private final long mCacheValidTime;
   private final ExecutorService mPrefetchExecutor;
@@ -112,15 +112,16 @@ public class UfsStatusCache {
    * @return the previous set of children if the mapping existed, null otherwise
    */
   @Nullable
-  public Collection<UfsStatus> addChildren(AlluxioURI path, UfsStatus[] children) {
-    List<UfsStatus> list = new ArrayList<>(children.length);
+  public UfsStatus[] addChildren(AlluxioURI path, UfsStatus[] children) {
+//    List<UfsStatus> list = new ArrayList<>(children.length);
+//    UfsStatus[] arr = new UfsStatus[children.length];
     for (int i = 0; i < children.length; i++) {
       UfsStatus child = children[i];
       AlluxioURI childPath = path.joinUnsafe(child.getName());
       addStatus(childPath, child);
-      list.add(child);
+//      list.add(child);
     }
-    return mChildren.put(path, Collections.unmodifiableList(list));
+    return mChildren.put(path, children);
   }
 
   /**
@@ -218,10 +219,10 @@ public class UfsStatusCache {
    * @throws InvalidPathException if the alluxio path can't be resolved to a UFS mount
    */
   @Nullable
-  public Collection<UfsStatus> fetchChildrenIfAbsent(RpcContext rpcContext, AlluxioURI path,
+  public UfsStatus[] fetchChildrenIfAbsent(RpcContext rpcContext, AlluxioURI path,
                                                      MountTable mountTable, boolean useFallback)
       throws InterruptedException, InvalidPathException {
-    Future<Collection<UfsStatus>> prefetchJob = mActivePrefetchJobs.get(path);
+    Future<UfsStatus[]> prefetchJob = mActivePrefetchJobs.get(path);
     if (prefetchJob != null) {
       while (true) {
         try {
@@ -243,7 +244,7 @@ public class UfsStatusCache {
         }
       }
     }
-    Collection<UfsStatus> children = getChildren(path);
+    UfsStatus[] children = getChildren(path);
     if (children != null) {
       return children;
     }
@@ -267,7 +268,7 @@ public class UfsStatusCache {
    * @throws InvalidPathException if the alluxio path can't be resolved to a UFS mount
    */
   @Nullable
-  public Collection<UfsStatus> fetchChildrenIfAbsent(RpcContext rpcContext, AlluxioURI path,
+  public UfsStatus[] fetchChildrenIfAbsent(RpcContext rpcContext, AlluxioURI path,
                                                      MountTable mountTable)
       throws InterruptedException, InvalidPathException {
     return fetchChildrenIfAbsent(rpcContext, path, mountTable, true);
@@ -286,9 +287,9 @@ public class UfsStatusCache {
    * @throws InvalidPathException when the table can't resolve the mount for the given URI
    */
   @Nullable
-  Collection<UfsStatus> getChildrenIfAbsent(AlluxioURI path, MountTable mountTable)
+  UfsStatus[] getChildrenIfAbsent(AlluxioURI path, MountTable mountTable)
       throws InvalidPathException {
-    Collection<UfsStatus> children = getChildren(path);
+    UfsStatus[] children = getChildren(path);
     if (children != null) {
       return children;
     }
@@ -304,7 +305,8 @@ public class UfsStatusCache {
         mAbsentCache.addSinglePath(path);
         return null;
       }
-      children = Arrays.asList(statuses);
+//      children = Arrays.asList(statuses);
+      children = statuses;
       addChildren(path, statuses);
     } catch (IllegalArgumentException | IOException e) {
       LOG.debug("Failed to add status to cache {}", path, e);
@@ -319,7 +321,7 @@ public class UfsStatusCache {
    * @return The corresponding {@link UfsStatus} or {@code null} if there is none stored
    */
   @Nullable
-  public Collection<UfsStatus> getChildren(AlluxioURI path) {
+  public UfsStatus[] getChildren(AlluxioURI path) {
     return mChildren.get(path);
   }
 
@@ -337,14 +339,14 @@ public class UfsStatusCache {
    * @return the future corresponding to the fetch task
    */
   @Nullable
-  public Future<Collection<UfsStatus>> prefetchChildren(AlluxioURI path, MountTable mountTable) {
+  public Future<UfsStatus[]> prefetchChildren(AlluxioURI path, MountTable mountTable) {
     if (mPrefetchExecutor == null) {
       return null;
     }
     try {
-      Future<Collection<UfsStatus>> job =
+      Future<UfsStatus[]> job =
           mPrefetchExecutor.submit(() -> getChildrenIfAbsent(path, mountTable));
-      Future<Collection<UfsStatus>> prev = mActivePrefetchJobs.put(path, job);
+      Future<UfsStatus[]> prev = mActivePrefetchJobs.put(path, job);
       if (prev != null) {
         prev.cancel(true);
       }

--- a/core/server/master/src/test/java/alluxio/underfs/UfsStatusCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/underfs/UfsStatusCacheTest.java
@@ -276,7 +276,7 @@ public class UfsStatusCacheTest {
     when(statChild.getName()).thenReturn("123");
 
     mCache.addStatus(path, stat);
-    mCache.addChildren(path, Collections.singleton(statChild));
+    mCache.addChildren(path, new UfsStatus[]{statChild});
     assertEquals(stat, mCache.getStatus(path));
     assertEquals(statChild, mCache.getStatus(pathChild));
     assertEquals(Collections.singleton(statChild), mCache.getChildren(path));

--- a/core/server/master/src/test/java/alluxio/underfs/UfsStatusCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/underfs/UfsStatusCacheTest.java
@@ -11,12 +11,7 @@
 
 package alluxio.underfs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -55,6 +50,7 @@ import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
@@ -156,10 +152,10 @@ public class UfsStatusCacheTest {
   public void testUseFallback() throws Exception {
     createUfsDirs("a");
     createUfsFile("a/b");
-    Collection<UfsStatus> children = mCache
+    UfsStatus[] children = mCache
         .fetchChildrenIfAbsent(null, new AlluxioURI("/a"), mMountTable);
-    assertEquals(1, children.size());
-    children.forEach(stat -> assertEquals("b", stat.getName()));
+    assertEquals(1, children.length);
+    Arrays.stream(children).forEach(stat -> assertEquals("b", stat.getName()));
   }
 
   @Test
@@ -279,8 +275,8 @@ public class UfsStatusCacheTest {
     mCache.addChildren(path, new UfsStatus[]{statChild});
     assertEquals(stat, mCache.getStatus(path));
     assertEquals(statChild, mCache.getStatus(pathChild));
-    assertEquals(Collections.singleton(statChild), mCache.getChildren(path));
-    assertEquals(Collections.singleton(statChild),
+    assertArrayEquals(new UfsStatus[]{statChild}, mCache.getChildren(path));
+    assertArrayEquals(new UfsStatus[]{statChild},
         mCache.fetchChildrenIfAbsent(null, path, mMountTable));
 
     mCache.remove(path);
@@ -304,22 +300,22 @@ public class UfsStatusCacheTest {
         mUfs.getStatus(PathUtils.concatPath(mUfsUri, "/mnt/dir2/dir0")).setName("dir0"));
     mCache.prefetchChildren(new AlluxioURI("/mnt/dir1/dir0"), mMountTable);
     mCache.prefetchChildren(new AlluxioURI("/mnt/dir2/dir0"), mMountTable);
-    Collection<UfsStatus> children;
+    UfsStatus[] children;
     children = mCache.fetchChildrenIfAbsent(
         null, new AlluxioURI("/mnt/dir1/dir0"), mMountTable, false);
     assertNotNull(children);
-    assertEquals(1, children.size());
-    children.forEach(s -> assertEquals("dir2", s.getName()));
+    assertEquals(1, children.length);
+    Arrays.stream(children).forEach(s -> assertEquals("dir2", s.getName()));
     children = mCache.fetchChildrenIfAbsent(
         null, new AlluxioURI("/mnt/dir2/dir0"), mMountTable, false);
     assertNotNull(children);
-    assertEquals(1, children.size());
-    children.forEach(s -> assertEquals("dir3", s.getName()));
+    assertEquals(1, children.length);
+    Arrays.stream(children).forEach(s -> assertEquals("dir3", s.getName()));
     children = mCache.fetchChildrenIfAbsent(
         null, new AlluxioURI("/mnt/dir1/dir0"), mMountTable, false);
     assertNotNull(children);
-    assertEquals(1, children.size());
-    children.forEach(s -> assertEquals("dir2", s.getName()));
+    assertEquals(1, children.length);
+    Arrays.stream(children).forEach(s -> assertEquals("dir2", s.getName()));
   }
 
   @Test
@@ -328,13 +324,13 @@ public class UfsStatusCacheTest {
     createUfsFile("dir0/dir0/file");
     mCache.prefetchChildren(new AlluxioURI("/dir0/dir0"), mMountTable);
     mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable);
-    Collection<UfsStatus> statuses =
+    UfsStatus[] statuses =
         mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/dir0/dir0"), mMountTable, false);
-    assertEquals(1, statuses.size());
-    statuses.forEach(s -> assertEquals("file", s.getName()));
+    assertEquals(1, statuses.length);
+    Arrays.stream(statuses).forEach(s -> assertEquals("file", s.getName()));
     statuses = mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/dir0"), mMountTable, false);
-    assertEquals(1, statuses.size());
-    statuses.forEach(s -> assertEquals("dir0", s.getName()));
+    assertEquals(1, statuses.length);
+    Arrays.stream(statuses).forEach(s -> assertEquals("dir0", s.getName()));
   }
 
   @Test
@@ -357,16 +353,16 @@ public class UfsStatusCacheTest {
     Future<?> f2 = mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable);
     assertNotNull(f1);
     assertTrue("first future is cancelled", f1.isCancelled());
-    Collection<UfsStatus> statuses =
+    UfsStatus[] statuses =
         mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/dir0/dir0"), mMountTable, true);
-    assertEquals(1, statuses.size());
-    statuses.forEach(s -> assertEquals("file", s.getName()));
+    assertEquals(1, statuses.length);
+    Arrays.stream(statuses).forEach(s -> assertEquals("file", s.getName()));
     l.unlock();
     statuses = mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/dir0"), mMountTable, false);
     assertNotNull(f2);
     assertTrue("second future should be finished", f2.isDone());
-    assertEquals(1, statuses.size());
-    statuses.forEach(s -> assertEquals("dir0", s.getName()));
+    assertEquals(1, statuses.length);
+    Arrays.stream(statuses).forEach(s -> assertEquals("dir0", s.getName()));
   }
 
   @Test
@@ -402,10 +398,10 @@ public class UfsStatusCacheTest {
     assertNull(mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable)); // rejected
     assertNull(mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable)); // rejected
     l.unlock();
-    Collection<UfsStatus> statuses =
+    UfsStatus[] statuses =
         mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/dir0"), mMountTable, false);
-    assertEquals(1, statuses.size());
-    statuses.forEach(s -> assertEquals("dir1", s.getName()));
+    assertEquals(1, statuses.length);
+    Arrays.stream(statuses).forEach(s -> assertEquals("dir1", s.getName()));
   }
 
   @Test

--- a/core/server/master/src/test/java/alluxio/underfs/UfsStatusCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/underfs/UfsStatusCacheTest.java
@@ -11,7 +11,13 @@
 
 package alluxio.underfs;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -51,8 +57,6 @@ import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR adds an unmodifiable List interface over an underlying array, so we no longer need to use `Collections.unmodifiableList(Arrays.asList())`

### Why are the changes needed?

In some JDKs. `Arrays.asList()` is internally `new ArrayList<>(array)`, which incurs a copy. And getting that array back from the List will create another copy with `list.toArray(new T[])`. We add this class to simplify interface conversion and reduce unnecessary copies created just merely for that conversion.

### Does this PR introduce any user facing changes?

NA
