### PR TITLE
Make worker block lock pool size observable

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1406,6 +1406,12 @@ public final class MetricKey implements Comparable<MetricKey> {
               + "Use this metric to monitor the RPC pressure on worker.")
           .setMetricType(MetricType.GAUGE)
           .build();
+  public static final MetricKey WORKER_BLOCK_LOCK_POOL_REMAINING_RESOURCES_KEY =
+      new Builder("Worker.BlockLockPoolRemainingResources")
+          .setDescription("Total number of remaining locks in the block client r/w lock pool.")
+          .setMetricType(MetricType.GAUGE)
+          .setIsClusterAggregated(false)
+          .build();
 
   // Client metrics
   public static final MetricKey CLIENT_BLOCK_READ_CHUNK_REMOTE =

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1406,7 +1406,7 @@ public final class MetricKey implements Comparable<MetricKey> {
               + "Use this metric to monitor the RPC pressure on worker.")
           .setMetricType(MetricType.GAUGE)
           .build();
-  public static final MetricKey WORKER_BLOCK_LOCK_POOL_REMAINING_RESOURCES_KEY =
+  public static final MetricKey WORKER_BLOCK_LOCK_POOL_REMAINING_RESOURCES_COUNT =
       new Builder("Worker.BlockLockPoolRemainingResources")
           .setDescription("Total number of remaining locks in the block client r/w lock pool.")
           .setMetricType(MetricType.GAUGE)

