### PR TITLE
Add missing options in DistributedLoad command

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/DistributedLoadCommand.java
@@ -233,10 +233,18 @@ public final class DistributedLoadCommand extends AbstractDistributedJobCommand 
 
   @Override
   public Options getOptions() {
-    return new Options().addOption(REPLICATION_OPTION).addOption(ACTIVE_JOB_COUNT_OPTION)
+    return new Options()
+        .addOption(REPLICATION_OPTION)
+        .addOption(ACTIVE_JOB_COUNT_OPTION)
         .addOption(INDEX_FILE)
         .addOption(HOSTS_OPTION)
         .addOption(HOST_FILE_OPTION)
+        .addOption(EXCLUDED_HOSTS_OPTION)
+        .addOption(EXCLUDED_HOST_FILE_OPTION)
+        .addOption(LOCALITY_OPTION)
+        .addOption(LOCALITY_FILE_OPTION)
+        .addOption(EXCLUDED_LOCALITY_OPTION)
+        .addOption(EXCLUDED_LOCALITY_FILE_OPTION)
         .addOption(PASSIVE_CACHE_OPTION)
         .addOption(DIRECT_CACHE_OPTION)
         .addOption(BATCH_SIZE_OPTION)


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add the missing options to distributed load cli.


### Why are the changes needed?

Options like `--excluded-hosts` etc., are missing in `alluxio fs distributedLoad` command. The functionalities controlled by the options are introduced in #13506, but not accessible from the command line interface. Attempting to run the command with this option results in an unrecognized option error:

```console
$ bin/alluxio fs distributedLoad --excluded-hosts host1,host2 /tmp
Failed to parse args for distributedLoad: Unrecognized option: --excluded-hosts
Usage: distributedLoad [--replication <num>] [--active-jobs <num>] [--batch-size <num>] [--index] [--hosts <host1>,<host2>,...,<hostN>] [--host-file <hostFilePath>] [--excluded-hosts <host1>,<host2>,...,<hostN>] [--excluded-host-file <hostFilePath>] [--locality <locality1>,<locality2>,...,<localityN>] [--locality-file <localityFilePath>] [--excluded-locality <locality1>,<locality2>,...,<localityN>] [--excluded-locality-file <localityFilePath>] [--passive-cache] <path>
Loads a file or all files in a directory into Alluxio space.
```

Note that the option is present in the usage string.

### Does this PR introduce any user facing changes?

Yes, now users can run the command with the new options introduced in #13506.
