### PR TITLE
Refactor Fuse in out stream

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1906,18 +1906,6 @@ public final class MetricKey implements Comparable<MetricKey> {
 
   // Fuse operation timer and failure counter metrics are added dynamically.
   // Other Fuse related metrics are added here
-  public static final MetricKey FUSE_BYTES_TO_READ =
-      new Builder("Fuse.BytesToRead")
-          .setDescription("Total number of bytes requested by Fuse.read() operations.")
-          .setMetricType(MetricType.COUNTER)
-          .setIsClusterAggregated(false)
-          .build();
-  public static final MetricKey FUSE_BYTES_READ =
-      new Builder("Fuse.BytesRead")
-          .setDescription("Total number of bytes read through Fuse.read() operations.")
-          .setMetricType(MetricType.COUNTER)
-          .setIsClusterAggregated(false)
-          .build();
   public static final MetricKey FUSE_TOTAL_CALLS =
       new Builder("Fuse.TotalCalls")
           .setDescription("Throughput of JNI FUSE operation calls. "
@@ -1925,15 +1913,9 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.TIMER)
           .setIsClusterAggregated(false)
           .build();
-  public static final MetricKey FUSE_WRITING_FILE_COUNT =
-      new Builder("Fuse.WritingFileCount")
-          .setDescription("Total number of files being written concurrently.")
-          .setMetricType(MetricType.GAUGE)
-          .setIsClusterAggregated(false)
-          .build();
-  public static final MetricKey FUSE_READING_FILE_COUNT =
-      new Builder("Fuse.ReadingFileCount")
-          .setDescription("Total number of files being read concurrently.")
+  public static final MetricKey FUSE_READ_WRITE_FILE_COUNT =
+      new Builder("Fuse.ReadWriteFileCount")
+          .setDescription("Total number of files being opened for reading or writing concurrently.")
           .setMetricType(MetricType.GAUGE)
           .setIsClusterAggregated(false)
           .build();

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -933,7 +933,6 @@ public final class AlluxioFuseFileSystem extends FuseStubFS
       LOG.error("Failed to remove {}", path, t);
       return AlluxioFuseUtils.getErrorCode(t);
     }
-
     return 0;
   }
 

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -41,7 +41,6 @@ import alluxio.util.OSUtils;
 import alluxio.util.ShellUtils;
 import alluxio.util.WaitForOptions;
 
