### PR TITLE
Support extra resources for master/worker pods

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
+++ b/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl
@@ -335,3 +335,163 @@ imagePullSecrets:
   - name: {{ $name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Extra volume mounts that can be added to a container
+@param .extraVolumeMounts   An object representing a list of volume mounts.
+                            Each volumeMount can contain the following fields:
+                                volumeMount.name
+                                volumeMount.mountPath
+                                volumeMount.readOnly
+*/}}
+{{- define "alluxio.extraVolumeMounts" -}}
+  {{- range $volMount := .extraVolumeMounts }}
+- name: {{ $volMount.name }}
+  mountPath: {{ $volMount.mountPath }}
+  readOnly: {{ $volMount.readOnly }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Extra volumes that can be added to a pod
+@param .extraVolumes    An object representing a list of volume mounts.
+                        Can use either configMap or emptyDir.
+                        Each volume can contain the following fields:
+                            volume.name
+                            volume.configMap.defaultMode
+                            volume.configMap.name
+                            volume.emptyDir
+*/}}
+{{- define "alluxio.extraVolumes" -}}
+  {{- range $vol := .extraVolumes }}
+- name: {{ $vol.name }}
+  {{- if $vol.configMap }}
+  configMap:
+    {{- if $vol.configMap.defaultMode }}
+    defaultMode: {{ $vol.configMap.defaultMode }}
+    {{- end}}
+    {{- if $vol.configMap.name }}
+    name: {{ $vol.configMap.name }}
+    {{- end}}
+  {{- else }}
+  emptyDir: {{ $vol.emptyDir | default "{}" }}
+  {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Extra ports that can be added to a service
+@param .extraServicePorts   An object representing a list of ports.
+                            Each item can contain the following fields:
+                              item.port
+                              item.name
+*/}}
+{{- define "alluxio.extraServicePorts" -}}
+  {{- range $item := .extraServicePorts }}
+- port: {{ $item.port }}
+  name: {{ $item.name }}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Extra container specs that can be added to a pod
+@param .extraContainers   An object representing a list of containers.
+                          Each container can contain the following fields:
+                            container.name
+                            container.image
+                            container.imagePullPolicy
+                            container.securityContext.runAsUser
+                            container.securityContext.runAsGroup
+                            container.resources.limit.cpu
+                            container.resources.limit.memory
+                            container.resources.requests.cpu
+                            container.resources.requests.memory
+                            container.command
+                            container.args
+                            container.env
+                            container.envValueFrom
+                            container.envFrom
+                            container.ports
+                            container.volumeMounts
+*/}}
+{{- define "alluxio.extraContainers" -}}
+  {{- range $container := .extraContainers }}
+- name: {{ $container.name }}
+  image: {{ $container.image }}
+  imagePullPolicy: {{ $container.imagePullPolicy }}
+  {{- if $container.securityContext }}
+  securityContext:
+    runAsUser: {{ $container.securityContext.runAsUser }}
+    {{- if $container.securityContext.runAsGroup }}
+    runAsGroup: {{ $container.securityContext.runAsGroup }}
+    {{- end }}
+  {{- end }}
+  {{- if $container.resources }}
+  resources:
+    limits:
+      {{- if $container.resources.limits }}
+        {{- if $container.resources.limits.cpu  }}
+      cpu: {{ $container.resources.limits.cpu }}
+        {{- end }}
+        {{- if $container.resources.limits.memory  }}
+      memory: {{ $container.resources.limits.memory }}
+        {{- end }}
+      {{- end }}
+    requests:
+      {{- if $container.resources.requests }}
+        {{- if $container.resources.requests.cpu  }}
+      cpu: {{ $container.resources.requests.cpu }}
+        {{- end }}
+        {{- if $container.resources.requests.memory  }}
+      memory: {{ $container.resources.requests.memory }}
+        {{- end }}
+      {{- end }}
+  {{- end }}
+  {{- if $container.command }}
+  command:
+{{ toYaml $container.command | trim | indent 4 }}
+  {{- end }}
+  {{- if $container.args }}
+  args:
+{{ toYaml $container.args | trim | indent 4 }}
+  {{- end }}
+  {{- if $container.env }}
+  env:
+    {{- range $key, $value := $container.env }}
+    - name: "{{ $key }}"
+      value: "{{ $value }}"
+    {{- end }}
+    {{- if $container.envValueFrom }}
+      {{- range $key, $value := $container.envValueFrom }}
+    - name: "{{ $key }}"
+      valueFrom:
+        fieldRef:
+          fieldPath: {{ $value }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- if $container.envFrom }}
+  envFrom:
+    {{- range $item := $container.envFrom }}
+    - configMapRef:
+        name: {{ $item.configMapRef.name }}
+    {{- end }}
+  {{- end }}
+  {{- if $container.ports }}
+  ports:
+    {{- range $port := $container.ports }}
+    - containerPort: {{ $port.containerPort }}
+      name: {{ $port.name }}
+    {{- end }}
+  {{- end }}
+  {{- if $container.volumeMounts }}
+  volumeMounts:
+    {{- range $volMount := $container.volumeMounts }}
+    - name: {{ $volMount.name }}
+      mountPath: {{ $volMount.mountPath }}
+      readOnly: {{ $volMount.readOnly }}
+      subPath: {{ $volMount.subPath | default "" }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end -}}

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/service.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/service.yaml
@@ -44,7 +44,9 @@ spec:
       name: embedded
     - port: 20003
       name: job-embedded
