### PR TITLE
Fix fuse readdir to fill in file statuses

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -46,6 +46,7 @@ import alluxio.security.authorization.Mode;
 import alluxio.util.CommonUtils;
 import alluxio.util.LogUtils;
 import alluxio.util.WaitForOptions;
+import alluxio.util.io.BufferUtils;
 import alluxio.wire.BlockMasterInfo;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -127,6 +128,8 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
   @VisibleForTesting
   public static final int MAX_NAME_LENGTH = 255;
 
+  public final int mFileStatSize;
+
   /**
    * Creates a new instance of {@link AlluxioJniFuseFileSystem}.
    *
@@ -181,6 +184,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
         LOG.error("Failed to set AlluxioJniFuseFileSystem log to debug level", e);
       }
     }
+    mFileStatSize = getFileStatSize();
     MetricsSystem.registerGaugeIfAbsent(
         MetricsSystem.getMetricName(MetricKey.FUSE_READING_FILE_COUNT.getName()),
         mOpenFileEntries::size);
@@ -330,7 +334,14 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
       FuseFillDir.apply(filter, buff, "..", null, 0);
 
       mFileSystem.iterateStatus(uri, file -> {
-        FuseFillDir.apply(filter, buff, file.getName(), null, 0);
+        ByteBuffer buffer = ByteBuffer.allocateDirect(mFileStatSize);
+        try {
+          FileStat stat = FileStat.of(buffer);
+          AlluxioFuseUtils.setStat(file, stat);
+          FuseFillDir.apply(filter, buff, file.getName(), stat, 0);
+        } finally {
+          BufferUtils.cleanDirectBuffer(buffer);
+        }
       });
     } catch (Throwable e) {
       LOG.error("Failed to readdir {}", path, e);

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/AbstractFuseFileSystem.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/AbstractFuseFileSystem.java
@@ -358,4 +358,9 @@ public abstract class AbstractFuseFileSystem implements FuseFileSystem {
     ByteBuffer buffer = libFuse.fuse_get_context();
     return FuseContext.of(buffer);
   }
+
+  @Override
+  public int getFileStatSize() {
+    return libFuse.fuse_get_stat_size();
+  }
 }

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/FuseFileSystem.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/FuseFileSystem.java
@@ -110,6 +110,10 @@ public interface FuseFileSystem {
     return FuseContext.of(ByteBuffer.allocate(32));
   }
 
+  default int getFileStatSize() {
+    return 256;
+  }
+
   default String getFileSystemName() {
     return "fusefs" + ThreadLocalRandom.current().nextInt();
   }

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/FuseFillDir.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/FuseFillDir.java
@@ -20,7 +20,10 @@ public class FuseFillDir {
 
   public static int apply(long fillerAddr, long bufaddr, String name, FileStat stbuf, long off) {
     if (stbuf != null) {
-      return fill(fillerAddr, bufaddr, name, stbuf.getBuffer(), off);
+      ByteBuffer buffer = stbuf.getBuffer();
+      buffer.position(0);
+      buffer.limit(buffer.capacity());
+      return fill(fillerAddr, bufaddr, name, buffer, off);
     } else {
       return fill(fillerAddr, bufaddr, name, null, off);
     }

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/LibFuse.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/LibFuse.java
@@ -33,6 +33,8 @@ public class LibFuse {
 
   public native ByteBuffer fuse_get_context();
 
+  public native int fuse_get_stat_size();
+
   public static void loadLibrary(VersionPreference preference) {
     if (libraryLoaded.get() == LibraryState.LOADED) {
       return;

--- a/integration/jnifuse/native/src/main/native/libjnifuse/jnifuse_helper.cc
+++ b/integration/jnifuse/native/src/main/native/libjnifuse/jnifuse_helper.cc
@@ -96,11 +96,19 @@ jint JNICALL Java_alluxio_jnifuse_FuseFillDir_fill(JNIEnv *env, jclass cls,
   LOGD("enter fill");
   fuse_fill_dir_t filler = (fuse_fill_dir_t)(void *)address;
   const char *fn = env->GetStringUTFChars(name, 0);
-
+  int ret;
 #if FUSE_USE_VERSION >= 30
-  int ret = filler((void *)bufaddr, fn, NULL, 0, fuse_fill_dir_flags::FUSE_FILL_DIR_PLUS);
+  if (stbuf) {
+    ret = filler((void *)bufaddr, fn, NULL, 0, fuse_fill_dir_flags::FUSE_FILL_DIR_PLUS);
+  } else {
+    ret = filler((void *)bufaddr, fn, (struct stat*)stbuf, 0, fuse_fill_dir_flags::FUSE_FILL_DIR_PLUS);
+  }
 #else
-  int ret = filler((void *)bufaddr, fn, NULL, 0);
+  if (stbuf) {
+    ret = filler((void *)bufaddr, fn, NULL, 0);
+  } else {
+    ret = filler((void *)bufaddr, fn, (struct stat*)stbuf, 0);
+  }
 #endif
   env->ReleaseStringUTFChars(name, fn);
 
@@ -113,6 +121,10 @@ jobject JNICALL Java_alluxio_jnifuse_LibFuse_fuse_1get_1context(JNIEnv *env, job
   jobject fibuf =
       env->NewDirectByteBuffer((void *)cxt, sizeof(struct fuse_context));
   return fibuf;
+}
+
+jint JNICALL Java_alluxio_jnifuse_LibFuse_fuse_1get_1stat_1size(JNIEnv *env, jobject obj) {
+  return sizeof(struct stat);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix fuse readdir method to fill in file statuses directly

### Why are the changes needed?

Improve Fuse readdir
### Does this PR introduce any user facing changes?
NA
