### PR TITLE
Store ms byte as string

### DIFF
--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -21,6 +21,7 @@ import alluxio.conf.PropertyKey.Template;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.PreconditionMessage;
 import alluxio.util.ConfigurationUtils;
+import alluxio.util.FormatUtils;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -328,13 +329,13 @@ public class InstancedConfiguration implements AlluxioConfiguration {
   @Override
   public long getBytes(PropertyKey key) {
     checkArgument(key.getType() == PropertyKey.PropertyType.DATASIZE);
-    return (long) get(key);
+    return FormatUtils.parseSpaceSize((String) get(key));
   }
 
   @Override
   public long getMs(PropertyKey key) {
     checkArgument(key.getType() == PropertyKey.PropertyType.DURATION);
-    return (long) get(key);
+    return FormatUtils.parseTimeSize((String) get(key));
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -170,11 +170,11 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     /**
      * The Property's value represents a time duration, stored as a Long in ms.
      */
-    DURATION(Long.class),
+    DURATION(String.class),
     /**
      * The Property's value represents a data size, stored as a Long in bytes.
      */
-    DATASIZE(Long.class),
+    DATASIZE(String.class),
     /**
      * The Property's value is of list type, stored as a delimiter separated string.
      */
@@ -8131,8 +8131,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       Object value, PropertyType type, Optional<Class<? extends Enum>> enumType,
       Function<Object, Boolean> valueValidationFunction) {
     if (value instanceof String) {
-      if (!type.getJavaType().equals(String.class) && type != PropertyType.ENUM
-          && type != PropertyType.DURATION && type != PropertyType.DATASIZE) {
+      if (!type.getJavaType().equals(String.class) && type != PropertyType.ENUM) {
         String stringValue = (String) value;
         Matcher matcher = CONF_REGEX.matcher(stringValue);
         if (!matcher.matches()) {
@@ -8202,7 +8201,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           break;
         case DURATION:
         case DATASIZE:
-          value = ((Number) value).longValue();
+          value = value.toString();
           break;
         default:
           break;
@@ -8218,10 +8217,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
             value = Enum.valueOf(enumType.get(), stringValue.toUpperCase());
             break;
           case DURATION:
-            value = FormatUtils.parseTimeSize(stringValue);
+            FormatUtils.parseTimeSize(stringValue);
             break;
           case DATASIZE:
-            value = FormatUtils.parseSpaceSize(stringValue);
+            FormatUtils.parseSpaceSize(stringValue);
             break;
           default:
             break;
@@ -8256,9 +8255,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           // Allow String value and try to use upper case to resolve enum.
           return Enum.valueOf(getEnumType(), stringValue.toUpperCase());
         case DURATION:
-          return FormatUtils.parseTimeSize(stringValue);
         case DATASIZE:
-          return FormatUtils.parseSpaceSize(stringValue);
         case STRING:
         case CLASS:
         case LIST:

--- a/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
@@ -140,7 +140,7 @@ public class InstancedConfigurationTest {
               new String[] {"b", "kb", "mb", "gb"} [random.nextInt(4)]);
           long storedDataSize = FormatUtils.parseSpaceSize(dataSizeValue);
           mConfiguration.set(key, dataSizeValue);
-          assertEquals(storedDataSize, mConfiguration.get(key));
+          assertEquals(dataSizeValue, mConfiguration.get(key));
           assertEquals(storedDataSize, mConfiguration.getBytes(key));
           assertThrows(IllegalArgumentException.class, () -> mConfiguration.getInt(key));
           assertThrows(IllegalArgumentException.class, () -> mConfiguration.getMs(key));
@@ -150,7 +150,7 @@ public class InstancedConfigurationTest {
               new String[] {"ms", "s", "m", "h", "d"} [random.nextInt(5)]);
           long storedDuration = FormatUtils.parseTimeSize(durationValue);
           mConfiguration.set(key, durationValue);
-          assertEquals(storedDuration, mConfiguration.get(key));
+          assertEquals(durationValue, mConfiguration.get(key));
           assertEquals(storedDuration, mConfiguration.getMs(key));
           assertThrows(IllegalArgumentException.class, () -> mConfiguration.getInt(key));
           assertThrows(IllegalArgumentException.class, () -> mConfiguration.getBytes(key));

--- a/tests/src/test/java/alluxio/client/cli/fs/GetConfTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/GetConfTest.java
@@ -64,7 +64,7 @@ public final class GetConfTest {
     ctx = ClientContext.create(ServerConfiguration.global());
     assertEquals(0, GetConf.getConf(ctx,
         PropertyKey.WORKER_RAMDISK_SIZE.toString()));
-    assertEquals("2097152\n", mOutputStream.toString());
+    assertEquals("2MB\n", mOutputStream.toString());
 
     mOutputStream.reset();
     ServerConfiguration.set(PropertyKey.WORKER_RAMDISK_SIZE, 2048);


### PR DESCRIPTION
### What changes are proposed in this pull request?
for `bin/alluxio getConf` backward compatibility, store duration and data size
properties as string for now.

### Why are the changes needed?
Backward compatibility requirement for 2.8
