### PR TITLE
Rename static pvc in CSI

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -269,3 +269,7 @@
 - Rename mountPath to mountPoint in fuse
 - Require non-empty values for fuse mountPoint
 - Passing fuse mountPoint and alluxioPath into containers as args instead of env variables
+
+0.6.43
+
+- Rename static pvc metadata.name in csi

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.41
+version: 0.6.43
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/csi/pvc-static.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/csi/pvc-static.yaml
@@ -13,7 +13,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: alluxio-pvc
+  name: alluxio-pvc-static
 spec:
   accessModes:
   {{ toYaml .Values.csi.accessModes }}


### PR DESCRIPTION
If using helm chart to deploy CSI directly (not using `kubectl`), the PVCs for static and dynamic provisioning have the same name and cause the deploy to fail.

Although we don't recommend user to use helm chart deploy CSI directly, if anyone gives it a try, the error returned by helm would be `Error: persistentvolumeclaims "alluxio-pvc" already exists`, which is not informative at all. 
