### PR TITLE
Move all static configuration logic into one place

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -17,6 +17,7 @@ import alluxio.annotation.PublicApi;
 import alluxio.client.file.cache.CacheManager;
 import alluxio.client.file.cache.LocalCacheFileSystem;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
 import alluxio.exception.AlluxioException;
@@ -48,7 +49,6 @@ import alluxio.grpc.UnmountPOptions;
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.user.UserState;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.wire.BlockLocationInfo;
 import alluxio.wire.MountPointInfo;
 import alluxio.wire.SyncPointInfo;
@@ -104,7 +104,7 @@ public interface FileSystem extends Closeable {
      * @return a FileSystem from the cache, creating a new one if it doesn't yet exist
      */
     public static FileSystem get(Subject subject) {
-      return get(subject, ConfigurationUtils.defaults());
+      return get(subject, Configuration.global());
     }
 
     /**

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
@@ -11,7 +11,7 @@
 
 package alluxio.client.block.stream;
 
-import alluxio.util.ConfigurationUtils;
+import alluxio.conf.Configuration;
 import alluxio.wire.WorkerNetAddress;
 
 import java.io.IOException;
@@ -29,7 +29,7 @@ public class TestBlockInStream extends BlockInStream {
   public TestBlockInStream(byte[] data, long id, long length, boolean shortCircuit,
       BlockInStreamSource source) {
     super(new Factory(data, shortCircuit),
-        ConfigurationUtils.defaults(),
+        Configuration.global(),
         new WorkerNetAddress(), source, id, length);
     mBytesRead = 0;
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemCacheTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemCacheTest.java
@@ -19,9 +19,9 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.AlluxioURI;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.security.User;
-import alluxio.util.ConfigurationUtils;
 
 import org.junit.Test;
 
@@ -131,6 +131,6 @@ public class FileSystemCacheTest {
     principals.add(user);
     return new FileSystemCache.Key(
         new Subject(false, principals, new HashSet<>(), new HashSet<>()),
-        ConfigurationUtils.defaults());
+        Configuration.global());
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemFactoryTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemFactoryTest.java
@@ -19,13 +19,14 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import alluxio.SystemPropertyRule;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.master.MasterInquireClient;
 import alluxio.security.User;
 import alluxio.uri.MultiMasterAuthority;
 import alluxio.uri.ZookeeperAuthority;
-import alluxio.util.ConfigurationUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -43,7 +44,7 @@ import javax.security.auth.Subject;
 public class FileSystemFactoryTest {
   @Before
   public void before() {
-    ConfigurationUtils.reloadProperties();
+    Configuration.reloadProperties();
   }
 
   @After
@@ -70,8 +71,8 @@ public class FileSystemFactoryTest {
   public void multiMasterFileSystemCacheTest()  {
     try (Closeable p = new SystemPropertyRule(PropertyKey.MASTER_RPC_ADDRESSES.getName(),
         "192.168.0.1:1234,192.168.0.2:1445,192.168.0.3:9943").toResource()) {
-      ConfigurationUtils.reloadProperties();
-      InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+      Configuration.reloadProperties();
+      AlluxioConfiguration conf = Configuration.global();
       MasterInquireClient.ConnectDetails connectDetails =
           MasterInquireClient.Factory.getConnectDetails(conf);
       // Make sure we have a MultiMaster authority
@@ -90,8 +91,8 @@ public class FileSystemFactoryTest {
     sysProps.put(PropertyKey.ZOOKEEPER_ELECTION_PATH.getName(), "/alluxio/leader");
 
     try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {
-      ConfigurationUtils.reloadProperties();
-      InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+      Configuration.reloadProperties();
+      AlluxioConfiguration conf = Configuration.global();
       MasterInquireClient.ConnectDetails connectDetails =
           MasterInquireClient.Factory.getConnectDetails(conf);
       // Make sure we have a Zookeeper authority
@@ -110,7 +111,7 @@ public class FileSystemFactoryTest {
   @Test
   public void uncachedFileSystemDoesntAffectCache() throws Exception {
     FileSystem fs1 = FileSystem.Factory.get();
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    InstancedConfiguration conf = Configuration.copyGlobal();
     conf.set(PropertyKey.USER_WORKER_LIST_REFRESH_INTERVAL, "1sec");
     FileSystem fs2 = FileSystem.Factory.create(conf);
     fs2.close();

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -20,6 +20,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.MockFileInStream;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
@@ -48,7 +49,6 @@ import alluxio.grpc.UnmountPOptions;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.security.authorization.AclEntry;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.wire.BlockLocationInfo;
@@ -91,8 +91,7 @@ import java.util.stream.IntStream;
  */
 @RunWith(Parameterized.class)
 public class LocalCacheFileInStreamTest {
-  private static InstancedConfiguration sConf = new InstancedConfiguration(
-      ConfigurationUtils.copyDefaults());
+  private static InstancedConfiguration sConf = Configuration.modifiableGlobal();
 
   @Parameters(name = "{index}: page_size({0}), in_stream_buffer_size({1})")
   public static Collection<Object[]> data() {

--- a/core/client/fs/src/test/java/alluxio/client/util/ClientTestUtils.java
+++ b/core/client/fs/src/test/java/alluxio/client/util/ClientTestUtils.java
@@ -19,7 +19,6 @@ import alluxio.wire.TieredIdentity;
 import alluxio.wire.TieredIdentity.LocalityTier;
 import alluxio.wire.WorkerNetAddress;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,7 +48,7 @@ public final class ClientTestUtils {
     }
   }
 
-  private static void resetContexts(InstancedConfiguration conf) throws IOException {
+  private static void resetContexts(InstancedConfiguration conf) {
     conf.set(PropertyKey.USER_METRICS_COLLECTION_ENABLED, false);
   }
 

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -36,7 +36,6 @@ import alluxio.grpc.SetAttributePOptions;
 import alluxio.master.MasterInquireClient.Factory;
 import alluxio.security.CurrentUser;
 import alluxio.security.authorization.Mode;
-import alluxio.util.ConfigurationUtils;
 import alluxio.wire.BlockLocationInfo;
 import alluxio.wire.FileBlockInfo;
 import alluxio.wire.WorkerNetAddress;
@@ -505,7 +504,7 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
         hadoopConfProperties, uriConfProperties);
     AlluxioProperties alluxioProps =
         (alluxioConfiguration != null) ? alluxioConfiguration.copyProperties()
-            : ConfigurationUtils.copyDefaults();
+            : alluxio.conf.Configuration.global().copyProperties();
     // Merge relevant Hadoop configuration into Alluxio's configuration.
     alluxioProps.merge(hadoopConfProperties, Source.RUNTIME);
     // Merge relevant connection details in the URI with the highest priority

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopUtils.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopUtils.java
@@ -17,7 +17,6 @@ import alluxio.conf.AlluxioProperties;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
-import alluxio.util.ConfigurationUtils;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -184,7 +183,7 @@ public final class HadoopUtils {
     // Take hadoop configuration to merge to Alluxio configuration
     Map<String, Object> hadoopConfProperties =
         HadoopConfigurationUtils.getConfigurationFromHadoop(conf);
-    AlluxioProperties alluxioProps = ConfigurationUtils.copyDefaults();
+    AlluxioProperties alluxioProps = alluxio.conf.Configuration.global().copyProperties();
     // Merge relevant Hadoop configuration into Alluxio's configuration.
     alluxioProps.merge(hadoopConfProperties, Source.RUNTIME);
     // Creating a new instanced configuration from an AlluxioProperties object isn't expensive.

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -492,7 +492,7 @@ public class AbstractFileSystemTest {
     sysProps.put(PropertyKey.ZOOKEEPER_ENABLED.getName(), "true");
     sysProps.put(PropertyKey.ZOOKEEPER_ADDRESS.getName(), "zkHost:2181");
     try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {
-      ConfigurationUtils.reloadProperties();
+      alluxio.conf.Configuration.reloadProperties();
       URI uri = URI.create("alluxio:///");
       FileSystem fs = getHadoopFilesystem(org.apache.hadoop.fs.FileSystem.get(uri, getConf()));
 
@@ -507,7 +507,7 @@ public class AbstractFileSystemTest {
     // those in the URI has the highest priority.
     try (Closeable p = new SystemPropertyRule(
          PropertyKey.ZOOKEEPER_ENABLED.getName(), "false").toResource()) {
-      ConfigurationUtils.reloadProperties();
+      alluxio.conf.Configuration.reloadProperties();
       URI uri = URI.create("alluxio://zk@zkHost:2181");
       FileSystem fs = getHadoopFilesystem(org.apache.hadoop.fs.FileSystem.get(uri, getConf()));
       assertTrue(fs.mFileSystem.getConf().getBoolean(PropertyKey.ZOOKEEPER_ENABLED));
@@ -519,14 +519,14 @@ public class AbstractFileSystemTest {
     sysProps.put(PropertyKey.ZOOKEEPER_ENABLED.getName(), "true");
     sysProps.put(PropertyKey.ZOOKEEPER_ADDRESS.getName(), "zkHost1:2181");
     try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {
-      ConfigurationUtils.reloadProperties();
+      alluxio.conf.Configuration.reloadProperties();
       URI uri = URI.create("alluxio://zk@zkHost2:2181");
       FileSystem fs = getHadoopFilesystem(org.apache.hadoop.fs.FileSystem.get(uri, getConf()));
       assertTrue(fs.mFileSystem.getConf().getBoolean(PropertyKey.ZOOKEEPER_ENABLED));
       assertEquals("zkHost2:2181", fs.mFileSystem.getConf().get(PropertyKey.ZOOKEEPER_ADDRESS));
       fs.close();
     }
-    ConfigurationUtils.reloadProperties();
+    alluxio.conf.Configuration.reloadProperties();
   }
 
   @Test

--- a/core/common/src/main/java/alluxio/ClientContext.java
+++ b/core/common/src/main/java/alluxio/ClientContext.java
@@ -15,6 +15,7 @@ import static java.util.Objects.requireNonNull;
 
 import alluxio.annotation.PublicApi;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.path.PathConfiguration;
 import alluxio.exception.status.AlluxioStatusException;
@@ -77,7 +78,7 @@ public class ClientContext {
    * an empty subject.
    */
   public static ClientContext create() {
-    return new ClientContext(new Subject(), ConfigurationUtils.defaults());
+    return new ClientContext(new Subject(), Configuration.global());
   }
 
   /**

--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -70,7 +70,7 @@ public class InstancedConfiguration implements AlluxioConfiguration {
    * @return an instanced configuration preset with defaults
    */
   public static InstancedConfiguration defaults() {
-    return new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    return Configuration.copyGlobal();
   }
 
   /**

--- a/core/common/src/main/java/alluxio/metrics/InstrumentedExecutorService.java
+++ b/core/common/src/main/java/alluxio/metrics/InstrumentedExecutorService.java
@@ -11,8 +11,8 @@
 
 package alluxio.metrics;
 
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.logging.SamplingLogger;
 
 import com.codahale.metrics.CachedGauge;
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeoutException;
 public class InstrumentedExecutorService implements ExecutorService {
   private final Logger mSamplingLog =
       new SamplingLogger(LoggerFactory.getLogger(InstrumentedExecutorService.class),
-          ConfigurationUtils.defaults().getMs(PropertyKey.METRICS_EXECUTOR_TASK_WARN_FREQUENCY));
+          Configuration.global().getMs(PropertyKey.METRICS_EXECUTOR_TASK_WARN_FREQUENCY));
 
   private com.codahale.metrics
       .InstrumentedExecutorService mDelegate;
@@ -102,7 +102,7 @@ public class InstrumentedExecutorService implements ExecutorService {
   private void addedTasks(int count) {
     long activeCount = mSubmitted.getCount() - mCompleted.getCount() + count;
     mHist.update(activeCount);
-    if (activeCount >= ConfigurationUtils.defaults()
+    if (activeCount >= Configuration.global()
         .getInt(PropertyKey.METRICS_EXECUTOR_TASK_WARN_SIZE)) {
       mSamplingLog.warn("Number of active tasks (queued and running) for executor {} is {}",
           mName, activeCount);

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -13,12 +13,12 @@ package alluxio.metrics;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.MetricType;
 import alluxio.grpc.MetricValue;
 import alluxio.metrics.sink.Sink;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.network.NetworkAddressUtils;
 
 import com.codahale.metrics.CachedGauge;
@@ -67,7 +67,7 @@ public final class MetricsSystem {
 
   private static final ConcurrentHashMap<String, String> CACHED_METRICS = new ConcurrentHashMap<>();
   private static int sResolveTimeout =
-      (int) ConfigurationUtils.defaults().getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS);
+      (int) Configuration.global().getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS);
   // A map from AlluxioURI to corresponding cached escaped path.
   private static final ConcurrentHashMap<AlluxioURI, String> CACHED_ESCAPED_PATH
       = new ConcurrentHashMap<>();
@@ -205,7 +205,7 @@ public final class MetricsSystem {
       default:
         break;
     }
-    AlluxioConfiguration conf = ConfigurationUtils.defaults();
+    AlluxioConfiguration conf = Configuration.global();
     if (sourceKey != null && conf.isSet(sourceKey)) {
       return conf.getString(sourceKey);
     }

--- a/core/common/src/main/java/alluxio/resource/AlluxioResourceLeakDetector.java
+++ b/core/common/src/main/java/alluxio/resource/AlluxioResourceLeakDetector.java
@@ -12,7 +12,7 @@
 package alluxio.resource;
 
 import alluxio.conf.PropertyKey;
-import alluxio.util.ConfigurationUtils;
+import alluxio.conf.Configuration;
 
 import io.netty.util.ResourceLeakDetector;
 import org.slf4j.Logger;
@@ -31,8 +31,8 @@ public class AlluxioResourceLeakDetector<T> extends ResourceLeakDetector<T> {
           + "Troubleshooting.html#resource-leak-detection";
 
   static {
-    ResourceLeakDetector.Level lev = (ResourceLeakDetector.Level) ConfigurationUtils
-        .getPropertyValue(PropertyKey.LEAK_DETECTOR_LEVEL);
+    ResourceLeakDetector.Level lev = (ResourceLeakDetector.Level) Configuration
+        .get(PropertyKey.LEAK_DETECTOR_LEVEL);
     ResourceLeakDetector.setLevel(lev);
   }
 

--- a/core/common/src/main/java/alluxio/resource/AlluxioResourceLeakDetectorFactory.java
+++ b/core/common/src/main/java/alluxio/resource/AlluxioResourceLeakDetectorFactory.java
@@ -12,7 +12,7 @@
 package alluxio.resource;
 
 import alluxio.conf.PropertyKey;
-import alluxio.util.ConfigurationUtils;
+import alluxio.conf.Configuration;
 
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetectorFactory;
@@ -25,7 +25,7 @@ public class AlluxioResourceLeakDetectorFactory extends ResourceLeakDetectorFact
   private static final ResourceLeakDetectorFactory INSTANCE =
       new AlluxioResourceLeakDetectorFactory();
 
-  private final boolean mExitOnLeak = (boolean) ConfigurationUtils.getPropertyValue(
+  private final boolean mExitOnLeak = (boolean) Configuration.get(
       PropertyKey.LEAK_DETECTOR_EXIT_ON_LEAK);
 
   /**

--- a/core/common/src/test/java/alluxio/AbstractClientTest.java
+++ b/core/common/src/test/java/alluxio/AbstractClientTest.java
@@ -13,14 +13,13 @@ package alluxio;
 
 import static alluxio.exception.ExceptionMessage.INCOMPATIBLE_VERSION;
 
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.NotFoundException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.ServiceType;
 import alluxio.retry.CountingRetry;
 import alluxio.security.user.BaseUserState;
-import alluxio.util.ConfigurationUtils;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -45,7 +44,7 @@ public final class AbstractClientTest {
     private long mRemoteServiceVersion;
 
     protected BaseTestClient() {
-      super(ClientContext.create(ConfigurationUtils.defaults()), null,
+      super(ClientContext.create(Configuration.global()), null,
           () -> new CountingRetry(1));
     }
 
@@ -133,7 +132,7 @@ public final class AbstractClientTest {
   public void confAddress() throws Exception {
     ClientContext context = Mockito.mock(ClientContext.class);
     Mockito.when(context.getClusterConf()).thenReturn(
-        new InstancedConfiguration(ConfigurationUtils.copyDefaults()));
+        Configuration.modifiableGlobal());
 
     InetSocketAddress baseAddress = new InetSocketAddress("0.0.0.0", 2000);
     InetSocketAddress confAddress = new InetSocketAddress("0.0.0.0", 2000);

--- a/core/common/src/test/java/alluxio/AuthenticatedUserRule.java
+++ b/core/common/src/test/java/alluxio/AuthenticatedUserRule.java
@@ -11,7 +11,7 @@
 
 package alluxio;
 
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.security.User;
 import alluxio.security.authentication.AuthenticatedClientUser;
 
@@ -30,12 +30,12 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class AuthenticatedUserRule extends AbstractResourceRule {
   private final String mUser;
   private User mPreviousUser;
-  private final InstancedConfiguration mConfiguration;
+  private final AlluxioConfiguration mConfiguration;
 
   /**
    * @param user the user name to set as authenticated user
    */
-  public AuthenticatedUserRule(String user, InstancedConfiguration conf) {
+  public AuthenticatedUserRule(String user, AlluxioConfiguration conf) {
     mUser = user;
     mConfiguration = conf;
   }

--- a/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
@@ -12,10 +12,10 @@
 package alluxio;
 
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.master.journal.JournalType;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Joiner;
@@ -35,7 +35,7 @@ public final class ConfigurationTestUtils {
    * @return the default configuration
    */
   public static InstancedConfiguration copyDefaults() {
-    return new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    return Configuration.copyGlobal();
   }
 
   /**
@@ -149,7 +149,6 @@ public final class ConfigurationTestUtils {
     conf.put(PropertyKey.MASTER_WORKER_INFO_CACHE_REFRESH_TIME, "20ms");
 
     // faster I/O retries.
-    conf.put(PropertyKey.USER_BLOCK_READ_RETRY_SLEEP_MIN, "1ms");
     conf.put(PropertyKey.USER_BLOCK_READ_RETRY_SLEEP_MIN, "5ms");
     conf.put(PropertyKey.USER_BLOCK_READ_RETRY_MAX_DURATION, "10ms");
 

--- a/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
@@ -31,7 +31,6 @@ import alluxio.TestLoggerRule;
 import alluxio.client.ReadType;
 import alluxio.conf.PropertyKey.Template;
 import alluxio.test.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.FormatUtils;
 
 import com.google.common.base.Joiner;
@@ -66,7 +65,7 @@ import java.util.stream.IntStream;
  */
 public class InstancedConfigurationTest {
 
-  private  InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
+  private  InstancedConfiguration mConfiguration = Configuration.copyGlobal();
   @Rule
   public final ExpectedException mThrown = ExpectedException.none();
 
@@ -82,13 +81,13 @@ public class InstancedConfigurationTest {
   }
 
   public void resetConf() {
-    ConfigurationUtils.reloadProperties();
+    Configuration.reloadProperties();
     mConfiguration = ConfigurationTestUtils.copyDefaults();
   }
 
   @AfterClass
   public static void after() {
-    ConfigurationUtils.reloadProperties();
+    Configuration.reloadProperties();
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/master/MasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/MasterInquireClientTest.java
@@ -14,13 +14,13 @@ package alluxio.master;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.ConfigurationRule;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.master.MasterInquireClient.ConnectDetails;
 import alluxio.master.SingleMasterInquireClient.SingleMasterConnectDetails;
 import alluxio.master.ZkMasterInquireClient.ZkMasterConnectDetails;
 import alluxio.master.journal.JournalType;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 
@@ -40,7 +40,7 @@ public final class MasterInquireClientTest {
 
   @Before
   public void before() {
-    mConfiguration = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    mConfiguration = new InstancedConfiguration(Configuration.global().copyProperties());
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/security/authentication/GrpcSecurityTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/GrpcSecurityTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.security.authentication;
 
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.UnauthenticatedException;
@@ -23,7 +24,6 @@ import alluxio.grpc.GrpcServerBuilder;
 import alluxio.security.User;
 import alluxio.security.user.UserState;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.network.NetworkAddressUtils;
 
@@ -58,7 +58,7 @@ public class GrpcSecurityTest {
 
   @Before
   public void before() {
-    mConfiguration = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    mConfiguration = new InstancedConfiguration(Configuration.global().copyProperties());
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/security/authorization/ModeTest.java
+++ b/core/common/src/test/java/alluxio/security/authorization/ModeTest.java
@@ -16,10 +16,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.Constants;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.ExceptionMessage;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.ModeUtils;
 
 import org.junit.Before;
@@ -42,7 +42,7 @@ public final class ModeTest {
 
   @Before
   public void before() {
-    mConfiguration = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    mConfiguration = new InstancedConfiguration(Configuration.global().copyProperties());
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/security/group/GroupMappingServiceTest.java
+++ b/core/common/src/test/java/alluxio/security/group/GroupMappingServiceTest.java
@@ -15,10 +15,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import alluxio.ConfigurationRule;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.security.group.provider.IdentityUserGroupsMapping;
-import alluxio.util.ConfigurationUtils;
 
 import org.junit.Test;
 
@@ -35,7 +35,7 @@ public final class GroupMappingServiceTest {
   @Test
   public void group() throws Throwable {
     String userName = "alluxio-user1";
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    InstancedConfiguration conf = Configuration.modifiableGlobal();
 
     try (Closeable mConfigurationRule =
         new ConfigurationRule(PropertyKey.SECURITY_GROUP_MAPPING_CLASS,

--- a/core/common/src/test/java/alluxio/underfs/options/CreateOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/CreateOptionsTest.java
@@ -15,13 +15,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.security.authentication.AuthType;
 import alluxio.security.authorization.Mode;
 import alluxio.security.group.provider.IdentityUserGroupsMapping;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.ModeUtils;
 
 import com.google.common.testing.EqualsTester;
@@ -40,7 +40,7 @@ public final class CreateOptionsTest {
 
   @Before
   public void before() {
-    mConfiguration = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    mConfiguration = Configuration.modifiableGlobal();
   }
 
   /**

--- a/core/common/src/test/java/alluxio/underfs/options/MkdirsOptionsTest.java
+++ b/core/common/src/test/java/alluxio/underfs/options/MkdirsOptionsTest.java
@@ -15,17 +15,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.security.authentication.AuthType;
 import alluxio.security.authorization.Mode;
 import alluxio.security.group.provider.IdentityUserGroupsMapping;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.ModeUtils;
 
 import com.google.common.testing.EqualsTester;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -36,12 +36,7 @@ import java.util.Random;
  */
 public final class MkdirsOptionsTest {
 
-  private InstancedConfiguration mConfiguration;
-
-  @Before
-  public void before() {
-    mConfiguration = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
-  }
+  private final AlluxioConfiguration mConfiguration = Configuration.global();
 
   /**
    * Tests for default {@link MkdirsOptions}.
@@ -64,8 +59,8 @@ public final class MkdirsOptionsTest {
    * configuration.
    */
   @Test
-  public void securityEnabled() throws IOException {
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+  public void securityEnabled() {
+    InstancedConfiguration conf = Configuration.copyGlobal();
     conf.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.SIMPLE);
     conf.set(PropertyKey.SECURITY_LOGIN_USERNAME, "foo");
     // Use IdentityUserGroupMapping to map user "foo" to group "foo".

--- a/core/common/src/test/java/alluxio/util/ConfigurationUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ConfigurationUtilsTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 import alluxio.Constants;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.AlluxioProperties;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.network.NetworkAddressUtils;
@@ -154,7 +155,7 @@ public final class ConfigurationUtilsTest {
   }
 
   private AlluxioConfiguration createConf(Map<PropertyKey, Object> properties) {
-    AlluxioProperties props = ConfigurationUtils.copyDefaults();
+    AlluxioProperties props = Configuration.global().copyProperties();
     for (PropertyKey key : properties.keySet()) {
       props.set(key, properties.get(key));
     }

--- a/core/common/src/test/java/alluxio/util/io/FileUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/FileUtilsTest.java
@@ -18,8 +18,8 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 
 import alluxio.AlluxioURI;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.util.ConfigurationUtils;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,8 +48,8 @@ import javax.annotation.Nullable;
  */
 public class FileUtilsTest {
 
-  private String mWorkerDataFolderPerms = (String) ConfigurationUtils.copyDefaults()
-      .get(PropertyKey.WORKER_DATA_FOLDER_PERMISSIONS);
+  private String mWorkerDataFolderPerms = Configuration.global()
+      .getString(PropertyKey.WORKER_DATA_FOLDER_PERMISSIONS);
 
   /**
    * The temporary folder.
@@ -226,7 +226,7 @@ public class FileUtilsTest {
   }
 
   /**
-   * Tests the {@link FileUtils#createBlockPath(String)} method.
+   * Tests the {@link FileUtils#createBlockPath} method.
    */
   @Test
   public void createBlockPath() throws IOException {

--- a/core/server/common/src/main/java/alluxio/DefaultStorageTierAssoc.java
+++ b/core/server/common/src/main/java/alluxio/DefaultStorageTierAssoc.java
@@ -14,7 +14,7 @@ package alluxio;
 import alluxio.annotation.SuppressFBWarnings;
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.BlockStoreLocation;
 
 import com.google.common.collect.ImmutableBiMap;
@@ -25,7 +25,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Creates a two-way mapping between storage tier aliases and ordinal numbers from the given
- * {@link ServerConfiguration}.
+ * {@link Configuration}.
  */
 @ThreadSafe
 public final class DefaultStorageTierAssoc
@@ -58,17 +58,17 @@ public final class DefaultStorageTierAssoc
   }
 
   /**
-   * Constructs a new instance using the given {@link ServerConfiguration} object. The mapping
+   * Constructs a new instance using the given {@link Configuration} object. The mapping
    * cannot be modified after creation.
    *
    * @param levelsProperty the property in the conf that specifies how many levels there are
    * @param template the format for the conf that identifies the alias for each level
    */
   public DefaultStorageTierAssoc(PropertyKey levelsProperty, PropertyKey.Template template) {
-    int levels = ServerConfiguration.getInt(levelsProperty);
+    int levels = Configuration.getInt(levelsProperty);
     ImmutableBiMap.Builder<String, Integer> builder = new ImmutableBiMap.Builder<>();
     for (int i = 0; i < levels; i++) {
-      String alias = ServerConfiguration.getString(template.format(i));
+      String alias = Configuration.getString(template.format(i));
       builder.put(alias, i);
     }
     mAliasToOrdinal = builder.build();

--- a/core/server/common/src/main/java/alluxio/ProcessUtils.java
+++ b/core/server/common/src/main/java/alluxio/ProcessUtils.java
@@ -12,7 +12,7 @@
 package alluxio;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import com.google.common.base.Throwables;
 import org.slf4j.Logger;
@@ -76,7 +76,7 @@ public final class ProcessUtils {
     if (t != null) {
       message += "\n" + Throwables.getStackTraceAsString(t);
     }
-    if (ServerConfiguration.getBoolean(PropertyKey.TEST_MODE)) {
+    if (Configuration.getBoolean(PropertyKey.TEST_MODE)) {
       throw new RuntimeException(message);
     }
     logger.error(message);

--- a/core/server/common/src/main/java/alluxio/cli/Format.java
+++ b/core/server/common/src/main/java/alluxio/cli/Format.java
@@ -14,14 +14,13 @@ package alluxio.cli;
 import alluxio.RuntimeConstants;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.NoopMaster;
 import alluxio.master.NoopUfsManager;
 import alluxio.master.ServiceUtils;
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.JournalUtils;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.io.FileUtils;
 
 import org.slf4j.Logger;
@@ -65,7 +64,7 @@ public final class Format {
     Files.createDirectory(path);
     // For short-circuit read/write to work, others needs to be able to access this directory.
     // Therefore, default is 777 but if the user specifies the permissions, respect those instead.
-    String permissions = ServerConfiguration.getString(PropertyKey.WORKER_DATA_FOLDER_PERMISSIONS);
+    String permissions = Configuration.getString(PropertyKey.WORKER_DATA_FOLDER_PERMISSIONS);
     Set<PosixFilePermission> perms = PosixFilePermissions.fromString(permissions);
     Files.setPosixFilePermissions(path, perms);
     FileUtils.setLocalDirStickyBit(path.toAbsolutePath().toString());
@@ -81,7 +80,7 @@ public final class Format {
       LOG.info(USAGE);
       System.exit(-1);
     }
-    AlluxioConfiguration conf = ConfigurationUtils.defaults();
+    AlluxioConfiguration conf = Configuration.global();
     // Set the process type as "MASTER" since format needs to access the journal like the master.
     CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.MASTER);
     Mode mode = null;
@@ -122,13 +121,13 @@ public final class Format {
         journalSystem.format();
         break;
       case WORKER:
-        String workerDataFolder = ServerConfiguration.getString(PropertyKey.WORKER_DATA_FOLDER);
+        String workerDataFolder = Configuration.getString(PropertyKey.WORKER_DATA_FOLDER);
         LOG.info("Formatting worker data folder: {}", workerDataFolder);
-        int storageLevels = ServerConfiguration.getInt(PropertyKey.WORKER_TIERED_STORE_LEVELS);
+        int storageLevels = Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_LEVELS);
         for (int level = 0; level < storageLevels; level++) {
           PropertyKey tierLevelDirPath =
               PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(level);
-          String[] dirPaths = ServerConfiguration.getString(tierLevelDirPath).split(",");
+          String[] dirPaths = Configuration.getString(tierLevelDirPath).split(",");
           String name = "Data path for tier " + level;
           for (String dirPath : dirPaths) {
             String dirWorkerDataFolder = CommonUtils.getWorkerDataDirectory(dirPath, alluxioConf);

--- a/core/server/common/src/main/java/alluxio/cli/extensions/ExtensionsShell.java
+++ b/core/server/common/src/main/java/alluxio/cli/extensions/ExtensionsShell.java
@@ -14,8 +14,8 @@ package alluxio.cli.extensions;
 import alluxio.cli.AbstractShell;
 import alluxio.cli.Command;
 import alluxio.cli.CommandUtils;
-import alluxio.conf.InstancedConfiguration;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 
 import java.util.Map;
 
@@ -28,7 +28,7 @@ public final class ExtensionsShell extends AbstractShell {
    *
    * @param conf the Alluxio configuration to use when instantiating the shell
    */
-  ExtensionsShell(InstancedConfiguration conf) {
+  ExtensionsShell(AlluxioConfiguration conf) {
     super(null, null, conf);
   }
 
@@ -39,7 +39,7 @@ public final class ExtensionsShell extends AbstractShell {
    */
   public static void main(String[] args) {
     ExtensionsShell extensionShell =
-        new ExtensionsShell(ServerConfiguration.global());
+        new ExtensionsShell(Configuration.global());
     System.exit(extensionShell.run(args));
   }
 

--- a/core/server/common/src/main/java/alluxio/cli/extensions/command/InstallCommand.java
+++ b/core/server/common/src/main/java/alluxio/cli/extensions/command/InstallCommand.java
@@ -16,7 +16,7 @@ import alluxio.cli.Command;
 import alluxio.cli.CommandUtils;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.util.ConfigurationUtils;
@@ -62,7 +62,7 @@ public final class InstallCommand implements Command {
   @Override
   public int run(CommandLine cl) {
     String uri = cl.getArgs()[0];
-    AlluxioConfiguration conf = ServerConfiguration.global();
+    AlluxioConfiguration conf = Configuration.global();
     String extensionsDir = conf.getString(PropertyKey.EXTENSIONS_DIR);
     File dir = new File(extensionsDir);
     if (!dir.exists() && !dir.mkdirs()) {

--- a/core/server/common/src/main/java/alluxio/cli/extensions/command/LsCommand.java
+++ b/core/server/common/src/main/java/alluxio/cli/extensions/command/LsCommand.java
@@ -14,7 +14,7 @@ package alluxio.cli.extensions.command;
 import alluxio.cli.Command;
 import alluxio.cli.CommandUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.util.ExtensionUtils;
 
@@ -61,7 +61,7 @@ public final class LsCommand implements Command {
   @Override
   public int run(CommandLine cl) {
     for (File extension : ExtensionUtils
-        .listExtensions(ServerConfiguration.getString(PropertyKey.EXTENSIONS_DIR))) {
+        .listExtensions(Configuration.getString(PropertyKey.EXTENSIONS_DIR))) {
       System.out.println(extension.getName());
     }
     return 0;

--- a/core/server/common/src/main/java/alluxio/cli/extensions/command/UninstallCommand.java
+++ b/core/server/common/src/main/java/alluxio/cli/extensions/command/UninstallCommand.java
@@ -16,7 +16,7 @@ import alluxio.cli.Command;
 import alluxio.cli.CommandUtils;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.util.ConfigurationUtils;
@@ -62,7 +62,7 @@ public final class UninstallCommand implements Command {
   @Override
   public int run(CommandLine cl) {
     String uri = cl.getArgs()[0];
-    AlluxioConfiguration conf = ServerConfiguration.global();
+    AlluxioConfiguration conf = Configuration.global();
     String extensionsDir = conf.getString(PropertyKey.EXTENSIONS_DIR);
     List<String> failedHosts = new ArrayList<>();
     for (String host : ConfigurationUtils.getServerHostnames(conf)) {

--- a/core/server/common/src/main/java/alluxio/executor/ExecutorServiceBuilder.java
+++ b/core/server/common/src/main/java/alluxio/executor/ExecutorServiceBuilder.java
@@ -13,7 +13,7 @@ package alluxio.executor;
 
 import alluxio.concurrent.jsr.ForkJoinPool;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.AlluxioExecutorService;
 import alluxio.util.ThreadFactoryUtils;
 
@@ -39,18 +39,18 @@ public class ExecutorServiceBuilder {
    */
   public static AlluxioExecutorService buildExecutorService(RpcExecutorHost executorHost) {
     // Get executor type for given host.
-    RpcExecutorType executorType = ServerConfiguration.getEnum(
+    RpcExecutorType executorType = Configuration.getEnum(
         PropertyKey.Template.RPC_EXECUTOR_TYPE.format(executorHost.toString()),
         RpcExecutorType.class);
     // Build thread name format.
     String threadNameFormat =
         String.format("%s-rpc-executor-%s-thread", executorHost, executorType) + "-%d";
     // Read shared configuration for all supported executors.
-    int corePoolSize = ServerConfiguration
+    int corePoolSize = Configuration
         .getInt(PropertyKey.Template.RPC_EXECUTOR_CORE_POOL_SIZE.format(executorHost.toString()));
-    int maxPoolSize = ServerConfiguration
+    int maxPoolSize = Configuration
         .getInt(PropertyKey.Template.RPC_EXECUTOR_MAX_POOL_SIZE.format(executorHost.toString()));
-    long keepAliveMs = ServerConfiguration
+    long keepAliveMs = Configuration
         .getMs(PropertyKey.Template.RPC_EXECUTOR_KEEPALIVE.format(executorHost.toString()));
     // Property validation.
     Preconditions.checkArgument(keepAliveMs > 0L,
@@ -65,11 +65,11 @@ public class ExecutorServiceBuilder {
     ExecutorService executorService = null;
     if (executorType == RpcExecutorType.FJP) {
       // Read FJP specific configurations.
-      int parallelism = ServerConfiguration.getInt(
+      int parallelism = Configuration.getInt(
           PropertyKey.Template.RPC_EXECUTOR_FJP_PARALLELISM.format(executorHost.toString()));
-      int minRunnable = ServerConfiguration.getInt(
+      int minRunnable = Configuration.getInt(
           PropertyKey.Template.RPC_EXECUTOR_FJP_MIN_RUNNABLE.format(executorHost.toString()));
-      boolean isAsync = ServerConfiguration
+      boolean isAsync = Configuration
           .getBoolean(PropertyKey.Template.RPC_EXECUTOR_FJP_ASYNC.format(executorHost.toString()));
       // Property validation.
       Preconditions.checkArgument(parallelism > 0,
@@ -91,11 +91,11 @@ public class ExecutorServiceBuilder {
           maxPoolSize, minRunnable, null, keepAliveMs, TimeUnit.MILLISECONDS);
     } else { // TPE
       // Read TPE specific configuration.
-      boolean allowCoreThreadsTimeout = ServerConfiguration
+      boolean allowCoreThreadsTimeout = Configuration
           .getBoolean(PropertyKey.Template.RPC_EXECUTOR_TPE_ALLOW_CORE_THREADS_TIMEOUT
               .format(executorHost.toString()));
       // Read TPE queue type.
-      ThreadPoolExecutorQueueType queueType = ServerConfiguration.getEnum(
+      ThreadPoolExecutorQueueType queueType = Configuration.getEnum(
           PropertyKey.Template.RPC_EXECUTOR_TPE_QUEUE_TYPE.format(executorHost.toString()),
           ThreadPoolExecutorQueueType.class);
       // Create internal queue.

--- a/core/server/common/src/main/java/alluxio/master/BackupManager.java
+++ b/core/server/common/src/main/java/alluxio/master/BackupManager.java
@@ -13,7 +13,7 @@ package alluxio.master;
 
 import alluxio.ProcessUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.JournalEntryAssociation;
 import alluxio.master.journal.JournalEntryStreamReader;
@@ -118,7 +118,7 @@ public class BackupManager {
     // Processing/draining one-by-one using {@link ConcurrentLinkedQueue} proved to be
     // inefficient compared to draining with dedicated method.
     LinkedBlockingQueue<JournalEntry> journalEntryQueue = new LinkedBlockingQueue<>(
-        ServerConfiguration.getInt(PropertyKey.MASTER_BACKUP_ENTRY_BUFFER_COUNT));
+        Configuration.getInt(PropertyKey.MASTER_BACKUP_ENTRY_BUFFER_COUNT));
 
     // Whether buffering is still active.
     AtomicBoolean bufferingActive = new AtomicBoolean(true);
@@ -218,7 +218,7 @@ public class BackupManager {
 
       // Entry queue will be used as a buffer and synchronization between readers and appliers.
       LinkedBlockingQueue<JournalEntry> journalEntryQueue = new LinkedBlockingQueue<>(
-          ServerConfiguration.getInt(PropertyKey.MASTER_BACKUP_ENTRY_BUFFER_COUNT));
+          Configuration.getInt(PropertyKey.MASTER_BACKUP_ENTRY_BUFFER_COUNT));
 
       // Whether still reading from backup.
       AtomicBoolean readingActive = new AtomicBoolean(true);

--- a/core/server/common/src/main/java/alluxio/master/MasterProcess.java
+++ b/core/server/common/src/main/java/alluxio/master/MasterProcess.java
@@ -14,9 +14,9 @@ package alluxio.master;
 import static alluxio.util.network.NetworkAddressUtils.ServiceType;
 
 import alluxio.Process;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.GrpcServer;
 import alluxio.grpc.GrpcServerBuilder;
 import alluxio.grpc.GrpcService;
@@ -88,7 +88,7 @@ public abstract class MasterProcess implements Process {
   }
 
   private static InetSocketAddress configureAddress(ServiceType service) {
-    InstancedConfiguration conf = ServerConfiguration.global();
+    AlluxioConfiguration conf = Configuration.global();
     int port = NetworkAddressUtils.getPort(service, conf);
     if (!ConfigurationUtils.isHaMode(conf) && port == 0) {
       throw new RuntimeException(
@@ -97,7 +97,7 @@ public abstract class MasterProcess implements Process {
     if (port == 0) {
       try (ServerSocket s = new ServerSocket(0)) {
         s.setReuseAddress(true);
-        conf.set(service.getPortKey(), s.getLocalPort());
+        Configuration.set(service.getPortKey(), s.getLocalPort());
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
@@ -184,7 +184,7 @@ public abstract class MasterProcess implements Process {
       CommonUtils.waitFor(this + " to start",
           () -> {
             boolean ready = isGrpcServing();
-            if (ready && !ServerConfiguration.getBoolean(PropertyKey.TEST_MODE)) {
+            if (ready && !Configuration.getBoolean(PropertyKey.TEST_MODE)) {
               ready &= mWebServer != null && mWebServer.getServer().isRunning();
             }
             return ready;

--- a/core/server/common/src/main/java/alluxio/master/PrimarySelector.java
+++ b/core/server/common/src/main/java/alluxio/master/PrimarySelector.java
@@ -12,7 +12,7 @@
 package alluxio.master;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.interfaces.Scoped;
 
 import java.io.IOException;
@@ -42,9 +42,9 @@ public interface PrimarySelector {
      * @return a primary selector based on zookeeper configuration
      */
     public static PrimarySelector createZkPrimarySelector() {
-      String zkAddress = ServerConfiguration.getString(PropertyKey.ZOOKEEPER_ADDRESS);
-      String zkElectionPath = ServerConfiguration.getString(PropertyKey.ZOOKEEPER_ELECTION_PATH);
-      String zkLeaderPath = ServerConfiguration.getString(PropertyKey.ZOOKEEPER_LEADER_PATH);
+      String zkAddress = Configuration.getString(PropertyKey.ZOOKEEPER_ADDRESS);
+      String zkElectionPath = Configuration.getString(PropertyKey.ZOOKEEPER_ELECTION_PATH);
+      String zkLeaderPath = Configuration.getString(PropertyKey.ZOOKEEPER_LEADER_PATH);
       return new PrimarySelectorClient(zkAddress, zkElectionPath, zkLeaderPath);
     }
 
@@ -52,10 +52,10 @@ public interface PrimarySelector {
      * @return a job master primary selector based on zookeeper configuration
      */
     public static PrimarySelector createZkJobPrimarySelector() {
-      String zkAddress = ServerConfiguration.getString(PropertyKey.ZOOKEEPER_ADDRESS);
-      String zkElectionPath = ServerConfiguration.getString(
+      String zkAddress = Configuration.getString(PropertyKey.ZOOKEEPER_ADDRESS);
+      String zkElectionPath = Configuration.getString(
           PropertyKey.ZOOKEEPER_JOB_ELECTION_PATH);
-      String zkLeaderPath = ServerConfiguration.getString(PropertyKey.ZOOKEEPER_JOB_LEADER_PATH);
+      String zkLeaderPath = Configuration.getString(PropertyKey.ZOOKEEPER_JOB_LEADER_PATH);
       return new PrimarySelectorClient(zkAddress, zkElectionPath, zkLeaderPath);
     }
 

--- a/core/server/common/src/main/java/alluxio/master/PrimarySelectorClient.java
+++ b/core/server/common/src/main/java/alluxio/master/PrimarySelectorClient.java
@@ -14,7 +14,7 @@ package alluxio.master;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import com.google.common.base.Preconditions;
 import org.apache.curator.framework.CuratorFramework;
@@ -78,7 +78,7 @@ public final class PrimarySelectorClient extends AbstractPrimarySelector
     } else {
       mLeaderFolder = leaderPath + AlluxioURI.SEPARATOR;
     }
-    mConnectionErrorPolicy = ServerConfiguration.getEnum(
+    mConnectionErrorPolicy = Configuration.getEnum(
         PropertyKey.ZOOKEEPER_LEADER_CONNECTION_ERROR_POLICY, ZookeeperConnectionErrorPolicy.class);
 
     mLeaderZkSessionId = NOT_A_LEADER;
@@ -245,9 +245,9 @@ public final class PrimarySelectorClient extends AbstractPrimarySelector
     curatorBuilder.connectString(mZookeeperAddress);
     curatorBuilder.retryPolicy(new ExponentialBackoffRetry(Constants.SECOND_MS, 3));
     curatorBuilder
-        .sessionTimeoutMs((int) ServerConfiguration.getMs(PropertyKey.ZOOKEEPER_SESSION_TIMEOUT));
+        .sessionTimeoutMs((int) Configuration.getMs(PropertyKey.ZOOKEEPER_SESSION_TIMEOUT));
     curatorBuilder.connectionTimeoutMs(
-        (int) ServerConfiguration.getMs(PropertyKey.ZOOKEEPER_CONNECTION_TIMEOUT));
+        (int) Configuration.getMs(PropertyKey.ZOOKEEPER_CONNECTION_TIMEOUT));
     // Force compatibility mode to support writing to 3.4.x servers.
     curatorBuilder.zk34CompatibilityMode(true);
     // Prevent using container parents as it breaks compatibility with 3.4.x servers.

--- a/core/server/common/src/main/java/alluxio/master/StateLockManager.java
+++ b/core/server/common/src/main/java/alluxio/master/StateLockManager.java
@@ -14,7 +14,7 @@ package alluxio.master;
 import alluxio.Constants;
 import alluxio.collections.ConcurrentHashSet;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.resource.LockResource;
 import alluxio.retry.RetryUtils;
@@ -94,12 +94,12 @@ public class StateLockManager {
     mScheduler = Executors
         .newSingleThreadScheduledExecutor(ThreadFactoryUtils.build("state-lock-manager-%d", true));
     // Read properties.
-    mInterruptCycleEnabled = ServerConfiguration
+    mInterruptCycleEnabled = Configuration
         .getBoolean(PropertyKey.MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_ENABLED);
     mInterruptCycleInterval =
-        ServerConfiguration.getMs(PropertyKey.MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_INTERVAL);
+        Configuration.getMs(PropertyKey.MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_INTERVAL);
     mForcedDurationMs =
-        ServerConfiguration.getMs(PropertyKey.MASTER_BACKUP_STATE_LOCK_FORCED_DURATION);
+        Configuration.getMs(PropertyKey.MASTER_BACKUP_STATE_LOCK_FORCED_DURATION);
     // Validate properties.
     Preconditions.checkArgument(mInterruptCycleInterval > 0,
         "Interrupt-cycle interval should be greater than 0.");
@@ -115,7 +115,7 @@ public class StateLockManager {
   public void mastersStartedCallback() {
     if (mExclusiveOnlyDeadlineMs == -1) {
       long exclusiveOnlyDurationMs =
-          ServerConfiguration.getMs(PropertyKey.MASTER_BACKUP_STATE_LOCK_EXCLUSIVE_DURATION);
+          Configuration.getMs(PropertyKey.MASTER_BACKUP_STATE_LOCK_EXCLUSIVE_DURATION);
       mExclusiveOnlyDeadlineMs = System.currentTimeMillis() + exclusiveOnlyDurationMs;
       if (exclusiveOnlyDurationMs > 0) {
         LOG.info("State-lock will remain in exclusive-only mode for {}ms until {}",

--- a/core/server/common/src/main/java/alluxio/master/StateLockOptions.java
+++ b/core/server/common/src/main/java/alluxio/master/StateLockOptions.java
@@ -12,7 +12,7 @@
 package alluxio.master;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -90,13 +90,13 @@ public class StateLockOptions {
    */
   public static StateLockOptions defaultsForShellBackup() {
     return new StateLockOptions(
-        ServerConfiguration.getEnum(
+        Configuration.getEnum(
             PropertyKey.MASTER_SHELL_BACKUP_STATE_LOCK_GRACE_MODE, GraceMode.class),
-        ServerConfiguration.getMs(
+        Configuration.getMs(
             PropertyKey.MASTER_SHELL_BACKUP_STATE_LOCK_TRY_DURATION),
-        ServerConfiguration.getMs(
+        Configuration.getMs(
             PropertyKey.MASTER_SHELL_BACKUP_STATE_LOCK_SLEEP_DURATION),
-        ServerConfiguration.getMs(
+        Configuration.getMs(
             PropertyKey.MASTER_SHELL_BACKUP_STATE_LOCK_TIMEOUT)
     );
   }
@@ -106,13 +106,13 @@ public class StateLockOptions {
    */
   public static StateLockOptions defaultsForDailyBackup() {
     return new StateLockOptions(
-        ServerConfiguration.getEnum(
+        Configuration.getEnum(
             PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_GRACE_MODE, GraceMode.class),
-        ServerConfiguration.getMs(
+        Configuration.getMs(
             PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_TRY_DURATION),
-        ServerConfiguration.getMs(
+        Configuration.getMs(
             PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_SLEEP_DURATION),
-        ServerConfiguration.getMs(
+        Configuration.getMs(
             PropertyKey.MASTER_DAILY_BACKUP_STATE_LOCK_TIMEOUT)
     );
   }

--- a/core/server/common/src/main/java/alluxio/master/audit/AsyncUserAccessAuditLogWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/audit/AsyncUserAccessAuditLogWriter.java
@@ -12,7 +12,7 @@
 package alluxio.master.audit;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
@@ -49,7 +49,7 @@ public final class AsyncUserAccessAuditLogWriter {
    * @param loggerName the logger name
    */
   public AsyncUserAccessAuditLogWriter(String loggerName) {
-    int queueCapacity = ServerConfiguration.getInt(PropertyKey.MASTER_AUDIT_LOGGING_QUEUE_CAPACITY);
+    int queueCapacity = Configuration.getInt(PropertyKey.MASTER_AUDIT_LOGGING_QUEUE_CAPACITY);
     mAuditLogEntries = new LinkedBlockingQueue<>(queueCapacity);
     mLog = LoggerFactory.getLogger(loggerName);
     LOG.info("Audit logging queue capacity is {}.", queueCapacity);

--- a/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
@@ -17,7 +17,7 @@ import alluxio.collections.ConcurrentHashSet;
 import alluxio.concurrent.ForkJoinPoolHelper;
 import alluxio.concurrent.jsr.ForkJoinPool;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.JournalClosedException;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.master.journal.sink.JournalSink;
@@ -174,7 +174,7 @@ public final class AsyncJournalWriter {
     mFlushCounter = new AtomicLong(0);
     mWriteCounter = 0L;
     mFlushBatchTimeNs = TimeUnit.NANOSECONDS.convert(
-        ServerConfiguration.getMs(PropertyKey.MASTER_JOURNAL_FLUSH_BATCH_TIME_MS),
+        Configuration.getMs(PropertyKey.MASTER_JOURNAL_FLUSH_BATCH_TIME_MS),
         TimeUnit.MILLISECONDS);
     mJournalSinks = journalSinks;
     mFlushThread.start();

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalSystem.java
@@ -12,7 +12,7 @@
 package alluxio.master.journal;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.GrpcService;
 import alluxio.master.Master;
 import alluxio.master.journal.noop.NoopJournalSystem;
@@ -245,7 +245,7 @@ public interface JournalSystem {
   class Builder {
     private URI mLocation;
     private long mQuietTimeMs =
-        ServerConfiguration.getMs(PropertyKey.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS);
+        Configuration.getMs(PropertyKey.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS);
 
     /**
      * Creates a new journal system builder.
@@ -276,7 +276,7 @@ public interface JournalSystem {
      */
     public JournalSystem build(CommonUtils.ProcessType processType) {
       JournalType journalType =
-          ServerConfiguration.getEnum(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.class);
+          Configuration.getEnum(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.class);
       switch (journalType) {
         case NOOP:
           return new NoopJournalSystem();

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalUpgrader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalUpgrader.java
@@ -15,7 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.RuntimeConstants;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.MasterFactory;
 import alluxio.master.NoopMaster;
 import alluxio.master.ServiceUtils;
@@ -23,7 +23,6 @@ import alluxio.master.journal.ufs.UfsJournal;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.MkdirsOptions;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.URIUtils;
 
 import org.apache.commons.cli.CommandLine;
@@ -95,7 +94,7 @@ public final class JournalUpgrader {
       mJournalV0 = (new alluxio.master.journalv0.MutableJournal.Factory(
           getJournalLocation(sJournalDirectoryV0))).create(master);
       mJournalV1 =
-          new UfsJournal(getJournalLocation(ServerConfiguration
+          new UfsJournal(getJournalLocation(Configuration
               .getString(PropertyKey.MASTER_JOURNAL_FOLDER)), new NoopMaster(master), 0,
               Collections::emptySet);
 
@@ -245,7 +244,7 @@ public final class JournalUpgrader {
     }
 
     for (String master : masters) {
-      Upgrader upgrader = new Upgrader(master, ConfigurationUtils.defaults());
+      Upgrader upgrader = new Upgrader(master, Configuration.global());
       try {
         upgrader.upgrade();
       } catch (IOException e) {
@@ -273,7 +272,7 @@ public final class JournalUpgrader {
     }
     sHelp = cmd.hasOption("help");
     sJournalDirectoryV0 = cmd.getOptionValue("journalDirectoryV0",
-        ServerConfiguration.getString(PropertyKey.MASTER_JOURNAL_FOLDER));
+        Configuration.getString(PropertyKey.MASTER_JOURNAL_FOLDER));
     return true;
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalUtils.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalUtils.java
@@ -14,7 +14,7 @@ package alluxio.master.journal;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.CheckpointOutputStream;
 import alluxio.master.journal.checkpoint.CheckpointType;
@@ -54,7 +54,7 @@ public final class JournalUtils {
    * @return the journal location
    */
   public static URI getJournalLocation() {
-    String journalDirectory = ServerConfiguration.getString(PropertyKey.MASTER_JOURNAL_FOLDER);
+    String journalDirectory = Configuration.getString(PropertyKey.MASTER_JOURNAL_FOLDER);
     if (!journalDirectory.endsWith(AlluxioURI.SEPARATOR)) {
       journalDirectory += AlluxioURI.SEPARATOR;
     }
@@ -181,11 +181,11 @@ public final class JournalUtils {
     if (t != null) {
       message += "\n" + Throwables.getStackTraceAsString(t);
     }
-    if (ServerConfiguration.getBoolean(PropertyKey.TEST_MODE)) {
+    if (Configuration.getBoolean(PropertyKey.TEST_MODE)) {
       throw new RuntimeException(message);
     }
     logger.error(message);
-    if (!ServerConfiguration.getBoolean(PropertyKey.MASTER_JOURNAL_TOLERATE_CORRUPTION)) {
+    if (!Configuration.getBoolean(PropertyKey.MASTER_JOURNAL_TOLERATE_CORRUPTION)) {
       System.exit(-1);
       throw new RuntimeException(t);
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/MasterJournalContext.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/MasterJournalContext.java
@@ -13,7 +13,7 @@ package alluxio.master.journal;
 
 import alluxio.ProcessUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.JournalClosedException;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnavailableException;
@@ -38,9 +38,9 @@ public final class MasterJournalContext implements JournalContext {
   private static final Logger LOG = LoggerFactory.getLogger(MasterJournalContext.class);
   private static final long INVALID_FLUSH_COUNTER = -1;
   private static final long FLUSH_RETRY_TIMEOUT_MS =
-      ServerConfiguration.getMs(PropertyKey.MASTER_JOURNAL_FLUSH_TIMEOUT_MS);
+      Configuration.getMs(PropertyKey.MASTER_JOURNAL_FLUSH_TIMEOUT_MS);
   private static final int FLUSH_RETRY_INTERVAL_MS =
-      (int) ServerConfiguration.getMs(PropertyKey.MASTER_JOURNAL_FLUSH_RETRY_INTERVAL);
+      (int) Configuration.getMs(PropertyKey.MASTER_JOURNAL_FLUSH_RETRY_INTERVAL);
 
   private final AsyncJournalWriter mAsyncJournalWriter;
   private long mFlushCounter;

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -15,7 +15,7 @@ import alluxio.Constants;
 import alluxio.ProcessUtils;
 import alluxio.annotation.SuppressFBWarnings;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.AddQuorumServerRequest;
 import alluxio.grpc.JournalQueryRequest;
@@ -170,8 +170,8 @@ public class JournalStateMachine extends BaseStateMachine {
     MetricsSystem.registerGaugeIfAbsent(
         MetricKey.MASTER_JOURNAL_CHECKPOINT_WARN.getName(),
         () -> getLastAppliedTermIndex().getIndex() - mSnapshotLastIndex
-                > ServerConfiguration.getInt(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES)
-                && System.currentTimeMillis() - mLastCheckPointTime > ServerConfiguration.getMs(
+                > Configuration.getInt(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES)
+                && System.currentTimeMillis() - mLastCheckPointTime > Configuration.getMs(
                 PropertyKey.MASTER_WEB_JOURNAL_CHECKPOINT_WARNING_THRESHOLD_TIME)
     );
   }
@@ -565,7 +565,7 @@ public class JournalStateMachine extends BaseStateMachine {
       JournalUtils.restoreFromCheckpoint(new CheckpointInputStream(stream), getStateMachines());
     } catch (Exception e) {
       JournalUtils.handleJournalReplayFailure(LOG, e, "Failed to install snapshot: %s", snapshotId);
-      if (ServerConfiguration.getBoolean(PropertyKey.MASTER_JOURNAL_TOLERATE_CORRUPTION)) {
+      if (Configuration.getBoolean(PropertyKey.MASTER_JOURNAL_TOLERATE_CORRUPTION)) {
         return;
       }
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalAppender.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalAppender.java
@@ -12,7 +12,7 @@
 package alluxio.master.journal.raft;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.LogUtils;
 
 import org.apache.ratis.client.RaftClient;
@@ -38,7 +38,7 @@ import java.util.function.Supplier;
 public class RaftJournalAppender implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(RaftJournalAppender.class);
   private static final boolean MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED =
-      ServerConfiguration.getBoolean(PropertyKey.MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED);
+      Configuration.getBoolean(PropertyKey.MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED);
   /** Hosting server for the appender. Used by default for appending log entries. */
   private final RaftServer mServer;
   /** local client ID, provided along with hosting server.  */

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -13,7 +13,7 @@ package alluxio.master.journal.raft;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.CancelledException;
 import alluxio.exception.status.UnavailableException;
@@ -249,15 +249,15 @@ public class RaftJournalSystem extends AbstractJournalSystem {
    */
   public RaftJournalSystem(URI path, ServiceType serviceType) {
     this(path,
-        NetworkAddressUtils.getConnectAddress(serviceType, ServerConfiguration.global()),
-        ConfigurationUtils.getEmbeddedJournalAddresses(ServerConfiguration.global(), serviceType));
+        NetworkAddressUtils.getConnectAddress(serviceType, Configuration.global()),
+        ConfigurationUtils.getEmbeddedJournalAddresses(Configuration.global(), serviceType));
   }
 
   @VisibleForTesting
   RaftJournalSystem(URI path, InetSocketAddress localAddress,
       List<InetSocketAddress> clusterAddresses) {
     Preconditions.checkState(clusterAddresses.contains(localAddress)
-        || NetworkAddressUtils.containsLocalIp(clusterAddresses, ServerConfiguration.global()),
+        || NetworkAddressUtils.containsLocalIp(clusterAddresses, Configuration.global()),
         "The cluster addresses (%s) must contain the local master address (%s)",
         clusterAddresses, localAddress);
 
@@ -293,7 +293,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
       mStateMachine.close();
     }
     mStateMachine = new JournalStateMachine(mJournals, this,
-        ServerConfiguration.getInt(PropertyKey.MASTER_JOURNAL_LOG_CONCURRENCY_MAX));
+        Configuration.getInt(PropertyKey.MASTER_JOURNAL_LOG_CONCURRENCY_MAX));
 
     RaftProperties properties = new RaftProperties();
     Parameters parameters = new Parameters();
@@ -310,7 +310,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
         RaftJournalUtils.getRaftJournalDir(mPath)));
 
     // segment size
-    long segmentSize = ServerConfiguration.getBytes(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX);
+    long segmentSize = Configuration.getBytes(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX);
     LOG.debug("Creating journal with max segment size {}", segmentSize);
     if (segmentSize > Integer.MAX_VALUE) {
       LOG.warn("{} has value {} but must not exceed {}. Resetting to {}.",
@@ -323,30 +323,30 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     // the following configurations need to be changed when the single journal entry
     // is unexpectedly big.
     RaftServerConfigKeys.Log.Appender.setBufferByteLimit(properties,
-        SizeInBytes.valueOf(ServerConfiguration.global()
+        SizeInBytes.valueOf(Configuration.global()
             .getBytes(PropertyKey.MASTER_EMBEDDED_JOURNAL_ENTRY_SIZE_MAX)));
     // this property defines the maximum allowed size of the concurrent journal flush requests.
     // if the total size of the journal entries contained in the flush requests
     // are bigger than the given threshold, Ratis may error out as
     // `Log entry size 117146048 exceeds the max buffer limit of 104857600`
     RaftServerConfigKeys.Write.setByteLimit(properties,
-        SizeInBytes.valueOf(ServerConfiguration.global()
+        SizeInBytes.valueOf(Configuration.global()
             .getBytes(PropertyKey.MASTER_EMBEDDED_JOURNAL_FLUSH_SIZE_MAX)));
     // this property defines the maximum allowed size of the concurrent journal write IO tasks.
     // if the total size of the journal entries contained in the write IO tasks
     // are bigger than the given threshold, ratis may error out as
     // `SegmentedRaftLogWorker: elementNumBytes = 78215699 > byteLimit = 67108864`
-    RaftServerConfigKeys.Log.setQueueByteLimit(properties, (int) ServerConfiguration
+    RaftServerConfigKeys.Log.setQueueByteLimit(properties, (int) Configuration
         .global().getBytes(PropertyKey.MASTER_EMBEDDED_JOURNAL_FLUSH_SIZE_MAX));
 
     // Override election/heartbeat timeouts for single master cluster if election timeout is not
     // set explicitly. This is to speed up single master cluster boot-up.
-    long min = ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT);
-    long max = ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT);
+    long min = Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT);
+    long max = Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT);
     if (mClusterAddresses.size() == 1
-        && !ServerConfiguration.isSetByUser(
+        && !Configuration.isSetByUser(
         PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT)
-        && !ServerConfiguration.isSetByUser(
+        && !Configuration.isSetByUser(
         PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT)) {
       LOG.info("Overriding election timeout to {}ms for single master cluster.",
           SINGLE_MASTER_ELECTION_TIMEOUT_MS);
@@ -364,11 +364,11 @@ public class RaftJournalSystem extends AbstractJournalSystem {
 
     // request timeout
     RaftServerConfigKeys.Rpc.setRequestTimeout(properties, TimeDuration.valueOf(
-        ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_TRANSPORT_REQUEST_TIMEOUT_MS),
+        Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_TRANSPORT_REQUEST_TIMEOUT_MS),
         TimeUnit.MILLISECONDS));
 
     RaftServerConfigKeys.RetryCache.setExpiryTime(properties, TimeDuration.valueOf(
-        ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RETRY_CACHE_EXPIRY_TIME),
+        Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RETRY_CACHE_EXPIRY_TIME),
         TimeUnit.MILLISECONDS));
 
     // snapshot retention
@@ -378,11 +378,11 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     RaftServerConfigKeys.Snapshot.setAutoTriggerEnabled(
         properties, true);
     int snapshotAutoTriggerThreshold =
-        ServerConfiguration.global().getInt(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES);
+        Configuration.global().getInt(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES);
     RaftServerConfigKeys.Snapshot.setAutoTriggerThreshold(properties,
         snapshotAutoTriggerThreshold);
 
-    if (ServerConfiguration.global().getBoolean(PropertyKey.MASTER_JOURNAL_LOCAL_LOG_COMPACTION)) {
+    if (Configuration.global().getBoolean(PropertyKey.MASTER_JOURNAL_LOCAL_LOG_COMPACTION)) {
       // purges log files after taking a snapshot successfully
       RaftServerConfigKeys.Log.setPurgeUptoSnapshotIndex(properties, true);
       // leaves no gap between log file purges: all log files included in a newly installed
@@ -418,7 +418,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     RaftServerConfigKeys.LeaderElection.setLeaderStepDownWaitTime(properties,
         TimeDuration.valueOf(Long.MAX_VALUE, TimeUnit.MILLISECONDS));
 
-    long messageSize = ServerConfiguration.global().getBytes(
+    long messageSize = Configuration.global().getBytes(
         PropertyKey.MASTER_EMBEDDED_JOURNAL_TRANSPORT_MAX_INBOUND_MESSAGE_SIZE);
     GrpcConfigKeys.setMessageSizeMax(properties,
         SizeInBytes.valueOf(messageSize));
@@ -460,11 +460,11 @@ public class RaftJournalSystem extends AbstractJournalSystem {
 
   private RaftClient createClient() {
     long timeoutMs =
-        ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT);
+        Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT);
     long retryBaseMs =
-        ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_INTERVAL);
+        Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_INTERVAL);
     long maxSleepTimeMs =
-        ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT);
+        Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT);
     RaftProperties properties = new RaftProperties();
     Parameters parameters = new Parameters();
     RaftClientConfigKeys.Rpc.setRequestTimeout(properties,
@@ -652,7 +652,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
       throws TimeoutException, InterruptedException {
     long startTime = System.currentTimeMillis();
     long waitBeforeRetry =
-        ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_CATCHUP_RETRY_WAIT);
+        Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_CATCHUP_RETRY_WAIT);
     // Wait for any outstanding snapshot to complete.
     CommonUtils.waitFor("snapshotting to finish", () -> !stateMachine.isSnapshotting(),
         WaitForOptions.defaults().setTimeoutMs(10 * Constants.MINUTE_MS));
@@ -729,7 +729,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
       // are not leader.
       try {
         long maxElectionTimeoutMs =
-            ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT);
+            Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT);
         CommonUtils.waitFor("check primacySN " + gainPrimacySN + " and lastAppliedSN "
             + lastAppliedSN + " to be applied to leader", () ->
             stateMachine.getLastAppliedSequenceNumber() == lastAppliedSN
@@ -850,7 +850,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
           .setRpcPort(hp.getPort()).build();
 
       long maxElectionTimeoutMs =
-          ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT);
+          Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT);
       quorumMemberStateList.add(QuorumServerInfo.newBuilder()
               .setIsLeader(false)
               .setPriority(member.getId().getPriority())

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
@@ -12,7 +12,7 @@
 package alluxio.master.journal.raft;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.JournalClosedException;
 import alluxio.master.journal.JournalWriter;
 import alluxio.proto.journal.Journal.JournalEntry;
@@ -42,9 +42,9 @@ public class RaftJournalWriter implements JournalWriter {
   private static final Logger LOG = LoggerFactory.getLogger(RaftJournalWriter.class);
   // How long to wait for a response from the cluster before giving up and trying again.
   private static final long MASTER_EMBEDDED_JOURNAL_WRITE_TIMEOUT =
-      ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_WRITE_TIMEOUT);
+      Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_WRITE_TIMEOUT);
   private static final long MASTER_EMBEDDED_JOURNAL_ENTRY_SIZE_MAX =
-      ServerConfiguration.getBytes(PropertyKey.MASTER_EMBEDDED_JOURNAL_ENTRY_SIZE_MAX);
+      Configuration.getBytes(PropertyKey.MASTER_EMBEDDED_JOURNAL_ENTRY_SIZE_MAX);
   // journal entry size max is the hard limit set by underlying ratis
   // we use a smaller value to guarantee we don't pass the hard limit
   private static final long FLUSH_BATCH_SIZE = MASTER_EMBEDDED_JOURNAL_ENTRY_SIZE_MAX / 3;

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
@@ -13,7 +13,7 @@ package alluxio.master.journal.raft;
 
 import alluxio.ClientContext;
 import alluxio.collections.Pair;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.AbortedException;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.NotFoundException;
@@ -525,7 +525,7 @@ public class SnapshotReplicationManager {
   synchronized RaftJournalServiceClient createJournalServiceClient()
       throws AlluxioStatusException {
     RaftJournalServiceClient client = new RaftJournalServiceClient(MasterClientContext
-        .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+        .newBuilder(ClientContext.create(Configuration.global())).build());
     client.connect();
     return client;
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotUploader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotUploader.java
@@ -12,7 +12,7 @@
 package alluxio.master.journal.raft;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.grpc.DownloadSnapshotPRequest;
 import alluxio.grpc.DownloadSnapshotPResponse;
@@ -47,7 +47,7 @@ import java.util.function.Function;
 public class SnapshotUploader<S, R>
     implements StreamObserver<R>, ClientResponseObserver<S, R> {
   private static final Logger LOG = LoggerFactory.getLogger(SnapshotUploader.class);
-  private static final int SNAPSHOT_CHUNK_SIZE = (int) ServerConfiguration.getBytes(
+  private static final int SNAPSHOT_CHUNK_SIZE = (int) Configuration.getBytes(
       PropertyKey.MASTER_EMBEDDED_JOURNAL_SNAPSHOT_REPLICATION_CHUNK_SIZE);
 
   private final Function<SnapshotData, S> mDataMessageBuilder;

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
@@ -12,7 +12,7 @@
 package alluxio.master.journal.ufs;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.JournalClosedException;
 import alluxio.exception.status.CancelledException;
 import alluxio.exception.status.UnavailableException;
@@ -137,8 +137,8 @@ public class UfsJournal implements Journal {
    */
   public static UnderFileSystemConfiguration getJournalUfsConf() {
     Map<String, Object> ufsConf =
-        ServerConfiguration.getNestedProperties(PropertyKey.MASTER_JOURNAL_UFS_OPTION);
-    return UnderFileSystemConfiguration.defaults(ServerConfiguration.global())
+        Configuration.getNestedProperties(PropertyKey.MASTER_JOURNAL_UFS_OPTION);
+    return UnderFileSystemConfiguration.defaults(Configuration.global())
                .createMountSpecificConf(ufsConf);
   }
 
@@ -426,7 +426,7 @@ public class UfsJournal implements Journal {
         return false;
       }
       // Search for the format file.
-      String filePrefix = ServerConfiguration.getString(PropertyKey.MASTER_FORMAT_FILE_PREFIX);
+      String filePrefix = Configuration.getString(PropertyKey.MASTER_FORMAT_FILE_PREFIX);
       return Arrays.stream(files).anyMatch(file -> file.getName().startsWith(filePrefix));
     } catch (IOException e) {
       return false;
@@ -461,7 +461,7 @@ public class UfsJournal implements Journal {
 
     // Create a breadcrumb that indicates that the journal folder has been formatted.
     UnderFileSystemUtils.touch(mUfs, URIUtils.appendPathOrDie(location,
-        ServerConfiguration.getString(
+        Configuration.getString(
             PropertyKey.MASTER_FORMAT_FILE_PREFIX) + System.currentTimeMillis())
         .toString());
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
@@ -13,7 +13,7 @@ package alluxio.master.journal.ufs;
 
 import alluxio.ProcessUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.Master;
 import alluxio.master.journal.JournalReader;
 import alluxio.master.journal.JournalUtils;
@@ -121,10 +121,10 @@ public final class UfsJournalCheckpointThread extends Thread {
     mJournal = Preconditions.checkNotNull(journal, "journal");
     mShutdownQuietWaitTimeMs = journal.getQuietPeriodMs();
     mJournalCheckpointSleepTimeMs =
-        (int) ServerConfiguration.getMs(PropertyKey.MASTER_JOURNAL_TAILER_SLEEP_TIME_MS);
+        (int) Configuration.getMs(PropertyKey.MASTER_JOURNAL_TAILER_SLEEP_TIME_MS);
     mJournalReader = new UfsJournalReader(mJournal, startSequence, false);
     mCheckpointPeriodEntries =
-        ServerConfiguration.getInt(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES);
+        Configuration.getInt(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES);
     mJournalSinks = journalSinks;
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalFileParser.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalFileParser.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.journal.ufs;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.journal.JournalFileParser;
 import alluxio.proto.journal.Journal;
 import alluxio.underfs.UnderFileSystem;
@@ -51,7 +51,7 @@ public final class UfsJournalFileParser implements JournalFileParser {
   public UfsJournalFileParser(URI location) {
     mLocation = Preconditions.checkNotNull(location, "location");
     mUfs = UnderFileSystem.Factory.create(mLocation.toString(),
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global()));
+        UnderFileSystemConfiguration.defaults(Configuration.global()));
   }
 
   @Override

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalGarbageCollector.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalGarbageCollector.java
@@ -13,7 +13,7 @@ package alluxio.master.journal.ufs;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.ThreadFactoryUtils;
 
@@ -55,7 +55,7 @@ final class UfsJournalGarbageCollector implements Closeable {
     mJournal = Preconditions.checkNotNull(journal, "journal");
     mUfs = mJournal.getUfs();
     mGc = mExecutor.scheduleAtFixedRate(this::gc,
-        Constants.SECOND_MS, ServerConfiguration.getMs(PropertyKey.MASTER_JOURNAL_GC_PERIOD_MS),
+        Constants.SECOND_MS, Configuration.getMs(PropertyKey.MASTER_JOURNAL_GC_PERIOD_MS),
         TimeUnit.MILLISECONDS);
   }
 
@@ -128,8 +128,8 @@ final class UfsJournalGarbageCollector implements Closeable {
     }
 
     long thresholdMs = file.isTmpCheckpoint()
-        ? ServerConfiguration.getMs(PropertyKey.MASTER_JOURNAL_TEMPORARY_FILE_GC_THRESHOLD_MS)
-        : ServerConfiguration.getMs(PropertyKey.MASTER_JOURNAL_GC_THRESHOLD_MS);
+        ? Configuration.getMs(PropertyKey.MASTER_JOURNAL_TEMPORARY_FILE_GC_THRESHOLD_MS)
+        : Configuration.getMs(PropertyKey.MASTER_JOURNAL_GC_THRESHOLD_MS);
 
     if (System.currentTimeMillis() - lastModifiedTimeMs > thresholdMs) {
       deleteNoException(file.getLocation());

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
@@ -13,7 +13,7 @@ package alluxio.master.journal.ufs;
 
 import alluxio.RuntimeConstants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.JournalClosedException;
 import alluxio.exception.JournalClosedException.IOJournalClosedException;
@@ -99,7 +99,7 @@ final class UfsJournalLogWriter implements JournalWriter {
     mJournal = Preconditions.checkNotNull(journal, "journal");
     mUfs = mJournal.getUfs();
     mNextSequenceNumber = nextSequenceNumber;
-    mMaxLogSize = ServerConfiguration.getBytes(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX);
+    mMaxLogSize = Configuration.getBytes(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX);
 
     mRotateLogForNextWrite = true;
     UfsJournalFile currentLog = UfsJournalSnapshot.getCurrentLog(mJournal);
@@ -294,7 +294,7 @@ final class UfsJournalLogWriter implements JournalWriter {
     UfsJournalFile currentLog = UfsJournalFile.createLogFile(newLog, startSequenceNumber,
         UfsJournal.UNKNOWN_SEQUENCE_NUMBER);
     OutputStream outputStream = mUfs.create(currentLog.getLocation().toString(),
-        CreateOptions.defaults(ServerConfiguration.global()).setEnsureAtomic(false)
+        CreateOptions.defaults(Configuration.global()).setEnsureAtomic(false)
             .setCreateParent(true));
     mJournalOutputStream = new JournalOutputStream(currentLog, outputStream);
     LOG.info("Created current log file: {}", currentLog);

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
@@ -13,7 +13,7 @@ package alluxio.master.journal.ufs;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.Master;
 import alluxio.master.journal.AbstractJournalSystem;
 import alluxio.master.journal.CatchupFuture;
@@ -162,7 +162,7 @@ public class UfsJournalSystem extends AbstractJournalSystem {
         }
         return true;
       }, WaitForOptions.defaults().setTimeoutMs(
-          (int) ServerConfiguration.getMs(PropertyKey.MASTER_UFS_JOURNAL_MAX_CATCHUP_TIME))
+          (int) Configuration.getMs(PropertyKey.MASTER_UFS_JOURNAL_MAX_CATCHUP_TIME))
           .setInterval(Constants.SECOND_MS));
     } catch (InterruptedException | TimeoutException e) {
       LOG.info("Journal catchup is interrupted or timeout", e);

--- a/core/server/common/src/main/java/alluxio/master/journalv0/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/AsyncJournalWriter.java
@@ -12,7 +12,7 @@
 package alluxio.master.journalv0;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.proto.journal.Journal.JournalEntry;
 
 import com.google.common.base.Preconditions;
@@ -61,7 +61,7 @@ public final class AsyncJournalWriter {
     mWriteCounter = new AtomicLong(0);
     // convert milliseconds to nanoseconds.
     mFlushBatchTimeNs =
-        1000000L * ServerConfiguration.getMs(PropertyKey.MASTER_JOURNAL_FLUSH_BATCH_TIME_MS);
+        1000000L * Configuration.getMs(PropertyKey.MASTER_JOURNAL_FLUSH_BATCH_TIME_MS);
   }
 
   /**

--- a/core/server/common/src/main/java/alluxio/master/journalv0/ufs/UfsJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/ufs/UfsJournal.java
@@ -12,7 +12,7 @@
 package alluxio.master.journalv0.ufs;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.journalv0.Journal;
 import alluxio.master.journalv0.JournalFormatter;
 import alluxio.master.journalv0.JournalReader;
@@ -131,7 +131,7 @@ public class UfsJournal implements Journal {
   public boolean isFormatted() throws IOException {
     UfsStatus[] files;
     try (UnderFileSystem ufs = UnderFileSystem.Factory.create(mLocation.toString(),
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global()))) {
+        UnderFileSystemConfiguration.defaults(Configuration.global()))) {
       files = ufs.listStatus(mLocation.toString());
     }
 
@@ -139,7 +139,7 @@ public class UfsJournal implements Journal {
       return false;
     }
     // Search for the format file.
-    String formatFilePrefix = ServerConfiguration.getString(PropertyKey.MASTER_FORMAT_FILE_PREFIX);
+    String formatFilePrefix = Configuration.getString(PropertyKey.MASTER_FORMAT_FILE_PREFIX);
     for (UfsStatus file : files) {
       if (file.getName().startsWith(formatFilePrefix)) {
         return true;

--- a/core/server/common/src/main/java/alluxio/master/journalv0/ufs/UfsJournalReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/ufs/UfsJournalReader.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.journalv0.ufs;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.journalv0.JournalInputStream;
 import alluxio.master.journalv0.JournalReader;
 import alluxio.underfs.UnderFileSystem;
@@ -55,7 +55,7 @@ public class UfsJournalReader implements JournalReader {
   UfsJournalReader(UfsJournal journal) {
     mJournal = Preconditions.checkNotNull(journal, "journal");
     mUfs = UnderFileSystem.Factory.create(mJournal.getLocation().toString(),
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global()));
+        UnderFileSystemConfiguration.defaults(Configuration.global()));
     mCheckpoint = mJournal.getCheckpoint();
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journalv0/ufs/UfsJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/ufs/UfsJournalWriter.java
@@ -13,7 +13,7 @@ package alluxio.master.journalv0.ufs;
 
 import alluxio.RuntimeConstants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.master.journalv0.JournalFormatter;
 import alluxio.master.journalv0.JournalOutputStream;
@@ -81,7 +81,7 @@ public final class UfsJournalWriter implements JournalWriter {
       throw new RuntimeException(e);
     }
     mUfs = UnderFileSystem.Factory.create(mJournal.getLocation().toString(),
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global()));
+        UnderFileSystemConfiguration.defaults(Configuration.global()));
     mCheckpointManager = new UfsCheckpointManager(mUfs, mJournal.getCheckpoint(), this);
   }
 
@@ -319,9 +319,9 @@ public final class UfsJournalWriter implements JournalWriter {
       mCurrentLog = log;
       mJournalFormatter = journalFormatter;
       mJournalWriter = journalWriter;
-      mMaxLogSize = ServerConfiguration.getBytes(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX);
+      mMaxLogSize = Configuration.getBytes(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX);
       mRawOutputStream = mUfs.create(mCurrentLog.toString(),
-          CreateOptions.defaults(ServerConfiguration.global())
+          CreateOptions.defaults(Configuration.global())
               .setEnsureAtomic(false).setCreateParent(true));
       LOG.info("Opened current log file: {}", mCurrentLog);
       mDataOutputStream = new DataOutputStream(mRawOutputStream);
@@ -400,7 +400,7 @@ public final class UfsJournalWriter implements JournalWriter {
       mDataOutputStream.close();
       mJournalWriter.completeCurrentLog();
       mRawOutputStream = mUfs.create(mCurrentLog.toString(),
-          CreateOptions.defaults(ServerConfiguration.global()).setEnsureAtomic(false)
+          CreateOptions.defaults(Configuration.global()).setEnsureAtomic(false)
               .setCreateParent(true));
       LOG.info("Opened current log file: {}", mCurrentLog);
       mDataOutputStream = new DataOutputStream(mRawOutputStream);

--- a/core/server/common/src/main/java/alluxio/master/journalv0/ufs/UfsMutableJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journalv0/ufs/UfsMutableJournal.java
@@ -12,7 +12,7 @@
 package alluxio.master.journalv0.ufs;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.journalv0.JournalWriter;
 import alluxio.master.journalv0.MutableJournal;
 import alluxio.underfs.UfsStatus;
@@ -48,7 +48,7 @@ public class UfsMutableJournal extends UfsJournal implements MutableJournal {
   public void format() throws IOException {
     LOG.info("Formatting {}", mLocation);
     try (UnderFileSystem ufs = UnderFileSystem.Factory.create(mLocation.toString(),
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global()))) {
+        UnderFileSystemConfiguration.defaults(Configuration.global()))) {
       if (ufs.isDirectory(mLocation.toString())) {
         for (UfsStatus p : ufs.listStatus(mLocation.toString())) {
           URI childPath;
@@ -75,7 +75,7 @@ public class UfsMutableJournal extends UfsJournal implements MutableJournal {
       // Create a breadcrumb that indicates that the journal folder has been formatted.
       try {
         UnderFileSystemUtils.touch(ufs, URIUtils.appendPath(mLocation,
-            ServerConfiguration.getString(PropertyKey.MASTER_FORMAT_FILE_PREFIX)
+            Configuration.getString(PropertyKey.MASTER_FORMAT_FILE_PREFIX)
                 + System.currentTimeMillis())
             .toString());
       } catch (URISyntaxException e) {

--- a/core/server/common/src/main/java/alluxio/security/user/ServerUserState.java
+++ b/core/server/common/src/main/java/alluxio/security/user/ServerUserState.java
@@ -11,13 +11,13 @@
 
 package alluxio.security.user;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 /**
  * Server global instance of the UserState.
  */
 public class ServerUserState {
-  private static final UserState INSTANCE = UserState.Factory.create(ServerConfiguration.global());
+  private static final UserState INSTANCE = UserState.Factory.create(Configuration.global());
 
   private ServerUserState() {} // prevent instantiation
 

--- a/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
+++ b/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
@@ -14,7 +14,7 @@ package alluxio.underfs;
 import alluxio.AlluxioURI;
 import alluxio.concurrent.ManagedBlockingUfsForwarder;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.NotFoundException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.journal.ufs.UfsJournal;
@@ -193,15 +193,15 @@ public abstract class AbstractUfsManager implements UfsManager {
   public UfsClient getRoot() {
     synchronized (this) {
       if (mRootUfsClient == null) {
-        String rootUri = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+        String rootUri = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
         boolean rootReadOnly =
-            ServerConfiguration.getBoolean(PropertyKey.MASTER_MOUNT_TABLE_ROOT_READONLY);
-        boolean rootShared = ServerConfiguration
+            Configuration.getBoolean(PropertyKey.MASTER_MOUNT_TABLE_ROOT_READONLY);
+        boolean rootShared = Configuration
             .getBoolean(PropertyKey.MASTER_MOUNT_TABLE_ROOT_SHARED);
         Map<String, Object> rootConf =
-            ServerConfiguration.getNestedProperties(PropertyKey.MASTER_MOUNT_TABLE_ROOT_OPTION);
+            Configuration.getNestedProperties(PropertyKey.MASTER_MOUNT_TABLE_ROOT_OPTION);
         addMount(IdUtils.ROOT_MOUNT_ID, new AlluxioURI(rootUri),
-            UnderFileSystemConfiguration.defaults(ServerConfiguration.global())
+            UnderFileSystemConfiguration.defaults(Configuration.global())
                 .setReadOnly(rootReadOnly).setShared(rootShared).createMountSpecificConf(rootConf));
         try {
           mRootUfsClient = get(IdUtils.ROOT_MOUNT_ID);

--- a/core/server/common/src/main/java/alluxio/util/FeatureUtils.java
+++ b/core/server/common/src/main/java/alluxio/util/FeatureUtils.java
@@ -12,7 +12,7 @@
 package alluxio.util;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.journal.JournalType;
 import alluxio.master.metastore.MetastoreType;
 
@@ -26,7 +26,7 @@ public final class FeatureUtils {
    * @return true, if running with embedded journal
    */
   public static boolean isEmbeddedJournal() {
-    return JournalType.EMBEDDED == ServerConfiguration.get(PropertyKey.MASTER_JOURNAL_TYPE);
+    return JournalType.EMBEDDED == Configuration.get(PropertyKey.MASTER_JOURNAL_TYPE);
   }
 
   /**
@@ -35,7 +35,7 @@ public final class FeatureUtils {
    * @return true, if running with rocks
    */
   public static boolean isRocks() {
-    return ServerConfiguration.get(PropertyKey.MASTER_METASTORE) == MetastoreType.ROCKS;
+    return Configuration.get(PropertyKey.MASTER_METASTORE) == MetastoreType.ROCKS;
   }
 
   /**
@@ -44,7 +44,7 @@ public final class FeatureUtils {
    * @return true, if Zookeeper is enabled
    */
   public static boolean isZookeeperEnabled() {
-    return ServerConfiguration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED);
+    return Configuration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED);
   }
 
   /**
@@ -53,7 +53,7 @@ public final class FeatureUtils {
    * @return true, if backup delegation is enabled
    */
   public static boolean isBackupDelegationEnabled() {
-    return ServerConfiguration.getBoolean(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED);
+    return Configuration.getBoolean(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED);
   }
 
   /**
@@ -62,7 +62,7 @@ public final class FeatureUtils {
    * @return true, if daily backup is enabled
    */
   public static boolean isDailyBackupEnabled() {
-    return ServerConfiguration.getBoolean(PropertyKey.MASTER_DAILY_BACKUP_ENABLED);
+    return Configuration.getBoolean(PropertyKey.MASTER_DAILY_BACKUP_ENABLED);
   }
 
   /**
@@ -71,8 +71,8 @@ public final class FeatureUtils {
    * @return true, if persistence black list is empty
    */
   public static boolean isPersistenceBlacklistEmpty() {
-    return !ServerConfiguration.isSet(PropertyKey.MASTER_PERSISTENCE_BLACKLIST)
-        || ServerConfiguration.getList(PropertyKey.MASTER_PERSISTENCE_BLACKLIST).isEmpty();
+    return !Configuration.isSet(PropertyKey.MASTER_PERSISTENCE_BLACKLIST)
+        || Configuration.getList(PropertyKey.MASTER_PERSISTENCE_BLACKLIST).isEmpty();
   }
 
   /**
@@ -81,7 +81,7 @@ public final class FeatureUtils {
    * @return true, if unsafe direct persistence is enabled
    */
   public static boolean isUnsafeDirectPersistEnabled() {
-    return ServerConfiguration.getBoolean(PropertyKey.MASTER_UNSAFE_DIRECT_PERSIST_OBJECT_ENABLED);
+    return Configuration.getBoolean(PropertyKey.MASTER_UNSAFE_DIRECT_PERSIST_OBJECT_ENABLED);
   }
 
   /**
@@ -90,6 +90,6 @@ public final class FeatureUtils {
    * @return true, if master audir logging is enabled
    */
   public static boolean isMasterAuditLoggingEnabled() {
-    return ServerConfiguration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED);
+    return Configuration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED);
   }
 }

--- a/core/server/common/src/main/java/alluxio/web/StacksServlet.java
+++ b/core/server/common/src/main/java/alluxio/web/StacksServlet.java
@@ -12,7 +12,7 @@
 package alluxio.web;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.ThreadUtils;
 
 import org.slf4j.Logger;
@@ -40,7 +40,7 @@ public class StacksServlet extends HttpServlet {
         resp.getOutputStream(), false, "UTF-8")) {
       ThreadUtils.printThreadInfo(out, "");
     }
-    if (ServerConfiguration.getBoolean(PropertyKey.WEB_THREAD_DUMP_TO_LOG)) {
+    if (Configuration.getBoolean(PropertyKey.WEB_THREAD_DUMP_TO_LOG)) {
       ThreadUtils.logThreadInfo(LOG, "jsp requested", 1);
     }
   }

--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -15,7 +15,7 @@ import static alluxio.Constants.REST_API_PREFIX;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.metrics.MetricsSystem;
 import alluxio.metrics.sink.MetricsServlet;
 import alluxio.metrics.sink.PrometheusMetricsServlet;
@@ -75,7 +75,7 @@ public abstract class WebServer {
     mServiceName = serviceName;
 
     QueuedThreadPool threadPool = new QueuedThreadPool();
-    int webThreadCount = ServerConfiguration.getInt(PropertyKey.WEB_THREADS);
+    int webThreadCount = Configuration.getInt(PropertyKey.WEB_THREADS);
 
     // Jetty needs at least (1 + selectors + acceptors) threads.
     threadPool.setMinThreads(webThreadCount * 2 + 1);

--- a/core/server/common/src/test/java/alluxio/DefaultStorageTierAssocTest.java
+++ b/core/server/common/src/test/java/alluxio/DefaultStorageTierAssocTest.java
@@ -13,7 +13,7 @@ package alluxio;
 
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.BlockStoreLocation;
 
 import org.junit.Assert;
@@ -31,13 +31,13 @@ public final class DefaultStorageTierAssocTest
 
   private void checkStorageTierAssoc(StorageTierAssoc assoc, PropertyKey levelsProperty,
       PropertyKey.Template template) {
-    int size = ServerConfiguration.getInt(levelsProperty);
+    int size = Configuration.getInt(levelsProperty);
     Assert.assertEquals(size, assoc.size());
 
     List<String> expectedOrderedAliases = new ArrayList<>();
 
     for (int i = 0; i < size; i++) {
-      String alias = ServerConfiguration.getString(template.format(i));
+      String alias = Configuration.getString(template.format(i));
       Assert.assertEquals(i, assoc.getOrdinal(alias));
       Assert.assertEquals(alias, assoc.getAlias(i));
       expectedOrderedAliases.add(alias);

--- a/core/server/common/src/test/java/alluxio/RestUtilsTest.java
+++ b/core/server/common/src/test/java/alluxio/RestUtilsTest.java
@@ -11,7 +11,7 @@
 
 package alluxio;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.AlluxioStatusException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,7 +33,7 @@ public class RestUtilsTest {
       public Void call() throws Exception {
         return null;
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     Assert.assertNull(response.getEntity());
   }
@@ -46,7 +46,7 @@ public class RestUtilsTest {
       public String call() throws Exception {
         return message;
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     ObjectMapper mapper = new ObjectMapper();
     String jsonMessage = mapper.writeValueAsString(message);
@@ -81,7 +81,7 @@ public class RestUtilsTest {
       public Obj call() throws Exception {
         return object;
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     Obj obj = (Obj) response.getEntity();
     Assert.assertEquals(status, obj.getStatus());
@@ -97,7 +97,7 @@ public class RestUtilsTest {
       public Void call() throws Exception {
         throw new AlluxioStatusException(status.withDescription(message));
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
     Assert.assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
         response.getStatus());
     RestUtils.ErrorResponse errorResponse = (RestUtils.ErrorResponse) response.getEntity();

--- a/core/server/common/src/test/java/alluxio/cli/FormatTest.java
+++ b/core/server/common/src/test/java/alluxio/cli/FormatTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.fail;
 
 import alluxio.ConfigurationRule;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.CommonUtils;
 import alluxio.util.io.FileUtils;
 import alluxio.util.io.PathUtils;
@@ -55,7 +55,7 @@ public final class FormatTest {
     };
     for (File dir : dirs) {
       workerDataFolder = CommonUtils.getWorkerDataDirectory(dir.getPath(),
-          ServerConfiguration.global());
+          Configuration.global());
       FileUtils.createDir(PathUtils.concatPath(workerDataFolder, "subdir"));
       FileUtils.createFile(PathUtils.concatPath(workerDataFolder, "file"));
     }
@@ -67,11 +67,11 @@ public final class FormatTest {
         put(PropertyKey.WORKER_TIERED_STORE_LEVELS, storageLevels);
         put(PropertyKey.WORKER_DATA_FOLDER_PERMISSIONS, perms);
       }
-    }, ServerConfiguration.global()).toResource()) {
-      Format.format(Format.Mode.WORKER, ServerConfiguration.global());
+    }, Configuration.modifiableGlobal()).toResource()) {
+      Format.format(Format.Mode.WORKER, Configuration.global());
       for (File dir : dirs) {
         workerDataFolder = CommonUtils.getWorkerDataDirectory(dir.getPath(),
-            ServerConfiguration.global());
+            Configuration.global());
         assertTrue(FileUtils.exists(dir.getPath()));
         assertTrue(FileUtils.exists(workerDataFolder));
         assertEquals(PosixFilePermissions.fromString(perms), Files.getPosixFilePermissions(Paths
@@ -98,7 +98,7 @@ public final class FormatTest {
     // Have files of same name as the target worker data dir in each tier
     for (File dir : dirs) {
       workerDataFolder = CommonUtils.getWorkerDataDirectory(dir.getPath(),
-          ServerConfiguration.global());
+          Configuration.global());
       FileUtils.createFile(workerDataFolder);
     }
     try (Closeable r = new ConfigurationRule(new HashMap<PropertyKey, Object>() {
@@ -108,13 +108,13 @@ public final class FormatTest {
         put(PropertyKey.WORKER_TIERED_STORE_LEVEL2_DIRS_PATH, dirs[2].getPath());
         put(PropertyKey.WORKER_TIERED_STORE_LEVELS, storageLevels);
       }
-    }, ServerConfiguration.global()).toResource()) {
-      final String perms = ServerConfiguration.getString(
+    }, Configuration.modifiableGlobal()).toResource()) {
+      final String perms = Configuration.getString(
           PropertyKey.WORKER_DATA_FOLDER_PERMISSIONS);
-      Format.format(Format.Mode.WORKER, ServerConfiguration.global());
+      Format.format(Format.Mode.WORKER, Configuration.global());
       for (File dir : dirs) {
         workerDataFolder = CommonUtils.getWorkerDataDirectory(dir.getPath(),
-            ServerConfiguration.global());
+            Configuration.global());
         assertTrue(Files.isDirectory(Paths.get(workerDataFolder)));
         assertEquals(PosixFilePermissions.fromString(perms), Files.getPosixFilePermissions(Paths
             .get(workerDataFolder)));

--- a/core/server/common/src/test/java/alluxio/master/ExecutorServiceBuilderTest.java
+++ b/core/server/common/src/test/java/alluxio/master/ExecutorServiceBuilderTest.java
@@ -13,7 +13,7 @@ package alluxio.master;
 
 import alluxio.executor.ExecutorServiceBuilder;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.executor.RpcExecutorType;
 import alluxio.executor.ThreadPoolExecutorQueueType;
 
@@ -31,13 +31,13 @@ public class ExecutorServiceBuilderTest {
 
   @Before
   public void before() throws Exception {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   @Test
   public void startZeroParallelism() {
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_TYPE, RpcExecutorType.FJP);
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_FJP_PARALLELISM, 0);
+    Configuration.set(PropertyKey.MASTER_RPC_EXECUTOR_TYPE, RpcExecutorType.FJP);
+    Configuration.set(PropertyKey.MASTER_RPC_EXECUTOR_FJP_PARALLELISM, 0);
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage(String.format(
         "Cannot start Alluxio master gRPC thread pool with "
@@ -48,8 +48,8 @@ public class ExecutorServiceBuilderTest {
 
   @Test
   public void startNegativeParallelism() {
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_TYPE, RpcExecutorType.FJP);
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_FJP_PARALLELISM, -1);
+    Configuration.set(PropertyKey.MASTER_RPC_EXECUTOR_TYPE, RpcExecutorType.FJP);
+    Configuration.set(PropertyKey.MASTER_RPC_EXECUTOR_FJP_PARALLELISM, -1);
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage(String.format(
         "Cannot start Alluxio master gRPC thread pool with"
@@ -60,7 +60,7 @@ public class ExecutorServiceBuilderTest {
 
   @Test
   public void startZeroKeepAliveTime() {
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_KEEPALIVE, "0");
+    Configuration.set(PropertyKey.MASTER_RPC_EXECUTOR_KEEPALIVE, "0");
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage(String.format(
         "Cannot start Alluxio master gRPC thread pool with %s=%s. "
@@ -71,7 +71,7 @@ public class ExecutorServiceBuilderTest {
 
   @Test
   public void startNegativeKeepAliveTime() {
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_KEEPALIVE, "-1");
+    Configuration.set(PropertyKey.MASTER_RPC_EXECUTOR_KEEPALIVE, "-1");
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage(String.format(
         "Cannot start Alluxio master gRPC thread pool with %s=%s. "
@@ -82,23 +82,23 @@ public class ExecutorServiceBuilderTest {
 
   @Test
   public void createTpeExecutor() {
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_TYPE, RpcExecutorType.TPE);
+    Configuration.set(PropertyKey.MASTER_RPC_EXECUTOR_TYPE, RpcExecutorType.TPE);
     ExecutorServiceBuilder.buildExecutorService(ExecutorServiceBuilder.RpcExecutorHost.MASTER);
   }
 
   @Test
   public void createTpeExecutorWithCoreThreadsTimeout() {
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_TYPE, RpcExecutorType.TPE);
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_TPE_ALLOW_CORE_THREADS_TIMEOUT, true);
+    Configuration.set(PropertyKey.MASTER_RPC_EXECUTOR_TYPE, RpcExecutorType.TPE);
+    Configuration.set(PropertyKey.MASTER_RPC_EXECUTOR_TPE_ALLOW_CORE_THREADS_TIMEOUT, true);
     ExecutorServiceBuilder.buildExecutorService(ExecutorServiceBuilder.RpcExecutorHost.MASTER);
   }
 
   @Test
   public void createTpeExecutorWithCustomQueues() {
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_TYPE, RpcExecutorType.TPE);
+    Configuration.set(PropertyKey.MASTER_RPC_EXECUTOR_TYPE, RpcExecutorType.TPE);
     for (ThreadPoolExecutorQueueType queueType:
         ThreadPoolExecutorQueueType.values()) {
-      ServerConfiguration.set(PropertyKey.MASTER_RPC_EXECUTOR_TPE_QUEUE_TYPE, queueType);
+      Configuration.set(PropertyKey.MASTER_RPC_EXECUTOR_TPE_QUEUE_TYPE, queueType);
       ExecutorServiceBuilder.buildExecutorService(ExecutorServiceBuilder.RpcExecutorHost.MASTER);
     }
   }

--- a/core/server/common/src/test/java/alluxio/master/StateLockManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/StateLockManagerTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.resource.LockResource;
 import alluxio.util.CommonUtils;
 import alluxio.util.ThreadUtils;
@@ -45,8 +45,8 @@ public class StateLockManagerTest {
   }
 
   private void configureInterruptCycle(boolean enabled, long intervalMs) {
-    ServerConfiguration.set(PropertyKey.MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_ENABLED, enabled);
-    ServerConfiguration.set(PropertyKey.MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_INTERVAL,
+    Configuration.set(PropertyKey.MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_ENABLED, enabled);
+    Configuration.set(PropertyKey.MASTER_BACKUP_STATE_LOCK_INTERRUPT_CYCLE_INTERVAL,
         intervalMs);
   }
 
@@ -113,7 +113,7 @@ public class StateLockManagerTest {
   public void testExclusiveOnlyMode() throws Throwable {
     // Configure exclusive-only duration to cover the entire test execution.
     final long exclusiveOnlyDurationMs = 30 * 1000;
-    ServerConfiguration.set(PropertyKey.MASTER_BACKUP_STATE_LOCK_EXCLUSIVE_DURATION,
+    Configuration.set(PropertyKey.MASTER_BACKUP_STATE_LOCK_EXCLUSIVE_DURATION,
         exclusiveOnlyDurationMs);
 
     // The state-lock instance.

--- a/core/server/common/src/test/java/alluxio/master/journal/AsyncJournalWriterTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/AsyncJournalWriterTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.proto.journal.Journal.JournalEntry;
 
 import org.junit.After;
@@ -40,14 +40,14 @@ public class AsyncJournalWriterTest {
 
   @After
   public void after() throws Exception {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   private void setupAsyncJournalWriter(boolean batchingEnabled) throws Exception {
     if (batchingEnabled) {
-      ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_FLUSH_BATCH_TIME_MS, "500ms");
+      Configuration.set(PropertyKey.MASTER_JOURNAL_FLUSH_BATCH_TIME_MS, "500ms");
     } else {
-      ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_FLUSH_BATCH_TIME_MS, "0ms");
+      Configuration.set(PropertyKey.MASTER_JOURNAL_FLUSH_BATCH_TIME_MS, "0ms");
     }
 
     mMockJournalWriter = mock(JournalWriter.class);

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalSystemConfigTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalSystemConfigTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
 
@@ -41,12 +41,12 @@ public final class RaftJournalSystemConfigTest {
 
   @After
   public void after() {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   @Test
   public void defaultDefaults() throws Exception {
-    ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "testhost");
+    Configuration.set(PropertyKey.MASTER_HOSTNAME, "testhost");
     RaftJournalSystem system =
         new RaftJournalSystem(mFolder.newFolder().toURI(), ServiceType.MASTER_RAFT);
     InetSocketAddress address = getLocalAddress(system);
@@ -56,7 +56,7 @@ public final class RaftJournalSystemConfigTest {
   @Test
   public void port() throws Exception {
     int testPort = 10000;
-    ServerConfiguration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_PORT, testPort);
+    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_PORT, testPort);
     RaftJournalSystem system =
         new RaftJournalSystem(mFolder.newFolder().toURI(), ServiceType.MASTER_RAFT);
     InetSocketAddress localAddress = getLocalAddress(system);
@@ -67,7 +67,7 @@ public final class RaftJournalSystemConfigTest {
 
   @Test
   public void derivedMasterHostname() throws Exception {
-    ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "test");
+    Configuration.set(PropertyKey.MASTER_HOSTNAME, "test");
     RaftJournalSystem system =
         new RaftJournalSystem(mFolder.newFolder().toURI(), ServiceType.MASTER_RAFT);
     InetSocketAddress address = getLocalAddress(system);
@@ -76,7 +76,7 @@ public final class RaftJournalSystemConfigTest {
 
   @Test
   public void derivedJobMasterHostname() throws Exception {
-    ServerConfiguration.set(PropertyKey.JOB_MASTER_HOSTNAME, "test");
+    Configuration.set(PropertyKey.JOB_MASTER_HOSTNAME, "test");
     RaftJournalSystem system =
         new RaftJournalSystem(mFolder.newFolder().toURI(), ServiceType.JOB_MASTER_RAFT);
     InetSocketAddress address = getLocalAddress(system);
@@ -85,7 +85,7 @@ public final class RaftJournalSystemConfigTest {
 
   @Test
   public void derivedJobMasterHostnameFromMasterHostname() throws Exception {
-    ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "test");
+    Configuration.set(PropertyKey.MASTER_HOSTNAME, "test");
     RaftJournalSystem system =
         new RaftJournalSystem(mFolder.newFolder().toURI(), ServiceType.JOB_MASTER_RAFT);
     InetSocketAddress address = getLocalAddress(system);
@@ -94,10 +94,10 @@ public final class RaftJournalSystemConfigTest {
 
   @Test
   public void derivedJobMasterAddressesFromMasterAddresses() throws Exception {
-    ServerConfiguration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES,
+    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES,
         "host1:10,host2:20,host3:10");
-    ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "host1");
-    ServerConfiguration.set(PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_PORT, 5);
+    Configuration.set(PropertyKey.MASTER_HOSTNAME, "host1");
+    Configuration.set(PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_PORT, 5);
     RaftJournalSystem system =
         new RaftJournalSystem(mFolder.newFolder().toURI(), ServiceType.JOB_MASTER_RAFT);
     List<InetSocketAddress> addresses = getClusterAddresses(system);
@@ -109,10 +109,10 @@ public final class RaftJournalSystemConfigTest {
 
   @Test
   public void derivedJobMasterAddressesFromJobMasterAddresses() throws Exception {
-    ServerConfiguration.set(PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_ADDRESSES,
+    Configuration.set(PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_ADDRESSES,
         "host1:10,host2:20,host3:10");
-    ServerConfiguration.set(PropertyKey.JOB_MASTER_HOSTNAME, "host1");
-    ServerConfiguration.set(PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_PORT, 10);
+    Configuration.set(PropertyKey.JOB_MASTER_HOSTNAME, "host1");
+    Configuration.set(PropertyKey.JOB_MASTER_EMBEDDED_JOURNAL_PORT, 10);
     RaftJournalSystem system =
         new RaftJournalSystem(mFolder.newFolder().toURI(), ServiceType.JOB_MASTER_RAFT);
     List<InetSocketAddress> addresses = getClusterAddresses(system);
@@ -131,7 +131,7 @@ public final class RaftJournalSystemConfigTest {
     // raftNodeAddress1's hostname is different with localAddress hostname, but
     // their ip both point to the local node.
     InetSocketAddress raftNodeAddress1 = new InetSocketAddress(NetworkAddressUtils
-        .getLocalHostName((int) ServerConfiguration.global()
+        .getLocalHostName((int) Configuration.global()
             .getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS)), 10);
     InetSocketAddress raftNodeAddress2 = new InetSocketAddress("host2", 20);
     InetSocketAddress raftNodeAddress3 = new InetSocketAddress("host3", 30);
@@ -139,7 +139,7 @@ public final class RaftJournalSystemConfigTest {
     clusterAddresses.add(raftNodeAddress2);
     clusterAddresses.add(raftNodeAddress3);
     assertTrue(clusterAddresses.contains(localAddress)
-        || NetworkAddressUtils.containsLocalIp(clusterAddresses, ServerConfiguration.global()));
+        || NetworkAddressUtils.containsLocalIp(clusterAddresses, Configuration.global()));
   }
 
   private InetSocketAddress getLocalAddress(RaftJournalSystem system) throws Exception {

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -12,7 +12,7 @@
 package alluxio.master.journal.raft;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.QuorumServerInfo;
 import alluxio.master.NoopMaster;
 import alluxio.master.journal.CatchupFuture;
@@ -59,7 +59,7 @@ public class RaftJournalTest {
     List<RaftJournalSystem> journalSystems = startJournalCluster(createJournalSystems(2));
     // Sleep for 2 leader election cycles for leadership to stabilize.
     Thread.sleep(2
-            * ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT));
+            * Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT));
 
     // Assign references for leader/follower journal systems.
     mLeaderJournalSystem = journalSystems.get(0);
@@ -174,7 +174,7 @@ public class RaftJournalTest {
     Assert.assertEquals(catchupIndex + 1, countingMaster.getApplyCount());
     // Wait for election timeout and verify follower master state hasn't changed.
     Thread.sleep(
-            ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT));
+            Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT));
     Assert.assertEquals(catchupIndex + 1, countingMaster.getApplyCount());
     // Exit backup mode and wait until follower master acquires the current knowledge.
     mFollowerJournalSystem.resume();
@@ -229,7 +229,7 @@ public class RaftJournalTest {
     // Restart the follower.
     mFollowerJournalSystem.stop();
     mFollowerJournalSystem.start();
-    Thread.sleep(ServerConfiguration.getMs(
+    Thread.sleep(Configuration.getMs(
         PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT));
 
     // Verify that all entries are replayed despite the snapshot was requested while some entries
@@ -456,8 +456,8 @@ public class RaftJournalTest {
    */
   private List<RaftJournalSystem> createJournalSystems(int journalSystemCount) throws Exception {
     // Override defaults for faster quorum formation.
-    ServerConfiguration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, 550);
-    ServerConfiguration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, 1100);
+    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, 550);
+    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, 1100);
 
     List<InetSocketAddress> clusterAddresses = new ArrayList<>(journalSystemCount);
     List<Integer> freePorts = getFreePorts(journalSystemCount);

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -15,7 +15,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 import alluxio.ConfigurationRule;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.JournalQueryRequest;
 import alluxio.grpc.NetAddress;
 import alluxio.grpc.QuorumServerInfo;
@@ -72,7 +72,7 @@ public class SnapshotReplicationManagerTest {
   @Rule
   public ConfigurationRule mConfigurationRule =
       new ConfigurationRule(PropertyKey.MASTER_EMBEDDED_JOURNAL_SNAPSHOT_REPLICATION_CHUNK_SIZE,
-          "32KB", ServerConfiguration.global());
+          "32KB", Configuration.modifiableGlobal());
 
   private final WaitForOptions mWaitOptions = WaitForOptions.defaults().setTimeoutMs(30_000);
   private SnapshotReplicationManager mLeaderSnapshotManager;

--- a/core/server/common/src/test/java/alluxio/master/transport/GrpcMessagingTransportTest.java
+++ b/core/server/common/src/test/java/alluxio/master/transport/GrpcMessagingTransportTest.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.transport;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.security.user.ServerUserState;
 
 import io.atomix.catalyst.buffer.BufferInput;
@@ -41,7 +41,7 @@ public class GrpcMessagingTransportTest {
   @Before
   public void before() {
     mTransport = new GrpcMessagingTransport(
-        ServerConfiguration.global(), ServerUserState.global(), "TestClient");
+        Configuration.global(), ServerUserState.global(), "TestClient");
   }
 
   @After

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -15,8 +15,8 @@ import static alluxio.util.network.NetworkAddressUtils.ServiceType;
 
 import alluxio.AlluxioURI;
 import alluxio.RuntimeConstants;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
 import alluxio.executor.ExecutorServiceBuilder;
 import alluxio.grpc.GrpcServer;
 import alluxio.grpc.GrpcServerAddress;
@@ -73,7 +73,7 @@ public class AlluxioMasterProcess extends MasterProcess {
 
   /** The connection address for the rpc server. */
   final InetSocketAddress mRpcConnectAddress =
-      NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, ServerConfiguration.global());
+      NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, Configuration.global());
 
   /** The manager of safe mode state. */
   protected final SafeModeManager mSafeModeManager = new DefaultSafeModeManager();
@@ -99,7 +99,7 @@ public class AlluxioMasterProcess extends MasterProcess {
           String.format("Journal %s has not been formatted!", mJournalSystem));
     }
     // Create masters.
-    String baseDir = ServerConfiguration.getString(PropertyKey.MASTER_METASTORE_DIR);
+    String baseDir = Configuration.getString(PropertyKey.MASTER_METASTORE_DIR);
     mContext = CoreMasterContext.newBuilder()
         .setJournalSystem(mJournalSystem)
         .setSafeModeManager(mSafeModeManager)
@@ -108,7 +108,7 @@ public class AlluxioMasterProcess extends MasterProcess {
         .setInodeStoreFactory(MasterUtils.getInodeStoreFactory(baseDir))
         .setStartTimeMs(mStartTimeMs)
         .setPort(NetworkAddressUtils
-            .getPort(ServiceType.MASTER_RPC, ServerConfiguration.global()))
+            .getPort(ServiceType.MASTER_RPC, Configuration.global()))
         .setUfsManager(mUfsManager)
         .build();
     MasterUtils.createMasters(mRegistry, mContext);
@@ -165,7 +165,7 @@ public class AlluxioMasterProcess extends MasterProcess {
     CloseableResource<UnderFileSystem> ufsResource;
     if (URIUtils.isLocalFilesystem(backup.toString())) {
       UnderFileSystem ufs = UnderFileSystem.Factory.create("/",
-          UnderFileSystemConfiguration.defaults(ServerConfiguration.global()));
+          UnderFileSystemConfiguration.defaults(Configuration.global()));
       ufsResource = new CloseableResource<UnderFileSystem>(ufs) {
         @Override
         public void closeResource() { }
@@ -188,9 +188,9 @@ public class AlluxioMasterProcess extends MasterProcess {
   protected void startMasters(boolean isLeader) throws IOException {
     LOG.info("Starting all masters as: {}.", (isLeader) ? "leader" : "follower");
     if (isLeader) {
-      if (ServerConfiguration.isSet(PropertyKey.MASTER_JOURNAL_INIT_FROM_BACKUP)) {
+      if (Configuration.isSet(PropertyKey.MASTER_JOURNAL_INIT_FROM_BACKUP)) {
         AlluxioURI backup =
-            new AlluxioURI(ServerConfiguration.getString(
+            new AlluxioURI(Configuration.getString(
                 PropertyKey.MASTER_JOURNAL_INIT_FROM_BACKUP));
         if (mJournalSystem.isEmpty()) {
           initFromBackup(backup);
@@ -241,11 +241,11 @@ public class AlluxioMasterProcess extends MasterProcess {
    * Starts jvm monitor process, to monitor jvm.
    */
   protected void startJvmMonitorProcess() {
-    if (ServerConfiguration.getBoolean(PropertyKey.MASTER_JVM_MONITOR_ENABLED)) {
+    if (Configuration.getBoolean(PropertyKey.MASTER_JVM_MONITOR_ENABLED)) {
       mJvmPauseMonitor = new JvmPauseMonitor(
-          ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_SLEEP_INTERVAL_MS),
-          ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS),
-          ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS));
+          Configuration.getMs(PropertyKey.JVM_MONITOR_SLEEP_INTERVAL_MS),
+          Configuration.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS),
+          Configuration.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS));
       mJvmPauseMonitor.start();
       MetricsSystem.registerGaugeIfAbsent(
               MetricsSystem.getMetricName(MetricKey.TOTAL_EXTRA_TIME.getName()),
@@ -290,7 +290,7 @@ public class AlluxioMasterProcess extends MasterProcess {
    */
   protected void startCommonServices() {
     MetricsSystem.startSinks(
-        ServerConfiguration.getString(PropertyKey.METRICS_CONF_FILE));
+        Configuration.getString(PropertyKey.METRICS_CONF_FILE));
     startServingWebServer();
   }
 
@@ -327,20 +327,20 @@ public class AlluxioMasterProcess extends MasterProcess {
     // Create underlying gRPC server.
     GrpcServerBuilder builder = GrpcServerBuilder
         .forAddress(GrpcServerAddress.create(mRpcConnectAddress.getHostName(), mRpcBindAddress),
-            ServerConfiguration.global(), ServerUserState.global())
+            Configuration.global(), ServerUserState.global())
         .executor(mRPCExecutor)
         .flowControlWindow(
-            (int) ServerConfiguration.getBytes(PropertyKey.MASTER_NETWORK_FLOWCONTROL_WINDOW))
+            (int) Configuration.getBytes(PropertyKey.MASTER_NETWORK_FLOWCONTROL_WINDOW))
         .keepAliveTime(
-            ServerConfiguration.getMs(PropertyKey.MASTER_NETWORK_KEEPALIVE_TIME_MS),
+            Configuration.getMs(PropertyKey.MASTER_NETWORK_KEEPALIVE_TIME_MS),
             TimeUnit.MILLISECONDS)
         .keepAliveTimeout(
-            ServerConfiguration.getMs(PropertyKey.MASTER_NETWORK_KEEPALIVE_TIMEOUT_MS),
+            Configuration.getMs(PropertyKey.MASTER_NETWORK_KEEPALIVE_TIMEOUT_MS),
             TimeUnit.MILLISECONDS)
         .permitKeepAlive(
-            ServerConfiguration.getMs(PropertyKey.MASTER_NETWORK_PERMIT_KEEPALIVE_TIME_MS),
+            Configuration.getMs(PropertyKey.MASTER_NETWORK_PERMIT_KEEPALIVE_TIME_MS),
             TimeUnit.MILLISECONDS)
-        .maxInboundMessageSize((int) ServerConfiguration.getBytes(
+        .maxInboundMessageSize((int) Configuration.getBytes(
             PropertyKey.MASTER_NETWORK_MAX_INBOUND_MESSAGE_SIZE));
     // Bind manifests of each Alluxio master to RPC server.
     for (Master master : mRegistry.getServers()) {
@@ -365,7 +365,7 @@ public class AlluxioMasterProcess extends MasterProcess {
       mRPCExecutor.shutdownNow();
       try {
         mRPCExecutor.awaitTermination(
-            ServerConfiguration.getMs(PropertyKey.NETWORK_CONNECTION_SERVER_SHUTDOWN_TIMEOUT),
+            Configuration.getMs(PropertyKey.NETWORK_CONNECTION_SERVER_SHUTDOWN_TIMEOUT),
             TimeUnit.MILLISECONDS);
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();
@@ -436,7 +436,7 @@ public class AlluxioMasterProcess extends MasterProcess {
       URI journalLocation = JournalUtils.getJournalLocation();
       JournalSystem journalSystem = new JournalSystem.Builder()
           .setLocation(journalLocation).build(ProcessType.MASTER);
-      if (ServerConfiguration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED)) {
+      if (Configuration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED)) {
         Preconditions.checkState(!(journalSystem instanceof RaftJournalSystem),
             "Raft-based embedded journal and Zookeeper cannot be used at the same time.");
         PrimarySelector primarySelector = PrimarySelector.Factory.createZkPrimarySelector();

--- a/core/server/master/src/main/java/alluxio/master/AlluxioSecondaryMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioSecondaryMaster.java
@@ -15,7 +15,7 @@ import alluxio.Process;
 import alluxio.ProcessUtils;
 import alluxio.RuntimeConstants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.JournalUtils;
 import alluxio.underfs.MasterUfsManager;
@@ -47,7 +47,7 @@ public final class AlluxioSecondaryMaster implements Process {
    * Creates a {@link AlluxioSecondaryMaster}.
    */
   AlluxioSecondaryMaster() {
-    String baseDir = ServerConfiguration.getString(PropertyKey.SECONDARY_MASTER_METASTORE_DIR);
+    String baseDir = Configuration.getString(PropertyKey.SECONDARY_MASTER_METASTORE_DIR);
     // Create masters.
     MasterUtils.createMasters(mRegistry, CoreMasterContext.newBuilder()
         .setJournalSystem(mJournalSystem)
@@ -56,7 +56,7 @@ public final class AlluxioSecondaryMaster implements Process {
         .setBlockStoreFactory(MasterUtils.getBlockStoreFactory(baseDir))
         .setInodeStoreFactory(MasterUtils.getInodeStoreFactory(baseDir))
         .setStartTimeMs(System.currentTimeMillis())
-        .setPort(ServerConfiguration.getInt(PropertyKey.MASTER_RPC_PORT))
+        .setPort(Configuration.getInt(PropertyKey.MASTER_RPC_PORT))
         .setUfsManager(new MasterUfsManager())
         .build());
     // Check that journals of each service have been formatted.

--- a/core/server/master/src/main/java/alluxio/master/DefaultSafeModeManager.java
+++ b/core/server/master/src/main/java/alluxio/master/DefaultSafeModeManager.java
@@ -13,7 +13,7 @@ package alluxio.master;
 
 import alluxio.clock.ElapsedTimeClock;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +60,7 @@ public class DefaultSafeModeManager implements SafeModeManager {
   @Override
   public void notifyRpcServerStarted() {
     // updates start time when Alluxio master waits for workers to register
-    long waitTime = ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME);
+    long waitTime = Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME);
     LOG.info(String.format("Rpc server started, waiting %dms for workers to register", waitTime));
     mWorkerConnectWaitStartTimeMs.set(mClock.millis(), true);
   }
@@ -79,7 +79,7 @@ public class DefaultSafeModeManager implements SafeModeManager {
     }
 
     // lazily updates safe mode state upon inquiry
-    long waitTime = ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME);
+    long waitTime = Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME);
     if (mClock.millis() - startTime < waitTime) {
       return true;
     }

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -14,7 +14,7 @@ package alluxio.master;
 import alluxio.Constants;
 import alluxio.ProcessUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.PrimarySelector.State;
 import alluxio.master.journal.JournalSystem;
@@ -45,7 +45,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       LoggerFactory.getLogger(FaultTolerantAlluxioMasterProcess.class);
 
   private final long mServingThreadTimeoutMs =
-      ServerConfiguration.getMs(PropertyKey.MASTER_SERVING_THREAD_TIMEOUT);
+      Configuration.getMs(PropertyKey.MASTER_SERVING_THREAD_TIMEOUT);
 
   private final PrimarySelector mLeaderSelector;
   private Thread mServingThread = null;
@@ -78,7 +78,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
 
     // Perform the initial catchup before joining leader election,
     // to avoid potential delay if this master is selected as leader
-    if (ServerConfiguration.getBoolean(PropertyKey.MASTER_JOURNAL_CATCHUP_PROTECT_ENABLED)) {
+    if (Configuration.getBoolean(PropertyKey.MASTER_JOURNAL_CATCHUP_PROTECT_ENABLED)) {
       LOG.info("Waiting for journals to catch up.");
       mJournalSystem.waitForCatchup();
     }
@@ -96,7 +96,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
         LOG.info("FT is not running. Breaking out");
         break;
       }
-      if (ServerConfiguration.getBoolean(PropertyKey.MASTER_JOURNAL_CATCHUP_PROTECT_ENABLED)) {
+      if (Configuration.getBoolean(PropertyKey.MASTER_JOURNAL_CATCHUP_PROTECT_ENABLED)) {
         LOG.info("Waiting for journals to catch up.");
         mJournalSystem.waitForCatchup();
       }
@@ -108,7 +108,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       }
       if (gainPrimacy()) {
         mLeaderSelector.waitForState(State.STANDBY);
-        if (ServerConfiguration.getBoolean(PropertyKey.MASTER_JOURNAL_EXIT_ON_DEMOTION)) {
+        if (Configuration.getBoolean(PropertyKey.MASTER_JOURNAL_EXIT_ON_DEMOTION)) {
           stop();
         } else {
           if (!mRunning) {
@@ -146,7 +146,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       // We only check unstable here because mJournalSystem.gainPrimacy() is the only slow method
       if (unstable.get()) {
         LOG.info("Terminating an unstable attempt to become a leader.");
-        if (ServerConfiguration.getBoolean(PropertyKey.MASTER_JOURNAL_EXIT_ON_DEMOTION)) {
+        if (Configuration.getBoolean(PropertyKey.MASTER_JOURNAL_EXIT_ON_DEMOTION)) {
           stop();
         } else {
           losePrimacy();
@@ -243,9 +243,9 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
   @Override
   protected void startCommonServices() {
     boolean standbyMetricsSinkEnabled =
-        ServerConfiguration.getBoolean(PropertyKey.STANDBY_MASTER_METRICS_SINK_ENABLED);
+        Configuration.getBoolean(PropertyKey.STANDBY_MASTER_METRICS_SINK_ENABLED);
     boolean standbyWebEnabled =
-        ServerConfiguration.getBoolean(PropertyKey.STANDBY_MASTER_WEB_ENABLED);
+        Configuration.getBoolean(PropertyKey.STANDBY_MASTER_WEB_ENABLED);
     // Masters will always start from standby state, and later be elected to primary.
     // If standby masters are enabled to start metric sink service,
     // the service will have been started before the master is promoted to primary.
@@ -260,7 +260,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
         || (mLeaderSelector.getState() == State.PRIMARY && !standbyMetricsSinkEnabled)) {
       LOG.info("Start metric sinks.");
       MetricsSystem.startSinks(
-          ServerConfiguration.getString(PropertyKey.METRICS_CONF_FILE));
+          Configuration.getString(PropertyKey.METRICS_CONF_FILE));
     }
 
     // Same as the metrics sink service
@@ -272,12 +272,12 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
   }
 
   void stopCommonServicesIfNecessary() throws Exception {
-    if (!ServerConfiguration.getBoolean(
+    if (!Configuration.getBoolean(
         PropertyKey.STANDBY_MASTER_METRICS_SINK_ENABLED)) {
       LOG.info("Stop metric sinks.");
       MetricsSystem.stopSinks();
     }
-    if (!ServerConfiguration.getBoolean(
+    if (!Configuration.getBoolean(
         PropertyKey.STANDBY_MASTER_WEB_ENABLED)) {
       LOG.info("Stop web server.");
       stopServingWebServer();

--- a/core/server/master/src/main/java/alluxio/master/MasterUtils.java
+++ b/core/server/master/src/main/java/alluxio/master/MasterUtils.java
@@ -12,9 +12,8 @@
 package alluxio.master;
 
 import alluxio.Constants;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.metastore.BlockStore;
 import alluxio.master.metastore.InodeStore;
 import alluxio.master.metastore.MetastoreType;
@@ -64,7 +63,7 @@ public final class MasterUtils {
    */
   public static BlockStore.Factory getBlockStoreFactory(String baseDir) {
     MetastoreType type =
-        ServerConfiguration.getEnum(PropertyKey.MASTER_METASTORE, MetastoreType.class);
+        Configuration.getEnum(PropertyKey.MASTER_METASTORE, MetastoreType.class);
     switch (type) {
       case HEAP:
         return HeapBlockStore::new;
@@ -81,13 +80,12 @@ public final class MasterUtils {
    */
   public static InodeStore.Factory getInodeStoreFactory(String baseDir) {
     MetastoreType type =
-        ServerConfiguration.getEnum(PropertyKey.MASTER_METASTORE, MetastoreType.class);
+        Configuration.getEnum(PropertyKey.MASTER_METASTORE, MetastoreType.class);
     switch (type) {
       case HEAP:
         return lockManager -> new HeapInodeStore();
       case ROCKS:
-        InstancedConfiguration conf = ServerConfiguration.global();
-        if (conf.getInt(PropertyKey.MASTER_METASTORE_INODE_CACHE_MAX_SIZE) == 0) {
+        if (Configuration.getInt(PropertyKey.MASTER_METASTORE_INODE_CACHE_MAX_SIZE) == 0) {
           return lockManager -> new RocksInodeStore(baseDir);
         } else {
           return lockManager -> new CachingInodeStore(new RocksInodeStore(baseDir), lockManager);

--- a/core/server/master/src/main/java/alluxio/master/backup/AbstractBackupRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/AbstractBackupRole.java
@@ -13,7 +13,7 @@ package alluxio.master.backup;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.BackupPRequest;
 import alluxio.master.BackupManager;
 import alluxio.master.CoreMasterContext;
@@ -103,7 +103,7 @@ public abstract class AbstractBackupRole implements BackupRole {
     initializeCatalystContext();
     // Read properties.
     mCatalystRequestTimeout =
-        ServerConfiguration.getMs(PropertyKey.MASTER_BACKUP_TRANSPORT_TIMEOUT);
+        Configuration.getMs(PropertyKey.MASTER_BACKUP_TRANSPORT_TIMEOUT);
     // Initialize backup tracker.
     mBackupTracker = new BackupTracker();
   }
@@ -152,18 +152,18 @@ public abstract class AbstractBackupRole implements BackupRole {
         mUfsManager.getRoot().acquireUfsResource()) {
       // Get backup parent directory.
       String backupParentDir = request.hasTargetDirectory() ? request.getTargetDirectory()
-          : ServerConfiguration.getString(PropertyKey.MASTER_BACKUP_DIRECTORY);
+          : Configuration.getString(PropertyKey.MASTER_BACKUP_DIRECTORY);
       // Get ufs resource for backup.
       UnderFileSystem ufs = ufsResource.get();
       if (request.getOptions().getLocalFileSystem() && !ufs.getUnderFSType().equals("local")) {
         // TODO(lu) Support getting UFS based on type from UfsManager
         ufs = closer.register(UnderFileSystem.Factory.create("/",
-            UnderFileSystemConfiguration.defaults(ServerConfiguration.global())));
+            UnderFileSystemConfiguration.defaults(Configuration.global())));
       }
       // Ensure parent directory for backup.
       if (!ufs.isDirectory(backupParentDir)) {
         if (!ufs.mkdirs(backupParentDir,
-            MkdirsOptions.defaults(ServerConfiguration.global()).setCreateParent(true))) {
+            MkdirsOptions.defaults(Configuration.global()).setCreateParent(true))) {
           throw new IOException(String.format("Failed to create directory %s", backupParentDir));
         }
       }
@@ -174,7 +174,7 @@ public abstract class AbstractBackupRole implements BackupRole {
           now.toEpochMilli());
       String backupFilePath = PathUtils.concatPath(backupParentDir, backupFileName);
       // Calculate URI for the path.
-      String rootUfs = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+      String rootUfs = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
       if (request.getOptions().getLocalFileSystem()) {
         rootUfs = "file:///";
       }

--- a/core/server/master/src/main/java/alluxio/master/backup/BackupLeaderRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupLeaderRole.java
@@ -14,7 +14,7 @@ package alluxio.master.backup;
 import alluxio.AlluxioURI;
 import alluxio.collections.ConcurrentHashSet;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.BackupAbortedException;
 import alluxio.exception.BackupDelegationException;
@@ -99,7 +99,7 @@ public class BackupLeaderRole extends AbstractBackupRole {
     // Store state lock manager pausing state change when necessary.
     mStateLockManager = masterContext.getStateLockManager();
     // Read properties.
-    mBackupAbandonTimeout = ServerConfiguration.getMs(PropertyKey.MASTER_BACKUP_ABANDON_TIMEOUT);
+    mBackupAbandonTimeout = Configuration.getMs(PropertyKey.MASTER_BACKUP_ABANDON_TIMEOUT);
   }
 
   @Override
@@ -141,7 +141,7 @@ public class BackupLeaderRole extends AbstractBackupRole {
                     new GrpcMessagingServiceClientHandler(
                         NetworkAddressUtils.getConnectAddress(
                             NetworkAddressUtils.ServiceType.MASTER_RPC,
-                            ServerConfiguration.global()),
+                            Configuration.global()),
                         (conn) -> activateWorkerConnection(conn), mGrpcMessagingContext,
                         mExecutorService, mCatalystRequestTimeout),
                     new ClientIpAddressInjector())).withCloseable(this));
@@ -162,8 +162,8 @@ public class BackupLeaderRole extends AbstractBackupRole {
       }
 
       // Whether to attempt to delegate backup to a backup worker.
-      delegateBackup = ServerConfiguration.getBoolean(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED)
-          && ConfigurationUtils.isHaMode(ServerConfiguration.global());
+      delegateBackup = Configuration.getBoolean(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED)
+          && ConfigurationUtils.isHaMode(Configuration.global());
       // Check if backup-delegation is suppressed by back-up client.
       if (delegateBackup && request.getOptions().getBypassDelegation()) {
         LOG.info("Back-up delegation is suppressed by back-up client.");
@@ -182,7 +182,7 @@ public class BackupLeaderRole extends AbstractBackupRole {
       // Initialize backup status.
       mBackupTracker.reset();
       mBackupTracker.updateState(BackupState.Initiating);
-      mBackupTracker.updateHostname(NetworkAddressUtils.getLocalHostName((int) ServerConfiguration
+      mBackupTracker.updateHostname(NetworkAddressUtils.getLocalHostName((int) Configuration
           .global().getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS)));
 
       // Store backup id to query later for async requests.

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -13,7 +13,7 @@ package alluxio.master.block;
 
 import alluxio.RpcUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.RegisterLeaseNotFoundException;
 import alluxio.grpc.BlockHeartbeatPRequest;
 import alluxio.grpc.BlockHeartbeatPResponse;
@@ -152,7 +152,7 @@ public final class BlockMasterWorkerServiceHandler extends
     RpcUtils.call(LOG,
         () -> {
           // The exception will be propagated to the worker side and the worker should retry.
-          if (ServerConfiguration.getBoolean(PropertyKey.MASTER_WORKER_REGISTER_LEASE_ENABLED)
+          if (Configuration.getBoolean(PropertyKey.MASTER_WORKER_REGISTER_LEASE_ENABLED)
               && !mBlockMaster.hasRegisterLease(workerId)) {
             String errorMsg = String.format("Worker %s does not have a lease or the lease "
                 + "has expired. The worker should acquire a new lease and retry to register.",

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -23,7 +23,7 @@ import alluxio.collections.ConcurrentHashSet;
 import alluxio.collections.IndexDefinition;
 import alluxio.collections.IndexedSet;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.BlockInfoException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.InvalidArgumentException;
@@ -293,7 +293,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     Metrics.registerGauges(this);
 
     mWorkerInfoCache = CacheBuilder.newBuilder()
-        .refreshAfterWrite(ServerConfiguration
+        .refreshAfterWrite(Configuration
             .getMs(PropertyKey.MASTER_WORKER_INFO_CACHE_REFRESH_TIME), TimeUnit.MILLISECONDS)
         .build(new CacheLoader<String, List<WorkerInfo>>() {
           @Override
@@ -422,7 +422,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
    * and propagate an error to the worker side.
    */
   public class WorkerRegisterStreamGCExecutor implements HeartbeatExecutor {
-    private final long mTimeout = ServerConfiguration.global()
+    private final long mTimeout = Configuration.global()
         .getMs(PropertyKey.MASTER_WORKER_REGISTER_STREAM_RESPONSE_TIMEOUT);
 
     @Override
@@ -471,17 +471,17 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     if (isLeader) {
       getExecutorService().submit(new HeartbeatThread(
           HeartbeatContext.MASTER_LOST_WORKER_DETECTION, new LostWorkerDetectionHeartbeatExecutor(),
-          (int) ServerConfiguration.getMs(PropertyKey.MASTER_LOST_WORKER_DETECTION_INTERVAL),
-          ServerConfiguration.global(), mMasterContext.getUserState()));
+          (int) Configuration.getMs(PropertyKey.MASTER_LOST_WORKER_DETECTION_INTERVAL),
+          Configuration.global(), mMasterContext.getUserState()));
     }
 
     // This periodically scans all open register streams and closes hanging ones
     getExecutorService().submit(new HeartbeatThread(
           HeartbeatContext.MASTER_WORKER_REGISTER_SESSION_CLEANER,
             new WorkerRegisterStreamGCExecutor(),
-            (int) ServerConfiguration.global().getMs(
+            (int) Configuration.global().getMs(
                 PropertyKey.MASTER_WORKER_REGISTER_STREAM_RESPONSE_TIMEOUT),
-            ServerConfiguration.global(), mMasterContext.getUserState()));
+            Configuration.global(), mMasterContext.getUserState()));
   }
 
   @Override
@@ -1453,7 +1453,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
     @Override
     public void heartbeat() {
-      long masterWorkerTimeoutMs = ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_TIMEOUT_MS);
+      long masterWorkerTimeoutMs = Configuration.getMs(PropertyKey.MASTER_WORKER_TIMEOUT_MS);
       for (MasterWorkerInfo worker : mWorkers) {
         try (LockResource r = worker.lockWorkerMeta(
             EnumSet.of(WorkerMetaLockSection.BLOCKS), false)) {

--- a/core/server/master/src/main/java/alluxio/master/block/RegisterLeaseManager.java
+++ b/core/server/master/src/main/java/alluxio/master/block/RegisterLeaseManager.java
@@ -12,7 +12,7 @@
 package alluxio.master.block;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.GetRegisterLeasePRequest;
 import alluxio.util.CommonUtils;
 import alluxio.wire.RegisterLease;
@@ -32,7 +32,7 @@ import java.util.concurrent.Semaphore;
 public class RegisterLeaseManager {
   private static final Logger LOG = LoggerFactory.getLogger(RegisterLeaseManager.class);
   private static final long LEASE_TTL_MS =
-      ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_REGISTER_LEASE_TTL);
+      Configuration.getMs(PropertyKey.MASTER_WORKER_REGISTER_LEASE_TTL);
 
   private final Semaphore mSemaphore;
   private final Map<Long, RegisterLease> mActiveLeases;
@@ -44,12 +44,12 @@ public class RegisterLeaseManager {
    */
   public RegisterLeaseManager() {
     int maxConcurrency =
-        ServerConfiguration.global().getInt(PropertyKey.MASTER_WORKER_REGISTER_LEASE_COUNT);
+        Configuration.global().getInt(PropertyKey.MASTER_WORKER_REGISTER_LEASE_COUNT);
     Preconditions.checkState(maxConcurrency > 0, "%s should be greater than 0",
         PropertyKey.MASTER_WORKER_REGISTER_LEASE_COUNT.toString());
     mSemaphore = new Semaphore(maxConcurrency);
 
-    if (ServerConfiguration.getBoolean(
+    if (Configuration.getBoolean(
         PropertyKey.MASTER_WORKER_REGISTER_LEASE_RESPECT_JVM_SPACE)) {
       mJvmChecker = new JvmSpaceReviewer(Runtime.getRuntime());
     }

--- a/core/server/master/src/main/java/alluxio/master/file/AccessTimeUpdater.java
+++ b/core/server/master/src/main/java/alluxio/master/file/AccessTimeUpdater.java
@@ -12,7 +12,7 @@
 package alluxio.master.file;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.file.meta.Inode;
 import alluxio.master.file.meta.InodeTree;
@@ -63,9 +63,9 @@ final class AccessTimeUpdater implements JournalSink {
   public AccessTimeUpdater(FileSystemMaster fileSystemMaster, InodeTree inodeTree,
       JournalSystem journalSystem) {
     this(fileSystemMaster, inodeTree, journalSystem,
-        ServerConfiguration.getMs(PropertyKey.MASTER_FILE_ACCESS_TIME_JOURNAL_FLUSH_INTERVAL),
-        ServerConfiguration.getMs(PropertyKey.MASTER_FILE_ACCESS_TIME_UPDATE_PRECISION),
-        ServerConfiguration.getMs(PropertyKey.MASTER_FILE_ACCESS_TIME_UPDATER_SHUTDOWN_TIMEOUT));
+        Configuration.getMs(PropertyKey.MASTER_FILE_ACCESS_TIME_JOURNAL_FLUSH_INTERVAL),
+        Configuration.getMs(PropertyKey.MASTER_FILE_ACCESS_TIME_UPDATE_PRECISION),
+        Configuration.getMs(PropertyKey.MASTER_FILE_ACCESS_TIME_UPDATER_SHUTDOWN_TIMEOUT));
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/BlockIntegrityChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/BlockIntegrityChecker.java
@@ -12,7 +12,7 @@
 package alluxio.master.file;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.heartbeat.HeartbeatExecutor;
 
 import org.slf4j.Logger;
@@ -34,7 +34,7 @@ public final class BlockIntegrityChecker implements HeartbeatExecutor {
    */
   public BlockIntegrityChecker(FileSystemMaster fsm) {
     mFileSystemMaster = fsm;
-    mRepair = ServerConfiguration
+    mRepair = Configuration
         .getBoolean(PropertyKey.MASTER_PERIODIC_BLOCK_INTEGRITY_CHECK_REPAIR);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -28,7 +28,7 @@ import alluxio.collections.PrefixList;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Reconfigurable;
 import alluxio.conf.ReconfigurableRegistry;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.BlockInfoException;
@@ -403,28 +403,28 @@ public class DefaultFileSystemMaster extends CoreMaster
   private final CallTracker mStateLockCallTracker;
 
   private final ThreadPoolExecutor mSyncPrefetchExecutor = new ThreadPoolExecutor(
-      ServerConfiguration.getInt(PropertyKey.MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE),
-      ServerConfiguration.getInt(PropertyKey.MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE),
+      Configuration.getInt(PropertyKey.MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE),
+      Configuration.getInt(PropertyKey.MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE),
       1, TimeUnit.MINUTES, new LinkedBlockingQueue<>(),
       ThreadFactoryUtils.build("alluxio-ufs-sync-prefetch-%d", false));
   final ExecutorService mSyncPrefetchExecutorIns =
-      ServerConfiguration.getBoolean(PropertyKey.MASTER_METADATA_SYNC_INSTRUMENT_EXECUTOR)
+      Configuration.getBoolean(PropertyKey.MASTER_METADATA_SYNC_INSTRUMENT_EXECUTOR)
           ? MetricsSystem.executorService(mSyncPrefetchExecutor,
           MetricKey.MASTER_METADATA_SYNC_PREFETCH_EXECUTOR.getName()) : mSyncPrefetchExecutor;
 
   private final ThreadPoolExecutor mSyncMetadataExecutor = new ThreadPoolExecutor(
-      ServerConfiguration.getInt(PropertyKey.MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE),
-      ServerConfiguration.getInt(PropertyKey.MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE),
+      Configuration.getInt(PropertyKey.MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE),
+      Configuration.getInt(PropertyKey.MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE),
       1, TimeUnit.MINUTES, new LinkedBlockingQueue<>(),
       ThreadFactoryUtils.build("alluxio-ufs-sync-%d", false));
   final ExecutorService mSyncMetadataExecutorIns =
-      ServerConfiguration.getBoolean(PropertyKey.MASTER_METADATA_SYNC_INSTRUMENT_EXECUTOR)
+      Configuration.getBoolean(PropertyKey.MASTER_METADATA_SYNC_INSTRUMENT_EXECUTOR)
           ? MetricsSystem.executorService(mSyncMetadataExecutor,
           MetricKey.MASTER_METADATA_SYNC_EXECUTOR.getName()) : mSyncMetadataExecutor;
 
   final ThreadPoolExecutor mActiveSyncMetadataExecutor = new ThreadPoolExecutor(
-      ServerConfiguration.getInt(PropertyKey.MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE),
-      ServerConfiguration.getInt(PropertyKey.MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE),
+      Configuration.getInt(PropertyKey.MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE),
+      Configuration.getInt(PropertyKey.MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE),
       1, TimeUnit.MINUTES, new LinkedBlockingQueue<>(),
       ThreadFactoryUtils.build("alluxio-ufs-active-sync-%d", false));
   private HeartbeatThread mReplicationCheckHeartbeatThread;
@@ -463,9 +463,9 @@ public class DefaultFileSystemMaster extends CoreMaster
         mDirectoryIdGenerator, mMountTable, mInodeLockManager);
 
     // TODO(gene): Handle default config value for whitelist.
-    mWhitelist = new PrefixList(ServerConfiguration.getList(PropertyKey.MASTER_WHITELIST));
-    mPersistBlacklist = ServerConfiguration.isSet(PropertyKey.MASTER_PERSISTENCE_BLACKLIST)
-        ? ServerConfiguration.getList(PropertyKey.MASTER_PERSISTENCE_BLACKLIST)
+    mWhitelist = new PrefixList(Configuration.getList(PropertyKey.MASTER_WHITELIST));
+    mPersistBlacklist = Configuration.isSet(PropertyKey.MASTER_PERSISTENCE_BLACKLIST)
+        ? Configuration.getList(PropertyKey.MASTER_PERSISTENCE_BLACKLIST)
         : Collections.emptyList();
 
     mStateLockCallTracker = new CallTracker() {
@@ -481,7 +481,7 @@ public class DefaultFileSystemMaster extends CoreMaster
     };
     mPermissionChecker = new DefaultPermissionChecker(mInodeTree);
     mJobMasterClientPool = new JobMasterClientPool(JobMasterClientContext
-        .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+        .newBuilder(ClientContext.create(Configuration.global())).build());
     mPersistRequests = new ConcurrentHashMap<>();
     mPersistJobs = new ConcurrentHashMap<>();
     mUfsAbsentPathCache = UfsAbsentPathCache.Factory.create(mMountTable);
@@ -522,14 +522,14 @@ public class DefaultFileSystemMaster extends CoreMaster
   private static MountInfo getRootMountInfo(MasterUfsManager ufsManager) {
     try (CloseableResource<UnderFileSystem> resource = ufsManager.getRoot().acquireUfsResource()) {
       boolean shared = resource.get().isObjectStorage()
-          && ServerConfiguration.getBoolean(PropertyKey.UNDERFS_OBJECT_STORE_MOUNT_SHARED_PUBLICLY);
-      boolean readonly = ServerConfiguration.getBoolean(
+          && Configuration.getBoolean(PropertyKey.UNDERFS_OBJECT_STORE_MOUNT_SHARED_PUBLICLY);
+      boolean readonly = Configuration.getBoolean(
           PropertyKey.MASTER_MOUNT_TABLE_ROOT_READONLY);
       String rootUfsUri = PathUtils.normalizePath(
-          ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS),
+          Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS),
           AlluxioURI.SEPARATOR);
       Map<String, String> rootUfsConf =
-          ServerConfiguration.getNestedProperties(PropertyKey.MASTER_MOUNT_TABLE_ROOT_OPTION)
+          Configuration.getNestedProperties(PropertyKey.MASTER_MOUNT_TABLE_ROOT_OPTION)
               .entrySet().stream()
               .filter(entry -> entry.getValue() != null)
               .collect(Collectors.toMap(Map.Entry::getKey,
@@ -581,18 +581,18 @@ public class DefaultFileSystemMaster extends CoreMaster
         try (JournalContext context = createJournalContext()) {
           mInodeTree.initializeRoot(
               SecurityUtils.getOwner(mMasterContext.getUserState()),
-              SecurityUtils.getGroup(mMasterContext.getUserState(), ServerConfiguration.global()),
+              SecurityUtils.getGroup(mMasterContext.getUserState(), Configuration.global()),
               ModeUtils.applyDirectoryUMask(Mode.createFullAccess(),
-                  ServerConfiguration.getString(
+                  Configuration.getString(
                       PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_UMASK)),
               context);
         }
-      } else if (!ServerConfiguration.getBoolean(PropertyKey.MASTER_SKIP_ROOT_ACL_CHECK)) {
+      } else if (!Configuration.getBoolean(PropertyKey.MASTER_SKIP_ROOT_ACL_CHECK)) {
         // For backwards-compatibility:
         // Empty root owner indicates that previously the master had no security. In this case, the
         // master is allowed to be started with security turned on.
         String serverOwner = SecurityUtils.getOwner(mMasterContext.getUserState());
-        if (SecurityUtils.isSecurityEnabled(ServerConfiguration.global())
+        if (SecurityUtils.isSecurityEnabled(Configuration.global())
             && !root.getOwner().isEmpty() && !root.getOwner().equals(serverOwner)) {
           // user is not the previous owner
           throw new PermissionDeniedException(ExceptionMessage.PERMISSION_DENIED.getMessage(String
@@ -608,7 +608,7 @@ public class DefaultFileSystemMaster extends CoreMaster
         }
         MountInfo mountInfo = mMountTable.getMountTable().get(key);
         UnderFileSystemConfiguration ufsConf =
-            UnderFileSystemConfiguration.defaults(ServerConfiguration.global())
+            UnderFileSystemConfiguration.defaults(Configuration.global())
                 .createMountSpecificConf(mountInfo.getOptions().getPropertiesMap())
                 .setReadOnly(mountInfo.getOptions().getReadOnly())
                 .setShared(mountInfo.getOptions().getShared());
@@ -619,11 +619,11 @@ public class DefaultFileSystemMaster extends CoreMaster
       // Rebuild the list of persist jobs (mPersistJobs) and map of pending persist requests
       // (mPersistRequests)
       long persistInitialIntervalMs =
-          ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS);
+          Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS);
       long persistMaxIntervalMs =
-          ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_INTERVAL_MS);
+          Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_INTERVAL_MS);
       long persistMaxWaitMs =
-          ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS);
+          Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS);
 
       for (Long id : mInodeTree.getToBePersistedIds()) {
         Inode inode = mInodeStore.get(id).get();
@@ -654,44 +654,44 @@ public class DefaultFileSystemMaster extends CoreMaster
               path, inodeFile.getTempUfsPath());
         }
       }
-      if (ServerConfiguration
+      if (Configuration
           .getBoolean(PropertyKey.MASTER_STARTUP_BLOCK_INTEGRITY_CHECK_ENABLED)) {
         validateInodeBlocks(true);
       }
 
-      long blockIntegrityCheckInterval = ServerConfiguration
+      long blockIntegrityCheckInterval = Configuration
           .getMs(PropertyKey.MASTER_PERIODIC_BLOCK_INTEGRITY_CHECK_INTERVAL);
 
       if (blockIntegrityCheckInterval > 0) { // negative or zero interval implies disabled
         getExecutorService().submit(
             new HeartbeatThread(HeartbeatContext.MASTER_BLOCK_INTEGRITY_CHECK,
                 new BlockIntegrityChecker(this), blockIntegrityCheckInterval,
-                ServerConfiguration.global(), mMasterContext.getUserState()));
+                Configuration.global(), mMasterContext.getUserState()));
       }
       getExecutorService().submit(
           new HeartbeatThread(HeartbeatContext.MASTER_TTL_CHECK,
               new InodeTtlChecker(this, mInodeTree),
-              ServerConfiguration.getMs(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS),
-              ServerConfiguration.global(), mMasterContext.getUserState()));
+              Configuration.getMs(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS),
+              Configuration.global(), mMasterContext.getUserState()));
       getExecutorService().submit(
           new HeartbeatThread(HeartbeatContext.MASTER_LOST_FILES_DETECTION,
               new LostFileDetector(this, mInodeTree),
-              ServerConfiguration.getMs(PropertyKey
+              Configuration.getMs(PropertyKey
                   .MASTER_LOST_WORKER_FILE_DETECTION_INTERVAL),
-              ServerConfiguration.global(), mMasterContext.getUserState()));
+              Configuration.global(), mMasterContext.getUserState()));
       mReplicationCheckHeartbeatThread = new HeartbeatThread(
           HeartbeatContext.MASTER_REPLICATION_CHECK,
           new alluxio.master.file.replication.ReplicationChecker(mInodeTree, mBlockMaster,
               mSafeModeManager, mJobMasterClientPool),
-          ServerConfiguration.getMs(PropertyKey.MASTER_REPLICATION_CHECK_INTERVAL_MS),
-          ServerConfiguration.global(), mMasterContext.getUserState());
+          Configuration.getMs(PropertyKey.MASTER_REPLICATION_CHECK_INTERVAL_MS),
+          Configuration.global(), mMasterContext.getUserState());
       ReconfigurableRegistry.register(this);
       getExecutorService().submit(mReplicationCheckHeartbeatThread);
       getExecutorService().submit(
           new HeartbeatThread(HeartbeatContext.MASTER_PERSISTENCE_SCHEDULER,
               new PersistenceScheduler(),
-              ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS),
-              ServerConfiguration.global(), mMasterContext.getUserState()));
+              Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_SCHEDULER_INTERVAL_MS),
+              Configuration.global(), mMasterContext.getUserState()));
       mPersistCheckerPool =
           new java.util.concurrent.ThreadPoolExecutor(PERSIST_CHECKER_POOL_THREADS,
               PERSIST_CHECKER_POOL_THREADS, 1, java.util.concurrent.TimeUnit.MINUTES,
@@ -701,14 +701,14 @@ public class DefaultFileSystemMaster extends CoreMaster
       getExecutorService().submit(
           new HeartbeatThread(HeartbeatContext.MASTER_PERSISTENCE_CHECKER,
               new PersistenceChecker(),
-              ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_CHECKER_INTERVAL_MS),
-              ServerConfiguration.global(), mMasterContext.getUserState()));
+              Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_CHECKER_INTERVAL_MS),
+              Configuration.global(), mMasterContext.getUserState()));
       getExecutorService().submit(
           new HeartbeatThread(HeartbeatContext.MASTER_METRICS_TIME_SERIES,
               new TimeSeriesRecorder(),
-              ServerConfiguration.getMs(PropertyKey.MASTER_METRICS_TIME_SERIES_INTERVAL),
-              ServerConfiguration.global(), mMasterContext.getUserState()));
-      if (ServerConfiguration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED)) {
+              Configuration.getMs(PropertyKey.MASTER_METRICS_TIME_SERIES_INTERVAL),
+              Configuration.global(), mMasterContext.getUserState()));
+      if (Configuration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED)) {
         mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter("AUDIT_LOG");
         mAsyncAuditLogWriter.start();
         MetricsSystem.registerGaugeIfAbsent(
@@ -716,11 +716,11 @@ public class DefaultFileSystemMaster extends CoreMaster
             () -> mAsyncAuditLogWriter != null
                     ? mAsyncAuditLogWriter.getAuditLogEntriesSize() : -1);
       }
-      if (ServerConfiguration.getBoolean(PropertyKey.UNDERFS_CLEANUP_ENABLED)) {
+      if (Configuration.getBoolean(PropertyKey.UNDERFS_CLEANUP_ENABLED)) {
         getExecutorService().submit(
             new HeartbeatThread(HeartbeatContext.MASTER_UFS_CLEANUP, new UfsCleaner(this),
-                ServerConfiguration.getMs(PropertyKey.UNDERFS_CLEANUP_INTERVAL),
-                ServerConfiguration.global(), mMasterContext.getUserState()));
+                Configuration.getMs(PropertyKey.UNDERFS_CLEANUP_INTERVAL),
+                Configuration.global(), mMasterContext.getUserState()));
       }
       mAccessTimeUpdater.start();
       mSyncManager.start();
@@ -2652,10 +2652,10 @@ public class DefaultFileSystemMaster extends CoreMaster
       long persistenceWaitTime = shouldPersistTime == Constants.NO_AUTO_PERSIST ? 0
           : getPersistenceWaitTime(shouldPersistTime);
       mPersistRequests.put(srcInode.getId(), new alluxio.time.ExponentialTimer(
-          ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS),
-          ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_INTERVAL_MS),
+          Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS),
+          Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_INTERVAL_MS),
           persistenceWaitTime,
-          ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS)));
+          Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS)));
     }
 
     // If a directory is being renamed with persist on rename, attempt to persist children
@@ -2678,10 +2678,10 @@ public class DefaultFileSystemMaster extends CoreMaster
             long persistenceWaitTime = shouldPersistTime == Constants.NO_AUTO_PERSIST ? 0
                 : getPersistenceWaitTime(shouldPersistTime);
             mPersistRequests.put(childInode.getId(), new alluxio.time.ExponentialTimer(
-                ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS),
-                ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_INTERVAL_MS),
+                Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS),
+                Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_INTERVAL_MS),
                 persistenceWaitTime,
-                ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS)));
+                Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS)));
           }
         }
       }
@@ -2915,7 +2915,7 @@ public class DefaultFileSystemMaster extends CoreMaster
 
   @Override
   public String getUfsAddress() {
-    return ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    return Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
   }
 
   @Override
@@ -3025,7 +3025,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       AlluxioURI alluxioPath = inodePath.getUri();
       // validate new UFS client before updating the mount table
       mUfsManager.addMount(newMountId, new AlluxioURI(ufsPath.toString()),
-          UnderFileSystemConfiguration.defaults(ServerConfiguration.global())
+          UnderFileSystemConfiguration.defaults(Configuration.global())
               .setReadOnly(context.getOptions().getReadOnly())
               .setShared(context.getOptions().getShared())
               .createMountSpecificConf(context.getOptions().getPropertiesMap()));
@@ -3158,7 +3158,7 @@ public class DefaultFileSystemMaster extends CoreMaster
     AlluxioURI alluxioPath = inodePath.getUri();
     // Adding the mount point will not create the UFS instance and thus not connect to UFS
     mUfsManager.addMount(mountId, new AlluxioURI(ufsPath.toString()),
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global())
+        UnderFileSystemConfiguration.defaults(Configuration.global())
             .setReadOnly(context.getOptions().getReadOnly())
             .setShared(context.getOptions().getShared())
             .createMountSpecificConf(context.getOptions().getPropertiesMap()));
@@ -3512,7 +3512,7 @@ public class DefaultFileSystemMaster extends CoreMaster
    */
   private void checkUserBelongsToGroup(String owner, String group)
       throws IOException {
-    List<String> groups = CommonUtils.getGroups(owner, ServerConfiguration.global());
+    List<String> groups = CommonUtils.getGroups(owner, Configuration.global());
     if (groups == null || !groups.contains(group)) {
       throw new FailedPreconditionException("Owner " + owner
           + " does not belong to the group " + group);
@@ -3564,10 +3564,10 @@ public class DefaultFileSystemMaster extends CoreMaster
           .setPersistenceState(PersistenceState.TO_BE_PERSISTED.name()).build());
       mPersistRequests.put(inode.getId(),
           new alluxio.time.ExponentialTimer(
-              ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS),
-              ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_INTERVAL_MS),
+              Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS),
+              Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_INTERVAL_MS),
               context.getPersistenceWaitTime(),
-              ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS)));
+              Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS)));
     }
   }
 
@@ -3699,7 +3699,7 @@ public class DefaultFileSystemMaster extends CoreMaster
   @Override
   public void update() {
     if (mReplicationCheckHeartbeatThread != null) {
-      long newValue = ServerConfiguration.getMs(
+      long newValue = Configuration.getMs(
           PropertyKey.MASTER_REPLICATION_CHECK_INTERVAL_MS);
       mReplicationCheckHeartbeatThread.updateIntervalMs(
           newValue);
@@ -4001,10 +4001,10 @@ public class DefaultFileSystemMaster extends CoreMaster
     alluxio.time.ExponentialTimer timer = mPersistRequests.remove(fileId);
     if (timer == null) {
       timer = new alluxio.time.ExponentialTimer(
-          ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS),
-          ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_INTERVAL_MS),
+          Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS),
+          Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_INTERVAL_MS),
           persistenceWaitTime,
-          ServerConfiguration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS));
+          Configuration.getMs(PropertyKey.MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS));
     }
     mPersistJobs.put(fileId, new PersistJob(jobId, fileId, uri, tempUfsPath, timer));
   }
@@ -4116,7 +4116,7 @@ public class DefaultFileSystemMaster extends CoreMaster
         // Generate a temporary path to be used by the persist job.
         // If the persist destination is on object store, let persist job copy files to destination
         // directly
-        if (ServerConfiguration.getBoolean(PropertyKey.MASTER_UNSAFE_DIRECT_PERSIST_OBJECT_ENABLED)
+        if (Configuration.getBoolean(PropertyKey.MASTER_UNSAFE_DIRECT_PERSIST_OBJECT_ENABLED)
             && ufsResource.get().isObjectStorage()) {
           tempUfsPath = resolution.getUri().toString();
         } else {
@@ -4295,8 +4295,8 @@ public class DefaultFileSystemMaster extends CoreMaster
 
               // Check if the size is the same to guard against a race condition where the Alluxio
               // file is mutated in between the persist command and execution
-              if (ServerConfiguration.isSet(PropertyKey.MASTER_ASYNC_PERSIST_SIZE_VALIDATION)
-                  && ServerConfiguration.getBoolean(
+              if (Configuration.isSet(PropertyKey.MASTER_ASYNC_PERSIST_SIZE_VALIDATION)
+                  && Configuration.getBoolean(
                       PropertyKey.MASTER_ASYNC_PERSIST_SIZE_VALIDATION)) {
                 UfsStatus ufsStatus = ufs.getStatus(tempUfsPath);
                 if (ufsStatus.isFile()) {
@@ -4414,7 +4414,7 @@ public class DefaultFileSystemMaster extends CoreMaster
         Pair<String, Inode> ancestor = ancestors.pop();
         String dir = ancestor.getFirst();
         Inode ancestorInode = ancestor.getSecond();
-        MkdirsOptions options = MkdirsOptions.defaults(ServerConfiguration.global())
+        MkdirsOptions options = MkdirsOptions.defaults(Configuration.global())
             .setCreateParent(false)
             .setOwner(ancestorInode.getOwner())
             .setGroup(ancestorInode.getGroup())
@@ -4828,7 +4828,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_FILE_SIZE.getName(),
           inodeTree::getFileSizeHistogram);
 
-      final String ufsDataFolder = ServerConfiguration.getString(
+      final String ufsDataFolder = Configuration.getString(
           PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
 
       MetricsSystem.registerGaugeIfAbsent(MetricKey.CLUSTER_ROOT_UFS_CAPACITY_TOTAL.getName(),
@@ -4885,7 +4885,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       @Nullable AlluxioURI dstPath, @Nullable Inode srcInode) {
     // Audit log may be enabled during runtime
     AsyncUserAccessAuditLogWriter auditLogWriter = null;
-    if (ServerConfiguration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED)) {
+    if (Configuration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED)) {
       auditLogWriter = mAsyncAuditLogWriter;
     }
     FileSystemMasterAuditContext auditContext =
@@ -4894,13 +4894,13 @@ public class DefaultFileSystemMaster extends CoreMaster
       String user = null;
       String ugi = "";
       try {
-        user = AuthenticatedClientUser.getClientUser(ServerConfiguration.global());
+        user = AuthenticatedClientUser.getClientUser(Configuration.global());
       } catch (AccessControlException e) {
         ugi = "N/A";
       }
       if (user != null) {
         try {
-          String primaryGroup = CommonUtils.getPrimaryGroupName(user, ServerConfiguration.global());
+          String primaryGroup = CommonUtils.getPrimaryGroupName(user, Configuration.global());
           ugi = user + "," + primaryGroup;
         } catch (IOException e) {
           LOG.debug("Failed to get primary group for user {}.", user);
@@ -4908,7 +4908,7 @@ public class DefaultFileSystemMaster extends CoreMaster
         }
       }
       AuthType authType =
-          ServerConfiguration.getEnum(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.class);
+          Configuration.getEnum(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.class);
       auditContext.setUgi(ugi)
           .setAuthType(authType)
           .setIp(ClientIpAddressInjector.getIpAddress())
@@ -4971,7 +4971,7 @@ public class DefaultFileSystemMaster extends CoreMaster
   }
 
   boolean isAclEnabled() {
-    return ServerConfiguration.getBoolean(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED);
+    return Configuration.getBoolean(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED);
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultPermissionChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultPermissionChecker.java
@@ -12,7 +12,7 @@
 package alluxio.master.file;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidPathException;
@@ -54,9 +54,9 @@ public class DefaultPermissionChecker implements PermissionChecker {
   public DefaultPermissionChecker(InodeTree inodeTree) {
     mInodeTree = Preconditions.checkNotNull(inodeTree, "inodeTree");
     mPermissionCheckEnabled =
-        ServerConfiguration.getBoolean(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED);
+        Configuration.getBoolean(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED);
     mFileSystemSuperGroup =
-        ServerConfiguration.getString(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP);
+        Configuration.getString(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP);
   }
 
   @Override
@@ -76,7 +76,7 @@ public class DefaultPermissionChecker implements PermissionChecker {
     List<InodeView> inodeList = inodePath.getInodeViewList();
 
     // collects user and groups
-    String user = AuthenticatedClientUser.getClientUser(ServerConfiguration.global());
+    String user = AuthenticatedClientUser.getClientUser(Configuration.global());
     List<String> groups = getGroups(user);
 
     // remove the last element if all components of the path exist, since we only check the parent.
@@ -97,7 +97,7 @@ public class DefaultPermissionChecker implements PermissionChecker {
     List<InodeView> inodeList = inodePath.getInodeViewList();
 
     // collects user and groups
-    String user = AuthenticatedClientUser.getClientUser(ServerConfiguration.global());
+    String user = AuthenticatedClientUser.getClientUser(Configuration.global());
     List<String> groups = getGroups(user);
 
     checkInodeList(user, groups, bits, inodePath.getUri().getPath(), inodeList, false);
@@ -113,7 +113,7 @@ public class DefaultPermissionChecker implements PermissionChecker {
 
     // collects user and groups
     try {
-      String user = AuthenticatedClientUser.getClientUser(ServerConfiguration.global());
+      String user = AuthenticatedClientUser.getClientUser(Configuration.global());
       List<String> groups = getGroups(user);
       return getPermissionInternal(user, groups, inodePath.getUri().getPath(), inodeList);
     } catch (AccessControlException e) {
@@ -146,7 +146,7 @@ public class DefaultPermissionChecker implements PermissionChecker {
   @Override
   public void checkSuperUser() throws AccessControlException {
     // collects user and groups
-    String user = AuthenticatedClientUser.getClientUser(ServerConfiguration.global());
+    String user = AuthenticatedClientUser.getClientUser(Configuration.global());
     List<String> groups = getGroups(user);
     if (!isPrivilegedUser(user, groups)) {
       throw new AccessControlException(ExceptionMessage.PERMISSION_DENIED
@@ -161,7 +161,7 @@ public class DefaultPermissionChecker implements PermissionChecker {
    */
   private List<String> getGroups(String user) throws AccessControlException {
     try {
-      return CommonUtils.getGroups(user, ServerConfiguration.global());
+      return CommonUtils.getGroups(user, Configuration.global());
     } catch (IOException e) {
       throw new AccessControlException(
           ExceptionMessage.PERMISSION_DENIED.getMessage(e.getMessage()));
@@ -180,7 +180,7 @@ public class DefaultPermissionChecker implements PermissionChecker {
     List<InodeView> inodeList = inodePath.getInodeViewList();
 
     // collects user and groups
-    String user = AuthenticatedClientUser.getClientUser(ServerConfiguration.global());
+    String user = AuthenticatedClientUser.getClientUser(Configuration.global());
     List<String> groups = getGroups(user);
 
     if (isPrivilegedUser(user, groups)) {

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -14,7 +14,7 @@ package alluxio.master.file;
 import alluxio.AlluxioURI;
 import alluxio.RpcUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CheckAccessPRequest;
 import alluxio.grpc.CheckAccessPResponse;
 import alluxio.grpc.CheckConsistencyPOptions;
@@ -243,7 +243,7 @@ public final class FileSystemMasterClientServiceHandler
   public void listStatus(ListStatusPRequest request,
       StreamObserver<ListStatusPResponse> responseObserver) {
     final int listStatusBatchSize =
-        ServerConfiguration.getInt(PropertyKey.MASTER_FILE_SYSTEM_LISTSTATUS_RESULTS_PER_MESSAGE);
+        Configuration.getInt(PropertyKey.MASTER_FILE_SYSTEM_LISTSTATUS_RESULTS_PER_MESSAGE);
 
     // Result streamer for listStatus.
     ListStatusResultStream resultStream =

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterOptions.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterOptions.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CompleteFilePOptions;
 import alluxio.util.FileSystemOptions;
 
@@ -28,7 +28,7 @@ public final class FileSystemMasterOptions {
    */
   public static CompleteFilePOptions completeFileDefaults() {
     return CompleteFilePOptions.newBuilder()
-        .setCommonOptions(FileSystemOptions.commonDefaults(ServerConfiguration.global()))
+        .setCommonOptions(FileSystemOptions.commonDefaults(Configuration.global()))
         .setUfsLength(0)
         .build();
   }

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -15,7 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.client.WriteType;
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.BlockInfoException;
 import alluxio.exception.DirectoryNotEmptyException;
@@ -196,7 +196,7 @@ public class InodeSyncStream {
 
   /** The maximum number of concurrent paths that can be syncing at any moment. */
   private final int mConcurrencyLevel =
-      ServerConfiguration.getInt(PropertyKey.MASTER_METADATA_SYNC_CONCURRENCY_LEVEL);
+      Configuration.getInt(PropertyKey.MASTER_METADATA_SYNC_CONCURRENCY_LEVEL);
 
   private final FileSystemMasterAuditContext mAuditContext;
   private final Function<LockedInodePath, Inode> mAuditContextSrcInodeFunc;
@@ -261,7 +261,7 @@ public class InodeSyncStream {
       }
     } else {
       long syncInterval = options.hasSyncIntervalMs() ? options.getSyncIntervalMs() :
-          ServerConfiguration.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL);
+          Configuration.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL);
       validCacheTime = System.currentTimeMillis() - syncInterval;
     }
     mStatusCache = new UfsStatusCache(fsMaster.mSyncPrefetchExecutorIns,
@@ -431,7 +431,7 @@ public class InodeSyncStream {
     }
 
     boolean success = syncPathCount > 0;
-    if (ServerConfiguration.getBoolean(PropertyKey.MASTER_METADATA_SYNC_REPORT_FAILURE)) {
+    if (Configuration.getBoolean(PropertyKey.MASTER_METADATA_SYNC_REPORT_FAILURE)) {
       // There should not be any failed or outstanding jobs
       success = (failedSyncPathCount == 0) && mSyncPathJobs.isEmpty() && mPendingPaths.isEmpty();
     }

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -15,7 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.ProcessUtils;
 import alluxio.SyncInfo;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidPathException;
 import alluxio.heartbeat.HeartbeatContext;
@@ -197,7 +197,7 @@ public class ActiveSyncManager implements Journaled {
       }
 
       try {
-        if ((txId == SyncInfo.INVALID_TXID) && ServerConfiguration.getBoolean(
+        if ((txId == SyncInfo.INVALID_TXID) && Configuration.getBoolean(
             PropertyKey.MASTER_UFS_ACTIVE_SYNC_INITIAL_SYNC_ENABLED)) {
           mExecutorService.submit(
               () -> entry.getValue().parallelStream().forEach(
@@ -242,8 +242,8 @@ public class ActiveSyncManager implements Journaled {
       ActiveSyncer syncer = new ActiveSyncer(mFileSystemMaster, this, mMountTable, mountId);
       Future<?> future = getExecutor().submit(
           new HeartbeatThread(HeartbeatContext.MASTER_ACTIVE_UFS_SYNC,
-              syncer, (int) ServerConfiguration.getMs(PropertyKey.MASTER_UFS_ACTIVE_SYNC_INTERVAL),
-              ServerConfiguration.global(), ServerUserState.global()));
+              syncer, (int) Configuration.getMs(PropertyKey.MASTER_UFS_ACTIVE_SYNC_INTERVAL),
+              Configuration.global(), ServerUserState.global()));
       mPollerMap.put(mountId, future);
     }
   }
@@ -527,12 +527,12 @@ public class ActiveSyncManager implements Journaled {
               // Notify ufs polling thread to keep track of events related to specified uri
               ufsResource.get().startSync(resolution.getUri());
               // Start the initial metadata sync between the ufs and alluxio for the specified uri
-              if (ServerConfiguration.getBoolean(
+              if (Configuration.getBoolean(
                   PropertyKey.MASTER_UFS_ACTIVE_SYNC_INITIAL_SYNC_ENABLED)) {
                 RetryUtils.retry("active sync during start",
                     () -> mFileSystemMaster.activeSyncMetadata(syncPoint,
                         null, getExecutor()),
-                    RetryUtils.defaultActiveSyncClientRetry(ServerConfiguration
+                    RetryUtils.defaultActiveSyncClientRetry(Configuration
                         .getMs(PropertyKey.MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT)));
               }
             } catch (IOException e) {

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncer.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncer.java
@@ -14,7 +14,7 @@ package alluxio.master.file.activesync;
 import alluxio.AlluxioURI;
 import alluxio.SyncInfo;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.heartbeat.HeartbeatExecutor;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.meta.MountTable;
@@ -120,7 +120,7 @@ public class ActiveSyncer implements HeartbeatExecutor {
           // sync tasks in the last 32 / (heartbeats/minute) minutes have not completed.
           for (CompletableFuture<?> f : mSyncTasks) {
             try {
-              long waitTime = ServerConfiguration.getMs(PropertyKey.MASTER_UFS_ACTIVE_SYNC_INTERVAL)
+              long waitTime = Configuration.getMs(PropertyKey.MASTER_UFS_ACTIVE_SYNC_INTERVAL)
                   / mSyncTasks.size();
               f.get(waitTime, TimeUnit.MILLISECONDS);
               mSyncTasks.remove(f);
@@ -168,7 +168,7 @@ public class ActiveSyncer implements HeartbeatExecutor {
         RetryUtils.retry("Full Sync", () -> {
           mFileSystemMaster.activeSyncMetadata(alluxioUri, null, mSyncManager.getExecutor());
         }, RetryUtils.defaultActiveSyncClientRetry(
-            ServerConfiguration.getMs(PropertyKey.MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT)));
+            Configuration.getMs(PropertyKey.MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT)));
       } else {
         LOG.debug("incremental sync {}", ufsUri);
         RetryUtils.retry("Incremental Sync", () -> {
@@ -178,7 +178,7 @@ public class ActiveSyncer implements HeartbeatExecutor {
                   .collect(Collectors.toSet()),
               mSyncManager.getExecutor());
         }, RetryUtils.defaultActiveSyncClientRetry(
-            ServerConfiguration.getMs(PropertyKey.MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT)));
+            Configuration.getMs(PropertyKey.MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT)));
       }
     } catch (IOException e) {
       LOG.warn("Failed to submit active sync job to master: ufsUri {}, syncPoint {} ", ufsUri,

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CheckAccessContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CheckAccessContext.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file.contexts;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CheckAccessPOptions;
 import alluxio.util.FileSystemOptions;
 
@@ -49,7 +49,7 @@ public class CheckAccessContext
    */
   public static CheckAccessContext mergeFrom(CheckAccessPOptions.Builder optionsBuilder) {
     CheckAccessPOptions masterOptions =
-        FileSystemOptions.checkAccessDefaults(ServerConfiguration.global());
+        FileSystemOptions.checkAccessDefaults(Configuration.global());
     CheckAccessPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -60,7 +60,7 @@ public class CheckAccessContext
    */
   public static CheckAccessContext defaults() {
     return create(FileSystemOptions
-        .checkAccessDefaults(ServerConfiguration.global()).toBuilder());
+        .checkAccessDefaults(Configuration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CheckConsistencyContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CheckConsistencyContext.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file.contexts;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CheckConsistencyPOptions;
 import alluxio.util.FileSystemOptions;
 
@@ -49,7 +49,7 @@ public class CheckConsistencyContext
    */
   public static CheckConsistencyContext mergeFrom(CheckConsistencyPOptions.Builder optionsBuilder) {
     CheckConsistencyPOptions masterOptions =
-        FileSystemOptions.checkConsistencyDefaults(ServerConfiguration.global());
+        FileSystemOptions.checkConsistencyDefaults(Configuration.global());
     CheckConsistencyPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -60,7 +60,7 @@ public class CheckConsistencyContext
    */
   public static CheckConsistencyContext defaults() {
     return create(FileSystemOptions
-        .checkConsistencyDefaults(ServerConfiguration.global()).toBuilder());
+        .checkConsistencyDefaults(Configuration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CreateDirectoryContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CreateDirectoryContext.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file.contexts;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.security.authorization.AclEntry;
 import alluxio.underfs.UfsStatus;
@@ -61,7 +61,7 @@ public class CreateDirectoryContext
    */
   public static CreateDirectoryContext mergeFrom(CreateDirectoryPOptions.Builder optionsBuilder) {
     CreateDirectoryPOptions masterOptions =
-        FileSystemOptions.createDirectoryDefaults(ServerConfiguration.global(), false);
+        FileSystemOptions.createDirectoryDefaults(Configuration.global(), false);
     CreateDirectoryPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -72,7 +72,7 @@ public class CreateDirectoryContext
    */
   public static CreateDirectoryContext defaults() {
     return create(FileSystemOptions
-        .createDirectoryDefaults(ServerConfiguration.global(), false).toBuilder());
+        .createDirectoryDefaults(Configuration.global(), false).toBuilder());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CreateFileContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CreateFileContext.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file.contexts;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.util.FileSystemOptions;
 import alluxio.wire.OperationId;
@@ -52,7 +52,7 @@ public class CreateFileContext
    */
   public static CreateFileContext mergeFrom(CreateFilePOptions.Builder optionsBuilder) {
     CreateFilePOptions masterOptions =
-        FileSystemOptions.createFileDefaults(ServerConfiguration.global(), false);
+        FileSystemOptions.createFileDefaults(Configuration.global(), false);
     CreateFilePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return new CreateFileContext(mergedOptionsBuilder);
@@ -63,7 +63,7 @@ public class CreateFileContext
    */
   public static CreateFileContext defaults() {
     return create(
-        FileSystemOptions.createFileDefaults(ServerConfiguration.global(), false).toBuilder());
+        FileSystemOptions.createFileDefaults(Configuration.global(), false).toBuilder());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CreatePathContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CreatePathContext.java
@@ -12,7 +12,7 @@
 package alluxio.master.file.contexts;
 
 import alluxio.client.WriteType;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.TtlAction;
@@ -78,9 +78,9 @@ public abstract class CreatePathContext<T extends GeneratedMessageV3.Builder<?>,
     mMetadataLoad = false;
     mGroup = "";
     mOwner = "";
-    if (SecurityUtils.isAuthenticationEnabled(ServerConfiguration.global())) {
-      mOwner = SecurityUtils.getOwnerFromGrpcClient(ServerConfiguration.global());
-      mGroup = SecurityUtils.getGroupFromGrpcClient(ServerConfiguration.global());
+    if (SecurityUtils.isAuthenticationEnabled(Configuration.global())) {
+      mOwner = SecurityUtils.getOwnerFromGrpcClient(Configuration.global());
+      mGroup = SecurityUtils.getGroupFromGrpcClient(Configuration.global());
     }
     // Initialize mPersisted based on proto write type.
     WritePType writeType = WritePType.NONE;

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/DeleteContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/DeleteContext.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file.contexts;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.DeletePOptions;
 import alluxio.util.FileSystemOptions;
 import alluxio.wire.OperationId;
@@ -48,7 +48,7 @@ public class DeleteContext extends OperationContext<DeletePOptions.Builder, Dele
    */
   public static DeleteContext mergeFrom(DeletePOptions.Builder optionsBuilder) {
     DeletePOptions masterOptions =
-        FileSystemOptions.deleteDefaults(ServerConfiguration.global(), false);
+        FileSystemOptions.deleteDefaults(Configuration.global(), false);
     DeletePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -59,7 +59,7 @@ public class DeleteContext extends OperationContext<DeletePOptions.Builder, Dele
    */
   public static DeleteContext defaults() {
     return create(
-        FileSystemOptions.deleteDefaults(ServerConfiguration.global(), false).toBuilder());
+        FileSystemOptions.deleteDefaults(Configuration.global(), false).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/ExistsContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/ExistsContext.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file.contexts;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.ExistsPOptions;
 import alluxio.util.FileSystemOptions;
 
@@ -49,7 +49,7 @@ public class ExistsContext
    */
   public static ExistsContext mergeFrom(ExistsPOptions.Builder optionsBuilder) {
     ExistsPOptions masterOptions =
-        FileSystemOptions.existsDefaults(ServerConfiguration.global());
+        FileSystemOptions.existsDefaults(Configuration.global());
     ExistsPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -60,7 +60,7 @@ public class ExistsContext
    */
   public static ExistsContext defaults() {
     return create(FileSystemOptions
-        .existsDefaults(ServerConfiguration.global()).toBuilder());
+        .existsDefaults(Configuration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/FreeContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/FreeContext.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file.contexts;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.FreePOptions;
 import alluxio.util.FileSystemOptions;
 
@@ -46,7 +46,7 @@ public class FreeContext extends OperationContext<FreePOptions.Builder, FreeCont
    * @return the instance of {@link FreeContext} with default values for master
    */
   public static FreeContext mergeFrom(FreePOptions.Builder optionsBuilder) {
-    FreePOptions masterOptions = FileSystemOptions.freeDefaults(ServerConfiguration.global());
+    FreePOptions masterOptions = FileSystemOptions.freeDefaults(Configuration.global());
     FreePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -56,7 +56,7 @@ public class FreeContext extends OperationContext<FreePOptions.Builder, FreeCont
    * @return the instance of {@link FreeContext} with default values for master
    */
   public static FreeContext defaults() {
-    return create(FileSystemOptions.freeDefaults(ServerConfiguration.global()).toBuilder());
+    return create(FileSystemOptions.freeDefaults(Configuration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/GetStatusContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/GetStatusContext.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file.contexts;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.util.FileSystemOptions;
 
@@ -47,7 +47,7 @@ public class GetStatusContext
    */
   public static GetStatusContext mergeFrom(GetStatusPOptions.Builder optionsBuilder) {
     GetStatusPOptions masterOptions =
-        FileSystemOptions.getStatusDefaults(ServerConfiguration.global());
+        FileSystemOptions.getStatusDefaults(Configuration.global());
     GetStatusPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -57,7 +57,7 @@ public class GetStatusContext
    * @return the instance of {@link GetStatusContext} with default values for master
    */
   public static GetStatusContext defaults() {
-    return create(FileSystemOptions.getStatusDefaults(ServerConfiguration.global()).toBuilder());
+    return create(FileSystemOptions.getStatusDefaults(Configuration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/ListStatusContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/ListStatusContext.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file.contexts;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.ListStatusPOptions;
 import alluxio.util.FileSystemOptions;
 
@@ -48,7 +48,7 @@ public class ListStatusContext
    */
   public static ListStatusContext mergeFrom(ListStatusPOptions.Builder optionsBuilder) {
     ListStatusPOptions masterOptions =
-        FileSystemOptions.listStatusDefaults(ServerConfiguration.global());
+        FileSystemOptions.listStatusDefaults(Configuration.global());
     ListStatusPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -58,7 +58,7 @@ public class ListStatusContext
    * @return the instance of {@link ListStatusContext} with default values for master
    */
   public static ListStatusContext defaults() {
-    return create(FileSystemOptions.listStatusDefaults(ServerConfiguration.global()).toBuilder());
+    return create(FileSystemOptions.listStatusDefaults(Configuration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/LoadMetadataContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/LoadMetadataContext.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file.contexts;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.LoadMetadataPOptions;
 import alluxio.underfs.UfsStatus;
 import alluxio.util.FileSystemOptions;
@@ -53,7 +53,7 @@ public class LoadMetadataContext
    */
   public static LoadMetadataContext mergeFrom(LoadMetadataPOptions.Builder optionsBuilder) {
     LoadMetadataPOptions masterOptions =
-        FileSystemOptions.loadMetadataDefaults(ServerConfiguration.global());
+        FileSystemOptions.loadMetadataDefaults(Configuration.global());
     LoadMetadataPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -64,7 +64,7 @@ public class LoadMetadataContext
    */
   public static LoadMetadataContext defaults() {
     return create(FileSystemOptions
-        .loadMetadataDefaults(ServerConfiguration.global()).toBuilder());
+        .loadMetadataDefaults(Configuration.global()).toBuilder());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/MountContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/MountContext.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file.contexts;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.MountPOptions;
 import alluxio.util.FileSystemOptions;
 
@@ -46,7 +46,7 @@ public class MountContext extends OperationContext<MountPOptions.Builder, MountC
    * @return the instance of {@link MountContext} with default values for master
    */
   public static MountContext mergeFrom(MountPOptions.Builder optionsBuilder) {
-    MountPOptions masterOptions = FileSystemOptions.mountDefaults(ServerConfiguration.global());
+    MountPOptions masterOptions = FileSystemOptions.mountDefaults(Configuration.global());
     MountPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -56,7 +56,7 @@ public class MountContext extends OperationContext<MountPOptions.Builder, MountC
    * @return the instance of {@link MountContext} with default values for master
    */
   public static MountContext defaults() {
-    return create(FileSystemOptions.mountDefaults(ServerConfiguration.global()).toBuilder());
+    return create(FileSystemOptions.mountDefaults(Configuration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/RenameContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/RenameContext.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file.contexts;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.RenamePOptions;
 import alluxio.util.FileSystemOptions;
 import alluxio.wire.OperationId;
@@ -53,7 +53,7 @@ public class RenameContext extends OperationContext<RenamePOptions.Builder, Rena
    */
   public static RenameContext mergeFrom(RenamePOptions.Builder optionsBuilder) {
     RenamePOptions masterOptions =
-        FileSystemOptions.renameDefaults(ServerConfiguration.global(), false);
+        FileSystemOptions.renameDefaults(Configuration.global(), false);
     RenamePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -64,7 +64,7 @@ public class RenameContext extends OperationContext<RenamePOptions.Builder, Rena
    */
   public static RenameContext defaults() {
     return create(
-        FileSystemOptions.renameDefaults(ServerConfiguration.global(), false).toBuilder());
+        FileSystemOptions.renameDefaults(Configuration.global(), false).toBuilder());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/ScheduleAsyncPersistenceContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/ScheduleAsyncPersistenceContext.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file.contexts;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.ScheduleAsyncPersistencePOptions;
 import alluxio.util.FileSystemOptions;
 
@@ -55,7 +55,7 @@ public class ScheduleAsyncPersistenceContext
   public static ScheduleAsyncPersistenceContext mergeFrom(
       ScheduleAsyncPersistencePOptions.Builder optionsBuilder) {
     ScheduleAsyncPersistencePOptions masterOptions =
-        FileSystemOptions.scheduleAsyncPersistenceDefaults(ServerConfiguration.global());
+        FileSystemOptions.scheduleAsyncPersistenceDefaults(Configuration.global());
     ScheduleAsyncPersistencePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -66,7 +66,7 @@ public class ScheduleAsyncPersistenceContext
    */
   public static ScheduleAsyncPersistenceContext defaults() {
     return create(FileSystemOptions
-        .scheduleAsyncPersistenceDefaults(ServerConfiguration.global()).toBuilder());
+        .scheduleAsyncPersistenceDefaults(Configuration.global()).toBuilder());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/SetAclContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/SetAclContext.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.file.contexts;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.SetAclPOptions;
 import alluxio.util.FileSystemOptions;
 
@@ -46,7 +46,7 @@ public class SetAclContext extends OperationContext<SetAclPOptions.Builder, SetA
    * @return the instance of {@link SetAclContext} with default values for master
    */
   public static SetAclContext mergeFrom(SetAclPOptions.Builder optionsBuilder) {
-    SetAclPOptions masterOptions = FileSystemOptions.setAclDefaults(ServerConfiguration.global());
+    SetAclPOptions masterOptions = FileSystemOptions.setAclDefaults(Configuration.global());
     SetAclPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -56,7 +56,7 @@ public class SetAclContext extends OperationContext<SetAclPOptions.Builder, SetA
    * @return the instance of {@link SetAclContext} with default values for master
    */
   public static SetAclContext defaults() {
-    return create(FileSystemOptions.setAclDefaults(ServerConfiguration.global()).toBuilder());
+    return create(FileSystemOptions.setAclDefaults(Configuration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/SetAttributeContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/SetAttributeContext.java
@@ -12,7 +12,7 @@
 package alluxio.master.file.contexts;
 
 import alluxio.Constants;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.util.FileSystemOptions;
 
@@ -54,7 +54,7 @@ public class SetAttributeContext
    */
   public static SetAttributeContext mergeFrom(SetAttributePOptions.Builder optionsBuilder) {
     SetAttributePOptions masterOptions =
-        FileSystemOptions.setAttributeDefaults(ServerConfiguration.global());
+        FileSystemOptions.setAttributeDefaults(Configuration.global());
     SetAttributePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -64,7 +64,7 @@ public class SetAttributeContext
    * @return the instance of {@link SetAttributeContext} with default values for master
    */
   public static SetAttributeContext defaults() {
-    return create(FileSystemOptions.setAttributeDefaults(ServerConfiguration.global()).toBuilder());
+    return create(FileSystemOptions.setAttributeDefaults(Configuration.global()).toBuilder());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
@@ -14,7 +14,7 @@ package alluxio.master.file.meta;
 import alluxio.AlluxioURI;
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.InvalidPathException;
 import alluxio.master.file.meta.options.MountInfo;
 import alluxio.metrics.MetricKey;
@@ -55,7 +55,7 @@ public class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
   private static final int THREAD_KEEP_ALIVE_SECONDS = 60;
   /** Number of paths to cache. */
   private static final int MAX_PATHS =
-      ServerConfiguration.getInt(PropertyKey.MASTER_UFS_PATH_CACHE_CAPACITY);
+      Configuration.getInt(PropertyKey.MASTER_UFS_PATH_CACHE_CAPACITY);
 
   /** The mount table. */
   private final MountTable mMountTable;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeLockManager.java
@@ -14,7 +14,7 @@ package alluxio.master.file.meta;
 import alluxio.collections.LockPool;
 import alluxio.concurrent.LockMode;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.resource.LockResource;
@@ -50,19 +50,19 @@ public class InodeLockManager implements Closeable {
    */
   private final LockPool<Long> mInodeLocks =
       new LockPool<>((key) -> new ReentrantReadWriteLock(),
-          ServerConfiguration.getInt(PropertyKey.MASTER_LOCK_POOL_INITSIZE),
-          ServerConfiguration.getInt(PropertyKey.MASTER_LOCK_POOL_LOW_WATERMARK),
-          ServerConfiguration.getInt(PropertyKey.MASTER_LOCK_POOL_HIGH_WATERMARK),
-          ServerConfiguration.getInt(PropertyKey.MASTER_LOCK_POOL_CONCURRENCY_LEVEL));
+          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_INITSIZE),
+          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_LOW_WATERMARK),
+          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_HIGH_WATERMARK),
+          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_CONCURRENCY_LEVEL));
   /**
    * Cache for supplying edge locks, similar to mInodeLocks.
    */
   private final LockPool<Edge> mEdgeLocks =
       new LockPool<>((key) -> new ReentrantReadWriteLock(),
-          ServerConfiguration.getInt(PropertyKey.MASTER_LOCK_POOL_INITSIZE),
-          ServerConfiguration.getInt(PropertyKey.MASTER_LOCK_POOL_LOW_WATERMARK),
-          ServerConfiguration.getInt(PropertyKey.MASTER_LOCK_POOL_HIGH_WATERMARK),
-          ServerConfiguration.getInt(PropertyKey.MASTER_LOCK_POOL_CONCURRENCY_LEVEL));
+          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_INITSIZE),
+          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_LOW_WATERMARK),
+          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_HIGH_WATERMARK),
+          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_CONCURRENCY_LEVEL));
 
   /**
    * Locks for guarding changes to last modified time and size on read-locked parent inodes.

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -16,7 +16,7 @@ import alluxio.client.WriteType;
 import alluxio.collections.Pair;
 import alluxio.concurrent.LockMode;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.BlockInfoException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;
@@ -943,7 +943,7 @@ public class InodeTree implements DelegatingJournaled {
   // Inherit owner and group from ancestor if both are empty
   private static void inheritOwnerAndGroupIfEmpty(MutableInode<?> newInode,
       InodeDirectoryView ancestorInode) {
-    if (ServerConfiguration.getBoolean(PropertyKey.MASTER_METASTORE_INODE_INHERIT_OWNER_AND_GROUP)
+    if (Configuration.getBoolean(PropertyKey.MASTER_METASTORE_INODE_INHERIT_OWNER_AND_GROUP)
         && newInode.getOwner().isEmpty() && newInode.getGroup().isEmpty()) {
       // Inherit owner / group if empty
       newInode.setOwner(ancestorInode.getOwner().intern());
@@ -1022,7 +1022,7 @@ public class InodeTree implements DelegatingJournaled {
   }
 
   private boolean checkPinningValidity(Set<String> pinnedMediumTypes) {
-    List<String> mediumTypeList = ServerConfiguration.getList(
+    List<String> mediumTypeList = Configuration.getList(
         PropertyKey.MASTER_TIERED_STORE_GLOBAL_MEDIUMTYPE);
     for (String medium : pinnedMediumTypes) {
       if (!mediumTypeList.contains(medium)) {
@@ -1278,7 +1278,7 @@ public class InodeTree implements DelegatingJournaled {
     try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
       UnderFileSystem ufs = ufsResource.get();
       MkdirsOptions mkdirsOptions =
-          MkdirsOptions.defaults(ServerConfiguration.global()).setCreateParent(false)
+          MkdirsOptions.defaults(Configuration.global()).setCreateParent(false)
           .setOwner(dir.getOwner()).setGroup(dir.getGroup()).setMode(new Mode(dir.getMode()));
       if (!ufs.mkdirs(ufsUri, mkdirsOptions)) {
         // Directory might already exist. Try loading the status from ufs.

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreeBufferedIterator.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreeBufferedIterator.java
@@ -12,7 +12,7 @@
 package alluxio.master.file.meta;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.metastore.InodeStore;
 import alluxio.proto.journal.Journal;
 import alluxio.resource.CloseableIterator;
@@ -94,9 +94,9 @@ public class InodeTreeBufferedIterator implements Iterator<Journal.JournalEntry>
     mRootInode = rootInode;
     // Initialize configuration values.
     int iteratorThreadCount =
-        ServerConfiguration.getInt(PropertyKey.MASTER_METASTORE_INODE_ITERATION_CRAWLER_COUNT);
+        Configuration.getInt(PropertyKey.MASTER_METASTORE_INODE_ITERATION_CRAWLER_COUNT);
     int entryBufferSize =
-        ServerConfiguration.getInt(PropertyKey.MASTER_METASTORE_INODE_ENUMERATOR_BUFFER_COUNT);
+        Configuration.getInt(PropertyKey.MASTER_METASTORE_INODE_ENUMERATOR_BUFFER_COUNT);
 
     // Create executors.
     mCoordinatorExecutor = Executors.newSingleThreadExecutor(

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreePersistentState.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreePersistentState.java
@@ -16,7 +16,7 @@ import static alluxio.conf.PropertyKey.MASTER_FILE_SYSTEM_OPERATION_RETRY_CACHE_
 import static alluxio.conf.PropertyKey.MASTER_METRICS_FILE_SIZE_DISTRIBUTION_BUCKETS;
 
 import alluxio.ProcessUtils;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.file.RpcContext;
 import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.JournalUtils;
@@ -131,12 +131,12 @@ public class InodeTreePersistentState implements Journaled {
     mInodeLockManager = lockManager;
     mTtlBuckets = ttlBucketList;
     mBucketCounter = new BucketCounter(
-        ServerConfiguration.getList(MASTER_METRICS_FILE_SIZE_DISTRIBUTION_BUCKETS)
+        Configuration.getList(MASTER_METRICS_FILE_SIZE_DISTRIBUTION_BUCKETS)
             .stream().map(FormatUtils::parseSpaceSize).collect(Collectors.toList()));
     mRetryCacheEnabled =
-        ServerConfiguration.getBoolean(MASTER_FILE_SYSTEM_OPERATION_RETRY_CACHE_ENABLED);
+        Configuration.getBoolean(MASTER_FILE_SYSTEM_OPERATION_RETRY_CACHE_ENABLED);
     mOpIdCache = CacheBuilder.newBuilder()
-        .maximumSize(ServerConfiguration.getInt(MASTER_FILE_SYSTEM_OPERATION_RETRY_CACHE_SIZE))
+        .maximumSize(Configuration.getInt(MASTER_FILE_SYSTEM_OPERATION_RETRY_CACHE_SIZE))
         .build();
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LazyUfsBlockLocationCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LazyUfsBlockLocationCache.java
@@ -13,7 +13,7 @@ package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.InvalidPathException;
 import alluxio.resource.CloseableResource;
 import alluxio.underfs.UnderFileSystem;
@@ -38,7 +38,7 @@ public class LazyUfsBlockLocationCache implements UfsBlockLocationCache {
 
   /** Number of blocks to cache. */
   private static final int MAX_BLOCKS =
-      ServerConfiguration.getInt(PropertyKey.MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY);
+      Configuration.getInt(PropertyKey.MASTER_UFS_BLOCK_LOCATION_CACHE_CAPACITY);
 
   /** Cache of ufs block locations, key is block ID, value is block locations. */
   private Cache<Long, List<String>> mCache;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockingScheme.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockingScheme.java
@@ -13,7 +13,7 @@ package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.master.file.contexts.GetStatusContext;
 import alluxio.master.file.meta.InodeTree.LockPattern;
@@ -63,7 +63,7 @@ public final class LockingScheme {
     // If client options didn't specify the interval, fallback to whatever the server has
     // configured to prevent unnecessary syncing due to the default value being 0
     long syncInterval = options.hasSyncIntervalMs() ? options.getSyncIntervalMs() :
-        ServerConfiguration.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL);
+        Configuration.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL);
     mShouldSync = pathCache.shouldSyncPath(path.getPath(), syncInterval, isGetFileInfo);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInode.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInode.java
@@ -13,7 +13,7 @@ package alluxio.master.file.meta;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.TtlAction;
 import alluxio.master.ProtobufUtils;
 import alluxio.proto.journal.File;
@@ -53,7 +53,7 @@ public abstract class MutableInode<T extends MutableInode> implements InodeView 
 
   public static final ImmutableSet<String> NO_MEDIUM = ImmutableSet.of();
   private static final ImmutableSet<String> MEDIUMS = ImmutableSet.copyOf(
-      ServerConfiguration.getList(PropertyKey.MASTER_TIERED_STORE_GLOBAL_MEDIUMTYPE));
+      Configuration.getList(PropertyKey.MASTER_TIERED_STORE_GLOBAL_MEDIUMTYPE));
   protected long mCreationTimeMs;
   private boolean mDeleted;
   protected final boolean mDirectory;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
@@ -12,7 +12,7 @@
 package alluxio.master.file.meta;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import com.google.common.base.Objects;
 
@@ -33,7 +33,7 @@ public final class TtlBucket implements Comparable<TtlBucket> {
    * This field is intentionally not final so that tests can change the value.
    */
   private static long sTtlIntervalMs =
-      ServerConfiguration.getMs(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS);
+      Configuration.getMs(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS);
   /**
    * Each bucket has a time to live interval, this value is the start of the interval, interval
    * value is the same as the configuration of {@link PropertyKey#MASTER_TTL_CHECKER_INTERVAL_MS}.

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsAbsentPathCache.java
@@ -13,7 +13,7 @@ package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,7 +75,7 @@ public interface UfsAbsentPathCache {
      * @return {@link UfsAbsentPathCache}
      */
     public static UfsAbsentPathCache create(MountTable mountTable) {
-      int numThreads = ServerConfiguration.getInt(PropertyKey.MASTER_UFS_PATH_CACHE_THREADS);
+      int numThreads = Configuration.getInt(PropertyKey.MASTER_UFS_PATH_CACHE_THREADS);
       if (numThreads <= 0) {
         LOG.info("UfsAbsentPathCache is disabled. {}: {}",
             PropertyKey.MASTER_UFS_PATH_CACHE_THREADS, numThreads);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncPathCache.java
@@ -13,7 +13,7 @@ package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.InvalidPathException;
 import alluxio.file.options.DescendantType;
 import alluxio.util.io.PathUtils;
@@ -35,7 +35,7 @@ public final class UfsSyncPathCache {
 
   /** Number of paths to cache. */
   private static final int MAX_PATHS =
-      ServerConfiguration.getInt(PropertyKey.MASTER_UFS_PATH_CACHE_CAPACITY);
+      Configuration.getInt(PropertyKey.MASTER_UFS_PATH_CACHE_CAPACITY);
 
   /** Cache of paths which have been synced. */
   private final Cache<String, SyncTime> mCache;

--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -15,7 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.client.job.JobMasterClientPool;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.BlockInfoException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.JobDoesNotExistException;
@@ -116,7 +116,7 @@ public final class ReplicationChecker implements HeartbeatExecutor {
 
     // Do not use more than 10% of the job service
     mMaxActiveJobs = Math.max(1,
-        (int) (ServerConfiguration.getInt(PropertyKey.JOB_MASTER_JOB_CAPACITY) * 0.1));
+        (int) (Configuration.getInt(PropertyKey.JOB_MASTER_JOB_CAPACITY) * 0.1));
     mActiveJobToInodeID = HashBiMap.create();
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricsSystem.getMetricName(MetricKey.MASTER_REPLICA_MGMT_ACTIVE_JOB_SIZE.getName()),
@@ -125,7 +125,7 @@ public final class ReplicationChecker implements HeartbeatExecutor {
 
   private boolean shouldRun() {
     // In unit tests there may not be workers, but we still want the ReplicationChecker to execute
-    if (ServerConfiguration.getBoolean(PropertyKey.TEST_MODE)) {
+    if (Configuration.getBoolean(PropertyKey.TEST_MODE)) {
       return true;
     }
     if (mSafeModeManager.isInSafeMode() || mBlockMaster.getWorkerCount() == 0) {

--- a/core/server/master/src/main/java/alluxio/master/journal/tool/JournalTool.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/JournalTool.java
@@ -14,7 +14,7 @@ package alluxio.master.journal.tool;
 import alluxio.RuntimeConstants;
 import alluxio.annotation.SuppressFBWarnings;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.journal.JournalType;
 
 import org.apache.commons.cli.CommandLine;
@@ -101,7 +101,7 @@ public final class JournalTool {
   @SuppressFBWarnings(value = "DB_DUPLICATE_SWITCH_CLAUSES")
   private static void dumpJournal() throws Throwable {
     JournalType journalType =
-        ServerConfiguration.getEnum(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.class);
+        Configuration.getEnum(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.class);
 
     AbstractJournalDumper journalDumper;
     switch (journalType) {
@@ -145,7 +145,7 @@ public final class JournalTool {
     if (cmd.hasOption(INPUT_DIR_OPTION_NAME)) {
       sInputDir = new File(cmd.getOptionValue(INPUT_DIR_OPTION_NAME)).getAbsolutePath();
     } else {
-      sInputDir = ServerConfiguration.getString(PropertyKey.MASTER_JOURNAL_FOLDER);
+      sInputDir = Configuration.getString(PropertyKey.MASTER_JOURNAL_FOLDER);
     }
     sOutputDir = new File(cmd.getOptionValue(OUTPUT_DIR_OPTION_NAME,
         "journal_dump-" + System.currentTimeMillis())).getAbsolutePath();

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -24,7 +24,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.ConfigurationValueOptions;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;
@@ -204,7 +204,7 @@ public final class AlluxioMasterRestServiceHandler {
           .setTierCapacity(getTierCapacityInternal()).setUfsCapacity(getUfsCapacityInternal())
           .setUptimeMs(mMasterProcess.getUptimeMs()).setVersion(RuntimeConstants.VERSION)
           .setWorkers(mBlockMaster.getWorkerInfoList());
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -219,24 +219,24 @@ public final class AlluxioMasterRestServiceHandler {
       MasterWebUIInit response = new MasterWebUIInit();
 
       String proxyHostname = NetworkAddressUtils
-          .getConnectHost(NetworkAddressUtils.ServiceType.PROXY_WEB, ServerConfiguration.global());
-      int proxyPort = ServerConfiguration.getInt(PropertyKey.PROXY_WEB_PORT);
+          .getConnectHost(NetworkAddressUtils.ServiceType.PROXY_WEB, Configuration.global());
+      int proxyPort = Configuration.getInt(PropertyKey.PROXY_WEB_PORT);
       Map<String, String> proxyDowloadFileApiUrl = new HashMap<>();
       proxyDowloadFileApiUrl
           .put("prefix", "http://" + proxyHostname + ":" + proxyPort + "/api/v1/paths/");
       proxyDowloadFileApiUrl.put("suffix", "/download-file/");
 
-      response.setDebug(ServerConfiguration.getBoolean(PropertyKey.DEBUG))
+      response.setDebug(Configuration.getBoolean(PropertyKey.DEBUG))
           .setNewerVersionAvailable(mMetaMaster.getNewerVersionAvailable())
-          .setWebFileInfoEnabled(ServerConfiguration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED))
+          .setWebFileInfoEnabled(Configuration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED))
           .setSecurityAuthorizationPermissionEnabled(
-              ServerConfiguration.getBoolean(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED))
-          .setWorkerPort(ServerConfiguration.getInt(PropertyKey.WORKER_WEB_PORT))
-          .setRefreshInterval((int) ServerConfiguration.getMs(PropertyKey.WEB_REFRESH_INTERVAL))
+              Configuration.getBoolean(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED))
+          .setWorkerPort(Configuration.getInt(PropertyKey.WORKER_WEB_PORT))
+          .setRefreshInterval((int) Configuration.getMs(PropertyKey.WEB_REFRESH_INTERVAL))
           .setProxyDownloadFileApiUrl(proxyDowloadFileApiUrl);
 
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -249,11 +249,11 @@ public final class AlluxioMasterRestServiceHandler {
   public Response getWebUIOverview() {
     return RestUtils.call(() -> {
       MasterWebUIOverview response = new MasterWebUIOverview();
-      response.setDebug(ServerConfiguration.getBoolean(PropertyKey.DEBUG))
+      response.setDebug(Configuration.getBoolean(PropertyKey.DEBUG))
           .setMasterNodeAddress(mMasterProcess.getRpcAddress().toString()).setUptime(CommonUtils
           .convertMsToClockTime(System.currentTimeMillis() - mMetaMaster.getStartTimeMs()))
           .setStartTime(CommonUtils.convertMsToDate(mMetaMaster.getStartTimeMs(),
-              ServerConfiguration.getString(PropertyKey.USER_DATE_FORMAT_PATTERN)))
+              Configuration.getString(PropertyKey.USER_DATE_FORMAT_PATTERN)))
           .setVersion(RuntimeConstants.VERSION)
           .setLiveWorkerNodes(Integer.toString(mBlockMaster.getWorkerCount()))
           .setCapacity(FormatUtils.getSizeFromBytes(mBlockMaster.getCapacityBytes()))
@@ -332,22 +332,22 @@ public final class AlluxioMasterRestServiceHandler {
         long entriesSinceCkpt = (Long) entriesSinceGauge.getValue();
         long lastCkptTime = (Long) lastCkPtGauge.getValue();
         long timeSinceCkpt = System.currentTimeMillis() - lastCkptTime;
-        boolean overThreshold = timeSinceCkpt > ServerConfiguration.getMs(
+        boolean overThreshold = timeSinceCkpt > Configuration.getMs(
             PropertyKey.MASTER_WEB_JOURNAL_CHECKPOINT_WARNING_THRESHOLD_TIME);
-        boolean passedThreshold = entriesSinceCkpt > ServerConfiguration
+        boolean passedThreshold = entriesSinceCkpt > Configuration
             .getInt(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES);
         if (passedThreshold && overThreshold) {
           String time = lastCkptTime > 0 ? ZonedDateTime
               .ofInstant(Instant.ofEpochMilli(lastCkptTime), ZoneOffset.UTC)
               .format(DateTimeFormatter.ISO_INSTANT) : "N/A";
-          String advice = ConfigurationUtils.isHaMode(ServerConfiguration.global()) ? ""
+          String advice = ConfigurationUtils.isHaMode(Configuration.global()) ? ""
               : "It is recommended to use the fsadmin tool to checkpoint the journal. This will "
               + "prevent the master from serving requests while checkpointing.";
           response.setJournalCheckpointTimeWarning(String.format("Journal has not checkpointed in "
               + "a timely manner since passing the checkpoint threshold (%d/%d). Last checkpoint:"
               + " %s. %s",
               entriesSinceCkpt,
-              ServerConfiguration.getInt(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES),
+              Configuration.getInt(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES),
               time, advice));
         }
       }
@@ -364,7 +364,7 @@ public final class AlluxioMasterRestServiceHandler {
         response.setLeaderId((String) leaderIdGauge.getValue());
       }
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -385,16 +385,16 @@ public final class AlluxioMasterRestServiceHandler {
     return RestUtils.call(() -> {
       MasterWebUIBrowse response = new MasterWebUIBrowse();
 
-      if (!ServerConfiguration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {
+      if (!Configuration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {
         return response;
       }
 
-      if (SecurityUtils.isSecurityEnabled(ServerConfiguration.global())
-          && AuthenticatedClientUser.get(ServerConfiguration.global()) == null) {
+      if (SecurityUtils.isSecurityEnabled(Configuration.global())
+          && AuthenticatedClientUser.get(Configuration.global()) == null) {
         AuthenticatedClientUser.set(ServerUserState.global().getUser().getName());
       }
-      response.setDebug(ServerConfiguration.getBoolean(PropertyKey.DEBUG)).setShowPermissions(
-          ServerConfiguration.getBoolean(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED))
+      response.setDebug(Configuration.getBoolean(PropertyKey.DEBUG)).setShowPermissions(
+          Configuration.getBoolean(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED))
           .setMasterNodeAddress(mMasterProcess.getRpcAddress().toString()).setInvalidPathError("");
       List<FileInfo> filesInfo;
       String path = URLDecoder.decode(requestPath, "UTF-8");
@@ -407,7 +407,7 @@ public final class AlluxioMasterRestServiceHandler {
       try {
         long fileId = mFileSystemMaster.getFileId(currentPath);
         FileInfo fileInfo = mFileSystemMaster.getFileInfo(fileId);
-        UIFileInfo currentFileInfo = new UIFileInfo(fileInfo, ServerConfiguration.global(),
+        UIFileInfo currentFileInfo = new UIFileInfo(fileInfo, Configuration.global(),
             mBlockMaster.getGlobalStorageTierAssoc().getOrderedStorageAliases());
         if (currentFileInfo.getAbsolutePath() == null) {
           throw new FileDoesNotExistException(currentPath.toString());
@@ -471,7 +471,7 @@ public final class AlluxioMasterRestServiceHandler {
             List<UIFileBlockInfo> uiBlockInfo = new ArrayList<>();
             for (FileBlockInfo fileBlockInfo : mFileSystemMaster
                 .getFileBlockInfoList(absolutePath)) {
-              uiBlockInfo.add(new UIFileBlockInfo(fileBlockInfo, ServerConfiguration.global()));
+              uiBlockInfo.add(new UIFileBlockInfo(fileBlockInfo, Configuration.global()));
             }
             response.setFileBlocks(uiBlockInfo).setFileData(fileData)
                 .setHighestTierAlias(mBlockMaster.getGlobalStorageTierAssoc().getAlias(0));
@@ -489,14 +489,14 @@ public final class AlluxioMasterRestServiceHandler {
           UIFileInfo[] pathInfos = new UIFileInfo[splitPath.length - 1];
           fileId = mFileSystemMaster.getFileId(currentPath);
           pathInfos[0] =
-              new UIFileInfo(mFileSystemMaster.getFileInfo(fileId), ServerConfiguration.global(),
+              new UIFileInfo(mFileSystemMaster.getFileInfo(fileId), Configuration.global(),
                   mBlockMaster.getGlobalStorageTierAssoc().getOrderedStorageAliases());
           AlluxioURI breadcrumb = new AlluxioURI(AlluxioURI.SEPARATOR);
           for (int i = 1; i < splitPath.length - 1; i++) {
             breadcrumb = breadcrumb.join(splitPath[i]);
             fileId = mFileSystemMaster.getFileId(breadcrumb);
             pathInfos[i] =
-                new UIFileInfo(mFileSystemMaster.getFileInfo(fileId), ServerConfiguration.global(),
+                new UIFileInfo(mFileSystemMaster.getFileInfo(fileId), Configuration.global(),
                     mBlockMaster.getGlobalStorageTierAssoc().getOrderedStorageAliases());
           }
           response.setPathInfos(pathInfos);
@@ -524,7 +524,7 @@ public final class AlluxioMasterRestServiceHandler {
 
       List<UIFileInfo> fileInfos = new ArrayList<>(filesInfo.size());
       for (FileInfo fileInfo : filesInfo) {
-        UIFileInfo toAdd = new UIFileInfo(fileInfo, ServerConfiguration.global(),
+        UIFileInfo toAdd = new UIFileInfo(fileInfo, Configuration.global(),
             mBlockMaster.getGlobalStorageTierAssoc().getOrderedStorageAliases());
         try {
           if (!toAdd.getIsDirectory() && fileInfo.getLength() > 0) {
@@ -579,7 +579,7 @@ public final class AlluxioMasterRestServiceHandler {
       }
 
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -596,16 +596,16 @@ public final class AlluxioMasterRestServiceHandler {
     return RestUtils.call(() -> {
       MasterWebUIData response = new MasterWebUIData();
 
-      if (!ServerConfiguration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {
+      if (!Configuration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {
         return response;
       }
 
-      if (SecurityUtils.isSecurityEnabled(ServerConfiguration.global())
-          && AuthenticatedClientUser.get(ServerConfiguration.global()) == null) {
+      if (SecurityUtils.isSecurityEnabled(Configuration.global())
+          && AuthenticatedClientUser.get(Configuration.global()) == null) {
         AuthenticatedClientUser.set(ServerUserState.global().getUser().getName());
       }
       response.setMasterNodeAddress(mMasterProcess.getRpcAddress().toString()).setFatalError("")
-          .setShowPermissions(ServerConfiguration
+          .setShowPermissions(Configuration
               .getBoolean(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED));
 
       List<AlluxioURI> inAlluxioFiles = mFileSystemMaster.getInAlluxioFiles();
@@ -617,7 +617,7 @@ public final class AlluxioMasterRestServiceHandler {
           long fileId = mFileSystemMaster.getFileId(file);
           FileInfo fileInfo = mFileSystemMaster.getFileInfo(fileId);
           if (fileInfo != null && fileInfo.getInAlluxioPercentage() == 100) {
-            fileInfos.add(new UIFileInfo(fileInfo, ServerConfiguration.global(),
+            fileInfos.add(new UIFileInfo(fileInfo, Configuration.global(),
                 mBlockMaster.getGlobalStorageTierAssoc().getOrderedStorageAliases()));
           }
         } catch (FileDoesNotExistException e) {
@@ -652,7 +652,7 @@ public final class AlluxioMasterRestServiceHandler {
       }
 
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -674,16 +674,16 @@ public final class AlluxioMasterRestServiceHandler {
       FilenameFilter filenameFilter = (dir, name) -> name.toLowerCase().endsWith(".log");
       MasterWebUILogs response = new MasterWebUILogs();
 
-      if (!ServerConfiguration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {
+      if (!Configuration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {
         return response;
       }
-      response.setDebug(ServerConfiguration.getBoolean(PropertyKey.DEBUG)).setInvalidPathError("")
+      response.setDebug(Configuration.getBoolean(PropertyKey.DEBUG)).setInvalidPathError("")
           .setViewingOffset(0).setCurrentPath("");
       //response.setDownloadLogFile(1);
       //response.setBaseUrl("./browseLogs");
       //response.setShowPermissions(false);
 
-      String logsPath = ServerConfiguration.getString(PropertyKey.LOGS_DIR);
+      String logsPath = Configuration.getString(PropertyKey.LOGS_DIR);
       File logsDir = new File(logsPath);
       String requestFile = requestPath;
 
@@ -698,7 +698,7 @@ public final class AlluxioMasterRestServiceHandler {
             fileInfos.add(new UIFileInfo(
                 new UIFileInfo.LocalFileInfo(logFileName, logFileName, logFile.length(),
                     UIFileInfo.LocalFileInfo.EMPTY_CREATION_TIME, logFile.lastModified(),
-                    logFile.isDirectory()), ServerConfiguration.global(),
+                    logFile.isDirectory()), Configuration.global(),
                 mBlockMaster.getGlobalStorageTierAssoc().getOrderedStorageAliases()));
           }
         }
@@ -788,7 +788,7 @@ public final class AlluxioMasterRestServiceHandler {
       }
 
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -820,7 +820,7 @@ public final class AlluxioMasterRestServiceHandler {
       response.setConfiguration(sortedProperties);
 
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -834,7 +834,7 @@ public final class AlluxioMasterRestServiceHandler {
     return RestUtils.call(() -> {
       MasterWebUIWorkers response = new MasterWebUIWorkers();
 
-      response.setDebug(ServerConfiguration.getBoolean(PropertyKey.DEBUG));
+      response.setDebug(Configuration.getBoolean(PropertyKey.DEBUG));
 
       List<WorkerInfo> workerInfos = mBlockMaster.getWorkerInfoList();
       NodeInfo[] normalNodeInfos = WebUtils.generateOrderedNodeInfos(workerInfos);
@@ -845,7 +845,7 @@ public final class AlluxioMasterRestServiceHandler {
       response.setFailedNodeInfos(failedNodeInfos);
 
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -859,13 +859,13 @@ public final class AlluxioMasterRestServiceHandler {
     return RestUtils.call(() -> {
       MasterWebUIMountTable response = new MasterWebUIMountTable();
 
-      response.setDebug(ServerConfiguration.getBoolean(PropertyKey.DEBUG));
+      response.setDebug(Configuration.getBoolean(PropertyKey.DEBUG));
       Map<String, MountPointInfo> mountPointInfo = getMountPointsInternal();
 
       response.setMountPointInfos(mountPointInfo);
 
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -1116,7 +1116,7 @@ public final class AlluxioMasterRestServiceHandler {
       }
 
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   private Capacity getCapacityInternal() {
@@ -1125,7 +1125,7 @@ public final class AlluxioMasterRestServiceHandler {
   }
 
   private Map<String, Object> getConfigurationInternal(boolean raw) {
-    return new TreeMap<>(ServerConfiguration
+    return new TreeMap<>(Configuration
         .toMap(ConfigurationValueOptions.defaults().useDisplayValue(true).useRawValue(raw)));
   }
 
@@ -1186,6 +1186,6 @@ public final class AlluxioMasterRestServiceHandler {
   @Path(LOG_LEVEL)
   public Response logLevel(@QueryParam(LOG_ARGUMENT_NAME) final String logName,
       @QueryParam(LOG_ARGUMENT_LEVEL) final String level) {
-    return RestUtils.call(() -> LogUtils.setLogLevel(logName, level), ServerConfiguration.global());
+    return RestUtils.call(() -> LogUtils.setLogLevel(logName, level), Configuration.global());
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/meta/DailyMetadataBackup.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DailyMetadataBackup.java
@@ -13,7 +13,7 @@ package alluxio.master.meta;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.BackupPOptions;
 import alluxio.grpc.BackupPRequest;
 import alluxio.master.BackupManager;
@@ -69,8 +69,8 @@ public final class DailyMetadataBackup {
   DailyMetadataBackup(MetaMaster metaMaster,
       ScheduledExecutorService service, UfsManager ufsManager) {
     mMetaMaster = metaMaster;
-    mBackupDir = ServerConfiguration.getString(PropertyKey.MASTER_BACKUP_DIRECTORY);
-    mRetainedFiles = ServerConfiguration.getInt(PropertyKey.MASTER_DAILY_BACKUP_FILES_RETAINED);
+    mBackupDir = Configuration.getString(PropertyKey.MASTER_BACKUP_DIRECTORY);
+    mRetainedFiles = Configuration.getInt(PropertyKey.MASTER_DAILY_BACKUP_FILES_RETAINED);
     mScheduledExecutor = service;
     mUfsManager = ufsManager;
     try (CloseableResource<UnderFileSystem> ufsResource =
@@ -100,7 +100,7 @@ public final class DailyMetadataBackup {
     LocalDateTime now = LocalDateTime.now(Clock.systemUTC());
 
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("H:mm");
-    LocalTime backupTime = LocalTime.parse(ServerConfiguration
+    LocalTime backupTime = LocalTime.parse(Configuration
         .getString(PropertyKey.MASTER_DAILY_BACKUP_TIME), formatter);
     LocalDateTime nextBackupTime = now.withHour(backupTime.getHour())
         .withMinute(backupTime.getMinute());

--- a/core/server/master/src/main/java/alluxio/master/meta/MetaMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/MetaMasterClientServiceHandler.java
@@ -14,7 +14,7 @@ package alluxio.master.meta;
 import alluxio.RpcUtils;
 import alluxio.RuntimeConstants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.BackupPRequest;
 import alluxio.grpc.BackupPStatus;
 import alluxio.grpc.BackupStatusPRequest;
@@ -121,9 +121,9 @@ public final class MetaMasterClientServiceHandler
                 .map(Address::toProto).collect(Collectors.toList()));
             break;
           case ZOOKEEPER_ADDRESSES:
-            if (ServerConfiguration.isSet(PropertyKey.ZOOKEEPER_ADDRESS)) {
+            if (Configuration.isSet(PropertyKey.ZOOKEEPER_ADDRESS)) {
               masterInfo.addAllZookeeperAddresses(
-                  Arrays.asList(ServerConfiguration.getString(PropertyKey.ZOOKEEPER_ADDRESS)
+                  Arrays.asList(Configuration.getString(PropertyKey.ZOOKEEPER_ADDRESS)
                       .split(",")));
             }
             break;

--- a/core/server/master/src/main/java/alluxio/master/meta/MetaMasterSync.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/MetaMasterSync.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.meta;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.MetaCommand;
 import alluxio.grpc.Scope;
 import alluxio.heartbeat.HeartbeatExecutor;
@@ -113,7 +113,7 @@ public final class MetaMasterSync implements HeartbeatExecutor {
   private void setIdAndRegister() throws IOException {
     mMasterId.set(mMasterClient.getId(mMasterAddress));
     mMasterClient.register(mMasterId.get(),
-        ConfigurationUtils.getConfiguration(ServerConfiguration.global(), Scope.MASTER));
+        ConfigurationUtils.getConfiguration(Configuration.global(), Scope.MASTER));
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
@@ -17,7 +17,7 @@ import alluxio.collections.TwoKeyConcurrentMap;
 import alluxio.concurrent.LockMode;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.file.meta.Edge;
 import alluxio.master.file.meta.EdgeEntry;
 import alluxio.master.file.meta.Inode;
@@ -124,7 +124,7 @@ public final class CachingInodeStore implements InodeStore, Closeable {
   public CachingInodeStore(InodeStore backingStore, InodeLockManager lockManager) {
     mBackingStore = backingStore;
     mLockManager = lockManager;
-    AlluxioConfiguration conf = ServerConfiguration.global();
+    AlluxioConfiguration conf = Configuration.global();
     int maxSize = conf.getInt(PropertyKey.MASTER_METASTORE_INODE_CACHE_MAX_SIZE);
     Preconditions.checkState(maxSize > 0,
         "Maximum cache size %s must be positive, but is set to %s",

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapBlockStore.java
@@ -13,7 +13,7 @@ package alluxio.master.metastore.heap;
 
 import alluxio.collections.TwoKeyConcurrentMap;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.metastore.BlockStore;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
@@ -53,7 +53,7 @@ public class HeapBlockStore implements BlockStore {
    */
   public HeapBlockStore() {
     super();
-    if (ServerConfiguration.getBoolean(PropertyKey.MASTER_METRICS_HEAP_ENABLED)) {
+    if (Configuration.getBoolean(PropertyKey.MASTER_METRICS_HEAP_ENABLED)) {
       MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_BLOCK_HEAP_SIZE.getName(),
           () -> ObjectSizeCalculator.getObjectSize(mBlocks,
               ImmutableSet.of(Long.class, BlockMeta.class)));

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
@@ -15,7 +15,7 @@ import static java.util.stream.Collectors.toList;
 
 import alluxio.collections.TwoKeyConcurrentMap;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.file.meta.EdgeEntry;
 import alluxio.master.file.meta.Inode;
 import alluxio.master.file.meta.InodeDirectoryView;
@@ -61,7 +61,7 @@ public class HeapInodeStore implements InodeStore {
    */
   public HeapInodeStore() {
     super();
-    if (ServerConfiguration.getBoolean(PropertyKey.MASTER_METRICS_HEAP_ENABLED)) {
+    if (Configuration.getBoolean(PropertyKey.MASTER_METRICS_HEAP_ENABLED)) {
       MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_INODE_HEAP_SIZE.getName(),
           () -> ObjectSizeCalculator.getObjectSize(mInodes,
           ImmutableSet.of(Long.class, MutableInodeFile.class, MutableInodeDirectory.class)));

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockStore.java
@@ -12,7 +12,7 @@
 package alluxio.master.metastore.rocks;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.metastore.BlockStore;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
@@ -79,7 +79,7 @@ public class RocksBlockStore implements BlockStore {
     RocksDB.loadLibrary();
     mDisableWAL = new WriteOptions().setDisableWAL(true);
     mIteratorOption = new ReadOptions().setReadaheadSize(
-        ServerConfiguration.getBytes(PropertyKey.MASTER_METASTORE_ITERATOR_READAHEAD_SIZE));
+        Configuration.getBytes(PropertyKey.MASTER_METASTORE_ITERATOR_READAHEAD_SIZE));
     mColumnFamilyOptions = new ColumnFamilyOptions()
         .setMemTableConfig(new HashLinkedListMemTableConfig())
         .setCompressionType(CompressionType.NO_COMPRESSION);
@@ -101,7 +101,7 @@ public class RocksBlockStore implements BlockStore {
 
     // metrics
     final long CACHED_GAUGE_TIMEOUT_S =
-        ServerConfiguration.getMs(PropertyKey.MASTER_METASTORE_METRICS_REFRESH_INTERVAL);
+        Configuration.getMs(PropertyKey.MASTER_METASTORE_METRICS_REFRESH_INTERVAL);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_BLOCK_BACKGROUND_ERRORS.getName(),
         () -> getProperty("rocksdb.background-errors"),

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -12,7 +12,7 @@
 package alluxio.master.metastore.rocks;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.file.meta.EdgeEntry;
 import alluxio.master.file.meta.Inode;
 import alluxio.master.file.meta.InodeDirectoryView;
@@ -87,7 +87,7 @@ public class RocksInodeStore implements InodeStore {
     mDisableWAL = new WriteOptions().setDisableWAL(true);
     mReadPrefixSameAsStart = new ReadOptions().setPrefixSameAsStart(true);
     mIteratorOption = new ReadOptions().setReadaheadSize(
-        ServerConfiguration.getBytes(PropertyKey.MASTER_METASTORE_ITERATOR_READAHEAD_SIZE));
+        Configuration.getBytes(PropertyKey.MASTER_METASTORE_ITERATOR_READAHEAD_SIZE));
     String dbPath = PathUtils.concatPath(baseDir, INODES_DB_NAME);
     String backupPath = PathUtils.concatPath(baseDir, INODES_DB_NAME + "-backup");
     mColumnFamilyOpts = new ColumnFamilyOptions()
@@ -102,7 +102,7 @@ public class RocksInodeStore implements InodeStore {
 
     // metrics
     final long CACHED_GAUGE_TIMEOUT_S =
-        ServerConfiguration.getMs(PropertyKey.MASTER_METASTORE_METRICS_REFRESH_INTERVAL);
+        Configuration.getMs(PropertyKey.MASTER_METASTORE_METRICS_REFRESH_INTERVAL);
     MetricsSystem.registerCachedGaugeIfAbsent(
         MetricKey.MASTER_ROCKS_INODE_BACKGROUND_ERRORS.getName(),
         () -> getProperty("rocksdb.background-errors"),

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -14,7 +14,7 @@ package alluxio.master.metrics;
 import alluxio.Constants;
 import alluxio.clock.SystemClock;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.GrpcService;
 import alluxio.grpc.MetricValue;
 import alluxio.grpc.ServiceType;
@@ -64,7 +64,7 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
   DefaultMetricsMaster(CoreMasterContext masterContext) {
     this(masterContext, new SystemClock(),
         ExecutorServiceFactories.fixedThreadPool(Constants.METRICS_MASTER_NAME,
-            ServerConfiguration.getInt(PropertyKey.MASTER_METRICS_SERVICE_THREADS)));
+            Configuration.getInt(PropertyKey.MASTER_METRICS_SERVICE_THREADS)));
   }
 
   /**
@@ -176,8 +176,8 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
     if (isLeader) {
       getExecutorService().submit(new HeartbeatThread(
           HeartbeatContext.MASTER_CLUSTER_METRICS_UPDATER, new ClusterMetricsUpdater(),
-          ServerConfiguration.getMs(PropertyKey.MASTER_CLUSTER_METRICS_UPDATE_INTERVAL),
-          ServerConfiguration.global(), mMasterContext.getUserState()));
+          Configuration.getMs(PropertyKey.MASTER_CLUSTER_METRICS_UPDATE_INTERVAL),
+          Configuration.global(), mMasterContext.getUserState()));
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/underfs/MasterUfsManager.java
+++ b/core/server/master/src/main/java/alluxio/underfs/MasterUfsManager.java
@@ -12,7 +12,7 @@
 package alluxio.underfs;
 
 import alluxio.AlluxioURI;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.InvalidPathException;
 import alluxio.master.journal.DelegatingJournaled;
 import alluxio.master.journal.JournalContext;
@@ -64,7 +64,7 @@ public final class MasterUfsManager extends AbstractUfsManager implements Delega
   protected void connectUfs(UnderFileSystem fs) throws IOException {
     fs.connectFromMaster(
         NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.MASTER_RPC,
-            ServerConfiguration.global()));
+            Configuration.global()));
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -14,7 +14,7 @@ package alluxio.underfs;
 import alluxio.AlluxioURI;
 import alluxio.collections.UnmodifiableArrayList;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.InvalidPathException;
 import alluxio.master.file.DefaultFileSystemMaster;
 import alluxio.master.file.RpcContext;
@@ -77,7 +77,7 @@ public class UfsStatusCache {
     mCacheValidTime = cacheValidTime;
     mPrefetchExecutor = prefetchExecutor;
     mUfsFetchTimeout =
-        ServerConfiguration.getMs(PropertyKey.MASTER_METADATA_SYNC_UFS_PREFETCH_TIMEOUT);
+        Configuration.getMs(PropertyKey.MASTER_METADATA_SYNC_UFS_PREFETCH_TIMEOUT);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
+++ b/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
@@ -14,7 +14,7 @@ package alluxio.web;
 import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.AlluxioMasterProcess;
 import alluxio.util.io.PathUtils;
 
@@ -62,7 +62,7 @@ public final class MasterWebServer extends WebServer {
     ResourceConfig config = new ResourceConfig()
         .packages("alluxio.master", "alluxio.master.block", "alluxio.master.file")
         .register(JacksonProtobufObjectMapperProvider.class);
-    mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
+    mFileSystem = FileSystem.Factory.create(Configuration.global());
     // Override the init method to inject a reference to AlluxioMaster into the servlet context.
     // ServletContext may not be modified until after super.init() is called.
     ServletContainer servlet = new ServletContainer(config) {
@@ -83,9 +83,9 @@ public final class MasterWebServer extends WebServer {
     // STATIC assets
     try {
       // If the Web UI is disabled, disable the resources and servlet together.
-      if (ServerConfiguration.getBoolean(PropertyKey.WEB_UI_ENABLED)) {
+      if (Configuration.getBoolean(PropertyKey.WEB_UI_ENABLED)) {
         String resourceDirPathString =
-                ServerConfiguration.getString(PropertyKey.WEB_RESOURCES) + "/master/build/";
+                Configuration.getString(PropertyKey.WEB_RESOURCES) + "/master/build/";
         File resourceDir = new File(resourceDirPathString);
         mServletContextHandler.setBaseResource(Resource.newResource(resourceDir.getAbsolutePath()));
         mServletContextHandler.setWelcomeFiles(new String[]{"index.html"});

--- a/core/server/master/src/test/java/alluxio/master/SafeModeManagerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/SafeModeManagerTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 import alluxio.ConfigurationRule;
 import alluxio.clock.ManualClock;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
@@ -37,7 +37,7 @@ public class SafeModeManagerTest {
   @Rule
   public ConfigurationRule mConfiguration = new ConfigurationRule(ImmutableMap
       .of(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME, SAFEMODE_WAIT_TEST),
-      ServerConfiguration.global());
+      Configuration.modifiableGlobal());
 
   @Rule
   public ExpectedException mThrown = ExpectedException.none();
@@ -73,7 +73,7 @@ public class SafeModeManagerTest {
   @Test
   public void leaveSafeModeAfterRpcServerStart() throws Exception {
     mSafeModeManager.notifyRpcServerStarted();
-    mClock.addTimeMs(ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) + 10);
+    mClock.addTimeMs(Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) + 10);
 
     assertFalse(mSafeModeManager.isInSafeMode());
   }
@@ -81,7 +81,7 @@ public class SafeModeManagerTest {
   @Test
   public void stayInSafeModeAfterPrimaryMasterStart() throws Exception {
     mSafeModeManager.notifyPrimaryMasterStarted();
-    mClock.addTimeMs(ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) + 10);
+    mClock.addTimeMs(Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) + 10);
 
     assertTrue(mSafeModeManager.isInSafeMode());
   }
@@ -89,7 +89,7 @@ public class SafeModeManagerTest {
   @Test
   public void reenterSafeModeOnPrimaryMasterStart() throws Exception {
     mSafeModeManager.notifyRpcServerStarted();
-    mClock.addTimeMs(ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) + 10);
+    mClock.addTimeMs(Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) + 10);
     mSafeModeManager.notifyPrimaryMasterStarted();
 
     assertTrue(mSafeModeManager.isInSafeMode());
@@ -98,7 +98,7 @@ public class SafeModeManagerTest {
   @Test
   public void reenterSafeModeOnRpcServerStart() throws Exception {
     mSafeModeManager.notifyRpcServerStarted();
-    mClock.addTimeMs(ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) + 10);
+    mClock.addTimeMs(Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) + 10);
     mSafeModeManager.notifyRpcServerStarted();
 
     assertTrue(mSafeModeManager.isInSafeMode());
@@ -109,9 +109,9 @@ public class SafeModeManagerTest {
     mSafeModeManager.notifyRpcServerStarted();
 
     // Enters safe mode again while in safe mode.
-    mClock.addTimeMs(ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) - 10);
+    mClock.addTimeMs(Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) - 10);
     mSafeModeManager.notifyRpcServerStarted();
-    mClock.addTimeMs(ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) - 10);
+    mClock.addTimeMs(Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) - 10);
 
     // Verifies safe mode timer is reset.
     assertTrue(mSafeModeManager.isInSafeMode());
@@ -124,9 +124,9 @@ public class SafeModeManagerTest {
     mSafeModeManager.notifyRpcServerStarted();
 
     // Enters safe mode again while in safe mode.
-    mClock.addTimeMs(ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) - 10);
+    mClock.addTimeMs(Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) - 10);
     mSafeModeManager.notifyPrimaryMasterStarted();
-    mClock.addTimeMs(ServerConfiguration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) - 10);
+    mClock.addTimeMs(Configuration.getMs(PropertyKey.MASTER_WORKER_CONNECT_WAIT_TIME) - 10);
 
     // Verifies safe mode timer is cleared.
     assertTrue(mSafeModeManager.isInSafeMode());

--- a/core/server/master/src/test/java/alluxio/master/block/BlockMasterWorkerServiceHandlerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/BlockMasterWorkerServiceHandlerTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.clock.ManualClock;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.BlockHeartbeatPRequest;
 import alluxio.grpc.BlockHeartbeatPResponse;
 import alluxio.grpc.BlockIdList;
@@ -74,13 +74,13 @@ public class BlockMasterWorkerServiceHandlerTest {
 
   public void initServiceHandler(boolean leaseEnabled) throws Exception {
     if (leaseEnabled) {
-      ServerConfiguration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_ENABLED, true);
-      ServerConfiguration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_TTL, "3s");
+      Configuration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_ENABLED, true);
+      Configuration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_TTL, "3s");
       // Tests on the JVM check logic will be done separately
-      ServerConfiguration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_RESPECT_JVM_SPACE, false);
-      ServerConfiguration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_COUNT, 1);
+      Configuration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_RESPECT_JVM_SPACE, false);
+      Configuration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_COUNT, 1);
     } else {
-      ServerConfiguration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_ENABLED, false);
+      Configuration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_ENABLED, false);
     }
 
     mRegistry = new MasterRegistry();

--- a/core/server/master/src/test/java/alluxio/master/block/RegisterLeaseManagerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/RegisterLeaseManagerTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.GetRegisterLeasePRequest;
 import alluxio.util.SleepUtils;
 import alluxio.wire.RegisterLease;
@@ -35,10 +35,10 @@ public class RegisterLeaseManagerTest {
 
   @Before
   public void before() {
-    ServerConfiguration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_COUNT, 2);
-    ServerConfiguration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_TTL, "3s");
+    Configuration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_COUNT, 2);
+    Configuration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_TTL, "3s");
     // Tests on the JVM check logic will be done separately
-    ServerConfiguration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_RESPECT_JVM_SPACE, false);
+    Configuration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_RESPECT_JVM_SPACE, false);
 
     mLeaseManager = new RegisterLeaseManager();
   }

--- a/core/server/master/src/test/java/alluxio/master/file/AccessTimeUpdaterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/AccessTimeUpdaterTest.java
@@ -23,7 +23,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.MasterRegistry;
 import alluxio.master.MasterTestUtils;
@@ -84,7 +84,7 @@ public final class AccessTimeUpdaterTest {
   public final void before() throws Exception {
     mFileSystemMaster = Mockito.mock(FileSystemMaster.class);
     when(mFileSystemMaster.getName()).thenReturn(Constants.FILE_SYSTEM_MASTER_NAME);
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
     MasterRegistry registry = new MasterRegistry();
     JournalSystem journalSystem = JournalTestUtils.createJournalSystem(mTestFolder);
     mContext = MasterTestUtils.testMasterContext(journalSystem);
@@ -102,8 +102,8 @@ public final class AccessTimeUpdaterTest {
     journalSystem.gainPrimacy();
     mBlockMaster.start(true);
 
-    ServerConfiguration.set(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, true);
-    ServerConfiguration
+    Configuration.set(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, true);
+    Configuration
         .set(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test-supergroup");
     mInodeTree.initializeRoot(TEST_OWNER, TEST_GROUP, TEST_MODE, NoopJournalContext.INSTANCE);
     mScheduler = new ControllableScheduler();

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterMetricsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterMetricsTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.file.DefaultFileSystemMaster.Metrics;
 import alluxio.master.file.meta.InodeTree;
 import alluxio.metrics.MetricKey;
@@ -59,7 +59,7 @@ public class FileSystemMasterMetricsTest {
   public void testMetricsUfsCapacity() throws Exception {
     UfsManager.UfsClient client = Mockito.mock(UfsManager.UfsClient.class);
     UnderFileSystem ufs = Mockito.mock(UnderFileSystem.class);
-    String ufsDataFolder = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufsDataFolder = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     when(ufs.getSpace(ufsDataFolder, UnderFileSystem.SpaceType.SPACE_TOTAL)).thenReturn(1000L);
     when(ufs.getSpace(ufsDataFolder, UnderFileSystem.SpaceType.SPACE_USED)).thenReturn(200L);
     when(ufs.getSpace(ufsDataFolder, UnderFileSystem.SpaceType.SPACE_FREE)).thenReturn(800L);

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTest.java
@@ -20,7 +20,7 @@ import static org.mockito.ArgumentMatchers.eq;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
@@ -103,16 +103,16 @@ public final class FileSystemMasterSyncMetadataTest {
 
   @Before
   public void before() throws Exception {
-    UserState s = UserState.Factory.create(ServerConfiguration.global());
+    UserState s = UserState.Factory.create(Configuration.global());
     AuthenticatedClientUser.set(s.getUser().getName());
     TemporaryFolder tmpFolder = new TemporaryFolder();
     tmpFolder.create();
     File ufsRoot = tmpFolder.newFolder();
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
-    ServerConfiguration.set(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, ufsRoot.getAbsolutePath());
-    ServerConfiguration.set(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS, 0);
-    ServerConfiguration.set(PropertyKey.MASTER_PERSISTENCE_MAX_INTERVAL_MS, 1000);
-    ServerConfiguration.set(PropertyKey.MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS, 1000);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    Configuration.set(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, ufsRoot.getAbsolutePath());
+    Configuration.set(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS, 0);
+    Configuration.set(PropertyKey.MASTER_PERSISTENCE_MAX_INTERVAL_MS, 1000);
+    Configuration.set(PropertyKey.MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS, 1000);
     mJournalFolder = tmpFolder.newFolder();
     startServices();
   }

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckerTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.mock;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidPathException;
@@ -197,12 +197,12 @@ public final class PermissionCheckerTest {
     sRegistry.start(true);
 
     GroupMappingServiceTestUtils.resetCache();
-    ServerConfiguration.set(PropertyKey.SECURITY_GROUP_MAPPING_CLASS,
+    Configuration.set(PropertyKey.SECURITY_GROUP_MAPPING_CLASS,
         FakeUserGroupsMapping.class.getName());
-    ServerConfiguration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE,
+    Configuration.set(PropertyKey.SECURITY_AUTHENTICATION_TYPE,
         AuthType.SIMPLE);
-    ServerConfiguration.set(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, true);
-    ServerConfiguration
+    Configuration.set(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, true);
+    Configuration
         .set(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, TEST_SUPER_GROUP);
     sTree.initializeRoot(TEST_USER_ADMIN.getUser(), TEST_USER_ADMIN.getGroup(), TEST_NORMAL_MODE,
         NoopJournalContext.INSTANCE);
@@ -217,7 +217,7 @@ public final class PermissionCheckerTest {
   public static void afterClass() throws Exception {
     sRegistry.stop();
     AuthenticatedClientUser.remove();
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   @Before

--- a/core/server/master/src/test/java/alluxio/master/file/PersistenceTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PersistenceTest.java
@@ -18,7 +18,7 @@ import alluxio.Constants;
 import alluxio.client.WriteType;
 import alluxio.client.job.JobMasterClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
@@ -100,27 +100,27 @@ public final class PersistenceTest {
 
   @Before
   public void before() throws Exception {
-    UserState s = UserState.Factory.create(ServerConfiguration.global());
+    UserState s = UserState.Factory.create(Configuration.global());
     AuthenticatedClientUser.set(s.getUser().getName());
     TemporaryFolder tmpFolder = new TemporaryFolder();
     tmpFolder.create();
     File ufsRoot = tmpFolder.newFolder();
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
-    ServerConfiguration.set(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, ufsRoot.getAbsolutePath());
-    ServerConfiguration.set(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS, 0);
-    ServerConfiguration.set(PropertyKey.MASTER_PERSISTENCE_MAX_INTERVAL_MS, 1000);
-    ServerConfiguration.set(PropertyKey.MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS, 1000);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    Configuration.set(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, ufsRoot.getAbsolutePath());
+    Configuration.set(PropertyKey.MASTER_PERSISTENCE_INITIAL_INTERVAL_MS, 0);
+    Configuration.set(PropertyKey.MASTER_PERSISTENCE_MAX_INTERVAL_MS, 1000);
+    Configuration.set(PropertyKey.MASTER_PERSISTENCE_MAX_TOTAL_WAIT_TIME_MS, 1000);
     mJournalFolder = tmpFolder.newFolder();
     mSafeModeManager = new DefaultSafeModeManager();
     mStartTimeMs = System.currentTimeMillis();
-    mPort = ServerConfiguration.getInt(PropertyKey.MASTER_RPC_PORT);
+    mPort = Configuration.getInt(PropertyKey.MASTER_RPC_PORT);
     startServices();
   }
 
   @After
   public void after() throws Exception {
     stopServices();
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
     AuthenticatedClientUser.remove();
   }
 
@@ -203,7 +203,7 @@ public final class PersistenceTest {
       Map<Long, PersistJob> persistJobs = getPersistJobs();
       PersistJob job = persistJobs.get(fileInfo.getFileId());
       UnderFileSystem ufs = UnderFileSystem.Factory.create(job.getTempUfsPath().toString(),
-          UnderFileSystemConfiguration.defaults(ServerConfiguration.global()));
+          UnderFileSystemConfiguration.defaults(Configuration.global()));
       UnderFileSystemUtils.touch(ufs, job.getTempUfsPath());
     }
 
@@ -312,7 +312,7 @@ public final class PersistenceTest {
    */
   @Test(timeout = 20000)
   public void retryPersistJobRenameDelete() throws Exception {
-    UserState s = UserState.Factory.create(ServerConfiguration.global());
+    UserState s = UserState.Factory.create(Configuration.global());
     AuthenticatedClientUser.set(s.getUser().getName());
     // Create src file and directory, checking the internal state.
     AlluxioURI alluxioDirSrc = new AlluxioURI("/src");
@@ -357,7 +357,7 @@ public final class PersistenceTest {
       Map<Long, PersistJob> persistJobs = getPersistJobs();
       PersistJob job = persistJobs.get(info.getFileId());
       UnderFileSystem ufs = UnderFileSystem.Factory.create(job.getTempUfsPath().toString(),
-          UnderFileSystemConfiguration.defaults(ServerConfiguration.global()));
+          UnderFileSystemConfiguration.defaults(Configuration.global()));
       UnderFileSystemUtils.touch(ufs, job.getTempUfsPath());
     }
 
@@ -445,8 +445,8 @@ public final class PersistenceTest {
 
   private AlluxioURI createTestFile() throws Exception {
     AlluxioURI path = new AlluxioURI("/" + CommonUtils.randomAlphaNumString(10));
-    String owner = SecurityUtils.getOwnerFromGrpcClient(ServerConfiguration.global());
-    String group = SecurityUtils.getGroupFromGrpcClient(ServerConfiguration.global());
+    String owner = SecurityUtils.getOwnerFromGrpcClient(Configuration.global());
+    String group = SecurityUtils.getGroupFromGrpcClient(Configuration.global());
     mFileSystemMaster.createFile(path,
         CreateFileContext
             .mergeFrom(

--- a/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
@@ -19,7 +19,7 @@ import alluxio.AlluxioURI;
 import alluxio.ConfigurationRule;
 import alluxio.ConfigurationTestUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.MountPOptions;
 import alluxio.master.file.contexts.MountContext;
 import alluxio.master.file.meta.options.MountInfo;
@@ -57,7 +57,7 @@ public class AsyncUfsAbsentPathCacheTest {
   public ConfigurationRule mMaxPathRule = new ConfigurationRule(
       PropertyKey.MASTER_UFS_PATH_CACHE_CAPACITY,
       3,
-      ServerConfiguration.global()
+      Configuration.modifiableGlobal()
   );
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -22,7 +22,7 @@ import alluxio.AlluxioURI;
 import alluxio.ConfigurationRule;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.BlockInfoException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;
@@ -108,7 +108,7 @@ public final class InodeTreeTest {
       new ConfigurationRule(new ImmutableMap.Builder<PropertyKey, Object>()
           .put(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, true)
           .put(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test-supergroup")
-          .build(), ServerConfiguration.global());
+          .build(), Configuration.modifiableGlobal());
 
   /**
    * Sets up all dependencies before a test runs.

--- a/core/server/master/src/test/java/alluxio/master/file/meta/LazyUfsBlockLocationCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/LazyUfsBlockLocationCacheTest.java
@@ -12,7 +12,7 @@
 package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.MountPOptions;
 import alluxio.master.file.contexts.MountContext;
 import alluxio.master.file.meta.options.MountInfo;
@@ -49,13 +49,13 @@ public class LazyUfsBlockLocationCacheTest {
   public void before() throws Exception {
     mLocalUfsPath = Files.createTempDir().getAbsolutePath();
     mLocalUfs = UnderFileSystem.Factory.create(mLocalUfsPath,
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global()));
+        UnderFileSystemConfiguration.defaults(Configuration.global()));
 
     mMountId = IdUtils.getRandomNonNegativeLong();
     mUfsManager = new MasterUfsManager();
     MountPOptions options = MountContext.defaults().getOptions().build();
     mUfsManager.addMount(mMountId, new AlluxioURI(mLocalUfsPath),
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global())
+        UnderFileSystemConfiguration.defaults(Configuration.global())
             .setReadOnly(options.getReadOnly()).setShared(options.getShared())
             .createMountSpecificConf(Collections.<String, String>emptyMap()));
 

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MountTableTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioURI;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;
@@ -46,7 +46,7 @@ public final class MountTableTest {
   private MountTable mMountTable;
   private static final String ROOT_UFS = "s3a://bucket/";
   private final UnderFileSystem mTestUfs = new LocalUnderFileSystemFactory().create("/",
-      UnderFileSystemConfiguration.defaults(ServerConfiguration.global()));
+      UnderFileSystemConfiguration.defaults(Configuration.global()));
 
   @Before
   public void before() throws Exception {

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MutableInodeDirectoryTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MutableInodeDirectoryTest.java
@@ -13,7 +13,7 @@ package alluxio.master.file.meta;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.file.contexts.CreateDirectoryContext;
 import alluxio.security.authorization.Mode;
 import alluxio.util.ModeUtils;
@@ -189,7 +189,7 @@ public final class MutableInodeDirectoryTest extends AbstractInodeTest {
     Assert.assertEquals(TEST_OWNER, inode2.getOwner());
     Assert.assertEquals(TEST_GROUP, inode2.getGroup());
     Assert.assertEquals(ModeUtils.applyDirectoryUMask(Mode.defaults(),
-        ServerConfiguration.getString(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_UMASK))
+        Configuration.getString(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_UMASK))
             .toShort(),
         inode2.getMode());
   }

--- a/core/server/master/src/test/java/alluxio/master/file/meta/MutableInodeFileTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/MutableInodeFileTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.BlockInfoException;
 import alluxio.security.authorization.Mode;
 import alluxio.util.ModeUtils;
@@ -133,7 +133,7 @@ public final class MutableInodeFileTest extends AbstractInodeTest {
     assertEquals(TEST_OWNER, inode1.getOwner());
     assertEquals(TEST_GROUP, inode1.getGroup());
     assertEquals(ModeUtils.applyFileUMask(Mode.defaults(),
-        ServerConfiguration.getString(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_UMASK))
+        Configuration.getString(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_UMASK))
             .toShort(),
         inode1.getMode());
   }

--- a/core/server/master/src/test/java/alluxio/master/file/meta/UfsAbsentPathCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/UfsAbsentPathCacheTest.java
@@ -12,7 +12,7 @@
 package alluxio.master.file.meta;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -27,7 +27,7 @@ public class UfsAbsentPathCacheTest {
    */
   @After
   public void after() throws Exception {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   @Test
@@ -38,14 +38,14 @@ public class UfsAbsentPathCacheTest {
 
   @Test
   public void noAsyncPathThreads() throws Exception {
-    ServerConfiguration.set(PropertyKey.MASTER_UFS_PATH_CACHE_THREADS, 0);
+    Configuration.set(PropertyKey.MASTER_UFS_PATH_CACHE_THREADS, 0);
     UfsAbsentPathCache cache = UfsAbsentPathCache.Factory.create(null);
     Assert.assertTrue(cache instanceof NoopUfsAbsentPathCache);
   }
 
   @Test
   public void negativeAsyncPathThreads() throws Exception {
-    ServerConfiguration.set(PropertyKey.MASTER_UFS_PATH_CACHE_THREADS, -1);
+    Configuration.set(PropertyKey.MASTER_UFS_PATH_CACHE_THREADS, -1);
     UfsAbsentPathCache cache = UfsAbsentPathCache.Factory.create(null);
     Assert.assertTrue(cache instanceof NoopUfsAbsentPathCache);
   }

--- a/core/server/master/src/test/java/alluxio/master/file/replication/ReplicationCheckerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/replication/ReplicationCheckerTest.java
@@ -17,7 +17,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.RegisterWorkerPOptions;
 import alluxio.grpc.StorageList;
@@ -161,7 +161,7 @@ public final class ReplicationCheckerTest {
 
   @Before
   public void before() throws Exception {
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
     MasterRegistry registry = new MasterRegistry();
     JournalSystem journalSystem = JournalTestUtils.createJournalSystem(mTestFolder);
     mContext = MasterTestUtils.testMasterContext(journalSystem);
@@ -179,9 +179,9 @@ public final class ReplicationCheckerTest {
     journalSystem.gainPrimacy();
     mBlockMaster.start(true);
 
-    ServerConfiguration.set(PropertyKey.TEST_MODE, true);
-    ServerConfiguration.set(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, true);
-    ServerConfiguration
+    Configuration.set(PropertyKey.TEST_MODE, true);
+    Configuration.set(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, true);
+    Configuration
         .set(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_SUPERGROUP, "test-supergroup");
     mInodeTree.initializeRoot(TEST_OWNER, TEST_GROUP, TEST_MODE, NoopJournalContext.INSTANCE);
 
@@ -192,7 +192,7 @@ public final class ReplicationCheckerTest {
 
   @After
   public void after() {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   /**
@@ -433,7 +433,7 @@ public final class ReplicationCheckerTest {
 
   @Test
   public void heartbeatPartial() throws Exception {
-    ServerConfiguration.set(PropertyKey.JOB_MASTER_JOB_CAPACITY, 20);
+    Configuration.set(PropertyKey.JOB_MASTER_JOB_CAPACITY, 20);
     mReplicationChecker = new ReplicationChecker(mInodeTree, mBlockMaster,
         mContext.getSafeModeManager(), mMockReplicationHandler);
     mFileContext.getOptions().setReplicationMin(3).setReplicationMax(-1);

--- a/core/server/master/src/test/java/alluxio/master/journal/JournalContextTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/JournalContextTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.doAnswer;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.MasterRegistry;
@@ -85,7 +85,7 @@ public class JournalContextTest {
 
   @Before
   public void before() throws Exception {
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, mJournalType);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, mJournalType);
 
     mRegistry = new MasterRegistry();
     mJournalSystem = JournalTestUtils.createJournalSystem(mTemporaryFolder);
@@ -104,7 +104,7 @@ public class JournalContextTest {
   public void after() throws Exception {
     mRegistry.stop();
     mJournalSystem.stop();
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   @Test

--- a/core/server/master/src/test/java/alluxio/master/journal/sink/JournalSinkTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/sink/JournalSinkTest.java
@@ -19,7 +19,7 @@ import alluxio.AlluxioTestDirectory;
 import alluxio.AlluxioURI;
 import alluxio.ConfigurationRule;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
@@ -89,7 +89,7 @@ public final class JournalSinkTest {
           put(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, AlluxioTestDirectory
               .createTemporaryDirectory("FileSystemMasterTest").getAbsolutePath());
         }
-      }, ServerConfiguration.global());
+      }, Configuration.modifiableGlobal());
 
   @Before
   public void before() throws Exception {

--- a/core/server/master/src/test/java/alluxio/master/journal/tool/JournalToolTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/tool/JournalToolTest.java
@@ -12,7 +12,7 @@
 package alluxio.master.journal.tool;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.journal.JournalType;
 
 import org.junit.Assert;
@@ -35,7 +35,7 @@ public class JournalToolTest {
 
   @Before
   public void before() throws Exception {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
     PowerMockito.spy(JournalTool.class);
     PowerMockito.doNothing().when(JournalTool.class, "dumpJournal");
   }
@@ -44,14 +44,14 @@ public class JournalToolTest {
   public void defaultJournalDir() throws Throwable {
     JournalTool.main(new String[0]);
     String inputUri = Whitebox.getInternalState(JournalTool.class, "sInputDir");
-    Assert.assertEquals(ServerConfiguration.get(PropertyKey.MASTER_JOURNAL_FOLDER), inputUri);
+    Assert.assertEquals(Configuration.get(PropertyKey.MASTER_JOURNAL_FOLDER), inputUri);
   }
 
   @Test
   public void hdfsJournalDir() throws Throwable {
     String journalPath = "hdfs://namenode:port/alluxio/journal";
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_FOLDER, journalPath);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_FOLDER, journalPath);
 
     JournalTool.main(new String[0]);
     String inputUri = Whitebox.getInternalState(JournalTool.class, "sInputDir");
@@ -60,8 +60,8 @@ public class JournalToolTest {
 
   @Test
   public void absoluteLocalJournalInput() throws Throwable {
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.EMBEDDED);
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_FOLDER,
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.EMBEDDED);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_FOLDER,
         "hdfs://namenode:port/alluxio/journal");
 
     String journalPath = "/path/to/local/file";

--- a/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalCheckpointThreadTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalCheckpointThreadTest.java
@@ -12,7 +12,7 @@
 package alluxio.master.journal.ufs;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.MockMaster;
 import alluxio.master.NoopMaster;
 import alluxio.proto.journal.Journal;
@@ -50,7 +50,7 @@ public final class UfsJournalCheckpointThreadTest {
     URI location = URIUtils
         .appendPathOrDie(new URI(mFolder.newFolder().getAbsolutePath()), "FileSystemMaster");
     mUfs = Mockito
-        .spy(UnderFileSystem.Factory.create(location.toString(), ServerConfiguration.global()));
+        .spy(UnderFileSystem.Factory.create(location.toString(), Configuration.global()));
     mJournal = new UfsJournal(location, new NoopMaster(), mUfs, 600, Collections::emptySet);
     mJournal.start();
     mJournal.gainPrimacy();
@@ -59,7 +59,7 @@ public final class UfsJournalCheckpointThreadTest {
   @After
   public void after() throws Exception {
     mJournal.close();
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   /**
@@ -67,8 +67,8 @@ public final class UfsJournalCheckpointThreadTest {
    */
   @Test
   public void catchupState() throws Exception {
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 15);
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TAILER_SLEEP_TIME_MS, "200ms");
+    Configuration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 15);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TAILER_SLEEP_TIME_MS, "200ms");
     buildCompletedLog(0, 10);
     buildIncompleteLog(10, 15);
     MockMaster mockMaster = new MockMaster();
@@ -89,8 +89,8 @@ public final class UfsJournalCheckpointThreadTest {
    */
   @Test
   public void catchStateShutdown() throws Exception {
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 15);
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TAILER_SLEEP_TIME_MS, "200ms");
+    Configuration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 15);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TAILER_SLEEP_TIME_MS, "200ms");
     buildCompletedLog(0, 10);
     buildIncompleteLog(10, 15);
     MockMaster mockMaster = new MockMaster();
@@ -109,7 +109,7 @@ public final class UfsJournalCheckpointThreadTest {
    */
   @Test
   public void checkpointBeforeShutdown() throws Exception {
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 2);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 2);
     buildCompletedLog(0, 10);
     buildIncompleteLog(10, 15);
     MockMaster mockMaster = new MockMaster();
@@ -142,7 +142,7 @@ public final class UfsJournalCheckpointThreadTest {
    */
   @Test
   public void checkpointAfterShutdown() throws Exception {
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 2);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 2);
     buildCompletedLog(0, 10);
     buildIncompleteLog(10, 15);
     MockMaster mockMaster = new MockMaster();

--- a/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalCheckpointWriterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalCheckpointWriterTest.java
@@ -11,7 +11,7 @@
 
 package alluxio.master.journal.ufs;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.NoopMaster;
 import alluxio.proto.journal.Journal;
 import alluxio.underfs.UnderFileSystem;
@@ -43,13 +43,13 @@ public final class UfsJournalCheckpointWriterTest {
     URI location = URIUtils
         .appendPathOrDie(new URI(mFolder.newFolder().getAbsolutePath()), "FileSystemMaster");
     mUfs = Mockito
-        .spy(UnderFileSystem.Factory.create(location.toString(), ServerConfiguration.global()));
+        .spy(UnderFileSystem.Factory.create(location.toString(), Configuration.global()));
     mJournal = new UfsJournal(location, new NoopMaster(), mUfs, 0, Collections::emptySet);
   }
 
   @After
   public void after() throws Exception {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalConfTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalConfTest.java
@@ -12,7 +12,7 @@
 package alluxio.master.journal.ufs;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemConfiguration;
 
 import org.junit.After;
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class UfsJournalConfTest {
   @After
   public void after() {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   @Test
@@ -40,7 +40,7 @@ public class UfsJournalConfTest {
         PropertyKey.Template.MASTER_JOURNAL_UFS_OPTION_PROPERTY
             .format(PropertyKey.UNDERFS_LISTING_LENGTH.toString());
     int value = 10000;
-    ServerConfiguration.set(key, value);
+    Configuration.set(key, value);
     UnderFileSystemConfiguration conf = UfsJournal.getJournalUfsConf();
     Assert.assertEquals(value, conf.getInt(PropertyKey.UNDERFS_LISTING_LENGTH));
     Assert.assertEquals(1, conf.getMountSpecificConf().size());

--- a/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalLogWriterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalLogWriterTest.java
@@ -15,7 +15,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 
 import alluxio.RuntimeConstants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidJournalEntryException;
 import alluxio.master.NoopMaster;
@@ -64,7 +64,7 @@ public final class UfsJournalLogWriterTest {
     URI location = URIUtils
         .appendPathOrDie(new URI(mFolder.newFolder().getAbsolutePath()), "FileSystemMaster");
     mUfs = Mockito
-        .spy(UnderFileSystem.Factory.create(location.toString(), ServerConfiguration.global()));
+        .spy(UnderFileSystem.Factory.create(location.toString(), Configuration.global()));
     mJournal = new UfsJournal(location, new NoopMaster(), mUfs, 0, Collections::emptySet);
     mJournal.start();
     mJournal.gainPrimacy();
@@ -73,7 +73,7 @@ public final class UfsJournalLogWriterTest {
   @After
   public void after() throws Exception {
     mJournal.close();
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   /**
@@ -181,7 +181,7 @@ public final class UfsJournalLogWriterTest {
   @Test
   public void writeJournalEntryRotate() throws Exception {
     Mockito.when(mUfs.supportsFlush()).thenReturn(true);
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, "1");
+    Configuration.set(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, "1");
 
     long nextSN = 0x20;
     UfsJournalLogWriter writer = new UfsJournalLogWriter(mJournal, nextSN);

--- a/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalReaderTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/ufs/UfsJournalReaderTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.NoopMaster;
 import alluxio.master.journal.JournalReader;
 import alluxio.master.journal.JournalReader.State;
@@ -53,7 +53,7 @@ public final class UfsJournalReaderTest {
     URI location = URIUtils
         .appendPathOrDie(new URI(mFolder.newFolder().getAbsolutePath()), "FileSystemMaster");
     mUfs = Mockito
-        .spy(UnderFileSystem.Factory.create(location.toString(), ServerConfiguration.global()));
+        .spy(UnderFileSystem.Factory.create(location.toString(), Configuration.global()));
     mJournal = new UfsJournal(location, new NoopMaster(), mUfs, 0, Collections::emptySet);
     mJournal.start();
     mJournal.gainPrimacy();
@@ -62,7 +62,7 @@ public final class UfsJournalReaderTest {
   @After
   public void after() throws Exception {
     mJournal.close();
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/AlluxioMasterRestServiceHandlerTest.java
@@ -26,7 +26,7 @@ import alluxio.ConfigurationRule;
 import alluxio.Constants;
 import alluxio.RuntimeConstants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.RegisterWorkerPOptions;
 import alluxio.grpc.StorageList;
 import alluxio.master.AlluxioMasterProcess;
@@ -119,7 +119,7 @@ public final class AlluxioMasterRestServiceHandlerTest {
         {
           put(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, TEST_PATH);
         }
-      }, ServerConfiguration.global());
+      }, Configuration.modifiableGlobal());
 
   @Before
   public void before() throws Exception {

--- a/core/server/master/src/test/java/alluxio/master/meta/DailyMetadataBackupTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/DailyMetadataBackupTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 
 import alluxio.ConfigurationRule;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.BackupPStatus;
 import alluxio.grpc.BackupState;
 import alluxio.master.BackupManager;
@@ -94,7 +94,7 @@ public class DailyMetadataBackupTest {
             PropertyKey.MASTER_BACKUP_DIRECTORY, mBackupDir,
             PropertyKey.MASTER_DAILY_BACKUP_ENABLED, true,
             PropertyKey.MASTER_DAILY_BACKUP_FILES_RETAINED,
-            fileToRetain), ServerConfiguration.global()).toResource()) {
+            fileToRetain), Configuration.modifiableGlobal()).toResource()) {
       DailyMetadataBackup dailyBackup =
           new DailyMetadataBackup(mMetaMaster, mScheduler, mUfsManager);
       dailyBackup.start();

--- a/core/server/master/src/test/java/alluxio/master/meta/UpdateCheckTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/UpdateCheckTest.java
@@ -13,7 +13,7 @@ package alluxio.master.meta;
 
 import alluxio.ProjectConstants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.journal.JournalType;
 import alluxio.master.metastore.MetastoreType;
 import alluxio.util.EnvironmentUtils;
@@ -127,65 +127,65 @@ public class UpdateCheckTest {
 
   @Test
   public void featureStringEmbeddedJournal() {
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
     Assert.assertFalse(UpdateCheck.getUserAgentFeatureList().contains("embedded"));
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.EMBEDDED);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.EMBEDDED);
     Assert.assertTrue(UpdateCheck.getUserAgentFeatureList().contains("embedded"));
   }
 
   @Test
   public void featureStringRocks() {
-    ServerConfiguration.set(PropertyKey.MASTER_METASTORE, MetastoreType.ROCKS);
+    Configuration.set(PropertyKey.MASTER_METASTORE, MetastoreType.ROCKS);
     Assert.assertTrue(UpdateCheck.getUserAgentFeatureList().contains("rocks"));
-    ServerConfiguration.set(PropertyKey.MASTER_METASTORE, MetastoreType.HEAP);
+    Configuration.set(PropertyKey.MASTER_METASTORE, MetastoreType.HEAP);
     Assert.assertFalse(UpdateCheck.getUserAgentFeatureList().contains("rocks"));
   }
 
   @Test
   public void featureStringZookeeper() {
-    ServerConfiguration.set(PropertyKey.ZOOKEEPER_ENABLED, true);
+    Configuration.set(PropertyKey.ZOOKEEPER_ENABLED, true);
     Assert.assertTrue(UpdateCheck.getUserAgentFeatureList().contains("zk"));
-    ServerConfiguration.set(PropertyKey.ZOOKEEPER_ENABLED, false);
+    Configuration.set(PropertyKey.ZOOKEEPER_ENABLED, false);
     Assert.assertFalse(UpdateCheck.getUserAgentFeatureList().contains("zk"));
   }
 
   @Test
   public void featureStringBackupDelegation() {
-    ServerConfiguration.set(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, true);
+    Configuration.set(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, true);
     Assert.assertTrue(UpdateCheck.getUserAgentFeatureList().contains("backupDelegation"));
-    ServerConfiguration.set(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, false);
+    Configuration.set(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, false);
     Assert.assertFalse(UpdateCheck.getUserAgentFeatureList().contains("backupDelegation"));
   }
 
   @Test
   public void featureStringDailyBackup() {
-    ServerConfiguration.set(PropertyKey.MASTER_DAILY_BACKUP_ENABLED, true);
+    Configuration.set(PropertyKey.MASTER_DAILY_BACKUP_ENABLED, true);
     Assert.assertTrue(UpdateCheck.getUserAgentFeatureList().contains("dailyBackup"));
-    ServerConfiguration.set(PropertyKey.MASTER_DAILY_BACKUP_ENABLED, false);
+    Configuration.set(PropertyKey.MASTER_DAILY_BACKUP_ENABLED, false);
     Assert.assertFalse(UpdateCheck.getUserAgentFeatureList().contains("dailyBackup"));
   }
 
   @Test
   public void featureStringPersistneceBlacklist() {
-    ServerConfiguration.set(PropertyKey.MASTER_PERSISTENCE_BLACKLIST, ".tmp");
+    Configuration.set(PropertyKey.MASTER_PERSISTENCE_BLACKLIST, ".tmp");
     Assert.assertTrue(UpdateCheck.getUserAgentFeatureList().contains("persistBlackList"));
-    ServerConfiguration.unset(PropertyKey.MASTER_PERSISTENCE_BLACKLIST);
+    Configuration.unset(PropertyKey.MASTER_PERSISTENCE_BLACKLIST);
     Assert.assertFalse(UpdateCheck.getUserAgentFeatureList().contains("persistBlackList"));
   }
 
   @Test
   public void featureStringUnsafePersist() {
-    ServerConfiguration.set(PropertyKey.MASTER_UNSAFE_DIRECT_PERSIST_OBJECT_ENABLED, true);
+    Configuration.set(PropertyKey.MASTER_UNSAFE_DIRECT_PERSIST_OBJECT_ENABLED, true);
     Assert.assertTrue(UpdateCheck.getUserAgentFeatureList().contains("unsafePersist"));
-    ServerConfiguration.set(PropertyKey.MASTER_UNSAFE_DIRECT_PERSIST_OBJECT_ENABLED, false);
+    Configuration.set(PropertyKey.MASTER_UNSAFE_DIRECT_PERSIST_OBJECT_ENABLED, false);
     Assert.assertFalse(UpdateCheck.getUserAgentFeatureList().contains("unsafePersist"));
   }
 
   @Test
   public void featureStringMasterAuditLogging() {
-    ServerConfiguration.set(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED, true);
+    Configuration.set(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED, true);
     Assert.assertTrue(UpdateCheck.getUserAgentFeatureList().contains("masterAuditLog"));
-    ServerConfiguration.set(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED, false);
+    Configuration.set(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED, false);
     Assert.assertFalse(UpdateCheck.getUserAgentFeatureList().contains("masterAuditLog"));
   }
 

--- a/core/server/master/src/test/java/alluxio/master/meta/checkconf/ConfigurationCheckerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/checkconf/ConfigurationCheckerTest.java
@@ -31,7 +31,8 @@ import java.util.Random;
 /**
  * Unit tests for {@link ServerConfigurationChecker}.
  */
-public class ServerConfigurationCheckerTest {
+public class ConfigurationCheckerTest
+{
   private ServerConfigurationStore mRecordOne;
   private ServerConfigurationStore mRecordTwo;
   private ServerConfigurationChecker mConfigChecker;

--- a/core/server/master/src/test/java/alluxio/master/meta/checkconf/ConfigurationStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/meta/checkconf/ConfigurationStoreTest.java
@@ -31,7 +31,8 @@ import java.util.Random;
 /**
  * Unit tests for {@link ServerConfigurationStore}.
  */
-public class ServerConfigurationStoreTest {
+public class ConfigurationStoreTest
+{
   private List<ConfigProperty> mConfigListOne;
   private List<ConfigProperty> mConfigListTwo;
   private Address mAddressOne;

--- a/core/server/master/src/test/java/alluxio/master/metastore/InodeStoreBench.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/InodeStoreBench.java
@@ -13,7 +13,7 @@ package alluxio.master.metastore;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.file.contexts.CreateDirectoryContext;
 import alluxio.master.file.meta.MutableInodeDirectory;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
@@ -56,7 +56,7 @@ public class InodeStoreBench {
     Logger.getRootLogger().addAppender(new ConsoleAppender(layout));
 
     System.out.printf("Running benchmarks for rocks inode store%n");
-    sStore = new RocksInodeStore(ServerConfiguration.getString(PropertyKey.MASTER_METASTORE_DIR));
+    sStore = new RocksInodeStore(Configuration.getString(PropertyKey.MASTER_METASTORE_DIR));
     runBenchmarks();
 
     System.out.printf("%nRunning benchmarks for heap inode store%n");

--- a/core/server/master/src/test/java/alluxio/master/metastore/InodeStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/InodeStoreTest.java
@@ -20,7 +20,7 @@ import alluxio.AlluxioTestDirectory;
 import alluxio.ConfigurationRule;
 import alluxio.concurrent.LockMode;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.file.contexts.CreateDirectoryContext;
 import alluxio.master.file.contexts.CreateFileContext;
 import alluxio.master.file.meta.Edge;
@@ -67,7 +67,7 @@ public class InodeStoreTest {
   @Rule
   public ConfigurationRule mConf =
       new ConfigurationRule(PropertyKey.MASTER_METASTORE_INODE_CACHE_MAX_SIZE,
-          CACHE_SIZE, ServerConfiguration.global());
+          CACHE_SIZE, Configuration.modifiableGlobal());
 
   private final MutableInodeDirectory mRoot = inodeDir(0, -1, "");
 

--- a/core/server/master/src/test/java/alluxio/master/metastore/caching/CachingInodeStoreMockedBackingStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/caching/CachingInodeStoreMockedBackingStoreTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.verify;
 
 import alluxio.ConfigurationRule;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.file.contexts.CreateDirectoryContext;
 import alluxio.master.file.contexts.CreateFileContext;
 import alluxio.master.file.meta.Inode;
@@ -68,7 +68,7 @@ public class CachingInodeStoreMockedBackingStoreTest {
   public ConfigurationRule mConf = new ConfigurationRule(
       ImmutableMap.of(PropertyKey.MASTER_METASTORE_INODE_CACHE_MAX_SIZE, CACHE_SIZE,
           PropertyKey.MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE, 5),
-      ServerConfiguration.global());
+      Configuration.modifiableGlobal());
 
   @Before
   public void before() {

--- a/core/server/master/src/test/java/alluxio/underfs/UfsStatusCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/underfs/UfsStatusCacheTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.InvalidPathException;
 import alluxio.grpc.MountPOptions;
 import alluxio.master.file.BlockDeletionContext;
@@ -91,7 +91,7 @@ public class UfsStatusCacheTest {
   public void before() throws Exception {
     mUfsUri = mTempDir.newFolder().getAbsolutePath();
     mUfs = new LocalUnderFileSystem(new AlluxioURI(mUfsUri),
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global()));
+        UnderFileSystemConfiguration.defaults(Configuration.global()));
     mService = Executors.newSingleThreadExecutor();
     mCache = new UfsStatusCache(mService, new NoopUfsAbsentPathCache(),
         UfsAbsentPathCache.ALWAYS);

--- a/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxy.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxy.java
@@ -13,7 +13,7 @@ package alluxio.proxy;
 
 import alluxio.ProcessUtils;
 import alluxio.RuntimeConstants;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.CommonUtils;
 import alluxio.util.ConfigurationUtils;
 
@@ -41,7 +41,7 @@ public final class AlluxioProxy {
       System.exit(-1);
     }
 
-    if (!ConfigurationUtils.masterHostConfigured(ServerConfiguration.global())) {
+    if (!ConfigurationUtils.masterHostConfigured(Configuration.global())) {
       ProcessUtils.fatalError(LOG,
           ConfigurationUtils.getMasterHostNotConfiguredMessage("Alluxio proxy"));
     }

--- a/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxyProcess.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxyProcess.java
@@ -13,7 +13,7 @@ package alluxio.proxy;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.network.NetworkAddressUtils;
@@ -76,10 +76,10 @@ public final class AlluxioProxyProcess implements ProxyProcess {
   @Override
   public void start() throws Exception {
     mWebServer = new ProxyWebServer(ServiceType.PROXY_WEB.getServiceName(),
-        NetworkAddressUtils.getBindAddress(ServiceType.PROXY_WEB, ServerConfiguration.global()),
+        NetworkAddressUtils.getBindAddress(ServiceType.PROXY_WEB, Configuration.global()),
         this);
     // reset proxy web port
-    ServerConfiguration.set(PropertyKey.PROXY_WEB_PORT,
+    Configuration.set(PropertyKey.PROXY_WEB_PORT,
         mWebServer.getLocalPort());
     mWebServer.start();
     mLatch.await();

--- a/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxyRestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/AlluxioProxyRestServiceHandler.java
@@ -14,7 +14,7 @@ package alluxio.proxy;
 import alluxio.RestUtils;
 import alluxio.RuntimeConstants;
 import alluxio.conf.ConfigurationValueOptions;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.web.ProxyWebServer;
 import alluxio.wire.AlluxioProxyInfo;
 
@@ -87,11 +87,11 @@ public final class AlluxioProxyRestServiceHandler {
               .setUptimeMs(mProxyProcess.getUptimeMs())
               .setVersion(RuntimeConstants.VERSION);
       return result;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   private Map<String, Object> getConfigurationInternal(boolean raw) {
-    return new TreeMap<>(ServerConfiguration
+    return new TreeMap<>(Configuration
         .toMap(ConfigurationValueOptions.defaults().useDisplayValue(true).useRawValue(raw)));
   }
 }

--- a/core/server/proxy/src/main/java/alluxio/proxy/PathsRestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/PathsRestServiceHandler.java
@@ -18,7 +18,7 @@ import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
@@ -115,7 +115,7 @@ public final class PathsRestServiceHandler {
         mFileSystem.createDirectory(new AlluxioURI(path), options);
       }
       return null;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -142,7 +142,7 @@ public final class PathsRestServiceHandler {
         }
         return mStreamCache.put(os);
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -165,7 +165,7 @@ public final class PathsRestServiceHandler {
         }
         return null;
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -190,7 +190,7 @@ public final class PathsRestServiceHandler {
         }
         throw new IllegalArgumentException("stream does not exist");
       }
-    }, ServerConfiguration.global(), headers);
+    }, Configuration.global(), headers);
   }
 
   /**
@@ -212,7 +212,7 @@ public final class PathsRestServiceHandler {
           return mFileSystem.exists(new AlluxioURI(path), options);
         }
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -235,7 +235,7 @@ public final class PathsRestServiceHandler {
         }
         return null;
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -258,7 +258,7 @@ public final class PathsRestServiceHandler {
           return mFileSystem.getStatus(new AlluxioURI(path), options);
         }
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -283,7 +283,7 @@ public final class PathsRestServiceHandler {
           return mFileSystem.listStatus(new AlluxioURI(path), options);
         }
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -309,7 +309,7 @@ public final class PathsRestServiceHandler {
         }
         return null;
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -335,7 +335,7 @@ public final class PathsRestServiceHandler {
         }
         return mStreamCache.put(is);
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -361,7 +361,7 @@ public final class PathsRestServiceHandler {
         }
         return null;
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -385,7 +385,7 @@ public final class PathsRestServiceHandler {
         }
         return null;
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -409,6 +409,6 @@ public final class PathsRestServiceHandler {
         }
         return null;
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 }

--- a/core/server/proxy/src/main/java/alluxio/proxy/StreamsRestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/StreamsRestServiceHandler.java
@@ -15,7 +15,7 @@ import alluxio.RestUtils;
 import alluxio.StreamCache;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.web.ProxyWebServer;
 
 import com.google.common.io.ByteStreams;
@@ -79,7 +79,7 @@ public final class StreamsRestServiceHandler {
         throw new IllegalArgumentException("stream does not exist");
       }
       return null;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -103,7 +103,7 @@ public final class StreamsRestServiceHandler {
         }
         throw new IllegalArgumentException("stream does not exist");
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -124,6 +124,6 @@ public final class StreamsRestServiceHandler {
         return ByteStreams.copy(is, os);
       }
       throw new IllegalArgumentException("stream does not exist");
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -18,7 +18,7 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
 
@@ -62,9 +62,9 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
    */
   public CompleteMultipartUploadHandler(final FileSystem fs) {
     mFileSystem = fs;
-    mExecutor = Executors.newFixedThreadPool(ServerConfiguration.getInt(
+    mExecutor = Executors.newFixedThreadPool(Configuration.getInt(
         PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_POOL_SIZE));
-    mKeepAliveTime = ServerConfiguration.getMs(
+    mKeepAliveTime = Configuration.getMs(
         PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_KEEPALIVE_TIME_INTERVAL);
   }
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/MultipartUploadCleaner.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/MultipartUploadCleaner.java
@@ -15,7 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.grpc.DeletePOptions;
@@ -51,13 +51,13 @@ public class MultipartUploadCleaner {
    */
   private MultipartUploadCleaner() {
     mTimeout =
-        ServerConfiguration.getMs(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_TIMEOUT);
+        Configuration.getMs(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_TIMEOUT);
     mRetry =
-        ServerConfiguration.getInt(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_COUNT);
+        Configuration.getInt(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_COUNT);
     mRetryDelay =
-        ServerConfiguration.getMs(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_DELAY);
+        Configuration.getMs(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_DELAY);
     mExecutor = new ScheduledThreadPoolExecutor(
-        ServerConfiguration.getInt(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_CLEANER_POOL_SIZE));
+        Configuration.getInt(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_CLEANER_POOL_SIZE));
     mTasks = new ConcurrentHashMap<>();
   }
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -19,7 +19,7 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.InstancedConfiguration;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.DirectoryNotEmptyException;
 import alluxio.exception.FileAlreadyExistsException;
@@ -536,7 +536,7 @@ public final class S3RestServiceHandler {
       }
 
       // Delete the bucket.
-      DeletePOptions options = DeletePOptions.newBuilder().setAlluxioOnly(ServerConfiguration
+      DeletePOptions options = DeletePOptions.newBuilder().setAlluxioOnly(Configuration
           .get(PropertyKey.PROXY_S3_DELETE_TYPE).equals(Constants.S3_DELETE_IN_ALLUXIO_ONLY))
           .build();
       try {
@@ -1243,7 +1243,7 @@ public final class S3RestServiceHandler {
     S3RestUtils.checkPathIsAlluxioDirectory(fs, bucketPath);
     // Delete the object.
     String objectPath = String.format("%s%s%s", bucketPath, AlluxioURI.SEPARATOR, object);
-    DeletePOptions options = DeletePOptions.newBuilder().setAlluxioOnly(ServerConfiguration
+    DeletePOptions options = DeletePOptions.newBuilder().setAlluxioOnly(Configuration
         .get(PropertyKey.PROXY_S3_DELETE_TYPE).equals(Constants.S3_DELETE_IN_ALLUXIO_ONLY))
         .build();
     try {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -17,7 +17,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.DirectoryNotEmptyException;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
@@ -68,8 +68,8 @@ public final class S3RestUtils {
   public static <T> Response call(String resource, S3RestUtils.RestCallable<T> callable) {
     try {
       // TODO(cc): reconsider how to enable authentication
-      if (SecurityUtils.isSecurityEnabled(ServerConfiguration.global())
-              && AuthenticatedClientUser.get(ServerConfiguration.global()) == null) {
+      if (SecurityUtils.isSecurityEnabled(Configuration.global())
+              && AuthenticatedClientUser.get(Configuration.global()) == null) {
         AuthenticatedClientUser.set(ServerUserState.global().getUser().getName());
       }
     } catch (IOException e) {
@@ -165,7 +165,7 @@ public final class S3RestUtils {
    */
   public static String getMultipartTemporaryDirForObject(String bucketPath, String objectKey) {
     String multipartTemporaryDirSuffix =
-        ServerConfiguration.getString(PropertyKey.PROXY_S3_MULTIPART_TEMPORARY_DIR_SUFFIX);
+        Configuration.getString(PropertyKey.PROXY_S3_MULTIPART_TEMPORARY_DIR_SUFFIX);
     return bucketPath + AlluxioURI.SEPARATOR + objectKey + multipartTemporaryDirSuffix;
   }
 
@@ -293,7 +293,7 @@ public final class S3RestUtils {
    * @return s3 WritePType
    */
   public static WritePType getS3WriteType() {
-    return ServerConfiguration.getEnum(PropertyKey.PROXY_S3_WRITE_TYPE, WriteType.class).toProto();
+    return Configuration.getEnum(PropertyKey.PROXY_S3_WRITE_TYPE, WriteType.class).toProto();
   }
 
   /**

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -14,9 +14,9 @@ package alluxio.web;
 import alluxio.Constants;
 import alluxio.StreamCache;
 import alluxio.client.file.FileSystem;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.proxy.ProxyProcess;
 import alluxio.proxy.s3.CompleteMultipartUploadHandler;
 import alluxio.util.io.PathUtils;
@@ -40,9 +40,9 @@ public final class ProxyWebServer extends WebServer {
   public static final String STREAM_CACHE_SERVLET_RESOURCE_KEY = "Stream Cache";
   public static final String SERVER_CONFIGURATION_RESOURCE_KEY = "Server Configuration";
 
-  private FileSystem mFileSystem;
+  private final FileSystem mFileSystem;
 
-  private InstancedConfiguration mSConf;
+  private final AlluxioConfiguration mSConf = Configuration.global();
 
   /**
    * Creates a new instance of {@link ProxyWebServer}.
@@ -59,7 +59,6 @@ public final class ProxyWebServer extends WebServer {
     ResourceConfig config = new ResourceConfig().packages("alluxio.proxy", "alluxio.proxy.s3")
         .register(JacksonProtobufObjectMapperProvider.class);
 
-    mSConf = ServerConfiguration.global();
     mFileSystem = FileSystem.Factory.create(mSConf);
 
     ServletContainer servlet = new ServletContainer(config) {
@@ -72,7 +71,7 @@ public final class ProxyWebServer extends WebServer {
         getServletContext()
             .setAttribute(FILE_SYSTEM_SERVLET_RESOURCE_KEY, mFileSystem);
         getServletContext().setAttribute(STREAM_CACHE_SERVLET_RESOURCE_KEY,
-            new StreamCache(ServerConfiguration.getMs(PropertyKey.PROXY_STREAM_CACHE_TIMEOUT_MS)));
+            new StreamCache(Configuration.getMs(PropertyKey.PROXY_STREAM_CACHE_TIMEOUT_MS)));
         getServletContext()
             .setAttribute(SERVER_CONFIGURATION_RESOURCE_KEY, mSConf);
       }

--- a/core/server/worker/src/main/java/alluxio/underfs/WorkerUfsManager.java
+++ b/core/server/worker/src/main/java/alluxio/underfs/WorkerUfsManager.java
@@ -13,7 +13,7 @@ package alluxio.underfs;
 
 import alluxio.AlluxioURI;
 import alluxio.ClientContext;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.NotFoundException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.UfsInfo;
@@ -42,7 +42,7 @@ public final class WorkerUfsManager extends AbstractUfsManager {
    */
   public WorkerUfsManager() {
     mMasterClient = mCloser.register(new FileSystemMasterClient(MasterClientContext
-        .newBuilder(ClientContext.create(ServerConfiguration.global())).build()));
+        .newBuilder(ClientContext.create(Configuration.global())).build()));
   }
 
   /**
@@ -68,7 +68,7 @@ public final class WorkerUfsManager extends AbstractUfsManager {
     }
     Preconditions.checkState((info.hasUri() && info.hasProperties()), "unknown mountId");
     super.addMount(mountId, new AlluxioURI(info.getUri()),
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global())
+        UnderFileSystemConfiguration.defaults(Configuration.global())
             .setReadOnly(info.getProperties().getReadOnly())
             .setShared(info.getProperties().getShared())
             .createMountSpecificConf(info.getProperties().getPropertiesMap()));
@@ -79,6 +79,6 @@ public final class WorkerUfsManager extends AbstractUfsManager {
   protected void connectUfs(UnderFileSystem fs) throws IOException {
     fs.connectFromWorker(
         NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.WORKER_RPC,
-            ServerConfiguration.global()));
+            Configuration.global()));
   }
 }

--- a/core/server/worker/src/main/java/alluxio/web/WorkerWebServer.java
+++ b/core/server/worker/src/main/java/alluxio/web/WorkerWebServer.java
@@ -14,7 +14,7 @@ package alluxio.web;
 import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.io.PathUtils;
 import alluxio.worker.WorkerProcess;
 import alluxio.worker.block.BlockWorker;
@@ -62,7 +62,7 @@ public final class WorkerWebServer extends WebServer {
     // REST configuration
     ResourceConfig config = new ResourceConfig().packages("alluxio.worker", "alluxio.worker.block")
         .register(JacksonProtobufObjectMapperProvider.class);
-    mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
+    mFileSystem = FileSystem.Factory.create(Configuration.global());
 
     // Override the init method to inject a reference to AlluxioWorker into the servlet context.
     // ServletContext may not be modified until after super.init() is called.
@@ -84,9 +84,9 @@ public final class WorkerWebServer extends WebServer {
     // STATIC assets
     try {
       // If the Web UI is disabled, disable the resources and servlet together.
-      if (ServerConfiguration.getBoolean(PropertyKey.WEB_UI_ENABLED)) {
+      if (Configuration.getBoolean(PropertyKey.WEB_UI_ENABLED)) {
         String resourceDirPathString =
-                ServerConfiguration.getString(PropertyKey.WEB_RESOURCES) + "/worker/build/";
+                Configuration.getString(PropertyKey.WEB_RESOURCES) + "/worker/build/";
         File resourceDir = new File(resourceDirPathString);
         mServletContextHandler.setBaseResource(Resource.newResource(resourceDir.getAbsolutePath()));
         mServletContextHandler.setWelcomeFiles(new String[]{"index.html"});

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorker.java
@@ -14,7 +14,8 @@ package alluxio.worker;
 import alluxio.ProcessUtils;
 import alluxio.RuntimeConstants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
+import alluxio.grpc.Scope;
 import alluxio.master.MasterInquireClient;
 import alluxio.retry.RetryUtils;
 import alluxio.security.user.ServerUserState;
@@ -47,20 +48,20 @@ public final class AlluxioWorker {
       System.exit(-1);
     }
 
-    if (!ConfigurationUtils.masterHostConfigured(ServerConfiguration.global())) {
+    if (!ConfigurationUtils.masterHostConfigured(Configuration.global())) {
       ProcessUtils.fatalError(LOG,
           ConfigurationUtils.getMasterHostNotConfiguredMessage("Alluxio worker"));
     }
 
     CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.WORKER);
     MasterInquireClient masterInquireClient =
-        MasterInquireClient.Factory.create(ServerConfiguration.global(), ServerUserState.global());
+        MasterInquireClient.Factory.create(Configuration.global(), ServerUserState.global());
     try {
       RetryUtils.retry("load cluster default configuration with master", () -> {
         InetSocketAddress masterAddress = masterInquireClient.getPrimaryRpcAddress();
-        ServerConfiguration.loadWorkerClusterDefaults(masterAddress);
+        Configuration.loadClusterDefaults(masterAddress, Scope.WORKER);
       }, RetryUtils.defaultWorkerMasterClientRetry(
-          ServerConfiguration.getDuration(PropertyKey.WORKER_MASTER_CONNECT_RETRY_TIMEOUT)));
+          Configuration.getDuration(PropertyKey.WORKER_MASTER_CONNECT_RETRY_TIMEOUT)));
     } catch (IOException e) {
       ProcessUtils.fatalError(LOG,
           "Failed to load cluster default configuration for worker. Please make sure that Alluxio "

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerProcess.java
@@ -12,7 +12,7 @@
 package alluxio.worker;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.network.ChannelType;
@@ -106,19 +106,19 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
         });
       }
       CommonUtils.invokeAll(callables,
-          ServerConfiguration.getMs(PropertyKey.WORKER_STARTUP_TIMEOUT));
+          Configuration.getMs(PropertyKey.WORKER_STARTUP_TIMEOUT));
 
       // Setup web server
       mWebServer =
           new WorkerWebServer(NetworkAddressUtils.getBindAddress(ServiceType.WORKER_WEB,
-              ServerConfiguration.global()), this,
+              Configuration.global()), this,
               mRegistry.get(BlockWorker.class));
 
       // Random port binding.
       int bindPort;
       InetSocketAddress configuredBindAddress =
               NetworkAddressUtils.getBindAddress(ServiceType.WORKER_RPC,
-                  ServerConfiguration.global());
+                  Configuration.global());
       if (configuredBindAddress.getPort() == 0) {
         mBindSocket = new ServerSocket(0);
         bindPort = mBindSocket.getLocalPort();
@@ -127,7 +127,7 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
       }
       mRpcBindAddress = new InetSocketAddress(configuredBindAddress.getHostName(), bindPort);
       mRpcConnectAddress = NetworkAddressUtils.getConnectAddress(ServiceType.WORKER_RPC,
-          ServerConfiguration.global());
+          Configuration.global());
       if (mBindSocket != null) {
         // Socket opened for auto bind.
         // Close it.
@@ -139,8 +139,8 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
       // Setup domain socket data server
       if (isDomainSocketEnabled()) {
         String domainSocketPath =
-            ServerConfiguration.getString(PropertyKey.WORKER_DATA_SERVER_DOMAIN_SOCKET_ADDRESS);
-        if (ServerConfiguration.getBoolean(PropertyKey.WORKER_DATA_SERVER_DOMAIN_SOCKET_AS_UUID)) {
+            Configuration.getString(PropertyKey.WORKER_DATA_SERVER_DOMAIN_SOCKET_ADDRESS);
+        if (Configuration.getBoolean(PropertyKey.WORKER_DATA_SERVER_DOMAIN_SOCKET_AS_UUID)) {
           domainSocketPath =
               PathUtils.concatPath(domainSocketPath, UUID.randomUUID().toString());
         }
@@ -213,7 +213,7 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
     // NOTE: the order to start different services is sensitive. If you change it, do it cautiously.
 
     // Start serving metrics system, this will not block
-    MetricsSystem.startSinks(ServerConfiguration.getString(PropertyKey.METRICS_CONF_FILE));
+    MetricsSystem.startSinks(Configuration.getString(PropertyKey.METRICS_CONF_FILE));
 
     // Start each worker. This must be done before starting the web or RPC servers.
     // Requirement: NetAddress set in WorkerContext, so block worker can initialize BlockMasterSync
@@ -224,12 +224,12 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
     mWebServer.start();
 
     // Start monitor jvm
-    if (ServerConfiguration.getBoolean(PropertyKey.WORKER_JVM_MONITOR_ENABLED)) {
+    if (Configuration.getBoolean(PropertyKey.WORKER_JVM_MONITOR_ENABLED)) {
       mJvmPauseMonitor =
           new JvmPauseMonitor(
-              ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_SLEEP_INTERVAL_MS),
-              ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS),
-              ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS));
+              Configuration.getMs(PropertyKey.JVM_MONITOR_SLEEP_INTERVAL_MS),
+              Configuration.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS),
+              Configuration.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS));
       mJvmPauseMonitor.start();
       MetricsSystem.registerGaugeIfAbsent(
               MetricsSystem.getMetricName(MetricKey.TOTAL_EXTRA_TIME.getName()),
@@ -245,10 +245,10 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
     // Start serving RPC, this will block
     LOG.info("Alluxio worker started. id={}, bindHost={}, connectHost={}, rpcPort={}, webPort={}",
         mRegistry.get(BlockWorker.class).getWorkerId(),
-        NetworkAddressUtils.getBindHost(ServiceType.WORKER_RPC, ServerConfiguration.global()),
-        NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC, ServerConfiguration.global()),
-        NetworkAddressUtils.getPort(ServiceType.WORKER_RPC, ServerConfiguration.global()),
-        NetworkAddressUtils.getPort(ServiceType.WORKER_WEB, ServerConfiguration.global()));
+        NetworkAddressUtils.getBindHost(ServiceType.WORKER_RPC, Configuration.global()),
+        NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC, Configuration.global()),
+        NetworkAddressUtils.getPort(ServiceType.WORKER_RPC, Configuration.global()),
+        NetworkAddressUtils.getPort(ServiceType.WORKER_WEB, Configuration.global()));
 
     mDataServer.awaitTermination();
 
@@ -297,8 +297,8 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
    * @return true if domain socket is enabled
    */
   private boolean isDomainSocketEnabled() {
-    return NettyUtils.getWorkerChannel(ServerConfiguration.global()) == ChannelType.EPOLL
-        && ServerConfiguration.isSet(PropertyKey.WORKER_DATA_SERVER_DOMAIN_SOCKET_ADDRESS);
+    return NettyUtils.getWorkerChannel(Configuration.global()) == ChannelType.EPOLL
+        && Configuration.isSet(PropertyKey.WORKER_DATA_SERVER_DOMAIN_SOCKET_ADDRESS);
   }
 
   @Override
@@ -321,8 +321,8 @@ public final class AlluxioWorkerProcess implements WorkerProcess {
   public WorkerNetAddress getAddress() {
     return new WorkerNetAddress()
         .setHost(NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC,
-            ServerConfiguration.global()))
-        .setContainerHost(ServerConfiguration.global()
+            Configuration.global()))
+        .setContainerHost(Configuration.global()
             .getOrDefault(PropertyKey.WORKER_CONTAINER_HOSTNAME, ""))
         .setRpcPort(mRpcBindAddress.getPort())
         .setDataPort(getDataLocalPort())

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -20,7 +20,7 @@ import alluxio.client.file.URIStatus;
 import alluxio.collections.Pair;
 import alluxio.conf.ConfigurationValueOptions;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.AlluxioRuntimeException;
 import alluxio.exception.FileDoesNotExistException;
@@ -164,7 +164,7 @@ public final class AlluxioWorkerRestServiceHandler {
           .setStartTimeMs(mWorkerProcess.getStartTimeMs())
           .setTierCapacity(getTierCapacityInternal()).setTierPaths(getTierPathsInternal())
           .setUptimeMs(mWorkerProcess.getUptimeMs()).setVersion(RuntimeConstants.VERSION);
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -178,18 +178,18 @@ public final class AlluxioWorkerRestServiceHandler {
     return RestUtils.call(() -> {
       WorkerWebUIInit response = new WorkerWebUIInit();
 
-      response.setDebug(ServerConfiguration.getBoolean(PropertyKey.DEBUG))
-          .setWebFileInfoEnabled(ServerConfiguration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED))
+      response.setDebug(Configuration.getBoolean(PropertyKey.DEBUG))
+          .setWebFileInfoEnabled(Configuration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED))
           .setSecurityAuthorizationPermissionEnabled(
-              ServerConfiguration.getBoolean(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED))
+              Configuration.getBoolean(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED))
           .setMasterHostname(NetworkAddressUtils
               .getConnectHost(NetworkAddressUtils.ServiceType.MASTER_WEB,
-                  ServerConfiguration.global()))
-          .setMasterPort(ServerConfiguration.getInt(PropertyKey.MASTER_WEB_PORT))
-          .setRefreshInterval((int) ServerConfiguration.getMs(PropertyKey.WEB_REFRESH_INTERVAL));
+                  Configuration.global()))
+          .setMasterPort(Configuration.getInt(PropertyKey.MASTER_WEB_PORT))
+          .setRefreshInterval((int) Configuration.getMs(PropertyKey.WEB_REFRESH_INTERVAL));
 
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -205,7 +205,7 @@ public final class AlluxioWorkerRestServiceHandler {
 
       response.setWorkerInfo(new UIWorkerInfo(mWorkerProcess.getRpcAddress().toString(),
           mWorkerProcess.getStartTimeMs(),
-          ServerConfiguration.getString(PropertyKey.USER_DATE_FORMAT_PATTERN)));
+          Configuration.getString(PropertyKey.USER_DATE_FORMAT_PATTERN)));
       BlockStoreMeta storeMeta = mBlockWorker.getStoreMetaFull();
       long capacityBytes = 0L;
       long usedBytes = 0L;
@@ -239,7 +239,7 @@ public final class AlluxioWorkerRestServiceHandler {
       response.setStorageDirs(storageDirs);
 
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -258,7 +258,7 @@ public final class AlluxioWorkerRestServiceHandler {
     return RestUtils.call(() -> {
       WorkerWebUIBlockInfo response = new WorkerWebUIBlockInfo();
 
-      if (!ServerConfiguration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {
+      if (!Configuration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {
         return response;
       }
       response.setFatalError("").setInvalidPathError("");
@@ -266,7 +266,7 @@ public final class AlluxioWorkerRestServiceHandler {
         // Display file block info
         try {
           URIStatus status = mFsClient.getStatus(new AlluxioURI(requestPath));
-          UIFileInfo uiFileInfo = new UIFileInfo(status, ServerConfiguration.global(),
+          UIFileInfo uiFileInfo = new UIFileInfo(status, Configuration.global(),
               mStoreMeta.getStorageTierAssoc().getOrderedStorageAliases());
           for (long blockId : status.getBlockIds()) {
             // The block last access time is not available. Use -1 for now.
@@ -322,7 +322,7 @@ public final class AlluxioWorkerRestServiceHandler {
         for (long fileId : subFileIds) {
           try {
             URIStatus status = new URIStatus(mBlockWorker.getFileInfo(fileId));
-            UIFileInfo uiFileInfo = new UIFileInfo(status, ServerConfiguration.global(),
+            UIFileInfo uiFileInfo = new UIFileInfo(status, Configuration.global(),
                 mStoreMeta.getStorageTierAssoc().getOrderedStorageAliases());
             for (long blockId : status.getBlockIds()) {
               // The block last access time is not available. Use -1 for now.
@@ -351,7 +351,7 @@ public final class AlluxioWorkerRestServiceHandler {
       }
 
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -388,7 +388,7 @@ public final class AlluxioWorkerRestServiceHandler {
       response.setOperationMetrics(operations);
 
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -410,13 +410,13 @@ public final class AlluxioWorkerRestServiceHandler {
       FilenameFilter filenameFilter = (dir, name) -> name.toLowerCase().endsWith(".log");
       WorkerWebUILogs response = new WorkerWebUILogs();
 
-      if (!ServerConfiguration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {
+      if (!Configuration.getBoolean(PropertyKey.WEB_FILE_INFO_ENABLED)) {
         return response;
       }
-      response.setDebug(ServerConfiguration.getBoolean(PropertyKey.DEBUG)).setInvalidPathError("")
+      response.setDebug(Configuration.getBoolean(PropertyKey.DEBUG)).setInvalidPathError("")
           .setViewingOffset(0).setCurrentPath("");
 
-      String logsPath = ServerConfiguration.getString(PropertyKey.LOGS_DIR);
+      String logsPath = Configuration.getString(PropertyKey.LOGS_DIR);
       File logsDir = new File(logsPath);
       String requestFile = requestPath;
 
@@ -431,7 +431,7 @@ public final class AlluxioWorkerRestServiceHandler {
             fileInfos.add(new UIFileInfo(
                 new UIFileInfo.LocalFileInfo(logFileName, logFileName, logFile.length(),
                     UIFileInfo.LocalFileInfo.EMPTY_CREATION_TIME, logFile.lastModified(),
-                    logFile.isDirectory()), ServerConfiguration.global(),
+                    logFile.isDirectory()), Configuration.global(),
                 mStoreMeta.getStorageTierAssoc().getOrderedStorageAliases()));
           }
         }
@@ -521,7 +521,7 @@ public final class AlluxioWorkerRestServiceHandler {
       }
 
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -552,7 +552,7 @@ public final class AlluxioWorkerRestServiceHandler {
       response.setConfiguration(sortedProperties);
 
       return response;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   private Capacity getCapacityInternal() {
@@ -561,7 +561,7 @@ public final class AlluxioWorkerRestServiceHandler {
   }
 
   private Map<String, Object> getConfigurationInternal(boolean raw) {
-    return new TreeMap<>(ServerConfiguration
+    return new TreeMap<>(Configuration
         .toMap(ConfigurationValueOptions.defaults().useDisplayValue(true).useRawValue(raw)));
   }
 
@@ -623,6 +623,6 @@ public final class AlluxioWorkerRestServiceHandler {
   @Path(LOG_LEVEL)
   public Response logLevel(@QueryParam(LOG_ARGUMENT_NAME) final String logName,
       @QueryParam(LOG_ARGUMENT_LEVEL) final String level) {
-    return RestUtils.call(() -> LogUtils.setLogLevel(logName, level), ServerConfiguration.global());
+    return RestUtils.call(() -> LogUtils.setLogLevel(logName, level), Configuration.global());
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
+++ b/core/server/worker/src/main/java/alluxio/worker/SessionCleaner.java
@@ -13,7 +13,7 @@ package alluxio.worker;
 
 import alluxio.Sessions;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.CommonUtils;
 
 import org.slf4j.Logger;
@@ -53,7 +53,7 @@ public final class SessionCleaner implements Runnable, Closeable {
     for (SessionCleanable sc : sessionCleanable) {
       mSessionCleanables.add(sc);
     }
-    mCheckIntervalMs = (int) ServerConfiguration
+    mCheckIntervalMs = (int) Configuration
         .getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS);
 
     mRunning = true;

--- a/core/server/worker/src/main/java/alluxio/worker/WorkerProcess.java
+++ b/core/server/worker/src/main/java/alluxio/worker/WorkerProcess.java
@@ -12,7 +12,7 @@
 package alluxio.worker;
 
 import alluxio.Process;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.network.TieredIdentityFactory;
 import alluxio.underfs.UfsManager;
 import alluxio.wire.TieredIdentity;
@@ -34,7 +34,7 @@ public interface WorkerProcess extends Process {
      * @return a new instance of {@link WorkerProcess}
      */
     public static WorkerProcess create() {
-      return create(TieredIdentityFactory.localIdentity(ServerConfiguration.global()));
+      return create(TieredIdentityFactory.localIdentity(Configuration.global()));
     }
 
     /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
@@ -11,8 +11,8 @@
 
 package alluxio.worker.block;
 
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
 import alluxio.exception.BlockDoesNotExistRuntimeException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidWorkerStateException;
@@ -55,7 +55,7 @@ public final class BlockLockManager {
 
  /** A pool of read write locks. */
   private final ResourcePool<ClientRWLock> mLockPool = new ResourcePool<ClientRWLock>(
-      ServerConfiguration.getInt(PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCKS)) {
+      Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCKS)) {
     @Override
     public void close() {}
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMapIterator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMapIterator.java
@@ -13,7 +13,7 @@ package alluxio.worker.block;
 
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.BlockIdList;
 import alluxio.grpc.BlockStoreLocationProto;
 import alluxio.grpc.LocationBlockIdListEntry;
@@ -54,7 +54,7 @@ public class BlockMapIterator implements Iterator<List<LocationBlockIdListEntry>
    * @param blockLocationMap the block lists for each location
    */
   public BlockMapIterator(Map<BlockStoreLocation, List<Long>> blockLocationMap) {
-    this(blockLocationMap, ServerConfiguration.global());
+    this(blockLocationMap, Configuration.global());
   }
 
   /**

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClientPool.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClientPool.java
@@ -13,7 +13,7 @@ package alluxio.worker.block;
 
 import alluxio.ClientContext;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.MasterClientContext;
 import alluxio.resource.ResourcePool;
 
@@ -38,10 +38,10 @@ public class BlockMasterClientPool extends ResourcePool<BlockMasterClient> {
    * Creates a new block master client pool.
    */
   public BlockMasterClientPool() {
-    super(ServerConfiguration.getInt(PropertyKey.WORKER_BLOCK_MASTER_CLIENT_POOL_SIZE));
+    super(Configuration.getInt(PropertyKey.WORKER_BLOCK_MASTER_CLIENT_POOL_SIZE));
     mClientList = new ConcurrentLinkedQueue<>();
     mMasterContext = MasterClientContext
-        .newBuilder(ClientContext.create(ServerConfiguration.global())).build();
+        .newBuilder(ClientContext.create(Configuration.global())).build();
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
@@ -13,7 +13,7 @@ package alluxio.worker.block;
 
 import alluxio.ProcessUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ConnectionFailedException;
 import alluxio.exception.FailedToAcquireRegisterLeaseException;
 import alluxio.grpc.Command;
@@ -53,17 +53,17 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class BlockMasterSync implements HeartbeatExecutor {
   private static final Logger LOG = LoggerFactory.getLogger(BlockMasterSync.class);
   private static final boolean ACQUIRE_LEASE =
-      ServerConfiguration.getBoolean(PropertyKey.WORKER_REGISTER_LEASE_ENABLED);
+      Configuration.getBoolean(PropertyKey.WORKER_REGISTER_LEASE_ENABLED);
   private static final long ACQUIRE_LEASE_WAIT_BASE_SLEEP_MS =
-      ServerConfiguration.getMs(PropertyKey.WORKER_REGISTER_LEASE_RETRY_SLEEP_MIN);
+      Configuration.getMs(PropertyKey.WORKER_REGISTER_LEASE_RETRY_SLEEP_MIN);
   private static final long ACQUIRE_LEASE_WAIT_MAX_SLEEP_MS =
-      ServerConfiguration.getMs(PropertyKey.WORKER_REGISTER_LEASE_RETRY_SLEEP_MAX);
+      Configuration.getMs(PropertyKey.WORKER_REGISTER_LEASE_RETRY_SLEEP_MAX);
   private static final long ACQUIRE_LEASE_WAIT_MAX_DURATION =
-      ServerConfiguration.getMs(PropertyKey.WORKER_REGISTER_LEASE_RETRY_MAX_DURATION);
+      Configuration.getMs(PropertyKey.WORKER_REGISTER_LEASE_RETRY_MAX_DURATION);
   private static final boolean USE_STREAMING =
-      ServerConfiguration.getBoolean(PropertyKey.WORKER_REGISTER_STREAM_ENABLED);
+      Configuration.getBoolean(PropertyKey.WORKER_REGISTER_STREAM_ENABLED);
   private static final int HEARTBEAT_TIMEOUT_MS =
-      (int) ServerConfiguration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS);
+      (int) Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_TIMEOUT_MS);
 
   /** The block worker responsible for interacting with Alluxio and UFS storage. */
   private final BlockWorker mBlockWorker;
@@ -128,7 +128,7 @@ public final class BlockMasterSync implements HeartbeatExecutor {
   private void registerWithMaster() throws IOException {
     BlockStoreMeta storeMeta = mBlockWorker.getStoreMetaFull();
     List<ConfigProperty> configList =
-        ConfigurationUtils.getConfiguration(ServerConfiguration.global(), Scope.WORKER);
+        ConfigurationUtils.getConfiguration(Configuration.global(), Scope.WORKER);
 
     if (ACQUIRE_LEASE) {
       LOG.info("Acquiring a RegisterLease from the master before registering");
@@ -139,7 +139,7 @@ public final class BlockMasterSync implements HeartbeatExecutor {
         LOG.info("Lease acquired");
       } catch (FailedToAcquireRegisterLeaseException e) {
         mMasterClient.disconnect();
-        if (ServerConfiguration.getBoolean(PropertyKey.TEST_MODE)) {
+        if (Configuration.getBoolean(PropertyKey.TEST_MODE)) {
           throw new RuntimeException(String.format("Master register lease timeout exceeded: %dms",
               ACQUIRE_LEASE_WAIT_MAX_DURATION));
         }
@@ -194,7 +194,7 @@ public final class BlockMasterSync implements HeartbeatExecutor {
       mMasterClient.disconnect();
       if (HEARTBEAT_TIMEOUT_MS > 0) {
         if (System.currentTimeMillis() - mLastSuccessfulHeartbeatMs >= HEARTBEAT_TIMEOUT_MS) {
-          if (ServerConfiguration.getBoolean(PropertyKey.TEST_MODE)) {
+          if (Configuration.getBoolean(PropertyKey.TEST_MODE)) {
             throw new RuntimeException(
                 String.format("Master heartbeat timeout exceeded: %s", HEARTBEAT_TIMEOUT_MS));
           }

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMetadataManager.java
@@ -18,7 +18,7 @@ import static java.util.function.Function.identity;
 import alluxio.StorageTierAssoc;
 import alluxio.DefaultStorageTierAssoc;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidWorkerStateException;
 import alluxio.exception.WorkerOutOfSpaceException;
@@ -96,22 +96,22 @@ public final class BlockMetadataManager {
         .collect(toImmutableList());
     mAliasToTiers = mTiers.stream().collect(toImmutableMap(StorageTier::getTierAlias, identity()));
     // Create the block iterator.
-    if (ServerConfiguration.isSet(PropertyKey.WORKER_EVICTOR_CLASS)) {
+    if (Configuration.isSet(PropertyKey.WORKER_EVICTOR_CLASS)) {
       LOG.warn(String.format("Evictor is being emulated. Please use %s instead.",
           PropertyKey.Name.WORKER_BLOCK_ANNOTATOR_CLASS));
-      String evictorType = ServerConfiguration.getString(PropertyKey.WORKER_EVICTOR_CLASS);
+      String evictorType = Configuration.getString(PropertyKey.WORKER_EVICTOR_CLASS);
       switch (evictorType) {
         case DEPRECATED_LRU_EVICTOR:
         case DEPRECATED_PARTIAL_LRUEVICTOR:
         case DEPRECATED_GREEDY_EVICTOR:
           LOG.warn("Evictor is deprecated, switching to LRUAnnotator");
-          ServerConfiguration.set(PropertyKey.WORKER_BLOCK_ANNOTATOR_CLASS,
+          Configuration.set(PropertyKey.WORKER_BLOCK_ANNOTATOR_CLASS,
               "alluxio.worker.block.annotator.LRUAnnotator");
           mBlockIterator = new DefaultBlockIterator(this, BlockAnnotator.Factory.create());
           break;
         case DEPRECATED_LRFU_EVICTOR:
           LOG.warn("Evictor is deprecated, switching to LRFUAnnotator");
-          ServerConfiguration.set(PropertyKey.WORKER_BLOCK_ANNOTATOR_CLASS,
+          Configuration.set(PropertyKey.WORKER_BLOCK_ANNOTATOR_CLASS,
               "alluxio.worker.block.annotator.LRFUAnnotator");
           mBlockIterator = new DefaultBlockIterator(this, BlockAnnotator.Factory.create());
           break;

--- a/core/server/worker/src/main/java/alluxio/worker/block/CacheRequestManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/CacheRequestManager.java
@@ -15,7 +15,7 @@ import alluxio.Constants;
 import alluxio.Sessions;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.CancelledException;
 import alluxio.grpc.CacheRequest;
@@ -57,7 +57,7 @@ public class CacheRequestManager {
   private static final Logger LOG = LoggerFactory.getLogger(CacheRequestManager.class);
   private static final Logger SAMPLING_LOG = new SamplingLogger(LOG, 10L * Constants.MINUTE_MS);
   private static final int NETWORK_HOST_RESOLUTION_TIMEOUT =
-      (int) ServerConfiguration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS);
+      (int) Configuration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS);
 
   /** Executor service for execute the async cache tasks. */
   private final ExecutorService mCacheExecutor;

--- a/core/server/worker/src/main/java/alluxio/worker/block/ClientRWLock.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/ClientRWLock.java
@@ -12,7 +12,7 @@
 package alluxio.worker.block;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class ClientRWLock implements ReadWriteLock {
   /** Total number of permits. This value decides the max number of concurrent readers. */
   private static final int MAX_AVAILABLE =
-          ServerConfiguration.getInt(PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCK_READERS);
+          Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCK_READERS);
   /**
    * Uses the unfair lock to prevent a read lock that fails to release from locking the block
    * forever and thus blocking all the subsequent write access.

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -22,7 +22,7 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.collections.PrefixList;
 import alluxio.conf.ConfigurationValueOptions;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.Source;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.BlockDoesNotExistRuntimeException;
@@ -48,7 +48,6 @@ import alluxio.retry.RetryUtils;
 import alluxio.security.user.ServerUserState;
 import alluxio.underfs.UfsManager;
 import alluxio.util.executor.ExecutorServiceFactories;
-import alluxio.wire.Configuration;
 import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.AbstractWorker;
@@ -96,7 +95,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultBlockWorker.class);
   private static final long UFS_BLOCK_OPEN_TIMEOUT_MS =
-      ServerConfiguration.getMs(PropertyKey.WORKER_UFS_BLOCK_OPEN_TIMEOUT_MS);
+      Configuration.getMs(PropertyKey.WORKER_UFS_BLOCK_OPEN_TIMEOUT_MS);
 
   /** Used to close resources during stop. */
   private final Closer mResourceCloser = Closer.create();
@@ -141,7 +140,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   DefaultBlockWorker(UfsManager ufsManager) {
     this(new BlockMasterClientPool(),
         new FileSystemMasterClient(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build()),
+            .newBuilder(ClientContext.create(Configuration.global())).build()),
         new Sessions(), LocalBlockStore.create(ufsManager), ufsManager);
   }
 
@@ -170,12 +169,12 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
     mLocalBlockStore.registerBlockStoreEventListener(mHeartbeatReporter);
     mLocalBlockStore.registerBlockStoreEventListener(metricsReporter);
     FileSystemContext fsContext = mResourceCloser.register(
-        FileSystemContext.create(ClientContext.create(ServerConfiguration.global()), this));
+        FileSystemContext.create(ClientContext.create(Configuration.global()), this));
     mUnderFileSystemBlockStore = new UnderFileSystemBlockStore(mLocalBlockStore, ufsManager);
     mCacheManager = new CacheRequestManager(
         GrpcExecutors.CACHE_MANAGER_EXECUTOR, this, fsContext);
     mFuseManager = mResourceCloser.register(new FuseManager(fsContext));
-    mWhitelist = new PrefixList(ServerConfiguration.getList(PropertyKey.WORKER_WHITELIST));
+    mWhitelist = new PrefixList(Configuration.getList(PropertyKey.WORKER_WHITELIST));
 
     Metrics.registerGauges(this);
   }
@@ -224,7 +223,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
     BlockMasterClient blockMasterClient = mBlockMasterClientPool.acquire();
     try {
       RetryUtils.retry("create worker id", () -> mWorkerId.set(blockMasterClient.getId(address)),
-          RetryUtils.defaultWorkerMasterClientRetry(ServerConfiguration
+          RetryUtils.defaultWorkerMasterClientRetry(Configuration
               .getDuration(PropertyKey.WORKER_MASTER_CONNECT_RETRY_TIMEOUT)));
     } catch (Exception e) {
       throw new RuntimeException("Failed to create a worker id from block master: "
@@ -241,16 +240,16 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
         .register(new BlockMasterSync(this, mWorkerId, mAddress, mBlockMasterClientPool));
     getExecutorService()
         .submit(new HeartbeatThread(HeartbeatContext.WORKER_BLOCK_SYNC, blockMasterSync,
-            (int) ServerConfiguration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS),
-            ServerConfiguration.global(), ServerUserState.global()));
+            (int) Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS),
+            Configuration.global(), ServerUserState.global()));
 
     // Setup PinListSyncer
     PinListSync pinListSync = mResourceCloser.register(
         new PinListSync(this, mFileSystemMasterClient));
     getExecutorService()
         .submit(new HeartbeatThread(HeartbeatContext.WORKER_PIN_LIST_SYNC, pinListSync,
-            (int) ServerConfiguration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS),
-            ServerConfiguration.global(), ServerUserState.global()));
+            (int) Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS),
+            Configuration.global(), ServerUserState.global()));
 
     // Setup session cleaner
     SessionCleaner sessionCleaner = mResourceCloser
@@ -258,16 +257,16 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
     getExecutorService().submit(sessionCleaner);
 
     // Setup storage checker
-    if (ServerConfiguration.getBoolean(PropertyKey.WORKER_STORAGE_CHECKER_ENABLED)) {
+    if (Configuration.getBoolean(PropertyKey.WORKER_STORAGE_CHECKER_ENABLED)) {
       StorageChecker storageChecker = mResourceCloser.register(new StorageChecker());
       getExecutorService()
           .submit(new HeartbeatThread(HeartbeatContext.WORKER_STORAGE_HEALTH, storageChecker,
-              (int) ServerConfiguration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS),
-                  ServerConfiguration.global(), ServerUserState.global()));
+              (int) Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS),
+                  Configuration.global(), ServerUserState.global()));
     }
 
     // Mounts the embedded Fuse application
-    if (ServerConfiguration.getBoolean(PropertyKey.WORKER_FUSE_ENABLED)) {
+    if (Configuration.getBoolean(PropertyKey.WORKER_FUSE_ENABLED)) {
       mFuseManager.start();
     }
   }
@@ -514,18 +513,18 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   }
 
   @Override
-  public Configuration getConfiguration(GetConfigurationPOptions options) {
+  public alluxio.wire.Configuration getConfiguration(GetConfigurationPOptions options) {
     // NOTE(cc): there is no guarantee that the returned cluster and path configurations are
     // consistent snapshot of the system's state at a certain time, the path configuration might
     // be in a newer state. But it's guaranteed that the hashes are respectively correspondent to
     // the properties.
-    Configuration.Builder builder = Configuration.newBuilder();
+    alluxio.wire.Configuration.Builder builder = alluxio.wire.Configuration.newBuilder();
 
     if (!options.getIgnoreClusterConf()) {
-      for (PropertyKey key : ServerConfiguration.keySet()) {
+      for (PropertyKey key : Configuration.keySet()) {
         if (key.isBuiltIn()) {
-          Source source = ServerConfiguration.getSource(key);
-          Object value = ServerConfiguration.getOrDefault(key, null,
+          Source source = Configuration.getSource(key);
+          Object value = Configuration.getOrDefault(key, null,
                   ConfigurationValueOptions.defaults().useDisplayValue(true)
                           .useRawValue(options.getRawValue()));
           builder.addClusterProperty(key.getName(), value, source);
@@ -533,7 +532,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
       }
       // NOTE(cc): assumes that ServerConfiguration is read-only when master is running, otherwise,
       // the following hash might not correspond to the above cluster configuration.
-      builder.setClusterConfHash(ServerConfiguration.hash());
+      builder.setClusterConfHash(Configuration.hash());
     }
 
     return builder.build();

--- a/core/server/worker/src/main/java/alluxio/worker/block/FuseManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/FuseManager.java
@@ -14,7 +14,7 @@ package alluxio.worker.block;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.fuse.AlluxioFuse;
 import alluxio.fuse.FuseMountConfig;
 import alluxio.fuse.FuseUmountable;
@@ -51,7 +51,7 @@ public class FuseManager implements Closeable {
    * Starts mounting the internal Fuse applications.
    */
   public void start() {
-    AlluxioConfiguration conf = ServerConfiguration.global();
+    AlluxioConfiguration conf = Configuration.global();
     try {
       FuseMountConfig config = FuseMountConfig.create(conf);
       // TODO(lu) consider launching fuse in a separate thread as blocking operation

--- a/core/server/worker/src/main/java/alluxio/worker/block/LocalBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/LocalBlockStore.java
@@ -12,9 +12,9 @@
 package alluxio.worker.block;
 
 import alluxio.client.file.cache.CacheManager;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
 import alluxio.exception.BlockDoesNotExistRuntimeException;
 import alluxio.exception.WorkerOutOfSpaceException;
 import alluxio.proto.dataserver.Protocol;
@@ -44,10 +44,10 @@ public interface LocalBlockStore
    * @return the instance of LocalBlockStore
    */
   static LocalBlockStore create(UfsManager ufsManager) {
-    switch (ServerConfiguration.getEnum(PropertyKey.USER_BLOCK_STORE_TYPE, BlockStoreType.class)) {
+    switch (Configuration.getEnum(PropertyKey.USER_BLOCK_STORE_TYPE, BlockStoreType.class)) {
       case PAGE:
         try {
-          InstancedConfiguration conf = ServerConfiguration.global();
+          AlluxioConfiguration conf = Configuration.global();
           PagedBlockMetaStore pagedBlockMetaStore = new PagedBlockMetaStore(conf);
           CacheManager cacheManager = CacheManager.Factory.create(conf, pagedBlockMetaStore);
           return new PagedLocalBlockStore(cacheManager, ufsManager, pagedBlockMetaStore, conf);

--- a/core/server/worker/src/main/java/alluxio/worker/block/RegisterStreamer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/RegisterStreamer.java
@@ -12,7 +12,7 @@
 package alluxio.worker.block;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.CancelledException;
 import alluxio.exception.status.DeadlineExceededException;
 import alluxio.exception.status.InternalException;
@@ -136,11 +136,11 @@ public class RegisterStreamer implements Iterator<RegisterWorkerPRequest> {
     mFinishLatch = new CountDownLatch(1);
 
     mResponseTimeoutMs =
-        (int) ServerConfiguration.getMs(PropertyKey.WORKER_REGISTER_STREAM_RESPONSE_TIMEOUT);
+        (int) Configuration.getMs(PropertyKey.WORKER_REGISTER_STREAM_RESPONSE_TIMEOUT);
     mDeadlineMs =
-        (int) ServerConfiguration.getMs(PropertyKey.WORKER_REGISTER_STREAM_DEADLINE);
+        (int) Configuration.getMs(PropertyKey.WORKER_REGISTER_STREAM_DEADLINE);
     mCompleteTimeoutMs =
-        (int) ServerConfiguration.getMs(PropertyKey.WORKER_REGISTER_STREAM_COMPLETE_TIMEOUT);
+        (int) Configuration.getMs(PropertyKey.WORKER_REGISTER_STREAM_COMPLETE_TIMEOUT);
 
     mMasterResponseObserver = new StreamObserver<RegisterWorkerPResponse>() {
       @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TieredBlockStore.java
@@ -14,8 +14,8 @@ package alluxio.worker.block;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
 import alluxio.exception.BlockDoesNotExistRuntimeException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidWorkerStateException;
@@ -95,7 +95,7 @@ public class TieredBlockStore implements LocalBlockStore
   private static final Logger LOG = LoggerFactory.getLogger(TieredBlockStore.class);
   private static final long REMOVE_BLOCK_TIMEOUT_MS = 60_000;
   private static final long FREE_AHEAD_BYTETS =
-      ServerConfiguration.getBytes(PropertyKey.WORKER_TIERED_STORE_FREE_AHEAD_BYTES);
+      Configuration.getBytes(PropertyKey.WORKER_TIERED_STORE_FREE_AHEAD_BYTES);
   private final BlockMetadataManager mMetaManager;
   private final BlockLockManager mLockManager;
   private final Allocator mAllocator;
@@ -876,7 +876,7 @@ public class TieredBlockStore implements LocalBlockStore
   // TODO(peis): Consider using domain socket to avoid setting the permission to 777.
   private static void createBlockFile(String blockPath) throws IOException {
     FileUtils.createBlockPath(blockPath,
-        ServerConfiguration.getString(PropertyKey.WORKER_DATA_FOLDER_PERMISSIONS));
+        Configuration.getString(PropertyKey.WORKER_DATA_FOLDER_PERMISSIONS));
     FileUtils.createFile(blockPath);
     FileUtils.changeLocalFileToFullPermission(blockPath);
     LOG.debug("Created new file block, block path: {}", blockPath);

--- a/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamCache.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamCache.java
@@ -13,7 +13,7 @@ package alluxio.worker.block;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.SeekableUnderFileInputStream;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.options.OpenOptions;
@@ -52,7 +52,7 @@ public final class UfsInputStreamCache {
   private static final Logger LOG = LoggerFactory.getLogger(UfsInputStreamCache.class);
   private static final Logger SAMPLING_LOG = new SamplingLogger(LOG, 10L * Constants.MINUTE_MS);
   private static final boolean CACHE_ENABLED =
-      ServerConfiguration.getBoolean(PropertyKey.WORKER_UFS_INSTREAM_CACHE_ENABLED);
+      Configuration.getBoolean(PropertyKey.WORKER_UFS_INSTREAM_CACHE_ENABLED);
 
   /**
    * A map from the ufs file id to the metadata of the input streams. Synchronization on this map
@@ -116,9 +116,9 @@ public final class UfsInputStreamCache {
           }
         };
     mStreamCache = CacheBuilder.newBuilder()
-        .maximumSize(ServerConfiguration.getInt(PropertyKey.WORKER_UFS_INSTREAM_CACHE_MAX_SIZE))
+        .maximumSize(Configuration.getInt(PropertyKey.WORKER_UFS_INSTREAM_CACHE_MAX_SIZE))
         .expireAfterAccess(
-            ServerConfiguration.getMs(PropertyKey.WORKER_UFS_INSTREAM_CACHE_EXPIRARTION_TIME),
+            Configuration.getMs(PropertyKey.WORKER_UFS_INSTREAM_CACHE_EXPIRARTION_TIME),
             TimeUnit.MILLISECONDS)
         .removalListener(RemovalListeners.asynchronous(listener, removalThreadPool)).build();
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/Allocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/Allocator.java
@@ -13,7 +13,7 @@ package alluxio.worker.block.allocator;
 
 import alluxio.annotation.PublicApi;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.CommonUtils;
 import alluxio.worker.block.BlockMetadataView;
 import alluxio.worker.block.BlockStoreLocation;
@@ -44,7 +44,7 @@ public interface Allocator {
     public static Allocator create(BlockMetadataView view) {
       BlockMetadataView metadataView = Preconditions.checkNotNull(view, "view");
       return CommonUtils.createNewClassInstance(
-          ServerConfiguration.getClass(PropertyKey.WORKER_ALLOCATOR_CLASS),
+          Configuration.getClass(PropertyKey.WORKER_ALLOCATOR_CLASS),
           new Class[] {BlockMetadataView.class}, new Object[] {metadataView});
     }
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/annotator/BlockAnnotator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/annotator/BlockAnnotator.java
@@ -14,7 +14,7 @@ package alluxio.worker.block.annotator;
 import alluxio.annotation.PublicApi;
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.CommonUtils;
 
 import java.util.List;
@@ -43,7 +43,7 @@ public interface BlockAnnotator<T extends BlockSortedField> {
      */
     public static BlockAnnotator create() {
       return CommonUtils.createNewClassInstance(
-          ServerConfiguration.getClass(PropertyKey.WORKER_BLOCK_ANNOTATOR_CLASS), null,
+          Configuration.getClass(PropertyKey.WORKER_BLOCK_ANNOTATOR_CLASS), null,
           null);
     }
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/annotator/EmulatingBlockIterator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/annotator/EmulatingBlockIterator.java
@@ -15,7 +15,7 @@ import static alluxio.worker.block.BlockMetadataManager.WORKER_STORAGE_TIER_ASSO
 
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.BlockMetadataEvictorView;
 import alluxio.worker.block.BlockMetadataManager;
 import alluxio.worker.block.BlockStoreEventListener;
@@ -78,7 +78,7 @@ public class EmulatingBlockIterator implements BlockIterator {
       // It's only validated in this emulator, it doesn't trigger any background task.
       PropertyKey tierHighWatermarkProp =
           PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_HIGH_WATERMARK_RATIO.format(ordinal);
-      double tierHighWatermarkConf = ServerConfiguration.getDouble(tierHighWatermarkProp);
+      double tierHighWatermarkConf = Configuration.getDouble(tierHighWatermarkProp);
       Preconditions.checkArgument(tierHighWatermarkConf > 0,
           "The high watermark of tier %s should be positive, but is %s", Integer.toString(ordinal),
           tierHighWatermarkConf);
@@ -89,7 +89,7 @@ public class EmulatingBlockIterator implements BlockIterator {
       // Low watermark defines when to stop the space reserving process if started
       PropertyKey tierLowWatermarkProp =
           PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_LOW_WATERMARK_RATIO.format(ordinal);
-      double tierLowWatermarkConf = ServerConfiguration.getDouble(tierLowWatermarkProp);
+      double tierLowWatermarkConf = Configuration.getDouble(tierLowWatermarkProp);
       Preconditions.checkArgument(tierLowWatermarkConf >= 0,
           "The low watermark of tier %s should not be negative, but is %s",
           Integer.toString(ordinal), tierLowWatermarkConf);

--- a/core/server/worker/src/main/java/alluxio/worker/block/annotator/LRFUAnnotator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/annotator/LRFUAnnotator.java
@@ -13,7 +13,7 @@ package alluxio.worker.block.annotator;
 
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -39,9 +39,9 @@ public class LRFUAnnotator implements BlockAnnotator<LRFUAnnotator.LRFUSortedFie
   private static final double ATTENUATION_FACTOR;
 
   static {
-    STEP_FACTOR = ServerConfiguration.getDouble(
+    STEP_FACTOR = Configuration.getDouble(
         PropertyKey.WORKER_BLOCK_ANNOTATOR_LRFU_STEP_FACTOR);
-    ATTENUATION_FACTOR = ServerConfiguration.getDouble(
+    ATTENUATION_FACTOR = Configuration.getDouble(
         PropertyKey.WORKER_BLOCK_ANNOTATOR_LRFU_ATTENUATION_FACTOR);
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/evictor/Evictor.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/evictor/Evictor.java
@@ -13,7 +13,7 @@ package alluxio.worker.block.evictor;
 
 import alluxio.annotation.PublicApi;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.CommonUtils;
 import alluxio.worker.block.BlockMetadataEvictorView;
 import alluxio.worker.block.BlockStoreLocation;
@@ -52,7 +52,7 @@ public interface Evictor {
      */
     public static Evictor create(BlockMetadataEvictorView view, Allocator allocator) {
       return CommonUtils.createNewClassInstance(
-          ServerConfiguration.getClass(PropertyKey.WORKER_EVICTOR_CLASS),
+          Configuration.getClass(PropertyKey.WORKER_EVICTOR_CLASS),
           new Class[] {BlockMetadataEvictorView.class, Allocator.class},
           new Object[] {view, allocator});
     }

--- a/core/server/worker/src/main/java/alluxio/worker/block/management/AbstractBlockManagementTask.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/management/AbstractBlockManagementTask.java
@@ -12,7 +12,7 @@
 package alluxio.worker.block.management;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.BlockMetadataEvictorView;
 import alluxio.worker.block.BlockMetadataManager;
 import alluxio.worker.block.LocalBlockStore;
@@ -48,6 +48,6 @@ public abstract class AbstractBlockManagementTask implements BlockManagementTask
     mLoadTracker = loadTracker;
     mExecutor = executor;
     mTransferExecutor = new BlockTransferExecutor(executor, blockStore, loadTracker,
-        ServerConfiguration.getInt(PropertyKey.WORKER_MANAGEMENT_BLOCK_TRANSFER_CONCURRENCY_LIMIT));
+        Configuration.getInt(PropertyKey.WORKER_MANAGEMENT_BLOCK_TRANSFER_CONCURRENCY_LIMIT));
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/management/DefaultStoreLoadTracker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/management/DefaultStoreLoadTracker.java
@@ -13,7 +13,7 @@ package alluxio.worker.block.management;
 
 import alluxio.collections.ConcurrentHashSet;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.ThreadFactoryUtils;
 import alluxio.worker.block.BlockStoreLocation;
 import alluxio.worker.block.io.BlockClient;
@@ -54,7 +54,7 @@ public class DefaultStoreLoadTracker implements StoreLoadTracker, BlockClientLis
     mScheduler = Executors
         .newSingleThreadScheduledExecutor(ThreadFactoryUtils.build("load-tracker-thread-%d", true));
     mLoadDetectionCoolDownMs =
-        ServerConfiguration.getMs(PropertyKey.WORKER_MANAGEMENT_LOAD_DETECTION_COOL_DOWN_TIME);
+        Configuration.getMs(PropertyKey.WORKER_MANAGEMENT_LOAD_DETECTION_COOL_DOWN_TIME);
 
     // BlockStreamTracker provides stream reader/writer events.
     BlockStreamTracker.registerListener(this);

--- a/core/server/worker/src/main/java/alluxio/worker/block/management/ManagementTaskCoordinator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/management/ManagementTaskCoordinator.java
@@ -12,7 +12,7 @@
 package alluxio.worker.block.management;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.ThreadFactoryUtils;
 import alluxio.worker.block.BlockMetadataEvictorView;
 import alluxio.worker.block.BlockMetadataManager;
@@ -38,16 +38,16 @@ public class ManagementTaskCoordinator implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(ManagementTaskCoordinator.class);
   /** Duration to sleep when a) load detected on worker. b) no work to do. */
   private static final long LOAD_DETECTION_COOL_DOWN_TIME =
-      ServerConfiguration.getMs(PropertyKey.WORKER_MANAGEMENT_LOAD_DETECTION_COOL_DOWN_TIME);
+      Configuration.getMs(PropertyKey.WORKER_MANAGEMENT_LOAD_DETECTION_COOL_DOWN_TIME);
   /** The back-off strategy. */
-  private static final BackoffStrategy BACKOFF_STRATEGY = ServerConfiguration
+  private static final BackoffStrategy BACKOFF_STRATEGY = Configuration
       .getEnum(PropertyKey.WORKER_MANAGEMENT_BACKOFF_STRATEGY, BackoffStrategy.class);
 
   /** Runner thread for launching management tasks. */
   private final Thread mRunnerThread;
   /** Executor that will run the management tasks. */
   private final ExecutorService mTaskExecutor = Executors.newFixedThreadPool(
-      ServerConfiguration.getInt(PropertyKey.WORKER_MANAGEMENT_TASK_THREAD_COUNT),
+      Configuration.getInt(PropertyKey.WORKER_MANAGEMENT_TASK_THREAD_COUNT),
         ThreadFactoryUtils.build("block-management-task-%d", true));
 
   private final LocalBlockStore mBlockStore;
@@ -108,7 +108,7 @@ public class ManagementTaskCoordinator implements Closeable {
    */
   private void initializeTaskProviders() {
     mTaskProviders = new ArrayList<>(1);
-    if (ServerConfiguration.isSet(PropertyKey.WORKER_EVICTOR_CLASS)) {
+    if (Configuration.isSet(PropertyKey.WORKER_EVICTOR_CLASS)) {
       LOG.warn("Tier management tasks will be disabled under eviction emulation mode.");
     } else {
       // TODO(ggezer): Improve on views per task type.

--- a/core/server/worker/src/main/java/alluxio/worker/block/management/tier/AlignTask.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/management/tier/AlignTask.java
@@ -13,7 +13,7 @@ package alluxio.worker.block.management.tier;
 
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.WorkerOutOfSpaceException;
 import alluxio.worker.block.BlockMetadataEvictorView;
 import alluxio.worker.block.BlockMetadataManager;
@@ -75,7 +75,7 @@ public class AlignTask extends AbstractBlockManagementTask {
     // Acquire align range from the configuration.
     // This will limit swap operations in a single run.
     final int alignRange =
-        ServerConfiguration.getInt(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RANGE);
+        Configuration.getInt(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RANGE);
 
     BlockManagementTaskResult result = new BlockManagementTaskResult();
     // Align each tier intersection by swapping blocks.

--- a/core/server/worker/src/main/java/alluxio/worker/block/management/tier/PromoteTask.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/management/tier/PromoteTask.java
@@ -13,7 +13,7 @@ package alluxio.worker.block.management.tier;
 
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.BlockMetadataEvictorView;
 import alluxio.worker.block.BlockMetadataManager;
 import alluxio.worker.block.LocalBlockStore;
@@ -97,13 +97,13 @@ public class PromoteTask extends AbstractBlockManagementTask {
     // Acquire promotion range from the configuration.
     // This will limit promotions in single task run.
     final int promoteRange =
-        ServerConfiguration.getInt(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_RANGE);
+        Configuration.getInt(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_RANGE);
 
     // Tier for where promotions are going to.
     StorageTier tierUp = mMetadataManager.getTier(tierUpLocation.tierAlias());
     // Get quota for promotions.
     int promotionQuota =
-        ServerConfiguration.getInt(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_QUOTA_PERCENT);
+        Configuration.getInt(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_QUOTA_PERCENT);
     Preconditions.checkArgument(promotionQuota >= 0 && promotionQuota <= 100,
         "Invalid promotion quota percent");
     double quotaRatio = (double) promotionQuota / 100;

--- a/core/server/worker/src/main/java/alluxio/worker/block/management/tier/TierManagementTaskProvider.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/management/tier/TierManagementTaskProvider.java
@@ -13,7 +13,7 @@ package alluxio.worker.block.management.tier;
 
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.BlockMetadataEvictorView;
 import alluxio.worker.block.BlockMetadataManager;
 import alluxio.worker.block.LocalBlockStore;
@@ -105,11 +105,11 @@ public class TierManagementTaskProvider implements ManagementTaskProvider {
   private TierManagementTaskType findNextTask() {
     // Fetch the configuration for supported tasks types.
     boolean alignEnabled =
-        ServerConfiguration.getBoolean(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED);
+        Configuration.getBoolean(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED);
     boolean swapRestoreEnabled =
-        ServerConfiguration.getBoolean(PropertyKey.WORKER_MANAGEMENT_TIER_SWAP_RESTORE_ENABLED);
+        Configuration.getBoolean(PropertyKey.WORKER_MANAGEMENT_TIER_SWAP_RESTORE_ENABLED);
     boolean promotionEnabled =
-        ServerConfiguration.getBoolean(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED);
+        Configuration.getBoolean(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED);
 
     // Return swap-restore task if marked.
     if (swapRestoreEnabled && sSwapRestoreRequired) {
@@ -140,7 +140,7 @@ public class TierManagementTaskProvider implements ManagementTaskProvider {
         double currentUsedRatio =
             1.0 - (double) highTier.getAvailableBytes() / highTier.getCapacityBytes();
         // Configured promotion quota percent for tiers.
-        double quotaRatio = (double) ServerConfiguration
+        double quotaRatio = (double) Configuration
             .getInt(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_QUOTA_PERCENT) / 100;
         // Check if the high tier allows for promotions.
         if (currentUsedRatio < quotaRatio) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageDir.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageDir.java
@@ -15,7 +15,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 import alluxio.annotation.SuppressFBWarnings;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidWorkerStateException;
 import alluxio.exception.WorkerOutOfSpaceException;
@@ -121,8 +121,8 @@ public final class DefaultStorageDir implements StorageDir {
   private void initializeMeta() throws IOException, WorkerOutOfSpaceException {
     // Create the storage directory path
     boolean isDirectoryNewlyCreated = FileUtils.createStorageDirPath(mDirPath,
-        ServerConfiguration.getString(PropertyKey.WORKER_DATA_FOLDER_PERMISSIONS));
-    String tmpDir = Paths.get(ServerConfiguration.getString(PropertyKey.WORKER_DATA_TMP_FOLDER))
+        Configuration.getString(PropertyKey.WORKER_DATA_FOLDER_PERMISSIONS));
+    String tmpDir = Paths.get(Configuration.getString(PropertyKey.WORKER_DATA_TMP_FOLDER))
         .getName(0).toString();
     if (isDirectoryNewlyCreated) {
       LOG.info("Folder {} was created!", mDirPath);

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageTier.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultStorageTier.java
@@ -13,7 +13,7 @@ package alluxio.worker.block.meta;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.PreconditionMessage;
 import alluxio.exception.WorkerOutOfSpaceException;
@@ -64,30 +64,30 @@ public final class DefaultStorageTier implements StorageTier {
 
   private void initStorageTier(boolean isMultiTier)
       throws WorkerOutOfSpaceException {
-    String tmpDir = ServerConfiguration.getString(PropertyKey.WORKER_DATA_TMP_FOLDER);
+    String tmpDir = Configuration.getString(PropertyKey.WORKER_DATA_TMP_FOLDER);
     PropertyKey tierDirPathConf =
         PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(mTierOrdinal);
-    List<String> dirPaths = ServerConfiguration.getList(tierDirPathConf).stream()
-        .map(path -> CommonUtils.getWorkerDataDirectory(path, ServerConfiguration.global()))
+    List<String> dirPaths = Configuration.getList(tierDirPathConf).stream()
+        .map(path -> CommonUtils.getWorkerDataDirectory(path, Configuration.global()))
         .collect(ImmutableList.toImmutableList());
 
     PropertyKey tierDirCapacityConf =
         PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA.format(mTierOrdinal);
-    List<String> dirQuotas = ServerConfiguration.getList(tierDirCapacityConf);
+    List<String> dirQuotas = Configuration.getList(tierDirCapacityConf);
     Preconditions.checkState(dirQuotas.size() > 0, PreconditionMessage.ERR_TIER_QUOTA_BLANK);
 
     PropertyKey tierDirMediumConf =
         PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_MEDIUMTYPE.format(mTierOrdinal);
-    List<String> dirMedium = ServerConfiguration.getList(tierDirMediumConf);
+    List<String> dirMedium = Configuration.getList(tierDirMediumConf);
     Preconditions.checkState(dirMedium.size() > 0,
         "Tier medium type configuration should not be blank");
 
     // Set reserved bytes on directories if tier aligning is enabled.
     long reservedBytes = 0;
     if (isMultiTier
-        && ServerConfiguration.getBoolean(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED)) {
+        && Configuration.getBoolean(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED)) {
       reservedBytes =
-          ServerConfiguration.getBytes(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES);
+          Configuration.getBytes(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES);
     }
 
     for (int i = 0; i < dirPaths.size(); i++) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultTempBlockMeta.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/meta/DefaultTempBlockMeta.java
@@ -12,7 +12,7 @@
 package alluxio.worker.block.meta;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.io.PathUtils;
 import alluxio.worker.block.BlockStoreLocation;
 
@@ -25,9 +25,9 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class DefaultTempBlockMeta implements TempBlockMeta {
-  private static final String TMP_DIR = ServerConfiguration.getString(
+  private static final String TMP_DIR = Configuration.getString(
       PropertyKey.WORKER_DATA_TMP_FOLDER);
-  private static final int SUB_DIR_MAX = ServerConfiguration.getInt(
+  private static final int SUB_DIR_MAX = Configuration.getInt(
       PropertyKey.WORKER_DATA_TMP_SUBDIR_MAX);
   private final long mBlockId;
   private final StorageDir mDir;

--- a/core/server/worker/src/main/java/alluxio/worker/block/reviewer/ProbabilisticBufferReviewer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/reviewer/ProbabilisticBufferReviewer.java
@@ -11,9 +11,9 @@
 
 package alluxio.worker.block.reviewer;
 
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.meta.StorageDir;
 import alluxio.worker.block.meta.StorageDirView;
 
@@ -43,7 +43,7 @@ public class ProbabilisticBufferReviewer implements Reviewer {
    * Constructor the instance from configuration.
    * */
   public ProbabilisticBufferReviewer() {
-    InstancedConfiguration conf = ServerConfiguration.global();
+    AlluxioConfiguration conf = Configuration.global();
     mHardLimitBytes = conf.getBytes(PropertyKey.WORKER_REVIEWER_PROBABILISTIC_HARDLIMIT_BYTES);
     long stopSoftBytes = conf.getBytes(PropertyKey.WORKER_REVIEWER_PROBABILISTIC_SOFTLIMIT_BYTES);
     if (stopSoftBytes <= mHardLimitBytes) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/reviewer/Reviewer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/reviewer/Reviewer.java
@@ -13,7 +13,7 @@ package alluxio.worker.block.reviewer;
 
 import alluxio.annotation.PublicApi;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.CommonUtils;
 import alluxio.worker.block.allocator.Allocator;
 import alluxio.worker.block.meta.StorageDirView;
@@ -54,7 +54,7 @@ public interface Reviewer {
      */
     public static Reviewer create() {
       return CommonUtils.createNewClassInstance(
-              ServerConfiguration.getClass(PropertyKey.WORKER_REVIEWER_CLASS),
+              Configuration.getClass(PropertyKey.WORKER_REVIEWER_CLASS),
               new Class[] {}, new Object[] {});
     }
   }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/AbstractWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/AbstractWriteHandler.java
@@ -15,7 +15,7 @@ import alluxio.Constants;
 import alluxio.RpcSensitiveConfigMask;
 import alluxio.client.block.stream.GrpcDataWriter;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.grpc.WriteRequest;
@@ -62,7 +62,7 @@ abstract class AbstractWriteHandler<T extends WriteRequestContext<?>> {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractWriteHandler.class);
   private static final Logger SLOW_WRITE_LOG = new SamplingLogger(LOG, 5 * Constants.MINUTE_MS);
   private static final long SLOW_WRITE_MS =
-      ServerConfiguration.getMs(PropertyKey.WORKER_REMOTE_IO_SLOW_THRESHOLD);
+      Configuration.getMs(PropertyKey.WORKER_REMOTE_IO_SLOW_THRESHOLD);
   public static final long FILE_BUFFER_SIZE = Constants.MB;
 
   /** The observer for sending response messages. */
@@ -71,7 +71,7 @@ abstract class AbstractWriteHandler<T extends WriteRequestContext<?>> {
   private final SerializingExecutor mSerializingExecutor;
   /** The semaphore to control the number of write tasks queued up in the executor.*/
   private final Semaphore mSemaphore = new Semaphore(
-      ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_WRITER_BUFFER_SIZE_MESSAGES), true);
+      Configuration.getInt(PropertyKey.WORKER_NETWORK_WRITER_BUFFER_SIZE_MESSAGES), true);
 
   /**
    * This is initialized only once for a whole file or block in

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -16,7 +16,7 @@ import static alluxio.worker.block.BlockMetadataManager.WORKER_STORAGE_TIER_ASSO
 import alluxio.Constants;
 import alluxio.RpcSensitiveConfigMask;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.grpc.Chunk;
@@ -85,14 +85,14 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest> {
   private static final Logger LOG = LoggerFactory.getLogger(BlockReadHandler.class);
   private static final long MAX_CHUNK_SIZE =
-      ServerConfiguration.getBytes(PropertyKey.WORKER_NETWORK_READER_MAX_CHUNK_SIZE_BYTES);
+      Configuration.getBytes(PropertyKey.WORKER_NETWORK_READER_MAX_CHUNK_SIZE_BYTES);
   private static final long MAX_BYTES_IN_FLIGHT =
-      ServerConfiguration.getBytes(PropertyKey.WORKER_NETWORK_READER_BUFFER_SIZE_BYTES);
+      Configuration.getBytes(PropertyKey.WORKER_NETWORK_READER_BUFFER_SIZE_BYTES);
   private static final Logger SLOW_BUFFER_LOG = new SamplingLogger(LOG, Constants.MINUTE_MS);
   private static final long SLOW_BUFFER_MS =
-      ServerConfiguration.getMs(PropertyKey.WORKER_REMOTE_IO_SLOW_THRESHOLD);
+      Configuration.getMs(PropertyKey.WORKER_REMOTE_IO_SLOW_THRESHOLD);
   private static final boolean IS_READER_BUFFER_POOLED =
-      ServerConfiguration.getBoolean(PropertyKey.WORKER_NETWORK_READER_BUFFER_POOLED);
+      Configuration.getBoolean(PropertyKey.WORKER_NETWORK_READER_BUFFER_POOLED);
   /** Metrics. */
   private static final Counter RPC_READ_COUNT =
       MetricsSystem.counterWithTags(MetricKey.WORKER_ACTIVE_RPC_READ_COUNT.getName(),

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerClientServiceHandler.java
@@ -14,7 +14,7 @@ package alluxio.worker.grpc;
 import alluxio.RpcUtils;
 import alluxio.annotation.SuppressFBWarnings;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.AsyncCacheRequest;
 import alluxio.grpc.AsyncCacheResponse;
 import alluxio.grpc.BlockStatus;
@@ -71,7 +71,7 @@ import java.util.Map;
 public class BlockWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerImplBase {
   private static final Logger LOG = LoggerFactory.getLogger(BlockWorkerClientServiceHandler.class);
   private static final boolean ZERO_COPY_ENABLED =
-      ServerConfiguration.getBoolean(PropertyKey.WORKER_NETWORK_ZEROCOPY_ENABLED);
+      Configuration.getBoolean(PropertyKey.WORKER_NETWORK_ZEROCOPY_ENABLED);
   private final DefaultBlockWorker mBlockWorker;
   private final UfsManager mUfsManager;
   private final ReadResponseMarshaller mReadResponseMarshaller = new ReadResponseMarshaller();
@@ -223,11 +223,11 @@ public class BlockWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorker
    */
   private AuthenticatedUserInfo getAuthenticatedUserInfo() {
     try {
-      if (SecurityUtils.isAuthenticationEnabled(ServerConfiguration.global())) {
+      if (SecurityUtils.isAuthenticationEnabled(Configuration.global())) {
         return new AuthenticatedUserInfo(
-            AuthenticatedClientUser.getClientUser(ServerConfiguration.global()),
-            AuthenticatedClientUser.getConnectionUser(ServerConfiguration.global()),
-            AuthenticatedClientUser.getAuthMethod(ServerConfiguration.global()));
+            AuthenticatedClientUser.getClientUser(Configuration.global()),
+            AuthenticatedClientUser.getConnectionUser(Configuration.global()),
+            AuthenticatedClientUser.getAuthMethod(Configuration.global()));
       } else {
         return new AuthenticatedUserInfo();
       }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcDataServer.java
@@ -13,7 +13,7 @@ package alluxio.worker.grpc;
 
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.GrpcSerializationUtils;
 import alluxio.grpc.GrpcServer;
 import alluxio.grpc.GrpcServerAddress;
@@ -53,19 +53,19 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class GrpcDataServer implements DataServer {
   private static final Logger LOG = LoggerFactory.getLogger(GrpcDataServer.class);
   private static final long SHUTDOWN_TIMEOUT =
-      ServerConfiguration.getMs(PropertyKey.WORKER_NETWORK_SHUTDOWN_TIMEOUT);
+      Configuration.getMs(PropertyKey.WORKER_NETWORK_SHUTDOWN_TIMEOUT);
   private static final long KEEPALIVE_TIME_MS =
-      ServerConfiguration.getMs(PropertyKey.WORKER_NETWORK_KEEPALIVE_TIME_MS);
+      Configuration.getMs(PropertyKey.WORKER_NETWORK_KEEPALIVE_TIME_MS);
   private static final long KEEPALIVE_TIMEOUT_MS =
-      ServerConfiguration.getMs(PropertyKey.WORKER_NETWORK_KEEPALIVE_TIMEOUT_MS);
+      Configuration.getMs(PropertyKey.WORKER_NETWORK_KEEPALIVE_TIMEOUT_MS);
   private static final long PERMIT_KEEPALIVE_TIME_MS =
-      ServerConfiguration.getMs(PropertyKey.WORKER_NETWORK_PERMIT_KEEPALIVE_TIME_MS);
+      Configuration.getMs(PropertyKey.WORKER_NETWORK_PERMIT_KEEPALIVE_TIME_MS);
   private static final long FLOWCONTROL_WINDOW =
-      ServerConfiguration.getBytes(PropertyKey.WORKER_NETWORK_FLOWCONTROL_WINDOW);
+      Configuration.getBytes(PropertyKey.WORKER_NETWORK_FLOWCONTROL_WINDOW);
   private static final long MAX_INBOUND_MESSAGE_SIZE =
-      ServerConfiguration.getBytes(PropertyKey.WORKER_NETWORK_MAX_INBOUND_MESSAGE_SIZE);
+      Configuration.getBytes(PropertyKey.WORKER_NETWORK_MAX_INBOUND_MESSAGE_SIZE);
   private static final long SHUTDOWN_QUIET_PERIOD =
-      ServerConfiguration.getMs(PropertyKey.WORKER_NETWORK_NETTY_SHUTDOWN_QUIET_PERIOD);
+      Configuration.getMs(PropertyKey.WORKER_NETWORK_NETTY_SHUTDOWN_QUIET_PERIOD);
 
   private final SocketAddress mSocketAddress;
   private EventLoopGroup mBossGroup;
@@ -77,7 +77,7 @@ public final class GrpcDataServer implements DataServer {
   private AlluxioExecutorService mRPCExecutor = null;
 
   private final FileSystemContext mFsContext =
-      FileSystemContext.create(ServerConfiguration.global());
+      FileSystemContext.create(Configuration.global());
 
   /**
    * Creates a new instance of {@link GrpcDataServer}.
@@ -99,7 +99,7 @@ public final class GrpcDataServer implements DataServer {
           new BlockWorkerClientServiceHandler(
               workerProcess, mDomainSocketAddress != null);
       mServer = createServerBuilder(hostName, bindAddress, NettyUtils.getWorkerChannel(
-          ServerConfiguration.global()))
+          Configuration.global()))
           .addService(ServiceType.FILE_SYSTEM_WORKER_WORKER_SERVICE, new GrpcService(
               GrpcSerializationUtils.overrideMethods(blockWorkerService.bindService(),
                   blockWorkerService.getOverriddenMethodDescriptors())
@@ -130,12 +130,12 @@ public final class GrpcDataServer implements DataServer {
     // Create underlying gRPC server.
     GrpcServerBuilder builder = GrpcServerBuilder
         .forAddress(GrpcServerAddress.create(hostName, bindAddress),
-            ServerConfiguration.global(), ServerUserState.global())
+            Configuration.global(), ServerUserState.global())
         .executor(mRPCExecutor);
-    int bossThreadCount = ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_NETTY_BOSS_THREADS);
+    int bossThreadCount = Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_BOSS_THREADS);
 
     int workerThreadCount =
-        ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_NETTY_WORKER_THREADS);
+        Configuration.getInt(PropertyKey.WORKER_NETWORK_NETTY_WORKER_THREADS);
     String dataServerEventLoopNamePrefix =
         "data-server-" + ((mSocketAddress instanceof DomainSocketAddress) ? "domain-socket" :
             "tcp-socket");
@@ -145,7 +145,7 @@ public final class GrpcDataServer implements DataServer {
         .createEventLoop(type, workerThreadCount, dataServerEventLoopNamePrefix + "-worker-%d",
             true);
     Class<? extends ServerChannel> socketChannelClass = NettyUtils.getServerChannelClass(
-        mSocketAddress instanceof DomainSocketAddress, ServerConfiguration.global());
+        mSocketAddress instanceof DomainSocketAddress, Configuration.global());
     if (type == ChannelType.EPOLL) {
       builder.withChildOption(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED);
     }
@@ -157,9 +157,9 @@ public final class GrpcDataServer implements DataServer {
         // set write buffer
         // this is the default, but its recommended to set it in case of change in future netty.
         .withChildOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK,
-            (int) ServerConfiguration.getBytes(PropertyKey.WORKER_NETWORK_NETTY_WATERMARK_HIGH))
+            (int) Configuration.getBytes(PropertyKey.WORKER_NETWORK_NETTY_WATERMARK_HIGH))
         .withChildOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK,
-            (int) ServerConfiguration.getBytes(PropertyKey.WORKER_NETWORK_NETTY_WATERMARK_LOW));
+            (int) Configuration.getBytes(PropertyKey.WORKER_NETWORK_NETTY_WATERMARK_LOW));
   }
 
   @Override
@@ -188,7 +188,7 @@ public final class GrpcDataServer implements DataServer {
       mRPCExecutor.shutdownNow();
       try {
         mRPCExecutor.awaitTermination(
-            ServerConfiguration.getMs(PropertyKey.NETWORK_CONNECTION_SERVER_SHUTDOWN_TIMEOUT),
+            Configuration.getMs(PropertyKey.NETWORK_CONNECTION_SERVER_SHUTDOWN_TIMEOUT),
             TimeUnit.MILLISECONDS);
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
@@ -13,7 +13,7 @@ package alluxio.worker.grpc;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.security.User;
@@ -40,15 +40,15 @@ public final class GrpcExecutors {
 
   private static final ThreadPoolExecutor CACHE_MANAGER_THREAD_POOL_EXECUTOR =
       new ThreadPoolExecutor(THREADS_MIN,
-          ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_ASYNC_CACHE_MANAGER_THREADS_MAX),
+          Configuration.getInt(PropertyKey.WORKER_NETWORK_ASYNC_CACHE_MANAGER_THREADS_MAX),
           THREAD_STOP_MS, TimeUnit.MILLISECONDS, new UniqueBlockingQueue<>(
-          ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_ASYNC_CACHE_MANAGER_QUEUE_MAX)),
+          Configuration.getInt(PropertyKey.WORKER_NETWORK_ASYNC_CACHE_MANAGER_QUEUE_MAX)),
           ThreadFactoryUtils.build("CacheManagerExecutor-%d", true));
   public static final ExecutorService CACHE_MANAGER_EXECUTOR =
       new ImpersonateThreadPoolExecutor(CACHE_MANAGER_THREAD_POOL_EXECUTOR);
 
   private static final ThreadPoolExecutor BLOCK_READER_THREAD_POOL_EXECUTOR =
-      new ThreadPoolExecutor(THREADS_MIN, ServerConfiguration.getInt(
+      new ThreadPoolExecutor(THREADS_MIN, Configuration.getInt(
           PropertyKey.WORKER_NETWORK_BLOCK_READER_THREADS_MAX), THREAD_STOP_MS,
           TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
           ThreadFactoryUtils.build("BlockDataReaderExecutor-%d", true));
@@ -57,13 +57,13 @@ public final class GrpcExecutors {
 
   public static final ExecutorService BLOCK_READER_SERIALIZED_RUNNER_EXECUTOR =
       new ImpersonateThreadPoolExecutor(new ThreadPoolExecutor(THREADS_MIN,
-          ServerConfiguration.getInt(PropertyKey.WORKER_NETWORK_BLOCK_READER_THREADS_MAX),
+          Configuration.getInt(PropertyKey.WORKER_NETWORK_BLOCK_READER_THREADS_MAX),
           THREAD_STOP_MS, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(32),
           ThreadFactoryUtils.build("BlockDataReaderSerializedExecutor-%d", true),
           new ThreadPoolExecutor.CallerRunsPolicy()));
 
   private static final ThreadPoolExecutor BLOCK_WRITE_THREAD_POOL_EXECUTOR =
-      new ThreadPoolExecutor(THREADS_MIN, ServerConfiguration.getInt(
+      new ThreadPoolExecutor(THREADS_MIN, Configuration.getInt(
           PropertyKey.WORKER_NETWORK_BLOCK_WRITER_THREADS_MAX), THREAD_STOP_MS,
           TimeUnit.MILLISECONDS, new SynchronousQueue<>(),
           ThreadFactoryUtils.build("BlockDataWriterExecutor-%d", true));

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandler.java
@@ -11,7 +11,7 @@
 
 package alluxio.worker.grpc;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.WorkerOutOfSpaceException;
 import alluxio.grpc.WriteRequestCommand;
 import alluxio.grpc.WriteResponse;
@@ -247,7 +247,7 @@ public final class UfsFallbackBlockWriteHandler
     // Set the atomic flag to be true to ensure only the creation of this file is atomic on close.
     OutputStream ufsOutputStream =
         ufs.createNonexistingFile(ufsPath,
-            CreateOptions.defaults(ServerConfiguration.global()).setEnsureAtomic(true)
+            CreateOptions.defaults(Configuration.global()).setEnsureAtomic(true)
                 .setCreateParent(true));
     context.setOutputStream(ufsOutputStream);
     context.setUfsPath(ufsPath);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFileWriteHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/UfsFileWriteHandler.java
@@ -11,7 +11,7 @@
 
 package alluxio.worker.grpc;
 
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.WriteRequest;
 import alluxio.grpc.WriteResponse;
 import alluxio.metrics.MetricInfo;
@@ -155,7 +155,7 @@ public final class UfsFileWriteHandler extends AbstractWriteHandler<UfsFileWrite
     CloseableResource<UnderFileSystem> ufsResource = ufsClient.acquireUfsResource();
     context.setUfsResource(ufsResource);
     UnderFileSystem ufs = ufsResource.get();
-    CreateOptions createOptions = CreateOptions.defaults(ServerConfiguration.global())
+    CreateOptions createOptions = CreateOptions.defaults(Configuration.global())
         .setCreateParent(true)
         .setOwner(createUfsFileOptions.getOwner()).setGroup(createUfsFileOptions.getGroup())
         .setMode(new Mode((short) createUfsFileOptions.getMode()));

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockLockManagerTest.java
@@ -16,8 +16,8 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.collections.ConcurrentHashSet;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
 import alluxio.exception.BlockDoesNotExistRuntimeException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidWorkerStateException;
@@ -66,7 +66,7 @@ public final class BlockLockManagerTest {
 
   @After
   public void after() {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   /**
@@ -352,7 +352,7 @@ public final class BlockLockManagerTest {
   }
 
   private void setMaxLocks(int maxLocks) {
-    ServerConfiguration.set(PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCKS,
+    Configuration.set(PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCKS,
         maxLocks);
   }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockMasterClientTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockMasterClientTest.java
@@ -14,8 +14,6 @@ package alluxio.worker.block;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.ClientContext;
-import alluxio.conf.InstancedConfiguration;
-import alluxio.conf.ServerConfiguration;
 import alluxio.grpc.BlockStoreLocationProto;
 import alluxio.grpc.LocationBlockIdListEntry;
 import alluxio.master.MasterClientContext;
@@ -32,12 +30,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class BlockMasterClientTest {
-  private InstancedConfiguration mConf = ServerConfiguration.global();
-
   @Test
   public void convertBlockListMapToProtoMergeDirsInSameTier() {
     BlockMasterClient client = new BlockMasterClient(
-        MasterClientContext.newBuilder(ClientContext.create(mConf)).build());
+        MasterClientContext.newBuilder(ClientContext.create()).build());
 
     Map<BlockStoreLocation, List<Long>> blockMap = new HashMap<>();
     BlockStoreLocation memDir0 = new BlockStoreLocation("MEM", 0);

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockMetadataManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockMetadataManagerTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.WorkerOutOfSpaceException;
 import alluxio.worker.block.meta.BlockMeta;
@@ -71,8 +71,8 @@ public final class BlockMetadataManagerTest {
   @Before
   public void before() throws Exception {
     String baseDir = mFolder.newFolder().getAbsolutePath();
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, false);
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, false);
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, false);
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, false);
     TieredBlockStoreTestUtils.setupConfWithMultiTier(baseDir, TIER_ORDINAL, TIER_ALIAS,
         TIER_PATH, TIER_CAPACITY_BYTES, TIER_MEDIA_TYPE, null);
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockStoreMetaTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockStoreMetaTest.java
@@ -14,7 +14,7 @@ package alluxio.worker.block;
 import alluxio.Constants;
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.meta.StorageDir;
 import alluxio.worker.block.meta.StorageTier;
 
@@ -54,8 +54,8 @@ public final class BlockStoreMetaTest {
   @Before
   public void before() throws Exception {
     String alluxioHome = mTestFolder.newFolder().getAbsolutePath();
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, false);
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, false);
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, false);
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, false);
     mMetadataManager = TieredBlockStoreTestUtils.defaultMetadataManager(alluxioHome);
 
     // Add and commit COMMITTED_BLOCKS_NUM temp blocks repeatedly

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockWorkerMetricsTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockWorkerMetricsTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.when;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.metrics.MetricInfo;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
@@ -40,9 +40,9 @@ public final class BlockWorkerMetricsTest {
 
   @Before
   public void before() throws Exception {
-    ServerConfiguration.set(PropertyKey.WORKER_TIERED_STORE_LEVELS, 2);
-    ServerConfiguration.set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(0), MEM);
-    ServerConfiguration.set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(1), HDD);
+    Configuration.set(PropertyKey.WORKER_TIERED_STORE_LEVELS, 2);
+    Configuration.set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(0), MEM);
+    Configuration.set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(1), HDD);
     MetricsSystem.clearAllMetrics();
     mBlockWorker = mock(BlockWorker.class);
     mBlockStoreMeta = mock(BlockStoreMeta.class);

--- a/core/server/worker/src/test/java/alluxio/worker/block/CacheRequestManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/CacheRequestManagerTest.java
@@ -27,7 +27,7 @@ import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.InStreamOptions;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CacheRequest;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.proto.dataserver.Protocol;
@@ -70,9 +70,9 @@ public class CacheRequestManagerTest {
   private LocalBlockStore mBlockStore;
   private String mRootUfs;
   private final String mLocalWorkerHostname = NetworkAddressUtils.getLocalHostName(
-      (int) ServerConfiguration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
+      (int) Configuration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
   private Protocol.OpenUfsBlockOptions mOpenUfsBlockOptions;
-  private final InstancedConfiguration mConf = ServerConfiguration.global();
+  private final InstancedConfiguration mConf = Configuration.modifiableGlobal();
   private final String mMemDir =
       AlluxioTestDirectory.createTemporaryDirectory(Constants.MEDIUM_MEM).getAbsolutePath();
 
@@ -103,10 +103,10 @@ public class CacheRequestManagerTest {
     Sessions sessions = mock(Sessions.class);
     // Connect to the real UFS for testing
     UfsManager ufsManager = mock(UfsManager.class);
-    mRootUfs = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    mRootUfs = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     UfsManager.UfsClient ufsClient = new UfsManager.UfsClient(
         () -> UnderFileSystem.Factory.create(mRootUfs,
-            UnderFileSystemConfiguration.defaults(ServerConfiguration.global())),
+            UnderFileSystemConfiguration.defaults(Configuration.global())),
         new AlluxioURI(mRootUfs));
     when(ufsManager.get(anyLong())).thenReturn(ufsClient);
     mBlockWorker = spy(new DefaultBlockWorker(blockMasterClientPool, fileSystemMasterClient,

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
@@ -25,7 +25,7 @@ import alluxio.ConfigurationRule;
 import alluxio.Constants;
 import alluxio.Sessions;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.WorkerOutOfSpaceException;
 import alluxio.exception.status.DeadlineExceededException;
 import alluxio.proto.dataserver.Protocol;
@@ -79,7 +79,7 @@ public class DefaultBlockWorkerTest {
           .put(PropertyKey.WORKER_TIERED_STORE_LEVEL1_DIRS_PATH, mHddDir)
           .put(PropertyKey.WORKER_RPC_PORT, 0)
           .put(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES, "0")
-          .build(), ServerConfiguration.global());
+          .build(), Configuration.modifiableGlobal());
 
   /**
    * Sets up all dependencies before a test runs.

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.WorkerOutOfSpaceException;
 import alluxio.retry.CountingRetry;
@@ -86,15 +86,15 @@ public final class TieredBlockStoreTest {
    */
   @Before
   public void before() throws Exception {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
     init(0);
   }
 
   private void init(long reservedBytes) throws Exception {
-    ServerConfiguration.set(PropertyKey.WORKER_REVIEWER_CLASS,
+    Configuration.set(PropertyKey.WORKER_REVIEWER_CLASS,
             "alluxio.worker.block.reviewer.AcceptingReviewer");
     // No reserved space for tests that are not swap related.
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES, reservedBytes);
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES, reservedBytes);
 
     File tempFolder = mTestFolder.newFolder();
     TieredBlockStoreTestUtils.setupDefaultConf(tempFolder.getAbsolutePath());
@@ -503,7 +503,7 @@ public final class TieredBlockStoreTest {
 
   @Test
   public void moveBlockWithReservedSpace() throws Exception {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
     final long RESERVE_SIZE = BLOCK_SIZE;
     init(RESERVE_SIZE);
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTestUtils.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/TieredBlockStoreTestUtils.java
@@ -15,7 +15,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.FileUtils;
 import alluxio.util.io.PathUtils;
@@ -53,7 +53,7 @@ public final class TieredBlockStoreTestUtils {
   public static final String WORKER_DATA_FOLDER = "/alluxioworker/";
 
   /**
-   * Sets up a {@link ServerConfiguration} for a {@link TieredBlockStore} with several tiers
+   * Sets up a {@link Configuration} for a {@link TieredBlockStore} with several tiers
    * configured by the parameters. For simplicity, you can use {@link #setupDefaultConf(String)}
    * which calls this method with default values.
    *
@@ -92,9 +92,9 @@ public final class TieredBlockStoreTestUtils {
 
     tierPath = createDirHierarchy(baseDir, tierPath);
     if (workerDataFolder != null) {
-      ServerConfiguration.set(PropertyKey.WORKER_DATA_FOLDER, workerDataFolder);
+      Configuration.set(PropertyKey.WORKER_DATA_FOLDER, workerDataFolder);
     }
-    ServerConfiguration.set(PropertyKey.WORKER_TIERED_STORE_LEVELS, nTier);
+    Configuration.set(PropertyKey.WORKER_TIERED_STORE_LEVELS, nTier);
 
     // sets up each tier in turn
     for (int i = 0; i < nTier; i++) {
@@ -103,7 +103,7 @@ public final class TieredBlockStoreTestUtils {
   }
 
   /**
-   * Sets up a {@link ServerConfiguration} for a {@link TieredBlockStore} with only *one tier*
+   * Sets up a {@link Configuration} for a {@link TieredBlockStore} with only *one tier*
    * configured by the parameters. For simplicity, you can use {@link #setupDefaultConf(String)}
    * which sets up the tierBlockStore with default values.
    *
@@ -125,14 +125,14 @@ public final class TieredBlockStoreTestUtils {
       tierPath = createDirHierarchy(baseDir, tierPath);
     }
     if (workerDataFolder != null) {
-      ServerConfiguration.set(PropertyKey.WORKER_DATA_FOLDER, workerDataFolder);
+      Configuration.set(PropertyKey.WORKER_DATA_FOLDER, workerDataFolder);
     }
-    ServerConfiguration.set(PropertyKey.WORKER_TIERED_STORE_LEVELS, 1);
+    Configuration.set(PropertyKey.WORKER_TIERED_STORE_LEVELS, 1);
     setupConfTier(tierOrdinal, tierAlias, tierPath, tierCapacity, tierMedia);
   }
 
   /**
-   * Sets up a specific tier's {@link ServerConfiguration} for a {@link TieredBlockStore}.
+   * Sets up a specific tier's {@link Configuration} for a {@link TieredBlockStore}.
    *
    * @param tierAlias alias of the tier
    * @param tierPath absolute path of the tier
@@ -146,19 +146,19 @@ public final class TieredBlockStoreTestUtils {
     Preconditions.checkArgument(tierPath.length == tierCapacity.length,
         "tierPath and tierCapacity should have the same length");
 
-    ServerConfiguration
+    Configuration
         .set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS.format(ordinal),
             tierAlias);
 
-    ServerConfiguration
+    Configuration
         .set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(ordinal),
             Arrays.stream(tierPath).collect(toImmutableList()));
 
-    ServerConfiguration
+    Configuration
         .set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA.format(ordinal),
             Arrays.stream(tierCapacity).boxed().map(String::valueOf).collect(toImmutableList()));
 
-    ServerConfiguration
+    Configuration
         .set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_MEDIUMTYPE.format(ordinal),
             Arrays.stream(tierMediumType).collect(toImmutableList()));
   }
@@ -228,7 +228,7 @@ public final class TieredBlockStoreTestUtils {
   }
 
   /**
-   * Sets up a {@link ServerConfiguration} with default values of {@link #TIER_ORDINAL},
+   * Sets up a {@link Configuration} with default values of {@link #TIER_ORDINAL},
    * {@link #TIER_ALIAS}, {@link #TIER_PATH} with the baseDir as path prefix,
    * {@link #TIER_CAPACITY_BYTES}.
    *

--- a/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamCacheTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UfsInputStreamCacheTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 
 import alluxio.ConfigurationRule;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.test.util.ConcurrencyUtils;
 import alluxio.underfs.SeekableUnderFileInputStream;
 import alluxio.underfs.UnderFileSystem;
@@ -117,7 +117,7 @@ public final class UfsInputStreamCacheTest {
       {
         put(PropertyKey.WORKER_UFS_INSTREAM_CACHE_EXPIRARTION_TIME, "2");
       }
-    }, ServerConfiguration.global()).toResource()) {
+    }, Configuration.modifiableGlobal()).toResource()) {
       mManager = new UfsInputStreamCache();
       // check out a stream
       InputStream instream =
@@ -137,7 +137,7 @@ public final class UfsInputStreamCacheTest {
       {
         put(PropertyKey.WORKER_UFS_INSTREAM_CACHE_EXPIRARTION_TIME, "2");
       }
-    }, ServerConfiguration.global()).toResource()) {
+    }, Configuration.modifiableGlobal()).toResource()) {
       mManager = new UfsInputStreamCache();
       // check out a stream
       InputStream instream =
@@ -162,7 +162,7 @@ public final class UfsInputStreamCacheTest {
       {
         put(PropertyKey.WORKER_UFS_INSTREAM_CACHE_EXPIRARTION_TIME, "2");
       }
-    }, ServerConfiguration.global()).toResource()) {
+    }, Configuration.modifiableGlobal()).toResource()) {
       mManager = new UfsInputStreamCache();
       // check out a stream
       InputStream instream =
@@ -188,7 +188,7 @@ public final class UfsInputStreamCacheTest {
         // use very large number
         put(PropertyKey.WORKER_UFS_INSTREAM_CACHE_EXPIRARTION_TIME, "200000");
       }
-    }, ServerConfiguration.global()).toResource()) {
+    }, Configuration.modifiableGlobal()).toResource()) {
       mManager = new UfsInputStreamCache();
       List<Thread> threads = new ArrayList<>();
       int numCheckOutPerThread = 10;
@@ -230,7 +230,7 @@ public final class UfsInputStreamCacheTest {
       {
         put(PropertyKey.WORKER_UFS_INSTREAM_CACHE_EXPIRARTION_TIME, "20");
       }
-    }, ServerConfiguration.global()).toResource()) {
+    }, Configuration.modifiableGlobal()).toResource()) {
       mManager = new UfsInputStreamCache();
       List<Thread> threads = new ArrayList<>();
       int numCheckOutPerThread = 4;

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
@@ -21,7 +21,7 @@ import alluxio.AlluxioTestDirectory;
 import alluxio.AlluxioURI;
 import alluxio.ConfigurationRule;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.WorkerOutOfSpaceException;
 import alluxio.metrics.MetricInfo;
 import alluxio.metrics.MetricKey;
@@ -79,11 +79,11 @@ public final class UnderFileSystemBlockReaderTest {
               .getAbsolutePath());
           put(PropertyKey.WORKER_TIERED_STORE_LEVELS, 1);
         }
-      }, ServerConfiguration.global());
+      }, Configuration.modifiableGlobal());
 
   @Before
   public void before() throws Exception {
-    String ufsFolder = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufsFolder = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     String testFilePath = File.createTempFile("temp", null, new File(ufsFolder)).getAbsolutePath();
     byte[] buffer = BufferUtils.getIncreasingByteArray((int) TEST_BLOCK_SIZE * 2);
     BufferUtils.writeBufferToFile(testFilePath, buffer);
@@ -92,7 +92,7 @@ public final class UnderFileSystemBlockReaderTest {
     mUfsInstreamCache = new UfsInputStreamCache();
     mUfsClient = new UfsClient(
         () -> UnderFileSystem.Factory.create(testFilePath,
-            UnderFileSystemConfiguration.defaults(ServerConfiguration.global())),
+            UnderFileSystemConfiguration.defaults(Configuration.global())),
         new AlluxioURI(testFilePath));
 
     mOpenUfsBlockOptions = Protocol.OpenUfsBlockOptions.newBuilder().setMaxUfsReadConcurrency(10)

--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorContractTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorContractTest.java
@@ -14,7 +14,7 @@ package alluxio.worker.block.allocator;
 import static org.junit.Assert.fail;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.meta.StorageTier;
 
 import com.google.common.reflect.ClassPath;
@@ -66,7 +66,7 @@ public final class AllocatorContractTest extends AllocatorTestBase {
   @Test
   public void shouldNotAllocate() throws Exception {
     for (String strategyName : mStrategies) {
-      ServerConfiguration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, strategyName);
+      Configuration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, strategyName);
       resetManagerView();
       Allocator allocator = Allocator.Factory.create(getMetadataEvictorView());
       assertTempBlockMeta(allocator, mAnyDirInTierLoc1, DEFAULT_RAM_SIZE + 1, false);
@@ -83,7 +83,7 @@ public final class AllocatorContractTest extends AllocatorTestBase {
   @Test
   public void shouldAllocate() throws Exception {
     for (String strategyName : mStrategies) {
-      ServerConfiguration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, strategyName);
+      Configuration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, strategyName);
       resetManagerView();
       Allocator tierAllocator = Allocator.Factory.create(getMetadataEvictorView());
       for (int i = 0; i < DEFAULT_RAM_NUM; i++) {
@@ -113,7 +113,7 @@ public final class AllocatorContractTest extends AllocatorTestBase {
   @Test
   public void allocateAfterDirDeletion() throws Exception {
     for (String strategyName : mStrategies) {
-      ServerConfiguration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, strategyName);
+      Configuration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, strategyName);
       resetManagerView();
       for (int i = 0; i < TIER_ALIAS.length; i++) {
         StorageTier tier = mManager.getTier(TIER_ALIAS[i]);

--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorFactoryTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorFactoryTest.java
@@ -14,7 +14,7 @@ package alluxio.worker.block.allocator;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.BlockMetadataEvictorView;
 import alluxio.worker.block.BlockMetadataView;
 import alluxio.worker.block.TieredBlockStoreTestUtils;
@@ -47,7 +47,7 @@ public final class AllocatorFactoryTest {
 
   @After
   public void after() {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   /**
@@ -56,7 +56,7 @@ public final class AllocatorFactoryTest {
    */
   @Test
   public void createGreedyAllocator() {
-    ServerConfiguration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, GreedyAllocator.class.getName());
+    Configuration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, GreedyAllocator.class.getName());
     Allocator allocator = Allocator.Factory.create(mMetadataView);
     assertTrue(allocator instanceof GreedyAllocator);
   }
@@ -67,7 +67,7 @@ public final class AllocatorFactoryTest {
    */
   @Test
   public void createMaxFreeAllocator() {
-    ServerConfiguration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, MaxFreeAllocator.class.getName());
+    Configuration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, MaxFreeAllocator.class.getName());
     Allocator allocator = Allocator.Factory.create(mMetadataView);
     assertTrue(allocator instanceof MaxFreeAllocator);
   }
@@ -78,7 +78,7 @@ public final class AllocatorFactoryTest {
    */
   @Test
   public void createRoundRobinAllocator() {
-    ServerConfiguration.set(PropertyKey.WORKER_ALLOCATOR_CLASS,
+    Configuration.set(PropertyKey.WORKER_ALLOCATOR_CLASS,
         RoundRobinAllocator.class.getName());
     Allocator allocator = Allocator.Factory.create(mMetadataView);
     assertTrue(allocator instanceof RoundRobinAllocator);

--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorTestBase.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/AllocatorTestBase.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.BlockMetadataEvictorView;
 import alluxio.worker.block.BlockMetadataManager;
 import alluxio.worker.block.BlockStoreLocation;
@@ -96,9 +96,9 @@ public class AllocatorTestBase {
    */
   protected void resetManagerView() throws Exception {
     String alluxioHome = mTestFolder.newFolder().getAbsolutePath();
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, false);
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, false);
-    ServerConfiguration.set(PropertyKey.WORKER_REVIEWER_CLASS,
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, false);
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, false);
+    Configuration.set(PropertyKey.WORKER_REVIEWER_CLASS,
             "alluxio.worker.block.reviewer.MockReviewer");
     // Reviewer will not reject by default.
     MockReviewer.resetBytesToReject(Sets.newHashSet());

--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/GreedyAllocatorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/GreedyAllocatorTest.java
@@ -13,7 +13,7 @@ package alluxio.worker.block.allocator;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.reviewer.MockReviewer;
 
 import com.google.common.collect.Sets;
@@ -27,13 +27,13 @@ import org.junit.Test;
 public final class GreedyAllocatorTest extends AllocatorTestBase {
   @Before
   public void initialize() {
-    ServerConfiguration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, GreedyAllocator.class.getName());
+    Configuration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, GreedyAllocator.class.getName());
     mAllocator = Allocator.Factory.create(getMetadataEvictorView());
   }
 
   @After
   public void reset() {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/MaxFreeAllocatorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/MaxFreeAllocatorTest.java
@@ -13,7 +13,7 @@ package alluxio.worker.block.allocator;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.reviewer.MockReviewer;
 
 import com.google.common.collect.Sets;
@@ -27,13 +27,13 @@ import org.junit.Test;
 public final class MaxFreeAllocatorTest extends AllocatorTestBase {
   @Before
   public void initialize() {
-    ServerConfiguration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, MaxFreeAllocator.class.getName());
+    Configuration.set(PropertyKey.WORKER_ALLOCATOR_CLASS, MaxFreeAllocator.class.getName());
     mAllocator = Allocator.Factory.create(getMetadataEvictorView());
   }
 
   @After
   public void reset() {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/allocator/RoundRobinAllocatorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/allocator/RoundRobinAllocatorTest.java
@@ -13,7 +13,7 @@ package alluxio.worker.block.allocator;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.reviewer.MockReviewer;
 
 import com.google.common.collect.Sets;
@@ -27,14 +27,14 @@ import org.junit.Test;
 public final class RoundRobinAllocatorTest extends AllocatorTestBase {
   @Before
   public void initialize() {
-    ServerConfiguration.set(PropertyKey.WORKER_ALLOCATOR_CLASS,
+    Configuration.set(PropertyKey.WORKER_ALLOCATOR_CLASS,
             RoundRobinAllocator.class.getName());
     mAllocator = Allocator.Factory.create(getMetadataEvictorView());
   }
 
   @After
   public void reset() {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/annotator/EmulatingBlockIteratorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/annotator/EmulatingBlockIteratorTest.java
@@ -13,7 +13,7 @@ package alluxio.worker.block.annotator;
 
 import alluxio.StorageTierAssoc;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.BlockMetadataManager;
 import alluxio.worker.block.BlockStoreEventListener;
 import alluxio.worker.block.TieredBlockStoreTestUtils;
@@ -52,10 +52,10 @@ public class EmulatingBlockIteratorTest {
   @Before
   public void before() throws Exception {
     // Set an evictor class in order to activate emulation.
-    ServerConfiguration.set(PropertyKey.WORKER_EVICTOR_CLASS, LRUEvictor.class.getName());
+    Configuration.set(PropertyKey.WORKER_EVICTOR_CLASS, LRUEvictor.class.getName());
     // No reserved bytes for precise capacity planning.
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, false);
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, false);
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, false);
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, false);
 
     File tempFolder = mTestFolder.newFolder();
     mMetaManager = TieredBlockStoreTestUtils.defaultMetadataManager(tempFolder.getAbsolutePath());

--- a/core/server/worker/src/test/java/alluxio/worker/block/annotator/LRFUAnnotatorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/annotator/LRFUAnnotatorTest.java
@@ -12,7 +12,7 @@
 package alluxio.worker.block.annotator;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.BlockStoreLocation;
 import alluxio.worker.block.meta.StorageDir;
 
@@ -30,10 +30,10 @@ public class LRFUAnnotatorTest extends AbstractBlockAnnotatorTest {
    */
   @Before
   public void before() throws Exception {
-    ServerConfiguration.set(PropertyKey.WORKER_BLOCK_ANNOTATOR_CLASS,
+    Configuration.set(PropertyKey.WORKER_BLOCK_ANNOTATOR_CLASS,
         LRFUAnnotator.class.getName());
     // To make it behave close to an absolute LFU.
-    ServerConfiguration.set(PropertyKey.WORKER_BLOCK_ANNOTATOR_LRFU_STEP_FACTOR, 0);
+    Configuration.set(PropertyKey.WORKER_BLOCK_ANNOTATOR_LRFU_STEP_FACTOR, 0);
     init();
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/annotator/LRUAnnotatorTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/annotator/LRUAnnotatorTest.java
@@ -12,7 +12,7 @@
 package alluxio.worker.block.annotator;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.BlockStoreLocation;
 import alluxio.worker.block.meta.StorageDir;
 
@@ -30,7 +30,7 @@ public class LRUAnnotatorTest extends AbstractBlockAnnotatorTest {
    */
   @Before
   public void before() throws Exception {
-    ServerConfiguration.set(PropertyKey.WORKER_BLOCK_ANNOTATOR_CLASS,
+    Configuration.set(PropertyKey.WORKER_BLOCK_ANNOTATOR_CLASS,
         LRUAnnotator.class.getName());
     init();
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/management/tier/AlignTaskTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/management/tier/AlignTaskTest.java
@@ -12,7 +12,7 @@
 package alluxio.worker.block.management.tier;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.worker.block.BlockStoreLocation;
@@ -34,12 +34,12 @@ public class AlignTaskTest extends BaseTierManagementTaskTest {
    */
   @Before
   public void before() throws Exception {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
     // Current tier layout could end up swapping 2 blocks concurrently.
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES,
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES,
         2 * BLOCK_SIZE);
     // Disable promotions to avoid interference.
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, false);
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, false);
     // Initialize the tier layout.
     init();
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/management/tier/BaseTierManagementTaskTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/management/tier/BaseTierManagementTaskTest.java
@@ -12,7 +12,7 @@
 package alluxio.worker.block.management.tier;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.worker.block.AllocateOptions;
 import alluxio.worker.block.BlockMetadataManager;
 import alluxio.worker.block.BlockStoreLocation;
@@ -59,13 +59,13 @@ public abstract class BaseTierManagementTaskTest {
    */
   protected void init() throws Exception {
     // Disable reviewer to make sure the allocator behavior stays deterministic
-    ServerConfiguration.set(PropertyKey.WORKER_REVIEWER_CLASS,
+    Configuration.set(PropertyKey.WORKER_REVIEWER_CLASS,
             "alluxio.worker.block.reviewer.AcceptingReviewer");
     // Use LRU for stronger overlap guarantee.
-    ServerConfiguration.set(PropertyKey.WORKER_BLOCK_ANNOTATOR_CLASS, LRUAnnotator.class.getName());
-    ServerConfiguration.set(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE);
+    Configuration.set(PropertyKey.WORKER_BLOCK_ANNOTATOR_CLASS, LRUAnnotator.class.getName());
+    Configuration.set(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE);
     // Set timeout for faster task execution.
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_LOAD_DETECTION_COOL_DOWN_TIME, "100ms");
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_LOAD_DETECTION_COOL_DOWN_TIME, "100ms");
 
     File tempFolder = mTestFolder.newFolder();
     TieredBlockStoreTestUtils.setupDefaultConf(tempFolder.getAbsolutePath());

--- a/core/server/worker/src/test/java/alluxio/worker/block/management/tier/PromoteTaskTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/management/tier/PromoteTaskTest.java
@@ -12,7 +12,7 @@
 package alluxio.worker.block.management.tier;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.worker.block.TieredBlockStoreTestUtils;
@@ -29,11 +29,11 @@ public class PromoteTaskTest extends BaseTierManagementTaskTest {
    */
   @Before
   public void before() throws Exception {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
     // Disable tier alignment to avoid interference.
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, false);
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_ENABLED, false);
     // Set promotion quota percentage.
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_QUOTA_PERCENT,
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_QUOTA_PERCENT,
         MOVE_QUOTA_PERCENT);
     // Initialize the tier layout.
     init();

--- a/core/server/worker/src/test/java/alluxio/worker/block/management/tier/SwapRestoreTaskTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/management/tier/SwapRestoreTaskTest.java
@@ -12,7 +12,7 @@
 package alluxio.worker.block.management.tier;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.worker.block.BlockStoreLocation;
@@ -34,11 +34,11 @@ public class SwapRestoreTaskTest extends BaseTierManagementTaskTest {
    */
   @Before
   public void before() throws Exception {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
     // Disable move task to avoid interference.
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, false);
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_PROMOTE_ENABLED, false);
     // Current tier layout could end up swapping 1 big block.
-    ServerConfiguration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES, BLOCK_SIZE);
+    Configuration.set(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES, BLOCK_SIZE);
     // Initialize the tier layout.
     init();
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/meta/DefaultStorageTierTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/meta/DefaultStorageTierTest.java
@@ -13,7 +13,7 @@ package alluxio.worker.block.meta;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.io.PathUtils;
 import alluxio.worker.block.TieredBlockStoreTestUtils;
 
@@ -149,7 +149,7 @@ public class DefaultStorageTierTest {
   public void tolerantFailureInStorageDir() throws Exception {
     PropertyKey tierDirPathConf =
         PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(0);
-    ServerConfiguration.set(tierDirPathConf, "/dev/null/invalid," + mTestDirPath1);
+    Configuration.set(tierDirPathConf, "/dev/null/invalid," + mTestDirPath1);
     mTier = DefaultStorageTier.newStorageTier(Constants.MEDIUM_MEM, 0, false);
     List<StorageDir> dirs = mTier.getStorageDirs();
     Assert.assertEquals(1, dirs.size());
@@ -158,10 +158,10 @@ public class DefaultStorageTierTest {
 
   @Test
   public void tolerantMisconfigurationInStorageDir() throws Exception {
-    ServerConfiguration
+    Configuration
         .set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_MEDIUMTYPE.format(0),
             Constants.MEDIUM_MEM);
-    ServerConfiguration
+    Configuration
         .set(PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_QUOTA.format(0),
             "2000");
     mTier = DefaultStorageTier.newStorageTier(Constants.MEDIUM_MEM, 0, false);

--- a/core/server/worker/src/test/java/alluxio/worker/block/reviewer/ProbabilisticBufferReviewerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/reviewer/ProbabilisticBufferReviewerTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.FormatUtils;
 import alluxio.worker.block.meta.StorageDirView;
 
@@ -36,10 +36,10 @@ public class ProbabilisticBufferReviewerTest {
 
   @Before
   public void createReviewerInstance() {
-    ServerConfiguration.set(PropertyKey.WORKER_REVIEWER_CLASS,
+    Configuration.set(PropertyKey.WORKER_REVIEWER_CLASS,
             ProbabilisticBufferReviewer.class.getName());
-    ServerConfiguration.set(PropertyKey.WORKER_REVIEWER_PROBABILISTIC_HARDLIMIT_BYTES, HARD_LIMIT);
-    ServerConfiguration.set(PropertyKey.WORKER_REVIEWER_PROBABILISTIC_SOFTLIMIT_BYTES, SOFT_LIMIT);
+    Configuration.set(PropertyKey.WORKER_REVIEWER_PROBABILISTIC_HARDLIMIT_BYTES, HARD_LIMIT);
+    Configuration.set(PropertyKey.WORKER_REVIEWER_PROBABILISTIC_SOFTLIMIT_BYTES, SOFT_LIMIT);
 
     Reviewer reviewer = Reviewer.Factory.create();
     assertTrue(reviewer instanceof ProbabilisticBufferReviewer);
@@ -49,7 +49,7 @@ public class ProbabilisticBufferReviewerTest {
   @After
   public void reset() {
     mReviewer = null;
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   @Test

--- a/core/server/worker/src/test/java/alluxio/worker/block/reviewer/ReviewerFactoryTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/reviewer/ReviewerFactoryTest.java
@@ -14,7 +14,7 @@ package alluxio.worker.block.reviewer;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import org.junit.Test;
 
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class ReviewerFactoryTest {
   @Test
   public void createProbabilisticBufferReviewer() {
-    ServerConfiguration.set(PropertyKey.WORKER_REVIEWER_CLASS,
+    Configuration.set(PropertyKey.WORKER_REVIEWER_CLASS,
             ProbabilisticBufferReviewer.class.getName());
     Reviewer allocator = Reviewer.Factory.create();
     assertTrue(allocator instanceof ProbabilisticBufferReviewer);

--- a/core/server/worker/src/test/java/alluxio/worker/block/stream/BlockWorkerDataReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/stream/BlockWorkerDataReaderTest.java
@@ -30,7 +30,7 @@ import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.InStreamOptions;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
 import alluxio.network.protocol.databuffer.DataBuffer;
@@ -70,7 +70,7 @@ public class BlockWorkerDataReaderTest {
   private static final long SESSION_ID = 10L;
   private static final int LOCK_NUM = 5;
 
-  private final InstancedConfiguration mConf = ServerConfiguration.global();
+  private final InstancedConfiguration mConf = Configuration.modifiableGlobal();
   private final String mMemDir =
       AlluxioTestDirectory.createTemporaryDirectory(Constants.MEDIUM_MEM).getAbsolutePath();
 
@@ -90,7 +90,7 @@ public class BlockWorkerDataReaderTest {
           .put(PropertyKey.WORKER_RPC_PORT, 0)
           .put(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS,
               AlluxioTestDirectory.createTemporaryDirectory("BlockWorkerDataReaderTest")
-                  .getAbsolutePath()).build(), mConf);
+                  .getAbsolutePath()).build(), Configuration.modifiableGlobal());
 
   @Before
   public void before() throws Exception {
@@ -103,10 +103,10 @@ public class BlockWorkerDataReaderTest {
 
     // Connect to the real UFS for UFS read testing
     UfsManager ufsManager = mock(UfsManager.class);
-    mRootUfs = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    mRootUfs = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     UfsManager.UfsClient ufsClient = new UfsManager.UfsClient(
         () -> UnderFileSystem.Factory.create(mRootUfs,
-            UnderFileSystemConfiguration.defaults(ServerConfiguration.global())),
+            UnderFileSystemConfiguration.defaults(Configuration.global())),
         new AlluxioURI(mRootUfs));
     when(ufsManager.get(anyLong())).thenReturn(ufsClient);
 

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/BlockReadHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/BlockReadHandlerTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.ReadRequest;
 import alluxio.grpc.ReadResponse;
 import alluxio.util.CommonUtils;
@@ -60,7 +60,7 @@ import java.util.concurrent.TimeoutException;
  */
 public class BlockReadHandlerTest {
   private static final long CHUNK_SIZE =
-      ServerConfiguration.getBytes(PropertyKey.USER_STREAMING_READER_CHUNK_SIZE_BYTES);
+      Configuration.getBytes(PropertyKey.USER_STREAMING_READER_CHUNK_SIZE_BYTES);
   private final Random mRandom = new Random();
 
   private BlockReadHandler mReadHandler;

--- a/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandlerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/grpc/UfsFallbackBlockWriteHandlerTest.java
@@ -18,7 +18,7 @@ import alluxio.AlluxioURI;
 import alluxio.ConfigurationRule;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.RequestType;
 import alluxio.grpc.WriteRequest;
 import alluxio.network.protocol.databuffer.DataBuffer;
@@ -76,7 +76,7 @@ public class UfsFallbackBlockWriteHandlerTest extends AbstractWriteHandlerTest {
               .getAbsolutePath());
           put(PropertyKey.WORKER_TIERED_STORE_LEVELS, 1);
         }
-      }, ServerConfiguration.global());
+      }, Configuration.modifiableGlobal());
 
   @Before
   public void before() throws Exception {

--- a/examples/src/main/java/alluxio/cli/MiniBenchmark.java
+++ b/examples/src/main/java/alluxio/cli/MiniBenchmark.java
@@ -18,8 +18,8 @@ import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.FormatUtils;
 
 import com.google.common.base.Preconditions;
@@ -129,7 +129,7 @@ public final class MiniBenchmark {
     }
 
     CommonUtils.warmUpLoop();
-    AlluxioConfiguration alluxioConf = ConfigurationUtils.defaults();
+    AlluxioConfiguration alluxioConf = Configuration.global();
 
     for (int i = 0; i < sIterations; ++i) {
       final AtomicInteger count = new AtomicInteger(0);

--- a/examples/src/main/java/alluxio/examples/Performance.java
+++ b/examples/src/main/java/alluxio/examples/Performance.java
@@ -17,12 +17,12 @@ import alluxio.RuntimeConstants;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.FormatUtils;
 
 import com.google.common.base.Preconditions;
@@ -582,7 +582,7 @@ public final class Performance {
       System.exit(-1);
     }
 
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    InstancedConfiguration conf = Configuration.modifiableGlobal();
 
     HostAndPort masterAddress = HostAndPort.fromString(args[0]);
     sFileName = args[1];

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -18,7 +18,7 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.jnifuse.FuseException;
 import alluxio.jnifuse.LibFuse;
 import alluxio.jnifuse.utils.NativeLibraryLoader;
@@ -142,7 +142,7 @@ public final class AlluxioFuse {
           NetworkAddressUtils.ServiceType.FUSE_WEB.getServiceName(),
           NetworkAddressUtils.getBindAddress(
               NetworkAddressUtils.ServiceType.FUSE_WEB,
-              ServerConfiguration.global()));
+              Configuration.global()));
       webServer.start();
     }
     startJvmMonitorProcess();
@@ -320,11 +320,11 @@ public final class AlluxioFuse {
    * Starts jvm monitor process, to monitor jvm.
    */
   private static void startJvmMonitorProcess() {
-    if (ServerConfiguration.getBoolean(PropertyKey.STANDALONE_FUSE_JVM_MONITOR_ENABLED)) {
+    if (Configuration.getBoolean(PropertyKey.STANDALONE_FUSE_JVM_MONITOR_ENABLED)) {
       JvmPauseMonitor jvmPauseMonitor = new JvmPauseMonitor(
-          ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_SLEEP_INTERVAL_MS),
-          ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS),
-          ServerConfiguration.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS));
+          Configuration.getMs(PropertyKey.JVM_MONITOR_SLEEP_INTERVAL_MS),
+          Configuration.getMs(PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS),
+          Configuration.getMs(PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS));
       jvmPauseMonitor.start();
       MetricsSystem.registerGaugeIfAbsent(
           MetricsSystem.getMetricName(MetricKey.TOTAL_EXTRA_TIME.getName()),

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystem.java
@@ -30,7 +30,6 @@ import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.master.MasterClientContext;
-import alluxio.util.ConfigurationUtils;
 import alluxio.wire.BlockMasterInfo;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -87,8 +86,6 @@ public final class AlluxioFuseFileSystem extends FuseStubFS
    */
   @VisibleForTesting
   public static final int MAX_NAME_LENGTH = 255;
-
-  private static AlluxioConfiguration sConf = ConfigurationUtils.defaults();
 
   /**
    * 4294967295 is unsigned long -1, -1 means that uid or gid is not set.
@@ -786,7 +783,7 @@ public final class AlluxioFuseFileSystem extends FuseStubFS
   }
 
   private int statfsInternal(String path, Statvfs stbuf) {
-    ClientContext ctx = ClientContext.create(sConf);
+    ClientContext ctx = ClientContext.create();
 
     try (BlockMasterClient blockClient =
              BlockMasterClient.Factory.create(MasterClientContext.newBuilder(ctx).build())) {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -14,6 +14,7 @@ package alluxio.fuse;
 import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
@@ -29,7 +30,6 @@ import alluxio.jnifuse.utils.VersionPreference;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.OSUtils;
 import alluxio.util.ShellUtils;
 import alluxio.util.WaitForOptions;
@@ -50,7 +50,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class AlluxioFuseUtils {
   private static final Logger LOG = LoggerFactory.getLogger(AlluxioFuseUtils.class);
-  private static final long THRESHOLD = ConfigurationUtils.defaults()
+  private static final long THRESHOLD = Configuration.global()
       .getMs(PropertyKey.FUSE_LOGGING_THRESHOLD);
   private static final int MAX_ASYNC_RELEASE_WAITTIME_MS = 5000;
 

--- a/integration/fuse/src/main/java/alluxio/fuse/StackMain.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/StackMain.java
@@ -12,12 +12,11 @@
 package alluxio.fuse;
 
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.jnifuse.LibFuse;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -37,8 +36,7 @@ public class StackMain {
     }
     Path root = Paths.get(args[1]);
     Path mountPoint = Paths.get(args[0]);
-    AlluxioConfiguration conf = new InstancedConfiguration(
-        ConfigurationUtils.copyDefaults());
+    AlluxioConfiguration conf = Configuration.global();
     LibFuse.loadLibrary(AlluxioFuseUtils.getVersionPreference(conf));
     StackFS fs = new StackFS(root, mountPoint);
     String[] fuseOpts = new String[args.length - 2];

--- a/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
@@ -13,6 +13,7 @@ package alluxio.cli;
 
 import static alluxio.conf.PropertyKey.PropertyType.STRING;
 
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
@@ -23,7 +24,6 @@ import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 import alluxio.underfs.options.DeleteOptions;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.io.PathUtils;
 
 import com.beust.jcommander.JCommander;
@@ -76,18 +76,7 @@ public final class UnderFileSystemContractTest {
    * A constructor from default.
    * */
   public UnderFileSystemContractTest() {
-    mConf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
-  }
-
-  /**
-   * Initiate the tests for a specific UFS path and UFS configs.
-   *
-   * @param path the UFS path
-   * @param conf the UFs configurations
-   * */
-  public UnderFileSystemContractTest(String path, InstancedConfiguration conf) {
-    mUfsPath = path;
-    mConf = conf;
+    mConf = Configuration.modifiableGlobal();
   }
 
   /**

--- a/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/migrate/MigrateDefinition.java
@@ -21,7 +21,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.grpc.CreateFilePOptions;
@@ -140,7 +140,7 @@ public final class MigrateDefinition
   public SerializableVoid runTask(MigrateConfig config, MigrateCommand command,
       RunTaskContext context) throws Exception {
     WriteType writeType = config.getWriteType() == null
-        ? ServerConfiguration.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class)
+        ? Configuration.getEnum(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class)
         : config.getWriteType();
     migrate(command, writeType.toProto(), context.getFileSystem(), config.isOverwrite());
     return null;

--- a/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/persist/PersistDefinition.java
@@ -17,7 +17,7 @@ import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.URIStatus;
 import alluxio.collections.Pair;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
 import alluxio.job.RunTaskContext;
@@ -153,7 +153,7 @@ public final class PersistDefinition
           String ancestorUfsPath = ancestorUfsAndAlluxioPath.getFirst();
           String ancestorAlluxioPath = ancestorUfsAndAlluxioPath.getSecond();
           URIStatus status = context.getFileSystem().getStatus(new AlluxioURI(ancestorAlluxioPath));
-          MkdirsOptions mkdirOptions = MkdirsOptions.defaults(ServerConfiguration.global())
+          MkdirsOptions mkdirOptions = MkdirsOptions.defaults(Configuration.global())
               .setCreateParent(false)
               .setOwner(status.getOwner())
               .setGroup(status.getGroup())
@@ -172,7 +172,7 @@ public final class PersistDefinition
         }
         OutputStream out = closer.register(
             ufs.createNonexistingFile(dstPath.toString(),
-                CreateOptions.defaults(ServerConfiguration.global()).setOwner(uriStatus.getOwner())
+                CreateOptions.defaults(Configuration.global()).setOwner(uriStatus.getOwner())
                 .setGroup(uriStatus.getGroup()).setMode(new Mode((short) uriStatus.getMode()))));
         URIStatus status = context.getFileSystem().getStatus(uri);
         List<AclEntry> allAcls = Stream.concat(status.getDefaultAcl().getEntries().stream(),

--- a/job/server/src/main/java/alluxio/job/plan/replicate/MoveDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/MoveDefinition.java
@@ -14,7 +14,7 @@ package alluxio.job.plan.replicate;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.collections.Pair;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.MoveBlockRequest;
 import alluxio.job.RunTaskContext;
@@ -87,7 +87,7 @@ public final class MoveDefinition
       throws Exception {
     long blockId = config.getBlockId();
     String localHostName = NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC,
-        ServerConfiguration.global());
+        Configuration.global());
     List<BlockWorkerInfo> workerInfoList = context.getFsContext().getCachedWorkers();
     WorkerNetAddress localNetAddress = null;
 

--- a/job/server/src/main/java/alluxio/job/plan/replicate/SetReplicaDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/replicate/SetReplicaDefinition.java
@@ -17,7 +17,7 @@ import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.client.file.URIStatus;
 import alluxio.collections.Pair;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.RemoveBlockRequest;
 import alluxio.job.RunTaskContext;
@@ -136,7 +136,7 @@ public final class SetReplicaDefinition
   private void evict(SetReplicaConfig config, RunTaskContext context) throws Exception {
     long blockId = config.getBlockId();
     String localHostName = NetworkAddressUtils
-        .getConnectHost(NetworkAddressUtils.ServiceType.WORKER_RPC, ServerConfiguration.global());
+        .getConnectHost(NetworkAddressUtils.ServiceType.WORKER_RPC, Configuration.global());
     List<BlockWorkerInfo> workerInfoList = context.getFsContext().getCachedWorkers();
     WorkerNetAddress localNetAddress = null;
 

--- a/job/server/src/main/java/alluxio/job/plan/stress/StressBenchDefinition.java
+++ b/job/server/src/main/java/alluxio/job/plan/stress/StressBenchDefinition.java
@@ -14,7 +14,7 @@ package alluxio.job.plan.stress;
 import alluxio.collections.Pair;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.job.RunTaskContext;
 import alluxio.job.SelectExecutorsContext;
 import alluxio.job.plan.PlanDefinition;
@@ -121,7 +121,7 @@ public final class StressBenchDefinition
   public String runTask(StressBenchConfig config, ArrayList<String> args,
       RunTaskContext runTaskContext) throws Exception {
     List<String> command = new ArrayList<>(3 + config.getArgs().size());
-    command.add(ServerConfiguration.get(PropertyKey.HOME) + "/bin/alluxio");
+    command.add(Configuration.get(PropertyKey.HOME) + "/bin/alluxio");
     command.add("runClass");
     command.add(config.getClassName());
 

--- a/job/server/src/main/java/alluxio/job/util/JobUtils.java
+++ b/job/server/src/main/java/alluxio/job/util/JobUtils.java
@@ -27,7 +27,7 @@ import alluxio.collections.IndexDefinition;
 import alluxio.collections.IndexedSet;
 import alluxio.collections.Pair;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.NotFoundException;
@@ -120,7 +120,7 @@ public final class JobUtils {
   public static void loadBlock(URIStatus status, FileSystemContext context, long blockId,
       WorkerNetAddress address, boolean directCache)
       throws AlluxioException, IOException {
-    AlluxioConfiguration conf = ServerConfiguration.global();
+    AlluxioConfiguration conf = Configuration.global();
     // Explicitly specified a worker to load
     WorkerNetAddress localNetAddress = address;
     String localHostName = NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC, conf);

--- a/job/server/src/main/java/alluxio/master/AlluxioJobMasterProcess.java
+++ b/job/server/src/main/java/alluxio/master/AlluxioJobMasterProcess.java
@@ -16,7 +16,7 @@ import alluxio.RuntimeConstants;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.GrpcServer;
 import alluxio.grpc.GrpcServerAddress;
 import alluxio.grpc.GrpcServerBuilder;
@@ -65,13 +65,13 @@ public class AlluxioJobMasterProcess extends MasterProcess {
   AlluxioJobMasterProcess(JournalSystem journalSystem) {
     super(journalSystem, ServiceType.JOB_MASTER_RPC, ServiceType.JOB_MASTER_WEB);
     mRpcConnectAddress = NetworkAddressUtils.getConnectAddress(ServiceType.JOB_MASTER_RPC,
-        ServerConfiguration.global());
-    if (!ServerConfiguration.isSet(PropertyKey.JOB_MASTER_HOSTNAME)) {
-      ServerConfiguration.set(PropertyKey.JOB_MASTER_HOSTNAME,
+        Configuration.global());
+    if (!Configuration.isSet(PropertyKey.JOB_MASTER_HOSTNAME)) {
+      Configuration.set(PropertyKey.JOB_MASTER_HOSTNAME,
           NetworkAddressUtils.getLocalHostName(
-              (int) ServerConfiguration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS)));
+              (int) Configuration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS)));
     }
-    FileSystemContext fsContext = FileSystemContext.create(ServerConfiguration.global());
+    FileSystemContext fsContext = FileSystemContext.create(Configuration.global());
     FileSystem fileSystem = FileSystem.Factory.create(fsContext);
     UfsManager ufsManager = new JobUfsManager();
     try {
@@ -214,18 +214,18 @@ public class AlluxioJobMasterProcess extends MasterProcess {
     // Create underlying gRPC server.
     GrpcServerBuilder builder = GrpcServerBuilder
         .forAddress(GrpcServerAddress.create(mRpcConnectAddress.getHostName(), mRpcBindAddress),
-            ServerConfiguration.global(), ServerUserState.global())
+            Configuration.global(), ServerUserState.global())
         .flowControlWindow(
-            (int) ServerConfiguration.getBytes(PropertyKey.JOB_MASTER_NETWORK_FLOWCONTROL_WINDOW))
-        .keepAliveTime(ServerConfiguration.getMs(PropertyKey.JOB_MASTER_NETWORK_KEEPALIVE_TIME_MS),
+            (int) Configuration.getBytes(PropertyKey.JOB_MASTER_NETWORK_FLOWCONTROL_WINDOW))
+        .keepAliveTime(Configuration.getMs(PropertyKey.JOB_MASTER_NETWORK_KEEPALIVE_TIME_MS),
             TimeUnit.MILLISECONDS)
         .keepAliveTimeout(
-            ServerConfiguration.getMs(PropertyKey.JOB_MASTER_NETWORK_KEEPALIVE_TIMEOUT_MS),
+            Configuration.getMs(PropertyKey.JOB_MASTER_NETWORK_KEEPALIVE_TIMEOUT_MS),
             TimeUnit.MILLISECONDS)
         .permitKeepAlive(
-            ServerConfiguration.getMs(PropertyKey.JOB_MASTER_NETWORK_PERMIT_KEEPALIVE_TIME_MS),
+            Configuration.getMs(PropertyKey.JOB_MASTER_NETWORK_PERMIT_KEEPALIVE_TIME_MS),
             TimeUnit.MILLISECONDS)
-        .maxInboundMessageSize((int) ServerConfiguration
+        .maxInboundMessageSize((int) Configuration
             .getBytes(PropertyKey.JOB_MASTER_NETWORK_MAX_INBOUND_MESSAGE_SIZE));
     // Register job-master services.
     registerServices(builder, mJobMaster.getServices());
@@ -271,7 +271,7 @@ public class AlluxioJobMasterProcess extends MasterProcess {
       JournalSystem journalSystem = new JournalSystem.Builder()
           .setLocation(URIUtils.appendPathOrDie(journalLocation, Constants.JOB_JOURNAL_NAME))
           .build(ProcessType.JOB_MASTER);
-      if (ServerConfiguration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED)) {
+      if (Configuration.getBoolean(PropertyKey.ZOOKEEPER_ENABLED)) {
         Preconditions.checkState(!(journalSystem instanceof RaftJournalSystem),
             "Raft journal cannot be used with Zookeeper enabled");
         PrimarySelector primarySelector = PrimarySelector.Factory.createZkJobPrimarySelector();

--- a/job/server/src/main/java/alluxio/master/AlluxioJobMasterRestServiceHandler.java
+++ b/job/server/src/main/java/alluxio/master/AlluxioJobMasterRestServiceHandler.java
@@ -14,7 +14,7 @@ package alluxio.master;
 import alluxio.RestUtils;
 import alluxio.RuntimeConstants;
 import alluxio.conf.ConfigurationValueOptions;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.LogUtils;
 import alluxio.web.JobMasterWebServer;
 import alluxio.wire.AlluxioJobMasterInfo;
@@ -93,7 +93,7 @@ public final class AlluxioJobMasterRestServiceHandler {
               .setVersion(RuntimeConstants.VERSION)
               .setWorkers(mJobMaster.getJobMaster().getWorkerInfoList());
       return result;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -107,14 +107,14 @@ public final class AlluxioJobMasterRestServiceHandler {
   public Response logLevel(@QueryParam(LOG_ARGUMENT_NAME) final String logName,
                            @QueryParam(LOG_ARGUMENT_LEVEL) final String level) {
     return RestUtils.call(() -> LogUtils.setLogLevel(logName, level),
-            ServerConfiguration.global());
+            Configuration.global());
   }
 
   private Map<String, Object> getConfigurationInternal(boolean raw) {
     if (raw) {
-      return ServerConfiguration.toMap(ConfigurationValueOptions.defaults().useRawValue(raw));
+      return Configuration.toMap(ConfigurationValueOptions.defaults().useRawValue(raw));
     } else {
-      return ServerConfiguration.toMap();
+      return Configuration.toMap();
     }
   }
 }

--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -18,7 +18,7 @@ import alluxio.clock.SystemClock;
 import alluxio.collections.IndexDefinition;
 import alluxio.collections.IndexedSet;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.JobDoesNotExistException;
@@ -164,9 +164,9 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
     mWorkflowTracker = new WorkflowTracker(this);
 
     mPlanTracker = new PlanTracker(
-        ServerConfiguration.getInt(PropertyKey.JOB_MASTER_JOB_CAPACITY),
-        ServerConfiguration.getMs(PropertyKey.JOB_MASTER_FINISHED_JOB_RETENTION_TIME),
-        ServerConfiguration.getInt(PropertyKey.JOB_MASTER_FINISHED_JOB_PURGE_COUNT),
+        Configuration.getInt(PropertyKey.JOB_MASTER_JOB_CAPACITY),
+        Configuration.getMs(PropertyKey.JOB_MASTER_FINISHED_JOB_RETENTION_TIME),
+        Configuration.getInt(PropertyKey.JOB_MASTER_FINISHED_JOB_PURGE_COUNT),
         mWorkflowTracker);
 
     mWorkerHealth = new ConcurrentHashMap<>();
@@ -204,9 +204,9 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
       getExecutorService()
           .submit(new HeartbeatThread(HeartbeatContext.JOB_MASTER_LOST_WORKER_DETECTION,
               new LostWorkerDetectionHeartbeatExecutor(),
-              (int) ServerConfiguration.getMs(PropertyKey.JOB_MASTER_LOST_WORKER_INTERVAL),
-              ServerConfiguration.global(), mMasterContext.getUserState()));
-      if (ServerConfiguration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED)) {
+              (int) Configuration.getMs(PropertyKey.JOB_MASTER_LOST_WORKER_INTERVAL),
+              Configuration.global(), mMasterContext.getUserState()));
+      if (Configuration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED)) {
         mAsyncAuditLogWriter = new AsyncUserAccessAuditLogWriter("JOB_MASTER_AUDIT_LOG");
         mAsyncAuditLogWriter.start();
         MetricsSystem.registerGaugeIfAbsent(
@@ -651,7 +651,7 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
   private JobMasterAuditContext createAuditContext(String command) {
     // Audit log may be enabled during runtime
     AsyncUserAccessAuditLogWriter auditLogWriter = null;
-    if (ServerConfiguration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED)) {
+    if (Configuration.getBoolean(PropertyKey.MASTER_AUDIT_LOGGING_ENABLED)) {
       auditLogWriter = mAsyncAuditLogWriter;
     }
     JobMasterAuditContext auditContext =
@@ -660,13 +660,13 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
       String user = null;
       String ugi = "";
       try {
-        user = AuthenticatedClientUser.getClientUser(ServerConfiguration.global());
+        user = AuthenticatedClientUser.getClientUser(Configuration.global());
       } catch (AccessControlException e) {
         ugi = "N/A";
       }
       if (user != null) {
         try {
-          String primaryGroup = CommonUtils.getPrimaryGroupName(user, ServerConfiguration.global());
+          String primaryGroup = CommonUtils.getPrimaryGroupName(user, Configuration.global());
           ugi = user + "," + primaryGroup;
         } catch (IOException e) {
           LOG.debug("Failed to get primary group for user {}.", user);
@@ -674,7 +674,7 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
         }
       }
       AuthType authType =
-          ServerConfiguration.getEnum(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.class);
+          Configuration.getEnum(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.class);
       auditContext.setUgi(ugi)
           .setAuthType(authType)
           .setIp(ClientIpAddressInjector.getIpAddress())
@@ -697,7 +697,7 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
 
     @Override
     public void heartbeat() {
-      int masterWorkerTimeoutMs = (int) ServerConfiguration
+      int masterWorkerTimeoutMs = (int) Configuration
           .getMs(PropertyKey.JOB_MASTER_WORKER_TIMEOUT);
       List<MasterWorkerInfo> lostWorkers = new ArrayList<>();
       // Run under shared lock for mWorkers

--- a/job/server/src/main/java/alluxio/master/job/JobMasterClientRestServiceHandler.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMasterClientRestServiceHandler.java
@@ -13,7 +13,7 @@ package alluxio.master.job;
 
 import alluxio.Constants;
 import alluxio.RestUtils;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.ListAllPOptions;
 import alluxio.job.JobConfig;
 import alluxio.job.ServiceConstants;
@@ -69,7 +69,7 @@ public final class JobMasterClientRestServiceHandler {
   public Response getServiceName() {
     // Need to encode the string as JSON because Jackson will not do it automatically.
     return RestUtils.call(() -> Constants.JOB_MASTER_CLIENT_SERVICE_NAME,
-        ServerConfiguration.global());
+        Configuration.global());
   }
 
   /**
@@ -79,7 +79,7 @@ public final class JobMasterClientRestServiceHandler {
   @Path(ServiceConstants.SERVICE_VERSION)
   public Response getServiceVersion() {
     return RestUtils.call(() -> Constants.JOB_MASTER_CLIENT_SERVICE_VERSION,
-        ServerConfiguration.global());
+        Configuration.global());
   }
 
   /**
@@ -94,7 +94,7 @@ public final class JobMasterClientRestServiceHandler {
     return RestUtils.call((RestUtils.RestCallable<Void>) () -> {
       mJobMaster.cancel(jobId);
       return null;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -108,7 +108,7 @@ public final class JobMasterClientRestServiceHandler {
   @JacksonFeatures(serializationEnable = {SerializationFeature.INDENT_OUTPUT})
   @ApiOperation(value = "Gets the status of a job", response = JobInfo.class)
   public Response getStatus(@QueryParam("jobId") final long jobId) {
-    return RestUtils.call(() -> mJobMaster.getStatus(jobId), ServerConfiguration.global());
+    return RestUtils.call(() -> mJobMaster.getStatus(jobId), Configuration.global());
   }
 
   /**
@@ -134,7 +134,7 @@ public final class JobMasterClientRestServiceHandler {
       } else {
         return mJobMaster.list(ListAllPOptions.getDefaultInstance());
       }
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -147,6 +147,6 @@ public final class JobMasterClientRestServiceHandler {
   @Path(ServiceConstants.RUN)
   @Consumes(MediaType.APPLICATION_JSON)
   public Response run(final JobConfig jobConfig) {
-    return RestUtils.call(() -> mJobMaster.run(jobConfig), ServerConfiguration.global());
+    return RestUtils.call(() -> mJobMaster.run(jobConfig), Configuration.global());
   }
 }

--- a/job/server/src/main/java/alluxio/underfs/JobUfsManager.java
+++ b/job/server/src/main/java/alluxio/underfs/JobUfsManager.java
@@ -13,7 +13,7 @@ package alluxio.underfs;
 
 import alluxio.AlluxioURI;
 import alluxio.ClientContext;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.NotFoundException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.UfsInfo;
@@ -45,14 +45,14 @@ public final class JobUfsManager extends AbstractUfsManager {
   public JobUfsManager() {
     mMasterClient =
         mCloser.register(new FileSystemMasterClient(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build()));
+            .newBuilder(ClientContext.create(Configuration.global())).build()));
   }
 
   @Override
   protected void connectUfs(UnderFileSystem fs) throws IOException {
     fs.connectFromWorker(
         NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.JOB_WORKER_RPC,
-            ServerConfiguration.global()));
+            Configuration.global()));
   }
 
   @Override
@@ -72,7 +72,7 @@ public final class JobUfsManager extends AbstractUfsManager {
     }
     Preconditions.checkState((info.hasUri() && info.hasProperties()), "unknown mountId");
     super.addMount(mountId, new AlluxioURI(info.getUri()),
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global())
+        UnderFileSystemConfiguration.defaults(Configuration.global())
             .setReadOnly(info.getProperties().getReadOnly())
             .setShared(info.getProperties().getShared())
             .createMountSpecificConf(info.getProperties().getPropertiesMap()));
@@ -81,7 +81,7 @@ public final class JobUfsManager extends AbstractUfsManager {
       UnderFileSystem ufs = ufsResource.get();
       ufs.connectFromWorker(
           NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.WORKER_RPC,
-              ServerConfiguration.global()));
+              Configuration.global()));
     } catch (IOException e) {
       removeMount(mountId);
       throw new UnavailableException(

--- a/job/server/src/main/java/alluxio/worker/AlluxioJobWorkerRestServiceHandler.java
+++ b/job/server/src/main/java/alluxio/worker/AlluxioJobWorkerRestServiceHandler.java
@@ -14,7 +14,7 @@ package alluxio.worker;
 import alluxio.RestUtils;
 import alluxio.RuntimeConstants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.LogUtils;
 import alluxio.web.JobWorkerWebServer;
 import alluxio.wire.AlluxioJobWorkerInfo;
@@ -95,7 +95,7 @@ public final class  AlluxioJobWorkerRestServiceHandler {
               .setUptimeMs(mJobWorker.getUptimeMs())
               .setVersion(RuntimeConstants.VERSION);
       return result;
-    }, ServerConfiguration.global());
+    }, Configuration.global());
   }
 
   /**
@@ -109,11 +109,11 @@ public final class  AlluxioJobWorkerRestServiceHandler {
   public Response logLevel(@QueryParam(LOG_ARGUMENT_NAME) final String logName,
                            @QueryParam(LOG_ARGUMENT_LEVEL) final String level) {
     return RestUtils.call(() -> LogUtils.setLogLevel(logName, level),
-            ServerConfiguration.global());
+            Configuration.global());
   }
 
   private Map<String, Object> getConfigurationInternal(boolean raw) {
-    Set<Map.Entry<String, Object>> properties = ServerConfiguration.toMap().entrySet();
+    Set<Map.Entry<String, Object>> properties = Configuration.toMap().entrySet();
     SortedMap<String, Object> configuration = new TreeMap<>();
     for (Map.Entry<String, Object> entry : properties) {
       String key = entry.getKey();
@@ -121,7 +121,7 @@ public final class  AlluxioJobWorkerRestServiceHandler {
         if (raw) {
           configuration.put(key, entry.getValue());
         } else {
-          configuration.put(key, ServerConfiguration.get(PropertyKey.fromString(key)));
+          configuration.put(key, Configuration.get(PropertyKey.fromString(key)));
         }
       }
     }

--- a/job/server/src/main/java/alluxio/worker/job/command/CommandHandlingExecutor.java
+++ b/job/server/src/main/java/alluxio/worker/job/command/CommandHandlingExecutor.java
@@ -12,7 +12,7 @@
 package alluxio.worker.job.command;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ConnectionFailedException;
 import alluxio.grpc.CancelTaskCommand;
@@ -77,7 +77,7 @@ public class CommandHandlingExecutor implements HeartbeatExecutor {
     mTaskExecutorManager = Preconditions.checkNotNull(taskExecutorManager, "taskExecutorManager");
     mMasterClient = Preconditions.checkNotNull(masterClient, "masterClient");
     mWorkerNetAddress = Preconditions.checkNotNull(workerNetAddress, "workerNetAddress");
-    if (ServerConfiguration.getBoolean(PropertyKey.JOB_WORKER_THROTTLING)) {
+    if (Configuration.getBoolean(PropertyKey.JOB_WORKER_THROTTLING)) {
       mHealthReporter = new JobWorkerHealthReporter();
     } else {
       mHealthReporter = new AlwaysHealthyJobWorkerHealthReporter();

--- a/job/server/src/main/java/alluxio/worker/job/task/TaskExecutorManager.java
+++ b/job/server/src/main/java/alluxio/worker/job/task/TaskExecutorManager.java
@@ -13,7 +13,7 @@ package alluxio.worker.job.task;
 
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.RunTaskCommand;
 import alluxio.job.ErrorUtils;
 import alluxio.job.RunTaskContext;
@@ -190,7 +190,7 @@ public class TaskExecutorManager {
     taskInfo.setStatus(Status.FAILED);
 
     String errorMessage;
-    if (ServerConfiguration.getBoolean(PropertyKey.DEBUG)) {
+    if (Configuration.getBoolean(PropertyKey.DEBUG)) {
       errorMessage = Throwables.getStackTraceAsString(t);
     } else {
       errorMessage = t.getMessage();

--- a/job/server/src/test/java/alluxio/job/plan/BatchedJobDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/BatchedJobDefinitionTest.java
@@ -21,7 +21,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.collections.Pair;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.job.JobServerContext;
 import alluxio.job.SelectExecutorsContext;
 import alluxio.job.plan.batch.BatchedJobDefinition;
@@ -115,10 +115,10 @@ public class BatchedJobDefinitionTest {
         .thenReturn(mMockBlockStore);
     Mockito.when(mMockFsContext.getCachedWorkers()).thenReturn(BLOCK_WORKERS);
     PowerMockito.when(mMockFsContext.getClientContext())
-        .thenReturn(ClientContext.create(ServerConfiguration.global()));
-    PowerMockito.when(mMockFsContext.getClusterConf()).thenReturn(ServerConfiguration.global());
+        .thenReturn(ClientContext.create(Configuration.global()));
+    PowerMockito.when(mMockFsContext.getClusterConf()).thenReturn(Configuration.global());
     PowerMockito.when(mMockFsContext.getPathConf(any(AlluxioURI.class)))
-        .thenReturn(ServerConfiguration.global());
+        .thenReturn(Configuration.global());
     mJobServerContext = new JobServerContext(mMockFileSystem, mMockFsContext,
         Mockito.mock(UfsManager.class));
   }

--- a/job/server/src/test/java/alluxio/job/plan/load/LoadDefinitionTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/load/LoadDefinitionTest.java
@@ -21,7 +21,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.collections.Pair;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.job.JobServerContext;
 import alluxio.job.SelectExecutorsContext;
 import alluxio.job.plan.load.LoadDefinition.LoadTask;
@@ -111,10 +111,10 @@ public class LoadDefinitionTest {
         .thenReturn(mMockBlockStore);
     Mockito.when(mMockFsContext.getCachedWorkers()).thenReturn(BLOCK_WORKERS);
     PowerMockito.when(mMockFsContext.getClientContext())
-        .thenReturn(ClientContext.create(ServerConfiguration.global()));
-    PowerMockito.when(mMockFsContext.getClusterConf()).thenReturn(ServerConfiguration.global());
+        .thenReturn(ClientContext.create(Configuration.global()));
+    PowerMockito.when(mMockFsContext.getClusterConf()).thenReturn(Configuration.global());
     PowerMockito.when(mMockFsContext.getPathConf(any(AlluxioURI.class)))
-        .thenReturn(ServerConfiguration.global());
+        .thenReturn(Configuration.global());
     mJobServerContext =
         new JobServerContext(mMockFileSystem, mMockFsContext, Mockito.mock(UfsManager.class));
   }

--- a/job/server/src/test/java/alluxio/job/plan/replicate/SetReplicaDefinitionReplicateTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/replicate/SetReplicaDefinitionReplicateTest.java
@@ -40,7 +40,7 @@ import alluxio.client.file.options.InStreamOptions;
 import alluxio.client.file.options.OutStreamOptions;
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.NotFoundException;
 import alluxio.job.JobServerContext;
@@ -93,7 +93,7 @@ public final class SetReplicaDefinitionReplicateTest {
       new WorkerNetAddress().setHost("host3").setDataPort(10);
   private static final WorkerNetAddress LOCAL_ADDRESS =
       new WorkerNetAddress().setHost(NetworkAddressUtils
-          .getLocalHostName((int) ServerConfiguration
+          .getLocalHostName((int) Configuration
               .getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS))).setDataPort(10);
   private static final WorkerInfo WORKER_INFO_1 = new WorkerInfo().setAddress(ADDRESS_1);
   private static final WorkerInfo WORKER_INFO_2 = new WorkerInfo().setAddress(ADDRESS_2);
@@ -115,9 +115,9 @@ public final class SetReplicaDefinitionReplicateTest {
   public void before() throws Exception {
     mMockFileSystemContext = PowerMockito.mock(FileSystemContext.class);
     when(mMockFileSystemContext.getClientContext())
-        .thenReturn(ClientContext.create(ServerConfiguration.global()));
+        .thenReturn(ClientContext.create(Configuration.global()));
     when(mMockFileSystemContext.getClusterConf())
-        .thenReturn(ServerConfiguration.global());
+        .thenReturn(Configuration.global());
     mMockBlockStore = PowerMockito.mock(BlockStoreClient.class);
     mMockFileSystem = mock(FileSystem.class);
     mMockUfsManager = mock(UfsManager.class);

--- a/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
+++ b/job/server/src/test/java/alluxio/master/job/JobMasterTest.java
@@ -22,7 +22,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.JobDoesNotExistException;
 import alluxio.exception.status.ResourceExhaustedException;
@@ -77,7 +77,7 @@ public final class JobMasterTest {
   @Before
   public void before() throws Exception {
     // Can't use ConfigurationRule due to conflicts with PowerMock.
-    ServerConfiguration.set(PropertyKey.JOB_MASTER_JOB_CAPACITY, TEST_JOB_MASTER_JOB_CAPACITY);
+    Configuration.set(PropertyKey.JOB_MASTER_JOB_CAPACITY, TEST_JOB_MASTER_JOB_CAPACITY);
     mockStatic(FileSystem.Factory.class);
     FileSystem fs = mock(FileSystem.class);
     when(FileSystem.Factory.create(any(FileSystemContext.class)))
@@ -90,7 +90,7 @@ public final class JobMasterTest {
   @After
   public void after() throws Exception {
     mJobMaster.stop();
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   @Test
@@ -175,7 +175,7 @@ public final class JobMasterTest {
       Assert.fail("should not be able to run more jobs than job master capacity");
     } catch (ResourceExhaustedException e) {
       Assert.assertEquals(ExceptionMessage.JOB_MASTER_FULL_CAPACITY
-          .getMessage(ServerConfiguration.get(PropertyKey.JOB_MASTER_JOB_CAPACITY)),
+          .getMessage(Configuration.get(PropertyKey.JOB_MASTER_JOB_CAPACITY)),
           e.getMessage());
     }
   }

--- a/logserver/src/main/java/alluxio/logserver/AlluxioLogServerProcess.java
+++ b/logserver/src/main/java/alluxio/logserver/AlluxioLogServerProcess.java
@@ -13,7 +13,7 @@ package alluxio.logserver;
 
 import alluxio.Process;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 
@@ -66,10 +66,10 @@ public class AlluxioLogServerProcess implements Process {
    * @param baseLogsDir base directory to store the logs pushed from remote Alluxio servers
    */
   public AlluxioLogServerProcess(String baseLogsDir) {
-    mPort = ServerConfiguration.getInt(PropertyKey.LOGSERVER_PORT);
+    mPort = Configuration.getInt(PropertyKey.LOGSERVER_PORT);
     // The log server serves the logging requests from Alluxio servers.
-    mMinNumberOfThreads = ServerConfiguration.getInt(PropertyKey.LOGSERVER_THREADS_MIN);
-    mMaxNumberOfThreads = ServerConfiguration.getInt(PropertyKey.LOGSERVER_THREADS_MAX);
+    mMinNumberOfThreads = Configuration.getInt(PropertyKey.LOGSERVER_THREADS_MIN);
+    mMaxNumberOfThreads = Configuration.getInt(PropertyKey.LOGSERVER_THREADS_MAX);
     mBaseLogsDir = baseLogsDir;
     mStopped = true;
   }

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -20,7 +20,7 @@ import alluxio.client.meta.MetaMasterClient;
 import alluxio.client.meta.RetryHandlingMetaMasterClient;
 import alluxio.client.util.ClientTestUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.block.DefaultBlockMaster;
@@ -165,8 +165,8 @@ public abstract class AbstractLocalAlluxioCluster {
    * Sets up corresponding directories for tests.
    */
   protected void setupTest() throws IOException {
-    UnderFileSystem ufs = UnderFileSystem.Factory.createForRoot(ServerConfiguration.global());
-    String underfsAddress = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    UnderFileSystem ufs = UnderFileSystem.Factory.createForRoot(Configuration.global());
+    String underfsAddress = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
 
     // Deletes the ufs dir for this test from to avoid permission problems
     UnderFileSystemUtils.deleteDirIfExists(ufs, underfsAddress);
@@ -175,18 +175,18 @@ public abstract class AbstractLocalAlluxioCluster {
     UnderFileSystemUtils.mkdirIfNotExists(ufs, underfsAddress);
 
     // Creates storage dirs for worker
-    int numLevel = ServerConfiguration.getInt(PropertyKey.WORKER_TIERED_STORE_LEVELS);
+    int numLevel = Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_LEVELS);
     for (int level = 0; level < numLevel; level++) {
       PropertyKey tierLevelDirPath =
           PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_DIRS_PATH.format(level);
-      String[] dirPaths = ServerConfiguration.getString(tierLevelDirPath).split(",");
+      String[] dirPaths = Configuration.getString(tierLevelDirPath).split(",");
       for (String dirPath : dirPaths) {
         FileUtils.createDir(dirPath);
       }
     }
 
     // Formats the journal
-    Format.format(Format.Mode.MASTER, ServerConfiguration.global());
+    Format.format(Format.Mode.MASTER, Configuration.global());
   }
 
   /**
@@ -195,7 +195,7 @@ public abstract class AbstractLocalAlluxioCluster {
   public void stop() throws Exception {
     stopFS();
     reset();
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   /**
@@ -214,7 +214,7 @@ public abstract class AbstractLocalAlluxioCluster {
    */
   public void formatAndRestartMasters() throws Exception {
     stopMasters();
-    Format.format(Format.Mode.MASTER, ServerConfiguration.global());
+    Format.format(Format.Mode.MASTER, Configuration.global());
     startMasters();
   }
 
@@ -274,7 +274,7 @@ public abstract class AbstractLocalAlluxioCluster {
   }
 
   /**
-   * Creates a default {@link ServerConfiguration} for testing.
+   * Creates a default {@link Configuration} for testing.
    *
    * @param name the name of the test/cluster
    */
@@ -316,7 +316,7 @@ public abstract class AbstractLocalAlluxioCluster {
       throws TimeoutException, InterruptedException, IOException {
     try (MetaMasterClient client =
              new RetryHandlingMetaMasterClient(MasterClientContext
-                 .newBuilder(ClientContext.create(ServerConfiguration.global())).build())) {
+                 .newBuilder(ClientContext.create(Configuration.global())).build())) {
       CommonUtils.waitFor("workers registered", () -> {
         try {
           return client.getMasterInfo(Collections.emptySet())
@@ -334,15 +334,15 @@ public abstract class AbstractLocalAlluxioCluster {
    * Resets the cluster to original state.
    */
   protected void reset() {
-    ClientTestUtils.resetClient(ServerConfiguration.global());
+    ClientTestUtils.resetClient(Configuration.modifiableGlobal());
     GroupMappingServiceTestUtils.resetCache();
   }
 
   /**
    * Resets the client pools to the original state.
    */
-  protected void resetClientPools() throws IOException {
-    ServerConfiguration.set(PropertyKey.USER_METRICS_COLLECTION_ENABLED, false);
+  protected void resetClientPools() {
+    Configuration.set(PropertyKey.USER_METRICS_COLLECTION_ENABLED, false);
   }
 
   /**

--- a/minicluster/src/main/java/alluxio/master/ClientPool.java
+++ b/minicluster/src/main/java/alluxio/master/ClientPool.java
@@ -13,7 +13,7 @@ package alluxio.master;
 
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -41,7 +41,7 @@ public final class ClientPool implements Closeable {
    * @return a {@link FileSystem} client
    */
   public FileSystem getClient() throws IOException {
-    final FileSystem fs = FileSystem.Factory.create(ServerConfiguration.global());
+    final FileSystem fs = FileSystem.Factory.create(Configuration.global());
     mClients.add(fs);
     return fs;
   }

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioCluster.java
@@ -15,7 +15,7 @@ import alluxio.ConfigurationTestUtils;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.WorkerProcess;
 
@@ -133,15 +133,15 @@ public final class LocalAlluxioCluster extends AbstractLocalAlluxioCluster {
     setAlluxioWorkDirectory(name);
     setHostname();
     for (Map.Entry<PropertyKey, Object> entry : ConfigurationTestUtils
-        .testConfigurationDefaults(ServerConfiguration.global(),
+        .testConfigurationDefaults(Configuration.global(),
             mHostname, mWorkDirectory).entrySet()) {
-      ServerConfiguration.set(entry.getKey(), entry.getValue());
+      Configuration.set(entry.getKey(), entry.getValue());
     }
-    ServerConfiguration.set(PropertyKey.TEST_MODE, true);
-    ServerConfiguration.set(PropertyKey.JOB_WORKER_THROTTLING, false);
-    ServerConfiguration.set(PropertyKey.PROXY_WEB_PORT, 0);
-    ServerConfiguration.set(PropertyKey.WORKER_RPC_PORT, 0);
-    ServerConfiguration.set(PropertyKey.WORKER_WEB_PORT, 0);
+    Configuration.set(PropertyKey.TEST_MODE, true);
+    Configuration.set(PropertyKey.JOB_WORKER_THROTTLING, false);
+    Configuration.set(PropertyKey.PROXY_WEB_PORT, 0);
+    Configuration.set(PropertyKey.WORKER_RPC_PORT, 0);
+    Configuration.set(PropertyKey.WORKER_WEB_PORT, 0);
   }
 
   @Override

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioJobCluster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioJobCluster.java
@@ -12,7 +12,7 @@
 package alluxio.master;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ConnectionFailedException;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.worker.JobWorkerProcess;
@@ -127,16 +127,16 @@ public final class LocalAlluxioJobCluster {
   private void updateTestConf() throws IOException {
     setHostname();
 
-    ServerConfiguration.set(PropertyKey.JOB_MASTER_BIND_HOST, mHostname);
-    ServerConfiguration.set(PropertyKey.JOB_MASTER_HOSTNAME, mHostname);
-    ServerConfiguration.set(PropertyKey.JOB_MASTER_WEB_BIND_HOST, mHostname);
-    ServerConfiguration.set(PropertyKey.JOB_WORKER_BIND_HOST, mHostname);
-    ServerConfiguration.set(PropertyKey.JOB_WORKER_RPC_PORT, 0);
-    ServerConfiguration.set(PropertyKey.JOB_WORKER_WEB_PORT, 0);
-    ServerConfiguration.set(PropertyKey.JOB_WORKER_WEB_BIND_HOST, mHostname);
+    Configuration.set(PropertyKey.JOB_MASTER_BIND_HOST, mHostname);
+    Configuration.set(PropertyKey.JOB_MASTER_HOSTNAME, mHostname);
+    Configuration.set(PropertyKey.JOB_MASTER_WEB_BIND_HOST, mHostname);
+    Configuration.set(PropertyKey.JOB_WORKER_BIND_HOST, mHostname);
+    Configuration.set(PropertyKey.JOB_WORKER_RPC_PORT, 0);
+    Configuration.set(PropertyKey.JOB_WORKER_WEB_PORT, 0);
+    Configuration.set(PropertyKey.JOB_WORKER_WEB_BIND_HOST, mHostname);
 
     for (Map.Entry<PropertyKey, Object> e : mConfiguration.entrySet()) {
-      ServerConfiguration.set(e.getKey(), e.getValue());
+      Configuration.set(e.getKey(), e.getValue());
     }
   }
 
@@ -159,7 +159,7 @@ public final class LocalAlluxioJobCluster {
   private void startMaster() throws IOException, ConnectionFailedException {
     mMaster = AlluxioJobMasterProcess.Factory.create();
 
-    ServerConfiguration
+    Configuration
         .set(PropertyKey.JOB_MASTER_RPC_PORT, mMaster.getRpcAddress().getPort());
     Runnable runMaster = new Runnable() {
       @Override
@@ -203,6 +203,6 @@ public final class LocalAlluxioJobCluster {
   private void setHostname() {
     mHostname =
         NetworkAddressUtils.getLocalHostName(
-            (int) ServerConfiguration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
+            (int) Configuration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS));
   }
 }

--- a/minicluster/src/main/java/alluxio/master/LocalAlluxioMaster.java
+++ b/minicluster/src/main/java/alluxio/master/LocalAlluxioMaster.java
@@ -16,7 +16,7 @@ import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.journal.JournalType;
 import alluxio.util.io.FileUtils;
 import alluxio.util.network.NetworkAddressUtils;
@@ -60,8 +60,8 @@ public final class LocalAlluxioMaster {
 
   private LocalAlluxioMaster(boolean includeSecondary) {
     mHostname = NetworkAddressUtils.getConnectHost(ServiceType.MASTER_RPC,
-        ServerConfiguration.global());
-    mJournalFolder = ServerConfiguration.getString(PropertyKey.MASTER_JOURNAL_FOLDER);
+        Configuration.global());
+    mJournalFolder = Configuration.getString(PropertyKey.MASTER_JOURNAL_FOLDER);
     mIncludeSecondary = includeSecondary;
   }
 
@@ -74,7 +74,7 @@ public final class LocalAlluxioMaster {
   public static LocalAlluxioMaster create(boolean includeSecondary) throws IOException {
     String workDirectory = uniquePath();
     FileUtils.deletePathRecursively(workDirectory);
-    ServerConfiguration.set(PropertyKey.WORK_DIR, workDirectory);
+    Configuration.set(PropertyKey.WORK_DIR, workDirectory);
     return create(workDirectory, includeSecondary);
   }
 
@@ -118,7 +118,7 @@ public final class LocalAlluxioMaster {
     mMasterThread.start();
     TestUtils.waitForReady(mMasterProcess);
     // Don't start a secondary master when using the Raft journal.
-    if (ServerConfiguration.getEnum(PropertyKey.MASTER_JOURNAL_TYPE,
+    if (Configuration.getEnum(PropertyKey.MASTER_JOURNAL_TYPE,
         JournalType.class) == JournalType.EMBEDDED) {
       return;
     }

--- a/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/MultiMasterLocalAlluxioCluster.java
@@ -18,7 +18,7 @@ import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.master.journal.JournalType;
@@ -85,18 +85,18 @@ public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCl
     setAlluxioWorkDirectory(name);
     setHostname();
     for (Map.Entry<PropertyKey, Object> entry : ConfigurationTestUtils
-        .testConfigurationDefaults(ServerConfiguration.global(),
+        .testConfigurationDefaults(Configuration.global(),
             mHostname, mWorkDirectory).entrySet()) {
-      ServerConfiguration.set(entry.getKey(), entry.getValue());
+      Configuration.set(entry.getKey(), entry.getValue());
     }
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_PORT, 0);
-    ServerConfiguration.set(PropertyKey.TEST_MODE, true);
-    ServerConfiguration.set(PropertyKey.JOB_WORKER_THROTTLING, false);
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
-    ServerConfiguration.set(PropertyKey.MASTER_WEB_PORT, 0);
-    ServerConfiguration.set(PropertyKey.PROXY_WEB_PORT, 0);
-    ServerConfiguration.set(PropertyKey.WORKER_RPC_PORT, 0);
-    ServerConfiguration.set(PropertyKey.WORKER_WEB_PORT, 0);
+    Configuration.set(PropertyKey.MASTER_RPC_PORT, 0);
+    Configuration.set(PropertyKey.TEST_MODE, true);
+    Configuration.set(PropertyKey.JOB_WORKER_THROTTLING, false);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    Configuration.set(PropertyKey.MASTER_WEB_PORT, 0);
+    Configuration.set(PropertyKey.PROXY_WEB_PORT, 0);
+    Configuration.set(PropertyKey.WORKER_RPC_PORT, 0);
+    Configuration.set(PropertyKey.WORKER_WEB_PORT, 0);
   }
 
   @Override
@@ -234,13 +234,13 @@ public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCl
 
   @Override
   protected void startMasters() throws IOException {
-    ServerConfiguration.set(PropertyKey.ZOOKEEPER_ENABLED, true);
-    ServerConfiguration.set(PropertyKey.ZOOKEEPER_ADDRESS, mCuratorServer.getConnectString());
-    ServerConfiguration.set(PropertyKey.ZOOKEEPER_ELECTION_PATH, "/alluxio/election");
-    ServerConfiguration.set(PropertyKey.ZOOKEEPER_LEADER_PATH, "/alluxio/leader");
+    Configuration.set(PropertyKey.ZOOKEEPER_ENABLED, true);
+    Configuration.set(PropertyKey.ZOOKEEPER_ADDRESS, mCuratorServer.getConnectString());
+    Configuration.set(PropertyKey.ZOOKEEPER_ELECTION_PATH, "/alluxio/election");
+    Configuration.set(PropertyKey.ZOOKEEPER_LEADER_PATH, "/alluxio/leader");
 
     for (int k = 0; k < mNumOfMasters; k++) {
-      ServerConfiguration.set(PropertyKey.MASTER_METASTORE_DIR,
+      Configuration.set(PropertyKey.MASTER_METASTORE_DIR,
           PathUtils.concatPath(mWorkDirectory, "metastore-" + k));
       final LocalAlluxioMaster master = LocalAlluxioMaster.create(mWorkDirectory, false);
       master.start();
@@ -248,14 +248,14 @@ public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCl
           master.getAddress());
       mMasters.add(master);
       // Each master should generate a new port for binding
-      ServerConfiguration.set(PropertyKey.MASTER_RPC_PORT, 0);
-      ServerConfiguration.set(PropertyKey.MASTER_WEB_PORT, 0);
+      Configuration.set(PropertyKey.MASTER_RPC_PORT, 0);
+      Configuration.set(PropertyKey.MASTER_WEB_PORT, 0);
     }
 
     // Create the UFS directory after LocalAlluxioMaster construction, because LocalAlluxioMaster
     // sets MASTER_MOUNT_TABLE_ROOT_UFS.
-    UnderFileSystem ufs = UnderFileSystem.Factory.createForRoot(ServerConfiguration.global());
-    String path = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    UnderFileSystem ufs = UnderFileSystem.Factory.createForRoot(Configuration.global());
+    String path = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     if (ufs.isDirectory(path)) {
       ufs.deleteExistingDirectory(path, DeleteOptions.defaults().setRecursive(true));
     }
@@ -271,7 +271,7 @@ public final class MultiMasterLocalAlluxioCluster extends AbstractLocalAlluxioCl
       throw new IOException(e);
     }
     // Use first master port
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_PORT,
+    Configuration.set(PropertyKey.MASTER_RPC_PORT,
         getLocalAlluxioMaster().getRpcLocalPort());
   }
 

--- a/shell/src/main/java/alluxio/cli/GetConf.java
+++ b/shell/src/main/java/alluxio/cli/GetConf.java
@@ -264,8 +264,7 @@ public final class GetConf {
    * @param args the arguments to specify the unit (optional) and configuration key (optional)
    */
   public static void main(String[] args) {
-    System.exit(getConf(
-        ClientContext.create(ConfigurationUtils.defaults()), args));
+    System.exit(getConf(ClientContext.create(), args));
   }
 
   private GetConf() {} // this class is not intended for instantiation

--- a/shell/src/main/java/alluxio/cli/HmsTests.java
+++ b/shell/src/main/java/alluxio/cli/HmsTests.java
@@ -11,7 +11,7 @@
 
 package alluxio.cli;
 
-import alluxio.util.ConfigurationUtils;
+import alluxio.conf.Configuration;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -101,7 +101,7 @@ public class HmsTests {
         .getOptionValue(ValidationConfig.SOCKET_TIMEOUT_OPTION_NAME, "-1"));
 
     ValidationToolRegistry registry
-        = new ValidationToolRegistry(ConfigurationUtils.defaults());
+        = new ValidationToolRegistry(Configuration.global());
     // Load hms validation tool from alluxio lib directory
     registry.refresh();
 

--- a/shell/src/main/java/alluxio/cli/JournalCrashTest.java
+++ b/shell/src/main/java/alluxio/cli/JournalCrashTest.java
@@ -14,14 +14,14 @@ package alluxio.cli;
 import alluxio.AlluxioURI;
 import alluxio.RuntimeConstants;
 import alluxio.client.file.FileSystem;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.io.PathUtils;
 
 import org.apache.commons.cli.CommandLine;
@@ -42,8 +42,7 @@ import java.util.List;
  */
 public final class JournalCrashTest {
 
-  private static InstancedConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+  private static AlluxioConfiguration sConf = Configuration.global();
 
   private JournalCrashTest() {} // prevent instantiation
 

--- a/shell/src/main/java/alluxio/cli/LogLevel.java
+++ b/shell/src/main/java/alluxio/cli/LogLevel.java
@@ -18,9 +18,9 @@ import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.job.JobMasterClient;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.job.wire.JobWorkerHealth;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.network.HttpUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
@@ -320,7 +320,7 @@ public final class LogLevel {
   public static void main(String[] args) {
     int exitCode = 1;
     try {
-      logLevel(args, ConfigurationUtils.defaults());
+      logLevel(args, Configuration.global());
       exitCode = 0;
     } catch (ParseException e) {
       printHelp("Unable to parse input args: " + e.getMessage());

--- a/shell/src/main/java/alluxio/cli/RunOperation.java
+++ b/shell/src/main/java/alluxio/cli/RunOperation.java
@@ -15,10 +15,9 @@ import alluxio.AlluxioURI;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.io.PathUtils;
 
 import com.beust.jcommander.JCommander;
@@ -73,8 +72,7 @@ public class RunOperation {
    * @param args command-line arguments
    */
   public static void main(String[] args) {
-    System.exit(new RunOperation(new InstancedConfiguration(ConfigurationUtils.copyDefaults()))
-        .run(args));
+    System.exit(new RunOperation(Configuration.global()).run(args));
   }
 
   /**

--- a/shell/src/main/java/alluxio/cli/ValidateConf.java
+++ b/shell/src/main/java/alluxio/cli/ValidateConf.java
@@ -12,8 +12,7 @@
 package alluxio.cli;
 
 import alluxio.annotation.PublicApi;
-import alluxio.conf.InstancedConfiguration;
-import alluxio.util.ConfigurationUtils;
+import alluxio.conf.Configuration;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +35,7 @@ public final class ValidateConf {
   public static void main(String[] args) {
     LOG.info("Validating configuration.");
     try {
-      new InstancedConfiguration(ConfigurationUtils.copyDefaults()).validate();
+      Configuration.global().validate();
       LOG.info("Configuration is valid.");
     } catch (IllegalStateException e) {
       LOG.error("Configuration is invalid", e);

--- a/shell/src/main/java/alluxio/cli/ValidateHdfsMount.java
+++ b/shell/src/main/java/alluxio/cli/ValidateHdfsMount.java
@@ -11,10 +11,10 @@
 
 package alluxio.cli;
 
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.Source;
 import alluxio.underfs.UnderFileSystemConfiguration;
-import alluxio.util.ConfigurationUtils;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -129,7 +129,7 @@ public class ValidateHdfsMount {
     }
 
     ValidationToolRegistry registry
-            = new ValidationToolRegistry(ConfigurationUtils.defaults());
+            = new ValidationToolRegistry(Configuration.global());
     // Load hdfs validation tool from alluxio lib directory
     registry.refresh();
 

--- a/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
+++ b/shell/src/main/java/alluxio/cli/bundler/CollectInfo.java
@@ -16,6 +16,8 @@ import alluxio.cli.Command;
 import alluxio.cli.CommandUtils;
 import alluxio.cli.bundler.command.AbstractCollectInfoCommand;
 import alluxio.client.file.FileSystemContext;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
@@ -149,7 +151,7 @@ public class CollectInfo extends AbstractShell {
    *
    * @param alluxioConf Alluxio configuration
    */
-  public CollectInfo(InstancedConfiguration alluxioConf) {
+  public CollectInfo(AlluxioConfiguration alluxioConf) {
     super(CMD_ALIAS, UNSTABLE_ALIAS, alluxioConf);
   }
 
@@ -210,7 +212,7 @@ public class CollectInfo extends AbstractShell {
     }
 
     // Create the shell instance
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    InstancedConfiguration conf = Configuration.modifiableGlobal();
 
     // Reduce the RPC retry max duration to fail earlier for CLIs
     conf.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "5s", Source.DEFAULT);

--- a/shell/src/main/java/alluxio/cli/docgen/ConfigurationDocGenerator.java
+++ b/shell/src/main/java/alluxio/cli/docgen/ConfigurationDocGenerator.java
@@ -12,8 +12,8 @@
 package alluxio.cli.docgen;
 
 import alluxio.annotation.PublicApi;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -208,7 +208,7 @@ public final class ConfigurationDocGenerator {
   public static void generate() throws IOException {
     Collection<? extends PropertyKey> defaultKeys = PropertyKey.defaultKeys();
     defaultKeys.removeIf(key -> key.isHidden());
-    String homeDir = ConfigurationUtils.defaults().getString(PropertyKey.HOME);
+    String homeDir = Configuration.global().getString(PropertyKey.HOME);
     // generate CSV files
     String filePath = PathUtils.concatPath(homeDir, CSV_FILE_DIR);
     writeCSVFile(defaultKeys, filePath);

--- a/shell/src/main/java/alluxio/cli/docgen/MetricsDocGenerator.java
+++ b/shell/src/main/java/alluxio/cli/docgen/MetricsDocGenerator.java
@@ -12,10 +12,10 @@
 package alluxio.cli.docgen;
 
 import alluxio.annotation.PublicApi;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Objects;
@@ -56,7 +56,7 @@ public final class MetricsDocGenerator {
     List<MetricKey> defaultKeys = new ArrayList<>(MetricKey.allMetricKeys());
     Collections.sort(defaultKeys);
 
-    String homeDir = ConfigurationUtils.defaults().getString(PropertyKey.HOME);
+    String homeDir = Configuration.global().getString(PropertyKey.HOME);
 
     // Map from metric key prefix to metric category
     Map<String, String> metricTypeMap = new HashMap<>();

--- a/shell/src/main/java/alluxio/cli/fs/FileSystemShell.java
+++ b/shell/src/main/java/alluxio/cli/fs/FileSystemShell.java
@@ -14,6 +14,8 @@ package alluxio.cli.fs;
 import alluxio.cli.AbstractShell;
 import alluxio.cli.Command;
 import alluxio.client.file.FileSystemContext;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
@@ -52,7 +54,7 @@ public final class FileSystemShell extends AbstractShell {
    */
   public static void main(String[] argv) throws IOException {
     int ret;
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    InstancedConfiguration conf = Configuration.modifiableGlobal();
     if (!ConfigurationUtils.masterHostConfigured(conf)
         && argv.length > 0 && !argv[0].equals("help")) {
       System.out.println(ConfigurationUtils.getMasterHostNotConfiguredMessage("Alluxio fs shell"));
@@ -72,7 +74,7 @@ public final class FileSystemShell extends AbstractShell {
    *
    * @param alluxioConf Alluxio configuration
    */
-  public FileSystemShell(InstancedConfiguration alluxioConf) {
+  public FileSystemShell(AlluxioConfiguration alluxioConf) {
     super(CMD_ALIAS, UNSTABLE_ALIAS, alluxioConf);
   }
 

--- a/shell/src/main/java/alluxio/cli/fsadmin/FileSystemAdminShell.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/FileSystemAdminShell.java
@@ -24,6 +24,7 @@ import alluxio.client.meta.RetryHandlingMetaMasterClient;
 import alluxio.client.meta.RetryHandlingMetaMasterConfigClient;
 import alluxio.client.metrics.RetryHandlingMetricsMasterClient;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
@@ -48,7 +49,7 @@ public final class FileSystemAdminShell extends AbstractShell {
    *
    * @param alluxioConf Alluxio configuration
    */
-  public FileSystemAdminShell(InstancedConfiguration alluxioConf) {
+  public FileSystemAdminShell(AlluxioConfiguration alluxioConf) {
     super(null, null, alluxioConf);
   }
 
@@ -59,7 +60,7 @@ public final class FileSystemAdminShell extends AbstractShell {
    */
   public static void main(String[] args) throws IOException {
     int ret;
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    InstancedConfiguration conf = Configuration.modifiableGlobal();
     if (!ConfigurationUtils.masterHostConfigured(conf) && args.length > 0) {
       System.out.println(ConfigurationUtils
           .getMasterHostNotConfiguredMessage("Alluxio fsadmin shell"));

--- a/shell/src/main/java/alluxio/cli/job/JobShell.java
+++ b/shell/src/main/java/alluxio/cli/job/JobShell.java
@@ -15,12 +15,11 @@ import alluxio.cli.AbstractShell;
 import alluxio.cli.Command;
 import alluxio.cli.CommandUtils;
 import alluxio.client.file.FileSystemContext;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.ConfigurationUtils;
 
 import com.google.common.collect.ImmutableMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Map;
@@ -31,8 +30,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class JobShell extends AbstractShell {
-  private static final Logger LOG = LoggerFactory.getLogger(JobShell.class);
-
   private static final Map<String, String[]> CMD_ALIAS = ImmutableMap.<String, String[]>builder()
       .build();
 
@@ -43,7 +40,7 @@ public final class JobShell extends AbstractShell {
    */
   public static void main(String[] argv) throws IOException {
     int ret;
-    InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    AlluxioConfiguration conf = Configuration.global();
 
     if (!ConfigurationUtils.masterHostConfigured(conf) && argv.length > 0) {
       System.out.println(ConfigurationUtils
@@ -62,7 +59,7 @@ public final class JobShell extends AbstractShell {
    *
    * @param alluxioConf Alluxio configuration
    */
-  public JobShell(InstancedConfiguration alluxioConf) {
+  public JobShell(AlluxioConfiguration alluxioConf) {
     super(CMD_ALIAS, null, alluxioConf);
   }
 

--- a/shell/src/main/java/alluxio/master/AlluxioMasterMonitor.java
+++ b/shell/src/main/java/alluxio/master/AlluxioMasterMonitor.java
@@ -14,6 +14,7 @@ package alluxio.master;
 import alluxio.HealthCheckClient;
 import alluxio.RuntimeConstants;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.retry.ExponentialBackoffRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.util.ConfigurationUtils;
@@ -44,7 +45,7 @@ public final class AlluxioMasterMonitor {
       LOG.warn("ignoring arguments");
     }
 
-    AlluxioConfiguration alluxioConf = ConfigurationUtils.defaults();
+    AlluxioConfiguration alluxioConf = Configuration.global();
 
     MasterHealthCheckClient.Builder builder = new MasterHealthCheckClient.Builder(alluxioConf);
     builder.withProcessCheck(ConfigurationUtils.isHaMode(alluxioConf));

--- a/shell/src/main/java/alluxio/master/job/AlluxioJobMasterMonitor.java
+++ b/shell/src/main/java/alluxio/master/job/AlluxioJobMasterMonitor.java
@@ -14,6 +14,7 @@ package alluxio.master.job;
 import alluxio.HealthCheckClient;
 import alluxio.RuntimeConstants;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.AlluxioMasterMonitor;
 import alluxio.master.MasterHealthCheckClient;
 import alluxio.util.ConfigurationUtils;
@@ -39,7 +40,7 @@ public final class AlluxioJobMasterMonitor {
           AlluxioJobMasterMonitor.class.getCanonicalName());
       LOG.warn("ignoring arguments");
     }
-    AlluxioConfiguration conf = ConfigurationUtils.defaults();
+    AlluxioConfiguration conf = Configuration.global();
     HealthCheckClient client;
     // Only the primary master serves RPCs, so if we're configured for HA, fall back to simply
     // checking for the running process.

--- a/shell/src/main/java/alluxio/proxy/AlluxioProxyMonitor.java
+++ b/shell/src/main/java/alluxio/proxy/AlluxioProxyMonitor.java
@@ -13,8 +13,8 @@ package alluxio.proxy;
 
 import alluxio.HealthCheckClient;
 import alluxio.RuntimeConstants;
+import alluxio.conf.Configuration;
 import alluxio.retry.ExponentialBackoffRetry;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.network.NetworkAddressUtils;
 
 import org.slf4j.Logger;
@@ -40,7 +40,7 @@ public final class AlluxioProxyMonitor {
 
     HealthCheckClient client = new ProxyHealthCheckClient(
         NetworkAddressUtils.getBindAddress(NetworkAddressUtils.ServiceType.PROXY_WEB,
-            ConfigurationUtils.defaults()),
+            Configuration.global()),
         () -> new ExponentialBackoffRetry(50, 100, 2));
     if (!client.isServing()) {
       System.exit(1);

--- a/shell/src/main/java/alluxio/worker/AlluxioWorkerMonitor.java
+++ b/shell/src/main/java/alluxio/worker/AlluxioWorkerMonitor.java
@@ -14,9 +14,9 @@ package alluxio.worker;
 import alluxio.HealthCheckClient;
 import alluxio.RuntimeConstants;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.retry.ExponentialBackoffRetry;
 import alluxio.retry.RetryPolicy;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.network.NetworkAddressUtils;
 
 import org.slf4j.Logger;
@@ -44,7 +44,7 @@ public final class AlluxioWorkerMonitor {
           AlluxioWorkerMonitor.class.getCanonicalName());
       LOG.warn("ignoring arguments");
     }
-    AlluxioConfiguration conf = ConfigurationUtils.defaults();
+    AlluxioConfiguration conf = Configuration.global();
 
     HealthCheckClient client = new WorkerHealthCheckClient(
         NetworkAddressUtils.getConnectAddress(NetworkAddressUtils.ServiceType.WORKER_RPC, conf),

--- a/shell/src/main/java/alluxio/worker/job/AlluxioJobWorkerMonitor.java
+++ b/shell/src/main/java/alluxio/worker/job/AlluxioJobWorkerMonitor.java
@@ -14,7 +14,7 @@ package alluxio.worker.job;
 import alluxio.HealthCheckClient;
 import alluxio.RuntimeConstants;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.util.ConfigurationUtils;
+import alluxio.conf.Configuration;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.worker.AlluxioWorkerMonitor;
 
@@ -38,7 +38,7 @@ public final class AlluxioJobWorkerMonitor {
               AlluxioJobWorkerMonitor.class.getCanonicalName());
       LOG.warn("ignoring arguments");
     }
-    AlluxioConfiguration conf = ConfigurationUtils.defaults();
+    AlluxioConfiguration conf = Configuration.global();
 
     HealthCheckClient client = new JobWorkerHealthCheckClient(
         NetworkAddressUtils.getConnectAddress(NetworkAddressUtils.ServiceType.JOB_WORKER_RPC, conf),

--- a/shell/src/test/java/alluxio/cli/bundler/CollectInfoTest.java
+++ b/shell/src/test/java/alluxio/cli/bundler/CollectInfoTest.java
@@ -15,8 +15,7 @@ import static org.junit.Assert.assertEquals;
 
 import alluxio.cli.Command;
 import alluxio.cli.bundler.command.AbstractCollectInfoCommand;
-import alluxio.conf.InstancedConfiguration;
-import alluxio.util.ConfigurationUtils;
+import alluxio.conf.Configuration;
 
 import org.junit.Test;
 import org.reflections.Reflections;
@@ -25,9 +24,6 @@ import java.lang.reflect.Modifier;
 import java.util.Collection;
 
 public class CollectInfoTest {
-  private static InstancedConfiguration sConf =
-          new InstancedConfiguration(ConfigurationUtils.copyDefaults());
-
   private int getNumberOfCommands() {
     Reflections reflections =
             new Reflections(AbstractCollectInfoCommand.class.getPackage().getName());
@@ -42,7 +38,7 @@ public class CollectInfoTest {
 
   @Test
   public void loadedCommands() {
-    CollectInfo ic = new CollectInfo(sConf);
+    CollectInfo ic = new CollectInfo(Configuration.global());
     Collection<Command> commands = ic.getCommands();
     assertEquals(getNumberOfCommands(), commands.size());
   }

--- a/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fsadmin/report/SummaryCommandTest.java
@@ -19,11 +19,10 @@ import alluxio.Constants;
 import alluxio.client.block.BlockMasterClient;
 import alluxio.client.meta.MetaMasterClient;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.MasterInfo;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.wire.BlockMasterInfo;
 
 import org.hamcrest.collection.IsIterableContainingInOrder;
@@ -44,8 +43,7 @@ import java.util.Map;
 
 public class SummaryCommandTest {
 
-  private static AlluxioConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+  private static AlluxioConfiguration sConf = Configuration.global();
 
   private MetaMasterClient mMetaMasterClient;
   private BlockMasterClient mBlockMasterClient;

--- a/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/Benchmark.java
@@ -14,6 +14,7 @@ package alluxio.stress.cli;
 import alluxio.annotation.SuppressFBWarnings;
 import alluxio.client.job.JobGrpcClientUtils;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.job.plan.PlanConfig;
 import alluxio.job.wire.JobInfo;
@@ -21,7 +22,6 @@ import alluxio.stress.BaseParameters;
 import alluxio.stress.StressConstants;
 import alluxio.stress.TaskResult;
 import alluxio.stress.job.StressBenchConfig;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.FormatUtils;
 import alluxio.util.ShellUtils;
 
@@ -160,7 +160,7 @@ public abstract class Benchmark<T extends TaskResult> {
           + "=" + BaseParameters.AGENT_OUTPUT_PATH);
     }
 
-    AlluxioConfiguration conf = ConfigurationUtils.defaults();
+    AlluxioConfiguration conf = Configuration.global();
     String className = this.getClass().getCanonicalName();
 
     if (mBaseParameters.mCluster) {

--- a/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/StressMasterBench.java
@@ -30,7 +30,6 @@ import alluxio.stress.master.MasterBenchTaskResult;
 import alluxio.stress.master.MasterBenchTaskResultStatistics;
 import alluxio.stress.master.Operation;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.FormatUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.util.io.PathUtils;
@@ -180,14 +179,14 @@ public class StressMasterBench extends AbstractStressBench<MasterBenchTaskResult
       }
     } else {
       LOG.info("Using ALLUXIO Native API to perform the test.");
-      alluxio.conf.AlluxioProperties alluxioProperties = ConfigurationUtils.copyDefaults();
+      InstancedConfiguration alluxioProperties = alluxio.conf.Configuration.copyGlobal();
       alluxioProperties.merge(HadoopConfigurationUtils.getConfigurationFromHadoop(hdfsConf),
           Source.RUNTIME);
 
       mCachedNativeFs = new alluxio.client.file.FileSystem[mParameters.mClients];
       for (int i = 0; i < mCachedNativeFs.length; i++) {
         mCachedNativeFs[i] = alluxio.client.file.FileSystem.Factory
-            .create(new InstancedConfiguration(alluxioProperties));
+            .create(alluxioProperties);
       }
     }
   }

--- a/stress/shell/src/main/java/alluxio/stress/cli/client/CompactionBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/CompactionBench.java
@@ -18,6 +18,7 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.AlluxioProperties;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
@@ -33,7 +34,6 @@ import alluxio.stress.cli.Benchmark;
 import alluxio.stress.client.CompactionParameters;
 import alluxio.stress.client.CompactionTaskResult;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.FormatUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
 
@@ -231,7 +231,7 @@ public class CompactionBench extends Benchmark<CompactionTaskResult> {
   }
 
   private static AlluxioProperties getCustomProperties(List<String> propertyList) {
-    AlluxioProperties properties = ConfigurationUtils.copyDefaults();
+    AlluxioProperties properties = Configuration.global().copyProperties();
     for (String property : propertyList) {
       String[] parts = property.split("=", 2);
       Preconditions.checkArgument(parts.length == 2,

--- a/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
@@ -31,7 +31,6 @@ import alluxio.stress.client.ClientIOTaskResult;
 import alluxio.stress.common.FileSystemClientType;
 import alluxio.stress.common.SummaryStatistics;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.FormatUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
 
@@ -169,7 +168,8 @@ public class StressClientIOBench extends AbstractStressBench
     } else {
       LOG.info("Using ALLUXIO Native API to perform the test.");
 
-      alluxio.conf.AlluxioProperties alluxioProperties = ConfigurationUtils.copyDefaults();
+      alluxio.conf.AlluxioProperties alluxioProperties = alluxio.conf.Configuration
+          .global().copyProperties();
       alluxioProperties.merge(HadoopConfigurationUtils.getConfigurationFromHadoop(hdfsConf),
           Source.RUNTIME);
 

--- a/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/fuse/FuseIOBench.java
@@ -23,7 +23,6 @@ import alluxio.stress.fuse.FuseIOOperation;
 import alluxio.stress.fuse.FuseIOParameters;
 import alluxio.stress.fuse.FuseIOTaskResult;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.FormatUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.worker.job.JobMasterClientContext;
@@ -173,8 +172,7 @@ public class FuseIOBench extends Benchmark<FuseIOTaskResult> {
     // for cluster mode, find 0-based id, and make sure directories and job workers are 1-to-1
     int numJobWorkers;
     try (JobMasterClient client = JobMasterClient.Factory.create(
-        JobMasterClientContext.newBuilder(ClientContext.create(
-            ConfigurationUtils.defaults())).build())) {
+        JobMasterClientContext.newBuilder(ClientContext.create()).build())) {
       numJobWorkers = client.getAllWorkerHealth().size();
     }
     if (numJobWorkers != jobWorkerDirs.length) {

--- a/stress/shell/src/main/java/alluxio/stress/cli/suite/AbstractMaxThroughput.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/suite/AbstractMaxThroughput.java
@@ -13,14 +13,12 @@ package alluxio.stress.cli.suite;
 
 import alluxio.ClientContext;
 import alluxio.client.job.JobMasterClient;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.stress.Parameters;
 import alluxio.stress.TaskResult;
 import alluxio.stress.cli.Benchmark;
 import alluxio.stress.common.AbstractMaxThroughputSummary;
 import alluxio.stress.common.GeneralBenchSummary;
 import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
 import alluxio.worker.job.JobMasterClientContext;
 
 import com.beust.jcommander.JCommander;
@@ -104,8 +102,7 @@ public abstract class AbstractMaxThroughput<Q extends TaskResult, T extends
 
     int numWorkers = 0;
     try (JobMasterClient client = JobMasterClient.Factory.create(
-        JobMasterClientContext.newBuilder(ClientContext.create(new InstancedConfiguration(
-            ConfigurationUtils.copyDefaults()))).build())) {
+        JobMasterClientContext.newBuilder(ClientContext.create()).build())) {
       numWorkers = client.getAllWorkerHealth().size();
     }
     if (numWorkers <= 0) {

--- a/stress/shell/src/main/java/alluxio/stress/cli/suite/MasterMaxThroughput.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/suite/MasterMaxThroughput.java
@@ -13,7 +13,6 @@ package alluxio.stress.cli.suite;
 
 import alluxio.ClientContext;
 import alluxio.client.job.JobMasterClient;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.job.util.SerializationUtils;
 import alluxio.stress.cli.Benchmark;
 import alluxio.stress.cli.StressMasterBench;
@@ -23,7 +22,6 @@ import alluxio.stress.master.MasterBenchTaskResult;
 import alluxio.stress.master.MasterMaxThroughputSummary;
 import alluxio.stress.master.Operation;
 import alluxio.stress.master.MasterBenchParameters;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.FormatUtils;
 import alluxio.util.JsonSerializable;
 import alluxio.worker.job.JobMasterClientContext;
@@ -76,8 +74,7 @@ public class MasterMaxThroughput extends
       prepareBeforeAllTests(mBaseArgs);
     }
     try (JobMasterClient client = JobMasterClient.Factory.create(
-        JobMasterClientContext.newBuilder(ClientContext.create(new InstancedConfiguration(
-            ConfigurationUtils.copyDefaults()))).build())) {
+        JobMasterClientContext.newBuilder(ClientContext.create()).build())) {
       mNumWorkers = client.getAllWorkerHealth().size();
     }
   }

--- a/table/server/common/src/main/java/alluxio/table/common/CatalogPathUtils.java
+++ b/table/server/common/src/main/java/alluxio/table/common/CatalogPathUtils.java
@@ -13,7 +13,7 @@ package alluxio.table.common;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.io.PathUtils;
 
 import org.slf4j.Logger;
@@ -45,7 +45,7 @@ public class CatalogPathUtils {
    */
   public static AlluxioURI getTablePathUdb(String dbName, String tableName, String udbType) {
     return new AlluxioURI(PathUtils
-        .concatPath(ServerConfiguration.get(PropertyKey.TABLE_CATALOG_PATH), dbName, TABLES_ROOT,
+        .concatPath(Configuration.get(PropertyKey.TABLE_CATALOG_PATH), dbName, TABLES_ROOT,
             tableName, udbType));
   }
 
@@ -56,7 +56,7 @@ public class CatalogPathUtils {
    */
   public static AlluxioURI getTablePathInternal(String dbName, String tableName) {
     return new AlluxioURI(PathUtils
-        .concatPath(ServerConfiguration.get(PropertyKey.TABLE_CATALOG_PATH), dbName, TABLES_ROOT,
+        .concatPath(Configuration.get(PropertyKey.TABLE_CATALOG_PATH), dbName, TABLES_ROOT,
             tableName, INTERNAL_ROOT));
   }
 }

--- a/table/server/common/src/main/java/alluxio/table/common/layout/HiveLayout.java
+++ b/table/server/common/src/main/java/alluxio/table/common/layout/HiveLayout.java
@@ -12,7 +12,7 @@
 package alluxio.table.common.layout;
 
 import alluxio.AlluxioURI;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.table.ColumnStatisticsInfo;
 import alluxio.grpc.table.layout.hive.PartitionInfo;
 import alluxio.grpc.table.layout.hive.StorageFormat;
@@ -146,7 +146,7 @@ public class HiveLayout implements Layout {
       TransformDefinition definition) throws IOException {
     AlluxioURI outputPath = transformContext.generateTransformedPath();
     AlluxioURI outputUri = new AlluxioURI(
-        ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global())
+        ConfigurationUtils.getSchemeAuthority(Configuration.global())
         + outputPath.getPath());
     HiveLayout transformedLayout = transformLayout(outputUri, definition);
     return new TransformPlan(this, transformedLayout, definition);

--- a/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/PathTranslator.java
@@ -12,7 +12,7 @@
 package alluxio.table.common.udb;
 
 import alluxio.AlluxioURI;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.InvalidPathException;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.io.PathUtils;
@@ -30,7 +30,7 @@ import java.io.IOException;
 public class PathTranslator {
   private static final Logger LOG = LoggerFactory.getLogger(PathTranslator.class);
   private static final String SCHEME_AUTHORITY_PREFIX =
-      ConfigurationUtils.getSchemeAuthority(ServerConfiguration.global());
+      ConfigurationUtils.getSchemeAuthority(Configuration.global());
   private static final AlluxioURI BASE_URI = new AlluxioURI(SCHEME_AUTHORITY_PREFIX);
   private final BiMap<AlluxioURI, AlluxioURI> mPathMap;
 

--- a/table/server/common/src/main/java/alluxio/table/common/udb/UnderDatabaseRegistry.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/UnderDatabaseRegistry.java
@@ -12,7 +12,7 @@
 package alluxio.table.common.udb;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.extensions.ExtensionsClassLoader;
 import alluxio.util.io.PathUtils;
 
@@ -55,7 +55,7 @@ public class UnderDatabaseRegistry {
     Map<String, UnderDatabaseFactory> map = new HashMap<>();
 
     String libDir =
-        PathUtils.concatPath(ServerConfiguration.global().get(PropertyKey.HOME), "lib");
+        PathUtils.concatPath(Configuration.global().get(PropertyKey.HOME), "lib");
     LOG.info("Loading udb jars from {}", libDir);
     List<File> files = new ArrayList<>();
     try (DirectoryStream<Path> stream = Files

--- a/table/server/common/src/test/java/alluxio/table/common/CatalogPathUtilsTest.java
+++ b/table/server/common/src/test/java/alluxio/table/common/CatalogPathUtilsTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertEquals;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.io.PathUtils;
 
 import org.junit.Test;
@@ -29,7 +29,7 @@ public class CatalogPathUtilsTest {
     String udbType = "udbType";
     AlluxioURI path = CatalogPathUtils.getTablePathUdb(dbName, tableName, udbType);
 
-    assertEquals(path.getPath(), PathUtils.concatPath(ServerConfiguration.global().get(
+    assertEquals(path.getPath(), PathUtils.concatPath(Configuration.global().get(
         PropertyKey.TABLE_CATALOG_PATH), dbName, "tables", tableName, udbType));
   }
 
@@ -39,7 +39,7 @@ public class CatalogPathUtilsTest {
     String tableName = "tableName";
     AlluxioURI path = CatalogPathUtils.getTablePathInternal(dbName, tableName);
 
-    assertEquals(path.getPath(), PathUtils.concatPath(ServerConfiguration.global().get(
+    assertEquals(path.getPath(), PathUtils.concatPath(Configuration.global().get(
         PropertyKey.TABLE_CATALOG_PATH), dbName, "tables", tableName, "_internal_"));
   }
 }

--- a/table/server/common/src/test/java/alluxio/table/common/udb/PathTranslatorTest.java
+++ b/table/server/common/src/test/java/alluxio/table/common/udb/PathTranslatorTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertEquals;
 
 import alluxio.ConfigurationRule;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.collect.ImmutableMap;
@@ -41,7 +41,7 @@ public class PathTranslatorTest {
       new ConfigurationRule(
           ImmutableMap.of(PropertyKey.MASTER_HOSTNAME, MASTER_HOSTNAME,
             PropertyKey.MASTER_RPC_PORT, MASTER_RPC_PORT),
-          ServerConfiguration.global());
+          Configuration.modifiableGlobal());
 
   private PathTranslator mTranslator;
 

--- a/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
+++ b/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
@@ -13,7 +13,7 @@ package alluxio.master.table;
 
 import alluxio.client.file.FileSystem;
 import alluxio.collections.Pair;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.table.ColumnStatisticsInfo;
@@ -70,7 +70,7 @@ public class AlluxioCatalog implements Journaled {
    * Creates an instance.
    */
   public AlluxioCatalog() {
-    mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
+    mFileSystem = FileSystem.Factory.create(Configuration.global());
     mUdbRegistry = new UnderDatabaseRegistry();
     mUdbRegistry.refresh();
     mLayoutRegistry = new LayoutRegistry();

--- a/table/server/master/src/main/java/alluxio/master/table/Database.java
+++ b/table/server/master/src/main/java/alluxio/master/table/Database.java
@@ -12,7 +12,7 @@
 package alluxio.master.table;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.table.FileStatistics;
@@ -74,7 +74,7 @@ public class Database implements Journaled {
   private final String mConfigPath;
   private DbConfig mDbConfig;
   private final long mUdbSyncTimeoutMs =
-      ServerConfiguration.getMs(PropertyKey.TABLE_CATALOG_UDB_SYNC_TIMEOUT);
+      Configuration.getMs(PropertyKey.TABLE_CATALOG_UDB_SYNC_TIMEOUT);
 
   private DatabaseInfo mDatabaseInfo;
 

--- a/table/server/master/src/main/java/alluxio/master/table/Table.java
+++ b/table/server/master/src/main/java/alluxio/master/table/Table.java
@@ -12,7 +12,7 @@
 package alluxio.master.table;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.table.ColumnStatisticsInfo;
 import alluxio.grpc.table.Schema;
 import alluxio.grpc.table.TableInfo;
@@ -47,7 +47,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class Table {
   private static final Logger LOG = LoggerFactory.getLogger(Table.class);
   private static final long UNDEFINED_VERSION = -1;
-  private static final int PARTITIONS_CHUNK_SIZE = ServerConfiguration
+  private static final int PARTITIONS_CHUNK_SIZE = Configuration
       .getInt(PropertyKey.TABLE_JOURNAL_PARTITIONS_CHUNK_SIZE);
 
   public static final long FIRST_VERSION = 1;

--- a/table/server/master/src/main/java/alluxio/master/table/TableMasterFactory.java
+++ b/table/server/master/src/main/java/alluxio/master/table/TableMasterFactory.java
@@ -15,7 +15,7 @@ import alluxio.ClientContext;
 import alluxio.Constants;
 import alluxio.client.job.JobMasterClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.MasterFactory;
 import alluxio.master.MasterRegistry;
@@ -40,7 +40,7 @@ public final class TableMasterFactory implements MasterFactory<CoreMasterContext
 
   @Override
   public boolean isEnabled() {
-    return ServerConfiguration.getBoolean(PropertyKey.TABLE_ENABLED);
+    return Configuration.getBoolean(PropertyKey.TABLE_ENABLED);
   }
 
   @Override
@@ -53,7 +53,7 @@ public final class TableMasterFactory implements MasterFactory<CoreMasterContext
     LOG.info("Creating {} ", TableMaster.class.getName());
 
     JobMasterClient jobMasterClient = JobMasterClient.Factory.create(JobMasterClientContext
-        .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+        .newBuilder(ClientContext.create(Configuration.global())).build());
     TableMaster master = new DefaultTableMaster(context, jobMasterClient);
     registry.add(TableMaster.class, master);
     return master;

--- a/table/server/master/src/main/java/alluxio/master/table/transform/TransformManager.java
+++ b/table/server/master/src/main/java/alluxio/master/table/transform/TransformManager.java
@@ -14,7 +14,7 @@ package alluxio.master.table.transform;
 import alluxio.client.job.JobMasterClient;
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.NotFoundException;
 import alluxio.exception.status.UnavailableException;
@@ -99,7 +99,7 @@ public class TransformManager implements DelegatingJournaled {
    * This is not journaled, so after restarting TableMaster, the job history is lost.
    */
   private final Cache<Long, TransformJobInfo> mJobHistory = CacheBuilder.newBuilder()
-      .expireAfterWrite(ServerConfiguration.getMs(
+      .expireAfterWrite(Configuration.getMs(
           PropertyKey.TABLE_TRANSFORM_MANAGER_JOB_HISTORY_RETENTION_TIME),
           TimeUnit.MILLISECONDS)
       .build();
@@ -135,8 +135,8 @@ public class TransformManager implements DelegatingJournaled {
   public void start(ExecutorService executorService, UserState userState) {
     executorService.submit(
         new HeartbeatThread(HeartbeatContext.MASTER_TABLE_TRANSFORMATION_MONITOR, new JobMonitor(),
-            ServerConfiguration.getMs(PropertyKey.TABLE_TRANSFORM_MANAGER_JOB_MONITOR_INTERVAL),
-            ServerConfiguration.global(), userState));
+            Configuration.getMs(PropertyKey.TABLE_TRANSFORM_MANAGER_JOB_MONITOR_INTERVAL),
+            Configuration.global(), userState));
   }
 
   /**

--- a/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/AlluxioCatalogTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.table.ColumnStatisticsData;
@@ -297,7 +297,7 @@ public class AlluxioCatalogTest {
     String tableName = TestDatabase.getTableName(0);
     // When generating transform plan, the authority of the output path
     // will be determined based on this hostname configuration.
-    ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
+    Configuration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
     List<TransformPlan> plans = mCatalog.getTransformPlan(dbName, tableName, TRANSFORM_DEFINITION);
     assertEquals(1, plans.size());
     Table table = mCatalog.getTable(dbName, tableName);
@@ -315,19 +315,19 @@ public class AlluxioCatalogTest {
     String tableName = TestDatabase.getTableName(0);
     Table table = mCatalog.getTable(dbName, tableName);
 
-    ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_PORT, 8080);
+    Configuration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
+    Configuration.set(PropertyKey.MASTER_RPC_PORT, 8080);
     List<TransformPlan> plans = mCatalog.getTransformPlan(dbName, tableName, TRANSFORM_DEFINITION);
     assertEquals("alluxio://localhost:8080/",
         plans.get(0).getTransformedLayout().getLocation().getRootPath());
 
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_ADDRESSES, "host1:1,host2:2");
+    Configuration.set(PropertyKey.MASTER_RPC_ADDRESSES, "host1:1,host2:2");
     plans = mCatalog.getTransformPlan(dbName, tableName, TRANSFORM_DEFINITION);
     assertEquals("alluxio://host1:1,host2:2/",
         plans.get(0).getTransformedLayout().getLocation().getRootPath());
 
-    ServerConfiguration.set(PropertyKey.ZOOKEEPER_ENABLED, true);
-    ServerConfiguration.set(PropertyKey.ZOOKEEPER_ADDRESS, "host:1000");
+    Configuration.set(PropertyKey.ZOOKEEPER_ENABLED, true);
+    Configuration.set(PropertyKey.ZOOKEEPER_ADDRESS, "host:1000");
     plans = mCatalog.getTransformPlan(dbName, tableName, TRANSFORM_DEFINITION);
     assertEquals("alluxio://zk@host:1000/",
         plans.get(0).getTransformedLayout().getLocation().getRootPath());
@@ -342,7 +342,7 @@ public class AlluxioCatalogTest {
         Collections.emptyMap(), false);
     String tableName = TestDatabase.getTableName(0);
 
-    ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
+    Configuration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
 
     final TransformDefinition transformDefinition =
         TransformDefinition.parse("file.count.max=100;file.parquet.compression=uncompressed");
@@ -394,7 +394,7 @@ public class AlluxioCatalogTest {
 
     // When generating transform plan, the authority of the output path
     // will be determined based on this hostname configuration.
-    ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
+    Configuration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
     List<TransformPlan> plans = mCatalog.getTransformPlan(dbName, tableName, TRANSFORM_DEFINITION);
 
     Map<String, Layout> transformedLayouts = Maps.newHashMapWithExpectedSize(plans.size());

--- a/table/server/master/src/test/java/alluxio/master/table/TableMasterFactoryTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/TableMasterFactoryTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.mock;
 import alluxio.Constants;
 import alluxio.Server;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.BackupManager;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.MasterRegistry;
@@ -55,17 +55,17 @@ public class TableMasterFactoryTest {
         .setInodeStoreFactory(x -> new HeapInodeStore())
         .setUfsManager(new MasterUfsManager())
         .build();
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_FOLDER, sTemp.getRoot().getAbsolutePath());
+    Configuration.set(PropertyKey.MASTER_JOURNAL_FOLDER, sTemp.getRoot().getAbsolutePath());
   }
 
   @After
   public void after() {
-    ServerConfiguration.global().set(PropertyKey.TABLE_ENABLED, true);
+    Configuration.set(PropertyKey.TABLE_ENABLED, true);
   }
 
   @Test
   public void enabled() throws Exception {
-    ServerConfiguration.global().set(PropertyKey.TABLE_ENABLED, true);
+    Configuration.set(PropertyKey.TABLE_ENABLED, true);
     MasterRegistry registry = new MasterRegistry();
     MasterUtils.createMasters(registry, mContext);
     Set<String> names =
@@ -74,8 +74,8 @@ public class TableMasterFactoryTest {
   }
 
   @Test
-  public void disabled() throws Exception {
-    ServerConfiguration.global().set(PropertyKey.TABLE_ENABLED, false);
+  public void disabled() {
+    Configuration.set(PropertyKey.TABLE_ENABLED, false);
     MasterRegistry registry = new MasterRegistry();
     MasterUtils.createMasters(registry, mContext);
     Set<String> names =

--- a/table/server/master/src/test/java/alluxio/master/table/TestDatabase.java
+++ b/table/server/master/src/test/java/alluxio/master/table/TestDatabase.java
@@ -13,7 +13,7 @@ package alluxio.master.table;
 
 import alluxio.client.file.FileSystem;
 import alluxio.collections.ConcurrentHashSet;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.table.PrincipalType;
 import alluxio.table.common.udb.UdbBypassSpec;
@@ -129,7 +129,7 @@ public class TestDatabase implements UnderDatabase {
     DATABASE.mUdbTables.clear();
     FileSystem fs = null;
     if (generateFiles) {
-      fs = FileSystem.Factory.create(ServerConfiguration.global());
+      fs = FileSystem.Factory.create(Configuration.global());
     }
     for (int i = 0; i < numOfTable; i++) {
       DATABASE.mUdbTables.put(getTableName(i),

--- a/table/server/master/src/test/java/alluxio/master/table/transform/TransformManagerTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/transform/TransformManagerTest.java
@@ -17,7 +17,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 import alluxio.client.job.JobMasterClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.NotFoundException;
 import alluxio.heartbeat.HeartbeatContext;
@@ -101,10 +101,10 @@ public class TransformManagerTest {
 
   @Before
   public void before() throws Exception {
-    ServerConfiguration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
-    ServerConfiguration.set(PropertyKey.MASTER_RPC_PORT, PortRegistry.getFreePort());
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
-    ServerConfiguration.set(PropertyKey.TABLE_TRANSFORM_MANAGER_JOB_HISTORY_RETENTION_TIME, "1h");
+    Configuration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
+    Configuration.set(PropertyKey.MASTER_RPC_PORT, PortRegistry.getFreePort());
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    Configuration.set(PropertyKey.TABLE_TRANSFORM_MANAGER_JOB_HISTORY_RETENTION_TIME, "1h");
 
     mJournalSystem = JournalTestUtils.createJournalSystem(mTemporaryFolder);
     mJournalSystem.format();

--- a/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/DefaultHiveClientPool.java
+++ b/table/server/underdb/hive/src/main/java/alluxio/table/under/hive/util/DefaultHiveClientPool.java
@@ -15,7 +15,7 @@ import static alluxio.conf.PropertyKey.TABLE_UDB_HIVE_CLIENTPOOL_MAX;
 import static alluxio.conf.PropertyKey.TABLE_UDB_HIVE_CLIENTPOOL_MIN;
 
 import alluxio.Constants;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.resource.CloseableResource;
@@ -55,8 +55,8 @@ public final class DefaultHiveClientPool extends AbstractHiveClientPool {
    */
   public DefaultHiveClientPool(String connectionUri) {
     super(Options.defaultOptions()
-        .setMinCapacity(ServerConfiguration.getInt(TABLE_UDB_HIVE_CLIENTPOOL_MIN))
-        .setMaxCapacity(ServerConfiguration.getInt(TABLE_UDB_HIVE_CLIENTPOOL_MAX))
+        .setMinCapacity(Configuration.getInt(TABLE_UDB_HIVE_CLIENTPOOL_MIN))
+        .setMaxCapacity(Configuration.getInt(TABLE_UDB_HIVE_CLIENTPOOL_MAX))
         .setGcIntervalMs(5L * Constants.MINUTE_MS)
         .setGcExecutor(GC_EXECUTOR));
     mConnectionUri = connectionUri;

--- a/table/shell/src/main/java/alluxio/cli/table/TableShell.java
+++ b/table/shell/src/main/java/alluxio/cli/table/TableShell.java
@@ -18,8 +18,8 @@ import alluxio.cli.CommandUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.table.TableMasterClient;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.MasterClientContext;
-import alluxio.util.ConfigurationUtils;
 
 import java.util.Map;
 
@@ -34,7 +34,7 @@ public class TableShell extends AbstractShell {
    * Construct a new instance of {@link TableShell}.
    */
   public TableShell() {
-    super(null, null, ConfigurationUtils.defaults());
+    super(null, null, Configuration.global());
   }
 
   /**

--- a/table/shell/src/test/java/alluxio/cli/table/TransformTableCommandTest.java
+++ b/table/shell/src/test/java/alluxio/cli/table/TransformTableCommandTest.java
@@ -18,8 +18,7 @@ import static org.mockito.Mockito.when;
 
 import alluxio.cli.table.command.TransformTableCommand;
 import alluxio.client.table.TableMasterClient;
-import alluxio.conf.InstancedConfiguration;
-import alluxio.util.ConfigurationUtils;
+import alluxio.conf.Configuration;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -41,8 +40,7 @@ public class TransformTableCommandTest {
     when(client.transformTable(ArgumentMatchers.anyString(), ArgumentMatchers.anyString(),
         ArgumentMatchers.anyString())).thenReturn(0L);
     TransformTableCommand command =
-        new TransformTableCommand(new InstancedConfiguration(ConfigurationUtils.copyDefaults()),
-            client, null);
+        new TransformTableCommand(Configuration.global(), client, null);
 
     ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
 

--- a/tests/src/main/java/alluxio/master/backcompat/ops/PersistFile.java
+++ b/tests/src/main/java/alluxio/master/backcompat/ops/PersistFile.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertTrue;
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.client.file.FileSystem;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.backcompat.TestOp;
 import alluxio.master.backcompat.Utils;
 import alluxio.multi.process.Clients;
@@ -38,10 +38,10 @@ public final class PersistFile implements TestOp {
     FileSystem fs = clients.getFileSystemClient();
     Utils.createFile(fs, PATH);
     clients.getFileSystemMasterClient().scheduleAsyncPersist(PATH,
-        FileSystemOptions.scheduleAsyncPersistDefaults(ServerConfiguration.global()));
+        FileSystemOptions.scheduleAsyncPersistDefaults(Configuration.global()));
     Utils.createFile(fs, NESTED_PATH);
     clients.getFileSystemMasterClient().scheduleAsyncPersist(NESTED_PATH,
-        FileSystemOptions.scheduleAsyncPersistDefaults(ServerConfiguration.global()));
+        FileSystemOptions.scheduleAsyncPersistDefaults(Configuration.global()));
     CommonUtils.waitFor("file to be async persisted", () -> {
       try {
         return fs.getStatus(PATH).isPersisted() && fs.getStatus(NESTED_PATH).isPersisted();

--- a/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
+++ b/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
@@ -26,7 +26,7 @@ import alluxio.client.WriteType;
 import alluxio.client.file.FileSystem;
 import alluxio.client.meta.RetryHandlingMetaMasterClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.master.MasterClientContext;
@@ -211,7 +211,7 @@ public class JournalToolTest extends BaseIntegrationTest {
 
     // Take snapshot on master.
     new RetryHandlingMetaMasterClient(MasterClientContext
-        .newBuilder(ClientContext.create(ServerConfiguration.global()))
+        .newBuilder(ClientContext.create(Configuration.global()))
         .setMasterInquireClient(new SingleMasterInquireClient(
             mLocalAlluxioClusterResource.get().getLocalAlluxioMaster().getAddress()))
         .build()).checkpoint();

--- a/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
@@ -21,7 +21,7 @@ import alluxio.cli.job.JobShell;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
@@ -122,8 +122,8 @@ public abstract class AbstractFileSystemShellTest extends AbstractShellIntegrati
     sLocalAlluxioJobCluster.start();
     sFileSystem = sLocalAlluxioCluster.getClient();
     sJobMaster = sLocalAlluxioJobCluster.getMaster().getJobMaster();
-    sJobShell = new alluxio.cli.job.JobShell(ServerConfiguration.global());
-    sFsShell = new FileSystemShell(ServerConfiguration.global());
+    sJobShell = new alluxio.cli.job.JobShell(Configuration.global());
+    sFsShell = new FileSystemShell(Configuration.global());
   }
 
   @AfterClass

--- a/tests/src/test/java/alluxio/client/cli/fs/ConfigurationDocGeneratorTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/ConfigurationDocGeneratorTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 import alluxio.cli.docgen.ConfigurationDocGenerator;
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Joiner;
@@ -128,7 +128,7 @@ public class ConfigurationDocGeneratorTest {
 
     //assert file contents
     List<String> userFile = Files.readAllLines(p, StandardCharsets.UTF_8);
-    Object defaultValue = ServerConfiguration.get(pKey);
+    Object defaultValue = Configuration.get(pKey);
     checkFileContents(String.format("%s,\"%s\"", pKey, defaultValue), userFile, mFileType);
   }
 

--- a/tests/src/test/java/alluxio/client/cli/fs/FileSystemShellUtilsTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/FileSystemShellUtilsTest.java
@@ -22,7 +22,7 @@ import alluxio.cli.fs.FileSystemShellUtils;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.FileSystemTestUtils;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.DeletePOptions;
@@ -301,7 +301,7 @@ public final class FileSystemShellUtilsTest {
   @Test
   public void loadCommands() {
     Map<String, Command> map =
-        FileSystemShellUtils.loadCommands(FileSystemContext.create(ServerConfiguration.global()));
+        FileSystemShellUtils.loadCommands(FileSystemContext.create(Configuration.global()));
 
     String pkgName = Command.class.getPackage().getName();
     Reflections reflections = new Reflections(pkgName);

--- a/tests/src/test/java/alluxio/client/cli/fs/GetConfTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/GetConfTest.java
@@ -21,10 +21,9 @@ import alluxio.SystemPropertyRule;
 import alluxio.cli.GetConf;
 import alluxio.client.meta.RetryHandlingMetaMasterConfigClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.ConfigProperty;
 import alluxio.grpc.GetConfigurationPResponse;
-import alluxio.wire.Configuration;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.After;
@@ -48,27 +47,27 @@ public final class GetConfTest {
 
   @After
   public void after() {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   @Test
   public void getConf() throws Exception {
-    ServerConfiguration.set(PropertyKey.WORKER_RAMDISK_SIZE, "2048");
-    ClientContext ctx = ClientContext.create(ServerConfiguration.global());
+    Configuration.set(PropertyKey.WORKER_RAMDISK_SIZE, "2048");
+    ClientContext ctx = ClientContext.create(Configuration.global());
     assertEquals(0, GetConf.getConf(ctx,
         PropertyKey.WORKER_RAMDISK_SIZE.toString()));
     assertEquals("2048\n", mOutputStream.toString());
 
     mOutputStream.reset();
-    ServerConfiguration.set(PropertyKey.WORKER_RAMDISK_SIZE, "2MB");
-    ctx = ClientContext.create(ServerConfiguration.global());
+    Configuration.set(PropertyKey.WORKER_RAMDISK_SIZE, "2MB");
+    ctx = ClientContext.create(Configuration.global());
     assertEquals(0, GetConf.getConf(ctx,
         PropertyKey.WORKER_RAMDISK_SIZE.toString()));
     assertEquals("2MB\n", mOutputStream.toString());
 
     mOutputStream.reset();
-    ServerConfiguration.set(PropertyKey.WORKER_RAMDISK_SIZE, 2048);
-    ctx = ClientContext.create(ServerConfiguration.global());
+    Configuration.set(PropertyKey.WORKER_RAMDISK_SIZE, 2048);
+    ctx = ClientContext.create(Configuration.global());
     assertEquals(0, GetConf.getConf(ctx,
         PropertyKey.WORKER_RAMDISK_SIZE.toString()));
     assertEquals("2048\n", mOutputStream.toString());
@@ -80,7 +79,7 @@ public final class GetConfTest {
         .setAlias(new String[] {"alluxio.test.property.alias"})
         .setDefaultValue("testValue")
         .build();
-    ClientContext ctx = ClientContext.create(ServerConfiguration.global());
+    ClientContext ctx = ClientContext.create(Configuration.global());
     assertEquals(0, GetConf.getConf(ctx, "alluxio.test.property.alias"));
     assertEquals("testValue\n", mOutputStream.toString());
 
@@ -92,29 +91,29 @@ public final class GetConfTest {
 
   @Test
   public void getConfWithCorrectUnit() throws Exception {
-    ServerConfiguration.set(PropertyKey.WORKER_RAMDISK_SIZE, "2048");
-    ClientContext ctx = ClientContext.create(ServerConfiguration.global());
+    Configuration.set(PropertyKey.WORKER_RAMDISK_SIZE, "2048");
+    ClientContext ctx = ClientContext.create(Configuration.global());
     assertEquals(0, GetConf.getConf(ctx, "--unit", "B",
         PropertyKey.WORKER_RAMDISK_SIZE.toString()));
     assertEquals("2048\n", mOutputStream.toString());
 
     mOutputStream.reset();
-    ServerConfiguration.set(PropertyKey.WORKER_RAMDISK_SIZE, "2048");
-    ctx = ClientContext.create(ServerConfiguration.global());
+    Configuration.set(PropertyKey.WORKER_RAMDISK_SIZE, "2048");
+    ctx = ClientContext.create(Configuration.global());
     assertEquals(0, GetConf.getConf(ctx, "--unit", "KB",
         PropertyKey.WORKER_RAMDISK_SIZE.toString()));
     assertEquals("2\n", mOutputStream.toString());
 
     mOutputStream.reset();
-    ServerConfiguration.set(PropertyKey.WORKER_RAMDISK_SIZE, "2MB");
-    ctx = ClientContext.create(ServerConfiguration.global());
+    Configuration.set(PropertyKey.WORKER_RAMDISK_SIZE, "2MB");
+    ctx = ClientContext.create(Configuration.global());
     assertEquals(0, GetConf.getConf(ctx, "--unit", "KB",
         PropertyKey.WORKER_RAMDISK_SIZE.toString()));
     assertEquals("2048\n", mOutputStream.toString());
 
     mOutputStream.reset();
-    ServerConfiguration.set(PropertyKey.WORKER_RAMDISK_SIZE, "2MB");
-    ctx = ClientContext.create(ServerConfiguration.global());
+    Configuration.set(PropertyKey.WORKER_RAMDISK_SIZE, "2MB");
+    ctx = ClientContext.create(Configuration.global());
     assertEquals(0, GetConf.getConf(ctx, "--unit", "MB",
         PropertyKey.WORKER_RAMDISK_SIZE.toString()));
     assertEquals("2\n", mOutputStream.toString());
@@ -122,9 +121,9 @@ public final class GetConfTest {
 
   @Test
   public void getConfWithWrongUnit() throws Exception {
-    ServerConfiguration.set(PropertyKey.WORKER_RAMDISK_SIZE, "2048");
+    Configuration.set(PropertyKey.WORKER_RAMDISK_SIZE, "2048");
     assertEquals(1,
-        GetConf.getConf(ClientContext.create(ServerConfiguration.global()), "--unit", "bad_unit",
+        GetConf.getConf(ClientContext.create(Configuration.global()), "--unit", "bad_unit",
             PropertyKey.WORKER_RAMDISK_SIZE.toString()));
   }
 
@@ -133,13 +132,13 @@ public final class GetConfTest {
     try (Closeable p = new SystemPropertyRule(ImmutableMap.of(
         PropertyKey.CONF_VALIDATION_ENABLED.toString(), "false",
         PropertyKey.ZOOKEEPER_ENABLED.toString(), "true")).toResource()) {
-      ServerConfiguration.reset();
-      ClientContext ctx = ClientContext.create(ServerConfiguration.global());
+      Configuration.reloadProperties();
+      ClientContext ctx = ClientContext.create(Configuration.global());
       assertEquals(0, GetConf.getConf(ctx,
           PropertyKey.ZOOKEEPER_ENABLED.toString()));
       assertEquals("true\n", mOutputStream.toString());
     } finally {
-      ServerConfiguration.reset();
+      Configuration.reloadProperties();
     }
   }
 
@@ -149,9 +148,9 @@ public final class GetConfTest {
     RetryHandlingMetaMasterConfigClient client =
         Mockito.mock(RetryHandlingMetaMasterConfigClient.class);
     Mockito.when(client.getConfiguration(any())).thenReturn(
-        Configuration.fromProto(prepareGetConfigurationResponse()));
+        alluxio.wire.Configuration.fromProto(prepareGetConfigurationResponse()));
 
-    assertEquals(0, GetConf.getConfImpl(() -> client, ServerConfiguration.global(), "--master"));
+    assertEquals(0, GetConf.getConfImpl(() -> client, Configuration.global(), "--master"));
     String expectedOutput = "alluxio.logger.type=MASTER_LOGGER\n"
         + "alluxio.master.audit.logger.type=MASTER_AUDIT_LOGGER\n"
         + "alluxio.master.hostname=localhost\n"
@@ -166,9 +165,9 @@ public final class GetConfTest {
     // Prepare mock meta master client
     RetryHandlingMetaMasterConfigClient client =
         Mockito.mock(RetryHandlingMetaMasterConfigClient.class);
-    Mockito.when(client.getConfiguration(any())).thenReturn(Configuration.fromProto(
+    Mockito.when(client.getConfiguration(any())).thenReturn(alluxio.wire.Configuration.fromProto(
         prepareGetConfigurationResponse()));
-    assertEquals(0, GetConf.getConfImpl(() -> client, ServerConfiguration.global(), "--master",
+    assertEquals(0, GetConf.getConfImpl(() -> client, Configuration.global(), "--master",
         "--source"));
     // CHECKSTYLE.OFF: LineLengthExceed - Much more readable
     String expectedOutput =

--- a/tests/src/test/java/alluxio/client/cli/fs/JobServiceFaultToleranceShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/JobServiceFaultToleranceShellTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 import alluxio.AlluxioURI;
 import alluxio.cli.fs.FileSystemShell;
 import alluxio.client.file.FileSystem;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.LocalAlluxioJobCluster;
 import alluxio.master.MultiMasterLocalAlluxioCluster;
 import alluxio.testutils.BaseIntegrationTest;
@@ -65,17 +65,17 @@ public final class JobServiceFaultToleranceShellTest extends BaseIntegrationTest
       mLocalAlluxioCluster.stop();
     }
     System.setOut(System.out);
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   @Test
   public void distributedCp() throws Exception {
-    FileSystem fs = FileSystem.Factory.create(ServerConfiguration.global());
+    FileSystem fs = FileSystem.Factory.create(Configuration.global());
     try (OutputStream out = fs.createFile(new AlluxioURI("/test"))) {
       out.write("Hello".getBytes());
     }
 
-    try (FileSystemShell shell = new FileSystemShell(ServerConfiguration.global())) {
+    try (FileSystemShell shell = new FileSystemShell(Configuration.global())) {
       int exitCode = shell.run("distributedCp", "/test", "/test2");
       assertEquals("Command failed, output: " + mOutput.toString(), 0, exitCode);
     }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CheckConsistencyCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CheckConsistencyCommandIntegrationTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 import alluxio.AlluxioURI;
 import alluxio.client.cli.fs.AbstractFileSystemShellTest;
 import alluxio.client.file.FileSystemTestUtils;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.ExistsPOptions;
 import alluxio.grpc.LoadMetadataPType;
@@ -64,7 +64,7 @@ public class CheckConsistencyCommandIntegrationTest extends AbstractFileSystemSh
     FileSystemTestUtils.createByteFile(sFileSystem, "/testRoot/testDir/testFileB",
             WritePType.CACHE_THROUGH, 20);
     String ufsPath = sFileSystem.getStatus(new AlluxioURI("/testRoot/testDir")).getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, Configuration.global());
     ufs.deleteDirectory(ufsPath, DeleteOptions.defaults().setRecursive(true));
     sFsShell.run("checkConsistency", "/testRoot");
     StringBuilder expected = new StringBuilder();
@@ -106,7 +106,7 @@ public class CheckConsistencyCommandIntegrationTest extends AbstractFileSystemSh
     FileSystemTestUtils
         .createByteFile(sFileSystem, "/testRoot/testFileA", WritePType.CACHE_THROUGH, 10);
     String ufsPath = sFileSystem.getStatus(new AlluxioURI("/testRoot")).getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, Configuration.global());
     ufs.deleteFile(sFileSystem.getStatus(new AlluxioURI("/testRoot/testFileA")).getUfsPath());
 
     sFsShell.run("checkConsistency", "/testRoot");
@@ -164,7 +164,7 @@ public class CheckConsistencyCommandIntegrationTest extends AbstractFileSystemSh
         .createByteFile(sFileSystem, path, WritePType.CACHE_THROUGH, 10));
 
     String ufsPath = sFileSystem.getStatus(new AlluxioURI("/testRoot/testDir")).getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, Configuration.global());
     ufs.deleteDirectory(ufsPath, DeleteOptions.defaults().setRecursive(true));
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/ChownCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/ChownCommandIntegrationTest.java
@@ -16,7 +16,7 @@ import alluxio.ConfigurationRule;
 import alluxio.client.cli.fs.AbstractFileSystemShellTest;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.WritePType;
 
@@ -35,7 +35,7 @@ public final class ChownCommandIntegrationTest extends AbstractFileSystemShellTe
   @Rule
   public ConfigurationRule mConfiguration = new ConfigurationRule(ImmutableMap
       .of(PropertyKey.SECURITY_GROUP_MAPPING_CLASS, FakeUserGroupsMapping.class.getName()),
-      ServerConfiguration.global());
+      Configuration.modifiableGlobal());
 
   @Test
   public void chown() throws IOException, AlluxioException {

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
@@ -22,7 +22,7 @@ import alluxio.client.cli.fs.FileSystemShellUtilsTest;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.OpenFilePOptions;
@@ -234,11 +234,11 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
   public void copyFromLocalMustCacheThenCacheThrough() throws Exception {
     File file = mTestFolder.newFile();
     try (Closeable c = new ConfigurationRule(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT,
-        WriteType.MUST_CACHE.toString(), ServerConfiguration.global()).toResource()) {
+        WriteType.MUST_CACHE.toString(), Configuration.modifiableGlobal()).toResource()) {
       Assert.assertEquals(0, sFsShell.run("copyFromLocal", file.getAbsolutePath(), "/"));
     }
     try (Closeable c = new ConfigurationRule(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT,
-        WriteType.CACHE_THROUGH.toString(), ServerConfiguration.global()).toResource()) {
+        WriteType.CACHE_THROUGH.toString(), Configuration.modifiableGlobal()).toResource()) {
       mOutput.reset();
       sFsShell.run("copyFromLocal", file.getAbsolutePath(), "/");
     }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
@@ -23,7 +23,7 @@ import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.OpenFilePOptions;
@@ -65,7 +65,7 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
   @Rule
   public ConfigurationRule mConfiguration = new ConfigurationRule(ImmutableMap
       .of(PropertyKey.SECURITY_GROUP_MAPPING_CLASS, FakeUserGroupsMapping.class.getName()),
-      ServerConfiguration.global());
+      Configuration.modifiableGlobal());
 
   /**
    * Tests copying a file to a new location.
@@ -199,7 +199,7 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
    */
   @Test
   public void copyFileWithPreservedAttributes() throws Exception {
-    InstancedConfiguration conf = new InstancedConfiguration(ServerConfiguration.global());
+    InstancedConfiguration conf = new InstancedConfiguration(Configuration.global());
     // avoid chown on UFS since test might not be run with root
     conf.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
     try (FileSystemShell fsShell = new FileSystemShell(conf)) {
@@ -237,7 +237,7 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
    */
   @Test
   public void copyDirectoryWithPreservedAttributes() throws Exception {
-    InstancedConfiguration conf = new InstancedConfiguration(ServerConfiguration.global());
+    InstancedConfiguration conf = new InstancedConfiguration(Configuration.global());
     conf.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
     try (FileSystemShell fsShell = new FileSystemShell(conf)) {
       String testDir = FileSystemShellUtilsTest.resetFileHierarchy(sFileSystem);
@@ -328,7 +328,7 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
 
   @Test
   public void copyAfterWorkersNotAvailableMustCache() throws Exception {
-    InstancedConfiguration conf = new InstancedConfiguration(ServerConfiguration.global());
+    InstancedConfiguration conf = new InstancedConfiguration(Configuration.global());
     conf.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
     try (FileSystemShell fsShell = new FileSystemShell(conf)) {
       File testFile = new File(sLocalAlluxioCluster.getAlluxioHome() + "/testFile");

--- a/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/DistributedLoadCommandTest.java
@@ -19,7 +19,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.WritePType;
 import alluxio.master.LocalAlluxioJobCluster;
@@ -72,8 +72,8 @@ public final class DistributedLoadCommandTest extends AbstractFileSystemShellTes
     sLocalAlluxioJobCluster.start();
     sFileSystem = sLocalAlluxioCluster.getClient();
     sJobMaster = sLocalAlluxioJobCluster.getMaster().getJobMaster();
-    sJobShell = new alluxio.cli.job.JobShell(ServerConfiguration.global());
-    sFsShell = new FileSystemShell(ServerConfiguration.global());
+    sJobShell = new alluxio.cli.job.JobShell(Configuration.global());
+    sFsShell = new FileSystemShell(Configuration.global());
   }
 
   @Test
@@ -257,7 +257,7 @@ public final class DistributedLoadCommandTest extends AbstractFileSystemShellTes
 
   @Test
   public void loadDirWithCorrectCount() throws IOException, AlluxioException {
-    FileSystemShell fsShell = new FileSystemShell(ServerConfiguration.global());
+    FileSystemShell fsShell = new FileSystemShell(Configuration.global());
     FileSystem fs = sResource.get().getClient();
     int fileSize = 66;
     for (int i = 0; i < fileSize; i++) {
@@ -276,7 +276,7 @@ public final class DistributedLoadCommandTest extends AbstractFileSystemShellTes
 
   @Test
   public void loadDirWithFailure() throws IOException, AlluxioException {
-    FileSystemShell fsShell = new FileSystemShell(ServerConfiguration.global());
+    FileSystemShell fsShell = new FileSystemShell(Configuration.global());
     FileSystem fs = sResource.get().getClient();
     int fileSize = 20;
     List<String> failures = new ArrayList<>();

--- a/tests/src/test/java/alluxio/client/cli/fs/command/HelpCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/HelpCommandIntegrationTest.java
@@ -16,7 +16,7 @@ import alluxio.cli.fs.FileSystemShellUtils;
 import alluxio.cli.fs.command.HelpCommand;
 import alluxio.client.cli.fs.AbstractFileSystemShellTest;
 import alluxio.client.file.FileSystemContext;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -49,7 +49,7 @@ public final class HelpCommandIntegrationTest extends AbstractFileSystemShellTes
   @Test
   public void help() throws IOException {
     Assert.assertEquals(0, sFsShell.run("help", "help"));
-    HelpCommand cmd = new HelpCommand(FileSystemContext.create(ServerConfiguration.global()));
+    HelpCommand cmd = new HelpCommand(FileSystemContext.create(Configuration.global()));
     StringWriter stringWriter = new StringWriter();
     PrintWriter printWriter = new PrintWriter(stringWriter);
     HelpCommand.printCommandInfo(cmd, printWriter);
@@ -65,7 +65,7 @@ public final class HelpCommandIntegrationTest extends AbstractFileSystemShellTes
   public void helpAllCommand() throws IOException {
     Assert.assertEquals(0, sFsShell.run("help"));
     final Map<String, Command> commands =
-        FileSystemShellUtils.loadCommands(FileSystemContext.create(ServerConfiguration.global()));
+        FileSystemShellUtils.loadCommands(FileSystemContext.create(Configuration.global()));
     String expected = "";
     SortedSet<String> sortedCmds = new TreeSet<>(commands.keySet());
     for (String cmd : sortedCmds) {

--- a/tests/src/test/java/alluxio/client/cli/fs/command/LsCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/LsCommandIntegrationTest.java
@@ -22,7 +22,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.WritePType;
@@ -46,8 +46,8 @@ public final class LsCommandIntegrationTest extends AbstractFileSystemShellTest 
     FileSystem fs = sFileSystem;
     if (user != null) {
       fs = sLocalAlluxioCluster.getClient(FileSystemContext
-          .create(new TestUserState(user, ServerConfiguration.global()).getSubject(),
-              ServerConfiguration.global()));
+          .create(new TestUserState(user, Configuration.global()).getSubject(),
+              Configuration.global()));
     }
     FileSystemTestUtils.createByteFile(fs, "/testRoot/testFileA", WritePType.MUST_CACHE, 10);
     FileSystemTestUtils

--- a/tests/src/test/java/alluxio/client/cli/fs/command/LsCommandSecurityIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/LsCommandSecurityIntegrationTest.java
@@ -23,7 +23,7 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.SetAclAction;
 import alluxio.grpc.WritePType;
@@ -52,8 +52,8 @@ public final class LsCommandSecurityIntegrationTest extends AbstractFileSystemSh
   // Helper function to create a set of files in the file system
   private void createFiles() throws Exception {
     FileSystem fs = sLocalAlluxioCluster.getClient(FileSystemContext
-        .create(new TestUserState("test_user_ls", ServerConfiguration.global()).getSubject(),
-            ServerConfiguration.global()));
+        .create(new TestUserState("test_user_ls", Configuration.global()).getSubject(),
+            Configuration.global()));
     FileSystemTestUtils.createByteFile(fs, "/testRoot/testFileA", WritePType.MUST_CACHE, 10);
     FileSystemTestUtils
         .createByteFile(fs, "/testRoot/testDir/testFileB", WritePType.MUST_CACHE, 20);
@@ -81,8 +81,8 @@ public final class LsCommandSecurityIntegrationTest extends AbstractFileSystemSh
   @Test
   public void lsWildcard() throws Exception {
     FileSystem fs = sLocalAlluxioCluster.getClient(FileSystemContext.create(
-        new TestUserState("test_user_ls", ServerConfiguration.global()).getSubject(),
-        ServerConfiguration.global()));
+        new TestUserState("test_user_ls", Configuration.global()).getSubject(),
+        Configuration.global()));
 
     String testDir = FileSystemShellUtilsTest.resetFileHierarchy(fs);
     sFsShell.run("ls", testDir + "/*/foo*");
@@ -119,7 +119,7 @@ public final class LsCommandSecurityIntegrationTest extends AbstractFileSystemSh
   }
 
   private String getDisplayTime(long timestamp) {
-    String formatString = ServerConfiguration.getString(PropertyKey.USER_DATE_FORMAT_PATTERN);
+    String formatString = Configuration.getString(PropertyKey.USER_DATE_FORMAT_PATTERN);
     return CommonUtils.convertMsToDate(timestamp, formatString);
   }
 
@@ -164,8 +164,8 @@ public final class LsCommandSecurityIntegrationTest extends AbstractFileSystemSh
     int size = 50;
 
     FileSystem fs = sLocalAlluxioCluster.getClient(FileSystemContext
-        .create(new TestUserState("test_user_ls", ServerConfiguration.global()).getSubject(),
-            ServerConfiguration.global()));
+        .create(new TestUserState("test_user_ls", Configuration.global()).getSubject(),
+            Configuration.global()));
     FileSystemTestUtils.createByteFile(fs, "/testRoot/testDir/testFileB",
         WritePType.MUST_CACHE, 20);
     FileSystemTestUtils.createByteFile(fs, "/testRoot/testFile",

--- a/tests/src/test/java/alluxio/client/cli/fs/command/PersistCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/PersistCommandTest.java
@@ -24,7 +24,7 @@ import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.WritePType;
@@ -68,7 +68,7 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
   @Test
   public void persistDirectory() throws Exception {
     // Set the default write type to MUST_CACHE, so that directories are not persisted by default
-    ServerConfiguration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
+    Configuration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
     String testDir = FileSystemShellUtilsTest.resetFileHierarchy(sFileSystem);
     assertFalse(sFileSystem.getStatus(new AlluxioURI(testDir)).isPersisted());
     assertFalse(sFileSystem.getStatus(new AlluxioURI(testDir + "/foo")).isPersisted());
@@ -86,7 +86,7 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
 
   @Test
   public void persistOnRenameDirectory() throws Exception {
-    InstancedConfiguration conf = new InstancedConfiguration(ServerConfiguration.global());
+    InstancedConfiguration conf = new InstancedConfiguration(Configuration.global());
     conf.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
     conf.set(PropertyKey.USER_FILE_PERSIST_ON_RENAME, true);
 
@@ -117,7 +117,7 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
 
   @Test
   public void persistOnRenameDirectoryBlacklist() throws Exception {
-    InstancedConfiguration conf = new InstancedConfiguration(ServerConfiguration.global());
+    InstancedConfiguration conf = new InstancedConfiguration(Configuration.global());
     conf.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
     conf.set(PropertyKey.USER_FILE_PERSIST_ON_RENAME, true);
     // MASTER_PERSISTENCE_BLACKLIST is set to "foobar_blacklist" for the server configuration
@@ -175,7 +175,7 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
    */
   @Test
   public void persistMultiFilesAndDirs() throws Exception {
-    ServerConfiguration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
+    Configuration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, "MUST_CACHE");
     String testDir = FileSystemShellUtilsTest.resetFileHierarchy(sFileSystem);
     assertFalse(sFileSystem.getStatus(new AlluxioURI(testDir)).isPersisted());
     assertFalse(sFileSystem.getStatus(new AlluxioURI(testDir + "/foo")).isPersisted());
@@ -222,7 +222,7 @@ public final class PersistCommandTest extends AbstractFileSystemShellTest {
   @Test
   public void persistWithAncestorPermission() throws Exception {
     String ufsRoot = sFileSystem.getStatus(new AlluxioURI("/")).getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.createForRoot(ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.createForRoot(Configuration.global());
     // Skip non-local and non-HDFS UFSs.
     Assume.assumeTrue(UnderFileSystemUtils.isLocal(ufs) || UnderFileSystemUtils.isHdfs(ufs));
 

--- a/tests/src/test/java/alluxio/client/cli/fs/command/PinCommandMultipleMediaIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/PinCommandMultipleMediaIntegrationTest.java
@@ -23,7 +23,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.WritePType;
 import alluxio.job.wire.Status;
@@ -108,7 +108,7 @@ public final class PinCommandMultipleMediaIntegrationTest extends BaseIntegratio
   @Test
   public void setPinToSpecificMedia() throws Exception {
     FileSystem fileSystem = sLocalAlluxioClusterResource.get().getClient();
-    FileSystemShell fsShell = new FileSystemShell(ServerConfiguration.global());
+    FileSystemShell fsShell = new FileSystemShell(Configuration.global());
 
     AlluxioURI filePathA = new AlluxioURI("/testFileA");
     AlluxioURI filePathB = new AlluxioURI("/testFileB");
@@ -147,7 +147,7 @@ public final class PinCommandMultipleMediaIntegrationTest extends BaseIntegratio
   @Test
   public void pinToMediumForceEviction() throws Exception {
     FileSystem fileSystem = sLocalAlluxioClusterResource.get().getClient();
-    FileSystemShell fsShell = new FileSystemShell(ServerConfiguration.global());
+    FileSystemShell fsShell = new FileSystemShell(Configuration.global());
 
     AlluxioURI filePathA = new AlluxioURI("/testFileA");
     AlluxioURI dirPath = new AlluxioURI("/testDirA");

--- a/tests/src/test/java/alluxio/client/cli/fs/command/SetFaclCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/SetFaclCommandIntegrationTest.java
@@ -18,7 +18,7 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.WritePType;
 import alluxio.security.user.TestUserState;
@@ -145,8 +145,8 @@ public final class SetFaclCommandIntegrationTest extends AbstractFileSystemShell
     FileSystem fs = sFileSystem;
     if (user != null) {
       fs = sLocalAlluxioCluster.getClient(FileSystemContext
-          .create(new TestUserState(user, ServerConfiguration.global()).getSubject(),
-              ServerConfiguration.global()));
+          .create(new TestUserState(user, Configuration.global()).getSubject(),
+              Configuration.global()));
     }
 
     FileSystemTestUtils.createByteFile(fs, "/testRoot/testFileA",

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/AbstractFsAdminShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/AbstractFsAdminShellTest.java
@@ -13,7 +13,7 @@ package alluxio.client.cli.fsadmin;
 
 import alluxio.cli.fsadmin.FileSystemAdminShell;
 import alluxio.client.cli.fs.AbstractShellIntegrationTest;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.LocalAlluxioCluster;
 
 import org.junit.After;
@@ -26,7 +26,7 @@ public class AbstractFsAdminShellTest extends AbstractShellIntegrationTest {
   @Before
   public final void before() throws Exception {
     mLocalAlluxioCluster = sLocalAlluxioClusterResource.get();
-    mFsAdminShell = new FileSystemAdminShell(ServerConfiguration.global());
+    mFsAdminShell = new FileSystemAdminShell(Configuration.global());
   }
 
   @After

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/BackupCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/BackupCommandIntegrationTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertEquals;
 import alluxio.AlluxioTestDirectory;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.PropertyKey.Name;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
 import org.junit.Test;
@@ -37,7 +37,7 @@ import java.nio.file.Paths;
 public final class BackupCommandIntegrationTest extends AbstractFsAdminShellTest {
   @Test
   public void defaultDirectory() throws IOException {
-    Path dir = Paths.get(ServerConfiguration.getString(PropertyKey.MASTER_BACKUP_DIRECTORY));
+    Path dir = Paths.get(Configuration.getString(PropertyKey.MASTER_BACKUP_DIRECTORY));
     Files.createDirectories(dir);
     assertEquals(0, Files.list(dir).count());
     int errCode = mFsAdminShell.run("backup");

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/BackupCommandStateLockingIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/BackupCommandStateLockingIntegrationTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.master.MasterContext;
@@ -54,7 +54,7 @@ public final class BackupCommandStateLockingIntegrationTest extends AbstractFsAd
     // Lock the state-change lock on the master before initiating the backup.
     try (LockResource lr = stateLockManager.lockExclusive(StateLockOptions.defaults())) {
       // Prepare for a backup.
-      Path dir = Paths.get(ServerConfiguration.getString(PropertyKey.MASTER_BACKUP_DIRECTORY));
+      Path dir = Paths.get(Configuration.getString(PropertyKey.MASTER_BACKUP_DIRECTORY));
       Files.createDirectories(dir);
       assertEquals(0, Files.list(dir).count());
       // Initiate backup. It should fail.
@@ -84,7 +84,7 @@ public final class BackupCommandStateLockingIntegrationTest extends AbstractFsAd
       mException.expect(AlluxioException.class);
       mLocalAlluxioCluster.getClient().getStatus(new AlluxioURI("/"));
       // Prepare for a backup.
-      Path dir = Paths.get(ServerConfiguration.getString(PropertyKey.MASTER_BACKUP_DIRECTORY));
+      Path dir = Paths.get(Configuration.getString(PropertyKey.MASTER_BACKUP_DIRECTORY));
       Files.createDirectories(dir);
       assertEquals(0, Files.list(dir).count());
       // Take the backup. It should be allowed.

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/QuorumCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/QuorumCommandIntegrationTest.java
@@ -21,7 +21,7 @@ import alluxio.cli.fsadmin.journal.QuorumElectCommand;
 import alluxio.cli.fsadmin.journal.QuorumInfoCommand;
 import alluxio.cli.fsadmin.journal.QuorumRemoveCommand;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.grpc.JournalDomain;
 import alluxio.grpc.QuorumServerInfo;
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
 public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
   @Rule
   public ConfigurationRule mConf = new ConfigurationRule(
-      PropertyKey.USER_METRICS_COLLECTION_ENABLED, false, ServerConfiguration.global());
+      PropertyKey.USER_METRICS_COLLECTION_ENABLED, false, Configuration.modifiableGlobal());
 
   public MultiProcessCluster mCluster;
 
@@ -87,7 +87,7 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
 
     String output;
 
-    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(Configuration.global())) {
       // Validate quorum state is dumped as expected.
       mOutput.reset();
       shell.run("journal", "quorum", "info", "-domain", "MASTER");
@@ -97,7 +97,7 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
       Assert.assertTrue(
           output.contains(String.format(QuorumInfoCommand.OUTPUT_HEADER_QUORUM_SIZE, 3)));
       List<String> journalAddresses =
-          ServerConfiguration.getList(PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES);
+          Configuration.getList(PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES);
       for (String address : journalAddresses) {
         String format = String.format(QuorumInfoCommand.OUTPUT_SERVER_INFO,
                 QuorumServerState.AVAILABLE.name(), "0", address).trim();
@@ -112,7 +112,7 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
         mOutput.reset();
         shell.run("journal", "quorum", "info", "-domain", "MASTER");
         return mOutput.toString().trim().contains(QuorumServerState.UNAVAILABLE.name());
-      }, WaitForOptions.defaults().setTimeoutMs(2 * (int) ServerConfiguration.getMs(
+      }, WaitForOptions.defaults().setTimeoutMs(2 * (int) Configuration.getMs(
           PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT)));
     }
     mCluster.notifySuccess();
@@ -131,7 +131,7 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
 
     String output;
 
-    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(Configuration.global())) {
       AlluxioURI testDir = new AlluxioURI("/testDir");
       mCluster.getFileSystemClient().createDirectory(testDir);
       // Verify cluster is reachable.
@@ -153,7 +153,7 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
         } catch (Exception e) {
           return false;
         }
-      }, WaitForOptions.defaults().setTimeoutMs(6 * (int) ServerConfiguration.getMs(
+      }, WaitForOptions.defaults().setTimeoutMs(6 * (int) Configuration.getMs(
           PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT)));
 
       // Remove unavailable masters using shell.
@@ -197,7 +197,7 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
             .build();
     mCluster.start();
 
-    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(Configuration.global())) {
       int newLeaderIdx = (mCluster.getPrimaryMasterIndex(MASTER_INDEX_WAIT_TIME) + 1) % numMasters;
       // `getPrimaryMasterIndex` uses the same `mMasterAddresses` variable as getMasterAddresses
       // we can therefore access to the new leader's address this ways
@@ -232,7 +232,7 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
         .build();
     mCluster.start();
 
-    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(Configuration.global())) {
       int newLeaderIdx = (mCluster.getPrimaryMasterIndex(MASTER_INDEX_WAIT_TIME) + 1) % numMasters;
       // `getPrimaryMasterIndex` uses the same `mMasterAddresses` variable as getMasterAddresses
       // we can therefore access to the new leader's address this ways
@@ -264,7 +264,7 @@ public final class QuorumCommandIntegrationTest extends BaseIntegrationTest {
         .addProperty(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, "750ms")
         .addProperty(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, "1500ms").build();
     mCluster.start();
-    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(Configuration.global())) {
       String output;
 
       // Validate quorum sub-commands are validated.

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/ReportEmbeddedJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/ReportEmbeddedJournalIntegrationTest.java
@@ -14,7 +14,7 @@ package alluxio.client.cli.fsadmin.command;
 import alluxio.ProjectConstants;
 import alluxio.client.cli.fsadmin.AbstractFsAdminShellTest;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.util.network.NetworkAddressUtils;
 
@@ -39,13 +39,13 @@ public class ReportEmbeddedJournalIntegrationTest  extends AbstractFsAdminShellT
     // Check if meta master values are available
     String expectedMasterAddress = NetworkAddressUtils
         .getConnectAddress(NetworkAddressUtils.ServiceType.MASTER_RPC,
-            ServerConfiguration.global()).toString();
+            Configuration.global()).toString();
     Assert.assertThat(output, CoreMatchers.containsString(
         "Master Address: " + expectedMasterAddress));
     Assert.assertThat(output, CoreMatchers.containsString(
-        "Web Port: " + ServerConfiguration.get(PropertyKey.MASTER_WEB_PORT)));
+        "Web Port: " + Configuration.get(PropertyKey.MASTER_WEB_PORT)));
     Assert.assertThat(output, CoreMatchers.containsString(
-        "Rpc Port: " + ServerConfiguration.get(PropertyKey.MASTER_RPC_PORT)));
+        "Rpc Port: " + Configuration.get(PropertyKey.MASTER_RPC_PORT)));
     Assert.assertFalse(output.contains("Started: 12-31-1969 16:00:00:000"));
     Assert.assertThat(output, CoreMatchers.containsString(
         "Version: " + ProjectConstants.VERSION));

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/AddCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/AddCommandIntegrationTest.java
@@ -23,7 +23,7 @@ import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.master.file.meta.PersistenceState;
@@ -52,7 +52,7 @@ public class AddCommandIntegrationTest extends AbstractShellIntegrationTest {
 
   @Test
   public void add() throws Exception {
-    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(Configuration.global())) {
       int ret = shell.run("pathConf", "list");
       Assert.assertEquals(0, ret);
       String output = mOutput.toString();
@@ -112,7 +112,7 @@ public class AddCommandIntegrationTest extends AbstractShellIntegrationTest {
 
   @Test
   public void invalidPropertyKey() throws Exception {
-    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(Configuration.global())) {
       int ret = shell.run("pathConf", "add", "--property", "unknown=value", "/");
       Assert.assertEquals(-1, ret);
       String output = mOutput.toString();
@@ -124,7 +124,7 @@ public class AddCommandIntegrationTest extends AbstractShellIntegrationTest {
   public void immediatelyEffectiveForShellCommands() throws Exception {
     // Tests that after adding some path configuration, it's immediately effective for command
     // line calls afterwards.
-    InstancedConfiguration conf = ServerConfiguration.global();
+    InstancedConfiguration conf = Configuration.modifiableGlobal();
     try (FileSystemShell fsShell = new FileSystemShell(conf);
          FileSystemAdminShell fsAdminShell = new FileSystemAdminShell(conf)) {
       Assert.assertEquals(0,
@@ -157,7 +157,7 @@ public class AddCommandIntegrationTest extends AbstractShellIntegrationTest {
 
   @Test
   public void addNoProperty() throws Exception {
-    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(Configuration.global())) {
       int ret = shell.run("pathConf", "add", "/");
       Assert.assertEquals(0, ret);
     }
@@ -165,7 +165,7 @@ public class AddCommandIntegrationTest extends AbstractShellIntegrationTest {
 
   @Test
   public void overwriteProperty() throws Exception {
-    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(Configuration.global())) {
       int ret = shell.run("pathConf", "add", "--property", READ_TYPE_NO_CACHE, "/");
       Assert.assertEquals(0, ret);
 
@@ -186,7 +186,7 @@ public class AddCommandIntegrationTest extends AbstractShellIntegrationTest {
 
   @Test
   public void nonClientScopeKey() throws Exception {
-    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(Configuration.global())) {
       PropertyKey key = PropertyKey.NETWORK_CONNECTION_SERVER_SHUTDOWN_TIMEOUT;
       int ret = shell.run("pathConf", "add", "--property",
           format(key, "10ms"), "/");

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ListCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ListCommandIntegrationTest.java
@@ -21,7 +21,7 @@ import alluxio.client.meta.MetaMasterConfigClient;
 import alluxio.client.meta.RetryHandlingMetaMasterConfigClient;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.MasterClientContext;
 
 import org.junit.Assert;
@@ -47,21 +47,21 @@ public class ListCommandIntegrationTest extends AbstractShellIntegrationTest {
    * @return the configuration after updating from meta master
    */
   private InstancedConfiguration setPathConfigurations() throws Exception {
-    FileSystemContext metaCtx = FileSystemContext.create(ServerConfiguration.global());
+    FileSystemContext metaCtx = FileSystemContext.create(Configuration.global());
     MetaMasterConfigClient client = new RetryHandlingMetaMasterConfigClient(
         MasterClientContext.newBuilder(metaCtx.getClientContext()).build());
     client.setPathConfiguration(new AlluxioURI(DIR1), PROPERTY_KEY1, PROPERTY_VALUE1);
     client.setPathConfiguration(new AlluxioURI(DIR2), PROPERTY_KEY2, PROPERTY_VALUE2);
     InetSocketAddress address = sLocalAlluxioClusterResource.get().getLocalAlluxioMaster()
         .getAddress();
-    FileSystemContext fsCtx = FileSystemContext.create(ServerConfiguration.global());
+    FileSystemContext fsCtx = FileSystemContext.create(Configuration.global());
     fsCtx.getClientContext().loadConf(address, true, true);
     return (InstancedConfiguration) fsCtx.getClusterConf();
   }
 
   @Test
   public void listEmpty() throws Exception {
-    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(Configuration.global())) {
       int ret = shell.run("pathConf", "list");
       Assert.assertEquals(0, ret);
       String output = mOutput.toString();

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/RemoveCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/RemoveCommandIntegrationTest.java
@@ -16,7 +16,7 @@ import alluxio.client.ReadType;
 import alluxio.client.WriteType;
 import alluxio.client.cli.fs.AbstractShellIntegrationTest;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -42,7 +42,7 @@ public class RemoveCommandIntegrationTest extends AbstractShellIntegrationTest {
 
   @Test
   public void remove() throws Exception {
-    try (FileSystemAdminShell shell = new FileSystemAdminShell(ServerConfiguration.global())) {
+    try (FileSystemAdminShell shell = new FileSystemAdminShell(Configuration.global())) {
       int ret = shell.run("pathConf", "list");
       Assert.assertEquals(0, ret);
       String output = mOutput.toString();

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ShowCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/pathconf/ShowCommandIntegrationTest.java
@@ -21,7 +21,7 @@ import alluxio.client.meta.MetaMasterConfigClient;
 import alluxio.client.meta.RetryHandlingMetaMasterConfigClient;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.MasterClientContext;
 
 import org.junit.Assert;
@@ -51,7 +51,7 @@ public class ShowCommandIntegrationTest extends AbstractShellIntegrationTest {
    * @return the configuration after updating from meta master
    */
   private InstancedConfiguration setPathConfigurations() throws Exception {
-    FileSystemContext metaCtx = FileSystemContext.create(ServerConfiguration.global());
+    FileSystemContext metaCtx = FileSystemContext.create(Configuration.global());
     MetaMasterConfigClient client = new RetryHandlingMetaMasterConfigClient(
         MasterClientContext.newBuilder(metaCtx.getClientContext()).build());
     client.setPathConfiguration(new AlluxioURI(DIR1), PROPERTY_KEY11, PROPERTY_VALUE11);
@@ -59,7 +59,7 @@ public class ShowCommandIntegrationTest extends AbstractShellIntegrationTest {
     client.setPathConfiguration(new AlluxioURI(DIR2), PROPERTY_KEY2, PROPERTY_VALUE2);
     InetSocketAddress address = sLocalAlluxioClusterResource.get().getLocalAlluxioMaster()
         .getAddress();
-    FileSystemContext fsCtx = FileSystemContext.create(ServerConfiguration.global());
+    FileSystemContext fsCtx = FileSystemContext.create(Configuration.global());
     fsCtx.getClientContext().loadConf(address, true, true);
     return (InstancedConfiguration) fsCtx.getClusterConf();
   }

--- a/tests/src/test/java/alluxio/client/cli/job/GetCmdStatusCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/GetCmdStatusCommandTest.java
@@ -17,7 +17,7 @@ import alluxio.client.cli.fs.AbstractFileSystemShellTest;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.WritePType;
 import alluxio.master.LocalAlluxioJobCluster;
@@ -60,8 +60,8 @@ public class GetCmdStatusCommandTest extends AbstractFileSystemShellTest  {
     sLocalAlluxioJobCluster.start();
     sFileSystem = sLocalAlluxioCluster.getClient();
     sJobMaster = sLocalAlluxioJobCluster.getMaster().getJobMaster();
-    sJobShell = new alluxio.cli.job.JobShell(ServerConfiguration.global());
-    sFsShell = new FileSystemShell(ServerConfiguration.global());
+    sJobShell = new alluxio.cli.job.JobShell(Configuration.global());
+    sFsShell = new FileSystemShell(Configuration.global());
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/fs/BlockMasterRegisterStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/BlockMasterRegisterStreamIntegrationTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertThrows;
 
 import alluxio.clock.ManualClock;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.BlockInfoException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.Command;
@@ -100,7 +100,7 @@ public class BlockMasterRegisterStreamIntegrationTest {
 
   private static final int MASTER_WORKER_TIMEOUT = 1_000_000;
   private static final long BLOCK_SIZE =
-      ServerConfiguration.global().getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);
+      Configuration.global().getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);
   private static final Map<String, StorageList> NO_LOST_STORAGE = ImmutableMap.of();
   private static final Command EMPTY_CMD =
       Command.newBuilder().setCommandType(CommandType.Nothing).build();
@@ -111,11 +111,11 @@ public class BlockMasterRegisterStreamIntegrationTest {
   @Before
   public void before() throws Exception {
     // Set the config properties
-    ServerConfiguration.set(PropertyKey.WORKER_REGISTER_STREAM_ENABLED, true);
-    ServerConfiguration.set(PropertyKey.WORKER_REGISTER_STREAM_BATCH_SIZE, BATCH_SIZE);
-    ServerConfiguration.set(PropertyKey.MASTER_WORKER_TIMEOUT_MS, MASTER_WORKER_TIMEOUT);
-    ServerConfiguration.set(PropertyKey.MASTER_WORKER_REGISTER_STREAM_RESPONSE_TIMEOUT, "1s");
-    ServerConfiguration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_ENABLED, false);
+    Configuration.set(PropertyKey.WORKER_REGISTER_STREAM_ENABLED, true);
+    Configuration.set(PropertyKey.WORKER_REGISTER_STREAM_BATCH_SIZE, BATCH_SIZE);
+    Configuration.set(PropertyKey.MASTER_WORKER_TIMEOUT_MS, MASTER_WORKER_TIMEOUT);
+    Configuration.set(PropertyKey.MASTER_WORKER_REGISTER_STREAM_RESPONSE_TIMEOUT, "1s");
+    Configuration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_ENABLED, false);
 
     mRegistry = new MasterRegistry();
     mMasterContext = MasterTestUtils.testMasterContext();

--- a/tests/src/test/java/alluxio/client/fs/BlockWorkerClientCloseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/BlockWorkerClientCloseIntegrationTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertTrue;
 import alluxio.TestLoggerRule;
 import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.client.file.FileSystemContext;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.resource.CloseableResource;
 import alluxio.security.user.TestUserState;
 import alluxio.testutils.BaseIntegrationTest;
@@ -48,8 +48,8 @@ public final class BlockWorkerClientCloseIntegrationTest extends BaseIntegration
   public void before() throws Exception {
     mWorkerNetAddress = mClusterResource.get().getWorkerAddress();
     mFsContext = FileSystemContext
-        .create(new TestUserState("test", ServerConfiguration.global()).getSubject(),
-            ServerConfiguration.global());
+        .create(new TestUserState("test", Configuration.global()).getSubject(),
+            Configuration.global());
   }
 
   @After

--- a/tests/src/test/java/alluxio/client/fs/BlockWorkerRegisterStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/BlockWorkerRegisterStreamIntegrationTest.java
@@ -41,7 +41,7 @@ import alluxio.ConfigurationRule;
 import alluxio.Constants;
 import alluxio.Sessions;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.DeadlineExceededException;
 import alluxio.exception.status.InternalException;
 import alluxio.exception.status.NotFoundException;
@@ -140,7 +140,7 @@ public class BlockWorkerRegisterStreamIntegrationTest {
           .put(PropertyKey.WORKER_RPC_PORT, 0)
           .put(PropertyKey.WORKER_MANAGEMENT_TIER_ALIGN_RESERVED_BYTES, "0")
           .put(PropertyKey.MASTER_WORKER_REGISTER_LEASE_ENABLED, false)
-          .build(), ServerConfiguration.global());
+          .build(), Configuration.modifiableGlobal());
 
   private ExecutorService mExecutorService;
 
@@ -150,10 +150,10 @@ public class BlockWorkerRegisterStreamIntegrationTest {
   @Before
   public void before() throws Exception {
     // Set the config properties
-    ServerConfiguration.set(PropertyKey.WORKER_REGISTER_STREAM_ENABLED, true);
-    ServerConfiguration.set(PropertyKey.WORKER_REGISTER_STREAM_BATCH_SIZE, BATCH_SIZE);
-    ServerConfiguration.set(PropertyKey.WORKER_REGISTER_STREAM_RESPONSE_TIMEOUT, "1s");
-    ServerConfiguration.set(PropertyKey.WORKER_REGISTER_STREAM_COMPLETE_TIMEOUT, "3s");
+    Configuration.set(PropertyKey.WORKER_REGISTER_STREAM_ENABLED, true);
+    Configuration.set(PropertyKey.WORKER_REGISTER_STREAM_BATCH_SIZE, BATCH_SIZE);
+    Configuration.set(PropertyKey.WORKER_REGISTER_STREAM_RESPONSE_TIMEOUT, "1s");
+    Configuration.set(PropertyKey.WORKER_REGISTER_STREAM_COMPLETE_TIMEOUT, "3s");
 
     // Prepare test data
     mTierAliases = getTierAliases(parseTierConfig(TIER_CONFIG));
@@ -428,7 +428,7 @@ public class BlockWorkerRegisterStreamIntegrationTest {
 
     // Prepare the block worker to use the overriden stream
     MasterClientContext context = MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build();
+            .newBuilder(ClientContext.create(Configuration.global())).build();
     // On heartbeat, the expected values will be checked against
     List<Long> expectedLostBlocks = ImmutableList.of(blockToRemove);
     Map<BlockStoreLocation, List<Long>> expectedAddedBlocks = ImmutableMap.of();

--- a/tests/src/test/java/alluxio/client/fs/CheckConsistencyIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/CheckConsistencyIntegrationTest.java
@@ -15,7 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.AuthenticatedUserRule;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
@@ -53,7 +53,7 @@ public class CheckConsistencyIntegrationTest extends BaseIntegrationTest {
 
   @Rule
   public AuthenticatedUserRule mAuthenticatedUser = new AuthenticatedUserRule(TEST_USER,
-      ServerConfiguration.global());
+      Configuration.global());
 
   private FileSystemMaster mFileSystemMaster;
   private FileSystem mFileSystem;
@@ -63,7 +63,7 @@ public class CheckConsistencyIntegrationTest extends BaseIntegrationTest {
     mFileSystemMaster =
         mLocalAlluxioClusterResource.get().getLocalAlluxioMaster().getMasterProcess()
             .getMaster(FileSystemMaster.class);
-    mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
+    mFileSystem = FileSystem.Factory.create(Configuration.global());
     CreateDirectoryPOptions dirOptions =
         CreateDirectoryPOptions.newBuilder().setWriteType(WritePType.CACHE_THROUGH).build();
     CreateFilePOptions fileOptions =
@@ -90,7 +90,7 @@ public class CheckConsistencyIntegrationTest extends BaseIntegrationTest {
   public void inconsistent() throws Exception {
     String ufsDirectory = mFileSystem.getStatus(DIRECTORY).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsDirectory,
-        ServerConfiguration.global());
+        Configuration.global());
     ufs.deleteDirectory(ufsDirectory, DeleteOptions.defaults().setRecursive(true));
 
     List<AlluxioURI> expected = Lists.newArrayList(FILE, DIRECTORY);
@@ -108,7 +108,7 @@ public class CheckConsistencyIntegrationTest extends BaseIntegrationTest {
   @Test
   public void partiallyInconsistent() throws Exception {
     String ufsFile = mFileSystem.getStatus(FILE).getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsFile, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsFile, Configuration.global());
     ufs.deleteFile(ufsFile);
     List<AlluxioURI> expected = Lists.newArrayList(FILE);
     Assert.assertEquals(expected, mFileSystemMaster.checkConsistency(new AlluxioURI("/"),
@@ -133,7 +133,7 @@ public class CheckConsistencyIntegrationTest extends BaseIntegrationTest {
     mFileSystem.createFile(thirdLevelFile, fileOptions).close();
     String ufsDirectory = mFileSystem.getStatus(nestedDir).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsDirectory,
-        ServerConfiguration.global());
+        Configuration.global());
     ufs.deleteDirectory(ufsDirectory, DeleteOptions.defaults().setRecursive(true));
 
     List<AlluxioURI> expected = Lists.newArrayList(nestedDir, thirdLevelFile);
@@ -151,7 +151,7 @@ public class CheckConsistencyIntegrationTest extends BaseIntegrationTest {
   @Test
   public void incorrectFileSize() throws Exception {
     String ufsFile = mFileSystem.getStatus(FILE).getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsFile, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsFile, Configuration.global());
     ufs.deleteFile(ufsFile);
     OutputStream out = ufs.create(ufsFile);
     out.write(1);
@@ -169,7 +169,7 @@ public class CheckConsistencyIntegrationTest extends BaseIntegrationTest {
   public void notADirectory() throws Exception {
     String ufsDirectory = mFileSystem.getStatus(DIRECTORY).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsDirectory,
-        ServerConfiguration.global());
+        Configuration.global());
     ufs.deleteDirectory(ufsDirectory, DeleteOptions.defaults().setRecursive(true));
     ufs.create(ufsDirectory).close();
     List<AlluxioURI> expected = Lists.newArrayList(DIRECTORY, FILE);
@@ -184,7 +184,7 @@ public class CheckConsistencyIntegrationTest extends BaseIntegrationTest {
   public void existsInUfsButNotAlluxio() throws Exception {
     String ufsDirectory = mFileSystem.getStatus(DIRECTORY).getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsDirectory,
-        ServerConfiguration.global());
+        Configuration.global());
     String filename = "ufs_exists";
     String newPath = ufsDirectory + AlluxioURI.SEPARATOR + filename;
     ufs.mkdirs(newPath);
@@ -200,7 +200,7 @@ public class CheckConsistencyIntegrationTest extends BaseIntegrationTest {
   @Test
   public void notAFile() throws Exception {
     String ufsFile = mFileSystem.getStatus(FILE).getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsFile, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsFile, Configuration.global());
     ufs.deleteFile(ufsFile);
     ufs.mkdirs(ufsFile);
     List<AlluxioURI> expected = Lists.newArrayList(FILE);
@@ -215,7 +215,7 @@ public class CheckConsistencyIntegrationTest extends BaseIntegrationTest {
   @Test
   public void inconsistentFile() throws Exception {
     String ufsFile = mFileSystem.getStatus(FILE).getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsFile, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsFile, Configuration.global());
     ufs.deleteFile(ufsFile);
     List<AlluxioURI> expected = Lists.newArrayList(FILE);
     Assert.assertEquals(expected, mFileSystemMaster.checkConsistency(FILE,

--- a/tests/src/test/java/alluxio/client/fs/FileSystemContextReinitIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemContextReinitIntegrationTest.java
@@ -22,7 +22,7 @@ import alluxio.client.file.FileSystemContextReinitializer;
 import alluxio.client.meta.MetaMasterConfigClient;
 import alluxio.client.meta.RetryHandlingMetaMasterConfigClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.master.MasterClientContext;
 import alluxio.resource.CloseableResource;
@@ -59,7 +59,7 @@ public final class FileSystemContextReinitIntegrationTest extends BaseIntegratio
 
   @Before
   public void before() throws Exception {
-    mContext = FileSystemContext.create(ServerConfiguration.global());
+    mContext = FileSystemContext.create(Configuration.global());
     mContext.getClientContext().loadConf(mContext.getMasterAddress(), true, true);
     updateHash();
 
@@ -116,7 +116,7 @@ public final class FileSystemContextReinitIntegrationTest extends BaseIntegratio
 
   @Test
   public void blockWorkerClientReinit() throws Exception {
-    FileSystemContext fsContext = FileSystemContext.create(ServerConfiguration.global());
+    FileSystemContext fsContext = FileSystemContext.create(Configuration.global());
     try (CloseableResource<BlockWorkerClient> client =
         fsContext.acquireBlockWorkerClient(mLocalAlluxioClusterResource.get().getWorkerAddress())) {
       fsContext.reinit(true, true);
@@ -169,7 +169,7 @@ public final class FileSystemContextReinitIntegrationTest extends BaseIntegratio
 
   private void updateClusterConf() throws Exception {
     mLocalAlluxioClusterResource.get().stopMasters();
-    ServerConfiguration.set(KEY_TO_UPDATE, UPDATED_VALUE);
+    Configuration.set(KEY_TO_UPDATE, UPDATED_VALUE);
     mLocalAlluxioClusterResource.get().startMasters();
   }
 

--- a/tests/src/test/java/alluxio/client/fs/FileSystemIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemIntegrationTest.java
@@ -22,7 +22,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.DirectoryNotEmptyException;
 import alluxio.exception.FileAlreadyExistsException;
@@ -77,7 +77,7 @@ public final class FileSystemIntegrationTest extends BaseIntegrationTest {
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
     mWriteBoth = CreateFilePOptions.newBuilder().setRecursive(true)
         .setWriteType(WritePType.CACHE_THROUGH).build();
-    mUfs = UnderFileSystem.Factory.createForRoot(ServerConfiguration.global());
+    mUfs = UnderFileSystem.Factory.createForRoot(Configuration.global());
   }
 
   @Test
@@ -189,7 +189,7 @@ public final class FileSystemIntegrationTest extends BaseIntegrationTest {
    */
   private String createAlternateUfs() throws Exception {
     AlluxioURI parentURI =
-        new AlluxioURI(ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS))
+        new AlluxioURI(Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS))
             .getParent();
     String alternateUfsRoot = parentURI.join("alternateUnderFSStorage").toString();
     UnderFileSystemUtils.mkdirIfNotExists(mUfs, alternateUfsRoot);
@@ -243,7 +243,7 @@ public final class FileSystemIntegrationTest extends BaseIntegrationTest {
   @Test
   public void mountPrefixUfs() throws Exception {
     // Primary UFS cannot be re-mounted
-    String ufsRoot = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufsRoot = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     String ufsSubdir = PathUtils.concatPath(ufsRoot, "dir1");
     UnderFileSystemUtils.mkdirIfNotExists(mUfs, ufsSubdir);
     try {
@@ -280,7 +280,7 @@ public final class FileSystemIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void mountShadowUfs() throws Exception {
-    String ufsRoot = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufsRoot = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     String ufsSubdir = PathUtils.concatPath(ufsRoot, "dir1");
     UnderFileSystemUtils.mkdirIfNotExists(mUfs, ufsSubdir);
 
@@ -336,7 +336,7 @@ public final class FileSystemIntegrationTest extends BaseIntegrationTest {
   public void testMultiSetAttribute() throws Exception {
     AlluxioURI testFile = new AlluxioURI("/test1");
     FileSystemTestUtils.createByteFile(mFileSystem, testFile, WritePType.MUST_CACHE, 512);
-    long expectedTtl = ServerConfiguration.getMs(PropertyKey.USER_FILE_CREATE_TTL);
+    long expectedTtl = Configuration.getMs(PropertyKey.USER_FILE_CREATE_TTL);
     URIStatus stat = mFileSystem.getStatus(testFile);
     assertEquals("TTL should be equal to configuration", expectedTtl, stat.getTtl());
 
@@ -376,7 +376,7 @@ public final class FileSystemIntegrationTest extends BaseIntegrationTest {
     AlluxioURI testFile = new AlluxioURI("/test1");
     FileSystemTestUtils.createByteFile(mFileSystem, testFile, WritePType.MUST_CACHE, 512);
     TtlAction expectedAction =
-        ServerConfiguration.getEnum(PropertyKey.USER_FILE_CREATE_TTL_ACTION, TtlAction.class);
+        Configuration.getEnum(PropertyKey.USER_FILE_CREATE_TTL_ACTION, TtlAction.class);
     URIStatus stat = mFileSystem.getStatus(testFile);
     assertEquals("TTL action should be same", expectedAction, stat.getTtlAction());
 

--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterClientIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterClientIntegrationTest.java
@@ -16,7 +16,7 @@ import alluxio.ClientContext;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemMasterClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.GetStatusPOptions;
@@ -37,7 +37,7 @@ import java.io.IOException;
  */
 public final class FileSystemMasterClientIntegrationTest extends BaseIntegrationTest {
   private static final GetStatusPOptions GET_STATUS_OPTIONS =
-      FileSystemOptions.getStatusDefaults(ServerConfiguration.global());
+      FileSystemOptions.getStatusDefaults(Configuration.global());
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
@@ -47,13 +47,13 @@ public final class FileSystemMasterClientIntegrationTest extends BaseIntegration
   public void openClose() throws AlluxioException, IOException {
     FileSystemMasterClient fsMasterClient =
         FileSystemMasterClient.Factory.create(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+            .newBuilder(ClientContext.create(Configuration.global())).build());
     AlluxioURI file = new AlluxioURI("/file");
     Assert.assertFalse(fsMasterClient.isConnected());
     fsMasterClient.connect();
     Assert.assertTrue(fsMasterClient.isConnected());
     fsMasterClient.createFile(file,
-        FileSystemOptions.createFileDefaults(ServerConfiguration.global()));
+        FileSystemOptions.createFileDefaults(Configuration.global()));
     Assert.assertNotNull(fsMasterClient.getStatus(file, GET_STATUS_OPTIONS));
     fsMasterClient.disconnect();
     Assert.assertFalse(fsMasterClient.isConnected());
@@ -70,7 +70,7 @@ public final class FileSystemMasterClientIntegrationTest extends BaseIntegration
     // in the cases we don't want to disconnect from master
     FileSystemMasterClient fsMasterClient =
         FileSystemMasterClient.Factory.create(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+            .newBuilder(ClientContext.create(Configuration.global())).build());
     fsMasterClient.getStatus(new AlluxioURI("/doesNotExist"), GET_STATUS_OPTIONS);
     fsMasterClient.close();
   }

--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
@@ -23,7 +23,7 @@ import alluxio.client.block.BlockMasterClient;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.DirectoryNotEmptyException;
 import alluxio.exception.ExceptionMessage;
@@ -143,7 +143,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
 
   @Rule
   public AuthenticatedUserRule mAuthenticatedUser = new AuthenticatedUserRule(TEST_USER,
-      ServerConfiguration.global());
+      Configuration.global());
 
   private FileSystemMaster mFsMaster;
 
@@ -345,7 +345,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
         CreateDirectoryContext.defaults().setWriteType(WriteType.CACHE_THROUGH));
     mFsMaster.createDirectory(new AlluxioURI("/testFolder/child"),
         CreateDirectoryContext.defaults().setWriteType(WriteType.CACHE_THROUGH));
-    String ufs = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufs = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     Files.createDirectory(Paths.get(ufs, "testFolder", "ufsOnlyDir"));
     try {
       mFsMaster.delete(new AlluxioURI("/testFolder"), DeleteContext
@@ -475,7 +475,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     // Make sure that the blocks are cleaned up
     BlockMasterClient blockClient =
         BlockMasterClient.Factory.create(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+            .newBuilder(ClientContext.create(Configuration.global())).build());
     CommonUtils.waitFor("data to be deleted", () -> {
       try {
         return blockClient.getUsedBytes() == 0;
@@ -858,7 +858,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     mFsMaster.setAttribute(root, SetAttributeContext
         .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0777).toProto())));
     try (AutoCloseable closeable =
-             new AuthenticatedUserRule("foo", ServerConfiguration.global()).toResource()) {
+             new AuthenticatedUserRule("foo", Configuration.global()).toResource()) {
       AlluxioURI alluxioFile = new AlluxioURI("/in_alluxio");
       FileInfo file = mFsMaster.createFile(alluxioFile, CreateFileContext.defaults());
 
@@ -882,7 +882,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
         .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0777).toProto())));
     AlluxioURI alluxioFile = new AlluxioURI("/in_alluxio");
     try (AutoCloseable closeable =
-             new AuthenticatedUserRule("foo", ServerConfiguration.global()).toResource()) {
+             new AuthenticatedUserRule("foo", Configuration.global()).toResource()) {
       FileInfo file = mFsMaster.createFile(alluxioFile, CreateFileContext.defaults());
 
       long opTimeMs = TEST_TIME_MS;
@@ -895,7 +895,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     }
     mThrown.expect(AccessControlException.class);
     try (AutoCloseable closeable =
-             new AuthenticatedUserRule("bar", ServerConfiguration.global()).toResource()) {
+             new AuthenticatedUserRule("bar", Configuration.global()).toResource()) {
       mFsMaster.setAttribute(alluxioFile, SetAttributeContext
           .mergeFrom(SetAttributePOptions.newBuilder().setMode(new Mode((short) 0677).toProto())));
     }
@@ -906,7 +906,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
    */
   @Test
   public void createDirectoryInNestedDirectories() throws Exception {
-    String ufs = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufs = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     String targetPath = Paths.get(ufs, "d1", "d2", "d3").toString();
     FileUtils.createDir(targetPath);
     FileUtils.changeLocalFilePermission(targetPath, new Mode((short) 0755).toString());
@@ -931,7 +931,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
    */
   @Test
   public void loadMetadataInNestedDirectories() throws Exception {
-    String ufs = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufs = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     String targetPath = Paths.get(ufs, "d1", "d2", "d3").toString();
     FileUtils.createDir(targetPath);
     FileUtils.changeLocalFilePermission(targetPath, new Mode((short) 0755).toString());
@@ -955,7 +955,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
    */
   @Test
   public void createNestedDirectories() throws Exception {
-    String ufs = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufs = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     String parentPath = Paths.get(ufs, "d1").toString();
     FileUtils.createDir(parentPath);
     FileUtils.changeLocalFilePermission(parentPath, new Mode((short) 0755).toString());
@@ -982,7 +982,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
     // Assume the user is not root. This test doesn't work as root because root *is* allowed to
     // create subdirectories even without execute permission on the parent directory.
     assumeFalse(ShellUtils.execCommand("id", "-u").trim().equals("0"));
-    String ufs = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufs = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     String parentPath = Paths.get(ufs, "d1").toString();
     FileUtils.createDir(parentPath);
     FileUtils.changeLocalFilePermission(parentPath, new Mode((short) 0600).toString());
@@ -1000,7 +1000,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
   @Test
   public void loadDirectoryTimestamps() throws Exception {
     String name = "d1";
-    String ufs = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufs = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     String ufsPath = Paths.get(ufs, name).toString();
     FileUtils.createDir(ufsPath);
     File file = new File(ufsPath);
@@ -1024,7 +1024,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
   @Test
   public void loadFileTimestamps() throws Exception {
     String name = "f1";
-    String ufs = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufs = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     String ufsPath = Paths.get(ufs, name).toString();
     FileUtils.createFile(ufsPath);
     File file = new File(ufsPath);
@@ -1049,7 +1049,7 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
   public void loadParentDirectoryTimestamps() throws Exception {
     String parentName = "d1";
     String childName = "d2";
-    String ufs = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufs = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     String parentUfsPath = Paths.get(ufs, parentName).toString();
     FileUtils.createDir(parentUfsPath);
     File file = new File(parentUfsPath);

--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterRestartIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterRestartIntegrationTest.java
@@ -15,7 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.AuthenticatedUserRule;
 import alluxio.client.WriteType;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AccessControlException;
 import alluxio.grpc.CompleteFilePOptions;
 import alluxio.grpc.CreateDirectoryPOptions;
@@ -101,7 +101,7 @@ public class FileSystemMasterRestartIntegrationTest extends BaseIntegrationTest 
 
   @Rule
   public AuthenticatedUserRule mAuthenticatedUser = new AuthenticatedUserRule(TEST_USER,
-      ServerConfiguration.global());
+      Configuration.global());
 
   private FileSystemMaster mFsMaster;
 
@@ -140,7 +140,7 @@ public class FileSystemMasterRestartIntegrationTest extends BaseIntegrationTest 
     Assert.assertEquals(alluxioFile.getName(), files.get(0).getName());
 
     // Add ufs only paths
-    String ufs = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufs = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     Files.createDirectory(Paths.get(ufs, "ufs_dir"));
     Files.createFile(Paths.get(ufs, "ufs_file"));
 
@@ -177,7 +177,7 @@ public class FileSystemMasterRestartIntegrationTest extends BaseIntegrationTest 
     AlluxioURI dir = new AlluxioURI("/dir/");
 
     // Add ufs nested file.
-    String ufs = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufs = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     Files.createDirectory(Paths.get(ufs, "dir"));
     Files.createFile(Paths.get(ufs, "dir", "file"));
 

--- a/tests/src/test/java/alluxio/client/fs/FileSystemReadonlyIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemReadonlyIntegrationTest.java
@@ -17,7 +17,7 @@ import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AccessControlException;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.testutils.LocalAlluxioClusterResource;
@@ -47,7 +47,7 @@ public class FileSystemReadonlyIntegrationTest {
 
   @Before
   public void before() throws Exception {
-    FileSystemContext fsCtx = FileSystemContext.create(ServerConfiguration.global());
+    FileSystemContext fsCtx = FileSystemContext.create(Configuration.global());
     fsCtx.getClientContext().loadConf(fsCtx.getMasterAddress(), true, true);
     mFileSystem = sLocalAlluxioClusterResource.get().getClient(fsCtx);
   }

--- a/tests/src/test/java/alluxio/client/fs/FileSystemUtilsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemUtilsIntegrationTest.java
@@ -20,7 +20,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.FileSystemUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
@@ -152,9 +152,9 @@ public class FileSystemUtilsIntegrationTest extends BaseIntegrationTest {
         try {
           // set the slow default polling period to a more sensible value, in order
           // to speed up the tests artificial waiting times
-          String original = ServerConfiguration.getString(
+          String original = Configuration.getString(
               PropertyKey.USER_FILE_WAITCOMPLETED_POLL_MS);
-          ServerConfiguration.set(PropertyKey.USER_FILE_WAITCOMPLETED_POLL_MS, "100");
+          Configuration.set(PropertyKey.USER_FILE_WAITCOMPLETED_POLL_MS, "100");
           try {
             // The write will take at most 600ms I am waiting for at most 400ms - epsilon.
             boolean completed = FileSystemUtils.waitCompleted(sFileSystem, uri, 300,
@@ -163,7 +163,7 @@ public class FileSystemUtilsIntegrationTest extends BaseIntegrationTest {
             completed = sFileSystem.getStatus(uri).isCompleted();
             assertFalse(completed);
           } finally {
-            ServerConfiguration.set(PropertyKey.USER_FILE_WAITCOMPLETED_POLL_MS, original);
+            Configuration.set(PropertyKey.USER_FILE_WAITCOMPLETED_POLL_MS, original);
           }
         } catch (Exception e) {
           e.printStackTrace();

--- a/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
@@ -24,7 +24,7 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
@@ -82,7 +82,7 @@ public class LoadMetadataIntegrationTest extends BaseIntegrationTest {
 
   @Rule
   public AuthenticatedUserRule mAuthenticatedUser = new AuthenticatedUserRule("test",
-      ServerConfiguration.global());
+      Configuration.global());
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
@@ -101,7 +101,7 @@ public class LoadMetadataIntegrationTest extends BaseIntegrationTest {
   @Before
   public void before() throws Exception {
     mLocalUfsPath = mTempFolder.getRoot().getAbsolutePath();
-    mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
+    mFileSystem = FileSystem.Factory.create(Configuration.global());
     mFileSystem.mount(new AlluxioURI("/mnt/"), new AlluxioURI("sleep://" + mLocalUfsPath));
 
     new File(mLocalUfsPath + "/dir1/dirA/").mkdirs();
@@ -117,7 +117,7 @@ public class LoadMetadataIntegrationTest extends BaseIntegrationTest {
 
   @After
   public void after() throws Exception {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   @Test
@@ -408,7 +408,7 @@ public class LoadMetadataIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void loadRecursive() throws Exception {
-    ServerConfiguration.set(PropertyKey.USER_FILE_METADATA_LOAD_TYPE,
+    Configuration.set(PropertyKey.USER_FILE_METADATA_LOAD_TYPE,
         LoadMetadataType.ONCE.toString());
     ListStatusPOptions options = ListStatusPOptions.newBuilder().setRecursive(true).build();
     int createdInodes = createUfsFiles(5);
@@ -421,10 +421,10 @@ public class LoadMetadataIntegrationTest extends BaseIntegrationTest {
   @Test
   public void testNoTtlOnLoadedFiles() throws Exception {
     int created = createUfsFiles(2);
-    ServerConfiguration.set(PropertyKey.USER_FILE_METADATA_LOAD_TYPE,
+    Configuration.set(PropertyKey.USER_FILE_METADATA_LOAD_TYPE,
         LoadMetadataType.ONCE.toString());
-    ServerConfiguration.set(PropertyKey.USER_FILE_CREATE_TTL, "11000");
-    ServerConfiguration.set(PropertyKey.USER_FILE_CREATE_TTL_ACTION, TtlAction.FREE.toString());
+    Configuration.set(PropertyKey.USER_FILE_CREATE_TTL, "11000");
+    Configuration.set(PropertyKey.USER_FILE_CREATE_TTL_ACTION, TtlAction.FREE.toString());
     ListStatusPOptions options = ListStatusPOptions.newBuilder().setRecursive(true)
         .setCommonOptions(
             FileSystemMasterCommonPOptions.newBuilder()

--- a/tests/src/test/java/alluxio/client/fs/LocalFirstPolicyIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LocalFirstPolicyIntegrationTest.java
@@ -20,7 +20,7 @@ import alluxio.Process;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.WritePType;
 import alluxio.master.AlluxioMasterProcess;
 import alluxio.master.TestUtils;
@@ -48,13 +48,13 @@ public class LocalFirstPolicyIntegrationTest extends BaseIntegrationTest {
   private ExecutorService mExecutor;
 
   @Rule
-  public ConfigurationRule mConf = new ConfigurationRule(conf(), ServerConfiguration.global());
+  public ConfigurationRule mConf = new ConfigurationRule(conf(), Configuration.modifiableGlobal());
 
   private static Map<PropertyKey, Object> conf() {
     Map<PropertyKey, Object> map =
-        ConfigurationTestUtils.testConfigurationDefaults(ServerConfiguration.global(),
+        ConfigurationTestUtils.testConfigurationDefaults(Configuration.global(),
         NetworkAddressUtils.getLocalHostName(
-            (int) ServerConfiguration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS)),
+            (int) Configuration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS)),
         AlluxioTestDirectory.createTemporaryDirectory("tiered_identity_test").getAbsolutePath());
     map.put(PropertyKey.WORKER_RPC_PORT, 0);
     map.put(PropertyKey.WORKER_WEB_PORT, 0);
@@ -77,10 +77,10 @@ public class LocalFirstPolicyIntegrationTest extends BaseIntegrationTest {
     AlluxioMasterProcess master = AlluxioMasterProcess.Factory.create();
     WorkerProcess worker1 = AlluxioWorkerProcess.Factory
         .create(TieredIdentityFactory.fromString("node=node1,rack=rack1",
-            ServerConfiguration.global()));
+            Configuration.global()));
     WorkerProcess worker2 = AlluxioWorkerProcess.Factory
         .create(TieredIdentityFactory.fromString("node=node2,rack=rack2",
-            ServerConfiguration.global()));
+            Configuration.global()));
 
     runProcess(mExecutor, master);
     runProcess(mExecutor, worker1);
@@ -90,13 +90,13 @@ public class LocalFirstPolicyIntegrationTest extends BaseIntegrationTest {
     TestUtils.waitForReady(worker1);
     TestUtils.waitForReady(worker2);
 
-    FileSystem fs = FileSystem.Factory.create(ServerConfiguration.global());
+    FileSystem fs = FileSystem.Factory.create(Configuration.global());
 
     // Write to the worker in node1
     {
       Whitebox.setInternalState(TieredIdentityFactory.class, "sInstance",
           TieredIdentityFactory.fromString("node=node1,rack=rack1",
-              ServerConfiguration.global()));
+              Configuration.global()));
       try {
         FileSystemTestUtils.createByteFile(fs, "/file1", WritePType.MUST_CACHE, 100);
       } finally {
@@ -112,7 +112,7 @@ public class LocalFirstPolicyIntegrationTest extends BaseIntegrationTest {
     {
       Whitebox.setInternalState(TieredIdentityFactory.class, "sInstance",
           TieredIdentityFactory.fromString("node=node3,rack=rack2",
-              ServerConfiguration.global()));
+              Configuration.global()));
       try {
         FileSystemTestUtils.createByteFile(fs, "/file2", WritePType.MUST_CACHE, 10);
       } finally {

--- a/tests/src/test/java/alluxio/client/fs/MultiUfsMountIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/MultiUfsMountIntegrationTest.java
@@ -16,7 +16,7 @@ import alluxio.client.WriteType;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.WritePType;
@@ -100,7 +100,7 @@ public final class MultiUfsMountIntegrationTest extends BaseIntegrationTest {
     mUfsUri3 = "ufs3://" + mFolder.newFolder().getAbsoluteFile();
     mUfsUri4 = "ufs4://" + mFolder.newFolder().getAbsoluteFile();
     mLocalUfs = new LocalUnderFileSystemFactory().create(mFolder.getRoot().getAbsolutePath(),
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global()));
+        UnderFileSystemConfiguration.defaults(Configuration.global()));
     mLocalAlluxioCluster = mLocalAlluxioClusterResource.get();
     mFileSystem = mLocalAlluxioCluster.getClient();
     // Mount ufs1 to /mnt1 with specified options.

--- a/tests/src/test/java/alluxio/client/fs/PathConfigurationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PathConfigurationIntegrationTest.java
@@ -21,7 +21,7 @@ import alluxio.client.file.FileSystemUtils;
 import alluxio.client.meta.MetaMasterConfigClient;
 import alluxio.client.meta.RetryHandlingMetaMasterConfigClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.master.MasterClientContext;
@@ -67,11 +67,11 @@ public class PathConfigurationIntegrationTest {
 
   @Before
   public void before() throws Exception {
-    FileSystemContext metaCtx = FileSystemContext.create(ServerConfiguration.global());
+    FileSystemContext metaCtx = FileSystemContext.create(Configuration.global());
     mMetaConfig = new RetryHandlingMetaMasterConfigClient(
         MasterClientContext.newBuilder(metaCtx.getClientContext()).build());
     setPathConfigurations(mMetaConfig);
-    FileSystemContext fsCtx = FileSystemContext.create(ServerConfiguration.global());
+    FileSystemContext fsCtx = FileSystemContext.create(Configuration.global());
     fsCtx.getClientContext().loadConf(fsCtx.getMasterAddress(), true, true);
     mFileSystem = mLocalAlluxioClusterResource.get().getClient(fsCtx);
     mWriteThrough = CreateFilePOptions.newBuilder().setRecursive(true)

--- a/tests/src/test/java/alluxio/client/fs/PersistMultipleMountsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PersistMultipleMountsIntegrationTest.java
@@ -16,7 +16,7 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.URIStatus;
 import alluxio.client.fs.io.AbstractFileOutStreamIntegrationTest;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.master.file.meta.PersistenceState;
@@ -51,13 +51,13 @@ public final class PersistMultipleMountsIntegrationTest
   public void before() throws Exception {
     super.before();
 
-    mUfsRoot = PathUtils.concatPath(ServerConfiguration
+    mUfsRoot = PathUtils.concatPath(Configuration
         .get(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS));
-    mUfs = UnderFileSystem.Factory.create(mUfsRoot, ServerConfiguration.global());
+    mUfs = UnderFileSystem.Factory.create(mUfsRoot, Configuration.global());
 
     mMountedUfsRoot = mTempFolder.getRoot().getAbsolutePath();
     mFileSystem.mount(new AlluxioURI(MOUNT_PATH), new AlluxioURI(mMountedUfsRoot));
-    mMountedUfs = UnderFileSystem.Factory.create(mMountedUfsRoot, ServerConfiguration.global());
+    mMountedUfs = UnderFileSystem.Factory.create(mMountedUfsRoot, Configuration.global());
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/fs/PersistPermissionIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PersistPermissionIntegrationTest.java
@@ -16,7 +16,7 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.URIStatus;
 import alluxio.client.fs.io.AbstractFileOutStreamIntegrationTest;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.master.file.meta.PersistenceState;
@@ -43,8 +43,8 @@ public final class PersistPermissionIntegrationTest extends AbstractFileOutStrea
   public void before() throws Exception {
     super.before();
 
-    mUfsRoot = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
-    mUfs = UnderFileSystem.Factory.createForRoot(ServerConfiguration.global());
+    mUfsRoot = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    mUfs = UnderFileSystem.Factory.createForRoot(Configuration.global());
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/fs/PinIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/PinIntegrationTest.java
@@ -18,7 +18,7 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
@@ -68,7 +68,7 @@ public final class PinIntegrationTest extends BaseIntegrationTest {
   public final void before() throws Exception {
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
     mFSMasterClient = new FileSystemMasterClient(MasterClientContext
-        .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+        .newBuilder(ClientContext.create(Configuration.global())).build());
     mSetPinned = SetAttributePOptions.newBuilder().setPinned(true).build();
     mUnsetPinned = SetAttributePOptions.newBuilder().setPinned(false).build();
     mFileSystem.mount(new AlluxioURI("/mnt/"), new AlluxioURI(mLocalUfsPath));
@@ -195,7 +195,7 @@ public final class PinIntegrationTest extends BaseIntegrationTest {
         .setCommonOptions(SYNC_NEVER).build();
     // Pin the dir
     mFileSystem.setAttribute(new AlluxioURI("/mnt/tmp/"), attributeOption);
-    ServerConfiguration.set(PropertyKey.USER_FILE_METADATA_LOAD_TYPE,
+    Configuration.set(PropertyKey.USER_FILE_METADATA_LOAD_TYPE,
         LoadMetadataType.NEVER.toString());
     URIStatus dirStat = mFileSystem.getStatus(new AlluxioURI("/mnt/tmp/"), getStatusOption);
     URIStatus fileStat = mFileSystem.getStatus(new AlluxioURI(PathUtils.concatPath("/mnt" ,

--- a/tests/src/test/java/alluxio/client/fs/ReadOnlyMountIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/ReadOnlyMountIntegrationTest.java
@@ -17,7 +17,7 @@ import alluxio.AlluxioURI;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
@@ -67,9 +67,9 @@ public class ReadOnlyMountIntegrationTest extends BaseIntegrationTest {
     // Create another directory on the local filesystem, alongside the existing Ufs, to be used as
     // a second Ufs.
     AlluxioURI parentURI =
-        new AlluxioURI(ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS))
+        new AlluxioURI(Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS))
             .getParent();
-    mUfs = UnderFileSystem.Factory.createForRoot(ServerConfiguration.global());
+    mUfs = UnderFileSystem.Factory.createForRoot(Configuration.global());
     mAlternateUfsRoot = parentURI.join("alternateUnderFSStorage").toString();
     String ufsMountDir = PathUtils.concatPath(mAlternateUfsRoot, MOUNT_PATH);
     UnderFileSystemUtils.mkdirIfNotExists(mUfs, mAlternateUfsRoot);

--- a/tests/src/test/java/alluxio/client/fs/RemoteReadIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/RemoteReadIntegrationTest.java
@@ -24,7 +24,7 @@ import alluxio.client.file.FileSystemUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.InStreamOptions;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.PreconditionMessage;
 import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.CreateFilePOptions;
@@ -83,8 +83,8 @@ public class RemoteReadIntegrationTest extends BaseIntegrationTest {
   @Before
   public final void before() throws Exception {
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
-    UserState us = UserState.Factory.create(ServerConfiguration.global());
-    mFsContext = FileSystemContext.create(us.getSubject(), ServerConfiguration.global());
+    UserState us = UserState.Factory.create(Configuration.global());
+    mFsContext = FileSystemContext.create(us.getSubject(), Configuration.global());
     mWriteAlluxio = CreateFilePOptions.newBuilder().setWriteType(WritePType.MUST_CACHE)
         .setRecursive(true).build();
     mWriteUnderStore = CreateFilePOptions.newBuilder().setWriteType(WritePType.THROUGH)
@@ -247,10 +247,10 @@ public class RemoteReadIntegrationTest extends BaseIntegrationTest {
       FileSystemTestUtils.createByteFile(mFileSystem, uri, mWriteAlluxio, k);
 
       URIStatus status = mFileSystem.getStatus(uri);
-      InStreamOptions options = new InStreamOptions(status, ServerConfiguration.global());
+      InStreamOptions options = new InStreamOptions(status, Configuration.global());
       long blockId = status.getBlockIds().get(0);
       BlockStoreClient blockStore =
-          BlockStoreClient.create(FileSystemContext.create(ServerConfiguration.global()));
+          BlockStoreClient.create(FileSystemContext.create(Configuration.global()));
       BlockInfo info = blockStore.getInfo(blockId);
       WorkerNetAddress workerAddr = info.getLocations().get(0).getWorkerAddress();
       BlockInStream is =
@@ -283,10 +283,10 @@ public class RemoteReadIntegrationTest extends BaseIntegrationTest {
       FileSystemTestUtils.createByteFile(mFileSystem, uri, mWriteAlluxio, k);
 
       URIStatus status = mFileSystem.getStatus(uri);
-      InStreamOptions options = new InStreamOptions(status, ServerConfiguration.global());
+      InStreamOptions options = new InStreamOptions(status, Configuration.global());
       long blockId = status.getBlockIds().get(0);
       BlockInfo info =
-          BlockStoreClient.create(FileSystemContext.create(ServerConfiguration.global()))
+          BlockStoreClient.create(FileSystemContext.create(Configuration.global()))
               .getInfo(blockId);
       WorkerNetAddress workerAddr = info.getLocations().get(0).getWorkerAddress();
       BlockInStream is =
@@ -313,11 +313,11 @@ public class RemoteReadIntegrationTest extends BaseIntegrationTest {
       FileSystemTestUtils.createByteFile(mFileSystem, uri, mWriteAlluxio, k);
 
       URIStatus status = mFileSystem.getStatus(uri);
-      InStreamOptions options = new InStreamOptions(status, ServerConfiguration.global());
+      InStreamOptions options = new InStreamOptions(status, Configuration.global());
       long blockId = status.getBlockIds().get(0);
       BlockInfo info =
           BlockStoreClient.create(FileSystemContext
-              .create(ServerConfiguration.global())).getInfo(blockId);
+              .create(Configuration.global())).getInfo(blockId);
       WorkerNetAddress workerAddr = info.getLocations().get(0).getWorkerAddress();
       BlockInStream is =
           BlockInStream.create(mFsContext, options.getBlockInfo(blockId),
@@ -555,10 +555,10 @@ public class RemoteReadIntegrationTest extends BaseIntegrationTest {
       FileSystemTestUtils.createByteFile(mFileSystem, uri, mWriteAlluxio, k);
 
       URIStatus status = mFileSystem.getStatus(uri);
-      InStreamOptions options = new InStreamOptions(status, ServerConfiguration.global());
+      InStreamOptions options = new InStreamOptions(status, Configuration.global());
       long blockId = status.getBlockIds().get(0);
       BlockInfo info = BlockStoreClient
-          .create(FileSystemContext.create(ServerConfiguration.global())).getInfo(blockId);
+          .create(FileSystemContext.create(Configuration.global())).getInfo(blockId);
 
       WorkerNetAddress workerAddr = info.getLocations().get(0).getWorkerAddress();
       BlockInStream is =

--- a/tests/src/test/java/alluxio/client/fs/TtlIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/TtlIntegrationTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.WritePType;
@@ -52,7 +52,7 @@ public class TtlIntegrationTest extends BaseIntegrationTest {
 
   @Before
   public void before() {
-    mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
+    mFileSystem = FileSystem.Factory.create(Configuration.global());
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -26,7 +26,7 @@ import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.FileSystemUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.grpc.CreateDirectoryPOptions;
@@ -101,7 +101,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
 
   @Rule
   public AuthenticatedUserRule mAuthenticatedUser = new AuthenticatedUserRule("test",
-      ServerConfiguration.global());
+      Configuration.global());
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
@@ -113,12 +113,12 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
 
   @After
   public void after() throws Exception {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   @Before
   public void before() throws Exception {
-    mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
+    mFileSystem = FileSystem.Factory.create(Configuration.global());
     mFileSystem.mount(new AlluxioURI("/mnt/"), new AlluxioURI(mLocalUfsPath));
 
     new File(ufsPath(EXISTING_DIR)).mkdirs();
@@ -576,7 +576,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
     mFileSystem.free(new AlluxioURI("/"), FreePOptions.newBuilder().setRecursive(true).build());
     BlockMasterClient blockClient =
         BlockMasterClient.Factory.create(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+            .newBuilder(ClientContext.create(Configuration.global())).build());
     CommonUtils.waitFor("data to be freed", () -> {
       try {
         return blockClient.getUsedBytes() == 0;
@@ -618,7 +618,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void createNestedFileSync() throws Exception {
-    ServerConfiguration.set(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL, "0");
+    Configuration.set(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL, "0");
 
     mFileSystem.createFile(new AlluxioURI(alluxioPath(NEW_NESTED_FILE)),
         CreateFilePOptions.newBuilder().setWriteType(WritePType.CACHE_THROUGH)
@@ -958,7 +958,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
       }
       // Check fingerprint.
       UnderFileSystem ufs = UnderFileSystem.Factory.create(uriStatus.getUfsPath(),
-          ServerConfiguration.global());
+          Configuration.global());
       String ufsFingerprint = ufs.getParsedFingerprint(uriStatus.getUfsPath()).serialize();
       String alluxioFingerprint = uriStatus.getUfsFingerprint();
       if (!ufsFingerprint.equals(alluxioFingerprint)) {

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentDeleteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentDeleteIntegrationTest.java
@@ -18,7 +18,7 @@ import alluxio.UnderFileSystemFactoryRegistryRule;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
@@ -70,7 +70,7 @@ public class ConcurrentDeleteIntegrationTest extends BaseIntegrationTest {
 
   @Rule
   public AuthenticatedUserRule mAuthenticatedUser = new AuthenticatedUserRule(TEST_USER,
-      ServerConfiguration.global());
+      Configuration.global());
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
@@ -85,7 +85,7 @@ public class ConcurrentDeleteIntegrationTest extends BaseIntegrationTest {
 
   @Before
   public void before() {
-    mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
+    mFileSystem = FileSystem.Factory.create(Configuration.global());
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileInStreamIntegrationTest.java
@@ -16,7 +16,7 @@ import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.test.util.ConcurrencyUtils;
@@ -59,7 +59,7 @@ public final class ConcurrentFileInStreamIntegrationTest extends BaseIntegration
   @Test
   public void FileInStreamConcurrency() throws Exception {
     int numReadThreads =
-        ServerConfiguration.getInt(PropertyKey.USER_BLOCK_MASTER_CLIENT_POOL_SIZE_MAX) * 10;
+        Configuration.getInt(PropertyKey.USER_BLOCK_MASTER_CLIENT_POOL_SIZE_MAX) * 10;
     AlluxioURI uniqPath = new AlluxioURI(PathUtils.uniqPath());
     FileSystemTestUtils.createByteFile(mFileSystem, uniqPath.getPath(), BLOCK_SIZE * 2,
         CreateFilePOptions.newBuilder().setWriteType(WritePType.MUST_CACHE).setRecursive(true)

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterCreateIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterCreateIntegrationTest.java
@@ -18,7 +18,7 @@ import alluxio.UnderFileSystemFactoryRegistryRule;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.LoadMetadataPType;
@@ -67,7 +67,7 @@ public class ConcurrentFileSystemMasterCreateIntegrationTest extends BaseIntegra
 
   @Rule
   public AuthenticatedUserRule mAuthenticatedUser = new AuthenticatedUserRule(TEST_USER,
-      ServerConfiguration.global());
+      Configuration.global());
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
@@ -91,13 +91,13 @@ public class ConcurrentFileSystemMasterCreateIntegrationTest extends BaseIntegra
 
   @Before
   public void before() {
-    mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
-    ServerConfiguration.set(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, "2b");
+    mFileSystem = FileSystem.Factory.create(Configuration.global());
+    Configuration.set(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, "2b");
   }
 
   @After
   public void after() {
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterLoadMetadataIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterLoadMetadataIntegrationTest.java
@@ -17,7 +17,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
 import org.junit.Before;
@@ -51,12 +51,12 @@ public final class ConcurrentFileSystemMasterLoadMetadataIntegrationTest {
 
   @Before
   public void before() {
-    mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
+    mFileSystem = FileSystem.Factory.create(Configuration.global());
   }
 
   @Test
   public void loadMetadataManyDirectories() throws Exception {
-    String ufsPath = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufsPath = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     for (int i = 0; i < 5000; i++) {
       Files.createDirectory(Paths.get(ufsPath, "a" + i));
     }
@@ -72,7 +72,7 @@ public final class ConcurrentFileSystemMasterLoadMetadataIntegrationTest {
 
   @Test
   public void loadMetadataManyFiles() throws Exception {
-    String ufsPath = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    String ufsPath = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     for (int i = 0; i < 5000; i++) {
       Files.createFile(Paths.get(ufsPath, "a" + i));
     }

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
@@ -17,7 +17,7 @@ import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.collections.ConcurrentHashSet;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.SetAttributePOptions;
@@ -70,7 +70,7 @@ public class ConcurrentFileSystemMasterSetTtlIntegrationTest extends BaseIntegra
 
   @Rule
   public AuthenticatedUserRule mAuthenticatedUser = new AuthenticatedUserRule(TEST_USER,
-      ServerConfiguration.global());
+      Configuration.global());
 
   @ClassRule
   public static ManuallyScheduleHeartbeat sManuallySchedule =
@@ -92,7 +92,7 @@ public class ConcurrentFileSystemMasterSetTtlIntegrationTest extends BaseIntegra
 
   @Before
   public void before() {
-    mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
+    mFileSystem = FileSystem.Factory.create(Configuration.global());
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentRecursiveCreateIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentRecursiveCreateIntegrationTest.java
@@ -17,7 +17,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.DeletePOptions;
 import alluxio.master.journal.JournalType;
@@ -54,8 +54,8 @@ public class ConcurrentRecursiveCreateIntegrationTest extends BaseIntegrationTes
   public void createDuringUfsRename() throws Exception {
     FileSystem fs = mClusterResource.get().getClient();
     ExecutorService executor = Executors.newCachedThreadPool();
-    UnderFileSystem ufs = Factory.createForRoot(ServerConfiguration.global());
-    String ufsRoot = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    UnderFileSystem ufs = Factory.createForRoot(Configuration.global());
+    String ufsRoot = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
     List<String> paths = new ArrayList<>();
     for (int i = 0; i < NUM_TOP_LEVEL_DIRS / 2; i++) {
       String alluxioPath = PathUtils.concatPath("/dir" + i, "a", "b", "c");

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentRenameIntegrationTest.java
@@ -19,7 +19,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.collections.ConcurrentHashSet;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
@@ -81,7 +81,7 @@ public class ConcurrentRenameIntegrationTest extends BaseIntegrationTest {
 
   @Rule
   public AuthenticatedUserRule mAuthenticatedUser = new AuthenticatedUserRule(TEST_USER,
-      ServerConfiguration.global());
+      Configuration.global());
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
@@ -96,7 +96,7 @@ public class ConcurrentRenameIntegrationTest extends BaseIntegrationTest {
 
   @Before
   public void before() {
-    mFileSystem = FileSystem.Factory.create(ServerConfiguration.global());
+    mFileSystem = FileSystem.Factory.create(Configuration.global());
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/fs/io/AbstractFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/AbstractFileOutStreamIntegrationTest.java
@@ -17,7 +17,7 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
@@ -173,7 +173,7 @@ public abstract class AbstractFileOutStreamIntegrationTest extends BaseIntegrati
     URIStatus status = mFileSystem.getStatus(filePath);
     String checkpointPath = status.getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.Factory.create(checkpointPath,
-        ServerConfiguration.global());
+        Configuration.global());
 
     try (InputStream is = ufs.open(checkpointPath)) {
       byte[] res = new byte[(int) status.getLength()];

--- a/tests/src/test/java/alluxio/client/fs/io/FileInStreamRehydrationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileInStreamRehydrationIntegrationTest.java
@@ -16,9 +16,8 @@ import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
-import alluxio.client.fs.io.AbstractFileOutStreamIntegrationTest;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.master.MasterProcess;
@@ -50,7 +49,7 @@ public class FileInStreamRehydrationIntegrationTest extends AbstractFileOutStrea
 
   @Test
   public void testRehydration() throws Exception {
-    FileSystem fs = FileSystem.Factory.create(ServerConfiguration.global());
+    FileSystem fs = FileSystem.Factory.create(Configuration.global());
 
     // Create a file with 10 blocks.
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());

--- a/tests/src/test/java/alluxio/client/fs/io/FileOutStreamAsyncWriteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileOutStreamAsyncWriteIntegrationTest.java
@@ -22,9 +22,8 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.FileSystemUtils;
 import alluxio.client.file.URIStatus;
-import alluxio.client.fs.io.AbstractFileOutStreamIntegrationTest;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
@@ -130,7 +129,7 @@ public final class FileOutStreamAsyncWriteIntegrationTest
     URIStatus status = mFileSystem.getStatus(filePath);
     alluxio.worker.file.FileSystemMasterClient fsMasterClient = new
         alluxio.worker.file.FileSystemMasterClient(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+            .newBuilder(ClientContext.create(Configuration.global())).build());
     Assert.assertTrue(fsMasterClient.getPinList().contains(status.getFileId()));
     IntegrationTestUtils.waitForPersist(mLocalAlluxioClusterResource, filePath);
     Assert.assertFalse(fsMasterClient.getPinList().contains(status.getFileId()));

--- a/tests/src/test/java/alluxio/client/fs/io/FileOutStreamAsyncWriteJobIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileOutStreamAsyncWriteJobIntegrationTest.java
@@ -15,8 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.URIStatus;
-import alluxio.client.fs.io.AbstractFileOutStreamIntegrationTest;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
@@ -301,7 +300,7 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     PersistenceTestUtils.pauseScheduler(mLocalAlluxioClusterResource);
     URIStatus status = createAsyncFile();
     String ufsPath = status.getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, Configuration.global());
     mFileSystem.setAttribute(mUri, TEST_OPTIONS);
     checkFileInAlluxio(mUri, LEN);
     checkFileNotInUnderStorage(status.getUfsPath());
@@ -330,7 +329,7 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     URIStatus status = createAsyncFile();
     PersistenceTestUtils.waitForJobScheduled(mLocalAlluxioClusterResource, status.getFileId());
     String ufsPath = status.getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, Configuration.global());
     mFileSystem.setAttribute(mUri, TEST_OPTIONS);
     checkFileInAlluxio(mUri, LEN);
     checkFileNotInUnderStorage(status.getUfsPath());
@@ -362,7 +361,7 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     checkFileInUnderStorage(mUri, LEN);
     URIStatus status = mFileSystem.getStatus(mUri);
     String ufsPath = status.getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, Configuration.global());
     Assert.assertEquals(ModeUtils.protoToShort(TEST_OPTIONS.getMode()), status.getMode());
     Assert.assertEquals(COMMON_OPTIONS.getTtl(), status.getTtl());
     Assert.assertEquals(COMMON_OPTIONS.getTtlAction(), status.getTtlAction());
@@ -455,7 +454,7 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
     PersistenceTestUtils.pauseChecker(mLocalAlluxioClusterResource);
     URIStatus status = createAsyncFile();
     String ufsPath = status.getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, Configuration.global());
     AlluxioURI newUri = new AlluxioURI(PathUtils.uniqPath());
     mFileSystem.createDirectory(newUri.getParent());
     mFileSystem.rename(mUri, newUri);
@@ -541,7 +540,7 @@ public final class FileOutStreamAsyncWriteJobIntegrationTest
    * @param ufsPath path of the tmp file
    */
   private void checkFileNotInUnderStorage(String ufsPath) throws Exception {
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, Configuration.global());
     Assert.assertFalse(ufs.exists(ufsPath));
   }
 }

--- a/tests/src/test/java/alluxio/client/fs/io/FileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileOutStreamIntegrationTest.java
@@ -17,7 +17,7 @@ import alluxio.client.WriteType;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
@@ -101,7 +101,7 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
     URIStatus status = mFileSystem.getStatus(parentPath);
     String checkpointPath = status.getUfsPath();
     UnderFileSystem ufs = UnderFileSystem.Factory.create(checkpointPath,
-        ServerConfiguration.global());
+        Configuration.global());
     ufs.deleteDirectory(checkpointPath);
 
     // write a file to a directory exists in Alluxio but not in UFS
@@ -239,7 +239,7 @@ public final class FileOutStreamIntegrationTest extends AbstractFileOutStreamInt
       os.write(BufferUtils.getIncreasingByteArray(0, BLOCK_SIZE_BYTES * 3 + 1));
       os.cancel();
     }
-    long gracePeriod = ServerConfiguration
+    long gracePeriod = Configuration
         .getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS) * 2;
     CommonUtils.sleepMs(gracePeriod);
     List<WorkerInfo> workers =

--- a/tests/src/test/java/alluxio/client/fs/io/UfsFallbackFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/UfsFallbackFileOutStreamIntegrationTest.java
@@ -17,7 +17,7 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.heartbeat.HeartbeatContext;
@@ -92,8 +92,8 @@ public class UfsFallbackFileOutStreamIntegrationTest extends AbstractFileOutStre
       {
         put(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, mBlockSize);
       }
-    }, ServerConfiguration.global()).toResource()) {
-      FileSystem fs = FileSystem.Factory.create(ServerConfiguration.global());
+    }, Configuration.modifiableGlobal()).toResource()) {
+      FileSystem fs = FileSystem.Factory.create(Configuration.global());
       AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
       CreateFilePOptions op = CreateFilePOptions.newBuilder()
           .setWriteType(WritePType.ASYNC_THROUGH).setRecursive(true).build();
@@ -125,7 +125,7 @@ public class UfsFallbackFileOutStreamIntegrationTest extends AbstractFileOutStre
         put(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, mBlockSize);
         put(PropertyKey.USER_SHORT_CIRCUIT_ENABLED, false);
       }
-    }, ServerConfiguration.global()).toResource()) {
+    }, Configuration.modifiableGlobal()).toResource()) {
       AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
       CreateFilePOptions op = CreateFilePOptions.newBuilder()
           .setWriteType(WritePType.ASYNC_THROUGH).setRecursive(true).build();

--- a/tests/src/test/java/alluxio/client/fuse/AbstractFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/AbstractFuseIntegrationTest.java
@@ -26,7 +26,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
@@ -108,13 +108,13 @@ public abstract class AbstractFuseIntegrationTest {
         IntegrationTestUtils.getTestName(getClass().getSimpleName(), mTestName.getMethodName());
     mMountPoint = AlluxioTestDirectory.createTemporaryDirectory(clusterName).getAbsolutePath();
     mAlluxioCluster.initConfiguration(ALLUXIO_ROOT);
-    ServerConfiguration.set(PropertyKey.FUSE_USER_GROUP_TRANSLATION_ENABLED, true);
-    ServerConfiguration.set(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE);
+    Configuration.set(PropertyKey.FUSE_USER_GROUP_TRANSLATION_ENABLED, true);
+    Configuration.set(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE);
     configure();
     IntegrationTestUtils.reserveMasterPorts();
-    ServerConfiguration.global().validate();
+    Configuration.global().validate();
     mAlluxioCluster.start();
-    mFileSystemContext = FileSystemContext.create(ServerConfiguration.global());
+    mFileSystemContext = FileSystemContext.create(Configuration.global());
     mFileSystem = mAlluxioCluster.getClient(mFileSystemContext);
     mountFuse(mFileSystemContext, mFileSystem, mMountPoint, ALLUXIO_ROOT);
     if (!waitForFuseMounted()) {

--- a/tests/src/test/java/alluxio/client/fuse/JNIFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNIFuseIntegrationTest.java
@@ -13,9 +13,9 @@ package alluxio.client.fuse;
 
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.fuse.AlluxioJniFuseFileSystem;
 import alluxio.fuse.FuseMountConfig;
 import alluxio.jnifuse.struct.FuseFileInfo;
@@ -39,13 +39,13 @@ public class JNIFuseIntegrationTest extends AbstractFuseIntegrationTest {
 
   @Override
   public void configure() {
-    ServerConfiguration.set(PropertyKey.FUSE_JNIFUSE_ENABLED, true);
+    Configuration.set(PropertyKey.FUSE_JNIFUSE_ENABLED, true);
   }
 
   @Override
   public void mountFuse(FileSystemContext context,
       FileSystem fileSystem, String mountPoint, String alluxioRoot) {
-    InstancedConfiguration conf = ServerConfiguration.global();
+    AlluxioConfiguration conf = Configuration.global();
     FuseMountConfig options =
         FuseMountConfig.create(mountPoint, alluxioRoot, ImmutableList.of(), conf);
     mFuseFileSystem =

--- a/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
@@ -13,9 +13,9 @@ package alluxio.client.fuse;
 
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.fuse.AlluxioFuseFileSystem;
 import alluxio.fuse.FuseMountConfig;
 
@@ -31,13 +31,13 @@ public class JNRFuseIntegrationTest extends AbstractFuseIntegrationTest {
 
   @Override
   public void configure() {
-    ServerConfiguration.set(PropertyKey.FUSE_JNIFUSE_ENABLED, false);
+    Configuration.set(PropertyKey.FUSE_JNIFUSE_ENABLED, false);
   }
 
   @Override
   public void mountFuse(FileSystemContext context,
       FileSystem fileSystem, String mountPoint, String alluxioRoot) {
-    InstancedConfiguration conf = ServerConfiguration.global();
+    AlluxioConfiguration conf = Configuration.global();
     FuseMountConfig options =
         FuseMountConfig.create(mountPoint, alluxioRoot, ImmutableList.of(), conf);
     mFuseFileSystem = new AlluxioFuseFileSystem(fileSystem, options, conf);

--- a/tests/src/test/java/alluxio/client/hadoop/DFSIOIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/DFSIOIntegrationTest.java
@@ -14,7 +14,7 @@ package alluxio.client.hadoop;
 import alluxio.Constants;
 import alluxio.client.WriteType;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.hadoop.FileSystem;
 import alluxio.hadoop.HadoopConfigurationUtils;
 import alluxio.testutils.BaseIntegrationTest;
@@ -259,7 +259,7 @@ public class DFSIOIntegrationTest extends BaseIntegrationTest implements Tool {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri,
             HadoopConfigurationUtils
-                .mergeAlluxioConfiguration(sBench.getConf(), ServerConfiguration.global()));
+                .mergeAlluxioConfiguration(sBench.getConf(), Configuration.global()));
     sBench.createControlFile(fs, DEFAULT_NR_BYTES, DEFAULT_NR_FILES);
 
     /** Check write here, as it is required for other tests */
@@ -271,7 +271,7 @@ public class DFSIOIntegrationTest extends BaseIntegrationTest implements Tool {
     // Clear DFSIOIntegrationTest
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, HadoopConfigurationUtils
-            .mergeAlluxioConfiguration(sBench.getConf(), ServerConfiguration.global()));
+            .mergeAlluxioConfiguration(sBench.getConf(), Configuration.global()));
     sBench.cleanup(fs);
   }
 
@@ -281,7 +281,7 @@ public class DFSIOIntegrationTest extends BaseIntegrationTest implements Tool {
   public static void writeTest() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, HadoopConfigurationUtils
-            .mergeAlluxioConfiguration(sBench.getConf(), ServerConfiguration.global()));
+            .mergeAlluxioConfiguration(sBench.getConf(), Configuration.global()));
     long tStart = System.currentTimeMillis();
     sBench.mapperWriteTest(fs);
     long execTime = System.currentTimeMillis() - tStart;
@@ -292,7 +292,7 @@ public class DFSIOIntegrationTest extends BaseIntegrationTest implements Tool {
   public void read() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, HadoopConfigurationUtils
-            .mergeAlluxioConfiguration(sBench.getConf(), ServerConfiguration.global()));
+            .mergeAlluxioConfiguration(sBench.getConf(), Configuration.global()));
     long tStart = System.currentTimeMillis();
     sBench.mapperReadTest(fs);
     long execTime = System.currentTimeMillis() - tStart;
@@ -303,7 +303,7 @@ public class DFSIOIntegrationTest extends BaseIntegrationTest implements Tool {
   public void readRandom() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, HadoopConfigurationUtils
-            .mergeAlluxioConfiguration(sBench.getConf(), ServerConfiguration.global()));
+            .mergeAlluxioConfiguration(sBench.getConf(), Configuration.global()));
     long tStart = System.currentTimeMillis();
     sBench.getConf().setLong("test.io.skip.size", 0);
     sBench.randomReadTest(fs);
@@ -315,7 +315,7 @@ public class DFSIOIntegrationTest extends BaseIntegrationTest implements Tool {
   public void readBackward() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, HadoopConfigurationUtils
-            .mergeAlluxioConfiguration(sBench.getConf(), ServerConfiguration.global()));
+            .mergeAlluxioConfiguration(sBench.getConf(), Configuration.global()));
     long tStart = System.currentTimeMillis();
     sBench.getConf().setLong("test.io.skip.size", -DEFAULT_BUFFER_SIZE);
     sBench.randomReadTest(fs);
@@ -327,7 +327,7 @@ public class DFSIOIntegrationTest extends BaseIntegrationTest implements Tool {
   public void readSkip() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, HadoopConfigurationUtils
-            .mergeAlluxioConfiguration(sBench.getConf(), ServerConfiguration.global()));
+            .mergeAlluxioConfiguration(sBench.getConf(), Configuration.global()));
     long tStart = System.currentTimeMillis();
     sBench.getConf().setLong("test.io.skip.size", 1);
     sBench.randomReadTest(fs);
@@ -339,7 +339,7 @@ public class DFSIOIntegrationTest extends BaseIntegrationTest implements Tool {
   public void readLargeSkip() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, HadoopConfigurationUtils
-            .mergeAlluxioConfiguration(sBench.getConf(), ServerConfiguration.global()));
+            .mergeAlluxioConfiguration(sBench.getConf(), Configuration.global()));
     long tStart = System.currentTimeMillis();
     sBench.getConf().setLong("test.io.skip.size", 5000);
     sBench.randomReadTest(fs);
@@ -352,7 +352,7 @@ public class DFSIOIntegrationTest extends BaseIntegrationTest implements Tool {
   public void append() throws Exception {
     org.apache.hadoop.fs.FileSystem fs =
         org.apache.hadoop.fs.FileSystem.get(sLocalAlluxioClusterUri, HadoopConfigurationUtils
-            .mergeAlluxioConfiguration(sBench.getConf(), ServerConfiguration.global()));
+            .mergeAlluxioConfiguration(sBench.getConf(), Configuration.global()));
     long tStart = System.currentTimeMillis();
     sBench.mapperAppendTest(fs);
     long execTime = System.currentTimeMillis() - tStart;

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemAclIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemAclIntegrationTest.java
@@ -14,7 +14,7 @@ package alluxio.client.hadoop;
 import alluxio.Constants;
 import alluxio.client.WriteType;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.hadoop.FileSystem;
 import alluxio.hadoop.HadoopClientTestUtils;
 import alluxio.hadoop.HadoopConfigurationUtils;
@@ -30,7 +30,6 @@ import alluxio.util.UnderFileSystemUtils;
 import alluxio.util.io.PathUtils;
 
 import com.google.common.collect.Lists;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -90,16 +89,16 @@ public final class FileSystemAclIntegrationTest extends BaseIntegrationTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    Configuration conf = new Configuration();
+    org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
     conf.set("fs.alluxio.impl", FileSystem.class.getName());
-    conf = HadoopConfigurationUtils.mergeAlluxioConfiguration(conf, ServerConfiguration.global());
+    conf = HadoopConfigurationUtils.mergeAlluxioConfiguration(conf, Configuration.global());
 
     URI uri = URI.create(sLocalAlluxioClusterResource.get().getMasterURI());
 
     sTFS = org.apache.hadoop.fs.FileSystem.get(uri, HadoopConfigurationUtils
-        .mergeAlluxioConfiguration(conf, ServerConfiguration.global()));
-    sUfsRoot = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
-    sUfs = UnderFileSystem.Factory.createForRoot(ServerConfiguration.global());
+        .mergeAlluxioConfiguration(conf, Configuration.global()));
+    sUfsRoot = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    sUfs = UnderFileSystem.Factory.createForRoot(Configuration.global());
   }
 
   @After
@@ -468,7 +467,7 @@ public final class FileSystemAclIntegrationTest extends BaseIntegrationTest {
       sTFS.delete(file, false);
       // Create a file directly in UFS and set the corresponding mode.
       String ufsPath = PathUtils.concatPath(sUfsRoot, file);
-      sUfs.create(ufsPath, CreateOptions.defaults(ServerConfiguration.global()).setOwner("testuser")
+      sUfs.create(ufsPath, CreateOptions.defaults(Configuration.global()).setOwner("testuser")
           .setGroup("testgroup").setMode(new Mode((short) value))).close();
       Assert.assertTrue(sUfs.isFile(PathUtils.concatPath(sUfsRoot, file)));
       // Check the mode is consistent in Alluxio namespace once it's loaded from UFS to Alluxio.
@@ -494,7 +493,7 @@ public final class FileSystemAclIntegrationTest extends BaseIntegrationTest {
       // Create a directory directly in UFS and set the corresponding mode.
       String ufsPath = PathUtils.concatPath(sUfsRoot, dir);
       sUfs.mkdirs(ufsPath,
-          MkdirsOptions.defaults(ServerConfiguration.global()).setCreateParent(false)
+          MkdirsOptions.defaults(Configuration.global()).setCreateParent(false)
               .setOwner("testuser").setGroup("testgroup").setMode(new Mode((short) value)));
       Assert.assertTrue(sUfs.isDirectory(PathUtils.concatPath(sUfsRoot, dir)));
       // Check the mode is consistent in Alluxio namespace once it's loaded from UFS to Alluxio.
@@ -507,7 +506,7 @@ public final class FileSystemAclIntegrationTest extends BaseIntegrationTest {
   public void s3GetPermission() throws Exception {
     Assume.assumeTrue(UnderFileSystemUtils.isS3(sUfs));
 
-    ServerConfiguration.unset(PropertyKey.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING);
+    Configuration.unset(PropertyKey.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING);
     Path fileA = new Path("/s3GetPermissionFile");
     create(sTFS, fileA);
     Assert.assertTrue(sUfs.isFile(PathUtils.concatPath(sUfsRoot, fileA)));
@@ -524,7 +523,7 @@ public final class FileSystemAclIntegrationTest extends BaseIntegrationTest {
   public void gcsGetPermission() throws Exception {
     Assume.assumeTrue(UnderFileSystemUtils.isGcs(sUfs));
 
-    ServerConfiguration.unset(PropertyKey.UNDERFS_GCS_OWNER_ID_TO_USERNAME_MAPPING);
+    Configuration.unset(PropertyKey.UNDERFS_GCS_OWNER_ID_TO_USERNAME_MAPPING);
     Path fileA = new Path("/gcsGetPermissionFile");
     create(sTFS, fileA);
     Assert.assertTrue(sUfs.isFile(PathUtils.concatPath(sUfsRoot, fileA)));

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemBlockLocationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemBlockLocationIntegrationTest.java
@@ -12,14 +12,13 @@
 package alluxio.client.hadoop;
 
 import alluxio.client.file.FileSystemTestUtils;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.WritePType;
 import alluxio.hadoop.FileSystem;
 import alluxio.hadoop.HadoopConfigurationUtils;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
@@ -43,7 +42,7 @@ public class FileSystemBlockLocationIntegrationTest extends BaseIntegrationTest 
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    Configuration conf = new Configuration();
+    org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
     conf.set("fs.alluxio.impl", FileSystem.class.getName());
 
     alluxio.client.file.FileSystem alluxioFS = sLocalAlluxioClusterResource.get().getClient();
@@ -52,7 +51,7 @@ public class FileSystemBlockLocationIntegrationTest extends BaseIntegrationTest 
 
     URI uri = URI.create(sLocalAlluxioClusterResource.get().getMasterURI());
     sTFS = org.apache.hadoop.fs.FileSystem.get(uri, HadoopConfigurationUtils
-        .mergeAlluxioConfiguration(conf, ServerConfiguration.global()));
+        .mergeAlluxioConfiguration(conf, Configuration.global()));
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemIntegrationTest.java
@@ -12,13 +12,12 @@
 package alluxio.client.hadoop;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.hadoop.FileSystem;
 import alluxio.hadoop.HadoopConfigurationUtils;
 import alluxio.security.authentication.AuthType;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -43,13 +42,13 @@ public class FileSystemIntegrationTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    Configuration conf = new Configuration();
+    org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
     conf.set("fs.alluxio.impl", FileSystem.class.getName());
 
     URI uri = URI.create(sLocalAlluxioClusterResource.get().getMasterURI());
 
     sTFS = org.apache.hadoop.fs.FileSystem.get(uri, HadoopConfigurationUtils
-        .mergeAlluxioConfiguration(conf, ServerConfiguration.global()));
+        .mergeAlluxioConfiguration(conf, Configuration.global()));
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -13,7 +13,7 @@ package alluxio.client.hadoop;
 
 import alluxio.client.WriteType;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.hadoop.FileSystem;
 import alluxio.hadoop.HadoopConfigurationUtils;
 import alluxio.testutils.BaseIntegrationTest;
@@ -21,7 +21,6 @@ import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.io.PathUtils;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -67,15 +66,15 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    Configuration conf = new Configuration();
+    org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
     conf.set("fs.alluxio.impl", FileSystem.class.getName());
 
     URI uri = URI.create(sLocalAlluxioClusterResource.get().getMasterURI());
 
     sTFS = org.apache.hadoop.fs.FileSystem.get(uri, HadoopConfigurationUtils
-        .mergeAlluxioConfiguration(conf, ServerConfiguration.global()));
-    sUfsRoot = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
-    sUfs = UnderFileSystem.Factory.createForRoot(ServerConfiguration.global());
+        .mergeAlluxioConfiguration(conf, Configuration.global()));
+    sUfsRoot = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    sUfs = UnderFileSystem.Factory.createForRoot(Configuration.global());
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemStatisticsTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemStatisticsTest.java
@@ -13,14 +13,13 @@ package alluxio.client.hadoop;
 
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.WritePType;
 import alluxio.hadoop.FileSystem;
 import alluxio.hadoop.HadoopConfigurationUtils;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
@@ -50,7 +49,7 @@ public class FileSystemStatisticsTest extends BaseIntegrationTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    Configuration conf = new Configuration();
+    org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
     conf.set("fs.alluxio.impl", FileSystem.class.getName());
 
     alluxio.client.file.FileSystem alluxioFS = sLocalAlluxioClusterResource.get().getClient();
@@ -59,7 +58,7 @@ public class FileSystemStatisticsTest extends BaseIntegrationTest {
 
     URI uri = URI.create(sLocalAlluxioClusterResource.get().getMasterURI());
     sTFS = org.apache.hadoop.fs.FileSystem.get(uri, HadoopConfigurationUtils
-        .mergeAlluxioConfiguration(conf, ServerConfiguration.global()));
+        .mergeAlluxioConfiguration(conf, Configuration.global()));
     sStatistics = org.apache.hadoop.fs.FileSystem.getStatistics(uri.getScheme(), sTFS.getClass());
   }
 

--- a/tests/src/test/java/alluxio/client/hadoop/HdfsFileInputStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/HdfsFileInputStreamIntegrationTest.java
@@ -19,7 +19,7 @@ import alluxio.client.file.FileSystemUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.PreconditionMessage;
 import alluxio.grpc.WritePType;
@@ -71,7 +71,7 @@ public final class HdfsFileInputStreamIntegrationTest extends BaseIntegrationTes
       mUfsInputStream.close();
       mFileSystem.delete(new AlluxioURI(UFS_ONLY_FILE));
     }
-    HadoopClientTestUtils.disableMetrics(ServerConfiguration.global());
+    HadoopClientTestUtils.disableMetrics(Configuration.modifiableGlobal());
   }
 
   @Before
@@ -84,7 +84,7 @@ public final class HdfsFileInputStreamIntegrationTest extends BaseIntegrationTes
   }
 
   private void createUfsInStream(ReadType readType) throws Exception {
-    InstancedConfiguration conf = new InstancedConfiguration(ServerConfiguration.copyProperties());
+    InstancedConfiguration conf = new InstancedConfiguration(Configuration.copyProperties());
     conf.set(PropertyKey.USER_FILE_READ_TYPE_DEFAULT, readType.name());
     FileSystem fs = FileSystem.Factory.create(conf);
     FileSystemTestUtils.createByteFile(fs, UFS_ONLY_FILE, WritePType.THROUGH,

--- a/tests/src/test/java/alluxio/client/hadoop/contract/FileSystemContractCreateIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/contract/FileSystemContractCreateIntegrationTest.java
@@ -12,11 +12,10 @@
 package alluxio.client.hadoop.contract;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.hadoop.HadoopConfigurationUtils;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractCreateTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.junit.Rule;
@@ -30,8 +29,8 @@ public class FileSystemContractCreateIntegrationTest extends AbstractContractCre
           .build();
 
   @Override
-  protected AbstractFSContract createContract(Configuration conf) {
+  protected AbstractFSContract createContract(org.apache.hadoop.conf.Configuration conf) {
     return new FileSystemContract(HadoopConfigurationUtils.mergeAlluxioConfiguration(conf,
-        ServerConfiguration.global()), mClusterResource.get());
+        Configuration.global()), mClusterResource.get());
   }
 }

--- a/tests/src/test/java/alluxio/client/hadoop/contract/FileSystemContractDeleteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/contract/FileSystemContractDeleteIntegrationTest.java
@@ -12,11 +12,10 @@
 package alluxio.client.hadoop.contract;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.hadoop.HadoopConfigurationUtils;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractDeleteTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.junit.Rule;
@@ -30,8 +29,8 @@ public class FileSystemContractDeleteIntegrationTest extends AbstractContractDel
           .build();
 
   @Override
-  protected AbstractFSContract createContract(Configuration conf) {
+  protected AbstractFSContract createContract(org.apache.hadoop.conf.Configuration conf) {
     return new FileSystemContract(HadoopConfigurationUtils.mergeAlluxioConfiguration(conf,
-        ServerConfiguration.global()), mClusterResource.get());
+        Configuration.global()), mClusterResource.get());
   }
 }

--- a/tests/src/test/java/alluxio/client/hadoop/contract/FileSystemContractLoadedIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/contract/FileSystemContractLoadedIntegrationTest.java
@@ -12,11 +12,10 @@
 package alluxio.client.hadoop.contract;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.hadoop.HadoopConfigurationUtils;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.AbstractFSContractTestBase;
 import org.junit.Rule;
@@ -33,9 +32,9 @@ public class FileSystemContractLoadedIntegrationTest extends AbstractFSContractT
           .build();
 
   @Override
-  protected AbstractFSContract createContract(Configuration conf) {
+  protected AbstractFSContract createContract(org.apache.hadoop.conf.Configuration conf) {
     return new FileSystemContract(HadoopConfigurationUtils.mergeAlluxioConfiguration(conf,
-        ServerConfiguration.global()), mClusterResource.get());
+        Configuration.global()), mClusterResource.get());
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/hadoop/contract/FileSystemContractMkdirIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/contract/FileSystemContractMkdirIntegrationTest.java
@@ -12,11 +12,10 @@
 package alluxio.client.hadoop.contract;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.hadoop.HadoopConfigurationUtils;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractMkdirTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.junit.Rule;
@@ -30,8 +29,8 @@ public class FileSystemContractMkdirIntegrationTest extends AbstractContractMkdi
           .build();
 
   @Override
-  protected AbstractFSContract createContract(Configuration conf) {
+  protected AbstractFSContract createContract(org.apache.hadoop.conf.Configuration conf) {
     return new FileSystemContract(HadoopConfigurationUtils.mergeAlluxioConfiguration(conf,
-        ServerConfiguration.global()), mClusterResource.get());
+        Configuration.global()), mClusterResource.get());
   }
 }

--- a/tests/src/test/java/alluxio/client/hadoop/contract/FileSystemContractOpenIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/contract/FileSystemContractOpenIntegrationTest.java
@@ -12,11 +12,10 @@
 package alluxio.client.hadoop.contract;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.hadoop.HadoopConfigurationUtils;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractOpenTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.junit.Rule;
@@ -30,8 +29,8 @@ public class FileSystemContractOpenIntegrationTest extends AbstractContractOpenT
           .build();
 
   @Override
-  protected AbstractFSContract createContract(Configuration conf) {
+  protected AbstractFSContract createContract(org.apache.hadoop.conf.Configuration conf) {
     return new FileSystemContract(HadoopConfigurationUtils.mergeAlluxioConfiguration(conf,
-        ServerConfiguration.global()), mClusterResource.get());
+        Configuration.global()), mClusterResource.get());
   }
 }

--- a/tests/src/test/java/alluxio/client/hadoop/contract/FileSystemContractRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/contract/FileSystemContractRenameIntegrationTest.java
@@ -12,11 +12,10 @@
 package alluxio.client.hadoop.contract;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.hadoop.HadoopConfigurationUtils;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractRenameTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.junit.Rule;
@@ -30,8 +29,8 @@ public class FileSystemContractRenameIntegrationTest extends AbstractContractRen
           .build();
 
   @Override
-  protected AbstractFSContract createContract(Configuration conf) {
+  protected AbstractFSContract createContract(org.apache.hadoop.conf.Configuration conf) {
     return new FileSystemContract(HadoopConfigurationUtils.mergeAlluxioConfiguration(conf,
-        ServerConfiguration.global()), mClusterResource.get());
+        Configuration.global()), mClusterResource.get());
   }
 }

--- a/tests/src/test/java/alluxio/client/hadoop/contract/FileSystemContractSeekIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/contract/FileSystemContractSeekIntegrationTest.java
@@ -12,11 +12,10 @@
 package alluxio.client.hadoop.contract;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.hadoop.HadoopConfigurationUtils;
 import alluxio.testutils.LocalAlluxioClusterResource;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractSeekTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.junit.Rule;
@@ -30,8 +29,8 @@ public class FileSystemContractSeekIntegrationTest extends AbstractContractSeekT
           .build();
 
   @Override
-  protected AbstractFSContract createContract(Configuration conf) {
+  protected AbstractFSContract createContract(org.apache.hadoop.conf.Configuration conf) {
     return new FileSystemContract(HadoopConfigurationUtils.mergeAlluxioConfiguration(conf,
-        ServerConfiguration.global()), mClusterResource.get());
+        Configuration.global()), mClusterResource.get());
   }
 }

--- a/tests/src/test/java/alluxio/client/meta/MetaMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/meta/MetaMasterIntegrationTest.java
@@ -14,7 +14,7 @@ package alluxio.client.meta;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.ClientContext;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.GetConfigurationPOptions;
 import alluxio.grpc.MasterInfo;
 import alluxio.grpc.MasterInfoField;
@@ -50,7 +50,7 @@ public final class MetaMasterIntegrationTest extends BaseIntegrationTest {
   public void getInfoAllFields() throws Exception {
     try (MetaMasterClient client =
         new RetryHandlingMetaMasterClient(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build())) {
+            .newBuilder(ClientContext.create(Configuration.global())).build())) {
       MasterInfo info = client.getMasterInfo(Collections.emptySet());
       assertEquals(mWebPort, info.getWebPort());
     }
@@ -60,7 +60,7 @@ public final class MetaMasterIntegrationTest extends BaseIntegrationTest {
   public void getMasterInfoWebPort() throws Exception {
     try (MetaMasterClient client =
         new RetryHandlingMetaMasterClient(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build())) {
+            .newBuilder(ClientContext.create(Configuration.global())).build())) {
       MasterInfo info = client.getMasterInfo(new HashSet<>(Arrays
           .asList(MasterInfoField.WEB_PORT)));
       assertEquals(mWebPort, info.getWebPort());
@@ -71,7 +71,7 @@ public final class MetaMasterIntegrationTest extends BaseIntegrationTest {
   public void getConfigurationWebPort() throws Exception {
     try (MetaMasterConfigClient client =
              new RetryHandlingMetaMasterConfigClient(MasterClientContext
-                 .newBuilder(ClientContext.create(ServerConfiguration.global())).build())) {
+                 .newBuilder(ClientContext.create(Configuration.global())).build())) {
       List<Property> configList = client.getConfiguration(GetConfigurationPOptions.newBuilder()
           .setIgnorePathConf(true).build()).getClusterConf();
       int configWebPort = -1;

--- a/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/AlluxioMasterRestApiTest.java
@@ -19,7 +19,7 @@ import alluxio.Constants;
 import alluxio.RuntimeConstants;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.WritePType;
 import alluxio.master.file.FileSystemMaster;
 import alluxio.master.file.contexts.GetStatusContext;
@@ -95,7 +95,7 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
 
   @Test
   public void getCapacity() throws Exception {
-    long total = ServerConfiguration.getBytes(PropertyKey.WORKER_RAMDISK_SIZE);
+    long total = Configuration.getBytes(PropertyKey.WORKER_RAMDISK_SIZE);
     Capacity capacity = getInfo(NO_PARAMS).getCapacity();
     assertEquals(total, capacity.getTotal());
     assertEquals(0, capacity.getUsed());
@@ -106,8 +106,8 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
     String home = "home";
     String rawConfDir = String.format("${%s}/conf", PropertyKey.Name.HOME);
     String resolvedConfDir = String.format("%s/conf", home);
-    ServerConfiguration.set(PropertyKey.HOME, home);
-    ServerConfiguration.set(PropertyKey.CONF_DIR, rawConfDir);
+    Configuration.set(PropertyKey.HOME, home);
+    Configuration.set(PropertyKey.CONF_DIR, rawConfDir);
 
     // with out any query parameter, configuration values are resolved.
     checkConfiguration(PropertyKey.CONF_DIR, resolvedConfDir, NO_PARAMS);
@@ -183,7 +183,7 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
   public void getRpcAddress() throws Exception {
     assertTrue(getInfo(NO_PARAMS).getRpcAddress()
         .contains(String.valueOf(NetworkAddressUtils.getPort(ServiceType.MASTER_RPC,
-            ServerConfiguration.global()))));
+            Configuration.global()))));
   }
 
   @Test
@@ -193,7 +193,7 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
 
   @Test
   public void getTierCapacity() throws Exception {
-    long total = ServerConfiguration.getBytes(PropertyKey.WORKER_RAMDISK_SIZE);
+    long total = Configuration.getBytes(PropertyKey.WORKER_RAMDISK_SIZE);
     Capacity capacity = getInfo(NO_PARAMS).getTierCapacity().get(Constants.MEDIUM_MEM);
     assertEquals(total, capacity.getTotal());
     assertEquals(0, capacity.getUsed());
@@ -221,7 +221,7 @@ public final class AlluxioMasterRestApiTest extends RestApiTest {
     assertEquals(1, workerInfos.size());
     WorkerInfo workerInfo = workerInfos.get(0);
     assertEquals(0, workerInfo.getUsedBytes());
-    long bytes = ServerConfiguration.getBytes(PropertyKey.WORKER_RAMDISK_SIZE);
+    long bytes = Configuration.getBytes(PropertyKey.WORKER_RAMDISK_SIZE);
     assertEquals(bytes, workerInfo.getCapacityBytes());
   }
 

--- a/tests/src/test/java/alluxio/client/rest/AlluxioWorkerRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/AlluxioWorkerRestApiTest.java
@@ -14,7 +14,7 @@ package alluxio.client.rest;
 import alluxio.Constants;
 import alluxio.RuntimeConstants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.security.authentication.AuthType;
@@ -67,7 +67,7 @@ public final class AlluxioWorkerRestApiTest extends RestApiTest {
 
   @Test
   public void getCapacity() throws Exception {
-    long total = ServerConfiguration.getBytes(PropertyKey.WORKER_RAMDISK_SIZE);
+    long total = Configuration.getBytes(PropertyKey.WORKER_RAMDISK_SIZE);
     Capacity capacity = getInfo().getCapacity();
     Assert.assertEquals(total, capacity.getTotal());
     Assert.assertEquals(0, capacity.getUsed());
@@ -75,7 +75,7 @@ public final class AlluxioWorkerRestApiTest extends RestApiTest {
 
   @Test
   public void getConfiguration() throws Exception {
-    ServerConfiguration.set(PropertyKey.METRICS_CONF_FILE, "abc");
+    Configuration.set(PropertyKey.METRICS_CONF_FILE, "abc");
     Assert.assertEquals("abc",
         getInfo().getConfiguration().get(PropertyKey.METRICS_CONF_FILE.toString()));
   }
@@ -100,7 +100,7 @@ public final class AlluxioWorkerRestApiTest extends RestApiTest {
 
   @Test
   public void getTierCapacity() throws Exception {
-    long total = ServerConfiguration.getBytes(PropertyKey.WORKER_RAMDISK_SIZE);
+    long total = Configuration.getBytes(PropertyKey.WORKER_RAMDISK_SIZE);
     Capacity capacity = getInfo().getTierCapacity().get(Constants.MEDIUM_MEM);
     Assert.assertEquals(total, capacity.getTotal());
     Assert.assertEquals(0, capacity.getUsed());

--- a/tests/src/test/java/alluxio/client/rest/JobMasterRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/JobMasterRestApiTest.java
@@ -12,7 +12,7 @@
 package alluxio.client.rest;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.AlluxioJobMasterRestServiceHandler;
 import alluxio.master.LocalAlluxioJobCluster;
 import alluxio.security.authentication.AuthType;
@@ -52,7 +52,7 @@ public final class JobMasterRestApiTest extends RestApiTest {
   @After
   public void after() throws Exception {
     mJobCluster.stop();
-    ServerConfiguration.reset();
+    Configuration.reloadProperties();
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -23,7 +23,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.SetAttributePOptions;
@@ -127,7 +127,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
     subject.getPrincipals().add(new User("user0"));
     AlluxioURI bucketPath = new AlluxioURI("/bucket0");
     FileSystem fs1 = sResource.get().getClient(FileSystemContext.create(subject,
-            ServerConfiguration.global()));
+            Configuration.global()));
     fs1.createDirectory(bucketPath);
     SetAttributePOptions setAttributeOptions =
         SetAttributePOptions.newBuilder().setOwner("user0").build();
@@ -138,7 +138,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
     subject.getPrincipals().add(new User("user1"));
     AlluxioURI bucket1Path = new AlluxioURI("/bucket1");
     FileSystem fs2 = sResource.get().getClient(FileSystemContext.create(subject,
-            ServerConfiguration.global()));
+            Configuration.global()));
     fs2.createDirectory(bucket1Path);
     setAttributeOptions = SetAttributePOptions.newBuilder().setOwner("user1").build();
     mFileSystem.setAttribute(new AlluxioURI("/bucket1"), setAttributeOptions);

--- a/tests/src/test/java/alluxio/client/table/TableMasterClientTest.java
+++ b/tests/src/test/java/alluxio/client/table/TableMasterClientTest.java
@@ -15,7 +15,7 @@ import alluxio.ClientContext;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.MasterClientContext;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
@@ -41,7 +41,7 @@ public final class TableMasterClientTest extends BaseIntegrationTest {
   public final void before() throws Exception {
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
     MasterClientContext context = MasterClientContext
-        .newBuilder(ClientContext.create(ServerConfiguration.global())).build();
+        .newBuilder(ClientContext.create(Configuration.global())).build();
     mTableMasterClient = new RetryHandlingTableMasterClient(context);
     mFSMasterClient = new FileSystemMasterClient(context);
   }

--- a/tests/src/test/java/alluxio/job/JobIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/JobIntegrationTest.java
@@ -15,7 +15,7 @@ import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.job.util.JobTestUtils;
 import alluxio.job.wire.JobInfo;
 import alluxio.job.wire.Status;
@@ -62,7 +62,7 @@ public abstract class JobIntegrationTest extends BaseIntegrationTest {
     mLocalAlluxioJobCluster = new LocalAlluxioJobCluster();
     mLocalAlluxioJobCluster.start();
     mJobMaster = mLocalAlluxioJobCluster.getMaster().getJobMaster();
-    mFsContext = FileSystemContext.create(ServerConfiguration.global());
+    mFsContext = FileSystemContext.create(Configuration.global());
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
   }
 

--- a/tests/src/test/java/alluxio/job/master/LostWorkerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/master/LostWorkerIntegrationTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertTrue;
 import alluxio.ConfigurationRule;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.heartbeat.ManuallyScheduleHeartbeat;
@@ -46,7 +46,7 @@ public class LostWorkerIntegrationTest extends BaseIntegrationTest {
   @Rule
   public ConfigurationRule mConfigurationRule = new ConfigurationRule(ImmutableMap.of(
       PropertyKey.JOB_MASTER_WORKER_TIMEOUT, WORKER_HEARTBEAT_TIMEOUT_MS),
-      ServerConfiguration.global());
+      Configuration.modifiableGlobal());
 
   // We need this because LocalAlluxioJobCluster doesn't work without it.
   @Rule
@@ -73,7 +73,7 @@ public class LostWorkerIntegrationTest extends BaseIntegrationTest {
     HeartbeatScheduler.execute(HeartbeatContext.JOB_WORKER_COMMAND_HANDLING);
     CommonUtils.waitFor("worker to reregister",
         () -> !mLocalAlluxioJobCluster.getMaster().getJobMaster().getWorkerInfoList().isEmpty()
-            && JobWorkerIdRegistry.getWorkerId() != initialId,
+            && JobWorkerIdRegistry.getWorkerId().longValue() != initialId,
         WaitForOptions.defaults().setTimeoutMs(10 * Constants.SECOND_MS));
   }
 }

--- a/tests/src/test/java/alluxio/job/plan/persist/PersistIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/plan/persist/PersistIntegrationTest.java
@@ -20,7 +20,7 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystemMasterClient;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.job.JobIntegrationTest;
@@ -67,7 +67,7 @@ public final class PersistIntegrationTest extends JobIntegrationTest {
     // run the persist job and check that it succeeds
     waitForJobToFinish(mJobMaster.run(new PersistConfig("/test", 1, true, status.getUfsPath())));
     String ufsPath = status.getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, Configuration.global());
     Assert.assertTrue(ufs.exists(ufsPath));
 
     // run the persist job again with the overwrite flag and check that it succeeds
@@ -100,7 +100,7 @@ public final class PersistIntegrationTest extends JobIntegrationTest {
     // run the persist job and check that it succeeds
     waitForJobToFinish(mJobMaster.run(new PersistConfig("/test", 1, true, status.getUfsPath())));
     String ufsPath = status.getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, Configuration.global());
     Assert.assertTrue(ufs.exists(ufsPath));
 
     // check file access time is not changed
@@ -132,7 +132,7 @@ public final class PersistIntegrationTest extends JobIntegrationTest {
     try (CloseableResource<FileSystemMasterClient> client =
         mFsContext.acquireMasterClientResource()) {
       client.get().scheduleAsyncPersist(new AlluxioURI(TEST_URI),
-          FileSystemOptions.scheduleAsyncPersistDefaults(ServerConfiguration.global()));
+          FileSystemOptions.scheduleAsyncPersistDefaults(Configuration.global()));
     }
     CommonUtils.waitFor("persist timeout", () -> {
       try {
@@ -152,7 +152,7 @@ public final class PersistIntegrationTest extends JobIntegrationTest {
     status = mFileSystem.getStatus(filePath);
     Assert.assertEquals(PersistenceState.NOT_PERSISTED.toString(), status.getPersistenceState());
     String ufsPath = status.getUfsPath();
-    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, ServerConfiguration.global());
+    UnderFileSystem ufs = UnderFileSystem.Factory.create(ufsPath, Configuration.global());
     Assert.assertFalse(ufs.exists(ufsPath));
   }
 
@@ -171,7 +171,7 @@ public final class PersistIntegrationTest extends JobIntegrationTest {
     try (CloseableResource<FileSystemMasterClient> client =
         mFsContext.acquireMasterClientResource()) {
       client.get().scheduleAsyncPersist(path,
-          FileSystemOptions.scheduleAsyncPersistDefaults(ServerConfiguration.global()));
+          FileSystemOptions.scheduleAsyncPersistDefaults(Configuration.global()));
       Assert.fail("Should not be able to schedule persistence for incomplete file");
     } catch (Exception e) {
       // expected

--- a/tests/src/test/java/alluxio/server/auth/ClusterInitializationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/auth/ClusterInitializationIntegrationTest.java
@@ -17,7 +17,7 @@ import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.PermissionDeniedException;
 import alluxio.master.file.FileSystemMaster;
@@ -107,6 +107,6 @@ public final class ClusterInitializationIntegrationTest extends BaseIntegrationT
         .getMessage("Unauthorized user on root"));
     // user jack cannot recover master from journal, in which the root is owned by alluxio.
     MasterTestUtils.createLeaderFileSystemMasterFromJournal(
-        new TestUserState(USER, ServerConfiguration.global())).close();
+        new TestUserState(USER, Configuration.global())).close();
   }
 }

--- a/tests/src/test/java/alluxio/server/auth/MasterClientAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/auth/MasterClientAuthenticationIntegrationTest.java
@@ -15,7 +15,7 @@ import alluxio.AlluxioURI;
 import alluxio.ClientContext;
 import alluxio.client.file.FileSystemMasterClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.UnauthenticatedException;
 import alluxio.master.MasterClientContext;
 import alluxio.security.authentication.AuthType;
@@ -92,10 +92,10 @@ public final class MasterClientAuthenticationIntegrationTest extends BaseIntegra
           NameMatchAuthenticationProvider.FULL_CLASS_NAME,
           PropertyKey.Name.SECURITY_LOGIN_USERNAME, "alluxio"})
   public void customAuthenticationDenyConnect() throws Exception {
-    UserState s = new TestUserState("no-alluxio", ServerConfiguration.global());
+    UserState s = new TestUserState("no-alluxio", Configuration.global());
     try (FileSystemMasterClient masterClient = FileSystemMasterClient.Factory.create(
         MasterClientContext
-            .newBuilder(ClientContext.create(s.getSubject(), ServerConfiguration.global()))
+            .newBuilder(ClientContext.create(s.getSubject(), Configuration.global()))
             .build())) {
       Assert.assertFalse(masterClient.isConnected());
       // Using no-alluxio as loginUser to connect to Master, the IOException will be thrown
@@ -110,7 +110,7 @@ public final class MasterClientAuthenticationIntegrationTest extends BaseIntegra
   public void simpleAuthenticationIsolatedClassLoader() throws Exception {
     FileSystemMasterClient masterClient =
         FileSystemMasterClient.Factory.create(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+            .newBuilder(ClientContext.create(Configuration.global())).build());
     Assert.assertFalse(masterClient.isConnected());
 
     // Get the current context class loader to retrieve the classpath URLs.
@@ -140,17 +140,17 @@ public final class MasterClientAuthenticationIntegrationTest extends BaseIntegra
    * @param filename the name of the file
    */
   private void authenticationOperationTest(String filename) throws Exception {
-    UserState s = new TestUserState(SUPERUSER, ServerConfiguration.global());
+    UserState s = new TestUserState(SUPERUSER, Configuration.global());
     FileSystemMasterClient masterClient = FileSystemMasterClient.Factory.create(MasterClientContext
-        .newBuilder(ClientContext.create(s.getSubject(), ServerConfiguration.global())).build());
+        .newBuilder(ClientContext.create(s.getSubject(), Configuration.global())).build());
     Assert.assertFalse(masterClient.isConnected());
     masterClient.connect();
     Assert.assertTrue(masterClient.isConnected());
     masterClient.createFile(new AlluxioURI(filename),
-        FileSystemOptions.createFileDefaults(ServerConfiguration.global()));
+        FileSystemOptions.createFileDefaults(Configuration.global()));
     Assert.assertNotNull(
         masterClient.getStatus(new AlluxioURI(filename),
-            FileSystemOptions.getStatusDefaults(ServerConfiguration.global())));
+            FileSystemOptions.getStatusDefaults(Configuration.global())));
     masterClient.disconnect();
     masterClient.close();
   }

--- a/tests/src/test/java/alluxio/server/configuration/ConfigCheckerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/configuration/ConfigCheckerIntegrationTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 import alluxio.Constants;
 import alluxio.client.meta.MetaMasterClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.ConfigStatus;
 import alluxio.grpc.Scope;
 import alluxio.master.journal.JournalType;
@@ -196,7 +196,7 @@ public class ConfigCheckerIntegrationTest extends BaseIntegrationTest {
     Map<Integer, Map<PropertyKey, String>> properties = new HashMap<>();
     for (int i = 0; i < nodeNum; i++) {
       Map<PropertyKey, String> prop = new HashMap<>();
-      prop.put(key, ((ServerConfiguration.getMs(key) / Constants.SECOND_MS) + i) + "sec");
+      prop.put(key, ((Configuration.getMs(key) / Constants.SECOND_MS) + i) + "sec");
       properties.put(i, prop);
     }
     return properties;

--- a/tests/src/test/java/alluxio/server/ft/FileSystemMasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/FileSystemMasterFaultToleranceIntegrationTest.java
@@ -17,7 +17,7 @@ import alluxio.AlluxioURI;
 import alluxio.AuthenticatedUserRule;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.FileAlreadyCompletedException;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
@@ -58,18 +58,18 @@ public final class FileSystemMasterFaultToleranceIntegrationTest extends BaseInt
 
   @Rule
   public AuthenticatedUserRule mAuthenticatedUser =
-      new AuthenticatedUserRule(TEST_USER, ServerConfiguration.global());
+      new AuthenticatedUserRule(TEST_USER, Configuration.global());
 
   @Before
   public final void before() throws Exception {
     mMultiMasterLocalAlluxioCluster = new MultiMasterLocalAlluxioCluster(2, 0);
     mMultiMasterLocalAlluxioCluster.initConfiguration(
         IntegrationTestUtils.getTestName(getClass().getSimpleName(), mTestName.getMethodName()));
-    ServerConfiguration.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "60sec");
-    ServerConfiguration.set(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS, "1sec");
-    ServerConfiguration.set(PropertyKey.NETWORK_CONNECTION_SERVER_SHUTDOWN_TIMEOUT, "30sec");
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS, "0sec");
-    ServerConfiguration.set(PropertyKey.SECURITY_LOGIN_USERNAME, TEST_USER);
+    Configuration.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "60sec");
+    Configuration.set(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS, "1sec");
+    Configuration.set(PropertyKey.NETWORK_CONNECTION_SERVER_SHUTDOWN_TIMEOUT, "30sec");
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS, "0sec");
+    Configuration.set(PropertyKey.SECURITY_LOGIN_USERNAME, TEST_USER);
     mMultiMasterLocalAlluxioCluster.start();
   }
 

--- a/tests/src/test/java/alluxio/server/ft/FlakyUfsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/FlakyUfsIntegrationTest.java
@@ -22,7 +22,7 @@ import alluxio.client.block.BlockMasterClient;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
@@ -53,7 +53,7 @@ public final class FlakyUfsIntegrationTest extends BaseIntegrationTest {
   // An under file system which fails 90% of its renames.
   private static final UnderFileSystem UFS =
       new DelegatingUnderFileSystem(UnderFileSystem.Factory.create(LOCAL_UFS_PATH,
-          ServerConfiguration.global())) {
+          Configuration.global())) {
         @Override
         public boolean deleteFile(String path) throws IOException {
           if (ThreadLocalRandom.current().nextBoolean()) {
@@ -116,7 +116,7 @@ public final class FlakyUfsIntegrationTest extends BaseIntegrationTest {
     mFs.free(new AlluxioURI("/"), FreePOptions.newBuilder().setRecursive(true).build());
     BlockMasterClient blockClient =
         BlockMasterClient.Factory.create(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+            .newBuilder(ClientContext.create(Configuration.global())).build());
     CommonUtils.waitFor("data to be freed", () -> {
       try {
         return blockClient.getUsedBytes() == 0;

--- a/tests/src/test/java/alluxio/server/ft/MasterFailoverIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MasterFailoverIntegrationTest.java
@@ -19,7 +19,7 @@ import alluxio.Constants;
 import alluxio.UnderFileSystemFactoryRegistryRule;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.MultiMasterLocalAlluxioCluster;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.IntegrationTestUtils;
@@ -54,7 +54,7 @@ public final class MasterFailoverIntegrationTest extends BaseIntegrationTest {
   // An under file system which has slow directory deletion.
   private static final UnderFileSystem UFS =
       new DelegatingUnderFileSystem(UnderFileSystem.Factory.create(LOCAL_UFS_PATH,
-          ServerConfiguration.global())) {
+          Configuration.global())) {
         @Override
         public boolean deleteDirectory(String path) throws IOException {
           CommonUtils.sleepMs(DELETE_DELAY);
@@ -81,11 +81,11 @@ public final class MasterFailoverIntegrationTest extends BaseIntegrationTest {
         new MultiMasterLocalAlluxioCluster(2);
     mMultiMasterLocalAlluxioCluster.initConfiguration(
         IntegrationTestUtils.getTestName(getClass().getSimpleName(), mTestName.getMethodName()));
-    ServerConfiguration.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "60sec");
-    ServerConfiguration.set(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS, "1sec");
-    ServerConfiguration.set(PropertyKey.NETWORK_CONNECTION_SERVER_SHUTDOWN_TIMEOUT, "30sec");
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS, "0sec");
-    ServerConfiguration.set(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS,
+    Configuration.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "60sec");
+    Configuration.set(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS, "1sec");
+    Configuration.set(PropertyKey.NETWORK_CONNECTION_SERVER_SHUTDOWN_TIMEOUT, "30sec");
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS, "0sec");
+    Configuration.set(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS,
         DelegatingUnderFileSystemFactory.DELEGATING_SCHEME + "://" + LOCAL_UFS_PATH);
     mMultiMasterLocalAlluxioCluster.start();
     mFileSystem = mMultiMasterLocalAlluxioCluster.getClient();

--- a/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
@@ -24,7 +24,7 @@ import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.collections.Pair;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.CommandType;
 import alluxio.grpc.CreateFilePOptions;
@@ -93,11 +93,11 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
         new MultiMasterLocalAlluxioCluster(MASTERS);
     mMultiMasterLocalAlluxioCluster.initConfiguration(
         IntegrationTestUtils.getTestName(getClass().getSimpleName(), mTestName.getMethodName()));
-    ServerConfiguration.set(PropertyKey.WORKER_RAMDISK_SIZE, WORKER_CAPACITY_BYTES);
-    ServerConfiguration.set(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE);
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS, 100);
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 2);
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, 32);
+    Configuration.set(PropertyKey.WORKER_RAMDISK_SIZE, WORKER_CAPACITY_BYTES);
+    Configuration.set(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, BLOCK_SIZE);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS, 100);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 2);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, 32);
     mMultiMasterLocalAlluxioCluster.start();
     mFileSystem = mMultiMasterLocalAlluxioCluster.getClient();
   }
@@ -170,7 +170,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
     for (int kills = 0; kills < MASTERS - 1; kills++) {
       assertTrue(mMultiMasterLocalAlluxioCluster.stopLeader());
       mMultiMasterLocalAlluxioCluster.waitForNewMaster(CLUSTER_WAIT_TIMEOUT_MS);
-      waitForWorkerRegistration(FileSystemContext.create(ServerConfiguration.global()), 1,
+      waitForWorkerRegistration(FileSystemContext.create(Configuration.global()), 1,
           CLUSTER_WAIT_TIMEOUT_MS);
       faultTestDataCheck(answer);
       faultTestDataCreation(new AlluxioURI("/data_kills_" + kills), answer);
@@ -184,7 +184,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
     for (int kills = 0; kills < MASTERS - 1; kills++) {
       assertTrue(mMultiMasterLocalAlluxioCluster.stopLeader());
       mMultiMasterLocalAlluxioCluster.waitForNewMaster(CLUSTER_WAIT_TIMEOUT_MS);
-      waitForWorkerRegistration(FileSystemContext.create(ServerConfiguration.global()), 1,
+      waitForWorkerRegistration(FileSystemContext.create(Configuration.global()), 1,
           CLUSTER_WAIT_TIMEOUT_MS);
 
       if (kills % 2 != 0) {
@@ -260,7 +260,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
     List<InetSocketAddress> addresses = mMultiMasterLocalAlluxioCluster.getMasterAddresses();
     Collections.shuffle(addresses);
     PollingMasterInquireClient inquireClient = new PollingMasterInquireClient(addresses,
-        ServerConfiguration.global(), ServerUserState.global());
+        Configuration.global(), ServerUserState.global());
     assertEquals(mMultiMasterLocalAlluxioCluster.getLocalAlluxioMaster().getAddress(),
         inquireClient.getPrimaryRpcAddress());
   }
@@ -270,7 +270,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
     for (int kills = 0; kills < MASTERS - 1; kills++) {
       assertTrue(mMultiMasterLocalAlluxioCluster.stopLeader());
       mMultiMasterLocalAlluxioCluster.waitForNewMaster(CLUSTER_WAIT_TIMEOUT_MS);
-      FileSystemContext context = FileSystemContext.create(ServerConfiguration.global());
+      FileSystemContext context = FileSystemContext.create(Configuration.global());
       BlockStoreClient store = BlockStoreClient.create(context);
       waitForWorkerRegistration(context, 1, 1 * Constants.MINUTE_MS);
       // If worker is successfully re-registered, the capacity bytes should not change.

--- a/tests/src/test/java/alluxio/server/ft/MultiWorkerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MultiWorkerIntegrationTest.java
@@ -29,7 +29,7 @@ import alluxio.client.file.options.InStreamOptions;
 import alluxio.client.file.options.OutStreamOptions;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.WritePType;
@@ -183,19 +183,19 @@ public final class MultiWorkerIntegrationTest extends BaseIntegrationTest {
   private void createFileOnWorker(int total, AlluxioURI filePath, WorkerNetAddress address)
       throws IOException {
     FindFirstBlockLocationPolicy.sWorkerAddress = address;
-    Class<?> previousPolicy = ServerConfiguration.getClass(
+    Class<?> previousPolicy = Configuration.getClass(
         PropertyKey.USER_BLOCK_WRITE_LOCATION_POLICY);
     // This only works because the client instance hasn't been created yet.
-    ServerConfiguration.set(PropertyKey.USER_BLOCK_WRITE_LOCATION_POLICY,
+    Configuration.set(PropertyKey.USER_BLOCK_WRITE_LOCATION_POLICY,
         FindFirstBlockLocationPolicy.class.getName());
     FileSystemTestUtils.createByteFile(mResource.get().getClient(), filePath,
         CreateFilePOptions.newBuilder().setWriteType(WritePType.MUST_CACHE).build(),
         total);
-    ServerConfiguration.set(PropertyKey.USER_BLOCK_WRITE_LOCATION_POLICY, previousPolicy);
+    Configuration.set(PropertyKey.USER_BLOCK_WRITE_LOCATION_POLICY, previousPolicy);
   }
 
   private void replicateFileBlocks(AlluxioURI filePath) throws Exception {
-    FileSystemContext fsContext = FileSystemContext.create(ServerConfiguration.global());
+    FileSystemContext fsContext = FileSystemContext.create(Configuration.global());
     BlockStoreClient store = BlockStoreClient.create(fsContext);
     URIStatus status =  mResource.get().getClient().getStatus(filePath);
     List<FileBlockInfo> blocks = status.getFileBlockInfos();
@@ -213,7 +213,7 @@ public final class MultiWorkerIntegrationTest extends BaseIntegrationTest {
           blockInfo.getLength(), dest, OutStreamOptions.defaults(fsContext.getClientContext())
               .setBlockSizeBytes(8 * Constants.MB).setWriteType(WriteType.MUST_CACHE))) {
         try (InputStream inStream = store.getInStream(blockInfo.getBlockId(),
-            new InStreamOptions(status, ServerConfiguration.global()))) {
+            new InStreamOptions(status, Configuration.global()))) {
           ByteStreams.copy(inStream, outStream);
         }
       }

--- a/tests/src/test/java/alluxio/server/ft/ZookeeperFailureIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/ZookeeperFailureIntegrationTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertNotEquals;
 
 import alluxio.ConfigurationRule;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.FileSystemMasterClientServiceGrpc;
 import alluxio.grpc.GrpcChannel;
 import alluxio.grpc.GrpcChannelBuilder;
@@ -55,8 +55,7 @@ public class ZookeeperFailureIntegrationTest extends BaseIntegrationTest {
       PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, "1000",
       PropertyKey.USER_RPC_RETRY_BASE_SLEEP_MS, "500",
       PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS, "500",
-      PropertyKey.USER_RPC_RETRY_MAX_DURATION, "2500"), ServerConfiguration.global()
-  );
+      PropertyKey.USER_RPC_RETRY_MAX_DURATION, "2500"), Configuration.modifiableGlobal());
 
   public MultiProcessCluster mCluster;
 
@@ -180,7 +179,7 @@ public class ZookeeperFailureIntegrationTest extends BaseIntegrationTest {
         new InetSocketAddress(netAddress.getHostname(), netAddress.getRpcPort());
     try {
       GrpcChannel channel = GrpcChannelBuilder
-          .newBuilder(GrpcServerAddress.create(address), ServerConfiguration.global()).build();
+          .newBuilder(GrpcServerAddress.create(address), Configuration.global()).build();
       FileSystemMasterClientServiceGrpc.FileSystemMasterClientServiceBlockingStub client =
           FileSystemMasterClientServiceGrpc.newBlockingStub(channel);
       client.listStatus(ListStatusPRequest.getDefaultInstance());

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
@@ -29,7 +29,7 @@ import alluxio.client.file.URIStatus;
 import alluxio.client.meta.MetaMasterClient;
 import alluxio.client.meta.RetryHandlingMetaMasterClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.BackupAbortedException;
 import alluxio.exception.status.FailedPreconditionException;
 import alluxio.grpc.BackupPOptions;
@@ -79,7 +79,7 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
     {
       put(PropertyKey.USER_METRICS_COLLECTION_ENABLED, false);
     }
-  }, ServerConfiguration.global());
+  }, Configuration.modifiableGlobal());
 
   @After
   public void after() throws Exception {
@@ -534,14 +534,14 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
 
   private MetaMasterClient getMetaClient(MultiProcessCluster cluster) {
     return new RetryHandlingMetaMasterClient(
-        MasterClientContext.newBuilder(ClientContext.create(ServerConfiguration.global()))
+        MasterClientContext.newBuilder(ClientContext.create(Configuration.global()))
             .setMasterInquireClient(cluster.getMasterInquireClient())
             .build());
   }
 
   private BlockMasterClient getBlockClient(MultiProcessCluster cluster) {
     return new RetryHandlingBlockMasterClient(
-        MasterClientContext.newBuilder(ClientContext.create(ServerConfiguration.global()))
+        MasterClientContext.newBuilder(ClientContext.create(Configuration.global()))
             .setMasterInquireClient(cluster.getMasterInquireClient()).build());
   }
 }

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalCheckpointIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalCheckpointIntegrationTest.java
@@ -21,7 +21,7 @@ import alluxio.client.file.RetryHandlingFileSystemMasterClient;
 import alluxio.client.meta.MetaMasterClient;
 import alluxio.client.meta.RetryHandlingMetaMasterClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.AccessControlException;
 import alluxio.grpc.BackupPOptions;
 import alluxio.grpc.BackupPRequest;
@@ -76,14 +76,14 @@ public class JournalCheckpointIntegrationTest extends BaseIntegrationTest {
     assertEquals(3, mCluster.getClient().getMountTable().size());
     mCluster.getClient().unmount(alluxioMount1);
     assertEquals(2, mCluster.getClient().getMountTable().size());
-    ServerConfiguration.unset(PropertyKey.MASTER_JOURNAL_INIT_FROM_BACKUP);
+    Configuration.unset(PropertyKey.MASTER_JOURNAL_INIT_FROM_BACKUP);
   }
 
   @Test
   public void recoverUfsState() throws Exception {
     FileSystemMasterClient client =
         new RetryHandlingFileSystemMasterClient(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+            .newBuilder(ClientContext.create(Configuration.global())).build());
     client.updateUfsMode(new AlluxioURI(""),
         UpdateUfsModePOptions.newBuilder().setUfsMode(UfsPMode.READ_ONLY).build());
 
@@ -101,12 +101,12 @@ public class JournalCheckpointIntegrationTest extends BaseIntegrationTest {
     File backup = mFolder.newFolder("backup");
     MetaMasterClient metaClient =
         new RetryHandlingMetaMasterClient(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+            .newBuilder(ClientContext.create(Configuration.global())).build());
     AlluxioURI backupURI = metaClient
         .backup(BackupPRequest.newBuilder().setTargetDirectory(backup.getAbsolutePath())
             .setOptions(BackupPOptions.newBuilder().setLocalFileSystem(true)).build())
         .getBackupUri();
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_INIT_FROM_BACKUP, backupURI);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_INIT_FROM_BACKUP, backupURI);
     mCluster.formatAndRestartMasters();
   }
 }

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalMigrationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalMigrationIntegrationTest.java
@@ -20,7 +20,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.meta.MetaMasterClient;
 import alluxio.client.meta.RetryHandlingMetaMasterClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.BackupPOptions;
 import alluxio.grpc.BackupPRequest;
 import alluxio.master.MasterClientContext;
@@ -53,7 +53,7 @@ public final class JournalMigrationIntegrationTest extends BaseIntegrationTest {
       cluster.start();
       FileSystem fs = cluster.getFileSystemClient();
       MetaMasterClient metaClient = new RetryHandlingMetaMasterClient(
-          MasterClientContext.newBuilder(ClientContext.create(ServerConfiguration.global()))
+          MasterClientContext.newBuilder(ClientContext.create(Configuration.global()))
               .setMasterInquireClient(cluster.getMasterInquireClient())
               .build());
       for (int i = 0; i < NUM_DIRS; i++) {

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalShutdownIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalShutdownIntegrationTest.java
@@ -26,7 +26,7 @@ import alluxio.client.WriteType;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.LocalAlluxioCluster;
 import alluxio.master.MultiMasterLocalAlluxioCluster;
 import alluxio.multi.process.MultiProcessCluster;
@@ -69,7 +69,7 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
 
   @Rule
   public AuthenticatedUserRule mAuthenticatedUser = new AuthenticatedUserRule("test",
-      ServerConfiguration.global());
+      Configuration.global());
 
   @Rule
   private TestName mTestName = new TestName();
@@ -81,7 +81,7 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
           .put(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 2)
           .put(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, 128)
           .put(PropertyKey.USER_RPC_RETRY_MAX_SLEEP_MS, "1sec").build(),
-          ServerConfiguration.global());
+          Configuration.modifiableGlobal());
 
   private static final long SHUTDOWN_TIME_MS = 15 * Constants.SECOND_MS;
   private static final String TEST_FILE_DIR = "/files/";
@@ -96,15 +96,15 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
   @Before
   public final void before() throws Exception {
     mExecutorsForClient = Executors.newFixedThreadPool(1);
-    mFsContext = FileSystemContext.create(ServerConfiguration.global());
+    mFsContext = FileSystemContext.create(Configuration.global());
   }
 
   @After
   public final void after() throws Exception {
     mExecutorsForClient.shutdown();
     mFsContext.close();
-    ServerConfiguration.reset();
-    ServerConfiguration.set(PropertyKey.USER_METRICS_COLLECTION_ENABLED, false);
+    Configuration.reloadProperties();
+    Configuration.set(PropertyKey.USER_METRICS_COLLECTION_ENABLED, false);
   }
 
   @Test
@@ -218,7 +218,7 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
   private UnderFileSystemFactory mountUnmount(FileSystem fs) throws Exception {
     SleepingUnderFileSystem sleepingUfs = new SleepingUnderFileSystem(new AlluxioURI("sleep:///"),
         new SleepingUnderFileSystemOptions(),
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global()));
+        UnderFileSystemConfiguration.defaults(Configuration.global()));
     SleepingUnderFileSystemFactory sleepingUfsFactory =
         new SleepingUnderFileSystemFactory(sleepingUfs);
     UnderFileSystemFactoryRegistry.register(sleepingUfsFactory);
@@ -253,7 +253,7 @@ public class JournalShutdownIntegrationTest extends BaseIntegrationTest {
     LocalAlluxioCluster cluster = new LocalAlluxioCluster();
     cluster.initConfiguration(
         IntegrationTestUtils.getTestName(getClass().getSimpleName(), mTestName.getMethodName()));
-    ServerConfiguration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.MUST_CACHE);
+    Configuration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.MUST_CACHE);
     cluster.start();
     return cluster;
   }

--- a/tests/src/test/java/alluxio/server/ft/journal/MultiMasterJournalTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/MultiMasterJournalTest.java
@@ -17,7 +17,7 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.TtlAction;
@@ -48,8 +48,8 @@ public class MultiMasterJournalTest extends BaseIntegrationTest {
     mCluster = new MultiMasterLocalAlluxioCluster(2, 0);
     mCluster.initConfiguration(
         IntegrationTestUtils.getTestName(getClass().getSimpleName(), mTestName.getMethodName()));
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 5);
-    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, 100);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 5);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, 100);
     mCluster.start();
   }
 

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestBase.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestBase.java
@@ -13,7 +13,7 @@ package alluxio.server.ft.journal.raft;
 
 import alluxio.ConfigurationRule;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.grpc.NetAddress;
 import alluxio.grpc.QuorumServerInfo;
@@ -34,7 +34,7 @@ public class EmbeddedJournalIntegrationTestBase extends BaseIntegrationTest {
   @Rule
   public ConfigurationRule mConf =
       new ConfigurationRule(PropertyKey.USER_METRICS_COLLECTION_ENABLED, false,
-          ServerConfiguration.global());
+          Configuration.modifiableGlobal());
 
   public MultiProcessCluster mCluster;
 

--- a/tests/src/test/java/alluxio/server/ft/journal/ufs/RenameFailureJournalTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/ufs/RenameFailureJournalTest.java
@@ -17,7 +17,7 @@ import alluxio.AlluxioURI;
 import alluxio.UnderFileSystemFactoryRegistryRule;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.testutils.underfs.delegating.DelegatingUnderFileSystem;
 import alluxio.testutils.underfs.delegating.DelegatingUnderFileSystemFactory;
@@ -47,7 +47,7 @@ public class RenameFailureJournalTest {
 
   // An under file system which fails 90% of its renames.
   private static final UnderFileSystem UFS =
-      new DelegatingUnderFileSystem(Factory.create(LOCAL_UFS_PATH, ServerConfiguration.global())) {
+      new DelegatingUnderFileSystem(Factory.create(LOCAL_UFS_PATH, Configuration.global())) {
         @Override
         public boolean renameFile(String src, String dst) throws IOException {
           if (ThreadLocalRandom.current().nextInt(10) == 0) {
@@ -75,7 +75,7 @@ public class RenameFailureJournalTest {
 
   @Before
   public void before() throws Exception {
-    mFs = FileSystem.Factory.create(ServerConfiguration.global());
+    mFs = FileSystem.Factory.create(Configuration.global());
   }
 
   @Test

--- a/tests/src/test/java/alluxio/server/ft/journal/ufs/UfsJournalIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/ufs/UfsJournalIntegrationTest.java
@@ -19,7 +19,7 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
@@ -143,7 +143,7 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
     journal.start();
     journal.gainPrimacy();
 
-    UfsStatus[] paths = UnderFileSystem.Factory.create(journalFolder, ServerConfiguration.global())
+    UfsStatus[] paths = UnderFileSystem.Factory.create(journalFolder, Configuration.global())
         .listStatus(journal.getLogDir().toString());
     int expectedSize = paths == null ? 0 : paths.length;
 
@@ -151,7 +151,7 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
     journal.flush();
     journal.flush();
     journal.close();
-    paths = UnderFileSystem.Factory.create(journalFolder, ServerConfiguration.global())
+    paths = UnderFileSystem.Factory.create(journalFolder, Configuration.global())
         .listStatus(journal.getLogDir().toString());
     int actualSize = paths == null ? 0 : paths.length;
     // No new files are created.
@@ -163,8 +163,8 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
    */
   @Test
   public void loadMetadata() throws Exception {
-    String ufsRoot = ServerConfiguration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
-    UnderFileSystem ufs = UnderFileSystem.Factory.createForRoot(ServerConfiguration.global());
+    String ufsRoot = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    UnderFileSystem ufs = UnderFileSystem.Factory.createForRoot(Configuration.global());
     ufs.create(ufsRoot + "/xyz").close();
     URIStatus status = mFileSystem.getStatus(new AlluxioURI("/xyz"));
     mLocalAlluxioCluster.stopFS();
@@ -208,11 +208,11 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
         new UfsJournal(new URI(journalFolder), new NoopMaster(), 0, Collections::emptySet);
     URI completedLocation = journal.getLogDir();
     Assert.assertTrue(UnderFileSystem.Factory.create(completedLocation.toString(),
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global()))
+        UnderFileSystemConfiguration.defaults(Configuration.global()))
         .listStatus(completedLocation.toString()).length > 1);
     multiEditLogTestUtil();
     Assert.assertTrue(UnderFileSystem.Factory.create(completedLocation.toString(),
-        UnderFileSystemConfiguration.defaults(ServerConfiguration.global()))
+        UnderFileSystemConfiguration.defaults(Configuration.global()))
         .listStatus(completedLocation.toString()).length > 1);
     multiEditLogTestUtil();
   }
@@ -574,7 +574,7 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
     AlluxioURI filePath = new AlluxioURI("/file");
 
     String user = "alluxio";
-    ServerConfiguration.set(PropertyKey.SECURITY_LOGIN_USERNAME, user);
+    Configuration.set(PropertyKey.SECURITY_LOGIN_USERNAME, user);
     CreateFilePOptions op = CreateFilePOptions.newBuilder().setBlockSizeBytes(64).build();
     mFileSystem.createFile(filePath, op).close();
 
@@ -610,7 +610,7 @@ public class UfsJournalIntegrationTest extends BaseIntegrationTest {
         new URI(PathUtils.concatPath(journalFolder, Constants.FILE_SYSTEM_MASTER_NAME)),
         new NoopMaster(), 0, Collections::emptySet);
     if (UfsJournalSnapshot.getCurrentLog(journal) != null) {
-      UnderFileSystem.Factory.create(journalFolder, ServerConfiguration.global())
+      UnderFileSystem.Factory.create(journalFolder, Configuration.global())
           .deleteFile(UfsJournalSnapshot.getCurrentLog(journal).getLocation().toString());
     }
   }

--- a/tests/src/test/java/alluxio/server/health/JobMasterHealthCheckClientIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/health/JobMasterHealthCheckClientIntegrationTest.java
@@ -12,7 +12,7 @@
 package alluxio.server.health;
 
 import alluxio.HealthCheckClient;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.LocalAlluxioJobCluster;
 import alluxio.master.MasterHealthCheckClient;
 import alluxio.master.job.JobMasterRpcHealthCheckClient;
@@ -43,7 +43,7 @@ public class JobMasterHealthCheckClientIntegrationTest extends BaseIntegrationTe
     mLocalAlluxioJobCluster.start();
     InetSocketAddress address = mLocalAlluxioJobCluster.getMaster().getRpcAddress();
     mHealthCheckClient = new JobMasterRpcHealthCheckClient(address, () -> new CountingRetry(1),
-        ServerConfiguration.global());
+        Configuration.global());
   }
 
   @After
@@ -64,7 +64,7 @@ public class JobMasterHealthCheckClientIntegrationTest extends BaseIntegrationTe
 
   @Test
   public void isServingMasterHealthCheck() {
-    mHealthCheckClient = new MasterHealthCheckClient.Builder(ServerConfiguration.global())
+    mHealthCheckClient = new MasterHealthCheckClient.Builder(Configuration.global())
         .withRetryPolicy(() -> new CountingRetry(1))
         .withProcessCheck(false)
         .withAlluxioMasterType(MasterHealthCheckClient.MasterType.JOB_MASTER)
@@ -75,7 +75,7 @@ public class JobMasterHealthCheckClientIntegrationTest extends BaseIntegrationTe
   @Test
   public void isServingStopJobsMasterHealthCheck() throws Exception {
     mLocalAlluxioJobCluster.stop();
-    mHealthCheckClient = new MasterHealthCheckClient.Builder(ServerConfiguration.global())
+    mHealthCheckClient = new MasterHealthCheckClient.Builder(Configuration.global())
         .withRetryPolicy(() -> new CountingRetry(1))
         .withProcessCheck(false)
         .withAlluxioMasterType(MasterHealthCheckClient.MasterType.JOB_MASTER)

--- a/tests/src/test/java/alluxio/server/health/JobWorkerHealthCheckClientIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/health/JobWorkerHealthCheckClientIntegrationTest.java
@@ -13,7 +13,7 @@ package alluxio.server.health;
 
 import alluxio.HealthCheckClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.LocalAlluxioJobCluster;
 import alluxio.retry.CountingRetry;
 import alluxio.testutils.BaseIntegrationTest;
@@ -44,7 +44,7 @@ public class JobWorkerHealthCheckClientIntegrationTest extends BaseIntegrationTe
     mLocalAlluxioJobCluster.start();
     InetSocketAddress address = mLocalAlluxioJobCluster.getWorker().getRpcAddress();
     mHealthCheckClient = new JobWorkerHealthCheckClient(address, () -> new CountingRetry(1),
-        ServerConfiguration.global());
+        Configuration.global());
   }
 
   @After

--- a/tests/src/test/java/alluxio/server/health/MasterHealthCheckClientIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/health/MasterHealthCheckClientIntegrationTest.java
@@ -12,7 +12,7 @@
 package alluxio.server.health;
 
 import alluxio.HealthCheckClient;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.LocalAlluxioCluster;
 import alluxio.master.MasterHealthCheckClient;
 import alluxio.retry.CountingRetry;
@@ -36,7 +36,7 @@ public class MasterHealthCheckClientIntegrationTest extends BaseIntegrationTest 
   @Before
   public final void before() {
     mLocalAlluxioCluster = mLocalAlluxioClusterResource.get();
-    mHealthCheckClient = new MasterHealthCheckClient.Builder(ServerConfiguration.global())
+    mHealthCheckClient = new MasterHealthCheckClient.Builder(Configuration.global())
         .withProcessCheck(false).withRetryPolicy(() -> new CountingRetry(1))
         .build();
   }

--- a/tests/src/test/java/alluxio/server/health/ProxyHealthCheckClientIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/health/ProxyHealthCheckClientIntegrationTest.java
@@ -12,7 +12,7 @@
 package alluxio.server.health;
 
 import alluxio.HealthCheckClient;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.LocalAlluxioCluster;
 import alluxio.proxy.ProxyHealthCheckClient;
 import alluxio.retry.CountingRetry;
@@ -39,7 +39,7 @@ public class ProxyHealthCheckClientIntegrationTest extends BaseIntegrationTest {
     mLocalAlluxioCluster = mLocalAlluxioClusterResource.get();
     mHealthCheckClient = new ProxyHealthCheckClient(
         NetworkAddressUtils.getBindAddress(NetworkAddressUtils.ServiceType.PROXY_WEB,
-            ServerConfiguration.global()),
+            Configuration.global()),
         () -> new CountingRetry(1));
   }
 

--- a/tests/src/test/java/alluxio/server/health/WorkerHealthCheckClientIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/health/WorkerHealthCheckClientIntegrationTest.java
@@ -13,7 +13,7 @@ package alluxio.server.health;
 
 import alluxio.HealthCheckClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.LocalAlluxioCluster;
 import alluxio.retry.CountingRetry;
 import alluxio.testutils.BaseIntegrationTest;
@@ -44,7 +44,7 @@ public class WorkerHealthCheckClientIntegrationTest extends BaseIntegrationTest 
         new InetSocketAddress(mLocalAlluxioCluster.getWorkerAddress().getHost(),
             mLocalAlluxioCluster.getWorkerAddress().getRpcPort());
     mHealthCheckClient = new WorkerHealthCheckClient(address, () -> new CountingRetry(1),
-        ServerConfiguration.global());
+        Configuration.global());
   }
 
   @Test

--- a/tests/src/test/java/alluxio/server/tieredstore/LostStorageIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/tieredstore/LostStorageIntegrationTest.java
@@ -22,7 +22,7 @@ import alluxio.ClientContext;
 import alluxio.Constants;
 import alluxio.client.block.BlockMasterClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.StorageList;
 import alluxio.grpc.WorkerLostStorageInfo;
 import alluxio.master.LocalAlluxioCluster;
@@ -114,7 +114,7 @@ public class LostStorageIntegrationTest extends BaseIntegrationTest {
     FileUtils.deleteDirectory(hddDir);
 
     // Make sure worker lost storage is detected and heartbeat with the master
-    Thread.sleep(10 * ServerConfiguration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS));
+    Thread.sleep(10 * Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS));
     checkLostStorageResults(ssdPath, hddPath);
   }
 
@@ -146,7 +146,7 @@ public class LostStorageIntegrationTest extends BaseIntegrationTest {
 
     FileUtils.deleteDirectory(hddDir);
     // Make sure lost storage is detected and reported to master
-    Thread.sleep(10 * ServerConfiguration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS));
+    Thread.sleep(10 * Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS));
     checkLostStorageResults(ssdPath, hddPath);
 
     mLocalAlluxioCluster.restartMasters();
@@ -181,7 +181,7 @@ public class LostStorageIntegrationTest extends BaseIntegrationTest {
     mLocalAlluxioCluster = mLocalAlluxioClusterResource.get();
     mBlockMasterClient =
         BlockMasterClient.Factory.create(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+            .newBuilder(ClientContext.create(Configuration.global())).build());
     mBlockMasterClient.connect();
   }
 

--- a/tests/src/test/java/alluxio/server/tieredstore/TieredStoreIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/tieredstore/TieredStoreIntegrationTest.java
@@ -18,7 +18,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
 import alluxio.grpc.SetAttributePOptions;
@@ -170,7 +170,7 @@ public class TieredStoreIntegrationTest extends BaseIntegrationTest {
     Assert.assertFalse(mFileSystem.getStatus(file1).isPinned());
 
     // Wait until worker receives the new pin-list.
-    Thread.sleep(2 * ServerConfiguration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS));
+    Thread.sleep(2 * Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS));
 
     // Try to create a file that cannot be stored unless the previous file is evicted, this
     // should succeed

--- a/tests/src/test/java/alluxio/server/worker/WorkerFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/worker/WorkerFuseIntegrationTest.java
@@ -15,7 +15,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.fuse.AbstractFuseIntegrationTest;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 
 /**
  * Integration tests for worker embedded Fuse application.
@@ -23,9 +23,9 @@ import alluxio.conf.ServerConfiguration;
 public class WorkerFuseIntegrationTest extends AbstractFuseIntegrationTest {
   @Override
   public void configure() {
-    ServerConfiguration.set(PropertyKey.WORKER_FUSE_ENABLED, true);
-    ServerConfiguration.set(PropertyKey.FUSE_MOUNT_POINT, mMountPoint);
-    ServerConfiguration.set(PropertyKey.FUSE_MOUNT_ALLUXIO_PATH, ALLUXIO_ROOT);
+    Configuration.set(PropertyKey.WORKER_FUSE_ENABLED, true);
+    Configuration.set(PropertyKey.FUSE_MOUNT_POINT, mMountPoint);
+    Configuration.set(PropertyKey.FUSE_MOUNT_ALLUXIO_PATH, ALLUXIO_ROOT);
   }
 
   @Override

--- a/tests/src/test/java/alluxio/testutils/IntegrationTestUtils.java
+++ b/tests/src/test/java/alluxio/testutils/IntegrationTestUtils.java
@@ -19,7 +19,7 @@ import alluxio.Constants;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemMasterClient;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.master.MasterClientContext;
@@ -73,11 +73,11 @@ public final class IntegrationTestUtils {
       final AlluxioURI uri, int timeoutMs) throws InterruptedException, TimeoutException {
     try (FileSystemMasterClient client =
         FileSystemMasterClient.Factory.create(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build())) {
+            .newBuilder(ClientContext.create(Configuration.global())).build())) {
       CommonUtils.waitFor(uri + " to be persisted", () -> {
         try {
           return client.getStatus(uri,
-              FileSystemOptions.getStatusDefaults(ServerConfiguration.global())).isPersisted();
+              FileSystemOptions.getStatusDefaults(Configuration.global())).isPersisted();
         } catch (Exception e) {
           throw Throwables.propagate(e);
         }
@@ -174,7 +174,7 @@ public final class IntegrationTestUtils {
         ServiceType.MASTER_RAFT, ServiceType.JOB_MASTER_RPC, ServiceType.JOB_MASTER_WEB,
         ServiceType.JOB_MASTER_RAFT)) {
       PropertyKey key = service.getPortKey();
-      ServerConfiguration.set(key, PortRegistry.reservePort());
+      Configuration.set(key, PortRegistry.reservePort());
     }
   }
 

--- a/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
+++ b/tests/src/test/java/alluxio/testutils/LocalAlluxioClusterResource.java
@@ -14,7 +14,7 @@ package alluxio.testutils;
 import alluxio.AlluxioURI;
 import alluxio.AuthenticatedClientUserResource;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.DeletePOptions;
 import alluxio.master.LocalAlluxioCluster;
 import alluxio.master.file.FileSystemMaster;
@@ -41,7 +41,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 /**
  * A JUnit Rule resource for automatically managing a local alluxio cluster for testing. To use it,
  * create an instance of the class under a {@literal @}Rule annotation, with the required
- * configuration parameters, and any necessary explicit {@link ServerConfiguration} settings. The
+ * configuration parameters, and any necessary explicit {@link Configuration} settings. The
  * Alluxio cluster will be set up from scratch at the end of every method (or at the start of
  * every suite if {@literal @}ClassRule is used), and destroyed at the end. Below is an example
  * of declaring and using it.
@@ -154,9 +154,9 @@ public final class LocalAlluxioClusterResource implements TestRule {
     mLocalAlluxioCluster.initConfiguration(mTestName);
     // Overwrite the test configuration with test specific parameters
     for (Entry<PropertyKey, Object> entry : mConfiguration.entrySet()) {
-      ServerConfiguration.set(entry.getKey(), entry.getValue());
+      Configuration.set(entry.getKey(), entry.getValue());
     }
-    ServerConfiguration.global().validate();
+    Configuration.global().validate();
     // Start the cluster
     mLocalAlluxioCluster.start();
   }
@@ -323,10 +323,10 @@ public final class LocalAlluxioClusterResource implements TestRule {
                 mCluster.mLocalAlluxioCluster.getLocalAlluxioMaster().getMasterProcess()
                     .getMaster(FileSystemMaster.class);
 
-            if (SecurityUtils.isAuthenticationEnabled(ServerConfiguration.global())) {
+            if (SecurityUtils.isAuthenticationEnabled(Configuration.global())) {
               // Reset the state as the root inode user (superuser).
               try (AuthenticatedClientUserResource r = new AuthenticatedClientUserResource(
-                  fsm.getRootInodeOwner(), ServerConfiguration.global())) {
+                  fsm.getRootInodeOwner(), Configuration.global())) {
                 resetCluster(fsm);
               }
             } else {

--- a/tests/src/test/java/alluxio/testutils/master/MasterTestUtils.java
+++ b/tests/src/test/java/alluxio/testutils/master/MasterTestUtils.java
@@ -14,7 +14,7 @@ package alluxio.testutils.master;
 import static org.mockito.Mockito.mock;
 
 import alluxio.conf.PropertyKey;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.BackupManager;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.MasterRegistry;
@@ -77,7 +77,7 @@ public class MasterTestUtils {
    * @return a resource that contains the master registry and the journal system
    */
   public static FsMasterResource createLeaderFileSystemMasterFromJournalCopy() throws Exception {
-    String masterJournal = ServerConfiguration.getString(PropertyKey.MASTER_JOURNAL_FOLDER);
+    String masterJournal = Configuration.getString(PropertyKey.MASTER_JOURNAL_FOLDER);
     File tmpDirFile = Files.createTempDir();
     tmpDirFile.deleteOnExit();
     String tempDir = tmpDirFile.getAbsolutePath();
@@ -95,7 +95,7 @@ public class MasterTestUtils {
    */
   private static FsMasterResource createFileSystemMasterFromJournal(boolean isLeader,
       UserState userState) throws Exception {
-    String masterJournal = ServerConfiguration.getString(PropertyKey.MASTER_JOURNAL_FOLDER);
+    String masterJournal = Configuration.getString(PropertyKey.MASTER_JOURNAL_FOLDER);
     return createFileSystemMasterFromJournal(isLeader, userState, masterJournal);
   }
 
@@ -114,8 +114,8 @@ public class MasterTestUtils {
     MasterRegistry registry = new MasterRegistry();
     SafeModeManager safeModeManager = new TestSafeModeManager();
     long startTimeMs = System.currentTimeMillis();
-    int port = ServerConfiguration.getInt(PropertyKey.MASTER_RPC_PORT);
-    String baseDir = ServerConfiguration.getString(PropertyKey.MASTER_METASTORE_DIR);
+    int port = Configuration.getInt(PropertyKey.MASTER_RPC_PORT);
+    String baseDir = Configuration.getString(PropertyKey.MASTER_METASTORE_DIR);
     JournalSystem journalSystem = JournalTestUtils.createJournalSystem(masterJournal);
     if (userState == null) {
       userState = ServerUserState.global();

--- a/tests/src/test/java/alluxio/web/ServiceSocketBindIntegrationTest.java
+++ b/tests/src/test/java/alluxio/web/ServiceSocketBindIntegrationTest.java
@@ -13,7 +13,7 @@ package alluxio.web;
 
 import alluxio.ClientContext;
 import alluxio.client.block.BlockMasterClient;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.ConnectionFailedException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.LocalAlluxioCluster;
@@ -69,7 +69,7 @@ public class ServiceSocketBindIntegrationTest extends BaseIntegrationTest {
     // connect Master RPC service
     mBlockMasterClient =
         BlockMasterClient.Factory.create(MasterClientContext
-            .newBuilder(ClientContext.create(ServerConfiguration.global())).build());
+            .newBuilder(ClientContext.create(Configuration.global())).build());
     mBlockMasterClient.connect();
 
     // connect Worker RPC service
@@ -81,7 +81,7 @@ public class ServiceSocketBindIntegrationTest extends BaseIntegrationTest {
 
     // connect Master Web service
     InetSocketAddress masterWebAddr =
-        NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_WEB, ServerConfiguration.global());
+        NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_WEB, Configuration.global());
     mMasterWebService = (HttpURLConnection) new URL("http://"
         + (masterWebAddr.isUnresolved() ? masterWebAddr.toString()
             : masterWebAddr.getAddress().getHostAddress() + ":" + masterWebAddr.getPort())
@@ -166,7 +166,7 @@ public class ServiceSocketBindIntegrationTest extends BaseIntegrationTest {
     InetSocketAddress masterRpcAddr = new InetSocketAddress("127.0.0.1",
         mLocalAlluxioCluster.getLocalAlluxioMaster().getRpcLocalPort());
     mBlockMasterClient = BlockMasterClient.Factory.create(MasterClientContext
-        .newBuilder(ClientContext.create(ServerConfiguration.global()))
+        .newBuilder(ClientContext.create(Configuration.global()))
         .setMasterInquireClient(new SingleMasterInquireClient(masterRpcAddr))
         .build());
     try {

--- a/tests/src/test/java/alluxio/web/WebServerIntegrationTest.java
+++ b/tests/src/test/java/alluxio/web/WebServerIntegrationTest.java
@@ -13,7 +13,7 @@ package alluxio.web;
 
 import alluxio.client.rest.TestCase;
 import alluxio.client.rest.TestCaseOptions;
-import alluxio.conf.ServerConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.metrics.sink.MetricsServlet;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
@@ -143,7 +143,7 @@ public class WebServerIntegrationTest extends BaseIntegrationTest {
     }
     InetSocketAddress webAddr =
         new InetSocketAddress(NetworkAddressUtils.getConnectHost(serviceType,
-            ServerConfiguration.global()), port);
+            Configuration.global()), port);
     return webAddr;
   }
 }

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactory.java
@@ -13,11 +13,11 @@ package alluxio.underfs.hdfs;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.UnderFileSystemFactory;
-import alluxio.util.ConfigurationUtils;
 
 import com.google.common.base.Preconditions;
 
@@ -53,7 +53,7 @@ public class HdfsUnderFileSystemFactory implements UnderFileSystemFactory {
       // FileSystem.getFileSystemClass() without any need for having users explicitly declare the
       // file system schemes to treat as being HDFS. However as long as pre 2.x versions of Hadoop
       // are supported this is not an option and we have to continue to use this method.
-      for (final String prefix : ConfigurationUtils.defaults()
+      for (final String prefix : Configuration.global()
           .getList(PropertyKey.UNDERFS_HDFS_PREFIXES)) {
         if (path.startsWith(prefix)) {
           return true;
@@ -69,7 +69,7 @@ public class HdfsUnderFileSystemFactory implements UnderFileSystemFactory {
       // This loads the configuration from the JVM's system properties and the site properties file
       // on disk. Because of this, setting the property UNDERFS_HDFS_PREFIXES programmatically *not*
       // work.
-      AlluxioConfiguration alluxioConf = ConfigurationUtils.defaults();
+      AlluxioConfiguration alluxioConf = Configuration.global();
 
       // TODO(hy): In Hadoop 2.x this can be replaced with the simpler call to
       // FileSystem.getFileSystemClass() without any need for having users explicitly declare the

--- a/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemFactoryTest.java
+++ b/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemFactoryTest.java
@@ -12,10 +12,9 @@
 package alluxio.underfs.local;
 
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
-import alluxio.util.ConfigurationUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,7 +29,7 @@ public class LocalUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
-    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    AlluxioConfiguration conf = Configuration.global();
     UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry.find("/local/test/path", conf);
     UnderFileSystemFactory factory2 = UnderFileSystemFactoryRegistry.find("file://local/test/path",
         conf);

--- a/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemTest.java
+++ b/underfs/local/src/test/java/alluxio/underfs/local/LocalUnderFileSystemTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.underfs.UfsDirectoryStatus;
@@ -29,7 +30,6 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.MkdirsOptions;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.util.network.NetworkAddressUtils;
 
@@ -59,8 +59,7 @@ import java.util.Map;
 public class LocalUnderFileSystemTest {
   private String mLocalUfsRoot;
   private UnderFileSystem mLocalUfs;
-  private static AlluxioConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+  private static AlluxioConfiguration sConf = Configuration.global();
 
   @Rule
   public TemporaryFolder mTemporaryFolder = new TemporaryFolder();

--- a/underfs/obs/src/test/java/alluxio/underfs/obs/OBSInputStreamTest.java
+++ b/underfs/obs/src/test/java/alluxio/underfs/obs/OBSInputStreamTest.java
@@ -20,10 +20,9 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.retry.CountingRetry;
-import alluxio.util.ConfigurationUtils;
 
 import com.obs.services.ObsClient;
 import com.obs.services.model.GetObjectRequest;
@@ -45,8 +44,7 @@ public class OBSInputStreamTest {
 
   private static final String BUCKET_NAME = "testBucket";
   private static final String OBJECT_KEY = "testObjectKey";
-  private static AlluxioConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+  private static AlluxioConfiguration sConf = Configuration.global();
 
   private OBSInputStream mOBSInputStream;
   private ObsClient mObsClient;

--- a/underfs/obs/src/test/java/alluxio/underfs/obs/OBSOutputStreamTest.java
+++ b/underfs/obs/src/test/java/alluxio/underfs/obs/OBSOutputStreamTest.java
@@ -12,9 +12,8 @@
 package alluxio.underfs.obs;
 
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.util.ConfigurationUtils;
 
 import com.obs.services.ObsClient;
 import com.obs.services.exception.ObsException;
@@ -44,8 +43,7 @@ import java.security.DigestOutputStream;
  */
 @RunWith(PowerMockRunner.class)
 public class OBSOutputStreamTest {
-  private static AlluxioConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+  private static AlluxioConfiguration sConf = Configuration.global();
 
   private ObsClient mObsClient;
   private File mFile;

--- a/underfs/obs/src/test/java/alluxio/underfs/obs/OBSUnderFileSystemFactoryTest.java
+++ b/underfs/obs/src/test/java/alluxio/underfs/obs/OBSUnderFileSystemFactoryTest.java
@@ -11,10 +11,9 @@
 
 package alluxio.underfs.obs;
 
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
-import alluxio.util.ConfigurationUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,7 +29,7 @@ public class OBSUnderFileSystemFactoryTest {
   @Test
   public void factory() {
     UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry.find("obs://bucket/key",
-        new InstancedConfiguration(ConfigurationUtils.copyDefaults()));
+        Configuration.global());
 
     Assert.assertNotNull(
         "A UnderFileSystemFactory should exist for obs paths when using this module", factory);

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSInputStreamTest.java
@@ -20,10 +20,9 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.retry.CountingRetry;
-import alluxio.util.ConfigurationUtils;
 
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.model.OSSObject;
@@ -44,8 +43,7 @@ public class OSSInputStreamTest {
 
   private static final String BUCKET_NAME = "testBucket";
   private static final String OBJECT_KEY = "testObjectKey";
-  private static AlluxioConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+  private static AlluxioConfiguration sConf = Configuration.global();
 
   private OSSInputStream mOssInputStream;
   private OSS mOssClient;

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSOutputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSOutputStreamTest.java
@@ -12,9 +12,8 @@
 package alluxio.underfs.oss;
 
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.util.ConfigurationUtils;
 
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.OSSException;
@@ -47,8 +46,7 @@ public class OSSOutputStreamTest {
   private OSS mOssClient;
   private File mFile;
   private BufferedOutputStream mLocalOutputStream;
-  private static AlluxioConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+  private static AlluxioConfiguration sConf = Configuration.global();
 
   /**
    * The exception expected to be thrown.

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemFactoryTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemFactoryTest.java
@@ -11,10 +11,9 @@
 
 package alluxio.underfs.oss;
 
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
-import alluxio.util.ConfigurationUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,7 +29,7 @@ public class OSSUnderFileSystemFactoryTest {
   @Test
   public void factory() {
     UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry.find("oss://test-bucket/path",
-        new InstancedConfiguration(ConfigurationUtils.copyDefaults()));
+        Configuration.global());
 
     Assert.assertNotNull(
         "A UnderFileSystemFactory should exist for oss paths when using this module", factory);

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3ALowLevelOutputStreamTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3ALowLevelOutputStreamTest.java
@@ -16,9 +16,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
-import alluxio.util.ConfigurationUtils;
 import alluxio.util.FormatUtils;
 
 import com.amazonaws.services.s3.AmazonS3;
@@ -57,8 +57,7 @@ public class S3ALowLevelOutputStreamTest {
   private static final String PARTITION_SIZE = "8MB";
   private static final String KEY = "testKey";
   private static final String UPLOAD_ID = "testUploadId";
-  private static InstancedConfiguration sConf = new InstancedConfiguration(
-      ConfigurationUtils.copyDefaults());
+  private static InstancedConfiguration sConf = Configuration.modifiableGlobal();
 
   private AmazonS3 mMockS3Client;
   private ListeningExecutorService mMockExecutor;

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AOutputStreamTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AOutputStreamTest.java
@@ -12,9 +12,8 @@
 package alluxio.underfs.s3a;
 
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.util.ConfigurationUtils;
 
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.transfer.TransferManager;
@@ -40,8 +39,7 @@ import java.security.DigestOutputStream;
 public class S3AOutputStreamTest {
   private static final String BUCKET_NAME = "testBucket";
   private static final String KEY = "testKey";
-  private static AlluxioConfiguration sConf = new InstancedConfiguration(
-      ConfigurationUtils.copyDefaults());
+  private static AlluxioConfiguration sConf = Configuration.global();
 
   private File mFile;
   private BufferedOutputStream mLocalOutputStream;

--- a/underfs/web/src/test/java/alluxio/underfs/web/WebUnderFileSystemFactoryTest.java
+++ b/underfs/web/src/test/java/alluxio/underfs/web/WebUnderFileSystemFactoryTest.java
@@ -12,10 +12,9 @@
 package alluxio.underfs.web;
 
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
-import alluxio.util.ConfigurationUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,7 +29,7 @@ public class WebUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
-    AlluxioConfiguration conf = new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+    AlluxioConfiguration conf = Configuration.global();
     UnderFileSystemFactory factory =
         UnderFileSystemFactoryRegistry.find("https://downloads.alluxio.io/downloads/files/2.0.0-preview/", conf);
     UnderFileSystemFactory factory2 =

--- a/underfs/web/src/test/java/alluxio/underfs/web/WebUnderFileSystemTest.java
+++ b/underfs/web/src/test/java/alluxio/underfs/web/WebUnderFileSystemTest.java
@@ -15,9 +15,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystem;
-import alluxio.util.ConfigurationUtils;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -30,8 +29,7 @@ import java.io.IOException;
 public class WebUnderFileSystemTest {
   private String mWebUfsRoot;
   private UnderFileSystem mWebUfs;
-  private static AlluxioConfiguration sConf =
-      new InstancedConfiguration(ConfigurationUtils.copyDefaults());
+  private static AlluxioConfiguration sConf = Configuration.global();
 
   @Before
   public void before() throws IOException {


### PR DESCRIPTION
### What changes are proposed in this pull request?

The loadProperties logic in ConfiguratinoUtils is updating a static
copy of a global configuration. ServerConfiguration is also a static
copy of a global configuration. Merging the two into one place and
call it Configuration.