### PR TITLE
Refactor and fix in worker

### DIFF
--- a/core/common/src/main/java/alluxio/worker/block/BlockStoreLocation.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockStoreLocation.java
@@ -36,6 +36,9 @@ public final class BlockStoreLocation {
   /** Special value to indicate any medium type. */
   public static final String ANY_MEDIUM = "";
 
+  private static final BlockStoreLocation ANY_TIER_LOCATION =
+      new BlockStoreLocation(ANY_TIER, ANY_DIR, ANY_MEDIUM);
+
   /** Alias of the storage tier. */
   private final String mTierAlias;
 
@@ -51,7 +54,7 @@ public final class BlockStoreLocation {
    * @return a BlockStoreLocation of any dir in any tier
    */
   public static BlockStoreLocation anyTier() {
-    return new BlockStoreLocation(ANY_TIER, ANY_DIR, ANY_MEDIUM);
+    return ANY_TIER_LOCATION;
   }
 
   /**
@@ -110,6 +113,15 @@ public final class BlockStoreLocation {
   }
 
   /**
+   * Check whether the location is {@link #ANY_TIER}.
+   *
+   * @return true if location is {@link #ANY_TIER}
+   */
+  public boolean isAnyTier() {
+    return tierAlias().equals(ANY_TIER);
+  }
+
+  /**
    * Gets the directory index of the location.
    *
    * @return the directory index of the location, {@link #ANY_DIR} for any directory
@@ -119,12 +131,30 @@ public final class BlockStoreLocation {
   }
 
   /**
+   * Check whether the location is {@link #ANY_DIR}.
+   *
+   * @return true if location is {@link #ANY_DIR}
+   */
+  public boolean isAnyDir() {
+    return dir() == ANY_DIR;
+  }
+
+  /**
    * Gets the medium type of the location.
    *
    * @return the medium type of the location
    */
   public String mediumType() {
     return mMediumType;
+  }
+
+  /**
+   * Check whether the location is {@link #ANY_MEDIUM}.
+   *
+   * @return true if location is {@link #ANY_MEDIUM}
+   */
+  public boolean isAnyMedium() {
+    return mediumType().equals(ANY_MEDIUM);
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/Allocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/Allocator.java
@@ -64,7 +64,6 @@ public interface Allocator {
    * and do not want it to be affected by the reviewer.
    * E.g. We just freed up some space in Alluxio and want the allocation to use the freed space.
    *
-   * @param sessionId the id of session to apply for the block allocation
    * @param blockSize the size of block in bytes
    * @param location the location in block store
    * @param view of the block metadata
@@ -72,6 +71,6 @@ public interface Allocator {
    * @return a {@link StorageDirView} in which to create the temp block meta if success, null
    *         otherwise
    */
-  StorageDirView allocateBlockWithView(long sessionId, long blockSize, BlockStoreLocation location,
+  StorageDirView allocateBlockWithView(long blockSize, BlockStoreLocation location,
       BlockMetadataView view, boolean skipReview);
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/GreedyAllocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/GreedyAllocator.java
@@ -46,24 +46,23 @@ public final class GreedyAllocator implements Allocator {
   }
 
   @Override
-  public StorageDirView allocateBlockWithView(long sessionId, long blockSize,
+  public StorageDirView allocateBlockWithView(long blockSize,
       BlockStoreLocation location, BlockMetadataView metadataView, boolean skipReview) {
     mMetadataView = Preconditions.checkNotNull(metadataView, "view");
-    return allocateBlock(sessionId, blockSize, location, skipReview);
+    return allocateBlock(blockSize, location, skipReview);
   }
 
   /**
    * Allocates a block from the given block store location. The location can be a specific location,
    * or {@link BlockStoreLocation#anyTier()} or {@link BlockStoreLocation#anyDirInTier(String)}.
    *
-   * @param sessionId the id of session to apply for the block allocation
    * @param blockSize the size of block in bytes
    * @param location the location in block store
    * @return a {@link StorageDirView} in which to create the temp block meta if success,
    *         null otherwise
    */
   @Nullable
-  private StorageDirView allocateBlock(long sessionId, long blockSize,
+  private StorageDirView allocateBlock(long blockSize,
       BlockStoreLocation location, boolean skipReview) {
     Preconditions.checkNotNull(location, "location");
     if (location.equals(BlockStoreLocation.anyTier())) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/MaxFreeAllocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/MaxFreeAllocator.java
@@ -45,24 +45,23 @@ public final class MaxFreeAllocator implements Allocator {
   }
 
   @Override
-  public StorageDirView allocateBlockWithView(long sessionId, long blockSize,
+  public StorageDirView allocateBlockWithView(long blockSize,
       BlockStoreLocation location, BlockMetadataView metadataView, boolean skipReview) {
     mMetadataView = Preconditions.checkNotNull(metadataView, "view");
-    return allocateBlock(sessionId, blockSize, location, skipReview);
+    return allocateBlock(blockSize, location, skipReview);
   }
 
   /**
    * Allocates a block from the given block store location. The location can be a specific location,
    * or {@link BlockStoreLocation#anyTier()} or {@link BlockStoreLocation#anyDirInTier(String)}.
    *
-   * @param sessionId the id of session to apply for the block allocation
    * @param blockSize the size of block in bytes
    * @param location the location in block store
    * @param skipReview whether the review should be skipped
    * @return a {@link StorageDirView} in which to create the temp block meta if success,
    *         null otherwise
    */
-  private StorageDirView allocateBlock(long sessionId, long blockSize,
+  private StorageDirView allocateBlock(long blockSize,
       BlockStoreLocation location, boolean skipReview) {
     Preconditions.checkNotNull(location, "location");
     StorageDirView candidateDirView = null;

--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/RoundRobinAllocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/RoundRobinAllocator.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
-import java.util.List;
+import java.util.Iterator;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -41,7 +41,7 @@ public final class RoundRobinAllocator implements Allocator {
   private Reviewer mReviewer;
 
   // We need to remember the last dir index for every storage tier
-  private Map<String, Integer> mTierAliasToLastDirMap = new HashMap<>();
+  private Map<String, Iterator<StorageDirView>> mTierAliasToDirIteratorMap = new HashMap<>();
 
   /**
    * Creates a new instance of {@link RoundRobinAllocator}.
@@ -51,23 +51,23 @@ public final class RoundRobinAllocator implements Allocator {
   public RoundRobinAllocator(BlockMetadataView view) {
     mMetadataView = Preconditions.checkNotNull(view, "view");
     for (StorageTierView tierView : mMetadataView.getTierViews()) {
-      mTierAliasToLastDirMap.put(tierView.getTierViewAlias(), -1);
+      mTierAliasToDirIteratorMap.put(
+          tierView.getTierViewAlias(), tierView.getDirViews().iterator());
     }
     mReviewer = Reviewer.Factory.create();
   }
 
   @Override
-  public StorageDirView allocateBlockWithView(long sessionId, long blockSize,
+  public StorageDirView allocateBlockWithView(long blockSize,
       BlockStoreLocation location, BlockMetadataView metadataView, boolean skipReview) {
     mMetadataView = Preconditions.checkNotNull(metadataView, "view");
-    return allocateBlock(sessionId, blockSize, location, skipReview);
+    return allocateBlock(blockSize, location, skipReview);
   }
 
   /**
    * Allocates a block from the given block store location. The location can be a specific location,
    * or {@link BlockStoreLocation#anyTier()} or {@link BlockStoreLocation#anyDirInTier(String)}.
    *
-   * @param sessionId the id of session to apply for the block allocation
    * @param blockSize the size of block in bytes
    * @param location the location in block store
    * @return a {@link StorageDirView} in which to create the temp block meta if success,
@@ -75,39 +75,21 @@ public final class RoundRobinAllocator implements Allocator {
    * @throws IllegalArgumentException if block location is invalid
    */
   @Nullable
-  private StorageDirView allocateBlock(long sessionId, long blockSize,
+  private StorageDirView allocateBlock(long blockSize,
       BlockStoreLocation location, boolean skipReview) {
     Preconditions.checkNotNull(location, "location");
-    if (location.equals(BlockStoreLocation.anyTier())) {
-      for (int i = 0; i < mMetadataView.getTierViews().size(); i++) {
-        StorageTierView tierView = mMetadataView.getTierViews().get(i);
-        // The review logic is handled in getNextAvailDirInTier
-        int dirViewIndex = getNextAvailDirInTier(tierView, blockSize,
-            BlockStoreLocation.ANY_MEDIUM, skipReview);
-        if (dirViewIndex >= 0) {
-          mTierAliasToLastDirMap.put(tierView.getTierViewAlias(), dirViewIndex);
-          return tierView.getDirView(dirViewIndex);
-        }
-      }
-    } else if (location.equals(BlockStoreLocation.anyDirInTier(location.tierAlias()))) {
+    if (!location.isAnyTier() && location.isAnyDir()) {
       StorageTierView tierView = mMetadataView.getTierView(location.tierAlias());
       // The review logic is handled in getNextAvailDirInTier
-      int dirViewIndex = getNextAvailDirInTier(tierView, blockSize,
-              BlockStoreLocation.ANY_MEDIUM, skipReview);
-      if (dirViewIndex >= 0) {
-        mTierAliasToLastDirMap.put(tierView.getTierViewAlias(), dirViewIndex);
-        return tierView.getDirView(dirViewIndex);
-      }
-    } else if (location.equals(BlockStoreLocation.anyDirInAnyTierWithMedium(
-            location.mediumType()))) {
-      for (int i = 0; i < mMetadataView.getTierViews().size(); i++) {
-        StorageTierView tierView = mMetadataView.getTierViews().get(i);
+      return getNextAvailDirInTier(tierView, blockSize,
+          location.mediumType(), skipReview);
+    } else if (location.isAnyTier() && location.isAnyDir()) {
+      for (StorageTierView tierView : mMetadataView.getTierViews()) {
         // The review logic is handled in getNextAvailDirInTier
-        int dirViewIndex = getNextAvailDirInTier(tierView, blockSize,
-                location.mediumType(), skipReview);
-        if (dirViewIndex >= 0) {
-          mTierAliasToLastDirMap.put(tierView.getTierViewAlias(), dirViewIndex);
-          return tierView.getDirView(dirViewIndex);
+        StorageDirView dir = getNextAvailDirInTier(tierView, blockSize,
+            location.mediumType(), skipReview);
+        if (dir != null) {
+          return dir;
         }
       }
     } else {
@@ -131,24 +113,28 @@ public final class RoundRobinAllocator implements Allocator {
    * @param mediumType the medium type to find a dir
    * @return the index of the dir if non-negative; -1 if fail to find a dir
    */
-  private int getNextAvailDirInTier(StorageTierView tierView, long blockSize, String mediumType,
-                                    boolean skipReview) {
-    int dirIndex = mTierAliasToLastDirMap.get(tierView.getTierViewAlias());
-    List<StorageDirView> dirs = tierView.getDirViews();
-    for (int i = 0; i < dirs.size(); i++) { // try this many times
-      dirIndex = (dirIndex + 1) % dirs.size();
-      StorageDirView dir = dirs.get(dirIndex);
+  private StorageDirView getNextAvailDirInTier(StorageTierView tierView, long blockSize,
+      String mediumType, boolean skipReview) {
+    Iterator<StorageDirView> iterator = mTierAliasToDirIteratorMap.get(tierView.getTierViewAlias());
+    int processed = 0;
+    while (processed < tierView.getDirViews().size()) {
+      if (!iterator.hasNext()) {
+        iterator = tierView.getDirViews().iterator();
+        mTierAliasToDirIteratorMap.put(tierView.getTierViewAlias(), iterator);
+      }
+      StorageDirView dir = iterator.next();
       if ((mediumType.equals(BlockStoreLocation.ANY_MEDIUM)
           || dir.getMediumType().equals(mediumType))
           && dir.getAvailableBytes() >= blockSize) {
         if (skipReview || mReviewer.acceptAllocation(dir)) {
-          return dir.getDirViewIndex();
+          return dir;
         }
         // The allocation is rejected. Try the next dir.
-        LOG.debug("Allocation to dirIndex {} rejected: {}", dirIndex,
-                dir.toBlockStoreLocation());
+        LOG.debug("Allocation to dir {} rejected: {}", dir,
+            dir.toBlockStoreLocation());
       }
+      processed++;
     }
-    return -1;
+    return null;
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/annotator/DefaultBlockIterator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/annotator/DefaultBlockIterator.java
@@ -20,12 +20,12 @@ import alluxio.worker.block.BlockStoreLocation;
 import alluxio.worker.block.meta.StorageDir;
 import alluxio.worker.block.meta.StorageTier;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -163,7 +163,7 @@ public class DefaultBlockIterator implements BlockIterator {
 
   @Override
   public List<BlockStoreEventListener> getListeners() {
-    return Arrays.asList(new BlockStoreEventListener[] {mListener});
+    return ImmutableList.of(mListener);
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/annotator/EmulatingBlockIterator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/annotator/EmulatingBlockIterator.java
@@ -25,8 +25,8 @@ import alluxio.worker.block.evictor.Evictor;
 import alluxio.worker.block.meta.StorageTier;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -187,9 +187,8 @@ public class EmulatingBlockIterator implements BlockIterator {
   @Override
   public List<BlockStoreEventListener> getListeners() {
     if (mEvictor instanceof BlockStoreEventListener) {
-      return Arrays.asList(new BlockStoreEventListener[] {(BlockStoreEventListener) mEvictor});
-    } else {
-      return Collections.emptyList();
+      return ImmutableList.of((BlockStoreEventListener) mEvictor);
     }
+    return ImmutableList.of();
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/AbstractEvictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/AbstractEvictor.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.block.evictor;
 
-import alluxio.Sessions;
 import alluxio.collections.Pair;
 import alluxio.exception.BlockDoesNotExistException;
 import alluxio.worker.block.AbstractBlockStoreEventListener;
@@ -150,7 +149,7 @@ public abstract class AbstractEvictor extends AbstractBlockStoreEventListener im
           }
           StorageDirEvictorView nextDirView
               = (StorageDirEvictorView) mAllocator.allocateBlockWithView(
-                  Sessions.MIGRATE_DATA_SESSION_ID, block.getBlockSize(),
+              block.getBlockSize(),
                   BlockStoreLocation.anyDirInTier(nextTierView.getTierViewAlias()),
                   mMetadataView, true);
           if (nextDirView == null) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTierView.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/StorageTierView.java
@@ -13,9 +13,8 @@ package alluxio.worker.block.meta;
 
 import com.google.common.base.Preconditions;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -54,8 +53,8 @@ public abstract class StorageTierView {
   /**
    * @return a list of directory views in this storage tier view
    */
-  public List<StorageDirView> getDirViews() {
-    return new ArrayList<>(mDirViews.values());
+  public Collection<StorageDirView> getDirViews() {
+    return mDirViews.values();
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockMetadataViewTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockMetadataViewTest.java
@@ -31,6 +31,7 @@ import alluxio.worker.block.meta.StorageTier;
 import alluxio.worker.block.meta.StorageTierEvictorView;
 import alluxio.worker.block.meta.StorageTierView;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -229,8 +230,8 @@ public final class BlockMetadataViewTest {
       StorageTierEvictorView tierView2) {
     assertEquals(tierView1.getTierViewAlias(), tierView2.getTierViewAlias());
     assertEquals(tierView1.getTierViewOrdinal(), tierView2.getTierViewOrdinal());
-    List<StorageDirView> dirViews1 = tierView1.getDirViews();
-    List<StorageDirView> dirViews2 = tierView2.getDirViews();
+    List<StorageDirView> dirViews1 = ImmutableList.copyOf(tierView1.getDirViews());
+    List<StorageDirView> dirViews2 = ImmutableList.copyOf(tierView2.getDirViews());
     assertEquals(dirViews1.size(), dirViews2.size());
     for (int i = 0; i < dirViews1.size(); i++) {
       StorageDirEvictorView dirView1 = (StorageDirEvictorView) dirViews1.get(i);

--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorTestBase.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorTestBase.java
@@ -121,7 +121,7 @@ public class AllocatorTestBase {
 
     mTestBlockId++;
     StorageDirView dirView =
-        allocator.allocateBlockWithView(SESSION_ID, blockSize, location,
+        allocator.allocateBlockWithView(blockSize, location,
                 getMetadataEvictorView(), true);
     TempBlockMeta tempBlockMeta =
         dirView == null ? null : dirView.createTempBlockMeta(SESSION_ID, mTestBlockId, blockSize);
@@ -150,7 +150,7 @@ public class AllocatorTestBase {
     mTestBlockId++;
 
     StorageDirView dirView =
-        allocator.allocateBlockWithView(SESSION_ID, blockSize, location,
+        allocator.allocateBlockWithView(blockSize, location,
                 getMetadataEvictorView(), false);
     TempBlockMeta tempBlockMeta =
         dirView == null ? null : dirView.createTempBlockMeta(SESSION_ID, mTestBlockId, blockSize);
@@ -183,7 +183,7 @@ public class AllocatorTestBase {
         mAnyDirInTierLoc2, mAnyDirInTierLoc3};
     for (int i = 0; i < locations.length; i++) {
       StorageDirView dirView =
-              mAllocator.allocateBlockWithView(AllocatorTestBase.SESSION_ID, 1,
+              mAllocator.allocateBlockWithView(1,
                       locations[i], getMetadataEvictorView(), true);
       assertNotNull(dirView);
       assertEquals(TIER_ALIAS[i], dirView.getParentTierView().getTierViewAlias());
@@ -197,7 +197,7 @@ public class AllocatorTestBase {
     for (String medium : MEDIA_TYPES) {
       BlockStoreLocation loc = BlockStoreLocation.anyDirInAnyTierWithMedium(medium);
       StorageDirView dirView =
-              mAllocator.allocateBlockWithView(AllocatorTestBase.SESSION_ID, 1, loc,
+              mAllocator.allocateBlockWithView(1, loc,
                       getMetadataEvictorView(), true);
       assertNotNull(dirView);
       assertEquals(medium, dirView.getMediumType());
@@ -210,7 +210,7 @@ public class AllocatorTestBase {
       for (int j = 0; j < TIER_PATH[i].length; j++) {
         BlockStoreLocation loc = new BlockStoreLocation(tier, j);
         StorageDirView dirView =
-                mAllocator.allocateBlockWithView(AllocatorTestBase.SESSION_ID, 1, loc,
+                mAllocator.allocateBlockWithView(1, loc,
                         getMetadataEvictorView(), true);
         assertNotNull(dirView);
         assertEquals(tier, dirView.getParentTierView().getTierViewAlias());


### PR DESCRIPTION
### What changes are proposed in this pull request?

1) Remove sessionId from Allocator API, it's not used
2) Add isAnyTier, isAnyDir, isAnyMedium in BlockStoreLocation
3) Remove unnecessary object creations in various places
4) Change StorageTierView.getDirViews to return Collection rather than creating List
5) Rewrite RoundRobinAllocator using iterator since dir index on List created from Collection is misleading
6) Any dir in tier with medium is not handled in original RoundRobinAllocator logic, cover this as well