+    {{- if $extraServicePorts }}
 {{- include "alluxio.extraServicePorts" (dict "extraServicePorts" $extraServicePorts) | indent 4 }}
+    {{- end }}
   clusterIP: None
   selector:
     role: alluxio-master

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/service.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/service.yaml
@@ -16,6 +16,7 @@
 {{- $name := include "alluxio.name" . }}
 {{- $fullName := include "alluxio.fullname" . }}
 {{- $chart := include "alluxio.chart" . }}
+{{- $extraServicePorts := .Values.master.extraServicePorts }}
 {{- range $i := until $masterCount }}
   {{- $masterName := printf "master-%v" $i }}
   {{- $masterJavaOpts := printf " -Dalluxio.master.hostname=%v-%v " $fullName $masterName }}
@@ -43,6 +44,7 @@ spec:
       name: embedded
     - port: 20003
       name: job-embedded
+{{- include "alluxio.extraServicePorts" (dict "extraServicePorts" $extraServicePorts) | indent 4 }}
   clusterIP: None
   selector:
     role: alluxio-master

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -105,9 +105,11 @@ spec:
           - name: alluxio-journal
             mountPath: {{ .Values.journal.folder }}
       {{- end}}
-      shareProcessNamespace: {{ .Values.master.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.master.shareProcessNamespace | default false }}
       containers:
+        {{- if .Values.master.extraContainers }}
 {{- include "alluxio.extraContainers" (dict "extraContainers" .Values.master.extraContainers) | indent 8 }}
+        {{- end }}
         - name: alluxio-master
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -174,7 +176,9 @@ spec:
             name: embedded
           {{- end }}
           volumeMounts:
+            {{- if .Values.master.extraVolumeMounts }}
 {{- include "alluxio.extraVolumeMounts" (dict "extraVolumeMounts" .Values.master.extraVolumeMounts) | indent 12 }}
+            {{- end }}
             {{- if .Values.metrics.enabled }}
             - name: {{ $fullName }}-metrics-volume
               mountPath: /config/metrics
@@ -264,7 +268,9 @@ spec:
             name: job-embedded
           {{- end }}
           volumeMounts:
+          {{- if .Values.master.extraVolumeMounts }}
 {{- include "alluxio.extraVolumeMounts" (dict "extraVolumeMounts" .Values.master.extraVolumeMounts) | indent 12 }}
+          {{- end }}
           {{- if .Values.metrics.enabled }}
             - name: {{ $fullName }}-metrics-volume
               mountPath: /config/metrics
@@ -282,7 +288,9 @@ spec:
           {{- end }}
       restartPolicy: Always
       volumes:
+        {{- if .Values.master.extraVolumes }}
 {{- include "alluxio.extraVolumes" (dict "extraVolumes" .Values.master.extraVolumes) | indent 8 }}
