### PR TITLE
Fix POSIX API write file bug

### DIFF
--- a/tests/src/test/java/alluxio/client/fuse/AbstractFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/AbstractFuseIntegrationTest.java
@@ -251,14 +251,10 @@ public abstract class AbstractFuseIntegrationTest {
     String testFile = "/lsTestFile";
     createFileInFuse(testFile);
 
-    // Fuse getattr() will wait for file to be completed
-    // when fuse release returns but does not finish
     String out = ShellUtils.execCommand("ls", "-sh", mMountPoint + testFile);
     assertFalse(out.isEmpty());
     assertEquals("40K", out.split("\\s+")[0]);
-
     assertTrue(mFileSystem.exists(new AlluxioURI(testFile)));
-    assertEquals(40 * Constants.KB, mFileSystem.getStatus(new AlluxioURI(testFile)).getLength());
   }
 
   @Test


### PR DESCRIPTION
### What changes are proposed in this pull request?

All the output stream operations should be synchronized to prevent concurrent operations and able to get correct written size in Fuse.getattr.

### Why are the changes needed?

Previously Fuse.write() didn't synchronize the write file operation and host the assumption that all write will be sequential and is guaranteed by the application which is not true.

### Does this PR introduce any user facing changes?

NA