### PR TITLE
Handle null in InstanceConfiguration.isResolvable

### DIFF
--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -168,6 +168,10 @@ public class InstancedConfiguration implements AlluxioConfiguration {
 
   private boolean isResolvable(PropertyKey key) {
     Object value = mProperties.get(key);
+    // null values are unresolvable
+    if (value == null) {
+      return false;
+    }
     try {
       // Lookup to resolve any key before simply returning isSet. An exception will be thrown if
       // the key can't be resolved or if a lower level value isn't set.


### PR DESCRIPTION
### What changes are proposed in this pull request?

See title.

### Why are the changes needed?

Fixing issue where null values are considered resolvable, so calling `InstanceConfiguration.get` throws a runtime exception for all unset property keys.

### Does this PR introduce any user facing changes?

No