### PR TITLE
Remove session ID from block store event listener

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/AbstractBlockStoreEventListener.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AbstractBlockStoreEventListener.java
@@ -21,33 +21,33 @@ import javax.annotation.concurrent.NotThreadSafe;
 public abstract class AbstractBlockStoreEventListener implements BlockStoreEventListener {
 
   @Override
-  public void onAccessBlock(long sessionId, long blockId) {}
+  public void onAccessBlock(long blockId) {}
 
   @Override
-  public void onAccessBlock(long sessionId, long blockId, BlockStoreLocation location) {}
+  public void onAccessBlock(long blockId, BlockStoreLocation location) {}
 
   @Override
-  public void onAbortBlock(long sessionId, long blockId) {}
+  public void onAbortBlock(long blockId) {}
 
   @Override
-  public void onCommitBlock(long sessionId, long blockId, BlockStoreLocation location) {}
+  public void onCommitBlock(long blockId, BlockStoreLocation location) {}
 
   @Override
-  public void onMoveBlockByClient(long sessionId, long blockId, BlockStoreLocation oldLocation,
+  public void onMoveBlockByClient(long blockId, BlockStoreLocation oldLocation,
       BlockStoreLocation newLocation) {}
 
   @Override
-  public void onMoveBlockByWorker(long sessionId, long blockId, BlockStoreLocation oldLocation,
+  public void onMoveBlockByWorker(long blockId, BlockStoreLocation oldLocation,
       BlockStoreLocation newLocation) {}
 
   @Override
-  public void onRemoveBlockByClient(long sessionId, long blockId) {}
+  public void onRemoveBlockByClient(long blockId) {}
 
   @Override
-  public void onRemoveBlockByWorker(long sessionId, long blockId) {}
+  public void onRemoveBlockByWorker(long blockId) {}
 
   @Override
-  public void onRemoveBlock(long sessionId, long blockId, BlockStoreLocation location) {}
+  public void onRemoveBlock(long blockId, BlockStoreLocation location) {}
 
   @Override
   public void onBlockLost(long blockId) {}

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockHeartbeatReporter.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockHeartbeatReporter.java
@@ -75,7 +75,7 @@ public final class BlockHeartbeatReporter extends AbstractBlockStoreEventListene
   }
 
   @Override
-  public void onMoveBlockByClient(long sessionId, long blockId, BlockStoreLocation oldLocation,
+  public void onMoveBlockByClient(long blockId, BlockStoreLocation oldLocation,
       BlockStoreLocation newLocation) {
     synchronized (mLock) {
       // Remove the block from our list of added blocks in this heartbeat, if it was added, to
@@ -87,21 +87,21 @@ public final class BlockHeartbeatReporter extends AbstractBlockStoreEventListene
   }
 
   @Override
-  public void onRemoveBlockByClient(long sessionId, long blockId) {
+  public void onRemoveBlockByClient(long blockId) {
     synchronized (mLock) {
       removeBlockInternal(blockId);
     }
   }
 
   @Override
-  public void onRemoveBlockByWorker(long sessionId, long blockId) {
+  public void onRemoveBlockByWorker(long blockId) {
     synchronized (mLock) {
       removeBlockInternal(blockId);
     }
   }
 
   @Override
-  public void onMoveBlockByWorker(long sessionId, long blockId, BlockStoreLocation oldLocation,
+  public void onMoveBlockByWorker(long blockId, BlockStoreLocation oldLocation,
       BlockStoreLocation newLocation) {
     synchronized (mLock) {
       // Remove the block from our list of added blocks in this heartbeat, if it was added, to

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMetricsReporter.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMetricsReporter.java
@@ -44,12 +44,12 @@ public final class BlockMetricsReporter extends AbstractBlockStoreEventListener 
         MetricKey.WORKER_BLOCKS_EVICTION_RATE.isClusterAggregated());
 
   @Override
-  public void onAccessBlock(long sessionId, long blockId) {
+  public void onAccessBlock(long blockId) {
     BLOCKS_ACCESSED.inc();
   }
 
   @Override
-  public void onMoveBlockByClient(long sessionId, long blockId, BlockStoreLocation oldLocation,
+  public void onMoveBlockByClient(long blockId, BlockStoreLocation oldLocation,
       BlockStoreLocation newLocation) {
     int oldTierOrdinal = WORKER_STORAGE_TIER_ASSOC.getOrdinal(oldLocation.tierAlias());
     int newTierOrdinal = WORKER_STORAGE_TIER_ASSOC.getOrdinal(newLocation.tierAlias());
@@ -59,12 +59,12 @@ public final class BlockMetricsReporter extends AbstractBlockStoreEventListener 
   }
 
   @Override
-  public void onRemoveBlockByClient(long sessionId, long blockId) {
+  public void onRemoveBlockByClient(long blockId) {
     BLOCKS_DELETED.inc();
   }
 
   @Override
-  public void onMoveBlockByWorker(long sessionId, long blockId, BlockStoreLocation oldLocation,
+  public void onMoveBlockByWorker(long blockId, BlockStoreLocation oldLocation,
       BlockStoreLocation newLocation) {
     int oldTierOrdinal = WORKER_STORAGE_TIER_ASSOC.getOrdinal(oldLocation.tierAlias());
     int newTierOrdinal = WORKER_STORAGE_TIER_ASSOC.getOrdinal(newLocation.tierAlias());
@@ -74,13 +74,13 @@ public final class BlockMetricsReporter extends AbstractBlockStoreEventListener 
   }
 
   @Override
-  public void onRemoveBlockByWorker(long sessionId, long blockId) {
+  public void onRemoveBlockByWorker(long blockId) {
     BLOCKS_EVICTED.inc();
     BLOCKS_EVICTION_RATE.mark();
   }
 
   @Override
-  public void onAbortBlock(long sessionId, long blockId) {
+  public void onAbortBlock(long blockId) {
     BLOCKS_CANCELLED.inc();
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockStoreEventListener.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockStoreEventListener.java
@@ -23,83 +23,69 @@ public interface BlockStoreEventListener {
   /**
    * Actions when accessing a block.
    *
-   * @param sessionId the id of the session to access this block
    * @param blockId the id of the block to access
    */
-  void onAccessBlock(long sessionId, long blockId);
+  void onAccessBlock(long blockId);
 
   /**
    * Actions when accessing a block.
-   *
-   * @param sessionId the id of the session to access this block
    * @param blockId the id of the block to access
    * @param location the location of the block
    */
-  void onAccessBlock(long sessionId, long blockId, BlockStoreLocation location);
+  void onAccessBlock(long blockId, BlockStoreLocation location);
 
   /**
    * Actions when aborting a temporary block.
    *
-   * @param sessionId the id of the session to abort on this block
    * @param blockId the id of the block where the mutation to abort
    */
-  void onAbortBlock(long sessionId, long blockId);
+  void onAbortBlock(long blockId);
 
   /**
    * Actions when committing a temporary block to a {@link BlockStoreLocation}.
-   *
-   * @param sessionId the id of the session to commit to this block
    * @param blockId the id of the block to commit
    * @param location the location of the block to be committed
    */
-  void onCommitBlock(long sessionId, long blockId, BlockStoreLocation location);
+  void onCommitBlock(long blockId, BlockStoreLocation location);
 
   /**
    * Actions when moving a block by a client from a {@link BlockStoreLocation} to another.
-   *
-   * @param sessionId the id of the session to move this block
    * @param blockId the id of the block to be moved
    * @param oldLocation the source location of the block to be moved
    * @param newLocation the destination location where the block is to be moved to
    */
-  void onMoveBlockByClient(long sessionId, long blockId, BlockStoreLocation oldLocation,
+  void onMoveBlockByClient(long blockId, BlockStoreLocation oldLocation,
       BlockStoreLocation newLocation);
 
   /**
    * Actions when moving a block by a worker from a {@link BlockStoreLocation} to another.
-   *
-   * @param sessionId the id of the session to move this block
    * @param blockId the id of the block to be moved
    * @param oldLocation the source location of the block to be moved
    * @param newLocation the destination location where the block is to be moved to
    */
-  void onMoveBlockByWorker(long sessionId, long blockId, BlockStoreLocation oldLocation,
+  void onMoveBlockByWorker(long blockId, BlockStoreLocation oldLocation,
       BlockStoreLocation newLocation);
 
   /**
    * Actions when removing an existing block.
    *
-   * @param sessionId the id of the session to remove this block
    * @param blockId the id of the block to be removed
    */
-  void onRemoveBlockByClient(long sessionId, long blockId);
+  void onRemoveBlockByClient(long blockId);
 
   /**
    * Actions when removing an existing block by worker.
    *
-   * @param sessionId the id of the session to remove this block
    * @param blockId the id of the block to be removed
    */
-  void onRemoveBlockByWorker(long sessionId, long blockId);
+  void onRemoveBlockByWorker(long blockId);
 
   /**
    * Actions when removing an existing block.
-   *
-   * @param sessionId the id of the session to remove this block
    * @param blockId the id of the block to be removed
    * @param location the location of the block to be removed
    */
-  void onRemoveBlock(long sessionId, long blockId, BlockStoreLocation location);
+  void onRemoveBlock(long blockId, BlockStoreLocation location);
 
   /**
    * Actions when a block is lost.

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -250,7 +250,7 @@ public class TieredBlockStore implements LocalBlockStore
       BlockStoreLocation loc = commitBlockInternal(sessionId, blockId, pinOnCreate);
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
         synchronized (listener) {
-          listener.onCommitBlock(sessionId, blockId, loc);
+          listener.onCommitBlock(blockId, loc);
         }
       }
     } finally {
@@ -269,7 +269,7 @@ public class TieredBlockStore implements LocalBlockStore
       BlockStoreLocation loc = commitBlockInternal(sessionId, blockId, pinOnCreate);
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
         synchronized (listener) {
-          listener.onCommitBlock(sessionId, blockId, loc);
+          listener.onCommitBlock(blockId, loc);
         }
       }
     } catch (Exception e) {
@@ -287,7 +287,7 @@ public class TieredBlockStore implements LocalBlockStore
     abortBlockInternal(sessionId, blockId);
     for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
       synchronized (listener) {
-        listener.onAbortBlock(sessionId, blockId);
+        listener.onAbortBlock(blockId);
       }
     }
   }
@@ -340,7 +340,7 @@ public class TieredBlockStore implements LocalBlockStore
     if (result.getSuccess()) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
         synchronized (listener) {
-          listener.onMoveBlockByClient(sessionId, blockId, result.getSrcLocation(),
+          listener.onMoveBlockByClient(blockId, result.getSrcLocation(),
               result.getDstLocation());
         }
       }
@@ -358,9 +358,9 @@ public class TieredBlockStore implements LocalBlockStore
         sessionId, blockId, REMOVE_BLOCK_TIMEOUT_MS);
     for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
       synchronized (listener) {
-        listener.onRemoveBlockByClient(sessionId, blockId);
+        listener.onRemoveBlockByClient(blockId);
         blockMeta.ifPresent(meta -> listener.onRemoveBlock(
-            sessionId, blockId, meta.getBlockLocation()));
+            blockId, meta.getBlockLocation()));
       }
     }
   }
@@ -405,8 +405,8 @@ public class TieredBlockStore implements LocalBlockStore
     if (blockMeta.isPresent()) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
         synchronized (listener) {
-          listener.onAccessBlock(sessionId, blockId);
-          listener.onAccessBlock(sessionId, blockId, blockMeta.get().getBlockLocation());
+          listener.onAccessBlock(blockId);
+          listener.onAccessBlock(blockId, blockMeta.get().getBlockLocation());
         }
       }
     }
@@ -795,8 +795,8 @@ public class TieredBlockStore implements LocalBlockStore
         blocksRemoved++;
         for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
           synchronized (listener) {
-            listener.onRemoveBlockByWorker(sessionId, blockMeta.getBlockId());
-            listener.onRemoveBlock(sessionId, blockMeta.getBlockId(),
+            listener.onRemoveBlockByWorker(blockMeta.getBlockId());
+            listener.onRemoveBlock(blockMeta.getBlockId(),
                 blockMeta.getBlockLocation());
           }
         }

--- a/core/server/worker/src/main/java/alluxio/worker/block/annotator/DefaultBlockIterator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/annotator/DefaultBlockIterator.java
@@ -381,17 +381,17 @@ public class DefaultBlockIterator implements BlockIterator {
    */
   class Listener extends AbstractBlockStoreEventListener {
     @Override
-    public void onAccessBlock(long sessionId, long blockId, BlockStoreLocation location) {
+    public void onAccessBlock(long blockId, BlockStoreLocation location) {
       blockUpdated(blockId, location);
     }
 
     @Override
-    public void onCommitBlock(long sessionId, long blockId, BlockStoreLocation location) {
+    public void onCommitBlock(long blockId, BlockStoreLocation location) {
       blockUpdated(blockId, location);
     }
 
     @Override
-    public void onRemoveBlock(long sessionId, long blockId, BlockStoreLocation location) {
+    public void onRemoveBlock(long blockId, BlockStoreLocation location) {
       blockRemoved(blockId, location);
     }
 
@@ -401,13 +401,13 @@ public class DefaultBlockIterator implements BlockIterator {
     }
 
     @Override
-    public void onMoveBlockByClient(long sessionId, long blockId, BlockStoreLocation oldLocation,
+    public void onMoveBlockByClient(long blockId, BlockStoreLocation oldLocation,
         BlockStoreLocation newLocation) {
       blockMoved(blockId, oldLocation, newLocation);
     }
 
     @Override
-    public void onMoveBlockByWorker(long sessionId, long blockId, BlockStoreLocation oldLocation,
+    public void onMoveBlockByWorker(long blockId, BlockStoreLocation oldLocation,
         BlockStoreLocation newLocation) {
       blockMoved(blockId, oldLocation, newLocation);
     }

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/LRUEvictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/LRUEvictor.java
@@ -77,23 +77,23 @@ public class LRUEvictor extends AbstractEvictor {
   }
 
   @Override
-  public void onAccessBlock(long sessionId, long blockId) {
+  public void onAccessBlock(long blockId) {
     mLRUCache.put(blockId, UNUSED_MAP_VALUE);
   }
 
   @Override
-  public void onCommitBlock(long sessionId, long blockId, BlockStoreLocation location) {
+  public void onCommitBlock(long blockId, BlockStoreLocation location) {
     // Since the temp block has been committed, update Evictor about the new added blocks
     mLRUCache.put(blockId, UNUSED_MAP_VALUE);
   }
 
   @Override
-  public void onRemoveBlockByClient(long sessionId, long blockId) {
+  public void onRemoveBlockByClient(long blockId) {
     mLRUCache.remove(blockId);
   }
 
   @Override
-  public void onRemoveBlockByWorker(long sessionId, long blockId) {
+  public void onRemoveBlockByWorker(long blockId) {
     mLRUCache.remove(blockId);
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/page/PagedLocalBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/page/PagedLocalBlockStore.java
@@ -115,7 +115,7 @@ public class PagedLocalBlockStore implements LocalBlockStore {
     BlockStoreLocation dummyLoc = new BlockStoreLocation(DEFAULT_TIER, 1);
     for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
       synchronized (listener) {
-        listener.onCommitBlock(sessionId, blockId, dummyLoc);
+        listener.onCommitBlock(blockId, dummyLoc);
       }
     }
     throw new UnsupportedOperationException();
@@ -129,7 +129,7 @@ public class PagedLocalBlockStore implements LocalBlockStore {
     BlockStoreLocation dummyLoc = new BlockStoreLocation(DEFAULT_TIER, 1);
     for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
       synchronized (listener) {
-        listener.onCommitBlock(sessionId, blockId, dummyLoc);
+        listener.onCommitBlock(blockId, dummyLoc);
       }
     }
     throw new UnsupportedOperationException();
@@ -144,7 +144,7 @@ public class PagedLocalBlockStore implements LocalBlockStore {
     if (blockAborted) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
         synchronized (listener) {
-          listener.onAbortBlock(sessionId, blockId);
+          listener.onAbortBlock(blockId);
         }
       }
     }
@@ -161,8 +161,8 @@ public class PagedLocalBlockStore implements LocalBlockStore {
       BlockStoreLocation evictedBlockLocation = new BlockStoreLocation(DEFAULT_TIER, 1);
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
         synchronized (listener) {
-          listener.onRemoveBlockByWorker(sessionId, evictedBlockId);
-          listener.onRemoveBlock(sessionId, evictedBlockId, evictedBlockLocation);
+          listener.onRemoveBlockByWorker(evictedBlockId);
+          listener.onRemoveBlock(evictedBlockId, evictedBlockLocation);
         }
       }
     }
@@ -198,7 +198,7 @@ public class PagedLocalBlockStore implements LocalBlockStore {
     BlockStoreLocation destLocation = new BlockStoreLocation(DEFAULT_TIER, 1);
     for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
       synchronized (listener) {
-        listener.onMoveBlockByClient(sessionId, blockId, srcLocation, destLocation);
+        listener.onMoveBlockByClient(blockId, srcLocation, destLocation);
       }
     }
     throw new UnsupportedOperationException();
@@ -212,10 +212,10 @@ public class PagedLocalBlockStore implements LocalBlockStore {
     boolean removeSuccess = true;
     for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
       synchronized (listener) {
-        listener.onRemoveBlockByClient(sessionId, blockId);
+        listener.onRemoveBlockByClient(blockId);
         if (removeSuccess) {
           BlockStoreLocation removedFrom = new BlockStoreLocation(DEFAULT_TIER, 1);
-          listener.onRemoveBlock(sessionId, blockId, removedFrom);
+          listener.onRemoveBlock(blockId, removedFrom);
         }
       }
     }
@@ -229,8 +229,8 @@ public class PagedLocalBlockStore implements LocalBlockStore {
       BlockStoreLocation dummyLoc = new BlockStoreLocation(DEFAULT_TIER, 1);
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
         synchronized (listener) {
-          listener.onAccessBlock(sessionId, blockId);
-          listener.onAccessBlock(sessionId, blockId, dummyLoc);
+          listener.onAccessBlock(blockId);
+          listener.onAccessBlock(blockId, dummyLoc);
         }
       }
     }

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockHeartbeatReporterTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockHeartbeatReporterTest.java
@@ -27,7 +27,6 @@ import java.util.Map;
  * Unit tests for {@link BlockHeartbeatReporter}.
  */
 public final class BlockHeartbeatReporterTest {
-  private static final int SESSION_ID = 1;
   private static final BlockStoreLocation MEM_LOC =
       new BlockStoreLocation(Constants.MEDIUM_MEM, 0, Constants.MEDIUM_MEM);
   private static final BlockStoreLocation SSD_LOC =

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockHeartbeatReporterTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockHeartbeatReporterTest.java
@@ -47,11 +47,11 @@ public final class BlockHeartbeatReporterTest {
   private void moveBlock(long blockId, BlockStoreLocation newLocation) {
     BlockStoreLocation unusedOldLocation =
         new BlockStoreLocation(Constants.MEDIUM_MEM, 0, Constants.MEDIUM_MEM);
-    mReporter.onMoveBlockByWorker(SESSION_ID, blockId, unusedOldLocation, newLocation);
+    mReporter.onMoveBlockByWorker(blockId, unusedOldLocation, newLocation);
   }
 
   private void removeBlock(long blockId) {
-    mReporter.onRemoveBlockByWorker(SESSION_ID, blockId);
+    mReporter.onRemoveBlockByWorker(blockId);
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTestUtils.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTestUtils.java
@@ -335,7 +335,7 @@ public final class TieredBlockStoreTestUtils {
     cache2(sessionId, blockId, bytes, dir, meta, (BlockStoreEventListener) null);
     if (iterator != null) {
       for (BlockStoreEventListener listener : iterator.getListeners()) {
-        listener.onCommitBlock(sessionId, blockId, dir.toBlockStoreLocation());
+        listener.onCommitBlock(blockId, dir.toBlockStoreLocation());
       }
     }
   }
@@ -360,7 +360,7 @@ public final class TieredBlockStoreTestUtils {
 
     // update iterator if a listener.
     if (listener != null) {
-      listener.onCommitBlock(sessionId, blockId, dir.toBlockStoreLocation());
+      listener.onCommitBlock(blockId, dir.toBlockStoreLocation());
     }
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/annotator/AbstractBlockAnnotatorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/annotator/AbstractBlockAnnotatorTest.java
@@ -35,7 +35,6 @@ public abstract class AbstractBlockAnnotatorTest {
 
   private HashMap<Long, StorageDir> mBlockLocation;
   private Long mUserSession = 1L;
-  private Long mInternalSession = Long.MIN_VALUE;
 
   protected BlockMetadataManager mMetaManager;
   protected BlockIterator mBlockIterator;

--- a/core/server/worker/src/test/java/alluxio/worker/block/annotator/AbstractBlockAnnotatorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/annotator/AbstractBlockAnnotatorTest.java
@@ -63,19 +63,19 @@ public abstract class AbstractBlockAnnotatorTest {
     mMetaManager.removeBlockMeta(mMetaManager.getBlockMeta(blockId).get());
     TieredBlockStoreTestUtils.cache2(mUserSession++, blockId, 1, destDir, mMetaManager,
         (BlockIterator) null);
-    mBlockEventListener.onMoveBlockByWorker(mInternalSession++, blockId,
+    mBlockEventListener.onMoveBlockByWorker(blockId,
         mBlockLocation.get(blockId).toBlockStoreLocation(), destDir.toBlockStoreLocation());
     mBlockLocation.put(blockId, destDir);
   }
 
   protected void removeBlock(long blockId) throws Exception {
     mMetaManager.removeBlockMeta(mMetaManager.getBlockMeta(blockId).get());
-    mBlockEventListener.onRemoveBlock(mUserSession++, blockId,
+    mBlockEventListener.onRemoveBlock(blockId,
         mBlockLocation.remove(blockId).toBlockStoreLocation());
   }
 
   protected void accessBlock(long blockId) throws Exception {
-    mBlockEventListener.onAccessBlock(mUserSession++, blockId,
+    mBlockEventListener.onAccessBlock(blockId,
         mBlockLocation.get(blockId).toBlockStoreLocation());
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/annotator/EmulatingBlockIteratorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/annotator/EmulatingBlockIteratorTest.java
@@ -101,8 +101,8 @@ public class EmulatingBlockIteratorTest {
   }
 
   private void accessBlock(long blockId) throws Exception {
-    mBlockEventListener.onAccessBlock(mUserSession++, blockId);
-    mBlockEventListener.onAccessBlock(mUserSession++, blockId,
+    mBlockEventListener.onAccessBlock(blockId);
+    mBlockEventListener.onAccessBlock(blockId,
         mBlockLocation.get(blockId).toBlockStoreLocation());
   }
 


### PR DESCRIPTION
Remove session IDs from the `BlockStoreEventListener` interface as the session ID is unused.