### PR TITLE
Add a default implementation of cache filter to local cache

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/filter/CacheFilter.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/filter/CacheFilter.java
@@ -31,9 +31,10 @@ public interface CacheFilter {
     return CommonUtils.createNewClassInstance(
         conf.getClass(PropertyKey.USER_CLIENT_CACHE_FILTER_CLASS),
         new Class[] {AlluxioConfiguration.class, String.class},
-        new Object[] {conf, conf.getOrDefault(
-            PropertyKey.USER_CLIENT_CACHE_FILTER_CONFIG_FILE, "")});
+        new Object[] {conf, conf.getString(
+            PropertyKey.USER_CLIENT_CACHE_FILTER_CONFIG_FILE)});
   }
+
   /**
    * Whether the specific uri needs to be cached or not.
    * @param uriStatus the uri status

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/filter/CacheFilter.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/filter/CacheFilter.java
@@ -1,0 +1,43 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file.cache.filter;
+
+import alluxio.client.file.URIStatus;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.util.CommonUtils;
+
+/**
+ * The Cache Filter interface which is used to determine
+ * whether a particular file (URI) needs to be cached.
+ */
+public interface CacheFilter {
+
+  /**
+   * Create a CacheFilter.
+   * @param conf the alluxio configuration
+   * @return the cache filter
+   */
+  static CacheFilter create(AlluxioConfiguration conf) {
+    return CommonUtils.createNewClassInstance(
+        conf.getClass(PropertyKey.USER_CLIENT_CACHE_FILTER_CLASS),
+        new Class[] {AlluxioConfiguration.class, String.class},
+        new Object[] {conf, conf.getOrDefault(
+            PropertyKey.USER_CLIENT_CACHE_FILTER_CONFIG_FILE, "")});
+  }
+  /**
+   * Whether the specific uri needs to be cached or not.
+   * @param uriStatus the uri status
+   * @return whether uriStatus needs to be cached
+   */
+  boolean needsCache(URIStatus uriStatus);
+}

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/filter/DefaultCacheFilter.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/filter/DefaultCacheFilter.java
@@ -1,0 +1,37 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file.cache.filter;
+
+import alluxio.client.file.URIStatus;
+import alluxio.conf.AlluxioConfiguration;
+
+/**
+ * Default Cache Filter cache everything.
+ */
+public class DefaultCacheFilter implements CacheFilter {
+  /**
+   * The default constructor.
+   * @param conf the Alluxio Configuration
+   * @param cacheConfigFile the cache config giles
+   */
+  public DefaultCacheFilter(AlluxioConfiguration conf, String cacheConfigFile) {
+  }
+
+  /**
+   * The implementation of needsCache.
+   * @param uriStatus the uri
+   * @return true for everything
+   */
+  public boolean needsCache(URIStatus uriStatus) {
+    return true;
+  }
+}

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/LocalCacheFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/LocalCacheFileSystem.java
@@ -20,6 +20,7 @@ import alluxio.client.file.CacheContext;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.cache.CacheManager;
 import alluxio.client.file.cache.LocalCacheFileInStream;
+import alluxio.client.file.cache.filter.CacheFilter;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.metrics.MetricsConfig;
 import alluxio.metrics.MetricsSystem;
@@ -62,6 +63,7 @@ public class LocalCacheFileSystem extends org.apache.hadoop.fs.FileSystem {
   private final HadoopFileOpener mHadoopFileOpener;
   private final LocalCacheFileInStream.FileInStreamOpener mAlluxioFileOpener;
   private CacheManager mCacheManager;
+  private CacheFilter mCacheFilter;
   private org.apache.hadoop.conf.Configuration mHadoopConf;
   private AlluxioConfiguration mAlluxioConf;
 
@@ -103,6 +105,7 @@ public class LocalCacheFileSystem extends org.apache.hadoop.fs.FileSystem {
     MetricsSystem.startSinksFromConfig(new MetricsConfig(metricsProperties));
     mCacheManager = CacheManager.Factory.get(mAlluxioConf);
     LocalCacheFileInStream.registerMetrics();
+    mCacheFilter = CacheFilter.create(mAlluxioConf);
   }
 
   @Override
@@ -154,7 +157,7 @@ public class LocalCacheFileSystem extends org.apache.hadoop.fs.FileSystem {
    * @return an {@link FSDataInputStream} at the indicated path of a file
    */
   public FSDataInputStream open(URIStatus status, int bufferSize) throws IOException {
-    if (mCacheManager == null) {
+    if (mCacheManager == null || !mCacheFilter.needsCache(status)) {
       return mExternalFileSystem.open(HadoopUtils.toPath(new AlluxioURI(status.getPath())),
           bufferSize);
     }

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4838,15 +4838,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_CLIENT_CACHE_FILTER_CLASS =
-      new Builder(Name.USER_CLIENT_CACHE_FILTER_CLASS)
+      classBuilder(Name.USER_CLIENT_CACHE_FILTER_CLASS)
           .setDefaultValue("alluxio.client.file.cache.filter.DefaultCacheFilter")
           .setDescription("The default cache filter caches everything")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_CLIENT_CACHE_FILTER_CONFIG_FILE =
-      new Builder(Name.USER_CLIENT_CACHE_FILTER_CONFIG_FILE)
-          .setDefaultValue("/tmp/alluxio-filter-config")
+      stringBuilder(Name.USER_CLIENT_CACHE_FILTER_CONFIG_FILE)
+          .setDefaultValue(format("${%s}/cache_filter.properties", Name.CONF_DIR))
           .setDescription("The alluxio cache filter config file")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4837,6 +4837,20 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_CLIENT_CACHE_FILTER_CLASS =
+      new Builder(Name.USER_CLIENT_CACHE_FILTER_CLASS)
+          .setDefaultValue("alluxio.client.file.cache.filter.DefaultCacheFilter")
+          .setDescription("The default cache filter caches everything")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey USER_CLIENT_CACHE_FILTER_CONFIG_FILE =
+      new Builder(Name.USER_CLIENT_CACHE_FILTER_CONFIG_FILE)
+          .setDefaultValue("/tmp/alluxio-filter-config")
+          .setDescription("The alluxio cache filter config file")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_CLIENT_CACHE_EVICTOR_CLASS =
       classBuilder(Name.USER_CLIENT_CACHE_EVICTOR_CLASS)
           .setDefaultValue("alluxio.client.file.cache.evictor.LRUCacheEvictor")
@@ -7146,6 +7160,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.client.cache.async.write.threads";
     public static final String USER_CLIENT_CACHE_ENABLED =
         "alluxio.user.client.cache.enabled";
+    public static final String USER_CLIENT_CACHE_FILTER_CLASS =
+        "alluxio.user.client.cache.filter.class";
+    public static final String USER_CLIENT_CACHE_FILTER_CONFIG_FILE =
+        "alluxio.user.client.cache.filter.config-file";
     public static final String USER_CLIENT_CACHE_EVICTION_RETRIES =
         "alluxio.user.client.cache.eviction.retries";
     public static final String USER_CLIENT_CACHE_EVICTOR_CLASS =


### PR DESCRIPTION
What changes are proposed in this pull request?
Add a cache filter to local cache. took over from the inactive PR https://github.com/Alluxio/alluxio/pull/13844

Why are the changes needed?
Please clarify why the changes are needed. For instance,
This feature might help to prevent the cache flushing on large tables.

Does this PR introduce any user facing changes?
Please list the user-facing changes introduced by your change, including
add two new property keys to config the cache filter