### PR TITLE
Add docker image env variable to Fuse github action

### DIFF
--- a/.github/workflows/fuse_integration_tests.yml
+++ b/.github/workflows/fuse_integration_tests.yml
@@ -39,6 +39,7 @@ jobs:
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
           ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server,!table/server/underdb/glue,!underfs/hdfs,!underfs/ozone,!underfs/adl,!underfs/abfs,!underfs/cosn,!underfs/wasb,!underfs/cos,!underfs/kodo,!underfs/oss,!underfs/swift \
+          ALLUXIO_DOCKER_IMAGE=alluxio/alluxio-maven:0.0.7-jdk${{ matrix.java }} \
           dev/github/run_docker.sh "\"-Dtest=alluxio.client.fuse.**\""  "\"-Dalluxio.fuse.jnifuse.libfuse.version=${{ matrix.version }}\"" -pl tests
         timeout-minutes: 60
 


### PR DESCRIPTION
Without ALLUXIO_DOCKER_IMAGE env variable, it always uses jdk8 image to test. Add jdk11 image for testing fuse module with jdk11.