### PR TITLE
Fix absent cache stats are always zero

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
@@ -79,7 +79,7 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
   public AsyncUfsAbsentPathCache(MountTable mountTable, int numThreads) {
     mMountTable = mountTable;
     mCurrentPaths = new ConcurrentHashMap<>(8, 0.95f, 8);
-    mCache = CacheBuilder.newBuilder().maximumSize(MAX_PATHS).build();
+    mCache = CacheBuilder.newBuilder().maximumSize(MAX_PATHS).recordStats().build();
     mThreads = numThreads;
 
     mPool = new ThreadPoolExecutor(mThreads, mThreads, THREAD_KEEP_ALIVE_SECONDS,
@@ -89,9 +89,9 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
     MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_ABSENT_CACHE_SIZE.getName(),
         mCache::size);
     MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_ABSENT_CACHE_MISSES.getName(),
-        mCache.stats()::missCount);
+        () -> mCache.stats().missCount());
     MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_ABSENT_CACHE_HITS.getName(),
-        mCache.stats()::hitCount);
+        () -> mCache.stats().hitCount());
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_UFS_ABSENT_PATH_CACHE_SIZE.getName(), mCache::size, 2, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(

--- a/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
@@ -11,20 +11,27 @@
 
 package alluxio.master.file.meta;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.AlluxioURI;
+import alluxio.ConfigurationRule;
 import alluxio.ConfigurationTestUtils;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.MountPOptions;
 import alluxio.master.file.contexts.MountContext;
 import alluxio.master.file.meta.options.MountInfo;
 import alluxio.master.journal.NoopJournalContext;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.underfs.MasterUfsManager;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.util.IdUtils;
 
+import com.codahale.metrics.Gauge;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +53,12 @@ public class AsyncUfsAbsentPathCacheTest {
 
   @Rule
   public TemporaryFolder mTemp = new TemporaryFolder();
+  @Rule
+  public ConfigurationRule mMaxPathRule = new ConfigurationRule(
+      PropertyKey.MASTER_UFS_PATH_CACHE_CAPACITY,
+      3,
+      ServerConfiguration.global()
+  );
 
   /**
    * Sets up a new {@link AsyncUfsAbsentPathCache} before a test runs.
@@ -234,6 +247,44 @@ public class AsyncUfsAbsentPathCacheTest {
         UfsAbsentPathCache.ALWAYS));
     assertFalse(mUfsAbsentPathCache.isAbsentSince(new AlluxioURI("/mnt/"),
         UfsAbsentPathCache.ALWAYS));
+  }
+
+  @Test
+  public void metricCacheSize() throws Exception {
+    Gauge<Long> cacheSize = (Gauge<Long>) MetricsSystem.METRIC_REGISTRY.getGauges()
+        .get(MetricKey.MASTER_ABSENT_CACHE_SIZE.getName());
+    mUfsAbsentPathCache.addSinglePath(new AlluxioURI("/mnt/1"));
+    assertEquals(1, (long) cacheSize.getValue());
+    mUfsAbsentPathCache.addSinglePath(new AlluxioURI("/mnt/2"));
+    assertEquals(2, (long) cacheSize.getValue());
+    mUfsAbsentPathCache.addSinglePath(new AlluxioURI("/mnt/3"));
+    assertEquals(3, (long) cacheSize.getValue());
+    mUfsAbsentPathCache.addSinglePath(new AlluxioURI("/mnt/4"));
+    assertEquals(3, (long) cacheSize.getValue());
+  }
+
+  @Test
+  public void metricCacheHitsAndMisses() throws Exception {
+    Gauge<Long> cacheHits = (Gauge<Long>) MetricsSystem.METRIC_REGISTRY.getGauges()
+        .get(MetricKey.MASTER_ABSENT_CACHE_HITS.getName());
+    Gauge<Long> cacheMisses = (Gauge<Long>) MetricsSystem.METRIC_REGISTRY.getGauges()
+        .get(MetricKey.MASTER_ABSENT_CACHE_MISSES.getName());
+    mUfsAbsentPathCache.addSinglePath(new AlluxioURI("/mnt/1"));
+    mUfsAbsentPathCache.addSinglePath(new AlluxioURI("/mnt/2"));
+    mUfsAbsentPathCache.addSinglePath(new AlluxioURI("/mnt/3"));
+
+    mUfsAbsentPathCache.isAbsentSince(new AlluxioURI("/mnt/1"), 0);
+    assertEquals(1, (long) cacheHits.getValue());
+    assertEquals(0, (long) cacheMisses.getValue());
+    mUfsAbsentPathCache.isAbsentSince(new AlluxioURI("/mnt/2"), 0);
+    assertEquals(2, (long) cacheHits.getValue());
+    assertEquals(0, (long) cacheMisses.getValue());
+    mUfsAbsentPathCache.isAbsentSince(new AlluxioURI("/mnt/1/1"), 0);
+    assertEquals(3, (long) cacheHits.getValue());
+    assertEquals(1, (long) cacheMisses.getValue());
+    mUfsAbsentPathCache.isAbsentSince(new AlluxioURI("/mnt/4"), 0);
+    assertEquals(3, (long) cacheHits.getValue());
+    assertEquals(2, (long) cacheMisses.getValue());
   }
 
   private void process(AlluxioURI path) throws Exception {

--- a/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
@@ -65,6 +65,8 @@ public class AsyncUfsAbsentPathCacheTest {
    */
   @Before
   public void before() throws Exception {
+    MetricsSystem.resetCountersAndGauges();
+
     mLocalUfsPath = mTemp.getRoot().getAbsolutePath();
     mUfsManager = new MasterUfsManager();
     mMountTable = new MountTable(mUfsManager, new MountInfo(new AlluxioURI("/"),


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix the absent cache stats which are always zero.

### Why are the changes needed?

From the doc on `Cache::stats()`:

> Returns a current **snapshot** of this cache's cumulative statistics, or a set of default values if the cache is not recording statistics. All statistics begin at zero and never decrease over the lifetime of the cache.
**Warning**: this cache may not be recording statistical data. For example, a cache created using CacheBuilder only does so if the CacheBuilder.recordStats method was called. If statistics are not being recorded, a CacheStats instance with zero for all values is returned.

This fix

1. enables stats collection on the cache
2. retrieves a new snapshot every time the gauge is polled, instead of the stale value captured by the lambda.

### Does this PR introduce any user facing changes?

Yes, the metrics are fixed.
