### PR TITLE
Remove duplicate metric for absent cache

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -246,6 +246,13 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("Size of the absent cache")
           .setMetricType(MetricType.GAUGE)
           .build();
+  public static final MetricKey MASTER_ABSENT_PATH_CACHE_QUEUE_SIZE =
+      new Builder("Master.AbsentPathCacheQueueSize")
+          .setDescription("Alluxio maintains a cache of absent UFS paths. "
+              + "This is the number of UFS paths being processed.")
+          .setMetricType(MetricType.GAUGE)
+          .setIsClusterAggregated(false)
+          .build();
 
   // Edge cache stats
   public static final MetricKey MASTER_EDGE_CACHE_EVICTIONS =
@@ -728,20 +735,6 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("Total number of UFS file metadata cached."
               + " The cache is used during metadata sync.")
           .setMetricType(MetricType.COUNTER)
-          .setIsClusterAggregated(false)
-          .build();
-  public static final MetricKey MASTER_UFS_ABSENT_PATH_CACHE_SIZE =
-      new Builder("Master.UfsAbsentPathCacheSize")
-          .setDescription("Alluxio maintains a cache of absent UFS paths. "
-              + "This is the number of UFS paths cached.")
-          .setMetricType(MetricType.GAUGE)
-          .setIsClusterAggregated(false)
-          .build();
-  public static final MetricKey MASTER_UFS_ABSENT_PATH_CACHE_QUEUE_SIZE =
-      new Builder("Master.UfsAbsentPathCacheQueueSize")
-          .setDescription("Alluxio maintains a cache of absent UFS paths. "
-              + "This is the number of UFS paths being processed.")
-          .setMetricType(MetricType.GAUGE)
           .setIsClusterAggregated(false)
           .build();
   public static final MetricKey MASTER_METADATA_SYNC_PREFETCH_EXECUTOR_QUEUE_SIZE =

--- a/core/server/master/pom.xml
+++ b/core/server/master/pom.xml
@@ -113,6 +113,11 @@
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Internal test dependencies -->
     <dependency>

--- a/core/server/master/pom.xml
+++ b/core/server/master/pom.xml
@@ -113,11 +113,6 @@
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <!-- Internal test dependencies -->
     <dependency>

--- a/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
@@ -86,16 +86,14 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
         TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(),
         ThreadFactoryUtils.build("UFS-Absent-Path-Cache-%d", true));
     mPool.allowCoreThreadTimeOut(true);
-    MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_ABSENT_CACHE_SIZE.getName(),
-        mCache::size);
-    MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_ABSENT_CACHE_MISSES.getName(),
-        () -> mCache.stats().missCount());
-    MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_ABSENT_CACHE_HITS.getName(),
-        () -> mCache.stats().hitCount());
+    MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_ABSENT_CACHE_SIZE.getName(),
+        mCache::size, 2, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_ABSENT_CACHE_MISSES.getName(),
+        () -> mCache.stats().missCount(), 2, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_ABSENT_CACHE_HITS.getName(),
+        () -> mCache.stats().hitCount(), 2, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_UFS_ABSENT_PATH_CACHE_SIZE.getName(), mCache::size, 2, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_UFS_ABSENT_PATH_CACHE_QUEUE_SIZE.getName(),
+        MetricKey.MASTER_ABSENT_PATH_CACHE_QUEUE_SIZE.getName(),
         () -> mPool.getQueue().size(), 2, TimeUnit.SECONDS);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
@@ -56,6 +56,8 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
   /** Number of paths to cache. */
   private static final int MAX_PATHS =
       ServerConfiguration.getInt(PropertyKey.MASTER_UFS_PATH_CACHE_CAPACITY);
+  @VisibleForTesting
+  static final int METRIC_CACHE_TIMEOUT_SEC = 2;
 
   /** The mount table. */
   private final MountTable mMountTable;
@@ -87,14 +89,14 @@ public final class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
         ThreadFactoryUtils.build("UFS-Absent-Path-Cache-%d", true));
     mPool.allowCoreThreadTimeOut(true);
     MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_ABSENT_CACHE_SIZE.getName(),
-        mCache::size, 2, TimeUnit.SECONDS);
+        mCache::size, METRIC_CACHE_TIMEOUT_SEC, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_ABSENT_CACHE_MISSES.getName(),
-        () -> mCache.stats().missCount(), 2, TimeUnit.SECONDS);
+        () -> mCache.stats().missCount(), METRIC_CACHE_TIMEOUT_SEC, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_ABSENT_CACHE_HITS.getName(),
-        () -> mCache.stats().hitCount(), 2, TimeUnit.SECONDS);
+        () -> mCache.stats().hitCount(), METRIC_CACHE_TIMEOUT_SEC, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ABSENT_PATH_CACHE_QUEUE_SIZE.getName(),
-        () -> mPool.getQueue().size(), 2, TimeUnit.SECONDS);
+        () -> mPool.getQueue().size(), METRIC_CACHE_TIMEOUT_SEC, TimeUnit.SECONDS);
   }
 
   @Override

