### PR TITLE
Fix wrong abs method in ExponentialBackoffRetry

### DIFF
--- a/core/common/src/main/java/alluxio/retry/ExponentialBackoffRetry.java
+++ b/core/common/src/main/java/alluxio/retry/ExponentialBackoffRetry.java
@@ -53,15 +53,7 @@ public class ExponentialBackoffRetry extends SleepingRetry {
       // use randomness to avoid contention between many operations using the same retry policy
       int sleepMs =
           mBaseSleepTimeMs * (ThreadLocalRandom.current().nextInt(1 << count, 1 << (count + 1)));
-      return Math.min(abs(sleepMs, mMaxSleepMs), mMaxSleepMs);
+      return Math.min(Math.abs(sleepMs), mMaxSleepMs);
     }
-  }
-
-  private static int abs(int value, int defaultValue) {
-    int result = Math.abs(value);
-    if (result == Integer.MIN_VALUE) {
-      result = defaultValue;
-    }
-    return result;
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix wrong abs method in `ExponentialBackoffRetry`.

### Why are the changes needed?

In the current implementation, the value of the `sleepMs` variable is
almost impossible to be `Integer.MIN_VALUE`, because the value of
`mBaseSleepTimeMs` is 50 or 100, neither is a power of 2.

As can be seen from the name of this method (`"abs"`), its function
is mainly to prevent negative numbers from appearing during overflow,
so it is OK to use `Math.abs()` directly.

### Does this PR introduce any user facing changes?
No
