### PR TITLE
Add cache for CapacityBaseRandomPolicy

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/policy/CapacityBaseRandomPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/CapacityBaseRandomPolicy.java
@@ -14,12 +14,22 @@ package alluxio.client.block.policy;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.options.GetWorkerOptions;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
 import alluxio.wire.WorkerNetAddress;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -30,19 +40,37 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class CapacityBaseRandomPolicy implements BlockLocationPolicy {
+  private final Cache<Long, List<WorkerNetAddress>> mBlockLocationCache;
+
+  private final int mMaxReplicaSize;
 
   /**
    * Constructs a new {@link CapacityBaseRandomPolicy}
    * needed for instantiation in {@link BlockLocationPolicy.Factory}.
    *
-   * @param ignoredConf is unused
+   * @param conf Alluxio configuration
    */
-  public CapacityBaseRandomPolicy(AlluxioConfiguration ignoredConf) {
+  public CapacityBaseRandomPolicy(AlluxioConfiguration conf) {
+    this(conf.getInt(PropertyKey.USER_FILE_REPLICATION_MAX),
+        conf.getInt(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_SIZE),
+        conf.getDuration(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_EXPIRATION_TIME));
+  }
+
+  CapacityBaseRandomPolicy(int maxReplicaSize, int cacheSize, Duration cacheTime) {
+    mBlockLocationCache =
+        CacheBuilder.newBuilder().maximumSize(cacheSize).expireAfterWrite(cacheTime).build();
+    mMaxReplicaSize = maxReplicaSize;
   }
 
   @Override
   public Optional<WorkerNetAddress> getWorker(GetWorkerOptions options) {
+    WorkerNetAddress cacheAddress = findCacheWorker(options);
+    if (cacheAddress != null) {
+      return Optional.of(cacheAddress);
+    }
+
     Iterable<BlockWorkerInfo> blockWorkerInfos = options.getBlockWorkerInfos();
+
     // All the capacities will form a ring of continuous intervals
     // And we throw a die in the ring and decide which worker to pick
     // For example if worker1 has capacity 10, worker2 has 20, worker3 has 40,
@@ -61,10 +89,44 @@ public class CapacityBaseRandomPolicy implements BlockLocationPolicy {
       return Optional.empty();
     }
     long randomLong = randomInCapacity(totalCapacity.get());
-    return Optional.of(rangeStartMap.floorEntry(randomLong).getValue().getNetAddress());
+    WorkerNetAddress targetWorker = rangeStartMap.floorEntry(randomLong).getValue().getNetAddress();
+    addWorkerToCache(options.getBlockInfo().getBlockId(), targetWorker);
+    return Optional.of(targetWorker);
   }
 
   protected long randomInCapacity(long totalCapacity) {
     return ThreadLocalRandom.current().nextLong(totalCapacity);
+  }
+
+  protected WorkerNetAddress findCacheWorker(GetWorkerOptions options) {
+    List<WorkerNetAddress> cacheCandidateList =
+        mBlockLocationCache.getIfPresent(options.getBlockInfo().getBlockId());
+    if (cacheCandidateList != null && mMaxReplicaSize > 0) {
+      Set<WorkerNetAddress> eligibleAddresses = new HashSet<>();
+      for (BlockWorkerInfo info : options.getBlockWorkerInfos()) {
+        eligibleAddresses.add(info.getNetAddress());
+      }
+      List<WorkerNetAddress> eligibleCacheList =
+          cacheCandidateList.stream().filter(eligibleAddresses::contains)
+              .collect(Collectors.toList());
+      if (eligibleCacheList.size() >= mMaxReplicaSize) {
+        int index = ThreadLocalRandom.current().nextInt(eligibleCacheList.size());
+        return eligibleCacheList.get(index);
+      }
+    }
+    return null;
+  }
+
+  protected void addWorkerToCache(Long blockId, WorkerNetAddress targetWorker) {
+    if (mMaxReplicaSize <= 0) {
+      return;
+    }
+    List<WorkerNetAddress> cacheWorkers = mBlockLocationCache.getIfPresent(blockId);
+    if (cacheWorkers == null) {
+      cacheWorkers = new ArrayList<>(mMaxReplicaSize);
+      // guava cache is thread-safe
+      mBlockLocationCache.put(blockId, cacheWorkers);
+    }
+    cacheWorkers.add(targetWorker);
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/CapacityBaseRandomPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/CapacityBaseRandomPolicyTest.java
@@ -13,19 +13,32 @@ package alluxio.client.block.policy;
 
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.options.GetWorkerOptions;
+import alluxio.conf.Configuration;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.WorkerNetAddress;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.Optional;
+import java.util.Set;
 
 public class CapacityBaseRandomPolicyTest {
+  private final InstancedConfiguration mNoCacheConf = Configuration.copyGlobal();
+
+  @Before
+  public void before() {
+    mNoCacheConf.set(PropertyKey.USER_FILE_REPLICATION_MAX, -1);
+    mNoCacheConf.set(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_EXPIRATION_TIME,
+        Duration.ofMinutes(1).toMillis());
+    mNoCacheConf.set(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_SIZE, 1000);
+  }
 
   @Test
   public void getWorkerDifferentCapacity() {
@@ -114,11 +127,15 @@ public class CapacityBaseRandomPolicyTest {
 
   @Test
   public void getWorkerWithCache() {
+    InstancedConfiguration withCacheConf = Configuration.copyGlobal();
+    withCacheConf.set(PropertyKey.USER_FILE_REPLICATION_MAX, 1);
+    withCacheConf.set(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_EXPIRATION_TIME,
+        Duration.ofMinutes(1).toMillis());
+    withCacheConf.set(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_SIZE, 1000);
     GetWorkerOptions getWorkerOptions = mockOptions();
-    CapacityBaseRandomPolicy policy =
-        new CapacityBaseRandomPolicy(1, 10000, Duration.ofMinutes(10));
+    CapacityBaseRandomPolicy policy = new CapacityBaseRandomPolicy(withCacheConf);
     Set<WorkerNetAddress> addressSet = new HashSet<>();
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 1000; i++) {
       policy.getWorker(getWorkerOptions).ifPresent(addressSet::add);
     }
     Assert.assertEquals(1, addressSet.size());
@@ -127,8 +144,7 @@ public class CapacityBaseRandomPolicyTest {
   @Test
   public void getWorkerWithoutCache() {
     GetWorkerOptions getWorkerOptions = mockOptions();
-    CapacityBaseRandomPolicy policy =
-        new CapacityBaseRandomPolicy(-1, 10000, Duration.ofMinutes(10));
+    CapacityBaseRandomPolicy policy = new CapacityBaseRandomPolicy(mNoCacheConf);
     Set<WorkerNetAddress> addressSet = new HashSet<>();
     for (int i = 0; i < 1000; i++) {
       policy.getWorker(getWorkerOptions).ifPresent(addressSet::add);
@@ -158,7 +174,7 @@ public class CapacityBaseRandomPolicyTest {
    * @param targetValue must be in [0,totalCapacity)
    */
   private CapacityBaseRandomPolicy buildPolicyWithTarget(final int targetValue) {
-    return new CapacityBaseRandomPolicy(-1, 10000, Duration.ofMinutes(10)) {
+    return new CapacityBaseRandomPolicy(mNoCacheConf) {
       @Override
       protected long randomInCapacity(long totalCapacity) {
         return targetValue;

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5604,6 +5604,25 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_SIZE =
+      intBuilder(Name.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_SIZE)
+          .setDefaultValue(10000)
+          .setDescription("When alluxio.user.ufs.block.read.location.policy is set "
+              + "to alluxio.client.block.policy.CapacityBaseRandomPolicy, "
+              + "this specifies cache size of block location.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_EXPIRATION_TIME =
+      durationBuilder(Name.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_EXPIRATION_TIME)
+          .setDefaultValue("10min")
+          .setDescription("When alluxio.user.ufs.block.read.location.policy is set "
+              + "to alluxio.client.block.policy.CapacityBaseRandomPolicy, "
+              + "this specifies cache expire time of block location.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
+
   public static final PropertyKey USER_UFS_BLOCK_READ_CONCURRENCY_MAX =
       intBuilder(Name.USER_UFS_BLOCK_READ_CONCURRENCY_MAX)
           .setDefaultValue(Integer.MAX_VALUE)
@@ -7442,6 +7461,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.ufs.block.read.location.policy";
     public static final String USER_UFS_BLOCK_READ_LOCATION_POLICY_DETERMINISTIC_HASH_SHARDS =
         "alluxio.user.ufs.block.read.location.policy.deterministic.hash.shards";
+    public static final String USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_SIZE =
+        "alluxio.user.ufs.block.read.location.policy.cache.size";
+    public static final String USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_EXPIRATION_TIME =
+        "alluxio.user.ufs.block.read.location.policy.cache.expiration.time";
     public static final String USER_UFS_BLOCK_READ_CONCURRENCY_MAX =
         "alluxio.user.ufs.block.read.concurrency.max";
     public static final String USER_UNSAFE_DIRECT_LOCAL_IO_ENABLED =


### PR DESCRIPTION
in scenary of presto+alluxio, presto break file to splits (a pice of file) and then read splits  concurrently.
This may result one block loaded by many workers concurrently. This result two problem:
1)  result too much replica in alluxio, and evict some important data
2)  ufs system (eg. hdfs datanode ) may result high workload