### PR TITLE
Decouple args parsing from actual benchmark run

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/AbstractStressBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/AbstractStressBench.java
@@ -36,8 +36,6 @@ public abstract class AbstractStressBench<T extends TaskResult, P extends FileSy
 
   @Override
   public String run(String[] args) throws Exception {
-    parseParameters(args);
-
     // if the benchmark execute multiple tasks
     if (mParameters.mWriteType.equals("ALL")) {
       List<String> writeTypes = ImmutableList.of("MUST_CACHE", "CACHE_THROUGH",

--- a/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
@@ -31,6 +31,7 @@ import com.beust.jcommander.ParametersDelegate;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.google.common.base.Preconditions;
 import org.HdrHistogram.Histogram;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,6 +88,8 @@ public abstract class Benchmark<T extends TaskResult> {
 
   protected static void mainInternal(String[] args, Benchmark benchmark) {
     int exitCode = 0;
+    JCommander jc = new JCommander(benchmark);
+    benchmark.parseParameters(jc, args);
     try {
       String result = benchmark.run(args);
       System.out.println(result);
@@ -130,25 +133,32 @@ public abstract class Benchmark<T extends TaskResult> {
    * @return the string result output
    */
   public String run(String[] args) throws Exception {
-    parseParameters(args);
     return runSingleTask(args);
   }
 
-  protected void parseParameters(String[] args) {
-    JCommander jc = new JCommander(this);
-    jc.setProgramName(this.getClass().getSimpleName());
+  /**
+   * Parses arguments from command line.
+   * Exits the program on {@code --help} flag and invalid arguments.
+   *
+   * @param jc the {@link JCommander} object that has been configured with this benchmark
+   * @param args arguments from command line
+   */
+  protected void parseParameters(JCommander jc, String[] args) {
+    Preconditions.checkArgument(jc.getObjects().size() > 0, "JCommander parser is not configured");
+
+    jc.setProgramName(getClass().getSimpleName());
     try {
       jc.parse(args);
-      if (mBaseParameters.mHelp) {
-        System.out.println(getBenchDescription());
-        jc.usage();
-        System.exit(0);
-      }
     } catch (Exception e) {
       LOG.error("Failed to parse command: ", e);
       System.out.println(getBenchDescription());
       jc.usage();
-      throw e;
+      System.exit(-1);
+    }
+    if (mBaseParameters.mHelp) {
+      System.out.println(getBenchDescription());
+      jc.usage();
+      System.exit(0);
     }
   }
 

--- a/stress/shell/src/main/java/alluxio/stress/cli/MaxFileBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/MaxFileBench.java
@@ -90,26 +90,12 @@ public class MaxFileBench extends StressMasterBench {
   }
 
   @Override
-  protected void parseParameters(String[] args) {
+  protected void parseParameters(JCommander jc, String[] args) {
     List<String> argsList = new ArrayList<>(Arrays.asList(args));
     argsList.addAll(mDefaultParams);
 
-    JCommander jc = new JCommander(this);
     jc.setAllowParameterOverwriting(true);
-    jc.setProgramName(this.getClass().getSimpleName());
-    try {
-      jc.parse(argsList.toArray(new String[0]));
-      if (mBaseParameters.mHelp) {
-        System.out.println(getBenchDescription());
-        jc.usage();
-        System.exit(0);
-      }
-    } catch (Exception e) {
-      LOG.error("Failed to parse command: ", e);
-      System.out.println(getBenchDescription());
-      jc.usage();
-      throw e;
-    }
+    super.parseParameters(jc, argsList.toArray(new String[0]));
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

Decouple argument parsing from actual benchmark run. 

### Why are the changes needed?

This makes sure cleanup code is not run when the benchmark exits because of invalid arguments, and when it is run, it can get correct arguments instead of their default values.

### Does this PR introduce any user facing changes?

No.