### PR TITLE
Support rm directory and reset DirectChildrenLoadedState

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2086,7 +2086,7 @@ public class DefaultFileSystemMaster extends CoreMaster
             && context.getOptions().hasSyncParentNextTime()) {
           boolean syncParentNextTime = context.getOptions().getSyncParentNextTime();
           mInodeTree.setDirectChildrenLoaded(
-              rpcContext, inodePath.getParentInodeDirectory(), syncParentNextTime);
+              rpcContext, inodePath.getParentInodeDirectory(), !syncParentNextTime);
         }
         auditContext.setSucceeded(true);
         cacheOperation(context);

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2083,8 +2083,8 @@ public class DefaultFileSystemMaster extends CoreMaster
 
         deleteInternal(rpcContext, inodePath, context, false);
         if (context.getOptions().getAlluxioOnly()
-            && context.getOptions().hasDirectChildrenUnloaded()
-            && context.getOptions().getDirectChildrenUnloaded()) {
+            && context.getOptions().hasSyncDirNextTime()
+            && context.getOptions().getSyncDirNextTime()) {
           mInodeTree.setDirectChildrenLoaded(
               rpcContext, inodePath.getParentInodeDirectory(), false);
         }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2084,7 +2084,7 @@ public class DefaultFileSystemMaster extends CoreMaster
         deleteInternal(rpcContext, inodePath, context, false);
         if (context.getOptions().getAlluxioOnly()
             && context.getOptions().hasSyncParentNextTime()) {
-            boolean syncParentNextTime = context.getOptions().getSyncParentNextTime();
+          boolean syncParentNextTime = context.getOptions().getSyncParentNextTime();
           mInodeTree.setDirectChildrenLoaded(
               rpcContext, inodePath.getParentInodeDirectory(), syncParentNextTime);
         }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2083,10 +2083,10 @@ public class DefaultFileSystemMaster extends CoreMaster
 
         deleteInternal(rpcContext, inodePath, context, false);
         if (context.getOptions().getAlluxioOnly()
-            && context.getOptions().hasSyncParentNextTime()
-            && context.getOptions().getSyncParentNextTime()) {
+            && context.getOptions().hasSyncParentNextTime()) {
+            boolean syncParentNextTime = context.getOptions().getSyncParentNextTime();
           mInodeTree.setDirectChildrenLoaded(
-              rpcContext, inodePath.getParentInodeDirectory(), false);
+              rpcContext, inodePath.getParentInodeDirectory(), syncParentNextTime);
         }
         auditContext.setSucceeded(true);
         cacheOperation(context);

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2083,8 +2083,8 @@ public class DefaultFileSystemMaster extends CoreMaster
 
         deleteInternal(rpcContext, inodePath, context, false);
         if (context.getOptions().getAlluxioOnly()
-            && context.getOptions().hasSyncDirNextTime()
-            && context.getOptions().getSyncDirNextTime()) {
+            && context.getOptions().hasSyncParentNextTime()
+            && context.getOptions().getSyncParentNextTime()) {
           mInodeTree.setDirectChildrenLoaded(
               rpcContext, inodePath.getParentInodeDirectory(), false);
         }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2082,6 +2082,12 @@ public class DefaultFileSystemMaster extends CoreMaster
         }
 
         deleteInternal(rpcContext, inodePath, context, false);