--- a/core/common/src/main/java/alluxio/resource/ResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/ResourcePool.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public abstract class ResourcePool<T> implements Pool<T> {
-  private static final long WAIT_INDEFINITELY = -1;
+  protected static final long WAIT_INDEFINITELY = -1;
   private final ReentrantLock mTakeLock;
   private final Condition mNotEmpty;
   protected final int mMaxCapacity;

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
@@ -51,17 +51,9 @@ public final class BlockLockManager {
   /** The unique id of each lock. */
   private static final AtomicLong LOCK_ID_GEN = new AtomicLong(0);
 
- /** A pool of read write locks. */
-  private final ResourcePool<ClientRWLock> mLockPool = new ResourcePool<ClientRWLock>(
-      ServerConfiguration.getInt(PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCKS)) {
-    @Override
-    public void close() {}
-
-    @Override
-    public ClientRWLock createNewResource() {
-      return new ClientRWLock();
-    }
-  };
+  /** A pool of read write locks. */
+  private final ResourcePool<ClientRWLock> mLockPool =
+      new BlockRWLockPool(ServerConfiguration.getInt(PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCKS));
 
   /** A map from block id to the read write lock used to guard that block. */
   @GuardedBy("mSharedMapsLock")

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockRWLockPool.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockRWLockPool.java
@@ -49,7 +49,7 @@ public final class BlockRWLockPool extends ResourcePool<ClientRWLock> {
     mRemainingPoolResources = new AtomicInteger(maxCapacity);
 
     MetricsSystem.registerGaugeIfAbsent(
-        MetricKey.WORKER_BLOCK_LOCK_POOL_REMAINING_RESOURCES_KEY.toString(),
+        MetricKey.WORKER_BLOCK_LOCK_POOL_REMAINING_RESOURCES_COUNT.toString(),
         this::getRemainingPoolResources
     );
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockRWLockPool.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockRWLockPool.java
@@ -37,7 +37,8 @@ public final class BlockRWLockPool extends ResourcePool<ClientRWLock> {
 
   @VisibleForTesting
   final AtomicBoolean mHasReachedFullCapacity;
-  private final AtomicInteger mRemainingPoolResources;
+  @VisibleForTesting
+  final AtomicInteger mRemainingPoolResources;
 
   /**
    * Creates a new client read/write lock pool.
@@ -50,17 +51,8 @@ public final class BlockRWLockPool extends ResourcePool<ClientRWLock> {
 
     MetricsSystem.registerGaugeIfAbsent(
         MetricKey.WORKER_BLOCK_LOCK_POOL_REMAINING_RESOURCES_COUNT.toString(),
-        this::getRemainingPoolResources
+        mRemainingPoolResources::get
     );
-  }
-
-  /**
-   * Get the number of remaining pool resources.
-   * @return the number of remaining resources
-   */
-  @VisibleForTesting
-  public long getRemainingPoolResources() {
-    return mRemainingPoolResources.get();
   }
 
   private void maybeLogPoolReachesFullCapacity() {

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockRWLockPool.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockRWLockPool.java
@@ -1,0 +1,105 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block;
+
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
+import alluxio.resource.ResourcePool;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Class for managing block read/write locks. After obtaining a lock with
+ * {@link ResourcePool#acquire()}, {@link ResourcePool#release(Object)} must be called when the
+ * thread is done using the client.
+ */
+@ThreadSafe
+public final class BlockRWLockPool extends ResourcePool<ClientRWLock> {
+  private static final Logger LOG = LoggerFactory.getLogger(BlockRWLockPool.class);
+
+  @VisibleForTesting
+  final AtomicBoolean mHasReachedFullCapacity;
+  private final AtomicInteger mRemainingPoolResources;
+
+  /**
+   * Creates a new client read/write lock pool.
+   * @param maxCapacity the max capacity of the pool
+   */
+  public BlockRWLockPool(int maxCapacity) {
+    super(maxCapacity);
+    mHasReachedFullCapacity = new AtomicBoolean(false);
+    mRemainingPoolResources = new AtomicInteger(maxCapacity);
+
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.WORKER_BLOCK_LOCK_POOL_REMAINING_RESOURCES_KEY.toString(),
+        this::getRemainingPoolResources
+    );
+  }
+
+  /**
+   * Get the number of remaining pool resources.
+   * @return the number of remaining resources
+   */
+  @VisibleForTesting
+  public long getRemainingPoolResources() {
+    return mRemainingPoolResources.get();
+  }
+
+  private void maybeLogPoolReachesFullCapacity() {
+    if (this.size() == mMaxCapacity
+        && !mHasReachedFullCapacity.get()
+        && mHasReachedFullCapacity.compareAndSet(false, true)
+    ) {
+      LOG.warn("Block lock manager client RW lock pool exhausted. Capacity size {}", mMaxCapacity);
+    }
+  }
+
+  @Override
+  public ClientRWLock acquire() {
+    return this.acquire(WAIT_INDEFINITELY, null);
+  }
+
+  @Nullable
+  @Override
+  public ClientRWLock acquire(long time, TimeUnit unit) {
+    ClientRWLock ret = super.acquire(time, unit);
+    maybeLogPoolReachesFullCapacity();
+    if (ret != null) {
+      mRemainingPoolResources.decrementAndGet();
+    }
+    return ret;
+  }
+
+  @Override
+  public void release(ClientRWLock resource) {
+    mRemainingPoolResources.incrementAndGet();
+    super.release(resource);
+  }
+
+  @Override
+  public void close() throws IOException {
+  }
+
+  @Override
+  public ClientRWLock createNewResource() {
+    return new ClientRWLock();
+  }
+}

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockRWLockPoolTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockRWLockPoolTest.java
@@ -1,0 +1,154 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+
+public class BlockRWLockPoolTest {
+  /**
+   * To test the number of remaining resources in the pool. We report this value as a metric.
+   * pool size of 10, 10 threads acquire locks and release early
+   * while another 10 threads acquire locks but release late.
+   * in the first checkpoint, the remaining resource should be 0,
+   * in the second checkpoint,
+   * the remaining resource should be the size of the pool as we returned all locks.
+   */
+  @Test
+  public void testMetricReporting() throws BrokenBarrierException, InterruptedException {
+    final int numIterations = 10;
+    final int numLocksEarlyRelease = 10;
+    final int numLocksLateRelease = 10;
+    final int poolCapacity = 10;
+    Random r = new Random();
+    for (int i = 0; i < numIterations; ++i) {
+      BlockRWLockPool pool = new BlockRWLockPool(poolCapacity);
+      List<Thread> threads = new ArrayList<>();
+      final CyclicBarrier barrier1 =
+          new CyclicBarrier(numLocksEarlyRelease + numLocksLateRelease + 1);
+      final CyclicBarrier barrier2 = new CyclicBarrier(numLocksLateRelease + 1);
+      for (int j = 0; j < numLocksEarlyRelease; ++j) {
+        threads.add(new Thread(
+            () -> {
+              try {
+                Thread.sleep(r.nextInt(50));
+                ClientRWLock l = pool.acquire();
+                Thread.sleep(r.nextInt(100));
+                pool.release(l);
+                barrier1.await();
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            }
+        ));
+      }
+      for (int j = 0; j < numLocksLateRelease; ++j) {
+        threads.add(new Thread(
+            () -> {
+              try {
+                Thread.sleep(100);
+                Thread.sleep(r.nextInt(100));
+                ClientRWLock l = pool.acquire();
+                Thread.sleep(r.nextInt(100));
+                barrier1.await();
+                barrier2.await();
+                pool.release(l);
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            }
+        ));
+      }
+      threads.forEach(Thread::start);
+      barrier1.await();
+      Assert.assertEquals(0, pool.getRemainingPoolResources());
+      barrier2.await();
+      threads.forEach((it) -> {
+        try {
+          it.join();
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      });
+      Assert.assertEquals(poolCapacity, pool.getRemainingPoolResources());
+    }
+  }
+
+  /**
+   * To test logging when the pool is exhausted.
+   * pool size of 10, 10 threads acquire locks and release early
+   * while another 10 threads acquire locks but release late.
+   * Since there must be a point where the pool is exhausted,
+   * mHasReachedFullCapacity must have been set true.
+   * And hence the message is guaranteed to be logged.
+   */
+  @Test
+  public void testLogging() {
+    final int numIterations = 10;
+    final int numLocksEarlyRelease = 10;
+    final int numLocksLateRelease = 10;
+    final int poolCapacity = 10;
+    Random r = new Random();
+    for (int i = 0; i < numIterations; ++i) {
+      BlockRWLockPool pool = new BlockRWLockPool(poolCapacity);
+      List<Thread> threads = new ArrayList<>();
+      final CyclicBarrier barrier = new CyclicBarrier(numLocksEarlyRelease + numLocksLateRelease);
+      for (int j = 0; j < numLocksEarlyRelease; ++j) {
+        threads.add(new Thread(
+            () -> {
+              try {
+                Thread.sleep(r.nextInt(50));
+                ClientRWLock l = pool.acquire();
+                Thread.sleep(r.nextInt(100));
+                pool.release(l);
+                barrier.await();
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            }
+        ));
+      }
+      for (int j = 0; j < numLocksLateRelease; ++j) {
+        threads.add(new Thread(
+            () -> {
+              try {
+                // Sleep 100ms to make sure early release locks acquire lock first.
+                Thread.sleep(100);
+                Thread.sleep(r.nextInt(100));
+                ClientRWLock l = pool.acquire();
+                barrier.await();
+                Thread.sleep(r.nextInt(100));
+                pool.release(l);
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            }
+        ));
+      }
+      threads.forEach(Thread::start);
+      threads.forEach((it) -> {
+        try {
+          it.join();
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      });
+      Assert.assertTrue(pool.mHasReachedFullCapacity.get());
+    }
+  }
+}

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockRWLockPoolTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockRWLockPoolTest.java
@@ -76,7 +76,7 @@ public class BlockRWLockPoolTest {
       }
       threads.forEach(Thread::start);
       barrier1.await();
-      Assert.assertEquals(0, pool.getRemainingPoolResources());
+      Assert.assertEquals(0, pool.mRemainingPoolResources.get());
       barrier2.await();
       threads.forEach((it) -> {
         try {
@@ -85,7 +85,7 @@ public class BlockRWLockPoolTest {
           throw new RuntimeException(e);
         }
       });
-      Assert.assertEquals(poolCapacity, pool.getRemainingPoolResources());
+      Assert.assertEquals(poolCapacity, pool.mRemainingPoolResources.get());
     }
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR implements a block lock resource pool for workers with more logs and metrics added.

### Why are the changes needed?

The pool size should be observable by metric and logging, so we know when this pool is full.

### Does this PR introduce any user facing changes?

N/A

Implemented #14803 