### PR TITLE
Fix java installation directory in Dockerfile-dev

### DIFF
--- a/integration/docker/Dockerfile-dev
+++ b/integration/docker/Dockerfile-dev
@@ -87,7 +87,7 @@ RUN wget -qO /tmp/async-profiler-1.8.3-linux-x64.tar.gz "https://github.com/jvm-
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk
 
 # Disable JVM DNS cache in both java8 and java11
-RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/java.security
+RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-1.8.0-openjdk/jre/lib/security/java.security
 RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-11-openjdk/conf/security/java.security
 
 # Add the following for native libraries needed by rocksdb


### PR DESCRIPTION
there's a line in the dockerfiles to disable jvm dns cache by appending to this file within the java installation directory
`/usr/lib/jvm/java-1.8-openjdk/jre/lib/security/java.security`. sometime between the morning of 3/23 and 3/24, something changed such that this path doesn't exist. maybe due to an upgrade in either the java version or the way the OS creates the symlinks, but now the path appends `.0` to the end of `java-1.8` -> `/usr/lib/jvm/java-1.8.0-openjdk/jre/lib/security/java.security`.

note this only affects java 8 on the centos base image; java 11 on the same image and java 8 on the alpine image are not affected