### PR TITLE
Allow string values when setting AlluxioConfiguration

### DIFF
--- a/core/common/src/main/java/alluxio/cli/ValidationToolRegistry.java
+++ b/core/common/src/main/java/alluxio/cli/ValidationToolRegistry.java
@@ -58,7 +58,7 @@ public class ValidationToolRegistry {
   public void refresh() {
     Map<String, ValidationToolFactory> map = new HashMap<>();
 
-    String libDir = PathUtils.concatPath(mConf.get(PropertyKey.HOME), "lib");
+    String libDir = PathUtils.concatPath(mConf.getString(PropertyKey.HOME), "lib");
     LOG.info("Loading validation tool jars from {}", libDir);
     List<File> files = new ArrayList<>();
     try (DirectoryStream<Path> stream = Files

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -59,7 +59,6 @@ import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
 import com.sun.management.OperatingSystemMXBean;
 import io.netty.util.ResourceLeakDetector;
 import org.slf4j.Logger;
@@ -7819,7 +7818,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
    * @return all pre-defined property keys
    */
   public static Collection<? extends PropertyKey> defaultKeys() {
-    return Sets.newHashSet(DEFAULT_KEYS_MAP.values());
+    return DEFAULT_KEYS_MAP.values();
   }
 
   /** Property name. */

--- a/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
+++ b/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
@@ -130,7 +130,7 @@ public class ExtensionFactoryRegistry<T extends ExtensionFactory<?, S>,
     Preconditions.checkArgument(path != null, "path may not be null");
 
     List<T> factories = new ArrayList<>(mFactories);
-    String libDir = PathUtils.concatPath(conf.get(PropertyKey.HOME), "lib");
+    String libDir = PathUtils.concatPath(conf.getString(PropertyKey.HOME), "lib");
     String extensionDir = conf.getString(PropertyKey.EXTENSIONS_DIR);
     scanLibs(factories, libDir);
     scanExtensions(factories, extensionDir);

--- a/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
@@ -13,6 +13,7 @@ package alluxio.conf;
 
 import static alluxio.conf.PropertyKey.Builder.intBuilder;
 import static alluxio.conf.PropertyKey.Builder.stringBuilder;
+import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -31,7 +32,9 @@ import alluxio.client.ReadType;
 import alluxio.conf.PropertyKey.Template;
 import alluxio.test.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
+import alluxio.util.FormatUtils;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.hamcrest.CoreMatchers;
@@ -49,10 +52,14 @@ import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Unit tests for the {@link alluxio.conf.InstancedConfiguration} class.
@@ -82,6 +89,95 @@ public class InstancedConfigurationTest {
   @AfterClass
   public static void after() {
     ConfigurationUtils.reloadProperties();
+  }
+
+  @Test
+  public void testAllKeyTypes() {
+    Random random = new Random();
+    for (PropertyKey key : PropertyKey.defaultKeys()) {
+      switch (key.getType()) {
+        case BOOLEAN:
+          mConfiguration.set(key, false);
+          assertEquals(false, mConfiguration.get(key));
+          assertFalse(mConfiguration.getBoolean(key));
+          mConfiguration.set(key, "true");
+          assertTrue(mConfiguration.getBoolean(key));
+          break;
+        case INTEGER:
+          int intValue = random.nextInt(Integer.MAX_VALUE);
+          mConfiguration.set(key, intValue);
+          assertEquals(intValue, mConfiguration.get(key));
+          assertEquals(intValue, mConfiguration.getInt(key));
+          assertThrows(IllegalArgumentException.class, () -> mConfiguration.getMs(key));
+          assertThrows(IllegalArgumentException.class, () -> mConfiguration.getDuration(key));
+          assertThrows(IllegalArgumentException.class, () -> mConfiguration.getDouble(key));
+          intValue = random.nextInt(Integer.MAX_VALUE);
+          mConfiguration.set(key, String.valueOf(intValue));
+          assertEquals(intValue, mConfiguration.getInt(key));
+          break;
+        case DOUBLE:
+          double doubleValue = random.nextDouble();
+          mConfiguration.set(key, doubleValue);
+          assertEquals(doubleValue, mConfiguration.get(key));
+          assertEquals(doubleValue, mConfiguration.getDouble(key), doubleValue / 1000);
+          assertThrows(IllegalArgumentException.class, () -> mConfiguration.getMs(key));
+          assertThrows(IllegalArgumentException.class, () -> mConfiguration.getDuration(key));
+          assertThrows(IllegalArgumentException.class, () -> mConfiguration.getInt(key));
+          break;
+        case STRING:
+          String stringValue = String.valueOf(random.nextInt(Integer.MAX_VALUE));
+          if (key.validateValue(stringValue)) {
+            mConfiguration.set(key, stringValue);
+            assertEquals(stringValue, mConfiguration.get(key));
+            assertEquals(stringValue, mConfiguration.getString(key));
+            assertThrows(IllegalArgumentException.class, () -> mConfiguration.getMs(key));
+            assertThrows(IllegalArgumentException.class, () -> mConfiguration.getDuration(key));
+            assertThrows(IllegalArgumentException.class, () -> mConfiguration.getInt(key));
+          }
+          break;
+        case DATASIZE:
+          String dataSizeValue = format("%s%s", random.nextInt(1000),
+              new String[] {"b", "kb", "mb", "gb"} [random.nextInt(4)]);
+          long storedDataSize = FormatUtils.parseSpaceSize(dataSizeValue);
+          mConfiguration.set(key, dataSizeValue);
+          assertEquals(storedDataSize, mConfiguration.get(key));
+          assertEquals(storedDataSize, mConfiguration.getBytes(key));
+          assertThrows(IllegalArgumentException.class, () -> mConfiguration.getInt(key));
+          assertThrows(IllegalArgumentException.class, () -> mConfiguration.getMs(key));
+          break;
+        case DURATION:
+          String durationValue = format("%s%s", random.nextInt(1000),
+              new String[] {"ms", "s", "m", "h", "d"} [random.nextInt(5)]);
+          long storedDuration = FormatUtils.parseTimeSize(durationValue);
+          mConfiguration.set(key, durationValue);
+          assertEquals(storedDuration, mConfiguration.get(key));
+          assertEquals(storedDuration, mConfiguration.getMs(key));
+          assertThrows(IllegalArgumentException.class, () -> mConfiguration.getInt(key));
+          assertThrows(IllegalArgumentException.class, () -> mConfiguration.getBytes(key));
+          break;
+        case LIST:
+          List<String> listValue = IntStream.range(0, 4)
+              .mapToObj(i -> String.valueOf(random.nextInt(Integer.MAX_VALUE)))
+              .collect(Collectors.toList());
+          String storedList = Joiner.on(key.getDelimiter()).join(listValue);
+          mConfiguration.set(key, listValue);
+          assertEquals(storedList, mConfiguration.get(key));
+          assertEquals(listValue, mConfiguration.getList(key));
+          mConfiguration.set(key, storedList);
+          assertEquals(storedList, mConfiguration.get(key));
+          assertEquals(listValue, mConfiguration.getList(key));
+          break;
+        case ENUM:
+          if (key.getDefaultValue() != null) {
+            assertEquals(key.getDefaultValue(), mConfiguration.getEnum(key, key.getEnumType()));
+          }
+          break;
+        case CLASS:
+          break;
+        default:
+          fail(format("Unknown PropertyKey type: %s", key.getType()));
+      }
+    }
   }
 
   @Test
@@ -523,17 +619,17 @@ public class InstancedConfigurationTest {
   }
 
   @Test
-  public void circularSubstitution() throws Exception {
-    mConfiguration.set(PropertyKey.HOME, String.format("${%s}", PropertyKey.HOME.toString()));
+  public void circularSubstitution() {
+    mConfiguration.set(PropertyKey.HOME, format("${%s}", PropertyKey.HOME));
     mThrown.expect(RuntimeException.class);
     mThrown.expectMessage(PropertyKey.HOME.toString());
-    mConfiguration.get(PropertyKey.HOME);
+    mConfiguration.getString(PropertyKey.HOME);
   }
 
   @Test
   public void userFileBufferBytesOverFlowException() {
     mConfiguration.set(PropertyKey.USER_FILE_BUFFER_BYTES,
-        String.valueOf(Integer.MAX_VALUE + 1) + "B");
+        (Integer.MAX_VALUE + 1) + "B");
     mThrown.expect(IllegalStateException.class);
     mConfiguration.validate();
   }
@@ -548,7 +644,7 @@ public class InstancedConfigurationTest {
 
   @Test
   public void setUserFileBufferBytesMaxInteger() {
-    mConfiguration.set(PropertyKey.USER_FILE_BUFFER_BYTES, String.valueOf(Integer.MAX_VALUE) + "B");
+    mConfiguration.set(PropertyKey.USER_FILE_BUFFER_BYTES, Integer.MAX_VALUE + "B");
     assertEquals(Integer.MAX_VALUE,
         (int) mConfiguration.getBytes(PropertyKey.USER_FILE_BUFFER_BYTES));
   }
@@ -722,7 +818,7 @@ public class InstancedConfigurationTest {
     // Create a nested property to test
     String testKeyName = "alluxio.extensions.dir";
     PropertyKey nestedKey = PropertyKey.SECURITY_LOGIN_USERNAME;
-    String nestedValue = String.format("${%s}.test", testKeyName);
+    String nestedValue = format("${%s}.test", testKeyName);
     mConfiguration.set(nestedKey, nestedValue);
 
     Map<String, Object> resolvedMap = mConfiguration.toMap();
@@ -730,14 +826,14 @@ public class InstancedConfigurationTest {
     // Test if the value of the created nested property is correct
     assertEquals(mConfiguration.get(PropertyKey.fromString(testKeyName)),
         resolvedMap.get(testKeyName));
-    String nestedResolvedValue = String.format("%s.test", resolvedMap.get(testKeyName));
+    String nestedResolvedValue = format("%s.test", resolvedMap.get(testKeyName));
     assertEquals(nestedResolvedValue, resolvedMap.get(nestedKey.toString()));
 
     // Test if the values in the resolvedMap is resolved
-    String resolvedValue1 = String.format("%s/extensions", resolvedMap.get("alluxio.home"));
+    String resolvedValue1 = format("%s/extensions", resolvedMap.get("alluxio.home"));
     assertEquals(resolvedValue1, resolvedMap.get(testKeyName));
 
-    String resolvedValue2 =  String.format("%s/logs", resolvedMap.get("alluxio.work.dir"));
+    String resolvedValue2 =  format("%s/logs", resolvedMap.get("alluxio.work.dir"));
     assertEquals(resolvedValue2, resolvedMap.get("alluxio.logs.dir"));
 
     // Test if the resolvedMap include all kinds of properties
@@ -754,7 +850,7 @@ public class InstancedConfigurationTest {
   public void toRawMap() throws Exception {
     // Create a nested property to test
     PropertyKey testKey = PropertyKey.SECURITY_LOGIN_USERNAME;
-    String testValue = String.format("${%s}.test", "alluxio.extensions.dir");
+    String testValue = format("${%s}.test", "alluxio.extensions.dir");
     mConfiguration.set(testKey, testValue);
 
     Map<String, Object> rawMap =
@@ -887,7 +983,7 @@ public class InstancedConfigurationTest {
       File props = new File(dir, "alluxio-site.properties");
 
       try (BufferedWriter writer = Files.newBufferedWriter(props.toPath())) {
-        writer.write(String.format("%s=%s", PropertyKey.MASTER_HOSTNAME, "test_hostname"));
+        writer.write(format("%s=%s", PropertyKey.MASTER_HOSTNAME, "test_hostname"));
       }
       resetConf();
       assertEquals("test_hostname", mConfiguration.get(PropertyKey.MASTER_HOSTNAME));
@@ -932,7 +1028,7 @@ public class InstancedConfigurationTest {
       fail("Should have thrown a runtime exception when validating with a removed key");
     } catch (RuntimeException e) {
       assertTrue(e.getMessage().contains(
-          String.format("%s is no longer a valid property",
+          format("%s is no longer a valid property",
               RemovedKey.Name.TEST_REMOVED_KEY)));
     }
     mConfiguration = ConfigurationTestUtils.defaults();
@@ -942,7 +1038,7 @@ public class InstancedConfigurationTest {
       fail("Should have thrown a runtime exception when validating with a removed key");
     } catch (RuntimeException e) {
       assertTrue(e.getMessage().contains(
-          String.format("%s is no longer a valid property",
+          format("%s is no longer a valid property",
               RemovedKey.Name.TEST_REMOVED_KEY)));
     }
   }
@@ -951,7 +1047,7 @@ public class InstancedConfigurationTest {
   public void testDeprecatedKey() {
     mConfiguration.set(PropertyKey.TEST_DEPRECATED_KEY, true);
     mConfiguration.validate();
-    String logString = String.format("%s is deprecated", PropertyKey.TEST_DEPRECATED_KEY);
+    String logString = format("%s is deprecated", PropertyKey.TEST_DEPRECATED_KEY);
     assertTrue(mLogger.wasLogged(logString));
     assertEquals(1, mLogger.logCount(logString));
   }
@@ -972,7 +1068,7 @@ public class InstancedConfigurationTest {
         fail("Should have thrown a runtime exception when using an unknown tier alias");
       } catch (RuntimeException e) {
         assertTrue(e.getMessage().contains(
-            String.format("Alias \"%s\" on tier 0 on worker (configured by %s) is not found "
+            format("Alias \"%s\" on tier 0 on worker (configured by %s) is not found "
                 + "in global tiered", alias, Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(0))
         ));
       }
@@ -989,7 +1085,7 @@ public class InstancedConfigurationTest {
       fail("Should have thrown a runtime exception when setting an unknown tier level");
     } catch (RuntimeException e) {
       assertTrue(e.getMessage().contains(
-          String.format("%s tiers on worker (configured by %s), larger than global %s tiers "
+          format("%s tiers on worker (configured by %s), larger than global %s tiers "
                   + "(configured by %s) ", 2, PropertyKey.WORKER_TIERED_STORE_LEVELS, 1,
               PropertyKey.MASTER_TIERED_STORE_GLOBAL_LEVELS)));
     }

--- a/core/common/src/test/java/alluxio/underfs/UnderFileSystemConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/underfs/UnderFileSystemConfigurationTest.java
@@ -66,7 +66,7 @@ public final class UnderFileSystemConfigurationTest {
         new ConfigurationRule(PropertyKey.UNDERFS_LISTING_LENGTH, 2000, mConfiguration)
             .toResource()) {
       UnderFileSystemConfiguration conf = UnderFileSystemConfiguration.defaults(mConfiguration);
-      assertEquals(2000, conf.get(PropertyKey.UNDERFS_LISTING_LENGTH));
+      assertEquals(2000, conf.getInt(PropertyKey.UNDERFS_LISTING_LENGTH));
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
+++ b/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
@@ -85,7 +85,7 @@ public final class MasterWebServer extends WebServer {
       // If the Web UI is disabled, disable the resources and servlet together.
       if (ServerConfiguration.getBoolean(PropertyKey.WEB_UI_ENABLED)) {
         String resourceDirPathString =
-                ServerConfiguration.get(PropertyKey.WEB_RESOURCES) + "/master/build/";
+                ServerConfiguration.getString(PropertyKey.WEB_RESOURCES) + "/master/build/";
         File resourceDir = new File(resourceDirPathString);
         mServletContextHandler.setBaseResource(Resource.newResource(resourceDir.getAbsolutePath()));
         mServletContextHandler.setWelcomeFiles(new String[]{"index.html"});

--- a/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalConfTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalConfTest.java
@@ -42,7 +42,7 @@ public class UfsJournalConfTest {
     int value = 10000;
     ServerConfiguration.set(key, value);
     UnderFileSystemConfiguration conf = UfsJournal.getJournalUfsConf();
-    Assert.assertEquals(value, conf.get(PropertyKey.UNDERFS_LISTING_LENGTH));
+    Assert.assertEquals(value, conf.getInt(PropertyKey.UNDERFS_LISTING_LENGTH));
     Assert.assertEquals(1, conf.getMountSpecificConf().size());
   }
 }

--- a/core/server/worker/src/main/java/alluxio/web/WorkerWebServer.java
+++ b/core/server/worker/src/main/java/alluxio/web/WorkerWebServer.java
@@ -88,7 +88,7 @@ public final class WorkerWebServer extends WebServer {
       // If the Web UI is disabled, disable the resources and servlet together.
       if (ServerConfiguration.getBoolean(PropertyKey.WEB_UI_ENABLED)) {
         String resourceDirPathString =
-                ServerConfiguration.get(PropertyKey.WEB_RESOURCES) + "/worker/build/";
+                ServerConfiguration.getString(PropertyKey.WEB_RESOURCES) + "/worker/build/";
         File resourceDir = new File(resourceDirPathString);
         mServletContextHandler.setBaseResource(Resource.newResource(resourceDir.getAbsolutePath()));
         mServletContextHandler.setWelcomeFiles(new String[]{"index.html"});

--- a/integration/tools/validation/src/main/java/alluxio/cli/ClusterConfConsistencyValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/ClusterConfConsistencyValidationTask.java
@@ -62,17 +62,17 @@ public final class ClusterConfConsistencyValidationTask extends AbstractValidati
     Set<String> propertyNames = new HashSet<>();
     if (masters.isEmpty()) {
       msg.append(String.format("No master nodes specified in %s/masters file. ",
-              mConf.get(PropertyKey.CONF_DIR)));
+              mConf.getString(PropertyKey.CONF_DIR)));
       advice.append(String.format("Please configure %s to contain the master node hostnames. ",
-              mConf.get(PropertyKey.CONF_DIR)));
+              mConf.getString(PropertyKey.CONF_DIR)));
       return new ValidationTaskResult(ValidationUtils.State.WARNING, getName(),
               msg.toString(), advice.toString());
     }
     if (workers.isEmpty()) {
       msg.append(String.format("No worker nodes specified in %s/workers file. ",
-              mConf.get(PropertyKey.CONF_DIR)));
+              mConf.getString(PropertyKey.CONF_DIR)));
       advice.append(String.format("Please configure %s to contain the worker node hostnames. ",
-              mConf.get(PropertyKey.CONF_DIR)));
+              mConf.getString(PropertyKey.CONF_DIR)));
       return new ValidationTaskResult(ValidationUtils.State.WARNING, getName(),
               msg.toString(), advice.toString());
     }

--- a/integration/tools/validation/src/main/java/alluxio/cli/SshValidationTask.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/SshValidationTask.java
@@ -49,7 +49,7 @@ public final class SshValidationTask extends AbstractValidationTask {
     if (nodes == null) {
       msg.append("Failed to find master/worker nodes from Alluxio configuration. ");
       advice.append(String.format("Please check your %s/master and %s/worker files. ",
-              mConf.get(PropertyKey.CONF_DIR)));
+              mConf.getString(PropertyKey.CONF_DIR)));
       return new ValidationTaskResult(ValidationUtils.State.FAILED, getName(),
               msg.toString(), advice.toString());
     }

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -261,7 +261,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
       } catch (SdkClientException e) {
         LOG.error("S3 region {} cannot be recognized, "
             + "fall back to use global bucket access with an extra HEAD request",
-            conf.get(PropertyKey.UNDERFS_S3_REGION), e);
+            conf.getString(PropertyKey.UNDERFS_S3_REGION), e);
       }
     }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Allow setting property key with string values but log a warning on
invalid values and let people know that this will be disallowed later.

### Why are the changes needed?

Some external systems might directly use this internal API to set
Alluxio properties. Give people some warning and time to fix the issues
before directly breaking them.

### Does this PR introduce any user facing changes?

It removes a potentially user facing change.
