### PR TITLE
Fix wrong pool when releasing BWC

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -542,20 +542,21 @@ public class FileSystemContext implements Closeable {
     SocketAddress address = NetworkAddressUtils
         .getDataPortSocketAddress(workerNetAddress, context.getClusterConf());
     GrpcServerAddress serverAddress = GrpcServerAddress.create(workerNetAddress.getHost(), address);
-    ClientPoolKey key = new ClientPoolKey(address, AuthenticationUtils
+    final ClientPoolKey key = new ClientPoolKey(address, AuthenticationUtils
             .getImpersonationUser(userState.getSubject(), context.getClusterConf()));
     final ConcurrentHashMap<ClientPoolKey, BlockWorkerClientPool> poolMap =
         mBlockWorkerClientPoolMap;
-    return new CloseableResource<BlockWorkerClient>(poolMap.computeIfAbsent(key,
+    BlockWorkerClientPool pool = poolMap.computeIfAbsent(
+        key,
         k -> new BlockWorkerClientPool(userState, serverAddress,
             context.getClusterConf().getInt(PropertyKey.USER_BLOCK_WORKER_CLIENT_POOL_MIN),
             context.getClusterConf().getInt(PropertyKey.USER_BLOCK_WORKER_CLIENT_POOL_MAX),
-            context.getClusterConf()))
-        .acquire()) {
-      // Save the reference to the original pool map.
+            context.getClusterConf())
+    );
+    return new CloseableResource<BlockWorkerClient>(pool.acquire()) {
       @Override
       public void closeResource() {
-        releaseBlockWorkerClient(workerNetAddress, get(), context, poolMap);
+        releaseBlockWorkerClient(get(), key, poolMap);
       }
     };
   }
@@ -563,19 +564,15 @@ public class FileSystemContext implements Closeable {
   /**
    * Releases a block worker client to the client pools.
    *
-   * @param workerNetAddress the address of the channel
    * @param client the client to release
+   * @param key the key in the map of the pool from which the client was acquired
+   * @param poolMap the client pool map
    */
-  private static void releaseBlockWorkerClient(WorkerNetAddress workerNetAddress,
-      BlockWorkerClient client, final ClientContext context, ConcurrentHashMap<ClientPoolKey,
-      BlockWorkerClientPool> poolMap) {
+  private static void releaseBlockWorkerClient(BlockWorkerClient client, final ClientPoolKey key,
+      ConcurrentHashMap<ClientPoolKey, BlockWorkerClientPool> poolMap) {
     if (client == null) {
       return;
     }
-    SocketAddress address = NetworkAddressUtils.getDataPortSocketAddress(workerNetAddress,
-        context.getClusterConf());
-    ClientPoolKey key = new ClientPoolKey(address, AuthenticationUtils.getImpersonationUser(
-        context.getSubject(), context.getClusterConf()));
     if (poolMap.containsKey(key)) {
       poolMap.get(key).release(client);
     } else {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix `IllegalArgumentException` when releasing a block worker client because it was released to the wrong pool.

### Why are the changes needed?

Fix #15556.

On the creation of the block worker and its release, the key used to retrieve the pool from the map are computed separately, and its ingredients could have changed in between. Therefore, when releasing the client, the wrong pool may be retrieved. This can be due to a number of reasons, for example the Alluxio configuration has changed during this time, and the client picks up new conf via client master config sync.

The fix is to embed the key inside the closable resource to avoid computing it a second time.

### Does this PR introduce any user facing changes?

No.