### PR TITLE
Update go to version 1.18.1 and terraform to version 1.0.1

### DIFF
--- a/dev/jenkins/Dockerfile-jdk11
+++ b/dev/jenkins/Dockerfile-jdk11
@@ -16,7 +16,7 @@ FROM maven:3.6.3-jdk-11
 # reference: https://github.com/docker-library/openjdk/blob/master/8/jdk/buster/Dockerfile 
 # we need jdk 8 in jdk 11 so that we can compile with jdk 8 and test with jdk 11
 
-ENV JAVA_HOME /usr/local/openjdk-11
+ENV JAVA_HOME /usr/local/openjdk-8
 ENV PATH $JAVA_HOME/bin:$PATH
 
 # backwards compatibility shim

--- a/dev/jenkins/Dockerfile-jdk11
+++ b/dev/jenkins/Dockerfile-jdk11
@@ -16,7 +16,7 @@ FROM maven:3.6.3-jdk-11
 # reference: https://github.com/docker-library/openjdk/blob/master/8/jdk/buster/Dockerfile 
 # we need jdk 8 in jdk 11 so that we can compile with jdk 8 and test with jdk 11
 
-ENV JAVA_HOME /usr/local/openjdk-8
+ENV JAVA_HOME /usr/local/openjdk-11
 ENV PATH $JAVA_HOME/bin:$PATH
 
 # backwards compatibility shim
@@ -109,12 +109,12 @@ RUN mkdir -p /home/jenkins && \
 # jekyll for documentation
 RUN gem install jekyll bundler
 # golang for tooling
-RUN wget https://dl.google.com/go/go1.12.linux-amd64.tar.gz && \
-    tar -xvf go1.12.linux-amd64.tar.gz && \
+RUN wget https://dl.google.com/go/go1.18.1.linux-amd64.tar.gz && \
+    tar -xvf go1.18.1.linux-amd64.tar.gz && \
     mv go /usr/local
 ENV GOROOT=/usr/local/go
 ENV PATH=$GOROOT/bin:$PATH
 # terraform for deployment scripts
-RUN wget --quiet https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_linux_amd64.zip && \
-    unzip -o ./terraform_0.12.24_linux_amd64.zip -d /usr/local/bin/ && \
-    rm terraform_0.12.24_linux_amd64.zip
+RUN wget --quiet https://releases.hashicorp.com/terraform/1.0.1/terraform_1.0.1_linux_amd64.zip && \
+    unzip -o ./terraform_1.0.1_linux_amd64.zip -d /usr/local/bin/ && \
+    rm terraform_1.0.1_linux_amd64.zip

--- a/dev/jenkins/Dockerfile-jdk8
+++ b/dev/jenkins/Dockerfile-jdk8
@@ -25,12 +25,12 @@ RUN mkdir -p /home/jenkins && \
 # jekyll for documentation
 RUN gem install jekyll bundler
 # golang for tooling
-RUN wget https://dl.google.com/go/go1.12.linux-amd64.tar.gz && \
-    tar -xvf go1.12.linux-amd64.tar.gz && \
+RUN wget https://dl.google.com/go/go1.18.1.linux-amd64.tar.gz && \
+    tar -xvf go1.18.1.linux-amd64.tar.gz && \
     mv go /usr/local
 ENV GOROOT=/usr/local/go
 ENV PATH=$GOROOT/bin:$PATH
 # terraform for deployment scripts
-RUN wget --quiet https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_linux_amd64.zip && \
-    unzip -o ./terraform_0.12.24_linux_amd64.zip -d /usr/local/bin/ && \
-    rm terraform_0.12.24_linux_amd64.zip
+RUN wget --quiet https://releases.hashicorp.com/terraform/1.0.1/terraform_1.0.1_linux_amd64.zip && \
+    unzip -o ./terraform_1.0.1_linux_amd64.zip -d /usr/local/bin/ && \
+    rm terraform_1.0.1_linux_amd64.zip


### PR DESCRIPTION
### What changes are proposed in this pull request?

Upgrade docker images to use more recent go version 1.18.1 and terraform 1.0.1

### Why are the changes needed?

Needed to remain consistent with version standards for tooling

### Does this PR introduce any user facing changes?

Indirectly user-facing with new docker image versions to be released in docker hub.
