### PR TITLE
Revert "Install libfuse3 in jenkins images"

### DIFF
--- a/dev/jenkins/Dockerfile-jdk11
+++ b/dev/jenkins/Dockerfile-jdk11
@@ -105,7 +105,7 @@ RUN mkdir -p /home/jenkins && \
     chmod -R 777 /.config && \
     apt-get update -y && \
     apt-get upgrade -y ca-certificates && \
-    apt-get install -y build-essential fuse libfuse-dev fuse3 libfuse3-dev make ruby ruby-dev
+    apt-get install -y build-essential fuse libfuse-dev make ruby ruby-dev
 # jekyll for documentation
 RUN gem install jekyll bundler
 # golang for tooling

--- a/dev/jenkins/Dockerfile-jdk8
+++ b/dev/jenkins/Dockerfile-jdk8
@@ -21,7 +21,7 @@ RUN mkdir -p /home/jenkins && \
     chmod -R 777 /.config && \
     apt-get update -y && \
     apt-get upgrade -y ca-certificates && \
-    apt-get install -y build-essential fuse libfuse-dev fuse3 libfuse3-dev make ruby ruby-dev
+    apt-get install -y build-essential fuse libfuse-dev make ruby ruby-dev
 # jekyll for documentation
 RUN gem install jekyll bundler
 # golang for tooling


### PR DESCRIPTION
Can't install fuse and fuse3 at the same time in ubuntu. Revert the change.

In Ubuntu, package `fuse3` replaces `fuse2`, as seen in https://ubuntu.pkgs.org/20.04/ubuntu-universe-arm64/fuse3_3.9.0-2_arm64.deb.html "Replaces" section. Also in the "Changelog" section, under "2018-12-25", `Make "fuse3" to replace "fuse", instead of conflict`. 

Therefore `fuse3` contains most files/binaries/libraries installed by `fuse`, which brings the conflict and can't install both simultaneously. 