### PR TITLE
Refactor RestApiTest and related classes for clarity

### DIFF
--- a/core/server/common/src/main/java/alluxio/metrics/sink/MetricsServlet.java
+++ b/core/server/common/src/main/java/alluxio/metrics/sink/MetricsServlet.java
@@ -31,7 +31,7 @@ import javax.servlet.http.HttpServletResponse;
  */
 @NotThreadSafe
 public class MetricsServlet implements Sink {
-  private static final String SERVLET_PATH = "/metrics/json";
+  public static final String SERVLET_PATH = "/metrics/json";
 
   private MetricRegistry mMetricsRegistry;
   private ObjectMapper mObjectMapper;

--- a/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
@@ -79,16 +79,16 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
 
   private AlluxioMasterInfo getInfo(Map<String, String> params) throws Exception {
     String result =
-        new TestCase(mHostname, mPort, getEndpoint(AlluxioMasterRestServiceHandler.GET_INFO),
-            params, HttpMethod.GET, null).call();
+        new TestCase(mHostname, mPort, AlluxioMasterRestServiceHandler.GET_INFO,
+            params, HttpMethod.GET, null, mServicePrefix).call();
     AlluxioMasterInfo info = new ObjectMapper().readValue(result, AlluxioMasterInfo.class);
     return info;
   }
 
   private Map<String, String> getMetrics(Map<String, String> params) throws Exception {
     String result =
-        new TestCase(mHostname, mPort, getEndpoint(AlluxioMasterRestServiceHandler.WEBUI_METRICS),
-            params, HttpMethod.GET, null).call();
+        new TestCase(mHostname, mPort, AlluxioMasterRestServiceHandler.WEBUI_METRICS,
+            params, HttpMethod.GET, null, mServicePrefix).call();
     Map<String, String> info = new ObjectMapper().readValue(result, Map.class);
     return info;
   }

--- a/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
@@ -74,21 +74,21 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
         .getMaster(FileSystemMaster.class);
     mHostname = sResource.get().getHostname();
     mPort = sResource.get().getLocalAlluxioMaster().getMasterProcess().getWebAddress().getPort();
-    mServicePrefix = AlluxioMasterRestServiceHandler.SERVICE_PREFIX;
+    mBaseUri = String.format("%s/%s", mBaseUri, AlluxioMasterRestServiceHandler.SERVICE_PREFIX);
   }
 
   private AlluxioMasterInfo getInfo(Map<String, String> params) throws Exception {
-    String result =
-        new TestCase(mHostname, mPort, AlluxioMasterRestServiceHandler.GET_INFO,
-            params, HttpMethod.GET, null, mServicePrefix).call();
+    String result = new TestCase(mHostname, mPort, mBaseUri,
+        AlluxioMasterRestServiceHandler.GET_INFO, params, HttpMethod.GET,
+        TestCaseOptions.defaults()).runAndGetResponse();
     AlluxioMasterInfo info = new ObjectMapper().readValue(result, AlluxioMasterInfo.class);
     return info;
   }
 
   private Map<String, String> getMetrics(Map<String, String> params) throws Exception {
-    String result =
-        new TestCase(mHostname, mPort, AlluxioMasterRestServiceHandler.WEBUI_METRICS,
-            params, HttpMethod.GET, null, mServicePrefix).call();
+    String result = new TestCase(mHostname, mPort, mBaseUri,
+        AlluxioMasterRestServiceHandler.WEBUI_METRICS, params, HttpMethod.GET,
+        TestCaseOptions.defaults()).runAndGetResponse();
     Map<String, String> info = new ObjectMapper().readValue(result, Map.class);
     return info;
   }

