### PR TITLE
Add InstrumentedExecutorService for monitoring executor services

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -643,6 +643,28 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setIsHidden(true)
           .setScope(Scope.ALL)
           .build();
+  public static final PropertyKey METRICS_EXECUTOR_TASK_WARN_SIZE =
+      intBuilder(Name.METRICS_EXECUTOR_TASK_WARN_SIZE)
+          .setDefaultValue(1000)
+          .setDescription(String.format("When instrumenting an executor with"
+                  + " InstrumentedExecutorService, if the number of"
+                  + " active tasks (queued or running) is greater than this value, a warning log"
+                  + " will be printed at the interval given by %s",
+              Name.METRICS_EXECUTOR_TASK_WARN_FREQUENCY))
+          .setScope(Scope.ALL)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .build();
+  public static final PropertyKey METRICS_EXECUTOR_TASK_WARN_FREQUENCY =
+      durationBuilder(Name.METRICS_EXECUTOR_TASK_WARN_FREQUENCY)
+          .setDefaultValue("5sec")
+          .setDescription(String.format("When instrumenting an executor with"
+                  + "InstrumentedExecutorService, if the number of"
+                  + " active tasks (queued or running) is greater than %s value, a warning log"
+                  + " will be printed at the given interval",
+              Name.METRICS_EXECUTOR_TASK_WARN_SIZE))
+          .setScope(Scope.ALL)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .build();
   public static final PropertyKey NETWORK_CONNECTION_AUTH_TIMEOUT =
       durationBuilder(Name.NETWORK_CONNECTION_AUTH_TIMEOUT)
           .setDefaultValue("30sec")
@@ -3005,6 +3027,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("The number of threads used to execute all metadata sync"
               + "operations")
           .setScope(Scope.MASTER)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .build();
+  public static final PropertyKey MASTER_METADATA_SYNC_INSTRUMENT_EXECUTOR =
+      booleanBuilder(Name.MASTER_METADATA_SYNC_INSTRUMENT_EXECUTOR)
+          .setDescription("If true the metadata sync thread pool executors will be"
+              + " instrumented with additional metrics.")
+          .setScope(Scope.MASTER)
+          .setDefaultValue(false)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
   public static final PropertyKey MASTER_METADATA_SYNC_REPORT_FAILURE =
@@ -6309,6 +6339,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String METRICS_CONF_FILE = "alluxio.metrics.conf.file";
     public static final String METRICS_CONTEXT_SHUTDOWN_TIMEOUT =
         "alluxio.metrics.context.shutdown.timeout";
+    public static final String METRICS_EXECUTOR_TASK_WARN_SIZE =
+        "alluxio.metrics.executor.task.warn.size";
+    public static final String METRICS_EXECUTOR_TASK_WARN_FREQUENCY =
+        "alluxio.metrics.executor.task.warn.frequency";
     public static final String NETWORK_CONNECTION_AUTH_TIMEOUT =
         "alluxio.network.connection.auth.timeout";
     public static final String NETWORK_CONNECTION_HEALTH_CHECK_TIMEOUT =
@@ -6670,6 +6704,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metadata.sync.concurrency.level";
     public static final String MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE =
         "alluxio.master.metadata.sync.executor.pool.size";
+    public static final String MASTER_METADATA_SYNC_INSTRUMENT_EXECUTOR =
+        "alluxio.master.metadata.sync.instrument.executor";
     public static final String MASTER_METADATA_SYNC_REPORT_FAILURE =
         "alluxio.master.metadata.sync.report.failure";
     public static final String MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE =

