### PR TITLE
Implement get page ids by the given file id

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -207,6 +208,16 @@ public interface CacheManager extends AutoCloseable {
    */
   int get(PageId pageId, int pageOffset, int bytesToRead, byte[] buffer, int offsetInBuffer,
       CacheContext cacheContext);
+
+  /**
+   * Get page ids by the given file id.
+   * @param fileId file identifier
+   * @param fileLength file length
+   * @return a list of page ids which belongs to the file
+   */
+  default List<PageId> getPageIdsByFileId(String fileId, long fileLength) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Deletes a page from the cache.

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -212,10 +212,10 @@ public interface CacheManager extends AutoCloseable {
   /**
    * Get page ids by the given file id.
    * @param fileId file identifier
-   * @param fileLength file length
+   * @param fileLength file length (this will not be needed after we have per-file metadata)
    * @return a list of page ids which belongs to the file
    */
-  default List<PageId> getPageIdsByFileId(String fileId, long fileLength) {
+  default List<PageId> getCachedPageIdsByFileId(String fileId, long fileLength) {
     throw new UnsupportedOperationException();
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -40,7 +40,9 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -617,6 +619,21 @@ public class LocalCacheManager implements CacheManager {
     return true;
   }
 
+  @Override
+  public List<PageId> getPageIdsByFileId(String fileId, long fileLength) {
+    int numOfPages = (int) (fileLength / mPageSize);
+    List<PageId> pageIds = new ArrayList<>(numOfPages);
+    try (LockResource r2 = new LockResource(mMetaLock.readLock())) {
+      for (long pageIndex = 0; pageIndex < numOfPages; pageIndex++) {
+        PageId pageId = new PageId(fileId, pageIndex);
+        if (mMetaStore.hasPage(pageId)) {
+          pageIds.add(pageId);
+        }
+      }
+    }
+    return pageIds;
+  }
+  
   @Override
   public void close() throws Exception {
     mPageStore.close();

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -620,10 +620,10 @@ public class LocalCacheManager implements CacheManager {
   }
 
   @Override
-  public List<PageId> getPageIdsByFileId(String fileId, long fileLength) {
+  public List<PageId> getCachedPageIdsByFileId(String fileId, long fileLength) {
     int numOfPages = (int) (fileLength / mPageSize);
     List<PageId> pageIds = new ArrayList<>(numOfPages);
-    try (LockResource r2 = new LockResource(mMetaLock.readLock())) {
+    try (LockResource r = new LockResource(mMetaLock.readLock())) {
       for (long pageIndex = 0; pageIndex < numOfPages; pageIndex++) {
         PageId pageId = new PageId(fileId, pageIndex);
         if (mMetaStore.hasPage(pageId)) {

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -633,7 +633,7 @@ public class LocalCacheManager implements CacheManager {
     }
     return pageIds;
   }
-  
+
   @Override
   public void close() throws Exception {
     mPageStore.close();

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -888,6 +888,22 @@ public final class LocalCacheManagerTest {
     assertFalse(mCacheManager.put(PAGE_ID1, PAGE1));
   }
 
+  @Test
+  public void listPageIds() throws Exception {
+    mCacheManager = createLocalCacheManager();
+    assertEquals(0,
+        mCacheManager.getPageIdsByFileId(PAGE_ID1.getFileId(), 64 * PAGE_SIZE_BYTES).size());
+    mCacheManager.put(PAGE_ID1, PAGE1);
+    assertEquals(PAGE_ID1,
+        mCacheManager.getPageIdsByFileId(PAGE_ID1.getFileId(), 64 * PAGE_SIZE_BYTES).get(0));
+    PageId pageId5 = new PageId(PAGE_ID1.getFileId(), 5);
+    mCacheManager.put(pageId5, PAGE1);
+    assertEquals(PAGE_ID1,
+        mCacheManager.getPageIdsByFileId(PAGE_ID1.getFileId(), 64 * PAGE_SIZE_BYTES).get(0));
+    assertEquals(pageId5,
+        mCacheManager.getPageIdsByFileId(PAGE_ID1.getFileId(), 64 * PAGE_SIZE_BYTES).get(1));
+  }
+
   /**
    * A PageStore where put can throw IOException on put or delete.
    */

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -892,16 +892,16 @@ public final class LocalCacheManagerTest {
   public void listPageIds() throws Exception {
     mCacheManager = createLocalCacheManager();
     assertEquals(0,
-        mCacheManager.getPageIdsByFileId(PAGE_ID1.getFileId(), 64 * PAGE_SIZE_BYTES).size());
+        mCacheManager.getCachedPageIdsByFileId(PAGE_ID1.getFileId(), 64 * PAGE_SIZE_BYTES).size());
     mCacheManager.put(PAGE_ID1, PAGE1);
     assertEquals(PAGE_ID1,
-        mCacheManager.getPageIdsByFileId(PAGE_ID1.getFileId(), 64 * PAGE_SIZE_BYTES).get(0));
+        mCacheManager.getCachedPageIdsByFileId(PAGE_ID1.getFileId(), 64 * PAGE_SIZE_BYTES).get(0));
     PageId pageId5 = new PageId(PAGE_ID1.getFileId(), 5);
     mCacheManager.put(pageId5, PAGE1);
     assertEquals(PAGE_ID1,
-        mCacheManager.getPageIdsByFileId(PAGE_ID1.getFileId(), 64 * PAGE_SIZE_BYTES).get(0));
+        mCacheManager.getCachedPageIdsByFileId(PAGE_ID1.getFileId(), 64 * PAGE_SIZE_BYTES).get(0));
     assertEquals(pageId5,
-        mCacheManager.getPageIdsByFileId(PAGE_ID1.getFileId(), 64 * PAGE_SIZE_BYTES).get(1));
+        mCacheManager.getCachedPageIdsByFileId(PAGE_ID1.getFileId(), 64 * PAGE_SIZE_BYTES).get(1));
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

Implement get page ids by the given file id

### Why are the changes needed?

The local cache callers are able to get a list of pages for a particular file, and then they can delete the pages for GDPR or invalidation purpose

### Does this PR introduce any user facing changes?

Add a new api for local cache
