### PR TITLE
Remove backcompat breaking stressbench header

### DIFF
--- a/job/common/src/main/java/alluxio/job/util/SerializationUtils.java
+++ b/job/common/src/main/java/alluxio/job/util/SerializationUtils.java
@@ -32,11 +32,6 @@ public final class SerializationUtils {
   private SerializationUtils() {} // prevent instantiation
 
   /**
-   * The identifier represents the starting position of the benchmark result.
-   */
-  public static final String BENCHMARK_RESULT_TAG = "BENCHMARK RESULT:";
-
-  /**
    * Serializes an object into a byte array. When the object is null, returns null.
    *
    * @param obj the object to serialize
@@ -128,14 +123,13 @@ public final class SerializationUtils {
     boolean isActualResultStart = false;
     StringBuilder actualResult = new StringBuilder();
 
-    for (int i = 0; i < taskResults.length; i++) {
+    for (String taskResult : taskResults) {
       if (isActualResultStart) {
-        actualResult.append(taskResults[i]);
-      }
-      if (taskResults[i].startsWith(BENCHMARK_RESULT_TAG)) {
+        actualResult.append(taskResult);
+      } else if (taskResult.trim().equals("{")) {
         isActualResultStart = true;
-        // We need to take account of the cluster mode.
-        actualResult = new StringBuilder();
+        // We found the start of the JSON output
+        actualResult.append(taskResult);
       }
     }
     return actualResult.toString();

--- a/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
@@ -17,7 +17,6 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.job.plan.PlanConfig;
-import alluxio.job.util.SerializationUtils;
 import alluxio.job.wire.JobInfo;
 import alluxio.stress.BaseParameters;
 import alluxio.stress.StressConstants;
@@ -90,7 +89,6 @@ public abstract class Benchmark<T extends TaskResult> {
     int exitCode = 0;
     try {
       String result = benchmark.run(args);
-      System.out.println(SerializationUtils.BENCHMARK_RESULT_TAG);
       System.out.println(result);
     } catch (Exception e) {
       e.printStackTrace();


### PR DESCRIPTION
#14819 introduced a header to the JSON output of Stressbench, which break backwards compatibility. This PR removes the header to restore backwards compatibility.

@jja725 @yabola please take a look. 