### PR TITLE
Optimize getattrInternal and write offset check

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -249,14 +249,6 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
             FileOutStream os = ce.getOut();
             size = os.getBytesWritten();
           }
-        } else if (!AlluxioFuseUtils.waitForFileCompleted(mFileSystem, uri)) {
-          // Always block waiting for file to be completed except when the file is writing
-          // We do not want to block the writing process
-          LOG.error("File {} is not completed", path);
-        } else {
-          // Update the file status after waiting
-          status = mFileSystem.getStatus(uri);
-          size = status.getLength();
         }
       }
       stat.st_size.set(size);

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -537,16 +537,10 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
 
     FileOutStream os = ce.getOut();
     long bytesWritten = os.getBytesWritten();
-    if (offset != bytesWritten && offset + sz > bytesWritten) {
+    if (offset != bytesWritten) {
       LOG.error("Only sequential write is supported. Cannot write bytes of size {} to offset {} "
           + "when {} bytes have written to path {}", size, offset, bytesWritten, path);
       return -ErrorCodes.EIO();
-    }
-    if (offset + sz <= bytesWritten) {
-      LOG.warn("Skip writting to file {} offset={} size={} when {} bytes has written to file",
-          path, offset, sz, bytesWritten);
-      // To fulfill vim :wq
-      return sz;
     }
 
     try {


### PR DESCRIPTION
### What changes are proposed in this pull request?
1. getattr not wait for file finished
2. write should strict check offset, to avoid data loss

### Why are the changes needed?
1. getattr should not wait for file finished
a. if a file have finished written and not commit file(due to mount point crashed), all stat for this file must wait for 5s，this used a long time for a large directory which contains many incomplete file, and this seems have no meaning for application，and user will regard alluxio fuse service is down.
b. if a file is writing, another mount point getattr call also needs to wait
Posix allow a file length is grow，i think we only needed wait for open，because we can't read a writing file.

2. write should check offset in strict mode,  to avoid data loss
