### PR TITLE
Replace invalid env with args in nodeserver

### DIFF
--- a/integration/docker/csi/alluxio/nodeserver.go
+++ b/integration/docker/csi/alluxio/nodeserver.go
@@ -252,8 +252,8 @@ func getAndCompleteFusePodObj(nodeId string, req *csi.NodeStageVolumeRequest) (*
 		strings.Join([]string{os.Getenv("ALLUXIO_FUSE_JAVA_OPTS"), req.GetVolumeContext()["javaOptions"]}, " ")
 	alluxioFuseJavaOptsEnv := v1.EnvVar{Name: "ALLUXIO_FUSE_JAVA_OPTS", Value: alluxioCSIFuseJavaOpts}
 	csiFusePodObj.Spec.Containers[0].Env = append(csiFusePodObj.Spec.Containers[0].Env, alluxioFuseJavaOptsEnv)
-        csiFusePodObj.Spec.Containers[0].Args = append(csiFusePodObj.Spec.Containers[0].Args, targetPath)
 	csiFusePodObj.Spec.Containers[0].Args = append(csiFusePodObj.Spec.Containers[0].Args, req.GetStagingTargetPath())
+        csiFusePodObj.Spec.Containers[0].Args = append(csiFusePodObj.Spec.Containers[0].Args, targetPath)
 	return csiFusePodObj, nil
 }
 

--- a/integration/docker/csi/alluxio/nodeserver.go
+++ b/integration/docker/csi/alluxio/nodeserver.go
@@ -232,12 +232,6 @@ func getAndCompleteFusePodObj(nodeId string, req *csi.NodeStageVolumeRequest) (*
 	if targetPath == "" {
 		targetPath = "/"
 	}
-	source := v1.EnvVar{Name: "FUSE_ALLUXIO_PATH", Value: targetPath}
-	csiFusePodObj.Spec.Containers[0].Env = append(csiFusePodObj.Spec.Containers[0].Env, source)
-
-	// Set mount path provided by CSI
-	mountPoint := v1.EnvVar{Name: "MOUNT_POINT", Value: req.GetStagingTargetPath()}
-	csiFusePodObj.Spec.Containers[0].Env = append(csiFusePodObj.Spec.Containers[0].Env, mountPoint)
 
 	// Set pre-stop command (umount) in pod lifecycle
 	lifecycle := &v1.Lifecycle {
@@ -258,7 +252,8 @@ func getAndCompleteFusePodObj(nodeId string, req *csi.NodeStageVolumeRequest) (*
 		strings.Join([]string{os.Getenv("ALLUXIO_FUSE_JAVA_OPTS"), req.GetVolumeContext()["javaOptions"]}, " ")
 	alluxioFuseJavaOptsEnv := v1.EnvVar{Name: "ALLUXIO_FUSE_JAVA_OPTS", Value: alluxioCSIFuseJavaOpts}
 	csiFusePodObj.Spec.Containers[0].Env = append(csiFusePodObj.Spec.Containers[0].Env, alluxioFuseJavaOptsEnv)
-
+        csiFusePodObj.Spec.Containers[0].Args = append(csiFusePodObj.Spec.Containers[0].Args, targetPath)
+	csiFusePodObj.Spec.Containers[0].Args = append(csiFusePodObj.Spec.Containers[0].Args, req.GetStagingTargetPath())
 	return csiFusePodObj, nil
 }
 

--- a/integration/docker/csi/alluxio/nodeserver.go
+++ b/integration/docker/csi/alluxio/nodeserver.go
@@ -246,14 +246,14 @@ func getAndCompleteFusePodObj(nodeId string, req *csi.NodeStageVolumeRequest) (*
 	// Set fuse mount options
 	fuseOptsStr := strings.Join(req.GetVolumeCapability().GetMount().GetMountFlags(), ",")
 	csiFusePodObj.Spec.Containers[0].Args = append(csiFusePodObj.Spec.Containers[0].Args, "--fuse-opts=" + fuseOptsStr)
+        csiFusePodObj.Spec.Containers[0].Args = append(csiFusePodObj.Spec.Containers[0].Args, req.GetStagingTargetPath())
+        csiFusePodObj.Spec.Containers[0].Args = append(csiFusePodObj.Spec.Containers[0].Args, targetPath)
 
 	// Update ALLUXIO_FUSE_JAVA_OPTS to include csi client java options
 	alluxioCSIFuseJavaOpts :=
 		strings.Join([]string{os.Getenv("ALLUXIO_FUSE_JAVA_OPTS"), req.GetVolumeContext()["javaOptions"]}, " ")
 	alluxioFuseJavaOptsEnv := v1.EnvVar{Name: "ALLUXIO_FUSE_JAVA_OPTS", Value: alluxioCSIFuseJavaOpts}
 	csiFusePodObj.Spec.Containers[0].Env = append(csiFusePodObj.Spec.Containers[0].Env, alluxioFuseJavaOptsEnv)
-	csiFusePodObj.Spec.Containers[0].Args = append(csiFusePodObj.Spec.Containers[0].Args, req.GetStagingTargetPath())
-        csiFusePodObj.Spec.Containers[0].Args = append(csiFusePodObj.Spec.Containers[0].Args, targetPath)
 	return csiFusePodObj, nil
 }
 

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -102,7 +102,7 @@ function formatWorkerIfSpecified {
 }
 
 function mountAlluxioFSWithFuseOption {
-  if [[ -n ${FUSE_ALLUXIO_PATH } || -n ${MOUNT_POINT} ]]; then
+  if [[ -n ${FUSE_ALLUXIO_PATH} || -n ${MOUNT_POINT} ]]; then
     echo "Use of environment variables FUSE_ALLUXIO_PATH and MOUNT_POINT for Alluxio Fuse are deprecated."
     printUsage
     exit 1


### PR DESCRIPTION
### What changes are proposed in this pull request?

The bash script entrypoint.sh  can not use FUSE_ALLUXIO_PATH and MOUNT_POINT env.

### Why are the changes needed?
Alluxio csi can not mount in fuse pod. 

### Does this PR introduce any user facing changes?
no