+        if (context.getOptions().getAlluxioOnly()
+            && context.getOptions().hasDirectChildrenUnloaded()
+            && context.getOptions().getDirectChildrenUnloaded()) {
+          mInodeTree.setDirectChildrenLoaded(
+              rpcContext, inodePath.getParentInodeDirectory(), false);
+        }
         auditContext.setSucceeded(true);
         cacheOperation(context);
       }

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -150,7 +150,7 @@ message DeletePOptions {
   optional bool alluxioOnly = 2;
   optional bool unchecked = 3;
   optional FileSystemMasterCommonPOptions commonOptions = 4;
-  optional bool directChildrenUnloaded = 5;
+  optional bool syncDirNextTime = 5;
   optional bool deleteMountPoint = 6;
 }
 message DeletePRequest {

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -150,6 +150,7 @@ message DeletePOptions {
   optional bool alluxioOnly = 2;
   optional bool unchecked = 3;
   optional FileSystemMasterCommonPOptions commonOptions = 4;
+  optional bool directChildrenUnloaded = 5;
   optional bool deleteMountPoint = 6;
 }
 message DeletePRequest {

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -150,7 +150,7 @@ message DeletePOptions {
   optional bool alluxioOnly = 2;
   optional bool unchecked = 3;
   optional FileSystemMasterCommonPOptions commonOptions = 4;
-  optional bool syncDirNextTime = 5;
+  optional bool syncParentNextTime = 5;
   optional bool deleteMountPoint = 6;
 }
 message DeletePRequest {

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -2441,6 +2441,11 @@
                 "type": "FileSystemMasterCommonPOptions"
               },
               {
+                "id": 5,
+                "name": "syncParentNextTime",
+                "type": "bool"
+              },
+              {
                 "id": 6,
                 "name": "deleteMountPoint",
                 "type": "bool"

--- a/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
@@ -70,6 +70,13 @@ public final class RmCommand extends AbstractFileSystemCommand {
           .hasArg(false)
           .desc("remove mount points in the directory")
           .build();
+  private static final Option RESET_DIRECT_CHILDREN_LOADED_STATE =
+      Option.builder()
+          .longOpt("directChildrenUnloaded")
+          .required(false)
+          .hasArg(false)
+          .desc("reset data and metadata from Alluxio space only")
+          .build();
 
   /**
    * @param fsContext the filesystem of Alluxio
@@ -90,7 +97,8 @@ public final class RmCommand extends AbstractFileSystemCommand {
         .addOption(RECURSIVE_ALIAS_OPTION)
         .addOption(REMOVE_UNCHECKED_OPTION)
         .addOption(REMOVE_ALLUXIO_ONLY)
-        .addOption(DELETE_MOUNT_POINT);
+        .addOption(DELETE_MOUNT_POINT)
+        .addOption(RESET_DIRECT_CHILDREN_LOADED_STATE);
   }
 
   @Override
@@ -111,6 +119,8 @@ public final class RmCommand extends AbstractFileSystemCommand {
     DeletePOptions options =
         DeletePOptions.newBuilder().setRecursive(recursive).setAlluxioOnly(isAlluxioOnly)
             .setDeleteMountPoint(isDeleteMountPoint)
+            .setDirectChildrenUnloaded(
+                cl.hasOption(RESET_DIRECT_CHILDREN_LOADED_STATE.getLongOpt()))
             .setUnchecked(cl.hasOption(REMOVE_UNCHECKED_OPTION_CHAR)).build();
 
     mFileSystem.delete(path, options);

--- a/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
@@ -70,12 +70,13 @@ public final class RmCommand extends AbstractFileSystemCommand {
           .hasArg(false)
           .desc("remove mount points in the directory")
           .build();
-  private static final Option RESET_DIRECT_CHILDREN_LOADED_STATE =
+  private static final Option SYNC_DIR_NEXT_TIME =
       Option.builder()
-          .longOpt("directChildrenUnloaded")
+          .longOpt("syncDirNextTime")
           .required(false)
           .hasArg(false)
-          .desc("reset data and metadata from Alluxio space only")
+          .desc("Marks a directory to either trigger a metadata sync or skip the "
+              + "metadata sync on next access.")
           .build();
 
   /**
@@ -98,7 +99,7 @@ public final class RmCommand extends AbstractFileSystemCommand {
         .addOption(REMOVE_UNCHECKED_OPTION)
         .addOption(REMOVE_ALLUXIO_ONLY)
         .addOption(DELETE_MOUNT_POINT)
-        .addOption(RESET_DIRECT_CHILDREN_LOADED_STATE);
+        .addOption(SYNC_DIR_NEXT_TIME);
   }
 
   @Override
@@ -119,8 +120,8 @@ public final class RmCommand extends AbstractFileSystemCommand {
     DeletePOptions options =
         DeletePOptions.newBuilder().setRecursive(recursive).setAlluxioOnly(isAlluxioOnly)
             .setDeleteMountPoint(isDeleteMountPoint)
-            .setDirectChildrenUnloaded(
-                cl.hasOption(RESET_DIRECT_CHILDREN_LOADED_STATE.getLongOpt()))
+            .setSyncDirNextTime(
+                cl.hasOption(SYNC_DIR_NEXT_TIME.getLongOpt()))
             .setUnchecked(cl.hasOption(REMOVE_UNCHECKED_OPTION_CHAR)).build();
 
     mFileSystem.delete(path, options);

--- a/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
@@ -70,11 +70,11 @@ public final class RmCommand extends AbstractFileSystemCommand {
           .hasArg(false)
           .desc("remove mount points in the directory")
           .build();
-  private static final Option SYNC_DIR_NEXT_TIME =
-      Option.builder()
-          .longOpt("syncDirNextTime")
+  private static final Option SYNC_PARENT_NEXT_TIME =
+      Option.builder("s")
+          .longOpt("syncParentNextTime")
           .required(false)
-          .hasArg(false)
+          .hasArg(true)
           .desc("Marks a directory to either trigger a metadata sync or skip the "
               + "metadata sync on next access.")
           .build();
@@ -99,7 +99,7 @@ public final class RmCommand extends AbstractFileSystemCommand {
         .addOption(REMOVE_UNCHECKED_OPTION)
         .addOption(REMOVE_ALLUXIO_ONLY)
         .addOption(DELETE_MOUNT_POINT)
-        .addOption(SYNC_DIR_NEXT_TIME);
+        .addOption(SYNC_PARENT_NEXT_TIME);
   }
 
   @Override
@@ -120,8 +120,8 @@ public final class RmCommand extends AbstractFileSystemCommand {
     DeletePOptions options =
         DeletePOptions.newBuilder().setRecursive(recursive).setAlluxioOnly(isAlluxioOnly)
             .setDeleteMountPoint(isDeleteMountPoint)
-            .setSyncDirNextTime(
-                cl.hasOption(SYNC_DIR_NEXT_TIME.getLongOpt()))
+            .setSyncParentNextTime(
+                cl.hasOption(SYNC_PARENT_NEXT_TIME.getLongOpt()))
             .setUnchecked(cl.hasOption(REMOVE_UNCHECKED_OPTION_CHAR)).build();
 
     mFileSystem.delete(path, options);

--- a/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/RmCommand.java
@@ -121,7 +121,8 @@ public final class RmCommand extends AbstractFileSystemCommand {
         DeletePOptions.newBuilder().setRecursive(recursive).setAlluxioOnly(isAlluxioOnly)
             .setDeleteMountPoint(isDeleteMountPoint)
             .setSyncParentNextTime(
-                cl.hasOption(SYNC_PARENT_NEXT_TIME.getLongOpt()))
+                cl.hasOption(SYNC_PARENT_NEXT_TIME.getLongOpt())
+                    && Boolean.parseBoolean(cl.getOptionValue(SYNC_PARENT_NEXT_TIME.getLongOpt())))
             .setUnchecked(cl.hasOption(REMOVE_UNCHECKED_OPTION_CHAR)).build();
 
     mFileSystem.delete(path, options);

--- a/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
@@ -23,6 +23,9 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.conf.Configuration;
 import alluxio.exception.AlluxioException;
+import alluxio.grpc.ExistsPOptions;
+import alluxio.grpc.FileSystemMasterCommonPOptions;
+import alluxio.grpc.LoadMetadataPType;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
 import alluxio.grpc.WritePType;
@@ -299,6 +302,22 @@ public abstract class AbstractFileSystemShellTest extends AbstractShellIntegrati
       return false;
     }
   }
+
+  /**
+   * @param path a file path
+   * @return whether the file exists in Alluxio
+   */
+  protected boolean fileExistsInAlluxio(AlluxioURI path) {
+    try {
+      return sFileSystem.exists(path, ExistsPOptions.newBuilder().setLoadMetadataType(
+          LoadMetadataPType.NEVER).setCommonOptions(
+              FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(-1).build())
+          .build());
+    } catch (IOException e) {
+      return false;
+    } catch (AlluxioException e) {
+      return false;
+    }
 
   /**
    * Checks whether the given file is actually persisted by freeing it, then

--- a/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/AbstractFileSystemShellTest.java
@@ -309,15 +309,15 @@ public abstract class AbstractFileSystemShellTest extends AbstractShellIntegrati
    */
   protected boolean fileExistsInAlluxio(AlluxioURI path) {
     try {
-      return sFileSystem.exists(path, ExistsPOptions.newBuilder().setLoadMetadataType(
-          LoadMetadataPType.NEVER).setCommonOptions(
-              FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(-1).build())
-          .build());
+      return sFileSystem.exists(path,
+          ExistsPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER).setCommonOptions(
+              FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(-1).build()).build());
     } catch (IOException e) {
       return false;
     } catch (AlluxioException e) {
       return false;
     }
+  }
 
   /**
    * Checks whether the given file is actually persisted by freeing it, then

--- a/tests/src/test/java/alluxio/client/cli/fs/command/RmCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/RmCommandIntegrationTest.java
@@ -130,4 +130,28 @@ public final class RmCommandIntegrationTest extends AbstractFileSystemShellTest 
     Assert.assertFalse(fileExists(new AlluxioURI(testDir + "/foo")));
     Assert.assertFalse(fileExists(new AlluxioURI(testDir + "/foobar4")));
   }
+
+  @Test
+  public void rmSyncDirNextTime() {
+    StringBuilder toCompare = new StringBuilder();
+    sFsShell.run("mkdir", "/testFolder1/testFolder2");
+    toCompare.append(getCommandOutput(new String[] {"mkdir", "/testFolder1/testFolder2"}));
+    sFsShell.run("touch", "/testFolder1/testFolder2/testFile2");
+    toCompare
+        .append(getCommandOutput(new String[] {"touch", "/testFolder1/testFolder2/testFile2"}));
+    AlluxioURI testFolder1 = new AlluxioURI("/testFolder1");
+    AlluxioURI testFolder2 = new AlluxioURI("/testFolder1/testFolder2");
+    AlluxioURI testFile2 = new AlluxioURI("/testFolder1/testFolder2/testFile2");
+    Assert.assertTrue(fileExists(testFolder1));
+    Assert.assertTrue(fileExists(testFolder2));
+    Assert.assertTrue(fileExists(testFile2));
+    sFsShell.run("rm", "-s", "/testFolder1/testFolder2/testFile2");
+    toCompare.append(getCommandOutput(new String[] {"rm", "/testFolder1/testFolder2/testFile2"}));
+    Assert.assertEquals(toCompare.toString(), mOutput.toString());
+    Assert.assertTrue(fileExists(testFolder1));
+    Assert.assertTrue(fileExists(testFolder2));
+    Assert.assertFalse(fileExistsInAlluxio(testFile2));
+    Assert.assertTrue(fileExists(testFile2));
+    Assert.assertTrue(fileExistsInAlluxio(testFile2));
+  }
 }

--- a/tests/src/test/java/alluxio/client/cli/fs/command/RmCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/RmCommandIntegrationTest.java
@@ -145,8 +145,10 @@ public final class RmCommandIntegrationTest extends AbstractFileSystemShellTest 
     Assert.assertTrue(fileExists(testFolder1));
     Assert.assertTrue(fileExists(testFolder2));
     Assert.assertTrue(fileExists(testFile2));
-    sFsShell.run("rm", "-s", "true", "/testFolder1/testFolder2/testFile2");
-    toCompare.append(getCommandOutput(new String[] {"rm", "/testFolder1/testFolder2/testFile2"}));
+    sFsShell.run("rm", "--alluxioOnly", "-s", "true", "/testFolder1/testFolder2/testFile2");
+    toCompare.append(getCommandOutput(new String[] {"rm", "/testFolder1/testFolder2/testFile2"})
+        .replace("\n", "")
+        + " only from Alluxio space\n");
     Assert.assertEquals(toCompare.toString(), mOutput.toString());
     Assert.assertTrue(fileExists(testFolder1));
     Assert.assertTrue(fileExists(testFolder2));

--- a/tests/src/test/java/alluxio/client/cli/fs/command/RmCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/RmCommandIntegrationTest.java
@@ -145,7 +145,7 @@ public final class RmCommandIntegrationTest extends AbstractFileSystemShellTest 
     Assert.assertTrue(fileExists(testFolder1));
     Assert.assertTrue(fileExists(testFolder2));
     Assert.assertTrue(fileExists(testFile2));
-    sFsShell.run("rm", "-s", "/testFolder1/testFolder2/testFile2");
+    sFsShell.run("rm", "-s", "true", "/testFolder1/testFolder2/testFile2");
     toCompare.append(getCommandOutput(new String[] {"rm", "/testFolder1/testFolder2/testFile2"}));
     Assert.assertEquals(toCompare.toString(), mOutput.toString());
     Assert.assertTrue(fileExists(testFolder1));


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support delete file from alluxio only and reset its directChildrenLoadedState of parent.
### Why are the changes needed?


### Does this PR introduce any user facing changes?
```Console
$ bin/alluxio fs rm -R --alluxioOnly --syncParentNextTime=true /test/bb
$ bin/alluxio fs ls /test/
drwxr-xr-x  mbl            staff                        0       PERSISTED 05-30-2022 14:45:24:142  DIR /test/bb

$ bin/alluxio fs rm -R --alluxioOnly --syncParentNextTime=false /test/bb
$ bin/alluxio fs ls /test/
# /test/bb will not be loaded because metadata sync on /test is disabled
```
