### PR TITLE
Print worker for loadCommand while cache failed

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/LoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LoadCommand.java
@@ -180,8 +180,8 @@ public final class LoadCommand extends AbstractFileSystemCommand {
         mFsContext.acquireBlockWorkerClient(dataSource)) {
       blockWorker.get().cache(request);
     } catch (Exception e) {
-      System.out.printf("Failed to complete cache request for block %d of file %s: %s", blockId,
-          status.getPath(), e);
+      System.out.printf("Failed to complete cache request from %s for block %d of file %s: %s",
+          dataSource, blockId, status.getPath(), e);
     }
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add worker to output information while cache failed.

### Why are the changes needed?

From the following output, I cannot identify the failed worker.

```
Failed to complete cache request for block 2484118487040 of file /test: io.grpc.StatusRuntimeException: UNKNOWN: java.io.IOException: Failed to read from UFS, sessionId=-8, blockId=2484118487040, offset=0, positionShort=false, options=ufs_path: "hdfs://ns1/test"
offset_in_file: 0
block_size: 161266153
maxUfsReadConcurrency: 2147483647
mountId: 1381858014512144475
no_cache: false
: com.google.common.util.concurrent.UncheckedExecutionException: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: java.net.UnknownHostException: ns1

/ns1/test loaded
```


### Does this PR introduce any user facing changes?

No
