### PR TITLE
Change createNonexisting to createoptions

### DIFF
--- a/core/common/src/main/java/alluxio/concurrent/ManagedBlockingUfsForwarder.java
+++ b/core/common/src/main/java/alluxio/concurrent/ManagedBlockingUfsForwarder.java
@@ -97,26 +97,6 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
   }
 
   @Override
-  public OutputStream createNonexistingFile(String path) throws IOException {
-    return new ManagedBlockingUfsMethod<OutputStream>() {
-      @Override
-      public OutputStream execute() throws IOException {
-        return mUfs.createNonexistingFile(path);
-      }
-    }.get();
-  }
-
-  @Override
-  public OutputStream createNonexistingFile(String path, CreateOptions options) throws IOException {
-    return new ManagedBlockingUfsMethod<OutputStream>() {
-      @Override
-      public OutputStream execute() throws IOException {
-        return mUfs.createNonexistingFile(path, options);
-      }
-    }.get();
-  }
-
-  @Override
   public boolean deleteDirectory(String path) throws IOException {
     return new ManagedBlockingUfsMethod<Boolean>() {
       @Override

--- a/core/common/src/main/java/alluxio/underfs/ConsistentUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ConsistentUnderFileSystem.java
@@ -37,16 +37,6 @@ public abstract class ConsistentUnderFileSystem extends BaseUnderFileSystem {
   }
 
   @Override
-  public OutputStream createNonexistingFile(String path) throws IOException {
-    return create(path);
-  }
-
-  @Override
-  public OutputStream createNonexistingFile(String path, CreateOptions options) throws IOException {
-    return create(path, options);
-  }
-
-  @Override
   public boolean deleteExistingDirectory(String path) throws IOException {
     return deleteDirectory(path);
   }

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -46,10 +46,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * Alluxio stores data into an under layer file system. Any file system implementing this interface
  * can be a valid under layer file system.
  *
- * There are two sets of APIs in the under file system:
- * (1) normal operations (e.g. create, renameFile, deleteFile)
- * (2) operations deal with the eventual consistency issue
- * (e.g. createNonexistingFile, renameRenamableFile)
  * When confirmed by Alluxio metadata that an operation should succeed but may fail because of the
  * under filesystem eventual consistency issue, use the second set of APIs.
  */
@@ -222,29 +218,6 @@ public interface UnderFileSystem extends Closeable {
    * @return A {@code OutputStream} object
    */
   OutputStream create(String path, CreateOptions options) throws IOException;
-
-  /**
-   * Creates a file in the under file system with the indicated name.
-   *
-   * Similar to {@link #create(String)} but
-   * deals with the delete-then-create eventual consistency issue.
-   *
-   * @param path the file name
-   * @return A {@code OutputStream} object
-   */
-  OutputStream createNonexistingFile(String path) throws IOException;
-
-  /**
-   * Creates a file in the under file system with the specified {@link CreateOptions}.
-   *
-   * Similar to {@link #create(String, CreateOptions)} but
-   * deals with the delete-then-create eventual consistency issue.
-   *
-   * @param path the file name
-   * @param options the options for create
-   * @return A {@code OutputStream} object
-   */
-  OutputStream createNonexistingFile(String path, CreateOptions options) throws IOException;
 
   /**
    * Deletes a directory from the under file system with the indicated name non-recursively. A

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -195,47 +195,6 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public OutputStream createNonexistingFile(final String path) throws IOException {
-    return call(new UfsCallable<OutputStream>() {
-      @Override
-      public OutputStream call() throws IOException {
-        return mUnderFileSystem.createNonexistingFile(path);
-      }
-
-      @Override
-      public String methodName() {
-        return "CreateNonexistingFile";
-      }
-
-      @Override
-      public String toString() {
-        return String.format("path=%s", path);
-      }
-    });
-  }
-
-  @Override
-  public OutputStream createNonexistingFile(final String path,
-      final CreateOptions options) throws IOException {
-    return call(new UfsCallable<OutputStream>() {
-      @Override
-      public OutputStream call() throws IOException {
-        return mUnderFileSystem.createNonexistingFile(path, options);
-      }
-
-      @Override
-      public String methodName() {
-        return "CreateNonexistingFile";
-      }
-
-      @Override
-      public String toString() {
-        return String.format("path=%s, options=%s", path, options);
-      }
-    });
-  }
-
-  @Override
   public boolean deleteDirectory(final String path) throws IOException {
     return call(new UfsCallable<Boolean>() {
       @Override

--- a/core/common/src/main/java/alluxio/underfs/options/CreateOptions.java
+++ b/core/common/src/main/java/alluxio/underfs/options/CreateOptions.java
@@ -35,6 +35,9 @@ public final class CreateOptions {
 
   // Ensure writes are not readable till close.
   private boolean mEnsureAtomic;
+  // Ensure consistency. When true, eventual consistency issues
+  // in workloads like delete-then-create will be taken care of
+  private boolean mEnsureConsistency;
 
   private String mOwner;
   private String mGroup;
@@ -56,6 +59,7 @@ public final class CreateOptions {
     mAcl = null;
     mCreateParent = false;
     mEnsureAtomic = false;
+    mEnsureConsistency = false;
     // default owner and group are null (unset)
     mOwner = null;
     mGroup = null;
@@ -105,6 +109,13 @@ public final class CreateOptions {
   }
 
   /**
+   * @return true, if consistency is guaranteed
+   */
+  public boolean isEnsureConsistency() {
+    return mEnsureConsistency;
+  }
+
+  /**
    * Sets an initial acl for the newly created file.
    *
    * @param acl option to set the ACL after creation
@@ -137,6 +148,18 @@ public final class CreateOptions {
    */
   public CreateOptions setEnsureAtomic(boolean atomic) {
     mEnsureAtomic = atomic;
+    return this;
+  }
+
+  /**
+   * Sets consistency guarantees. When true, eventual consistency issues
+   * in workloads like delete-then-create will be taken care of.
+   *
+   * @param ensureConsistency whether to ensure the data consistency
+   * @return the updated object
+   */
+  public CreateOptions setEnsureConsistency(boolean ensureConsistency) {
+    mEnsureConsistency = ensureConsistency;
     return this;
   }
 
@@ -179,6 +202,7 @@ public final class CreateOptions {
     return Objects.equal(mAcl, that.mAcl)
         && (mCreateParent == that.mCreateParent)
         && (mEnsureAtomic == that.mEnsureAtomic)
+        && (mEnsureConsistency == that.mEnsureConsistency)
         && Objects.equal(mOwner, that.mOwner)
         && Objects.equal(mGroup, that.mGroup)
         && Objects.equal(mMode, that.mMode);
@@ -186,7 +210,8 @@ public final class CreateOptions {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(mAcl, mCreateParent, mEnsureAtomic, mOwner, mGroup, mMode);
+    return Objects.hashCode(mAcl, mCreateParent, mEnsureAtomic, mEnsureConsistency,
+        mOwner, mGroup, mMode);
   }
 
   @Override
@@ -195,6 +220,7 @@ public final class CreateOptions {
         .add("acl", mAcl)
         .add("createParent", mCreateParent)
         .add("ensureAtomic", mEnsureAtomic)
+        .add("ensureConsistency", mEnsureConsistency)
         .add("owner", mOwner)
         .add("group", mGroup)
         .add("mode", mMode)

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandler.java
@@ -246,9 +246,9 @@ public final class UfsFallbackBlockWriteHandler
     UnderFileSystem ufs = ufsResource.get();
     // Set the atomic flag to be true to ensure only the creation of this file is atomic on close.
     OutputStream ufsOutputStream =
-        ufs.createNonexistingFile(ufsPath,
+        ufs.create(ufsPath,
             CreateOptions.defaults(ServerConfiguration.global()).setEnsureAtomic(true)
-                .setCreateParent(true));
+                .setCreateParent(true).setEnsureConsistency(true));
     context.setOutputStream(ufsOutputStream);
     context.setUfsPath(ufsPath);
 

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFileWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFileWriteHandler.java
@@ -157,13 +157,14 @@ public final class UfsFileWriteHandler extends AbstractWriteHandler<UfsFileWrite
     UnderFileSystem ufs = ufsResource.get();
     CreateOptions createOptions = CreateOptions.defaults(ServerConfiguration.global())
         .setCreateParent(true)
+        .setEnsureConsistency(true)
         .setOwner(createUfsFileOptions.getOwner()).setGroup(createUfsFileOptions.getGroup())
         .setMode(new Mode((short) createUfsFileOptions.getMode()));
     if (createUfsFileOptions.hasAcl()) {
       // This acl information will be ignored by all but HDFS implementations
       createOptions.setAcl(ProtoUtils.fromProto(createUfsFileOptions.getAcl()));
     }
-    context.setOutputStream(ufs.createNonexistingFile(request.getUfsPath(), createOptions));
+    context.setOutputStream(ufs.create(request.getUfsPath(), createOptions));
     context.setCreateOptions(createOptions);
     String ufsString = MetricsSystem.escape(ufsClient.getUfsMountPointUri());
 

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandlerTest.java
@@ -90,7 +90,7 @@ public class UfsFallbackBlockWriteHandlerTest extends AbstractWriteHandlerTest {
     UfsManager ufsManager = Mockito.mock(UfsManager.class);
     UfsManager.UfsClient ufsClient = new UfsManager.UfsClient(() -> mockUfs, AlluxioURI.EMPTY_URI);
     Mockito.when(ufsManager.get(Mockito.anyLong())).thenReturn(ufsClient);
-    Mockito.when(mockUfs.createNonexistingFile(Mockito.anyString(),
+    Mockito.when(mockUfs.create(Mockito.anyString(),
         Mockito.any(CreateOptions.class))).thenReturn(mOutputStream)
         .thenReturn(new FileOutputStream(mFile, true));
 

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFileWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFileWriteHandlerTest.java
@@ -52,7 +52,7 @@ public final class UfsFileWriteHandlerTest extends AbstractWriteHandlerTest {
     UfsManager ufsManager = Mockito.mock(UfsManager.class);
     UfsClient ufsClient = new UfsClient(() -> mockUfs, AlluxioURI.EMPTY_URI);
     Mockito.when(ufsManager.get(TEST_MOUNT_ID)).thenReturn(ufsClient);
-    Mockito.when(mockUfs.createNonexistingFile(Mockito.anyString(),
+    Mockito.when(mockUfs.create(Mockito.anyString(),
         Mockito.any(CreateOptions.class))).thenReturn(mOutputStream)
         .thenReturn(new FileOutputStream(mFile, true));
     mResponseObserver = Mockito.mock(StreamObserver.class);

--- a/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemCommonOperations.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemCommonOperations.java
@@ -393,7 +393,7 @@ public final class UnderFileSystemCommonOperations {
       throw new IOException(FILE_EXISTS_CHECK_SHOULD_FAILED);
     }
 
-    OutputStream o = mUfs.createNonexistingFile(testFile);
+    OutputStream o = mUfs.create(testFile, CreateOptions.defaults(mConfiguration).setEnsureConsistency(true));
     o.write(TEST_BYTES);
     o.close();
     if (!mUfs.exists(testFile)) {

--- a/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
@@ -171,9 +171,10 @@ public final class PersistDefinition
           }
         }
         OutputStream out = closer.register(
-            ufs.createNonexistingFile(dstPath.toString(),
-                CreateOptions.defaults(ServerConfiguration.global()).setOwner(uriStatus.getOwner())
-                .setGroup(uriStatus.getGroup()).setMode(new Mode((short) uriStatus.getMode()))));
+            ufs.create(dstPath.toString(),
+                CreateOptions.defaults(ServerConfiguration.global()).setEnsureConsistency(true)
+                    .setOwner(uriStatus.getOwner()).setGroup(uriStatus.getGroup())
+                    .setMode(new Mode((short) uriStatus.getMode()))));
         URIStatus status = context.getFileSystem().getStatus(uri);
         List<AclEntry> allAcls = Stream.concat(status.getDefaultAcl().getEntries().stream(),
             status.getAcl().getEntries().stream()).collect(Collectors.toList());

--- a/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
+++ b/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
@@ -81,16 +81,6 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public OutputStream createNonexistingFile(String path, CreateOptions options) throws IOException {
-    return mUfs.createNonexistingFile(path, options);
-  }
-
-  @Override
-  public OutputStream createNonexistingFile(String path) throws IOException {
-    return mUfs.createNonexistingFile(path);
-  }
-
-  @Override
   public boolean deleteDirectory(String path) throws IOException {
     return mUfs.deleteDirectory(path);
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove createNonexistingFile method from ufs and move ensureConsistency option to create file options
### Why are the changes needed?
Avoid adding a new set of methods when a new option is needed

### Does this PR introduce any user facing changes?
Change the UFS level API
