### PR TITLE
Reduce metric tracking overhead in UnderFileSystemBlockReader

### DIFF
--- a/core/common/src/main/java/alluxio/AlluxioURI.java
+++ b/core/common/src/main/java/alluxio/AlluxioURI.java
@@ -20,8 +20,6 @@ import alluxio.util.URIUtils;
 import alluxio.util.io.PathUtils;
 
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -52,8 +50,6 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class AlluxioURI implements Comparable<AlluxioURI>, Serializable {
   private static final long serialVersionUID = -1207227692436086387L;
-
-  private static final Logger LOG = LoggerFactory.getLogger(AlluxioURI.class);
 
   public static final String SEPARATOR = "/";
   public static final String CUR_DIR = ".";

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -525,7 +525,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
       throws BlockDoesNotExistException, IOException {
     try {
       openUfsBlock(sessionId, blockId, options);
-      BlockReader reader = mUnderFileSystemBlockStore.getBlockReader(sessionId, blockId, offset,
+      BlockReader reader = mUnderFileSystemBlockStore.createBlockReader(sessionId, blockId, offset,
           positionShort, options.getUser());
       return new DelegatingBlockReader(reader, () -> {
         try {

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.block;
 
-import alluxio.AlluxioURI;
 import alluxio.StorageTierAssoc;
 import alluxio.WorkerStorageTierAssoc;
 import alluxio.exception.AlluxioException;
@@ -20,7 +19,6 @@ import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.InvalidWorkerStateException;
 import alluxio.exception.PreconditionMessage;
 import alluxio.exception.status.AlluxioStatusException;
-import alluxio.metrics.MetricInfo;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.resource.CloseableResource;
@@ -57,8 +55,8 @@ public final class UnderFileSystemBlockReader extends BlockReader {
   private static final Counter BLOCKS_READ_UFS =
       MetricsSystem.counter(MetricKey.WORKER_BLOCKS_READ_UFS.getName());
 
-  private final Counter mCounter;
-  private final Meter mMeter;
+  private final Counter mUfsBytesRead;
+  private final Meter mUfsBytesReadThroughput;
   /** An object storing the mapping of tier aliases to ordinals. */
   private final StorageTierAssoc mStorageTierAssoc = new WorkerStorageTierAssoc();
 
@@ -68,22 +66,18 @@ public final class UnderFileSystemBlockReader extends BlockReader {
   private final UnderFileSystemBlockMeta mBlockMeta;
   /** The Local block store. It is used to interact with Alluxio. */
   private final BlockStore mLocalBlockStore;
+  /** The cache for all ufs instream. */
+  private final UfsInputStreamCache mUfsInstreamCache;
+  /** The ufs client resource. */
+  private final CloseableResource<UnderFileSystem> mUfsResource;
+  private final boolean mIsPositionShort;
 
   /** The input stream to read from UFS. */
   private InputStream mUnderFileSystemInputStream;
-  /** The mount point URI of the UFS we are reading from. */
-  private AlluxioURI mUfsMountPointUri;
   /** The block writer to write the block to Alluxio. */
   private BlockWriter mBlockWriter;
   /** If set, the reader is closed and should not be used afterwards. */
   private boolean mClosed;
-  /** The manager for different ufs. */
-  private final UfsManager mUfsManager;
-  /** The cache for all ufs instream. */
-  private final UfsInputStreamCache mUfsInstreamCache;
-  /** The ufs client resource. */
-  private CloseableResource<UnderFileSystem> mUfsResource;
-  private boolean mIsPositionShort;
 
   /**
    * The position of mUnderFileSystemInputStream (if not null) is blockStart + mInStreamPos.
@@ -100,18 +94,20 @@ public final class UnderFileSystemBlockReader extends BlockReader {
    * @param blockMeta the block meta
    * @param offset the position within the block to start the read
    * @param localBlockStore the Local block store
-   * @param ufsManager the manager of ufs
+   * @param ufsClient the manager of ufs
    * @param positionShort whether the client op is a positioned read to a small buffer
    * @param ufsInStreamCache the UFS in stream cache
-   * @param user the user that requests the block reader
+   * @param ufsBytesRead counter metric to track ufs bytes read
+   * @param ufsBytesReadThroughput meter metric to track bytes read throughput
    * @return the block reader
    */
   public static UnderFileSystemBlockReader create(UnderFileSystemBlockMeta blockMeta, long offset,
-      boolean positionShort, BlockStore localBlockStore, UfsManager ufsManager,
-      UfsInputStreamCache ufsInStreamCache, String user) throws IOException {
+      boolean positionShort, BlockStore localBlockStore, UfsManager.UfsClient ufsClient,
+      UfsInputStreamCache ufsInStreamCache, Counter ufsBytesRead, Meter ufsBytesReadThroughput)
+      throws IOException {
     UnderFileSystemBlockReader ufsBlockReader =
-        new UnderFileSystemBlockReader(blockMeta, positionShort, localBlockStore, ufsManager,
-            ufsInStreamCache, user);
+        new UnderFileSystemBlockReader(blockMeta, positionShort, localBlockStore, ufsClient,
+            ufsInStreamCache, ufsBytesRead, ufsBytesReadThroughput);
     ufsBlockReader.init(offset);
     return ufsBlockReader;
   }
@@ -121,37 +117,24 @@ public final class UnderFileSystemBlockReader extends BlockReader {
    *
    * @param blockMeta the block meta
    * @param localBlockStore the Local block store
-   * @param ufsManager the manager of ufs
+   * @param ufsClient the ufs client
    * @param positionShort whether the client op is a positioned read to a small buffer
    * @param ufsInStreamCache the UFS in stream cache
-   * @param user the user that requests the block reader
+   * @param ufsBytesRead counter metric to track ufs bytes read
+   * @param ufsBytesReadThroughput meter metric to track bytes read throughput
    */
   private UnderFileSystemBlockReader(UnderFileSystemBlockMeta blockMeta, boolean positionShort,
-      BlockStore localBlockStore, UfsManager ufsManager, UfsInputStreamCache ufsInStreamCache,
-      String user) throws IOException {
+      BlockStore localBlockStore, UfsManager.UfsClient ufsClient,
+      UfsInputStreamCache ufsInStreamCache, Counter ufsBytesRead, Meter ufsBytesReadThroughput) {
     mInitialBlockSize = blockMeta.getBlockSize();
     mBlockMeta = blockMeta;
     mLocalBlockStore = localBlockStore;
     mInStreamPos = -1;
-    mUfsManager = ufsManager;
     mUfsInstreamCache = ufsInStreamCache;
-    UfsManager.UfsClient ufsClient = mUfsManager.get(mBlockMeta.getMountId());
     mUfsResource = ufsClient.acquireUfsResource();
-    mUfsMountPointUri = ufsClient.getUfsMountPointUri();
     mIsPositionShort = positionShort;
-    String ufsString = MetricsSystem.escape(mUfsMountPointUri);
-    MetricKey counterKey = MetricKey.WORKER_BYTES_READ_UFS;
-    MetricKey meterKey = MetricKey.WORKER_BYTES_READ_UFS_THROUGHPUT;
-    if (user != null) {
-      mCounter = MetricsSystem.counterWithTags(counterKey.getName(),
-          counterKey.isClusterAggregated(), MetricInfo.TAG_UFS, ufsString,
-          MetricInfo.TAG_USER, user);
-    } else {
-      mCounter = MetricsSystem.counterWithTags(counterKey.getName(),
-          counterKey.isClusterAggregated(), MetricInfo.TAG_UFS, ufsString);
-    }
-    mMeter = MetricsSystem.meterWithTags(meterKey.getName(),
-        meterKey.isClusterAggregated(), MetricInfo.TAG_UFS, ufsString);
+    mUfsBytesRead = ufsBytesRead;
+    mUfsBytesReadThroughput = ufsBytesReadThroughput;
   }
 
   /**
@@ -223,8 +206,8 @@ public final class UnderFileSystemBlockReader extends BlockReader {
         }
       }
     }
-    mCounter.inc(bytesRead);
-    mMeter.mark(bytesRead);
+    mUfsBytesRead.inc(bytesRead);
+    mUfsBytesReadThroughput.mark(bytesRead);
     return ByteBuffer.wrap(data, 0, bytesRead);
   }
 
@@ -271,8 +254,8 @@ public final class UnderFileSystemBlockReader extends BlockReader {
         cancelBlockWriter();
       }
     }
-    mCounter.inc(bytesRead);
-    mMeter.mark(bytesRead);
+    mUfsBytesRead.inc(bytesRead);
+    mUfsBytesReadThroughput.mark(bytesRead);
     return bytesRead;
   }
 
@@ -316,13 +299,6 @@ public final class UnderFileSystemBlockReader extends BlockReader {
   @Override
   public String getLocation() {
     return mBlockMeta.getUnderFileSystemPath();
-  }
-
-  /**
-   * @return the mount point URI of the UFS that this reader is currently reading from
-   */
-  public AlluxioURI getUfsMountPointUri() {
-    return mUfsMountPointUri;
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
@@ -15,9 +15,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioTestDirectory;
 import alluxio.AlluxioURI;
@@ -25,6 +23,9 @@ import alluxio.ConfigurationRule;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.WorkerOutOfSpaceException;
+import alluxio.metrics.MetricInfo;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UfsManager.UfsClient;
@@ -34,6 +35,8 @@ import alluxio.util.io.BufferUtils;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.meta.UnderFileSystemBlockMeta;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import org.junit.Assert;
@@ -54,9 +57,11 @@ public final class UnderFileSystemBlockReaderTest {
   private UnderFileSystemBlockReader mReader;
   private BlockStore mAlluxioBlockStore;
   private UnderFileSystemBlockMeta mUnderFileSystemBlockMeta;
-  private UfsManager mUfsManager;
+  private UfsManager.UfsClient mUfsClient;
   private UfsInputStreamCache mUfsInstreamCache;
   private Protocol.OpenUfsBlockOptions mOpenUfsBlockOptions;
+  private Counter mUfsBytesRead;
+  private Meter mUfsBytesReadThroughput;
 
   @Rule
   public TemporaryFolder mFolder = new TemporaryFolder();
@@ -84,19 +89,26 @@ public final class UnderFileSystemBlockReaderTest {
     BufferUtils.writeBufferToFile(testFilePath, buffer);
 
     mAlluxioBlockStore = new TieredBlockStore();
-    mUfsManager = mock(UfsManager.class);
     mUfsInstreamCache = new UfsInputStreamCache();
-    UfsClient ufsClient = new UfsClient(
+    mUfsClient = new UfsClient(
         () -> UnderFileSystem.Factory.create(testFilePath,
             UnderFileSystemConfiguration.defaults(ServerConfiguration.global())),
         new AlluxioURI(testFilePath));
-    when(mUfsManager.get(anyLong())).thenReturn(ufsClient);
 
     mOpenUfsBlockOptions = Protocol.OpenUfsBlockOptions.newBuilder().setMaxUfsReadConcurrency(10)
         .setBlockSize(TEST_BLOCK_SIZE).setOffsetInFile(TEST_BLOCK_SIZE).setUfsPath(testFilePath)
         .build();
     mUnderFileSystemBlockMeta =
         new UnderFileSystemBlockMeta(SESSION_ID, BLOCK_ID, mOpenUfsBlockOptions);
+    mUfsBytesRead = MetricsSystem.counterWithTags(
+        MetricKey.WORKER_BYTES_READ_UFS.getName(),
+        MetricKey.WORKER_BYTES_READ_UFS.isClusterAggregated(),
+        MetricInfo.TAG_UFS, MetricsSystem.escape(mUfsClient.getUfsMountPointUri()));
+    mUfsBytesReadThroughput = MetricsSystem.meterWithTags(
+        MetricKey.WORKER_BYTES_READ_UFS_THROUGHPUT.getName(),
+        MetricKey.WORKER_BYTES_READ_UFS_THROUGHPUT.isClusterAggregated(),
+        MetricInfo.TAG_UFS,
+        MetricsSystem.escape(mUfsClient.getUfsMountPointUri()));
   }
 
   private void checkTempBlock(long start, long length) throws Exception {
@@ -113,7 +125,7 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void readFullBlock() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache, null);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
     mReader.close();
@@ -123,7 +135,7 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void readPartialBlock() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache, null);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE - 1);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE - 1, buffer));
     mReader.close();
@@ -134,7 +146,7 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void offset() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache, null);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuffer buffer = mReader.read(2, TEST_BLOCK_SIZE - 2);
     assertTrue(BufferUtils
         .equalIncreasingByteBuffer(2, (int) TEST_BLOCK_SIZE - 2, buffer));
@@ -146,7 +158,7 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void readOverlap() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 2, false,
-        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache, null);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuffer buffer = mReader.read(2, TEST_BLOCK_SIZE - 2);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(2, (int) TEST_BLOCK_SIZE - 2, buffer));
     buffer = mReader.read(0, TEST_BLOCK_SIZE - 2);
@@ -163,7 +175,7 @@ public final class UnderFileSystemBlockReaderTest {
     mUnderFileSystemBlockMeta = new UnderFileSystemBlockMeta(SESSION_ID, BLOCK_ID,
         mOpenUfsBlockOptions.toBuilder().setNoCache(true).build());
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache, null);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     // read should succeed even if error is thrown when caching
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
@@ -178,7 +190,8 @@ public final class UnderFileSystemBlockReaderTest {
         .when(errorThrowingBlockStore)
         .requestSpace(anyLong(), anyLong(), anyLong());
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        errorThrowingBlockStore, mUfsManager, mUfsInstreamCache, null);
+        errorThrowingBlockStore, mUfsClient, mUfsInstreamCache,
+        mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
     mReader.close();
@@ -191,7 +204,8 @@ public final class UnderFileSystemBlockReaderTest {
     doThrow(new WorkerOutOfSpaceException("Ignored")).when(errorThrowingBlockStore)
         .createBlock(anyLong(), anyLong(), any(AllocateOptions.class));
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        errorThrowingBlockStore, mUfsManager, mUfsInstreamCache, null);
+        errorThrowingBlockStore, mUfsClient, mUfsInstreamCache,
+        mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
     mReader.close();
@@ -201,7 +215,7 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void transferFullBlock() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache, null);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuf buf =
         PooledByteBufAllocator.DEFAULT.buffer((int) TEST_BLOCK_SIZE * 2, (int) TEST_BLOCK_SIZE * 2);
     try {
@@ -219,7 +233,7 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void transferPartialBlock() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache, null);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuf buf =
         PooledByteBufAllocator.DEFAULT.buffer((int) TEST_BLOCK_SIZE / 2, (int) TEST_BLOCK_SIZE / 2);
     try {
@@ -238,7 +252,7 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void getLocation() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsManager, mUfsInstreamCache, null);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
     assertTrue(mReader.getLocation().startsWith(mOpenUfsBlockOptions.getUfsPath()));
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Reduce the overhead of metric tracking in UnderFileSystemBlockReader by not creating the metric name for every reader created. Also some coding style clean up in UnderFileSystemBlockStore and UnderFileSystemBlockReader.
