### PR TITLE
Fix parameter loading issues and add more checks in the watch-metrics.sh

### DIFF
--- a/dev/scripts/watch-metrics.sh
+++ b/dev/scripts/watch-metrics.sh
@@ -101,12 +101,6 @@ if [[ -z "${host}" || -z "${port}" || -z "${metrics_file_prefix}" || -z "${metri
     exit 1
 fi
 
-# check if command `jq` exists
-if ! command -v jq > /dev/null 2>&1; then
-  echo "ERROR: jq command not found"
-  exit 1
-fi
-
 nslookup ${host} > /dev/null 2>&1
 if [[ ${?} -ne 0 ]]; then
     echo "ERROR: Unknown host ${host}"

--- a/dev/scripts/watch-metrics.sh
+++ b/dev/scripts/watch-metrics.sh
@@ -101,12 +101,6 @@ if [[ -z "${host}" || -z "${port}" || -z "${metrics_file_prefix}" || -z "${metri
     exit 1
 fi
 
-# check if command `nslookup` exists
-if ! command -v nslookup > /dev/null 2>&1; then
-  echo "ERROR: nslookup command not found"
-  exit 1
-fi
-
 # check if command `jq` exists
 if ! command -v jq > /dev/null 2>&1; then
   echo "ERROR: jq command not found"

--- a/dev/scripts/watch-metrics.sh
+++ b/dev/scripts/watch-metrics.sh
@@ -101,10 +101,16 @@ if [[ -z "${host}" || -z "${port}" || -z "${metrics_file_prefix}" || -z "${metri
     exit 1
 fi
 
-nslookup ${host} > /dev/null 2>&1
-if [[ ${?} -ne 0 ]]; then
-    echo "ERROR: Unknown host ${host}"
-    exit 1
+# check if command `nslookup` exists
+if ! command -v nslookup > /dev/null 2>&1; then
+  echo "ERROR: nslookup command not found"
+  exit 1
+fi
+
+# check if command `jq` exists
+if ! command -v jq > /dev/null 2>&1; then
+  echo "ERROR: jq command not found"
+  exit 1
 fi
 
 if [[ ${port} -le 0 ]]; then

--- a/dev/scripts/watch-metrics.sh
+++ b/dev/scripts/watch-metrics.sh
@@ -98,6 +98,18 @@ if [[ -z "${host}" || -z "${port}" || -z "${metrics_file_prefix}" || -z "${metri
     exit 1
 fi
 
+# check if command `nslookup` exists
+if ! command -v nslookup > /dev/null 2>&1; then
+  echo "ERROR: nslookup command not found"
+  exit 1
+fi
+
+# check if command `jq` exists
+if ! command -v jq > /dev/null 2>&1; then
+  echo "ERROR: jq command not found"
+  exit 1
+fi
+
 nslookup ${host} > /dev/null 2>&1
 if [[ ${?} -ne 0 ]]; then
     echo "ERROR: Unknown host ${host}"

--- a/dev/scripts/watch-metrics.sh
+++ b/dev/scripts/watch-metrics.sh
@@ -59,8 +59,11 @@ WDIFF_OPTS is required, and is one of:
 
 # argument parsing
 OPTIND=1
-while getopts ":hH:p:f:F:n:w:" opt; do
+while getopts ":hH:d:p:f:F:n:w:" opt; do
     case ${opt} in
+        d )
+            metrics_dir="${OPTARG}"
+            ;;
         f )
             metrics_file_prefix="${OPTARG}"
             ;;


### PR DESCRIPTION
### What changes are proposed in this pull request?

I fixed the bug that the previous `watch-metrics.sh`, when running, cannot correctly recognize the `metrics_dir` parameter; I also add two command checks, checking whether `nslookup` and `jq` commands are existed before running the actual command.
### Why are the changes needed?
1. Bug: `watch-metrics.sh` cannot recognize the `-d` parameter and will popup `ERROR: Unknown argument`
2. The error message is misleading in some circumstance: If the `nslookup` command is not installed, the error message will be `ERROR: Unknown host` even if the provided hostname can be recognized.

### Does this PR introduce any user facing changes?
No.
