### PR TITLE
Use correct AlluxioConfiguration API to get PropertyKey value

### DIFF
--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/v2/GCSV2UnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/v2/GCSV2UnderFileSystem.java
@@ -91,14 +91,14 @@ public class GCSV2UnderFileSystem extends ObjectUnderFileSystem {
     Storage storage = StorageOptions.newBuilder().setRetrySettings(
         RetrySettings.newBuilder()
             .setInitialRetryDelay(
-                Duration.ofMillis(conf.getInt(PropertyKey.UNDERFS_GCS_RETRY_INITIAL_DELAY_MS)))
+                Duration.ofMillis(conf.getMs(PropertyKey.UNDERFS_GCS_RETRY_INITIAL_DELAY_MS)))
             .setMaxRetryDelay(
-                Duration.ofMillis(conf.getInt(PropertyKey.UNDERFS_GCS_RETRY_MAX_DELAY_MS)))
+                Duration.ofMillis(conf.getMs(PropertyKey.UNDERFS_GCS_RETRY_MAX_DELAY_MS)))
             .setRetryDelayMultiplier(
                 conf.getInt(PropertyKey.UNDERFS_GCS_RETRY_DELAY_MULTIPLIER))
             .setMaxAttempts(conf.getInt(PropertyKey.UNDERFS_GCS_RETRY_MAX))
             .setTotalTimeout(
-                Duration.ofMillis(conf.getInt(PropertyKey.UNDERFS_GCS_RETRY_TOTAL_DURATION_MS)))
+                Duration.ofMillis(conf.getMs(PropertyKey.UNDERFS_GCS_RETRY_TOTAL_DURATION_MS)))
             .setJittered(conf.getBoolean(PropertyKey.UNDERFS_GCS_RETRY_JITTER))
             .build())
         .setCredentials(credentials).build().getService();


### PR DESCRIPTION
### What changes are proposed in this pull request?
For duration type property keys, AlluxioConfiguration.getMs should
be used, rather than getInt.
