### PR TITLE
[DOCFIX] Update configuration doc

### DIFF
--- a/docs/_data/table/en/env_vars.yml
+++ b/docs/_data/table/en/env_vars.yml
@@ -1,34 +1,25 @@
 - name: ALLUXIO_CONF_DIR
-  description: The path to the alluxio configuration directory.
+  description: >
+    The path to the alluxio configuration directory. This defines the value for the property key
+    `alluxio.conf.dir` which should never be set directly outside the environment variable.
 - name: ALLUXIO_LOGS_DIR
-  description: The path to the directory that stores Alluxio server logs
+  description: >
+    The path to the directory that stores Alluxio server logs. This defines the value for the
+    property key `alluxio.logs.dir` which should never be set directly outside the environment
+    variable.
 - name: ALLUXIO_USER_LOGS_DIR
-  description: The path to the directory that stores Alluxio user logs
+  description: >
+    The path to the directory that stores Alluxio user logs. This defines the value for the
+    property key `alluxio.user.logs.dir` which should never be set directly outside the environment
+    variable.
 - name: ALLUXIO_MASTER_HOSTNAME
-  description: hostname of the Alluxio master. Defaults to localhost
+  description: Hostname of the Alluxio master. Defaults to `localhost`.
 - name: ALLUXIO_MASTER_MOUNT_TABLE_ROOT_UFS
   description: >
-    The under storage system addess. Defaults to `${ALLUXIO_HOME}`/underFSStorage which is a local
+    The under storage system address. Defaults to `${ALLUXIO_HOME}`/underFSStorage which is a local
     file system.
 - name: ALLUXIO_RAM_FOLDER
-  description: The directory where a worker stores its in-memory data. Defaults to `/mnt/ramdisk`
-- name: ALLUXIO_JAVA_OPTS
-  description: >
-    Java VM options for the Alluxio master, worker, and shell commands. Note that, by default
-    `ALLUXIO_JAVA_OPTS` is included in `ALLUXIO_MASTER_JAVA_OPTS`, `ALLUXIO_WORKER_JAVA_OPTS`,
-    and `ALLUXIO_USER_JAVA_OPTS`
-- name: ALLUXIO_MASTER_JAVA_OPTS
-  description: Additional Java VM options for Alluxio master configuration.
-- name: ALLUXIO_WORKER_JAVA_OPTS
-  description: Additional Java VM options for Alluxio worker configuration.
-- name: ALLUXIO_JOB_MASTER_JAVA_OPTS
-  description: Additional Java VM options for Alluxio job master configuration.
-- name: ALLUXIO_JOB_WORKER_JAVA_OPTS
-  description: Additional Java VM options for Alluxio job worker configuration.
-- name: ALLUXIO_USER_JAVA_OPTS
-  description: Additional Java VM options for Alluxio shell command configuration.
-- name: ALLUXIO_CLASSPATH
-  description: Additional classpath entries for Alluxio processes. Empty by default.
+  description: The directory where a worker stores its in-memory data. Defaults to `/mnt/ramdisk`.
 - name: ALLUXIO_LOGSERVER_HOSTNAME
   description: Hostname of the log server. Empty by default.
 - name: ALLUXIO_LOGSERVER_PORT
@@ -36,5 +27,41 @@
 - name: ALLUXIO_LOGSERVER_LOGS_DIR
   description: >
     The path to the local directory where the Alluxio log server stores logs received from the