-import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ru.serce.jnrfuse.ErrorCodes;
@@ -88,9 +87,6 @@ public final class AlluxioFuseUtils {
    */
   public static FileOutStream createFile(FileSystem fileSystem, AuthPolicy authPolicy,
       AlluxioURI uri, long mode) {
-    Preconditions.checkNotNull(fileSystem);
-    Preconditions.checkNotNull(authPolicy);
-    Preconditions.checkNotNull(uri);
     CreateFilePOptions.Builder optionsBuilder = CreateFilePOptions.newBuilder();
     if (mode != MODE_NOT_SET_VALUE) {
       optionsBuilder.setMode(new Mode((short) mode).toProto());
@@ -112,8 +108,6 @@ public final class AlluxioFuseUtils {
    * @param uri the alluxio uri
    */
   public static void deleteFile(FileSystem fileSystem, AlluxioURI uri) {
-    Preconditions.checkNotNull(fileSystem);
-    Preconditions.checkNotNull(uri);
     try {
       fileSystem.delete(uri);
     } catch (IOException | AlluxioException e) {
@@ -130,9 +124,6 @@ public final class AlluxioFuseUtils {
    */
   public static void setAttribute(FileSystem fileSystem,
       AlluxioURI uri, SetAttributePOptions options) {
-    Preconditions.checkNotNull(fileSystem);
-    Preconditions.checkNotNull(uri);
-    Preconditions.checkNotNull(options);
     try {
       fileSystem.setAttribute(uri, options);
     } catch (IOException | AlluxioException e) {
@@ -355,8 +346,6 @@ public final class AlluxioFuseUtils {
    * @return the file status
    */
   public static Optional<URIStatus> getPathStatus(FileSystem fileSystem, AlluxioURI uri) {
-    Preconditions.checkNotNull(fileSystem);
-    Preconditions.checkNotNull(uri);
     try {
       return Optional.of(fileSystem.getStatus(uri));
     } catch (InvalidPathException | FileNotFoundException | FileDoesNotExistException e) {
@@ -376,8 +365,6 @@ public final class AlluxioFuseUtils {
    * @return whether the file is completed or not
    */
   public static boolean waitForFileCompleted(FileSystem fileSystem, AlluxioURI uri) {
-    Preconditions.checkNotNull(fileSystem);
-    Preconditions.checkNotNull(uri);
     try {
       CommonUtils.waitFor("file completed", () -> {
         try {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -73,6 +73,8 @@ public final class AlluxioFuseUtils {
   public static final long ID_NOT_SET_VALUE = -1;
   public static final long ID_NOT_SET_VALUE_UNSIGNED = 4294967295L;
 
+  public static final long MODE_NOT_SET_VALUE = -1;
+
   private AlluxioFuseUtils() {}
 
   /**

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -48,9 +48,10 @@ import ru.serce.jnrfuse.ErrorCodes;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -84,7 +85,7 @@ public final class AlluxioFuseUtils {
    * @return a file out stream
    */
   public static FileOutStream createFile(FileSystem fileSystem, AuthPolicy authPolicy,
-      AlluxioURI uri, long mode) throws Exception {
+      AlluxioURI uri, long mode) throws IOException, ExecutionException, AlluxioException {
     Preconditions.checkNotNull(uri);
     FileOutStream out = fileSystem.createFile(uri,
         CreateFilePOptions.newBuilder()
@@ -307,15 +308,14 @@ public final class AlluxioFuseUtils {
    *
    * @param fileSystem the file system
    * @param uri the Alluxio uri to get status of
-   * @return the file status, null if the path does not exist in Alluxio
-   * @throws Exception when failed to get path status
+   * @return the file status
    */
-  @Nullable
-  public static URIStatus getPathStatus(FileSystem fileSystem, AlluxioURI uri) throws Exception {
+  public static Optional<URIStatus> getPathStatus(FileSystem fileSystem, AlluxioURI uri)
+      throws IOException, AlluxioException {
     try {
-      return fileSystem.getStatus(uri);
+      return Optional.of(fileSystem.getStatus(uri));
     } catch (InvalidPathException | FileNotFoundException | FileDoesNotExistException e) {
-      return null;
+      return Optional.empty();
     }
   }
 

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -50,6 +50,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -309,6 +310,7 @@ public final class AlluxioFuseUtils {
    * @return the file status, null if the path does not exist in Alluxio
    * @throws Exception when failed to get path status
    */
+  @Nullable
   public static URIStatus getPathStatus(FileSystem fileSystem, AlluxioURI uri) throws Exception {
     try {
       return fileSystem.getStatus(uri);

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -451,6 +451,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
         LOG.error("Failed to release {}: Cannot find fd {}", path, fd);
         return -ErrorCodes.EBADFD();
       }
+      mFileEntries.remove(entry);
       entry.getFileStream().close();
     } catch (IOException e) {
       LOG.error("Failed to close {}:", path, e);

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -625,7 +625,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
     try {
       if (entry != null) {
         entry.getFileStream().truncate(size);
-        return (int) size;
+        return 0;
       }
     } catch (Exception e) {
       LOG.info("Failed to truncate {} to {}:", path, size, e);

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -447,10 +447,13 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
         return -ErrorCodes.EBADFD();
       }
       entry.getFileStream().close();
-      mFileEntries.remove(entry);
     } catch (IOException e) {
       LOG.error("Failed to close {}:", path, e);
       return -ErrorCodes.EIO();
+    } finally {
+      if (entry != null) {
+        mFileEntries.remove(entry);
+      }
     }
     return 0;
   }

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -582,7 +582,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
         optionsBuilder.setOwner(userName);
       }
 
-      String groupName = "";
+      String groupName;
       if (gid != AlluxioFuseUtils.ID_NOT_SET_VALUE
           && gid != AlluxioFuseUtils.ID_NOT_SET_VALUE_UNSIGNED) {
         groupName = AlluxioFuseUtils.getGroupName(gid);

--- a/integration/fuse/src/main/java/alluxio/fuse/auth/AuthPolicy.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/auth/AuthPolicy.java
@@ -12,6 +12,10 @@
 package alluxio.fuse.auth;
 
 import alluxio.AlluxioURI;
+import alluxio.exception.AlluxioException;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Fuse Auth Policy Interface.
@@ -22,5 +26,6 @@ public interface AuthPolicy {
    *
    * @param uri the path uri
    */
-  void setUserGroupIfNeeded(AlluxioURI uri) throws Exception;
+  void setUserGroupIfNeeded(AlluxioURI uri)
+      throws IOException, AlluxioException, ExecutionException;
 }

--- a/integration/fuse/src/main/java/alluxio/fuse/auth/AuthPolicy.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/auth/AuthPolicy.java
@@ -12,10 +12,6 @@
 package alluxio.fuse.auth;
 
 import alluxio.AlluxioURI;
-import alluxio.exception.AlluxioException;
-
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Fuse Auth Policy Interface.
@@ -26,6 +22,5 @@ public interface AuthPolicy {
    *
    * @param uri the path uri
    */
-  void setUserGroupIfNeeded(AlluxioURI uri)
-      throws IOException, AlluxioException, ExecutionException;
+  void setUserGroupIfNeeded(AlluxioURI uri);
 }

--- a/integration/fuse/src/main/java/alluxio/fuse/auth/CustomAuthPolicy.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/auth/CustomAuthPolicy.java
@@ -15,12 +15,15 @@ import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.AlluxioException;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.jnifuse.AbstractFuseFileSystem;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 /**
  * A Fuse authentication policy supports user-defined user and group.
@@ -45,7 +48,7 @@ public class CustomAuthPolicy implements AuthPolicy {
   }
 
   @Override
-  public void setUserGroupIfNeeded(AlluxioURI uri) throws Exception {
+  public void setUserGroupIfNeeded(AlluxioURI uri) throws IOException, AlluxioException {
     if (StringUtils.isEmpty(mUname) || StringUtils.isEmpty(mGname)) {
       return;
     }

--- a/integration/fuse/src/main/java/alluxio/fuse/auth/CustomAuthPolicy.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/auth/CustomAuthPolicy.java
@@ -48,7 +48,7 @@ public class CustomAuthPolicy implements AuthPolicy {
   }
 
   @Override
-  public void setUserGroupIfNeeded(AlluxioURI uri) throws IOException, AlluxioException {
+  public void setUserGroupIfNeeded(AlluxioURI uri) {
     if (StringUtils.isEmpty(mUname) || StringUtils.isEmpty(mGname)) {
       return;
     }
@@ -56,7 +56,11 @@ public class CustomAuthPolicy implements AuthPolicy {
         .setGroup(mGname)
         .setOwner(mUname)
         .build();
-    mFileSystem.setAttribute(uri, attributeOptions);
+    try {
+      mFileSystem.setAttribute(uri, attributeOptions);
+    } catch (IOException | AlluxioException e) {
+      throw new RuntimeException(e);
+    }
     LOG.debug("Set attributes of path {} to {}", uri, attributeOptions);
   }
 }

--- a/integration/fuse/src/main/java/alluxio/fuse/auth/NoopAuthPolicy.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/auth/NoopAuthPolicy.java
@@ -1,0 +1,36 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.fuse.auth;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileSystem;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.jnifuse.AbstractFuseFileSystem;
+
+/**
+ * A Fuse authentication policy that does nothing.
+ * Mainly for testing purpose.
+ */
+public class NoopAuthPolicy implements AuthPolicy {
+
+  /**
+   * @param fileSystem     the Alluxio file system
+   * @param conf           alluxio configuration
+   * @param fuseFileSystem the FuseFileSystem
+   */
+  public NoopAuthPolicy(FileSystem fileSystem, AlluxioConfiguration conf,
+      AbstractFuseFileSystem fuseFileSystem) {
+  }
+
+  @Override
+  public void setUserGroupIfNeeded(AlluxioURI uri) {}
+}

--- a/integration/fuse/src/main/java/alluxio/fuse/auth/SystemUserGroupAuthPolicy.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/auth/SystemUserGroupAuthPolicy.java
@@ -15,6 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.AlluxioException;
 import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.jnifuse.AbstractFuseFileSystem;
@@ -25,6 +26,9 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Default Fuse Auth Policy.
@@ -69,7 +73,8 @@ public final class SystemUserGroupAuthPolicy implements AuthPolicy {
   }
 
   @Override
-  public void setUserGroupIfNeeded(AlluxioURI uri) throws Exception {
+  public void setUserGroupIfNeeded(AlluxioURI uri)
+      throws IOException, AlluxioException, ExecutionException {
     FuseContext fc = mFuseFileSystem.getContext();
     if (!mIsUserGroupTranslation) {
       return;

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileEntry.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileEntry.java
@@ -40,10 +40,9 @@ public final class FuseFileEntry<T extends FuseFileStream>
     Preconditions.checkArgument(id >= 0, "id should not be negative");
     Preconditions.checkArgument(path != null && !path.isEmpty(),
         "path should not be null or empty");
-    Preconditions.checkNotNull(fileStream, "file stream cannot be null");
+    mFileStream = Preconditions.checkNotNull(fileStream, "file stream cannot be null");
     mId = id;
     mPath = path;
-    mFileStream = fileStream;
   }
 
   /**

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileEntry.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileEntry.java
@@ -26,9 +26,8 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class FuseFileEntry<T extends FuseFileStream>
     implements Closeable {
   private final long mId;
+  private final String mPath;
   private final T mFileStream;
-  // Path is likely to be changed when fuse rename() is called
-  private String mPath;
 
   /**
    * Constructs a new {@link FuseFileEntry} for an Alluxio file.
@@ -38,11 +37,13 @@ public final class FuseFileEntry<T extends FuseFileStream>
    * @param fileStream the in/out stream of the file
    */
   public FuseFileEntry(long id, String path, T fileStream) {
-    Preconditions.checkArgument(id != -1 && !path.isEmpty());
+    Preconditions.checkArgument(id >= 0, "id should not be negative");
+    Preconditions.checkArgument(path != null && !path.isEmpty(),
+        "path should not be null or empty");
     Preconditions.checkNotNull(fileStream, "file stream cannot be null");
     mId = id;
-    mFileStream = fileStream;
     mPath = path;
+    mFileStream = fileStream;
   }
 
   /**
@@ -73,8 +74,6 @@ public final class FuseFileEntry<T extends FuseFileStream>
    */
   @Override
   public void close() throws IOException {
-    if (mFileStream != null) {
-      mFileStream.close();
-    }
+    mFileStream.close();
   }
 }

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileEntry.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileEntry.java
@@ -1,10 +1,28 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.fuse.file;
 
 import com.google.common.base.Preconditions;
 
 import java.io.Closeable;
 import java.io.IOException;
+import javax.annotation.concurrent.ThreadSafe;
 
+/**
+ * Convenience class to encapsulate file stream
+ * and its information (path, id) for reading or writing alluxio file.
+ * @param <T> the concrete fuse file stream subclass
+ */
+@ThreadSafe
 public final class FuseFileEntry<T extends FuseFileStream>
     implements Closeable {
   private final long mId;
@@ -21,7 +39,7 @@ public final class FuseFileEntry<T extends FuseFileStream>
    */
   public FuseFileEntry(long id, String path, T fileStream) {
     Preconditions.checkArgument(id != -1 && !path.isEmpty());
-    Preconditions.checkArgument(fileStream != null);
+    Preconditions.checkNotNull(fileStream, "file stream cannot be null");
     mId = id;
     mFileStream = fileStream;
     mPath = path;
@@ -42,10 +60,9 @@ public final class FuseFileEntry<T extends FuseFileStream>
   }
 
   /**
-   * Gets the opened output stream for this open file entry. The value returned can be {@code null}
-   * if the file is not open for writing.
+   * Gets the fuse file stream for this entry.
    *
-   * @return an opened input stream for the open alluxio file, or null
+   * @return a fuse file stream
    */
   public T getFileStream() {
     return mFileStream;

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileEntry.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileEntry.java
@@ -1,0 +1,63 @@
+package alluxio.fuse.file;
+
+import com.google.common.base.Preconditions;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public final class FuseFileEntry<T extends FuseFileStream>
+    implements Closeable {
+  private final long mId;
+  private final T mFileStream;
+  // Path is likely to be changed when fuse rename() is called
+  private String mPath;
+
+  /**
+   * Constructs a new {@link FuseFileEntry} for an Alluxio file.
+   *
+   * @param id the id of the file
+   * @param path the path of the file
+   * @param fileStream the in/out stream of the file
+   */
+  public FuseFileEntry(long id, String path, T fileStream) {
+    Preconditions.checkArgument(id != -1 && !path.isEmpty());
+    Preconditions.checkArgument(fileStream != null);
+    mId = id;
+    mFileStream = fileStream;
+    mPath = path;
+  }
+
+  /**
+   * @return the id of the file
+   */
+  public long getId() {
+    return mId;
+  }
+
+  /**
+   * @return the path of the file
+   */
+  public String getPath() {
+    return mPath;
+  }
+
+  /**
+   * Gets the opened output stream for this open file entry. The value returned can be {@code null}
+   * if the file is not open for writing.
+   *
+   * @return an opened input stream for the open alluxio file, or null
+   */
+  public T getFileStream() {
+    return mFileStream;
+  }
+
+  /**
+   * Closes the underlying open streams.
+   */
+  @Override
+  public void close() throws IOException {
+    if (mFileStream != null) {
+      mFileStream.close();
+    }
+  }
+}

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
@@ -97,7 +97,8 @@ public class FuseFileInOrOutStream implements FuseFileStream {
       mStream = FuseFileInStream.create(mFileSystem, mUri,
           OpenFlags.O_RDONLY.intValue(), mStatus);
     } else if (!isRead()) {
-      throw new IOException("Alluxio does not support reading while writing");
+      throw new UnsupportedOperationException(
+          "Alluxio does not support reading while writing/truncating");
     }
     return mStream.read(buf, size, offset);
   }
@@ -108,7 +109,8 @@ public class FuseFileInOrOutStream implements FuseFileStream {
       mStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy, mUri,
           OpenFlags.O_WRONLY.intValue(), mMode, mStatus);
     } else if (isRead()) {
-      throw new IOException("Alluxio does not support reading while writing");
+      throw new UnsupportedOperationException(
+          "Alluxio does not support reading while writing/truncating");
     }
     mStream.write(buf, size, offset);
   }
@@ -143,7 +145,7 @@ public class FuseFileInOrOutStream implements FuseFileStream {
     if (size == 0) {
       mFileSystem.delete(mUri);
       mStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy, mUri,
-          OpenFlags.O_WRONLY.intValue(), mMode, mStatus);
+          OpenFlags.O_WRONLY.intValue(), mMode, null);
     }
   }
 

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
@@ -87,20 +87,16 @@ public class FuseFileInOrOutStream implements FuseFileStream {
 
   private FuseFileInOrOutStream(FileSystem fileSystem, AuthPolicy authPolicy,
       Optional<FuseFileInStream> inStream, Optional<FuseFileOutStream> outStream,
-      Optional<URIStatus> status, AlluxioURI uri, long mode) {
-    Preconditions.checkNotNull(fileSystem);
-    Preconditions.checkNotNull(authPolicy);
-    Preconditions.checkNotNull(status);
-    Preconditions.checkNotNull(uri);
+      Optional<URIStatus> originalStatus, AlluxioURI uri, long mode) {
+    mFileSystem = Preconditions.checkNotNull(fileSystem);
+    mAuthPolicy = Preconditions.checkNotNull(authPolicy);
+    mOriginalStatus = Preconditions.checkNotNull(originalStatus);
+    mUri = Preconditions.checkNotNull(uri);
     Preconditions.checkArgument(!(inStream.isPresent() && outStream.isPresent()),
         "Cannot create both input and output stream");
-    mFileSystem = fileSystem;
-    mAuthPolicy = authPolicy;
-    mOriginalStatus = status;
-    mUri = uri;
-    mMode = mode;
     mInStream = inStream;
     mOutStream = outStream;
+    mMode = mode;
   }
 
   @Override

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
@@ -1,15 +1,39 @@
 package alluxio.fuse.file;
 
 import alluxio.AlluxioURI;
+import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
+import alluxio.client.file.URIStatus;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.FileDoesNotExistException;
+import alluxio.fuse.AlluxioFuseOpenUtils;
+import alluxio.fuse.AlluxioFuseUtils;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.InvalidPathException;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
+@NotThreadSafe
 public class FuseFileInOrOutStream implements FuseFileStream {
-  
+  private 
 
-  public FuseFileInOrOutStream(FileSystem fileSystem, AlluxioURI uri, long mode) {
+  public static FuseFileInOrOutStream create(FileSystem fileSystem, AlluxioURI uri, int flags, long mode) throws IOException, AlluxioException {
+    URIStatus status;
+    try {
+      status = fileSystem.getStatus(uri);
+    } catch (InvalidPathException | FileNotFoundException | FileDoesNotExistException e) {
+      status = null;
+    } catch (Throwable t) {
+      throw new IOException(String.format("Failed to create fuse stream for %s, unexpected error when getting file status", uri), t);
+    }
+    boolean truncate = AlluxioFuseOpenUtils.containsTruncate(flags));
+
+  }  
+  
+  private FuseFileInOrOutStream(FileSystem fileSystem, AlluxioURI uri, long mode) {
 
   }
   
@@ -20,6 +44,11 @@ public class FuseFileInOrOutStream implements FuseFileStream {
 
   @Override
   public int write(ByteBuffer buf, long size, long offset) throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int getFileLength() throws IOException {
     return 0;
   }
 

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
@@ -1,69 +1,169 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.fuse.file;
 
 import alluxio.AlluxioURI;
-import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.fuse.AlluxioFuseOpenUtils;
-import alluxio.fuse.AlluxioFuseUtils;
+import alluxio.fuse.auth.AuthPolicy;
+
+import jnr.constants.platform.OpenFlags;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.InvalidPathException;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
-@NotThreadSafe
+/**
+ * An implementation for {@link FuseFileStream} for read only or write only workloads.
+ * Fuse can open file for reading and writing concurrently but Alluxio only support
+ * read-only or write-only workloads. This class will treat the stream as read-only or write-only
+ * workloads based on whether truncate is called and the first operation is read or write.
+ */
+@ThreadSafe
 public class FuseFileInOrOutStream implements FuseFileStream {
-  private 
+  private static final Logger LOG = LoggerFactory.getLogger(FuseFileInOrOutStream.class);
+  private final FileSystem mFileSystem;
+  private final AlluxioURI mUri;
+  private final long mMode;
+  private final AuthPolicy mAuthPolicy;
 
-  public static FuseFileInOrOutStream create(FileSystem fileSystem, AlluxioURI uri, int flags, long mode) throws IOException, AlluxioException {
+  // Treat as read only or write only stream based on first operation is read or truncate or write
+  private FuseFileStream mStream;
+
+  /**
+   * Creates a {@link FuseFileInOrOutStream}.
+   *
+   * @param fileSystem the file system
+   * @param uri the alluxio uri
+   * @param flags the fuse create/open flags
+   * @param authPolicy the authentication policy
+   * @param mode the filesystem mode, -1 if not set
+   * @return a {@link FuseFileInOrOutStream}
+   */
+  public static FuseFileInOrOutStream create(FileSystem fileSystem, AlluxioURI uri, int flags,
+      AuthPolicy authPolicy, long mode) throws Exception {
     URIStatus status;
     try {
       status = fileSystem.getStatus(uri);
     } catch (InvalidPathException | FileNotFoundException | FileDoesNotExistException e) {
       status = null;
     } catch (Throwable t) {
-      throw new IOException(String.format("Failed to create fuse stream for %s, unexpected error when getting file status", uri), t);
+      throw new IOException(String.format("Failed to create fuse stream for %s, "
+          + "unexpected error when getting file status", uri), t);
     }
-    boolean truncate = AlluxioFuseOpenUtils.containsTruncate(flags));
-
-  }  
-  
-  private FuseFileInOrOutStream(FileSystem fileSystem, AlluxioURI uri, long mode) {
-
-  }
-  
-  @Override
-  public int read(ByteBuffer buf, long size, long offset) throws IOException {
-    return 0;
-  }
-
-  @Override
-  public int write(ByteBuffer buf, long size, long offset) throws IOException {
-    return 0;
-  }
-
-  @Override
-  public int getFileLength() throws IOException {
-    return 0;
+    boolean truncate = AlluxioFuseOpenUtils.containsTruncate(flags);
+    if (status != null && truncate) {
+      fileSystem.delete(uri);
+      LOG.debug(String.format("Open path %s with flag 0x%x for overwriting. "
+          + "Alluxio deleted the old file and created a new file for writing", uri, flags));
+    }
+    if (status == null || truncate) {
+      FuseFileOutStream stream = FuseFileOutStream.create(fileSystem,
+          uri, OpenFlags.O_WRONLY.intValue(), authPolicy, mode);
+      return new FuseFileInOrOutStream(stream, fileSystem, uri, authPolicy, mode);
+    }
+    // Left for next operation to decide read-only or write-only mode
+    // read-only: open(READ_WRITE) existing file - read()
+    // write-only: open(READ_WRITE) existing file - truncate(0) - write()
+    return new FuseFileInOrOutStream(null, fileSystem, uri, authPolicy, mode);
   }
 
-  @Override
-  public int flush() throws IOException {
-    return 0;
+  private FuseFileInOrOutStream(@Nullable FuseFileStream stream, FileSystem fileSystem,
+      AlluxioURI uri, AuthPolicy authPolicy, long mode) {
+    mStream = stream;
+    mFileSystem = fileSystem;
+    mUri = uri;
+    mMode = mode;
+    mAuthPolicy = authPolicy;
   }
 
   @Override
-  public int truncate(long size) throws IOException {
-    return 0;
+  public synchronized int read(ByteBuffer buf, long size, long offset)
+      throws IOException, AlluxioException {
+    if (mStream == null) {
+      mStream = FuseFileInStream.create(mFileSystem, mUri, OpenFlags.O_RDONLY.intValue());
+    } else if (!isRead()) {
+      throw new IOException("Alluxio does not support reading while writing");
+    }
+    return mStream.read(buf, size, offset);
   }
 
   @Override
-  public int close() throws IOException {
-    return 0;
+  public synchronized void write(ByteBuffer buf, long size, long offset) throws Exception {
+    if (mStream == null) {
+      mStream = FuseFileOutStream.create(mFileSystem, mUri, OpenFlags.O_WRONLY.intValue(),
+          mAuthPolicy, mMode);
+    } else if (isRead()) {
+      throw new IOException("Alluxio does not support reading while writing");
+    }
+    mStream.write(buf, size, offset);
+  }
+
+  @Override
+  public synchronized long getFileLength() throws IOException {
+    if (mStream != null) {
+      return mStream.getFileLength();
+    }
+    URIStatus status;
+    try {
+      status = mFileSystem.getStatus(mUri);
+      return status.getLength();
+    } catch (InvalidPathException | FileNotFoundException | FileDoesNotExistException e) {
+      return 0;
+    } catch (Throwable t) {
+      throw new IOException(String
+          .format("Failed to get file length of %s: failed to get file status", mUri), t);
+    }
+  }
+
+  @Override
+  public synchronized void flush() throws IOException {
+    if (mStream != null) {
+      mStream.flush();
+    }
+  }
+
+  @Override
+  public synchronized void truncate(long size) throws Exception {
+    if (mStream != null) {
+      mStream.truncate(size);
+      return;
+    }
+    if (size == getFileLength()) {
+      return;
+    }
+    if (size == 0) {
+      mFileSystem.delete(mUri);
+      mStream = FuseFileOutStream.create(mFileSystem, mUri,
+          OpenFlags.O_WRONLY.intValue(), mAuthPolicy, mMode);
+    }
+  }
+
+  @Override
+  public synchronized void close() throws IOException {
+    if (mStream != null) {
+      mStream.close();
+    }
+  }
+
+  private boolean isRead() {
+    return mStream != null && mStream instanceof FuseFileInStream;
   }
 }

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
@@ -125,10 +125,7 @@ public class FuseFileInOrOutStream implements FuseFileStream {
     if (mStream != null) {
       return mStream.getFileLength();
     }
-    if (mStatus.isPresent()) {
-      return mStatus.get().getLength();
-    }
-    return 0;
+    return mStatus.map(URIStatus::getLength).orElse(0L);
   }
 
   @Override
@@ -151,7 +148,7 @@ public class FuseFileInOrOutStream implements FuseFileStream {
     if (size == 0) {
       mFileSystem.delete(mUri);
       mStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy, mUri,
-          OpenFlags.O_WRONLY.intValue(), mMode, null);
+          OpenFlags.O_WRONLY.intValue(), mMode, Optional.empty());
     }
   }
 

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
@@ -1,0 +1,40 @@
+package alluxio.fuse.file;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileSystem;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class FuseFileInOrOutStream implements FuseFileStream {
+  
+
+  public FuseFileInOrOutStream(FileSystem fileSystem, AlluxioURI uri, long mode) {
+
+  }
+  
+  @Override
+  public int read(ByteBuffer buf, long size, long offset) throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int write(ByteBuffer buf, long size, long offset) throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int flush() throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int truncate(long size) throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int close() throws IOException {
+    return 0;
+  }
+}

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
@@ -55,10 +55,15 @@ public class FuseFileInStream implements FuseFileStream {
     try {
       status = fileSystem.getStatus(uri);
     } catch (InvalidPathException | FileNotFoundException | FileDoesNotExistException e) {
-      status = null;
+      throw new IOException(String.format(
+          "Failed to create read-only stream for %s: file does not exist", uri), e);
     } catch (Throwable t) {
       throw new IOException(String.format(
           "Failed to create read-only stream for %s: failed to get file status", uri), t);
+    }
+    if (status == null) {
+      throw new IOException(String.format(
+          "Failed to create read-only stream for %s: unexpected null file status", uri));
     }
 
     if (status != null && !status.isCompleted()) {

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
@@ -77,11 +77,9 @@ public class FuseFileInStream implements FuseFileStream {
   }
 
   private FuseFileInStream(FileInStream inStream, long fileLength, AlluxioURI uri) {
-    Preconditions.checkNotNull(inStream);
-    Preconditions.checkNotNull(uri);
-    mInStream = inStream;
+    mInStream = Preconditions.checkNotNull(inStream);
+    mURI = Preconditions.checkNotNull(uri);
     mFileLength = fileLength;
-    mURI = uri;
   }
 
   @Override

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
@@ -1,14 +1,53 @@
 package alluxio.fuse.file;
 
 import alluxio.AlluxioURI;
+import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
+import alluxio.client.file.URIStatus;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.FileDoesNotExistException;
+import alluxio.fuse.AlluxioFuseOpenUtils;
+import alluxio.fuse.AlluxioFuseUtils;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.InvalidPathException;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
+@NotThreadSafe
 public class FuseFileInStream implements FuseFileStream {
-  public FuseFileInStream(FileSystem fileSystem, AlluxioURI uri) {
+  private final FileInStream mInStream;
 
+  public static FuseFileInStream create(FileSystem fileSystem, AlluxioURI uri, int flags) throws IOException, AlluxioException {
+    if (AlluxioFuseOpenUtils.containsTruncate(flags)) {
+      throw new IOException(String.format("Cannot create readonly stream for path %s with flags 0x%x contains truncate", uri, flags));
+    }
+    // TODO(lu) create utils method for waitForFileCompleted
+    URIStatus status;
+    try {
+      status = fileSystem.getStatus(uri);
+    } catch (InvalidPathException | FileNotFoundException | FileDoesNotExistException e) {
+      status = null;
+    } catch (Throwable t) {
+      throw new IOException(String.format("Failed to create fuse stream for %s, unexpected error when getting file status", uri), t);
+    }
+
+    if (status != null && !status.isCompleted()) {
+      // Cannot open incomplete file for read or write
+      // wait for file to complete in read or read_write mode
+      if (!AlluxioFuseUtils.waitForFileCompleted(fileSystem, uri)) {
+        throw new IOException(String.format("Failed to create fuse stream for incomplete file %s", uri));
+      }
+    }
+
+    FileInStream is = fileSystem.openFile(uri);
+    return new FuseFileInStream(is);
+  }
+  
+  private FuseFileInStream(FileInStream inStream) {
+    mInStream = inStream;
   }
   
   @Override
@@ -18,6 +57,11 @@ public class FuseFileInStream implements FuseFileStream {
 
   @Override
   public int write(ByteBuffer buf, long size, long offset) throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int getFileLength() throws IOException {
     return 0;
   }
 

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.fuse.file;
 
 import alluxio.AlluxioURI;
@@ -13,16 +24,31 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.InvalidPathException;
+import javax.annotation.concurrent.ThreadSafe;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
-@NotThreadSafe
+/**
+ * An implementation for {@link FuseFileStream} for read only operations against an Alluxio uri.
+ */
+@ThreadSafe
 public class FuseFileInStream implements FuseFileStream {
   private final FileInStream mInStream;
+  private final long mFileLength;
+  private final AlluxioURI mURI;
 
-  public static FuseFileInStream create(FileSystem fileSystem, AlluxioURI uri, int flags) throws IOException, AlluxioException {
+  /**
+   * Creates a {@link FuseFileInStream}.
+   *
+   * @param fileSystem the file system
+   * @param uri the alluxio uri
+   * @param flags the fuse create/open flags
+   * @return a {@link FuseFileInStream}
+   */
+  public static FuseFileInStream create(FileSystem fileSystem, AlluxioURI uri, int flags)
+      throws IOException, AlluxioException {
     if (AlluxioFuseOpenUtils.containsTruncate(flags)) {
-      throw new IOException(String.format("Cannot create readonly stream for path %s with flags 0x%x contains truncate", uri, flags));
+      throw new IOException(String.format(
+          "Failed to create read-only stream for path %s: flags 0x%x contains truncate",
+          uri, flags));
     }
     // TODO(lu) create utils method for waitForFileCompleted
     URIStatus status;
@@ -31,52 +57,69 @@ public class FuseFileInStream implements FuseFileStream {
     } catch (InvalidPathException | FileNotFoundException | FileDoesNotExistException e) {
       status = null;
     } catch (Throwable t) {
-      throw new IOException(String.format("Failed to create fuse stream for %s, unexpected error when getting file status", uri), t);
+      throw new IOException(String.format(
+          "Failed to create read-only stream for %s: failed to get file status", uri), t);
     }
 
     if (status != null && !status.isCompleted()) {
       // Cannot open incomplete file for read or write
       // wait for file to complete in read or read_write mode
       if (!AlluxioFuseUtils.waitForFileCompleted(fileSystem, uri)) {
-        throw new IOException(String.format("Failed to create fuse stream for incomplete file %s", uri));
+        throw new IOException(String.format(
+            "Failed to create read-only stream for %s: incomplete file", uri));
       }
     }
 
     FileInStream is = fileSystem.openFile(uri);
-    return new FuseFileInStream(is);
+    return new FuseFileInStream(is, status.getLength(), uri);
   }
-  
-  private FuseFileInStream(FileInStream inStream) {
+
+  private FuseFileInStream(FileInStream inStream, long fileLength, AlluxioURI uri) {
     mInStream = inStream;
-  }
-  
-  @Override
-  public int read(ByteBuffer buf, long size, long offset) throws IOException {
-    return 0;
+    mFileLength = fileLength;
+    mURI = uri;
   }
 
   @Override
-  public int write(ByteBuffer buf, long size, long offset) throws IOException {
-    return 0;
+  public synchronized int read(ByteBuffer buf, long size, long offset) throws IOException {
+    final int sz = (int) size;
+    int nread = 0;
+    int rd = 0;
+    if (offset - mInStream.getPos() >= mInStream.remaining()) {
+      return 0;
+    }
+    mInStream.seek(offset);
+    while (rd >= 0 && nread < sz) {
+      rd = mInStream.read(buf, nread, sz - nread);
+      if (rd >= 0) {
+        nread += rd;
+      }
+    }
+    return nread;
   }
 
   @Override
-  public int getFileLength() throws IOException {
-    return 0;
+  public void write(ByteBuffer buf, long size, long offset) throws UnsupportedOperationException {
+    throw new UnsupportedOperationException(String
+        .format("Cannot write to read-only stream of path %s", mURI));
   }
 
   @Override
-  public int flush() throws IOException {
-    return 0;
+  public long getFileLength() {
+    return mFileLength;
   }
 
   @Override
-  public int truncate(long size) throws IOException {
-    return 0;
+  public void flush() {}
+
+  @Override
+  public void truncate(long size) throws UnsupportedOperationException {
+    throw new UnsupportedOperationException(String
+        .format("Cannot truncate read-only stream of path %s", mURI));
   }
 
   @Override
-  public int close() throws IOException {
-    return 0;
+  public synchronized void close() throws IOException {
+    mInStream.close();
   }
 }

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
@@ -1,0 +1,38 @@
+package alluxio.fuse.file;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileSystem;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class FuseFileInStream implements FuseFileStream {
+  public FuseFileInStream(FileSystem fileSystem, AlluxioURI uri) {
+
+  }
+  
+  @Override
+  public int read(ByteBuffer buf, long size, long offset) throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int write(ByteBuffer buf, long size, long offset) throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int flush() throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int truncate(long size) throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int close() throws IOException {
+    return 0;
+  }
+}

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.fuse.file;
 
 import alluxio.AlluxioURI;
@@ -6,12 +17,10 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.fuse.AlluxioFuseOpenUtils;
-import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.fuse.auth.AuthPolicy;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.security.authorization.Mode;
 
-import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,83 +28,132 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.InvalidPathException;
+import javax.annotation.concurrent.ThreadSafe;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.NotThreadSafe;
-
-@NotThreadSafe
+/**
+ * An implementation for {@link FuseFileStream} for sequential write only operations
+ * against an Alluxio uri.
+ */
+@ThreadSafe
 public class FuseFileOutStream implements FuseFileStream {
   private static final Logger LOG = LoggerFactory.getLogger(FuseFileOutStream.class);
-  private final FileOutStream mOutStream;
+  private final AuthPolicy mAuthPolicy;
+  private final CreateFilePOptions mCreateFileOptions;
+  private final FileSystem mFileSystem;
+  private final AlluxioURI mURI;
 
-  public static FuseFileOutStream create(FileSystem fileSystem, AlluxioURI uri, int flags, long mode, @Nullable AuthPolicy authPolicy) 
-      throws Exception {
-    Preconditions.checkNotNull(fileSystem, "file system");
-    Preconditions.checkNotNull(uri, "uri");
-    if (AlluxioFuseOpenUtils.containsTruncate(flags)) {
-      throw new IOException(String.format("Cannot create readonly stream for path %s with flags 0x%x contains truncate", uri, flags));
-    }
+  private FileOutStream mOutStream;
 
+  /**
+   * Creates a {@link FuseFileInOrOutStream}.
+   *
+   * @param fileSystem the file system
+   * @param uri the alluxio uri
+   * @param flags the fuse create/open flags
+   * @param authPolicy the authentication policy
+   * @param mode the filesystem mode, -1 if not set
+   * @return a {@link FuseFileInOrOutStream}
+   */
+  public static FuseFileOutStream create(FileSystem fileSystem, AlluxioURI uri, int flags,
+      AuthPolicy authPolicy, long mode) throws Exception {
     URIStatus status;
     try {
       status = fileSystem.getStatus(uri);
     } catch (InvalidPathException | FileNotFoundException | FileDoesNotExistException e) {
       status = null;
     } catch (Throwable t) {
-      throw new IOException(String.format("Failed to create fuse stream for %s, unexpected error when getting file status", uri), t);
+      throw new IOException(String.format(
+          "Failed to create write-only stream for %s: failed to get file status", uri), t);
     }
-
+    boolean truncate = AlluxioFuseOpenUtils.containsTruncate(flags);
     if (status != null) {
-      if (AlluxioFuseOpenUtils.containsTruncate(flags)) {
+      if (truncate) {
         fileSystem.delete(uri);
         LOG.debug(String.format("Open path %s with flag 0x%x for overwriting. "
             + "Alluxio deleted the old file and created a new file for writing", uri, flags));
       } else {
-        throw new IOException(String.format("Cannot create fuse file output stream for existing file {}. Alluxio does not support overwrite without truncate", uri));
+        throw new IOException(String.format("Failed to create write-only stream for %s: "
+            + "cannot overwrite existing file without truncate flag", uri));
       }
     }
-
-    FileOutStream out = fileSystem.createFile(uri,
-        CreateFilePOptions.newBuilder()
-            .setMode(new Mode((short) mode).toProto())
-            .build());
+    CreateFilePOptions.Builder optionsBuilder = CreateFilePOptions.newBuilder();
+    if (mode == MODE_NOT_SET && status != null) {
+      optionsBuilder.setMode(new Mode((short) status.getMode()).toProto());
+    }
+    if (mode != MODE_NOT_SET) {
+      optionsBuilder.setMode(new Mode((short) mode).toProto());
+    }
+    CreateFilePOptions options = optionsBuilder.build();
+    FileOutStream out = fileSystem.createFile(uri, options);
     if (authPolicy != null) {
       authPolicy.setUserGroupIfNeeded(uri);
     }
-    return new FuseFileOutStream(out);
+    return new FuseFileOutStream(out, fileSystem, uri, options, authPolicy);
   }
-  
-  private FuseFileOutStream(FileOutStream outStream) {
+
+  private FuseFileOutStream(FileOutStream outStream, FileSystem fileSystem,
+      AlluxioURI uri, CreateFilePOptions options, AuthPolicy authPolicy) {
     mOutStream = outStream;
+    mCreateFileOptions = options;
+    mFileSystem = fileSystem;
+    mURI = uri;
+    mAuthPolicy = authPolicy;
   }
-  
+
   @Override
   public int read(ByteBuffer buf, long size, long offset) throws IOException {
-    return 0;
+    throw new UnsupportedOperationException("Cannot read from write only stream");
   }
 
   @Override
-  public int write(ByteBuffer buf, long size, long offset) throws IOException {
-    return 0;
+  public synchronized void write(ByteBuffer buf, long size, long offset) throws IOException {
+    if (size > Integer.MAX_VALUE) {
+      throw new IOException(String.format("Cannot write more than %s", Integer.MAX_VALUE));
+    }
+    int sz = (int) size;
+    long bytesWritten = mOutStream.getBytesWritten();
+    if (offset != bytesWritten && offset + sz > bytesWritten) {
+      throw new UnsupportedOperationException(String.format("Only sequential write is supported. "
+          + "Cannot write bytes of size %s to offset %s when %s bytes have written to path %s",
+          size, offset, bytesWritten, mURI));
+    }
+    if (offset + sz <= bytesWritten) {
+      LOG.warn("Skip writing to file {} offset={} size={} when {} bytes has written to file",
+          mURI, offset, sz, bytesWritten);
+      // To fulfill vim :wq
+    }
+    final byte[] dest = new byte[sz];
+    buf.get(dest, 0, sz);
+    mOutStream.write(dest);
   }
 
   @Override
-  public int getFileLength() throws IOException {
-    return 0;
+  public synchronized long getFileLength() {
+    return mOutStream.getBytesWritten();
   }
 
   @Override
-  public int flush() throws IOException {
-    return 0;
+  public synchronized void flush() throws IOException {
+    mOutStream.flush();
   }
 
   @Override
-  public int truncate(long size) throws IOException {
-    return 0;
+  public synchronized void truncate(long size) throws Exception {
+    if (mOutStream.getBytesWritten() == size) {
+      return;
+    }
+    if (size == 0) {
+      mOutStream.close();
+      mFileSystem.delete(mURI);
+      mOutStream = mFileSystem.createFile(mURI, mCreateFileOptions);
+      if (mAuthPolicy != null) {
+        mAuthPolicy.setUserGroupIfNeeded(mURI);
+      }
+    }
   }
 
   @Override
-  public int close() throws IOException {
-    return 0;
+  public synchronized void close() throws IOException {
+    mOutStream.close();
   }
 }

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -64,7 +64,7 @@ public class FuseFileOutStream implements FuseFileStream {
     Preconditions.checkNotNull(authPolicy);
     Preconditions.checkNotNull(uri);
     Preconditions.checkNotNull(status);
-    if (mode == MODE_NOT_SET && status.isPresent()) {
+    if (mode == AlluxioFuseUtils.MODE_NOT_SET_VALUE && status.isPresent()) {
       mode = status.get().getMode();
     }
     long fileLen = status.isPresent() ? status.get().getLength() : 0;

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -137,7 +137,7 @@ public class FuseFileOutStream implements FuseFileStream {
     if (size == 0) {
       close();
       mFuseFileSystem.deleteFile(mURI);
-      mFuseFileSystem.createFile(mURI, mMode);
+      mOutStream = mFuseFileSystem.createFile(mURI, mMode);
       return;
     }
     throw new IOException(String.format("Cannot truncate file %s to size %s", mURI, size));

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -82,15 +82,11 @@ public class FuseFileOutStream implements FuseFileStream {
 
   private FuseFileOutStream(FileSystem fileSystem, AuthPolicy authPolicy,
       Optional<FileOutStream> outStream, long fileLen, AlluxioURI uri, long mode) {
-    Preconditions.checkNotNull(fileSystem);
-    Preconditions.checkNotNull(authPolicy);
-    Preconditions.checkNotNull(outStream);
-    Preconditions.checkNotNull(uri);
-    mFileSystem = fileSystem;
-    mAuthPolicy = authPolicy;
-    mOutStream = outStream;
+    mFileSystem = Preconditions.checkNotNull(fileSystem);
+    mAuthPolicy = Preconditions.checkNotNull(authPolicy);
+    mOutStream = Preconditions.checkNotNull(outStream);
+    mURI = Preconditions.checkNotNull(uri);
     mOriginalFileLen = fileLen;
-    mURI = uri;
     mMode = mode;
   }
 

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -67,8 +67,8 @@ public class FuseFileOutStream implements FuseFileStream {
     if (mode == AlluxioFuseUtils.MODE_NOT_SET_VALUE && status.isPresent()) {
       mode = status.get().getMode();
     }
-    long fileLen = status.isPresent() ? status.get().getLength() : 0;
-    if (!status.isPresent()) {
+    long fileLen = status.map(URIStatus::getLength).orElse(0L);
+    if (status.isPresent()) {
       if (AlluxioFuseOpenUtils.containsTruncate(flags)) {
         fileSystem.delete(uri);
         fileLen = 0;

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -100,7 +100,7 @@ public class FuseFileOutStream implements FuseFileStream {
     }
     if (mOutStream == null) {
       throw new IOException(
-          "Cannot overwrite existing file without O_TRUNC flag or truncate(0) operation");
+          "Cannot overwrite/extending existing file without O_TRUNC flag or truncate(0) operation");
     }
     int sz = (int) size;
     long bytesWritten = mOutStream.getBytesWritten();
@@ -146,7 +146,8 @@ public class FuseFileOutStream implements FuseFileStream {
       mOutStream = AlluxioFuseUtils.createFile(mFileSystem, mAuthPolicy, mURI, mMode);
       return;
     }
-    throw new IOException(String.format("Cannot truncate file %s to size %s", mURI, size));
+    throw new UnsupportedOperationException(
+        String.format("Cannot truncate file %s to size %s", mURI, size));
   }
 
   @Override

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -3,24 +3,58 @@ package alluxio.fuse.file;
 import alluxio.AlluxioURI;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
+import alluxio.client.file.URIStatus;
+import alluxio.exception.FileDoesNotExistException;
+import alluxio.fuse.AlluxioFuseOpenUtils;
+import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.fuse.auth.AuthPolicy;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.security.authorization.Mode;
 
 import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.InvalidPathException;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
 
+@NotThreadSafe
 public class FuseFileOutStream implements FuseFileStream {
-  private final FileOutStream mOut;
+  private static final Logger LOG = LoggerFactory.getLogger(FuseFileOutStream.class);
+  private final FileOutStream mOutStream;
 
-  public static FuseFileOutStream create(FileSystem fileSystem, AlluxioURI uri, long mode, @Nullable AuthPolicy authPolicy) 
+  public static FuseFileOutStream create(FileSystem fileSystem, AlluxioURI uri, int flags, long mode, @Nullable AuthPolicy authPolicy) 
       throws Exception {
     Preconditions.checkNotNull(fileSystem, "file system");
     Preconditions.checkNotNull(uri, "uri");
+    if (AlluxioFuseOpenUtils.containsTruncate(flags)) {
+      throw new IOException(String.format("Cannot create readonly stream for path %s with flags 0x%x contains truncate", uri, flags));
+    }
+
+    URIStatus status;
+    try {
+      status = fileSystem.getStatus(uri);
+    } catch (InvalidPathException | FileNotFoundException | FileDoesNotExistException e) {
+      status = null;
+    } catch (Throwable t) {
+      throw new IOException(String.format("Failed to create fuse stream for %s, unexpected error when getting file status", uri), t);
+    }
+
+    if (status != null) {
+      if (AlluxioFuseOpenUtils.containsTruncate(flags)) {
+        fileSystem.delete(uri);
+        LOG.debug(String.format("Open path %s with flag 0x%x for overwriting. "
+            + "Alluxio deleted the old file and created a new file for writing", uri, flags));
+      } else {
+        throw new IOException(String.format("Cannot create fuse file output stream for existing file {}. Alluxio does not support overwrite without truncate", uri));
+      }
+    }
+
     FileOutStream out = fileSystem.createFile(uri,
         CreateFilePOptions.newBuilder()
             .setMode(new Mode((short) mode).toProto())
@@ -31,8 +65,8 @@ public class FuseFileOutStream implements FuseFileStream {
     return new FuseFileOutStream(out);
   }
   
-  private FuseFileOutStream(FileOutStream out) {
-    mOut = out;
+  private FuseFileOutStream(FileOutStream outStream) {
+    mOutStream = outStream;
   }
   
   @Override
@@ -42,6 +76,11 @@ public class FuseFileOutStream implements FuseFileStream {
 
   @Override
   public int write(ByteBuffer buf, long size, long offset) throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int getFileLength() throws IOException {
     return 0;
   }
 

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -1,0 +1,62 @@
+package alluxio.fuse.file;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.FileSystem;
+import alluxio.fuse.auth.AuthPolicy;
+import alluxio.grpc.CreateFilePOptions;
+import alluxio.security.authorization.Mode;
+
+import com.google.common.base.Preconditions;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import javax.annotation.Nullable;
+
+public class FuseFileOutStream implements FuseFileStream {
+  private final FileOutStream mOut;
+
+  public static FuseFileOutStream create(FileSystem fileSystem, AlluxioURI uri, long mode, @Nullable AuthPolicy authPolicy) 
+      throws Exception {
+    Preconditions.checkNotNull(fileSystem, "file system");
+    Preconditions.checkNotNull(uri, "uri");
+    FileOutStream out = fileSystem.createFile(uri,
+        CreateFilePOptions.newBuilder()
+            .setMode(new Mode((short) mode).toProto())
+            .build());
+    if (authPolicy != null) {
+      authPolicy.setUserGroupIfNeeded(uri);
+    }
+    return new FuseFileOutStream(out);
+  }
+  
+  private FuseFileOutStream(FileOutStream out) {
+    mOut = out;
+  }
+  
+  @Override
+  public int read(ByteBuffer buf, long size, long offset) throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int write(ByteBuffer buf, long size, long offset) throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int flush() throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int truncate(long size) throws IOException {
+    return 0;
+  }
+
+  @Override
+  public int close() throws IOException {
+    return 0;
+  }
+}

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
@@ -32,7 +32,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * This interface should be implemented by all fuse file streams.
  */
 public interface FuseFileStream extends AutoCloseable {
-  long MODE_NOT_SET = -1;
 
   /**
    * Reads data from the stream.
@@ -124,23 +123,10 @@ public interface FuseFileStream extends AutoCloseable {
      * @return the created fuse file stream
      */
     public static FuseFileStream create(FileSystem fileSystem, AuthPolicy authPolicy,
-        AlluxioURI uri, int flags, long mode) throws IOException, AlluxioException {
+        AlluxioURI uri, int flags, long mode)
+        throws IOException, AlluxioException, ExecutionException {
       return create(fileSystem, authPolicy, uri, flags, mode,
           AlluxioFuseUtils.getPathStatus(fileSystem, uri));
-    }
-
-    /**
-     * Factory method for creating an implementation of {@link FuseFileStream}.
-     *
-     * @param fileSystem the Alluxio file system
-     * @param authPolicy the Authentication policy
-     * @param uri the Alluxio URI
-     * @param flags the create/open flags
-     * @return the created fuse file stream
-     */
-    public static FuseFileStream create(FileSystem fileSystem, AuthPolicy authPolicy,
-        AlluxioURI uri, int flags) throws IOException, AlluxioException {
-      return create(fileSystem, authPolicy, uri, flags, FuseFileStream.MODE_NOT_SET);
     }
   }
 }

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
@@ -1,15 +1,27 @@
 package alluxio.fuse.file;
 
 import static jnr.constants.platform.OpenFlags.O_ACCMODE;
+import static jnr.constants.platform.OpenFlags.O_RDONLY;
 
 import alluxio.AlluxioURI;
+import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
+import alluxio.client.file.URIStatus;
+import alluxio.exception.FileDoesNotExistException;
+import alluxio.fuse.AlluxioFuseOpenUtils;
+import alluxio.fuse.AlluxioFuseUtils;
+import alluxio.fuse.AlluxioJniFuseFileSystem;
 import alluxio.fuse.auth.AuthPolicy;
+import alluxio.jnifuse.ErrorCodes;
 
 import jnr.constants.platform.OpenFlags;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.InvalidPathException;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -28,27 +40,31 @@ public interface FuseFileStream {
    */
   @ThreadSafe
   class Factory {
+    private static final Logger LOG = LoggerFactory.getLogger(FuseFileStream.Factory.class);
 
     private Factory() {} // prevent instantiation
 
     /**
      * Factory for {@link FuseFileStream}.
      */
-    public static FuseFileStream create(FileSystem fileSystem, AlluxioURI uri, int flags, long mode, @Nullable AuthPolicy policy) throws IOException {
+    public static FuseFileStream create(FileSystem fileSystem, AlluxioURI uri, int flags, long mode, @Nullable AuthPolicy policy) throws Exception {
+      // TODO(lu) how can i avoid passing that many parameters to create in out stream
       switch (OpenFlags.valueOf(flags & O_ACCMODE.intValue())) {
         case O_RDONLY:
-          return new FuseFileInStream(fileSystem, uri);
+          return FuseFileInStream.create(fileSystem, uri, flags);
         case O_WRONLY:
-          return FuseFileOutStream.create(fileSystem, uri, mode, policy);
+          return FuseFileOutStream.create(fileSystem, uri, flags, mode, policy);
         case O_RDWR:
-          return new FuseFileInOrOutStream(fileSystem, uri, mode);
+          return new FuseFileInOrOutStream(fileSystem, uri, flags, mode);
         default:
           // TODO(lu) what's the default createInternal flag?
-          throw new IOException(String.format("Cannot create file stream with flag %s", flags));
+          throw new IOException(String.format("Cannot create file stream with flag 0x%x. "
+              + "Alluxio does not support file modification. "
+              + "Cannot open directory in fuse.open().", flags));
       }
     }
 
-    public static FuseFileStream create(FileSystem fileSystem, AlluxioURI uri, int flags) throws IOException {
+    public static FuseFileStream create(FileSystem fileSystem, AlluxioURI uri, int flags) throws Exception {
       return create(fileSystem, uri, flags, -1, null);
     }
   }

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
@@ -1,61 +1,105 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.fuse.file;
 
 import static jnr.constants.platform.OpenFlags.O_ACCMODE;
-import static jnr.constants.platform.OpenFlags.O_RDONLY;
 
 import alluxio.AlluxioURI;
-import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
-import alluxio.client.file.URIStatus;
-import alluxio.exception.FileDoesNotExistException;
-import alluxio.fuse.AlluxioFuseOpenUtils;
-import alluxio.fuse.AlluxioFuseUtils;
-import alluxio.fuse.AlluxioJniFuseFileSystem;
+import alluxio.exception.AlluxioException;
 import alluxio.fuse.auth.AuthPolicy;
-import alluxio.jnifuse.ErrorCodes;
 
 import jnr.constants.platform.OpenFlags;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.file.InvalidPathException;
-
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
+/**
+ * This interface should be implemented by all fuse file streams.
+ */
 public interface FuseFileStream {
-  int read(ByteBuffer buf, long size, long offset) throws IOException;
-  int write(ByteBuffer buf, long size, long offset) throws IOException;
-  int getFileLength() throws IOException;
-  int flush() throws IOException;
-  int truncate(long size) throws IOException;
-  int close() throws IOException;
-  
+  long MODE_NOT_SET = -1;
+
+  /**
+   * Reads data from the stream.
+   *
+   * @param buf the byte buffer to read data to
+   * @param size the size to read
+   * @param offset the offset to read
+   * @return the bytes read
+   */
+  int read(ByteBuffer buf, long size, long offset) throws IOException, AlluxioException;
+
+  /**
+   * Writes data to the stream.
+   *
+   * @param buf the byte buffer to read data from and write to the stream
+   * @param size the size to write
+   * @param offset the offset to write
+   */
+  void write(ByteBuffer buf, long size, long offset) throws Exception;
+
+  /**
+   * Gets the file length.
+   *
+   * @return file length
+   */
+  long getFileLength() throws IOException;
+
+  /**
+   * Flushes the stream.
+   */
+  void flush() throws IOException;
+
+  /**
+   * Truncates the file to the given size.
+   *
+   * @param size the truncate size
+   */
+  void truncate(long size) throws Exception;
+
+  /**
+   * Closes the stream.
+   */
+  void close() throws IOException;
 
   /**
    * Factory for {@link FuseFileInStream}.
    */
   @ThreadSafe
   class Factory {
-    private static final Logger LOG = LoggerFactory.getLogger(FuseFileStream.Factory.class);
-
     private Factory() {} // prevent instantiation
 
     /**
-     * Factory for {@link FuseFileStream}.
+     * Factory method for creating an implementation of {@link FuseFileStream}.
+     *
+     * @param fileSystem the file system
+     * @param uri the Alluxio URI
+     * @param flags the create/open flags
+     * @param policy the authentication policy
+     * @param mode the create file mode, -1 if not set
+     * @return the created fuse file stream
      */
-    public static FuseFileStream create(FileSystem fileSystem, AlluxioURI uri, int flags, long mode, @Nullable AuthPolicy policy) throws Exception {
+    public static FuseFileStream create(FileSystem fileSystem, AlluxioURI uri,
+        int flags, AuthPolicy policy, long mode) throws Exception {
       // TODO(lu) how can i avoid passing that many parameters to create in out stream
       switch (OpenFlags.valueOf(flags & O_ACCMODE.intValue())) {
         case O_RDONLY:
           return FuseFileInStream.create(fileSystem, uri, flags);
         case O_WRONLY:
-          return FuseFileOutStream.create(fileSystem, uri, flags, mode, policy);
+          return FuseFileOutStream.create(fileSystem, uri, flags, policy, mode);
         case O_RDWR:
-          return new FuseFileInOrOutStream(fileSystem, uri, flags, mode);
+          return FuseFileInOrOutStream.create(fileSystem, uri, flags, policy, mode);
         default:
           // TODO(lu) what's the default createInternal flag?
           throw new IOException(String.format("Cannot create file stream with flag 0x%x. "
@@ -64,8 +108,18 @@ public interface FuseFileStream {
       }
     }
 
-    public static FuseFileStream create(FileSystem fileSystem, AlluxioURI uri, int flags) throws Exception {
-      return create(fileSystem, uri, flags, -1, null);
+    /**
+     * Factory method for creating an implementation of {@link FuseFileStream}.
+     *
+     * @param fileSystem the file system
+     * @param uri the Alluxio URI
+     * @param flags the create/open flags
+     * @param authPolicy the authentication policy
+     * @return the created fuse file stream
+     */
+    public static FuseFileStream create(FileSystem fileSystem, AlluxioURI uri,
+        int flags, AuthPolicy authPolicy) throws Exception {
+      return create(fileSystem, uri, flags, authPolicy, FuseFileStream.MODE_NOT_SET);
     }
   }
 }

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
@@ -30,7 +30,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * This interface should be implemented by all fuse file streams.
  */
-public interface FuseFileStream {
+public interface FuseFileStream extends AutoCloseable {
   long MODE_NOT_SET = -1;
 
   /**

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
@@ -1,0 +1,55 @@
+package alluxio.fuse.file;
+
+import static jnr.constants.platform.OpenFlags.O_ACCMODE;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileSystem;
+import alluxio.fuse.auth.AuthPolicy;
+
+import jnr.constants.platform.OpenFlags;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+public interface FuseFileStream {
+  int read(ByteBuffer buf, long size, long offset) throws IOException;
+  int write(ByteBuffer buf, long size, long offset) throws IOException;
+  int getFileLength() throws IOException;
+  int flush() throws IOException;
+  int truncate(long size) throws IOException;
+  int close() throws IOException;
+  
+
+  /**
+   * Factory for {@link FuseFileInStream}.
+   */
+  @ThreadSafe
+  class Factory {
+
+    private Factory() {} // prevent instantiation
+
+    /**
+     * Factory for {@link FuseFileStream}.
+     */
+    public static FuseFileStream create(FileSystem fileSystem, AlluxioURI uri, int flags, long mode, @Nullable AuthPolicy policy) throws IOException {
+      switch (OpenFlags.valueOf(flags & O_ACCMODE.intValue())) {
+        case O_RDONLY:
+          return new FuseFileInStream(fileSystem, uri);
+        case O_WRONLY:
+          return FuseFileOutStream.create(fileSystem, uri, mode, policy);
+        case O_RDWR:
+          return new FuseFileInOrOutStream(fileSystem, uri, mode);
+        default:
+          // TODO(lu) what's the default createInternal flag?
+          throw new IOException(String.format("Cannot create file stream with flag %s", flags));
+      }
+    }
+
+    public static FuseFileStream create(FileSystem fileSystem, AlluxioURI uri, int flags) throws IOException {
+      return create(fileSystem, uri, flags, -1, null);
+    }
+  }
+}

--- a/tests/src/test/java/alluxio/client/fuse/file/AbstractFuseFileStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/AbstractFuseFileStreamIntegrationTest.java
@@ -1,0 +1,89 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.fuse.file;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.URIStatus;
+import alluxio.conf.PropertyKey;
+import alluxio.fuse.auth.AuthPolicy;
+import alluxio.fuse.auth.NoopAuthPolicy;
+import alluxio.fuse.file.FuseFileStream;
+import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.OpenFilePOptions;
+import alluxio.grpc.ReadPType;
+import alluxio.grpc.WritePType;
+import alluxio.testutils.BaseIntegrationTest;
+import alluxio.testutils.LocalAlluxioClusterResource;
+import alluxio.util.io.BufferUtils;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+
+/**
+ * Abstract classes for all integration tests of {@link FuseFileStream}.
+ */
+public abstract class AbstractFuseFileStreamIntegrationTest extends BaseIntegrationTest {
+  protected static final int DEFAULT_FILE_LEN = 64;
+  protected static final long MODE = 10644;
+
+  @Rule
+  public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
+      new LocalAlluxioClusterResource.Builder()
+          .setProperty(PropertyKey.FUSE_AUTH_POLICY_CLASS, "alluxio.fuse.auth.NoopAuthPolicy")
+          .build();
+
+  protected FileSystem mFileSystem = null;
+  protected AuthPolicy mAuthPolicy = null;
+
+  @Before
+  public void before() throws Exception {
+    mFileSystem = mLocalAlluxioClusterResource.get().getClient();
+    mAuthPolicy = new NoopAuthPolicy(mFileSystem, mFileSystem.getConf(), null);
+  }
+
+  /**
+   * Helper to write an Alluxio file with one increasing byte array, using a single
+   * {@link FileOutStream#write(byte[], int, int)} invocation.
+   *
+   * @param filePath path of the tmp file
+   * @param fileLen length of the file
+   */
+  protected void writeIncreasingByteArrayToFile(AlluxioURI filePath, int fileLen) throws Exception {
+    try (FileOutStream os = mFileSystem.createFile(filePath, CreateFilePOptions.newBuilder()
+        .setWriteType(WritePType.MUST_CACHE).setRecursive(true).build())) {
+      os.write(BufferUtils.getIncreasingByteArray(fileLen));
+    }
+  }
+
+  /**
+   * Checks the given file exists in Alluxio storage and expects its content to be an increasing
+   * array of the given length.
+   *
+   * @param filePath path of the tmp file
+   * @param fileLen length of the file
+   */
+  protected void checkFileInAlluxio(AlluxioURI filePath, int fileLen, int startValue)
+      throws Exception {
+    URIStatus status = mFileSystem.getStatus(filePath);
+    Assert.assertEquals(fileLen, status.getLength());
+    try (FileInStream is = mFileSystem.openFile(filePath,
+        OpenFilePOptions.newBuilder().setReadType(ReadPType.NO_CACHE).build())) {
+      byte[] res = new byte[(int) status.getLength()];
+      Assert.assertEquals((int) status.getLength(), is.read(res));
+      Assert.assertTrue(BufferUtils.equalIncreasingByteArray(startValue, fileLen, res));
+    }
+  }
+}

--- a/tests/src/test/java/alluxio/client/fuse/file/FuseFileInOrOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/FuseFileInOrOutStreamIntegrationTest.java
@@ -54,7 +54,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     URIStatus status = mFileSystem.getStatus(alluxioURI);
     Assert.assertNotNull(status);
     Assert.assertTrue(status.isCompleted());
-    Assert.assertEquals(15, status.getLength());
+    Assert.assertEquals(DEFAULT_FILE_LEN, status.getLength());
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/fuse/file/FuseFileInOrOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/FuseFileInOrOutStreamIntegrationTest.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.util.Optional;
 
 /**
  * Integration test for {@link alluxio.fuse.file.FuseFileInOrOutStream}.
@@ -35,7 +36,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     mFileSystem.createDirectory(alluxioURI.getParent(),
         CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy, alluxioURI,
-        OpenFlags.O_RDWR.intValue(), MODE, null).close();
+        OpenFlags.O_RDWR.intValue(), MODE, Optional.empty()).close();
     URIStatus status = mFileSystem.getStatus(alluxioURI);
     Assert.assertNotNull(status);
     Assert.assertTrue(status.isCompleted());
@@ -50,7 +51,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
     URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
     FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy, alluxioURI,
-        OpenFlags.O_RDWR.intValue(), MODE, uriStatus).close();
+        OpenFlags.O_RDWR.intValue(), MODE, Optional.of(uriStatus)).close();
     URIStatus status = mFileSystem.getStatus(alluxioURI);
     Assert.assertNotNull(status);
     Assert.assertTrue(status.isCompleted());
@@ -66,7 +67,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
     FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy, alluxioURI,
         OpenFlags.O_RDWR.intValue() | OpenFlags.O_TRUNC.intValue(),
-        MODE, uriStatus).close();
+        MODE, Optional.of(uriStatus)).close();
     URIStatus status = mFileSystem.getStatus(alluxioURI);
     Assert.assertNotNull(status);
     Assert.assertTrue(status.isCompleted());
@@ -82,7 +83,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
     try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
         alluxioURI, OpenFlags.O_RDWR.intValue() | OpenFlags.O_TRUNC.intValue(),
-        MODE, uriStatus)) {
+        MODE, Optional.of(uriStatus))) {
       ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN);
       stream.read(buffer, DEFAULT_FILE_LEN, 0);
     }
@@ -98,7 +99,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     int newFileLength = 30;
     try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
         alluxioURI, OpenFlags.O_RDWR.intValue() | OpenFlags.O_TRUNC.intValue(),
-        MODE, uriStatus)) {
+        MODE, Optional.of(uriStatus))) {
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(0, newFileLength);
       stream.write(buffer, newFileLength, 0);
     }
@@ -115,7 +116,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     int newFileLength = 45;
     try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
         alluxioURI, OpenFlags.O_RDWR.intValue(),
-        MODE, uriStatus)) {
+        MODE, Optional.of(uriStatus))) {
       Assert.assertEquals(DEFAULT_FILE_LEN, stream.getFileLength());
       stream.truncate(0);
       Assert.assertEquals(0, stream.getFileLength());
@@ -132,7 +133,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
     URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
     try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, uriStatus)) {
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, Optional.of(uriStatus))) {
       Assert.assertEquals(uriStatus.getLength(), stream.getFileLength());
       ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN);
       Assert.assertEquals(DEFAULT_FILE_LEN, stream.read(buffer, DEFAULT_FILE_LEN, 0));
@@ -147,7 +148,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
     URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
     try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, uriStatus)) {
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, Optional.of(uriStatus))) {
       ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN / 2);
       Assert.assertEquals(DEFAULT_FILE_LEN / 2,
           stream.read(buffer, DEFAULT_FILE_LEN / 2, DEFAULT_FILE_LEN / 3));
@@ -162,7 +163,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     mFileSystem.createDirectory(alluxioURI.getParent(),
         CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, null)) {
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, Optional.empty())) {
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
       stream.write(buffer, DEFAULT_FILE_LEN, 0);
       Assert.assertEquals(DEFAULT_FILE_LEN, stream.getFileLength());
@@ -179,7 +180,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     mFileSystem.createDirectory(alluxioURI.getParent(),
         CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, null)) {
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, Optional.empty())) {
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
       stream.write(buffer, DEFAULT_FILE_LEN, 0);
       Assert.assertEquals(DEFAULT_FILE_LEN, stream.getFileLength());
@@ -200,7 +201,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     mFileSystem.createDirectory(alluxioURI.getParent(),
         CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, null)) {
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, Optional.empty())) {
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
       stream.write(buffer, DEFAULT_FILE_LEN, 15);
     }
@@ -212,7 +213,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
     URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
     try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, uriStatus)) {
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, Optional.of(uriStatus))) {
       ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN);
       Assert.assertEquals(DEFAULT_FILE_LEN, stream.read(buffer, DEFAULT_FILE_LEN, 0));
       stream.write(buffer, DEFAULT_FILE_LEN, 0);
@@ -225,7 +226,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     mFileSystem.createDirectory(alluxioURI.getParent(),
         CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, null)) {
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, Optional.empty())) {
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
       stream.write(buffer, DEFAULT_FILE_LEN, 0);
       stream.read(buffer, DEFAULT_FILE_LEN, 0);
@@ -238,7 +239,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
     URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
     try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, uriStatus)) {
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, Optional.of(uriStatus))) {
       ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN);
       Assert.assertEquals(DEFAULT_FILE_LEN, stream.read(buffer, DEFAULT_FILE_LEN, 0));
       stream.truncate(0);
@@ -251,7 +252,7 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
     mFileSystem.createDirectory(alluxioURI.getParent(),
         CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, null)) {
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, Optional.empty())) {
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
       stream.write(buffer, DEFAULT_FILE_LEN, 0);
       Assert.assertEquals(DEFAULT_FILE_LEN, stream.getFileLength());

--- a/tests/src/test/java/alluxio/client/fuse/file/FuseFileInOrOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/FuseFileInOrOutStreamIntegrationTest.java
@@ -1,0 +1,261 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.fuse.file;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.URIStatus;
+import alluxio.fuse.file.FuseFileInOrOutStream;
+import alluxio.grpc.CreateDirectoryPOptions;
+import alluxio.util.io.BufferUtils;
+import alluxio.util.io.PathUtils;
+
+import jnr.constants.platform.OpenFlags;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Integration test for {@link alluxio.fuse.file.FuseFileInOrOutStream}.
+ */
+public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStreamIntegrationTest {
+
+  @Test
+  public void createNonexistingClose() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy, alluxioURI,
+        OpenFlags.O_RDWR.intValue(), MODE, null).close();
+    URIStatus status = mFileSystem.getStatus(alluxioURI);
+    Assert.assertNotNull(status);
+    Assert.assertTrue(status.isCompleted());
+    Assert.assertEquals(0, status.getLength());
+  }
+
+  @Test
+  public void createExistingClose() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy, alluxioURI,
+        OpenFlags.O_RDWR.intValue(), MODE, uriStatus).close();
+    URIStatus status = mFileSystem.getStatus(alluxioURI);
+    Assert.assertNotNull(status);
+    Assert.assertTrue(status.isCompleted());
+    Assert.assertEquals(15, status.getLength());
+  }
+
+  @Test
+  public void createTruncateFlagClose() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy, alluxioURI,
+        OpenFlags.O_RDWR.intValue() | OpenFlags.O_TRUNC.intValue(),
+        MODE, uriStatus).close();
+    URIStatus status = mFileSystem.getStatus(alluxioURI);
+    Assert.assertNotNull(status);
+    Assert.assertTrue(status.isCompleted());
+    Assert.assertEquals(0, status.getLength());
+  }
+
+  @Test (expected = UnsupportedOperationException.class)
+  public void createTruncateFlagRead() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_RDWR.intValue() | OpenFlags.O_TRUNC.intValue(),
+        MODE, uriStatus)) {
+      ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN);
+      stream.read(buffer, DEFAULT_FILE_LEN, 0);
+    }
+  }
+
+  @Test
+  public void createTruncateFlagWrite() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    int newFileLength = 30;
+    try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_RDWR.intValue() | OpenFlags.O_TRUNC.intValue(),
+        MODE, uriStatus)) {
+      ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(0, newFileLength);
+      stream.write(buffer, newFileLength, 0);
+    }
+    checkFileInAlluxio(alluxioURI, newFileLength, 0);
+  }
+
+  @Test
+  public void createTruncateZeroWrite() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    int newFileLength = 45;
+    try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_RDWR.intValue(),
+        MODE, uriStatus)) {
+      Assert.assertEquals(DEFAULT_FILE_LEN, stream.getFileLength());
+      stream.truncate(0);
+      Assert.assertEquals(0, stream.getFileLength());
+      ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(0, newFileLength);
+      stream.write(buffer, newFileLength, 0);
+      Assert.assertEquals(newFileLength, stream.getFileLength());
+    }
+    checkFileInAlluxio(alluxioURI, newFileLength, 0);
+  }
+
+  @Test
+  public void sequentialRead() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, uriStatus)) {
+      Assert.assertEquals(uriStatus.getLength(), stream.getFileLength());
+      ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN);
+      Assert.assertEquals(DEFAULT_FILE_LEN, stream.read(buffer, DEFAULT_FILE_LEN, 0));
+      Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(0, DEFAULT_FILE_LEN, buffer));
+      Assert.assertEquals(uriStatus.getLength(), stream.getFileLength());
+    }
+  }
+
+  @Test
+  public void randomRead() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, uriStatus)) {
+      ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN / 2);
+      Assert.assertEquals(DEFAULT_FILE_LEN / 2,
+          stream.read(buffer, DEFAULT_FILE_LEN / 2, DEFAULT_FILE_LEN / 3));
+      Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(
+          DEFAULT_FILE_LEN / 3, DEFAULT_FILE_LEN / 2, buffer));
+    }
+  }
+
+  @Test
+  public void sequentialWrite() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, null)) {
+      ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
+      stream.write(buffer, DEFAULT_FILE_LEN, 0);
+      Assert.assertEquals(DEFAULT_FILE_LEN, stream.getFileLength());
+      buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN, DEFAULT_FILE_LEN);
+      stream.write(buffer, DEFAULT_FILE_LEN, DEFAULT_FILE_LEN);
+      Assert.assertEquals(DEFAULT_FILE_LEN * 2, stream.getFileLength());
+    }
+    checkFileInAlluxio(alluxioURI, DEFAULT_FILE_LEN * 2, 0);
+  }
+
+  @Test
+  public void truncateZeroOrDEFAULT_FILE_LENgth() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, null)) {
+      ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
+      stream.write(buffer, DEFAULT_FILE_LEN, 0);
+      Assert.assertEquals(DEFAULT_FILE_LEN, stream.getFileLength());
+      stream.truncate(0);
+      Assert.assertEquals(0, stream.getFileLength());
+      buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN * 2);
+      stream.write(buffer, DEFAULT_FILE_LEN * 2,  0);
+      Assert.assertEquals(DEFAULT_FILE_LEN * 2, stream.getFileLength());
+      stream.truncate(DEFAULT_FILE_LEN * 2);
+      Assert.assertEquals(DEFAULT_FILE_LEN * 2, stream.getFileLength());
+    }
+    checkFileInAlluxio(alluxioURI, DEFAULT_FILE_LEN * 2, 0);
+  }
+
+  @Test (expected = UnsupportedOperationException.class)
+  public void randomWrite() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, null)) {
+      ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
+      stream.write(buffer, DEFAULT_FILE_LEN, 15);
+    }
+  }
+
+  @Test (expected = UnsupportedOperationException.class)
+  public void readThenWrite() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, uriStatus)) {
+      ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN);
+      Assert.assertEquals(DEFAULT_FILE_LEN, stream.read(buffer, DEFAULT_FILE_LEN, 0));
+      stream.write(buffer, DEFAULT_FILE_LEN, 0);
+    }
+  }
+
+  @Test (expected = UnsupportedOperationException.class)
+  public void writeThenRead() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, null)) {
+      ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
+      stream.write(buffer, DEFAULT_FILE_LEN, 0);
+      stream.read(buffer, DEFAULT_FILE_LEN, 0);
+    }
+  }
+
+  @Test (expected = UnsupportedOperationException.class)
+  public void readTruncateZero() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, uriStatus)) {
+      ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN);
+      Assert.assertEquals(DEFAULT_FILE_LEN, stream.read(buffer, DEFAULT_FILE_LEN, 0));
+      stream.truncate(0);
+    }
+  }
+
+  @Test (expected = UnsupportedOperationException.class)
+  public void truncateMiddle() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_RDWR.intValue(), MODE, null)) {
+      ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
+      stream.write(buffer, DEFAULT_FILE_LEN, 0);
+      Assert.assertEquals(DEFAULT_FILE_LEN, stream.getFileLength());
+      stream.truncate(DEFAULT_FILE_LEN / 2);
+    }
+  }
+}

--- a/tests/src/test/java/alluxio/client/fuse/file/FuseFileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/FuseFileInStreamIntegrationTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Optional;
 
 /**
  * Integration test for {@link alluxio.fuse.file.FuseFileInStream}.
@@ -34,7 +35,7 @@ public class FuseFileInStreamIntegrationTest extends AbstractFuseFileStreamInteg
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
     URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
     try (FuseFileInStream inStream = FuseFileInStream.create(mFileSystem, alluxioURI,
-        OpenFlags.O_RDONLY.intValue(), uriStatus)) {
+        OpenFlags.O_RDONLY.intValue(), Optional.of(uriStatus))) {
       Assert.assertEquals(uriStatus.getLength(), inStream.getFileLength());
       ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN);
       Assert.assertEquals(DEFAULT_FILE_LEN, inStream.read(buffer, DEFAULT_FILE_LEN, 0));
@@ -46,7 +47,8 @@ public class FuseFileInStreamIntegrationTest extends AbstractFuseFileStreamInteg
   @Test (expected = IOException.class)
   public void createNonexisting() throws Exception {
     AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
-    FuseFileInStream.create(mFileSystem, alluxioURI, OpenFlags.O_RDONLY.intValue(), null);
+    FuseFileInStream.create(mFileSystem, alluxioURI,
+        OpenFlags.O_RDONLY.intValue(), Optional.empty());
   }
 
   @Test (expected = IOException.class)
@@ -55,7 +57,8 @@ public class FuseFileInStreamIntegrationTest extends AbstractFuseFileStreamInteg
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
     URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
     FuseFileInStream.create(mFileSystem, alluxioURI,
-        OpenFlags.O_RDONLY.intValue() | OpenFlags.O_TRUNC.intValue(), uriStatus);
+        OpenFlags.O_RDONLY.intValue() | OpenFlags.O_TRUNC.intValue(),
+        Optional.of(uriStatus));
   }
 
   @Test
@@ -64,7 +67,7 @@ public class FuseFileInStreamIntegrationTest extends AbstractFuseFileStreamInteg
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
     URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
     try (FuseFileInStream inStream = FuseFileInStream.create(mFileSystem, alluxioURI,
-        OpenFlags.O_RDONLY.intValue(), uriStatus)) {
+        OpenFlags.O_RDONLY.intValue(), Optional.of(uriStatus))) {
       ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN / 2);
       Assert.assertEquals(DEFAULT_FILE_LEN / 2,
           inStream.read(buffer, DEFAULT_FILE_LEN / 2, DEFAULT_FILE_LEN / 3));
@@ -79,7 +82,7 @@ public class FuseFileInStreamIntegrationTest extends AbstractFuseFileStreamInteg
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
     URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
     try (FuseFileInStream inStream = FuseFileInStream.create(mFileSystem, alluxioURI,
-        OpenFlags.O_RDONLY.intValue(), uriStatus)) {
+        OpenFlags.O_RDONLY.intValue(), Optional.of(uriStatus))) {
       ByteBuffer buffer = ByteBuffer.allocate(1);
       buffer.put((byte) 'a');
       inStream.write(buffer, 1, 0);
@@ -92,7 +95,7 @@ public class FuseFileInStreamIntegrationTest extends AbstractFuseFileStreamInteg
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
     URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
     try (FuseFileInStream inStream = FuseFileInStream.create(mFileSystem, alluxioURI,
-        OpenFlags.O_RDONLY.intValue(), uriStatus)) {
+        OpenFlags.O_RDONLY.intValue(), Optional.of(uriStatus))) {
       inStream.truncate(0);
     }
   }

--- a/tests/src/test/java/alluxio/client/fuse/file/FuseFileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/FuseFileInStreamIntegrationTest.java
@@ -1,0 +1,99 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.fuse.file;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.URIStatus;
+import alluxio.fuse.file.FuseFileInStream;
+import alluxio.util.io.BufferUtils;
+import alluxio.util.io.PathUtils;
+
+import jnr.constants.platform.OpenFlags;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Integration test for {@link alluxio.fuse.file.FuseFileInStream}.
+ */
+public class FuseFileInStreamIntegrationTest extends AbstractFuseFileStreamIntegrationTest {
+  @Test
+  public void createRead() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    try (FuseFileInStream inStream = FuseFileInStream.create(mFileSystem, alluxioURI,
+        OpenFlags.O_RDONLY.intValue(), uriStatus)) {
+      Assert.assertEquals(uriStatus.getLength(), inStream.getFileLength());
+      ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN);
+      Assert.assertEquals(DEFAULT_FILE_LEN, inStream.read(buffer, DEFAULT_FILE_LEN, 0));
+      Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(0, DEFAULT_FILE_LEN, buffer));
+      Assert.assertEquals(uriStatus.getLength(), inStream.getFileLength());
+    }
+  }
+
+  @Test (expected = IOException.class)
+  public void createNonexisting() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    FuseFileInStream.create(mFileSystem, alluxioURI, OpenFlags.O_RDONLY.intValue(), null);
+  }
+
+  @Test (expected = IOException.class)
+  public void createTruncate() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    FuseFileInStream.create(mFileSystem, alluxioURI,
+        OpenFlags.O_RDONLY.intValue() | OpenFlags.O_TRUNC.intValue(), uriStatus);
+  }
+
+  @Test
+  public void randomRead() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    try (FuseFileInStream inStream = FuseFileInStream.create(mFileSystem, alluxioURI,
+        OpenFlags.O_RDONLY.intValue(), uriStatus)) {
+      ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN / 2);
+      Assert.assertEquals(DEFAULT_FILE_LEN / 2,
+          inStream.read(buffer, DEFAULT_FILE_LEN / 2, DEFAULT_FILE_LEN / 3));
+      Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(
+          DEFAULT_FILE_LEN / 3, DEFAULT_FILE_LEN / 2, buffer));
+    }
+  }
+
+  @Test (expected = UnsupportedOperationException.class)
+  public void write() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    try (FuseFileInStream inStream = FuseFileInStream.create(mFileSystem, alluxioURI,
+        OpenFlags.O_RDONLY.intValue(), uriStatus)) {
+      ByteBuffer buffer = ByteBuffer.allocate(1);
+      buffer.put((byte) 'a');
+      inStream.write(buffer, 1, 0);
+    }
+  }
+
+  @Test (expected = UnsupportedOperationException.class)
+  public void truncate() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    try (FuseFileInStream inStream = FuseFileInStream.create(mFileSystem, alluxioURI,
+        OpenFlags.O_RDONLY.intValue(), uriStatus)) {
+      inStream.truncate(0);
+    }
+  }
+}

--- a/tests/src/test/java/alluxio/client/fuse/file/FuseFileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/FuseFileInStreamIntegrationTest.java
@@ -21,7 +21,6 @@ import jnr.constants.platform.OpenFlags;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 
@@ -44,14 +43,14 @@ public class FuseFileInStreamIntegrationTest extends AbstractFuseFileStreamInteg
     }
   }
 
-  @Test (expected = IOException.class)
+  @Test (expected = UnsupportedOperationException.class)
   public void createNonexisting() throws Exception {
     AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
     FuseFileInStream.create(mFileSystem, alluxioURI,
         OpenFlags.O_RDONLY.intValue(), Optional.empty());
   }
 
-  @Test (expected = IOException.class)
+  @Test (expected = UnsupportedOperationException.class)
   public void createTruncate() throws Exception {
     AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);

--- a/tests/src/test/java/alluxio/client/fuse/file/FuseFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/FuseFileOutStreamIntegrationTest.java
@@ -22,7 +22,6 @@ import jnr.constants.platform.OpenFlags;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 
@@ -43,7 +42,7 @@ public class FuseFileOutStreamIntegrationTest extends AbstractFuseFileStreamInte
     Assert.assertEquals(0, status.getLength());
   }
 
