### PR TITLE
Fix root object store UFS directory not being listed

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -944,12 +944,12 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     String dir = stripPrefixIfPresent(path);
     ObjectListingChunk objs = getObjectListingChunk(dir, recursive);
     // If there are, this is a folder and we can create the necessary metadata
-    if (objs != null && !isRoot(dir)
+    if (objs != null
         && ((objs.getObjectStatuses() != null && objs.getObjectStatuses().length > 0)
         || (objs.getCommonPrefixes() != null && objs.getCommonPrefixes().length > 0))) {
       // Do not recreate the breadcrumb if it already exists
       String folderName = convertToFolderName(dir);
-      if (!mUfsConf.isReadOnly() && mBreadcrumbsEnabled
+      if (!mUfsConf.isReadOnly() && mBreadcrumbsEnabled && !isRoot(dir)
           && Arrays.stream(objs.getObjectStatuses()).noneMatch(
               x -> x.mContentLength == 0 && x.getName().equals(folderName))) {
         mkdirsInternal(dir);

--- a/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemCommonOperations.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemCommonOperations.java
@@ -605,6 +605,17 @@ public final class UnderFileSystemCommonOperations {
   }
 
   /**
+   * Test for listing status of the root directory of the UFS.
+   */
+  @RelatedS3Operations(operations = {"putObject", "listObjectsV2", "getObjectMetadata"})
+  public void listStatusRootTest() throws IOException {
+    UfsStatus[] rootList = mUfs.listStatus("/");
+    if (rootList == null || rootList.length == 0) {
+      throw new IOException("Unable to list UFS root path");
+    }
+  }
+
+  /**
    * Test for listing status.
    */
   @RelatedS3Operations(operations = {"putObject", "listObjectsV2", "getObjectMetadata"})


### PR DESCRIPTION
### What changes are proposed in this pull request?

This ensures when using an object store as the UFS, the root directory will be listed when doing a sync operation.

### Why are the changes needed?

The check for the root directory was on the wrong line, meaning that the function would always return null for the root directory.

### Does this PR introduce any user facing changes?

No
