### PR TITLE
Improve BlockWorker and LocalBlockStore APIs

### DIFF
--- a/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -38,9 +38,6 @@ import java.util.concurrent.atomic.AtomicReference;
  * A block worker in the Alluxio system.
  */
 public interface BlockWorker extends Worker, SessionCleanable {
-  /** Invalid lock ID. */
-  long INVALID_LOCK_ID = -1;
-
   /**
    * @return the worker id
    */
@@ -57,17 +54,6 @@ public interface BlockWorker extends Worker, SessionCleanable {
    */
   void abortBlock(long sessionId, long blockId) throws BlockAlreadyExistsException,
       BlockDoesNotExistException, InvalidWorkerStateException, IOException;
-
-  /**
-   * Access the block for a given session. This should be called to update the evictor when
-   * necessary.
-   *
-   * @param sessionId the id of the client
-   * @param blockId the id of the block to access
-   * @throws BlockDoesNotExistException this exception is not thrown in the tiered block store
-   *         implementation
-   */
-  void accessBlock(long sessionId, long blockId) throws BlockDoesNotExistException;
 
   /**
    * Commits a block to Alluxio managed space. The block must be temporary. The block will not be
@@ -179,17 +165,6 @@ public interface BlockWorker extends Worker, SessionCleanable {
   boolean hasBlockMeta(long blockId);
 
   /**
-   * Obtains a read lock on a block. If lock is not acquired successfully, return
-   * {@link #INVALID_LOCK_ID}.
-   *
-   * @param sessionId the id of the client
-   * @param blockId the id of the block to be locked
-   * @return the lock id that uniquely identifies the lock obtained or
-   *         {@link #INVALID_LOCK_ID} if it failed to lock
-   */
-  long lockBlock(long sessionId, long blockId) throws BlockDoesNotExistException;
-
-  /**
    * Moves a block from its current location to a target location, currently only tier level moves
    * are supported. Throws an {@link IllegalArgumentException} if the tierAlias is out of range of
    * tiered storage.
@@ -279,14 +254,6 @@ public interface BlockWorker extends Worker, SessionCleanable {
    */
   void requestSpace(long sessionId, long blockId, long additionalBytes)
       throws BlockDoesNotExistException, WorkerOutOfSpaceException, IOException;
-
-  /**
-   * Releases the lock with the specified lock id.
-   *
-   * @param lockId the id of the lock to release
-   * @throws BlockDoesNotExistException if lock id cannot be found
-   */
-  void unlockBlock(long lockId) throws BlockDoesNotExistException;
 
   /**
    * Submits the async cache request to async cache manager to execute.

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -96,7 +97,9 @@ public final class BlockLockManager {
    * @return lock id
    */
   public long lockBlock(long sessionId, long blockId, BlockLockType blockLockType) {
-    return lockBlockInternal(sessionId, blockId, blockLockType, true, null, null);
+    OptionalLong lockId = lockBlockInternal(sessionId, blockId, blockLockType, true, null, null);
+    Preconditions.checkState(lockId.isPresent(), "lockBlock should always return a lockId");
+    return lockId.getAsLong();
   }
 
   /**
@@ -114,12 +117,12 @@ public final class BlockLockManager {
    * @param unit the time unit of the {@code time} argument
    * @return lock id or INVALID_LOCK_ID if not able to lock within the given time
    */
-  public long tryLockBlock(long sessionId, long blockId, BlockLockType blockLockType,
+  public OptionalLong tryLockBlock(long sessionId, long blockId, BlockLockType blockLockType,
       long time, TimeUnit unit) {
     return lockBlockInternal(sessionId, blockId, blockLockType, false, time, unit);
   }
 
-  private long lockBlockInternal(long sessionId, long blockId, BlockLockType blockLockType,
+  private OptionalLong lockBlockInternal(long sessionId, long blockId, BlockLockType blockLockType,
       boolean blocking, @Nullable Long time, @Nullable TimeUnit unit) {
     ClientRWLock blockLock = getBlockLock(blockId);
     Lock lock = blockLockType == BlockLockType.READ ? blockLock.readLock() : blockLock.writeLock();
@@ -140,11 +143,11 @@ public final class BlockLockManager {
                   + "session: {}, blockLockType: {}, lock reference count = {}",
               blockId, time, unit, sessionId, blockLockType,
               blockLock.getReferenceCount());
-          return BlockWorker.INVALID_LOCK_ID;
+          return OptionalLong.empty();
         }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        return BlockWorker.INVALID_LOCK_ID;
+        return OptionalLong.empty();
       }
     }
     try {
@@ -158,7 +161,7 @@ public final class BlockLockManager {
           sessionLockIds.add(lockId);
         }
       }
-      return lockId;
+      return OptionalLong.of(lockId);
     } catch (Throwable e) {
       // If an unexpected exception occurs, we should release the lock to be conservative.
       unlock(lock, blockId);
@@ -233,15 +236,14 @@ public final class BlockLockManager {
    * Releases the lock with the specified lock id.
    *
    * @param lockId the id of the lock to release
-   * @return whether the lock corresponding the lock ID has been successfully unlocked
    */
-  public boolean unlockBlockNoException(long lockId) {
+  public void unlockBlock(long lockId) {
     Lock lock;
     LockRecord record;
     try (LockResource r = new LockResource(mSharedMapsLock.writeLock())) {
       record = mLockIdToRecordMap.get(lockId);
       if (record == null) {
-        return false;
+        return;
       }
       long sessionId = record.getSessionId();
       lock = record.getLock();
@@ -253,69 +255,6 @@ public final class BlockLockManager {
       }
     }
     unlock(lock, record.getBlockId());
-    return true;
-  }
-
-  /**
-   * Releases the lock with the specified lock id.
-   *
-   * @param lockId the id of the lock to release
-   * @throws BlockDoesNotExistException if lock id cannot be found
-   */
-  public void unlockBlock(long lockId) throws BlockDoesNotExistException {
-    Lock lock;
-    LockRecord record;
-    try (LockResource r = new LockResource(mSharedMapsLock.writeLock())) {
-      record = mLockIdToRecordMap.get(lockId);
-      if (record == null) {
-        throw new BlockDoesNotExistException(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_LOCK_ID,
-            lockId);
-      }
-      long sessionId = record.getSessionId();
-      lock = record.getLock();
-      mLockIdToRecordMap.remove(lockId);
-      Set<Long> sessionLockIds = mSessionIdToLockIdsMap.get(sessionId);
-      sessionLockIds.remove(lockId);
-      if (sessionLockIds.isEmpty()) {
-        mSessionIdToLockIdsMap.remove(sessionId);
-      }
-    }
-    unlock(lock, record.getBlockId());
-  }
-
-  /**
-   * Releases the lock with the specified session and block id.
-   *
-   * @param sessionId the session id
-   * @param blockId the block id
-   * @return whether the block has been successfully unlocked
-   */
-  // TODO(bin): Temporary, remove me later.
-  public boolean unlockBlock(long sessionId, long blockId) {
-    try (LockResource r = new LockResource(mSharedMapsLock.writeLock())) {
-      Set<Long> sessionLockIds = mSessionIdToLockIdsMap.get(sessionId);
-      if (sessionLockIds == null) {
-        return false;
-      }
-      for (long lockId : sessionLockIds) {
-        LockRecord record = mLockIdToRecordMap.get(lockId);
-        if (record == null) {
-          // TODO(peis): Should this be a check failure?
-          return false;
-        }
-        if (blockId == record.getBlockId()) {
-          mLockIdToRecordMap.remove(lockId);
-          sessionLockIds.remove(lockId);
-          if (sessionLockIds.isEmpty()) {
-            mSessionIdToLockIdsMap.remove(sessionId);
-          }
-          Lock lock = record.getLock();
-          unlock(lock, blockId);
-          return true;
-        }
-      }
-      return false;
-    }
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -30,7 +30,7 @@ import alluxio.security.authentication.AuthenticatedUserInfo;
 import alluxio.util.LogUtils;
 import alluxio.util.logging.SamplingLogger;
 import alluxio.wire.BlockReadRequest;
-import alluxio.worker.block.BlockWorker;
+import alluxio.worker.block.DefaultBlockWorker;
 import alluxio.worker.block.io.BlockReader;
 
 import com.codahale.metrics.Counter;
@@ -97,7 +97,7 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
   /** A serializing executor for sending responses. */
   private Executor mSerializingExecutor;
   /** The Block Worker. */
-  private final BlockWorker mWorker;
+  private final DefaultBlockWorker mWorker;
   private final ReentrantLock mLock = new ReentrantLock();
   private final boolean mDomainSocketEnabled;
   private final AuthenticatedUserInfo mUserInfo;
@@ -120,7 +120,7 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
    * @param domainSocketEnabled if domain socket is enabled
    */
   BlockReadHandler(ExecutorService executorService,
-      BlockWorker blockWorker,
+      DefaultBlockWorker blockWorker,
       StreamObserver<ReadResponse> responseObserver,
       AuthenticatedUserInfo userInfo,
       boolean domainSocketEnabled) {

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/ShortCircuitBlockReadHandler.java
@@ -11,8 +11,9 @@
 
 package alluxio.worker.grpc;
 
+import static alluxio.worker.block.BlockMetadataManager.WORKER_STORAGE_TIER_ASSOC;
+
 import alluxio.RpcUtils;
-import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidWorkerStateException;
 import alluxio.grpc.GrpcExceptionUtils;
@@ -21,7 +22,11 @@ import alluxio.grpc.OpenLocalBlockResponse;
 import alluxio.security.authentication.AuthenticatedUserInfo;
 import alluxio.util.IdUtils;
 import alluxio.util.LogUtils;
-import alluxio.worker.block.BlockWorker;
+import alluxio.worker.block.AllocateOptions;
+import alluxio.worker.block.BlockStoreLocation;
+import alluxio.worker.block.DefaultBlockWorker;
+import alluxio.worker.block.LocalBlockStore;
+import alluxio.worker.block.meta.BlockMeta;
 
 import com.google.common.base.Preconditions;
 import io.grpc.stub.StreamObserver;
@@ -29,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.util.OptionalLong;
 
 /**
  * gRPC handler that handles short circuit read requests.
@@ -38,25 +44,24 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
   private static final Logger LOG =
       LoggerFactory.getLogger(ShortCircuitBlockReadHandler.class);
 
-  /** The block worker. */
-  private final BlockWorker mWorker;
+  private final LocalBlockStore mLocalBlockStore;
   private final StreamObserver<OpenLocalBlockResponse> mResponseObserver;
+  private final AuthenticatedUserInfo mUserInfo;
   private OpenLocalBlockRequest mRequest;
   /** The lock Id of the block being read. */
-  private long mLockId;
+  private OptionalLong mLockId;
   private long mSessionId;
-  private AuthenticatedUserInfo mUserInfo;
 
   /**
    * Creates an instance of {@link ShortCircuitBlockReadHandler}.
    *
-   * @param blockWorker the block worker
+   * @param localBlockStore the local block store
    * @param userInfo the authenticated user info
    */
-  ShortCircuitBlockReadHandler(BlockWorker blockWorker,
+  ShortCircuitBlockReadHandler(LocalBlockStore localBlockStore,
       StreamObserver<OpenLocalBlockResponse> responseObserver, AuthenticatedUserInfo userInfo) {
-    mWorker = blockWorker;
-    mLockId = BlockWorker.INVALID_LOCK_ID;
+    mLocalBlockStore = localBlockStore;
+    mLockId = OptionalLong.empty();
     mResponseObserver = responseObserver;
     mUserInfo = userInfo;
   }
@@ -71,42 +76,40 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
       public OpenLocalBlockResponse call() throws Exception {
         Preconditions.checkState(mRequest == null);
         mRequest = request;
-        if (mLockId == BlockWorker.INVALID_LOCK_ID) {
-          mSessionId = IdUtils.createSessionId();
-          // TODO(calvin): Update the locking logic so this can be done better
-          if (mRequest.getPromote()) {
-            try {
-              mWorker.moveBlock(mSessionId, mRequest.getBlockId(), 0);
-            } catch (BlockDoesNotExistException e) {
-              LOG.debug("Block {} to promote does not exist in Alluxio", mRequest.getBlockId(), e);
-            } catch (Exception e) {
-              LOG.warn("Failed to promote block {}: {}", mRequest.getBlockId(), e.toString());
-            }
-          }
-          mLockId = mWorker.lockBlock(mSessionId, mRequest.getBlockId());
-          mWorker.accessBlock(mSessionId, mRequest.getBlockId());
-        } else {
+        if (mLockId.isPresent()) {
           LOG.warn("Lock block {} without releasing previous block lock {}.",
               mRequest.getBlockId(), mLockId);
           throw new InvalidWorkerStateException(
               ExceptionMessage.LOCK_NOT_RELEASED.getMessage(mLockId));
         }
-        OpenLocalBlockResponse response = OpenLocalBlockResponse.newBuilder()
-            .setPath(mWorker.getVolatileBlockMeta(mRequest.getBlockId()).getPath())
+        mSessionId = IdUtils.createSessionId();
+        // TODO(calvin): Update the locking logic so this can be done better
+        BlockMeta meta = mLocalBlockStore.getVolatileBlockMeta(mRequest.getBlockId());
+        if (mRequest.getPromote()) {
+          // TODO(calvin): Move this logic into BlockStore#moveBlockInternal if possible
+          // Because the move operation is expensive, we first check if the operation is necessary
+          BlockStoreLocation dst = BlockStoreLocation.anyDirInTier(
+              WORKER_STORAGE_TIER_ASSOC.getAlias(0));
+          if (!meta.getBlockLocation().belongsTo(dst)) {
+            // Execute the block move if necessary
+            mLocalBlockStore.moveBlock(mSessionId, mRequest.getBlockId(),
+                AllocateOptions.forMove(dst));
+          }
+        }
+        mLockId = mLocalBlockStore.pinBlock(mSessionId, mRequest.getBlockId());
+        mLocalBlockStore.accessBlock(mSessionId, mRequest.getBlockId());
+        DefaultBlockWorker.Metrics.WORKER_ACTIVE_CLIENTS.inc();
+        return OpenLocalBlockResponse.newBuilder()
+            .setPath(meta.getPath())
             .build();
-        return response;
       }
 
       @Override
       public void exceptionCaught(Throwable e) {
-        if (mLockId != BlockWorker.INVALID_LOCK_ID) {
-          try {
-            mWorker.unlockBlock(mLockId);
-          } catch (BlockDoesNotExistException ee) {
-            LOG.warn("Failed to unlock lock {} of block {} with error {}.",
-                mLockId, mRequest.getBlockId(), e.toString());
-          }
-          mLockId = BlockWorker.INVALID_LOCK_ID;
+        if (mLockId.isPresent()) {
+          DefaultBlockWorker.Metrics.WORKER_ACTIVE_CLIENTS.dec();
+          mLocalBlockStore.unpinBlock(mLockId.getAsLong());
+          mLockId = OptionalLong.empty();
         }
         mResponseObserver.onError(GrpcExceptionUtils.fromThrowable(e));
       }
@@ -118,14 +121,10 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
   @Override
   public void onError(Throwable t) {
     LogUtils.warnWithException(LOG, "Exception occurred processing read request {}.", mRequest, t);
-    if (mLockId != BlockWorker.INVALID_LOCK_ID) {
-      try {
-        mWorker.unlockBlock(mLockId);
-      } catch (BlockDoesNotExistException e) {
-        LOG.warn("Failed to unlock lock {} of block {} with error {}.",
-            mLockId, mRequest.getBlockId(), e.toString());
-      }
-      mWorker.cleanupSession(mSessionId);
+    if (mLockId.isPresent()) {
+      DefaultBlockWorker.Metrics.WORKER_ACTIVE_CLIENTS.dec();
+      mLocalBlockStore.unpinBlock(mLockId.getAsLong());
+      mLocalBlockStore.cleanupSession(mSessionId);
     }
     mResponseObserver.onError(GrpcExceptionUtils.fromThrowable(t));
   }
@@ -138,14 +137,10 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
     RpcUtils.streamingRPCAndLog(LOG, new RpcUtils.StreamingRpcCallable<OpenLocalBlockResponse>() {
       @Override
       public OpenLocalBlockResponse call() throws Exception {
-        if (mLockId != BlockWorker.INVALID_LOCK_ID) {
-          try {
-            mWorker.unlockBlock(mLockId);
-          } catch (BlockDoesNotExistException e) {
-            LOG.warn("Failed to unlock lock {} of block {} with error {}.",
-                mLockId, mRequest.getBlockId(), e.toString());
-          }
-          mLockId = BlockWorker.INVALID_LOCK_ID;
+        if (mLockId.isPresent()) {
+          DefaultBlockWorker.Metrics.WORKER_ACTIVE_CLIENTS.dec();
+          mLocalBlockStore.unpinBlock(mLockId.getAsLong());
+          mLockId = OptionalLong.empty();
         } else if (mRequest != null) {
           LOG.warn("Close a closed block {}.", mRequest.getBlockId());
         }
@@ -155,7 +150,7 @@ class ShortCircuitBlockReadHandler implements StreamObserver<OpenLocalBlockReque
       @Override
       public void exceptionCaught(Throwable e) {
         mResponseObserver.onError(GrpcExceptionUtils.fromThrowable(e));
-        mLockId = BlockWorker.INVALID_LOCK_ID;
+        mLockId = OptionalLong.empty();
       }
     }, "CloseBlock", false, true, mResponseObserver, "Session=%d, Request=%s",
         mSessionId, mRequest);

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
@@ -11,11 +11,8 @@
 
 package alluxio.worker.block;
 
-import static alluxio.worker.block.BlockWorker.INVALID_LOCK_ID;
-import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -115,17 +112,6 @@ public class DefaultBlockWorkerTest {
         new CreateBlockOptions(null, Constants.MEDIUM_MEM, 1));
     mBlockWorker.abortBlock(sessionId, blockId);
     assertThrows(BlockDoesNotExistException.class, () -> mBlockWorker.getTempBlockMeta(blockId));
-  }
-
-  @Test
-  public void accessBlock() throws Exception {
-    long blockId = mRandom.nextLong();
-    long sessionId = mRandom.nextLong();
-    mBlockWorker.createBlock(sessionId, blockId, 0,
-        new CreateBlockOptions(null, Constants.MEDIUM_MEM, 1));
-    mBlockWorker.commitBlock(sessionId, blockId, true);
-    mBlockWorker.accessBlock(sessionId, blockId);
-    verify(mBlockStore).accessBlock(sessionId, blockId);
   }
 
   @Test
@@ -263,18 +249,6 @@ public class DefaultBlockWorkerTest {
   }
 
   @Test
-  public void lockBlock() throws Exception {
-    long blockId = mRandom.nextLong();
-    long sessionId = mRandom.nextLong();
-    assertThrows(BlockDoesNotExistException.class,
-        () -> mBlockWorker.lockBlock(sessionId, blockId));
-    mBlockWorker.createBlock(sessionId, blockId, 0,
-        new CreateBlockOptions(null, Constants.MEDIUM_MEM, 1));
-    mBlockWorker.commitBlock(sessionId, blockId, true);
-    assertNotEquals(INVALID_LOCK_ID, mBlockWorker.lockBlock(sessionId, blockId));
-  }
-
-  @Test
   public void moveBlock() throws Exception {
     long blockId = mRandom.nextLong();
     long sessionId = mRandom.nextLong();
@@ -330,18 +304,6 @@ public class DefaultBlockWorkerTest {
     assertThrows(WorkerOutOfSpaceException.class,
         () -> mBlockWorker.requestSpace(sessionId, blockId, additionalBytes)
     );
-  }
-
-  @Test
-  public void unlockBlock() throws Exception {
-    long blockId = mRandom.nextLong();
-    long sessionId = mRandom.nextLong();
-    mBlockWorker.createBlock(sessionId, blockId, 0,
-        new CreateBlockOptions(null, Constants.MEDIUM_MEM, 1));
-    mBlockWorker.commitBlock(sessionId, blockId, true);
-    long lockId = mBlockWorker.lockBlock(sessionId, blockId);
-    assertNotNull(mBlockWorker.getVolatileBlockMeta(blockId));
-    mBlockWorker.unlockBlock(lockId);
   }
 
   @Test

--- a/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
@@ -54,11 +54,6 @@ public class NoopBlockWorker implements BlockWorker {
   }
 
   @Override
-  public void accessBlock(long sessionId, long blockId) throws BlockDoesNotExistException {
-    // noop
-  }
-
-  @Override
   public void commitBlock(long sessionId, long blockId, boolean pinOnCreate)
       throws BlockAlreadyExistsException, BlockDoesNotExistException, InvalidWorkerStateException,
       IOException, WorkerOutOfSpaceException {
@@ -116,11 +111,6 @@ public class NoopBlockWorker implements BlockWorker {
   }
 
   @Override
-  public long lockBlock(long sessionId, long blockId) {
-    return 0;
-  }
-
-  @Override
   public void moveBlock(long sessionId, long blockId, int tier)
       throws BlockDoesNotExistException, InvalidWorkerStateException,
       WorkerOutOfSpaceException, IOException {
@@ -150,11 +140,6 @@ public class NoopBlockWorker implements BlockWorker {
   @Override
   public void requestSpace(long sessionId, long blockId, long additionalBytes)
       throws BlockDoesNotExistException, WorkerOutOfSpaceException, IOException {
-    // noop
-  }
-
-  @Override
-  public void unlockBlock(long lockId) throws BlockDoesNotExistException {
     // noop
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
@@ -114,8 +114,8 @@ public final class UnderFileSystemBlockReaderTest {
   private void checkTempBlock(long start, long length) throws Exception {
     Assert.assertTrue(mAlluxioBlockStore.hasTempBlockMeta(BLOCK_ID));
     mAlluxioBlockStore.commitBlock(SESSION_ID, BLOCK_ID, false);
-    long lockId = mAlluxioBlockStore.lockBlock(SESSION_ID, BLOCK_ID);
-    BlockReader reader = mAlluxioBlockStore.getBlockReader(SESSION_ID, BLOCK_ID, lockId);
+    long lockId = mAlluxioBlockStore.pinBlock(SESSION_ID, BLOCK_ID).getAsLong();
+    BlockReader reader = mAlluxioBlockStore.createBlockReader(SESSION_ID, BLOCK_ID, lockId);
     Assert.assertEquals(length, reader.getLength());
     ByteBuffer buffer = reader.read(0, length);
     assertTrue(BufferUtils.equalIncreasingByteBuffer((int) start, (int) length, buffer));


### PR DESCRIPTION
1) APIs like accessBlock lockBlock, unlockBlock in BlockWorker are just
wrappers on the corresponding LocalBlockStore APIs that are specific to
LocalBlockStore. Using the LocalBlockStore APIs directly and removing the
wrapper APIs in BlockWorker.

2) Rename LocalBlockStore.lockBlock to pinBlock. The API is supposed to
be indicating future block read access and is intended to avoid eviction.
Currently the underlying implementation in TieredBlockStore is still using
locking and the API still returns lockId. But changing the API to indicate
that such strong guarantee is not necessary for all implementations. In the
future this function should just return void.

3) Rename LocalBlockStore.unlockBlock to unpinBlock and remove Exceptions not thrown.

4) Remove BlockWorker.INVALID_LOCK_ID. Using OptionalLong to represent lockId.
Invalid lock is represented as OptionalLong.empty(), making special case
handling explicit.