### PR TITLE
Remove BlockWorker.moveBlock APIs

### DIFF
--- a/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -145,40 +145,6 @@ public interface BlockWorker extends Worker, SessionCleanable {
   boolean hasBlockMeta(long blockId);
 
   /**
-   * Moves a block from its current location to a target location, currently only tier level moves
-   * are supported. Throws an {@link IllegalArgumentException} if the tierAlias is out of range of
-   * tiered storage.
-   *
-   * @param sessionId the id of the client
-   * @param blockId the id of the block to move
-   * @param tier the tier to move the block to
-   * @throws BlockDoesNotExistException if blockId cannot be found
-   * @throws InvalidWorkerStateException if blockId has not been committed
-   * @throws WorkerOutOfSpaceException if newLocation does not have enough extra space to hold the
-   *         block
-   */
-  void moveBlock(long sessionId, long blockId, int tier)
-      throws BlockDoesNotExistException, InvalidWorkerStateException,
-      WorkerOutOfSpaceException, IOException;
-
-  /**
-   * Moves a block from its current location to a target location, with a specific medium type.
-   * Throws an {@link IllegalArgumentException} if the medium type is not one of the listed medium
-   * types.
-   *
-   * @param sessionId the id of the client
-   * @param blockId the id of the block to move
-   * @param mediumType the medium type to move to
-   * @throws BlockDoesNotExistException if blockId cannot be found
-   * @throws InvalidWorkerStateException if blockId has not been committed
-   * @throws WorkerOutOfSpaceException if newLocation does not have enough extra space to hold the
-   *         block
-   */
-  void moveBlockToMedium(long sessionId, long blockId, String mediumType)
-      throws BlockDoesNotExistException, InvalidWorkerStateException,
-      WorkerOutOfSpaceException, IOException;
-
-  /**
    * Creates the block reader to read from Alluxio block or UFS block.
    * Owner of this block reader must close it or lock will leak.
    *

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -400,36 +400,6 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   }
 
   @Override
-  public void moveBlock(long sessionId, long blockId, int tier)
-      throws BlockDoesNotExistException, InvalidWorkerStateException,
-      WorkerOutOfSpaceException, IOException {
-    // TODO(calvin): Move this logic into BlockStore#moveBlockInternal if possible
-    // Because the move operation is expensive, we first check if the operation is necessary
-    moveBlockInternal(sessionId, blockId, BlockStoreLocation.anyDirInTier(
-        WORKER_STORAGE_TIER_ASSOC.getAlias(tier)));
-  }
-
-  @Override
-  public void moveBlockToMedium(long sessionId, long blockId, String mediumType)
-      throws BlockDoesNotExistException, InvalidWorkerStateException,
-      WorkerOutOfSpaceException, IOException {
-    moveBlockInternal(sessionId, blockId,
-        BlockStoreLocation.anyDirInAnyTierWithMedium(mediumType));
-  }
-
-  private void moveBlockInternal(long sessionId, long blockId, BlockStoreLocation dst)
-      throws BlockDoesNotExistException, InvalidWorkerStateException,
-      WorkerOutOfSpaceException, IOException {
-    BlockMeta meta = mLocalBlockStore.getVolatileBlockMeta(blockId).orElseThrow(
-        () -> new BlockDoesNotExistException(ExceptionMessage.BLOCK_META_NOT_FOUND, blockId));
-    if (meta.getBlockLocation().belongsTo(dst)) {
-      return;
-    }
-    // Execute the block move if necessary
-    mLocalBlockStore.moveBlock(sessionId, blockId, AllocateOptions.forMove(dst));
-  }
-
-  @Override
   public List<String> getWhiteList() {
     return mWhitelist.getList();
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -330,6 +330,12 @@ public class TieredBlockStore implements LocalBlockStore
       WorkerOutOfSpaceException, IOException {
     LOG.debug("moveBlock: sessionId={}, blockId={}, options={}", sessionId,
         blockId, moveOptions);
+    BlockMeta meta = getVolatileBlockMeta(blockId).orElseThrow(
+        () -> new BlockDoesNotExistException(ExceptionMessage.BLOCK_META_NOT_FOUND, blockId));
+    if (meta.getBlockLocation().belongsTo(moveOptions.getLocation())) {
+      return;
+    }
+    // Execute the block move if necessary
     MoveBlockResult result = moveBlockInternal(sessionId, blockId, moveOptions);
     if (result.getSuccess()) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerClientServiceHandler.java
@@ -41,6 +41,8 @@ import alluxio.underfs.UfsManager;
 import alluxio.util.IdUtils;
 import alluxio.util.SecurityUtils;
 import alluxio.worker.WorkerProcess;
+import alluxio.worker.block.AllocateOptions;
+import alluxio.worker.block.BlockStoreLocation;
 import alluxio.worker.block.BlockWorker;
 import alluxio.worker.block.DefaultBlockWorker;
 
@@ -179,8 +181,10 @@ public class BlockWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorker
       StreamObserver<MoveBlockResponse> responseObserver) {
     long sessionId = IdUtils.createSessionId();
     RpcUtils.call(LOG, () -> {
-      mBlockWorker.moveBlockToMedium(sessionId,
-          request.getBlockId(), request.getMediumType());
+      mBlockWorker.getLocalBlockStore()
+          .moveBlock(sessionId, request.getBlockId(),
+              AllocateOptions.forMove(
+                  BlockStoreLocation.anyDirInAnyTierWithMedium(request.getMediumType())));
       return MoveBlockResponse.getDefaultInstance();
     }, "moveBlock", "request=%s", responseObserver, request);
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
@@ -221,23 +221,6 @@ public class DefaultBlockWorkerTest {
   }
 
   @Test
-  public void moveBlock() throws Exception {
-    long blockId = mRandom.nextLong();
-    long sessionId = mRandom.nextLong();
-    mBlockWorker.createBlock(sessionId, blockId, 1, new CreateBlockOptions(null, "", 1));
-    mBlockWorker.commitBlock(sessionId, blockId, true);
-    // move sure this block is on tier 1
-    mBlockWorker.moveBlock(sessionId, blockId, 1);
-    assertEquals(Constants.MEDIUM_HDD,
-        mBlockWorker.getLocalBlockStore().getVolatileBlockMeta(blockId).get()
-            .getBlockLocation().tierAlias());
-    mBlockWorker.moveBlock(sessionId, blockId, 0);
-    assertEquals(Constants.MEDIUM_MEM,
-        mBlockWorker.getLocalBlockStore().getVolatileBlockMeta(blockId).get()
-            .getBlockLocation().tierAlias());
-  }
-
-  @Test
   public void removeBlock() throws Exception {
     long blockId = mRandom.nextLong();
     long sessionId = mRandom.nextLong();

--- a/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
@@ -97,20 +97,6 @@ public class NoopBlockWorker implements BlockWorker {
   }
 
   @Override
-  public void moveBlock(long sessionId, long blockId, int tier)
-      throws BlockDoesNotExistException, InvalidWorkerStateException,
-      WorkerOutOfSpaceException, IOException {
-    // noop
-  }
-
-  @Override
-  public void moveBlockToMedium(long sessionId, long blockId, String mediumType)
-      throws BlockDoesNotExistException, InvalidWorkerStateException,
-      WorkerOutOfSpaceException, IOException {
-    // noop
-  }
-
-  @Override
   public BlockReader createUfsBlockReader(long sessionId, long blockId, long offset,
       boolean positionShort, Protocol.OpenUfsBlockOptions options)
       throws IOException {

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -634,8 +634,8 @@ public final class TieredBlockStoreTest {
    */
   @Test
   public void moveTempBlock() throws Exception {
-    mThrown.expect(InvalidWorkerStateException.class);
-    mThrown.expectMessage(ExceptionMessage.MOVE_UNCOMMITTED_BLOCK.getMessage(TEMP_BLOCK_ID));
+    mThrown.expect(BlockDoesNotExistException.class);
+    mThrown.expectMessage(ExceptionMessage.BLOCK_META_NOT_FOUND.getMessage(TEMP_BLOCK_ID));
 
     TieredBlockStoreTestUtils.createTempBlock(SESSION_ID1, TEMP_BLOCK_ID, BLOCK_SIZE, mTestDir1);
     mBlockStore.moveBlock(SESSION_ID1, TEMP_BLOCK_ID,


### PR DESCRIPTION
The moveBlock APIs are very light wrappers on top of the API for LocalBlockStore. They don't really need to exist.