### PR TITLE
Check if dir belongs to tier before removing it

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageTier.java
@@ -235,8 +235,13 @@ public final class DefaultStorageTier implements StorageTier {
     return new ArrayList<>(mLostStorage);
   }
 
+  /**
+   * @throws IllegalArgumentException if dir does not belong to this tier
+   */
   @Override
   public void removeStorageDir(StorageDir dir) {
+    Preconditions.checkArgument(this == dir.getParentTier(),
+        "storage dir %s does not belong to tier %s", dir.getDirPath(), getTierAlias());
     if (mDirs.remove(dir.getDirIndex()) != null) {
       mCapacityBytes -=  dir.getCapacityBytes();
     }

--- a/core/server/worker/src/test/java/alluxio/worker/block/meta/DefaultStorageTierTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/meta/DefaultStorageTierTest.java
@@ -17,6 +17,7 @@ import alluxio.conf.ServerConfiguration;
 import alluxio.util.io.PathUtils;
 import alluxio.worker.block.TieredBlockStoreTestUtils;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -167,5 +168,23 @@ public class DefaultStorageTierTest {
     List<StorageDir> dirs = mTier.getStorageDirs();
     Assert.assertEquals(2, dirs.size());
     Assert.assertEquals(mTestBlockDirPath1, dirs.get(0).getDirPath());
+  }
+
+  @Test
+  public void removeDir() throws Exception {
+    List<StorageDir> dirs = mTier.getStorageDirs();
+    Assert.assertEquals(2, dirs.size());
+    StorageDir dir0 = dirs.get(0);
+    StorageDir dir1 = dirs.get(1);
+    mTier.removeStorageDir(dir0);
+    Assert.assertEquals(ImmutableList.of(dir1), mTier.getStorageDirs());
+    mTier.removeStorageDir(dir1);
+    Assert.assertEquals(ImmutableList.of(), mTier.getStorageDirs());
+
+    StorageTier anotherTier = DefaultStorageTier.newStorageTier("anotherTier", 0, false);
+    StorageDir dirInAnotherTier =
+        DefaultStorageDir.newStorageDir(anotherTier, 0, 0, 0, "dir", "medium");
+    Assert.assertThrows("should not remove a dir that does not belong to this tier",
+        IllegalArgumentException.class, () -> mTier.removeStorageDir(dirInAnotherTier));
   }
 }


### PR DESCRIPTION
Check if the directory to remove actually belong to the tier.