### PR TITLE
Fix sync directory meta repeatedly

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -496,10 +496,15 @@ public class InodeSyncStream {
 
     boolean hasCache;
     try {
+      // Generally 'hasCache=true' means that 'listStatus' of the directory
+      // has already prefetched the metadata for files under it
       hasCache = (mStatusCache.getStatus(path) != null);
     } catch (FileNotFoundException e) {
-      LogUtils.warnWithException(LOG, "Failed to process sync path: {}", path, e);
-      return false;
+      LogUtils.warnWithException(LOG, "Failed to getStatus: {}", path, e);
+      // Sometimes the following "syncInodeMetadata" is still needed even
+      // encountered FileNotFoundException. For example, the path is a
+      // parent directory of a mount point. So do not return from here.
+      hasCache = false;
     }
 
     LockingScheme scheme;

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -487,7 +487,7 @@ public class InodeSyncStream {
    * be synced as well.
    *
    * @param path The path to sync
-   * @return true if this path was synced
+   * @return true if the system has valid cache for this path
    */
   private boolean processSyncPath(AlluxioURI path) {
     if (path == null) {
@@ -502,7 +502,7 @@ public class InodeSyncStream {
     }
 
     if (!scheme.shouldSync() && !mForceSync) {
-      return false;
+      return true;
     }
     try (LockedInodePath inodePath = mInodeTree.tryLockInodePath(scheme)) {
       if (Thread.currentThread().isInterrupted()) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix the issue: A file with a lastSync time newer than its directory causes the meta sync of the directory triggered repeatedly

### Why are the changes needed?

Fix https://github.com/Alluxio/alluxio/issues/15265

### Does this PR introduce any user facing changes?

No