### PR TITLE
Fix max reservoir metric initialization

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MaxReservoir.java
+++ b/core/common/src/main/java/alluxio/metrics/MaxReservoir.java
@@ -30,7 +30,7 @@ public class MaxReservoir implements Reservoir {
    * @param delegate the delegate reservoir to wrap
    */
   public MaxReservoir(Reservoir delegate) {
-    mMaxUpdate = new LongAccumulator(Long::max, Long.MIN_VALUE);
+    mMaxUpdate = new LongAccumulator(Long::max, 0);
     mDelegate = delegate;
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

The max reservoir metric is now initialized to 0.

### Why are the changes needed?

Previously the max reservoir metric was initialized to Long.MIN_VALUE which is a negative value, but the max reservoir is used to track the max size of something that should be initialized to 0.

### Does this PR introduce any user facing changes?

Any metric that uses the max reservoir (currently the thread pool executor monitoring the metadata queues) will now be initialized to 0.
