### PR TITLE
Fix metric not being decremented in case of cancelled sync operation

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -442,8 +442,18 @@ public class InodeSyncStream {
     }
     mStatusCache.cancelAllPrefetch();
     mSyncPathJobs.forEach(f -> f.cancel(true));
-    DefaultFileSystemMaster.Metrics.INODE_SYNC_STREAM_SYNC_PATHS_CANCEL.inc(
-        mPendingPaths.size() + mSyncPathJobs.size());
+    if (!mPendingPaths.isEmpty() || !mSyncPathJobs.isEmpty()) {
+      DefaultFileSystemMaster.Metrics.INODE_SYNC_STREAM_SYNC_PATHS_CANCEL.inc(
+          mPendingPaths.size() + mSyncPathJobs.size());
+    }
+    if (!mSyncPathJobs.isEmpty()) {
+      DefaultFileSystemMaster.Metrics
+          .INODE_SYNC_STREAM_ACTIVE_PATHS_TOTAL.dec(mSyncPathJobs.size());
+    }
+    if (!mPendingPaths.isEmpty()) {
+      DefaultFileSystemMaster.Metrics
+          .INODE_SYNC_STREAM_PENDING_PATHS_TOTAL.dec(mPendingPaths.size());
+    }
 
     // Update metrics at the end of operation
     updateMetrics(success, startTime, syncPathCount, failedSyncPathCount);


### PR DESCRIPTION
### What changes are proposed in this pull request? /Why are the changes needed?
The metrics INODE_SYNC_STREAM_ACTIVE_PATHS_TOTAL, INODE_SYNC_STREAM_PENDING_PATHS_TOTAL keep track of active elements in queues during sync operations. They were not being decremented after a sync failed or was cancelled leading to them having incorrect values. This PR decrements them in this case.

### Does this PR introduce any user facing changes?

No
