### PR TITLE
Fix the security vulnerability from jackcon databind

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadResult.java
@@ -11,6 +11,7 @@
 
 package alluxio.proxy.s3;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
@@ -24,6 +25,7 @@ import java.util.Objects;
  */
 @JacksonXmlRootElement(localName = "CompleteMultipartUploadResult")
 @JsonPropertyOrder({ "Location", "Bucket", "Key", "ETag" })
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class CompleteMultipartUploadResult {
   /* The URI that identifies the newly created object. */
   private String mLocation;

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <protobuf.version>3.19.2</protobuf.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.30</slf4j.version>
-    <jackson.version>2.11.1</jackson.version>
+    <jackson.version>2.13.3</jackson.version>
     <hadoop-cos.version>3.1.0-5.8.5</hadoop-cos.version>
     <cos_api.version>5.6.19</cos_api.version>
     <surefire.forkCount>2</surefire.forkCount>


### PR DESCRIPTION
### What changes are proposed in this pull request?

fix https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518


### Why are the changes needed?
jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.

### Does this PR introduce any user facing changes?

no
