### PR TITLE
Fix Inode modification not visible in memory state

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1624,8 +1624,7 @@ public class DefaultFileSystemMaster extends CoreMaster
         .setLastAccessTimeMs(opTimeMs)
         .setOverwriteModificationTime(true)
         .build());
-    // inodePath.replaceInode(mInodeTree.updateInodeFile(rpcContext, entry.build()));
-    inodePath.replaceInode(mInodeTree.updateInodeFile(rpcContext, entry.build()));
+    inodePath.replaceWithUpdatedInode(mInodeTree.updateInodeFile(rpcContext, entry.build()));
 
     Metrics.FILES_COMPLETED.inc();
   }
@@ -2481,7 +2480,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       mInodeTree.updateInode(rpcContext, UpdateInodeEntry.newBuilder()
           .setId(inodeDirectory.getId())
           .setUfsFingerprint(ufsFingerprint)
-          .build()).ifPresent(inodePath::replaceInode);
+          .build()).ifPresent(inodePath::replaceWithUpdatedInode);
 
       if (context.isPersisted()) {
         // The path exists in UFS, so it is no longer absent.
@@ -2650,7 +2649,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       mInodeTree.updateInode(rpcContext, UpdateInodeEntry.newBuilder()
           .setId(srcInode.getId())
           .setPersistenceState(PersistenceState.TO_BE_PERSISTED.name())
-          .build()).ifPresent(srcInodePath::replaceInode);
+          .build()).ifPresent(srcInodePath::replaceWithUpdatedInode);
       long shouldPersistTime = srcInode.asFile().getShouldPersistTime();
       long persistenceWaitTime = shouldPersistTime == Constants.NO_AUTO_PERSIST ? 0
           : getPersistenceWaitTime(shouldPersistTime);
@@ -2676,7 +2675,7 @@ public class DefaultFileSystemMaster extends CoreMaster
             mInodeTree.updateInode(rpcContext, UpdateInodeEntry.newBuilder()
                 .setId(childInode.getId())
                 .setPersistenceState(PersistenceState.TO_BE_PERSISTED.name())
-                .build()).ifPresent(childPath::replaceInode);
+                .build()).ifPresent(childPath::replaceWithUpdatedInode);
             long shouldPersistTime = childInode.asFile().getShouldPersistTime();
             long persistenceWaitTime = shouldPersistTime == Constants.NO_AUTO_PERSIST ? 0
                 : getPersistenceWaitTime(shouldPersistTime);
@@ -2724,7 +2723,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       throw new InvalidPathException("Destination path: " + dstPath + " already exists.");
     }
 
