### PR TITLE
[SMALLFIX] Add JVM argument to enable console logging on master

### DIFF
--- a/dev/intellij/runConfigurations/AlluxioMaster.xml
+++ b/dev/intellij/runConfigurations/AlluxioMaster.xml
@@ -15,7 +15,7 @@
     <option name="INCLUDE_PROVIDED_SCOPE" value="true" />
     <option name="MAIN_CLASS_NAME" value="alluxio.master.AlluxioMaster" />
     <module name="alluxio-core-server-master" />
-    <option name="VM_PARAMETERS" value="-Dalluxio.logger.type=Console -Dalluxio.home=$PROJECT_DIR$" />
+    <option name="VM_PARAMETERS" value="-Xbootclasspath/a:$PROJECT_DIR$/conf -Dalluxio.logger.type=Console -Dalluxio.home=$PROJECT_DIR$" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="alluxio.master.*" />


### PR DESCRIPTION
`AlluxioMaster.xml` is the only IntelliJ config file that is lacking the `-Xbootclasspath/a:$PROJECT_DIR$/conf` JVM parameter. Adding it ensures that the master logs to the console when launched.