### PR TITLE
Remove unnecessary code in GrpcChannelKey

### DIFF
--- a/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannel.java
@@ -138,7 +138,7 @@ public final class GrpcChannel extends Channel {
    * @return a short identifier for the channel
    */
   public String toStringShort() {
-    return mConnection.getChannelKey().toStringShort();
+    return mConnection.getChannelKey().toString();
   }
 
   /**

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -137,12 +137,12 @@ public final class GrpcChannelBuilder {
         connection.close();
       } catch (Exception e) {
         throw new RuntimeException(
-            "Failed to release the connection. " + mChannelKey.toStringShort(), e);
+            "Failed to release the connection. " + mChannelKey.toString(), e);
       }
       // Pretty print unavailable cases.
       if (t instanceof UnavailableException) {
         throw new UnavailableException(String.format("Failed to connect to remote server %s. %s",
-            mChannelKey.getServerAddress(), mChannelKey.toStringShort()),
+            mChannelKey.getServerAddress(), mChannelKey.toString()),
             t.getCause());
       }
       throw AlluxioStatusException.fromThrowable(t);

--- a/core/common/src/main/java/alluxio/security/authentication/AuthenticatedChannelClientDriver.java
+++ b/core/common/src/main/java/alluxio/security/authentication/AuthenticatedChannelClientDriver.java
@@ -94,19 +94,19 @@ public class AuthenticatedChannelClientDriver implements StreamObserver<SaslMess
   public void onNext(SaslMessage saslMessage) {
     try {
       LOG.debug("Received message for channel: {}. Message: {}",
-          mChannelKey.toStringShort(), saslMessage);
+          mChannelKey.toString(), saslMessage);
       SaslMessage response = mSaslClientHandler.handleMessage(saslMessage);
       if (response != null) {
         mRequestObserver.onNext(response);
       } else {
         // {@code null} response means server message was a success.
         // Release blocked waiters.
-        LOG.debug("Authentication established for {}", mChannelKey.toStringShort());
+        LOG.debug("Authentication established for {}", mChannelKey.toString());
         mChannelAuthenticatedFuture.set(null);
       }
     } catch (Throwable t) {
       LOG.debug("Exception while handling message for {}. Message: {}. Error: {}",
-          mChannelKey.toStringShort(), saslMessage, t);
+          mChannelKey.toString(), saslMessage, t);
       // Fail blocked waiters.
       mChannelAuthenticatedFuture.setException(t);
       mRequestObserver.onError(AlluxioStatusException.fromThrowable(t).toGrpcStatusException());
@@ -116,7 +116,7 @@ public class AuthenticatedChannelClientDriver implements StreamObserver<SaslMess
   @Override
   public void onError(Throwable throwable) {
     LOG.debug("Authentication stream failed for client. Channel: {}. Error: {}",
-        mChannelKey.toStringShort(), throwable);
+        mChannelKey.toString(), throwable);
     closeAuthenticatedChannel(false);
 
     // Fail blocked waiters.
@@ -125,7 +125,7 @@ public class AuthenticatedChannelClientDriver implements StreamObserver<SaslMess
 
   @Override
   public void onCompleted() {
-    LOG.debug("Authentication revoked by server. Channel: {}", mChannelKey.toStringShort());
+    LOG.debug("Authentication revoked by server. Channel: {}", mChannelKey.toString());
     closeAuthenticatedChannel(false);
   }
 
@@ -133,7 +133,7 @@ public class AuthenticatedChannelClientDriver implements StreamObserver<SaslMess
    * Stops authenticated session with the server by releasing the long poll.
    */
   public void close() {
-    LOG.debug("Authentication client-driver closing. Channel: {}", mChannelKey.toStringShort());
+    LOG.debug("Authentication client-driver closing. Channel: {}", mChannelKey.toString());
     closeAuthenticatedChannel(true);
   }
 
@@ -152,7 +152,7 @@ public class AuthenticatedChannelClientDriver implements StreamObserver<SaslMess
    */
   public void startAuthenticatedChannel(long timeoutMs) throws AlluxioStatusException {
     try {
-      LOG.debug("Initiating authentication for channel: {}", mChannelKey.toStringShort());
+      LOG.debug("Initiating authentication for channel: {}", mChannelKey.toString());
       // Send the server initial message.
       try {
         mRequestObserver.onNext(mInitiateMessage);
@@ -171,7 +171,7 @@ public class AuthenticatedChannelClientDriver implements StreamObserver<SaslMess
   private SaslMessage generateInitialMessage() throws SaslException {
     SaslMessage.Builder initialMsg = mSaslClientHandler.handleMessage(null).toBuilder();
     initialMsg.setClientId(mChannelKey.getChannelId().toString());
-    initialMsg.setChannelRef(mChannelKey.toStringShort());
+    initialMsg.setChannelRef(mChannelKey.toString());
     return initialMsg.build();
   }
 
@@ -206,7 +206,7 @@ public class AuthenticatedChannelClientDriver implements StreamObserver<SaslMess
       } catch (Exception e) {
         LogUtils.warnWithException(LOG,
             "Failed signaling server for stream completion for channel: {}.",
-            mChannelKey.toStringShort(), e);
+            mChannelKey.toString(), e);
       }
     }
   }

--- a/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ChannelAuthenticator.java
@@ -79,7 +79,7 @@ public class ChannelAuthenticator {
    * @throws AlluxioStatusException
    */
   public void authenticate() throws AlluxioStatusException {
-    LOG.debug("Authenticating channel: {}. AuthType: {}", mChannelKey.toStringShort(), mAuthType);
+    LOG.debug("Authenticating channel: {}. AuthType: {}", mChannelKey.toString(), mAuthType);
 
     ChannelAuthenticationScheme authScheme = getChannelAuthScheme(mAuthType, mParentSubject,
         mChannelKey.getServerAddress().getSocketAddress());
@@ -108,7 +108,7 @@ public class ChannelAuthenticator {
       // Build a pretty message for authentication failure.
       String message = String.format(
           "Channel authentication failed with code:%s. Channel: %s, AuthType: %s, Error: %s",
-          e.getStatusCode().name(), mChannelKey.toStringShort(), mAuthType, e.toString());
+          e.getStatusCode().name(), mChannelKey.toString(), mAuthType, e.toString());
       throw AlluxioStatusException
           .from(Status.fromCode(e.getStatusCode()).withDescription(message).withCause(t));
     }


### PR DESCRIPTION
The `IdentityField` annotation is unnecessary and makes `hashCode` and `equals` expensive.
The `toStringShort` method is longer than `toString`, which also seems to be unnecessary.