### PR TITLE
Refactor ConfigurationUtils

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -17,7 +17,6 @@ import alluxio.annotation.PublicApi;
 import alluxio.client.file.cache.CacheManager;
 import alluxio.client.file.cache.LocalCacheFileSystem;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
 import alluxio.exception.AlluxioException;
@@ -105,7 +104,7 @@ public interface FileSystem extends Closeable {
      * @return a FileSystem from the cache, creating a new one if it doesn't yet exist
      */
     public static FileSystem get(Subject subject) {
-      return get(subject, new InstancedConfiguration(ConfigurationUtils.defaults()));
+      return get(subject, ConfigurationUtils.defaults());
     }
 
     /**

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
@@ -11,7 +11,6 @@
 
 package alluxio.client.block.stream;
 
-import alluxio.conf.InstancedConfiguration;
 import alluxio.util.ConfigurationUtils;
 import alluxio.wire.WorkerNetAddress;
 
@@ -30,7 +29,7 @@ public class TestBlockInStream extends BlockInStream {
   public TestBlockInStream(byte[] data, long id, long length, boolean shortCircuit,
       BlockInStreamSource source) {
     super(new Factory(data, shortCircuit),
-        new InstancedConfiguration(ConfigurationUtils.defaults()),
+        ConfigurationUtils.defaults(),
         new WorkerNetAddress(), source, id, length);
     mBytesRead = 0;
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemCacheTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemCacheTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.AlluxioURI;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.exception.AlluxioException;
 import alluxio.security.User;
 import alluxio.util.ConfigurationUtils;
@@ -132,7 +131,6 @@ public class FileSystemCacheTest {
     principals.add(user);
     return new FileSystemCache.Key(
         new Subject(false, principals, new HashSet<>(), new HashSet<>()),
-        new InstancedConfiguration(ConfigurationUtils.defaults())
-        );
+        ConfigurationUtils.defaults());
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemFactoryTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemFactoryTest.java
@@ -71,7 +71,7 @@ public class FileSystemFactoryTest {
     try (Closeable p = new SystemPropertyRule(PropertyKey.MASTER_RPC_ADDRESSES.getName(),
         "192.168.0.1:1234,192.168.0.2:1445,192.168.0.3:9943").toResource()) {
       ConfigurationUtils.reloadProperties();
-      InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+      InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
       MasterInquireClient.ConnectDetails connectDetails =
           MasterInquireClient.Factory.getConnectDetails(conf);
       // Make sure we have a MultiMaster authority
@@ -91,7 +91,7 @@ public class FileSystemFactoryTest {
 
     try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {
       ConfigurationUtils.reloadProperties();
-      InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+      InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
       MasterInquireClient.ConnectDetails connectDetails =
           MasterInquireClient.Factory.getConnectDetails(conf);
       // Make sure we have a Zookeeper authority
@@ -110,7 +110,7 @@ public class FileSystemFactoryTest {
   @Test
   public void uncachedFileSystemDoesntAffectCache() throws Exception {
     FileSystem fs1 = FileSystem.Factory.get();
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
     conf.set(PropertyKey.USER_WORKER_LIST_REFRESH_INTERVAL, "1sec");
     FileSystem fs2 = FileSystem.Factory.create(conf);
     fs2.close();

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -92,7 +92,7 @@ import java.util.stream.IntStream;
 @RunWith(Parameterized.class)
 public class LocalCacheFileInStreamTest {
   private static InstancedConfiguration sConf = new InstancedConfiguration(
-      ConfigurationUtils.defaults());
+      ConfigurationUtils.copyDefaults());
 
   @Parameters(name = "{index}: page_size({0}), in_stream_buffer_size({1})")
   public static Collection<Object[]> data() {

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -505,7 +505,7 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
         hadoopConfProperties, uriConfProperties);
     AlluxioProperties alluxioProps =
         (alluxioConfiguration != null) ? alluxioConfiguration.copyProperties()
-            : ConfigurationUtils.defaults();
+            : ConfigurationUtils.copyDefaults();
     // Merge relevant Hadoop configuration into Alluxio's configuration.
     alluxioProps.merge(hadoopConfProperties, Source.RUNTIME);
     // Merge relevant connection details in the URI with the highest priority

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopUtils.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopUtils.java
@@ -184,7 +184,7 @@ public final class HadoopUtils {
     // Take hadoop configuration to merge to Alluxio configuration
     Map<String, Object> hadoopConfProperties =
         HadoopConfigurationUtils.getConfigurationFromHadoop(conf);
-    AlluxioProperties alluxioProps = ConfigurationUtils.defaults();
+    AlluxioProperties alluxioProps = ConfigurationUtils.copyDefaults();
     // Merge relevant Hadoop configuration into Alluxio's configuration.
     alluxioProps.merge(hadoopConfProperties, Source.RUNTIME);
     // Creating a new instanced configuration from an AlluxioProperties object isn't expensive.

--- a/core/common/src/main/java/alluxio/ClientContext.java
+++ b/core/common/src/main/java/alluxio/ClientContext.java
@@ -103,7 +103,7 @@ public class ClientContext {
           alluxioConf.clusterDefaultsLoaded());
       mClusterConfHash = alluxioConf.hash();
     } else {
-      mClusterConf = new InstancedConfiguration(ConfigurationUtils.defaults());
+      mClusterConf = ConfigurationUtils.defaults();
       mClusterConfHash = mClusterConf.hash();
     }
     mPathConf = PathConfiguration.create(new HashMap<>());

--- a/core/common/src/main/java/alluxio/cli/AbstractShell.java
+++ b/core/common/src/main/java/alluxio/cli/AbstractShell.java
@@ -11,7 +11,7 @@
 
 package alluxio.cli;
 
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.status.InvalidArgumentException;
 
 import com.google.common.io.Closer;
@@ -42,7 +42,7 @@ public abstract class AbstractShell implements Closeable {
   private Map<String, String[]> mCommandAlias;
   private Set<String> mUnstableAlias;
   private Map<String, Command> mCommands;
-  protected InstancedConfiguration mConfiguration;
+  protected AlluxioConfiguration mConfiguration;
   protected Closer mCloser;
 
   /**
@@ -53,7 +53,7 @@ public abstract class AbstractShell implements Closeable {
    * @param conf Alluxio configuration
    */
   public AbstractShell(Map<String, String[]> commandAlias,
-      Set<String> unstableAlias, InstancedConfiguration conf) {
+      Set<String> unstableAlias, AlluxioConfiguration conf) {
     mCloser = Closer.create();
     mConfiguration = conf; // This needs to go first in case loadCommands() uses the reference to
     // the configuration

--- a/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
+++ b/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
@@ -58,7 +58,7 @@ public class AlluxioProperties {
   /** Map of property sources. */
   private final ConcurrentHashMap<PropertyKey, Source> mSources = new ConcurrentHashMap<>();
 
-  private Hash mHash = new Hash(() -> keySet().stream()
+  private final Hash mHash = new Hash(() -> keySet().stream()
       .filter(key -> get(key) != null)
       .sorted(Comparator.comparing(PropertyKey::getName))
       .map(key -> String.format("%s:%s:%s", key.getName(), get(key), getSource(key)).getBytes()));

--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -70,7 +70,7 @@ public class InstancedConfiguration implements AlluxioConfiguration {
    * @return an instanced configuration preset with defaults
    */
   public static InstancedConfiguration defaults() {
-    return new InstancedConfiguration(ConfigurationUtils.defaults());
+    return new InstancedConfiguration(ConfigurationUtils.copyDefaults());
   }
 
   /**

--- a/core/common/src/main/java/alluxio/metrics/InstrumentedExecutorService.java
+++ b/core/common/src/main/java/alluxio/metrics/InstrumentedExecutorService.java
@@ -11,8 +11,6 @@
 
 package alluxio.metrics;
 
-import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.logging.SamplingLogger;
@@ -46,13 +44,9 @@ import java.util.concurrent.TimeoutException;
  * tracks the maximum overall number active tasks at any time.
  */
 public class InstrumentedExecutorService implements ExecutorService {
-
-  private static final AlluxioConfiguration CONF =
-      new InstancedConfiguration(ConfigurationUtils.defaults());
-
   private final Logger mSamplingLog =
       new SamplingLogger(LoggerFactory.getLogger(InstrumentedExecutorService.class),
-          CONF.getMs(PropertyKey.METRICS_EXECUTOR_TASK_WARN_FREQUENCY));
+          ConfigurationUtils.defaults().getMs(PropertyKey.METRICS_EXECUTOR_TASK_WARN_FREQUENCY));
 
   private com.codahale.metrics
       .InstrumentedExecutorService mDelegate;
@@ -108,7 +102,8 @@ public class InstrumentedExecutorService implements ExecutorService {
   private void addedTasks(int count) {
     long activeCount = mSubmitted.getCount() - mCompleted.getCount() + count;
     mHist.update(activeCount);
-    if (activeCount >= CONF.getInt(PropertyKey.METRICS_EXECUTOR_TASK_WARN_SIZE)) {
+    if (activeCount >= ConfigurationUtils.defaults()
+        .getInt(PropertyKey.METRICS_EXECUTOR_TASK_WARN_SIZE)) {
       mSamplingLog.warn("Number of active tasks (queued and running) for executor {} is {}",
           mName, activeCount);
     }

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -13,7 +13,6 @@ package alluxio.metrics;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.MetricType;
 import alluxio.grpc.MetricValue;
@@ -68,8 +67,7 @@ public final class MetricsSystem {
 
   private static final ConcurrentHashMap<String, String> CACHED_METRICS = new ConcurrentHashMap<>();
   private static int sResolveTimeout =
-      (int) new InstancedConfiguration(ConfigurationUtils.defaults())
-          .getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS);
+      (int) ConfigurationUtils.defaults().getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS);
   // A map from AlluxioURI to corresponding cached escaped path.
   private static final ConcurrentHashMap<AlluxioURI, String> CACHED_ESCAPED_PATH
       = new ConcurrentHashMap<>();
@@ -207,7 +205,7 @@ public final class MetricsSystem {
       default:
         break;
     }
-    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    AlluxioConfiguration conf = ConfigurationUtils.defaults();
     if (sourceKey != null && conf.isSet(sourceKey)) {
       return conf.getString(sourceKey);
     }

--- a/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
+++ b/core/common/src/main/java/alluxio/util/ConfigurationUtils.java
@@ -42,6 +42,7 @@ import alluxio.util.network.NetworkAddressUtils.ServiceType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.slf4j.Logger;
@@ -58,12 +59,13 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
 
 /**
  * Utilities for working with Alluxio configurations.
@@ -71,11 +73,13 @@ import javax.annotation.concurrent.GuardedBy;
 public final class ConfigurationUtils {
   private static final Logger LOG = LoggerFactory.getLogger(ConfigurationUtils.class);
 
-  @GuardedBy("DEFAULT_PROPERTIES_LOCK")
-  private static volatile AlluxioProperties sDefaultProperties = null;
-  private static String sSourcePropertyFile = null;
+  private static final AtomicReference<AlluxioProperties> DEFAULT_PROPERTIES_REFERENCE =
+      new AtomicReference<>();
 
-  private static final Object DEFAULT_PROPERTIES_LOCK = new Object();
+  static {
+    reloadProperties();
+  }
+
   private static final String MASTERS = "masters";
   private static final String WORKERS = "workers";
 
@@ -198,77 +202,18 @@ public final class ConfigurationUtils {
   }
 
   /**
-   * Loads properties from a resource.
-   *
-   * @param resource url of the properties file
-   * @return a set of properties on success, or null if failed
-   */
-  @Nullable
-  public static Properties loadPropertiesFromResource(URL resource) {
-    try (InputStream stream = resource.openStream()) {
-      return loadProperties(stream);
-    } catch (IOException e) {
-      LOG.warn("Failed to read properties from {}: {}", resource, e.toString());
-      return null;
-    }
-  }
-
-  /**
-   * Loads properties from the given file.
-   *
-   * @param filePath the absolute path of the file to load properties
-   * @return a set of properties on success, or null if failed
-   */
-  @Nullable
-  public static Properties loadPropertiesFromFile(String filePath) {
-    try (FileInputStream fileInputStream = new FileInputStream(filePath)) {
-      return loadProperties(fileInputStream);
-    } catch (FileNotFoundException e) {
-      return null;
-    } catch (IOException e) {
-      LOG.warn("Failed to close property input stream from {}: {}", filePath, e.toString());
-      return null;
-    }
-  }
-
-  /**
    * @param stream the stream to read properties from
    * @return a properties object populated from the stream
    */
-  @Nullable
-  public static Properties loadProperties(InputStream stream) {
+  private static Optional<Properties> loadProperties(InputStream stream) {
     Properties properties = new Properties();
     try {
       properties.load(stream);
     } catch (IOException e) {
       LOG.warn("Unable to load properties: {}", e.toString());
-      return null;
+      return Optional.empty();
     }
-    return properties;
-  }
-
-  /**
-   * Searches the given properties file from a list of paths.
-   *
-   * @param propertiesFile the file to load properties
-   * @param confPathList a list of paths to search the propertiesFile
-   * @return the site properties file on success search, or null if failed
-   */
-  @Nullable
-  public static String searchPropertiesFile(String propertiesFile,
-      List<String> confPathList) {
-    if (propertiesFile == null || confPathList == null) {
-      return null;
-    }
-    for (String path : confPathList) {
-      String file = PathUtils.concatPath(path, propertiesFile);
-      Properties properties = loadPropertiesFromFile(file);
-      if (properties != null) {
-        // If a site conf is successfully loaded, stop trying different paths.
-        return file;
-      }
-    }
-    return null;
+    return Optional.of(properties);
   }
 
   /**
@@ -389,22 +334,23 @@ public final class ConfigurationUtils {
   }
 
   /**
-   * Returns an instance of {@link AlluxioProperties} with the defaults and values from
+   * Returns a new instance of {@link AlluxioProperties} with the defaults and values from
    * alluxio-site properties.
    *
    * @return the set of Alluxio properties loaded from the site-properties file
    */
-  public static AlluxioProperties defaults() {
-    if (sDefaultProperties == null) {
-      synchronized (DEFAULT_PROPERTIES_LOCK) { // We don't want multiple threads to reload
-        // properties at the same time.
-        // Check if properties are still null so we don't reload a second time.
-        if (sDefaultProperties == null) {
-          reloadProperties();
-        }
-      }
-    }
-    return sDefaultProperties.copy();
+  public static AlluxioProperties copyDefaults() {
+    return DEFAULT_PROPERTIES_REFERENCE.get().copy();
+  }
+
+  /**
+   * Returns a reference to {@link AlluxioProperties} with the defaults and values from
+   * alluxio-site properties.
+   *
+   * @return a reference to Alluxio properties loaded from the site-properties file
+   */
+  public static AlluxioConfiguration defaults() {
+    return new InstancedConfiguration(DEFAULT_PROPERTIES_REFERENCE.get());
   }
 
   /**
@@ -416,61 +362,65 @@ public final class ConfigurationUtils {
    * @return the value configured for this property key
    */
   public static Object getPropertyValue(PropertyKey key) {
-    if (sDefaultProperties == null) {
-      return defaults().get(key);
-    } else {
-      synchronized (DEFAULT_PROPERTIES_LOCK) {
-        return sDefaultProperties.get(key);
-      }
-    }
+    return DEFAULT_PROPERTIES_REFERENCE.get().get(key);
   }
 
   /**
    * Reloads site properties from disk.
    */
   public static void reloadProperties() {
-    synchronized (DEFAULT_PROPERTIES_LOCK) {
-      // Step1: bootstrap the configuration. This is necessary because we need to resolve alluxio
-      // .home (likely to be in system properties) to locate the conf dir to search for the site
-      // property file.
-      AlluxioProperties properties = new AlluxioProperties();
-      InstancedConfiguration conf = new InstancedConfiguration(properties);
-      // Can't directly pass System.getProperties() because it is not thread-safe
-      // This can cause a ConcurrentModificationException when merging.
-      Properties sysProps = new Properties();
-      System.getProperties().stringPropertyNames()
-          .forEach(key -> sysProps.setProperty(key, System.getProperty(key)));
-      properties.merge(sysProps, Source.SYSTEM_PROPERTY);
-
-      // Step2: Load site specific properties file if not in test mode. Note that we decide
-      // whether in test mode by default properties and system properties (via getBoolean).
-      if (conf.getBoolean(PropertyKey.TEST_MODE)) {
-        conf.validate();
-        sDefaultProperties = properties;
-        return;
+    // Bootstrap the configuration. This is necessary because we need to resolve alluxio.home
+    // (likely to be in system properties) to locate the conf dir to search for the site
+    // property file.
+    AlluxioProperties alluxioProperties = new AlluxioProperties();
+    // Can't directly pass System.getProperties() because it is not thread-safe
+    // This can cause a ConcurrentModificationException when merging.
+    alluxioProperties.merge(System.getProperties().entrySet().stream()
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)),
+        Source.SYSTEM_PROPERTY);
+    InstancedConfiguration conf = new InstancedConfiguration(alluxioProperties);
+    // Load site specific properties file if not in test mode. Note that we decide
+    // whether in test mode by default properties and system properties (via getBoolean).
+    if (conf.getBoolean(PropertyKey.TEST_MODE)) {
+      conf.validate();
+      DEFAULT_PROPERTIES_REFERENCE.set(alluxioProperties);
+      return;
+    }
+    // We are not in test mode, load site properties
+    // First try loading from config file
+    for (String path : conf.getList(PropertyKey.SITE_CONF_DIR)) {
+      String file = PathUtils.concatPath(path, Constants.SITE_PROPERTIES);
+      try (FileInputStream fileInputStream = new FileInputStream(file)) {
+        Optional<Properties> properties = loadProperties(fileInputStream);
+        if (properties.isPresent()) {
+          alluxioProperties.merge(properties.get(), Source.siteProperty(file));
+          new InstancedConfiguration(alluxioProperties).validate();
+          DEFAULT_PROPERTIES_REFERENCE.set(alluxioProperties);
+          // If a site conf is successfully loaded, stop trying different paths.
+          return;
+        }
+      } catch (FileNotFoundException e) {
+        // skip
+      } catch (IOException e) {
+        LOG.warn("Failed to close property input stream from {}: {}", file, e.toString());
       }
+    }
 
-      // we are not in test mode, load site properties
-      List<String> confPathList = conf.getList(PropertyKey.SITE_CONF_DIR);
-      String sitePropertyFile = ConfigurationUtils
-          .searchPropertiesFile(Constants.SITE_PROPERTIES, confPathList);
-      Properties siteProps = null;
-      if (sitePropertyFile != null) {
-        siteProps = loadPropertiesFromFile(sitePropertyFile);
-        sSourcePropertyFile = sitePropertyFile;
-      } else {
-        URL resource =
-            ConfigurationUtils.class.getClassLoader().getResource(Constants.SITE_PROPERTIES);
-        if (resource != null) {
-          siteProps = loadPropertiesFromResource(resource);
-          if (siteProps != null) {
-            sSourcePropertyFile = resource.getPath();
-          }
+    // Try to load from resource
+    URL resource =
+        ConfigurationUtils.class.getClassLoader().getResource(Constants.SITE_PROPERTIES);
+    if (resource != null) {
+      try (InputStream stream = resource.openStream()) {
+        Optional<Properties> properties = loadProperties(stream);
+        if (properties.isPresent()) {
+          alluxioProperties.merge(properties.get(), Source.siteProperty(resource.getPath()));
+          new InstancedConfiguration(alluxioProperties).validate();
+          DEFAULT_PROPERTIES_REFERENCE.set(alluxioProperties);
         }
       }
-      properties.merge(siteProps, Source.siteProperty(sSourcePropertyFile));
-      conf.validate();
-      sDefaultProperties = properties;
+      catch (IOException e) {
+        LOG.warn("Failed to read properties from {}: {}", resource, e.toString());
+      }
     }
   }
 

--- a/core/common/src/test/java/alluxio/AbstractClientTest.java
+++ b/core/common/src/test/java/alluxio/AbstractClientTest.java
@@ -45,7 +45,7 @@ public final class AbstractClientTest {
     private long mRemoteServiceVersion;
 
     protected BaseTestClient() {
-      super(ClientContext.create(new InstancedConfiguration(ConfigurationUtils.defaults())), null,
+      super(ClientContext.create(ConfigurationUtils.defaults()), null,
           () -> new CountingRetry(1));
     }
 
@@ -133,7 +133,7 @@ public final class AbstractClientTest {
   public void confAddress() throws Exception {
     ClientContext context = Mockito.mock(ClientContext.class);
     Mockito.when(context.getClusterConf()).thenReturn(
-        new InstancedConfiguration(ConfigurationUtils.defaults()));
+        new InstancedConfiguration(ConfigurationUtils.copyDefaults()));
 
     InetSocketAddress baseAddress = new InetSocketAddress("0.0.0.0", 2000);
     InetSocketAddress confAddress = new InetSocketAddress("0.0.0.0", 2000);

--- a/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
@@ -35,7 +35,7 @@ public final class ConfigurationTestUtils {
    * @return the default configuration
    */
   public static InstancedConfiguration defaults() {
-    return new InstancedConfiguration(ConfigurationUtils.defaults());
+    return new InstancedConfiguration(ConfigurationUtils.copyDefaults());
   }
 
   /**

--- a/core/common/src/test/java/alluxio/master/MasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/MasterInquireClientTest.java
@@ -40,7 +40,7 @@ public final class MasterInquireClientTest {
 
   @Before
   public void before() {
-    mConfiguration = new InstancedConfiguration(ConfigurationUtils.defaults());
+    mConfiguration = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/security/authentication/GrpcSecurityTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/GrpcSecurityTest.java
@@ -58,7 +58,7 @@ public class GrpcSecurityTest {
 
   @Before
   public void before() {
-    mConfiguration = new InstancedConfiguration(ConfigurationUtils.defaults());
+    mConfiguration = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/security/authorization/ModeTest.java
+++ b/core/common/src/test/java/alluxio/security/authorization/ModeTest.java
@@ -42,7 +42,7 @@ public final class ModeTest {
 
   @Before
   public void before() {
-    mConfiguration = new InstancedConfiguration(ConfigurationUtils.defaults());
+    mConfiguration = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/security/group/GroupMappingServiceTest.java
+++ b/core/common/src/test/java/alluxio/security/group/GroupMappingServiceTest.java
@@ -35,7 +35,7 @@ public final class GroupMappingServiceTest {
   @Test
   public void group() throws Throwable {
     String userName = "alluxio-user1";
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
 
     try (Closeable mConfigurationRule =
         new ConfigurationRule(PropertyKey.SECURITY_GROUP_MAPPING_CLASS,

--- a/core/common/src/test/java/alluxio/underfs/options/CreateOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/CreateOptionsTest.java
@@ -40,7 +40,7 @@ public final class CreateOptionsTest {
 
   @Before
   public void before() {
-    mConfiguration = new InstancedConfiguration(ConfigurationUtils.defaults());
+    mConfiguration = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
   }
 
   /**

--- a/core/common/src/test/java/alluxio/underfs/options/MkdirsOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/MkdirsOptionsTest.java
@@ -40,7 +40,7 @@ public final class MkdirsOptionsTest {
 
   @Before
   public void before() {
-    mConfiguration = new InstancedConfiguration(ConfigurationUtils.defaults());
+    mConfiguration = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
   }
 
   /**
@@ -65,7 +65,7 @@ public final class MkdirsOptionsTest {
    */
   @Test
   public void securityEnabled() throws IOException {
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
     conf.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE);
     conf.set(PropertyKey.SECURITY_LOGIN_USERNAME, "foo");
     // Use IdentityUserGroupMapping to map user "foo" to group "foo".

--- a/core/common/src/test/java/alluxio/util/ConfigurationUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ConfigurationUtilsTest.java
@@ -154,7 +154,7 @@ public final class ConfigurationUtilsTest {
   }
 
   private AlluxioConfiguration createConf(Map<PropertyKey, Object> properties) {
-    AlluxioProperties props = ConfigurationUtils.defaults();
+    AlluxioProperties props = ConfigurationUtils.copyDefaults();
     for (PropertyKey key : properties.keySet()) {
       props.set(key, properties.get(key));
     }

--- a/core/common/src/test/java/alluxio/util/io/FileUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/FileUtilsTest.java
@@ -48,7 +48,7 @@ import javax.annotation.Nullable;
  */
 public class FileUtilsTest {
 
-  private String mWorkerDataFolderPerms = (String) ConfigurationUtils.defaults()
+  private String mWorkerDataFolderPerms = (String) ConfigurationUtils.copyDefaults()
       .get(PropertyKey.WORKER_DATA_FOLDER_PERMISSIONS);
 
   /**

--- a/core/server/common/src/main/java/alluxio/cli/Format.java
+++ b/core/server/common/src/main/java/alluxio/cli/Format.java
@@ -13,7 +13,6 @@ package alluxio.cli;
 
 import alluxio.RuntimeConstants;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.master.NoopMaster;
@@ -82,7 +81,7 @@ public final class Format {
       LOG.info(USAGE);
       System.exit(-1);
     }
-    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    AlluxioConfiguration conf = ConfigurationUtils.defaults();
     // Set the process type as "MASTER" since format needs to access the journal like the master.
     CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.MASTER);
     Mode mode = null;

--- a/core/server/common/src/main/java/alluxio/conf/ServerConfiguration.java
+++ b/core/server/common/src/main/java/alluxio/conf/ServerConfiguration.java
@@ -63,7 +63,7 @@ public final class ServerConfiguration {
    */
   public static void reset() {
     ConfigurationUtils.reloadProperties();
-    sConf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    sConf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
   }
 
   /**

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalUpgrader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalUpgrader.java
@@ -14,7 +14,6 @@ package alluxio.master.journal;
 import alluxio.AlluxioURI;
 import alluxio.RuntimeConstants;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.master.MasterFactory;
@@ -246,8 +245,7 @@ public final class JournalUpgrader {
     }
 
     for (String master : masters) {
-      Upgrader upgrader = new Upgrader(master,
-          new InstancedConfiguration(ConfigurationUtils.defaults()));
+      Upgrader upgrader = new Upgrader(master, ConfigurationUtils.defaults());
       try {
         upgrader.upgrade();
       } catch (IOException e) {

--- a/examples/src/main/java/alluxio/cli/MiniBenchmark.java
+++ b/examples/src/main/java/alluxio/cli/MiniBenchmark.java
@@ -18,7 +18,6 @@ import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.FormatUtils;
@@ -130,7 +129,7 @@ public final class MiniBenchmark {
     }
 
     CommonUtils.warmUpLoop();
-    AlluxioConfiguration alluxioConf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    AlluxioConfiguration alluxioConf = ConfigurationUtils.defaults();
 
     for (int i = 0; i < sIterations; ++i) {
       final AtomicInteger count = new AtomicInteger(0);

--- a/examples/src/main/java/alluxio/examples/MultiMount.java
+++ b/examples/src/main/java/alluxio/examples/MultiMount.java
@@ -15,8 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
-import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.util.ConfigurationUtils;
@@ -49,8 +47,6 @@ public final class MultiMount {
       System.exit(-1);
     }
 
-    AlluxioConfiguration alluxioConf = new InstancedConfiguration(ConfigurationUtils.defaults());
-
     AlluxioURI mntPath = new AlluxioURI("/mnt");
     AlluxioURI s3Mount = new AlluxioURI("/mnt/s3");
     AlluxioURI inputPath = new AlluxioURI("/mnt/s3/hello.txt");
@@ -58,7 +54,7 @@ public final class MultiMount {
     AlluxioURI hdfsMount = new AlluxioURI("/mnt/hdfs");
     AlluxioURI outputPath = new AlluxioURI("/mnt/hdfs/hello.txt");
     AlluxioURI hdfsPath = new AlluxioURI(args[0]);
-    FileSystem fileSystem = FileSystem.Factory.create(alluxioConf);
+    FileSystem fileSystem = FileSystem.Factory.create(ConfigurationUtils.defaults());
 
     try {
       // Make sure mount directory exists.

--- a/examples/src/main/java/alluxio/examples/Performance.java
+++ b/examples/src/main/java/alluxio/examples/Performance.java
@@ -582,7 +582,7 @@ public final class Performance {
       System.exit(-1);
     }
 
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
 
     HostAndPort masterAddress = HostAndPort.fromString(args[0]);
     sFileName = args[1];

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -22,7 +22,6 @@ import alluxio.client.file.URIStatus;
 import alluxio.collections.IndexDefinition;
 import alluxio.collections.IndexedSet;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.FileIncompleteException;
@@ -89,8 +88,7 @@ public final class AlluxioFuseFileSystem extends FuseStubFS
   @VisibleForTesting
   public static final int MAX_NAME_LENGTH = 255;
 
-  private static InstancedConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.defaults());
+  private static AlluxioConfiguration sConf = ConfigurationUtils.defaults();
 
   /**
    * 4294967295 is unsigned long -1, -1 means that uid or gid is not set.

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -14,7 +14,6 @@ package alluxio.fuse;
 import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
@@ -51,7 +50,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class AlluxioFuseUtils {
   private static final Logger LOG = LoggerFactory.getLogger(AlluxioFuseUtils.class);
-  private static final long THRESHOLD = new InstancedConfiguration(ConfigurationUtils.defaults())
+  private static final long THRESHOLD = ConfigurationUtils.defaults()
       .getMs(PropertyKey.FUSE_LOGGING_THRESHOLD);
   private static final int MAX_ASYNC_RELEASE_WAITTIME_MS = 5000;
 

--- a/integration/fuse/src/main/java/alluxio/fuse/StackMain.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/StackMain.java
@@ -38,7 +38,7 @@ public class StackMain {
     Path root = Paths.get(args[1]);
     Path mountPoint = Paths.get(args[0]);
     AlluxioConfiguration conf = new InstancedConfiguration(
-        ConfigurationUtils.defaults());
+        ConfigurationUtils.copyDefaults());
     LibFuse.loadLibrary(AlluxioFuseUtils.getVersionPreference(conf));
     StackFS fs = new StackFS(root, mountPoint);
     String[] fuseOpts = new String[args.length - 2];

--- a/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
@@ -76,7 +76,7 @@ public final class UnderFileSystemContractTest {
    * A constructor from default.
    * */
   public UnderFileSystemContractTest() {
-    mConf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    mConf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
   }
 
   /**

--- a/job/server/src/main/java/alluxio/master/job/tracker/AbstractCmdRunner.java
+++ b/job/server/src/main/java/alluxio/master/job/tracker/AbstractCmdRunner.java
@@ -13,7 +13,6 @@ package alluxio.master.job.tracker;
 
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.job.wire.Status;
 import alluxio.master.job.JobMaster;
 import alluxio.util.CommonUtils;
@@ -55,7 +54,7 @@ public abstract class AbstractCmdRunner {
     mJobMap = Maps.newHashMap();
     if (fsContext == null) {
       fsContext =
-        FileSystemContext.create(new InstancedConfiguration(ConfigurationUtils.defaults()));
+        FileSystemContext.create(ConfigurationUtils.defaults());
     }
     mFsContext = fsContext;
     mFileSystem = FileSystem.Factory.create(fsContext);

--- a/job/server/src/main/java/alluxio/master/job/tracker/PersistRunner.java
+++ b/job/server/src/main/java/alluxio/master/job/tracker/PersistRunner.java
@@ -13,7 +13,6 @@ package alluxio.master.job.tracker;
 
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.grpc.OperationType;
 import alluxio.job.cmd.persist.PersistCmdConfig;
 import alluxio.job.wire.JobSource;
@@ -24,8 +23,6 @@ import alluxio.retry.CountingRetry;
 import alluxio.util.ConfigurationUtils;
 
 import com.google.common.collect.Lists;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import javax.annotation.Nullable;
@@ -34,7 +31,6 @@ import javax.annotation.Nullable;
  * A config runner for a Persist job.
  */
 public class PersistRunner {
-  private static final Logger LOG = LoggerFactory.getLogger(PersistRunner.class);
   static final long DEFAULT_FILE_COUNT = 1;
 
   private FileSystem mFileSystem;
@@ -47,8 +43,7 @@ public class PersistRunner {
    */
   public PersistRunner(@Nullable FileSystemContext fsContext, JobMaster jobMaster) {
     if (fsContext == null) {
-      fsContext =
-              FileSystemContext.create(new InstancedConfiguration(ConfigurationUtils.defaults()));
+      fsContext = FileSystemContext.create(ConfigurationUtils.defaults());
     }
     mFileSystem = FileSystem.Factory.create(fsContext);
     mJobMaster = jobMaster;

--- a/shell/src/main/java/alluxio/cli/BasicCheckpoint.java
+++ b/shell/src/main/java/alluxio/cli/BasicCheckpoint.java
@@ -17,7 +17,6 @@ import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.util.ConfigurationUtils;
@@ -107,7 +106,7 @@ public class BasicCheckpoint implements Callable<Boolean> {
       System.exit(-1);
     }
     FileSystemContext fsContext =
-        FileSystemContext.create(new InstancedConfiguration(ConfigurationUtils.defaults()));
+        FileSystemContext.create(ConfigurationUtils.defaults());
     boolean result = RunTestUtils.runExample(new BasicCheckpoint(args[0], Integer.parseInt(args[1]),
         fsContext));
     System.exit(result ? 0 : 1);

--- a/shell/src/main/java/alluxio/cli/GetConf.java
+++ b/shell/src/main/java/alluxio/cli/GetConf.java
@@ -16,7 +16,6 @@ import alluxio.annotation.PublicApi;
 import alluxio.client.meta.RetryHandlingMetaMasterConfigClient;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.ConfigurationValueOptions;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.ConfigProperty;
 import alluxio.grpc.GetConfigurationPOptions;
@@ -266,7 +265,7 @@ public final class GetConf {
    */
   public static void main(String[] args) {
     System.exit(getConf(
-        ClientContext.create(new InstancedConfiguration(ConfigurationUtils.defaults())), args));
+        ClientContext.create(ConfigurationUtils.defaults()), args));
   }
 
   private GetConf() {} // this class is not intended for instantiation

--- a/shell/src/main/java/alluxio/cli/HmsTests.java
+++ b/shell/src/main/java/alluxio/cli/HmsTests.java
@@ -11,7 +11,6 @@
 
 package alluxio.cli;
 
-import alluxio.conf.InstancedConfiguration;
 import alluxio.util.ConfigurationUtils;
 
 import org.apache.commons.cli.CommandLine;
@@ -102,7 +101,7 @@ public class HmsTests {
         .getOptionValue(ValidationConfig.SOCKET_TIMEOUT_OPTION_NAME, "-1"));
 
     ValidationToolRegistry registry
-        = new ValidationToolRegistry(new InstancedConfiguration(ConfigurationUtils.defaults()));
+        = new ValidationToolRegistry(ConfigurationUtils.defaults());
     // Load hms validation tool from alluxio lib directory
     registry.refresh();
 

--- a/shell/src/main/java/alluxio/cli/JournalCrashTest.java
+++ b/shell/src/main/java/alluxio/cli/JournalCrashTest.java
@@ -43,7 +43,7 @@ import java.util.List;
 public final class JournalCrashTest {
 
   private static InstancedConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.defaults());
+      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
 
   private JournalCrashTest() {} // prevent instantiation
 

--- a/shell/src/main/java/alluxio/cli/LogLevel.java
+++ b/shell/src/main/java/alluxio/cli/LogLevel.java
@@ -18,7 +18,6 @@ import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.job.JobMasterClient;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.job.wire.JobWorkerHealth;
 import alluxio.util.ConfigurationUtils;
@@ -321,7 +320,7 @@ public final class LogLevel {
   public static void main(String[] args) {
     int exitCode = 1;
     try {
-      logLevel(args, new InstancedConfiguration(ConfigurationUtils.defaults()));
+      logLevel(args, ConfigurationUtils.defaults());
       exitCode = 0;
     } catch (ParseException e) {
       printHelp("Unable to parse input args: " + e.getMessage());

--- a/shell/src/main/java/alluxio/cli/RunOperation.java
+++ b/shell/src/main/java/alluxio/cli/RunOperation.java
@@ -73,7 +73,7 @@ public class RunOperation {
    * @param args command-line arguments
    */
   public static void main(String[] args) {
-    System.exit(new RunOperation(new InstancedConfiguration(ConfigurationUtils.defaults()))
+    System.exit(new RunOperation(new InstancedConfiguration(ConfigurationUtils.copyDefaults()))
         .run(args));
   }
 

--- a/shell/src/main/java/alluxio/cli/TestRunner.java
+++ b/shell/src/main/java/alluxio/cli/TestRunner.java
@@ -110,7 +110,7 @@ public final class TestRunner {
 
     AlluxioURI testDir = new AlluxioURI(mDirectory);
     FileSystemContext fsContext =
-        FileSystemContext.create(new InstancedConfiguration(ConfigurationUtils.defaults()));
+        FileSystemContext.create(new InstancedConfiguration(ConfigurationUtils.copyDefaults()));
     FileSystem fs =
         FileSystem.Factory.create(fsContext);
     if (fs.exists(testDir)) {

--- a/shell/src/main/java/alluxio/cli/ValidateConf.java
+++ b/shell/src/main/java/alluxio/cli/ValidateConf.java
@@ -36,7 +36,7 @@ public final class ValidateConf {
   public static void main(String[] args) {
     LOG.info("Validating configuration.");
     try {
-      new InstancedConfiguration(ConfigurationUtils.defaults()).validate();
+      new InstancedConfiguration(ConfigurationUtils.copyDefaults()).validate();
       LOG.info("Configuration is valid.");
     } catch (IllegalStateException e) {
       LOG.error("Configuration is invalid", e);

--- a/shell/src/main/java/alluxio/cli/ValidateHdfsMount.java
+++ b/shell/src/main/java/alluxio/cli/ValidateHdfsMount.java
@@ -129,7 +129,7 @@ public class ValidateHdfsMount {
     }
 
     ValidationToolRegistry registry
-            = new ValidationToolRegistry(new InstancedConfiguration(ConfigurationUtils.defaults()));
+            = new ValidationToolRegistry(ConfigurationUtils.defaults());
     // Load hdfs validation tool from alluxio lib directory
     registry.refresh();
 

--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -210,7 +210,7 @@ public class CollectInfo extends AbstractShell {
     }
 
     // Create the shell instance
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
 
     // Reduce the RPC retry max duration to fail earlier for CLIs
     conf.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "5s", Source.DEFAULT);

--- a/shell/src/main/java/alluxio/cli/docgen/ConfigurationDocGenerator.java
+++ b/shell/src/main/java/alluxio/cli/docgen/ConfigurationDocGenerator.java
@@ -12,7 +12,6 @@
 package alluxio.cli.docgen;
 
 import alluxio.annotation.PublicApi;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.io.PathUtils;
@@ -209,8 +208,7 @@ public final class ConfigurationDocGenerator {
   public static void generate() throws IOException {
     Collection<? extends PropertyKey> defaultKeys = PropertyKey.defaultKeys();
     defaultKeys.removeIf(key -> key.isHidden());
-    String homeDir = new InstancedConfiguration(ConfigurationUtils.defaults())
-        .getString(PropertyKey.HOME);
+    String homeDir = ConfigurationUtils.defaults().getString(PropertyKey.HOME);
     // generate CSV files
     String filePath = PathUtils.concatPath(homeDir, CSV_FILE_DIR);
     writeCSVFile(defaultKeys, filePath);

--- a/shell/src/main/java/alluxio/cli/docgen/MetricsDocGenerator.java
+++ b/shell/src/main/java/alluxio/cli/docgen/MetricsDocGenerator.java
@@ -12,7 +12,6 @@
 package alluxio.cli.docgen;
 
 import alluxio.annotation.PublicApi;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
@@ -57,8 +56,7 @@ public final class MetricsDocGenerator {
     List<MetricKey> defaultKeys = new ArrayList<>(MetricKey.allMetricKeys());
     Collections.sort(defaultKeys);
 
-    String homeDir = new InstancedConfiguration(ConfigurationUtils.defaults())
-        .getString(PropertyKey.HOME);
+    String homeDir = ConfigurationUtils.defaults().getString(PropertyKey.HOME);
 
     // Map from metric key prefix to metric category
     Map<String, String> metricTypeMap = new HashMap<>();

--- a/shell/src/main/java/alluxio/cli/fs/FileSystemShell.java
+++ b/shell/src/main/java/alluxio/cli/fs/FileSystemShell.java
@@ -52,7 +52,7 @@ public final class FileSystemShell extends AbstractShell {
    */
   public static void main(String[] argv) throws IOException {
     int ret;
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
     if (!ConfigurationUtils.masterHostConfigured(conf)
         && argv.length > 0 && !argv[0].equals("help")) {
       System.out.println(ConfigurationUtils.getMasterHostNotConfiguredMessage("Alluxio fs shell"));

--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractFileSystemCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractFileSystemCommand.java
@@ -16,7 +16,6 @@ import alluxio.cli.Command;
 import alluxio.cli.fs.FileSystemShellUtils;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.exception.AlluxioException;
 import alluxio.util.ConfigurationUtils;
 
@@ -48,7 +47,7 @@ public abstract class AbstractFileSystemCommand implements Command {
   protected AbstractFileSystemCommand(@Nullable FileSystemContext fsContext) {
     if (fsContext == null) {
       fsContext =
-          FileSystemContext.create(new InstancedConfiguration(ConfigurationUtils.defaults()));
+          FileSystemContext.create(ConfigurationUtils.defaults());
     }
     mFsContext = fsContext;
     mFileSystem = FileSystem.Factory.create(fsContext);

--- a/shell/src/main/java/alluxio/cli/fsadmin/FileSystemAdminShell.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/FileSystemAdminShell.java
@@ -59,7 +59,7 @@ public final class FileSystemAdminShell extends AbstractShell {
    */
   public static void main(String[] args) throws IOException {
     int ret;
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
     if (!ConfigurationUtils.masterHostConfigured(conf) && args.length > 0) {
       System.out.println(ConfigurationUtils
           .getMasterHostNotConfiguredMessage("Alluxio fsadmin shell"));

--- a/shell/src/main/java/alluxio/cli/job/JobShell.java
+++ b/shell/src/main/java/alluxio/cli/job/JobShell.java
@@ -43,7 +43,7 @@ public final class JobShell extends AbstractShell {
    */
   public static void main(String[] argv) throws IOException {
     int ret;
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
 
     if (!ConfigurationUtils.masterHostConfigured(conf) && argv.length > 0) {
       System.out.println(ConfigurationUtils

--- a/shell/src/main/java/alluxio/master/AlluxioMasterMonitor.java
+++ b/shell/src/main/java/alluxio/master/AlluxioMasterMonitor.java
@@ -14,7 +14,6 @@ package alluxio.master;
 import alluxio.HealthCheckClient;
 import alluxio.RuntimeConstants;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.retry.ExponentialBackoffRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.util.ConfigurationUtils;
@@ -45,14 +44,10 @@ public final class AlluxioMasterMonitor {
       LOG.warn("ignoring arguments");
     }
 
-    AlluxioConfiguration alluxioConf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    AlluxioConfiguration alluxioConf = ConfigurationUtils.defaults();
 
     MasterHealthCheckClient.Builder builder = new MasterHealthCheckClient.Builder(alluxioConf);
-    if (ConfigurationUtils.isHaMode(alluxioConf)) {
-      builder.withProcessCheck(true);
-    } else {
-      builder.withProcessCheck(false);
-    }
+    builder.withProcessCheck(ConfigurationUtils.isHaMode(alluxioConf));
     HealthCheckClient client = builder.build();
     if (!client.isServing()) {
       System.exit(1);

--- a/shell/src/main/java/alluxio/master/job/AlluxioJobMasterMonitor.java
+++ b/shell/src/main/java/alluxio/master/job/AlluxioJobMasterMonitor.java
@@ -14,7 +14,6 @@ package alluxio.master.job;
 import alluxio.HealthCheckClient;
 import alluxio.RuntimeConstants;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.master.AlluxioMasterMonitor;
 import alluxio.master.MasterHealthCheckClient;
 import alluxio.util.ConfigurationUtils;
@@ -40,7 +39,7 @@ public final class AlluxioJobMasterMonitor {
           AlluxioJobMasterMonitor.class.getCanonicalName());
       LOG.warn("ignoring arguments");
     }
-    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    AlluxioConfiguration conf = ConfigurationUtils.defaults();
     HealthCheckClient client;
     // Only the primary master serves RPCs, so if we're configured for HA, fall back to simply
     // checking for the running process.

--- a/shell/src/main/java/alluxio/proxy/AlluxioProxyMonitor.java
+++ b/shell/src/main/java/alluxio/proxy/AlluxioProxyMonitor.java
@@ -13,7 +13,6 @@ package alluxio.proxy;
 
 import alluxio.HealthCheckClient;
 import alluxio.RuntimeConstants;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.retry.ExponentialBackoffRetry;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.network.NetworkAddressUtils;
@@ -41,7 +40,7 @@ public final class AlluxioProxyMonitor {
 
     HealthCheckClient client = new ProxyHealthCheckClient(
         NetworkAddressUtils.getBindAddress(NetworkAddressUtils.ServiceType.PROXY_WEB,
-            new InstancedConfiguration(ConfigurationUtils.defaults())),
+            ConfigurationUtils.defaults()),
         () -> new ExponentialBackoffRetry(50, 100, 2));
     if (!client.isServing()) {
       System.exit(1);

--- a/shell/src/main/java/alluxio/worker/AlluxioWorkerMonitor.java
+++ b/shell/src/main/java/alluxio/worker/AlluxioWorkerMonitor.java
@@ -14,7 +14,6 @@ package alluxio.worker;
 import alluxio.HealthCheckClient;
 import alluxio.RuntimeConstants;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.retry.ExponentialBackoffRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.util.ConfigurationUtils;
@@ -45,7 +44,7 @@ public final class AlluxioWorkerMonitor {
           AlluxioWorkerMonitor.class.getCanonicalName());
       LOG.warn("ignoring arguments");
     }
-    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    AlluxioConfiguration conf = ConfigurationUtils.defaults();
 
     HealthCheckClient client = new WorkerHealthCheckClient(
         NetworkAddressUtils.getConnectAddress(NetworkAddressUtils.ServiceType.WORKER_RPC, conf),

--- a/shell/src/main/java/alluxio/worker/job/AlluxioJobWorkerMonitor.java
+++ b/shell/src/main/java/alluxio/worker/job/AlluxioJobWorkerMonitor.java
@@ -14,7 +14,6 @@ package alluxio.worker.job;
 import alluxio.HealthCheckClient;
 import alluxio.RuntimeConstants;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.worker.AlluxioWorkerMonitor;
@@ -39,7 +38,7 @@ public final class AlluxioJobWorkerMonitor {
               AlluxioJobWorkerMonitor.class.getCanonicalName());
       LOG.warn("ignoring arguments");
     }
-    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    AlluxioConfiguration conf = ConfigurationUtils.defaults();
 
     HealthCheckClient client = new JobWorkerHealthCheckClient(
         NetworkAddressUtils.getConnectAddress(NetworkAddressUtils.ServiceType.JOB_WORKER_RPC, conf),

--- a/shell/src/test/java/alluxio/cli/bundler/CollectInfoTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/CollectInfoTest.java
@@ -26,7 +26,7 @@ import java.util.Collection;
 
 public class CollectInfoTest {
   private static InstancedConfiguration sConf =
-          new InstancedConfiguration(ConfigurationUtils.defaults());
+          new InstancedConfiguration(ConfigurationUtils.copyDefaults());
 
   private int getNumberOfCommands() {
     Reflections reflections =

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
@@ -45,7 +45,7 @@ import java.util.Map;
 public class SummaryCommandTest {
 
   private static AlluxioConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.defaults());
+      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
 
   private MetaMasterClient mMetaMasterClient;
   private BlockMasterClient mBlockMasterClient;

--- a/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
@@ -14,7 +14,6 @@ package alluxio.stress.cli;
 import alluxio.annotation.SuppressFBWarnings;
 import alluxio.client.job.JobGrpcClientUtils;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.job.plan.PlanConfig;
 import alluxio.job.wire.JobInfo;
@@ -161,7 +160,7 @@ public abstract class Benchmark<T extends TaskResult> {
           + "=" + BaseParameters.AGENT_OUTPUT_PATH);
     }
 
-    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    AlluxioConfiguration conf = ConfigurationUtils.defaults();
     String className = this.getClass().getCanonicalName();
 
     if (mBaseParameters.mCluster) {

--- a/stress/shell/src/main/java/alluxio/stress/cli/StressJobServiceBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/StressJobServiceBench.java
@@ -21,7 +21,6 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.job.JobMasterClient;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
@@ -88,7 +87,7 @@ public class StressJobServiceBench extends Benchmark<JobServiceBenchTaskResult> 
   @Override
   public void prepare() throws Exception {
     mFsContext =
-        FileSystemContext.create(new InstancedConfiguration(ConfigurationUtils.defaults()));
+        FileSystemContext.create(ConfigurationUtils.defaults());
     final ClientContext clientContext = mFsContext.getClientContext();
     mJobMasterClient =
         JobMasterClient.Factory.create(JobMasterClientContext.newBuilder(clientContext).build());

--- a/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
@@ -180,7 +180,7 @@ public class StressMasterBench extends AbstractStressBench<MasterBenchTaskResult
       }
     } else {
       LOG.info("Using ALLUXIO Native API to perform the test.");
-      alluxio.conf.AlluxioProperties alluxioProperties = ConfigurationUtils.defaults();
+      alluxio.conf.AlluxioProperties alluxioProperties = ConfigurationUtils.copyDefaults();
       alluxioProperties.merge(HadoopConfigurationUtils.getConfigurationFromHadoop(hdfsConf),
           Source.RUNTIME);
 

--- a/stress/shell/src/main/java/alluxio/stress/cli/client/CompactionBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/CompactionBench.java
@@ -231,7 +231,7 @@ public class CompactionBench extends Benchmark<CompactionTaskResult> {
   }
 
   private static AlluxioProperties getCustomProperties(List<String> propertyList) {
-    AlluxioProperties properties = ConfigurationUtils.defaults();
+    AlluxioProperties properties = ConfigurationUtils.copyDefaults();
     for (String property : propertyList) {
       String[] parts = property.split("=", 2);
       Preconditions.checkArgument(parts.length == 2,

--- a/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
@@ -169,7 +169,7 @@ public class StressClientIOBench extends AbstractStressBench
     } else {
       LOG.info("Using ALLUXIO Native API to perform the test.");
 
-      alluxio.conf.AlluxioProperties alluxioProperties = ConfigurationUtils.defaults();
+      alluxio.conf.AlluxioProperties alluxioProperties = ConfigurationUtils.copyDefaults();
       alluxioProperties.merge(HadoopConfigurationUtils.getConfigurationFromHadoop(hdfsConf),
           Source.RUNTIME);
 

--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -15,7 +15,6 @@ import alluxio.ClientContext;
 import alluxio.Constants;
 import alluxio.annotation.SuppressFBWarnings;
 import alluxio.client.job.JobMasterClient;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.stress.BaseParameters;
 import alluxio.stress.StressConstants;
 import alluxio.stress.cli.Benchmark;
@@ -174,8 +173,8 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
     // for cluster mode, find 0-based id, and make sure directories and job workers are 1-to-1
     int numJobWorkers;
     try (JobMasterClient client = JobMasterClient.Factory.create(
-        JobMasterClientContext.newBuilder(ClientContext.create(new InstancedConfiguration(
-            ConfigurationUtils.defaults()))).build())) {
+        JobMasterClientContext.newBuilder(ClientContext.create(
+            ConfigurationUtils.defaults())).build())) {
       numJobWorkers = client.getAllWorkerHealth().size();
     }
     if (numJobWorkers != jobWorkerDirs.length) {

--- a/stress/shell/src/main/java/alluxio/stress/cli/suite/AbstractMaxThroughput.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/suite/AbstractMaxThroughput.java
@@ -105,7 +105,7 @@ public abstract class AbstractMaxThroughput<Q extends TaskResult, T extends
     int numWorkers = 0;
     try (JobMasterClient client = JobMasterClient.Factory.create(
         JobMasterClientContext.newBuilder(ClientContext.create(new InstancedConfiguration(
-            ConfigurationUtils.defaults()))).build())) {
+            ConfigurationUtils.copyDefaults()))).build())) {
       numWorkers = client.getAllWorkerHealth().size();
     }
     if (numWorkers <= 0) {

--- a/stress/shell/src/main/java/alluxio/stress/cli/suite/MasterMaxThroughput.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/suite/MasterMaxThroughput.java
@@ -77,7 +77,7 @@ public class MasterMaxThroughput extends
     }
     try (JobMasterClient client = JobMasterClient.Factory.create(
         JobMasterClientContext.newBuilder(ClientContext.create(new InstancedConfiguration(
-            ConfigurationUtils.defaults()))).build())) {
+            ConfigurationUtils.copyDefaults()))).build())) {
       mNumWorkers = client.getAllWorkerHealth().size();
     }
   }

--- a/table/shell/src/main/java/alluxio/cli/table/TableShell.java
+++ b/table/shell/src/main/java/alluxio/cli/table/TableShell.java
@@ -18,7 +18,6 @@ import alluxio.cli.CommandUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.table.TableMasterClient;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.master.MasterClientContext;
 import alluxio.util.ConfigurationUtils;
 
@@ -33,11 +32,9 @@ public class TableShell extends AbstractShell {
 
   /**
    * Construct a new instance of {@link TableShell}.
-   *
-   * @param conf the Alluxio configuration to use when instantiating the shell
    */
-  public TableShell(InstancedConfiguration conf) {
-    super(null, null, conf);
+  public TableShell() {
+    super(null, null, ConfigurationUtils.defaults());
   }
 
   /**
@@ -46,8 +43,7 @@ public class TableShell extends AbstractShell {
    * @param args array of arguments given by the user's input from the terminal
    */
   public static void main(String[] args) {
-    TableShell tableShell =
-        new TableShell(new InstancedConfiguration(ConfigurationUtils.defaults()));
+    TableShell tableShell = new TableShell();
     System.exit(tableShell.run(args));
   }
 

--- a/table/shell/src/test/java/alluxio/cli/table/TransformTableCommandTest.java
+++ b/table/shell/src/test/java/alluxio/cli/table/TransformTableCommandTest.java
@@ -41,7 +41,7 @@ public class TransformTableCommandTest {
     when(client.transformTable(ArgumentMatchers.anyString(), ArgumentMatchers.anyString(),
         ArgumentMatchers.anyString())).thenReturn(0L);
     TransformTableCommand command =
-        new TransformTableCommand(new InstancedConfiguration(ConfigurationUtils.defaults()),
+        new TransformTableCommand(new InstancedConfiguration(ConfigurationUtils.copyDefaults()),
             client, null);
 
     ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
@@ -13,7 +13,6 @@ package alluxio.underfs.hdfs;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
@@ -48,14 +47,14 @@ public class HdfsUnderFileSystemFactory implements UnderFileSystemFactory {
     // This loads the static configuration from the JVM's system properties and the site properties
     // file at the time of instantiation. Because of this, setting the property
     // UNDERFS_HDFS_PREFIXES programmatically *not* work.
-    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
 
     if (path != null) {
       // TODO(hy): In Hadoop 2.x this can be replaced with the simpler call to
       // FileSystem.getFileSystemClass() without any need for having users explicitly declare the
       // file system schemes to treat as being HDFS. However as long as pre 2.x versions of Hadoop
       // are supported this is not an option and we have to continue to use this method.
-      for (final String prefix : conf.getList(PropertyKey.UNDERFS_HDFS_PREFIXES)) {
+      for (final String prefix : ConfigurationUtils.defaults()
+          .getList(PropertyKey.UNDERFS_HDFS_PREFIXES)) {
         if (path.startsWith(prefix)) {
           return true;
         }
@@ -70,7 +69,7 @@ public class HdfsUnderFileSystemFactory implements UnderFileSystemFactory {
       // This loads the configuration from the JVM's system properties and the site properties file
       // on disk. Because of this, setting the property UNDERFS_HDFS_PREFIXES programmatically *not*
       // work.
-      AlluxioConfiguration alluxioConf = new InstancedConfiguration(ConfigurationUtils.defaults());
+      AlluxioConfiguration alluxioConf = ConfigurationUtils.defaults();
 
       // TODO(hy): In Hadoop 2.x this can be replaced with the simpler call to
       // FileSystem.getFileSystemClass() without any need for having users explicitly declare the

--- a/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemFactoryTest.java
+++ b/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemFactoryTest.java
@@ -30,7 +30,7 @@ public class LocalUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
-    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
     UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry.find("/local/test/path", conf);
     UnderFileSystemFactory factory2 = UnderFileSystemFactoryRegistry.find("file://local/test/path",
         conf);

--- a/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemTest.java
+++ b/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemTest.java
@@ -60,7 +60,7 @@ public class LocalUnderFileSystemTest {
   private String mLocalUfsRoot;
   private UnderFileSystem mLocalUfs;
   private static AlluxioConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.defaults());
+      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
 
   @Rule
   public TemporaryFolder mTemporaryFolder = new TemporaryFolder();

--- a/underfs/obs/src/test/java/alluxio/underfs/obs/OBSInputStreamTest.java
+++ b/underfs/obs/src/test/java/alluxio/underfs/obs/OBSInputStreamTest.java
@@ -46,7 +46,7 @@ public class OBSInputStreamTest {
   private static final String BUCKET_NAME = "testBucket";
   private static final String OBJECT_KEY = "testObjectKey";
   private static AlluxioConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.defaults());
+      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
 
   private OBSInputStream mOBSInputStream;
   private ObsClient mObsClient;

--- a/underfs/obs/src/test/java/alluxio/underfs/obs/OBSOutputStreamTest.java
+++ b/underfs/obs/src/test/java/alluxio/underfs/obs/OBSOutputStreamTest.java
@@ -45,7 +45,7 @@ import java.security.DigestOutputStream;
 @RunWith(PowerMockRunner.class)
 public class OBSOutputStreamTest {
   private static AlluxioConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.defaults());
+      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
 
   private ObsClient mObsClient;
   private File mFile;

--- a/underfs/obs/src/test/java/alluxio/underfs/obs/OBSUnderFileSystemFactoryTest.java
+++ b/underfs/obs/src/test/java/alluxio/underfs/obs/OBSUnderFileSystemFactoryTest.java
@@ -30,7 +30,7 @@ public class OBSUnderFileSystemFactoryTest {
   @Test
   public void factory() {
     UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry.find("obs://bucket/key",
-        new InstancedConfiguration(ConfigurationUtils.defaults()));
+        new InstancedConfiguration(ConfigurationUtils.copyDefaults()));
 
     Assert.assertNotNull(
         "A UnderFileSystemFactory should exist for obs paths when using this module", factory);

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
@@ -45,7 +45,7 @@ public class OSSInputStreamTest {
   private static final String BUCKET_NAME = "testBucket";
   private static final String OBJECT_KEY = "testObjectKey";
   private static AlluxioConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.defaults());
+      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
 
   private OSSInputStream mOssInputStream;
   private OSS mOssClient;

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSOutputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSOutputStreamTest.java
@@ -48,7 +48,7 @@ public class OSSOutputStreamTest {
   private File mFile;
   private BufferedOutputStream mLocalOutputStream;
   private static AlluxioConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.defaults());
+      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
 
   /**
    * The exception expected to be thrown.

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemFactoryTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemFactoryTest.java
@@ -30,7 +30,7 @@ public class OSSUnderFileSystemFactoryTest {
   @Test
   public void factory() {
     UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry.find("oss://test-bucket/path",
-        new InstancedConfiguration(ConfigurationUtils.defaults()));
+        new InstancedConfiguration(ConfigurationUtils.copyDefaults()));
 
     Assert.assertNotNull(
         "A UnderFileSystemFactory should exist for oss paths when using this module", factory);

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3ALowLevelOutputStreamTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3ALowLevelOutputStreamTest.java
@@ -58,7 +58,7 @@ public class S3ALowLevelOutputStreamTest {
   private static final String KEY = "testKey";
   private static final String UPLOAD_ID = "testUploadId";
   private static InstancedConfiguration sConf = new InstancedConfiguration(
-      ConfigurationUtils.defaults());
+      ConfigurationUtils.copyDefaults());
 
   private AmazonS3 mMockS3Client;
   private ListeningExecutorService mMockExecutor;

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AOutputStreamTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AOutputStreamTest.java
@@ -41,7 +41,7 @@ public class S3AOutputStreamTest {
   private static final String BUCKET_NAME = "testBucket";
   private static final String KEY = "testKey";
   private static AlluxioConfiguration sConf = new InstancedConfiguration(
-      ConfigurationUtils.defaults());
+      ConfigurationUtils.copyDefaults());
 
   private File mFile;
   private BufferedOutputStream mLocalOutputStream;

--- a/underfs/web/src/test/java/alluxio/underfs/web/WebUnderFileSystemFactoryTest.java
+++ b/underfs/web/src/test/java/alluxio/underfs/web/WebUnderFileSystemFactoryTest.java
@@ -30,7 +30,7 @@ public class WebUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
-    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
+    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
     UnderFileSystemFactory factory =
         UnderFileSystemFactoryRegistry.find("https://downloads.alluxio.io/downloads/files/2.0.0-preview/", conf);
     UnderFileSystemFactory factory2 =

--- a/underfs/web/src/test/java/alluxio/underfs/web/WebUnderFileSystemTest.java
+++ b/underfs/web/src/test/java/alluxio/underfs/web/WebUnderFileSystemTest.java
@@ -31,7 +31,7 @@ public class WebUnderFileSystemTest {
   private String mWebUfsRoot;
   private UnderFileSystem mWebUfs;
   private static AlluxioConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.defaults());
+      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
 
   @Before
   public void before() throws IOException {


### PR DESCRIPTION
* Make reloadProperties more efficient
* Rename ConfigurationUtils.defaults to copyDefaults so copy is explicit
* Add no-copy implementation of ConfigurationUtils.defaults