### PR TITLE
Support specify role for a target when execute logLevel command

### DIFF
--- a/shell/src/main/java/alluxio/cli/LogLevel.java
+++ b/shell/src/main/java/alluxio/cli/LogLevel.java
@@ -74,9 +74,8 @@ public final class LogLevel {
           .required(false)
           .longOpt(TARGET_OPTION_NAME)
           .hasArg(true)
-          .desc("<master|workers|job_master|job_workers|host:webPort>."
+          .desc("<master|workers|job_master|job_workers|host:webPort[:role]>."
               + " A list of targets separated by " + TARGET_SEPARATOR + " can be specified."
-              + " host:webPort pair must be one of workers."
               + " Default target is master, job master, all workers and all job workers.")
           .build();
   private static final String LOG_NAME_OPTION_NAME = "logName";
@@ -239,11 +238,16 @@ public final class LogLevel {
           targetInfoList.add(jobWorker);
         }
       } else if (target.contains(":")) {
-        String[] hostPortPair = target.split(":");
-        int port = Integer.parseInt(hostPortPair[1]);
-        String role = inferRoleFromPort(port, conf);
+        String[] targetInfoParts = target.split(":");
+        int port = Integer.parseInt(targetInfoParts[1]);
+        String role;
+        if (targetInfoParts.length > 2) {
+          role = targetInfoParts[2];
+        } else {
+          role = inferRoleFromPort(port, conf);
+        }
         LOG.debug("Port {} maps to role {}", port, role);
-        TargetInfo unspecifiedTarget = new TargetInfo(hostPortPair[0], port, role);
+        TargetInfo unspecifiedTarget = new TargetInfo(targetInfoParts[0], port, role);
         System.out.format("Role inferred from port: %s%n", unspecifiedTarget);
         targetInfoList.add(unspecifiedTarget);
       } else {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Please outline the changes and how this PR fixes the issue.

### Why are the changes needed?

Sometimes, both workers and masters are use the same web port, so it cannot infer role from port atomically, so we should supply a way to specify the role for the targets.

### Does this PR introduce any user facing changes?

```console
$ bin/alluxio logLevel --logName alluxio.worker.block.TieredBlockStore --level DEBUG --target localhost:30000:worker
```
