### PR TITLE
Remove Java doc for private functions

### DIFF
--- a/job/client/src/main/java/alluxio/client/job/JobContext.java
+++ b/job/client/src/main/java/alluxio/client/job/JobContext.java
@@ -58,7 +58,7 @@ public final class JobContext implements Closeable  {
 
   private JobContext() {} // private constructor to prevent instantiation
 
-  /**
+  /*
    * Initializes the context. Only called in the factory methods and reset.
    */
   private synchronized void init(AlluxioConfiguration alluxioConf, UserState userState) {

--- a/job/client/src/main/java/alluxio/client/job/JobContext.java
+++ b/job/client/src/main/java/alluxio/client/job/JobContext.java
@@ -56,9 +56,6 @@ public final class JobContext implements Closeable  {
     return context;
   }
 
-  /**
-   * Create a job context.
-   */
   private JobContext() {} // private constructor to prevent instantiation
 
   /**

--- a/job/client/src/main/java/alluxio/client/job/JobGrpcClientUtils.java
+++ b/job/client/src/main/java/alluxio/client/job/JobGrpcClientUtils.java
@@ -93,7 +93,7 @@ public final class JobGrpcClientUtils {
     throw new RuntimeException("Failed to successfully complete the job: " + errorMessage);
   }
 
-  /**
+  /*
    * @param jobId the ID of the job to wait for
    * @return the job info once it finishes or null if the status cannot be fetched
    */

--- a/job/common/src/main/java/alluxio/job/util/TimeSeries.java
+++ b/job/common/src/main/java/alluxio/job/util/TimeSeries.java
@@ -208,7 +208,7 @@ public final class TimeSeries implements Serializable {
     }
   }
 
-  /**
+  /*
    * @param timeNano the time in nano seconds
    * @return the bucketed timestamp in nano seconds
    */

--- a/job/server/src/main/java/alluxio/job/plan/PlanDefinitionRegistry.java
+++ b/job/server/src/main/java/alluxio/job/plan/PlanDefinitionRegistry.java
@@ -55,7 +55,7 @@ public enum PlanDefinitionRegistry {
 
   private PlanDefinitionRegistry() {}
 
-  /**
+  /*
    * Adds a mapping from the job configuration to the definition.
    */
   private <T extends JobConfig> void add(Class<T> jobConfig,

--- a/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/load/LoadDefinition.java
@@ -159,7 +159,7 @@ public final class LoadDefinition
     return result;
   }
 
-  /**
+  /*
    * @param blockWorkers a list of block workers
    * @param blockInfo information about a block
    * @return the block worker hosts which are not storing the specified block

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -146,7 +146,7 @@ public final class MigrateDefinition
     return null;
   }
 
-  /**
+  /*
    * @param command the migrate command to execute
    * @param writeType the write type to use for the moved file
    * @param fileSystem the Alluxio file system

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
@@ -47,11 +47,6 @@ public final class CsvReader implements TableReader {
   private final Closer mCloser;
   private final CsvSchema mSchema;
 
-  /*
-   * @param inputPath the input path
-   * @param pInfo the partition info
-   * @throws IOException when failed to open the input
-   */
   private CsvReader(JobPath inputPath, PartitionInfo pInfo) throws IOException {
     mCloser = Closer.create();
     try {

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvReader.java
@@ -47,7 +47,7 @@ public final class CsvReader implements TableReader {
   private final Closer mCloser;
   private final CsvSchema mSchema;
 
-  /**
+  /*
    * @param inputPath the input path
    * @param pInfo the partition info
    * @throws IOException when failed to open the input

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvRow.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/csv/CsvRow.java
@@ -68,7 +68,7 @@ public final class CsvRow implements TableRow {
     return new ParquetRow(recordBuilder.build());
   }
 
-  /**
+  /*
    * @param value the value read based on the read schema
    * @param name the name of the field
    * @param type the type of the value based on Alluxio table schema

--- a/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetReader.java
+++ b/job/server/src/main/java/alluxio/job/plan/transform/format/parquet/ParquetReader.java
@@ -41,11 +41,6 @@ public final class ParquetReader implements TableReader {
   private final ParquetSchema mSchema;
   private final ParquetMetadata mMetadata;
 
-  /**
-   * @param reader the Parquet reader
-   * @param schema the schema
-   * @param metadata the Parquet metadata
-   */
   private ParquetReader(org.apache.parquet.hadoop.ParquetReader<Record> reader, Schema schema,
                         ParquetMetadata metadata) {
     mReader = reader;

--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -118,51 +118,31 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
    */
   private final JobServerContext mJobServerContext;
 
-  /**
+  /*
    * All worker information. Access must be controlled on mWorkers using the RW lock(mWorkerRWLock).
    */
   @GuardedBy("mWorkerRWLock")
   private final IndexedSet<MasterWorkerInfo> mWorkers = new IndexedSet<>(mIdIndex, mAddressIndex);
 
-  /**
-   * All worker health information.
-   */
   private final ConcurrentHashMap<Long, JobWorkerHealth> mWorkerHealth;
 
-  /**
-   * An RW lock that is used to control access to mWorkers.
-   */
   private final ReentrantReadWriteLock mWorkerRWLock = new ReentrantReadWriteLock(true);
 
-  /**
-   * The next worker id to use.
-   */
   private final AtomicLong mNextWorkerId = new AtomicLong(CommonUtils.getCurrentMs());
 
-  /**
-   * Manager for worker tasks.
-   */
+  // Manager for worker tasks.
   private final CommandManager mCommandManager;
 
-  /**
-   * Manager for adding and removing plans.
-   */
+  // Manager for adding and removing plans.
   private final PlanTracker mPlanTracker;
 
-  /**
-   * Manager for adding and removing workflows.
-   */
+  // Manager for adding and removing workflows.s
   private final WorkflowTracker mWorkflowTracker;
 
-  /**
-   * The job id generator.
-   */
   private final JobIdGenerator mJobIdGenerator;
 
-  /** Log writer for user access audit log. */
   private AsyncUserAccessAuditLogWriter mAsyncAuditLogWriter;
 
-  /** Distributed command job tracker. */
   private CmdJobTracker mCmdJobTracker;
 
   /**

--- a/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
+++ b/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
@@ -66,12 +66,12 @@ public final class PlanCoordinator {
    * to represent an already-completed job, this list will be empty.
    */
   private List<WorkerInfo> mWorkersInfoList;
-  /**
+  /*
    * Map containing the worker info for every task associated with the coordinated job. If this
    * coordinator was created to represent an already-completed job, this map will be empty.
    */
   private final Map<Long, WorkerInfo> mTaskIdToWorkerInfo = Maps.newHashMap();
-  /**
+  /*
    * Mapping from workers running tasks for this job to the ids of those tasks. If this coordinator
    * was created to represent an already-completed job, this map will be empty.
    */


### PR DESCRIPTION
### What changes are proposed in this pull request?

change the Java doc for private functions into comment if they are still useful. removed if information is trivil. 

### Why are the changes needed?

We shouldn't write javadoc for private methods. End users don't have access to private fields or methods so there really isn't a point in providing javadoc for them. Private fields and methods are only meant for the developer. So leaving them as comments if seem useful.

### Does this PR introduce any user facing changes?

No
