### PR TITLE
Remove unused API in LocalBlockStore

### DIFF
--- a/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -198,14 +198,12 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @param blockId the id of the block to move
    * @param tier the tier to move the block to
    * @throws BlockDoesNotExistException if blockId cannot be found
-   * @throws BlockAlreadyExistsException if blockId already exists in committed blocks of the
-   *         newLocation
    * @throws InvalidWorkerStateException if blockId has not been committed
    * @throws WorkerOutOfSpaceException if newLocation does not have enough extra space to hold the
    *         block
    */
   void moveBlock(long sessionId, long blockId, int tier)
-      throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
+      throws BlockDoesNotExistException, InvalidWorkerStateException,
       WorkerOutOfSpaceException, IOException;
 
   /**
@@ -217,14 +215,12 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @param blockId the id of the block to move
    * @param mediumType the medium type to move to
    * @throws BlockDoesNotExistException if blockId cannot be found
-   * @throws BlockAlreadyExistsException if blockId already exists in committed blocks of the
-   *         newLocation
    * @throws InvalidWorkerStateException if blockId has not been committed
    * @throws WorkerOutOfSpaceException if newLocation does not have enough extra space to hold the
    *         block
    */
   void moveBlockToMedium(long sessionId, long blockId, String mediumType)
-      throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
+      throws BlockDoesNotExistException, InvalidWorkerStateException,
       WorkerOutOfSpaceException, IOException;
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -416,7 +416,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
 
   @Override
   public void moveBlock(long sessionId, long blockId, int tier)
