### PR TITLE
[DOCFIX] Add the memory overhead of rm/unmount/sync in the doc

### DIFF
--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -1149,6 +1149,7 @@ Options:
 * `-d` option lists the directories as plain files. For example, `ls -d /` shows the attributes of root directory.
 * `-f` option forces loading metadata for immediate children in a directory.
 By default, it loads metadata only at the first time at which a directory is listed.
+`-f` is equivalent to `-Dalluxio.user.file.metadata.sync.interval=0`.
 * `-h` option displays file sizes in human-readable formats.
 * `-p` option lists all pinned files.
 * `-R` option also recursively lists child directories, displaying the entire subtree starting from the input path.
@@ -1171,6 +1172,19 @@ $ ./bin/alluxio fs ls -f /s3/data
 # Files are not removed from Alluxio if they are removed from the UFS (s3 here) only.
 $ aws s3 rm s3://data-bucket/somedata
 $ ./bin/alluxio fs ls -f /s3/data
+```
+
+Metadata sync is an expensive operation. A rough estimation is metadata sync
+on 1 million files will consume 2GB heap until the sync operation is complete.
+Therefore, we recommend not using forced sync to avoid accidental repeated sync operations.
+It is recommended to always specify a non-zero sync interval for metadata sync, so
+even if the sync is repeatedly triggered, the paths that have just been sync-ed can be identified and skipped. 
+```console
+# Should be avoided
+$ ./bin/alluxio fs ls -f -R /s3/data
+
+# Recommended. This will not sync files repeatedly in 1 minute.
+$ ./bin/alluxio fs ls -Dalluxio.user.file.metadata.sync.interval=1min -R /s3/data
 ```
 
 ### masterInfo

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -1340,8 +1340,7 @@ If the metadata sync and UFS check are both disabled, deleting 1 million files f
 by around 2.5GB. If the UFS check is disabled by `-U`, deleting the files from UFS as well introduces around 10% extra overhead.
 Alluxio 2.8 introduced improvements to memory usage and reduced the JVM heap increase by around 20%.
 Metadata sync and UFS check will each add around 2GB extra overhead per 1 million files.
-So before issuing the recursive deletion command, measure the scale and estimate how much extra
-memory pressure this operation will add to the master.
+Using this example as a guideline, estimate the total additional memory overhead as a proportion to the number of files to be deleted. Ensure that the leading master has sufficient available heap memory to perform the operation before issuing a large recursive delete command.
 
 ### setfacl
 

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -1490,6 +1490,10 @@ data from that system.
 $ ./bin/alluxio fs unmount /s3/data
 ```
 
+If there are files under the mount point, the `unmount` operation will implicitly delete those files from Alluxio.
+See the [rm command]({{ '/en/operation/User-CLI.html#rm' | relativize_url }}) for how to estimate the memory consumption.
+It is recommended to remove those files in Alluxio first, before the `unmount`.
+
 ### unpin
 
 The `unpin` command unmarks a file or directory in Alluxio as pinned.

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -1319,7 +1319,7 @@ $ ./bin/alluxio fs rm --alluxioOnly /tmp/unused-file2
 When deleting only from Alluxio but leaving the files in UFS, you can use `-U` and `-Dalluxio.user.file.metadata.sync.interval=-1`
 to skip the metadata sync and the UFS check. This will save time and memory consumption on the Alluxio master.
 ```console
-$ bin/alluxio fs rm -R -U --alluxioOnly -Dalluxio.user.file.metadata.sync.interval=-1 /path
+$ bin/alluxio fs rm -R -U --alluxioOnly -Dalluxio.user.file.metadata.sync.interval=-1 /dir
 ```
 
 When deleting a large directory (with millions of files) recursively both from Alluxio and UFS,

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -1330,7 +1330,7 @@ We recommend doing the deletion in the following way:
 For example if the UFS is HDFS, use `hdfs dfs -ls -R /dir` to list the UFS files and check.
 Please do not sync the directory from Alluxio and check with `alluxio fs ls -R /dir`, because the loaded file metadata will
 be deleted anyway and the expensive metadata sync operation will essentially be wasted.
-2. Then issue the deletion from Alluxio and delete both in-Alluxio and in-UFS files:
+2. Issue the deletion from Alluxio to delete files from both Alluxio and the UFS:
 ```console
 # Disable the sync and skip the UFS check, to reduce memory consumption on the master side
 $ bin/alluxio fs rm -R -U -Dalluxio.user.file.metadata.sync.interval=-1 /dir


### PR DESCRIPTION
### What changes are proposed in this pull request?

This adds the recent perf evaluation results of `rm/unmount` command and sync to the doc.

### Why are the changes needed?

This adds how to make a good memory estimation, and the recommended command to perform the operation.

### Does this PR introduce any user facing changes?

Users should look at the updated doc to use the memory most efficiently.