### PR TITLE
Change storage medium from String to enum in metadata

### DIFF
--- a/core/common/src/main/java/alluxio/client/file/URIStatus.java
+++ b/core/common/src/main/java/alluxio/client/file/URIStatus.java
@@ -19,6 +19,7 @@ import alluxio.wire.BlockInfo;
 import alluxio.wire.FileBlockInfo;
 import alluxio.wire.FileInfo;
 
+import alluxio.wire.Medium;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
@@ -275,7 +276,7 @@ public class URIStatus {
   /**
    * @return the pinned location list
    */
-  public Set<String> getPinnedMediumTypes() {
+  public Set<Medium> getPinnedMediumTypes() {
     return mInfo.getMediumTypes();
   }
 

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2756,6 +2756,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
+  // TODO(jiacheng): This will be demised once we convert mediums to enum
   public static final PropertyKey MASTER_TIERED_STORE_GLOBAL_MEDIUMTYPE =
       listBuilder(Name.MASTER_TIERED_STORE_GLOBAL_MEDIUMTYPE)
           .setDefaultValue("MEM,SSD,HDD")

--- a/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcUtils.java
@@ -28,6 +28,7 @@ import alluxio.wire.FileBlockInfo;
 import alluxio.wire.FileInfo;
 import alluxio.wire.FileSystemCommand;
 import alluxio.wire.LoadMetadataType;
+import alluxio.wire.Medium;
 import alluxio.wire.MountPointInfo;
 import alluxio.wire.PersistFile;
 import alluxio.wire.RegisterLease;
@@ -41,9 +42,12 @@ import com.google.common.net.HostAndPort;
 import com.google.protobuf.ByteString;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -236,7 +240,7 @@ public final class GrpcUtils {
         .setBlockSizeBytes(pInfo.getBlockSizeBytes()).setCreationTimeMs(pInfo.getCreationTimeMs())
         .setCompleted(pInfo.getCompleted()).setFolder(pInfo.getFolder())
         .setPinned(pInfo.getPinned()).setCacheable(pInfo.getCacheable())
-        .setMediumTypes(ImmutableSet.copyOf(pInfo.getMediumTypeList()))
+        .setMediumTypes(Medium.fromValues(pInfo.getMediumTypeList()))
         .setPersisted(pInfo.getPersisted()).setBlockIds(pInfo.getBlockIdsList())
         .setLastModificationTimeMs(pInfo.getLastModificationTimeMs()).setTtl(pInfo.getTtl())
         .setLastAccessTimeMs(pInfo.getLastAccessTimeMs())
@@ -501,7 +505,11 @@ public final class GrpcUtils {
       }
     }
     if (!fileInfo.getMediumTypes().isEmpty()) {
-      builder.addAllMediumType(fileInfo.getMediumTypes());
+      Set<String> mediums = new HashSet<>();
+      for (Medium m : fileInfo.getMediumTypes()) {
+        mediums.add(m.toString());
+      }
+      builder.addAllMediumType(mediums);
     }
     return builder.build();
   }

--- a/core/common/src/main/java/alluxio/wire/FileInfo.java
+++ b/core/common/src/main/java/alluxio/wire/FileInfo.java
@@ -48,7 +48,7 @@ public final class FileInfo implements Serializable {
   private boolean mCompleted;
   private boolean mFolder;
   private boolean mPinned;
-  private Set<String> mMediumTypes = new HashSet<>();
+  private Set<Medium> mMediumTypes = new HashSet<>();
   private boolean mCacheable;
   private boolean mPersisted;
   private ArrayList<Long> mBlockIds = new ArrayList<>();
@@ -323,7 +323,7 @@ public final class FileInfo implements Serializable {
   /**
    * @return a set of pinned locations
    */
-  public Set<String> getMediumTypes() {
+  public Set<Medium> getMediumTypes() {
     return mMediumTypes;
   }
 
@@ -628,7 +628,7 @@ public final class FileInfo implements Serializable {
    * @param mediumTypes the pinned locations
    * @return the file information
    */
-  public FileInfo setMediumTypes(Set<String> mediumTypes) {
+  public FileInfo setMediumTypes(Set<Medium> mediumTypes) {
     mMediumTypes = mediumTypes;
     return this;
   }

--- a/core/common/src/main/java/alluxio/wire/Medium.java
+++ b/core/common/src/main/java/alluxio/wire/Medium.java
@@ -1,0 +1,29 @@
+package alluxio.wire;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+public enum Medium {
+  MEM,
+  SSD,
+  HDD;
+
+  public static final Set<Medium> EMPTY_SET =
+      Collections.unmodifiableSet(EnumSet.noneOf(Medium.class));
+
+  public static Set<Medium> fromValues(Collection<String> values) {
+    Set<Medium> mediums;
+    if (values.isEmpty()) {
+      mediums = Medium.EMPTY_SET;
+    } else {
+      mediums = EnumSet.noneOf(Medium.class);
+      for (String s : values) {
+        // TODO(jiacheng): If the value is not defined, IllegalArgumentException
+        mediums.add(Medium.valueOf(s));
+      }
+    }
+    return mediums;
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/Inode.java
@@ -20,6 +20,7 @@ import alluxio.security.authorization.AclActions;
 import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.wire.FileInfo;
 
+import alluxio.wire.Medium;
 import com.google.common.base.Preconditions;
 
 import java.util.List;
@@ -144,7 +145,7 @@ public abstract class Inode implements InodeView {
   }
 
   @Override
-  public Set<String> getMediumTypes() {
+  public Set<Medium> getMediumTypes() {
     return mDelegate.getMediumTypes();
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeView.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeView.java
@@ -19,6 +19,7 @@ import alluxio.security.authorization.AclAction;
 import alluxio.security.authorization.AclActions;
 import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.wire.FileInfo;
+import alluxio.wire.Medium;
 
 import java.util.List;
 import java.util.Map;
@@ -124,7 +125,7 @@ public interface InodeView extends JournalEntryRepresentable, Comparable<InodeVi
   /**
    * @return the pinned medium types set
    */
-  Set<String> getMediumTypes();
+  Set<Medium> getMediumTypes();
 
   /**
    * @return the UFS fingerprint

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeDirectory.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeDirectory.java
@@ -24,8 +24,11 @@ import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.util.CommonUtils;
 import alluxio.util.proto.ProtoUtils;
 import alluxio.wire.FileInfo;
+import alluxio.wire.Medium;
 
+import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -209,7 +212,7 @@ public final class MutableInodeDirectory extends MutableInode<MutableInodeDirect
     } else {
       ret.mDefaultAcl = new DefaultAccessControlList();
     }
-    ret.setMediumTypes(new HashSet<>(entry.getMediumTypeList()));
+    ret.setMediumTypes(Medium.fromValues(entry.getMediumTypeList()));
     if (entry.getXAttrCount() > 0) {
       ret.setXAttr(CommonUtils.convertFromByteString(entry.getXAttrMap()));
     }
@@ -260,7 +263,7 @@ public final class MutableInodeDirectory extends MutableInode<MutableInodeDirect
         .setDirectChildrenLoaded(isDirectChildrenLoaded())
         .setAcl(ProtoUtils.toProto(mAcl))
         .setDefaultAcl(ProtoUtils.toProto(mDefaultAcl))
-        .addAllMediumType(getMediumTypes());
+        .addAllMediumType(getMediumTypes().stream().map(Medium::toString).collect(Collectors.toList()));
     if (getXAttr() != null) {
       inodeDirectory.putAllXAttr(CommonUtils.convertToByteString(getXAttr()));
     }
@@ -304,7 +307,7 @@ public final class MutableInodeDirectory extends MutableInode<MutableInodeDirect
         .setDirectChildrenLoaded(inode.getHasDirectChildrenLoaded())
         .setChildCount(inode.getChildCount())
         .setDefaultACL((DefaultAccessControlList) ProtoUtils.fromProto(inode.getDefaultAcl()))
-        .setMediumTypes(new HashSet<>(inode.getMediumTypeList()));
+        .setMediumTypes(Medium.fromValues(inode.getMediumTypeList()));
     if (inode.getXAttrCount() > 0) {
       d.setXAttr(CommonUtils.convertFromByteString(inode.getXAttrMap()));
     }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeFile.java
@@ -28,11 +28,13 @@ import alluxio.util.CommonUtils;
 import alluxio.util.proto.ProtoUtils;
 import alluxio.wire.FileInfo;
 
+import alluxio.wire.Medium;
 import com.google.common.base.Preconditions;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -417,7 +419,7 @@ public final class MutableInodeFile extends MutableInode<MutableInodeFile>
       ret.setXAttr(CommonUtils.convertFromByteString(entry.getXAttrMap()));
     }
 
-    ret.setMediumTypes(new HashSet<>(entry.getMediumTypeList()));
+    ret.setMediumTypes(Medium.fromValues(entry.getMediumTypeList()));
     return ret;
   }
 
@@ -465,7 +467,7 @@ public final class MutableInodeFile extends MutableInode<MutableInodeFile>
   public JournalEntry toJournalEntry() {
     InodeFileEntry.Builder inodeFile = InodeFileEntry.newBuilder()
         .addAllBlocks(getBlockIds())
-        .addAllMediumType(getMediumTypes())
+        .addAllMediumType(getMediumTypes().stream().map(Medium::toString).collect(Collectors.toList()))
         .setBlockSizeBytes(getBlockSizeBytes())
         .setCacheable(isCacheable())
         .setCompleted(isCompleted())
@@ -543,7 +545,7 @@ public final class MutableInodeFile extends MutableInode<MutableInodeFile>
         .setPersistJobId(inode.getPersistJobId())
         .setShouldPersistTime(inode.getShouldPersistTime())
         .setTempUfsPath(inode.getPersistJobTempUfsPath())
-        .setMediumTypes(new HashSet<>(inode.getMediumTypeList()));
+        .setMediumTypes(Medium.fromValues(inode.getMediumTypeList()));
     if (inode.getXAttrCount() > 0) {
       f.setXAttr(CommonUtils.convertFromByteString(inode.getXAttrMap()));
     }

--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -38,6 +38,7 @@ import alluxio.util.logging.SamplingLogger;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.BlockLocation;
 
+import alluxio.wire.Medium;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
@@ -206,19 +207,20 @@ public final class ReplicationChecker implements HeartbeatExecutor {
    */
   private Map<String, String> findMisplacedBlock(
       InodeFile file, BlockInfo blockInfo) {
-    Set<String> pinnedMediumTypes = file.getMediumTypes();
+    Set<Medium> pinnedMediumTypes = file.getMediumTypes();
     if (pinnedMediumTypes.isEmpty()) {
       // nothing needs to be moved
       return Collections.emptyMap();
     }
     Map<String, String> movement = new HashMap<>();
     // at least pinned to one medium type
-    String firstPinnedMedium = pinnedMediumTypes.iterator().next();
+    String firstPinnedMedium = pinnedMediumTypes.iterator().next().toString();
     int minReplication = file.getReplicationMin();
     int correctReplication = 0;
     List<String> candidates = new ArrayList<>();
     for (BlockLocation loc: blockInfo.getLocations()) {
-      if (pinnedMediumTypes.contains(loc.getMediumType())) {
+      // TODO(jiacheng): handle exception?
+      if (pinnedMediumTypes.contains(Medium.valueOf(loc.getMediumType()))) {
         correctReplication++;
       } else {
         candidates.add(loc.getWorkerAddress().getHost());

--- a/job/server/src/main/java/alluxio/job/util/JobUtils.java
+++ b/job/server/src/main/java/alluxio/job/util/JobUtils.java
@@ -41,6 +41,7 @@ import alluxio.util.network.NetworkAddressUtils.ServiceType;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.BlockLocation;
 import alluxio.wire.FileBlockInfo;
+import alluxio.wire.Medium;
 import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.base.Preconditions;
@@ -137,7 +138,7 @@ public final class JobUtils {
           .getMessage(blockId));
     }
 
-    Set<String> pinnedLocation = status.getPinnedMediumTypes();
+    Set<Medium> pinnedLocation = status.getPinnedMediumTypes();
     if (pinnedLocation.size() > 1) {
       throw new AlluxioException(
           ExceptionMessage.PINNED_TO_MULTIPLE_MEDIUMTYPES.getMessage(status.getPath()));
@@ -157,7 +158,7 @@ public final class JobUtils {
 
     // TODO(bin): remove the following case when we consolidate tier and medium
     // since there is only one element in the set, we take the first element in the set
-    String medium = pinnedLocation.isEmpty() ? "" : pinnedLocation.iterator().next();
+    String medium = pinnedLocation.isEmpty() ? "" : pinnedLocation.iterator().next().toString();
 
     OpenFilePOptions openOptions =
         OpenFilePOptions.newBuilder().setReadType(ReadPType.NO_CACHE).build();

--- a/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/ReplicateDefinitionTest.java
@@ -54,6 +54,7 @@ import alluxio.wire.BlockInfo;
 import alluxio.wire.BlockLocation;
 import alluxio.wire.FileBlockInfo;
 import alluxio.wire.FileInfo;
+import alluxio.wire.Medium;
 import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 
@@ -72,6 +73,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -280,7 +282,7 @@ public final class ReplicateDefinitionTest {
     for (boolean persisted : new boolean[] {true, false}) {
       for (boolean pinned : new boolean[] {true, false}) {
         mTestStatus.getFileInfo().setPersisted(persisted)
-            .setMediumTypes(pinned ? Sets.newHashSet(Constants.MEDIUM_MEM)
+            .setMediumTypes(pinned ? EnumSet.of(Medium.MEM)
                 : Collections.emptySet());
         byte[] input = BufferUtils.getIncreasingByteArray(0, (int) TEST_BLOCK_SIZE);
         TestBlockInStream mockInStream =
@@ -304,7 +306,7 @@ public final class ReplicateDefinitionTest {
   @Test
   public void runTaskInputIOException() throws Exception {
     // file is pinned on a medium
-    mTestStatus.getFileInfo().setMediumTypes(Sets.newHashSet(Constants.MEDIUM_MEM));
+    mTestStatus.getFileInfo().setMediumTypes(EnumSet.of(Medium.MEM));
     BlockInStream mockInStream = mock(BlockInStream.class);
     BlockOutStream mockOutStream = mock(BlockOutStream.class);
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR constraints mediums to MEM,SSD,HDD so the mediums can be converted to a Enum and everything else can be more smaller in memory.

### Why are the changes needed?


### Does this PR introduce any user facing changes?

