### PR TITLE
Validate `Journal.md`

### DIFF
--- a/bin/alluxio-start.sh
+++ b/bin/alluxio-start.sh
@@ -576,6 +576,7 @@ main() {
       ;;
     secondary_master)
       ALLUXIO_MASTER_SECONDARY=true
+      async=true # there does not exist a monitor process for secondary_master
       start_master
       ALLUXIO_MASTER_SECONDARY=false
       ;;

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1993,15 +1993,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.MASTER)
           .setIsHidden(true)
           .build();
-  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_PROXY_HOST =
-      stringBuilder(Name.MASTER_EMBEDDED_JOURNAL_PROXY_HOST)
-          .setDescription(format(
-              "Used to bind embedded journal servers to a proxied host."
-                  + "Proxy hostname will still make use of %s for bind port.",
-              Name.MASTER_EMBEDDED_JOURNAL_PORT))
-          // No default value for proxy-host. Server will bind to "alluxio.master.hostname"
-          // as default.
-          .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_ADDRESSES =
       listBuilder(Name.MASTER_EMBEDDED_JOURNAL_ADDRESSES)
           .setDescription(format("A comma-separated list of journal addresses for all "

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalConfiguration.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalConfiguration.java
@@ -102,18 +102,6 @@ public class RaftJournalConfiguration {
   }
 
   /**
-   * @return proxy address of this Raft cluster node
-   */
-  public InetSocketAddress getProxyAddress() {
-    if (ServerConfiguration.isSet(PropertyKey.MASTER_EMBEDDED_JOURNAL_PROXY_HOST)) {
-      return InetSocketAddress.createUnresolved(
-          ServerConfiguration.getString(PropertyKey.MASTER_EMBEDDED_JOURNAL_PROXY_HOST),
-          getLocalAddress().getPort());
-    }
-    return null;
-  }
-
-  /**
    * @return max log file size
    */
   public long getMaxLogSize() {


### PR DESCRIPTION
Removing a `PropertyKey` mentioned in the doc that is no longer in use (the doc will update dynamically from the removal of this `PropertyKey`.
Also made `bin/alluxio-start.sh secondary_master` always async, as there is no monitor process available to launch it synchronously. Currently try to launch it synchronously produces an error message. 