--- a/core/common/src/main/java/alluxio/metrics/InstrumentedExecutorService.java
+++ b/core/common/src/main/java/alluxio/metrics/InstrumentedExecutorService.java
@@ -1,0 +1,181 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.metrics;
+
+import alluxio.Constants;
+import alluxio.util.logging.SamplingLogger;
+
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A wrapper around {@link com.codahale.metrics.InstrumentedExecutorService}
+ * that allows the metrics to be reset by {@link MetricsSystem#resetAllMetrics()}.
+ * Additional it tracks in a histogram called name.active.tasks
+ * the number of active tasks (queued or running) each
+ * time a new task is added to the executor. This histogram is additionally
+ * tracks the maximum overall number active tasks at any time.
+ */
+public class InstrumentedExecutorService implements ExecutorService {
+
+  private static final Logger SAMPLING_LOG =
+      new SamplingLogger(LoggerFactory.getLogger(InstrumentedExecutorService.class),
+          5L * Constants.SECOND_MS);
+  // If the number of active tasks (queued or running) is above this amount
+  // when a new task is added, then a warning log is printed at the given
+  // rate of the above sampling log.
+  private static final long ACTIVE_TASK_WARNING_SIZE = 1000;
+
+  private com.codahale.metrics
+      .InstrumentedExecutorService mDelegate;
+  private final String mName;
+  private final MetricRegistry mRegistry;
+  private final ExecutorService mExecutorService;
+  private final MetricRegistry.MetricSupplier<Histogram> mSupplier =
+      () -> new Histogram(new MaxReservoir(new ExponentiallyDecayingReservoir()));
+  private Meter mSubmitted;
+  private Meter mCompleted;
+  private Histogram mHist;
+
+  /**
+   * @param executorService the executor service to instrument
+   * @param registry the metric registry
+   * @param name the name that will be used for the associated metrics
+   */
+  public InstrumentedExecutorService(
+      ExecutorService executorService, MetricRegistry registry, String name) {
+    mName = name;
+    mRegistry = registry;
+    mExecutorService = executorService;
+    reset();
+  }
+
+  /**
+   * Resets the metrics monitored about the executor service.
+   * This is only called by {@link MetricsSystem#resetAllMetrics()}
+   * after all metrics have already been cleared, then this method
+   * will update the pointers of this object to the new metrics.
+   */
+  protected void reset() {
+    mDelegate = new com.codahale.metrics.InstrumentedExecutorService(
+        mExecutorService, mRegistry, mName);
+    mSubmitted = mRegistry.meter(MetricRegistry.name(mName, "submitted"));
+    mCompleted = mRegistry.meter(MetricRegistry.name(mName, "completed"));
+    String histName = MetricRegistry.name(mName, "activeTaskQueue");
+    mRegistry.remove(histName);
+    mHist = mRegistry.histogram(histName, mSupplier);
+  }
+
+  private void addedTasks(int count) {
+    long activeCount = mSubmitted.getCount() - mCompleted.getCount() + count;
+    mHist.update(activeCount);
+    if (activeCount >= ACTIVE_TASK_WARNING_SIZE) {
+      SAMPLING_LOG.warn("Number of active tasks (queued and running) for executor {} is {}",
+          mName, activeCount);
+    }
+  }
+
+  @Override
+  public void execute(@Nonnull Runnable runnable) {
+    addedTasks(1);
+    mDelegate.execute(runnable);
+  }
+
+  @Override
+  public Future<?> submit(@Nonnull Runnable runnable) {
+    addedTasks(1);
+    return mDelegate.submit(runnable);
+  }
+
+  @Override
+  public <T> Future<T> submit(@Nonnull Runnable runnable, T result) {
+    addedTasks(1);
+    return mDelegate.submit(runnable, result);
+  }
+
+  @Override
+  public <T> Future<T> submit(@Nonnull Callable<T> task) {
+    addedTasks(1);
+    return mDelegate.submit(task);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(
+      @Nonnull Collection<? extends Callable<T>> tasks) throws InterruptedException {
+    addedTasks(tasks.size());
+    return mDelegate.invokeAll(tasks);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(
+      @Nonnull Collection<? extends Callable<T>> tasks, long timeout,
+      @Nonnull TimeUnit unit) throws InterruptedException {
+    addedTasks(tasks.size());
+    return mDelegate.invokeAll(tasks, timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(
+      @Nonnull Collection<? extends Callable<T>> tasks)
+      throws ExecutionException, InterruptedException {
+    addedTasks(tasks.size());
+    return mDelegate.invokeAny(tasks);
+  }
+
+  @Override
+  public <T> T invokeAny(
+      @Nonnull Collection<? extends Callable<T>> tasks,
+      long timeout, @Nonnull TimeUnit unit)
+      throws ExecutionException, InterruptedException, TimeoutException {
+    addedTasks(tasks.size());
+    return mDelegate.invokeAny(tasks, timeout, unit);
+  }
+
+  @Override
+  public void shutdown() {
+    mDelegate.shutdown();
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return mDelegate.shutdownNow();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return mDelegate.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return mDelegate.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long l, @Nonnull TimeUnit timeUnit) throws InterruptedException {
+    return mDelegate.awaitTermination(l, timeUnit);
+  }
+}

--- a/core/common/src/main/java/alluxio/metrics/MaxReservoir.java
+++ b/core/common/src/main/java/alluxio/metrics/MaxReservoir.java
@@ -1,0 +1,115 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.metrics;
+
+import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.Snapshot;
+
+import java.io.OutputStream;
+import java.util.concurrent.atomic.LongAccumulator;
+
+/**
+ * A wrapper around {@link Reservoir} that keeps track of the max
+ * value sent as an update to this reservoir. Any snapshot returned
+ * by the reservoir will return this max value.
+ */
+public class MaxReservoir implements Reservoir {
+  private final Reservoir mDelegate;
+  private final LongAccumulator mMaxUpdate;
+
+  /**
+   * @param delegate the delegate reservoir to wrap
+   */
+  public MaxReservoir(Reservoir delegate) {
+    mMaxUpdate = new LongAccumulator(Long::max, Long.MIN_VALUE);
+    mDelegate = delegate;
+  }
+
+  /**
+   * Returns the number of values recorded.
+   *
+   * @return the number of values recorded
+   */
+  public int size() {
+    return mDelegate.size();
+  }
+
+  /**
+   * Adds a new recorded value to the reservoir.
+   *
+   * @param value a new recorded value
+   */
+  public void update(long value) {
+    mMaxUpdate.accumulate(value);
+    mDelegate.update(value);
+  }
+
+  /**
+   * Returns a snapshot of the reservoir's values, which has the max value
+   * set as the overall max value sent as an update to this reservoir.
+   *
+   * @return a snapshot of the reservoir's values
+   */
+  public Snapshot getSnapshot() {
+    return new MaxSnapshot(mDelegate.getSnapshot(), mMaxUpdate.get());
+  }
+
+  private static class MaxSnapshot extends Snapshot {
+    private final Snapshot mDelegate;
+    private final long mMax;
+
+    private MaxSnapshot(Snapshot delegate, long max) {
+      mDelegate = delegate;
+      mMax = max;
+    }
+
+    @Override
+    public double getValue(double quantile) {
+      return mDelegate.getValue(quantile);
+    }
+
+    @Override
+    public long[] getValues() {
+      return mDelegate.getValues();
+    }
+
+    @Override
+    public int size() {
+      return mDelegate.size();
+    }
+
+    @Override
+    public long getMax() {
+      return mMax;
+    }
+
+    @Override
+    public double getMean() {
+      return mDelegate.getMean();
+    }
+
+    @Override
+    public long getMin() {
+      return mDelegate.getMin();
+    }
+
+    @Override
+    public double getStdDev() {
+      return mDelegate.getStdDev();
+    }
+
+    @Override
+    public void dump(OutputStream output) {
+      mDelegate.dump(output);
+    }
+  }
+}

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -229,6 +229,16 @@ public final class MetricKey implements Comparable<MetricKey> {
     }
   }
 
+  private static final String EXECUTOR_STRING = "%1$s.submitted is a meter of the tasks submitted"
+      + " to the executor. %1$s.completed is a meter of the tasks completed by the executor."
+      + " %1$s.activeTaskQueue is exponentially-decaying random reservoir of the number of"
+      + " active tasks (running or submitted) at the executor calculated each time a new"
+      + " task is added to the executor. The max value is the maximum number of active"
+      + " tasks at any time during execution. %1$s.running is the number of tasks actively"
+      + " being run by the executor. %1$s.idle is the time spent idling by the submitted"
+      + " tasks (i.e. waiting the the queue before being executed)."
+      + " %1$s.duration is the time spent running the submitted tasks.";
+
   // Master metrics
   // Absent cache stats
   public static final MetricKey MASTER_ABSENT_CACHE_HITS =
@@ -737,11 +747,23 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+  public static final MetricKey MASTER_METADATA_SYNC_PREFETCH_EXECUTOR =
+      new Builder("Master.MetadataSyncPrefetchExecutor")
+          .setDescription(String.format("Metrics concerning the master metadata sync prefetch"
+              + "executor threads. " + EXECUTOR_STRING, "Master.MetadataSyncPrefetchExecutor"))
+          .setMetricType(MetricType.EXECUTOR_SERVICE)
+          .build();
   public static final MetricKey MASTER_METADATA_SYNC_PREFETCH_EXECUTOR_QUEUE_SIZE =
       new Builder("Master.MetadataSyncPrefetchExecutorQueueSize")
           .setDescription("The number of queuing prefetch tasks in the metadata sync thread pool"
               + " controlled by " + PropertyKey.MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE)
           .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_METADATA_SYNC_EXECUTOR =
+      new Builder("Master.MetadataSyncExecutor")
+          .setDescription(String.format("Metrics concerning the master metadata sync "
+              + "executor threads. " + EXECUTOR_STRING, "Master.MetadataSyncExecutor"))
+          .setMetricType(MetricType.EXECUTOR_SERVICE)
           .build();
   public static final MetricKey MASTER_METADATA_SYNC_EXECUTOR_QUEUE_SIZE =
       new Builder("Master.MetadataSyncExecutorQueueSize")

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -237,7 +237,9 @@ public final class MetricKey implements Comparable<MetricKey> {
       + " tasks at any time during execution. %1$s.running is the number of tasks actively"
       + " being run by the executor. %1$s.idle is the time spent idling by the submitted"
       + " tasks (i.e. waiting the the queue before being executed)."
-      + " %1$s.duration is the time spent running the submitted tasks.";
+      + " %1$s.duration is the time spent running the submitted tasks."
+      + " If the executor is a thread pool executor then %1$s.queueSize is"
+      + " the size of the task queue.";
 
   // Master metrics
   // Absent cache stats

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -88,6 +89,8 @@ public final class MetricsSystem {
   // Local hostname will be used if no related property key founds.
   private static Supplier<String> sSourceNameSupplier =
       CommonUtils.memoize(() -> constructSourceName());
+  private static final Map<String, InstrumentedExecutorService>
+      EXECUTOR_SERVICES = new ConcurrentHashMap<>();
 
   /**
    * An enum of supported instance type.
@@ -505,6 +508,21 @@ public final class MetricsSystem {
   }
 
   // Some helper functions.
+  /** Get or add the instrumented executor service metrics for the given name and executor service.
+   *
+   * @param delegate the executor service delegate that will be instrumented with metrics
+   * @param name the name of the metric
+   * @return the instrumented executor service
+   */
+  public static InstrumentedExecutorService executorService(ExecutorService delegate, String name) {
+    InstrumentedExecutorService service = EXECUTOR_SERVICES.get(name);
+    if (service != null) {
+      return service;
+    }
+    service = new InstrumentedExecutorService(delegate, METRIC_REGISTRY, getMetricName(name));
+    EXECUTOR_SERVICES.put(name, service);
+    return service;
+  }
 
   /**
    * Get or add counter with the given name.
@@ -872,6 +890,11 @@ public final class MetricsSystem {
       METRIC_REGISTRY.remove(timerName);
       METRIC_REGISTRY.timer(timerName);
     }
+
+    // Reset the InstrumentedExecutorServices last as it needs to keep the
+    // reference to the new metrics objects
+    EXECUTOR_SERVICES.values().forEach(InstrumentedExecutorService::reset);
+
     LAST_REPORTED_METRICS.clear();
     LOG.info("Reset all metrics in the metrics system in {}ms",
         System.currentTimeMillis() - startTime);
@@ -885,6 +908,7 @@ public final class MetricsSystem {
     for (String name : METRIC_REGISTRY.getNames()) {
       METRIC_REGISTRY.remove(name);
     }
+    EXECUTOR_SERVICES.clear();
   }
 
   /**

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -508,18 +508,14 @@ public final class MetricsSystem {
   }
 
   // Some helper functions.
-  /** Get or add the instrumented executor service metrics for the given name and executor service.
+  /** Add or replace the instrumented executor service metrics for the given name and executor service.
    *
    * @param delegate the executor service delegate that will be instrumented with metrics
    * @param name the name of the metric
    * @return the instrumented executor service
    */
   public static InstrumentedExecutorService executorService(ExecutorService delegate, String name) {
-    InstrumentedExecutorService service = EXECUTOR_SERVICES.get(name);
-    if (service != null) {
-      return service;
-    }
-    service = new InstrumentedExecutorService(delegate, METRIC_REGISTRY, getMetricName(name));
+    InstrumentedExecutorService service = new InstrumentedExecutorService(delegate, METRIC_REGISTRY, getMetricName(name));
     EXECUTOR_SERVICES.put(name, service);
     return service;
   }

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -508,14 +508,16 @@ public final class MetricsSystem {
   }
 
   // Some helper functions.
-  /** Add or replace the instrumented executor service metrics for the given name and executor service.
+  /** Add or replace the instrumented executor service metrics for
+   * the given name and executor service.
    *
    * @param delegate the executor service delegate that will be instrumented with metrics
    * @param name the name of the metric
    * @return the instrumented executor service
    */
   public static InstrumentedExecutorService executorService(ExecutorService delegate, String name) {
-    InstrumentedExecutorService service = new InstrumentedExecutorService(delegate, METRIC_REGISTRY, getMetricName(name));
+    InstrumentedExecutorService service = new InstrumentedExecutorService(
+        delegate, METRIC_REGISTRY, getMetricName(name));
     EXECUTOR_SERVICES.put(name, service);
     return service;
   }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -122,7 +122,6 @@ import alluxio.master.metastore.DelegatingReadOnlyInodeStore;
 import alluxio.master.metastore.InodeStore;
 import alluxio.master.metastore.ReadOnlyInodeStore;
 import alluxio.master.metrics.TimeSeriesStore;
-import alluxio.metrics.InstrumentedExecutorService;
 import alluxio.metrics.Metric;
 import alluxio.metrics.MetricInfo;
 import alluxio.metrics.MetricKey;
@@ -408,18 +407,20 @@ public class DefaultFileSystemMaster extends CoreMaster
       ServerConfiguration.getInt(PropertyKey.MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE),
       1, TimeUnit.MINUTES, new LinkedBlockingQueue<>(),
       ThreadFactoryUtils.build("alluxio-ufs-sync-prefetch-%d", false));
-  final InstrumentedExecutorService mSyncPrefetchExecutorIns =
-      MetricsSystem.executorService(mSyncPrefetchExecutor,
-          MetricKey.MASTER_METADATA_SYNC_PREFETCH_EXECUTOR.getName());
+  final ExecutorService mSyncPrefetchExecutorIns =
+      ServerConfiguration.getBoolean(PropertyKey.MASTER_METADATA_SYNC_INSTRUMENT_EXECUTOR)
+          ? MetricsSystem.executorService(mSyncPrefetchExecutor,
+          MetricKey.MASTER_METADATA_SYNC_PREFETCH_EXECUTOR.getName()) : mSyncPrefetchExecutor;
 
   private final ThreadPoolExecutor mSyncMetadataExecutor = new ThreadPoolExecutor(
       ServerConfiguration.getInt(PropertyKey.MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE),
       ServerConfiguration.getInt(PropertyKey.MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE),
       1, TimeUnit.MINUTES, new LinkedBlockingQueue<>(),
       ThreadFactoryUtils.build("alluxio-ufs-sync-%d", false));
-  final InstrumentedExecutorService mSyncMetadataExecutorIns =
-      MetricsSystem.executorService(mSyncMetadataExecutor,
-      MetricKey.MASTER_METADATA_SYNC_EXECUTOR.getName());
+  final ExecutorService mSyncMetadataExecutorIns =
+      ServerConfiguration.getBoolean(PropertyKey.MASTER_METADATA_SYNC_INSTRUMENT_EXECUTOR)
+          ? MetricsSystem.executorService(mSyncMetadataExecutor,
+          MetricKey.MASTER_METADATA_SYNC_EXECUTOR.getName()) : mSyncMetadataExecutor;
 
   final ThreadPoolExecutor mActiveSyncMetadataExecutor = new ThreadPoolExecutor(
       ServerConfiguration.getInt(PropertyKey.MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE),

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -235,7 +235,7 @@ public class InodeSyncStream {
     mPendingPaths = new ConcurrentLinkedQueue<>();
     mDescendantType = descendantType;
     mRpcContext = rpcContext;
-    mMetadataSyncService = fsMaster.mSyncMetadataExecutor;
+    mMetadataSyncService = fsMaster.mSyncMetadataExecutorIns;
     mForceSync = forceSync;
     mRootScheme = rootPath;
     mSyncOptions = options;
@@ -264,7 +264,7 @@ public class InodeSyncStream {
           ServerConfiguration.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL);
       validCacheTime = System.currentTimeMillis() - syncInterval;
     }
-    mStatusCache = new UfsStatusCache(fsMaster.mSyncPrefetchExecutor,
+    mStatusCache = new UfsStatusCache(fsMaster.mSyncPrefetchExecutorIns,
         fsMaster.getAbsentPathCache(), validCacheTime);
     // Maintain a global counter of active sync streams
     DefaultFileSystemMaster.Metrics.INODE_SYNC_STREAM_COUNT.inc();
@@ -535,7 +535,7 @@ public class InodeSyncStream {
   }
 
   private Object getFromUfs(Callable<Object> task) throws InterruptedException {
-    final Future<Object> future = mFsMaster.mSyncPrefetchExecutor.submit(task);
+    final Future<Object> future = mFsMaster.mSyncPrefetchExecutorIns.submit(task);
     DefaultFileSystemMaster.Metrics.METADATA_SYNC_PREFETCH_OPS_COUNT.inc();
     while (true) {
       try {

--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -154,6 +154,7 @@ public class UfsStatusCache {
     }
     Collection<UfsStatus> removedChildren = mChildren.remove(path);
     if (removedChildren != null) {
+      DefaultFileSystemMaster.Metrics.UFS_STATUS_CACHE_SIZE_TOTAL.dec(removedChildren.size());
       DefaultFileSystemMaster.Metrics
           .UFS_STATUS_CACHE_CHILDREN_SIZE_TOTAL.dec(removedChildren.size());
     }

--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -154,7 +154,6 @@ public class UfsStatusCache {
     }
     Collection<UfsStatus> removedChildren = mChildren.remove(path);
     if (removedChildren != null) {
-      DefaultFileSystemMaster.Metrics.UFS_STATUS_CACHE_SIZE_TOTAL.dec(removedChildren.size());
       DefaultFileSystemMaster.Metrics
           .UFS_STATUS_CACHE_CHILDREN_SIZE_TOTAL.dec(removedChildren.size());
     }

--- a/core/transport/src/main/proto/grpc/common.proto
+++ b/core/transport/src/main/proto/grpc/common.proto
@@ -67,6 +67,8 @@ enum MetricType {
   METER = 2;
   // TIMER represents a histogram of the rate of the specified events.
   TIMER = 3;
+  // EXECUTOR_SERVICE represents an executor service.
+  EXECUTOR_SERVICE = 4;
 }
 
 enum CommandType {

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -1313,6 +1313,10 @@
               {
                 "name": "TIMER",
                 "integer": 3
+              },
+              {
+                "name": "EXECUTOR_SERVICE",
+                "integer": 4
               }
             ]
           },


### PR DESCRIPTION
### What changes are proposed in this pull request?

This allows better monitoring of thread pool executors using the InstrumentedThreadPool executor from https://github.com/dropwizard/metrics. It adds instrumentation for the thread pool executors in DefaultFileSystemMaster for the meta data sync executors.

### Why are the changes needed?

This helps monitor the queues and executors in case of high load and memory usage.

### Does this PR introduce any user facing changes?

New metrics for the thread pool executors in DefaultFileSystemMaster for the meta data sync executors, by default this is disabled by property key {alluxio.master.metadata.sync.instrument.executor}. A warning log is printed every {alluxio.metrics.executor.task.warn.frequency} seconds with the number of active tasks (running or queued) if the number is above {alluxio.metrics.executor.task.warn.size}.