### PR TITLE
Handle null in PropertyKey.parseValue

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -8398,6 +8398,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
    * @return property value in the expected type
    */
   public Object parseValue(String stringValue) {
+    if (stringValue == null) {
+      return null;
+    }
     try {
       switch (mType) {
         case BOOLEAN:


### PR DESCRIPTION
parseTimeSize throws NPE for null input. Since it returns primitive
long, it's unclear what null should default to. Thus making parseValue
to handle null uniformly.
