### PR TITLE
Expose RockDB metrics as Alluxio metrics

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2273,6 +2273,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_METASTORE_METRICS_REFRESH_INTERVAL =
+      durationBuilder(Name.MASTER_METASTORE_METRICS_REFRESH_INTERVAL)
+          .setDefaultValue("5s")
+          .setDescription("Interval with which the master refreshes and reports metastore metrics")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_METRICS_SERVICE_THREADS =
       intBuilder(Name.MASTER_METRICS_SERVICE_THREADS)
           .setDefaultValue(5)
@@ -6694,6 +6701,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metastore.iterator.readahead.size";
     public static final String MASTER_METASTORE_INODE_INHERIT_OWNER_AND_GROUP =
         "alluxio.master.metastore.inode.inherit.owner.and.group";
+    public static final String MASTER_METASTORE_METRICS_REFRESH_INTERVAL =
+        "alluxio.master.metastore.metrics.refresh.interval";
     public static final String MASTER_PERSISTENCE_CHECKER_INTERVAL_MS =
         "alluxio.master.persistence.checker.interval";
     public static final String MASTER_METRICS_HEAP_ENABLED =

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -978,19 +978,9 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
 
   // Rocks Block metrics
-  public static final MetricKey MASTER_ROCKS_BLOCK_ACTUAL_DELAYED_WRITE_RATE =
-      new Builder("Master.RocksBlockActualDelayedWriteRate")
-          .setDescription("RocksDB block table. Actual delayed write rate.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_BACKGROUND_ERRORS =
       new Builder("Master.RocksBlockBackgroundErrors")
           .setDescription("RocksDB block table. Accumulated number of background errors.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
-  public static final MetricKey MASTER_ROCKS_BLOCK_BASE_LEVEL =
-      new Builder("Master.RocksBlockBaseLevel")
-          .setDescription("RocksDB block table. Base level.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_BLOCK_CACHE_CAPACITY =
@@ -1027,16 +1017,6 @@ public final class MetricKey implements Comparable<MetricKey> {
               + "memtables that are kept in memory to maintain write history in memory.")
           .setMetricType(MetricType.GAUGE)
           .build();
-  public static final MetricKey MASTER_ROCKS_BLOCK_CURRENT_SUPER_VERSION_NUMBER =
-      new Builder("Master.RocksBlockCurrentSuperVersionNumber")
-          .setDescription("RocksDB block table. Current super version number.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
-  public static final MetricKey MASTER_ROCKS_BLOCK_ESTIMATE_LIVE_DATA_SIZE =
-      new Builder("Master.RocksBlockEstimateLiveDataSize")
-          .setDescription("RocksDB block table. Estimate live data size.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_ESTIMATE_NUM_KEYS =
       new Builder("Master.RocksBlockEstimateNumKeys")
           .setDescription("RocksDB block table. Estimated number of total keys in the active and "
@@ -1060,16 +1040,6 @@ public final class MetricKey implements Comparable<MetricKey> {
               + "metric reports the memory used outside the block cache to read data.")
           .setMetricType(MetricType.GAUGE)
           .build();
-  public static final MetricKey MASTER_ROCKS_BLOCK_IS_FILE_DELETIONS_ENABLED =
-      new Builder("Master.RocksBlockIsFileDeletionsEnabled")
-          .setDescription("RocksDB block table. Is file deletions enabled.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
-  public static final MetricKey MASTER_ROCKS_BLOCK_IS_WRITE_STOPPED =
-      new Builder("Master.RocksBlockIsWriteStopped")
-          .setDescription("RocksDB block table. Is write stopped.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_LIVE_SST_FILES_SIZE =
       new Builder("Master.RocksBlockLiveSstFilesSize")
           .setDescription("RocksDB block table. Total size in bytes of all SST files that belong "
@@ -1080,16 +1050,6 @@ public final class MetricKey implements Comparable<MetricKey> {
       new Builder("Master.RocksBlockMemTableFlushPending")
           .setDescription("RocksDB block table. This metric returns 1 if a memtable flush "
               + "is pending; otherwhise it returns 0.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
-  public static final MetricKey MASTER_ROCKS_BLOCK_MIN_LOG_NUMBER_TO_KEEP =
-      new Builder("Master.RocksBlockMinLogNumberToKeep")
-          .setDescription("RocksDB block table. Min log number to keep.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
-  public static final MetricKey MASTER_ROCKS_BLOCK_MIN_OBSOLETE_SST_NUMBER_TO_KEEP =
-      new Builder("Master.RocksBlockMinObsoleteSstNumberToKeep")
-          .setDescription("RocksDB block table. Min obsolete sst number to keep.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_NUM_DELETES_ACTIVE_MEM_TABLE =
@@ -1138,16 +1098,6 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("RocksDB block table. Number of currently running flushes.")
           .setMetricType(MetricType.GAUGE)
           .build();
-  public static final MetricKey MASTER_ROCKS_BLOCK_NUM_SNAPSHOTS =
-      new Builder("Master.RocksBlockNumSnapshots")
-          .setDescription("RocksDB block table. Num snapshots.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
-  public static final MetricKey MASTER_ROCKS_BLOCK_OLDEST_SNAPSHOT_TIME =
-      new Builder("Master.RocksBlockOldestSnapshotTime")
-          .setDescription("RocksDB block table. Oldest snapshot time.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_SIZE_ALL_MEM_TABLES =
       new Builder("Master.RocksBlockSizeAllMemTables")
           .setDescription("RocksDB block table. Size all mem tables.")
@@ -1160,19 +1110,9 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
 
   // Rocks Inode metrics
-  public static final MetricKey MASTER_ROCKS_INODE_ACTUAL_DELAYED_WRITE_RATE =
-      new Builder("Master.RocksInodeActualDelayedWriteRate")
-          .setDescription("RocksDB inode table. Actual delayed write rate.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
   public static final MetricKey MASTER_ROCKS_INODE_BACKGROUND_ERRORS =
       new Builder("Master.RocksInodeBackgroundErrors")
           .setDescription("RocksDB inode table. Accumulated number of background errors.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
-  public static final MetricKey MASTER_ROCKS_INODE_BASE_LEVEL =
-      new Builder("Master.RocksInodeBaseLevel")
-          .setDescription("RocksDB inode table. Base level.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_BLOCK_CACHE_CAPACITY =
@@ -1208,16 +1148,6 @@ public final class MetricKey implements Comparable<MetricKey> {
               + "immutable memtable in bytes.")
           .setMetricType(MetricType.GAUGE)
           .build();
-  public static final MetricKey MASTER_ROCKS_INODE_CURRENT_SUPER_VERSION_NUMBER =
-      new Builder("Master.RocksInodeCurrentSuperVersionNumber")
-          .setDescription("RocksDB inode table. Current super version number.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
-  public static final MetricKey MASTER_ROCKS_INODE_ESTIMATE_LIVE_DATA_SIZE =
-      new Builder("Master.RocksInodeEstimateLiveDataSize")
-          .setDescription("RocksDB inode table. Estimate live data size.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
   public static final MetricKey MASTER_ROCKS_INODE_ESTIMATE_NUM_KEYS =
       new Builder("Master.RocksInodeEstimateNumKeys")
           .setDescription("RocksDB inode table. Estimated number of total keys in the active and "
@@ -1241,16 +1171,6 @@ public final class MetricKey implements Comparable<MetricKey> {
               + "metric reports the memory used outside the block cache to read data.")
           .setMetricType(MetricType.GAUGE)
           .build();
-  public static final MetricKey MASTER_ROCKS_INODE_IS_FILE_DELETIONS_ENABLED =
-      new Builder("Master.RocksInodeIsFileDeletionsEnabled")
-          .setDescription("RocksDB inode table. Is file deletions enabled.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
-  public static final MetricKey MASTER_ROCKS_INODE_IS_WRITE_STOPPED =
-      new Builder("Master.RocksInodeIsWriteStopped")
-          .setDescription("RocksDB inode table. Is write stopped.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
   public static final MetricKey MASTER_ROCKS_INODE_LIVE_SST_FILES_SIZE =
       new Builder("Master.RocksInodeLiveSstFilesSize")
           .setDescription("RocksDB inode table. Total size in bytes of all SST files that belong "
@@ -1261,16 +1181,6 @@ public final class MetricKey implements Comparable<MetricKey> {
       new Builder("Master.RocksInodeMemTableFlushPending")
           .setDescription("RocksDB inode table. This metric returns 1 if a memtable flush "
               + "is pending; otherwhise it returns 0.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
-  public static final MetricKey MASTER_ROCKS_INODE_MIN_LOG_NUMBER_TO_KEEP =
-      new Builder("Master.RocksInodeMinLogNumberToKeep")
-          .setDescription("RocksDB inode table. Min log number to keep.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
-  public static final MetricKey MASTER_ROCKS_INODE_MIN_OBSOLETE_SST_NUMBER_TO_KEEP =
-      new Builder("Master.RocksInodeMinObsoleteSstNumberToKeep")
-          .setDescription("RocksDB inode table. Min obsolete sst number to keep.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_NUM_DELETES_ACTIVE_MEM_TABLE =
@@ -1317,16 +1227,6 @@ public final class MetricKey implements Comparable<MetricKey> {
   public static final MetricKey MASTER_ROCKS_INODE_NUM_RUNNING_FLUSHES =
       new Builder("Master.RocksInodeNumRunningFlushes")
           .setDescription("RocksDB inode table. Number of currently running flushes.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
-  public static final MetricKey MASTER_ROCKS_INODE_NUM_SNAPSHOTS =
-      new Builder("Master.RocksInodeNumSnapshots")
-          .setDescription("RocksDB inode table. Num snapshots.")
-          .setMetricType(MetricType.GAUGE)
-          .build();
-  public static final MetricKey MASTER_ROCKS_INODE_OLDEST_SNAPSHOT_TIME =
-      new Builder("Master.RocksInodeOldestSnapshotTime")
-          .setDescription("RocksDB inode table. Oldest snapshot time.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_SIZE_ALL_MEM_TABLES =

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -985,7 +985,7 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_BACKGROUND_ERRORS =
       new Builder("Master.RocksBlockBackgroundErrors")
-          .setDescription("RocksDB block table. Background errors.")
+          .setDescription("RocksDB block table. Accumulated number of background errors.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_BASE_LEVEL =
@@ -1000,27 +1000,31 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_BLOCK_CACHE_PINNED_USAGE =
       new Builder("Master.RocksBlockBlockCachePinnedUsage")
-          .setDescription("RocksDB block table. Block cache pinned usage.")
+          .setDescription("RocksDB block table. Memory size for the entries being pinned.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_BLOCK_CACHE_USAGE =
       new Builder("Master.RocksBlockBlockCacheUsage")
-          .setDescription("RocksDB block table. Block cache usage.")
+          .setDescription("RocksDB block table. Memory size for the entries residing in block "
+              + "cache.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_COMPACTION_PENDING =
       new Builder("Master.RocksBlockCompactionPending")
-          .setDescription("RocksDB block table. Compaction pending.")
+          .setDescription("RocksDB block table. This metric 1 if at least one compaction "
+              + "is pending; otherwise, the metric reports 0.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_CUR_SIZE_ACTIVE_MEM_TABLE =
       new Builder("Master.RocksBlockCurSizeActiveMemTable")
-          .setDescription("RocksDB block table. Cur size active mem table.")
+          .setDescription("RocksDB block table. Approximate size of active memtable in bytes.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_CUR_SIZE_ALL_MEM_TABLES =
       new Builder("Master.RocksBlockCurSizeAllMemTables")
-          .setDescription("RocksDB block table. Cur size all mem tables.")
+          .setDescription("RocksDB block table. Approximate size of active, unflushed immutable, "
+              + "and pinned immutable memtables in bytes. Pinned immutable memtables are flushed "
+              + "memtables that are kept in memory to maintain write history in memory.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_CURRENT_SUPER_VERSION_NUMBER =
@@ -1035,17 +1039,25 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_ESTIMATE_NUM_KEYS =
       new Builder("Master.RocksBlockEstimateNumKeys")
-          .setDescription("RocksDB block table. Estimate num keys.")
+          .setDescription("RocksDB block table. Estimated number of total keys in the active and "
+              + "unflushed immutable memtables and storage.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_ESTIMATE_PENDING_COMPACTION_BYTES =
       new Builder("Master.RocksBlockEstimatePendingCompactionBytes")
-          .setDescription("RocksDB block table. Estimate pending compaction bytes.")
+          .setDescription("RocksDB block table. Estimated total number of bytes a compaction needs "
+              + "to rewrite on disk to get all levels down to under target size. In other words, "
+              + "this metrics relates to the write amplification in level compaction. "
+              + "Thus, this metric is not valid for compactions other than level-based.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_ESTIMATE_TABLE_READERS_MEM =
       new Builder("Master.RocksBlockEstimateTableReadersMem")
-          .setDescription("RocksDB block table. Estimate table readers mem.")
+          .setDescription("RocksDB inode table. Estimated memory in bytes used for reading SST "
+              + "tables, excluding memory used in block cache (e.g., filter and index blocks). "
+              + "This metric records the memory used by iterators as well as filters and indices "
+              + "if the filters and indices are not maintained in the block cache. Basically this "
+              + "metric reports the memory used outside the block cache to read data.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_IS_FILE_DELETIONS_ENABLED =
@@ -1060,12 +1072,14 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_LIVE_SST_FILES_SIZE =
       new Builder("Master.RocksBlockLiveSstFilesSize")
-          .setDescription("RocksDB block table. Live sst files size.")
+          .setDescription("RocksDB block table. Total size in bytes of all SST files that belong "
+              + "to the latest LSM tree.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_MEM_TABLE_FLUSH_PENDING =
       new Builder("Master.RocksBlockMemTableFlushPending")
-          .setDescription("RocksDB block table. Mem table flush pending.")
+          .setDescription("RocksDB block table. This metric returns 1 if a memtable flush "
+              + "is pending; otherwhise it returns 0.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_MIN_LOG_NUMBER_TO_KEEP =
@@ -1080,42 +1094,48 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_NUM_DELETES_ACTIVE_MEM_TABLE =
       new Builder("Master.RocksBlockNumDeletesActiveMemTable")
-          .setDescription("RocksDB block table. Num deletes active mem table.")
+          .setDescription("RocksDB block table. Total number of delete entries in the active "
+              + "memtable.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_NUM_DELETES_IMM_MEM_TABLES =
       new Builder("Master.RocksBlockNumDeletesImmMemTables")
-          .setDescription("RocksDB block table. Num deletes imm mem tables.")
+          .setDescription("RocksDB block table. Total number of delete entries in the unflushed "
+              + "immutable memtables.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_NUM_ENTRIES_ACTIVE_MEM_TABLE =
       new Builder("Master.RocksBlockNumEntriesActiveMemTable")
-          .setDescription("RocksDB block table. Num entries active mem table.")
+          .setDescription("RocksDB block table. Total number of entries in the active memtable.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_NUM_ENTRIES_IMM_MEM_TABLES =
       new Builder("Master.RocksBlockNumEntriesImmMemTables")
-          .setDescription("RocksDB block table. Num entries imm mem tables.")
+          .setDescription("RocksDB block table. Total number of entries in the unflushed "
+              + "immutable memtables.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_NUM_IMMUTABLE_MEM_TABLE =
       new Builder("Master.RocksBlockNumImmutableMemTable")
-          .setDescription("RocksDB block table. Num immutable mem table.")
+          .setDescription("RocksDB block table. Number of immutable memtables that have not yet "
+              + "been flushed.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_NUM_LIVE_VERSIONS =
       new Builder("Master.RocksBlockNumLiveVersions")
-          .setDescription("RocksDB block table. Num live versions.")
+          .setDescription("RocksDB inode table. Number of live versions. More live versions often "
+              + "mean more SST files are held from being deleted, by iterators or unfinished "
+              + "compactions.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_NUM_RUNNING_COMPACTIONS =
       new Builder("Master.RocksBlockNumRunningCompactions")
-          .setDescription("RocksDB block table. Num running compactions.")
+          .setDescription("RocksDB block table. Number of currently running compactions.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_NUM_RUNNING_FLUSHES =
       new Builder("Master.RocksBlockNumRunningFlushes")
-          .setDescription("RocksDB block table. Num running flushes.")
+          .setDescription("RocksDB block table. Number of currently running flushes.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_NUM_SNAPSHOTS =
@@ -1135,7 +1155,7 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey MASTER_ROCKS_BLOCK_TOTAL_SST_FILES_SIZE =
       new Builder("Master.RocksBlockTotalSstFilesSize")
-          .setDescription("RocksDB block table. Total sst files size.")
+          .setDescription("RocksDB block table. Total size in bytes of all SST files.")
           .setMetricType(MetricType.GAUGE)
           .build();
 
@@ -1147,7 +1167,7 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_BACKGROUND_ERRORS =
       new Builder("Master.RocksInodeBackgroundErrors")
-          .setDescription("RocksDB inode table. Background errors.")
+          .setDescription("RocksDB inode table. Accumulated number of background errors.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_BASE_LEVEL =
@@ -1162,27 +1182,30 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_BLOCK_CACHE_PINNED_USAGE =
       new Builder("Master.RocksInodeBlockCachePinnedUsage")
-          .setDescription("RocksDB inode table. Block cache pinned usage.")
+          .setDescription("RocksDB inode table. Memory size for the entries being pinned.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_BLOCK_CACHE_USAGE =
       new Builder("Master.RocksInodeBlockCacheUsage")
-          .setDescription("RocksDB inode table. Block cache usage.")
+          .setDescription("RocksDB inode table. Memory size for the entries residing in block "
+              + "cache.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_COMPACTION_PENDING =
       new Builder("Master.RocksInodeCompactionPending")
-          .setDescription("RocksDB inode table. Compaction pending.")
+          .setDescription("RocksDB inode table. This metric 1 if at least one compaction is "
+              + "pending; otherwise, the metric reports 0.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_CUR_SIZE_ACTIVE_MEM_TABLE =
       new Builder("Master.RocksInodeCurSizeActiveMemTable")
-          .setDescription("RocksDB inode table. Cur size active mem table.")
+          .setDescription("RocksDB inode table. Approximate size of active memtable in bytes.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_CUR_SIZE_ALL_MEM_TABLES =
       new Builder("Master.RocksInodeCurSizeAllMemTables")
-          .setDescription("RocksDB inode table. Cur size all mem tables.")
+          .setDescription("RocksDB inode table. Approximate size of active and unflushed "
+              + "immutable memtable in bytes.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_CURRENT_SUPER_VERSION_NUMBER =
@@ -1197,17 +1220,25 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_ESTIMATE_NUM_KEYS =
       new Builder("Master.RocksInodeEstimateNumKeys")
-          .setDescription("RocksDB inode table. Estimate num keys.")
+          .setDescription("RocksDB inode table. Estimated number of total keys in the active and "
+              + "unflushed immutable memtables and storage.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_ESTIMATE_PENDING_COMPACTION_BYTES =
       new Builder("Master.RocksInodeEstimatePendingCompactionBytes")
-          .setDescription("RocksDB inode table. Estimate pending compaction bytes.")
+          .setDescription("RocksDB block table. Estimated total number of bytes a compaction needs "
+              + "to rewrite on disk to get all levels down to under target size. In other words, "
+              + "this metrics relates to the write amplification in level compaction. "
+              + "Thus, this metric is not valid for compactions other than level-based.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_ESTIMATE_TABLE_READERS_MEM =
       new Builder("Master.RocksInodeEstimateTableReadersMem")
-          .setDescription("RocksDB inode table. Estimate table readers mem.")
+          .setDescription("RocksDB inode table. Estimated memory in bytes used for reading SST "
+              + "tables, excluding memory used in block cache (e.g., filter and index blocks). "
+              + "This metric records the memory used by iterators as well as filters and indices "
+              + "if the filters and indices are not maintained in the block cache. Basically this "
+              + "metric reports the memory used outside the block cache to read data.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_IS_FILE_DELETIONS_ENABLED =
@@ -1222,12 +1253,14 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_LIVE_SST_FILES_SIZE =
       new Builder("Master.RocksInodeLiveSstFilesSize")
-          .setDescription("RocksDB inode table. Live sst files size.")
+          .setDescription("RocksDB inode table. Total size in bytes of all SST files that belong "
+              + "to the latest LSM tree.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_MEM_TABLE_FLUSH_PENDING =
       new Builder("Master.RocksInodeMemTableFlushPending")
-          .setDescription("RocksDB inode table. Mem table flush pending.")
+          .setDescription("RocksDB inode table. This metric returns 1 if a memtable flush "
+              + "is pending; otherwhise it returns 0.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_MIN_LOG_NUMBER_TO_KEEP =
@@ -1242,42 +1275,48 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_NUM_DELETES_ACTIVE_MEM_TABLE =
       new Builder("Master.RocksInodeNumDeletesActiveMemTable")
-          .setDescription("RocksDB inode table. Num deletes active mem table.")
+          .setDescription("RocksDB inode table. Total number of delete entries in the active "
+              + "memtable.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_NUM_DELETES_IMM_MEM_TABLES =
       new Builder("Master.RocksInodeNumDeletesImmMemTables")
-          .setDescription("RocksDB inode table. Num deletes imm mem tables.")
+          .setDescription("RocksDB inode table. Total number of delete entries in the unflushed "
+              + "immutable memtables.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_NUM_ENTRIES_ACTIVE_MEM_TABLE =
       new Builder("Master.RocksInodeNumEntriesActiveMemTable")
-          .setDescription("RocksDB inode table. Num entries active mem table.")
+          .setDescription("RocksDB inode table. Total number of entries in the active memtable.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_NUM_ENTRIES_IMM_MEM_TABLES =
       new Builder("Master.RocksInodeNumEntriesImmMemTables")
-          .setDescription("RocksDB inode table. Num entries imm mem tables.")
+          .setDescription("RocksDB inode table. Total number of entries in the unflushed "
+              + "immutable memtables.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_NUM_IMMUTABLE_MEM_TABLE =
       new Builder("Master.RocksInodeNumImmutableMemTable")
-          .setDescription("RocksDB inode table. Num immutable mem table.")
+          .setDescription("RocksDB inode table. Number of immutable memtables that have not yet "
+              + "been flushed.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_NUM_LIVE_VERSIONS =
       new Builder("Master.RocksInodeNumLiveVersions")
-          .setDescription("RocksDB inode table. Num live versions.")
+          .setDescription("RocksDB inode table. Number of live versions. More live versions often "
+              + "mean more SST files are held from being deleted, by iterators or unfinished "
+              + "compactions.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_NUM_RUNNING_COMPACTIONS =
       new Builder("Master.RocksInodeNumRunningCompactions")
-          .setDescription("RocksDB inode table. Num running compactions.")
+          .setDescription("RocksDB inode table. Number of currently running compactions.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_NUM_RUNNING_FLUSHES =
       new Builder("Master.RocksInodeNumRunningFlushes")
-          .setDescription("RocksDB inode table. Num running flushes.")
+          .setDescription("RocksDB inode table. Number of currently running flushes.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_NUM_SNAPSHOTS =
@@ -1292,12 +1331,14 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_SIZE_ALL_MEM_TABLES =
       new Builder("Master.RocksInodeSizeAllMemTables")
-          .setDescription("RocksDB inode table. Size all mem tables.")
+          .setDescription("RocksDB inode table. Approximate size of active, unflushed immutable, "
+              + "and pinned immutable memtables in bytes. Pinned immutable memtables are flushed "
+              + "memtables that are kept in memory to maintain write history in memory.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_ROCKS_INODE_TOTAL_SST_FILES_SIZE =
       new Builder("Master.RocksInodeTotalSstFilesSize")
-          .setDescription("RocksDB inode table. Total sst files size.")
+          .setDescription("RocksDB inode table. Total size in bytes of all SST files.")
           .setMetricType(MetricType.GAUGE)
           .build();
 

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -977,6 +977,168 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .build();
 
+  // Rocks Block metrics
+  public static final MetricKey MASTER_ROCKS_BLOCK_ACTUAL_DELAYED_WRITE_RATE =
+      new Builder("Master.RocksBlockActualDelayedWriteRate")
+          .setDescription("RocksDB block table. Actual delayed write rate.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_BACKGROUND_ERRORS =
+      new Builder("Master.RocksBlockBackgroundErrors")
+          .setDescription("RocksDB block table. Background errors.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_BASE_LEVEL =
+      new Builder("Master.RocksBlockBaseLevel")
+          .setDescription("RocksDB block table. Base level.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_BLOCK_CACHE_CAPACITY =
+      new Builder("Master.RocksBlockBlockCacheCapacity")
+          .setDescription("RocksDB block table. Block cache capacity.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_BLOCK_CACHE_PINNED_USAGE =
+      new Builder("Master.RocksBlockBlockCachePinnedUsage")
+          .setDescription("RocksDB block table. Block cache pinned usage.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_BLOCK_CACHE_USAGE =
+      new Builder("Master.RocksBlockBlockCacheUsage")
+          .setDescription("RocksDB block table. Block cache usage.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_COMPACTION_PENDING =
+      new Builder("Master.RocksBlockCompactionPending")
+          .setDescription("RocksDB block table. Compaction pending.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_CUR_SIZE_ACTIVE_MEM_TABLE =
+      new Builder("Master.RocksBlockCurSizeActiveMemTable")
+          .setDescription("RocksDB block table. Cur size active mem table.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_CUR_SIZE_ALL_MEM_TABLES =
+      new Builder("Master.RocksBlockCurSizeAllMemTables")
+          .setDescription("RocksDB block table. Cur size all mem tables.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_CURRENT_SUPER_VERSION_NUMBER =
+      new Builder("Master.RocksBlockCurrentSuperVersionNumber")
+          .setDescription("RocksDB block table. Current super version number.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_ESTIMATE_LIVE_DATA_SIZE =
+      new Builder("Master.RocksBlockEstimateLiveDataSize")
+          .setDescription("RocksDB block table. Estimate live data size.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_ESTIMATE_NUM_KEYS =
+      new Builder("Master.RocksBlockEstimateNumKeys")
+          .setDescription("RocksDB block table. Estimate num keys.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_ESTIMATE_PENDING_COMPACTION_BYTES =
+      new Builder("Master.RocksBlockEstimatePendingCompactionBytes")
+          .setDescription("RocksDB block table. Estimate pending compaction bytes.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_ESTIMATE_TABLE_READERS_MEM =
+      new Builder("Master.RocksBlockEstimateTableReadersMem")
+          .setDescription("RocksDB block table. Estimate table readers mem.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_IS_FILE_DELETIONS_ENABLED =
+      new Builder("Master.RocksBlockIsFileDeletionsEnabled")
+          .setDescription("RocksDB block table. Is file deletions enabled.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_IS_WRITE_STOPPED =
+      new Builder("Master.RocksBlockIsWriteStopped")
+          .setDescription("RocksDB block table. Is write stopped.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_LIVE_SST_FILES_SIZE =
+      new Builder("Master.RocksBlockLiveSstFilesSize")
+          .setDescription("RocksDB block table. Live sst files size.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_MEM_TABLE_FLUSH_PENDING =
+      new Builder("Master.RocksBlockMemTableFlushPending")
+          .setDescription("RocksDB block table. Mem table flush pending.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_MIN_LOG_NUMBER_TO_KEEP =
+      new Builder("Master.RocksBlockMinLogNumberToKeep")
+          .setDescription("RocksDB block table. Min log number to keep.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_MIN_OBSOLETE_SST_NUMBER_TO_KEEP =
+      new Builder("Master.RocksBlockMinObsoleteSstNumberToKeep")
+          .setDescription("RocksDB block table. Min obsolete sst number to keep.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_NUM_DELETES_ACTIVE_MEM_TABLE =
+      new Builder("Master.RocksBlockNumDeletesActiveMemTable")
+          .setDescription("RocksDB block table. Num deletes active mem table.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_NUM_DELETES_IMM_MEM_TABLES =
+      new Builder("Master.RocksBlockNumDeletesImmMemTables")
+          .setDescription("RocksDB block table. Num deletes imm mem tables.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_NUM_ENTRIES_ACTIVE_MEM_TABLE =
+      new Builder("Master.RocksBlockNumEntriesActiveMemTable")
+          .setDescription("RocksDB block table. Num entries active mem table.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_NUM_ENTRIES_IMM_MEM_TABLES =
+      new Builder("Master.RocksBlockNumEntriesImmMemTables")
+          .setDescription("RocksDB block table. Num entries imm mem tables.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_NUM_IMMUTABLE_MEM_TABLE =
+      new Builder("Master.RocksBlockNumImmutableMemTable")
+          .setDescription("RocksDB block table. Num immutable mem table.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_NUM_LIVE_VERSIONS =
+      new Builder("Master.RocksBlockNumLiveVersions")
+          .setDescription("RocksDB block table. Num live versions.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_NUM_RUNNING_COMPACTIONS =
+      new Builder("Master.RocksBlockNumRunningCompactions")
+          .setDescription("RocksDB block table. Num running compactions.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_NUM_RUNNING_FLUSHES =
+      new Builder("Master.RocksBlockNumRunningFlushes")
+          .setDescription("RocksDB block table. Num running flushes.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_NUM_SNAPSHOTS =
+      new Builder("Master.RocksBlockNumSnapshots")
+          .setDescription("RocksDB block table. Num snapshots.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_OLDEST_SNAPSHOT_TIME =
+      new Builder("Master.RocksBlockOldestSnapshotTime")
+          .setDescription("RocksDB block table. Oldest snapshot time.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_SIZE_ALL_MEM_TABLES =
+      new Builder("Master.RocksBlockSizeAllMemTables")
+          .setDescription("RocksDB block table. Size all mem tables.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_TOTAL_SST_FILES_SIZE =
+      new Builder("Master.RocksBlockTotalSstFilesSize")
+          .setDescription("RocksDB block table. Total sst files size.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+
   // Cluster metrics
   public static final MetricKey CLUSTER_ACTIVE_RPC_READ_COUNT =
       new Builder("Cluster.ActiveRpcReadCount")

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1108,6 +1108,14 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("RocksDB block table. Total size in bytes of all SST files.")
           .setMetricType(MetricType.GAUGE)
           .build();
+  public static final MetricKey MASTER_ROCKS_BLOCK_ESTIMATED_MEM_USAGE =
+      new Builder("Master.RocksBlockEstimatedMemUsage")
+          .setDescription("RocksDB block table. This metric estimates the memory usage of the "
+              + "RockDB Block table by aggregating the values of "
+              + "Master.RocksBlockBlockCacheUsage, Master.RocksBlockEstimateTableReadersMem, "
+              + "Master.RocksBlockCurSizeAllMemTables, and Master.RocksBlockBlockCachePinnedUsage")
+          .setMetricType(MetricType.GAUGE)
+          .build();
 
   // Rocks Inode metrics
   public static final MetricKey MASTER_ROCKS_INODE_BACKGROUND_ERRORS =
@@ -1239,6 +1247,21 @@ public final class MetricKey implements Comparable<MetricKey> {
   public static final MetricKey MASTER_ROCKS_INODE_TOTAL_SST_FILES_SIZE =
       new Builder("Master.RocksInodeTotalSstFilesSize")
           .setDescription("RocksDB inode table. Total size in bytes of all SST files.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_ESTIMATED_MEM_USAGE =
+      new Builder("Master.RocksInodeEstimatedMemUsage")
+          .setDescription("RocksDB block table. This metric estimates the memory usage of the "
+              + "RockDB Inode table by aggregating the values of "
+              + "Master.RocksInodeBlockCacheUsage, Master.RocksInodeEstimateTableReadersMem, "
+              + "Master.RocksInodeCurSizeAllMemTables, and Master.RocksInodeBlockCachePinnedUsage")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_TOTAL_ESTIMATED_MEM_USAGE =
+      new Builder("Master.RocksTotalEstimatedMemUsage")
+          .setDescription("This metric gives an estimate of the total memory used by RocksDB by "
+              + "aggregating the values of Master.RocksBlockEstimatedMemUsage and "
+              + "Master.RocksInodeEstimatedMemUsage")
           .setMetricType(MetricType.GAUGE)
           .build();
 

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1139,6 +1139,168 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.GAUGE)
           .build();
 
+  // Rocks Inode metrics
+  public static final MetricKey MASTER_ROCKS_INODE_ACTUAL_DELAYED_WRITE_RATE =
+      new Builder("Master.RocksInodeActualDelayedWriteRate")
+          .setDescription("RocksDB inode table. Actual delayed write rate.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_BACKGROUND_ERRORS =
+      new Builder("Master.RocksInodeBackgroundErrors")
+          .setDescription("RocksDB inode table. Background errors.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_BASE_LEVEL =
+      new Builder("Master.RocksInodeBaseLevel")
+          .setDescription("RocksDB inode table. Base level.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_BLOCK_CACHE_CAPACITY =
+      new Builder("Master.RocksInodeBlockCacheCapacity")
+          .setDescription("RocksDB inode table. Block cache capacity.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_BLOCK_CACHE_PINNED_USAGE =
+      new Builder("Master.RocksInodeBlockCachePinnedUsage")
+          .setDescription("RocksDB inode table. Block cache pinned usage.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_BLOCK_CACHE_USAGE =
+      new Builder("Master.RocksInodeBlockCacheUsage")
+          .setDescription("RocksDB inode table. Block cache usage.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_COMPACTION_PENDING =
+      new Builder("Master.RocksInodeCompactionPending")
+          .setDescription("RocksDB inode table. Compaction pending.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_CUR_SIZE_ACTIVE_MEM_TABLE =
+      new Builder("Master.RocksInodeCurSizeActiveMemTable")
+          .setDescription("RocksDB inode table. Cur size active mem table.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_CUR_SIZE_ALL_MEM_TABLES =
+      new Builder("Master.RocksInodeCurSizeAllMemTables")
+          .setDescription("RocksDB inode table. Cur size all mem tables.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_CURRENT_SUPER_VERSION_NUMBER =
+      new Builder("Master.RocksInodeCurrentSuperVersionNumber")
+          .setDescription("RocksDB inode table. Current super version number.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_ESTIMATE_LIVE_DATA_SIZE =
+      new Builder("Master.RocksInodeEstimateLiveDataSize")
+          .setDescription("RocksDB inode table. Estimate live data size.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_ESTIMATE_NUM_KEYS =
+      new Builder("Master.RocksInodeEstimateNumKeys")
+          .setDescription("RocksDB inode table. Estimate num keys.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_ESTIMATE_PENDING_COMPACTION_BYTES =
+      new Builder("Master.RocksInodeEstimatePendingCompactionBytes")
+          .setDescription("RocksDB inode table. Estimate pending compaction bytes.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_ESTIMATE_TABLE_READERS_MEM =
+      new Builder("Master.RocksInodeEstimateTableReadersMem")
+          .setDescription("RocksDB inode table. Estimate table readers mem.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_IS_FILE_DELETIONS_ENABLED =
+      new Builder("Master.RocksInodeIsFileDeletionsEnabled")
+          .setDescription("RocksDB inode table. Is file deletions enabled.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_IS_WRITE_STOPPED =
+      new Builder("Master.RocksInodeIsWriteStopped")
+          .setDescription("RocksDB inode table. Is write stopped.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_LIVE_SST_FILES_SIZE =
+      new Builder("Master.RocksInodeLiveSstFilesSize")
+          .setDescription("RocksDB inode table. Live sst files size.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_MEM_TABLE_FLUSH_PENDING =
+      new Builder("Master.RocksInodeMemTableFlushPending")
+          .setDescription("RocksDB inode table. Mem table flush pending.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_MIN_LOG_NUMBER_TO_KEEP =
+      new Builder("Master.RocksInodeMinLogNumberToKeep")
+          .setDescription("RocksDB inode table. Min log number to keep.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_MIN_OBSOLETE_SST_NUMBER_TO_KEEP =
+      new Builder("Master.RocksInodeMinObsoleteSstNumberToKeep")
+          .setDescription("RocksDB inode table. Min obsolete sst number to keep.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_NUM_DELETES_ACTIVE_MEM_TABLE =
+      new Builder("Master.RocksInodeNumDeletesActiveMemTable")
+          .setDescription("RocksDB inode table. Num deletes active mem table.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_NUM_DELETES_IMM_MEM_TABLES =
+      new Builder("Master.RocksInodeNumDeletesImmMemTables")
+          .setDescription("RocksDB inode table. Num deletes imm mem tables.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_NUM_ENTRIES_ACTIVE_MEM_TABLE =
+      new Builder("Master.RocksInodeNumEntriesActiveMemTable")
+          .setDescription("RocksDB inode table. Num entries active mem table.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_NUM_ENTRIES_IMM_MEM_TABLES =
+      new Builder("Master.RocksInodeNumEntriesImmMemTables")
+          .setDescription("RocksDB inode table. Num entries imm mem tables.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_NUM_IMMUTABLE_MEM_TABLE =
+      new Builder("Master.RocksInodeNumImmutableMemTable")
+          .setDescription("RocksDB inode table. Num immutable mem table.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_NUM_LIVE_VERSIONS =
+      new Builder("Master.RocksInodeNumLiveVersions")
+          .setDescription("RocksDB inode table. Num live versions.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_NUM_RUNNING_COMPACTIONS =
+      new Builder("Master.RocksInodeNumRunningCompactions")
+          .setDescription("RocksDB inode table. Num running compactions.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_NUM_RUNNING_FLUSHES =
+      new Builder("Master.RocksInodeNumRunningFlushes")
+          .setDescription("RocksDB inode table. Num running flushes.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_NUM_SNAPSHOTS =
+      new Builder("Master.RocksInodeNumSnapshots")
+          .setDescription("RocksDB inode table. Num snapshots.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_OLDEST_SNAPSHOT_TIME =
+      new Builder("Master.RocksInodeOldestSnapshotTime")
+          .setDescription("RocksDB inode table. Oldest snapshot time.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_SIZE_ALL_MEM_TABLES =
+      new Builder("Master.RocksInodeSizeAllMemTables")
+          .setDescription("RocksDB inode table. Size all mem tables.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_ROCKS_INODE_TOTAL_SST_FILES_SIZE =
+      new Builder("Master.RocksInodeTotalSstFilesSize")
+          .setDescription("RocksDB inode table. Total sst files size.")
+          .setMetricType(MetricType.GAUGE)
+          .build();
+
   // Cluster metrics
   public static final MetricKey CLUSTER_ACTIVE_RPC_READ_COUNT =
       new Builder("Cluster.ActiveRpcReadCount")

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -612,6 +612,32 @@ public final class MetricsSystem {
   }
 
   /**
+   * Created a gauge that aggregates the value of existing gauges.
+   *
+   * @param name the gauge name
+   * @param metrics the set of metric values to be aggregated
+   * @param timeout the cached gauge timeout
+   * @param timeUnit the unit of timeout
+   */
+  public static synchronized void registerAggregatedCachedGauge(
+      String name, Set<MetricKey> metrics, long timeout, TimeUnit timeUnit) {
+    METRIC_REGISTRY.register(name, new CachedGauge<Double>(timeout, timeUnit) {
+      @Override
+      protected Double loadValue() {
+        double total = 0.0;
+        for (MetricKey key : metrics) {
+          Metric m = getMetricValue(key.getName());
+          if (m == null || m.getMetricType() != MetricType.GAUGE) {
+            continue;
+          }
+          total += m.getValue();
+        }
+        return total;
+      }
+    });
+  }
+
+  /**
    * Removes the metric with the given name.
    *
    * @param name the metric name

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -619,8 +619,11 @@ public final class MetricsSystem {
    * @param timeout the cached gauge timeout
    * @param timeUnit the unit of timeout
    */
-  public static synchronized void registerAggregatedCachedGauge(
+  public static synchronized void registerAggregatedCachedGaugeIfAbsent(
       String name, Set<MetricKey> metrics, long timeout, TimeUnit timeUnit) {
+    if (METRIC_REGISTRY.getMetrics().containsKey(name)) {
+      return;
+    }
     METRIC_REGISTRY.register(name, new CachedGauge<Double>(timeout, timeUnit) {
       @Override
       protected Double loadValue() {

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import javax.annotation.concurrent.ThreadSafe;
@@ -98,109 +99,109 @@ public class RocksBlockStore implements BlockStore {
         Arrays.asList(mBlockMetaColumn, mBlockLocationsColumn));
 
     // metrics
-    MetricsSystem.registerGaugeIfAbsent(
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_ACTUAL_DELAYED_WRITE_RATE.getName(),
-        () -> getProperty("rocksdb.actual-delayed-write-rate"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.actual-delayed-write-rate"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_BACKGROUND_ERRORS.getName(),
-        () -> getProperty("rocksdb.background-errors"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.background-errors"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_BASE_LEVEL.getName(),
-        () -> getProperty("rocksdb.base-level"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.base-level"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_CAPACITY.getName(),
-        () -> getProperty("rocksdb.block-cache-capacity"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.block-cache-capacity"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_PINNED_USAGE.getName(),
-        () -> getProperty("rocksdb.block-cache-pinned-usage"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.block-cache-pinned-usage"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_USAGE.getName(),
-        () -> getProperty("rocksdb.block-cache-usage"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.block-cache-usage"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_COMPACTION_PENDING.getName(),
-        () -> getProperty("rocksdb.compaction-pending"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.compaction-pending"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_CUR_SIZE_ACTIVE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.cur-size-active-mem-table"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.cur-size-active-mem-table"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_CUR_SIZE_ALL_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.cur-size-all-mem-tables"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.cur-size-all-mem-tables"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_CURRENT_SUPER_VERSION_NUMBER.getName(),
-        () -> getProperty("rocksdb.current-super-version-number"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.current-super-version-number"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_LIVE_DATA_SIZE.getName(),
-        () -> getProperty("rocksdb.estimate-live-data-size"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.estimate-live-data-size"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_NUM_KEYS.getName(),
-        () -> getProperty("rocksdb.estimate-num-keys"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.estimate-num-keys"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_PENDING_COMPACTION_BYTES.getName(),
-        () -> getProperty("rocksdb.estimate-pending-compaction-bytes"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.estimate-pending-compaction-bytes"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_TABLE_READERS_MEM.getName(),
-        () -> getProperty("rocksdb.estimate-table-readers-mem"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.estimate-table-readers-mem"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_IS_FILE_DELETIONS_ENABLED.getName(),
-        () -> getProperty("rocksdb.is-file-deletions-enabled"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.is-file-deletions-enabled"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_IS_WRITE_STOPPED.getName(),
-        () -> getProperty("rocksdb.is-write-stopped"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.is-write-stopped"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_LIVE_SST_FILES_SIZE.getName(),
-        () -> getProperty("rocksdb.live-sst-files-size"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.live-sst-files-size"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_MEM_TABLE_FLUSH_PENDING.getName(),
-        () -> getProperty("rocksdb.mem-table-flush-pending"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.mem-table-flush-pending"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_MIN_LOG_NUMBER_TO_KEEP.getName(),
-        () -> getProperty("rocksdb.min-log-number-to-keep"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.min-log-number-to-keep"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_MIN_OBSOLETE_SST_NUMBER_TO_KEEP.getName(),
-        () -> getProperty("rocksdb.min-obsolete-sst-number-to-keep"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.min-obsolete-sst-number-to-keep"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_DELETES_ACTIVE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.num-deletes-active-mem-table"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-deletes-active-mem-table"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_DELETES_IMM_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.num-deletes-imm-mem-tables"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-deletes-imm-mem-tables"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_ENTRIES_ACTIVE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.num-entries-active-mem-table"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-entries-active-mem-table"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_ENTRIES_IMM_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.num-entries-imm-mem-tables"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-entries-imm-mem-tables"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_IMMUTABLE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.num-immutable-mem-table"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-immutable-mem-table"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_LIVE_VERSIONS.getName(),
-        () -> getProperty("rocksdb.num-live-versions"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-live-versions"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_RUNNING_COMPACTIONS.getName(),
-        () -> getProperty("rocksdb.num-running-compactions"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-running-compactions"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_RUNNING_FLUSHES.getName(),
-        () -> getProperty("rocksdb.num-running-flushes"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-running-flushes"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_SNAPSHOTS.getName(),
-        () -> getProperty("rocksdb.num-snapshots"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-snapshots"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_OLDEST_SNAPSHOT_TIME.getName(),
-        () -> getProperty("rocksdb.oldest-snapshot-time"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.oldest-snapshot-time"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_SIZE_ALL_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.size-all-mem-tables"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.size-all-mem-tables"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_TOTAL_SST_FILES_SIZE.getName(),
-        () -> getProperty("rocksdb.total-sst-files-size"));
+        () -> getProperty("rocksdb.total-sst-files-size"), 15, TimeUnit.SECONDS);
   }
 
   private String getProperty(String rocksPropertyName) {
     try {
       return mRocksStore.getDb().getProperty(rocksPropertyName);
     } catch (RocksDBException e) {
-      LOG.warn("error collecting " + rocksPropertyName, e);
+      LOG.warn(String.format("error collecting %s", rocksPropertyName), e);
     }
     return "";
   }

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -14,6 +14,8 @@ package alluxio.master.metastore.rocks;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.master.metastore.BlockStore;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.proto.meta.Block.BlockLocation;
 import alluxio.proto.meta.Block.BlockMeta;
 import alluxio.resource.CloseableIterator;
@@ -94,6 +96,113 @@ public class RocksBlockStore implements BlockStore {
     }
     mRocksStore = new RocksStore(ROCKS_STORE_NAME, dbPath, backupPath, columns,
         Arrays.asList(mBlockMetaColumn, mBlockLocationsColumn));
+
+    // metrics
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_ACTUAL_DELAYED_WRITE_RATE.getName(),
+        () -> getProperty("rocksdb.actual-delayed-write-rate"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_BACKGROUND_ERRORS.getName(),
+        () -> getProperty("rocksdb.background-errors"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_BASE_LEVEL.getName(),
+        () -> getProperty("rocksdb.base-level"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_CAPACITY.getName(),
+        () -> getProperty("rocksdb.block-cache-capacity"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_PINNED_USAGE.getName(),
+        () -> getProperty("rocksdb.block-cache-pinned-usage"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_USAGE.getName(),
+        () -> getProperty("rocksdb.block-cache-usage"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_COMPACTION_PENDING.getName(),
+        () -> getProperty("rocksdb.compaction-pending"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_CUR_SIZE_ACTIVE_MEM_TABLE.getName(),
+        () -> getProperty("rocksdb.cur-size-active-mem-table"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_CUR_SIZE_ALL_MEM_TABLES.getName(),
+        () -> getProperty("rocksdb.cur-size-all-mem-tables"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_CURRENT_SUPER_VERSION_NUMBER.getName(),
+        () -> getProperty("rocksdb.current-super-version-number"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_LIVE_DATA_SIZE.getName(),
+        () -> getProperty("rocksdb.estimate-live-data-size"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_NUM_KEYS.getName(),
+        () -> getProperty("rocksdb.estimate-num-keys"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_PENDING_COMPACTION_BYTES.getName(),
+        () -> getProperty("rocksdb.estimate-pending-compaction-bytes"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_TABLE_READERS_MEM.getName(),
+        () -> getProperty("rocksdb.estimate-table-readers-mem"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_IS_FILE_DELETIONS_ENABLED.getName(),
+        () -> getProperty("rocksdb.is-file-deletions-enabled"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_IS_WRITE_STOPPED.getName(),
+        () -> getProperty("rocksdb.is-write-stopped"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_LIVE_SST_FILES_SIZE.getName(),
+        () -> getProperty("rocksdb.live-sst-files-size"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_MEM_TABLE_FLUSH_PENDING.getName(),
+        () -> getProperty("rocksdb.mem-table-flush-pending"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_MIN_LOG_NUMBER_TO_KEEP.getName(),
+        () -> getProperty("rocksdb.min-log-number-to-keep"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_MIN_OBSOLETE_SST_NUMBER_TO_KEEP.getName(),
+        () -> getProperty("rocksdb.min-obsolete-sst-number-to-keep"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_NUM_DELETES_ACTIVE_MEM_TABLE.getName(),
+        () -> getProperty("rocksdb.num-deletes-active-mem-table"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_NUM_DELETES_IMM_MEM_TABLES.getName(),
+        () -> getProperty("rocksdb.num-deletes-imm-mem-tables"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_NUM_ENTRIES_ACTIVE_MEM_TABLE.getName(),
+        () -> getProperty("rocksdb.num-entries-active-mem-table"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_NUM_ENTRIES_IMM_MEM_TABLES.getName(),
+        () -> getProperty("rocksdb.num-entries-imm-mem-tables"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_NUM_IMMUTABLE_MEM_TABLE.getName(),
+        () -> getProperty("rocksdb.num-immutable-mem-table"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_NUM_LIVE_VERSIONS.getName(),
+        () -> getProperty("rocksdb.num-live-versions"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_NUM_RUNNING_COMPACTIONS.getName(),
+        () -> getProperty("rocksdb.num-running-compactions"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_NUM_RUNNING_FLUSHES.getName(),
+        () -> getProperty("rocksdb.num-running-flushes"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_NUM_SNAPSHOTS.getName(),
+        () -> getProperty("rocksdb.num-snapshots"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_OLDEST_SNAPSHOT_TIME.getName(),
+        () -> getProperty("rocksdb.oldest-snapshot-time"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_SIZE_ALL_MEM_TABLES.getName(),
+        () -> getProperty("rocksdb.size-all-mem-tables"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_BLOCK_TOTAL_SST_FILES_SIZE.getName(),
+        () -> getProperty("rocksdb.total-sst-files-size"));
+  }
+
+  private String getProperty(String rocksPropertyName) {
+    try {
+      return mRocksStore.getDb().getProperty(rocksPropertyName);
+    } catch (RocksDBException e) {
+      LOG.warn("error collecting " + rocksPropertyName, e);
+    }
+    return "";
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -99,95 +99,96 @@ public class RocksBlockStore implements BlockStore {
         Arrays.asList(mBlockMetaColumn, mBlockLocationsColumn));
 
     // metrics
-    final int CACHED_GAUGE_TIMEOUT_S = 15;
+    final long CACHED_GAUGE_TIMEOUT_S =
+        ServerConfiguration.getMs(PropertyKey.MASTER_METASTORE_METRICS_REFRESH_INTERVAL);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_BACKGROUND_ERRORS.getName(),
         () -> getProperty("rocksdb.background-errors"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_CAPACITY.getName(),
         () -> getProperty("rocksdb.block-cache-capacity"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_PINNED_USAGE.getName(),
         () -> getProperty("rocksdb.block-cache-pinned-usage"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_USAGE.getName(),
         () -> getProperty("rocksdb.block-cache-usage"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_COMPACTION_PENDING.getName(),
         () -> getProperty("rocksdb.compaction-pending"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_CUR_SIZE_ACTIVE_MEM_TABLE.getName(),
         () -> getProperty("rocksdb.cur-size-active-mem-table"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_CUR_SIZE_ALL_MEM_TABLES.getName(),
         () -> getProperty("rocksdb.cur-size-all-mem-tables"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_NUM_KEYS.getName(),
         () -> getProperty("rocksdb.estimate-num-keys"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_PENDING_COMPACTION_BYTES.getName(),
         () -> getProperty("rocksdb.estimate-pending-compaction-bytes"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_TABLE_READERS_MEM.getName(),
         () -> getProperty("rocksdb.estimate-table-readers-mem"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_LIVE_SST_FILES_SIZE.getName(),
         () -> getProperty("rocksdb.live-sst-files-size"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_MEM_TABLE_FLUSH_PENDING.getName(),
         () -> getProperty("rocksdb.mem-table-flush-pending"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_DELETES_ACTIVE_MEM_TABLE.getName(),
         () -> getProperty("rocksdb.num-deletes-active-mem-table"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_DELETES_IMM_MEM_TABLES.getName(),
         () -> getProperty("rocksdb.num-deletes-imm-mem-tables"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_ENTRIES_ACTIVE_MEM_TABLE.getName(),
         () -> getProperty("rocksdb.num-entries-active-mem-table"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_ENTRIES_IMM_MEM_TABLES.getName(),
         () -> getProperty("rocksdb.num-entries-imm-mem-tables"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_IMMUTABLE_MEM_TABLE.getName(),
         () -> getProperty("rocksdb.num-immutable-mem-table"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_LIVE_VERSIONS.getName(),
         () -> getProperty("rocksdb.num-live-versions"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_RUNNING_COMPACTIONS.getName(),
         () -> getProperty("rocksdb.num-running-compactions"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_RUNNING_FLUSHES.getName(),
         () -> getProperty("rocksdb.num-running-flushes"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_SIZE_ALL_MEM_TABLES.getName(),
         () -> getProperty("rocksdb.size-all-mem-tables"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_TOTAL_SST_FILES_SIZE.getName(),
         () -> getProperty("rocksdb.total-sst-files-size"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
   }
 
   private long getProperty(String rocksPropertyName) {

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -195,7 +195,7 @@ public class RocksBlockStore implements BlockStore {
         MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_TABLE_READERS_MEM,
         MetricKey.MASTER_ROCKS_BLOCK_CUR_SIZE_ALL_MEM_TABLES,
         MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_PINNED_USAGE);
-    MetricsSystem.registerAggregatedCachedGauge(
+    MetricsSystem.registerAggregatedCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_ESTIMATED_MEM_USAGE.getName(),
         s, CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
   }

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -199,7 +199,7 @@ public class RocksBlockStore implements BlockStore {
 
   private String getProperty(String rocksPropertyName) {
     try {
-      return mRocksStore.getDb().getProperty(rocksPropertyName);
+      return db().getProperty(rocksPropertyName);
     } catch (RocksDBException e) {
       LOG.warn(String.format("error collecting %s", rocksPropertyName), e);
     }

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -22,6 +22,7 @@ import alluxio.resource.CloseableIterator;
 import alluxio.util.io.FileUtils;
 import alluxio.util.io.PathUtils;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Longs;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
@@ -189,6 +190,14 @@ public class RocksBlockStore implements BlockStore {
         MetricKey.MASTER_ROCKS_BLOCK_TOTAL_SST_FILES_SIZE.getName(),
         () -> getProperty("rocksdb.total-sst-files-size"),
         CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
+
+    ImmutableSet<MetricKey> s = ImmutableSet.of(MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_USAGE,
+        MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_TABLE_READERS_MEM,
+        MetricKey.MASTER_ROCKS_BLOCK_CUR_SIZE_ALL_MEM_TABLES,
+        MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_PINNED_USAGE);
+    MetricsSystem.registerAggregatedCachedGauge(
+        MetricKey.MASTER_ROCKS_BLOCK_ESTIMATED_MEM_USAGE.getName(),
+        s, CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
   }
 
   private long getProperty(String rocksPropertyName) {

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -99,102 +99,95 @@ public class RocksBlockStore implements BlockStore {
         Arrays.asList(mBlockMetaColumn, mBlockLocationsColumn));
 
     // metrics
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_BLOCK_ACTUAL_DELAYED_WRITE_RATE.getName(),
-        () -> getProperty("rocksdb.actual-delayed-write-rate"), 15, TimeUnit.SECONDS);
+    final int CACHED_GAUGE_TIMEOUT_S = 15;
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_BACKGROUND_ERRORS.getName(),
-        () -> getProperty("rocksdb.background-errors"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_BLOCK_BASE_LEVEL.getName(),
-        () -> getProperty("rocksdb.base-level"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.background-errors"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_CAPACITY.getName(),
-        () -> getProperty("rocksdb.block-cache-capacity"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.block-cache-capacity"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_PINNED_USAGE.getName(),
-        () -> getProperty("rocksdb.block-cache-pinned-usage"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.block-cache-pinned-usage"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_BLOCK_CACHE_USAGE.getName(),
-        () -> getProperty("rocksdb.block-cache-usage"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.block-cache-usage"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_COMPACTION_PENDING.getName(),
-        () -> getProperty("rocksdb.compaction-pending"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.compaction-pending"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_CUR_SIZE_ACTIVE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.cur-size-active-mem-table"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.cur-size-active-mem-table"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_CUR_SIZE_ALL_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.cur-size-all-mem-tables"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_BLOCK_CURRENT_SUPER_VERSION_NUMBER.getName(),
-        () -> getProperty("rocksdb.current-super-version-number"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_LIVE_DATA_SIZE.getName(),
-        () -> getProperty("rocksdb.estimate-live-data-size"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.cur-size-all-mem-tables"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_NUM_KEYS.getName(),
-        () -> getProperty("rocksdb.estimate-num-keys"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.estimate-num-keys"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_PENDING_COMPACTION_BYTES.getName(),
-        () -> getProperty("rocksdb.estimate-pending-compaction-bytes"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.estimate-pending-compaction-bytes"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_ESTIMATE_TABLE_READERS_MEM.getName(),
-        () -> getProperty("rocksdb.estimate-table-readers-mem"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_BLOCK_IS_FILE_DELETIONS_ENABLED.getName(),
-        () -> getProperty("rocksdb.is-file-deletions-enabled"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_BLOCK_IS_WRITE_STOPPED.getName(),
-        () -> getProperty("rocksdb.is-write-stopped"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.estimate-table-readers-mem"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_LIVE_SST_FILES_SIZE.getName(),
-        () -> getProperty("rocksdb.live-sst-files-size"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.live-sst-files-size"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_MEM_TABLE_FLUSH_PENDING.getName(),
-        () -> getProperty("rocksdb.mem-table-flush-pending"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_BLOCK_MIN_LOG_NUMBER_TO_KEEP.getName(),
-        () -> getProperty("rocksdb.min-log-number-to-keep"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_BLOCK_MIN_OBSOLETE_SST_NUMBER_TO_KEEP.getName(),
-        () -> getProperty("rocksdb.min-obsolete-sst-number-to-keep"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.mem-table-flush-pending"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_DELETES_ACTIVE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.num-deletes-active-mem-table"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-deletes-active-mem-table"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_DELETES_IMM_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.num-deletes-imm-mem-tables"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-deletes-imm-mem-tables"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_ENTRIES_ACTIVE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.num-entries-active-mem-table"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-entries-active-mem-table"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_ENTRIES_IMM_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.num-entries-imm-mem-tables"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-entries-imm-mem-tables"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_IMMUTABLE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.num-immutable-mem-table"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-immutable-mem-table"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_LIVE_VERSIONS.getName(),
-        () -> getProperty("rocksdb.num-live-versions"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-live-versions"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_RUNNING_COMPACTIONS.getName(),
-        () -> getProperty("rocksdb.num-running-compactions"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-running-compactions"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_NUM_RUNNING_FLUSHES.getName(),
-        () -> getProperty("rocksdb.num-running-flushes"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_BLOCK_NUM_SNAPSHOTS.getName(),
-        () -> getProperty("rocksdb.num-snapshots"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_BLOCK_OLDEST_SNAPSHOT_TIME.getName(),
-        () -> getProperty("rocksdb.oldest-snapshot-time"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-running-flushes"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_SIZE_ALL_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.size-all-mem-tables"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.size-all-mem-tables"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_TOTAL_SST_FILES_SIZE.getName(),
-        () -> getProperty("rocksdb.total-sst-files-size"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.total-sst-files-size"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
   }
 
   private String getProperty(String rocksPropertyName) {

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -190,13 +190,13 @@ public class RocksBlockStore implements BlockStore {
         CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
   }
 
-  private String getProperty(String rocksPropertyName) {
+  private long getProperty(String rocksPropertyName) {
     try {
-      return db().getProperty(rocksPropertyName);
+      return db().getAggregatedLongProperty(rocksPropertyName);
     } catch (RocksDBException e) {
       LOG.warn(String.format("error collecting %s", rocksPropertyName), e);
     }
-    return "";
+    return -1;
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -50,6 +50,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -99,109 +100,109 @@ public class RocksInodeStore implements InodeStore {
         Arrays.asList(mInodesColumn, mEdgesColumn));
 
     // metrics
-    MetricsSystem.registerGaugeIfAbsent(
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_ACTUAL_DELAYED_WRITE_RATE.getName(),
-        () -> getProperty("rocksdb.actual-delayed-write-rate"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.actual-delayed-write-rate"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_BACKGROUND_ERRORS.getName(),
-        () -> getProperty("rocksdb.background-errors"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.background-errors"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_BASE_LEVEL.getName(),
-        () -> getProperty("rocksdb.base-level"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.base-level"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_CAPACITY.getName(),
-        () -> getProperty("rocksdb.block-cache-capacity"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.block-cache-capacity"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_PINNED_USAGE.getName(),
-        () -> getProperty("rocksdb.block-cache-pinned-usage"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.block-cache-pinned-usage"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_USAGE.getName(),
-        () -> getProperty("rocksdb.block-cache-usage"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.block-cache-usage"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_COMPACTION_PENDING.getName(),
-        () -> getProperty("rocksdb.compaction-pending"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.compaction-pending"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_CUR_SIZE_ACTIVE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.cur-size-active-mem-table"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.cur-size-active-mem-table"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_CUR_SIZE_ALL_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.cur-size-all-mem-tables"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.cur-size-all-mem-tables"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_CURRENT_SUPER_VERSION_NUMBER.getName(),
-        () -> getProperty("rocksdb.current-super-version-number"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.current-super-version-number"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_ESTIMATE_LIVE_DATA_SIZE.getName(),
-        () -> getProperty("rocksdb.estimate-live-data-size"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.estimate-live-data-size"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_ESTIMATE_NUM_KEYS.getName(),
-        () -> getProperty("rocksdb.estimate-num-keys"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.estimate-num-keys"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_ESTIMATE_PENDING_COMPACTION_BYTES.getName(),
-        () -> getProperty("rocksdb.estimate-pending-compaction-bytes"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.estimate-pending-compaction-bytes"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_ESTIMATE_TABLE_READERS_MEM.getName(),
-        () -> getProperty("rocksdb.estimate-table-readers-mem"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.estimate-table-readers-mem"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_IS_FILE_DELETIONS_ENABLED.getName(),
-        () -> getProperty("rocksdb.is-file-deletions-enabled"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.is-file-deletions-enabled"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_IS_WRITE_STOPPED.getName(),
-        () -> getProperty("rocksdb.is-write-stopped"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.is-write-stopped"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_LIVE_SST_FILES_SIZE.getName(),
-        () -> getProperty("rocksdb.live-sst-files-size"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.live-sst-files-size"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_MEM_TABLE_FLUSH_PENDING.getName(),
-        () -> getProperty("rocksdb.mem-table-flush-pending"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.mem-table-flush-pending"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_MIN_LOG_NUMBER_TO_KEEP.getName(),
-        () -> getProperty("rocksdb.min-log-number-to-keep"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.min-log-number-to-keep"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_MIN_OBSOLETE_SST_NUMBER_TO_KEEP.getName(),
-        () -> getProperty("rocksdb.min-obsolete-sst-number-to-keep"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.min-obsolete-sst-number-to-keep"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_DELETES_ACTIVE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.num-deletes-active-mem-table"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-deletes-active-mem-table"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_DELETES_IMM_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.num-deletes-imm-mem-tables"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-deletes-imm-mem-tables"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_ENTRIES_ACTIVE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.num-entries-active-mem-table"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-entries-active-mem-table"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_ENTRIES_IMM_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.num-entries-imm-mem-tables"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-entries-imm-mem-tables"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_IMMUTABLE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.num-immutable-mem-table"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-immutable-mem-table"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_LIVE_VERSIONS.getName(),
-        () -> getProperty("rocksdb.num-live-versions"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-live-versions"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_RUNNING_COMPACTIONS.getName(),
-        () -> getProperty("rocksdb.num-running-compactions"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-running-compactions"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_RUNNING_FLUSHES.getName(),
-        () -> getProperty("rocksdb.num-running-flushes"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-running-flushes"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_SNAPSHOTS.getName(),
-        () -> getProperty("rocksdb.num-snapshots"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.num-snapshots"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_OLDEST_SNAPSHOT_TIME.getName(),
-        () -> getProperty("rocksdb.oldest-snapshot-time"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.oldest-snapshot-time"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_SIZE_ALL_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.size-all-mem-tables"));
-    MetricsSystem.registerGaugeIfAbsent(
+        () -> getProperty("rocksdb.size-all-mem-tables"), 15, TimeUnit.SECONDS);
+    MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_TOTAL_SST_FILES_SIZE.getName(),
-        () -> getProperty("rocksdb.total-sst-files-size"));
+        () -> getProperty("rocksdb.total-sst-files-size"), 15, TimeUnit.SECONDS);
   }
 
   private String getProperty(String rocksPropertyName) {
     try {
       return mRocksStore.getDb().getProperty(rocksPropertyName);
     } catch (RocksDBException e) {
-      LOG.warn("error collecting " + rocksPropertyName, e);
+      LOG.warn(String.format("error collecting %s", rocksPropertyName), e);
     }
     return "";
   }

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -191,13 +191,13 @@ public class RocksInodeStore implements InodeStore {
         CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
   }
 
-  private String getProperty(String rocksPropertyName) {
+  private long getProperty(String rocksPropertyName) {
     try {
-      return db().getProperty(rocksPropertyName);
+      return db().getAggregatedLongProperty(rocksPropertyName);
     } catch (RocksDBException e) {
       LOG.warn(String.format("error collecting %s", rocksPropertyName), e);
     }
-    return "";
+    return -1;
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -22,6 +22,8 @@ import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.master.metastore.InodeStore;
 import alluxio.master.metastore.ReadOption;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.proto.meta.InodeMeta;
 import alluxio.resource.CloseableIterator;
 import alluxio.util.io.PathUtils;
@@ -95,6 +97,113 @@ public class RocksInodeStore implements InodeStore {
         new ColumnFamilyDescriptor(EDGES_COLUMN.getBytes(), mColumnFamilyOpts));
     mRocksStore = new RocksStore(ROCKS_STORE_NAME, dbPath, backupPath, columns,
         Arrays.asList(mInodesColumn, mEdgesColumn));
+
+    // metrics
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_ACTUAL_DELAYED_WRITE_RATE.getName(),
+        () -> getProperty("rocksdb.actual-delayed-write-rate"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_BACKGROUND_ERRORS.getName(),
+        () -> getProperty("rocksdb.background-errors"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_BASE_LEVEL.getName(),
+        () -> getProperty("rocksdb.base-level"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_CAPACITY.getName(),
+        () -> getProperty("rocksdb.block-cache-capacity"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_PINNED_USAGE.getName(),
+        () -> getProperty("rocksdb.block-cache-pinned-usage"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_USAGE.getName(),
+        () -> getProperty("rocksdb.block-cache-usage"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_COMPACTION_PENDING.getName(),
+        () -> getProperty("rocksdb.compaction-pending"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_CUR_SIZE_ACTIVE_MEM_TABLE.getName(),
+        () -> getProperty("rocksdb.cur-size-active-mem-table"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_CUR_SIZE_ALL_MEM_TABLES.getName(),
+        () -> getProperty("rocksdb.cur-size-all-mem-tables"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_CURRENT_SUPER_VERSION_NUMBER.getName(),
+        () -> getProperty("rocksdb.current-super-version-number"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_ESTIMATE_LIVE_DATA_SIZE.getName(),
+        () -> getProperty("rocksdb.estimate-live-data-size"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_ESTIMATE_NUM_KEYS.getName(),
+        () -> getProperty("rocksdb.estimate-num-keys"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_ESTIMATE_PENDING_COMPACTION_BYTES.getName(),
+        () -> getProperty("rocksdb.estimate-pending-compaction-bytes"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_ESTIMATE_TABLE_READERS_MEM.getName(),
+        () -> getProperty("rocksdb.estimate-table-readers-mem"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_IS_FILE_DELETIONS_ENABLED.getName(),
+        () -> getProperty("rocksdb.is-file-deletions-enabled"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_IS_WRITE_STOPPED.getName(),
+        () -> getProperty("rocksdb.is-write-stopped"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_LIVE_SST_FILES_SIZE.getName(),
+        () -> getProperty("rocksdb.live-sst-files-size"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_MEM_TABLE_FLUSH_PENDING.getName(),
+        () -> getProperty("rocksdb.mem-table-flush-pending"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_MIN_LOG_NUMBER_TO_KEEP.getName(),
+        () -> getProperty("rocksdb.min-log-number-to-keep"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_MIN_OBSOLETE_SST_NUMBER_TO_KEEP.getName(),
+        () -> getProperty("rocksdb.min-obsolete-sst-number-to-keep"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_NUM_DELETES_ACTIVE_MEM_TABLE.getName(),
+        () -> getProperty("rocksdb.num-deletes-active-mem-table"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_NUM_DELETES_IMM_MEM_TABLES.getName(),
+        () -> getProperty("rocksdb.num-deletes-imm-mem-tables"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_NUM_ENTRIES_ACTIVE_MEM_TABLE.getName(),
+        () -> getProperty("rocksdb.num-entries-active-mem-table"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_NUM_ENTRIES_IMM_MEM_TABLES.getName(),
+        () -> getProperty("rocksdb.num-entries-imm-mem-tables"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_NUM_IMMUTABLE_MEM_TABLE.getName(),
+        () -> getProperty("rocksdb.num-immutable-mem-table"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_NUM_LIVE_VERSIONS.getName(),
+        () -> getProperty("rocksdb.num-live-versions"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_NUM_RUNNING_COMPACTIONS.getName(),
+        () -> getProperty("rocksdb.num-running-compactions"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_NUM_RUNNING_FLUSHES.getName(),
+        () -> getProperty("rocksdb.num-running-flushes"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_NUM_SNAPSHOTS.getName(),
+        () -> getProperty("rocksdb.num-snapshots"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_OLDEST_SNAPSHOT_TIME.getName(),
+        () -> getProperty("rocksdb.oldest-snapshot-time"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_SIZE_ALL_MEM_TABLES.getName(),
+        () -> getProperty("rocksdb.size-all-mem-tables"));
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricKey.MASTER_ROCKS_INODE_TOTAL_SST_FILES_SIZE.getName(),
+        () -> getProperty("rocksdb.total-sst-files-size"));
+  }
+
+  private String getProperty(String rocksPropertyName) {
+    try {
+      return mRocksStore.getDb().getProperty(rocksPropertyName);
+    } catch (RocksDBException e) {
+      LOG.warn("error collecting " + rocksPropertyName, e);
+    }
+    return "";
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -100,102 +100,95 @@ public class RocksInodeStore implements InodeStore {
         Arrays.asList(mInodesColumn, mEdgesColumn));
 
     // metrics
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_INODE_ACTUAL_DELAYED_WRITE_RATE.getName(),
-        () -> getProperty("rocksdb.actual-delayed-write-rate"), 15, TimeUnit.SECONDS);
+    final int CACHED_GAUGE_TIMEOUT_S = 15;
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_BACKGROUND_ERRORS.getName(),
-        () -> getProperty("rocksdb.background-errors"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_INODE_BASE_LEVEL.getName(),
-        () -> getProperty("rocksdb.base-level"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.background-errors"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_CAPACITY.getName(),
-        () -> getProperty("rocksdb.block-cache-capacity"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.block-cache-capacity"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_PINNED_USAGE.getName(),
-        () -> getProperty("rocksdb.block-cache-pinned-usage"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.block-cache-pinned-usage"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_USAGE.getName(),
-        () -> getProperty("rocksdb.block-cache-usage"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.block-cache-usage"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_COMPACTION_PENDING.getName(),
-        () -> getProperty("rocksdb.compaction-pending"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.compaction-pending"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_CUR_SIZE_ACTIVE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.cur-size-active-mem-table"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.cur-size-active-mem-table"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_CUR_SIZE_ALL_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.cur-size-all-mem-tables"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_INODE_CURRENT_SUPER_VERSION_NUMBER.getName(),
-        () -> getProperty("rocksdb.current-super-version-number"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_INODE_ESTIMATE_LIVE_DATA_SIZE.getName(),
-        () -> getProperty("rocksdb.estimate-live-data-size"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.cur-size-all-mem-tables"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_ESTIMATE_NUM_KEYS.getName(),
-        () -> getProperty("rocksdb.estimate-num-keys"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.estimate-num-keys"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_ESTIMATE_PENDING_COMPACTION_BYTES.getName(),
-        () -> getProperty("rocksdb.estimate-pending-compaction-bytes"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.estimate-pending-compaction-bytes"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_ESTIMATE_TABLE_READERS_MEM.getName(),
-        () -> getProperty("rocksdb.estimate-table-readers-mem"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_INODE_IS_FILE_DELETIONS_ENABLED.getName(),
-        () -> getProperty("rocksdb.is-file-deletions-enabled"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_INODE_IS_WRITE_STOPPED.getName(),
-        () -> getProperty("rocksdb.is-write-stopped"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.estimate-table-readers-mem"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_LIVE_SST_FILES_SIZE.getName(),
-        () -> getProperty("rocksdb.live-sst-files-size"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.live-sst-files-size"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_MEM_TABLE_FLUSH_PENDING.getName(),
-        () -> getProperty("rocksdb.mem-table-flush-pending"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_INODE_MIN_LOG_NUMBER_TO_KEEP.getName(),
-        () -> getProperty("rocksdb.min-log-number-to-keep"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_INODE_MIN_OBSOLETE_SST_NUMBER_TO_KEEP.getName(),
-        () -> getProperty("rocksdb.min-obsolete-sst-number-to-keep"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.mem-table-flush-pending"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_DELETES_ACTIVE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.num-deletes-active-mem-table"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-deletes-active-mem-table"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_DELETES_IMM_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.num-deletes-imm-mem-tables"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-deletes-imm-mem-tables"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_ENTRIES_ACTIVE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.num-entries-active-mem-table"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-entries-active-mem-table"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_ENTRIES_IMM_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.num-entries-imm-mem-tables"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-entries-imm-mem-tables"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_IMMUTABLE_MEM_TABLE.getName(),
-        () -> getProperty("rocksdb.num-immutable-mem-table"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-immutable-mem-table"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_LIVE_VERSIONS.getName(),
-        () -> getProperty("rocksdb.num-live-versions"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-live-versions"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_RUNNING_COMPACTIONS.getName(),
-        () -> getProperty("rocksdb.num-running-compactions"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-running-compactions"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_RUNNING_FLUSHES.getName(),
-        () -> getProperty("rocksdb.num-running-flushes"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_INODE_NUM_SNAPSHOTS.getName(),
-        () -> getProperty("rocksdb.num-snapshots"), 15, TimeUnit.SECONDS);
-    MetricsSystem.registerCachedGaugeIfAbsent(
-        MetricKey.MASTER_ROCKS_INODE_OLDEST_SNAPSHOT_TIME.getName(),
-        () -> getProperty("rocksdb.oldest-snapshot-time"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.num-running-flushes"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_SIZE_ALL_MEM_TABLES.getName(),
-        () -> getProperty("rocksdb.size-all-mem-tables"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.size-all-mem-tables"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_TOTAL_SST_FILES_SIZE.getName(),
-        () -> getProperty("rocksdb.total-sst-files-size"), 15, TimeUnit.SECONDS);
+        () -> getProperty("rocksdb.total-sst-files-size"),
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
   }
 
   private String getProperty(String rocksPropertyName) {

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -200,7 +200,7 @@ public class RocksInodeStore implements InodeStore {
 
   private String getProperty(String rocksPropertyName) {
     try {
-      return mRocksStore.getDb().getProperty(rocksPropertyName);
+      return db().getProperty(rocksPropertyName);
     } catch (RocksDBException e) {
       LOG.warn(String.format("error collecting %s", rocksPropertyName), e);
     }

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -196,13 +196,13 @@ public class RocksInodeStore implements InodeStore {
         MetricKey.MASTER_ROCKS_INODE_ESTIMATE_TABLE_READERS_MEM,
         MetricKey.MASTER_ROCKS_INODE_CUR_SIZE_ALL_MEM_TABLES,
         MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_PINNED_USAGE);
-    MetricsSystem.registerAggregatedCachedGauge(
+    MetricsSystem.registerAggregatedCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_ESTIMATED_MEM_USAGE.getName(),
         s, CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
 
     ImmutableSet<MetricKey> s1 = ImmutableSet.of(MetricKey.MASTER_ROCKS_BLOCK_ESTIMATED_MEM_USAGE,
         MetricKey.MASTER_ROCKS_INODE_ESTIMATED_MEM_USAGE);
-    MetricsSystem.registerAggregatedCachedGauge(
+    MetricsSystem.registerAggregatedCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_TOTAL_ESTIMATED_MEM_USAGE.getName(),
         s1, CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
   }

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -100,95 +100,96 @@ public class RocksInodeStore implements InodeStore {
         Arrays.asList(mInodesColumn, mEdgesColumn));
 
     // metrics
-    final int CACHED_GAUGE_TIMEOUT_S = 15;
+    final long CACHED_GAUGE_TIMEOUT_S =
+        ServerConfiguration.getMs(PropertyKey.MASTER_METASTORE_METRICS_REFRESH_INTERVAL);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_BACKGROUND_ERRORS.getName(),
         () -> getProperty("rocksdb.background-errors"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_CAPACITY.getName(),
         () -> getProperty("rocksdb.block-cache-capacity"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_PINNED_USAGE.getName(),
         () -> getProperty("rocksdb.block-cache-pinned-usage"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_USAGE.getName(),
         () -> getProperty("rocksdb.block-cache-usage"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_COMPACTION_PENDING.getName(),
         () -> getProperty("rocksdb.compaction-pending"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_CUR_SIZE_ACTIVE_MEM_TABLE.getName(),
         () -> getProperty("rocksdb.cur-size-active-mem-table"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_CUR_SIZE_ALL_MEM_TABLES.getName(),
         () -> getProperty("rocksdb.cur-size-all-mem-tables"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_ESTIMATE_NUM_KEYS.getName(),
         () -> getProperty("rocksdb.estimate-num-keys"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_ESTIMATE_PENDING_COMPACTION_BYTES.getName(),
         () -> getProperty("rocksdb.estimate-pending-compaction-bytes"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_ESTIMATE_TABLE_READERS_MEM.getName(),
         () -> getProperty("rocksdb.estimate-table-readers-mem"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_LIVE_SST_FILES_SIZE.getName(),
         () -> getProperty("rocksdb.live-sst-files-size"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_MEM_TABLE_FLUSH_PENDING.getName(),
         () -> getProperty("rocksdb.mem-table-flush-pending"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_DELETES_ACTIVE_MEM_TABLE.getName(),
         () -> getProperty("rocksdb.num-deletes-active-mem-table"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_DELETES_IMM_MEM_TABLES.getName(),
         () -> getProperty("rocksdb.num-deletes-imm-mem-tables"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_ENTRIES_ACTIVE_MEM_TABLE.getName(),
         () -> getProperty("rocksdb.num-entries-active-mem-table"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_ENTRIES_IMM_MEM_TABLES.getName(),
         () -> getProperty("rocksdb.num-entries-imm-mem-tables"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_IMMUTABLE_MEM_TABLE.getName(),
         () -> getProperty("rocksdb.num-immutable-mem-table"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_LIVE_VERSIONS.getName(),
         () -> getProperty("rocksdb.num-live-versions"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_RUNNING_COMPACTIONS.getName(),
         () -> getProperty("rocksdb.num-running-compactions"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_NUM_RUNNING_FLUSHES.getName(),
         () -> getProperty("rocksdb.num-running-flushes"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_SIZE_ALL_MEM_TABLES.getName(),
         () -> getProperty("rocksdb.size-all-mem-tables"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_TOTAL_SST_FILES_SIZE.getName(),
         () -> getProperty("rocksdb.total-sst-files-size"),
-        CACHED_GAUGE_TIMEOUT_S, TimeUnit.SECONDS);
+        CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
   }
 
   private long getProperty(String rocksPropertyName) {

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -28,6 +28,7 @@ import alluxio.proto.meta.InodeMeta;
 import alluxio.resource.CloseableIterator;
 import alluxio.util.io.PathUtils;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Longs;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
@@ -190,6 +191,20 @@ public class RocksInodeStore implements InodeStore {
         MetricKey.MASTER_ROCKS_INODE_TOTAL_SST_FILES_SIZE.getName(),
         () -> getProperty("rocksdb.total-sst-files-size"),
         CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
+
+    ImmutableSet<MetricKey> s = ImmutableSet.of(MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_USAGE,
+        MetricKey.MASTER_ROCKS_INODE_ESTIMATE_TABLE_READERS_MEM,
+        MetricKey.MASTER_ROCKS_INODE_CUR_SIZE_ALL_MEM_TABLES,
+        MetricKey.MASTER_ROCKS_INODE_BLOCK_CACHE_PINNED_USAGE);
+    MetricsSystem.registerAggregatedCachedGauge(
+        MetricKey.MASTER_ROCKS_INODE_ESTIMATED_MEM_USAGE.getName(),
+        s, CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
+
+    ImmutableSet<MetricKey> s1 = ImmutableSet.of(MetricKey.MASTER_ROCKS_BLOCK_ESTIMATED_MEM_USAGE,
+        MetricKey.MASTER_ROCKS_INODE_ESTIMATED_MEM_USAGE);
+    MetricsSystem.registerAggregatedCachedGauge(
+        MetricKey.MASTER_ROCKS_TOTAL_ESTIMATED_MEM_USAGE.getName(),
+        s1, CACHED_GAUGE_TIMEOUT_S, TimeUnit.MILLISECONDS);
   }
 
   private long getProperty(String rocksPropertyName) {

--- a/docs/en/operation/Metastore.md
+++ b/docs/en/operation/Metastore.md
@@ -68,6 +68,11 @@ governed by the JVM arguments `-Xmx` and `-Xms`. Here's how they are exposed in 
 - `Master.RocksBlockCurSizeAllMemTables` and `Master.RocksInodeCurSizeAllMemTables` (derived from `rocksdb.cur-size-all-mem-tables`).
 - `Master.RocksBlockBlockCachePinnedUsage` and `Master.RocksInodeBlockCachePinnedUsage` (derived from `rocksdb.block-cache-pinned-usage`).
 
+These four metrics are aggregated on a blocks and inodes basis to estimate total memory usage. `Master.RocksBlockEstimatedMemUsage`
+and `Master.RocksInodeEstimatedMemUsage` estimate the total memory usage for the blocks table and the inodes table, respectively.
+These two metrics are further combined in `Master.RocksTotalEstimatedMemUsage` to estimate the total memory usage of RocksDB across
+all of Alluxio.
+
 ## Heap Metastore
 
 The heap metastore is simple: it stores all metadata on the heap. This gives consistent,

--- a/docs/en/operation/Metastore.md
+++ b/docs/en/operation/Metastore.md
@@ -54,6 +54,19 @@ These tuning parameters primarily affect the behavior of the cache.
 * `alluxio.master.metastore.inode.cache.low.water.mark.ratio`: Ratio of the maximum cache size
   that eviction will evict down to. Default: `0.8`
 
+### Metrics and memory usage
+Alluxio exposes all RocksDB metrics found [here](https://github.com/facebook/rocksdb/blob/2b5c29f9f3a5c622031368bf3bf4566f5c590ce5/include/rocksdb/db.h#L1104-L1136).
+Alluxio uses one RocksDB database for blocks and one for inodes. Both databases have their own set of metrics. The naming of
+such metrics follows the pattern of `rocksdb.name-of-metric > Master.Rocks<Block | Inode>NameOfMetric`.
+
+The metrics that concern memory usage are explored in the [RocksDB wiki](https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB).
+These are important as RocksDB is written in C++ and used through the JNI in Java. This means that RocksDB's memory usage is not
+governed by the JVM arguments `-Xmx` and `-Xms`. Here's how they are exposed in Alluxio:
+- `Master.RocksBlockBlockCacheUsage` and `Master.RocksInodeBlockCacheUsage` (derived from `rocksdb.block-cache-usage`).
+- `Master.RocksBlockEstimateTableReadersMem` and `Master.RocksInodeEstimateTableReadersMem` (derived from `rocksdb.estimate-table-readers-mem`).
+- `Master.RocksBlockCurSizeAllMemTables` and `Master.RocksInodeCurSizeAllMemTables` (derived from `rocksdb.cur-size-all-mem-tables`).
+- `Master.RocksBlockBlockCachePinnedUsage` and `Master.RocksInodeBlockCachePinnedUsage` (derived from `rocksdb.block-cache-pinned-usage`).
+
 ## Heap Metastore
 
 The heap metastore is simple: it stores all metadata on the heap. This gives consistent,

--- a/docs/en/operation/Metastore.md
+++ b/docs/en/operation/Metastore.md
@@ -57,7 +57,8 @@ These tuning parameters primarily affect the behavior of the cache.
 ### Metrics and memory usage
 Alluxio exposes all RocksDB metrics found [here](https://github.com/facebook/rocksdb/blob/2b5c29f9f3a5c622031368bf3bf4566f5c590ce5/include/rocksdb/db.h#L1104-L1136).
 Alluxio uses one RocksDB database for blocks and one for inodes. Both databases have their own set of metrics. The naming of
-such metrics follows the pattern of `rocksdb.name-of-metric > Master.Rocks<Block | Inode>NameOfMetric`.
+such metrics follows the pattern of `rocksdb.name-of-metric > Master.Rocks<Block | Inode>NameOfMetric`. All metrics are 
+aggregated across all columns present in RocksDB.
 
 The metrics that concern memory usage are explored in the [RocksDB wiki](https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB).
 These are important as RocksDB is written in C++ and used through the JNI in Java. This means that RocksDB's memory usage is not


### PR DESCRIPTION
Fix #15466 

Exposing all RocksDB metrics listed [here](https://github.com/facebook/rocksdb/blob/2b5c29f9f3a5c622031368bf3bf4566f5c590ce5/include/rocksdb/db.h#L1104-L1136) except for `rocksdb.estimate-oldest-key-time` as preliminary testing showed it was not working. 
Metics names follow the convention `num-immutable-mem-table` --> `Master.Rocks<Block | Inode>ImmutableMemTable` (depending on whether one wants to study the Inode RocksDB store or the Block RocksDB store).