### PR TITLE
Close client outside if statement

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
@@ -191,9 +191,9 @@ public class SnapshotReplicationManager {
         if (throwable != null) {
           LOG.error("Unexpected exception downloading snapshot from leader {}.", address,
               throwable);
-          client.close();
           transitionState(DownloadState.STREAM_DATA, DownloadState.IDLE);
         }
+        client.close();
       });
     } catch (Exception e) {
       transitionState(DownloadState.STREAM_DATA, DownloadState.IDLE);


### PR DESCRIPTION
Client is being close inside `if` block incorrectly. Moving the `close` statement outside the `if` block.