-      throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
+      throws BlockDoesNotExistException, InvalidWorkerStateException,
       WorkerOutOfSpaceException, IOException {
     // TODO(calvin): Move this logic into BlockStore#moveBlockInternal if possible
     // Because the move operation is expensive, we first check if the operation is necessary
@@ -437,7 +437,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
 
   @Override
   public void moveBlockToMedium(long sessionId, long blockId, String mediumType)
-      throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
+      throws BlockDoesNotExistException, InvalidWorkerStateException,
       WorkerOutOfSpaceException, IOException {
     BlockStoreLocation dst = BlockStoreLocation.anyDirInAnyTierWithMedium(mediumType);
     BlockMeta meta = mLocalBlockStore.getVolatileBlockMeta(blockId);

--- a/core/server/worker/src/main/java/alluxio/worker/block/LocalBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/LocalBlockStore.java
@@ -15,7 +15,6 @@ import alluxio.exception.BlockAlreadyExistsException;
 import alluxio.exception.BlockDoesNotExistException;
 import alluxio.exception.InvalidWorkerStateException;
 import alluxio.exception.WorkerOutOfSpaceException;
-import alluxio.exception.status.DeadlineExceededException;
 import alluxio.worker.SessionCleanable;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
@@ -195,35 +194,13 @@ public interface LocalBlockStore
    * @param moveOptions the options for move
    * @throws IllegalArgumentException if newLocation does not belong to the tiered storage
    * @throws BlockDoesNotExistException if block id can not be found
-   * @throws BlockAlreadyExistsException if block id already exists in committed blocks of the
-   *         newLocation
    * @throws InvalidWorkerStateException if block id has not been committed
    * @throws WorkerOutOfSpaceException if newLocation does not have enough extra space to hold the
    *         block
    */
   void moveBlock(long sessionId, long blockId, AllocateOptions moveOptions)
-      throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
+      throws BlockDoesNotExistException, InvalidWorkerStateException,
       WorkerOutOfSpaceException, IOException;
-
-  /**
-   * Moves an existing block to a new location.
-   *
-   * @param sessionId the id of the session to remove a block
-   * @param blockId the id of an existing block
-   * @param oldLocation the location of the source
-   * @param moveOptions the options for move
-   * @throws IllegalArgumentException if newLocation does not belong to the tiered storage
-   * @throws BlockDoesNotExistException if block id can not be found
-   * @throws BlockAlreadyExistsException if block id already exists in committed blocks of the
-   *         newLocation
-   * @throws InvalidWorkerStateException if block id has not been committed
-   * @throws WorkerOutOfSpaceException if newLocation does not have enough extra space to hold the
-   *         block
-   */
-  void moveBlock(long sessionId, long blockId, BlockStoreLocation oldLocation,
-      AllocateOptions moveOptions) throws BlockDoesNotExistException,
-      BlockAlreadyExistsException, InvalidWorkerStateException, WorkerOutOfSpaceException,
-      IOException;
 
   /**
    * Removes an existing block. If the block can not be found in this store.
@@ -235,19 +212,6 @@ public interface LocalBlockStore
    */
   void removeBlock(long sessionId, long blockId) throws InvalidWorkerStateException,
       BlockDoesNotExistException, IOException;
-
-  /**
-   * Removes an existing block. If the block can not be found in this store.
-   *
-   * @param sessionId the id of the session to move a block
-   * @param blockId the id of an existing block
-   * @param location the location of the block
-   * @throws InvalidWorkerStateException if block id has not been committed
-   * @throws BlockDoesNotExistException if block can not be found
-   * @throws DeadlineExceededException if locking takes longer than timeout
-   */
-  void removeBlock(long sessionId, long blockId, BlockStoreLocation location)
-      throws InvalidWorkerStateException, BlockDoesNotExistException, IOException;
 
   /**
    * Notifies the block store that a block was accessed so the block store could update accordingly

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
@@ -371,9 +371,9 @@ public class DefaultBlockWorkerTest {
         false, Protocol.OpenUfsBlockOptions.newBuilder().build());
     // reader will hold the lock
     assertThrows(DeadlineExceededException.class,
-        () -> mBlockStore.removeBlockInternal(sessionId, blockId, BlockStoreLocation.anyTier(), 10)
+        () -> mBlockStore.removeBlockInternal(sessionId, blockId, 10)
     );
     reader.close();
-    mBlockStore.removeBlockInternal(sessionId, blockId, BlockStoreLocation.anyTier(), 10);
+    mBlockStore.removeBlockInternal(sessionId, blockId, 10);
   }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
@@ -122,14 +122,14 @@ public class NoopBlockWorker implements BlockWorker {
 
   @Override
   public void moveBlock(long sessionId, long blockId, int tier)
-      throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
+      throws BlockDoesNotExistException, InvalidWorkerStateException,
       WorkerOutOfSpaceException, IOException {
     // noop
   }
 
   @Override
   public void moveBlockToMedium(long sessionId, long blockId, String mediumType)
-      throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
+      throws BlockDoesNotExistException, InvalidWorkerStateException,
       WorkerOutOfSpaceException, IOException {
     // noop
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -227,24 +227,8 @@ public final class TieredBlockStoreTest {
     // Move block from the specific Dir
     TieredBlockStoreTestUtils.cache2(SESSION_ID2, BLOCK_ID2, BLOCK_SIZE, mTestDir1, mMetaManager,
         mBlockIterator);
-    // Move block from wrong Dir
-    mThrown.expect(BlockDoesNotExistException.class);
-    mThrown.expectMessage(ExceptionMessage.BLOCK_NOT_FOUND_AT_LOCATION.getMessage(BLOCK_ID2,
-        mTestDir2.toBlockStoreLocation()));
-    mBlockStore.moveBlock(SESSION_ID2, BLOCK_ID2, mTestDir2.toBlockStoreLocation(),
-        AllocateOptions.forMove(mTestDir3.toBlockStoreLocation()));
     // Move block from right Dir
-    mBlockStore.moveBlock(SESSION_ID2, BLOCK_ID2, mTestDir1.toBlockStoreLocation(),
-        AllocateOptions.forMove(mTestDir3.toBlockStoreLocation()));
-    assertFalse(mTestDir1.hasBlockMeta(BLOCK_ID2));
-    assertTrue(mTestDir3.hasBlockMeta(BLOCK_ID2));
-    assertTrue(mBlockStore.hasBlockMeta(BLOCK_ID2));
-    assertFalse(FileUtils.exists(DefaultBlockMeta.commitPath(mTestDir1, BLOCK_ID2)));
-    assertTrue(FileUtils.exists(DefaultBlockMeta.commitPath(mTestDir3, BLOCK_ID2)));
-
-    // Move block from the specific tier
     mBlockStore.moveBlock(SESSION_ID2, BLOCK_ID2,
-        BlockStoreLocation.anyDirInTier(mTestDir1.getParentTier().getTierAlias()),
         AllocateOptions.forMove(mTestDir3.toBlockStoreLocation()));
     assertFalse(mTestDir1.hasBlockMeta(BLOCK_ID2));
     assertTrue(mTestDir3.hasBlockMeta(BLOCK_ID2));
@@ -309,13 +293,8 @@ public final class TieredBlockStoreTest {
     // Remove block from specific Dir
     TieredBlockStoreTestUtils.cache2(SESSION_ID2, BLOCK_ID2, BLOCK_SIZE, mTestDir1, mMetaManager,
         mBlockIterator);
-    // Remove block from wrong Dir
-    mThrown.expect(BlockDoesNotExistException.class);
-    mThrown.expectMessage(ExceptionMessage.BLOCK_NOT_FOUND_AT_LOCATION.getMessage(BLOCK_ID2,
-        mTestDir2.toBlockStoreLocation()));
-    mBlockStore.removeBlock(SESSION_ID2, BLOCK_ID2, mTestDir2.toBlockStoreLocation());
     // Remove block from right Dir
-    mBlockStore.removeBlock(SESSION_ID2, BLOCK_ID2, mTestDir1.toBlockStoreLocation());
+    mBlockStore.removeBlock(SESSION_ID2, BLOCK_ID2);
     assertFalse(mTestDir1.hasBlockMeta(BLOCK_ID2));
     assertFalse(mBlockStore.hasBlockMeta(BLOCK_ID2));
     assertFalse(FileUtils.exists(DefaultBlockMeta.commitPath(mTestDir1, BLOCK_ID2)));
@@ -323,8 +302,7 @@ public final class TieredBlockStoreTest {
     // Remove block from the specific tier
     TieredBlockStoreTestUtils.cache2(SESSION_ID2, BLOCK_ID2, BLOCK_SIZE, mTestDir1, mMetaManager,
         mBlockIterator);
-    mBlockStore.removeBlock(SESSION_ID2, BLOCK_ID2,
-        BlockStoreLocation.anyDirInTier(mTestDir1.getParentTier().getTierAlias()));
+    mBlockStore.removeBlock(SESSION_ID2, BLOCK_ID2);
     assertFalse(mTestDir1.hasBlockMeta(BLOCK_ID2));
     assertFalse(mBlockStore.hasBlockMeta(BLOCK_ID2));
     assertFalse(FileUtils.exists(DefaultBlockMeta.commitPath(mTestDir1, BLOCK_ID2)));


### PR DESCRIPTION
The moveBlock and removeBlock API with location are only used in test. The
actual API always uses BlockStoreLocation.anyTier() as location. So removing
the APIs and the usage in tests.
