### PR TITLE
Remove getBlockMeta from BlockWorker and LocalBlockStore

### DIFF
--- a/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -171,24 +171,6 @@ public interface BlockWorker extends Worker, SessionCleanable {
   BlockMeta getVolatileBlockMeta(long blockId) throws BlockDoesNotExistException;
 
   /**
-   * Gets the metadata of a specific block from local storage.
-   * <p>
-   * Unlike {@link #getVolatileBlockMeta(long)}, this method requires the lock id returned by a
-   * previously acquired {@link #lockBlock(long, long)}.
-   *
-   * @param sessionId the id of the session to get this file
-   * @param blockId the id of the block
-   * @param lockId the id of the lock
-   * @return metadata of the block
-   * @throws BlockDoesNotExistException if the block id can not be found in committed blocks or
-   *         lockId can not be found
-   * @throws InvalidWorkerStateException if session id or block id is not the same as that in the
-   *         LockRecord of lockId
-   */
-  BlockMeta getBlockMeta(long sessionId, long blockId, long lockId)
-      throws BlockDoesNotExistException, InvalidWorkerStateException;
-
-  /**
    * Checks if the storage has a given block.
    *
    * @param blockId the block id

--- a/core/server/worker/src/main/java/alluxio/worker/block/LocalBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/LocalBlockStore.java
@@ -85,24 +85,6 @@ public interface LocalBlockStore
   BlockMeta getVolatileBlockMeta(long blockId) throws BlockDoesNotExistException;
 
   /**
-   * Gets the metadata of a specific block from local storage.
-   * <p>
-   * This method requires the lock id returned by a previously acquired
-   * {@link #lockBlock(long, long)}.
-   *
-   * @param sessionId the id of the session to get this file
-   * @param blockId the id of the block
-   * @param lockId the id of the lock
-   * @return metadata of the block
-   * @throws BlockDoesNotExistException if the block id can not be found in committed blocks or
-   *         lockId can not be found
-   * @throws InvalidWorkerStateException if session id or block id is not the same as that in the
-   *         LockRecord of lockId
-   */
-  BlockMeta getBlockMeta(long sessionId, long blockId, long lockId)
-      throws BlockDoesNotExistException, InvalidWorkerStateException;
-
-  /**
    * Gets the temp metadata of a specific block from local storage.
    *
    * @param blockId the id of the block

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -213,16 +213,6 @@ public class TieredBlockStore implements LocalBlockStore
   }
 
   @Override
-  public BlockMeta getBlockMeta(long sessionId, long blockId, long lockId)
-      throws BlockDoesNotExistException, InvalidWorkerStateException {
-    LOG.debug("getBlockMeta: sessionId={}, blockId={}, lockId={}", sessionId, blockId, lockId);
-    mLockManager.validateLock(sessionId, blockId, lockId);
-    try (LockResource r = new LockResource(mMetadataReadLock)) {
-      return mMetaManager.getBlockMeta(blockId);
-    }
-  }
-
-  @Override
   public TempBlockMeta getTempBlockMeta(long blockId)
       throws BlockDoesNotExistException {
     LOG.debug("getTempBlockMeta: blockId={}", blockId);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerClientServiceHandler.java
@@ -13,7 +13,6 @@ package alluxio.worker.grpc;
 
 import alluxio.RpcUtils;
 import alluxio.annotation.SuppressFBWarnings;
-import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.AsyncCacheRequest;
@@ -73,10 +72,9 @@ public class BlockWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorker
    * Creates a new implementation of gRPC BlockWorker interface.
    *
    * @param workerProcess the worker process
-   * @param fsContext context used to read blocks
    * @param domainSocketEnabled is using domain sockets
    */
-  public BlockWorkerClientServiceHandler(WorkerProcess workerProcess, FileSystemContext fsContext,
+  public BlockWorkerClientServiceHandler(WorkerProcess workerProcess,
       boolean domainSocketEnabled) {
     mWorkerProcess = workerProcess;
     mBlockWorker = mWorkerProcess.getWorker(BlockWorker.class);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
@@ -54,7 +54,6 @@ public final class GrpcDataServer implements DataServer {
   private static final Logger LOG = LoggerFactory.getLogger(GrpcDataServer.class);
 
   private final SocketAddress mSocketAddress;
-  private final WorkerProcess mWorkerProcess;
   private final long mTimeoutMs =
       ServerConfiguration.getMs(PropertyKey.WORKER_NETWORK_SHUTDOWN_TIMEOUT);
   private final long mKeepAliveTimeMs =
@@ -91,7 +90,6 @@ public final class GrpcDataServer implements DataServer {
   public GrpcDataServer(final String hostName, final SocketAddress bindAddress,
       final WorkerProcess workerProcess) {
     mSocketAddress = bindAddress;
-    mWorkerProcess = workerProcess;
     try {
       // There is no way to query domain socket address afterwards.
       // So store the bind address if it's domain socket address.
@@ -100,7 +98,7 @@ public final class GrpcDataServer implements DataServer {
       }
       BlockWorkerClientServiceHandler blockWorkerService =
           new BlockWorkerClientServiceHandler(
-              workerProcess, mFsContext, mDomainSocketAddress != null);
+              workerProcess, mDomainSocketAddress != null);
       mServer = createServerBuilder(hostName, bindAddress, NettyUtils.getWorkerChannel(
           ServerConfiguration.global()))
           .addService(ServiceType.FILE_SYSTEM_WORKER_WORKER_SERVICE, new GrpcService(

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
@@ -92,7 +92,7 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
               ExceptionMessage.LOCK_NOT_RELEASED.getMessage(mLockId));
         }
         OpenLocalBlockResponse response = OpenLocalBlockResponse.newBuilder()
-            .setPath(mWorker.getBlockMeta(mSessionId, mRequest.getBlockId(), mLockId).getPath())
+            .setPath(mWorker.getVolatileBlockMeta(mRequest.getBlockId()).getPath())
             .build();
         return response;
       }

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
@@ -245,23 +245,10 @@ public class DefaultBlockWorkerTest {
 
   @Test
   public void getBlockMetaNotFound() throws Exception {
-    long sessionId = mRandom.nextLong();
     long blockId = mRandom.nextLong();
-    long lockId = mRandom.nextLong();
     assertThrows(BlockDoesNotExistException.class,
-        () -> mBlockWorker.getBlockMeta(sessionId, blockId, lockId)
+        () -> mBlockWorker.getVolatileBlockMeta(blockId)
     );
-  }
-
-  @Test
-  public void getBlockMeta() throws Exception {
-    long sessionId = mRandom.nextLong();
-    long blockId = mRandom.nextLong();
-    mBlockWorker.createBlock(sessionId, blockId, 0,
-        new CreateBlockOptions(null, Constants.MEDIUM_MEM, 1));
-    mBlockWorker.commitBlock(sessionId, blockId, true);
-    long lockId = mBlockWorker.lockBlock(sessionId, blockId);
-    assertEquals(blockId, mBlockWorker.getBlockMeta(sessionId, blockId, lockId).getBlockId());
   }
 
   @Test
@@ -353,10 +340,10 @@ public class DefaultBlockWorkerTest {
         new CreateBlockOptions(null, Constants.MEDIUM_MEM, 1));
     mBlockWorker.commitBlock(sessionId, blockId, true);
     long lockId = mBlockWorker.lockBlock(sessionId, blockId);
-    assertNotNull(mBlockWorker.getBlockMeta(sessionId, blockId, lockId));
+    assertNotNull(mBlockWorker.getVolatileBlockMeta(blockId));
     mBlockWorker.unlockBlock(lockId);
     assertThrows(BlockDoesNotExistException.class,
-        () -> mBlockWorker.getBlockMeta(sessionId, blockId, lockId));
+        () -> mBlockWorker.getVolatileBlockMeta(blockId));
   }
 
   @Test

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
@@ -342,8 +342,6 @@ public class DefaultBlockWorkerTest {
     long lockId = mBlockWorker.lockBlock(sessionId, blockId);
     assertNotNull(mBlockWorker.getVolatileBlockMeta(blockId));
     mBlockWorker.unlockBlock(lockId);
-    assertThrows(BlockDoesNotExistException.class,
-        () -> mBlockWorker.getVolatileBlockMeta(blockId));
   }
 
   @Test

--- a/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
@@ -111,12 +111,6 @@ public class NoopBlockWorker implements BlockWorker {
   }
 
   @Override
-  public BlockMeta getBlockMeta(long sessionId, long blockId, long lockId)
-      throws BlockDoesNotExistException, InvalidWorkerStateException {
-    return null;
-  }
-
-  @Override
   public boolean hasBlockMeta(long blockId) {
     return false;
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove getBlockMeta from BlockWorker and LocalBlockStore.

### Why are the changes needed?

There are getBlockMeta and getVolatileBlockMeta. The difference is
getBlockMeta requires a sessionId and blockId, and validates the lock.
This is more like a debugging feature. Since the caller has already acquired
the lock, calling getVolatileBlockMeta is always safe in this situation, and
avoids the overhead of validating the lock.