-  @Test (expected = IOException.class)
+  @Test (expected = UnsupportedOperationException.class)
   public void createExisting() throws Exception {
     AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);

--- a/tests/src/test/java/alluxio/client/fuse/file/FuseFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/FuseFileOutStreamIntegrationTest.java
@@ -1,0 +1,164 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.fuse.file;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.URIStatus;
+import alluxio.fuse.file.FuseFileOutStream;
+import alluxio.grpc.CreateDirectoryPOptions;
+import alluxio.util.io.BufferUtils;
+import alluxio.util.io.PathUtils;
+
+import jnr.constants.platform.OpenFlags;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Integration test for {@link alluxio.fuse.file.FuseFileOutStream}.
+ */
+public class FuseFileOutStreamIntegrationTest extends AbstractFuseFileStreamIntegrationTest {
+  @Test
+  public void createEmpty() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    FuseFileOutStream.create(mFileSystem, mAuthPolicy, alluxioURI,
+        OpenFlags.O_WRONLY.intValue(), MODE, null).close();
+    URIStatus status = mFileSystem.getStatus(alluxioURI);
+    Assert.assertNotNull(status);
+    Assert.assertTrue(status.isCompleted());
+    Assert.assertEquals(0, status.getLength());
+  }
+
+  @Test (expected = IOException.class)
+  public void createExisting() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    try (FuseFileOutStream outStream = FuseFileOutStream
+        .create(mFileSystem, mAuthPolicy, alluxioURI,
+        OpenFlags.O_WRONLY.intValue(), MODE, uriStatus)) {
+      ByteBuffer buffer = ByteBuffer.allocate(1);
+      buffer.put((byte) 'a');
+      outStream.write(buffer, 1, 0);
+    }
+  }
+
+  @Test
+  public void createTruncateFlag() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    int newLen = 30;
+    int newStartValue = 15;
+    try (FuseFileOutStream outStream = FuseFileOutStream
+        .create(mFileSystem, mAuthPolicy, alluxioURI,
+        OpenFlags.O_WRONLY.intValue() | OpenFlags.O_TRUNC.intValue(), MODE, uriStatus)) {
+      ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(newStartValue, newLen);
+      outStream.write(buffer, newLen, 0);
+    }
+    checkFileInAlluxio(alluxioURI, newLen, newStartValue);
+  }
+
+  @Test
+  public void createTruncateZeroWrite() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    int newLen = 30;
+    int newStartValue = 15;
+    try (FuseFileOutStream outStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, uriStatus)) {
+      outStream.truncate(0);
+      ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(newStartValue, newLen);
+      outStream.write(buffer, newLen, 0);
+    }
+    checkFileInAlluxio(alluxioURI, newLen, newStartValue);
+  }
+
+  @Test (expected = UnsupportedOperationException.class)
+  public void read() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    try (FuseFileOutStream outStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, uriStatus)) {
+      ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN);
+      outStream.read(buffer, DEFAULT_FILE_LEN, 0);
+    }
+  }
+
+  @Test (expected = UnsupportedOperationException.class)
+  public void randomWrite() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    try (FuseFileOutStream outStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, null)) {
+      ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
+      outStream.write(buffer, DEFAULT_FILE_LEN, 15);
+    }
+  }
+
+  @Test
+  public void sequentialWriteAndgetFileLength() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    try (FuseFileOutStream outStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, null)) {
+      ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
+      outStream.write(buffer, DEFAULT_FILE_LEN, 0);
+      Assert.assertEquals(DEFAULT_FILE_LEN, outStream.getFileLength());
+      buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN, DEFAULT_FILE_LEN);
+      outStream.write(buffer, DEFAULT_FILE_LEN, DEFAULT_FILE_LEN);
+      Assert.assertEquals(DEFAULT_FILE_LEN * 2, outStream.getFileLength());
+    }
+    checkFileInAlluxio(alluxioURI, DEFAULT_FILE_LEN * 2, 0);
+  }
+
+  @Test
+  public void truncateZeroOrDEFAULT_FILE_LENgth() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    try (FuseFileOutStream outStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, null)) {
+      ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
+      outStream.write(buffer, DEFAULT_FILE_LEN, 0);
+      Assert.assertEquals(DEFAULT_FILE_LEN, outStream.getFileLength());
+      outStream.truncate(0);
+      Assert.assertEquals(0, outStream.getFileLength());
+      buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN * 2);
+      outStream.write(buffer, DEFAULT_FILE_LEN * 2,  0);
+      Assert.assertEquals(DEFAULT_FILE_LEN * 2, outStream.getFileLength());
+      outStream.truncate(DEFAULT_FILE_LEN * 2);
+      Assert.assertEquals(DEFAULT_FILE_LEN * 2, outStream.getFileLength());
+    }
+    checkFileInAlluxio(alluxioURI, DEFAULT_FILE_LEN * 2, 0);
+  }
+
+  @Test (expected = UnsupportedOperationException.class)
+  public void truncateMiddle() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    try (FuseFileOutStream outStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy,
+        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, null)) {
+      ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
+      outStream.write(buffer, DEFAULT_FILE_LEN, 0);
+      Assert.assertEquals(DEFAULT_FILE_LEN, outStream.getFileLength());
+      outStream.truncate(DEFAULT_FILE_LEN / 2);
+    }
+  }
+}

