### PR TITLE
[SMALLFIX] Improve log in job worker heartbeat

### DIFF
--- a/job/server/src/main/java/alluxio/worker/job/RetryHandlingJobMasterClient.java
+++ b/job/server/src/main/java/alluxio/worker/job/RetryHandlingJobMasterClient.java
@@ -21,6 +21,7 @@ import alluxio.grpc.JobMasterWorkerServiceGrpc;
 import alluxio.grpc.RegisterJobWorkerPRequest;
 import alluxio.grpc.ServiceType;
 import alluxio.job.wire.JobWorkerHealth;
+import alluxio.util.CommonUtils;
 import alluxio.wire.WorkerNetAddress;
 
 import org.slf4j.Logger;
@@ -83,6 +84,7 @@ public final class RetryHandlingJobMasterClient extends AbstractJobMasterClient
         mClient.heartbeat(JobHeartbeatPRequest.newBuilder()
             .setJobWorkerHealth(jobWorkerHealth.toProto()).addAllTaskInfos(taskInfoList).build())
             .getCommandsList(),
-        RPC_LOG, "Heartbeat", "jobWorkerHealth=%s,taskInfoList=%s", jobWorkerHealth, taskInfoList);
+        RPC_LOG, "Heartbeat", "jobWorkerHealth=%s,taskInfoList=%s", jobWorkerHealth,
+            CommonUtils.summarizeCollection(taskInfoList));
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove one full collection log

### Why are the changes needed?

Shorter log and avoid printing the whole collection. The current log is multiple lines like below. I don't think we need to see all the contents.
```
2022-04-07 04:59:47,890 WARN  JobMasterClient - Heartbeat(jobWorkerHealth=JobWorkerHealth{workerId=1649306176300, loadAverage=[1.82, 1.93, 1.68], lastUpdated=1649307369406, hostname=OperationHdfsrm-worker-0, taskPoolSize=10, numActiveTasks=0},taskInfoList=[id: 0
errorMessage: ""
status: COMPLETED
lastUpdated: 1649307368755
type: TASK
parentId: 1649306390187
workerHost: "OperationHdfsrm-worker-0"
description: ""
errorType: ""
, id: 0
errorMessage: ""
status: COMPLETED
lastUpdated: 1649307368799
type: TASK
parentId: 1649306390286
workerHost: "OperationHdfsrm-worker-0"
description: ""
errorType: ""
, id: 0
errorMessage: ""
status: COMPLETED
lastUpdated: 1649307368741
type: TASK
parentId: 1649306390179
workerHost: "OperationHdfsrm-worker-0"
description: ""
errorType: ""
, id: 0
errorMessage: ""
status: COMPLETED
lastUpdated: 1649307368963
type: TASK
parentId: 1649306390435
workerHost: "OperationHdfsrm-worker-0"
description: ""
errorType: ""
, id: 0
...
```

### Does this PR introduce any user facing changes?

NA