-    srcInodePath.replaceInode(mInodeTree.rename(rpcContext, RenameEntry.newBuilder()
+    srcInodePath.replaceWithUpdatedInode(mInodeTree.rename(rpcContext, RenameEntry.newBuilder()
         .setId(srcInode.getId())
         .setOpTimeMs(context.getOperationTimeMs())
         .setNewParentId(dstParentInode.getId())
@@ -3392,7 +3391,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       }
     }
 
-    inodePath.replaceInode(mInodeTree.setAcl(rpcContext, SetAclEntry.newBuilder()
+    inodePath.replaceWithUpdatedInode(mInodeTree.setAcl(rpcContext, SetAclEntry.newBuilder()
         .setId(inode.getId())
         .setOpTimeMs(opTimeMs)
         .setAction(ProtoUtils.toProto(action))
@@ -3567,7 +3566,7 @@ public class DefaultFileSystemMaster extends CoreMaster
     if (shouldPersistPath(inodePath.toString())) {
       mInodeTree.updateInode(rpcContext, UpdateInodeEntry.newBuilder().setId(inode.getId())
           .setPersistenceState(PersistenceState.TO_BE_PERSISTED.name()).build())
-          .ifPresent(inodePath::replaceInode);
+          .ifPresent(inodePath::replaceWithUpdatedInode);
       mPersistRequests.put(inode.getId(),
           new alluxio.time.ExponentialTimer(
               ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS),
@@ -3919,7 +3918,7 @@ public class DefaultFileSystemMaster extends CoreMaster
     if (modeChanged) {
       entry.setMode(ModeUtils.protoToShort(protoOptions.getMode()));
     }
-    mInodeTree.updateInode(rpcContext, entry.build()).ifPresent(inodePath::replaceInode);
+    mInodeTree.updateInode(rpcContext, entry.build()).ifPresent(inodePath::replaceWithUpdatedInode);
   }
 
   @Override
@@ -4071,7 +4070,7 @@ public class DefaultFileSystemMaster extends CoreMaster
                 .setId(inode.getId())
                 .setPersistenceState(PersistenceState.NOT_PERSISTED.name())
                 .build());
-            inodePath.replaceInode(mInodeTree.updateInodeFile(journalContext,
+            inodePath.replaceWithUpdatedInode(mInodeTree.updateInodeFile(journalContext,
                 UpdateInodeFileEntry.newBuilder()
                     .setId(inode.getId())
                     .setPersistJobId(Constants.PERSISTENCE_INVALID_JOB_ID)
@@ -4156,7 +4155,7 @@ public class DefaultFileSystemMaster extends CoreMaster
           LockedInodePath inodePath = mInodeTree
               .lockFullInodePath(fileId, LockPattern.WRITE_INODE)) {
         InodeFile inode = inodePath.getInodeFile();
-        inodePath.replaceInode(mInodeTree.updateInodeFile(
+        inodePath.replaceWithUpdatedInode(mInodeTree.updateInodeFile(
             journalContext, UpdateInodeFileEntry.newBuilder()
                 .setId(inode.getId())
                 .setPersistJobId(jobId)
@@ -4344,7 +4343,7 @@ public class DefaultFileSystemMaster extends CoreMaster
             mInodeTree.updateInode(journalContext, builder
                 .setId(inode.getId())
                 .setPersistenceState(PersistenceState.PERSISTED.name())
-                .build()).ifPresent(inodePath::replaceInode);
+                .build()).ifPresent(inodePath::replaceWithUpdatedInode);
             propagatePersistedInternal(journalContext, inodePath);
             Metrics.FILES_PERSISTED.inc();
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1624,7 +1624,7 @@ public class DefaultFileSystemMaster extends CoreMaster
         .setLastAccessTimeMs(opTimeMs)
         .setOverwriteModificationTime(true)
         .build());
-    mInodeTree.updateInodeFile(rpcContext, entry.build());
+    inodePath.replaceInode(mInodeTree.updateInodeFile(rpcContext, entry.build()));
 
     Metrics.FILES_COMPLETED.inc();
   }
@@ -2480,7 +2480,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       mInodeTree.updateInode(rpcContext, UpdateInodeEntry.newBuilder()
           .setId(inodeDirectory.getId())
           .setUfsFingerprint(ufsFingerprint)
-          .build());
+          .build()).ifPresent(inodePath::replaceInode);
 
       if (context.isPersisted()) {
         // The path exists in UFS, so it is no longer absent.
@@ -2649,7 +2649,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       mInodeTree.updateInode(rpcContext, UpdateInodeEntry.newBuilder()
           .setId(srcInode.getId())
           .setPersistenceState(PersistenceState.TO_BE_PERSISTED.name())
-          .build());
+          .build()).ifPresent(srcInodePath::replaceInode);
       long shouldPersistTime = srcInode.asFile().getShouldPersistTime();
       long persistenceWaitTime = shouldPersistTime == Constants.NO_AUTO_PERSIST ? 0
           : getPersistenceWaitTime(shouldPersistTime);
@@ -2675,7 +2675,7 @@ public class DefaultFileSystemMaster extends CoreMaster
             mInodeTree.updateInode(rpcContext, UpdateInodeEntry.newBuilder()
                 .setId(childInode.getId())
                 .setPersistenceState(PersistenceState.TO_BE_PERSISTED.name())
-                .build());
+                .build()).ifPresent(childPath::replaceInode);
             long shouldPersistTime = childInode.asFile().getShouldPersistTime();
             long persistenceWaitTime = shouldPersistTime == Constants.NO_AUTO_PERSIST ? 0
                 : getPersistenceWaitTime(shouldPersistTime);
@@ -2723,14 +2723,14 @@ public class DefaultFileSystemMaster extends CoreMaster
       throw new InvalidPathException("Destination path: " + dstPath + " already exists.");
     }
 
-    mInodeTree.rename(rpcContext, RenameEntry.newBuilder()
+    srcInodePath.replaceInode(mInodeTree.rename(rpcContext, RenameEntry.newBuilder()
         .setId(srcInode.getId())
         .setOpTimeMs(context.getOperationTimeMs())
         .setNewParentId(dstParentInode.getId())
         .setNewName(dstName)
         .setPath(srcPath.getPath())
         .setNewPath(dstPath.getPath())
-        .build());
+        .build()));
 
     // 3. Do UFS operations if necessary.
     // If the source file is persisted, rename it in the UFS.
@@ -3391,12 +3391,12 @@ public class DefaultFileSystemMaster extends CoreMaster
       }
     }
 
-    mInodeTree.setAcl(rpcContext, SetAclEntry.newBuilder()
+    inodePath.replaceInode(mInodeTree.setAcl(rpcContext, SetAclEntry.newBuilder()
         .setId(inode.getId())
         .setOpTimeMs(opTimeMs)
         .setAction(ProtoUtils.toProto(action))
         .addAllEntries(entries.stream().map(ProtoUtils::toProto).collect(Collectors.toList()))
-        .build());
+        .build()));
 
     try {
       if (!replay && inode.isPersisted()) {
@@ -3565,7 +3565,8 @@ public class DefaultFileSystemMaster extends CoreMaster
     }
     if (shouldPersistPath(inodePath.toString())) {
       mInodeTree.updateInode(rpcContext, UpdateInodeEntry.newBuilder().setId(inode.getId())
-          .setPersistenceState(PersistenceState.TO_BE_PERSISTED.name()).build());
+          .setPersistenceState(PersistenceState.TO_BE_PERSISTED.name()).build())
+          .ifPresent(inodePath::replaceInode);
       mPersistRequests.put(inode.getId(),
           new alluxio.time.ExponentialTimer(
               ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS),
@@ -3917,7 +3918,7 @@ public class DefaultFileSystemMaster extends CoreMaster
     if (modeChanged) {
       entry.setMode(ModeUtils.protoToShort(protoOptions.getMode()));
     }
-    mInodeTree.updateInode(rpcContext, entry.build());
+    mInodeTree.updateInode(rpcContext, entry.build()).ifPresent(inodePath::replaceInode);
   }
 
   @Override
@@ -4069,11 +4070,12 @@ public class DefaultFileSystemMaster extends CoreMaster
                 .setId(inode.getId())
                 .setPersistenceState(PersistenceState.NOT_PERSISTED.name())
                 .build());
-            mInodeTree.updateInodeFile(journalContext, UpdateInodeFileEntry.newBuilder()
-                .setId(inode.getId())
-                .setPersistJobId(Constants.PERSISTENCE_INVALID_JOB_ID)
-                .setTempUfsPath(Constants.PERSISTENCE_INVALID_UFS_PATH)
-                .build());
+            inodePath.replaceInode(mInodeTree.updateInodeFile(journalContext,
+                UpdateInodeFileEntry.newBuilder()
+                    .setId(inode.getId())
+                    .setPersistJobId(Constants.PERSISTENCE_INVALID_JOB_ID)
+                    .setTempUfsPath(Constants.PERSISTENCE_INVALID_UFS_PATH)
+                    .build()));
             break;
           default:
             throw new IllegalStateException(
@@ -4153,11 +4155,12 @@ public class DefaultFileSystemMaster extends CoreMaster
           LockedInodePath inodePath = mInodeTree
               .lockFullInodePath(fileId, LockPattern.WRITE_INODE)) {
         InodeFile inode = inodePath.getInodeFile();
-        mInodeTree.updateInodeFile(journalContext, UpdateInodeFileEntry.newBuilder()
-            .setId(inode.getId())
-            .setPersistJobId(jobId)
-            .setTempUfsPath(tempUfsPath)
-            .build());
+        inodePath.replaceInode(mInodeTree.updateInodeFile(
+            journalContext, UpdateInodeFileEntry.newBuilder()
+                .setId(inode.getId())
+                .setPersistJobId(jobId)
+                .setTempUfsPath(tempUfsPath)
+                .build()));
       }
     }
 
@@ -4340,7 +4343,7 @@ public class DefaultFileSystemMaster extends CoreMaster
             mInodeTree.updateInode(journalContext, builder
                 .setId(inode.getId())
                 .setPersistenceState(PersistenceState.PERSISTED.name())
-                .build());
+                .build()).ifPresent(inodePath::replaceInode);
             propagatePersistedInternal(journalContext, inodePath);
             Metrics.FILES_PERSISTED.inc();
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1624,6 +1624,7 @@ public class DefaultFileSystemMaster extends CoreMaster
         .setLastAccessTimeMs(opTimeMs)
         .setOverwriteModificationTime(true)
         .build());
+    // inodePath.replaceInode(mInodeTree.updateInodeFile(rpcContext, entry.build()));
     inodePath.replaceInode(mInodeTree.updateInodeFile(rpcContext, entry.build()));
 
     Metrics.FILES_COMPLETED.inc();

--- a/core/server/master/src/main/java/alluxio/master/file/meta/CompositeInodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/CompositeInodeLockList.java
@@ -140,6 +140,15 @@ public class CompositeInodeLockList implements InodeLockList {
   }
 
   @Override
+  public void replace(int index, Inode newInode) {
+    if (index < mBaseListSize) {
+      mBaseLockList.replace(index, newInode);
+    } else {
+      mSubLockList.replace(index - mBaseListSize, newInode);
+    }
+  }
+
+  @Override
   public int numInodes() {
     return mBaseListSize + mSubLockList.numInodes();
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockList.java
@@ -161,6 +161,13 @@ public interface InodeLockList extends AutoCloseable {
   Inode get(int index);
 
   /**
+   * Replaces the inode at the given index in the list.
+   * @param index the index in the list
+   * @param newInode the new inode to place at the index
+   */
+  void replace(int index, Inode newInode);
+
+  /**
    * @return the size of the list in terms of locked inodes
    */
   int numInodes();

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -308,17 +308,19 @@ public class InodeTree implements DelegatingJournaled {
   /**
    * @param context journal context supplier
    * @param entry an entry representing an update inode file operation
+   * @return the updated inode
    */
-  public void updateInodeFile(Supplier<JournalContext> context, UpdateInodeFileEntry entry) {
-    mState.applyAndJournal(context, entry);
+  public Inode updateInodeFile(Supplier<JournalContext> context, UpdateInodeFileEntry entry) {
+    return mState.applyAndJournal(context, entry);
   }
 
   /**
    * @param context journal context supplier
    * @param entry an entry representing an update inode operation
+   * @return the updated inode if there is one
    */
-  public void updateInode(Supplier<JournalContext> context, UpdateInodeEntry entry) {
-    mState.applyAndJournal(context, entry);
+  public Optional<Inode> updateInode(Supplier<JournalContext> context, UpdateInodeEntry entry) {
+    return mState.applyAndJournal(context, entry);
   }
 
   /**
@@ -333,17 +335,19 @@ public class InodeTree implements DelegatingJournaled {
   /**
    * @param context journal context supplier
    * @param entry an entry representing a rename operation
+   * @return the updated inode
    */
-  public void rename(Supplier<JournalContext> context, RenameEntry entry) {
-    mState.applyAndJournal(context, entry);
+  public Inode rename(Supplier<JournalContext> context, RenameEntry entry) {
+    return mState.applyAndJournal(context, entry);
   }
 
   /**
    * @param context journal context supplier
    * @param entry an entry representing a set acl operation
+   * @return the updated inode
    */
-  public void setAcl(Supplier<JournalContext> context, SetAclEntry entry) {
-    mState.applyAndJournal(context, entry);
+  public Inode setAcl(Supplier<JournalContext> context, SetAclEntry entry) {
+    return mState.applyAndJournal(context, entry);
   }
 
   /**
@@ -1057,7 +1061,7 @@ public class InodeTree implements DelegatingJournaled {
         .setPinned(pinned)
         .addAllMediumType(mediumSet)
         .setLastModificationTimeMs(opTimeMs)
-        .build());
+        .build()).ifPresent(inodePath::replaceInode);
 
     if (inode.isDirectory()) {
       assert inode instanceof InodeDirectory;
@@ -1115,7 +1119,7 @@ public class InodeTree implements DelegatingJournaled {
           .setPinned(newMin > 0)
           .addAllMediumType(inode.getMediumTypes())
           .setLastModificationTimeMs(opTimeMs)
-          .build());
+          .build()).ifPresent(inodePath::replaceInode);
     } else {
       for (Inode child : mInodeStore.getChildren(inode.asDirectory())) {
         try (LockedInodePath tempInodePath =

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -1061,7 +1061,7 @@ public class InodeTree implements DelegatingJournaled {
         .setPinned(pinned)
         .addAllMediumType(mediumSet)
         .setLastModificationTimeMs(opTimeMs)
-        .build()).ifPresent(inodePath::replaceInode);
+        .build()).ifPresent(inodePath::replaceWithUpdatedInode);
 
     if (inode.isDirectory()) {
       assert inode instanceof InodeDirectory;
@@ -1119,7 +1119,7 @@ public class InodeTree implements DelegatingJournaled {
           .setPinned(newMin > 0)
           .addAllMediumType(inode.getMediumTypes())
           .setLastModificationTimeMs(opTimeMs)
-          .build()).ifPresent(inodePath::replaceInode);
+          .build()).ifPresent(inodePath::replaceWithUpdatedInode);
     } else {
       for (Inode child : mInodeStore.getChildren(inode.asDirectory())) {
         try (LockedInodePath tempInodePath =

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreePersistentState.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreePersistentState.java
@@ -257,16 +257,18 @@ public class InodeTreePersistentState implements Journaled {
    *
    * @param context journal context supplier
    * @param entry rename entry
+   * @return the updated inode
    */
-  public void applyAndJournal(Supplier<JournalContext> context, RenameEntry entry) {
+  public Inode applyAndJournal(Supplier<JournalContext> context, RenameEntry entry) {
     try {
-      applyRename(entry);
+      Inode updated = applyRename(entry);
       JournalEntry.Builder builder = JournalEntry.newBuilder().setRename(entry);
       OperationId opId = getOpId(context);
       if (opId != null) {
         builder.setOperationId(opId.toJournalProto());
       }
       context.get().append(builder.build());
+      return updated;
     } catch (Throwable t) {
       ProcessUtils.fatalError(LOG, t, "Failed to apply %s", entry);
       throw t; // fatalError will usually system.exit
@@ -278,11 +280,13 @@ public class InodeTreePersistentState implements Journaled {
    *
    * @param context journal context supplier
    * @param entry set acl entry
+   * @return the updated inode
    */
-  public void applyAndJournal(Supplier<JournalContext> context, SetAclEntry entry) {
+  public Inode applyAndJournal(Supplier<JournalContext> context, SetAclEntry entry) {
     try {
-      applySetAcl(entry);
+      Inode updated = applySetAcl(entry);
       context.get().append(JournalEntry.newBuilder().setSetAcl(entry).build());
+      return updated;
     } catch (Throwable t) {
       ProcessUtils.fatalError(LOG, t, "Failed to apply %s", entry);
       throw t; // fatalError will usually system.exit
@@ -294,16 +298,18 @@ public class InodeTreePersistentState implements Journaled {
    *
    * @param context journal context supplier
    * @param entry update inode entry
+   * @return the updated inode
    */
-  public void applyAndJournal(Supplier<JournalContext> context, UpdateInodeEntry entry) {
+  public Optional<Inode> applyAndJournal(Supplier<JournalContext> context, UpdateInodeEntry entry) {
     try {
-      applyUpdateInode(entry);
+      Optional<Inode> updated = applyUpdateInode(entry);
       JournalEntry.Builder builder = JournalEntry.newBuilder().setUpdateInode(entry);
       OperationId opId = getOpId(context);
       if (opId != null) {
         builder.setOperationId(opId.toJournalProto());
       }
       context.get().append(builder.build());
+      return updated;
     } catch (Throwable t) {
       ProcessUtils.fatalError(LOG, t, "Failed to apply %s", entry);
       throw t; // fatalError will usually system.exit
@@ -331,11 +337,13 @@ public class InodeTreePersistentState implements Journaled {
    *
    * @param context journal context supplier
    * @param entry update inode file entry
+   * @return the updated inode
    */
-  public void applyAndJournal(Supplier<JournalContext> context, UpdateInodeFileEntry entry) {
+  public Inode applyAndJournal(Supplier<JournalContext> context, UpdateInodeFileEntry entry) {
     try {
-      applyUpdateInodeFile(entry);
+      Inode updated = applyUpdateInodeFile(entry);
       context.get().append(JournalEntry.newBuilder().setUpdateInodeFile(entry).build());
+      return updated;
     } catch (Throwable t) {
       ProcessUtils.fatalError(LOG, t, "Failed to apply %s", entry);
       throw t; // fatalError will usually system.exit
@@ -436,7 +444,7 @@ public class InodeTreePersistentState implements Journaled {
     return newBlockId;
   }
 
-  private void applySetAcl(SetAclEntry entry) {
+  private Inode applySetAcl(SetAclEntry entry) {
     MutableInode<?> inode = mInodeStore.getMutable(entry.getId()).get();
     List<AclEntry> entries = StreamUtils.map(ProtoUtils::fromProto, entry.getEntriesList());
     switch (entry.getAction()) {
@@ -460,14 +468,15 @@ public class InodeTreePersistentState implements Journaled {
         LOG.warn("Unrecognized acl action: " + entry.getAction());
     }
     mInodeStore.writeInode(inode);
+    return Inode.wrap(inode);
   }
 
-  private void applyUpdateInode(UpdateInodeEntry entry) {
+  private Optional<Inode> applyUpdateInode(UpdateInodeEntry entry) {
     Optional<MutableInode<?>> inodeOpt = mInodeStore.getMutable(entry.getId());
     if (!inodeOpt.isPresent()) {
       if (isJournalUpdateAsync(entry)) {
         // do not throw if the entry is journaled asynchronously
-        return;
+        return Optional.empty();
       }
       throw new IllegalStateException("Inode " + entry.getId() + " not found");
     }
@@ -486,6 +495,7 @@ public class InodeTreePersistentState implements Journaled {
     }
     mInodeStore.writeInode(inode);
     updateToBePersistedIds(inode);
+    return Optional.of(Inode.wrap(inode));
   }
 
   private void setReplicationForPin(MutableInode<?> inode, boolean pinned) {
@@ -538,7 +548,7 @@ public class InodeTreePersistentState implements Journaled {
     mInodeStore.writeInode(inode);
   }
 
-  private void applyUpdateInodeFile(UpdateInodeFileEntry entry) {
+  private Inode applyUpdateInodeFile(UpdateInodeFileEntry entry) {
     MutableInode<?> inode = mInodeStore.getMutable(entry.getId()).get();
     Preconditions.checkState(inode.isFile(), "Encountered non-file id in update file entry %s",
         entry);
@@ -555,6 +565,7 @@ public class InodeTreePersistentState implements Journaled {
     inode.asFile().updateFromEntry(entry);
     mInodeStore.writeInode(inode);
     mBucketCounter.insert(inode.asFile().getLength());
+    return Inode.wrap(inode);
   }
 
   ////
@@ -658,7 +669,7 @@ public class InodeTreePersistentState implements Journaled {
     }
   }
 
-  private void applyRename(RenameEntry entry) {
+  private Inode applyRename(RenameEntry entry) {
     if (entry.hasDstPath()) {
       entry = rewriteDeprecatedRenameEntry(entry);
     }
@@ -679,6 +690,7 @@ public class InodeTreePersistentState implements Journaled {
       updateTimestampsAndChildCount(oldParent, entry.getOpTimeMs(), -1);
       updateTimestampsAndChildCount(newParent, entry.getOpTimeMs(), 1);
     }
+    return Inode.wrap(inode);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -146,6 +146,14 @@ public class LockedInodePath implements Closeable {
   }
 
   /**
+   * Replaces the target inode with a new one.
+   * @param newInode the updated inode
+   */
+  public void replaceInode(Inode newInode) {
+    mLockList.replace(mLockList.numInodes() - 1, newInode);
+  }
+
+  /**
    * @return the target inode, or null if it does not exist
    */
   @Nullable

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -146,11 +146,12 @@ public class LockedInodePath implements Closeable {
   }
 
   /**
-   * Replaces the target inode with a new one.
-   * @param newInode the updated inode
+   * Replaces the target inode with an updated one.
+   * This should be called if the internal state of the target inode has changed.
+   * @param updatedInode the target inode containing the updated state
    */
-  public void replaceInode(Inode newInode) {
-    mLockList.replace(mLockList.numInodes() - 1, newInode);
+  public void replaceWithUpdatedInode(Inode updatedInode) {
+    mLockList.replace(mLockList.numInodes() - 1, updatedInode);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
@@ -264,6 +264,11 @@ public class SimpleInodeLockList implements InodeLockList {
   }
 
   @Override
+  public void replace(int index, Inode newInode) {
+    mInodes.set(index, newInode);
+  }
+
+  @Override
   public int numInodes() {
     return mInodes.size();
   }

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -53,6 +53,7 @@ import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.LoadMetadataPType;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.RegisterWorkerPOptions;
+import alluxio.grpc.ScheduleAsyncPersistencePOptions;
 import alluxio.grpc.SetAclAction;
 import alluxio.grpc.SetAclPOptions;
 import alluxio.grpc.SetAttributePOptions;
@@ -86,7 +87,12 @@ import alluxio.master.file.meta.TtlIntervalRule;
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.JournalTestUtils;
 import alluxio.master.journal.JournalType;
+import alluxio.master.metastore.InodeStore;
+import alluxio.master.metastore.MetastoreType;
 import alluxio.master.metastore.ReadOnlyInodeStore;
+import alluxio.master.metastore.heap.HeapBlockStore;
+import alluxio.master.metastore.heap.HeapInodeStore;
+import alluxio.master.metastore.rocks.RocksInodeStore;
 import alluxio.master.metrics.MetricsMaster;
 import alluxio.master.metrics.MetricsMasterFactory;
 import alluxio.metrics.Metric;
@@ -277,6 +283,28 @@ public final class FileSystemMasterTest {
     mThrown.expect(FileAlreadyExistsException.class);
     mFileSystemMaster.createFile(path,
         CreateFileContext.defaults().setWriteType(WriteType.MUST_CACHE));
+  }
+
+  @Test
+  public void completeFileAsyncThrough() throws Exception {
+    // stop the services and restart them using the rocks inode store
+    // this is to make sure modifications made to inodes are visible in memory
+    // even after updating them in RocksDB,
+    // so that when async persist is called after complete, the in memory
+    // inode is also seen as completed
+    stopServices();
+    startServices(any -> new RocksInodeStore(mJournalFolder));
+
+    AlluxioURI path = new AlluxioURI("/test");
+    mFileSystemMaster.createFile(path,
+        CreateFileContext.defaults().setWriteType(WriteType.ASYNC_THROUGH));
+    long blockId = mFileSystemMaster.getNewBlockIdForFile(path);
+    mBlockMaster.commitBlock(mWorkerId1, Constants.KB,
+        Constants.MEDIUM_MEM, Constants.MEDIUM_MEM, blockId, Constants.KB);
+    CompleteFileContext context =
+        CompleteFileContext.mergeFrom(CompleteFilePOptions.newBuilder().setUfsLength(Constants.KB)
+            .setAsyncPersistOptions(ScheduleAsyncPersistencePOptions.newBuilder()));
+    mFileSystemMaster.completeFile(path, context);
   }
 
   @Test
@@ -3158,10 +3186,15 @@ public final class FileSystemMasterTest {
   }
 
   private void startServices() throws Exception {
+    startServices(any -> new HeapInodeStore());
+  }
+
+  private void startServices(InodeStore.Factory inodeStoreFactory) throws Exception {
     mRegistry = new MasterRegistry();
     mJournalSystem = JournalTestUtils.createJournalSystem(mJournalFolder);
     CoreMasterContext masterContext = MasterTestUtils.testMasterContext(mJournalSystem,
-        new TestUserState(TEST_USER, ServerConfiguration.global()));
+        new TestUserState(TEST_USER, ServerConfiguration.global()),
+        HeapBlockStore::new, inodeStoreFactory);
     mMetricsMaster = new MetricsMasterFactory().create(mRegistry, masterContext);
     mRegistry.add(MetricsMaster.class, mMetricsMaster);
     mMetrics = Lists.newArrayList();

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -88,7 +88,6 @@ import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.JournalTestUtils;
 import alluxio.master.journal.JournalType;
 import alluxio.master.metastore.InodeStore;
-import alluxio.master.metastore.MetastoreType;
 import alluxio.master.metastore.ReadOnlyInodeStore;
 import alluxio.master.metastore.heap.HeapBlockStore;
 import alluxio.master.metastore.heap.HeapInodeStore;


### PR DESCRIPTION
### What changes are proposed in this pull request?

In the file system master references to inodes are not mutable. If the operation performs an update to the inode, it must first fetch a mutable inode from the metastore, then update it. If they reference the same object, then the update to the inode will be visible to the calling operation. If RocksDB is used and the mutable inode is loaded from RocksDB then they will be different objects and the modification will not be visible. This PR has the applyAndJournal operations that modify internal inode state return a reference to the modified inode and the calling operation then updates its reference to the inode in its LockedInodePath.

### Why are the changes needed?

When using RocksDB when the internal state of an inode is updated, it is only changed in the on disk store and not to the in memory reference of the current method being run. If the method relies on viewing this updated state it will cause an error. The async persist test is an example of this, as after complete is called, the async persist option expects to see the inode as completed.

### Does this PR introduce any user facing changes?

No