--- a/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
@@ -335,6 +335,9 @@ public class AsyncUfsAbsentPathCacheTest {
     }
   }
 
+  /**
+   * Class with customized gauge timeouts to facilitate metrics testing.
+   */
   static class TestAsyncUfsAbsentPathCache extends AsyncUfsAbsentPathCache {
     private final long mCacheTimeout;
 

--- a/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
@@ -31,27 +31,18 @@ import alluxio.underfs.UfsManager;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.util.IdUtils;
 
-import com.codahale.metrics.Clock;
-import com.codahale.metrics.Gauge;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Callable;
 
 /**
  * Unit tests for {@link AsyncUfsAbsentPathCache}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Clock.class})
 public class AsyncUfsAbsentPathCacheTest {
   private static final int THREADS = 4;
   private AsyncUfsAbsentPathCache mUfsAbsentPathCache;
@@ -261,44 +252,38 @@ public class AsyncUfsAbsentPathCacheTest {
   @Test
   public void metricCacheSize() throws Exception {
     MetricsSystem.resetCountersAndGauges();
-    ManualClock clock =
-        new ManualClock(AsyncUfsAbsentPathCache.METRIC_CACHE_TIMEOUT_SEC + 1, TimeUnit.SECONDS);
-    PowerMockito.mockStatic(Clock.class);
-    Mockito.when(Clock.defaultClock()).thenReturn(clock);
-    AsyncUfsAbsentPathCache cache = new AsyncUfsAbsentPathCache(mMountTable, THREADS);
+    AsyncUfsAbsentPathCache cache = new TestAsyncUfsAbsentPathCache(mMountTable, THREADS, 1);
 
-    Gauge<Long> cacheSize = () -> {
-      clock.nextEpoch();
+    // this metric is cached, sleep some time before reading it
+    Callable<Long> cacheSize = () -> {
+      Thread.sleep(2);
       return (long) MetricsSystem.METRIC_REGISTRY.getGauges()
           .get(MetricKey.MASTER_ABSENT_CACHE_SIZE.getName()).getValue();
     };
 
     cache.addSinglePath(new AlluxioURI("/mnt/1"));
-    assertEquals(1, (long) cacheSize.getValue());
+    assertEquals(1, (long) cacheSize.call());
     cache.addSinglePath(new AlluxioURI("/mnt/2"));
-    assertEquals(2, (long) cacheSize.getValue());
+    assertEquals(2, (long) cacheSize.call());
     cache.addSinglePath(new AlluxioURI("/mnt/3"));
-    assertEquals(3, (long) cacheSize.getValue());
+    assertEquals(3, (long) cacheSize.call());
     cache.addSinglePath(new AlluxioURI("/mnt/4"));
-    assertEquals(3, (long) cacheSize.getValue());
+    assertEquals(3, (long) cacheSize.call());
   }
 
   @Test
   public void metricCacheHitsAndMisses() throws Exception {
     MetricsSystem.resetCountersAndGauges();
-    ManualClock clock =
-        new ManualClock(AsyncUfsAbsentPathCache.METRIC_CACHE_TIMEOUT_SEC + 1, TimeUnit.SECONDS);
-    PowerMockito.mockStatic(Clock.class);
-    Mockito.when(Clock.defaultClock()).thenReturn(clock);
-    AsyncUfsAbsentPathCache cache = new AsyncUfsAbsentPathCache(mMountTable, THREADS);
+    AsyncUfsAbsentPathCache cache = new TestAsyncUfsAbsentPathCache(mMountTable, THREADS, 1);
 
-    Gauge<Long> cacheHits = () -> {
-      clock.nextEpoch();
+    // these metrics are cached, sleep some time before reading them
+    Callable<Long> cacheHits = () -> {
+      Thread.sleep(2);
       return (long) MetricsSystem.METRIC_REGISTRY.getGauges()
           .get(MetricKey.MASTER_ABSENT_CACHE_HITS.getName()).getValue();
     };
-    Gauge<Long> cacheMisses = () -> {
-      clock.nextEpoch();
+    Callable<Long> cacheMisses = () -> {
+      Thread.sleep(2);
       return (long) MetricsSystem.METRIC_REGISTRY.getGauges()
           .get(MetricKey.MASTER_ABSENT_CACHE_MISSES.getName()).getValue();
     };
@@ -308,17 +293,17 @@ public class AsyncUfsAbsentPathCacheTest {
     cache.addSinglePath(new AlluxioURI("/mnt/3"));
 
     cache.isAbsentSince(new AlluxioURI("/mnt/1"), 0);
-    assertEquals(1, (long) cacheHits.getValue());
-    assertEquals(0, (long) cacheMisses.getValue());
+    assertEquals(1, (long) cacheHits.call());
+    assertEquals(0, (long) cacheMisses.call());
     cache.isAbsentSince(new AlluxioURI("/mnt/2"), 0);
-    assertEquals(2, (long) cacheHits.getValue());
-    assertEquals(0, (long) cacheMisses.getValue());
+    assertEquals(2, (long) cacheHits.call());
+    assertEquals(0, (long) cacheMisses.call());
     cache.isAbsentSince(new AlluxioURI("/mnt/1/1"), 0);
-    assertEquals(3, (long) cacheHits.getValue());
-    assertEquals(1, (long) cacheMisses.getValue());
+    assertEquals(3, (long) cacheHits.call());
+    assertEquals(1, (long) cacheMisses.call());
     cache.isAbsentSince(new AlluxioURI("/mnt/4"), 0);
-    assertEquals(3, (long) cacheHits.getValue());
-    assertEquals(2, (long) cacheMisses.getValue());
+    assertEquals(3, (long) cacheHits.call());
+    assertEquals(2, (long) cacheMisses.call());
   }
 
   private void process(AlluxioURI path) throws Exception {
@@ -350,22 +335,17 @@ public class AsyncUfsAbsentPathCacheTest {
     }
   }
 
-  static class ManualClock extends Clock {
-    private long mNow;
-    private final long mStep;
+  static class TestAsyncUfsAbsentPathCache extends AsyncUfsAbsentPathCache {
+    private final long mCacheTimeout;
 
-    public ManualClock(long step, TimeUnit timeUnit) {
-      mNow = 0;
-      mStep = timeUnit.toNanos(step);
-    }
-
-    public void nextEpoch() {
-      mNow += mStep;
+    TestAsyncUfsAbsentPathCache(MountTable mountTable, int numThreads, long cacheTimeout) {
+      super(mountTable, numThreads);
+      mCacheTimeout = cacheTimeout;
     }
 
     @Override
-    public long getTick() {
-      return mNow;
+    protected long getCachedGaugeTimeoutMillis() {
+      return mCacheTimeout;
     }
   }
 }

--- a/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
@@ -37,8 +37,11 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.MockedStatic;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.util.Collections;
@@ -47,6 +50,8 @@ import java.util.concurrent.TimeUnit;
 /**
  * Unit tests for {@link AsyncUfsAbsentPathCache}.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Clock.class})
 public class AsyncUfsAbsentPathCacheTest {
   private static final int THREADS = 4;
   private AsyncUfsAbsentPathCache mUfsAbsentPathCache;
@@ -258,11 +263,9 @@ public class AsyncUfsAbsentPathCacheTest {
     MetricsSystem.resetCountersAndGauges();
     ManualClock clock =
         new ManualClock(AsyncUfsAbsentPathCache.METRIC_CACHE_TIMEOUT_SEC + 1, TimeUnit.SECONDS);
-    AsyncUfsAbsentPathCache cache;
-    try (MockedStatic<Clock> mockedClock = Mockito.mockStatic(Clock.class)) {
-      mockedClock.when(Clock::defaultClock).thenReturn(clock);
-      cache = new AsyncUfsAbsentPathCache(mMountTable, THREADS);
-    }
+    PowerMockito.mockStatic(Clock.class);
+    Mockito.when(Clock.defaultClock()).thenReturn(clock);
+    AsyncUfsAbsentPathCache cache = new AsyncUfsAbsentPathCache(mMountTable, THREADS);
 
     Gauge<Long> cacheSize = () -> {
       clock.nextEpoch();
@@ -285,11 +288,9 @@ public class AsyncUfsAbsentPathCacheTest {
     MetricsSystem.resetCountersAndGauges();
     ManualClock clock =
         new ManualClock(AsyncUfsAbsentPathCache.METRIC_CACHE_TIMEOUT_SEC + 1, TimeUnit.SECONDS);
-    AsyncUfsAbsentPathCache cache;
-    try (MockedStatic<Clock> mockedClock = Mockito.mockStatic(Clock.class)) {
-      mockedClock.when(Clock::defaultClock).thenReturn(clock);
-      cache = new AsyncUfsAbsentPathCache(mMountTable, THREADS);
-    }
+    PowerMockito.mockStatic(Clock.class);
+    Mockito.when(Clock.defaultClock()).thenReturn(clock);
+    AsyncUfsAbsentPathCache cache = new AsyncUfsAbsentPathCache(mMountTable, THREADS);
 
     Gauge<Long> cacheHits = () -> {
       clock.nextEpoch();


### PR DESCRIPTION
Remove duplicate metric `Master.UfsAbsentPathCacheSize`. 

Rename `UfsAbsentPathCacheQueueSize` to `AbsentPathCacheQueueSize` to be consistent with already existing metric name.

Also make other similar metrics cached.