### PR TITLE
Fix FUSE deprecated property key

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3393,43 +3393,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
-  /**
-   * @deprecated use {@link #FUSE_MOUNT_ALLUXIO_PATH} instead
-   */
-  @Deprecated
-  public static final PropertyKey WORKER_FUSE_MOUNT_ALLUXIO_PATH =
-      stringBuilder(Name.WORKER_FUSE_MOUNT_ALLUXIO_PATH)
-          .setDefaultValue("/")
-          .setDescription(format("The Alluxio path to mount to the given "
-                  + "Fuse mount point configured by %s in this worker.",
-              Name.WORKER_FUSE_MOUNT_POINT))
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.WORKER)
-          .build();
-  /**
-   * @deprecated use {@link #FUSE_MOUNT_OPTIONS} instead
-   */
-  @Deprecated
-  public static final PropertyKey WORKER_FUSE_MOUNT_OPTIONS =
-      listBuilder(Name.WORKER_FUSE_MOUNT_OPTIONS)
-          .setDescription("The platform specific Fuse mount options "
-              + "to mount the given Fuse mount point. "
-              + "If multiple mount options are provided, separate them with comma.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.WORKER)
-          .build();
-  /**
-   * @deprecated use {@link #FUSE_MOUNT_POINT} instead
-   */
-  @Deprecated
-  public static final PropertyKey WORKER_FUSE_MOUNT_POINT =
-      stringBuilder(Name.WORKER_FUSE_MOUNT_POINT)
-          .setDefaultValue("/mnt/alluxio-fuse")
-          .setDescription("The absolute local filesystem path that this worker will "
-              + "mount Alluxio path to.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.WORKER)
-          .build();
   public static final PropertyKey WORKER_STARTUP_TIMEOUT =
       durationBuilder(Name.WORKER_STARTUP_TIMEOUT)
           .setDefaultValue("10min")


### PR DESCRIPTION
### What changes are proposed in this pull request?

Alluxio deprecated property key doesn't work well with new property key with alias.
Remove the deprecated property key as a workaround and will fix the general problem in a later PR.

### Why are the changes needed?
When setting the value for deprecated property key,
the new property key with the alias name as the deprecated property key name does not take the value.

### Does this PR introduce any user facing changes?
Supporting alluxio.worker.fuse.mount.point, alluxio.worker.fuse.mount.alluxio.path, and alluxio.worker.fuse.mount.options.