### PR TITLE
Fix client side leak caused by Gauge

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/BlockMasterClientPool.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/BlockMasterClientPool.java
@@ -18,6 +18,7 @@ import alluxio.metrics.MetricsSystem;
 import alluxio.resource.DynamicResourcePool;
 import alluxio.resource.ResourcePool;
 import alluxio.util.ThreadFactoryUtils;
+
 import com.codahale.metrics.Counter;
 
 import java.io.IOException;

--- a/core/client/fs/src/main/java/alluxio/client/block/BlockMasterClientPool.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/BlockMasterClientPool.java
@@ -13,9 +13,12 @@ package alluxio.client.block;
 
 import alluxio.conf.PropertyKey;
 import alluxio.master.MasterClientContext;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.resource.DynamicResourcePool;
 import alluxio.resource.ResourcePool;
 import alluxio.util.ThreadFactoryUtils;
+import com.codahale.metrics.Counter;
 
 import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -36,6 +39,8 @@ public final class BlockMasterClientPool extends DynamicResourcePool<BlockMaster
   private static final ScheduledExecutorService GC_EXECUTOR =
       new ScheduledThreadPoolExecutor(BLOCK_MASTER_CLIENT_POOL_GC_THREADPOOL_SIZE,
           ThreadFactoryUtils.build("BlockMasterClientPoolGcThreads-%d", true));