-    Alluxio servers
-
+    Alluxio servers.
+- name: ALLUXIO_JAVA_OPTS
+  description: >
+    Java VM options for the Alluxio master, worker, and shell commands. By default,
+    `ALLUXIO_JAVA_OPTS` is prepended to other `ALLUXIO_*_JAVA_OPTS` environment variables,
+    such as `ALLUXIO_MASTER_JAVA_OPTS` and `ALLUXIO_USER_JAVA_OPTS`.
+- name: ALLUXIO_MASTER_JAVA_OPTS
+  description: Additional Java VM options for Alluxio master configuration.
+- name: ALLUXIO_JOB_MASTER_JAVA_OPTS
+  description: Additional Java VM options for Alluxio job master configuration.
+- name: ALLUXIO_WORKER_JAVA_OPTS
+  description: Additional Java VM options for Alluxio worker configuration.
+- name: ALLUXIO_JOB_WORKER_JAVA_OPTS
+  description: Additional Java VM options for Alluxio job worker configuration.
+- name: ALLUXIO_PROXY_JAVA_OPTS
+  description: Additional Java VM options for Alluxio proxy configuration.
+- name: ALLUXIO_LOGSERVER_JAVA_OPTS
+  description: Additional Java VM options for Alluxio log server configuration.
+- name: ALLUXIO_USER_JAVA_OPTS
+  description: Additional Java VM options for Alluxio shell command configuration.
+- name: ALLUXIO_CLASSPATH
+  description: Additional classpath entries for Alluxio processes. Empty by default.
+- name: ALLUXIO_MASTER_ATTACH_OPTS
+  description: Additional Java VM options to apply when attaching a debugger to Alluxio master.
+- name: ALLUXIO_JOB_MASTER_ATTACH_OPTS
+  description: Additional Java VM options to apply when attaching a debugger to Alluxio job master.
+- name: ALLUXIO_WORKER_ATTACH_OPTS
+  description: Additional Java VM options to apply when attaching a debugger to Alluxio worker.
+- name: ALLUXIO_JOB_WORKER_ATTACH_OPTS
+  description: Additional Java VM options to apply when attaching a debugger to Alluxio job worker.
+- name: ALLUXIO_PROXY_ATTACH_OPTS
+  description: Additional Java VM options to apply when attaching a debugger to Alluxio proxy.
+- name: ALLUXIO_LOGSERVER_ATTACH_OPTS
+  description: Additional Java VM options to apply when attaching a debugger to Alluxio log server.
+- name: ALLUXIO_FUSE_ATTACH_OPTS
+  description: Additional Java VM options to apply when attaching a debugger to Alluxio FUSE process.
+- name: ALLUXIO_USER_ATTACH_OPTS
+  description: Additional Java VM options to apply when attaching a debugger to Alluxio shell command.

--- a/docs/en/operation/Basic-Logging.md
+++ b/docs/en/operation/Basic-Logging.md
@@ -31,8 +31,7 @@ Files suffixed with `.out` like `master.out` or `worker.out` are the redirection
 `stdout` and `stderr` of the corresponding process. 
 Fatal error messages (e.g., killed by the OS), will most likely go to these files.  
 
