### PR TITLE
Put failed worker in list before retry

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
@@ -12,6 +12,7 @@
 package alluxio.client.block.stream;
 
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.CacheRequest;
 import alluxio.grpc.ClearMetricsRequest;
 import alluxio.grpc.ClearMetricsResponse;
@@ -57,6 +58,8 @@ public interface BlockWorkerClient extends Closeable {
         throws IOException {
       try {
         return new DefaultBlockWorkerClient(userState, address, alluxioConf);
+      } catch (UnavailableException e) {
+        throw e;
       } catch (Exception e) {
         throw new IOException(
             String.format("Failed to connect to block worker (%s)", address), e);


### PR DESCRIPTION
### What changes are proposed in this pull request?

add exception throw to avoid reading failed worker again 

### Why are the changes needed?

If worker is failed during reading local worker, block client will retry this worker without try other workers. In this pr, throw an exception can fix this situation.

### Does this PR introduce any user facing changes?
No user-facing changes.

#15169 