--- a/tests/src/test/java/alluxio/client/fuse/file/FuseFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/FuseFileOutStreamIntegrationTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Optional;
 
 /**
  * Integration test for {@link alluxio.fuse.file.FuseFileOutStream}.
@@ -35,7 +36,7 @@ public class FuseFileOutStreamIntegrationTest extends AbstractFuseFileStreamInte
     mFileSystem.createDirectory(alluxioURI.getParent(),
         CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     FuseFileOutStream.create(mFileSystem, mAuthPolicy, alluxioURI,
-        OpenFlags.O_WRONLY.intValue(), MODE, null).close();
+        OpenFlags.O_WRONLY.intValue(), MODE, Optional.empty()).close();
     URIStatus status = mFileSystem.getStatus(alluxioURI);
     Assert.assertNotNull(status);
     Assert.assertTrue(status.isCompleted());
@@ -49,7 +50,7 @@ public class FuseFileOutStreamIntegrationTest extends AbstractFuseFileStreamInte
     URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
     try (FuseFileOutStream outStream = FuseFileOutStream
         .create(mFileSystem, mAuthPolicy, alluxioURI,
-        OpenFlags.O_WRONLY.intValue(), MODE, uriStatus)) {
+        OpenFlags.O_WRONLY.intValue(), MODE, Optional.of(uriStatus))) {
       ByteBuffer buffer = ByteBuffer.allocate(1);
       buffer.put((byte) 'a');
       outStream.write(buffer, 1, 0);
@@ -65,7 +66,8 @@ public class FuseFileOutStreamIntegrationTest extends AbstractFuseFileStreamInte
     int newStartValue = 15;
     try (FuseFileOutStream outStream = FuseFileOutStream
         .create(mFileSystem, mAuthPolicy, alluxioURI,
-        OpenFlags.O_WRONLY.intValue() | OpenFlags.O_TRUNC.intValue(), MODE, uriStatus)) {
+        OpenFlags.O_WRONLY.intValue() | OpenFlags.O_TRUNC.intValue(),
+            MODE, Optional.of(uriStatus))) {
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(newStartValue, newLen);
       outStream.write(buffer, newLen, 0);
     }
@@ -80,7 +82,7 @@ public class FuseFileOutStreamIntegrationTest extends AbstractFuseFileStreamInte
     int newLen = 30;
     int newStartValue = 15;
     try (FuseFileOutStream outStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, uriStatus)) {
+        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, Optional.of(uriStatus))) {
       outStream.truncate(0);
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(newStartValue, newLen);
       outStream.write(buffer, newLen, 0);
@@ -94,7 +96,7 @@ public class FuseFileOutStreamIntegrationTest extends AbstractFuseFileStreamInte
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
     URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
     try (FuseFileOutStream outStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, uriStatus)) {
+        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, Optional.of(uriStatus))) {
       ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN);
       outStream.read(buffer, DEFAULT_FILE_LEN, 0);
     }
@@ -106,7 +108,7 @@ public class FuseFileOutStreamIntegrationTest extends AbstractFuseFileStreamInte
     mFileSystem.createDirectory(alluxioURI.getParent(),
         CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     try (FuseFileOutStream outStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, null)) {
+        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, Optional.empty())) {
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
       outStream.write(buffer, DEFAULT_FILE_LEN, 15);
     }
@@ -118,7 +120,7 @@ public class FuseFileOutStreamIntegrationTest extends AbstractFuseFileStreamInte
     mFileSystem.createDirectory(alluxioURI.getParent(),
         CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     try (FuseFileOutStream outStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, null)) {
+        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, Optional.empty())) {
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
       outStream.write(buffer, DEFAULT_FILE_LEN, 0);
       Assert.assertEquals(DEFAULT_FILE_LEN, outStream.getFileLength());
@@ -135,7 +137,7 @@ public class FuseFileOutStreamIntegrationTest extends AbstractFuseFileStreamInte
     mFileSystem.createDirectory(alluxioURI.getParent(),
         CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     try (FuseFileOutStream outStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, null)) {
+        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, Optional.empty())) {
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
       outStream.write(buffer, DEFAULT_FILE_LEN, 0);
       Assert.assertEquals(DEFAULT_FILE_LEN, outStream.getFileLength());
@@ -156,7 +158,7 @@ public class FuseFileOutStreamIntegrationTest extends AbstractFuseFileStreamInte
     mFileSystem.createDirectory(alluxioURI.getParent(),
         CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     try (FuseFileOutStream outStream = FuseFileOutStream.create(mFileSystem, mAuthPolicy,
-        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, null)) {
+        alluxioURI, OpenFlags.O_WRONLY.intValue(), MODE, Optional.empty())) {
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
       outStream.write(buffer, DEFAULT_FILE_LEN, 0);
       Assert.assertEquals(DEFAULT_FILE_LEN, outStream.getFileLength());

--- a/tests/src/test/java/alluxio/client/fuse/file/FuseFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/FuseFileOutStreamIntegrationTest.java
@@ -32,6 +32,8 @@ public class FuseFileOutStreamIntegrationTest extends AbstractFuseFileStreamInte
   @Test
   public void createEmpty() throws Exception {
     AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     FuseFileOutStream.create(mFileSystem, mAuthPolicy, alluxioURI,
         OpenFlags.O_WRONLY.intValue(), MODE, null).close();
     URIStatus status = mFileSystem.getStatus(alluxioURI);


### PR DESCRIPTION
### What changes are proposed in this pull request?
Refactor the Fuse in out streamS logic. 
Alluxio Fuse can open/create files in read/write/read_and_write mode, while Alluxio only supports read only or sequential write only workloads.
Added FuseInStream, FuseOutStream, FuseInOrOutStream to transfer Fuse stream logic into Alluxio stream logic.

### Why are the changes needed?

The original code is hard to understand, maintain, and extend.
In the new approach, different streams are isolated, it's easier to troubleshoot or add a new stream (e.g. InAndOutStream)

### Does this PR introduce any user facing changes?

NA
