### PR TITLE
Statically check existence of UFS blocks

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -408,19 +408,25 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   public BlockReader createUfsBlockReader(long sessionId, long blockId, long offset,
       boolean positionShort, Protocol.OpenUfsBlockOptions options)
       throws IOException {
+    UnderFileSystemBlockStore.ExistingBlock block =
+        mUnderFileSystemBlockStore.acquireAccess(sessionId, blockId, options)
+            .orElseThrow(() -> new UnavailableException(
+                String.format("Failed to read from UFS, the block has already been acquired from "
+                + "another thread, sessionId=%d, blockId=%d, offset=%d, positionShort=%s, "
+                + "options=%s", sessionId, blockId, offset, positionShort, options)));
     try {
-      BlockReader reader = mUnderFileSystemBlockStore.createBlockReader(sessionId, blockId, offset,
+      BlockReader reader = mUnderFileSystemBlockStore.createBlockReader(block, offset,
           positionShort, options);
       return new DelegatingBlockReader(reader, () -> {
         try {
-          closeUfsBlock(sessionId, blockId);
+          closeUfsBlock(block);
         } catch (BlockAlreadyExistsException | IOException | WorkerOutOfSpaceException e) {
           throw new IOException(e);
         }
       });
     } catch (Exception e) {
       try {
-        closeUfsBlock(sessionId, blockId);
+        closeUfsBlock(block);
       } catch (Exception ee) {
         LOG.warn("Failed to close UFS block", ee);
       }
@@ -475,19 +481,18 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
    * Closes a UFS block for a client session. It also commits the block to Alluxio block store
    * if the UFS block has been cached successfully.
    *
-   * @param sessionId the session ID
-   * @param blockId the block ID
+   * @param block the UFS block
    * @throws BlockAlreadyExistsException if it fails to commit the block to Alluxio block store
    *         because the block exists in the Alluxio block store
-   * @throws BlockDoesNotExistException if the UFS block does not exist in the
-   *         UFS block store
-   * @throws WorkerOutOfSpaceException the the worker does not have enough space to commit the block
+   * @throws WorkerOutOfSpaceException the worker does not have enough space to commit the block
    */
   @VisibleForTesting
-  public void closeUfsBlock(long sessionId, long blockId)
+  public void closeUfsBlock(UnderFileSystemBlockStore.ExistingBlock block)
       throws BlockAlreadyExistsException, IOException, WorkerOutOfSpaceException {
+    long sessionId = block.getSessionId();
+    long blockId = block.getBlockId();
     try {
-      mUnderFileSystemBlockStore.close(sessionId, blockId);
+      mUnderFileSystemBlockStore.close(block);
       if (mLocalBlockStore.hasTempBlockMeta(blockId)) {
         try {
           commitBlock(sessionId, blockId, false);
@@ -503,15 +508,15 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
           LOG.debug("Invalid worker state while committing block.", e);
         }
       } else {
-        // When getTempBlockMeta() return null, such as a block readType NO_CACHE writeType THROUGH.
-        // Counter will not be decrement in the commitblock().
+        // When no such temp block exists, such as a block readType NO_CACHE writeType THROUGH.
+        // Counter will not be decremented in commitBlock().
         // So we should decrement counter here.
-        if (mUnderFileSystemBlockStore.isNoCache(sessionId, blockId)) {
+        if (block.isNoCache()) {
           Metrics.WORKER_ACTIVE_CLIENTS.dec();
         }
       }
     } finally {
-      mUnderFileSystemBlockStore.releaseAccess(sessionId, blockId);
+      mUnderFileSystemBlockStore.releaseAccess(block);
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/UnderFileSystemBlockMeta.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/UnderFileSystemBlockMeta.java
@@ -12,11 +12,12 @@
 package alluxio.worker.block.meta;
 
 import alluxio.proto.dataserver.Protocol;
+import alluxio.worker.block.UnderFileSystemBlockStore;
 
 /**
  * This class represents the metadata of a block that is in UFS. This class is immutable.
  */
-public final class UnderFileSystemBlockMeta {
+public class UnderFileSystemBlockMeta {
   private final long mSessionId;
   private final long mBlockId;
   private final String mUnderFileSystemPath;
@@ -31,13 +32,16 @@ public final class UnderFileSystemBlockMeta {
   private final String mUser;
 
   /**
-   * Creates an instance of {@link UnderFileSystemBlockMeta}.
+   * Creates an instance of {@link UnderFileSystemBlockMeta}. An instance of this class should
+   * only be acquired via
+   * {@link UnderFileSystemBlockStore#acquireAccess(long, long, Protocol.OpenUfsBlockOptions)}.
    *
    * @param sessionId the session ID
    * @param blockId the block ID
-   * @param options the {@link Protocol.OpenUfsBlUfsInputStreamCacheTestockOptions}
+   * @param options the {@link Protocol.OpenUfsBlockOptions}
    */
-  public UnderFileSystemBlockMeta(long sessionId, long blockId,
+  // protected access to prevent accidental instantiation
+  protected UnderFileSystemBlockMeta(long sessionId, long blockId,
       Protocol.OpenUfsBlockOptions options) {
     mSessionId = sessionId;
     mBlockId = blockId;

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
@@ -99,7 +99,7 @@ public final class UnderFileSystemBlockReaderTest {
         .setBlockSize(TEST_BLOCK_SIZE).setOffsetInFile(TEST_BLOCK_SIZE).setUfsPath(testFilePath)
         .build();
     mUnderFileSystemBlockMeta =
-        new UnderFileSystemBlockMeta(SESSION_ID, BLOCK_ID, mOpenUfsBlockOptions);
+        new TestUfsBlockMeta(SESSION_ID, BLOCK_ID, mOpenUfsBlockOptions);
     mUfsBytesRead = MetricsSystem.counterWithTags(
         MetricKey.WORKER_BYTES_READ_UFS.getName(),
         MetricKey.WORKER_BYTES_READ_UFS.isClusterAggregated(),
@@ -172,7 +172,7 @@ public final class UnderFileSystemBlockReaderTest {
 
   @Test
   public void readFullBlockNoCache() throws Exception {
-    mUnderFileSystemBlockMeta = new UnderFileSystemBlockMeta(SESSION_ID, BLOCK_ID,
+    mUnderFileSystemBlockMeta = new TestUfsBlockMeta(SESSION_ID, BLOCK_ID,
         mOpenUfsBlockOptions.toBuilder().setNoCache(true).build());
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
         mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
@@ -254,5 +254,11 @@ public final class UnderFileSystemBlockReaderTest {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
         mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
     assertTrue(mReader.getLocation().startsWith(mOpenUfsBlockOptions.getUfsPath()));
+  }
+
+  private static class TestUfsBlockMeta extends UnderFileSystemBlockMeta {
+    public TestUfsBlockMeta(long sessionId, long blockId, Protocol.OpenUfsBlockOptions options) {
+      super(sessionId, blockId, options);
+    }
   }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockStoreTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
+import java.util.Optional;
+
 public final class UnderFileSystemBlockStoreTest {
   private static final long TEST_BLOCK_SIZE = 1024;
   private static final long BLOCK_ID = 2;
@@ -47,7 +49,7 @@ public final class UnderFileSystemBlockStoreTest {
     UnderFileSystemBlockStore blockStore =
         new UnderFileSystemBlockStore(mAlluxioBlockStore, mUfsManager);
     for (int i = 0; i < 5; i++) {
-      assertTrue(blockStore.acquireAccess(i + 1, BLOCK_ID, mOpenUfsBlockOptions));
+      assertTrue(blockStore.acquireAccess(i + 1, BLOCK_ID, mOpenUfsBlockOptions).isPresent());
     }
   }
 
@@ -56,10 +58,12 @@ public final class UnderFileSystemBlockStoreTest {
     UnderFileSystemBlockStore blockStore =
         new UnderFileSystemBlockStore(mAlluxioBlockStore, mUfsManager);
     for (int i = 0; i < 5; i++) {
-      assertTrue(blockStore.acquireAccess(i + 1, BLOCK_ID, mOpenUfsBlockOptions));
-      blockStore.releaseAccess(i + 1, BLOCK_ID);
+      Optional<UnderFileSystemBlockStore.ExistingBlock> block =
+          blockStore.acquireAccess(i + 1, BLOCK_ID, mOpenUfsBlockOptions);
+      assertTrue(block.isPresent());
+      blockStore.releaseAccess(block.get());
     }
 
-    assertTrue(blockStore.acquireAccess(6, BLOCK_ID, mOpenUfsBlockOptions));
+    assertTrue(blockStore.acquireAccess(6, BLOCK_ID, mOpenUfsBlockOptions).isPresent());
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Replace `(sessionId, blockId)` pair with a type `ExistingBlock` whose instances can only be acquired by calling `acquireAccess`, therefore the existence of the block can be statically known.

### Why are the changes needed?

This eliminates the need to check for the existence of the block repetitively throughout the code. 

### Does this PR introduce any user facing changes?

No.
