### PR TITLE
Avoid one copy in PathUtils.findLowestCommonAncestor

### DIFF
--- a/core/common/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/PathUtils.java
@@ -159,9 +159,8 @@ public final class PathUtils {
         matchedLen = pathComp.length;
       }
     }
-
     return new AlluxioURI(PathUtils.concatPath(AlluxioURI.SEPARATOR,
-            Arrays.copyOf(matchedComponents, matchedLen)));
+        Arrays.copyOf(matchedComponents, matchedLen)));
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/PathUtils.java
@@ -21,10 +21,8 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Preconditions;
 import org.apache.commons.io.FilenameUtils;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import javax.annotation.concurrent.ThreadSafe;
@@ -137,18 +135,18 @@ public final class PathUtils {
     if (paths == null || paths.isEmpty()) {
       return null;
     }
-    List<String> matchedComponents = null;
+    String[] matchedComponents = null;
     int matchedLen = 0;
     for (AlluxioURI path : paths) {
       String[] pathComp = path.getPath().split(AlluxioURI.SEPARATOR);
       if (matchedComponents == null) {
-        matchedComponents = new ArrayList<>(Arrays.asList(pathComp));
+        matchedComponents = pathComp;
         matchedLen = pathComp.length;
         continue;
       }
 
       for (int i = 0; i < pathComp.length && i < matchedLen; ++i) {
-        if (!matchedComponents.get(i).equals(pathComp[i])) {
+        if (!matchedComponents[i].equals(pathComp[i])) {
           matchedLen = i;
           break;
         }
@@ -161,8 +159,9 @@ public final class PathUtils {
         matchedLen = pathComp.length;
       }
     }
+
     return new AlluxioURI(PathUtils.concatPath(AlluxioURI.SEPARATOR,
-        matchedComponents.subList(0, matchedLen).toArray()));
+            Arrays.copyOf(matchedComponents, matchedLen)));
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?
An ArrayList that will eventually be converted to an Array is used to hold the common components in `PathUtils.findLowestCommonAncestor()` .  It is better to use Array because the length of ArrayList is fixed in the method.

### Why are the changes needed?
`ArrayList.toArray()` dose a copy. Using Array can reduce one copy if we know very well how many elements there are.

### Does this PR introduce any user facing changes?
NA
