### PR TITLE
Fix the vulnerability caused by xstream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -786,7 +786,7 @@
       <dependency>
         <artifactId>xstream</artifactId>
         <groupId>com.thoughtworks.xstream</groupId>
-        <version>1.4.18</version>
+        <version>1.4.19</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
### What changes are proposed in this pull request?

fix https://x-stream.github.io/CVE-2021-43859.html

see https://github.com/x-stream/xstream/security/advisories/GHSA-rmr5-cpv2-vgjf

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
The vulnerability may allow a remote attacker to allocate 100% CPU time on the target system depending on CPU type or parallel execution of such a payload resulting in a denial of service only by manipulating the processed input stream.

### Does this PR introduce any user facing changes?

no
