### PR TITLE
Change LocalBlockStore.getVolatileBlockMeta to return Optional

### DIFF
--- a/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -26,8 +26,6 @@ import alluxio.worker.SessionCleanable;
 import alluxio.worker.Worker;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
-import alluxio.worker.block.meta.BlockMeta;
-import alluxio.worker.block.meta.TempBlockMeta;
 
 import java.io.IOException;
 import java.util.List;
@@ -100,14 +98,6 @@ public interface BlockWorker extends Worker, SessionCleanable {
       throws BlockAlreadyExistsException, WorkerOutOfSpaceException, IOException;
 
   /**
-   * @param blockId the id of the block
-   *
-   * @return metadata of the block if the temp block exists
-   * @throws BlockDoesNotExistException if the block cannot be found
-   */
-  TempBlockMeta getTempBlockMeta(long blockId) throws BlockDoesNotExistException;
-
-  /**
    * Creates a {@link BlockWriter} for an existing temporary block which is already created by
    * {@link #createBlock}.
    *
@@ -145,16 +135,6 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @return the full block store metadata
    */
   BlockStoreMeta getStoreMetaFull();
-
-  /**
-   * Gets the metadata of a block given its blockId or throws IOException. This method does not
-   * require a lock id so the block is possible to be moved or removed after it returns.
-   *
-   * @param blockId the block id
-   * @return metadata of the block
-   * @throws BlockDoesNotExistException if no {@link BlockMeta} for this blockId is found
-   */
-  BlockMeta getVolatileBlockMeta(long blockId) throws BlockDoesNotExistException;
 
   /**
    * Checks if the storage has a given block.

--- a/core/common/src/main/java/alluxio/worker/block/meta/StorageDir.java
+++ b/core/common/src/main/java/alluxio/worker/block/meta/StorageDir.java
@@ -18,6 +18,7 @@ import alluxio.exception.WorkerOutOfSpaceException;
 import alluxio.worker.block.BlockStoreLocation;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents a directory in a storage tier. It has a fixed capacity allocated to it on
@@ -106,10 +107,9 @@ public interface StorageDir {
    * Gets the {@link BlockMeta} from this storage dir by its block id.
    *
    * @param blockId the block id
-   * @return {@link BlockMeta} of the given block or null
-   * @throws BlockDoesNotExistException if no block is found
+   * @return {@link BlockMeta} of the given block or empty
    */
-  BlockMeta getBlockMeta(long blockId) throws BlockDoesNotExistException;
+  Optional<BlockMeta> getBlockMeta(long blockId);
 
   /**
    * Gets the {@link TempBlockMeta} from this storage dir by its block id.
@@ -143,9 +143,8 @@ public interface StorageDir {
    * Removes a block from this storage dir.
    *
    * @param blockMeta the metadata of the block
-   * @throws BlockDoesNotExistException if no block is found
    */
-  void removeBlockMeta(BlockMeta blockMeta) throws BlockDoesNotExistException;
+  void removeBlockMeta(BlockMeta blockMeta);
 
   /**
    * Removes a temp block from this storage dir.

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataEvictorView.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataEvictorView.java
@@ -11,7 +11,6 @@
 
 package alluxio.worker.block;
 
-import alluxio.exception.BlockDoesNotExistException;
 import alluxio.master.block.BlockId;
 import alluxio.worker.block.meta.BlockMeta;
 import alluxio.worker.block.meta.StorageDirEvictorView;
@@ -27,8 +26,8 @@ import org.slf4j.LoggerFactory;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -174,19 +173,17 @@ public class BlockMetadataEvictorView extends BlockMetadataView {
   }
 
   /**
-   * Returns null if block is pinned or currently being locked, otherwise returns
+   * Returns Optional.empty() if block is pinned or currently being locked, otherwise returns
    * {@link BlockMetadataManager#getBlockMeta(long)}.
    *
    * @param blockId the block id
    * @return metadata of the block or null
-   * @throws BlockDoesNotExistException if no {@link BlockMeta} for this block id is found
    */
-  @Nullable
-  public BlockMeta getBlockMeta(long blockId) throws BlockDoesNotExistException {
+  public Optional<BlockMeta> getBlockMeta(long blockId) {
     if (isBlockEvictable(blockId)) {
       return mMetadataManager.getBlockMeta(blockId);
     } else {
-      return null;
+      return Optional.empty();
     }
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -313,14 +313,11 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
     }
     BlockMasterClient blockMasterClient = mBlockMasterClientPool.acquire();
     try {
-      BlockMeta meta = mLocalBlockStore.getVolatileBlockMeta(blockId);
+      BlockMeta meta = mLocalBlockStore.getVolatileBlockMeta(blockId).get();
       BlockStoreLocation loc = meta.getBlockLocation();
-      String mediumType = loc.mediumType();
-      Long length = meta.getBlockSize();
-      BlockStoreMeta storeMeta = mLocalBlockStore.getBlockStoreMeta();
-      Long bytesUsedOnTier = storeMeta.getUsedBytesOnTiers().get(loc.tierAlias());
-      blockMasterClient.commitBlock(mWorkerId.get(), bytesUsedOnTier, loc.tierAlias(), mediumType,
-          blockId, length);
+      blockMasterClient.commitBlock(mWorkerId.get(),
+          mLocalBlockStore.getBlockStoreMeta().getUsedBytesOnTiers().get(loc.tierAlias()),
+          loc.tierAlias(), loc.mediumType(), blockId, meta.getBlockSize());
     } catch (Exception e) {
       throw new IOException(ExceptionMessage.FAILED_COMMIT_BLOCK_TO_MASTER.getMessage(blockId), e);
     } finally {
@@ -376,12 +373,6 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   }
 
   @Override
-  public TempBlockMeta getTempBlockMeta(long blockId)
-      throws BlockDoesNotExistException {
-    return mLocalBlockStore.getTempBlockMeta(blockId);
-  }
-
-  @Override
   public BlockWriter createBlockWriter(long sessionId, long blockId)
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
       IOException {
@@ -404,11 +395,6 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   }
 
   @Override
-  public BlockMeta getVolatileBlockMeta(long blockId) throws BlockDoesNotExistException {
-    return mLocalBlockStore.getVolatileBlockMeta(blockId);
-  }
-
-  @Override
   public boolean hasBlockMeta(long blockId) {
     return mLocalBlockStore.hasBlockMeta(blockId);
   }
@@ -419,27 +405,23 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
       WorkerOutOfSpaceException, IOException {
     // TODO(calvin): Move this logic into BlockStore#moveBlockInternal if possible
     // Because the move operation is expensive, we first check if the operation is necessary
-    BlockStoreLocation dst = BlockStoreLocation.anyDirInTier(
-        WORKER_STORAGE_TIER_ASSOC.getAlias(tier));
-    long lockId = mLocalBlockStore.pinBlock(sessionId, blockId).getAsLong();
-    try {
-      BlockMeta meta = mLocalBlockStore.getVolatileBlockMeta(blockId);
-      if (meta.getBlockLocation().belongsTo(dst)) {
-        return;
-      }
-    } finally {
-      mLocalBlockStore.unpinBlock(lockId);
-    }
-    // Execute the block move if necessary
-    mLocalBlockStore.moveBlock(sessionId, blockId, AllocateOptions.forMove(dst));
+    moveBlockInternal(sessionId, blockId, BlockStoreLocation.anyDirInTier(
+        WORKER_STORAGE_TIER_ASSOC.getAlias(tier)));
   }
 
   @Override
   public void moveBlockToMedium(long sessionId, long blockId, String mediumType)
       throws BlockDoesNotExistException, InvalidWorkerStateException,
       WorkerOutOfSpaceException, IOException {
-    BlockStoreLocation dst = BlockStoreLocation.anyDirInAnyTierWithMedium(mediumType);
-    BlockMeta meta = mLocalBlockStore.getVolatileBlockMeta(blockId);
+    moveBlockInternal(sessionId, blockId,
+        BlockStoreLocation.anyDirInAnyTierWithMedium(mediumType));
+  }
+
+  private void moveBlockInternal(long sessionId, long blockId, BlockStoreLocation dst)
+      throws BlockDoesNotExistException, InvalidWorkerStateException,
+      WorkerOutOfSpaceException, IOException {
+    BlockMeta meta = mLocalBlockStore.getVolatileBlockMeta(blockId).orElseThrow(
+        () -> new BlockDoesNotExistException(ExceptionMessage.BLOCK_META_NOT_FOUND, blockId));
     if (meta.getBlockLocation().belongsTo(dst)) {
       return;
     }

--- a/core/server/worker/src/main/java/alluxio/worker/block/LocalBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/LocalBlockStore.java
@@ -23,6 +23,7 @@ import alluxio.worker.block.meta.TempBlockMeta;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 
@@ -72,15 +73,14 @@ public interface LocalBlockStore
       throws BlockAlreadyExistsException, WorkerOutOfSpaceException, IOException;
 
   /**
-   * Gets the metadata of a block given its block id or throws {@link BlockDoesNotExistException}.
+   * Gets the metadata of a block given its block id or empty if block does not exist.
    * This method does not require a lock id so the block is possible to be moved or removed after it
    * returns.
    *
    * @param blockId the block id
    * @return metadata of the block
-   * @throws BlockDoesNotExistException if no BlockMeta for this block id is found
    */
-  BlockMeta getVolatileBlockMeta(long blockId) throws BlockDoesNotExistException;
+  Optional<BlockMeta> getVolatileBlockMeta(long blockId);
 
   /**
    * Gets the temp metadata of a specific block from local storage.
@@ -205,10 +205,8 @@ public interface LocalBlockStore
    * @param sessionId the id of the session to remove a block
    * @param blockId the id of an existing block
    * @throws InvalidWorkerStateException if block id has not been committed
-   * @throws BlockDoesNotExistException if block can not be found
    */
-  void removeBlock(long sessionId, long blockId) throws InvalidWorkerStateException,
-      BlockDoesNotExistException, IOException;
+  void removeBlock(long sessionId, long blockId) throws InvalidWorkerStateException, IOException;
 
   /**
    * Notifies the block store that a block was accessed so the block store could update accordingly

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -52,6 +52,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -191,18 +192,21 @@ public class TieredBlockStore implements LocalBlockStore
     LOG.debug("createBlockReader: sessionId={}, blockId={}, offset={}",
         sessionId, blockId, offset);
     long lockId = mLockManager.lockBlock(sessionId, blockId, BlockLockType.READ);
-    BlockMeta blockMeta;
+    Optional<BlockMeta> blockMeta;
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       blockMeta = mMetaManager.getBlockMeta(blockId);
-      BlockReader reader = new StoreBlockReader(sessionId, blockMeta);
+    }
+    if (!blockMeta.isPresent()) {
+      unpinBlock(lockId);
+      throw new BlockDoesNotExistException(ExceptionMessage.BLOCK_META_NOT_FOUND, blockId);
+    }
+    try {
+      BlockReader reader = new StoreBlockReader(sessionId, blockMeta.get());
       ((FileChannel) reader.getChannel()).position(offset);
       accessBlock(sessionId, blockId);
       return new DelegatingBlockReader(reader, () -> unpinBlock(lockId));
     } catch (Exception e) {
       unpinBlock(lockId);
-      if (e instanceof BlockDoesNotExistException) {
-        throw e;
-      }
       throw new IOException(String.format("Failed to get local block reader, sessionId=%d, "
           + "blockId=%d, offset=%d", sessionId, blockId, offset), e);
     }
@@ -219,7 +223,7 @@ public class TieredBlockStore implements LocalBlockStore
 
   // TODO(bin): Make this method to return a snapshot.
   @Override
-  public BlockMeta getVolatileBlockMeta(long blockId) throws BlockDoesNotExistException {
+  public Optional<BlockMeta> getVolatileBlockMeta(long blockId) {
     LOG.debug("getVolatileBlockMeta: blockId={}", blockId);
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       return mMetaManager.getBlockMeta(blockId);
@@ -342,20 +346,22 @@ public class TieredBlockStore implements LocalBlockStore
 
   @Override
   public void removeBlock(long sessionId, long blockId)
-      throws InvalidWorkerStateException, BlockDoesNotExistException, IOException {
+      throws InvalidWorkerStateException, IOException {
     LOG.debug("removeBlock: sessionId={}, blockId={}", sessionId, blockId);
-    BlockMeta blockMeta = removeBlockInternal(sessionId, blockId, REMOVE_BLOCK_TIMEOUT_MS);
+    Optional<BlockMeta> blockMeta = removeBlockInternal(
+        sessionId, blockId, REMOVE_BLOCK_TIMEOUT_MS);
     for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
       synchronized (listener) {
         listener.onRemoveBlockByClient(sessionId, blockId);
-        listener.onRemoveBlock(sessionId, blockId, blockMeta.getBlockLocation());
+        blockMeta.ifPresent(meta -> listener.onRemoveBlock(
+            sessionId, blockId, meta.getBlockLocation()));
       }
     }
   }
 
   @VisibleForTesting
-  BlockMeta removeBlockInternal(long sessionId, long blockId, long timeoutMs)
-      throws InvalidWorkerStateException, BlockDoesNotExistException, IOException {
+  Optional<BlockMeta> removeBlockInternal(long sessionId, long blockId, long timeoutMs)
+      throws InvalidWorkerStateException, IOException {
     OptionalLong lockId = mLockManager.tryLockBlock(sessionId, blockId, BlockLockType.WRITE,
         timeoutMs, TimeUnit.MILLISECONDS);
     if (!lockId.isPresent()) {
@@ -363,36 +369,39 @@ public class TieredBlockStore implements LocalBlockStore
           String.format("Can not acquire lock to remove block %d for session %d after %d ms",
               blockId, sessionId, REMOVE_BLOCK_TIMEOUT_MS));
     }
-    BlockMeta blockMeta;
+    Optional<BlockMeta> blockMeta;
     try (LockResource r = new LockResource(mMetadataReadLock)) {
       if (mMetaManager.hasTempBlockMeta(blockId)) {
+        mLockManager.unlockBlock(lockId.getAsLong());
         throw new InvalidWorkerStateException(ExceptionMessage.REMOVE_UNCOMMITTED_BLOCK, blockId);
       }
 
       blockMeta = mMetaManager.getBlockMeta(blockId);
-    } catch (Exception e) {
-      mLockManager.unlockBlock(lockId.getAsLong());
-      throw e;
     }
 
-    try (LockResource r = new LockResource(mMetadataWriteLock)) {
-      removeBlockFileAndMeta(blockMeta);
-    } finally {
-      mLockManager.unlockBlock(lockId.getAsLong());
+    if (blockMeta.isPresent()) {
+      try (LockResource r = new LockResource(mMetadataWriteLock)) {
+        removeBlockFileAndMeta(blockMeta.get());
+      }
+      finally {
+        mLockManager.unlockBlock(lockId.getAsLong());
+      }
     }
     return blockMeta;
   }
 
   @Override
-  public void accessBlock(long sessionId, long blockId) throws BlockDoesNotExistException {
+  public void accessBlock(long sessionId, long blockId) {
     LOG.debug("accessBlock: sessionId={}, blockId={}", sessionId, blockId);
+    Optional<BlockMeta> blockMeta;
     try (LockResource r = new LockResource(mMetadataReadLock)) {
-      BlockMeta blockMeta = mMetaManager.getBlockMeta(blockId);
-
+      blockMeta = mMetaManager.getBlockMeta(blockId);
+    }
+    if (blockMeta.isPresent()) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
         synchronized (listener) {
           listener.onAccessBlock(sessionId, blockId);
-          listener.onAccessBlock(sessionId, blockId, blockMeta.getBlockLocation());
+          listener.onAccessBlock(sessionId, blockId, blockMeta.get().getBlockLocation());
         }
       }
     }
@@ -691,11 +700,11 @@ public class TieredBlockStore implements LocalBlockStore
         // Add allocated temp block to metadata manager. This should never fail if allocator
         // correctly assigns a StorageDir.
         mMetaManager.addTempBlockMeta(tempBlock);
-      } catch (WorkerOutOfSpaceException | BlockAlreadyExistsException e) {
+      } catch (WorkerOutOfSpaceException e) {
         // If we reach here, allocator is not working properly
         LOG.error("Unexpected failure: {} bytes allocated at {} by allocator, "
             + "but addTempBlockMeta failed", options.getSize(), options.getLocation());
-        throw Throwables.propagate(e);
+        throw e;
       }
       return tempBlock;
     }
@@ -771,22 +780,22 @@ public class TieredBlockStore implements LocalBlockStore
       long blockToDelete = evictionCandidates.next();
       blocksIterated++;
       if (evictorView.isBlockEvictable(blockToDelete)) {
-        try {
-          BlockMeta blockMeta = mMetaManager.getBlockMeta(blockToDelete);
-          removeBlockFileAndMeta(blockMeta);
-          blocksRemoved++;
-          for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
-            synchronized (listener) {
-              listener.onRemoveBlockByWorker(sessionId, blockMeta.getBlockId());
-              listener.onRemoveBlock(sessionId, blockMeta.getBlockId(),
-                  blockMeta.getBlockLocation());
-            }
-          }
-          spaceFreed += blockMeta.getBlockSize();
-        } catch (BlockDoesNotExistException e) {
+        Optional<BlockMeta> optionalBlockMeta = mMetaManager.getBlockMeta(blockToDelete);
+        if (!optionalBlockMeta.isPresent()) {
           LOG.warn("Failed to evict blockId {}, it could be already deleted", blockToDelete);
           continue;
         }
+        BlockMeta blockMeta = optionalBlockMeta.get();
+        removeBlockFileAndMeta(blockMeta);
+        blocksRemoved++;
+        for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
+          synchronized (listener) {
+            listener.onRemoveBlockByWorker(sessionId, blockMeta.getBlockId());
+            listener.onRemoveBlock(sessionId, blockMeta.getBlockId(),
+                blockMeta.getBlockLocation());
+          }
+        }
+        spaceFreed += blockMeta.getBlockSize();
       }
     }
 
@@ -830,25 +839,20 @@ public class TieredBlockStore implements LocalBlockStore
       throws BlockDoesNotExistException, InvalidWorkerStateException, IOException {
     long lockId = mLockManager.lockBlock(sessionId, blockId, BlockLockType.WRITE);
     try {
-      long blockSize;
-      String srcFilePath;
-      String dstFilePath;
       BlockMeta srcBlockMeta;
-      BlockStoreLocation srcLocation;
-      BlockStoreLocation dstLocation;
-
       try (LockResource r = new LockResource(mMetadataReadLock)) {
         if (mMetaManager.hasTempBlockMeta(blockId)) {
           throw new InvalidWorkerStateException(ExceptionMessage.MOVE_UNCOMMITTED_BLOCK, blockId);
         }
-        srcBlockMeta = mMetaManager.getBlockMeta(blockId);
-        srcLocation = srcBlockMeta.getBlockLocation();
-        srcFilePath = srcBlockMeta.getPath();
-        blockSize = srcBlockMeta.getBlockSize();
-        // Update moveOptions with the block size.
-        moveOptions.setSize(blockSize);
+        srcBlockMeta = mMetaManager.getBlockMeta(blockId).orElseThrow(() ->
+          new BlockDoesNotExistException(ExceptionMessage.BLOCK_META_NOT_FOUND, blockId));
       }
 
+      BlockStoreLocation srcLocation = srcBlockMeta.getBlockLocation();
+      String srcFilePath = srcBlockMeta.getPath();
+      long blockSize = srcBlockMeta.getBlockSize();
+      // Update moveOptions with the block size.
+      moveOptions.setSize(blockSize);
       if (srcLocation.belongsTo(moveOptions.getLocation())) {
         return new MoveBlockResult(true, blockSize, srcLocation, srcLocation);
       }
@@ -863,7 +867,7 @@ public class TieredBlockStore implements LocalBlockStore
       // When `newLocation` is some specific location, the `newLocation` and the `dstLocation` are
       // just the same; while for `newLocation` with a wildcard significance, the `dstLocation`
       // is a specific one with specific tier and dir which belongs to newLocation.
-      dstLocation = dstTempBlock.getBlockLocation();
+      BlockStoreLocation dstLocation = dstTempBlock.getBlockLocation();
 
       // When the dstLocation belongs to srcLocation, simply abort the tempBlockMeta just created
       // internally from the newLocation and return success with specific block location.
@@ -871,7 +875,7 @@ public class TieredBlockStore implements LocalBlockStore
         mMetaManager.abortTempBlockMeta(dstTempBlock);
         return new MoveBlockResult(true, blockSize, srcLocation, dstLocation);
       }
-      dstFilePath = dstTempBlock.getCommitPath();
+      String dstFilePath = dstTempBlock.getCommitPath();
 
       // Heavy IO is guarded by block lock but not metadata lock. This may throw IOException.
       FileUtils.move(srcFilePath, dstFilePath);
@@ -897,11 +901,9 @@ public class TieredBlockStore implements LocalBlockStore
    * Removes a block physically and from metadata.
    *
    * @param blockMeta block metadata
-   *
-   * @throws BlockDoesNotExistException if this block can not be found
    */
   private void removeBlockFileAndMeta(BlockMeta blockMeta)
-      throws BlockDoesNotExistException, IOException {
+      throws IOException {
     String filePath = blockMeta.getPath();
     Files.delete(Paths.get(filePath));
     mMetaManager.removeBlockMeta(blockMeta);

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/AbstractEvictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/AbstractEvictor.java
@@ -12,7 +12,6 @@
 package alluxio.worker.block.evictor;
 
 import alluxio.collections.Pair;
-import alluxio.exception.BlockDoesNotExistException;
 import alluxio.worker.block.AbstractBlockStoreEventListener;
 import alluxio.worker.block.BlockMetadataEvictorView;
 import alluxio.worker.block.BlockStoreLocation;
@@ -23,12 +22,11 @@ import alluxio.worker.block.meta.StorageDirView;
 import alluxio.worker.block.meta.StorageTierView;
 
 import com.google.common.base.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -40,7 +38,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 @Deprecated
 public abstract class AbstractEvictor extends AbstractBlockStoreEventListener implements Evictor {
-  private static final Logger LOG = LoggerFactory.getLogger(AbstractEvictor.class);
   protected final Allocator mAllocator;
   protected BlockMetadataEvictorView mMetadataView;
 
@@ -77,8 +74,6 @@ public abstract class AbstractEvictor extends AbstractBlockStoreEventListener im
    */
   protected StorageDirEvictorView cascadingEvict(long bytesToBeAvailable,
       BlockStoreLocation location, EvictionPlan plan, Mode mode) {
-    location = updateBlockStoreLocation(bytesToBeAvailable, location);
-
     // 1. If bytesToBeAvailable can already be satisfied without eviction, return the eligible
     // StorageDirView
     StorageDirEvictorView candidateDirView = selectDirWithRequestedSpace(
@@ -94,22 +89,21 @@ public abstract class AbstractEvictor extends AbstractBlockStoreEventListener im
     Iterator<Long> it = getBlockIterator();
     while (it.hasNext() && dirCandidates.candidateSize() < bytesToBeAvailable) {
       long blockId = it.next();
-      try {
-        BlockMeta block = mMetadataView.getBlockMeta(blockId);
-        if (block != null) { // might not present in this view
-          if (block.getBlockLocation().belongsTo(location)) {
-            String tierAlias = block.getParentDir().getParentTier().getTierAlias();
-            int dirIndex = block.getParentDir().getDirIndex();
-            StorageDirView dirView = mMetadataView.getTierView(tierAlias).getDirView(dirIndex);
-            if (dirView != null) {
-              dirCandidates.add((StorageDirEvictorView) dirView, blockId, block.getBlockSize());
-            }
-          }
-        }
-      } catch (BlockDoesNotExistException e) {
-        LOG.warn("Remove block {} from evictor cache because {}", blockId, e);
+      Optional<BlockMeta> optionalBlockMeta = mMetadataView.getBlockMeta(blockId);
+      if (!optionalBlockMeta.isPresent()) {
         it.remove();
         onRemoveBlockFromIterator(blockId);
+        continue;
+      }
+      BlockMeta block = optionalBlockMeta.get();
+      // might not present in this view
+      if (block.getBlockLocation().belongsTo(location)) {
+        String tierAlias = block.getParentDir().getParentTier().getTierAlias();
+        int dirIndex = block.getParentDir().getDirIndex();
+        StorageDirView dirView = mMetadataView.getTierView(tierAlias).getDirView(dirIndex);
+        if (dirView != null) {
+          dirCandidates.add((StorageDirEvictorView) dirView, blockId, block.getBlockSize());
+        }
       }
     }
 
@@ -131,46 +125,39 @@ public abstract class AbstractEvictor extends AbstractBlockStoreEventListener im
     if (nextTierView == null) {
       // This is the last tier, evict all the blocks.
       for (Long blockId : candidateBlocks) {
-        try {
-          BlockMeta block = mMetadataView.getBlockMeta(blockId);
-          if (block != null) {
-            candidateDirView.markBlockMoveOut(blockId, block.getBlockSize());
-            plan.toEvict().add(new Pair<>(blockId, candidateDirView.toBlockStoreLocation()));
-          }
-        } catch (BlockDoesNotExistException e) {
-          continue;
+        Optional<BlockMeta> block = mMetadataView.getBlockMeta(blockId);
+        if (block.isPresent()) {
+          candidateDirView.markBlockMoveOut(blockId, block.get().getBlockSize());
+          plan.toEvict().add(new Pair<>(blockId, candidateDirView.toBlockStoreLocation()));
         }
       }
     } else {
       for (Long blockId : candidateBlocks) {
-        try {
-          BlockMeta block = mMetadataView.getBlockMeta(blockId);
-          if (block == null) {
-            continue;
-          }
-          StorageDirEvictorView nextDirView
-              = (StorageDirEvictorView) mAllocator.allocateBlockWithView(
-              block.getBlockSize(),
-                  BlockStoreLocation.anyDirInTier(nextTierView.getTierViewAlias()),
-                  mMetadataView, true);
-          if (nextDirView == null) {
-            nextDirView = cascadingEvict(block.getBlockSize(),
-                BlockStoreLocation.anyDirInTier(nextTierView.getTierViewAlias()), plan, mode);
-          }
-          if (nextDirView == null) {
-            // If we failed to find a dir in the next tier to move this block, evict it and
-            // continue. Normally this should not happen.
-            plan.toEvict().add(new Pair<>(blockId, block.getBlockLocation()));
-            candidateDirView.markBlockMoveOut(blockId, block.getBlockSize());
-            continue;
-          }
-          plan.toMove().add(BlockTransferInfo.createMove(block.getBlockLocation(), blockId,
-              nextDirView.toBlockStoreLocation()));
-          candidateDirView.markBlockMoveOut(blockId, block.getBlockSize());
-          nextDirView.markBlockMoveIn(blockId, block.getBlockSize());
-        } catch (BlockDoesNotExistException e) {
+        Optional<BlockMeta> optionalBlock = mMetadataView.getBlockMeta(blockId);
+        if (!optionalBlock.isPresent()) {
           continue;
         }
+        BlockMeta block = optionalBlock.get();
+        StorageDirEvictorView nextDirView =
+            (StorageDirEvictorView) mAllocator.allocateBlockWithView(
+                block.getBlockSize(),
+                BlockStoreLocation.anyDirInTier(nextTierView.getTierViewAlias()),
+                mMetadataView, true);
+        if (nextDirView == null) {
+          nextDirView = cascadingEvict(block.getBlockSize(),
+              BlockStoreLocation.anyDirInTier(nextTierView.getTierViewAlias()), plan, mode);
+        }
+        if (nextDirView == null) {
+          // If we failed to find a dir in the next tier to move this block, evict it and
+          // continue. Normally this should not happen.
+          plan.toEvict().add(new Pair<>(blockId, block.getBlockLocation()));
+          candidateDirView.markBlockMoveOut(blockId, block.getBlockSize());
+          continue;
+        }
+        plan.toMove().add(BlockTransferInfo.createMove(block.getBlockLocation(), blockId,
+            nextDirView.toBlockStoreLocation()));
+        candidateDirView.markBlockMoveOut(blockId, block.getBlockSize());
+        nextDirView.markBlockMoveIn(blockId, block.getBlockSize());
       }
     }
 
@@ -215,18 +202,6 @@ public abstract class AbstractEvictor extends AbstractBlockStoreEventListener im
    * {@link #getBlockIterator()}.
    */
   protected void onRemoveBlockFromIterator(long blockId) {}
-
-  /**
-   * Updates the block store location if the evictor wants to free space in a specific location.
-   *
-   * @param bytesToBeAvailable bytes to be available after eviction
-   * @param location the original block store location
-   * @return the updated block store location
-   */
-  protected BlockStoreLocation updateBlockStoreLocation(long bytesToBeAvailable,
-      BlockStoreLocation location) {
-    return location;
-  }
 
   /**
    * Finds a directory in the given location range with capacity upwards of the given bound.

--- a/core/server/worker/src/main/java/alluxio/worker/block/management/tier/SwapRestoreTask.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/management/tier/SwapRestoreTask.java
@@ -14,7 +14,6 @@ package alluxio.worker.block.management.tier;
 import alluxio.Sessions;
 import alluxio.StorageTierAssoc;
 import alluxio.collections.Pair;
-import alluxio.exception.BlockDoesNotExistException;
 import alluxio.worker.block.BlockMetadataEvictorView;
 import alluxio.worker.block.BlockMetadataManager;
 import alluxio.worker.block.LocalBlockStore;
@@ -37,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
@@ -139,21 +139,18 @@ public class SwapRestoreTask extends AbstractBlockManagementTask {
           .getIterator(BlockStoreLocation.anyDirInTier(tierAlias), BlockOrder.NATURAL);
       while (tierIterator.hasNext() && moveOutBytes > 0) {
         long blockId = tierIterator.next();
-        try {
-          BlockMeta nextBlockFromTier = mEvictorView.getBlockMeta(blockId);
-          if (nextBlockFromTier == null) {
-            LOG.debug("Block:{} exist but not available for moving.", blockId);
-            continue;
-          }
-          moveOutBytes -= nextBlockFromTier.getBlockSize();
-          if (lastTier) {
-            blocksToRemove.add(nextBlockFromTier.getBlockId());
-          } else {
-            blocksToTransfer.add(BlockTransferInfo.createMove(nextBlockFromTier.getBlockLocation(),
-                nextBlockFromTier.getBlockId(), destLocation));
-          }
-        } catch (BlockDoesNotExistException e) {
-          LOG.warn("Failed to find block:{} during cascading calculation.", blockId);
+        Optional<BlockMeta> nextBlockFromTier = mEvictorView.getBlockMeta(blockId);
+        if (!nextBlockFromTier.isPresent()) {
+          LOG.debug("Block:{} exist but not available for moving.", blockId);
+          continue;
+        }
+        moveOutBytes -= nextBlockFromTier.get().getBlockSize();
+        if (lastTier) {
+          blocksToRemove.add(nextBlockFromTier.get().getBlockId());
+        } else {
+          blocksToTransfer.add(BlockTransferInfo.createMove(
+              nextBlockFromTier.get().getBlockLocation(),
+              nextBlockFromTier.get().getBlockId(), destLocation));
         }
       }
     }
@@ -181,45 +178,39 @@ public class SwapRestoreTask extends AbstractBlockManagementTask {
             BlockOrder.NATURAL);
         while (dirBlockIter.hasNext() && dirView.getAvailableBytes() < dirView.getReservedBytes()) {
           long blockId = dirBlockIter.next();
-          try {
-            BlockMeta movingOutBlock = mEvictorView.getBlockMeta(blockId);
-            if (movingOutBlock == null) {
-              LOG.debug("Block:{} exist but not available for balancing.", blockId);
+          Optional<BlockMeta> movingOutBlock = mEvictorView.getBlockMeta(blockId);
+          if (!movingOutBlock.isPresent()) {
+            LOG.debug("Block:{} exist but not available for balancing.", blockId);
+            continue;
+          }
+          // Find where to move the block.
+          StorageDirView dstDirView = null;
+          for (StorageDirView candidateDirView : tierView.getDirViews()) {
+            if (candidateDirView.getDirViewIndex() == dirView.getDirViewIndex()) {
               continue;
             }
-            // Find where to move the block.
-            StorageDirView dstDirView = null;
-            for (StorageDirView candidateDirView : tierView.getDirViews()) {
-              if (candidateDirView.getDirViewIndex() == dirView.getDirViewIndex()) {
-                continue;
-              }
-              if (candidateDirView.getAvailableBytes()
-                  - candidateDirView.getReservedBytes() >= movingOutBlock.getBlockSize()) {
-                dstDirView = candidateDirView;
-                break;
-              }
-            }
-
-            if (dstDirView == null) {
-              LOG.warn("Could not balance swap-restore space for location: {}",
-                  dirView.toBlockStoreLocation());
+            if (candidateDirView.getAvailableBytes()
+                - candidateDirView.getReservedBytes() >= movingOutBlock.get().getBlockSize()) {
+              dstDirView = candidateDirView;
               break;
             }
-
-            // TODO(ggezer): Consider allowing evictions for this move.
-            transferInfos.add(BlockTransferInfo.createMove(movingOutBlock.getBlockLocation(),
-                blockId, dstDirView.toBlockStoreLocation()));
-
-            // Account for moving-out blocks.
-            ((StorageDirEvictorView) dirView).markBlockMoveOut(blockId,
-                movingOutBlock.getBlockSize());
-            // Account for moving-in blocks.
-            ((StorageDirEvictorView) dstDirView).markBlockMoveIn(blockId,
-                movingOutBlock.getBlockSize());
-          } catch (BlockDoesNotExistException e) {
-            LOG.warn("Failed to find metadata for block:{} during swap-restore balancing.",
-                blockId);
           }
+          if (dstDirView == null) {
+            LOG.warn("Could not balance swap-restore space for location: {}",
+                dirView.toBlockStoreLocation());
+            break;
+          }
+
+          // TODO(ggezer): Consider allowing evictions for this move.
+          transferInfos.add(BlockTransferInfo.createMove(movingOutBlock.get().getBlockLocation(),
+              blockId, dstDirView.toBlockStoreLocation()));
+
+          // Account for moving-out blocks.
+          ((StorageDirEvictorView) dirView).markBlockMoveOut(blockId,
+              movingOutBlock.get().getBlockSize());
+          // Account for moving-in blocks.
+          ((StorageDirEvictorView) dstDirView).markBlockMoveIn(blockId,
+              movingOutBlock.get().getBlockSize());
         }
       }
     }

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageDir.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageDir.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -223,12 +224,8 @@ public final class DefaultStorageDir implements StorageDir {
   }
 
   @Override
-  public BlockMeta getBlockMeta(long blockId) throws BlockDoesNotExistException {
-    BlockMeta blockMeta = mBlockIdToBlockMap.get(blockId);
-    if (blockMeta == null) {
-      throw new BlockDoesNotExistException(ExceptionMessage.BLOCK_META_NOT_FOUND, blockId);
-    }
-    return blockMeta;
+  public Optional<BlockMeta> getBlockMeta(long blockId) {
+    return Optional.ofNullable(mBlockIdToBlockMap.get(blockId));
   }
 
   @Override
@@ -283,14 +280,13 @@ public final class DefaultStorageDir implements StorageDir {
   }
 
   @Override
-  public void removeBlockMeta(BlockMeta blockMeta) throws BlockDoesNotExistException {
+  public void removeBlockMeta(BlockMeta blockMeta) {
     Preconditions.checkNotNull(blockMeta, "blockMeta");
     long blockId = blockMeta.getBlockId();
     BlockMeta deletedBlockMeta = mBlockIdToBlockMap.remove(blockId);
-    if (deletedBlockMeta == null) {
-      throw new BlockDoesNotExistException(ExceptionMessage.BLOCK_META_NOT_FOUND, blockId);
+    if (deletedBlockMeta != null) {
+      reclaimSpace(blockMeta.getBlockSize(), true);
     }
-    reclaimSpace(blockMeta.getBlockSize(), true);
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerClientServiceHandler.java
@@ -11,9 +11,6 @@
 
 package alluxio.worker.grpc;
 
-import static com.google.common.base.Preconditions.checkState;
-import static java.lang.String.format;
-
 import alluxio.RpcUtils;
 import alluxio.annotation.SuppressFBWarnings;
 import alluxio.conf.PropertyKey;
@@ -40,6 +37,7 @@ import alluxio.grpc.WriteRequestMarshaller;
 import alluxio.grpc.WriteResponse;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.authentication.AuthenticatedUserInfo;
+import alluxio.underfs.UfsManager;
 import alluxio.util.IdUtils;
 import alluxio.util.SecurityUtils;
 import alluxio.worker.WorkerProcess;
@@ -66,8 +64,8 @@ public class BlockWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorker
   private static final Logger LOG = LoggerFactory.getLogger(BlockWorkerClientServiceHandler.class);
   private static final boolean ZERO_COPY_ENABLED =
       ServerConfiguration.getBoolean(PropertyKey.WORKER_NETWORK_ZEROCOPY_ENABLED);
-  private final WorkerProcess mWorkerProcess;
   private final DefaultBlockWorker mBlockWorker;
+  private final UfsManager mUfsManager;
   private final ReadResponseMarshaller mReadResponseMarshaller = new ReadResponseMarshaller();
   private final WriteRequestMarshaller mWriteRequestMarshaller = new WriteRequestMarshaller();
   private final boolean mDomainSocketEnabled;
@@ -80,11 +78,8 @@ public class BlockWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorker
    */
   public BlockWorkerClientServiceHandler(WorkerProcess workerProcess,
       boolean domainSocketEnabled) {
-    mWorkerProcess = workerProcess;
-    BlockWorker blockWorker = mWorkerProcess.getWorker(BlockWorker.class);
-    checkState(blockWorker instanceof DefaultBlockWorker,
-        format("Expect DefaultBlockWorker, get %s", blockWorker.getClass().getName()));
-    mBlockWorker = (DefaultBlockWorker) blockWorker;
+    mBlockWorker = (DefaultBlockWorker) workerProcess.getWorker(BlockWorker.class);
+    mUfsManager = workerProcess.getUfsManager();
     mDomainSocketEnabled = domainSocketEnabled;
   }
 
@@ -128,8 +123,8 @@ public class BlockWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorker
       responseObserver =
           new DataMessageServerRequestObserver<>(responseObserver, mWriteRequestMarshaller, null);
     }
-    DelegationWriteHandler handler = new DelegationWriteHandler(mWorkerProcess, responseObserver,
-        getAuthenticatedUserInfo(), mDomainSocketEnabled);
+    DelegationWriteHandler handler = new DelegationWriteHandler(mBlockWorker, mUfsManager,
+        responseObserver, getAuthenticatedUserInfo(), mDomainSocketEnabled);
     serverResponseObserver.setOnCancelHandler(handler::onCancel);
     return handler;
   }
@@ -184,7 +179,7 @@ public class BlockWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorker
       StreamObserver<MoveBlockResponse> responseObserver) {
     long sessionId = IdUtils.createSessionId();
     RpcUtils.call(LOG, () -> {
-      mWorkerProcess.getWorker(BlockWorker.class).moveBlockToMedium(sessionId,
+      mBlockWorker.moveBlockToMedium(sessionId,
           request.getBlockId(), request.getMediumType());
       return MoveBlockResponse.getDefaultInstance();
     }, "moveBlock", "request=%s", responseObserver, request);
@@ -194,7 +189,7 @@ public class BlockWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorker
   public void clearMetrics(ClearMetricsRequest request,
       StreamObserver<ClearMetricsResponse> responseObserver) {
     RpcUtils.call(LOG, () -> {
-      mWorkerProcess.getWorker(BlockWorker.class).clearMetrics();
+      mBlockWorker.clearMetrics();
       return ClearMetricsResponse.getDefaultInstance();
     }, "clearMetrics", "request=%s", responseObserver, request);
   }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/DelegationWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/DelegationWriteHandler.java
@@ -16,8 +16,8 @@ import alluxio.grpc.DataMessageMarshallerProvider;
 import alluxio.grpc.WriteRequest;
 import alluxio.grpc.WriteResponse;
 import alluxio.security.authentication.AuthenticatedUserInfo;
-import alluxio.worker.WorkerProcess;
-import alluxio.worker.block.BlockWorker;
+import alluxio.underfs.UfsManager;
+import alluxio.worker.block.DefaultBlockWorker;
 
 import io.grpc.stub.StreamObserver;
 
@@ -27,22 +27,25 @@ import io.grpc.stub.StreamObserver;
  */
 public class DelegationWriteHandler implements StreamObserver<alluxio.grpc.WriteRequest> {
   private final StreamObserver<WriteResponse> mResponseObserver;
-  private final WorkerProcess mWorkerProcess;
+  private final DefaultBlockWorker mBlockWorker;
+  private final UfsManager mUfsManager;
   private final DataMessageMarshaller<WriteRequest> mMarshaller;
   private AbstractWriteHandler mWriteHandler;
   private AuthenticatedUserInfo mUserInfo;
   private final boolean mDomainSocketEnabled;
 
   /**
-   * @param workerProcess the worker process instance
+   * @param blockWorker the block worker instance
+   * @param ufsManager the UFS manager
    * @param responseObserver the response observer of the gRPC stream
    * @param userInfo the authenticated user info
    * @param domainSocketEnabled whether using a domain socket
    */
-  public DelegationWriteHandler(WorkerProcess workerProcess,
+  public DelegationWriteHandler(DefaultBlockWorker blockWorker, UfsManager ufsManager,
       StreamObserver<WriteResponse> responseObserver, AuthenticatedUserInfo userInfo,
       boolean domainSocketEnabled) {
-    mWorkerProcess = workerProcess;
+    mBlockWorker = blockWorker;
+    mUfsManager = ufsManager;
     mResponseObserver = responseObserver;
     mUserInfo = userInfo;
     if (mResponseObserver instanceof DataMessageMarshallerProvider) {
@@ -57,14 +60,14 @@ public class DelegationWriteHandler implements StreamObserver<alluxio.grpc.Write
   private AbstractWriteHandler createWriterHandler(alluxio.grpc.WriteRequest request) {
     switch (request.getCommand().getType()) {
       case ALLUXIO_BLOCK:
-        return new BlockWriteHandler(mWorkerProcess.getWorker(BlockWorker.class), mResponseObserver,
+        return new BlockWriteHandler(mBlockWorker, mResponseObserver,
             mUserInfo, mDomainSocketEnabled);
       case UFS_FILE:
-        return new UfsFileWriteHandler(mWorkerProcess.getUfsManager(), mResponseObserver,
+        return new UfsFileWriteHandler(mUfsManager, mResponseObserver,
             mUserInfo);
       case UFS_FALLBACK_BLOCK:
-        return new UfsFallbackBlockWriteHandler(mWorkerProcess.getWorker(BlockWorker.class),
-            mWorkerProcess.getUfsManager(), mResponseObserver, mUserInfo, mDomainSocketEnabled);
+        return new UfsFallbackBlockWriteHandler(
+            mBlockWorker, mUfsManager, mResponseObserver, mUserInfo, mDomainSocketEnabled);
       default:
         throw new IllegalArgumentException(String.format("Invalid request type %s",
             request.getCommand().getType().name()));

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandler.java
@@ -25,8 +25,8 @@ import alluxio.underfs.UfsManager;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.worker.BlockUtils;
-import alluxio.worker.block.BlockWorker;
 import alluxio.worker.block.CreateBlockOptions;
+import alluxio.worker.block.DefaultBlockWorker;
 import alluxio.worker.block.meta.TempBlockMeta;
 
 import com.google.common.base.Preconditions;
@@ -52,7 +52,7 @@ public final class UfsFallbackBlockWriteHandler
   private static final Logger LOG = LoggerFactory.getLogger(UfsFallbackBlockWriteHandler.class);
 
   /** The Block Worker which handles blocks stored in the Alluxio storage of the worker. */
-  private final BlockWorker mWorker;
+  private final DefaultBlockWorker mWorker;
   private final UfsManager mUfsManager;
   private final BlockWriteHandler mBlockWriteHandler;
   private final boolean mDomainSocketEnabled;
@@ -64,7 +64,7 @@ public final class UfsFallbackBlockWriteHandler
    * @param userInfo the authenticated user info
    * @param domainSocketEnabled whether using a domain socket
    */
-  UfsFallbackBlockWriteHandler(BlockWorker blockWorker, UfsManager ufsManager,
+  UfsFallbackBlockWriteHandler(DefaultBlockWorker blockWorker, UfsManager ufsManager,
       StreamObserver<WriteResponse> responseObserver, AuthenticatedUserInfo userInfo,
       boolean domainSocketEnabled) {
     super(responseObserver, userInfo);
@@ -266,10 +266,8 @@ public final class UfsFallbackBlockWriteHandler
    */
   private void transferToUfsBlock(BlockWriteRequestContext context, long pos) throws Exception {
     OutputStream ufsOutputStream = context.getOutputStream();
-
-    long sessionId = context.getRequest().getSessionId();
     long blockId = context.getRequest().getId();
-    TempBlockMeta block = mWorker.getTempBlockMeta(blockId);
+    TempBlockMeta block = mWorker.getLocalBlockStore().getTempBlockMeta(blockId);
     Preconditions.checkState(Files.copy(Paths.get(block.getPath()), ufsOutputStream) == pos);
   }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockMetadataManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockMetadataManagerTest.java
@@ -202,7 +202,7 @@ public final class BlockMetadataManagerTest {
     assertFalse(mMetaManager.hasTempBlockMeta(TEST_TEMP_BLOCK_ID));
     assertTrue(mMetaManager.hasBlockMeta(TEST_TEMP_BLOCK_ID));
     // Get block
-    BlockMeta blockMeta = mMetaManager.getBlockMeta(TEST_TEMP_BLOCK_ID);
+    BlockMeta blockMeta = mMetaManager.getBlockMeta(TEST_TEMP_BLOCK_ID).get();
     assertEquals(TEST_TEMP_BLOCK_ID, blockMeta.getBlockId());
     // Remove block
     mMetaManager.removeBlockMeta(blockMeta);
@@ -211,14 +211,12 @@ public final class BlockMetadataManagerTest {
   }
 
   /**
-   * Tests that an exception is thrown in the {@link BlockMetadataManager#getBlockMeta(long)} method
-   * when trying to retrieve metadata of a block which does not exist.
+   * Tests that the {@link BlockMetadataManager#getBlockMeta(long)} method returns
+   * Optional.empty() when trying to retrieve metadata of a block which does not exist.
    */
   @Test
   public void getBlockMetaNotExisting() throws Exception {
-    mThrown.expect(BlockDoesNotExistException.class);
-    mThrown.expectMessage(ExceptionMessage.BLOCK_META_NOT_FOUND.getMessage(TEST_BLOCK_ID));
-    mMetaManager.getBlockMeta(TEST_BLOCK_ID);
+    assertFalse(mMetaManager.getBlockMeta(TEST_BLOCK_ID).isPresent());
   }
 
   /**
@@ -249,7 +247,7 @@ public final class BlockMetadataManagerTest {
 
     // commit the first temp block meta
     mMetaManager.commitTempBlockMeta(tempBlockMeta1);
-    BlockMeta blockMeta = mMetaManager.getBlockMeta(TEST_TEMP_BLOCK_ID);
+    BlockMeta blockMeta = mMetaManager.getBlockMeta(TEST_TEMP_BLOCK_ID).get();
 
     mMetaManager.moveBlockMeta(blockMeta, tempBlockMeta2);
 
@@ -279,7 +277,7 @@ public final class BlockMetadataManagerTest {
 
     // commit the first temp block meta
     mMetaManager.commitTempBlockMeta(tempBlockMeta1);
-    BlockMeta blockMeta = mMetaManager.getBlockMeta(TEST_TEMP_BLOCK_ID);
+    BlockMeta blockMeta = mMetaManager.getBlockMeta(TEST_TEMP_BLOCK_ID).get();
 
     mMetaManager.moveBlockMeta(blockMeta, tempBlockMeta2);
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
@@ -55,14 +55,10 @@ import java.util.Set;
  * Unit tests for {@link DefaultBlockWorker}.
  */
 public class DefaultBlockWorkerTest {
-  private BlockMasterClient mBlockMasterClient;
-  private BlockMasterClientPool mBlockMasterClientPool;
   private TieredBlockStore mBlockStore;
   private DefaultBlockWorker mBlockWorker;
   private FileSystemMasterClient mFileSystemMasterClient;
   private Random mRandom;
-  private Sessions mSessions;
-  private UfsManager mUfsManager;
   private String mMemDir =
       AlluxioTestDirectory.createTemporaryDirectory(Constants.MEDIUM_MEM).getAbsolutePath();
   private String mHddDir =
@@ -92,16 +88,16 @@ public class DefaultBlockWorkerTest {
   @Before
   public void before() throws IOException {
     mRandom = new Random();
-    mBlockMasterClient = mock(BlockMasterClient.class);
-    mBlockMasterClientPool = spy(new BlockMasterClientPool());
-    when(mBlockMasterClientPool.createNewResource()).thenReturn(mBlockMasterClient);
+    BlockMasterClient blockMasterClient = mock(BlockMasterClient.class);
+    BlockMasterClientPool blockMasterClientPool = spy(new BlockMasterClientPool());
+    when(blockMasterClientPool.createNewResource()).thenReturn(blockMasterClient);
     mBlockStore = spy(new TieredBlockStore());
     mFileSystemMasterClient = mock(FileSystemMasterClient.class);
-    mSessions = mock(Sessions.class);
-    mUfsManager = mock(UfsManager.class);
+    Sessions sessions = mock(Sessions.class);
+    UfsManager ufsManager = mock(UfsManager.class);
 
-    mBlockWorker = new DefaultBlockWorker(mBlockMasterClientPool, mFileSystemMasterClient,
-        mSessions, mBlockStore, mUfsManager);
+    mBlockWorker = new DefaultBlockWorker(blockMasterClientPool, mFileSystemMasterClient,
+        sessions, mBlockStore, ufsManager);
   }
 
   @Test
@@ -111,7 +107,8 @@ public class DefaultBlockWorkerTest {
     mBlockWorker.createBlock(sessionId, blockId, 0,
         new CreateBlockOptions(null, Constants.MEDIUM_MEM, 1));
     mBlockWorker.abortBlock(sessionId, blockId);
-    assertThrows(BlockDoesNotExistException.class, () -> mBlockWorker.getTempBlockMeta(blockId));
+    assertThrows(BlockDoesNotExistException.class,
+        () -> mBlockWorker.getLocalBlockStore().getTempBlockMeta(blockId));
   }
 
   @Test
@@ -164,7 +161,7 @@ public class DefaultBlockWorkerTest {
         new CreateBlockOptions(null, Constants.MEDIUM_MEM, 1));
     try (BlockWriter blockWriter = mBlockWorker.createBlockWriter(sessionId, blockId)) {
       blockWriter.append(BufferUtils.getIncreasingByteBuffer(10));
-      TempBlockMeta meta = mBlockWorker.getTempBlockMeta(blockId);
+      TempBlockMeta meta = mBlockWorker.getLocalBlockStore().getTempBlockMeta(blockId);
       assertEquals(Constants.MEDIUM_MEM, meta.getBlockLocation().mediumType());
     }
     mBlockWorker.abortBlock(sessionId, blockId);
@@ -213,31 +210,6 @@ public class DefaultBlockWorkerTest {
   }
 
   @Test
-  public void getVolatileBlockMetaNotFound() throws Exception {
-    long blockId = mRandom.nextLong();
-    assertThrows(BlockDoesNotExistException.class,
-        () -> mBlockWorker.getVolatileBlockMeta(blockId));
-  }
-
-  @Test
-  public void getVolatileBlockMeta() throws Exception {
-    long sessionId = mRandom.nextLong();
-    long blockId = mRandom.nextLong();
-    mBlockWorker.createBlock(sessionId, blockId, 0,
-        new CreateBlockOptions(null, Constants.MEDIUM_MEM, 1));
-    mBlockWorker.commitBlock(sessionId, blockId, true);
-    assertEquals(blockId, mBlockWorker.getVolatileBlockMeta(blockId).getBlockId());
-  }
-
-  @Test
-  public void getBlockMetaNotFound() throws Exception {
-    long blockId = mRandom.nextLong();
-    assertThrows(BlockDoesNotExistException.class,
-        () -> mBlockWorker.getVolatileBlockMeta(blockId)
-    );
-  }
-
-  @Test
   public void hasBlockMeta() throws Exception  {
     long sessionId = mRandom.nextLong();
     long blockId = mRandom.nextLong();
@@ -257,10 +229,12 @@ public class DefaultBlockWorkerTest {
     // move sure this block is on tier 1
     mBlockWorker.moveBlock(sessionId, blockId, 1);
     assertEquals(Constants.MEDIUM_HDD,
-        mBlockWorker.getVolatileBlockMeta(blockId).getBlockLocation().tierAlias());
+        mBlockWorker.getLocalBlockStore().getVolatileBlockMeta(blockId).get()
+            .getBlockLocation().tierAlias());
     mBlockWorker.moveBlock(sessionId, blockId, 0);
     assertEquals(Constants.MEDIUM_MEM,
-        mBlockWorker.getVolatileBlockMeta(blockId).getBlockLocation().tierAlias());
+        mBlockWorker.getLocalBlockStore().getVolatileBlockMeta(blockId).get()
+            .getBlockLocation().tierAlias());
   }
 
   @Test
@@ -282,7 +256,7 @@ public class DefaultBlockWorkerTest {
     mBlockWorker.createBlock(sessionId, blockId, 1, new CreateBlockOptions(null, "", initialBytes));
     mBlockWorker.requestSpace(sessionId, blockId, additionalBytes);
     assertEquals(initialBytes + additionalBytes,
-        mBlockWorker.getTempBlockMeta(blockId).getBlockSize());
+        mBlockWorker.getLocalBlockStore().getTempBlockMeta(blockId).getBlockSize());
   }
 
   @Test

--- a/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
@@ -27,15 +27,12 @@ import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
-import alluxio.worker.block.meta.BlockMeta;
-import alluxio.worker.block.meta.TempBlockMeta;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.Nullable;
 
 /**
  * A block worker mock for testing.
@@ -72,12 +69,6 @@ public class NoopBlockWorker implements BlockWorker {
     return null;
   }
 
-  @Nullable
-  @Override
-  public TempBlockMeta getTempBlockMeta(long blockId) throws BlockDoesNotExistException {
-    return null;
-  }
-
   @Override
   public BlockWriter createBlockWriter(long sessionId, long blockId)
       throws BlockDoesNotExistException, BlockAlreadyExistsException, InvalidWorkerStateException,
@@ -97,11 +88,6 @@ public class NoopBlockWorker implements BlockWorker {
 
   @Override
   public BlockStoreMeta getStoreMetaFull() {
-    return null;
-  }
-
-  @Override
-  public BlockMeta getVolatileBlockMeta(long blockId) throws BlockDoesNotExistException {
     return null;
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -723,17 +723,6 @@ public final class TieredBlockStoreTest {
   }
 
   /**
-   * Tests that an exception is thrown when trying to remove a block which does not exist.
-   */
-  @Test
-  public void removeNonExistingBlock() throws Exception {
-    mThrown.expect(BlockDoesNotExistException.class);
-    mThrown.expectMessage(ExceptionMessage.BLOCK_META_NOT_FOUND.getMessage(BLOCK_ID1));
-
-    mBlockStore.removeBlock(SESSION_ID1, BLOCK_ID1);
-  }
-
-  /**
    * Tests that check storage fails when a directory is inaccessible.
    */
   @Test

--- a/core/server/worker/src/test/java/alluxio/worker/block/annotator/AbstractBlockAnnotatorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/annotator/AbstractBlockAnnotatorTest.java
@@ -60,7 +60,7 @@ public abstract class AbstractBlockAnnotatorTest {
   }
 
   protected void moveBlock(long blockId, StorageDir destDir) throws Exception {
-    mMetaManager.removeBlockMeta(mMetaManager.getBlockMeta(blockId));
+    mMetaManager.removeBlockMeta(mMetaManager.getBlockMeta(blockId).get());
     TieredBlockStoreTestUtils.cache2(mUserSession++, blockId, 1, destDir, mMetaManager,
         (BlockIterator) null);
     mBlockEventListener.onMoveBlockByWorker(mInternalSession++, blockId,
@@ -69,7 +69,7 @@ public abstract class AbstractBlockAnnotatorTest {
   }
 
   protected void removeBlock(long blockId) throws Exception {
-    mMetaManager.removeBlockMeta(mMetaManager.getBlockMeta(blockId));
+    mMetaManager.removeBlockMeta(mMetaManager.getBlockMeta(blockId).get());
     mBlockEventListener.onRemoveBlock(mUserSession++, blockId,
         mBlockLocation.remove(blockId).toBlockStoreLocation());
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/meta/DefaultStorageDirTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/meta/DefaultStorageDirTest.java
@@ -342,25 +342,11 @@ public final class DefaultStorageDirTest {
   }
 
   /**
-   * Tests that an exception is thrown when trying to remove the metadata of a block which does not
-   * exist.
+   * Tests get the metadata of a block which does not exist returns Optional.empty().
    */
   @Test
-  public void removeBlockMetaNotExisting() throws Exception {
-    mThrown.expect(BlockDoesNotExistException.class);
-    mThrown.expectMessage(ExceptionMessage.BLOCK_META_NOT_FOUND.getMessage(TEST_BLOCK_ID));
-    mDir.removeBlockMeta(mBlockMeta);
-  }
-
-  /**
-   * Tests that an exception is thrown when trying to get the metadata of a block which does not
-   * exist.
-   */
-  @Test
-  public void getBlockMetaNotExisting() throws Exception {
-    mThrown.expect(BlockDoesNotExistException.class);
-    mThrown.expectMessage(ExceptionMessage.BLOCK_META_NOT_FOUND.getMessage(TEST_BLOCK_ID));
-    mDir.getBlockMeta(TEST_BLOCK_ID);
+  public void getBlockMetaNotExisting() {
+    assertFalse(mDir.getBlockMeta(TEST_BLOCK_ID).isPresent());
   }
 
   /**
@@ -424,14 +410,11 @@ public final class DefaultStorageDirTest {
   }
 
   /**
-   * Tests that an exception is thrown when trying to get the metadata of a temporary block that
-   * does not exist.
+   * Tests getting the metadata of a temporary block that does not exist returns Optional.empty().
    */
   @Test
-  public void getTempBlockMetaNotExisting() throws Exception {
-    mThrown.expect(BlockDoesNotExistException.class);
-    mThrown.expectMessage(ExceptionMessage.BLOCK_META_NOT_FOUND.getMessage(TEST_TEMP_BLOCK_ID));
-    mDir.getBlockMeta(TEST_TEMP_BLOCK_ID);
+  public void getTempBlockMetaNotExisting() {
+    assertFalse(mDir.getBlockMeta(TEST_TEMP_BLOCK_ID).isPresent());
   }
 
   /**
@@ -445,7 +428,7 @@ public final class DefaultStorageDirTest {
 
     mDir.addBlockMeta(mBlockMeta);
     assertTrue(mDir.hasBlockMeta(TEST_BLOCK_ID));
-    assertEquals(mBlockMeta, mDir.getBlockMeta(TEST_BLOCK_ID));
+    assertEquals(mBlockMeta, mDir.getBlockMeta(TEST_BLOCK_ID).get());
     assertEquals(TEST_DIR_CAPACITY - TEST_REVERSED_BYTES - TEST_BLOCK_SIZE,
         mDir.getAvailableBytes());
 

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandlerTest.java
@@ -19,7 +19,6 @@ import alluxio.ConfigurationRule;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
-import alluxio.exception.BlockDoesNotExistException;
 import alluxio.grpc.RequestType;
 import alluxio.grpc.WriteRequest;
 import alluxio.network.protocol.databuffer.DataBuffer;
@@ -29,13 +28,11 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.CreateOptions;
 import alluxio.util.CommonUtils;
 import alluxio.worker.block.AllocateOptions;
+import alluxio.worker.block.DefaultBlockWorker;
 import alluxio.worker.block.LocalBlockStore;
 import alluxio.worker.block.BlockStoreLocation;
-import alluxio.worker.block.BlockWorker;
-import alluxio.worker.block.NoopBlockWorker;
 import alluxio.worker.block.TieredBlockStore;
 import alluxio.worker.block.io.BlockWriter;
-import alluxio.worker.block.meta.TempBlockMeta;
 
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
@@ -61,23 +58,10 @@ public class UfsFallbackBlockWriteHandlerTest extends AbstractWriteHandlerTest {
   private static final int PARTIAL_WRITTEN = 512;
 
   private OutputStream mOutputStream;
-  private BlockWorker mBlockWorker;
   private LocalBlockStore mBlockStore;
   /** The file used to hold the data written by the test. */
   private File mFile;
   private long mPartialChecksum;
-
-  class MockBlockWorker extends NoopBlockWorker {
-    @Override
-    public AtomicReference<Long> getWorkerId() {
-      return new AtomicReference<>(TEST_WORKER_ID);
-    }
-
-    @Override
-    public TempBlockMeta getTempBlockMeta(long blockId) throws BlockDoesNotExistException {
-      return mBlockStore.getTempBlockMeta(blockId);
-    }
-  }
 
   @Rule
   public ConfigurationRule mConfigurationRule =
@@ -99,7 +83,9 @@ public class UfsFallbackBlockWriteHandlerTest extends AbstractWriteHandlerTest {
     mFile = mTestFolder.newFile();
     mOutputStream = new FileOutputStream(mFile);
     mBlockStore = new TieredBlockStore();
-    mBlockWorker = new MockBlockWorker();
+    DefaultBlockWorker blockWorker = Mockito.mock(DefaultBlockWorker.class);
+    Mockito.when(blockWorker.getWorkerId()).thenReturn(new AtomicReference<>(TEST_WORKER_ID));
+    Mockito.when(blockWorker.getLocalBlockStore()).thenReturn(mBlockStore);
     UnderFileSystem mockUfs = Mockito.mock(UnderFileSystem.class);
     UfsManager ufsManager = Mockito.mock(UfsManager.class);
     UfsManager.UfsClient ufsClient = new UfsManager.UfsClient(() -> mockUfs, AlluxioURI.EMPTY_URI);
@@ -109,7 +95,7 @@ public class UfsFallbackBlockWriteHandlerTest extends AbstractWriteHandlerTest {
         .thenReturn(new FileOutputStream(mFile, true));
 
     mResponseObserver = Mockito.mock(StreamObserver.class);
-    mWriteHandler = new UfsFallbackBlockWriteHandler(mBlockWorker, ufsManager, mResponseObserver,
+    mWriteHandler = new UfsFallbackBlockWriteHandler(blockWorker, ufsManager, mResponseObserver,
         mUserInfo, false);
     setupResponseTrigger();
 
@@ -161,10 +147,9 @@ public class UfsFallbackBlockWriteHandlerTest extends AbstractWriteHandlerTest {
         newWriteRequestCommand(0).getCommand().getCreateUfsBlockOptions().toBuilder()
             .setBytesInBlockStore(bytesInBlockStore)
             .build();
-    WriteRequest request = super.newWriteRequestCommand(0).toBuilder().setCommand(
+    return super.newWriteRequestCommand(0).toBuilder().setCommand(
         super.newWriteRequestCommand(0).getCommand().toBuilder()
         .setCreateUfsBlockOptions(createUfsBlockOptions)).build();
-    return request;
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

Return Optional instead of throwing BlockDoesNotExistException.
Using exception to handle special case is expensive, using Optional.empty()
instead.

Also remove the block meta related APIs in BlockWorker.
