### PR TITLE
Enable files larger than 2GB for distributed load bench

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/StressJobServiceBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/StressJobServiceBench.java
@@ -173,7 +173,7 @@ public class StressJobServiceBench extends Benchmark<JobServiceBenchTaskResult> 
       try {
         mResult.merge(threadResult);
       } catch (Exception e) {
-        mResult.addErrorMessage(e.getMessage());
+        mResult.addErrorMessage(e.toString());
       }
     }
 
@@ -223,7 +223,7 @@ public class StressJobServiceBench extends Benchmark<JobServiceBenchTaskResult> 
       try {
         runInternal();
       } catch (Exception e) {
-        mResult.addErrorMessage(e.getMessage());
+        mResult.addErrorMessage(e.toString());
       }
       // Update local thread result
       mResult.setEndMs(CommonUtils.getCurrentMs());

--- a/stress/shell/src/main/java/alluxio/stress/cli/StressJobServiceBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/StressJobServiceBench.java
@@ -263,7 +263,7 @@ public class StressJobServiceBench extends Benchmark<JobServiceBenchTaskResult> 
           deletePath(fileSystem, dirPath);
           long deleteEnd = CommonUtils.getCurrentMs();
           LOG.info("Cleanup delete took: {} s", (deleteEnd - start) / 1000.0);
-          int fileSize = (int) FormatUtils.parseSpaceSize(mParameters.mFileSize);
+          long fileSize = FormatUtils.parseSpaceSize(mParameters.mFileSize);
           mResult.setRecordStartMs(mContext.getStartMs());
           createFiles(fileSystem, mParameters.mNumFilesPerDir, dirPath, fileSize);
           long createEnd = CommonUtils.getCurrentMs();
@@ -323,27 +323,25 @@ public class StressJobServiceBench extends Benchmark<JobServiceBenchTaskResult> 
       return stopTime;
     }
 
-    private void createFiles(FileSystem fs, int numFiles, String dirPath, int fileSize)
+    private void createFiles(FileSystem fs, int numFiles, String dirPath, long fileSize)
         throws IOException, AlluxioException {
       CreateFilePOptions options = CreateFilePOptions.newBuilder()
           .setRecursive(true).setWriteType(WritePType.THROUGH).build();
 
+      byte[] buf = new byte[Constants.MB];
+      Arrays.fill(buf, (byte) 'A');
       for (int fileId = 0; fileId < numFiles; fileId++) {
         String filePath = String.format("%s/%d", dirPath, fileId);
-        createByteFile(fs, new AlluxioURI(filePath), options, fileSize);
+        try (FileOutStream os = fs.createFile(new AlluxioURI(filePath), options)) {
+          long bytesWritten = 0;
+          while (bytesWritten < fileSize) {
+            int toWrite = (int) Math.min(buf.length, fileSize - bytesWritten);
+            os.write(buf, 0, toWrite);
+            bytesWritten += toWrite;
+          }
+        }
       }
       mResult.incrementNumSuccess(numFiles);
-    }
-  }
-
-  private void createByteFile(FileSystem fs, AlluxioURI fileURI, CreateFilePOptions options,
-      int len) throws IOException, AlluxioException {
-    try (FileOutStream os = fs.createFile(fileURI, options)) {
-      byte[] arr = new byte[len];
-      for (int k = 0; k < len; k++) {
-        arr[k] = (byte) k;
-      }
-      os.write(arr);
     }
   }
 


### PR DESCRIPTION
Enable files larger than 2GB for distributed load stress bench. 

Using `int` for file size would cause an integer overflow when the file is larger than 2GB.

Cross reference: #15442 