### PR TITLE
Install libfuse3 in jenkins images

### DIFF
--- a/dev/jenkins/Dockerfile-jdk11
+++ b/dev/jenkins/Dockerfile-jdk11
@@ -105,7 +105,7 @@ RUN mkdir -p /home/jenkins && \
     chmod -R 777 /.config && \
     apt-get update -y && \
     apt-get upgrade -y ca-certificates && \
-    apt-get install -y build-essential fuse libfuse-dev libfuse3-3 libfuse3-dev make ruby ruby-dev
+    apt-get install -y build-essential fuse libfuse-dev fuse3 libfuse3-dev make ruby ruby-dev
 # jekyll for documentation
 RUN gem install jekyll bundler
 # golang for tooling

--- a/dev/jenkins/Dockerfile-jdk11
+++ b/dev/jenkins/Dockerfile-jdk11
@@ -105,7 +105,7 @@ RUN mkdir -p /home/jenkins && \
     chmod -R 777 /.config && \
     apt-get update -y && \
     apt-get upgrade -y ca-certificates && \
-    apt-get install -y build-essential fuse libfuse-dev make ruby ruby-dev
+    apt-get install -y build-essential fuse libfuse-dev libfuse3-3 libfuse3-dev make ruby ruby-dev
 # jekyll for documentation
 RUN gem install jekyll bundler
 # golang for tooling

--- a/dev/jenkins/Dockerfile-jdk8
+++ b/dev/jenkins/Dockerfile-jdk8
@@ -21,7 +21,7 @@ RUN mkdir -p /home/jenkins && \
     chmod -R 777 /.config && \
     apt-get update -y && \
     apt-get upgrade -y ca-certificates && \
-    apt-get install -y build-essential fuse libfuse-dev libfuse3-3 libfuse3-dev make ruby ruby-dev
+    apt-get install -y build-essential fuse libfuse-dev fuse3 libfuse3-dev make ruby ruby-dev
 # jekyll for documentation
 RUN gem install jekyll bundler
 # golang for tooling

--- a/dev/jenkins/Dockerfile-jdk8
+++ b/dev/jenkins/Dockerfile-jdk8
@@ -21,7 +21,7 @@ RUN mkdir -p /home/jenkins && \
     chmod -R 777 /.config && \
     apt-get update -y && \
     apt-get upgrade -y ca-certificates && \
-    apt-get install -y build-essential fuse libfuse-dev make ruby ruby-dev
+    apt-get install -y build-essential fuse libfuse-dev libfuse3-3 libfuse3-dev make ruby ruby-dev
 # jekyll for documentation
 RUN gem install jekyll bundler
 # golang for tooling


### PR DESCRIPTION
The jenkins image didn't install libfuse3 packages, which means in github actions the Fuse integration tests never ran with libfuse3. 

Tested on https://github.com/ssz1997/alluxio/pull/2 and the Fuse integration tests passed: https://github.com/ssz1997/alluxio/runs/6293974135?check_suite_focus=true