### PR TITLE
Make log compaction local in embedded journal

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2582,6 +2582,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_JOURNAL_LOCAL_LOG_COMPACTION =
+      booleanBuilder(Name.MASTER_JOURNAL_LOCAL_LOG_COMPACTION)
+          .setDefaultValue(true)
+          .setDescription("Whether to employ a quorum level log compaction policy or a "
+              + "local (individual) log compaction policy.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_JOURNAL_GC_PERIOD_MS =
       durationBuilder(Name.MASTER_JOURNAL_GC_PERIOD_MS)
           .setAlias("alluxio.master.journal.gc.period.ms")
@@ -6777,6 +6785,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_WORKER_TIMEOUT_MS = "alluxio.master.worker.timeout";
     public static final String MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES =
         "alluxio.master.journal.checkpoint.period.entries";
+    public static final String MASTER_JOURNAL_LOCAL_LOG_COMPACTION =
+        "alluxio.master.journal.local.log.compaction";
     public static final String MASTER_JOURNAL_GC_PERIOD_MS = "alluxio.master.journal.gc.period";
     public static final String MASTER_JOURNAL_GC_THRESHOLD_MS =
         "alluxio.master.journal.gc.threshold";

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -377,11 +377,13 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     RaftServerConfigKeys.Snapshot.setAutoTriggerThreshold(properties,
         snapshotAutoTriggerThreshold);
 
-    // purges log files after taking a snapshot successfully
-    RaftServerConfigKeys.Log.setPurgeUptoSnapshotIndex(properties, true);
-    // leaves no gap between log file purges: all log files included in a newly installed
-    // snapshot are purged right away
-    RaftServerConfigKeys.Log.setPurgeGap(properties, 1);
+    if (ServerConfiguration.global().getBoolean(PropertyKey.MASTER_JOURNAL_LOCAL_LOG_COMPACTION)) {
+      // purges log files after taking a snapshot successfully
+      RaftServerConfigKeys.Log.setPurgeUptoSnapshotIndex(properties, true);
+      // leaves no gap between log file purges: all log files included in a newly installed
+      // snapshot are purged right away
+      RaftServerConfigKeys.Log.setPurgeGap(properties, 1);
+    }
 
     RaftServerConfigKeys.Log.Appender.setInstallSnapshotEnabled(
         properties, false);

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -377,6 +377,12 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     RaftServerConfigKeys.Snapshot.setAutoTriggerThreshold(properties,
         snapshotAutoTriggerThreshold);
 
+    // purges log files after taking a snapshot successfully
+    RaftServerConfigKeys.Log.setPurgeUptoSnapshotIndex(properties, true);
+    // leaves no gap between log file purges: all log files included in a newly installed
+    // snapshot are purged right away
+    RaftServerConfigKeys.Log.setPurgeGap(properties, 1);
+
     RaftServerConfigKeys.Log.Appender.setInstallSnapshotEnabled(
         properties, false);
 


### PR DESCRIPTION
### What changes are proposed in this pull request?
Making `RaftServerConfigKeys.Log.setPurgeUptoSnapshotIndex` to `true` by default. This enables each master in the quorum to look only at the local snapshots it possesses in order to determine which log files to prune. 
Before, masters would only prune based on the quorum consensus of committed log index. 

### Why are the changes needed?
Community members have noticed that Ratis logs grow unbounded in the presence of a slow master, which can crash certain masters when the UFS runs out of space in extreme cases. 

### Does this PR introduce any user facing changes?
Adds a `PropertyKey` to enable or disable this new feature.