### PR TITLE
File based cache filter

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/filter/DatabaseFilterSpec.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/filter/DatabaseFilterSpec.java
@@ -1,0 +1,64 @@
+package alluxio.client.file.cache.filter;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class DatabaseFilterSpec
+{
+    private final String name;
+    private final List<TableFilterSpec> tables;
+
+    @JsonCreator
+    public DatabaseFilterSpec(
+            @JsonProperty("name") String databaseName,
+            @JsonProperty("tables") List<TableFilterSpec> tables)
+    {
+        this.name = requireNonNull(databaseName, "tableName is null");
+        this.tables = requireNonNull(tables, "tables is null");
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public List<TableFilterSpec> getTables()
+    {
+        return tables;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof DatabaseFilterSpec)) {
+            return false;
+        }
+        DatabaseFilterSpec that = (DatabaseFilterSpec) other;
+        return name.equals(that.name) && tables.equals(that.tables);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, tables);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .add("tables", tables)
+                .toString();
+    }
+}

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/filter/FileBasedDateCacheFilter.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/filter/FileBasedDateCacheFilter.java
@@ -1,0 +1,134 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file.cache.filter;
+
+import alluxio.client.file.URIStatus;
+import alluxio.client.hive.HiveCacheContext;
+import alluxio.conf.AlluxioConfiguration;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.String.format;
+
+public class FileBasedDateCacheFilter
+        implements CacheFilter
+{
+    private static final DateTimeFormatter DATE_FORMATTER = ISODateTimeFormat.date().withZoneUTC();
+
+    private final Map<String, Map<String, PartitionLimit>> databaseCacheFilter;
+
+    public FileBasedDateCacheFilter(AlluxioConfiguration conf, String cacheConfigFile)
+    {
+        this.databaseCacheFilter = new HashMap<>();
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            FilterSpec filterSpec = objectMapper.readValue(
+                    Paths.get(cacheConfigFile).toFile(), FilterSpec.class);
+            for (DatabaseFilterSpec dbFilterSpec : filterSpec.getDatabases()) {
+                databaseCacheFilter.computeIfAbsent(dbFilterSpec.getName(), key -> new HashMap<>());
+                dbFilterSpec.getTables().forEach(
+                        table -> {
+                            PartitionLimit partitionLimit = new PartitionLimit(table.getMaxCachedPartitions());
+                            databaseCacheFilter.get(dbFilterSpec.getName()).put(table.getName(), partitionLimit);
+                        }
+                );
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        catch (IllegalArgumentException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof UnrecognizedPropertyException) {
+                UnrecognizedPropertyException ex = (UnrecognizedPropertyException) cause;
+                String message = format("Unknown property at line %s:%s: %s",
+                        ex.getLocation().getLineNr(),
+                        ex.getLocation().getColumnNr(),
+                        ex.getPropertyName());
+                throw new IllegalArgumentException(message, e);
+            }
+            if (cause instanceof JsonMappingException) {
+                // remove the extra "through reference chain" message
+                if (cause.getCause() != null) {
+                    cause = cause.getCause();
+                }
+                throw new IllegalArgumentException(cause.getMessage(), e);
+            }
+            throw e;
+        }
+    }
+
+    private static int parseDate(String value)
+    {
+        return (int) TimeUnit.MILLISECONDS.toDays(DATE_FORMATTER.parseMillis(value));
+    }
+
+    public boolean needsCache(URIStatus uriStatus)
+    {
+        HiveCacheContext hiveCacheContext = uriStatus.getCacheContext().getHiveCacheContext();
+        if (hiveCacheContext == null) {
+            return false;
+        }
+        String database = hiveCacheContext.getDatabase();
+        String table = hiveCacheContext.getTable();
+        String partition = hiveCacheContext.getPartition();
+
+        if (!databaseCacheFilter.containsKey(database)) {
+            return false;
+        }
+        Map<String, PartitionLimit> tableLimit = databaseCacheFilter.get(database);
+        if (tableLimit.isEmpty()) {
+            return true;
+        }
+        if (partition == null) {
+            return tableLimit.containsKey(table);
+        }
+
+        if (!tableLimit.containsKey(table)) {
+            return false;
+        }
+        PartitionLimit partitionLimit = tableLimit.get(table);
+        try {
+            int partitionDay = parseDate(partition);
+            int currentDay = (int) TimeUnit.MILLISECONDS.toDays(System.currentTimeMillis());
+            return (currentDay - partitionDay) <= partitionLimit.getCount();
+        }
+        catch (IllegalArgumentException exception) {
+            return false;
+        }
+    }
+
+    private static class PartitionLimit
+    {
+        private final int count;
+
+        public PartitionLimit(int count)
+        {
+            this.count = count;
+        }
+
+        public int getCount()
+        {
+            return count;
+        }
+    }
+}

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/filter/FilterSpec.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/filter/FilterSpec.java
@@ -1,0 +1,34 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file.cache.filter;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class FilterSpec
+{
+    private final List<DatabaseFilterSpec> databases;
+    @JsonCreator
+    public FilterSpec(@JsonProperty("databases") List<DatabaseFilterSpec> databases)
+    {
+        this.databases = requireNonNull(databases, "databases is null");
+    }
+
+    public List<DatabaseFilterSpec> getDatabases()
+    {
+        return databases;
+    }
+}

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/filter/TableFilterSpec.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/filter/TableFilterSpec.java
@@ -1,0 +1,66 @@
+package alluxio.client.file.cache.filter;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class TableFilterSpec
+{
+    private final String name;
+    private final int maxCachedPartitions;
+
+    @JsonCreator
+    public TableFilterSpec(
+            @JsonProperty("name") String tableName,
+            @JsonProperty("maxCachedPartitions") int maxCachedPartitions)
+    {
+        this.name = requireNonNull(tableName, "tableName is null");
+        checkArgument(maxCachedPartitions >= 0, "maxCachedPartitions is negative");
+        this.maxCachedPartitions = maxCachedPartitions;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public int getMaxCachedPartitions()
+    {
+        return maxCachedPartitions;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof TableFilterSpec)) {
+            return false;
+        }
+        TableFilterSpec that = (TableFilterSpec) other;
+        return (name.equals(that.name) &&
+                maxCachedPartitions == that.maxCachedPartitions);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, maxCachedPartitions);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .add("maxCachedPartitions", maxCachedPartitions)
+                .toString();
+    }
+}

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/TestFileBasedDateCacheFilter.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/TestFileBasedDateCacheFilter.java
@@ -1,0 +1,77 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file.cache;
+
+import alluxio.client.file.CacheContext;
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.cache.filter.FileBasedDateCacheFilter;
+import alluxio.client.hive.HiveCacheContext;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.wire.FileInfo;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TestFileBasedDateCacheFilter {
+    private static FileBasedDateCacheFilter filter;
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+
+    @BeforeClass
+    public static void setup()
+            throws IOException
+    {
+        filter = new FileBasedDateCacheFilter(InstancedConfiguration.defaults(), getResourceFilePath("alluxio_cache_filter.json"));
+    }
+
+    @Test()
+    public void testNeedsCache()
+    {
+        Calendar calendar = Calendar.getInstance();
+        assertTrue(filter.needsCache(new URIStatus(new FileInfo(), getCacheContext(new HiveCacheContext("db1", "table1", null), "id"))));
+        calendar.add(Calendar.DATE, -2);
+        assertTrue(filter.needsCache(new URIStatus(new FileInfo(), getCacheContext(new HiveCacheContext("db1", "table1", sdf.format(calendar.getTime())), "id"))));
+        assertTrue(filter.needsCache(new URIStatus(new FileInfo(), getCacheContext(new HiveCacheContext("db1", "table3", "2021-03-02"), "id"))));
+        assertTrue(filter.needsCache(new URIStatus(new FileInfo(), getCacheContext(new HiveCacheContext("db2", "tableX", null), "id"))));
+        assertTrue(filter.needsCache(new URIStatus(new FileInfo(), getCacheContext(new HiveCacheContext("db2", "tableX", "partitionX"), "id"))));
+    }
+
+    @Test()
+    public void testNotNeedsCache()
+    {
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.DATE, -11);
+        assertFalse(filter.needsCache(new URIStatus(new FileInfo(), getCacheContext(new HiveCacheContext("db1", "table1", sdf.format(calendar.getTime())), "id"))));
+        assertFalse(filter.needsCache(new URIStatus(new FileInfo(), getCacheContext(new HiveCacheContext("db1", "table4", "p1"), "id"))));
+        assertFalse(filter.needsCache(new URIStatus(new FileInfo(), getCacheContext(new HiveCacheContext("db1", "table2", "2021-03-01"), "id"))));
+        assertFalse(filter.needsCache(new URIStatus(new FileInfo(), getCacheContext(new HiveCacheContext("db1", "table2", "p3"), "id"))));
+        assertFalse(filter.needsCache(new URIStatus(new FileInfo(), getCacheContext(new HiveCacheContext("dbX", "table2", "p1"), "id"))));
+    }
+
+    private static String getResourceFilePath(String fileName)
+    {
+        return TestFileBasedDateCacheFilter.class.getClassLoader().getResource(fileName).getPath();
+    }
+
+    private CacheContext getCacheContext(HiveCacheContext hiveCacheContext, String id)
+    {
+        CacheContext context = CacheContext.defaults();
+        context.setHiveCacheContext(hiveCacheContext);
+        context.setCacheIdentifier(id);
+        return context;
+    }
+}