--- a/tests/src/test/java/alluxio/client/rest/AlluxioWorkerRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/AlluxioWorkerRestApiTest.java
@@ -54,13 +54,13 @@ public final class AlluxioWorkerRestApiTest extends RestApiTest {
   public void before() {
     mHostname = sResource.get().getHostname();
     mPort = sResource.get().getWorkerProcess().getWebLocalPort();
-    mServicePrefix = AlluxioWorkerRestServiceHandler.SERVICE_PREFIX;
+    mBaseUri = String.format("%s/%s", mBaseUri, AlluxioWorkerRestServiceHandler.SERVICE_PREFIX);
   }
 
   private AlluxioWorkerInfo getInfo() throws Exception {
-    String result =
-        new TestCase(mHostname, mPort, AlluxioWorkerRestServiceHandler.GET_INFO,
-            NO_PARAMS, HttpMethod.GET, null, mServicePrefix).call();
+    String result = new TestCase(mHostname, mPort, mBaseUri,
+        AlluxioWorkerRestServiceHandler.GET_INFO, NO_PARAMS, HttpMethod.GET,
+        TestCaseOptions.defaults()).runAndGetResponse();
     AlluxioWorkerInfo info = new ObjectMapper().readValue(result, AlluxioWorkerInfo.class);
     return info;
   }

--- a/tests/src/test/java/alluxio/client/rest/AlluxioWorkerRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/AlluxioWorkerRestApiTest.java
@@ -59,8 +59,8 @@ public final class AlluxioWorkerRestApiTest extends RestApiTest {
 
   private AlluxioWorkerInfo getInfo() throws Exception {
     String result =
-        new TestCase(mHostname, mPort, getEndpoint(AlluxioWorkerRestServiceHandler.GET_INFO),
-            NO_PARAMS, HttpMethod.GET, null).call();
+        new TestCase(mHostname, mPort, AlluxioWorkerRestServiceHandler.GET_INFO,
+            NO_PARAMS, HttpMethod.GET, null, mServicePrefix).call();
     AlluxioWorkerInfo info = new ObjectMapper().readValue(result, AlluxioWorkerInfo.class);
     return info;
   }

--- a/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
@@ -85,14 +85,15 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
 
   @Test
   public void serviceName() throws Exception {
-    new TestCase(mHostname, mPort, getEndpoint(ServiceConstants.SERVICE_NAME),
-        NO_PARAMS, HttpMethod.GET, Constants.JOB_MASTER_CLIENT_SERVICE_NAME).run();
+    new TestCase(mHostname, mPort, ServiceConstants.SERVICE_NAME,
+        NO_PARAMS, HttpMethod.GET, Constants.JOB_MASTER_CLIENT_SERVICE_NAME, mServicePrefix).run();
   }
 
   @Test
   public void serviceVersion() throws Exception {
-    new TestCase(mHostname, mPort, getEndpoint(ServiceConstants.SERVICE_VERSION),
-        NO_PARAMS, HttpMethod.GET, Constants.JOB_MASTER_CLIENT_SERVICE_VERSION).run();
+    new TestCase(mHostname, mPort, ServiceConstants.SERVICE_VERSION,
+        NO_PARAMS, HttpMethod.GET, Constants.JOB_MASTER_CLIENT_SERVICE_VERSION, mServicePrefix)
+        .run();
   }
 
   @Test
@@ -111,8 +112,8 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
     CommonUtils.sleepMs(30);
     Map<String, String> params = Maps.newHashMap();
     params.put("jobId", Long.toString(jobId));
-    new TestCase(mHostname, mPort, getEndpoint(ServiceConstants.CANCEL),
-        params, HttpMethod.POST, null).run();
+    new TestCase(mHostname, mPort, ServiceConstants.CANCEL,
+        params, HttpMethod.POST, null, mServicePrefix).run();
     waitForStatus(jobId, Status.CANCELED);
   }
 
@@ -122,8 +123,8 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
     Map<String, String> params = Maps.newHashMap();
     params.put("name", "");
     params.put("status", "");
-    new TestCase(mHostname, mPort, getEndpoint(ServiceConstants.LIST), params,
-        HttpMethod.GET, empty).run();
+    new TestCase(mHostname, mPort, ServiceConstants.LIST, params,
+        HttpMethod.GET, empty, mServicePrefix).run();
   }
 
   @Test
