### PR TITLE
Reduce the use of Collection.toArray() in project

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/transport/GrpcMessagingTransport.java
+++ b/core/server/common/src/main/java/alluxio/master/transport/GrpcMessagingTransport.java
@@ -141,25 +141,29 @@ public class GrpcMessagingTransport {
       mClosed = true;
 
       // Close created clients.
-      List<CompletableFuture<Void>> clientCloseFutures = new ArrayList<>(mClients.size());
+      int index = 0;
+      CompletableFuture<Void>[] clientCloseFutures = new CompletableFuture[mClients.size()];
       for (GrpcMessagingClient client : mClients) {
-        clientCloseFutures.add(client.close());
+        clientCloseFutures[index] = client.close();
+        index++;
       }
       mClients.clear();
       try {
-        CompletableFuture.allOf(clientCloseFutures.toArray(new CompletableFuture[0])).get();
+        CompletableFuture.allOf(clientCloseFutures).get();
       } catch (Exception e) {
         LOG.warn("Failed to close messaging transport clients.", e);
       }
 
       // Close created servers.
-      List<CompletableFuture<Void>> serverCloseFutures = new ArrayList<>(mServers.size());
+      index = 0;
+      CompletableFuture<Void>[] serverCloseFutures = new CompletableFuture[mServers.size()];
       for (GrpcMessagingServer server : mServers) {
-        serverCloseFutures.add(server.close());
+        serverCloseFutures[index] = server.close();
+        index++;
       }
       mServers.clear();
       try {
-        CompletableFuture.allOf(serverCloseFutures.toArray(new CompletableFuture[0])).get();
+        CompletableFuture.allOf(serverCloseFutures).get();
       } catch (Exception e) {
         LOG.warn("Failed to close messaging transport servers.", e);
       }

--- a/core/server/common/src/main/java/alluxio/master/transport/GrpcMessagingTransport.java
+++ b/core/server/common/src/main/java/alluxio/master/transport/GrpcMessagingTransport.java
@@ -19,7 +19,6 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncer.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncer.java
@@ -108,9 +108,9 @@ public class ActiveSyncer implements HeartbeatExecutor {
         // Journal the latest processed txId
         CompletableFuture<Void> syncTask =
             CompletableFuture.allOf(tasksPerSync)
-                .thenRunAsync(() -> mFileSystemMaster
-                        .recordActiveSyncTxid(syncInfo.getTxId(), mMountId),
-                    mSyncManager.getExecutor());
+            .thenRunAsync(() -> mFileSystemMaster
+                    .recordActiveSyncTxid(syncInfo.getTxId(), mMountId),
+                mSyncManager.getExecutor());
         int attempts = 0;
         while (!mSyncTasks.offer(syncTask)) {
           if (Thread.currentThread().isInterrupted()) {

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncer.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncer.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
@@ -97,19 +96,21 @@ public class ActiveSyncer implements HeartbeatExecutor {
         // This returns a list of ufsUris that we need to sync.
         Set<AlluxioURI> ufsSyncPoints = syncInfo.getSyncPoints();
         // Parallelize across sync points
-        List<CompletableFuture<Long>> tasksPerSync = new ArrayList<>();
+        CompletableFuture<Long>[] tasksPerSync = new CompletableFuture[ufsSyncPoints.size()];
+        int idx = 0;
         for (AlluxioURI ufsUri : ufsSyncPoints) {
-          tasksPerSync.add(CompletableFuture.supplyAsync(() -> {
+          tasksPerSync[idx] = CompletableFuture.supplyAsync(() -> {
             processSyncPoint(ufsUri, syncInfo);
             return syncInfo.getTxId();
-          }, mSyncManager.getExecutor()));
+          }, mSyncManager.getExecutor());
+          idx++;
         }
         // Journal the latest processed txId
         CompletableFuture<Void> syncTask =
-            CompletableFuture.allOf(tasksPerSync.toArray(new CompletableFuture<?>[0]))
-            .thenRunAsync(() -> mFileSystemMaster
-                    .recordActiveSyncTxid(syncInfo.getTxId(), mMountId),
-                mSyncManager.getExecutor());
+            CompletableFuture.allOf(tasksPerSync)
+                .thenRunAsync(() -> mFileSystemMaster
+                        .recordActiveSyncTxid(syncInfo.getTxId(), mMountId),
+                    mSyncManager.getExecutor());
         int attempts = 0;
         while (!mSyncTasks.offer(syncTask)) {
           if (Thread.currentThread().isInterrupted()) {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -194,9 +194,10 @@ public final class AlluxioFuse {
         Signal.handle(new Signal("TERM"), fuseSignalHandler);
 
         try {
+          String[] fuseOptsArray = fuseOpts.toArray(new String[fuseOpts.size()]);
           LOG.info("Mounting AlluxioJniFuseFileSystem: mount point=\"{}\", OPTIONS=\"{}\"",
-              mountConfig.getMountPoint(), fuseOpts.toArray(new String[0]));
-          fuseFs.mount(blocking, mountConfig.isDebug(), fuseOpts.toArray(new String[0]));
+              mountConfig.getMountPoint(), fuseOptsArray);
+          fuseFs.mount(blocking, mountConfig.isDebug(), fuseOptsArray);
           return fuseFs;
         } catch (FuseException e) {
           // only try to umount file system when exception occurred.

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -194,7 +194,7 @@ public final class AlluxioFuse {
         Signal.handle(new Signal("TERM"), fuseSignalHandler);
 
         try {
-          String[] fuseOptsArray = fuseOpts.toArray(new String[fuseOpts.size()]);
+          String[] fuseOptsArray = fuseOpts.toArray(new String[0]);
           LOG.info("Mounting AlluxioJniFuseFileSystem: mount point=\"{}\", OPTIONS=\"{}\"",
               mountConfig.getMountPoint(), fuseOptsArray);
           fuseFs.mount(blocking, mountConfig.isDebug(), fuseOptsArray);


### PR DESCRIPTION
### What changes are proposed in this pull request?
Collection.toArray() is widely used throughout the project, but inappropriate use can waste memory. Find out where is wrong and fix it

### Why are the changes needed?
Collection.toArray() does a copy. Using Array can reduce one copy to save memory and time if we know very well how many elements there are. 

### Does this PR introduce any user facing changes?
NA