+  private static final Counter COUNTER = MetricsSystem.counter(
+      MetricKey.CLIENT_BLOCK_MASTER_CLIENT_COUNT.getName());
 
   /**
    * Creates a new block master client pool.
@@ -73,6 +78,11 @@ public final class BlockMasterClientPool extends DynamicResourcePool<BlockMaster
   @Override
   protected boolean isHealthy(BlockMasterClient client) {
     return client.isConnected();
+  }
+
+  @Override
+  protected Counter getMetricCounter() {
+    return COUNTER;
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClientPool.java
@@ -14,10 +14,13 @@ package alluxio.client.block.stream;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.GrpcServerAddress;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.resource.DynamicResourcePool;
 import alluxio.security.user.UserState;
 import alluxio.util.ThreadFactoryUtils;
 
+import com.codahale.metrics.Counter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +43,8 @@ public final class BlockWorkerClientPool extends DynamicResourcePool<BlockWorker
   private static final ScheduledExecutorService GC_EXECUTOR =
       new ScheduledThreadPoolExecutor(WORKER_CLIENT_POOL_GC_THREADPOOL_SIZE,
           ThreadFactoryUtils.build("BlockWorkerClientPoolGcThreads-%d", true));
+  private static final Counter COUNTER = MetricsSystem.counter(
+      MetricKey.CLIENT_BLOCK_WORKER_CLIENT_COUNT.getName());
   private final AlluxioConfiguration mConf;
 
   /**
@@ -80,6 +85,11 @@ public final class BlockWorkerClientPool extends DynamicResourcePool<BlockWorker
   @Override
   protected boolean isHealthy(BlockWorkerClient client) {
     return client.isHealthy();
+  }
+
+  @Override
+  protected Counter getMetricCounter() {
+    return COUNTER;
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -32,7 +32,6 @@ import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.GrpcServerAddress;
 import alluxio.master.MasterClientContext;
 import alluxio.master.MasterInquireClient;
-import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.refresh.RefreshPolicy;
 import alluxio.refresh.TimeoutRefresh;
@@ -46,7 +45,6 @@ import alluxio.wire.WorkerInfo;
 import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.block.BlockWorker;
 
-import com.codahale.metrics.CachedGauge;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -61,7 +59,6 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
@@ -94,8 +91,6 @@ import javax.security.auth.Subject;
 @ThreadSafe
 public class FileSystemContext implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(FileSystemContext.class);
-  private static final String TOTAL_RPC_CLIENTS_METRICS_NAME
-      = MetricsSystem.getMetricName(MetricKey.CLIENT_TOTAL_RPC_CLIENTS.getName());
 
   /**
    * Unique ID for each FileSystemContext.
@@ -278,17 +273,6 @@ public class FileSystemContext implements Closeable {
     mBlockMasterClientPool = new BlockMasterClientPool(mMasterClientContext);
     mBlockWorkerClientPoolMap = new ConcurrentHashMap<>();
     mUriValidationEnabled = ctx.getUriValidationEnabled();
-
-    MetricsSystem.registerGaugeIfAbsent(TOTAL_RPC_CLIENTS_METRICS_NAME,
-       new CachedGauge<Integer>(1, TimeUnit.MINUTES) {
-          @Override
-          protected Integer loadValue() {
-            int totalClients = mFileSystemMasterClientPool.size() + mBlockMasterClientPool.size();
-            totalClients += mBlockWorkerClientPoolMap.values()
-                .stream().mapToInt(DynamicResourcePool::size).sum();
-            return totalClients;
-          }
-        });
   }
 
   /**
@@ -313,7 +297,6 @@ public class FileSystemContext implements Closeable {
       // developers should first mark their resources as closed prior to any exceptions being
       // thrown.
       mClosed.set(true);
-      MetricsSystem.removeMetrics(TOTAL_RPC_CLIENTS_METRICS_NAME);
       LOG.debug("Closing fs master client pool with current size: {} for id: {}",
           mFileSystemMasterClientPool.size(), mId);
       mFileSystemMasterClientPool.close();

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClientPool.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClientPool.java
@@ -13,8 +13,11 @@ package alluxio.client.file;
 
 import alluxio.conf.PropertyKey;
 import alluxio.master.MasterClientContext;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.resource.DynamicResourcePool;
 import alluxio.util.ThreadFactoryUtils;
+import com.codahale.metrics.Counter;
 
 import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -33,6 +36,8 @@ public final class FileSystemMasterClientPool extends DynamicResourcePool<FileSy
   private static final ScheduledExecutorService GC_EXECUTOR =
       new ScheduledThreadPoolExecutor(FS_MASTER_CLIENT_POOL_GC_THREADPOOL_SIZE,
           ThreadFactoryUtils.build("FileSystemMasterClientPoolGcThreads-%d", true));
+  private static final Counter COUNTER = MetricsSystem.counter(
+      MetricKey.CLIENT_FILE_SYSTEM_MASTER_CLIENT_COUNT.getName());
 
   /**
    * Creates a new file system master client pool.
@@ -70,6 +75,11 @@ public final class FileSystemMasterClientPool extends DynamicResourcePool<FileSy
   @Override
   protected boolean isHealthy(FileSystemMasterClient client) {
     return client.isConnected();
+  }
+
+  @Override
+  protected Counter getMetricCounter() {
+    return COUNTER;
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClientPool.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClientPool.java
@@ -17,6 +17,7 @@ import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.resource.DynamicResourcePool;
 import alluxio.util.ThreadFactoryUtils;
+
 import com.codahale.metrics.Counter;
 
 import java.io.IOException;

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1904,15 +1904,6 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
-  public static final MetricKey CLIENT_TOTAL_RPC_CLIENTS =
-      new Builder("Client.TotalRPCClients")
-          .setDescription("The total number of RPC clients exist that is using to "
-              + "or can be used to connect to master or worker for operations. "
-              + "The sum of the sizes of FileSystemMasterClientPool, "
-              + "BlockMasterClientPool, and BlockWorkerClientPool.")
-          .setMetricType(MetricType.COUNTER)
-          .setIsClusterAggregated(false)
-          .build();
   public static final MetricKey CLIENT_META_DATA_CACHE_SIZE =
       new Builder("Client.MetadataCacheSize")
           .setDescription("The total number of files and directories whose metadata is cached "
@@ -1923,25 +1914,25 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey CLIENT_FILE_SYSTEM_MASTER_CLIENT_COUNT =
       new Builder("Client.FileSystemMasterClientCount")
-          .setDescription("Number of FileSystemMasterClient instances.")
+          .setDescription("Number of instances in the FileSystemMasterClientPool.")
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
   public static final MetricKey CLIENT_BLOCK_MASTER_CLIENT_COUNT =
       new Builder("Client.BlockMasterClientCount")
-          .setDescription("Number of BlockMasterClient instances.")
+          .setDescription("Number of instances in the BlockMasterClientPool.")
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
   public static final MetricKey CLIENT_BLOCK_WORKER_CLIENT_COUNT =
       new Builder("Client.BlockWorkerClientCount")
-          .setDescription("Number of BlockWorkerClient instances.")
+          .setDescription("Number of instances in the BlockWorkerClientPool.")
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
   public static final MetricKey CLIENT_DEFAULT_HIVE_CLIENT_COUNT =
       new Builder("Client.DefaultHiveClientCount")
-          .setDescription("Number of DefaultHiveClient instances.")
+          .setDescription("Number of instances in the DefaultHiveClientPool.")
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1921,6 +1921,30 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.GAUGE)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey CLIENT_FILE_SYSTEM_MASTER_CLIENT_COUNT =
+      new Builder("Client.FileSystemMasterClientCount")
+          .setDescription("Number of FileSystemMasterClient instances.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_BLOCK_MASTER_CLIENT_COUNT =
+      new Builder("Client.BlockMasterClientCount")
+          .setDescription("Number of BlockMasterClient instances.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_BLOCK_WORKER_CLIENT_COUNT =
+      new Builder("Client.BlockWorkerClientCount")
+          .setDescription("Number of BlockWorkerClient instances.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey CLIENT_DEFAULT_HIVE_CLIENT_COUNT =
+      new Builder("Client.DefaultHiveClientCount")
+          .setDescription("Number of DefaultHiveClient instances.")
+          .setMetricType(MetricType.COUNTER)
+          .setIsClusterAggregated(false)
+          .build();
 
   // Fuse operation timer and failure counter metrics are added dynamically.
   // Other Fuse related metrics are added here

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -288,8 +288,7 @@ public final class MetricsSystem {
    * @return metrics string
    */
   public static String getResourcePoolMetricName(Object obj) {
-    return MetricsSystem.getMetricName("ResourcePool." + obj.getClass().getName() + "."
-        + Integer.toHexString(System.identityHashCode(obj)));
+    return MetricsSystem.getMetricName("ResourcePool." + obj.getClass().getSimpleName());
   }
 
   /**

--- a/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
@@ -15,6 +15,7 @@ import alluxio.Constants;
 import alluxio.clock.SystemClock;
 import alluxio.metrics.MetricsSystem;
 
+import com.codahale.metrics.Counter;
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -221,6 +222,7 @@ public abstract class DynamicResourcePool<T> implements Pool<T> {
   // any performance overhead.
   private final ConcurrentHashMap<T, ResourceInternal<T>> mResources =
       new ConcurrentHashMap<>(32);
+  private final Counter mCounter;
 
   // Thread to scan mAvailableResources to close those resources that are old.
   private ScheduledExecutorService mExecutor;
@@ -235,11 +237,11 @@ public abstract class DynamicResourcePool<T> implements Pool<T> {
    */
   public DynamicResourcePool(Options options) {
     mExecutor = Preconditions.checkNotNull(options.getGcExecutor(), "executor");
-
+    mCounter = Preconditions.checkNotNull(getMetricCounter(),
+        "cannot find resource count metric for %s", getClass().getName());
     mMaxCapacity = options.getMaxCapacity();
     mMinCapacity = options.getMinCapacity();
     mAvailableResources = new ArrayDeque<>(Math.min(mMaxCapacity, 32));
-
     mGcFuture = mExecutor.scheduleAtFixedRate(() -> {
       List<T> resourcesToGc = new ArrayList<>();
 
@@ -256,6 +258,7 @@ public abstract class DynamicResourcePool<T> implements Pool<T> {
             resourcesToGc.add(next.mResource);
             iterator.remove();
             mResources.remove(next.mResource);
+            mCounter.dec();
             currentSize--;
             if (currentSize <= mMinCapacity) {
               break;
@@ -275,15 +278,9 @@ public abstract class DynamicResourcePool<T> implements Pool<T> {
         }
       }
     }, options.getInitialDelayMs(), options.getGcIntervalMs(), TimeUnit.MILLISECONDS);
-
-    registerGauges();
   }
 
-  private void registerGauges() {
-    MetricsSystem.registerGaugeIfAbsent(
-        MetricsSystem.getResourcePoolMetricName(this),
-        () -> size());
-  }
+  protected abstract Counter getMetricCounter();
 
   /**
    * Acquires a resource of type {code T} from the pool.
@@ -436,6 +433,7 @@ public abstract class DynamicResourcePool<T> implements Pool<T> {
         return false;
       } else {
         mResources.put(resource.mResource, resource);
+        mCounter.inc();
         return true;
       }
     } finally {
@@ -452,6 +450,7 @@ public abstract class DynamicResourcePool<T> implements Pool<T> {
     try {
       mLock.lock();
       mResources.remove(resource);
+      mCounter.dec();
     } finally {
       mLock.unlock();
     }

--- a/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/DynamicResourcePool.java
@@ -13,7 +13,6 @@ package alluxio.resource;
 
 import alluxio.Constants;
 import alluxio.clock.SystemClock;
-import alluxio.metrics.MetricsSystem;
 
 import com.codahale.metrics.Counter;
 import com.google.common.base.Preconditions;

--- a/core/common/src/test/java/alluxio/resource/DynamicResourcePoolTest.java
+++ b/core/common/src/test/java/alluxio/resource/DynamicResourcePoolTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.Constants;
 import alluxio.clock.ManualClock;
-import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.ThreadFactoryUtils;
 

--- a/core/common/src/test/java/alluxio/resource/DynamicResourcePoolTest.java
+++ b/core/common/src/test/java/alluxio/resource/DynamicResourcePoolTest.java
@@ -17,8 +17,11 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.Constants;
 import alluxio.clock.ManualClock;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.util.ThreadFactoryUtils;
 
+import com.codahale.metrics.Counter;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -54,7 +57,7 @@ public final class DynamicResourcePoolTest {
     }
 
     /**
-     * Sets the the number representing current capacity of Resource and returns Resource Object.
+     * Sets the number representing current capacity of Resource and returns Resource Object.
      *
      * @param i the value of member variable represents the current capacity of Resource
      * @return the Resource object
@@ -93,6 +96,11 @@ public final class DynamicResourcePoolTest {
      */
     public TestPool(Options options) {
       super(options.setGcExecutor(GC_EXECUTOR));
+    }
+
+    @Override
+    protected Counter getMetricCounter() {
+      return MetricsSystem.counter("Test.DynamicResourcePoolResourceCount");
     }
 
     @Override

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/DefaultHiveClientPool.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/DefaultHiveClientPool.java
@@ -16,9 +16,12 @@ import static alluxio.conf.PropertyKey.TABLE_UDB_HIVE_CLIENTPOOL_MIN;
 
 import alluxio.Constants;
 import alluxio.conf.ServerConfiguration;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.resource.CloseableResource;
 import alluxio.util.ThreadFactoryUtils;
 
+import com.codahale.metrics.Counter;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
@@ -39,6 +42,8 @@ public final class DefaultHiveClientPool extends AbstractHiveClientPool {
   private static final ScheduledExecutorService GC_EXECUTOR =
       new ScheduledThreadPoolExecutor(1, ThreadFactoryUtils.build("HiveClientPool-GC-%d", true));
   private static final HiveMetaHookLoader NOOP_HOOK = table -> null;
+  private static final Counter COUNTER = MetricsSystem.counter(
+      MetricKey.CLIENT_DEFAULT_HIVE_CLIENT_COUNT.getName());
 
   private final long mGcThresholdMs;
   private final String mConnectionUri;
@@ -91,6 +96,11 @@ public final class DefaultHiveClientPool extends AbstractHiveClientPool {
     // there is no way to check if a hive client is connected.
     // TODO(gpang): periodically and asynchronously check the health of clients
     return true;
+  }
+
+  @Override
+  protected Counter getMetricCounter() {
+    return COUNTER;
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fixes #14766

This change replaces two client side gauges with counters.

### Why are the changes needed?

![image](https://user-images.githubusercontent.com/14806853/163751880-8a96c098-b390-4e7e-a891-24d5da00f842.png)
On the bottom right corner, it can be seen that the references of EpollGroup are from the metric Gauge lambda in `DynamicResourcePool`. Using `() -> size()` in lambda will implicitly leak the `this` reference or the `mResources` reference used in `size()`(Not sure if JVM just inlined that `size()`).

In my environment, the HMS can spend 40% heap on metrics due to this gauge.
<img width="1512" alt="Screen Shot 2022-04-13 at 5 13 18 PM" src="https://user-images.githubusercontent.com/14806853/163752366-b6270e93-0753-4c44-ab86-085c8ba33aea.png">

In one user environment, the HMS can spend 50G on such metrics.

### Does this PR introduce any user facing changes?

The metric to monitor will change