@@ -134,8 +135,8 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
     params.put("jobId", Long.toString(jobId));
 
     TestCaseOptions options = TestCaseOptions.defaults().setPrettyPrint(true);
-    String result = new TestCase(mHostname, mPort, getEndpoint(ServiceConstants.GET_STATUS),
-        params, HttpMethod.GET, null, options).call();
+    String result = new TestCase(mHostname, mPort, ServiceConstants.GET_STATUS,
+        params, HttpMethod.GET, null, options, mServicePrefix).call();
     TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>(){};
     HashMap<String, Object> jobInfo = new ObjectMapper().readValue(result, typeRef);
     Assert.assertEquals(jobId, jobInfo.get("id"));
@@ -144,8 +145,8 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
 
   private long startJob(JobConfig config) throws Exception {
     TestCaseOptions options = TestCaseOptions.defaults().setBody(config);
-    String result = new TestCase(mHostname, mPort, getEndpoint(ServiceConstants.RUN),
-        NO_PARAMS, HttpMethod.POST, null, options).call();
+    String result = new TestCase(mHostname, mPort, ServiceConstants.RUN,
+        NO_PARAMS, HttpMethod.POST, null, options, mServicePrefix).call();
     return new ObjectMapper().readValue(result, Long.TYPE);
   }
 

--- a/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
@@ -120,13 +120,10 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
   }
 
   @Test
-  public void list() throws Exception {
+  public void listEmpty() throws Exception {
     List<Long> empty = Lists.newArrayList();
-    Map<String, String> params = Maps.newHashMap();
-    params.put("name", "");
-    params.put("status", "");
     new TestCase(mHostname, mPort, mBaseUri,
-        ServiceConstants.LIST, params, HttpMethod.GET,
+        ServiceConstants.LIST, NO_PARAMS, HttpMethod.GET,
         TestCaseOptions.defaults()).runAndCheckResult(empty);
   }
 

--- a/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
@@ -50,7 +50,6 @@ import javax.ws.rs.HttpMethod;
  * Tests {@link JobMasterClientRestServiceHandler}.
  */
 public final class JobMasterClientRestApiTest extends RestApiTest {
-  private static final Map<String, String> NO_PARAMS = Maps.newHashMap();
   private LocalAlluxioJobCluster mJobCluster;
   private JobMaster mJobMaster;
 

--- a/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/JobMasterClientRestApiTest.java
@@ -75,7 +75,7 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
     mJobMaster = mJobCluster.getMaster().getJobMaster();
     mHostname = mJobCluster.getHostname();
     mPort = mJobCluster.getMaster().getWebAddress().getPort();
-    mServicePrefix = ServiceConstants.MASTER_SERVICE_PREFIX;
+    mBaseUri = String.format("%s/%s", mBaseUri, ServiceConstants.MASTER_SERVICE_PREFIX);
   }
 
   @After
@@ -85,15 +85,16 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
 
   @Test
   public void serviceName() throws Exception {
-    new TestCase(mHostname, mPort, ServiceConstants.SERVICE_NAME,
-        NO_PARAMS, HttpMethod.GET, Constants.JOB_MASTER_CLIENT_SERVICE_NAME, mServicePrefix).run();
+    new TestCase(mHostname, mPort, mBaseUri,
+        ServiceConstants.SERVICE_NAME, NO_PARAMS, HttpMethod.GET,
+        TestCaseOptions.defaults()).runAndCheckResult(Constants.JOB_MASTER_CLIENT_SERVICE_NAME);
   }
 
   @Test
   public void serviceVersion() throws Exception {
-    new TestCase(mHostname, mPort, ServiceConstants.SERVICE_VERSION,
-        NO_PARAMS, HttpMethod.GET, Constants.JOB_MASTER_CLIENT_SERVICE_VERSION, mServicePrefix)
-        .run();
+    new TestCase(mHostname, mPort, mBaseUri,
+        ServiceConstants.SERVICE_VERSION, NO_PARAMS, HttpMethod.GET,
+        TestCaseOptions.defaults()).runAndCheckResult(Constants.JOB_MASTER_CLIENT_SERVICE_VERSION);
   }
 
   @Test
@@ -112,8 +113,9 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
     CommonUtils.sleepMs(30);
     Map<String, String> params = Maps.newHashMap();
     params.put("jobId", Long.toString(jobId));
-    new TestCase(mHostname, mPort, ServiceConstants.CANCEL,
-        params, HttpMethod.POST, null, mServicePrefix).run();
+    new TestCase(mHostname, mPort, mBaseUri,
+        ServiceConstants.CANCEL, params, HttpMethod.POST,
+        TestCaseOptions.defaults()).runAndCheckResult();
     waitForStatus(jobId, Status.CANCELED);
   }
 
