### PR TITLE
Return error if alluxioPath is set but mountPoint is not in Fuse yaml

### DIFF
--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -101,6 +101,10 @@ function formatWorkerIfSpecified {
 }
 
 function mountAlluxioRootFSWithFuseOption {
+  if [[ -n ${FUSE_ALLUXIO_PATH} ]] && [[ -z ${MOUNT_POINT} ]]; then
+    echo "Environment variable MOUNT_POINT must be set for using FUSE_ALLUXIO_PATH."
+    exit 1
+  fi
   local mountOptions=""
   if [[ -n ${OPTIONS} ]]; then
     if [[ ! ${OPTIONS} =~ ${FUSE_OPTS}=* ]] || [[ ! -n ${OPTIONS#*=} ]]; then


### PR DESCRIPTION
In fuse yaml file, if env variable `FUSE_ALLUXIO_PATH` is set but `MOUNT_POINT` is not, we should not silently ignore the user input. Return error if this is the case.