### PR TITLE
Avoid ArrayList resizing in getFileBlockInfoListInternal

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2069,7 +2069,7 @@ public class DefaultFileSystemMaster extends CoreMaster
     InodeFile file = inodePath.getInodeFile();
     List<BlockInfo> blockInfoList = mBlockMaster.getBlockInfoList(file.getBlockIds());
 
-    List<FileBlockInfo> ret = new ArrayList<>();
+    List<FileBlockInfo> ret = new ArrayList<>(blockInfoList.size());
     for (BlockInfo blockInfo : blockInfoList) {
       ret.add(generateFileBlockInfo(inodePath, blockInfo));
     }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Init the ArrayList with size to avoid internal resizing.

If no size is given on ArrayList construction, internally I believe ArrayList init with 0 size and on adding the 1st element, it allocates a 10 element array. So when the average block count in Alluxio is significantly less than 10, we can save some space on ArrayList init. And when the average block count in Alluxio is significantly over 10, we half the overall mem allocation of ArrayList by avoiding resizing.

However, the save is mostly mem allocations in the Young Gen and Young GC, so it's not going to be that observable.

### Does this PR introduce any user facing changes?

NA