-The log location can be customized by setting environment variable `ALLUXIO_LOGS_DIR`
-or appending `alluxio.logs.dir` property through JVM properties (e.g. `ALLUXIO_JAVA_OPTS+=" -Dalluxio.logs.dir=/foo"`)
+The log location can be customized by setting environment variable `ALLUXIO_LOGS_DIR`.
 See the
 [configuration settings page]({{ '/en/operation/Configuration.html' | relativize_url }}#environment-variables)
 for more information.

--- a/docs/en/operation/Configuration.md
+++ b/docs/en/operation/Configuration.md
@@ -12,20 +12,20 @@ An Alluxio cluster can be configured by setting the values of Alluxio
 [configuration properties]({{ '/en/reference/Properties-List.html' | relativize_url }}) within
 `${ALLUXIO_HOME}/conf/alluxio-site.properties`.
 
-The two major components to configure are
-- [Alluxio servers](#configure-an-alluxio-cluster), consisting of masters and workers
-- [Alluxio clients](#configure-applications), which are typically a part of compute applications.
+The two major components to configure are:
+- [Alluxio servers](#configure-an-alluxio-cluster), consisting of Alluxio processes such as masters and workers
+- [Alluxio clients](#configure-applications), which are typically a part of compute applications
+
+Alluxio properties mostly fall into three categories:
+
+- properties prefixed with `alluxio.user` affect Alluxio client operations (e.g. compute applications)
+- properties prefixed with `alluxio.master` affect the Alluxio master processes
+- properties prefixed with `alluxio.worker` affect the Alluxio worker processes
 
 ## Configure Applications
 
 Customizing how an application interacts with Alluxio is specific to each application.
 The following are recommendations for some common applications.
-
-Alluxio properties mostly fall into three categories 
-
-- properties prefixed with `alluxio.user` affect Alluxio client operations (e.g. compute applications)
-- properties prefixed with `alluxio.master` affect the Alluxio master processes
-- properties prefixed with `alluxio.worker` affect the Alluxio worker processes
 
 ### Alluxio Shell Commands
 
@@ -75,9 +75,9 @@ See
 
 ### `alluxio-site.properties` Files (Recommended)
 
-Alluxio admins can create and edit the properties file `alluxio-site.properties` to
+Alluxio admins can create and edit the properties file `conf/alluxio-site.properties` to
 configure Alluxio masters or workers.
-If this file does not exist, it can be created from the template file under `${ALLUXIO_HOME}/conf`:
+If this file does not exist, it can be copied from the template file under `${ALLUXIO_HOME}/conf`:
 
 ```console
 $ cp conf/alluxio-site.properties.template conf/alluxio-site.properties
@@ -85,7 +85,7 @@ $ cp conf/alluxio-site.properties.template conf/alluxio-site.properties
 
 Make sure that this file is distributed to `${ALLUXIO_HOME}/conf` on every Alluxio master
 and worker before starting the cluster.
-Any updates to the server configuration requires a restart of the process.
+Restarting Alluxio processes is the safesty way to ensure any configuration updates are applied.
 
 ### Environment Variables
 
@@ -102,30 +102,26 @@ variables, including:
 {% endfor %}
 </table>
 
-For example, to setup the following:
+For example, the following example will set up:
 - an Alluxio master at `localhost`
 - the root mount point as an HDFS cluster with a namenode also running at `localhost`
 - enable Java remote debugging at port 7001
-run the following commands before startingthe master process:
 
 ```console
 $ export ALLUXIO_MASTER_HOSTNAME="localhost"
 $ export ALLUXIO_MASTER_MOUNT_TABLE_ROOT_UFS="hdfs://localhost:9000"
 $ export ALLUXIO_MASTER_JAVA_OPTS=\
-"$ALLUXIO_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,server=y, suspend=n,address=7001"
+"$ALLUXIO_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=7001"
 ```
 
 Users can either set these variables through the shell or in `conf/alluxio-env.sh`.
-If this file does not exist yet, create one by copying the template:
+If this file does not exist yet, it can be copied from the template file under `${ALLUXIO_HOME}/conf`:
 
 ```console
 $ cp conf/alluxio-env.sh.template conf/alluxio-env.sh
 ```
 
 ### Cluster Defaults
-
-> Since version 1.8, each Alluxio client or worker can initialize its configuration
-with the cluster-wide configuration values retrieved from Alluxio masters.
 
 When different client applications (Alluxio Shell CLI, Spark jobs, MapReduce jobs)
 or Alluxio workers connect to an Alluxio master, they will initialize their own Alluxio
@@ -147,17 +143,13 @@ to `CACHE_THROUGH`.
 Clients can ignore or overwrite the cluster-wide default values by following the approaches
 described in [Configure Applications](#configure-applications) to overwrite the same properties.
 
-> Note that, before version 1.8, `${ALLUXIO_HOME}/conf/alluxio-site.properties` file is only loaded
-by Alluxio server processes and will be ignored by applications interacting with Alluxio service
-through Alluxio client, unless `${ALLUXIO_HOME}/conf` is on applications' classpath.
-
 ### Path Defaults
 
-Since version 2.0, Alluxio administrators can set default client-side configurations for specific
+Alluxio administrators can set default client-side configurations for specific
 Alluxio filesystem paths.
 Filesystem client operations have options which are derived from client side configuration
 properties.
-Only client-side configuration properties can be set as as path defaults.
+Only client-side configuration properties can be set as path defaults.
 
 For example, the `createFile` operation has an option to specify write type.
 By default, the write type is the value of the configuration key `alluxio.user.file.writetype.default`.
@@ -172,14 +164,14 @@ After executing this command any create operations on paths with prefix `/tmp` w
 `MUST_CACHE` write type by default unless the application configuration overrides the cluster
 defaults.
 
-Path defaults will be automatically propagated to long running clients if they are updated.
-If the administrator updates path defaults using
+Path defaults will be automatically propagated to long-running clients if they are updated.
+If the administrator updates path defaults using the following:
 
 ```console
 $ bin/alluxio fsadmin pathConf add --property alluxio.user.file.writetype.default=THROUGH /tmp
 ```
 
-afterwards, all write operations that occur on a path with the prefix `/tmp` prefix will use
+All write operations that occur on a path with the prefix `/tmp` prefix will use
 the `THROUGH` write type by default.
 
 See [`fsadmin pathConf`]({{ '/en/operation/Admin-CLI.html' | relativize_url }}#pathconf) on how to
@@ -237,13 +229,13 @@ alluxio.debug=false (DEFAULT)
 
 ## Java 11 Configuration
 
-Alluxio now supports Java 11.
-To run alluxio on Java 11, configure the `JAVA_HOME` environment variable to point to a Java 11
+Alluxio also supports Java 11.
+To run Alluxio on Java 11, configure the `JAVA_HOME` environment variable to point to a Java 11
 installation directory.
 If you only want to use Java 11 for Alluxio, you can set the `JAVA_HOME` environment variable in
 the `alluxio-env.sh` file.
-Setting the `JAVA_HOME` in `alluxio-env.sh`will not affect the Java version which may be used
-by other application running in the same environment.
+Setting the `JAVA_HOME` in `alluxio-env.sh` will not affect the Java version which may be used
+by other applications running in the same environment.
 
 ## Server Configuration Checker
 

--- a/docs/en/operation/Configuration.md
+++ b/docs/en/operation/Configuration.md
@@ -85,7 +85,7 @@ $ cp conf/alluxio-site.properties.template conf/alluxio-site.properties
 
 Make sure that this file is distributed to `${ALLUXIO_HOME}/conf` on every Alluxio master
 and worker before starting the cluster.
-Restarting Alluxio processes is the safesty way to ensure any configuration updates are applied.
+Restarting Alluxio processes is the safest way to ensure any configuration updates are applied.
 
 ### Environment Variables
 
@@ -105,13 +105,14 @@ variables, including:
 For example, the following example will set up:
 - an Alluxio master at `localhost`
 - the root mount point as an HDFS cluster with a namenode also running at `localhost`
+- defines the maximum heap space of the VM to be 30g
 - enable Java remote debugging at port 7001
 
 ```console
 $ export ALLUXIO_MASTER_HOSTNAME="localhost"
 $ export ALLUXIO_MASTER_MOUNT_TABLE_ROOT_UFS="hdfs://localhost:9000"
-$ export ALLUXIO_MASTER_JAVA_OPTS=\
-"$ALLUXIO_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=7001"
+$ export ALLUXIO_MASTER_JAVA_OPTS="-Xmx30g"
+$ export ALLUXIO_MASTER_ATTACH_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=7001"
 ```
 
 Users can either set these variables through the shell or in `conf/alluxio-env.sh`.


### PR DESCRIPTION
update configuration doc with new env vars
also check for references to `alluxio.logs.dir` to ensure no one tries to set it as a property key, since it can only be set as an env var as discussed in https://github.com/Alluxio/alluxio/pull/14980