@@ -123,8 +125,9 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
     Map<String, String> params = Maps.newHashMap();
     params.put("name", "");
     params.put("status", "");
-    new TestCase(mHostname, mPort, ServiceConstants.LIST, params,
-        HttpMethod.GET, empty, mServicePrefix).run();
+    new TestCase(mHostname, mPort, mBaseUri,
+        ServiceConstants.LIST, params, HttpMethod.GET,
+        TestCaseOptions.defaults()).runAndCheckResult(empty);
   }
 
   @Test
@@ -135,8 +138,9 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
     params.put("jobId", Long.toString(jobId));
 
     TestCaseOptions options = TestCaseOptions.defaults().setPrettyPrint(true);
-    String result = new TestCase(mHostname, mPort, ServiceConstants.GET_STATUS,
-        params, HttpMethod.GET, null, options, mServicePrefix).call();
+    String result = new TestCase(mHostname, mPort, mBaseUri,
+        ServiceConstants.GET_STATUS, params, HttpMethod.GET,
+        options).runAndGetResponse();
     TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>(){};
     HashMap<String, Object> jobInfo = new ObjectMapper().readValue(result, typeRef);
     Assert.assertEquals(jobId, jobInfo.get("id"));
@@ -145,8 +149,9 @@ public final class JobMasterClientRestApiTest extends RestApiTest {
 
   private long startJob(JobConfig config) throws Exception {
     TestCaseOptions options = TestCaseOptions.defaults().setBody(config);
-    String result = new TestCase(mHostname, mPort, ServiceConstants.RUN,
-        NO_PARAMS, HttpMethod.POST, null, options, mServicePrefix).call();
+    String result = new TestCase(mHostname, mPort, mBaseUri,
+        ServiceConstants.RUN, NO_PARAMS, HttpMethod.POST,
+        options).runAndGetResponse();
     return new ObjectMapper().readValue(result, Long.TYPE);
   }
 

--- a/tests/src/test/java/alluxio/client/rest/JobMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/JobMasterRestApiTest.java
@@ -60,7 +60,7 @@ public final class JobMasterRestApiTest extends RestApiTest {
 
   @Test
   public void getInfo() throws Exception {
-    new TestCase(mHostname, mPort, getEndpoint(AlluxioJobMasterRestServiceHandler.GET_INFO),
-        NO_PARAMS, HttpMethod.GET, null).call();
+    new TestCase(mHostname, mPort, AlluxioJobMasterRestServiceHandler.GET_INFO,
+        NO_PARAMS, HttpMethod.GET, null, mServicePrefix).call();
   }
 }

--- a/tests/src/test/java/alluxio/client/rest/JobMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/JobMasterRestApiTest.java
@@ -49,7 +49,7 @@ public final class JobMasterRestApiTest extends RestApiTest {
     mJobCluster.start();
     mHostname = mJobCluster.getHostname();
     mPort = mJobCluster.getMaster().getWebAddress().getPort();
-    mServicePrefix = AlluxioJobMasterRestServiceHandler.SERVICE_PREFIX;
+    mBaseUri = String.format("%s/%s", mBaseUri, AlluxioJobMasterRestServiceHandler.SERVICE_PREFIX);
   }
 
   @After
@@ -60,7 +60,8 @@ public final class JobMasterRestApiTest extends RestApiTest {
 
   @Test
   public void getInfo() throws Exception {
-    new TestCase(mHostname, mPort, AlluxioJobMasterRestServiceHandler.GET_INFO,
-        NO_PARAMS, HttpMethod.GET, null, mServicePrefix).call();
+    new TestCase(mHostname, mPort, mBaseUri,
+        AlluxioJobMasterRestServiceHandler.GET_INFO, NO_PARAMS, HttpMethod.GET,
+        TestCaseOptions.defaults()).runAndGetResponse();
   }
 }

--- a/tests/src/test/java/alluxio/client/rest/JobMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/JobMasterRestApiTest.java
@@ -18,20 +18,17 @@ import alluxio.master.LocalAlluxioJobCluster;
 import alluxio.security.authentication.AuthType;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
-import com.google.common.collect.Maps;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.Map;
 import javax.ws.rs.HttpMethod;
 
 /**
  * Tests for {@link AlluxioJobMasterRestServiceHandler}.
  */
 public final class JobMasterRestApiTest extends RestApiTest {
-  private static final Map<String, String> NO_PARAMS = Maps.newHashMap();
   private LocalAlluxioJobCluster mJobCluster;
 
   // TODO(chaomin): Rest API integration tests are only run in NOSASL mode now. Need to

--- a/tests/src/test/java/alluxio/client/rest/RestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/RestApiTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.client.rest;
 
+import alluxio.Constants;
 import alluxio.testutils.BaseIntegrationTest;
 
 import com.google.common.collect.ImmutableMap;
@@ -22,5 +23,5 @@ public abstract class RestApiTest extends BaseIntegrationTest {
 
   protected String mHostname;
   protected int mPort;
-  protected String mServicePrefix;
+  protected String mBaseUri = Constants.REST_API_PREFIX;
 }

--- a/tests/src/test/java/alluxio/client/rest/RestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/RestApiTest.java
@@ -13,17 +13,14 @@ package alluxio.client.rest;
 
 import alluxio.testutils.BaseIntegrationTest;
 
-import java.util.HashMap;
+import com.google.common.collect.ImmutableMap;
+
 import java.util.Map;
 
 public abstract class RestApiTest extends BaseIntegrationTest {
-  protected static final Map<String, String> NO_PARAMS = new HashMap<>();
+  protected static final Map<String, String> NO_PARAMS = ImmutableMap.of();
 
   protected String mHostname;
   protected int mPort;
   protected String mServicePrefix;
-
-  protected String getEndpoint(String suffix) {
-    return mServicePrefix + "/" + suffix;
-  }
 }

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -81,10 +81,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
   private static final int LARGE_DATA_SIZE = 256 * Constants.KB;
 
   private static final GetStatusContext GET_STATUS_CONTEXT = GetStatusContext.defaults();
-  private static final Map<String, String> NO_PARAMS = new HashMap<>();
   private static final XmlMapper XML_MAPPER = new XmlMapper();
-
-  private static final String S3_SERVICE_PREFIX = S3RestServiceHandler.SERVICE_PREFIX;
 
   private FileSystem mFileSystem;
   private FileSystemMaster mFileSystemMaster;

--- a/tests/src/test/java/alluxio/client/rest/TestCase.java
+++ b/tests/src/test/java/alluxio/client/rest/TestCase.java
@@ -16,6 +16,7 @@ import alluxio.exception.status.InvalidArgumentException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.google.common.base.Joiner;
 import com.google.common.io.ByteStreams;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
@@ -83,20 +84,10 @@ public final class TestCase {
    * @return The URL which is created
    */
   public URL createURL() throws Exception {
-    StringBuilder sb = new StringBuilder();
-    boolean addAmpersands = false;
-    for (Map.Entry<String, String> parameter : mParameters.entrySet()) {
-      if (!addAmpersands) { addAmpersands = true; }
-      else { sb.append("&"); }
-      sb.append(parameter.getKey());
-      if (parameter.getValue() != null && !parameter.getValue().isEmpty()) {
-        sb.append("=").append(parameter.getValue());
-      }
-    }
-    String url = String.format("http://%s:%s%s/%s",
-        mHostname, mPort, mBaseUri, mEndpoint);
-    if (sb.length() > 0) {
-      url = String.format("%s?%s", url, sb);
+    String url = String.format("http://%s:%s%s/%s", mHostname, mPort, mBaseUri, mEndpoint);
+    String params = Joiner.on("&").withKeyValueSeparator("=").join(mParameters.entrySet());
+    if (params.length() > 0) {
+      url = String.format("%s?%s", url, params);
     }
     return new URL(url);
   }

--- a/tests/src/test/java/alluxio/client/rest/TestCaseOptions.java
+++ b/tests/src/test/java/alluxio/client/rest/TestCaseOptions.java
@@ -16,6 +16,7 @@ import com.google.common.base.Objects;
 
 import java.io.InputStream;
 import javax.annotation.concurrent.NotThreadSafe;
+import javax.ws.rs.core.MediaType;
 
 /**
  * Method options for creating a REST API test case.
@@ -23,8 +24,8 @@ import javax.annotation.concurrent.NotThreadSafe;
 // TODO(jiri): consolidate input stream and body fields
 @NotThreadSafe
 public final class TestCaseOptions {
-  public static final String JSON_CONTENT_TYPE = "application/json";
-  public static final String XML_CONTENT_TYPE = "application/xml";
+  public static final String JSON_CONTENT_TYPE = MediaType.APPLICATION_JSON;
+  public static final String XML_CONTENT_TYPE = MediaType.APPLICATION_XML;
 
   private Object mBody;
   private InputStream mInputStream;

--- a/tests/src/test/java/alluxio/web/WebServerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/web/WebServerIntegrationTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.web;
 
+import alluxio.Constants;
 import alluxio.client.rest.TestCase;
 import alluxio.client.rest.TestCaseOptions;
 import alluxio.conf.ServerConfiguration;
@@ -66,8 +67,10 @@ public class WebServerIntegrationTest extends BaseIntegrationTest {
   private void verifyMetricsJson(ServiceType serviceType) throws Exception {
     InetSocketAddress address = getInetSocketAddresss(serviceType);
     Map<String, String> params = new HashMap<>();
-    String result = new TestCase(address.getHostName(), address.getPort(), "metrics/json", params,
-        HttpMethod.GET, null, TestCaseOptions.defaults(), "").call();
+    String result = new TestCase(address.getHostName(), address.getPort(),
+        Constants.REST_API_PREFIX,
+        "metrics/json", params, HttpMethod.GET,
+        TestCaseOptions.defaults()).runAndGetResponse();
 
     TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {
     };

--- a/tests/src/test/java/alluxio/web/WebServerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/web/WebServerIntegrationTest.java
@@ -11,10 +11,10 @@
 
 package alluxio.web;
 
-import alluxio.Constants;
 import alluxio.client.rest.TestCase;
 import alluxio.client.rest.TestCaseOptions;
 import alluxio.conf.ServerConfiguration;
+import alluxio.metrics.sink.MetricsServlet;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.util.network.NetworkAddressUtils;
@@ -67,9 +67,9 @@ public class WebServerIntegrationTest extends BaseIntegrationTest {
   private void verifyMetricsJson(ServiceType serviceType) throws Exception {
     InetSocketAddress address = getInetSocketAddresss(serviceType);
     Map<String, String> params = new HashMap<>();
-    String result = new TestCase(address.getHostName(), address.getPort(),
-        Constants.REST_API_PREFIX,
-        "metrics/json", params, HttpMethod.GET,
+    String result = new TestCase(
+        address.getHostName(), address.getPort(), MetricsServlet.SERVLET_PATH,
+        "", params, HttpMethod.GET,
         TestCaseOptions.defaults()).runAndGetResponse();
 
     TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR refactors the classes related to `RestApiTest` to remove confusing code such as redundant methods or general Java anti-patterns.

### Why are the changes needed?

Improving development clarity & ease-of-use.

### Does this PR introduce any user facing changes?

No user-facing changes.