### PR TITLE
Fix the deadlock caused by remove block

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -385,13 +385,12 @@ public class TieredBlockStore implements LocalBlockStore
       blockMeta = mMetaManager.getBlockMeta(blockId);
     }
 
-    if (blockMeta.isPresent()) {
-      try (LockResource r = new LockResource(mMetadataWriteLock)) {
+    try (LockResource r = new LockResource(mMetadataWriteLock)) {
+      if (blockMeta.isPresent()) {
         removeBlockFileAndMeta(blockMeta.get());
       }
-      finally {
-        mLockManager.unlockBlock(lockId.getAsLong());
-      }
+    } finally {
+      mLockManager.unlockBlock(lockId.getAsLong());
     }
     return blockMeta;
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix the deadlock caused by remove block.  There might be a race in the remove block method, i.e the block meta could be removed by other thread.  No matter the block meta is present or not, we have to release the lock acquired in the remove block method.

### Why are the changes needed?

fix the deadlock issue found by the microbench

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
no
