### PR TITLE
Fix the vulnerbility caused by jetty-webapp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <java.version>1.8</java.version>
     <jaxb.version>2.3.3</jaxb.version>
     <jersey.version>2.34</jersey.version>
-    <jetty.version>9.4.43.v20210629</jetty.version>
+    <jetty.version>9.4.46.v20220331</jetty.version>
     <junit.version>4.13.1</junit.version>
     <log4j.version>2.17.1</log4j.version>
     <maven.version>3.3.9</maven.version>


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-34429
see: https://github.com/eclipse/jetty.project/security/advisories/GHSA-vjv5-gp2w-65vm

### Why are the changes needed?
The default compliance mode allows requests with URIs that contain a %u002e segment to access protected resources within the WEB-INF directory. For example, a request to /%u002e/WEB-INF/web.xml can retrieve the web.xml file. This can reveal sensitive information regarding the implementation of a web application. Similarly, an encoded null character can prevent correct normalization so that /.%00/WEB-INF/web.xml cal also retrieve the web.xml file.

### Does this PR introduce any user facing changes?

no 
