### PR TITLE
Improve Fuse.statfs to avoid copyProperties and cache on client side

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5707,6 +5707,20 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.ALL)
           .build();
+  public static final PropertyKey FUSE_STAT_CACHE_REFRESH_INTERVAL =
+      durationBuilder(Name.FUSE_STAT_CACHE_REFRESH_INTERVAL)
+          .setDefaultValue("5min")
+          .setDescription("The fuse filesystem statistics (e.g. Alluxio capacity information) "
+              + "will be refreshed after being cached for this time period. "
+              + "If the refresh time is too big, operations on the FUSE may fail because of "
+              + "the stale filesystem statistics. If it is too small, "
+              + "continuously fetching filesystem statistics create "
+              + "a large amount of master RPC calls and lower the overall performance of "
+              + "the Fuse application. A value small than or equal to zero "
+              + "means no statistics cache on the Fuse side.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.ALL)
+          .build();
   public static final PropertyKey FUSE_UMOUNT_TIMEOUT =
       durationBuilder(Name.FUSE_UMOUNT_TIMEOUT)
           .setDefaultValue("1min")
@@ -7369,6 +7383,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.fuse.mount.options";
     public static final String FUSE_MOUNT_POINT =
         "alluxio.fuse.mount.point";
+    public static final String FUSE_STAT_CACHE_REFRESH_INTERVAL =
+        "alluxio.fuse.stat.cache.refresh.interval";
     public static final String FUSE_UMOUNT_TIMEOUT =
         "alluxio.fuse.umount.timeout";
     public static final String FUSE_USER_GROUP_TRANSLATION_ENABLED =

--- a/core/server/worker/src/main/java/alluxio/worker/block/FuseManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/FuseManager.java
@@ -58,7 +58,7 @@ public class FuseManager implements Closeable {
       // TODO(lu) consider launching fuse in a separate thread as blocking operation
       // so that we can know about the fuse application status
       FileSystem fileSystem = mResourceCloser.register(FileSystem.Factory.create(mFsContext));
-      mFuseUmountable = AlluxioFuse.launchFuse(fileSystem, conf, config, false);
+      mFuseUmountable = AlluxioFuse.launchFuse(mFsContext, fileSystem, conf, config, false);
     } catch (Throwable throwable) {
       // TODO(lu) for already mounted application, unmount first and then remount
       LOG.error("Failed to launch worker internal Fuse application", throwable);

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -147,7 +147,7 @@ public final class AlluxioFuse {
     }
     startJvmMonitorProcess();
     try (FileSystem fs = FileSystem.Factory.create(fsContext)) {
-      FuseUmountable fuseUmountable = launchFuse(fs, conf, config, true);
+      FuseUmountable fuseUmountable = launchFuse(fsContext, fs, conf, config, true);
     } catch (IOException e) {
       LOG.error("Failed to launch FUSE", e);
       System.exit(-1);
@@ -157,14 +157,15 @@ public final class AlluxioFuse {
   /**
    * Launches Fuse application.
    *
+   * @param fsContext file system context for Fuse client to communicate to servers
    * @param fs file system for Fuse client to communicate to servers
    * @param conf the alluxio configuration to create Fuse file system
    * @param mountConfig the fuse mount configuration
    * @param blocking whether the Fuse application is blocking or not
    * @return the Fuse application handler for future Fuse umount operation
    */
-  public static FuseUmountable launchFuse(FileSystem fs, AlluxioConfiguration conf,
-      FuseMountConfig mountConfig, boolean blocking) throws IOException {
+  public static FuseUmountable launchFuse(FileSystemContext fsContext, FileSystem fs,
+      AlluxioConfiguration conf, FuseMountConfig mountConfig, boolean blocking) throws IOException {
     Preconditions.checkNotNull(mountConfig,
         "Fuse mount configuration should not be null to launch a Fuse application");
 
@@ -186,7 +187,8 @@ public final class AlluxioFuse {
 
       final List<String> fuseOpts = mountConfig.getFuseMountOptions();
       if (conf.getBoolean(PropertyKey.FUSE_JNIFUSE_ENABLED)) {
-        final AlluxioJniFuseFileSystem fuseFs = new AlluxioJniFuseFileSystem(fs, mountConfig, conf);
+        final AlluxioJniFuseFileSystem fuseFs
+            = new AlluxioJniFuseFileSystem(fsContext, fs, mountConfig, conf);
 
         FuseSignalHandler fuseSignalHandler = new FuseSignalHandler(fuseFs);
         Signal.handle(new Signal("TERM"), fuseSignalHandler);

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -12,13 +12,13 @@
 package alluxio.fuse;
 
 import alluxio.AlluxioURI;
-import alluxio.ClientContext;
 import alluxio.Constants;
 import alluxio.cli.FuseShell;
 import alluxio.client.block.BlockMasterClient;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.collections.IndexDefinition;
 import alluxio.collections.IndexedSet;
@@ -39,9 +39,9 @@ import alluxio.jnifuse.FuseFillDir;
 import alluxio.jnifuse.struct.FileStat;
 import alluxio.jnifuse.struct.FuseFileInfo;
 import alluxio.jnifuse.struct.Statvfs;
-import alluxio.master.MasterClientContext;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
+import alluxio.resource.CloseableResource;
 import alluxio.security.authorization.Mode;
 import alluxio.util.CommonUtils;
 import alluxio.util.LogUtils;
@@ -49,6 +49,7 @@ import alluxio.util.WaitForOptions;
 import alluxio.wire.BlockMasterInfo;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Suppliers;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -66,8 +67,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -80,6 +84,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
     implements FuseUmountable {
   private static final Logger LOG = LoggerFactory.getLogger(AlluxioJniFuseFileSystem.class);
   private final FileSystem mFileSystem;
+  private final FileSystemContext mFileSystemContext;
   private final AlluxioConfiguration mConf;
   // base path within Alluxio namespace that is used for FUSE operations
   // For example, if alluxio-fuse is mounted in /mnt/alluxio and mAlluxioRootPath
@@ -88,6 +93,8 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
   private final Path mAlluxioRootPath;
   private final String mMountPoint;
   private final String mFsName;
+  // Caches the filesystem statistics for Fuse.statfs
+  private final Supplier<BlockMasterInfo> mFsStatCache;
   // Keeps a cache of the most recently translated paths from String to Alluxio URI
   private final LoadingCache<String, AlluxioURI> mPathResolverCache;
   // Cache Uid<->Username and Gid<->Groupname mapping for local OS
@@ -130,19 +137,25 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
   /**
    * Creates a new instance of {@link AlluxioJniFuseFileSystem}.
    *
+   * @param fsContext the file system context
    * @param fs Alluxio file system
    * @param opts options
    * @param conf Alluxio configuration
    */
   public AlluxioJniFuseFileSystem(
-      FileSystem fs, FuseMountConfig opts, AlluxioConfiguration conf) {
+      FileSystemContext fsContext, FileSystem fs, FuseMountConfig opts, AlluxioConfiguration conf) {
     super(Paths.get(opts.getMountPoint()));
     mFsName = conf.getString(PropertyKey.FUSE_FS_NAME);
+    mFileSystemContext = fsContext;
     mFileSystem = fs;
     mConf = conf;
     mAlluxioRootPath = Paths.get(opts.getMountAlluxioPath());
     mMountPoint = opts.getMountPoint();
     mFuseShell = new FuseShell(fs, conf);
+    long statCacheTimeout = conf.getMs(PropertyKey.FUSE_STAT_CACHE_REFRESH_INTERVAL);
+    mFsStatCache = statCacheTimeout > 0 ? Suppliers.memoizeWithExpiration(
+        this::acquireBlockMasterInfo, statCacheTimeout, TimeUnit.MILLISECONDS)
+        : this::acquireBlockMasterInfo;
     mPathResolverCache = CacheBuilder.newBuilder()
         .maximumSize(conf.getInt(PropertyKey.FUSE_CACHED_PATHS_MAX))
         .build(new CacheLoader<String, AlluxioURI>() {
@@ -952,43 +965,46 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
   }
 
   private int statfsInternal(String path, Statvfs stbuf) {
-    ClientContext ctx = ClientContext.create(mConf);
+    BlockMasterInfo info = mFsStatCache.get();
+    if (info == null) {
+      LOG.error("Failed to statfs {}: cannot get block master info", path);
+      return -ErrorCodes.EIO();
+    }
+    long blockSize = 16L * Constants.KB;
+    // fs block size
+    // The size in bytes of the minimum unit of allocation on this file system
+    stbuf.f_bsize.set(blockSize);
+    // The preferred length of I/O requests for files on this file system.
+    stbuf.f_frsize.set(blockSize);
+    // total data blocks in fs
+    stbuf.f_blocks.set(info.getCapacityBytes() / blockSize);
+    // free blocks in fs
+    long freeBlocks = info.getFreeBytes() / blockSize;
+    stbuf.f_bfree.set(freeBlocks);
+    stbuf.f_bavail.set(freeBlocks);
+    // inode info in fs
+    stbuf.f_files.set(UNKNOWN_INODES);
+    stbuf.f_ffree.set(UNKNOWN_INODES);
+    stbuf.f_favail.set(UNKNOWN_INODES);
+    // max file name length
+    stbuf.f_namemax.set(MAX_NAME_LENGTH);
+    return 0;
+  }
 
-    try (BlockMasterClient blockClient =
-             BlockMasterClient.Factory.create(
-                 MasterClientContext.newBuilder(ctx).build())) {
+  @Nullable
+  private BlockMasterInfo acquireBlockMasterInfo() {
+    try (CloseableResource<BlockMasterClient> masterClientResource =
+             mFileSystemContext.acquireBlockMasterClientResource()) {
       Set<BlockMasterInfo.BlockMasterInfoField> blockMasterInfoFilter =
           new HashSet<>(Arrays.asList(
               BlockMasterInfo.BlockMasterInfoField.CAPACITY_BYTES,
               BlockMasterInfo.BlockMasterInfoField.FREE_BYTES,
               BlockMasterInfo.BlockMasterInfoField.USED_BYTES));
-      BlockMasterInfo blockMasterInfo = blockClient.getBlockMasterInfo(blockMasterInfoFilter);
-
-      // although user may set different block size for different files,
-      // small block size can result more accurate compute.
-      long blockSize = 4L * Constants.KB;
-      // fs block size
-      // The size in bytes of the minimum unit of allocation on this file system
-      stbuf.f_bsize.set(blockSize);
-      // The preferred length of I/O requests for files on this file system.
-      stbuf.f_frsize.set(blockSize);
-      // total data blocks in fs
-      stbuf.f_blocks.set(blockMasterInfo.getCapacityBytes() / blockSize);
-      // free blocks in fs
-      long freeBlocks = blockMasterInfo.getFreeBytes() / blockSize;
-      stbuf.f_bfree.set(freeBlocks);
-      stbuf.f_bavail.set(freeBlocks);
-      // inode info in fs
-      stbuf.f_files.set(UNKNOWN_INODES);
-      stbuf.f_ffree.set(UNKNOWN_INODES);
-      stbuf.f_favail.set(UNKNOWN_INODES);
-      // max file name length
-      stbuf.f_namemax.set(MAX_NAME_LENGTH);
-    } catch (IOException e) {
-      LOG.error("Failed to statfs {}", path, e);
-      return -ErrorCodes.EIO();
+      return masterClientResource.get().getBlockMasterInfo(blockMasterInfoFilter);
+    } catch (Throwable t) {
+      LOG.error("Failed to acquire block master information", t);
+      return null;
     }
-    return 0;
   }
 
   /**

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
@@ -35,6 +35,7 @@ import alluxio.client.block.BlockMasterClient;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
@@ -81,6 +82,7 @@ public class AlluxioJniFuseFileSystemTest {
   private static final AlluxioURI BASE_EXPECTED_URI = new AlluxioURI(TEST_ROOT_PATH);
 
   private AlluxioJniFuseFileSystem mFuseFs;
+  private FileSystemContext mFileSystemContext;
   private FileSystem mFileSystem;
   private FuseFileInfo mFileInfo;
   private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
@@ -94,10 +96,10 @@ public class AlluxioJniFuseFileSystemTest {
   public void before() throws Exception {
     FuseMountConfig opts =
         FuseMountConfig.create("/doesnt/matter", TEST_ROOT_PATH, ImmutableList.of(), mConf);
-
+    mFileSystemContext = mock(FileSystemContext.class);
     mFileSystem = mock(FileSystem.class);
     try {
-      mFuseFs = new AlluxioJniFuseFileSystem(mFileSystem, opts, mConf);
+      mFuseFs = new AlluxioJniFuseFileSystem(mFileSystemContext, mFileSystem, opts, mConf);
     } catch (UnsatisfiedLinkError e) {
       // stop test and ignore if FuseFileSystem fails to create due to missing libfuse library
       Assume.assumeNoException(e);

--- a/tests/src/test/java/alluxio/client/fuse/AbstractFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/AbstractFuseIntegrationTest.java
@@ -113,7 +113,6 @@ public abstract class AbstractFuseIntegrationTest {
     IntegrationTestUtils.reserveMasterPorts();
     ServerConfiguration.global().validate();
     mAlluxioCluster.start();
-    // TODO(lu) how to get FileSystemContext
     mFileSystemContext = FileSystemContext.create(ServerConfiguration.global());
     mFileSystem = mAlluxioCluster.getClient(mFileSystemContext);
     mountFuse(mFileSystemContext, mFileSystem, mMountPoint, ALLUXIO_ROOT);

--- a/tests/src/test/java/alluxio/client/fuse/JNIFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNIFuseIntegrationTest.java
@@ -12,6 +12,7 @@
 package alluxio.client.fuse;
 
 import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
@@ -42,12 +43,13 @@ public class JNIFuseIntegrationTest extends AbstractFuseIntegrationTest {
   }
 
   @Override
-  public void mountFuse(FileSystem fileSystem, String mountPoint, String alluxioRoot) {
+  public void mountFuse(FileSystemContext context,
+      FileSystem fileSystem, String mountPoint, String alluxioRoot) {
     InstancedConfiguration conf = ServerConfiguration.global();
     FuseMountConfig options =
         FuseMountConfig.create(mountPoint, alluxioRoot, ImmutableList.of(), conf);
     mFuseFileSystem =
-        new AlluxioJniFuseFileSystem(fileSystem, options, conf);
+        new AlluxioJniFuseFileSystem(context, fileSystem, options, conf);
     mFuseFileSystem.mount(false, false, new String[] {});
   }
 

--- a/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
@@ -12,6 +12,7 @@
 package alluxio.client.fuse;
 
 import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
@@ -34,7 +35,8 @@ public class JNRFuseIntegrationTest extends AbstractFuseIntegrationTest {
   }
 
   @Override
-  public void mountFuse(FileSystem fileSystem, String mountPoint, String alluxioRoot) {
+  public void mountFuse(FileSystemContext context,
+      FileSystem fileSystem, String mountPoint, String alluxioRoot) {
     InstancedConfiguration conf = ServerConfiguration.global();
     FuseMountConfig options =
         FuseMountConfig.create(mountPoint, alluxioRoot, ImmutableList.of(), conf);

--- a/tests/src/test/java/alluxio/server/worker/WorkerFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/worker/WorkerFuseIntegrationTest.java
@@ -12,6 +12,7 @@
 package alluxio.server.worker;
 
 import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemContext;
 import alluxio.client.fuse.AbstractFuseIntegrationTest;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
@@ -28,7 +29,8 @@ public class WorkerFuseIntegrationTest extends AbstractFuseIntegrationTest {
   }
 
   @Override
-  public void mountFuse(FileSystem fileSystem, String mountPoint, String alluxioRoot) {
+  public void mountFuse(FileSystemContext context,
+      FileSystem fileSystem, String mountPoint, String alluxioRoot) {
     // Fuse application is mounted automatically by the worker
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fixes #15295

### Why are the changes needed?

Cache the capacity info for Fuse.statfs on Fuse side to reduce the master RPC calls.
Improve the Fuse.statfs() to avoid create client context and copyProperties for each call.

### Does this PR introduce any user facing changes?
NA
