### PR TITLE
Fix client io bench integer overflow

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
@@ -335,7 +335,7 @@ public class StressClientIOBench extends AbstractStressBench
         try {
           mThreadCountResult.merge(threadResult);
         } catch (Exception e) {
-          mThreadCountResult.addErrorMessage(e.getMessage());
+          mThreadCountResult.addErrorMessage(e.toString());
         }
       }
     }
@@ -392,7 +392,7 @@ public class StressClientIOBench extends AbstractStressBench
         runInternal();
       } catch (Exception e) {
         LOG.error(Thread.currentThread().getName() + ": failed", e);
-        mThreadCountResult.addErrorMessage(e.getMessage());
+        mThreadCountResult.addErrorMessage(e.toString());
       } finally {
         closeInStream();
       }
@@ -495,7 +495,7 @@ public class StressClientIOBench extends AbstractStressBench
           return bytesRead;
         }
         case READ_FULLY: {
-          int toRead = Math.min(mBuffer.length, (int) (mFileSize - mInStream.getPos()));
+          int toRead = (int) Math.min(mBuffer.length, mFileSize - mInStream.getPos());
           mInStream.readFully(mBuffer, 0, toRead);
           if (mInStream.getPos() == mFileSize) {
             closeInStream();
@@ -534,7 +534,7 @@ public class StressClientIOBench extends AbstractStressBench
           mInStream.close();
         }
       } catch (IOException e) {
-        mThreadCountResult.addErrorMessage(e.getMessage());
+        mThreadCountResult.addErrorMessage(e.toString());
       } finally {
         mInStream = null;
       }
@@ -627,7 +627,7 @@ public class StressClientIOBench extends AbstractStressBench
           mInStream.close();
         }
       } catch (IOException e) {
-        mThreadCountResult.addErrorMessage(e.getMessage());
+        mThreadCountResult.addErrorMessage(e.toString());
       } finally {
         mInStream = null;
       }


### PR DESCRIPTION
Fix an integer overflow in client IO bench that prevents the correct execution of the `ReadFully` operation. To reproduce, test with a file size greater than or equal to 2GB.

Also make the error reporting more useful for some exception types which have no messages. In this case, reading with a negative length throws a`IndexOutOfBoundsException`.

```
java.lang.IndexOutOfBoundsException
        at java.io.DataInputStream.readFully(DataInputStream.java:192)
        at alluxio.stress.cli.client.StressClientIOBench$AlluxioHDFSBenchThread.applyOperation(StressClientIOBench.java:499)
        at alluxio.stress.cli.client.StressClientIOBench$BenchThread.runInternal(StressClientIOBench.java:425)
```

This results in a `null` error in the final JSON output.