### PR TITLE
Revert k8s fuse force umount

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5723,7 +5723,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey FUSE_UMOUNT_TIMEOUT =
       durationBuilder(Name.FUSE_UMOUNT_TIMEOUT)
-          .setDefaultValue("1min")
+          .setDefaultValue("0s")
           .setDescription("The timeout to wait for all in progress file read and write to finish "
               + "before unmounting the Fuse filesystem when SIGTERM signal is received. "
               + "A value smaller than or equal to zero means no umount wait time. ")

--- a/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/fuse/daemonset.yaml
@@ -129,7 +129,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/opt/alluxio/integration/fuse/bin/alluxio-fuse", "unmount", "-f", "{{ .Values.fuse.mountPoint }}"]
+                command: ["/opt/alluxio/integration/fuse/bin/alluxio-fuse", "unmount", "{{ .Values.fuse.mountPoint }}"]
           envFrom:
           - configMapRef:
               name: {{ template "alluxio.fullname" . }}-config


### PR DESCRIPTION
The force umount doesn't work in k8s, because after the force kill process, the pod immediately terminated without cleaning up the mount point.