### PR TITLE
Optimize the checks of the loop in getMountPoint

### DIFF
--- a/core/common/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/PathUtils.java
@@ -291,14 +291,10 @@ public final class PathUtils {
    * @throws InvalidPathException when the path or prefix is invalid
    */
   public static boolean hasPrefix(String path, String prefix) throws InvalidPathException {
-    try {
-      // normalize path and prefix(e.g. "/a/b/../c" -> "/a/c", "/a/b/" --> "/a/b")
-      path = cleanPath(path);
-      prefix = cleanPath(prefix);
-    } catch (InvalidPathException e) {
-      // if the literal is invalid, throw an exception
-      throw e;
-    }
+    // normalize path and prefix(e.g. "/a/b/../c" -> "/a/c", "/a/b/" --> "/a/b")
+    path = cleanPath(path);
+    prefix = cleanPath(prefix);
+
     if (prefix.equals("/")) {
       return true;
     }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -240,7 +240,7 @@ public final class MountTable implements DelegatingJournaled {
         // we choose a new candidate path if the previous candidatepath is a prefix
         // of the current alluxioPath and the alluxioPath is a prefix of the path
         if (!mount.equals(ROOT) && PathUtils.hasPrefix(path, mount)
-            && PathUtils.hasPrefix(mount, lastMount)) {
+            && lastMount.length() < mount.length()) {
           lastMount = mount;
         }
       }


### PR DESCRIPTION
### What changes are proposed in this pull request?

According to the implementation of `getMountPoint`, it receives an alluxio uri as the parameter, gets the `path` from this uri by calling `uri.getPath()`, iterates the whole mount table's key-value pairs to find the key that is the nearest parent directory of `path`, which in other words is the longest prefix of `path`.

To make sure that the longest prefix can be recorded in `lastMount`, the condition is as follow:
```java
// ...
for (Map.Entry<String, MountInfo> entry : mState.getMountTable().entrySet()) {
  String mount = entry.getKey();
  if (!mount.equals(ROOT) && PathUtils.hasPrefix(path, mount)
            && PathUtils.hasPrefix(mount, lastMount)) {
      lastMount = mount;
  }
}
return lastMount;
```
`mount` is the current looped entry's key. The first two && condition check if the `mount` is the prefix of `path`, and the third condition checks if `lastMount` is the prefix of `mount`. However, since when executing the third condition, `mount` is already the prefix of `path`, so if the `mount` is longer than `lastMount`, `mount` is sure to be the path that is more close to `path` than `lastMount`. Therefore, it is no need to call `hasPrefix` and we can instead simply compares the length of `mount` and `lastMount`. 

I also removed the redundant `try-catch` block in `hasPrefix`
### Why are the changes needed?

To reduce unnecessary function call that will be called many times in a loop, in order to speed up `getMountPoint`.

### Does this PR introduce any user facing changes? 
No
