### PR TITLE
Avoid list resizing in generateBlockInfo

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1414,7 +1414,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     Collections.sort(blockLocations,
         Comparator.comparingInt(o -> mGlobalStorageTierAssoc.getOrdinal(o.getTier())));
 
-    List<alluxio.wire.BlockLocation> locations = new ArrayList<>();
+    List<alluxio.wire.BlockLocation> locations = new ArrayList<>(blockLocations.size());
     for (BlockLocation location : blockLocations) {
       MasterWorkerInfo workerInfo =
           mWorkers.getFirstByField(ID_INDEX, location.getWorkerId());


### PR DESCRIPTION
### What changes are proposed in this pull request?

Init `ArrayList` with size to avoid resizing. 