### PR TITLE
Rename ConfigurationTestUtils.defaults to copyDefaults

### DIFF
--- a/core/client/fs/src/test/java/alluxio/client/block/BlockMasterClientPoolTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/BlockMasterClientPoolTest.java
@@ -33,7 +33,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest(BlockMasterClient.Factory.class)
 public class BlockMasterClientPoolTest {
 
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   @Test
   public void create() throws Exception {

--- a/core/client/fs/src/test/java/alluxio/client/block/BlockStoreClientTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/BlockStoreClientTest.java
@@ -93,7 +93,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @PrepareForTest({FileSystemContext.class})
 public final class BlockStoreClientTest {
 
-  private static InstancedConfiguration sConf = ConfigurationTestUtils.defaults();
+  private static InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
 
   private static final long BLOCK_ID = 3L;
   private static final long BLOCK_LENGTH = 100L;

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/DeterministicHashPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/DeterministicHashPolicyTest.java
@@ -38,7 +38,7 @@ public final class DeterministicHashPolicyTest {
   private static final int PORT = 1;
 
   private final List<BlockWorkerInfo> mWorkerInfos = new ArrayList<>();
-  private static InstancedConfiguration sConf = ConfigurationTestUtils.defaults();
+  private static InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
 
   @Before
   public void before() {
@@ -55,7 +55,7 @@ public final class DeterministicHashPolicyTest {
     mWorkerInfos.add(new BlockWorkerInfo(
         new WorkerNetAddress().setHost("worker4").setRpcPort(PORT).setDataPort(PORT)
             .setWebPort(PORT), 3 * (long) Constants.GB, 0));
-    sConf = ConfigurationTestUtils.defaults();
+    sConf = ConfigurationTestUtils.copyDefaults();
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstAvoidEvictionPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstAvoidEvictionPolicyTest.java
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public class LocalFirstAvoidEvictionPolicyTest {
 
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   @Test
   public void chooseClosestTierAvoidEviction() throws Exception {

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstPolicyTest.java
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public final class LocalFirstPolicyTest {
 
-  private static InstancedConfiguration sConf = ConfigurationTestUtils.defaults();
+  private static InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
   private static int sResolutionTimeout =
       (int) sConf.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS);
 

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/MostAvailableFirstPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/MostAvailableFirstPolicyTest.java
@@ -55,6 +55,6 @@ public final class MostAvailableFirstPolicyTest {
   public void equalsTest() throws Exception {
     CommonUtils.testEquals(MostAvailableFirstPolicy.class,
         new Class[]{AlluxioConfiguration.class},
-        new Object[]{ConfigurationTestUtils.defaults()});
+        new Object[]{ConfigurationTestUtils.copyDefaults()});
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
@@ -48,7 +48,7 @@ public final class RoundRobinPolicyTest {
         .setRpcPort(PORT).setDataPort(PORT).setWebPort(PORT), 2 * (long) Constants.GB, 0));
     workerInfoList.add(new BlockWorkerInfo(new WorkerNetAddress().setHost("worker3")
         .setRpcPort(PORT).setDataPort(PORT).setWebPort(PORT), 3 * (long) Constants.GB, 0));
-    RoundRobinPolicy policy = new RoundRobinPolicy(ConfigurationTestUtils.defaults());
+    RoundRobinPolicy policy = new RoundRobinPolicy(ConfigurationTestUtils.copyDefaults());
 
     GetWorkerOptions options = GetWorkerOptions.defaults().setBlockWorkerInfos(workerInfoList)
         .setBlockInfo(new BlockInfo().setLength(2 * (long) Constants.GB));
@@ -66,7 +66,7 @@ public final class RoundRobinPolicyTest {
    */
   @Test
   public void getWorkerNoneEligible() {
-    RoundRobinPolicy policy = new RoundRobinPolicy(ConfigurationTestUtils.defaults());
+    RoundRobinPolicy policy = new RoundRobinPolicy(ConfigurationTestUtils.copyDefaults());
     GetWorkerOptions options = GetWorkerOptions.defaults().setBlockWorkerInfos(new ArrayList<>())
         .setBlockInfo(new BlockInfo().setLength(2 * (long) Constants.GB));
     assertNull(policy.getWorker(options));
@@ -82,7 +82,7 @@ public final class RoundRobinPolicyTest {
     workerInfoList.add(new BlockWorkerInfo(new WorkerNetAddress().setHost("worker1")
         .setRpcPort(PORT).setDataPort(PORT).setWebPort(PORT), Constants.GB, 0));
 
-    RoundRobinPolicy policy = new RoundRobinPolicy(ConfigurationTestUtils.defaults());
+    RoundRobinPolicy policy = new RoundRobinPolicy(ConfigurationTestUtils.copyDefaults());
     GetWorkerOptions options = GetWorkerOptions.defaults().setBlockWorkerInfos(workerInfoList)
         .setBlockInfo(new BlockInfo().setLength((long) Constants.MB));
     assertNotNull(policy.getWorker(options));
@@ -92,7 +92,7 @@ public final class RoundRobinPolicyTest {
 
   @Test
   public void equalsTest() throws Exception {
-    AlluxioConfiguration conf = ConfigurationTestUtils.defaults();
+    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
     CommonUtils.testEquals(RoundRobinPolicy.class, new Class[]{AlluxioConfiguration.class},
         new Object[]{conf});
   }

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
@@ -61,7 +61,7 @@ public class BlockInStreamTest {
   private FileSystemContext mMockContext;
   private BlockInfo mInfo;
   private InStreamOptions mOptions;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
   private StreamObserver<OpenLocalBlockResponse> mResponseObserver;
 
   @Before

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataReaderTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataReaderTest.java
@@ -65,8 +65,8 @@ public final class GrpcDataReaderTest {
   public void before() throws Exception {
     mContext = Mockito.mock(FileSystemContext.class);
     when(mContext.getClientContext())
-        .thenReturn(ClientContext.create(ConfigurationTestUtils.defaults()));
-    when(mContext.getClusterConf()).thenReturn(ConfigurationTestUtils.defaults());
+        .thenReturn(ClientContext.create(ConfigurationTestUtils.copyDefaults()));
+    when(mContext.getClusterConf()).thenReturn(ConfigurationTestUtils.copyDefaults());
     mAddress = new WorkerNetAddress().setHost("localhost").setDataPort(1234);
     ReadRequest.Builder readRequestBuilder =
         ReadRequest.newBuilder().setBlockId(BLOCK_ID).setChunkSize(CHUNK_SIZE);

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataWriterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataWriterTest.java
@@ -78,7 +78,7 @@ public final class GrpcDataWriterTest {
   private WorkerNetAddress mAddress;
   private BlockWorkerClient mClient;
   private ClientCallStreamObserver<WriteRequest> mRequestObserver;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
   private ClientContext mClientContext;
 
   @Rule

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/LocalFileDataWriterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/LocalFileDataWriterTest.java
@@ -51,7 +51,7 @@ public class LocalFileDataWriterTest {
   private WorkerNetAddress mAddress;
   private BlockWorkerClient mClient;
   private ClientContext mClientContext;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
   private FileSystemContext mContext;
   private GrpcBlockingStream<CreateLocalBlockRequest, CreateLocalBlockResponse> mStream;
 

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/UfsFallbackLocalFileDataWriterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/UfsFallbackLocalFileDataWriterTest.java
@@ -143,7 +143,7 @@ public class UfsFallbackLocalFileDataWriterTest {
   private BlockWorkerClient mClient;
   private ClientCallStreamObserver<WriteRequest> mRequestObserver;
 
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   @Rule
   public ConfigurationRule mConfigurationRule =

--- a/core/client/fs/src/test/java/alluxio/client/block/util/BlockLocationUtilsTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/util/BlockLocationUtilsTest.java
@@ -64,7 +64,7 @@ public final class BlockLocationUtilsTest {
         any(AlluxioConfiguration.class))).thenReturn(true);
 
     // choose worker with domain socket accessible ignoring rack
-    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
     conf.set(PropertyKey.WORKER_DATA_SERVER_DOMAIN_SOCKET_AS_UUID, true);
     List<WorkerNetAddress> addresses = workers.stream()
         .map(worker -> worker.getNetAddress())

--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -90,7 +90,7 @@ public final class AlluxioFileInStreamTest {
   private FileInfo mInfo;
   private URIStatus mStatus;
 
-  private final InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private final InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   private List<TestBlockInStream> mInStreams;
 

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -68,7 +68,7 @@ public final class BaseFileSystemTest {
   private static final String SHOULD_HAVE_PROPAGATED_MESSAGE =
       "Exception should have been propagated";
 
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   @Rule
   private TestLoggerRule mTestLogger = new TestLoggerRule();
@@ -109,7 +109,7 @@ public final class BaseFileSystemTest {
 
   @After
   public void after() {
-    mConf = ConfigurationTestUtils.defaults();
+    mConf = ConfigurationTestUtils.copyDefaults();
   }
 
   /**

--- a/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
@@ -86,7 +86,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
     UnderFileSystemFileOutStream.class})
 public class FileOutStreamTest {
 
-  private static InstancedConfiguration sConf = ConfigurationTestUtils.defaults();
+  private static InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
 
   private static final long BLOCK_LENGTH = 100L;
   private static final AlluxioURI FILE_NAME = new AlluxioURI("/file");

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
@@ -29,11 +29,11 @@ import org.junit.Test;
  */
 public final class FileSystemContextTest {
 
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   @Before
   public void before() {
-    mConf = ConfigurationTestUtils.defaults();
+    mConf = ConfigurationTestUtils.copyDefaults();
   }
 
   /**

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemMasterClientPoolTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemMasterClientPoolTest.java
@@ -31,7 +31,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public class FileSystemMasterClientPoolTest {
   @Test
   public void create() throws Exception {
-    AlluxioConfiguration conf = ConfigurationTestUtils.defaults();
+    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
     FileSystemMasterClient expectedClient = Mockito.mock(FileSystemMasterClient.class);
     PowerMockito.mockStatic(FileSystemMasterClient.Factory.class);
     Mockito.when(FileSystemMasterClient.Factory

--- a/core/client/fs/src/test/java/alluxio/client/file/MetadataCachingBaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/MetadataCachingBaseFileSystemTest.java
@@ -59,7 +59,7 @@ public class MetadataCachingBaseFileSystemTest {
   private static final URIStatus FILE_STATUS =
       new URIStatus(new FileInfo().setPath(FILE.getPath()).setCompleted(true));
 
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
   private FileSystemContext mFileContext;
   private ClientContext mClientContext;
   private RpcCountingFileSystemMasterClient mFileSystemMasterClient;
@@ -90,7 +90,7 @@ public class MetadataCachingBaseFileSystemTest {
 
   @After
   public void after() {
-    mConf = ConfigurationTestUtils.defaults();
+    mConf = ConfigurationTestUtils.copyDefaults();
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 public class CacheManagerTest {
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   @Test
   public void factoryGet() throws Exception {

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
@@ -43,7 +43,7 @@ public final class CacheManagerWithShadowCacheTest {
   private static final byte[] PAGE2 = BufferUtils.getIncreasingByteArray(255, PAGE_SIZE_BYTES);
   private final byte[] mBuf = new byte[PAGE_SIZE_BYTES];
   private CacheManagerWithShadowCache mCacheManager;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   private final ShadowCacheType mShadowCacheType;
   private final int mAgeBits;

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/ClockCuckooShadowCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/ClockCuckooShadowCacheManagerTest.java
@@ -37,7 +37,7 @@ public final class ClockCuckooShadowCacheManagerTest {
   private static final CacheScope SCOPE1 = CacheScope.create("schema1.table1");
   private static final CacheScope SCOPE2 = CacheScope.create("schema1.table2");
   private ClockCuckooShadowCacheManager mCacheManager;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   @Before
   public void before() {

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/DefaultMetaStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/DefaultMetaStoreTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 public class DefaultMetaStoreTest {
   protected final PageId mPage = new PageId("1L", 2L);
   protected final PageInfo mPageInfo = new PageInfo(mPage, 1024);
-  protected final InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  protected final InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
   protected DefaultMetaStore mMetaStore;
   protected Gauge mCachedPageGauge;
 

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/FIFOCacheEvictorTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/FIFOCacheEvictorTest.java
@@ -21,7 +21,8 @@ import org.junit.Test;
  * Tests for the {@link FIFOCacheEvictor} class.
  */
 public final class FIFOCacheEvictorTest {
-  private final FIFOCacheEvictor mEvictor = new FIFOCacheEvictor(ConfigurationTestUtils.defaults());
+  private final FIFOCacheEvictor mEvictor = new FIFOCacheEvictor(
+      ConfigurationTestUtils.copyDefaults());
   private final PageId mFirst = new PageId("1L", 2L);
   private final PageId mSecond = new PageId("3L", 4L);
   private final PageId mThird = new PageId("5L", 6L);

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LFUCacheEvictorTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LFUCacheEvictorTest.java
@@ -33,7 +33,7 @@ public final class LFUCacheEvictorTest {
    */
   @Before
   public void before() {
-    mEvictor = new LFUCacheEvictor(ConfigurationTestUtils.defaults());
+    mEvictor = new LFUCacheEvictor(ConfigurationTestUtils.copyDefaults());
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LRUCacheEvictorTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LRUCacheEvictorTest.java
@@ -32,7 +32,7 @@ public final class LRUCacheEvictorTest {
    */
   @Before
   public void before() {
-    mEvictor = new LRUCacheEvictor(ConfigurationTestUtils.defaults());
+    mEvictor = new LRUCacheEvictor(ConfigurationTestUtils.copyDefaults());
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -73,7 +73,7 @@ public final class LocalCacheManagerTest {
   private static final byte[] PAGE2 = BufferUtils.getIncreasingByteArray(255, PAGE_SIZE_BYTES);
 
   private LocalCacheManager mCacheManager;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
   private MetaStore mMetaStore;
   private PageStore mPageStore;
   private CacheEvictor mEvictor;

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerWithMemPageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerWithMemPageStoreTest.java
@@ -55,7 +55,7 @@ public final class LocalCacheManagerWithMemPageStoreTest {
   private static final byte[] PAGE2 = BufferUtils.getIncreasingByteArray(255, PAGE_SIZE_BYTES);
 
   private LocalCacheManager mCacheManager;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
   private MetaStore mMetaStore;
   private PageStore mPageStore;
   private CacheEvictor mEvictor;

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/MultipleBloomShadowCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/MultipleBloomShadowCacheManagerTest.java
@@ -38,7 +38,7 @@ public final class MultipleBloomShadowCacheManagerTest {
   private static final CacheScope SCOPE1 = CacheScope.create("schema1.table1");
   private static final CacheScope SCOPE2 = CacheScope.create("schema1.table2");
   private MultipleBloomShadowCacheManager mCacheManager;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   @Before
   public void before() {

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/NondeterministicLRUCacheEvictorTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/NondeterministicLRUCacheEvictorTest.java
@@ -34,7 +34,7 @@ public final class NondeterministicLRUCacheEvictorTest {
    */
   @Before
   public void before() {
-    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
     mEvictor = new NondeterministicLRUCacheEvictor(conf);
     mEvictor.setNumOfCandidate(2);
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/TimeBoundPageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/TimeBoundPageStoreTest.java
@@ -56,7 +56,7 @@ public class TimeBoundPageStoreTest {
 
   @Before
   public void before() throws Exception {
-    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
     conf.set(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE, PAGE_SIZE_BYTES);
     conf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, CACHE_SIZE_BYTES);
     conf.set(PropertyKey.USER_CLIENT_CACHE_DIR, mTemp.getRoot().getAbsolutePath());

--- a/core/client/fs/src/test/java/alluxio/client/file/options/OutStreamOptionsTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/options/OutStreamOptionsTest.java
@@ -50,7 +50,7 @@ import javax.security.auth.Subject;
  */
 public class OutStreamOptionsTest {
 
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   /**
    * A mapping from a user to its corresponding group.
@@ -73,7 +73,7 @@ public class OutStreamOptionsTest {
 
   @After
   public void after() {
-    mConf = ConfigurationTestUtils.defaults();
+    mConf = ConfigurationTestUtils.copyDefaults();
   }
 
   /**

--- a/core/client/fs/src/test/java/alluxio/client/metrics/MetricsHeartbeatContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/metrics/MetricsHeartbeatContextTest.java
@@ -41,7 +41,7 @@ public class MetricsHeartbeatContextTest {
 
   @Test
   public void testExecutorInitialized() {
-    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
     conf.set(PropertyKey.MASTER_HOSTNAME, "localhost");
     conf.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "1s");
     ClientContext ctx = ClientContext.create(conf);
@@ -77,7 +77,7 @@ public class MetricsHeartbeatContextTest {
         getContextMap();
     assertTrue(map.isEmpty());
 
-    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
     conf.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "1s");
     ClientContext ctx = ClientContext.create(conf);
     MasterInquireClient client = MasterInquireClient.Factory
@@ -92,7 +92,7 @@ public class MetricsHeartbeatContextTest {
     map.forEach((details, context) ->
         assertEquals(2, (int) Whitebox.getInternalState(context, "mCtxCount")));
 
-    conf = ConfigurationTestUtils.defaults();
+    conf = ConfigurationTestUtils.copyDefaults();
     conf.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "1s");
     conf.set(PropertyKey.MASTER_RPC_ADDRESSES, "master1:19998,master2:19998,master3:19998");
     ClientContext haCtx = ClientContext.create(conf);
@@ -120,7 +120,7 @@ public class MetricsHeartbeatContextTest {
 
     ScheduledFuture<?> future = Mockito.mock(ScheduledFuture.class);
     when(future.cancel(any(Boolean.class))).thenReturn(true);
-    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
     conf.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "1s");
     ClientContext ctx = ClientContext.create(conf);
     MasterInquireClient client = MasterInquireClient.Factory

--- a/core/client/fs/src/test/java/alluxio/util/FileSystemOptionsTest.java
+++ b/core/client/fs/src/test/java/alluxio/util/FileSystemOptionsTest.java
@@ -32,7 +32,7 @@ public class FileSystemOptionsTest {
 
   @Before
   public void before() throws Exception {
-    mConf = ConfigurationTestUtils.defaults();
+    mConf = ConfigurationTestUtils.copyDefaults();
   }
 
   @Test

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemApiTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemApiTest.java
@@ -38,7 +38,7 @@ public final class AbstractFileSystemApiTest {
   @Rule
   public TestLoggerRule mTestLogger = new TestLoggerRule();
 
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   @Before
   public void before() {
@@ -48,7 +48,7 @@ public final class AbstractFileSystemApiTest {
 
   @After
   public void after() {
-    mConf = ConfigurationTestUtils.defaults();
+    mConf = ConfigurationTestUtils.copyDefaults();
     HadoopClientTestUtils.disableMetrics(mConf);
   }
 

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -92,7 +92,7 @@ import java.util.Map;
 public class AbstractFileSystemTest {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractFileSystemTest.class);
 
-  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
 
   /**
    * Sets up the configuration before a test runs.
@@ -113,7 +113,7 @@ public class AbstractFileSystemTest {
 
   @After
   public void after() {
-    mConfiguration = ConfigurationTestUtils.defaults();
+    mConfiguration = ConfigurationTestUtils.copyDefaults();
     HadoopClientTestUtils.disableMetrics(mConfiguration);
   }
 

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
@@ -30,7 +30,7 @@ public final class HadoopConfigurationUtilsTest {
   private static final String TEST_S3_SECRET_KEY = "TEST SECRET KEY";
   private static final String TEST_ALLUXIO_PROPERTY = "alluxio.unsupported.parameter";
   private static final String TEST_ALLUXIO_VALUE = "alluxio.unsupported.value";
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   /**
    * Test for the {@link HadoopConfigurationUtils#getConfigurationFromHadoop} method for an empty

--- a/core/common/src/test/java/alluxio/AuthenticatedClientUserResourceTest.java
+++ b/core/common/src/test/java/alluxio/AuthenticatedClientUserResourceTest.java
@@ -34,7 +34,7 @@ public final class AuthenticatedClientUserResourceTest {
 
   @Test
   public void userRestored() throws Exception {
-    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
     AuthenticatedClientUser.set(ORIGINAL_USER);
     User original = AuthenticatedClientUser.get(conf);
     new AuthenticatedClientUserResource(TESTCASE_USER, conf).close();

--- a/core/common/src/test/java/alluxio/AuthenticatedUserRuleTest.java
+++ b/core/common/src/test/java/alluxio/AuthenticatedUserRuleTest.java
@@ -28,7 +28,7 @@ public final class AuthenticatedUserRuleTest {
   private static final String RULE_USER = "rule-user";
   private static final String OUTSIDE_RULE_USER = "outside-rule-user";
 
-  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
 
   private final Statement mStatement = new Statement() {
     @Override

--- a/core/common/src/test/java/alluxio/ConfigurationRuleTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationRuleTest.java
@@ -28,7 +28,7 @@ public final class ConfigurationRuleTest {
 
   @Test
   public void changeConfiguration() throws Throwable {
-    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
     Statement statement = new Statement() {
       @Override
       public void evaluate() throws Throwable {
@@ -41,7 +41,7 @@ public final class ConfigurationRuleTest {
 
   @Test
   public void changeConfigurationForDefaultNullValue() throws Throwable {
-    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
 
     Statement statement = new Statement() {
       @Override

--- a/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
@@ -34,7 +34,7 @@ public final class ConfigurationTestUtils {
    * Return an instanced configuration with default value from the site properties file.
    * @return the default configuration
    */
-  public static InstancedConfiguration defaults() {
+  public static InstancedConfiguration copyDefaults() {
     return new InstancedConfiguration(ConfigurationUtils.copyDefaults());
   }
 

--- a/core/common/src/test/java/alluxio/UnderFileSystemFactoryRegistryRuleTest.java
+++ b/core/common/src/test/java/alluxio/UnderFileSystemFactoryRegistryRuleTest.java
@@ -32,7 +32,7 @@ public class UnderFileSystemFactoryRegistryRuleTest {
   private static final String UFS_PATH = "test://foo";
 
   private UnderFileSystemFactory mUnderFileSystemFactory;
-  private final InstancedConfiguration mConfiguration = ConfigurationTestUtils.defaults();
+  private final InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
 
   private Statement mStatement = new Statement() {
     @Override

--- a/core/common/src/test/java/alluxio/cli/AbstractShellTest.java
+++ b/core/common/src/test/java/alluxio/cli/AbstractShellTest.java
@@ -52,7 +52,7 @@ public final class AbstractShellTest {
       super(ImmutableMap.<String, String[]>builder().put("cmdAlias", new String[] {"cmd", "-O"})
           .put("stableAlias", new String[]{"cmd", "-O"})
           .build(), ImmutableSet.<String>builder().add("cmdAlias").build(),
-          ConfigurationTestUtils.defaults());
+          ConfigurationTestUtils.copyDefaults());
     }
 
     @Override

--- a/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
@@ -66,7 +66,7 @@ import java.util.stream.IntStream;
  */
 public class InstancedConfigurationTest {
 
-  private  InstancedConfiguration mConfiguration = ConfigurationTestUtils.defaults();
+  private  InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
   @Rule
   public final ExpectedException mThrown = ExpectedException.none();
 
@@ -83,7 +83,7 @@ public class InstancedConfigurationTest {
 
   public void resetConf() {
     ConfigurationUtils.reloadProperties();
-    mConfiguration = ConfigurationTestUtils.defaults();
+    mConfiguration = ConfigurationTestUtils.copyDefaults();
   }
 
   @AfterClass
@@ -697,7 +697,7 @@ public class InstancedConfigurationTest {
     sysProps.put(PropertyKey.LOGGER_TYPE.toString(), null);
     sysProps.put(PropertyKey.SITE_CONF_DIR.toString(), mFolder.getRoot().getCanonicalPath());
     try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {
-      mConfiguration = ConfigurationTestUtils.defaults();
+      mConfiguration = ConfigurationTestUtils.copyDefaults();
       assertEquals(PropertyKey.LOGGER_TYPE.getDefaultValue(),
           mConfiguration.get(PropertyKey.LOGGER_TYPE));
     }
@@ -1031,7 +1031,7 @@ public class InstancedConfigurationTest {
           format("%s is no longer a valid property",
               RemovedKey.Name.TEST_REMOVED_KEY)));
     }
-    mConfiguration = ConfigurationTestUtils.defaults();
+    mConfiguration = ConfigurationTestUtils.copyDefaults();
     try {
       mConfiguration.set(PropertyKey.fromString(RemovedKey.Name.TEST_REMOVED_KEY), true);
       mConfiguration.validate();

--- a/core/common/src/test/java/alluxio/grpc/GrpcConnectionPoolTest.java
+++ b/core/common/src/test/java/alluxio/grpc/GrpcConnectionPoolTest.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  */
 public final class GrpcConnectionPoolTest {
 
-  private static InstancedConfiguration sConf = ConfigurationTestUtils.defaults();
+  private static InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
 
   @BeforeClass
   public static void classSetup() {
@@ -45,7 +45,7 @@ public final class GrpcConnectionPoolTest {
 
   @After
   public void after() throws Exception {
-    sConf = ConfigurationTestUtils.defaults();
+    sConf = ConfigurationTestUtils.copyDefaults();
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/heartbeat/HeartbeatThreadTest.java
+++ b/core/common/src/test/java/alluxio/heartbeat/HeartbeatThreadTest.java
@@ -67,7 +67,7 @@ public final class HeartbeatThreadTest {
 
   private ExecutorService mExecutorService;
 
-  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
 
   @Before
   public void before() {

--- a/core/common/src/test/java/alluxio/network/TieredIdentityFactoryTest.java
+++ b/core/common/src/test/java/alluxio/network/TieredIdentityFactoryTest.java
@@ -52,7 +52,7 @@ public class TieredIdentityFactoryTest {
 
   @Before
   public void before() {
-    mConfiguration = ConfigurationTestUtils.defaults();
+    mConfiguration = ConfigurationTestUtils.copyDefaults();
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/security/authentication/PlainSaslServerCallbackHandlerTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/PlainSaslServerCallbackHandlerTest.java
@@ -42,7 +42,7 @@ public final class PlainSaslServerCallbackHandlerTest {
   @Rule
   public ExpectedException mThrown = ExpectedException.none();
 
-  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
 
   @Rule
   public ConfigurationRule mConfigurationRule =

--- a/core/common/src/test/java/alluxio/security/authentication/SaslHandlersTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/SaslHandlersTest.java
@@ -26,7 +26,7 @@ import javax.security.auth.Subject;
  * Tests {@link SaslClientHandler} and {@link SaslServerHandler} implementations.
  */
 public class SaslHandlersTest {
-  private AlluxioConfiguration mConfiguration = ConfigurationTestUtils.defaults();
+  private AlluxioConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
 
   /**
    * The exception expected to be thrown.

--- a/core/common/src/test/java/alluxio/security/user/UserStateTest.java
+++ b/core/common/src/test/java/alluxio/security/user/UserStateTest.java
@@ -28,11 +28,11 @@ import org.junit.Test;
  * Unit test for {@link UserState}.
  */
 public final class UserStateTest {
-  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
 
   @After
   public void after() {
-    mConfiguration = ConfigurationTestUtils.defaults();
+    mConfiguration = ConfigurationTestUtils.copyDefaults();
   }
 
   /**

--- a/core/common/src/test/java/alluxio/underfs/UnderFileSystemConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/underfs/UnderFileSystemConfigurationTest.java
@@ -34,7 +34,7 @@ public final class UnderFileSystemConfigurationTest {
 
   @Before
   public void before() {
-    mConfiguration = ConfigurationTestUtils.defaults();
+    mConfiguration = ConfigurationTestUtils.copyDefaults();
   }
 
   @Test
@@ -46,11 +46,11 @@ public final class UnderFileSystemConfigurationTest {
       boolean readOnly = random.nextBoolean();
       boolean shared = random.nextBoolean();
       UnderFileSystemConfiguration conf = UnderFileSystemConfiguration
-          .defaults(ConfigurationTestUtils.defaults()).setReadOnly(readOnly).setShared(shared);
+          .defaults(ConfigurationTestUtils.copyDefaults()).setReadOnly(readOnly).setShared(shared);
       assertEquals(readOnly, conf.isReadOnly());
       assertEquals(shared, conf.isShared());
       assertEquals("bar", mConfiguration.get(PropertyKey.S3A_ACCESS_KEY));
-      conf = UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.defaults())
+      conf = UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults())
           .setReadOnly(readOnly).setShared(shared)
           .createMountSpecificConf(ImmutableMap.of(PropertyKey.S3A_ACCESS_KEY.toString(), "foo"));
       assertEquals(readOnly, conf.isReadOnly());

--- a/core/common/src/test/java/alluxio/underfs/UnderFileSystemTest.java
+++ b/core/common/src/test/java/alluxio/underfs/UnderFileSystemTest.java
@@ -29,7 +29,7 @@ public final class UnderFileSystemTest {
 
   @Before
   public void before() {
-    mConfiguration = ConfigurationTestUtils.defaults();
+    mConfiguration = ConfigurationTestUtils.copyDefaults();
   }
 
   /**

--- a/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
@@ -299,7 +299,7 @@ public class CommonUtilsTest {
    */
   @Test
   public void getGroups() throws Throwable {
-    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
 
     String userName = "alluxio-user1";
     String userGroup1 = "alluxio-user1-group1";

--- a/core/common/src/test/java/alluxio/util/SecurityUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/SecurityUtilsTest.java
@@ -29,7 +29,7 @@ public final class SecurityUtilsTest {
 
   @Before
   public void before() {
-    mConfiguration = ConfigurationTestUtils.defaults();
+    mConfiguration = ConfigurationTestUtils.copyDefaults();
   }
 
   /**

--- a/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
+++ b/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
@@ -35,7 +35,7 @@ public class GetMasterWorkerAddressTest {
    */
   @Test
   public void getMasterAddress() {
-    InstancedConfiguration conf = ConfigurationTestUtils.defaults();
+    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
 
     // connect host and port
     conf.set(PropertyKey.MASTER_HOSTNAME, "RemoteMaster1");
@@ -46,19 +46,19 @@ public class GetMasterWorkerAddressTest {
     InetSocketAddress masterAddress =
         NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
     assertEquals(InetSocketAddress.createUnresolved("RemoteMaster1", 10000), masterAddress);
-    conf = ConfigurationTestUtils.defaults();
+    conf = ConfigurationTestUtils.copyDefaults();
 
     // port only
     conf.set(PropertyKey.MASTER_RPC_PORT, 20000);
     masterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
     assertEquals(InetSocketAddress.createUnresolved(defaultHostname, 20000), masterAddress);
-    conf = ConfigurationTestUtils.defaults();
+    conf = ConfigurationTestUtils.copyDefaults();
 
     // connect host only
     conf.set(PropertyKey.MASTER_HOSTNAME, "RemoteMaster3");
     masterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
     assertEquals(InetSocketAddress.createUnresolved("RemoteMaster3", defaultPort), masterAddress);
-    conf = ConfigurationTestUtils.defaults();
+    conf = ConfigurationTestUtils.copyDefaults();
 
     // all default
     masterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);

--- a/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
@@ -40,11 +40,11 @@ import java.util.List;
  */
 public class NetworkAddressUtilsTest {
 
-  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
 
   @After
   public void after() {
-    mConfiguration = ConfigurationTestUtils.defaults();
+    mConfiguration = ConfigurationTestUtils.copyDefaults();
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/wire/TieredIdentityTest.java
+++ b/core/common/src/test/java/alluxio/wire/TieredIdentityTest.java
@@ -39,11 +39,11 @@ import java.util.Random;
  */
 public class TieredIdentityTest {
 
-  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
 
   @Before
   public void before() {
-    mConfiguration = ConfigurationTestUtils.defaults();
+    mConfiguration = ConfigurationTestUtils.copyDefaults();
   }
 
   @Test

--- a/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
@@ -74,7 +74,7 @@ public class AsyncUfsAbsentPathCacheTest {
     mMountId = IdUtils.getRandomNonNegativeLong();
     MountPOptions options = MountContext.defaults().getOptions().build();
     mUfsManager.addMount(mMountId, new AlluxioURI(mLocalUfsPath),
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.defaults())
+        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults())
             .setReadOnly(options.getReadOnly()).setShared(options.getShared())
             .createMountSpecificConf(Collections.<String, String>emptyMap()));
     mMountTable.add(NoopJournalContext.INSTANCE, new AlluxioURI("/mnt"),
@@ -203,7 +203,7 @@ public class AsyncUfsAbsentPathCacheTest {
     long newMountId = IdUtils.getRandomNonNegativeLong();
     MountPOptions options = MountContext.defaults().getOptions().build();
     mUfsManager.addMount(newMountId, new AlluxioURI(mLocalUfsPath),
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.defaults())
+        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults())
             .setReadOnly(options.getReadOnly()).setShared(options.getShared())
             .createMountSpecificConf(Collections.<String, String>emptyMap()));
     mMountTable.add(NoopJournalContext.INSTANCE, new AlluxioURI("/mnt"),

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioFuseFileSystemTest.java
@@ -83,7 +83,7 @@ public class AlluxioFuseFileSystemTest {
   private AlluxioFuseFileSystem mFuseFs;
   private FileSystem mFileSystem;
   private FuseFileInfo mFileInfo;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   @Rule
   public ConfigurationRule mConfiguration =

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
@@ -85,7 +85,7 @@ public class AlluxioJniFuseFileSystemTest {
   private FileSystemContext mFileSystemContext;
   private FileSystem mFileSystem;
   private FuseFileInfo mFileInfo;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
 
   @Rule
   public ConfigurationRule mConfiguration =

--- a/integration/fuse/src/test/java/alluxio/fuse/cli/FuseShellTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/cli/FuseShellTest.java
@@ -53,7 +53,7 @@ public class FuseShellTest {
   private FuseShell mFuseShell;
   private Map<AlluxioURI, URIStatus> mFileStatusMap;
   private FileSystem mFileSystem;
-  private final InstancedConfiguration mConf = ConfigurationTestUtils.defaults();
+  private final InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
   private FileSystemMasterClient mFileSystemMasterClient;
 
   private static final AlluxioURI DIR = new AlluxioURI("/dir");

--- a/job/client/src/test/java/alluxio/client/job/JobContextTest.java
+++ b/job/client/src/test/java/alluxio/client/job/JobContextTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
  * Unit tests for {@link JobContext}.
  */
 public final class JobContextTest {
-  private static InstancedConfiguration sConf = ConfigurationTestUtils.defaults();
+  private static InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
 
   @Rule
   public ConfigurationRule mConf = new ConfigurationRule(ImmutableMap.of(

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
@@ -71,7 +71,7 @@ public final class MigrateDefinitionRunTaskTest {
 
   @Before
   public void before() throws Exception {
-    AlluxioConfiguration conf = ConfigurationTestUtils.defaults();
+    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
     mMockFileSystem = Mockito.mock(FileSystem.class);
     mMockFileSystemContext = PowerMockito.mock(FileSystemContext.class);
     when(mMockFileSystemContext.getClientContext())

--- a/tests/src/test/java/alluxio/client/cli/fs/FileSystemShellUtilsTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/FileSystemShellUtilsTest.java
@@ -76,7 +76,7 @@ public final class FileSystemShellUtilsTest {
         new String[] {Constants.HEADER + "localhost:19998/dir", "/dir", "dir"};
     String expected = "/dir";
     for (String path : paths) {
-      String result = FileSystemShellUtils.getFilePath(path, ConfigurationTestUtils.defaults());
+      String result = FileSystemShellUtils.getFilePath(path, ConfigurationTestUtils.copyDefaults());
       assertEquals(expected, result);
     }
   }

--- a/underfs/abfs/src/test/java/alluxio/underfs/abfs/AbfsUnderFileSystemFactoryTest.java
+++ b/underfs/abfs/src/test/java/alluxio/underfs/abfs/AbfsUnderFileSystemFactoryTest.java
@@ -30,7 +30,7 @@ public class AbfsUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
-    AlluxioConfiguration conf = ConfigurationTestUtils.defaults();
+    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
     UnderFileSystemFactory factory =
         UnderFileSystemFactoryRegistry.find("abfs://localhost/test/path", conf);
     Assert.assertNotNull(

--- a/underfs/adl/src/test/java/alluxio/underfs/adl/AdlUnderFileSystemFactoryTest.java
+++ b/underfs/adl/src/test/java/alluxio/underfs/adl/AdlUnderFileSystemFactoryTest.java
@@ -30,7 +30,7 @@ public class AdlUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
-    AlluxioConfiguration conf = ConfigurationTestUtils.defaults();
+    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
     UnderFileSystemFactory factory =
         UnderFileSystemFactoryRegistry.find("adl://localhost/test/path", conf);
     Assert.assertNotNull(

--- a/underfs/cosn/src/test/java/alluxio/underfs/cosn/CosNUnderFileSystemFactoryTest.java
+++ b/underfs/cosn/src/test/java/alluxio/underfs/cosn/CosNUnderFileSystemFactoryTest.java
@@ -29,7 +29,7 @@ public class CosNUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
-    AlluxioConfiguration conf = ConfigurationTestUtils.defaults();
+    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
     UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry
                             .find("cosn://test-bucket/path", conf);
 

--- a/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemFactoryTest.java
+++ b/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemFactoryTest.java
@@ -29,7 +29,7 @@ public final class GCSUnderFileSystemFactoryTest {
   @Test
   public void factory() {
     UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry.find("gs://test-bucket/path",
-        ConfigurationTestUtils.defaults());
+        ConfigurationTestUtils.copyDefaults());
 
     Assert.assertNotNull(
         "A UnderFileSystemFactory should exist for gs paths when using this module", factory);

--- a/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemTest.java
+++ b/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemTest.java
@@ -51,7 +51,7 @@ public class GCSUnderFileSystemTest {
     mClient = mock(GoogleStorageService.class);
 
     mGCSUnderFileSystem = new GCSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME,
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.defaults()));
+        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults()));
   }
 
   /**

--- a/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactoryTest.java
+++ b/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactoryTest.java
@@ -30,22 +30,22 @@ public class HdfsUnderFileSystemFactoryTest {
   public void factory() {
     UnderFileSystemFactory factory =
         UnderFileSystemFactoryRegistry.find("hdfs://localhost/test/path",
-            ConfigurationTestUtils.defaults());
+            ConfigurationTestUtils.copyDefaults());
     Assert.assertNotNull(
         "A UnderFileSystemFactory should exist for HDFS paths when using this module", factory);
 
     factory = UnderFileSystemFactoryRegistry.find("s3://localhost/test/path",
-        ConfigurationTestUtils.defaults());
+        ConfigurationTestUtils.copyDefaults());
     Assert.assertNull(
         "A UnderFileSystemFactory should not exist for S3 paths when using this module", factory);
 
     factory = UnderFileSystemFactoryRegistry.find("s3n://localhost/test/path",
-        ConfigurationTestUtils.defaults());
+        ConfigurationTestUtils.copyDefaults());
     Assert.assertNull(
         "A UnderFileSystemFactory should not exist for S3 paths when using this module", factory);
 
     factory = UnderFileSystemFactoryRegistry.find("alluxio://localhost:19999/test",
-        ConfigurationTestUtils.defaults());
+        ConfigurationTestUtils.copyDefaults());
     Assert.assertNull("A UnderFileSystemFactory should not exist for non supported paths when "
         + "using this module", factory);
   }

--- a/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemTest.java
+++ b/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemTest.java
@@ -47,7 +47,7 @@ import java.io.File;
 public final class HdfsUnderFileSystemTest {
 
   private HdfsUnderFileSystem mHdfsUnderFileSystem;
-  private final AlluxioConfiguration mAlluxioConf = ConfigurationTestUtils.defaults();
+  private final AlluxioConfiguration mAlluxioConf = ConfigurationTestUtils.copyDefaults();
 
   @Rule
   public TemporaryFolder mTemporaryFolder = new TemporaryFolder();
@@ -55,7 +55,7 @@ public final class HdfsUnderFileSystemTest {
   @Before
   public final void before() throws Exception {
     UnderFileSystemConfiguration conf =
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.defaults())
+        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults())
             .createMountSpecificConf(ImmutableMap.of("hadoop.security.group.mapping",
                 "org.apache.hadoop.security.ShellBasedUnixGroupsMapping", "fs.hdfs.impl",
             PropertyKey.UNDERFS_HDFS_IMPL.getDefaultValue()));
@@ -80,7 +80,7 @@ public final class HdfsUnderFileSystemTest {
   @Test
   public void prepareConfiguration() throws Exception {
     UnderFileSystemConfiguration ufsConf =
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.defaults());
+        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults());
     org.apache.hadoop.conf.Configuration conf = HdfsUnderFileSystem.createConfiguration(ufsConf);
     Assert.assertEquals(ufsConf.get(PropertyKey.UNDERFS_HDFS_IMPL), conf.get("fs.hdfs.impl"));
     Assert.assertTrue(conf.getBoolean("fs.hdfs.impl.disable.cache", false));

--- a/underfs/kodo/src/test/java/alluxio/underfs/kodo/KodoOutputStreamTest.java
+++ b/underfs/kodo/src/test/java/alluxio/underfs/kodo/KodoOutputStreamTest.java
@@ -40,7 +40,7 @@ import java.util.List;
 @RunWith(PowerMockRunner.class)
 public class KodoOutputStreamTest {
 
-  private static InstancedConfiguration sConf = ConfigurationTestUtils.defaults();
+  private static InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
   private static List<String> sTmpDirs = sConf.getList(PropertyKey.TMP_DIRS);
 
   /**

--- a/underfs/kodo/src/test/java/alluxio/underfs/kodo/KodoUnderFileSystemFactoryTest.java
+++ b/underfs/kodo/src/test/java/alluxio/underfs/kodo/KodoUnderFileSystemFactoryTest.java
@@ -29,7 +29,7 @@ public class KodoUnderFileSystemFactoryTest {
   @Test
   public void factory() {
     UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry.find("kodo://test-bucket/path",
-        ConfigurationTestUtils.defaults());
+        ConfigurationTestUtils.copyDefaults());
 
     Assert.assertNotNull(
         "A UnderFileSystemFactory should exist for oss paths when using this module", factory);

--- a/underfs/kodo/src/test/java/alluxio/underfs/kodo/KodoUnderFileSystemTest.java
+++ b/underfs/kodo/src/test/java/alluxio/underfs/kodo/KodoUnderFileSystemTest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  */
 public class KodoUnderFileSystemTest {
 
-  private static InstancedConfiguration sConf = ConfigurationTestUtils.defaults();
+  private static InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
 
   private KodoUnderFileSystem mKodoUnderFileSystem;
   private KodoClient mClient;

--- a/underfs/obs/src/test/java/alluxio/underfs/obs/OBSUnderFileSystemTest.java
+++ b/underfs/obs/src/test/java/alluxio/underfs/obs/OBSUnderFileSystemTest.java
@@ -51,7 +51,7 @@ public class OBSUnderFileSystemTest {
   public void before() throws InterruptedException, ObsException {
     mClient = Mockito.mock(ObsClient.class);
     mOBSUnderFileSystem = new OBSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME,
-        BUCKET_TYPE, UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.defaults()));
+        BUCKET_TYPE, UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults()));
   }
 
   /**
@@ -123,7 +123,7 @@ public class OBSUnderFileSystemTest {
 
     // PFS Bucket
     mOBSUnderFileSystem = new OBSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME, "pfs",
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.defaults()));
+        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults()));
     Assert.assertNotNull(mOBSUnderFileSystem.getObjectStatus("pfs_file1"));
     Assert.assertNull(mOBSUnderFileSystem.getObjectStatus("pfs_file1/"));
     Assert.assertNull(mOBSUnderFileSystem.getObjectStatus("dir1"));
@@ -132,7 +132,7 @@ public class OBSUnderFileSystemTest {
 
     // OBS Bucket
     mOBSUnderFileSystem = new OBSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME, "obs",
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.defaults()));
+        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults()));
     Mockito.when(mClient.getObjectMetadata(BUCKET_NAME, "dir1"))
         .thenReturn(null);
     Assert.assertNotNull(mOBSUnderFileSystem.getObjectStatus("obs_file1"));
@@ -159,7 +159,7 @@ public class OBSUnderFileSystemTest {
         .thenReturn(dirMeta);
 
     mOBSUnderFileSystem = new OBSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME, "obs",
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.defaults()));
+        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults()));
     Assert.assertNotNull(mOBSUnderFileSystem.getObjectStatus("pfs_file1"));
     Assert.assertNotNull(mOBSUnderFileSystem.getObjectStatus("dir1"));
   }

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemTest.java
@@ -49,7 +49,7 @@ public class OSSUnderFileSystemTest {
     mClient = Mockito.mock(OSSClient.class);
 
     mOSSUnderFileSystem = new OSSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME,
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.defaults()));
+        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults()));
   }
 
   /**

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemFactoryTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemFactoryTest.java
@@ -40,7 +40,7 @@ public class S3AUnderFileSystemFactoryTest {
 
   @Before
   public void before() {
-    mAlluxioConf = ConfigurationTestUtils.defaults();
+    mAlluxioConf = ConfigurationTestUtils.copyDefaults();
     mConf = UnderFileSystemConfiguration.defaults(mAlluxioConf);
     mFactory1 = UnderFileSystemFactoryRegistry.find(mS3APath, mAlluxioConf);
   }

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
@@ -54,7 +54,7 @@ public class S3AUnderFileSystemTest {
   private static final String PATH = "path";
   private static final String SRC = "src";
   private static final String DST = "dst";
-  private static  InstancedConfiguration sConf = ConfigurationTestUtils.defaults();
+  private static  InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
 
   private static final String BUCKET_NAME = "bucket";
   private static final String DEFAULT_OWNER = "";

--- a/underfs/swift/src/test/java/alluxio/underfs/swift/SwiftUnderFileSystemFactoryTest.java
+++ b/underfs/swift/src/test/java/alluxio/underfs/swift/SwiftUnderFileSystemFactoryTest.java
@@ -29,7 +29,7 @@ public class SwiftUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
-    AlluxioConfiguration conf = ConfigurationTestUtils.defaults();
+    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
     UnderFileSystemFactory factory =
         UnderFileSystemFactoryRegistry.find("swift://localhost/test/path", conf);
     UnderFileSystemFactory factory2 =

--- a/underfs/wasb/src/test/java/alluxio/underfs/wasb/WasbUnderFileSystemFactoryTest.java
+++ b/underfs/wasb/src/test/java/alluxio/underfs/wasb/WasbUnderFileSystemFactoryTest.java
@@ -30,7 +30,7 @@ public class WasbUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
-    AlluxioConfiguration conf = ConfigurationTestUtils.defaults();
+    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
     UnderFileSystemFactory factory =
         UnderFileSystemFactoryRegistry.find("wasb://localhost/test/path", conf);
     Assert.assertNotNull(


### PR DESCRIPTION
The function makes a copy from the default configuration. Makes this explicit.
