### PR TITLE
Add fall back for availableProcessor()

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3673,11 +3673,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
+  // In Java8 in container environment Runtime.availableProcessors() always returns 1,
+  // which is not the actual number of cpus, so we set a safe default value 2.
   public static final PropertyKey WORKER_NETWORK_NETTY_WORKER_THREADS =
       intBuilder(Name.WORKER_NETWORK_NETTY_WORKER_THREADS)
-          .setDefaultValue(0)
-          .setDescription("How many threads to use for processing requests. Zero defaults to "
-              + "#cpuCores * 2.")
+          .setDefaultSupplier(() -> Math.max(4, 2 * Runtime.getRuntime().availableProcessors()),
+              "2 * {CPU core count}")
+          .setDescription("Number of threads to use for processing requests in worker")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
@@ -137,7 +137,6 @@ public final class GrpcDataServer implements DataServer {
         .executor(mRPCExecutor);
     int bossThreadCount = ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_NETTY_BOSS_THREADS);
 
-    // If number of worker threads is 0, Netty creates (#processors * 2) threads by default.
     int workerThreadCount =
         ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_NETTY_WORKER_THREADS);
     String dataServerEventLoopNamePrefix =


### PR DESCRIPTION
Due to https://github.com/Alluxio/alluxio/issues/14243#issuecomment-941441855, Netty is not able to to get the correct number of processors in certain container environments. Thus set a higher default value. The default value is debatable.