+        {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: {{ $fullName }}-metrics-volume
           configMap:

--- a/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/master/statefulset.yaml
@@ -105,7 +105,9 @@ spec:
           - name: alluxio-journal
             mountPath: {{ .Values.journal.folder }}
       {{- end}}
+      shareProcessNamespace: {{ .Values.master.shareProcessNamespace }}
       containers:
+{{- include "alluxio.extraContainers" (dict "extraContainers" .Values.master.extraContainers) | indent 8 }}
         - name: alluxio-master
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -172,6 +174,7 @@ spec:
             name: embedded
           {{- end }}
           volumeMounts:
+{{- include "alluxio.extraVolumeMounts" (dict "extraVolumeMounts" .Values.master.extraVolumeMounts) | indent 12 }}
             {{- if .Values.metrics.enabled }}
             - name: {{ $fullName }}-metrics-volume
               mountPath: /config/metrics
@@ -261,6 +264,7 @@ spec:
             name: job-embedded
           {{- end }}
           volumeMounts:
+{{- include "alluxio.extraVolumeMounts" (dict "extraVolumeMounts" .Values.master.extraVolumeMounts) | indent 12 }}
           {{- if .Values.metrics.enabled }}
             - name: {{ $fullName }}-metrics-volume
               mountPath: /config/metrics
@@ -278,6 +282,7 @@ spec:
           {{- end }}
       restartPolicy: Always
       volumes:
+{{- include "alluxio.extraVolumes" (dict "extraVolumes" .Values.master.extraVolumes) | indent 8 }}
         {{- if .Values.metrics.enabled }}
         - name: {{ $fullName }}-metrics-volume
           configMap:

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
@@ -63,6 +63,7 @@ spec:
       {{- else if .Values.nodeSelector }}
 {{ toYaml .Values.nodeSelector | trim | indent 8  }}
       {{- end }}
+      shareProcessNamespace: {{ .Values.worker.shareProcessNamespace }}
       tolerations:
       {{- if .Values.worker.tolerations }}
 {{ toYaml .Values.worker.tolerations | trim | indent 8  }}
@@ -88,6 +89,7 @@ spec:
 {{ include "alluxio.imagePullSecrets" . | indent 6 }}
       {{- end}}
       containers:
+{{ include "alluxio.extraContainers" (dict "extraContainers" .Values.worker.extraContainers) | indent 8 }}
         - name: alluxio-worker
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -158,6 +160,7 @@ spec:
           - containerPort: {{ .Values.worker.ports.web }}
             name: web
           volumeMounts:
+{{- include "alluxio.extraVolumeMounts" (dict "extraVolumeMounts" .Values.worker.extraVolumeMounts) | indent 12 }}
             {{- if .Values.metrics.enabled }}
             - name: {{ $fullName }}-metrics-volume
               mountPath: /config/metrics
@@ -245,6 +248,7 @@ spec:
           - containerPort: {{ .Values.jobWorker.ports.web }}
             name: job-web
           volumeMounts:
+{{- include "alluxio.extraVolumeMounts" (dict "extraVolumeMounts" .Values.worker.extraVolumeMounts) | indent 12 }}
             {{- if .Values.metrics.enabled }}
             - name: {{ $fullName }}-metrics-volume
               mountPath: /config/metrics
@@ -266,6 +270,7 @@ spec:
             {{- end }}
       restartPolicy: Always
       volumes:
+{{- include "alluxio.extraVolumes" (dict "extraVolumes" .Values.worker.extraVolumes) | indent 8 }}
         {{- if .Values.metrics.enabled }}
         - name: {{ $fullName }}-metrics-volume
           configMap:

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
@@ -63,7 +63,7 @@ spec:
       {{- else if .Values.nodeSelector }}
 {{ toYaml .Values.nodeSelector | trim | indent 8  }}
       {{- end }}
-      shareProcessNamespace: {{ .Values.worker.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.worker.shareProcessNamespace | default false }}
       tolerations:
       {{- if .Values.worker.tolerations }}
 {{ toYaml .Values.worker.tolerations | trim | indent 8  }}
@@ -89,7 +89,9 @@ spec:
 {{ include "alluxio.imagePullSecrets" . | indent 6 }}
       {{- end}}
       containers:
+        {{- if .Values.worker.extraContainers }}
 {{ include "alluxio.extraContainers" (dict "extraContainers" .Values.worker.extraContainers) | indent 8 }}
+        {{- end }}
         - name: alluxio-worker
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -160,7 +162,9 @@ spec:
           - containerPort: {{ .Values.worker.ports.web }}
             name: web
           volumeMounts:
+            {{- if .Values.worker.extraVolumeMounts }}
 {{- include "alluxio.extraVolumeMounts" (dict "extraVolumeMounts" .Values.worker.extraVolumeMounts) | indent 12 }}
+            {{- end }}
             {{- if .Values.metrics.enabled }}
             - name: {{ $fullName }}-metrics-volume
               mountPath: /config/metrics
@@ -248,7 +252,9 @@ spec:
           - containerPort: {{ .Values.jobWorker.ports.web }}
             name: job-web
           volumeMounts:
+            {{- if .Values.worker.extraVolumeMounts }}
 {{- include "alluxio.extraVolumeMounts" (dict "extraVolumeMounts" .Values.worker.extraVolumeMounts) | indent 12 }}
+            {{- end }}
             {{- if .Values.metrics.enabled }}
             - name: {{ $fullName }}-metrics-volume
               mountPath: /config/metrics
@@ -270,7 +276,9 @@ spec:
             {{- end }}
       restartPolicy: Always
       volumes:
+        {{- if .Values.worker.extraVolumes }}
 {{- include "alluxio.extraVolumes" (dict "extraVolumes" .Values.worker.extraVolumes) | indent 8 }}
+        {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: {{ $fullName }}-metrics-volume
           configMap:

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -99,6 +99,11 @@ master:
     web: 19999
   hostPID: false
   hostNetwork: false
+  shareProcessNamespace: false
+  extraContainers: []
+  extraVolumeMounts: []
+  extraVolumes: []
+  extraServicePorts: []
   # dnsPolicy will be ClusterFirstWithHostNet if hostNetwork: true
   # and ClusterFirst if hostNetwork: false
   # You can specify dnsPolicy here to override this inference
@@ -276,6 +281,10 @@ worker:
   # hostPID requires escalated privileges
   hostPID: false
   hostNetwork: false
+  shareProcessNamespace: false
+  extraContainers: []
+  extraVolumeMounts: []
+  extraVolumes: []
   # dnsPolicy will be ClusterFirstWithHostNet if hostNetwork: true
   # and ClusterFirst if hostNetwork: false
   # You can specify dnsPolicy here to override this inference


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PRs introduces support for extra containers, volume mounts, and volumes for master/worker pods. This flexibility allows for extra customizations without having to directly change the Alluxio helm charts. The structure of the new fields are similarly structured to their respective k8s objects. See example below to get an idea of how the structure looks like.

### Why are the changes needed?

See above.

### Does this PR introduce any user facing changes?

See [change](https://github.com/tieujason330/alluxio/blob/c5e1fbf70ab25bbd1b7b67e91788c79b78ccdb26/integration/kubernetes/helm-chart/alluxio/templates/_helpers.tpl) for detailed explanations on each new parameter

Extra Helm template values:
- master
  - shareProcessNamespace: boolean
  - extraContainers: list
  - extraVolumeMounts: list
  - extraVolumes: list
  - extraServicePorts: list
- worker
  - shareProcessNamespace: boolean
  - extraContainers: list
  - extraVolumeMounts: list
  - extraVolumes: list

Example structure of new values parameters:
```
master:
  shareProcessNamespace: true
  extraContainers:
    - name: imageName
      image: image:tag
      imagePullPolicy: IfNotPresent
      securityContext:
        runAsUser: 1000
        runAsGroup: 1000
      resources:
        limits:
          cpu: "1"
          memory: "1G"
        requests:
          cpu: "1"
          memory: "1G"
      command: [ "/entrypoint.sh" ]
      args:
        - example_arg
      env:
        EXAMPLE_ENV_VAR: "example"
      envValueFrom:
        EXAMPLE_ENV_VALUE_FROM: "status.podIP"
      envFrom:
        - configMapRef:
            name: "example-config"
      ports:
        - containerPort: 8000
          name: example-port
      volumeMounts:
        - name: test-volume
          mountPath: /test/dir/vol
          readOnly: false
  extraVolumeMounts:
    - name: test-volume
      mountPath: /test/dir/vol
      readOnly: false
  extraVolumes:
    - name: test-volume
      emptyDir: {}
    - name: example-config
      configMap:
        defaultMode: "0644"
        name: example-config-map
  extraServicePorts:
    - port: 8000
      name: example-port
```
