### PR TITLE
Fix fuse3 packages in dev image

### DIFF
--- a/integration/docker/Dockerfile-dev
+++ b/integration/docker/Dockerfile-dev
@@ -67,7 +67,7 @@ RUN \
     yum install -y gcc gcc-c++ make cmake gettext-devel libtool autoconf && \
     yum clean all && \
     ./dockerfile-common.sh install-libfuse2 && \
-    yum install -y fuse3-libs
+    yum install -y fuse3 fuse3-devel fuse3-lib
 
 ENV LD_LIBRARY_PATH "/usr/local/lib:${LD_LIBRARY_PATH}"
 


### PR DESCRIPTION
Solely install `fuse3-libs` can't start alluxio fuse process successfully. It would return error something like "fusermount3 not found"