### PR TITLE
Stop generating operationID (UUID) for internal operations

### DIFF
--- a/core/client/fs/src/main/java/alluxio/util/FileSystemOptions.java
+++ b/core/client/fs/src/main/java/alluxio/util/FileSystemOptions.java
@@ -63,9 +63,19 @@ public class FileSystemOptions {
    * @return options based on the configuration
    */
   public static CreateDirectoryPOptions createDirectoryDefaults(AlluxioConfiguration conf) {
+    return createDirectoryDefaults(conf, true);
+  }
+
+  /**
+   * @param conf Alluxio configuration
+   * @param withOpId Whether to include unique operation-ID in options
+   * @return options based on the configuration
+   */
+  public static CreateDirectoryPOptions createDirectoryDefaults(AlluxioConfiguration conf,
+      boolean withOpId) {
     return CreateDirectoryPOptions.newBuilder()
         .setAllowExists(false)
-        .setCommonOptions(commonDefaults(conf, true))
+        .setCommonOptions(commonDefaults(conf, withOpId))
         .setMode(ModeUtils.applyDirectoryUMask(Mode.defaults(),
             conf.get(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_UMASK)).toProto())
         .setRecursive(false)
@@ -98,9 +108,18 @@ public class FileSystemOptions {
    * @return options based on the configuration
    */
   public static CreateFilePOptions createFileDefaults(AlluxioConfiguration conf) {
+    return createFileDefaults(conf, true);
+  }
+
+  /**
+   * @param conf Alluxio configuration
+   * @param withOpId Whether to include unique operation-ID in options
+   * @return options based on the configuration
+   */
+  public static CreateFilePOptions createFileDefaults(AlluxioConfiguration conf, boolean withOpId) {
     return CreateFilePOptions.newBuilder()
         .setBlockSizeBytes(conf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT))
-        .setCommonOptions(commonDefaults(conf, true))
+        .setCommonOptions(commonDefaults(conf, withOpId))
         .setMode(ModeUtils.applyFileUMask(Mode.defaults(),
             conf.get(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_UMASK)).toProto())
         .setPersistenceWaitTime(conf.getMs(PropertyKey.USER_FILE_PERSISTENCE_INITIAL_WAIT_TIME))
@@ -118,9 +137,18 @@ public class FileSystemOptions {
    * @return options based on the configuration
    */
   public static DeletePOptions deleteDefaults(AlluxioConfiguration conf) {
+    return deleteDefaults(conf, true);
+  }
+
+  /**
+   * @param conf Alluxio configuration
+   * @param withOpId Whether to include unique operation-ID in options
+   * @return options based on the configuration
+   */
+  public static DeletePOptions deleteDefaults(AlluxioConfiguration conf, boolean withOpId) {
     return DeletePOptions.newBuilder()
         .setAlluxioOnly(false)
-        .setCommonOptions(commonDefaults(conf, true))
+        .setCommonOptions(commonDefaults(conf, withOpId))
         .setRecursive(false)
         .setUnchecked(conf.getBoolean(PropertyKey.USER_FILE_DELETE_UNCHECKED))
         .build();
@@ -243,8 +271,17 @@ public class FileSystemOptions {
    * @return options based on the configuration
    */
   public static RenamePOptions renameDefaults(AlluxioConfiguration conf) {
+    return renameDefaults(conf, true);
+  }
+
+  /**
+   * @param conf Alluxio configuration
+   * @param withOpId Whether to include unique operation-ID in options
+   * @return options based on the configuration
+   */
+  public static RenamePOptions renameDefaults(AlluxioConfiguration conf, boolean withOpId) {
     return RenamePOptions.newBuilder()
-        .setCommonOptions(commonDefaults(conf, true))
+        .setCommonOptions(commonDefaults(conf, withOpId))
         .setPersist(conf.getBoolean(PropertyKey.USER_FILE_PERSIST_ON_RENAME))
         .build();
   }

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CreateDirectoryContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CreateDirectoryContext.java
@@ -61,7 +61,7 @@ public class CreateDirectoryContext
    */
   public static CreateDirectoryContext mergeFrom(CreateDirectoryPOptions.Builder optionsBuilder) {
     CreateDirectoryPOptions masterOptions =
-        FileSystemOptions.createDirectoryDefaults(ServerConfiguration.global());
+        FileSystemOptions.createDirectoryDefaults(ServerConfiguration.global(), false);
     CreateDirectoryPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -72,7 +72,7 @@ public class CreateDirectoryContext
    */
   public static CreateDirectoryContext defaults() {
     return create(FileSystemOptions
-        .createDirectoryDefaults(ServerConfiguration.global()).toBuilder());
+        .createDirectoryDefaults(ServerConfiguration.global(), false).toBuilder());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CreateFileContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CreateFileContext.java
@@ -52,7 +52,7 @@ public class CreateFileContext
    */
   public static CreateFileContext mergeFrom(CreateFilePOptions.Builder optionsBuilder) {
     CreateFilePOptions masterOptions =
-        FileSystemOptions.createFileDefaults(ServerConfiguration.global());
+        FileSystemOptions.createFileDefaults(ServerConfiguration.global(), false);
     CreateFilePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return new CreateFileContext(mergedOptionsBuilder);
@@ -62,7 +62,8 @@ public class CreateFileContext
    * @return the instance of {@link CreateFileContext} with default values for master
    */
   public static CreateFileContext defaults() {
-    return create(FileSystemOptions.createFileDefaults(ServerConfiguration.global()).toBuilder());
+    return create(
+        FileSystemOptions.createFileDefaults(ServerConfiguration.global(), false).toBuilder());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/DeleteContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/DeleteContext.java
@@ -47,7 +47,8 @@ public class DeleteContext extends OperationContext<DeletePOptions.Builder, Dele
    * @return the instance of {@link DeleteContext} with default values for master
    */
   public static DeleteContext mergeFrom(DeletePOptions.Builder optionsBuilder) {
-    DeletePOptions masterOptions = FileSystemOptions.deleteDefaults(ServerConfiguration.global());
+    DeletePOptions masterOptions =
+        FileSystemOptions.deleteDefaults(ServerConfiguration.global(), false);
     DeletePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -57,7 +58,8 @@ public class DeleteContext extends OperationContext<DeletePOptions.Builder, Dele
    * @return the instance of {@link DeleteContext} with default values for master
    */
   public static DeleteContext defaults() {
-    return create(FileSystemOptions.deleteDefaults(ServerConfiguration.global()).toBuilder());
+    return create(
+        FileSystemOptions.deleteDefaults(ServerConfiguration.global(), false).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/RenameContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/RenameContext.java
@@ -52,7 +52,8 @@ public class RenameContext extends OperationContext<RenamePOptions.Builder, Rena
    * @return the instance of {@link RenameContext} with default values for master
    */
   public static RenameContext mergeFrom(RenamePOptions.Builder optionsBuilder) {
-    RenamePOptions masterOptions = FileSystemOptions.renameDefaults(ServerConfiguration.global());
+    RenamePOptions masterOptions =
+        FileSystemOptions.renameDefaults(ServerConfiguration.global(), false);
     RenamePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -62,7 +63,8 @@ public class RenameContext extends OperationContext<RenamePOptions.Builder, Rena
    * @return the instance of {@link RenameContext} with default values for master
    */
   public static RenameContext defaults() {
-    return create(FileSystemOptions.renameDefaults(ServerConfiguration.global()).toBuilder());
+    return create(
+        FileSystemOptions.renameDefaults(ServerConfiguration.global(), false).toBuilder());
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?
For file-system option defaults, gives support for skipping operation-ID generation by argument.
Then makes use of it from internal operations to avoid generating UUIDs.

### Why are the changes needed?
Internal operations are not retried against the new master. Hence, generating an operation-Id doesn't make sense.

 Fixes https://github.com/Alluxio/alluxio/issues/15261