### PR TITLE
Fix fuse shell drop metadata cache

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
@@ -142,7 +142,16 @@ public final class MetadataCache {
    */
   @Nullable
   public List<URIStatus> listStatus(AlluxioURI dir) {
-    CachedItem item = mCache.getIfPresent(dir.getPath());
+    return listStatus(dir.getPath());
+  }
+
+  /**
+   * @param dir the directory
+   * @return the cached list status results or null
+   */
+  @Nullable
+  public List<URIStatus> listStatus(String dir) {
+    CachedItem item = mCache.getIfPresent(dir);
     if (item != null && item.getDirStatuses() != null) {
       return item.getDirStatuses();
     }
@@ -155,7 +164,16 @@ public final class MetadataCache {
    * @param path the path
    */
   public void invalidate(AlluxioURI path) {
-    mCache.invalidate(path.getPath());
+    invalidate(path.getPath());
+  }
+
+  /**
+   * Invalidates the cache of path.
+   *
+   * @param path the path
+   */
+  public void invalidate(String path) {
+    mCache.invalidate(path);
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCachingBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCachingBaseFileSystem.java
@@ -230,43 +230,43 @@ public class MetadataCachingBaseFileSystem extends BaseFileSystem {
 
   /**
    * Best efforts to drops metadata cache of a given uri,
-   * all its parents and all its children.
+   * all its ancestors and descendants.
    *
    * @param uri the uri need to drop metadata cache
    */
   public void dropMetadataCache(AlluxioURI uri) {
-    dropMetadataCacheChildren(uri.getPath());
-    dropMetadataCacheParent(uri);
+    dropMetadataCacheDescendants(uri.getPath());
+    dropMetadataCacheAncestors(uri);
   }
 
   /**
    * Best efforts to drop metadata cache of a given uri
-   * and all its parents.
+   * and all its ancestors.
    *
    * @param uri the uri need to drop metadata cache
    */
-  private void dropMetadataCacheParent(AlluxioURI uri) {
+  private void dropMetadataCacheAncestors(AlluxioURI uri) {
     mMetadataCache.invalidate(uri);
     LOG.debug("Invalidated metadata cache for path {}", uri);
     if (!uri.isRoot()) {
       AlluxioURI parentUri = uri.getParent();
       if (parentUri != null) {
-        dropMetadataCacheParent(parentUri);
+        dropMetadataCacheAncestors(parentUri);
       }
     }
   }
 
   /**
    * Best efforts to drop metadata cache of a given uri
-   * and all its children.
+   * and all its descendants.
    *
    * @param path the path need to drop metadata cache
    */
-  private void dropMetadataCacheChildren(String path) {
+  private void dropMetadataCacheDescendants(String path) {
     List<URIStatus> children = mMetadataCache.listStatus(path);
     if (children != null) {
       for (URIStatus child : children) {
-        dropMetadataCacheChildren(child.getPath());
+        dropMetadataCacheDescendants(child.getPath());
       }
     }
     mMetadataCache.invalidate(path);

--- a/core/client/fs/src/test/java/alluxio/client/file/MetadataCachingBaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/MetadataCachingBaseFileSystemTest.java
@@ -19,6 +19,7 @@ import alluxio.AlluxioURI;
 import alluxio.ClientContext;
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.NotFoundException;
@@ -67,6 +68,8 @@ public class MetadataCachingBaseFileSystemTest {
 
   @Before
   public void before() throws Exception {
+    // Avoid async update file access time to call getStatus to mess up the test results
+    mConf.set(PropertyKey.USER_UPDATE_FILE_ACCESSTIME_DISABLED, true);
     mClientContext = ClientContext.create(mConf);
     mFileContext = PowerMockito.mock(FileSystemContext.class);
     mFileSystemMasterClient = new RpcCountingFileSystemMasterClient();
@@ -238,6 +241,39 @@ public class MetadataCachingBaseFileSystemTest {
       // expected exception thrown. test passes
     }
     assertEquals(2, mFileSystemMasterClient.getStatusRpcCount(NOT_EXIST_FILE));
+  }
+
+  @Test
+  public void dropMetadataCacheFile() throws Exception {
+    mFs.getStatus(FILE);
+    assertEquals(1, mFileSystemMasterClient.getStatusRpcCount(FILE));
+    mFs.getStatus(FILE);
+    assertEquals(1, mFileSystemMasterClient.getStatusRpcCount(FILE));
+    mFs.dropMetadataCache(FILE);
+    mFs.getStatus(FILE);
+    assertEquals(2, mFileSystemMasterClient.getStatusRpcCount(FILE));
+  }
+
+  @Test
+  public void dropMetadataCacheDir() throws Exception {
+    mFs.listStatus(DIR);
+    assertEquals(1, mFileSystemMasterClient.listStatusRpcCount(DIR));
+    mFs.dropMetadataCache(DIR);
+    mFs.listStatus(DIR);
+    assertEquals(2, mFileSystemMasterClient.listStatusRpcCount(DIR));
+  }
+
+  @Test
+  public void dropMetadataCacheDirFile() throws Exception {
+    mFs.listStatus(DIR);
+    mFs.getStatus(FILE);
+    assertEquals(1, mFileSystemMasterClient.listStatusRpcCount(DIR));
+    assertEquals(0, mFileSystemMasterClient.getStatusRpcCount(FILE));
+    mFs.dropMetadataCache(FILE);
+    mFs.getStatus(FILE);
+    assertEquals(1, mFileSystemMasterClient.getStatusRpcCount(FILE));
+    mFs.listStatus(DIR);
+    assertEquals(2, mFileSystemMasterClient.listStatusRpcCount(DIR));
   }
 
   class RpcCountingFileSystemMasterClient extends MockFileSystemMasterClient {

--- a/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/DropCommand.java
+++ b/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/DropCommand.java
@@ -54,6 +54,8 @@ public final class DropCommand extends AbstractMetadataCacheSubCommand {
 
   @Override
   public String getDescription() {
-    return "Clear the specific fuse path metadata cache.";
+    return "Clear the metadata cache of a path and its parents."
+        + "If the given path is a directory, "
+        + "clear the metadata cache of all it's children recursively";
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fixes the fuse shell drop metadata cache

### Why are the changes needed?

Supports drop metadata cache of a directory with all its parents and all its children

### Does this PR introduce any user facing changes?
Improve the Fuse shell