### PR TITLE
Fix local variable names starting with "m"

### DIFF
--- a/build/checkstyle/alluxio_checks.xml
+++ b/build/checkstyle/alluxio_checks.xml
@@ -162,7 +162,7 @@
     </module>
     <module name="LocalVariableName">
       <property name="tokens" value="VARIABLE_DEF"/>
-      <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+      <property name="format" value="^[a-ln-z][a-zA-Z0-9]*$|^m([a-z0-9][a-zA-Z0-9]*)?$"/>
       <property name="allowOneCharVarInForLoop" value="true"/>
       <message key="name.invalidPattern"
                value="Local variable name ''{0}'' must match pattern ''{1}''."/>

--- a/core/client/fs/src/main/java/alluxio/client/block/policy/LocalFirstAvoidEvictionPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/LocalFirstAvoidEvictionPolicy.java
@@ -97,9 +97,9 @@ public final class LocalFirstAvoidEvictionPolicy implements BlockLocationPolicy 
    * @return the available bytes of the worker
    */
   private long getAvailableBytes(BlockWorkerInfo workerInfo) {
-    long mCapacityBytes = workerInfo.getCapacityBytes();
-    long mUsedBytes = workerInfo.getUsedBytes();
-    return mCapacityBytes - mUsedBytes - mBlockCapacityReserved;
+    long capacityBytes = workerInfo.getCapacityBytes();
+    long usedBytes = workerInfo.getUsedBytes();
+    return capacityBytes - usedBytes - mBlockCapacityReserved;
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/MemoryPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/MemoryPageStore.java
@@ -22,11 +22,11 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * The {@link MemoryPageStore} is an implementation of {@link PageStore} which
@@ -55,9 +55,9 @@ public class MemoryPageStore implements PageStore {
   public void put(PageId pageId, byte[] page) throws ResourceExhaustedException, IOException {
     PageId pageKey = getKeyFromPageId(pageId);
     try {
-      byte[] mPage = new byte[page.length];
-      System.arraycopy(page, 0, mPage, 0, page.length);
-      mPageStoreMap.put(pageKey, mPage);
+      byte[] pageCopy = new byte[page.length];
+      System.arraycopy(page, 0, pageCopy, 0, page.length);
+      mPageStoreMap.put(pageKey, pageCopy);
     } catch (Exception e) {
       throw new IOException("Failed to put cached data in memory for page " + pageId);
     }
@@ -75,12 +75,12 @@ public class MemoryPageStore implements PageStore {
     if (!mPageStoreMap.containsKey(pageKey)) {
       throw new PageNotFoundException(pageId.getFileId() + "_" + pageId.getPageIndex());
     }
-    byte[] mPage = mPageStoreMap.get(pageKey);
-    Preconditions.checkArgument(pageOffset <= mPage.length, "page offset %s exceeded page size %s",
-        pageOffset, mPage.length);
-    int bytesLeft = (int) Math.min(mPage.length - pageOffset, buffer.length - bufferOffset);
+    byte[] page = mPageStoreMap.get(pageKey);
+    Preconditions.checkArgument(pageOffset <= page.length, "page offset %s exceeded page size %s",
+        pageOffset, page.length);
+    int bytesLeft = (int) Math.min(page.length - pageOffset, buffer.length - bufferOffset);
     bytesLeft = Math.min(bytesLeft, bytesToRead);
-    System.arraycopy(mPage, pageOffset, buffer, bufferOffset, bytesLeft);
+    System.arraycopy(page, pageOffset, buffer, bufferOffset, bytesLeft);
     return bytesLeft;
   }
 

--- a/core/server/master/src/test/java/alluxio/master/block/SignalBlockMaster.java
+++ b/core/server/master/src/test/java/alluxio/master/block/SignalBlockMaster.java
@@ -36,10 +36,10 @@ class SignalBlockMaster extends DefaultBlockMaster {
 
   SignalBlockMaster(MetricsMaster mMetricsMaster,
                     CoreMasterContext masterContext,
-                    ManualClock mClock,
+                    ManualClock clock,
                     ExecutorServiceFactory constantExecutorServiceFactory,
                     CountDownLatch targetLatch) {
-    super(mMetricsMaster, masterContext, mClock, constantExecutorServiceFactory);
+    super(mMetricsMaster, masterContext, clock, constantExecutorServiceFactory);
     mLatch = targetLatch;
   }
 

--- a/core/server/master/src/test/java/alluxio/master/file/meta/TtlBucketTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/TtlBucketTest.java
@@ -72,26 +72,26 @@ public class TtlBucketTest {
    */
   @Test
   public void addAndRemoveInodeFile() {
-    Inode mFileTtl1 = TtlTestUtils.createFileWithIdAndTtl(0, 1);
-    Inode mFileTtl2 = TtlTestUtils.createFileWithIdAndTtl(1, 2);
+    Inode fileTtl1 = TtlTestUtils.createFileWithIdAndTtl(0, 1);
+    Inode fileTtl2 = TtlTestUtils.createFileWithIdAndTtl(1, 2);
     Assert.assertTrue(mBucket.getInodes().isEmpty());
 
-    mBucket.addInode(mFileTtl1);
+    mBucket.addInode(fileTtl1);
     Assert.assertEquals(1, mBucket.getInodes().size());
 
     // The same file, won't be added.
-    mBucket.addInode(mFileTtl1);
+    mBucket.addInode(fileTtl1);
     Assert.assertEquals(1, mBucket.getInodes().size());
 
     // Different file, will be added.
-    mBucket.addInode(mFileTtl2);
+    mBucket.addInode(fileTtl2);
     Assert.assertEquals(2, mBucket.getInodes().size());
 
     // Remove files;
-    mBucket.removeInode(mFileTtl1);
+    mBucket.removeInode(fileTtl1);
     Assert.assertEquals(1, mBucket.getInodes().size());
-    Assert.assertTrue(mBucket.getInodes().contains(mFileTtl2));
-    mBucket.removeInode(mFileTtl2);
+    Assert.assertTrue(mBucket.getInodes().contains(fileTtl2));
+    mBucket.removeInode(fileTtl2);
     Assert.assertEquals(0, mBucket.getInodes().size());
   }
 
@@ -101,26 +101,26 @@ public class TtlBucketTest {
    */
   @Test
   public void addAndRemoveInodeDirectory() {
-    Inode mDirectoryTtl1 = TtlTestUtils.createDirectoryWithIdAndTtl(0, 1);
-    Inode mDirectoryTtl2 = TtlTestUtils.createDirectoryWithIdAndTtl(1, 2);
+    Inode directoryTtl1 = TtlTestUtils.createDirectoryWithIdAndTtl(0, 1);
+    Inode directoryTtl2 = TtlTestUtils.createDirectoryWithIdAndTtl(1, 2);
     Assert.assertTrue(mBucket.getInodes().isEmpty());
 
-    mBucket.addInode(mDirectoryTtl1);
+    mBucket.addInode(directoryTtl1);
     Assert.assertEquals(1, mBucket.getInodes().size());
 
     // The same directory, won't be added.
-    mBucket.addInode(mDirectoryTtl1);
+    mBucket.addInode(directoryTtl1);
     Assert.assertEquals(1, mBucket.getInodes().size());
 
     // Different directory, will be added.
-    mBucket.addInode(mDirectoryTtl2);
+    mBucket.addInode(directoryTtl2);
     Assert.assertEquals(2, mBucket.getInodes().size());
 
     // Remove directorys;
-    mBucket.removeInode(mDirectoryTtl1);
+    mBucket.removeInode(directoryTtl1);
     Assert.assertEquals(1, mBucket.getInodes().size());
-    Assert.assertTrue(mBucket.getInodes().contains(mDirectoryTtl2));
-    mBucket.removeInode(mDirectoryTtl2);
+    Assert.assertTrue(mBucket.getInodes().contains(directoryTtl2));
+    mBucket.removeInode(directoryTtl2);
     Assert.assertEquals(0, mBucket.getInodes().size());
   }
 

--- a/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalLogWriterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalLogWriterTest.java
@@ -457,9 +457,9 @@ public final class UfsJournalLogWriterTest {
    */
   private void flushOutputStream(UfsJournalLogWriter writer) throws IOException {
     Object journalOutputStream = writer.getJournalOutputStream();
-    DataOutputStream mOutputStream =
+    DataOutputStream outputStream =
         Whitebox.getInternalState(journalOutputStream, "mOutputStream");
-    mOutputStream.flush();
+    outputStream.flush();
   }
 
   /**

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -170,8 +170,8 @@ public class ListBucketResult {
       return;
     }
     // contains both ends of "/" character
-    final String mBucketPrefix = AlluxioURI.SEPARATOR + mName + AlluxioURI.SEPARATOR;
-    buildListBucketResult(mBucketPrefix, children);
+    final String bucketPrefix = AlluxioURI.SEPARATOR + mName + AlluxioURI.SEPARATOR;
+    buildListBucketResult(bucketPrefix, children);
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
@@ -273,8 +273,8 @@ public final class UnderFileSystemBlockStore implements SessionCleanable {
   public boolean isNoCache(long sessionId, long blockId) {
     Key key = new Key(sessionId, blockId);
     BlockInfo blockInfo = mBlocks.get(key);
-    UnderFileSystemBlockMeta mMeta = blockInfo.getMeta();
-    return mMeta.isNoCache();
+    UnderFileSystemBlockMeta meta = blockInfo.getMeta();
+    return meta.isNoCache();
   }
 
   /**

--- a/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/DropAllCommand.java
+++ b/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/DropAllCommand.java
@@ -46,8 +46,8 @@ public final class DropAllCommand extends AbstractMetadataCacheSubCommand {
 
   @Override
   protected URIStatus runSubCommand(AlluxioURI path, String [] argv,
-      MetadataCachingBaseFileSystem mFileSystem) {
-    mFileSystem.dropMetadataCacheAll();
+      MetadataCachingBaseFileSystem fileSystem) {
+    fileSystem.dropMetadataCacheAll();
     return new URIStatus(new FileInfo().setCompleted(true));
   }
 

--- a/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/DropCommand.java
+++ b/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/DropCommand.java
@@ -47,8 +47,8 @@ public final class DropCommand extends AbstractMetadataCacheSubCommand {
 
   @Override
   protected URIStatus runSubCommand(AlluxioURI path, String [] argv,
-      MetadataCachingBaseFileSystem mFileSystem) {
-    mFileSystem.dropMetadataCache(path);
+      MetadataCachingBaseFileSystem fileSystem) {
+    fileSystem.dropMetadataCache(path);
     return new URIStatus(new FileInfo().setCompleted(true));
   }
 

--- a/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/SizeCommand.java
+++ b/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/SizeCommand.java
@@ -46,9 +46,9 @@ public final class SizeCommand extends AbstractMetadataCacheSubCommand {
 
   @Override
   protected URIStatus runSubCommand(AlluxioURI path, String [] argv,
-      MetadataCachingBaseFileSystem mFileSystem) {
+      MetadataCachingBaseFileSystem fileSystem) {
     // The 'ls -l' command will show metadata cache size in the <filesize> field.
-    long size = mFileSystem.getMetadataCacheSize();
+    long size = fileSystem.getMetadataCacheSize();
     return new URIStatus(new FileInfo().setLength(size).setCompleted(true));
   }
 

--- a/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
+++ b/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
@@ -79,9 +79,9 @@ public final class JobMasterTest {
     // Can't use ConfigurationRule due to conflicts with PowerMock.
     ServerConfiguration.set(PropertyKey.JOB_MASTER_JOB_CAPACITY, TEST_JOB_MASTER_JOB_CAPACITY);
     mockStatic(FileSystem.Factory.class);
-    FileSystem mFs = mock(FileSystem.class);
+    FileSystem fs = mock(FileSystem.class);
     when(FileSystem.Factory.create(any(FileSystemContext.class)))
-            .thenReturn(mFs);
+            .thenReturn(fs);
     mJobMaster = new JobMaster(new MasterContext<>(new NoopJournalSystem(), new NoopUfsManager()),
         mock(FileSystem.class), mock(FileSystemContext.class), mock(UfsManager.class));
     mJobMaster.start(true);

--- a/shell/src/main/java/alluxio/cli/fsadmin/report/UfsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/report/UfsCommand.java
@@ -53,7 +53,7 @@ public class UfsCommand {
    */
   public static void printMountInfo(Map<String, MountPointInfo> mountTable) {
     for (Map.Entry<String, MountPointInfo> entry : mountTable.entrySet()) {
-      String mMountPoint = entry.getKey();
+      String mountPoint = entry.getKey();
       MountPointInfo mountPointInfo = entry.getValue();
 
       long capacityBytes = mountPointInfo.getUfsCapacityBytes();
@@ -67,7 +67,7 @@ public class UfsCommand {
 
       String leftAlignFormat = getAlignFormat(mountTable);
 
-      System.out.format(leftAlignFormat, mountPointInfo.getUfsUri(), mMountPoint,
+      System.out.format(leftAlignFormat, mountPointInfo.getUfsUri(), mountPoint,
           mountPointInfo.getUfsType(), FormatUtils.getSizeFromBytes(capacityBytes),
           FormatUtils.getSizeFromBytes(usedBytes) + usedPercentageInfo,
           mountPointInfo.getReadOnly() ? "" : "not ",

--- a/tests/src/test/java/alluxio/client/fs/BlockWorkerRegisterStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/BlockWorkerRegisterStreamIntegrationTest.java
@@ -175,13 +175,13 @@ public class BlockWorkerRegisterStreamIntegrationTest {
     mBlockMasterClientPool = spy(new BlockMasterClientPool());
     when(mBlockMasterClientPool.createNewResource()).thenReturn(mBlockMasterClient);
     when(mBlockMasterClientPool.acquire()).thenReturn(mBlockMasterClient);
-    TieredBlockStore mBlockStore = spy(new TieredBlockStore());
-    FileSystemMasterClient mFileSystemMasterClient = mock(FileSystemMasterClient.class);
-    Sessions mSessions = mock(Sessions.class);
-    UfsManager mUfsManager = mock(UfsManager.class);
+    TieredBlockStore blockStore = spy(new TieredBlockStore());
+    FileSystemMasterClient fileSystemMasterClient = mock(FileSystemMasterClient.class);
+    Sessions sessions = mock(Sessions.class);
+    UfsManager ufsManager = mock(UfsManager.class);
 
-    mBlockWorker = new DefaultBlockWorker(mBlockMasterClientPool, mFileSystemMasterClient,
-            mSessions, mBlockStore, mUfsManager);
+    mBlockWorker = new DefaultBlockWorker(mBlockMasterClientPool, fileSystemMasterClient,
+            sessions, blockStore, ufsManager);
   }
 
   /**

--- a/tests/src/test/java/alluxio/server/ft/journal/TableMasterJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/TableMasterJournalIntegrationTest.java
@@ -86,9 +86,9 @@ public class TableMasterJournalIntegrationTest {
 
   @Test
   public void journalSync() throws Exception {
-    LocalAlluxioCluster mCluster = sClusterResource.get();
+    LocalAlluxioCluster cluster = sClusterResource.get();
     TableMaster tableMaster =
-        mCluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
+        cluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
     genTable(1, 2, true);
     tableMaster
         .attachDatabase(TestUdbFactory.TYPE, "connect", DB_NAME, DB_NAME, Collections.emptyMap(),
@@ -118,7 +118,7 @@ public class TableMasterJournalIntegrationTest {
     restartMaster();
 
     TableMaster tableMasterRestart =
-        mCluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
+        cluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
     TestDatabase.sTestDbInfo = newInfo;
     checkDb(tableMasterRestart, DB_NAME, oldInfo);
     tableMasterRestart.syncDatabase(DB_NAME);
@@ -148,9 +148,9 @@ public class TableMasterJournalIntegrationTest {
 
   @Test
   public void journalAttachDb() throws Exception {
-    LocalAlluxioCluster mCluster = sClusterResource.get();
+    LocalAlluxioCluster cluster = sClusterResource.get();
     TableMaster tableMaster =
-        mCluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
+        cluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
     try {
       tableMaster.getDatabase(DB_NAME);
       fail();
@@ -170,7 +170,7 @@ public class TableMasterJournalIntegrationTest {
     // Update Udb, the table should stay the same, until we detach / reattach
     genTable(2, 2, true);
     TableMaster tableMasterRestart =
-        mCluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
+        cluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
     List<String> newTableNames = tableMaster.getAllTables(DB_NAME);
     assertEquals(oldTableNames, newTableNames);
     Table tableNew = tableMasterRestart.getTable(DB_NAME, newTableNames.get(0));
@@ -179,9 +179,9 @@ public class TableMasterJournalIntegrationTest {
 
   @Test
   public void journalDetachDb() throws Exception {
-    LocalAlluxioCluster mCluster = sClusterResource.get();
+    LocalAlluxioCluster cluster = sClusterResource.get();
     TableMaster tableMaster =
-        mCluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
+        cluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
     genTable(1, 2, true);
     tableMaster
         .attachDatabase(TestUdbFactory.TYPE, "connect", DB_NAME, DB_NAME, Collections.emptyMap(),
@@ -193,15 +193,15 @@ public class TableMasterJournalIntegrationTest {
     restartMaster();
 
     TableMaster tableMasterRestart =
-        mCluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
+        cluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
     assertTrue(tableMasterRestart.getAllDatabases().isEmpty());
   }
 
   @Test
   public void journalTransformDb() throws Exception {
-    LocalAlluxioCluster mCluster = sClusterResource.get();
+    LocalAlluxioCluster cluster = sClusterResource.get();
     TableMaster tableMaster =
-        mCluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
+        cluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
     LocalAlluxioJobCluster jobCluster = new LocalAlluxioJobCluster();
     jobCluster.start();
     JobMaster jobMaster = jobCluster.getMaster().getJobMaster();
@@ -232,7 +232,7 @@ public class TableMasterJournalIntegrationTest {
 
     genTable(1, 4, true);
     TableMaster tableMasterRestart =
-        mCluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
+        cluster.getLocalAlluxioMaster().getMasterProcess().getMaster(TableMaster.class);
     Table table = tableMaster.getTable(DB_NAME, tableName);
     // all partitions remain transformed
     assertTrue(tableMaster.getTable(DB_NAME, tableName).getPartitions().stream().allMatch(
@@ -248,9 +248,9 @@ public class TableMasterJournalIntegrationTest {
    * Restarts the masters (without formatting) and waits for the workers to re-register.
    */
   private void restartMaster() throws Exception {
-    LocalAlluxioCluster mCluster = sClusterResource.get();
-    mCluster.stopMasters();
-    mCluster.startMasters();
-    mCluster.waitForWorkersRegistered(10 * Constants.SECOND_MS);
+    LocalAlluxioCluster cluster = sClusterResource.get();
+    cluster.stopMasters();
+    cluster.startMasters();
+    cluster.waitForWorkersRegistered(10 * Constants.SECOND_MS);
   }
 }

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemFactoryTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemFactoryTest.java
@@ -11,11 +11,11 @@
 
 package alluxio.underfs.s3a;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.AlluxioConfiguration;
@@ -47,14 +47,14 @@ public class S3AUnderFileSystemFactoryTest {
 
   @Test
   public void factory() {
-    UnderFileSystemFactory mFactory2 = UnderFileSystemFactoryRegistry.find(
+    UnderFileSystemFactory factory2 = UnderFileSystemFactoryRegistry.find(
         mS3Path, mAlluxioConf);
-    UnderFileSystemFactory mFactory3 = UnderFileSystemFactoryRegistry.find(
+    UnderFileSystemFactory factory3 = UnderFileSystemFactoryRegistry.find(
         mS3NPath, mAlluxioConf);
 
     assertNotNull(mFactory1);
-    assertNotNull(mFactory2);
-    assertNull(mFactory3);
+    assertNotNull(factory2);
+    assertNull(factory3);
   }
 
   @Test


### PR DESCRIPTION
Fix local variables whose names start with a "m", easy to be confused as a class field.

Update checkstyle rules to enforce this.