--- a/core/client/fs/src/test/resources/alluxio_cache_filter.json
+++ b/core/client/fs/src/test/resources/alluxio_cache_filter.json
@@ -1,0 +1,24 @@
+{
+  "databases": [
+    {
+      "name": "db1",
+      "tables": [
+        {
+          "name" : "table1",
+          "maxCachedPartitions": 10
+        },{
+          "name" : "table2",
+          "maxCachedPartitions": 1
+        }, {
+          "name" : "table3",
+          "maxCachedPartitions": 99999
+        }
+      ]
+    },
+    {
+      "name": "db2",
+      "tables" : []
+    }
+  ]
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,7 @@
     <cephfs-hadoop.version>0.0.1</cephfs-hadoop.version>
     <libcephfs.version>0.0.1</libcephfs.version>
     <jnr-fuse.version>0.5.5</jnr-fuse.version>
+    <joda-time.version>2.10.13</joda-time.version>
   </properties>
 
   <modules>
@@ -867,6 +868,11 @@
       <artifactId>xstream</artifactId>
       <groupId>com.thoughtworks.xstream</groupId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>${joda-time.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

This change adds one default implementation for cache filter. Key points about the cache filter:
- the filter config is specified in a json file. User can specify which table and how many partitions in the json config
- one assumption is that the partitions have date in the partition name. For example in Hive, it is common to see a partition name in format like "datestr=YYYY-MM-DD". This cache filter parses the partition name and infers number of partitions based on dates 

### Why are the changes needed?

This filter implementation can be used to config which tables and how many partitions to cache. In the scenarios where caching capacity is limited and users know which table should be cached, this filter allows users to fine turn their caching, especially in Hive cases.

### Does this PR introduce any user facing changes?

- a new json file to configure using this new cache filter
