### PR TITLE
Add RaftJournalSystem toString

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -1137,6 +1137,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("Journal Path", mConf.getPath())
+        .add("Local Address", mConf.getLocalAddress())
         .add("State", mPrimarySelector.getState())
         .add("Configuration ClusterAddress", mConf.getClusterAddresses())
         .add("RaftGroup", mRaftGroup)

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -1136,10 +1136,10 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("Journal Path", mConf.getPath())
-        .add("Local Address", mConf.getLocalAddress())
+        .add("JournalPath", mConf.getPath())
+        .add("Address", mConf.getLocalAddress())
         .add("State", mPrimarySelector.getState())
-        .add("Configuration ClusterAddress", mConf.getClusterAddresses())
+        .add("Cluster", mConf.getClusterAddresses())
         .add("RaftGroup", mRaftGroup)
         .toString();
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -1138,7 +1138,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     return MoreObjects.toStringHelper(this)
         .add("Journal Path", mConf.getPath())
         .add("State", mPrimarySelector.getState())
-        .add("ClientId", mRawClientId)
+        .add("Configuration ClusterAddress", mConf.getClusterAddresses())
         .add("RaftGroup", mRaftGroup)
         .toString();
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -1132,6 +1132,16 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     }
   }
 
+  @Override
+  public String toString() {
+    return "RaftJournalSystem{"
+        + "Journal Path=" + mConf.getPath()
+        + ", State=" + mPrimarySelector.getState()
+        + ", ClientId=" + mRawClientId
+        + ", RaftGroup=" + mRaftGroup
+        + '}';
+  }
+
   /**
    * @return a primary selector backed by leadership within the Raft cluster
    */

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -40,6 +40,7 @@ import alluxio.util.LogUtils;
 import alluxio.util.WaitForOptions;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.net.HostAndPort;
 import org.apache.commons.io.FileUtils;
@@ -1134,12 +1135,12 @@ public class RaftJournalSystem extends AbstractJournalSystem {
 
   @Override
   public String toString() {
-    return "RaftJournalSystem{"
-        + "Journal Path=" + mConf.getPath()
-        + ", State=" + mPrimarySelector.getState()
-        + ", ClientId=" + mRawClientId
-        + ", RaftGroup=" + mRaftGroup
-        + '}';
+    return MoreObjects.toStringHelper(this)
+        .add("Journal Path", mConf.getPath())
+        .add("State", mPrimarySelector.getState())
+        .add("ClientId", mRawClientId)
+        .add("RaftGroup", mRaftGroup)
+        .toString();
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

Added `toString` method to RaftJournalSystem
RaftJournalSystem does not have a `toString` method, which can result in insufficient information for debugging when RaftJournalSystem exceptions are thrown.

### Why are the changes needed?

```java
AlluxioMasterProcess(JournalSystem journalSystem) {
//....
      if (!mJournalSystem.isFormatted()) {
        throw new RuntimeException(
            String.format("Journal %s has not been formatted!", mJournalSystem));
      }
//...
```

This is a raft journal log
```
bin/launch-process master -c
2022-04-27 09:21:54,626 ERROR AlluxioMaster - Fatal error: Failed to create master process
java.lang.RuntimeException: java.lang.RuntimeException: Journal alluxio.master.journal.raft.RaftJournalSystem@5c7fa833 has not been formatted!
        at alluxio.master.AlluxioMasterProcess.<init>(AlluxioMasterProcess.java:125)
        at alluxio.master.FaultTolerantAlluxioMasterProcess.<init>(FaultTolerantAlluxioMasterProcess.java:61)
        at alluxio.master.AlluxioMasterProcess$Factory.create(AlluxioMasterProcess.java:471)
        at alluxio.master.AlluxioMaster.main(AlluxioMaster.java:45)
Caused by: java.lang.RuntimeException: Journal alluxio.master.journal.raft.RaftJournalSystem@5c7fa833 has not been formatted!
        at alluxio.master.AlluxioMasterProcess.<init>(AlluxioMasterProcess.java:102)
        ... 3 more
```
The path of RaftJournal is not output in the log, which is not helpful for finding bugs with the wrong Journal path

Example
```java
RaftJournalSystem{Journal Path=/mnt/share1/alluxio/journal, Local Address=localhost:19200, State=STANDBY, Configuration ClusterAddress=[localhost:19200], RaftGroup=null}
```


### Does this PR introduce any user facing changes?
No
