### PR TITLE
Close JournalServiceClient asynchronously to account for async calls

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
@@ -164,7 +164,8 @@ public class SnapshotReplicationManager {
       return RaftJournalUtils.completeExceptionally(
           new IllegalStateException("State is not IDLE when starting a snapshot installation"));
     }
-    try (RaftJournalServiceClient client = createJournalServiceClient()) {
+    try {
+      RaftJournalServiceClient client = createJournalServiceClient();
       String address = String.valueOf(client.getAddress());
       SnapshotDownloader<DownloadSnapshotPRequest, DownloadSnapshotPResponse> observer =
           SnapshotDownloader.forFollower(mStorage, address);
@@ -190,6 +191,7 @@ public class SnapshotReplicationManager {
         if (throwable != null) {
           LOG.error("Unexpected exception downloading snapshot from leader {}.", address,
               throwable);
+          client.close();
           transitionState(DownloadState.STREAM_DATA, DownloadState.IDLE);
         }
       });

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
@@ -164,7 +164,7 @@ public class SnapshotReplicationManager {
       return RaftJournalUtils.completeExceptionally(
           new IllegalStateException("State is not IDLE when starting a snapshot installation"));
     }
-    try (RaftJournalServiceClient client = getJournalServiceClient()) {
+    try (RaftJournalServiceClient client = createJournalServiceClient()) {
       String address = String.valueOf(client.getAddress());
       SnapshotDownloader<DownloadSnapshotPRequest, DownloadSnapshotPResponse> observer =
           SnapshotDownloader.forFollower(mStorage, address);
@@ -216,7 +216,7 @@ public class SnapshotReplicationManager {
 
     SnapshotUploader<UploadSnapshotPRequest, UploadSnapshotPResponse> snapshotUploader =
         SnapshotUploader.forFollower(mStorage, snapshot);
-    RaftJournalServiceClient client = getJournalServiceClient();
+    RaftJournalServiceClient client = createJournalServiceClient();
     LOG.info("Sending stream request to {} for snapshot {}", client.getAddress(),
         snapshot.getTermIndex());
     StreamObserver<UploadSnapshotPRequest> requestObserver =
@@ -522,7 +522,7 @@ public class SnapshotReplicationManager {
   }
 
   @VisibleForTesting
-  synchronized RaftJournalServiceClient getJournalServiceClient()
+  synchronized RaftJournalServiceClient createJournalServiceClient()
       throws AlluxioStatusException {
     RaftJournalServiceClient client = new RaftJournalServiceClient(MasterClientContext
         .newBuilder(ClientContext.create(ServerConfiguration.global())).build());

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -110,7 +110,7 @@ public class SnapshotReplicationManagerTest {
       StreamObserver responseObserver = args.getArgument(0, StreamObserver.class);
       return stub.uploadSnapshot(responseObserver);
     });
-    Mockito.doReturn(mClient).when(mLeaderSnapshotManager).getJournalServiceClient();
+    Mockito.doReturn(mClient).when(mLeaderSnapshotManager).createJournalServiceClient();
 
     for (int i = 0; i < numFollowers; i++) {
       Follower follower = new Follower(mClient);
@@ -342,7 +342,7 @@ public class SnapshotReplicationManagerTest {
       mStore = getSimpleStateMachineStorage();
       mJournalSystem = Mockito.mock(RaftJournalSystem.class);
       mSnapshotManager = Mockito.spy(new SnapshotReplicationManager(mJournalSystem, mStore));
-      Mockito.doReturn(client).when(mSnapshotManager).getJournalServiceClient();
+      Mockito.doReturn(client).when(mSnapshotManager).createJournalServiceClient();
     }
 
     RaftPeerId getRaftPeerId() {

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -36,6 +36,7 @@ public class PortCoordination {
   public static final List<ReservedPort> EMBEDDED_JOURNAL_FAILOVER = allocate(3, 0);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_SNAPSHOT_MASTER = allocate(3, 0);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_SNAPSHOT_FOLLOWER = allocate(3, 0);
+  public static final List<ReservedPort> EMBEDDED_JOURNAL_SNAPSHOT_TRANSFER_LOAD = allocate(3, 0);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_RESTART = allocate(3, 0);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_RESTART_STRESS = allocate(3, 0);
   // for EmbeddedJournalIntegrationTestResizing
@@ -45,7 +46,6 @@ public class PortCoordination {
   // for EmbeddedJournalIntegrationTestTransferLeadership
   public static final List<ReservedPort> EMBEDDED_JOURNAL_TRANSFER_LEADER = allocate(5, 0);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_REPEAT_TRANSFER_LEADER = allocate(5, 0);
-  public static final List<ReservedPort> EMBEDDED_JOURNAL_RESET_PRIORITIES = allocate(5, 0);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_ALREADY_TRANSFERRING = allocate(5, 0);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_OUTSIDE_CLUSTER = allocate(5, 0);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_NEW_MEMBER = allocate(6, 0);

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
@@ -166,8 +166,8 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
 
   @Test
   public void snapshotTransferLoad() throws Exception {
-    int numFile = 1_500;
-    int snapshotPeriod = 100;
+    int numFile = 500;
+    int snapshotPeriod = 50;
 
     mCluster =
         MultiProcessCluster.newBuilder(PortCoordination.EMBEDDED_JOURNAL_SNAPSHOT_TRANSFER_LOAD)
@@ -178,8 +178,6 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
         .addProperty(PropertyKey.MASTER_JOURNAL_FLUSH_TIMEOUT_MS, "5min")
         .addProperty(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, "750ms")
         .addProperty(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, "1500ms")
-        .addProperty(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, "10KB")
-        .addProperty(PropertyKey.MASTER_EMBEDDED_JOURNAL_SNAPSHOT_REPLICATION_CHUNK_SIZE, "4KB")
         .addProperty(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, snapshotPeriod)
         .build();
     mCluster.start();


### PR DESCRIPTION
Currently, the `JournalServiceClient` used in `SnapshotReplicationManager` is closed using try-resource blocks. This causes the async calls within said blocks to fail sometimes as the client is closed when the call is launched.
This PR ensures that the clients are closed asynchronously after the call is finished using `whenComplete` blocks. 
A test accompanies this to ensure proper snapshot propagation. 