### PR TITLE
Rename ufs eventual consistency method names to be easier to understand

### DIFF
--- a/core/common/src/main/java/alluxio/concurrent/ManagedBlockingUfsForwarder.java
+++ b/core/common/src/main/java/alluxio/concurrent/ManagedBlockingUfsForwarder.java
@@ -97,21 +97,21 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
   }
 
   @Override
-  public OutputStream createNonexistingFile(String path) throws IOException {
+  public OutputStream createWithRetry(String path) throws IOException {
     return new ManagedBlockingUfsMethod<OutputStream>() {
       @Override
       public OutputStream execute() throws IOException {
-        return mUfs.createNonexistingFile(path);
+        return mUfs.createWithRetry(path);
       }
     }.get();
   }
 
   @Override
-  public OutputStream createNonexistingFile(String path, CreateOptions options) throws IOException {
+  public OutputStream createWithRetry(String path, CreateOptions options) throws IOException {
     return new ManagedBlockingUfsMethod<OutputStream>() {
       @Override
       public OutputStream execute() throws IOException {
-        return mUfs.createNonexistingFile(path, options);
+        return mUfs.createWithRetry(path, options);
       }
     }.get();
   }
@@ -137,21 +137,21 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
   }
 
   @Override
-  public boolean deleteExistingDirectory(String path) throws IOException {
+  public boolean deleteDirectoryWithRetry(String path) throws IOException {
     return new ManagedBlockingUfsMethod<Boolean>() {
       @Override
       public Boolean execute() throws IOException {
-        return mUfs.deleteExistingDirectory(path);
+        return mUfs.deleteDirectoryWithRetry(path);
       }
     }.get();
   }
 
   @Override
-  public boolean deleteExistingDirectory(String path, DeleteOptions options) throws IOException {
+  public boolean deleteDirectoryWithRetry(String path, DeleteOptions options) throws IOException {
     return new ManagedBlockingUfsMethod<Boolean>() {
       @Override
       public Boolean execute() throws IOException {
-        return mUfs.deleteExistingDirectory(path, options);
+        return mUfs.deleteDirectoryWithRetry(path, options);
       }
     }.get();
   }
@@ -167,11 +167,11 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
   }
 
   @Override
-  public boolean deleteExistingFile(String path) throws IOException {
+  public boolean deleteFileWithRetry(String path) throws IOException {
     return new ManagedBlockingUfsMethod<Boolean>() {
       @Override
       public Boolean execute() throws IOException {
-        return mUfs.deleteExistingFile(path);
+        return mUfs.deleteFileWithRetry(path);
       }
     }.get();
   }
@@ -228,11 +228,11 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
   }
 
   @Override
-  public UfsDirectoryStatus getExistingDirectoryStatus(String path) throws IOException {
+  public UfsDirectoryStatus getDirectoryStatusWithRetry(String path) throws IOException {
     return new ManagedBlockingUfsMethod<UfsDirectoryStatus>() {
       @Override
       public UfsDirectoryStatus execute() throws IOException {
-        return mUfs.getExistingDirectoryStatus(path);
+        return mUfs.getDirectoryStatusWithRetry(path);
       }
     }.get();
   }
@@ -269,11 +269,11 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
   }
 
   @Override
-  public UfsFileStatus getExistingFileStatus(String path) throws IOException {
+  public UfsFileStatus getFileStatusWithRetry(String path) throws IOException {
     return new ManagedBlockingUfsMethod<UfsFileStatus>() {
       @Override
       public UfsFileStatus execute() throws IOException {
-        return mUfs.getExistingFileStatus(path);
+        return mUfs.getFileStatusWithRetry(path);
       }
     }.get();
   }
@@ -319,11 +319,11 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
   }
 
   @Override
-  public UfsStatus getExistingStatus(String path) throws IOException {
+  public UfsStatus getStatusWithRetry(String path) throws IOException {
     return new ManagedBlockingUfsMethod<UfsStatus>() {
       @Override
       public UfsStatus execute() throws IOException {
-        return mUfs.getExistingStatus(path);
+        return mUfs.getStatusWithRetry(path);
       }
     }.get();
   }
@@ -344,11 +344,11 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
   }
 
   @Override
-  public boolean isExistingDirectory(String path) throws IOException {
+  public boolean isDirectoryWithRetry(String path) throws IOException {
     return new ManagedBlockingUfsMethod<Boolean>() {
       @Override
       public Boolean execute() throws IOException {
-        return mUfs.isExistingDirectory(path);
+        return mUfs.isDirectoryWithRetry(path);
       }
     }.get();
   }
@@ -434,21 +434,21 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
   }
 
   @Override
-  public InputStream openExistingFile(String path) throws IOException {
+  public InputStream openWithRetry(String path) throws IOException {
     return new ManagedBlockingUfsMethod<InputStream>() {
       @Override
       public InputStream execute() throws IOException {
-        return mUfs.openExistingFile(path);
+        return mUfs.openWithRetry(path);
       }
     }.get();
   }
 
   @Override
-  public InputStream openExistingFile(String path, OpenOptions options) throws IOException {
+  public InputStream openWithRetry(String path, OpenOptions options) throws IOException {
     return new ManagedBlockingUfsMethod<InputStream>() {
       @Override
       public InputStream execute() throws IOException {
-        return mUfs.openExistingFile(path, options);
+        return mUfs.openWithRetry(path, options);
       }
     }.get();
   }
@@ -464,11 +464,11 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
   }
 
   @Override
-  public boolean renameRenamableDirectory(String src, String dst) throws IOException {
+  public boolean renameDirectoryWithRetry(String src, String dst) throws IOException {
     return new ManagedBlockingUfsMethod<Boolean>() {
       @Override
       public Boolean execute() throws IOException {
-        return mUfs.renameRenamableDirectory(src, dst);
+        return mUfs.renameDirectoryWithRetry(src, dst);
       }
     }.get();
   }
@@ -484,11 +484,11 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
   }
 
   @Override
-  public boolean renameRenamableFile(String src, String dst) throws IOException {
+  public boolean renameFileWithRetry(String src, String dst) throws IOException {
     return new ManagedBlockingUfsMethod<Boolean>() {
       @Override
       public Boolean execute() throws IOException {
-        return mUfs.renameRenamableFile(src, dst);
+        return mUfs.renameFileWithRetry(src, dst);
       }
     }.get();
   }

--- a/core/common/src/main/java/alluxio/underfs/ConsistentUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ConsistentUnderFileSystem.java
@@ -37,67 +37,67 @@ public abstract class ConsistentUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public OutputStream createNonexistingFile(String path) throws IOException {
+  public OutputStream createWithRetry(String path) throws IOException {
     return create(path);
   }
 
   @Override
-  public OutputStream createNonexistingFile(String path, CreateOptions options) throws IOException {
+  public OutputStream createWithRetry(String path, CreateOptions options) throws IOException {
     return create(path, options);
   }
 
   @Override
-  public boolean deleteExistingDirectory(String path) throws IOException {
+  public boolean deleteDirectoryWithRetry(String path) throws IOException {
     return deleteDirectory(path);
   }
 
   @Override
-  public boolean deleteExistingDirectory(String path, DeleteOptions options) throws IOException {
+  public boolean deleteDirectoryWithRetry(String path, DeleteOptions options) throws IOException {
     return deleteDirectory(path, options);
   }
 
   @Override
-  public boolean deleteExistingFile(String path) throws IOException {
+  public boolean deleteFileWithRetry(String path) throws IOException {
     return deleteFile(path);
   }
 
   @Override
-  public  UfsDirectoryStatus getExistingDirectoryStatus(String path) throws IOException {
+  public  UfsDirectoryStatus getDirectoryStatusWithRetry(String path) throws IOException {
     return getDirectoryStatus(path);
   }
 
   @Override
-  public UfsFileStatus getExistingFileStatus(String path) throws IOException {
+  public UfsFileStatus getFileStatusWithRetry(String path) throws IOException {
     return getFileStatus(path);
   }
 
   @Override
-  public UfsStatus getExistingStatus(String path) throws IOException {
+  public UfsStatus getStatusWithRetry(String path) throws IOException {
     return getStatus(path);
   }
 
   @Override
-  public boolean isExistingDirectory(String path) throws IOException {
+  public boolean isDirectoryWithRetry(String path) throws IOException {
     return isDirectory(path);
   }
 
   @Override
-  public InputStream openExistingFile(String path) throws IOException {
+  public InputStream openWithRetry(String path) throws IOException {
     return open(path);
   }
 
   @Override
-  public InputStream openExistingFile(String path, OpenOptions options) throws IOException {
+  public InputStream openWithRetry(String path, OpenOptions options) throws IOException {
     return open(path, options);
   }
 
   @Override
-  public boolean renameRenamableDirectory(String src, String dst) throws IOException {
+  public boolean renameDirectoryWithRetry(String src, String dst) throws IOException {
     return renameDirectory(src, dst);
   }
 
   @Override
-  public boolean renameRenamableFile(String src, String dst) throws IOException {
+  public boolean renameFileWithRetry(String src, String dst) throws IOException {
     return renameFile(src, dst);
   }
 }

--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -383,12 +383,12 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public OutputStream createNonexistingFile(String path) throws IOException {
+  public OutputStream createWithRetry(String path) throws IOException {
     return retryOnException(() -> create(path), () -> "create file " + path);
   }
 
   @Override
-  public OutputStream createNonexistingFile(String path, CreateOptions options) throws IOException {
+  public OutputStream createWithRetry(String path, CreateOptions options) throws IOException {
     return retryOnException(() -> create(path, options),
         () -> "create file " + path + " with options " + options);
   }
@@ -399,7 +399,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public boolean deleteExistingFile(String path) throws IOException {
+  public boolean deleteFileWithRetry(String path) throws IOException {
     return retryOnFalse(() -> deleteFile(path), () -> "delete existing file " + path);
   }
 
@@ -447,12 +447,12 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public boolean deleteExistingDirectory(String path) throws IOException {
+  public boolean deleteDirectoryWithRetry(String path) throws IOException {
     return retryOnFalse(() -> deleteDirectory(path), () -> "delete directory " + path);
   }
 
   @Override
-  public boolean deleteExistingDirectory(String path, DeleteOptions options) throws IOException {
+  public boolean deleteDirectoryWithRetry(String path, DeleteOptions options) throws IOException {
     return retryOnFalse(() -> deleteDirectory(path, options),
         () -> "delete directory " + path + " with options " + options);
   }
@@ -502,7 +502,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public  UfsDirectoryStatus getExistingDirectoryStatus(String path) throws IOException {
+  public  UfsDirectoryStatus getDirectoryStatusWithRetry(String path) throws IOException {
     return retryOnException(() -> getDirectoryStatus(path),
         () -> "get status of directory " + path);
   }
@@ -545,7 +545,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public  UfsFileStatus getExistingFileStatus(String path) throws IOException {
+  public  UfsFileStatus getFileStatusWithRetry(String path) throws IOException {
     return retryOnException(() -> getFileStatus(path), () -> "get status of file " + path);
   }
 
@@ -565,7 +565,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public UfsStatus getExistingStatus(String path) throws IOException {
+  public UfsStatus getStatusWithRetry(String path) throws IOException {
     return retryOnException(() -> getStatus(path),
         () -> "get status of " + path);
   }
@@ -584,7 +584,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public boolean isExistingDirectory(String path) throws IOException {
+  public boolean isDirectoryWithRetry(String path) throws IOException {
     return retryOnException(() -> isDirectory(path),
         () -> "check if " + path + " is a directory");
   }
@@ -649,12 +649,12 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public InputStream openExistingFile(String path) throws IOException {
-    return openExistingFile(path, OpenOptions.defaults());
+  public InputStream openWithRetry(String path) throws IOException {
+    return openWithRetry(path, OpenOptions.defaults());
   }
 
   @Override
-  public InputStream openExistingFile(String path, OpenOptions options) throws IOException {
+  public InputStream openWithRetry(String path, OpenOptions options) throws IOException {
     return openObject(stripPrefixIfPresent(path), options, getRetryPolicy());
   }
 
@@ -704,7 +704,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public boolean renameRenamableDirectory(String src, String dst) throws IOException {
+  public boolean renameDirectoryWithRetry(String src, String dst) throws IOException {
     return retryOnFalse(() -> renameDirectory(src, dst),
         () -> "rename directory from " + src + " to " + dst);
   }
@@ -754,7 +754,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public boolean renameRenamableFile(String src, String dst) throws IOException {
+  public boolean renameFileWithRetry(String src, String dst) throws IOException {
     return retryOnFalse(() -> renameFile(src, dst),
         () -> "rename file from " + src + " to " + dst);
   }

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -232,19 +232,19 @@ public interface UnderFileSystem extends Closeable {
    * @param path the file name
    * @return A {@code OutputStream} object
    */
-  OutputStream createNonexistingFile(String path) throws IOException;
+  OutputStream createWithRetry(String path) throws IOException;
 
   /**
    * Creates a file in the under file system with the specified {@link CreateOptions}.
    *
    * Similar to {@link #create(String, CreateOptions)} but
-   * deals with the delete-then-create eventual consistency issue.
+   * adds retry logic if needed to deal with the delete-then-create eventual consistency issue.
    *
    * @param path the file name
    * @param options the options for create
    * @return A {@code OutputStream} object
    */
-  OutputStream createNonexistingFile(String path, CreateOptions options) throws IOException;
+  OutputStream createWithRetry(String path, CreateOptions options) throws IOException;
 
   /**
    * Deletes a directory from the under file system with the indicated name non-recursively. A
@@ -268,24 +268,25 @@ public interface UnderFileSystem extends Closeable {
    * Deletes a directory from the under file system.
    *
    * Similar to {@link #deleteDirectory(String)} but
-   * deals with the create-delete eventual consistency issue.
+   * adds retry logic if needed to deal with the create-delete eventual consistency issue.
    *
    * @param path of the directory to delete
    * @return true if directory was found and deleted, false otherwise
    */
-  boolean deleteExistingDirectory(String path) throws IOException;
+  boolean deleteDirectoryWithRetry(String path) throws IOException;
 
   /**
    * Deletes a directory from the under file system with the indicated name.
    *
    * Similar to {@link #deleteDirectory(String, DeleteOptions)} but
-   * deals with the create-then-delete eventual consistency issue.
+   * adds retry logic if needed to deal with the create-then-delete
+   * eventual consistency issue.
    *
    * @param path of the directory to delete
    * @param options for directory delete semantics
    * @return true if directory was found and deleted, false otherwise
    */
-  boolean deleteExistingDirectory(String path, DeleteOptions options) throws IOException;
+  boolean deleteDirectoryWithRetry(String path, DeleteOptions options) throws IOException;
 
   /**
    * Deletes a file from the under file system with the indicated name.
@@ -299,12 +300,13 @@ public interface UnderFileSystem extends Closeable {
    * Deletes a file from the under file system with the indicated name.
    *
    * Similar to {@link #deleteFile(String)} but
-   * deals with the create-then-delete eventual consistency issue.
+   * adds retry logic if needed to deal with the create-then-delete
+   * eventual consistency issue.
    *
    * @param path of the file to delete
    * @return true if file was found and deleted, false otherwise
    */
-  boolean deleteExistingFile(String path) throws IOException;
+  boolean deleteFileWithRetry(String path) throws IOException;
 
   /**
    * Checks if a file or directory exists in under file system.
@@ -329,7 +331,7 @@ public interface UnderFileSystem extends Closeable {
    * Gets the block size of a file in under file system, in bytes.
    *
    * @deprecated block size should be returned as part of the {@link UfsFileStatus} from
-   * {@link #getFileStatus(String)} or {@link #getExistingFileStatus(String)}
+   * {@link #getFileStatus(String)} or {@link #getFileStatusWithRetry(String)}
    *
    * @param path the file name
    * @return the block size in bytes
@@ -360,12 +362,13 @@ public interface UnderFileSystem extends Closeable {
    * Gets the directory status.
    *
    * Similar to {@link #getDirectoryStatus(String)} but
-   * deals with the write-then-get-status eventual consistency issue.
+   * adds retry logic if needed to deal with the write-then-get-status
+   * eventual consistency issue.
    *
    * @param path the path to the directory
    * @return the directory status
    */
-  UfsDirectoryStatus getExistingDirectoryStatus(String path) throws IOException;
+  UfsDirectoryStatus getDirectoryStatusWithRetry(String path) throws IOException;
 
   /**
    * Gets the list of locations of the indicated path.
@@ -398,12 +401,12 @@ public interface UnderFileSystem extends Closeable {
    * Gets the file status.
    *
    * Similar to {@link #getFileStatus(String)} but
-   * deals with the write-then-get-status eventual consistency issue.
+   * adds retry logic if needed to deal with the write-then-get-status eventual consistency issue.
    *
    * @param path the path to the file
    * @return the file status
    */
-  UfsFileStatus getExistingFileStatus(String path) throws IOException;
+  UfsFileStatus getFileStatusWithRetry(String path) throws IOException;
 
   /**
    * Computes and returns a fingerprint for the path. The fingerprint is used to determine if two
@@ -481,12 +484,12 @@ public interface UnderFileSystem extends Closeable {
    * Gets the file or directory status.
    *
    * Similar to {@link #getStatus(String)} but
-   * deals with the write-then-get-status eventual consistency issue.
+   * adds retry logic if needed to deal with the write-then-get-status eventual consistency issue.
    *
    * @param path the path to get the status
    * @return the file or directory status
    */
-  UfsStatus getExistingStatus(String path) throws IOException;
+  UfsStatus getStatusWithRetry(String path) throws IOException;
 
   /**
    * Returns the name of the under filesystem implementation.
@@ -509,12 +512,13 @@ public interface UnderFileSystem extends Closeable {
    * Checks if a directory exists in under file system.
    *
    * Similar to {@link #isDirectory(String)} but
-   * deals with the write-then-list eventual consistency issue.
+   * adds retry logic if needed to deal with the write-then-list
+   * eventual consistency issue.
    *
    * @param path the absolute directory path
    * @return true if the path exists and is a directory, false otherwise
    */
-  boolean isExistingDirectory(String path) throws IOException;
+  boolean isDirectoryWithRetry(String path) throws IOException;
 
   /**
    * Checks if a file exists in under file system.
@@ -623,24 +627,24 @@ public interface UnderFileSystem extends Closeable {
    * Opens an {@link InputStream} for a file in under filesystem at the indicated path.
    *
    * Similar to {@link #open(String)} but
-   * deals with the write-then-read eventual consistency issue.
+   * adds retry logic if needed to deal with the write-then-read eventual consistency issue.
    *
    * @param path the file name
    * @return The {@code InputStream} object
    */
-  InputStream openExistingFile(String path) throws IOException;
+  InputStream openWithRetry(String path) throws IOException;
 
   /**
    * Opens an {@link InputStream} for a file in under filesystem at the indicated path.
    *
    * Similar to {@link #open(String, OpenOptions)} but
-   * deals with the write-then-read eventual consistency issue.
+   * adds retry logic if needed to deal with the write-then-read eventual consistency issue.
    *
    * @param path the file name
    * @param options to open input stream
    * @return The {@code InputStream} object
    */
-  InputStream openExistingFile(String path, OpenOptions options) throws IOException;
+  InputStream openWithRetry(String path, OpenOptions options) throws IOException;
 
   /**
    * Renames a directory from {@code src} to {@code dst} in under file system.
@@ -655,13 +659,14 @@ public interface UnderFileSystem extends Closeable {
    * Renames a directory from {@code src} to {@code dst} in under file system.
    *
    * Similar to {@link #renameDirectory(String, String)} but
-   * deals with the write-src-then-rename and delete-dst-then-rename eventual consistency issue.
+   * adds retry logic if needed to deal with the write-src-then-rename
+   * and delete-dst-then-rename eventual consistency issue.
    *
    * @param src the source directory path
    * @param dst the destination directory path
    * @return true if succeed, false otherwise
    */
-  boolean renameRenamableDirectory(String src, String dst) throws IOException;
+  boolean renameDirectoryWithRetry(String src, String dst) throws IOException;
 
   /**
    * Renames a file from {@code src} to {@code dst} in under file system.
@@ -676,13 +681,14 @@ public interface UnderFileSystem extends Closeable {
    * Renames a file from {@code src} to {@code dst} in under file system.
    *
    * Similar to {@link #renameFile(String, String)} but
-   * deals with the write-src-then-rename and delete-dst-then-rename eventual consistency issue.
+   * adds retry logic if needed to deal with the write-src-then-rename
+   * and delete-dst-then-rename eventual consistency issue.
    *
    * @param src the source file path
    * @param dst the destination file path
    * @return true if succeed, false otherwise
    */
-  boolean renameRenamableFile(String src, String dst) throws IOException;
+  boolean renameFileWithRetry(String src, String dst) throws IOException;
 
   /**
    * Returns an {@link AlluxioURI} representation for the {@link UnderFileSystem} given a base

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -195,11 +195,11 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public OutputStream createNonexistingFile(final String path) throws IOException {
+  public OutputStream createWithRetry(final String path) throws IOException {
     return call(new UfsCallable<OutputStream>() {
       @Override
       public OutputStream call() throws IOException {
-        return mUnderFileSystem.createNonexistingFile(path);
+        return mUnderFileSystem.createWithRetry(path);
       }
 
       @Override
@@ -215,12 +215,12 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public OutputStream createNonexistingFile(final String path,
-      final CreateOptions options) throws IOException {
+  public OutputStream createWithRetry(final String path,
+                                      final CreateOptions options) throws IOException {
     return call(new UfsCallable<OutputStream>() {
       @Override
       public OutputStream call() throws IOException {
-        return mUnderFileSystem.createNonexistingFile(path, options);
+        return mUnderFileSystem.createWithRetry(path, options);
       }
 
       @Override
@@ -277,11 +277,11 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public boolean deleteExistingDirectory(final String path) throws IOException {
+  public boolean deleteDirectoryWithRetry(final String path) throws IOException {
     return call(new UfsCallable<Boolean>() {
       @Override
       public Boolean call() throws IOException {
-        return mUnderFileSystem.deleteExistingDirectory(path);
+        return mUnderFileSystem.deleteDirectoryWithRetry(path);
       }
 
       @Override
@@ -297,12 +297,12 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public boolean deleteExistingDirectory(final String path, final DeleteOptions options)
+  public boolean deleteDirectoryWithRetry(final String path, final DeleteOptions options)
       throws IOException {
     return call(new UfsCallable<Boolean>() {
       @Override
       public Boolean call() throws IOException {
-        return mUnderFileSystem.deleteExistingDirectory(path, options);
+        return mUnderFileSystem.deleteDirectoryWithRetry(path, options);
       }
 
       @Override
@@ -338,11 +338,11 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public boolean deleteExistingFile(final String path) throws IOException {
+  public boolean deleteFileWithRetry(final String path) throws IOException {
     return call(new UfsCallable<Boolean>() {
       @Override
       public Boolean call() throws IOException {
-        return mUnderFileSystem.deleteExistingFile(path);
+        return mUnderFileSystem.deleteFileWithRetry(path);
       }
 
       @Override
@@ -459,11 +459,11 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public UfsDirectoryStatus getExistingDirectoryStatus(final String path) throws IOException {
+  public UfsDirectoryStatus getDirectoryStatusWithRetry(final String path) throws IOException {
     return call(new UfsCallable<UfsDirectoryStatus>() {
       @Override
       public UfsDirectoryStatus call() throws IOException {
-        return mUnderFileSystem.getExistingDirectoryStatus(path);
+        return mUnderFileSystem.getDirectoryStatusWithRetry(path);
       }
 
       @Override
@@ -540,11 +540,11 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public UfsFileStatus getExistingFileStatus(final String path) throws IOException {
+  public UfsFileStatus getFileStatusWithRetry(final String path) throws IOException {
     return call(new UfsCallable<UfsFileStatus>() {
       @Override
       public UfsFileStatus call() throws IOException {
-        return mUnderFileSystem.getExistingFileStatus(path);
+        return mUnderFileSystem.getFileStatusWithRetry(path);
       }
 
       @Override
@@ -655,11 +655,11 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public UfsStatus getExistingStatus(String path) throws IOException {
+  public UfsStatus getStatusWithRetry(String path) throws IOException {
     return call(new UfsCallable<UfsStatus>() {
       @Override
       public UfsStatus call() throws IOException {
-        return mUnderFileSystem.getExistingStatus(path);
+        return mUnderFileSystem.getStatusWithRetry(path);
       }
 
       @Override
@@ -700,11 +700,11 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public boolean isExistingDirectory(final String path) throws IOException {
+  public boolean isDirectoryWithRetry(final String path) throws IOException {
     return call(new UfsCallable<Boolean>() {
       @Override
       public Boolean call() throws IOException {
-        return mUnderFileSystem.isExistingDirectory(path);
+        return mUnderFileSystem.isDirectoryWithRetry(path);
       }
 
       @Override
@@ -899,11 +899,11 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public InputStream openExistingFile(final String path) throws IOException {
+  public InputStream openWithRetry(final String path) throws IOException {
     return call(new UfsCallable<InputStream>() {
       @Override
       public InputStream call() throws IOException {
-        return mUnderFileSystem.openExistingFile(path);
+        return mUnderFileSystem.openWithRetry(path);
       }
 
       @Override
@@ -919,12 +919,12 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public InputStream openExistingFile(final String path, final OpenOptions options)
+  public InputStream openWithRetry(final String path, final OpenOptions options)
       throws IOException {
     return call(new UfsCallable<InputStream>() {
       @Override
       public InputStream call() throws IOException {
-        return mUnderFileSystem.openExistingFile(path, options);
+        return mUnderFileSystem.openWithRetry(path, options);
       }
 
       @Override
@@ -960,11 +960,11 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public boolean renameRenamableDirectory(final String src, final String dst) throws IOException {
+  public boolean renameDirectoryWithRetry(final String src, final String dst) throws IOException {
     return call(new UfsCallable<Boolean>() {
       @Override
       public Boolean call() throws IOException {
-        return mUnderFileSystem.renameRenamableDirectory(src, dst);
+        return mUnderFileSystem.renameDirectoryWithRetry(src, dst);
       }
 
       @Override
@@ -1000,11 +1000,11 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public boolean renameRenamableFile(final String src, final String dst) throws IOException {
+  public boolean renameFileWithRetry(final String src, final String dst) throws IOException {
     return call(new UfsCallable<Boolean>() {
       @Override
       public Boolean call() throws IOException {
-        return mUnderFileSystem.renameRenamableFile(src, dst);
+        return mUnderFileSystem.renameFileWithRetry(src, dst);
       }
 
       @Override

--- a/core/server/master/src/main/java/alluxio/master/backup/AbstractBackupRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/AbstractBackupRole.java
@@ -190,7 +190,7 @@ public abstract class AbstractBackupRole implements BackupRole {
         ufs.create(backupFilePath + ".complete").close();
       } catch (IOException e) {
         try {
-          ufs.deleteExistingFile(backupFilePath);
+          ufs.deleteFileWithRetry(backupFilePath);
         } catch (Exception e2) {
           LOG.error("Failed to clean up failed backup at {}", backupFilePath, e2);
           e.addSuppressed(e2);

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2769,9 +2769,9 @@ public class DefaultFileSystemMaster extends CoreMaster
           String ufsDstUri = mMountTable.resolve(dstPath).getUri().toString();
           boolean success;
           if (srcInode.isFile()) {
-            success = ufs.renameRenamableFile(ufsSrcPath, ufsDstUri);
+            success = ufs.renameFileWithRetry(ufsSrcPath, ufsDstUri);
           } else {
-            success = ufs.renameRenamableDirectory(ufsSrcPath, ufsDstUri);
+            success = ufs.renameDirectoryWithRetry(ufsSrcPath, ufsDstUri);
           }
           if (!success) {
             throw new IOException(
@@ -4324,7 +4324,7 @@ public class DefaultFileSystemMaster extends CoreMaster
                 // check if the destination direction is valid, if there isn't exist directory,
                 // create it and it's parents
                 createParentPath(inodePath.getInodeList(), ufsPath, ufs, job.getId());
-                if (!ufs.renameRenamableFile(tempUfsPath, ufsPath)) {
+                if (!ufs.renameFileWithRetry(tempUfsPath, ufsPath)) {
                   throw new IOException(
                       String.format("Failed to rename %s to %s.", tempUfsPath, ufsPath));
                 }
@@ -4612,7 +4612,7 @@ public class DefaultFileSystemMaster extends CoreMaster
   private static void cleanup(UnderFileSystem ufs, String ufsPath) {
     if (!ufsPath.isEmpty()) {
       try {
-        if (!ufs.deleteExistingFile(ufsPath)) {
+        if (!ufs.deleteFileWithRetry(ufsPath)) {
           LOG.warn("Failed to delete UFS file {}.", ufsPath);
         }
       } catch (IOException e) {

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -934,7 +934,7 @@ public class InodeSyncStream {
       UnderFileSystem ufs = ufsResource.get();
 
       if (context.getUfsStatus() == null) {
-        context.setUfsStatus(ufs.getExistingFileStatus(ufsUri.toString()));
+        context.setUfsStatus(ufs.getFileStatusWithRetry(ufsUri.toString()));
       }
       ufsLength = ((UfsFileStatus) context.getUfsStatus()).getContentLength();
       long blockSize = ((UfsFileStatus) context.getUfsStatus()).getBlockSize();
@@ -1040,7 +1040,7 @@ public class InodeSyncStream {
     try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
       UnderFileSystem ufs = ufsResource.get();
       if (context.getUfsStatus() == null) {
-        context.setUfsStatus(ufs.getExistingDirectoryStatus(ufsUri.toString()));
+        context.setUfsStatus(ufs.getDirectoryStatusWithRetry(ufsUri.toString()));
       }
       Pair<AccessControlList, DefaultAccessControlList> aclPair =
           ufs.getAclPair(ufsUri.toString());

--- a/core/server/master/src/main/java/alluxio/master/file/SafeUfsDeleter.java
+++ b/core/server/master/src/main/java/alluxio/master/file/SafeUfsDeleter.java
@@ -81,7 +81,7 @@ public final class SafeUfsDeleter implements UfsDeleter {
       if (!isRecursiveDeleteSafe(parentUri)) {
         // Parent will not recursively delete, so delete this inode individually
         if (inode.isFile()) {
-          if (!ufs.deleteExistingFile(ufsUri)) {
+          if (!ufs.deleteFileWithRetry(ufsUri)) {
             if (ufs.isFile(ufsUri)) {
               throw new IOException(ExceptionMessage.DELETE_FAILED_UFS_FILE.getMessage());
             } else {
@@ -92,7 +92,7 @@ public final class SafeUfsDeleter implements UfsDeleter {
           if (isRecursiveDeleteSafe(alluxioUri)) {
             DeleteOptions options =
                 DeleteOptions.defaults().setRecursive(true);
-            if (!ufs.deleteExistingDirectory(ufsUri, options)) {
+            if (!ufs.deleteDirectoryWithRetry(ufsUri, options)) {
               // TODO(adit): handle partial failures of recursive deletes
               if (ufs.isDirectory(ufsUri)) {
                 throw new IOException(ExceptionMessage.DELETE_FAILED_UFS_DIR.getMessage());

--- a/core/server/master/src/main/java/alluxio/master/meta/DailyMetadataBackup.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DailyMetadataBackup.java
@@ -170,7 +170,7 @@ public final class DailyMetadataBackup {
       for (int i = 0; i < toDeleteFileNum; i++) {
         String toDeleteFile = PathUtils.concatPath(mBackupDir,
             timeToFile.pollFirstEntry().getValue());
-        ufs.deleteExistingFile(toDeleteFile);
+        ufs.deleteFileWithRetry(toDeleteFile);
       }
       LOG.info("Deleted {} stale metadata backup files at {}", toDeleteFileNum, mBackupDir);
     }

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTest.java
@@ -230,7 +230,7 @@ public final class FileSystemMasterSyncMetadataTest {
     Mockito.when(mUfs.isObjectStorage()).thenReturn(true);
     Mockito.when(mUfs.isDirectory(ufsMount.toString())).thenReturn(true);
     short mode = ModeUtils.getUMask("0700").toShort();
-    Mockito.when(mUfs.getExistingDirectoryStatus(ufsMount.toString()))
+    Mockito.when(mUfs.getDirectoryStatusWithRetry(ufsMount.toString()))
         .thenReturn(new UfsDirectoryStatus(ufsMount.toString(), "", "", mode));
     Mockito.when(mUfs.resolveUri(Mockito.eq(ufsMount), anyString()))
         .thenAnswer(invocation -> new AlluxioURI(ufsMount,

--- a/core/server/master/src/test/java/alluxio/master/meta/DailyMetadataBackupTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/DailyMetadataBackupTest.java
@@ -110,13 +110,13 @@ public class DailyMetadataBackupTest {
       mScheduler.jumpAndExecute(1, TimeUnit.DAYS);
       verify(mMetaMaster, times(backUpFileNum)).backup(any(), any());
       deleteFileNum += getNumOfDeleteFile(backUpFileNum, fileToRetain);
-      verify(mUfs, times(deleteFileNum)).deleteExistingFile(any());
+      verify(mUfs, times(deleteFileNum)).deleteFileWithRetry(any());
 
       when(mUfs.listStatus(mBackupDir)).thenReturn(generateUfsStatuses(++backUpFileNum));
       mScheduler.jumpAndExecute(1, TimeUnit.DAYS);
       verify(mMetaMaster, times(backUpFileNum)).backup(any(), any());
       deleteFileNum += getNumOfDeleteFile(backUpFileNum, fileToRetain);
-      verify(mUfs, times(deleteFileNum)).deleteExistingFile(any());
+      verify(mUfs, times(deleteFileNum)).deleteFileWithRetry(any());
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamCache.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamCache.java
@@ -173,7 +173,7 @@ public final class UfsInputStreamCache {
       throws IOException {
     if (!ufs.isSeekable() || !CACHE_ENABLED) {
       // only seekable UFSes are cachable/reusable, always return a new input stream
-      return ufs.openExistingFile(path, openOptions);
+      return ufs.openWithRetry(path, openOptions);
     }
 
     // explicit cache cleanup
@@ -217,7 +217,7 @@ public final class UfsInputStreamCache {
     try {
       inputStream = mStreamCache.get(newId, () -> {
         SeekableUnderFileInputStream ufsStream = (SeekableUnderFileInputStream) ufs
-            .openExistingFile(path,
+            .openWithRetry(path,
                 OpenOptions.defaults().setPositionShort(openOptions.getPositionShort())
                     .setOffset(openOptions.getOffset()));
         LOG.debug("Created the under file input stream resource of {}", newId);
@@ -227,7 +227,7 @@ public final class UfsInputStreamCache {
       LOG.warn("Failed to create a new cached ufs instream of file id {} and path {}", fileId,
           path, e);
       // fall back to an uncached ufs creation.
-      return ufs.openExistingFile(path,
+      return ufs.openWithRetry(path,
           OpenOptions.defaults().setOffset(openOptions.getOffset()));
     }
     return inputStream;

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandler.java
@@ -128,7 +128,7 @@ public final class UfsFallbackBlockWriteHandler
         context.setOutputStream(null);
       }
       if (context.getUfsResource() != null) {
-        context.getUfsResource().get().deleteExistingFile(context.getUfsPath());
+        context.getUfsResource().get().deleteFileWithRetry(context.getUfsPath());
       }
     }
     if (context.getUfsResource() != null) {
@@ -246,7 +246,7 @@ public final class UfsFallbackBlockWriteHandler
     UnderFileSystem ufs = ufsResource.get();
     // Set the atomic flag to be true to ensure only the creation of this file is atomic on close.
     OutputStream ufsOutputStream =
-        ufs.createNonexistingFile(ufsPath,
+        ufs.createWithRetry(ufsPath,
             CreateOptions.defaults(ServerConfiguration.global()).setEnsureAtomic(true)
                 .setCreateParent(true));
     context.setOutputStream(ufsOutputStream);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFileWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFileWriteHandler.java
@@ -110,7 +110,7 @@ public final class UfsFileWriteHandler extends AbstractWriteHandler<UfsFileWrite
     // TODO(calvin): Consider adding cancel to the ufs stream api.
     if (context.getOutputStream() != null && context.getUfsResource() != null) {
       context.getOutputStream().close();
-      context.getUfsResource().get().deleteExistingFile(request.getUfsPath());
+      context.getUfsResource().get().deleteFileWithRetry(request.getUfsPath());
       context.setOutputStream(null);
       context.setCreateOptions(null);
       context.getUfsResource().close();
@@ -163,7 +163,7 @@ public final class UfsFileWriteHandler extends AbstractWriteHandler<UfsFileWrite
       // This acl information will be ignored by all but HDFS implementations
       createOptions.setAcl(ProtoUtils.fromProto(createUfsFileOptions.getAcl()));
     }
-    context.setOutputStream(ufs.createNonexistingFile(request.getUfsPath(), createOptions));
+    context.setOutputStream(ufs.createWithRetry(request.getUfsPath(), createOptions));
     context.setCreateOptions(createOptions);
     String ufsString = MetricsSystem.escape(ufsClient.getUfsMountPointUri());
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamCacheTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamCacheTest.java
@@ -58,7 +58,7 @@ public final class UfsInputStreamCacheTest {
       SeekableUnderFileInputStream instream = mock(SeekableUnderFileInputStream.class);
       mSeekableInStreams[i] = instream;
     }
-    when(mUfs.openExistingFile(eq(FILE_NAME), any(OpenOptions.class))).thenReturn(
+    when(mUfs.openWithRetry(eq(FILE_NAME), any(OpenOptions.class))).thenReturn(
         mSeekableInStreams[0], Arrays.copyOfRange(mSeekableInStreams, 1, mNumOfInputStreams));
     mManager = new UfsInputStreamCache();
   }
@@ -68,7 +68,7 @@ public final class UfsInputStreamCacheTest {
     when(mUfs.isSeekable()).thenReturn(false);
 
     SeekableUnderFileInputStream mockedStream = mock(SeekableUnderFileInputStream.class);
-    when(mUfs.openExistingFile(eq(FILE_NAME), any(OpenOptions.class)))
+    when(mUfs.openWithRetry(eq(FILE_NAME), any(OpenOptions.class)))
         .thenReturn(mockedStream).thenThrow(new IllegalStateException("Should be called once"));
 
     // acquire a stream
@@ -84,7 +84,7 @@ public final class UfsInputStreamCacheTest {
   @Test
   public void acquireAndRelease() throws Exception {
     SeekableUnderFileInputStream mockedStream = mock(SeekableUnderFileInputStream.class);
-    when(mUfs.openExistingFile(eq(FILE_NAME), any(OpenOptions.class)))
+    when(mUfs.openWithRetry(eq(FILE_NAME), any(OpenOptions.class)))
         .thenReturn(mockedStream).thenThrow(new IllegalStateException("Should be called once"));
 
     // acquire a stream
@@ -107,7 +107,7 @@ public final class UfsInputStreamCacheTest {
     mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(4));
     mManager.acquire(mUfs, FILE_NAME, FILE_ID, OpenOptions.defaults().setOffset(6));
     // 3 different input streams are acquired
-    verify(mUfs, times(3)).openExistingFile(eq(FILE_NAME),
+    verify(mUfs, times(3)).openWithRetry(eq(FILE_NAME),
         any(OpenOptions.class));
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandlerTest.java
@@ -90,7 +90,7 @@ public class UfsFallbackBlockWriteHandlerTest extends AbstractWriteHandlerTest {
     UfsManager ufsManager = Mockito.mock(UfsManager.class);
     UfsManager.UfsClient ufsClient = new UfsManager.UfsClient(() -> mockUfs, AlluxioURI.EMPTY_URI);
     Mockito.when(ufsManager.get(Mockito.anyLong())).thenReturn(ufsClient);
-    Mockito.when(mockUfs.createNonexistingFile(Mockito.anyString(),
+    Mockito.when(mockUfs.createWithRetry(Mockito.anyString(),
         Mockito.any(CreateOptions.class))).thenReturn(mOutputStream)
         .thenReturn(new FileOutputStream(mFile, true));
 

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFileWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFileWriteHandlerTest.java
@@ -52,7 +52,7 @@ public final class UfsFileWriteHandlerTest extends AbstractWriteHandlerTest {
     UfsManager ufsManager = Mockito.mock(UfsManager.class);
     UfsClient ufsClient = new UfsClient(() -> mockUfs, AlluxioURI.EMPTY_URI);
     Mockito.when(ufsManager.get(TEST_MOUNT_ID)).thenReturn(ufsClient);
-    Mockito.when(mockUfs.createNonexistingFile(Mockito.anyString(),
+    Mockito.when(mockUfs.createWithRetry(Mockito.anyString(),
         Mockito.any(CreateOptions.class))).thenReturn(mOutputStream)
         .thenReturn(new FileOutputStream(mFile, true));
     mResponseObserver = Mockito.mock(StreamObserver.class);

--- a/integration/tools/validation/src/main/java/alluxio/cli/S3ASpecificOperations.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/S3ASpecificOperations.java
@@ -101,7 +101,7 @@ public final class S3ASpecificOperations {
       }
     }
     // Validate data written successfully and content is correct
-    try (InputStream inputStream = mUfs.openExistingFile(testFile)) {
+    try (InputStream inputStream = mUfs.openWithRetry(testFile)) {
       byte[] buf = new byte[numCopies * TEST_BYTES.length];
       int offset = 0;
       while (offset < buf.length) {

--- a/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemCommonOperations.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemCommonOperations.java
@@ -249,7 +249,7 @@ public final class UnderFileSystemCommonOperations {
   public void createOpenExistingLargeFileTest() throws IOException {
     String testFile = PathUtils.concatPath(mTopLevelTestDirectory, "createOpenExistingLargeFile");
     int numCopies = prepareMultiBlockFile(testFile);
-    InputStream inputStream = mUfs.openExistingFile(testFile);
+    InputStream inputStream = mUfs.openWithRetry(testFile);
     byte[] buf = new byte[numCopies * TEST_BYTES.length];
     int offset = 0;
     while (offset < buf.length) {
@@ -355,7 +355,7 @@ public final class UnderFileSystemCommonOperations {
       "listObjectsV2", "getObjectMetadata"})
   public void deleteLargeDirectoryTest() throws Exception {
     LargeDirectoryConfig config = prepareLargeDirectory();
-    mUfs.deleteExistingDirectory(config.getTopLevelDirectory(),
+    mUfs.deleteDirectoryWithRetry(config.getTopLevelDirectory(),
         DeleteOptions.defaults().setRecursive(true));
 
     String[] children = config.getChildren();
@@ -388,12 +388,12 @@ public final class UnderFileSystemCommonOperations {
       throw new IOException(IS_FAIL_CHECK_SHOULD_SUCCEED);
     }
 
-    mUfs.deleteExistingFile(testFile);
+    mUfs.deleteFileWithRetry(testFile);
     if (mUfs.exists(testFile)) {
       throw new IOException(FILE_EXISTS_CHECK_SHOULD_FAILED);
     }
 
-    OutputStream o = mUfs.createNonexistingFile(testFile);
+    OutputStream o = mUfs.createWithRetry(testFile);
     o.write(TEST_BYTES);
     o.close();
     if (!mUfs.exists(testFile)) {
@@ -408,7 +408,7 @@ public final class UnderFileSystemCommonOperations {
       "listObjectsV2", "getObjectMetadata"})
   public void createThenDeleteExistingDirectoryTest() throws IOException {
     LargeDirectoryConfig config = prepareLargeDirectory();
-    if (!mUfs.deleteExistingDirectory(config.getTopLevelDirectory(),
+    if (!mUfs.deleteDirectoryWithRetry(config.getTopLevelDirectory(),
         DeleteOptions.defaults().setRecursive(true))) {
       throw new IOException("Failed to delete existing directory");
     }
@@ -458,7 +458,7 @@ public final class UnderFileSystemCommonOperations {
   public void createThenGetExistingDirectoryStatusTest() throws IOException {
     String testDir = PathUtils.concatPath(mTopLevelTestDirectory, "testDir");
     mUfs.mkdirs(testDir);
-    UfsStatus status = mUfs.getExistingStatus(testDir);
+    UfsStatus status = mUfs.getStatusWithRetry(testDir);
     if (!(status instanceof UfsDirectoryStatus)) {
       throw new IOException("Failed to get ufs directory status");
     }
@@ -488,9 +488,9 @@ public final class UnderFileSystemCommonOperations {
     String testFileLarge = PathUtils.concatPath(mTopLevelTestDirectory, "testFileLarge");
     createTestBytesFile(testFileNonEmpty);
     int numCopies = prepareMultiBlockFile(testFileLarge);
-    if (TEST_BYTES.length != mUfs.getExistingFileStatus(testFileNonEmpty).getContentLength()
+    if (TEST_BYTES.length != mUfs.getFileStatusWithRetry(testFileNonEmpty).getContentLength()
         || TEST_BYTES.length * numCopies
-        != mUfs.getExistingFileStatus(testFileLarge).getContentLength()) {
+        != mUfs.getFileStatusWithRetry(testFileLarge).getContentLength()) {
       throw new IOException(FILE_STATUS_RESULT_INCORRECT);
     }
   }
@@ -517,7 +517,7 @@ public final class UnderFileSystemCommonOperations {
     String testFile = PathUtils.concatPath(mTopLevelTestDirectory, "testFile");
     createTestBytesFile(testFile);
 
-    UfsStatus status = mUfs.getExistingStatus(testFile);
+    UfsStatus status = mUfs.getStatusWithRetry(testFile);
     if (!(status instanceof UfsFileStatus)) {
       throw new IOException("Failed to get ufs file status");
     }
@@ -1011,7 +1011,7 @@ public final class UnderFileSystemCommonOperations {
     String testFileSrc = PathUtils.concatPath(mTopLevelTestDirectory, "renameFileSrc");
     String testFileDst = PathUtils.concatPath(mTopLevelTestDirectory, "renameFileDst");
     prepareMultiBlockFile(testFileSrc);
-    mUfs.renameRenamableFile(testFileSrc, testFileDst);
+    mUfs.renameFileWithRetry(testFileSrc, testFileDst);
     if (mUfs.isFile(testFileSrc)) {
       throw new IOException(IS_FAIL_CHECK_SHOULD_FAILED);
     }
@@ -1106,7 +1106,7 @@ public final class UnderFileSystemCommonOperations {
     mUfs.mkdirs(testDirSrcNested, MkdirsOptions.defaults(mConfiguration).setCreateParent(false));
     prepareMultiBlockFile(testDirSrcNestedChild);
 
-    mUfs.renameRenamableDirectory(testDirSrc, testDirDst);
+    mUfs.renameDirectoryWithRetry(testDirSrc, testDirDst);
 
     if (mUfs.isDirectory(testDirSrc) || mUfs.isDirectory(testDirSrcNested)) {
       throw new IOException(IS_DIRECTORY_CHECK_SHOULD_FAILED);

--- a/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
@@ -114,7 +114,7 @@ public final class PersistDefinition
       if (ufs.exists(ufsPath)) {
         if (config.isOverwrite()) {
           LOG.info("File {} is already persisted in UFS. Removing it.", config.getFilePath());
-          ufs.deleteExistingFile(ufsPath);
+          ufs.deleteFileWithRetry(ufsPath);
         } else {
           throw new IOException("File " + config.getFilePath()
               + " is already persisted in UFS, to overwrite the file, please set the overwrite flag"
@@ -171,7 +171,7 @@ public final class PersistDefinition
           }
         }
         OutputStream out = closer.register(
-            ufs.createNonexistingFile(dstPath.toString(),
+            ufs.createWithRetry(dstPath.toString(),
                 CreateOptions.defaults(ServerConfiguration.global()).setOwner(uriStatus.getOwner())
                 .setGroup(uriStatus.getGroup()).setMode(new Mode((short) uriStatus.getMode()))));
         URIStatus status = context.getFileSystem().getStatus(uri);

--- a/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
@@ -257,7 +257,7 @@ public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCl
     UnderFileSystem ufs = UnderFileSystem.Factory.createForRoot(ServerConfiguration.global());
     String path = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     if (ufs.isDirectory(path)) {
-      ufs.deleteExistingDirectory(path, DeleteOptions.defaults().setRecursive(true));
+      ufs.deleteDirectoryWithRetry(path, DeleteOptions.defaults().setRecursive(true));
     }
     if (!ufs.mkdirs(path)) {
       throw new IOException("Failed to make folder: " + path);

--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterRestartIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterRestartIntegrationTest.java
@@ -247,7 +247,7 @@ public class FileSystemMasterRestartIntegrationTest extends BaseIntegrationTest 
         .thenReturn(new AlluxioURI(ufsBase));
     Mockito.when(mockUfs.resolveUri(new AlluxioURI(ufsBase), "/dir1"))
         .thenReturn(new AlluxioURI(ufsBase + "/dir1"));
-    Mockito.when(mockUfs.getExistingDirectoryStatus(ufsBase))
+    Mockito.when(mockUfs.getDirectoryStatusWithRetry(ufsBase))
         .thenReturn(ufsStatus);
     Mockito.when(mockUfs.mkdirs(ArgumentMatchers.eq(ufsBase + "/dir1"), ArgumentMatchers.any()))
         .thenThrow(new IOException("ufs unavailable"));

--- a/tests/src/test/java/alluxio/server/ft/FlakyUfsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/FlakyUfsIntegrationTest.java
@@ -64,9 +64,9 @@ public final class FlakyUfsIntegrationTest extends BaseIntegrationTest {
         }
 
         @Override
-        public boolean deleteExistingFile(String path) throws IOException {
+        public boolean deleteFileWithRetry(String path) throws IOException {
           if (ThreadLocalRandom.current().nextBoolean()) {
-            return mUfs.deleteExistingFile(path);
+            return mUfs.deleteFileWithRetry(path);
           } else {
             return false;
           }

--- a/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
+++ b/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
@@ -81,13 +81,13 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public OutputStream createNonexistingFile(String path, CreateOptions options) throws IOException {
-    return mUfs.createNonexistingFile(path, options);
+  public OutputStream createWithRetry(String path, CreateOptions options) throws IOException {
+    return mUfs.createWithRetry(path, options);
   }
 
   @Override
-  public OutputStream createNonexistingFile(String path) throws IOException {
-    return mUfs.createNonexistingFile(path);
+  public OutputStream createWithRetry(String path) throws IOException {
+    return mUfs.createWithRetry(path);
   }
 
   @Override
@@ -101,13 +101,13 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public boolean deleteExistingDirectory(String path) throws IOException {
-    return mUfs.deleteExistingDirectory(path);
+  public boolean deleteDirectoryWithRetry(String path) throws IOException {
+    return mUfs.deleteDirectoryWithRetry(path);
   }
 
   @Override
-  public boolean deleteExistingDirectory(String path, DeleteOptions options) throws IOException {
-    return mUfs.deleteExistingDirectory(path, options);
+  public boolean deleteDirectoryWithRetry(String path, DeleteOptions options) throws IOException {
+    return mUfs.deleteDirectoryWithRetry(path, options);
   }
 
   @Override
@@ -116,8 +116,8 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public boolean deleteExistingFile(String path) throws IOException {
-    return mUfs.deleteExistingFile(path);
+  public boolean deleteFileWithRetry(String path) throws IOException {
+    return mUfs.deleteFileWithRetry(path);
   }
 
   @Override
@@ -147,8 +147,8 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public UfsDirectoryStatus getExistingDirectoryStatus(String path) throws IOException {
-    return mUfs.getExistingDirectoryStatus(path);
+  public UfsDirectoryStatus getDirectoryStatusWithRetry(String path) throws IOException {
+    return mUfs.getDirectoryStatusWithRetry(path);
   }
 
   @Override
@@ -168,8 +168,8 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public UfsFileStatus getExistingFileStatus(String path) throws IOException {
-    return mUfs.getExistingFileStatus(path);
+  public UfsFileStatus getFileStatusWithRetry(String path) throws IOException {
+    return mUfs.getFileStatusWithRetry(path);
   }
 
   @Override
@@ -203,8 +203,8 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public UfsStatus getExistingStatus(String path) throws IOException {
-    return mUfs.getExistingStatus(path);
+  public UfsStatus getStatusWithRetry(String path) throws IOException {
+    return mUfs.getStatusWithRetry(path);
   }
 
   @Override
@@ -218,8 +218,8 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public boolean isExistingDirectory(String path) throws IOException {
-    return mUfs.isExistingDirectory(path);
+  public boolean isDirectoryWithRetry(String path) throws IOException {
+    return mUfs.isDirectoryWithRetry(path);
   }
 
   @Override
@@ -268,13 +268,13 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public InputStream openExistingFile(String path, OpenOptions options) throws IOException {
-    return mUfs.openExistingFile(path, options);
+  public InputStream openWithRetry(String path, OpenOptions options) throws IOException {
+    return mUfs.openWithRetry(path, options);
   }
 
   @Override
-  public InputStream openExistingFile(String path) throws IOException {
-    return mUfs.openExistingFile(path);
+  public InputStream openWithRetry(String path) throws IOException {
+    return mUfs.openWithRetry(path);
   }
 
   @Override
@@ -283,8 +283,8 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public boolean renameRenamableDirectory(String src, String dst) throws IOException {
-    return mUfs.renameRenamableDirectory(src, dst);
+  public boolean renameDirectoryWithRetry(String src, String dst) throws IOException {
+    return mUfs.renameDirectoryWithRetry(src, dst);
   }
 
   @Override
@@ -293,8 +293,8 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public boolean renameRenamableFile(String src, String dst) throws IOException {
-    return mUfs.renameRenamableFile(src, dst);
+  public boolean renameFileWithRetry(String src, String dst) throws IOException {
+    return mUfs.renameFileWithRetry(src, dst);
   }
 
   @Override

--- a/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephFSUnderFileSystem.java
+++ b/underfs/cephfs/src/main/java/alluxio/underfs/cephfs/CephFSUnderFileSystem.java
@@ -578,12 +578,12 @@ public class CephFSUnderFileSystem extends ConsistentUnderFileSystem
   }
 
   @Override
-  public boolean renameRenamableDirectory(String src, String dst) throws IOException {
+  public boolean renameDirectoryWithRetry(String src, String dst) throws IOException {
     return renameDirectory(src, dst);
   }
 
   @Override
-  public boolean renameRenamableFile(String src, String dst) throws IOException {
+  public boolean renameFileWithRetry(String src, String dst) throws IOException {
     return renameFile(src, dst);
   }
 

--- a/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
+++ b/underfs/gcs/src/main/java/alluxio/underfs/gcs/GCSUnderFileSystem.java
@@ -134,19 +134,19 @@ public class GCSUnderFileSystem extends ObjectUnderFileSystem {
   public void setMode(String path, short mode) throws IOException {}
 
   @Override
-  public UfsDirectoryStatus getExistingDirectoryStatus(String path) throws IOException {
+  public UfsDirectoryStatus getDirectoryStatusWithRetry(String path) throws IOException {
     return getDirectoryStatus(path);
   }
 
   // GCS provides strong global consistency for read-after-write and read-after-metadata-update
   @Override
-  public InputStream openExistingFile(String path) throws IOException {
+  public InputStream openWithRetry(String path) throws IOException {
     return open(path);
   }
 
   // GCS provides strong global consistency for read-after-write and read-after-metadata-update
   @Override
-  public InputStream openExistingFile(String path, OpenOptions options) throws IOException {
+  public InputStream openWithRetry(String path, OpenOptions options) throws IOException {
     return open(path, options);
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?
Rename the eventual consistency methods to <method>WithRetry to be easier to understand by API caller.
### Why are the changes needed?
Avoid method confusion
### Does this PR introduce any user facing changes?
NA
