### PR TITLE
Make java version configuable in dev image

### DIFF
--- a/integration/docker/Dockerfile-dev
+++ b/integration/docker/Dockerfile-dev
@@ -9,6 +9,9 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
+# ARG defined before the first FROM can be used in FROM lines
+ARG JAVA_VERSION=8
+
 # setup CSI
 # Make sure any changes to CSI installation are made in Dockerfile as well
 FROM golang:1.15.13-alpine AS dev
@@ -18,8 +21,14 @@ COPY ./csi /alluxio-csi
 RUN cd /alluxio-csi && \
     CGO_ENABLED=0 go build -o /usr/local/bin/alluxio-csi
 
-# Use CentOS as base image for alluxio-dev image
-FROM centos:7 AS final
+# Configure JAVA_HOME
+FROM centos:7 as build_java8
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk
+
+FROM centos:7 as build_java11
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
+
+FROM build_java${JAVA_VERSION} AS final
 
 # Note that downloads for *-SNAPSHOT tarballs are not available
 ARG ALLUXIO_TARBALL=http://downloads.alluxio.io/downloads/files/2.8.0-SNAPSHOT/alluxio-2.8.0-SNAPSHOT-bin.tar.gz
@@ -83,8 +92,6 @@ RUN wget -qO /tmp/async-profiler-1.8.3-linux-x64.tar.gz "https://github.com/jvm-
     tar -xvf /tmp/async-profiler-1.8.3-linux-x64.tar.gz -C /opt && \
     mv /opt/async-profiler-* /opt/async-profiler && \
     rm /tmp/async-profiler-1.8.3-linux-x64.tar.gz
-
-ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk
 
 # Disable JVM DNS cache in both java8 and java11
 RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-1.8.0-openjdk/jre/lib/security/java.security

--- a/integration/docker/README.md
+++ b/integration/docker/README.md
@@ -13,7 +13,7 @@ To build with a local Alluxio tarball, specify the `ALLUXIO_TARBALL` build argum
 $ docker build -t alluxio/alluxio --build-arg ALLUXIO_TARBALL=alluxio-${version}.tar.gz .
 ```
 
-Starting from v2.6.0, alluxio-fuse image is deprecated. It is embedded in alluxio/alluxio image.
+Starting from v2.6.0, alluxio-fuse image is deprecated. It is embedded in `alluxio/alluxio` image.
 
 ## Building docker image for development
 Starting from now, Alluxio has a separate image for development usage. Unlike the default Alluxio 
@@ -31,6 +31,15 @@ To build with a local Alluxio tarball, specify the `ALLUXIO_TARBALL` build argum
 ```console
 $ docker build -t alluxio/alluxio-dev -f Dockerfile-dev \
 --build-arg ALLUXIO_TARBALL=alluxio-${version}.tar.gz .
+```
+
+Development image also has Java11 installed. To run Alluxio with Java11, build development image 
+with the `JAVA_VERSION` build argument specified.
+
+```console
+$ docker build -t alluxio/alluxio-dev -f Dockerfile-dev \
+--build-arg ALLUXIO_TARBALL=alluxio-${version}.tar.gz \
+--build-arg JAVA_VERSION=11 .
 ```
 
 ## Running docker image


### PR DESCRIPTION
### What changes are proposed in this pull request?
User is able to build dev image running Alluxio with Java11 by using build-arg to specify java version.

### Why are the changes needed?
Java11 solves a jvm bug in Java8 (See https://github.com/Alluxio/alluxio/issues/15015). If users want to use java11, they have to modify the Dockerfile code then build the image. With this change they can input the java version (for example, 11) to build the image without modifying code.


