### PR TITLE
Access RocksDB object behind atomic reference

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
@@ -159,7 +159,7 @@ public final class RocksStore implements Closeable {
     RocksDB dbRef = null;
     while (retryPolicy.attempt()) {
       try {
-        dbRef = (RocksDB.open(mDbOpts, mDbPath, cfDescriptors, columns));
+        dbRef = RocksDB.open(mDbOpts, mDbPath, cfDescriptors, columns);
         break;
       } catch (RocksDBException e) {
         // sometimes the previous terminated process's lock may not have been fully cleared yet


### PR DESCRIPTION
### What changes are proposed in this pull request?

The RocksDB reference is now accessed by an atomic reference instead of a synchronized method.

### Why are the changes needed?

Currently the reference to RocksDB is accessed through a synchronized method on every access (read/write/delete/etc). This creates contention especially on highly concurrent read workloads, lowering performance.

The change should not modify the behavior of the system.

Note that in both cases, while a method is holding a reference to the RocksDB object, the DB may be closed. This will cause the holder of the reference to throw an exception if it tries to access the DB after it is closed. I am assuming the system handles this behavior since it already exists, but this change makes this type of data race more likely to happen, as previously the call to getDB would be blocked during a concurrent closure.

### Does this PR introduce any user facing changes?

No