### PR TITLE
Remove unnecessary Configuration usage

### DIFF
--- a/core/client/fs/src/test/java/alluxio/client/block/BlockMasterClientPoolTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/BlockMasterClientPoolTest.java
@@ -18,8 +18,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import alluxio.ClientContext;
-import alluxio.ConfigurationTestUtils;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.MasterClientContext;
 import alluxio.master.MasterInquireClient;
 
@@ -33,7 +33,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest(BlockMasterClient.Factory.class)
 public class BlockMasterClientPoolTest {
 
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private final AlluxioConfiguration mConf = Configuration.global();
 
   @Test
   public void create() throws Exception {

--- a/core/client/fs/src/test/java/alluxio/client/block/BlockStoreClientTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/BlockStoreClientTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 
 import alluxio.ClientContext;
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
 import alluxio.client.WriteType;
 import alluxio.client.block.policy.BlockLocationPolicy;
 import alluxio.client.block.policy.options.GetWorkerOptions;
@@ -36,6 +35,7 @@ import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.InStreamOptions;
 import alluxio.client.file.options.OutStreamOptions;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.ExceptionMessage;
@@ -91,7 +91,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @PrepareForTest({FileSystemContext.class})
 public final class BlockStoreClientTest {
 
-  private static final InstancedConfiguration S_CONF = ConfigurationTestUtils.copyDefaults();
+  private static final InstancedConfiguration S_CONF = Configuration.copyGlobal();
 
   private static final long BLOCK_ID = 3L;
   private static final long BLOCK_LENGTH = 100L;

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/DeterministicHashPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/DeterministicHashPolicyTest.java
@@ -14,10 +14,10 @@ package alluxio.client.block.policy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.options.GetWorkerOptions;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.wire.BlockInfo;
@@ -38,7 +38,7 @@ public final class DeterministicHashPolicyTest {
   private static final int PORT = 1;
 
   private final List<BlockWorkerInfo> mWorkerInfos = new ArrayList<>();
-  private static InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
+  private static InstancedConfiguration sConf = Configuration.copyGlobal();
 
   @Before
   public void before() {
@@ -55,7 +55,6 @@ public final class DeterministicHashPolicyTest {
     mWorkerInfos.add(new BlockWorkerInfo(
         new WorkerNetAddress().setHost("worker4").setRpcPort(PORT).setDataPort(PORT)
             .setWebPort(PORT), 3 * (long) Constants.GB, 0));
-    sConf = ConfigurationTestUtils.copyDefaults();
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstAvoidEvictionPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstAvoidEvictionPolicyTest.java
@@ -14,11 +14,11 @@ package alluxio.client.block.policy;
 import static alluxio.client.util.ClientTestUtils.worker;
 import static org.junit.Assert.assertEquals;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.options.GetWorkerOptions;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.network.TieredIdentityFactory;
 import alluxio.util.network.NetworkAddressUtils;
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public class LocalFirstAvoidEvictionPolicyTest {
 
-  private final InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private final AlluxioConfiguration mConf = Configuration.global();
 
   @Test
   public void chooseClosestTierAvoidEviction() throws Exception {

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/LocalFirstPolicyTest.java
@@ -15,11 +15,11 @@ import static alluxio.client.util.ClientTestUtils.worker;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.options.GetWorkerOptions;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.network.TieredIdentityFactory;
 import alluxio.util.network.NetworkAddressUtils;
@@ -37,9 +37,9 @@ import java.util.List;
  */
 public final class LocalFirstPolicyTest {
 
-  private static final InstancedConfiguration S_CONF = ConfigurationTestUtils.copyDefaults();
+  private static final AlluxioConfiguration S_CONF = Configuration.global();
   private static final int S_RESOLUTION_TIMEOUT =
-      (int) S_CONF.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS);
+      (int) Configuration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS);
 
   /**
    * Tests that the local host is returned first.

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/MostAvailableFirstPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/MostAvailableFirstPolicyTest.java
@@ -11,11 +11,11 @@
 
 package alluxio.client.block.policy;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.options.GetWorkerOptions;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.test.util.CommonUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.WorkerNetAddress;
@@ -56,6 +56,6 @@ public final class MostAvailableFirstPolicyTest {
   public void equalsTest() {
     CommonUtils.testEquals(MostAvailableFirstPolicy.class,
         new Class[]{AlluxioConfiguration.class},
-        new Object[]{ConfigurationTestUtils.copyDefaults()});
+        new Object[]{Configuration.global()});
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/RoundRobinPolicyTest.java
@@ -16,11 +16,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.policy.options.GetWorkerOptions;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.test.util.CommonUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.WorkerNetAddress;
@@ -48,7 +48,7 @@ public final class RoundRobinPolicyTest {
         .setRpcPort(PORT).setDataPort(PORT).setWebPort(PORT), 2 * (long) Constants.GB, 0));
     workerInfoList.add(new BlockWorkerInfo(new WorkerNetAddress().setHost("worker3")
         .setRpcPort(PORT).setDataPort(PORT).setWebPort(PORT), 3 * (long) Constants.GB, 0));
-    RoundRobinPolicy policy = new RoundRobinPolicy(ConfigurationTestUtils.copyDefaults());
+    RoundRobinPolicy policy = new RoundRobinPolicy(Configuration.global());
 
     GetWorkerOptions options = GetWorkerOptions.defaults().setBlockWorkerInfos(workerInfoList)
         .setBlockInfo(new BlockInfo().setLength(2 * (long) Constants.GB));
@@ -70,7 +70,7 @@ public final class RoundRobinPolicyTest {
    */
   @Test
   public void getWorkerNoneEligible() {
-    RoundRobinPolicy policy = new RoundRobinPolicy(ConfigurationTestUtils.copyDefaults());
+    RoundRobinPolicy policy = new RoundRobinPolicy(Configuration.global());
     GetWorkerOptions options = GetWorkerOptions.defaults().setBlockWorkerInfos(new ArrayList<>())
         .setBlockInfo(new BlockInfo().setLength(2 * (long) Constants.GB));
     assertFalse(policy.getWorker(options).isPresent());
@@ -86,7 +86,7 @@ public final class RoundRobinPolicyTest {
     workerInfoList.add(new BlockWorkerInfo(new WorkerNetAddress().setHost("worker1")
         .setRpcPort(PORT).setDataPort(PORT).setWebPort(PORT), Constants.GB, 0));
 
-    RoundRobinPolicy policy = new RoundRobinPolicy(ConfigurationTestUtils.copyDefaults());
+    RoundRobinPolicy policy = new RoundRobinPolicy(Configuration.global());
     GetWorkerOptions options = GetWorkerOptions.defaults().setBlockWorkerInfos(workerInfoList)
         .setBlockInfo(new BlockInfo().setLength(Constants.MB));
     assertTrue(policy.getWorker(options).isPresent());
@@ -96,7 +96,7 @@ public final class RoundRobinPolicyTest {
 
   @Test
   public void equalsTest() {
-    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    AlluxioConfiguration conf = Configuration.global();
     CommonUtils.testEquals(RoundRobinPolicy.class, new Class[]{AlluxioConfiguration.class},
         new Object[]{conf});
   }

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/BlockInStreamTest.java
@@ -21,10 +21,10 @@ import static org.mockito.Mockito.when;
 
 import alluxio.ClientContext;
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
 import alluxio.client.file.options.InStreamOptions;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.OpenLocalBlockRequest;
@@ -61,7 +61,7 @@ public class BlockInStreamTest {
   private FileSystemContext mMockContext;
   private BlockInfo mInfo;
   private InStreamOptions mOptions;
-  private final InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private final InstancedConfiguration mConf = Configuration.copyGlobal();
   private StreamObserver<OpenLocalBlockResponse> mResponseObserver;
 
   @Before

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataReaderTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataReaderTest.java
@@ -21,8 +21,8 @@ import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import alluxio.ClientContext;
-import alluxio.ConfigurationTestUtils;
 import alluxio.client.file.FileSystemContext;
+import alluxio.conf.Configuration;
 import alluxio.grpc.Chunk;
 import alluxio.grpc.ReadRequest;
 import alluxio.grpc.ReadResponse;
@@ -65,8 +65,8 @@ public final class GrpcDataReaderTest {
   public void before() throws Exception {
     mContext = Mockito.mock(FileSystemContext.class);
     when(mContext.getClientContext())
-        .thenReturn(ClientContext.create(ConfigurationTestUtils.copyDefaults()));
-    when(mContext.getClusterConf()).thenReturn(ConfigurationTestUtils.copyDefaults());
+        .thenReturn(ClientContext.create(Configuration.global()));
+    when(mContext.getClusterConf()).thenReturn(Configuration.global());
     mAddress = new WorkerNetAddress().setHost("localhost").setDataPort(1234);
     ReadRequest.Builder readRequestBuilder =
         ReadRequest.newBuilder().setBlockId(BLOCK_ID).setChunkSize(CHUNK_SIZE);

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataWriterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/GrpcDataWriterTest.java
@@ -23,9 +23,9 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 import alluxio.ClientContext;
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.options.OutStreamOptions;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.Chunk;
@@ -78,7 +78,7 @@ public final class GrpcDataWriterTest {
   private WorkerNetAddress mAddress;
   private BlockWorkerClient mClient;
   private ClientCallStreamObserver<WriteRequest> mRequestObserver;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConf = Configuration.copyGlobal();
   private ClientContext mClientContext;
 
   @Rule

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/LocalFileDataWriterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/LocalFileDataWriterTest.java
@@ -15,10 +15,9 @@ import static org.mockito.Mockito.mock;
 
 import alluxio.AlluxioTestDirectory;
 import alluxio.ClientContext;
-import alluxio.ConfigurationTestUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.options.OutStreamOptions;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.grpc.CreateLocalBlockRequest;
 import alluxio.grpc.CreateLocalBlockResponse;
 import alluxio.util.IdUtils;
@@ -51,7 +50,6 @@ public class LocalFileDataWriterTest {
   private WorkerNetAddress mAddress;
   private BlockWorkerClient mClient;
   private ClientContext mClientContext;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
   private FileSystemContext mContext;
   private GrpcBlockingStream<CreateLocalBlockRequest, CreateLocalBlockResponse> mStream;
 
@@ -60,7 +58,7 @@ public class LocalFileDataWriterTest {
     mWorkDirectory =
         AlluxioTestDirectory.createTemporaryDirectory("blocks").getAbsolutePath();
 
-    mClientContext = ClientContext.create(mConf);
+    mClientContext = ClientContext.create(Configuration.global());
 
     mContext = PowerMockito.mock(FileSystemContext.class);
     mAddress = mock(WorkerNetAddress.class);
@@ -69,7 +67,7 @@ public class LocalFileDataWriterTest {
     PowerMockito.when(mContext.acquireBlockWorkerClient(mAddress)).thenReturn(
         new NoopClosableResource<>(mClient));
     PowerMockito.when(mContext.getClientContext()).thenReturn(mClientContext);
-    PowerMockito.when(mContext.getClusterConf()).thenReturn(mConf);
+    PowerMockito.when(mContext.getClusterConf()).thenReturn(Configuration.global());
 
     mStream = mock(GrpcBlockingStream.class);
     PowerMockito.doNothing().when(mStream).send(ArgumentMatchers.any(), ArgumentMatchers.anyLong());

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/UfsFallbackLocalFileDataWriterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/UfsFallbackLocalFileDataWriterTest.java
@@ -21,9 +21,9 @@ import static org.mockito.Mockito.verify;
 
 import alluxio.ClientContext;
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.options.OutStreamOptions;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.ResourceExhaustedException;
@@ -143,7 +143,7 @@ public class UfsFallbackLocalFileDataWriterTest {
   private BlockWorkerClient mClient;
   private ClientCallStreamObserver<WriteRequest> mRequestObserver;
 
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConf = Configuration.copyGlobal();
 
   @Rule
   public ConfigurationRule mConfigurationRule =

--- a/core/client/fs/src/test/java/alluxio/client/block/util/BlockLocationUtilsTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/util/BlockLocationUtilsTest.java
@@ -18,11 +18,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.collections.Pair;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.network.TieredIdentityFactory;
@@ -64,7 +64,7 @@ public final class BlockLocationUtilsTest {
         any(AlluxioConfiguration.class))).thenReturn(true);
 
     // choose worker with domain socket accessible ignoring rack
-    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    InstancedConfiguration conf = Configuration.copyGlobal();
     conf.set(PropertyKey.WORKER_DATA_SERVER_DOMAIN_SOCKET_AS_UUID, true);
     List<WorkerNetAddress> addresses = workers.stream()
         .map(worker -> worker.getNetAddress())

--- a/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/AlluxioFileInStreamTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioURI;
 import alluxio.ClientContext;
-import alluxio.ConfigurationTestUtils;
 import alluxio.client.block.BlockStoreClient;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.stream.BlockInStream;
@@ -38,6 +37,7 @@ import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.client.block.stream.TestBlockInStream;
 import alluxio.client.file.options.InStreamOptions;
 import alluxio.client.util.ClientTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.PreconditionMessage;
@@ -56,7 +56,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.mockito.MockedStatic;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
@@ -90,12 +89,11 @@ public final class AlluxioFileInStreamTest {
   private FileInfo mInfo;
   private URIStatus mStatus;
 
-  private final InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private final InstancedConfiguration mConf = Configuration.copyGlobal();
 
   private List<TestBlockInStream> mInStreams;
 
   private AlluxioFileInStream mTestStream;
-  private MockedStatic mMockedStaticBlockStore;
 
   /**
    * @return a list of all sources of where the blocks reside and file size

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -25,8 +25,8 @@ import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioURI;
 import alluxio.ClientContext;
-import alluxio.ConfigurationTestUtils;
 import alluxio.TestLoggerRule;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.Bits;
@@ -68,7 +68,7 @@ public final class BaseFileSystemTest {
   private static final String SHOULD_HAVE_PROPAGATED_MESSAGE =
       "Exception should have been propagated";
 
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConf = Configuration.copyGlobal();
 
   @Rule
   private TestLoggerRule mTestLogger = new TestLoggerRule();
@@ -109,7 +109,7 @@ public final class BaseFileSystemTest {
 
   @After
   public void after() {
-    mConf = ConfigurationTestUtils.copyDefaults();
+    mConf = Configuration.copyGlobal();
   }
 
   /**

--- a/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileOutStreamTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioURI;
 import alluxio.ClientContext;
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.UnderStorageType;
 import alluxio.client.WriteType;
@@ -41,6 +40,7 @@ import alluxio.client.block.stream.TestUnderFileSystemFileOutStream;
 import alluxio.client.block.stream.UnderFileSystemFileOutStream;
 import alluxio.client.file.options.OutStreamOptions;
 import alluxio.client.util.ClientTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.ExceptionMessage;
@@ -88,7 +88,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
     UnderFileSystemFileOutStream.class})
 public class FileOutStreamTest {
 
-  private static InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
+  private static InstancedConfiguration sConf = Configuration.copyGlobal();
 
   private static final long BLOCK_LENGTH = 100L;
   private static final AlluxioURI FILE_NAME = new AlluxioURI("/file");

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemContextTest.java
@@ -14,27 +14,18 @@ package alluxio.client.file;
 import static org.junit.Assert.fail;
 
 import alluxio.ClientContext;
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.resource.CloseableResource;
 
 import com.google.common.io.Closer;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
  * Tests {@link FileSystemContext}.
  */
 public final class FileSystemContextTest {
-
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
-
-  @Before
-  public void before() {
-    mConf = ConfigurationTestUtils.copyDefaults();
-  }
 
   /**
    * This test ensures acquiring all the available FileSystem master clients blocks further
@@ -45,11 +36,11 @@ public final class FileSystemContextTest {
   @Test(timeout = 10000)
   public void acquireAtMaxLimit() throws Exception {
     Closer closer = Closer.create();
-
     // Acquire all the clients
     FileSystemContext fsContext = FileSystemContext.create(
-        ClientContext.create(mConf));
-    for (int i = 0; i < mConf.getInt(PropertyKey.USER_FILE_MASTER_CLIENT_POOL_SIZE_MAX); i++) {
+        ClientContext.create());
+    for (int i = 0; i < Configuration
+        .getInt(PropertyKey.USER_FILE_MASTER_CLIENT_POOL_SIZE_MAX); i++) {
       closer.register(fsContext.acquireMasterClientResource());
     }
     Thread acquireThread = new Thread(new AcquireClient(fsContext));

--- a/core/client/fs/src/test/java/alluxio/client/file/FileSystemMasterClientPoolTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/FileSystemMasterClientPoolTest.java
@@ -14,8 +14,8 @@ package alluxio.client.file;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.ClientContext;
-import alluxio.ConfigurationTestUtils;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.master.MasterClientContext;
 import alluxio.master.MasterInquireClient;
 
@@ -31,7 +31,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public class FileSystemMasterClientPoolTest {
   @Test
   public void create() throws Exception {
-    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    AlluxioConfiguration conf = Configuration.global();
     FileSystemMasterClient expectedClient = Mockito.mock(FileSystemMasterClient.class);
     PowerMockito.mockStatic(FileSystemMasterClient.Factory.class);
     Mockito.when(FileSystemMasterClient.Factory

--- a/core/client/fs/src/test/java/alluxio/client/file/MetadataCachingBaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/MetadataCachingBaseFileSystemTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioURI;
 import alluxio.ClientContext;
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.FileDoesNotExistException;
@@ -59,7 +59,7 @@ public class MetadataCachingBaseFileSystemTest {
   private static final URIStatus FILE_STATUS =
       new URIStatus(new FileInfo().setPath(FILE.getPath()).setCompleted(true));
 
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConf = Configuration.copyGlobal();
   private FileSystemContext mFileContext;
   private ClientContext mClientContext;
   private RpcCountingFileSystemMasterClient mFileSystemMasterClient;
@@ -90,7 +90,7 @@ public class MetadataCachingBaseFileSystemTest {
 
   @After
   public void after() {
-    mConf = ConfigurationTestUtils.copyDefaults();
+    mConf = Configuration.copyGlobal();
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerTest.java
@@ -15,8 +15,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
-import alluxio.ConfigurationTestUtils;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 
 import org.junit.Test;
 
@@ -27,7 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 public class CacheManagerTest {
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private final AlluxioConfiguration mConf = Configuration.global();
 
   @Test
   public void factoryGet() throws Exception {

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
@@ -15,9 +15,9 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.file.CacheContext;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.io.BufferUtils;
@@ -43,7 +43,7 @@ public final class CacheManagerWithShadowCacheTest {
   private static final byte[] PAGE2 = BufferUtils.getIncreasingByteArray(255, PAGE_SIZE_BYTES);
   private final byte[] mBuf = new byte[PAGE_SIZE_BYTES];
   private CacheManagerWithShadowCache mCacheManager;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private final InstancedConfiguration mConf = Configuration.copyGlobal();
 
   private final ShadowCacheType mShadowCacheType;
   private final int mAgeBits;

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/ClockCuckooShadowCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/ClockCuckooShadowCacheManagerTest.java
@@ -14,9 +14,9 @@ package alluxio.client.file.cache;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.quota.CacheScope;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 
@@ -37,7 +37,7 @@ public final class ClockCuckooShadowCacheManagerTest {
   private static final CacheScope SCOPE1 = CacheScope.create("schema1.table1");
   private static final CacheScope SCOPE2 = CacheScope.create("schema1.table2");
   private ClockCuckooShadowCacheManager mCacheManager;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private final InstancedConfiguration mConf = Configuration.copyGlobal();
 
   @Before
   public void before() {

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/DefaultMetaStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/DefaultMetaStoreTest.java
@@ -13,8 +13,8 @@ package alluxio.client.file.cache;
 
 import static org.junit.Assert.assertThrows;
 
-import alluxio.ConfigurationTestUtils;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.PageNotFoundException;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
@@ -30,7 +30,7 @@ import org.junit.Test;
 public class DefaultMetaStoreTest {
   protected final PageId mPage = new PageId("1L", 2L);
   protected final PageInfo mPageInfo = new PageInfo(mPage, 1024);
-  protected final InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  protected final AlluxioConfiguration mConf = Configuration.global();
   protected DefaultMetaStore mMetaStore;
   protected Gauge mCachedPageGauge;
 

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/FIFOCacheEvictorTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/FIFOCacheEvictorTest.java
@@ -11,8 +11,8 @@
 
 package alluxio.client.file.cache;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.client.file.cache.evictor.FIFOCacheEvictor;
+import alluxio.conf.Configuration;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -21,8 +21,7 @@ import org.junit.Test;
  * Tests for the {@link FIFOCacheEvictor} class.
  */
 public final class FIFOCacheEvictorTest {
-  private final FIFOCacheEvictor mEvictor = new FIFOCacheEvictor(
-      ConfigurationTestUtils.copyDefaults());
+  private final FIFOCacheEvictor mEvictor = new FIFOCacheEvictor(Configuration.global());
   private final PageId mFirst = new PageId("1L", 2L);
   private final PageId mSecond = new PageId("3L", 4L);
   private final PageId mThird = new PageId("5L", 6L);

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LFUCacheEvictorTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LFUCacheEvictorTest.java
@@ -11,8 +11,8 @@
 
 package alluxio.client.file.cache;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.client.file.cache.evictor.LFUCacheEvictor;
+import alluxio.conf.Configuration;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,7 +33,7 @@ public final class LFUCacheEvictorTest {
    */
   @Before
   public void before() {
-    mEvictor = new LFUCacheEvictor(ConfigurationTestUtils.copyDefaults());
+    mEvictor = new LFUCacheEvictor(Configuration.global());
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LRUCacheEvictorTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LRUCacheEvictorTest.java
@@ -11,8 +11,8 @@
 
 package alluxio.client.file.cache;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.client.file.cache.evictor.LRUCacheEvictor;
+import alluxio.conf.Configuration;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -32,7 +32,7 @@ public final class LRUCacheEvictorTest {
    */
   @Before
   public void before() {
-    mEvictor = new LRUCacheEvictor(ConfigurationTestUtils.copyDefaults());
+    mEvictor = new LRUCacheEvictor(Configuration.global());
   }
 
   @Test

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.file.CacheContext;
 import alluxio.client.file.cache.evictor.CacheEvictor;
@@ -31,6 +30,7 @@ import alluxio.client.file.cache.store.PageStoreType;
 import alluxio.client.quota.CacheQuota;
 import alluxio.client.quota.CacheScope;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.PageNotFoundException;
@@ -73,7 +73,7 @@ public final class LocalCacheManagerTest {
   private static final byte[] PAGE2 = BufferUtils.getIncreasingByteArray(255, PAGE_SIZE_BYTES);
 
   private LocalCacheManager mCacheManager;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConf = Configuration.copyGlobal();
   private MetaStore mMetaStore;
   private PageStore mPageStore;
   private CacheEvictor mEvictor;

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerWithMemPageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerWithMemPageStoreTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.file.CacheContext;
 import alluxio.client.file.cache.evictor.CacheEvictor;
@@ -28,6 +27,7 @@ import alluxio.client.file.cache.store.PageStoreType;
 import alluxio.client.quota.CacheQuota;
 import alluxio.client.quota.CacheScope;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.CommonUtils;
@@ -55,7 +55,7 @@ public final class LocalCacheManagerWithMemPageStoreTest {
   private static final byte[] PAGE2 = BufferUtils.getIncreasingByteArray(255, PAGE_SIZE_BYTES);
 
   private LocalCacheManager mCacheManager;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConf = Configuration.copyGlobal();
   private MetaStore mMetaStore;
   private PageStore mPageStore;
   private CacheEvictor mEvictor;

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/MultipleBloomShadowCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/MultipleBloomShadowCacheManagerTest.java
@@ -15,9 +15,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.quota.CacheScope;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 
@@ -38,7 +38,7 @@ public final class MultipleBloomShadowCacheManagerTest {
   private static final CacheScope SCOPE1 = CacheScope.create("schema1.table1");
   private static final CacheScope SCOPE2 = CacheScope.create("schema1.table2");
   private MultipleBloomShadowCacheManager mCacheManager;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConf = Configuration.copyGlobal();
 
   @Before
   public void before() {

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/NondeterministicLRUCacheEvictorTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/NondeterministicLRUCacheEvictorTest.java
@@ -11,9 +11,8 @@
 
 package alluxio.client.file.cache;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.client.file.cache.evictor.NondeterministicLRUCacheEvictor;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -34,8 +33,7 @@ public final class NondeterministicLRUCacheEvictorTest {
    */
   @Before
   public void before() {
-    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
-    mEvictor = new NondeterministicLRUCacheEvictor(conf);
+    mEvictor = new NondeterministicLRUCacheEvictor(Configuration.global());
     mEvictor.setNumOfCandidate(2);
   }
 

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/TimeBoundPageStoreTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/TimeBoundPageStoreTest.java
@@ -19,9 +19,9 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.file.cache.store.PageStoreOptions;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.PageNotFoundException;
@@ -56,7 +56,7 @@ public class TimeBoundPageStoreTest {
 
   @Before
   public void before() throws Exception {
-    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    InstancedConfiguration conf = Configuration.copyGlobal();
     conf.set(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE, PAGE_SIZE_BYTES);
     conf.set(PropertyKey.USER_CLIENT_CACHE_SIZE, CACHE_SIZE_BYTES);
     conf.set(PropertyKey.USER_CLIENT_CACHE_DIR, mTemp.getRoot().getAbsolutePath());

--- a/core/client/fs/src/test/java/alluxio/client/file/options/OutStreamOptionsTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/options/OutStreamOptionsTest.java
@@ -16,7 +16,6 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.ClientContext;
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.AlluxioStorageType;
 import alluxio.client.UnderStorageType;
@@ -24,6 +23,7 @@ import alluxio.client.WriteType;
 import alluxio.client.block.policy.BlockLocationPolicy;
 import alluxio.client.block.policy.LocalFirstPolicy;
 import alluxio.client.block.policy.RoundRobinPolicy;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.TtlAction;
@@ -50,7 +50,7 @@ import javax.security.auth.Subject;
  */
 public class OutStreamOptionsTest {
 
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConf = Configuration.copyGlobal();
 
   /**
    * A mapping from a user to its corresponding group.
@@ -73,7 +73,7 @@ public class OutStreamOptionsTest {
 
   @After
   public void after() {
-    mConf = ConfigurationTestUtils.copyDefaults();
+    mConf = Configuration.copyGlobal();
   }
 
   /**
@@ -115,7 +115,7 @@ public class OutStreamOptionsTest {
     Random random = new Random();
     long blockSize = random.nextLong();
     BlockLocationPolicy locationPolicy = new RoundRobinPolicy(
-        ConfigurationTestUtils.copyDefaults());
+        Configuration.global());
     String owner = CommonUtils.randomAlphaNumString(10);
     String group = CommonUtils.randomAlphaNumString(10);
     Mode mode = new Mode((short) random.nextInt());

--- a/core/client/fs/src/test/java/alluxio/client/metrics/MetricsHeartbeatContextTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/metrics/MetricsHeartbeatContextTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import alluxio.ClientContext;
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.master.MasterInquireClient;
@@ -41,7 +41,7 @@ public class MetricsHeartbeatContextTest {
 
   @Test
   public void testExecutorInitialized() {
-    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    InstancedConfiguration conf = Configuration.copyGlobal();
     conf.set(PropertyKey.MASTER_HOSTNAME, "localhost");
     conf.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "1s");
     ClientContext ctx = ClientContext.create(conf);
@@ -77,7 +77,7 @@ public class MetricsHeartbeatContextTest {
         getContextMap();
     assertTrue(map.isEmpty());
 
-    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    InstancedConfiguration conf = Configuration.copyGlobal();
     conf.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "1s");
     ClientContext ctx = ClientContext.create(conf);
     MasterInquireClient client = MasterInquireClient.Factory
@@ -92,7 +92,7 @@ public class MetricsHeartbeatContextTest {
     map.forEach((details, context) ->
         assertEquals(2, (int) Whitebox.getInternalState(context, "mCtxCount")));
 
-    conf = ConfigurationTestUtils.copyDefaults();
+    conf = Configuration.copyGlobal();
     conf.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "1s");
     conf.set(PropertyKey.MASTER_RPC_ADDRESSES, "master1:19998,master2:19998,master3:19998");
     ClientContext haCtx = ClientContext.create(conf);
@@ -120,7 +120,7 @@ public class MetricsHeartbeatContextTest {
 
     ScheduledFuture<?> future = Mockito.mock(ScheduledFuture.class);
     when(future.cancel(any(Boolean.class))).thenReturn(true);
-    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    InstancedConfiguration conf = Configuration.copyGlobal();
     conf.set(PropertyKey.USER_RPC_RETRY_MAX_DURATION, "1s");
     ClientContext ctx = ClientContext.create(conf);
     MasterInquireClient client = MasterInquireClient.Factory

--- a/core/client/fs/src/test/java/alluxio/util/FileSystemOptionsTest.java
+++ b/core/client/fs/src/test/java/alluxio/util/FileSystemOptionsTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.LoadDescendantPType;
@@ -23,17 +23,11 @@ import alluxio.grpc.LoadMetadataPOptions;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.SetAclPOptions;
 
-import org.junit.Before;
 import org.junit.Test;
 
 public class FileSystemOptionsTest {
 
-  private InstancedConfiguration mConf;
-
-  @Before
-  public void before() throws Exception {
-    mConf = ConfigurationTestUtils.copyDefaults();
-  }
+  private InstancedConfiguration mConf = Configuration.copyGlobal();
 
   @Test
   public void loadMetadataOptionsDefaults() {

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -504,7 +504,7 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
         hadoopConfProperties, uriConfProperties);
     AlluxioProperties alluxioProps =
         (alluxioConfiguration != null) ? alluxioConfiguration.copyProperties()
-            : alluxio.conf.Configuration.global().copyProperties();
+            : alluxio.conf.Configuration.copyProperties();
     // Merge relevant Hadoop configuration into Alluxio's configuration.
     alluxioProps.merge(hadoopConfProperties, Source.RUNTIME);
     // Merge relevant connection details in the URI with the highest priority

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopUtils.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/HadoopUtils.java
@@ -183,7 +183,7 @@ public final class HadoopUtils {
     // Take hadoop configuration to merge to Alluxio configuration
     Map<String, Object> hadoopConfProperties =
         HadoopConfigurationUtils.getConfigurationFromHadoop(conf);
-    AlluxioProperties alluxioProps = alluxio.conf.Configuration.global().copyProperties();
+    AlluxioProperties alluxioProps = alluxio.conf.Configuration.copyProperties();
     // Merge relevant Hadoop configuration into Alluxio's configuration.
     alluxioProps.merge(hadoopConfProperties, Source.RUNTIME);
     // Creating a new instanced configuration from an AlluxioProperties object isn't expensive.

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemApiTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemApiTest.java
@@ -16,8 +16,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.TestLoggerRule;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 
@@ -38,7 +38,7 @@ public final class AbstractFileSystemApiTest {
   @Rule
   public TestLoggerRule mTestLogger = new TestLoggerRule();
 
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConf = Configuration.copyGlobal();
 
   @Before
   public void before() {
@@ -48,7 +48,7 @@ public final class AbstractFileSystemApiTest {
 
   @After
   public void after() {
-    mConf = ConfigurationTestUtils.copyDefaults();
+    mConf = Configuration.copyGlobal();
     HadoopClientTestUtils.disableMetrics(mConf);
   }
 

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 import alluxio.AlluxioURI;
 import alluxio.ClientContext;
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.SystemPropertyRule;
 import alluxio.client.block.BlockStoreClient;
@@ -92,7 +91,7 @@ import java.util.Map;
 public class AbstractFileSystemTest {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractFileSystemTest.class);
 
-  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConfiguration = alluxio.conf.Configuration.copyGlobal();
 
   /**
    * Sets up the configuration before a test runs.
@@ -113,7 +112,7 @@ public class AbstractFileSystemTest {
 
   @After
   public void after() {
-    mConfiguration = ConfigurationTestUtils.copyDefaults();
+    mConfiguration = alluxio.conf.Configuration.copyGlobal();
     HadoopClientTestUtils.disableMetrics(mConfiguration);
   }
 

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/HadoopConfigurationUtilsTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
@@ -30,7 +30,7 @@ public final class HadoopConfigurationUtilsTest {
   private static final String TEST_S3_SECRET_KEY = "TEST SECRET KEY";
   private static final String TEST_ALLUXIO_PROPERTY = "alluxio.unsupported.parameter";
   private static final String TEST_ALLUXIO_VALUE = "alluxio.unsupported.value";
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConf = Configuration.copyGlobal();
 
   /**
    * Test for the {@link HadoopConfigurationUtils#getConfigurationFromHadoop} method for an empty

--- a/core/common/src/main/java/alluxio/metrics/InstrumentedExecutorService.java
+++ b/core/common/src/main/java/alluxio/metrics/InstrumentedExecutorService.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeoutException;
 public class InstrumentedExecutorService implements ExecutorService {
   private final Logger mSamplingLog =
       new SamplingLogger(LoggerFactory.getLogger(InstrumentedExecutorService.class),
-          Configuration.global().getMs(PropertyKey.METRICS_EXECUTOR_TASK_WARN_FREQUENCY));
+          Configuration.getMs(PropertyKey.METRICS_EXECUTOR_TASK_WARN_FREQUENCY));
 
   private com.codahale.metrics
       .InstrumentedExecutorService mDelegate;

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -67,7 +67,7 @@ public final class MetricsSystem {
 
   private static final ConcurrentHashMap<String, String> CACHED_METRICS = new ConcurrentHashMap<>();
   private static int sResolveTimeout =
-      (int) Configuration.global().getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS);
+      (int) Configuration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS);
   // A map from AlluxioURI to corresponding cached escaped path.
   private static final ConcurrentHashMap<AlluxioURI, String> CACHED_ESCAPED_PATH
       = new ConcurrentHashMap<>();

--- a/core/common/src/test/java/alluxio/AuthenticatedClientUserResourceTest.java
+++ b/core/common/src/test/java/alluxio/AuthenticatedClientUserResourceTest.java
@@ -13,7 +13,8 @@ package alluxio;
 
 import static org.junit.Assert.assertSame;
 
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.security.User;
 import alluxio.security.authentication.AuthenticatedClientUser;
 
@@ -34,7 +35,7 @@ public final class AuthenticatedClientUserResourceTest {
 
   @Test
   public void userRestored() throws Exception {
-    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    AlluxioConfiguration conf = Configuration.global();
     AuthenticatedClientUser.set(ORIGINAL_USER);
     User original = AuthenticatedClientUser.get(conf);
     new AuthenticatedClientUserResource(TESTCASE_USER, conf).close();

--- a/core/common/src/test/java/alluxio/AuthenticatedUserRuleTest.java
+++ b/core/common/src/test/java/alluxio/AuthenticatedUserRuleTest.java
@@ -12,8 +12,10 @@
 package alluxio;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.security.authentication.AuthenticatedClientUser;
 
 import org.junit.After;
@@ -28,7 +30,7 @@ public final class AuthenticatedUserRuleTest {
   private static final String RULE_USER = "rule-user";
   private static final String OUTSIDE_RULE_USER = "outside-rule-user";
 
-  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
+  private final AlluxioConfiguration mConfiguration = Configuration.global();
 
   private final Statement mStatement = new Statement() {
     @Override
@@ -55,6 +57,6 @@ public final class AuthenticatedUserRuleTest {
   public void noUserBeforeRule() throws Throwable {
     AuthenticatedClientUser.remove();
     new AuthenticatedUserRule(RULE_USER, mConfiguration).apply(mStatement, null).evaluate();
-    assertEquals(null, AuthenticatedClientUser.get(mConfiguration));
+    assertNull(AuthenticatedClientUser.get(mConfiguration));
   }
 }

--- a/core/common/src/test/java/alluxio/ConfigurationRuleTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationRuleTest.java
@@ -14,6 +14,7 @@ package alluxio;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 
@@ -28,7 +29,7 @@ public final class ConfigurationRuleTest {
 
   @Test
   public void changeConfiguration() throws Throwable {
-    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    InstancedConfiguration conf = Configuration.copyGlobal();
     Statement statement = new Statement() {
       @Override
       public void evaluate() throws Throwable {
@@ -41,7 +42,7 @@ public final class ConfigurationRuleTest {
 
   @Test
   public void changeConfigurationForDefaultNullValue() throws Throwable {
-    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    InstancedConfiguration conf = Configuration.copyGlobal();
 
     Statement statement = new Statement() {
       @Override

--- a/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
+++ b/core/common/src/test/java/alluxio/ConfigurationTestUtils.java
@@ -12,8 +12,6 @@
 package alluxio;
 
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.Configuration;
-import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.master.journal.JournalType;
 import alluxio.util.io.PathUtils;
@@ -29,14 +27,6 @@ import java.util.Map;
  * Utility methods for the configuration tests.
  */
 public final class ConfigurationTestUtils {
-
-  /**
-   * Return an instanced configuration with default value from the site properties file.
-   * @return the default configuration
-   */
-  public static InstancedConfiguration copyDefaults() {
-    return Configuration.copyGlobal();
-  }
 
   /**
    * Returns reasonable default configuration values for running integration tests.

--- a/core/common/src/test/java/alluxio/UnderFileSystemFactoryRegistryRuleTest.java
+++ b/core/common/src/test/java/alluxio/UnderFileSystemFactoryRegistryRuleTest.java
@@ -12,12 +12,14 @@
 package alluxio;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
@@ -32,9 +34,9 @@ public class UnderFileSystemFactoryRegistryRuleTest {
   private static final String UFS_PATH = "test://foo";
 
   private UnderFileSystemFactory mUnderFileSystemFactory;
-  private final InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
+  private final AlluxioConfiguration mConfiguration = Configuration.global();
 
-  private Statement mStatement = new Statement() {
+  private final Statement mStatement = new Statement() {
     @Override
     public void evaluate() throws Throwable {
       assertEquals(mUnderFileSystemFactory, UnderFileSystemFactoryRegistry
@@ -49,10 +51,10 @@ public class UnderFileSystemFactoryRegistryRuleTest {
         mUnderFileSystemFactory.supportsPath(eq(UFS_PATH), any(UnderFileSystemConfiguration.class)))
             .thenReturn(true);
     // check before
-    assertEquals(null, UnderFileSystemFactoryRegistry.find(UFS_PATH, mConfiguration));
+    assertNull(UnderFileSystemFactoryRegistry.find(UFS_PATH, mConfiguration));
     new UnderFileSystemFactoryRegistryRule(mUnderFileSystemFactory)
         .apply(mStatement, null).evaluate();
     // check after
-    assertEquals(null, UnderFileSystemFactoryRegistry.find(UFS_PATH, mConfiguration));
+    assertNull(UnderFileSystemFactoryRegistry.find(UFS_PATH, mConfiguration));
   }
 }

--- a/core/common/src/test/java/alluxio/cli/AbstractShellTest.java
+++ b/core/common/src/test/java/alluxio/cli/AbstractShellTest.java
@@ -18,8 +18,8 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.SystemOutRule;
+import alluxio.conf.Configuration;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -52,7 +52,7 @@ public final class AbstractShellTest {
       super(ImmutableMap.<String, String[]>builder().put("cmdAlias", new String[] {"cmd", "-O"})
           .put("stableAlias", new String[]{"cmd", "-O"})
           .build(), ImmutableSet.<String>builder().add("cmdAlias").build(),
-          ConfigurationTestUtils.copyDefaults());
+          Configuration.global());
     }
 
     @Override

--- a/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import alluxio.AlluxioTestDirectory;
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.DefaultSupplier;
 import alluxio.SystemPropertyRule;
@@ -82,7 +81,7 @@ public class InstancedConfigurationTest {
 
   public void resetConf() {
     Configuration.reloadProperties();
-    mConfiguration = ConfigurationTestUtils.copyDefaults();
+    mConfiguration = Configuration.copyGlobal();
   }
 
   @AfterClass
@@ -696,7 +695,7 @@ public class InstancedConfigurationTest {
     sysProps.put(PropertyKey.LOGGER_TYPE.toString(), null);
     sysProps.put(PropertyKey.SITE_CONF_DIR.toString(), mFolder.getRoot().getCanonicalPath());
     try (Closeable p = new SystemPropertyRule(sysProps).toResource()) {
-      mConfiguration = ConfigurationTestUtils.copyDefaults();
+      mConfiguration = Configuration.copyGlobal();
       assertEquals(PropertyKey.LOGGER_TYPE.getDefaultValue(),
           mConfiguration.get(PropertyKey.LOGGER_TYPE));
     }
@@ -1030,7 +1029,7 @@ public class InstancedConfigurationTest {
           format("%s is no longer a valid property",
               RemovedKey.Name.TEST_REMOVED_KEY)));
     }
-    mConfiguration = ConfigurationTestUtils.copyDefaults();
+    mConfiguration = Configuration.copyGlobal();
     try {
       mConfiguration.set(PropertyKey.fromString(RemovedKey.Name.TEST_REMOVED_KEY), true);
       mConfiguration.validate();

--- a/core/common/src/test/java/alluxio/grpc/GrpcConnectionPoolTest.java
+++ b/core/common/src/test/java/alluxio/grpc/GrpcConnectionPoolTest.java
@@ -14,7 +14,7 @@ package alluxio.grpc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.security.user.UserState;
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  */
 public final class GrpcConnectionPoolTest {
 
-  private static InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
+  private static InstancedConfiguration sConf = Configuration.copyGlobal();
 
   @BeforeClass
   public static void classSetup() {
@@ -45,7 +45,7 @@ public final class GrpcConnectionPoolTest {
 
   @After
   public void after() throws Exception {
-    sConf = ConfigurationTestUtils.copyDefaults();
+    sConf = Configuration.copyGlobal();
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/heartbeat/HeartbeatThreadTest.java
+++ b/core/common/src/test/java/alluxio/heartbeat/HeartbeatThreadTest.java
@@ -13,8 +13,7 @@ package alluxio.heartbeat;
 
 import static org.junit.Assert.assertEquals;
 
-import alluxio.ConfigurationTestUtils;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.security.user.UserState;
 
 import org.junit.After;
@@ -66,8 +65,6 @@ public final class HeartbeatThreadTest {
   private static final int NUMBER_OF_THREADS = 10;
 
   private ExecutorService mExecutorService;
-
-  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
 
   @Before
   public void before() {
@@ -142,8 +139,8 @@ public final class HeartbeatThreadTest {
       try (ManuallyScheduleHeartbeat.Resource r =
           new ManuallyScheduleHeartbeat.Resource(Arrays.asList(mThreadName))) {
         DummyHeartbeatExecutor executor = new DummyHeartbeatExecutor();
-        HeartbeatThread ht = new HeartbeatThread(mThreadName, executor, 1, mConfiguration,
-            UserState.Factory.create(mConfiguration));
+        HeartbeatThread ht = new HeartbeatThread(mThreadName, executor, 1, Configuration.global(),
+            UserState.Factory.create(Configuration.global()));
 
         // Run the HeartbeatThread.
         mExecutorService.submit(ht);

--- a/core/common/src/test/java/alluxio/master/MasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/MasterInquireClientTest.java
@@ -40,7 +40,7 @@ public final class MasterInquireClientTest {
 
   @Before
   public void before() {
-    mConfiguration = new InstancedConfiguration(Configuration.global().copyProperties());
+    mConfiguration = Configuration.copyGlobal();
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/network/TieredIdentityFactoryTest.java
+++ b/core/common/src/test/java/alluxio/network/TieredIdentityFactoryTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.PropertyKey.Template;
@@ -28,7 +28,6 @@ import alluxio.wire.TieredIdentity.LocalityTier;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.io.FileUtils;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -48,12 +47,7 @@ public class TieredIdentityFactoryTest {
   @Rule
   public ExpectedException mThrown = ExpectedException.none();
 
-  private InstancedConfiguration mConfiguration;
-
-  @Before
-  public void before() {
-    mConfiguration = ConfigurationTestUtils.copyDefaults();
-  }
+  private final InstancedConfiguration mConfiguration = Configuration.copyGlobal();
 
   @Test
   public void defaultConf() throws Exception {

--- a/core/common/src/test/java/alluxio/security/authentication/GrpcSecurityTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/GrpcSecurityTest.java
@@ -58,7 +58,7 @@ public class GrpcSecurityTest {
 
   @Before
   public void before() {
-    mConfiguration = new InstancedConfiguration(Configuration.global().copyProperties());
+    mConfiguration = Configuration.copyGlobal();
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/security/authentication/PlainSaslServerCallbackHandlerTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/PlainSaslServerCallbackHandlerTest.java
@@ -12,7 +12,7 @@
 package alluxio.security.authentication;
 
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.security.authentication.plain.PlainSaslServerCallbackHandler;
@@ -42,7 +42,7 @@ public final class PlainSaslServerCallbackHandlerTest {
   @Rule
   public ExpectedException mThrown = ExpectedException.none();
 
-  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConfiguration = Configuration.copyGlobal();
 
   @Rule
   public ConfigurationRule mConfigurationRule =

--- a/core/common/src/test/java/alluxio/security/authentication/SaslHandlersTest.java
+++ b/core/common/src/test/java/alluxio/security/authentication/SaslHandlersTest.java
@@ -11,8 +11,8 @@
 
 package alluxio.security.authentication;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.status.UnauthenticatedException;
 import alluxio.security.authentication.plain.SaslClientHandlerPlain;
 
@@ -26,7 +26,7 @@ import javax.security.auth.Subject;
  * Tests {@link SaslClientHandler} and {@link SaslServerHandler} implementations.
  */
 public class SaslHandlersTest {
-  private AlluxioConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
+  private final AlluxioConfiguration mConfiguration = Configuration.global();
 
   /**
    * The exception expected to be thrown.

--- a/core/common/src/test/java/alluxio/security/authorization/ModeTest.java
+++ b/core/common/src/test/java/alluxio/security/authorization/ModeTest.java
@@ -42,7 +42,7 @@ public final class ModeTest {
 
   @Before
   public void before() {
-    mConfiguration = new InstancedConfiguration(Configuration.global().copyProperties());
+    mConfiguration = Configuration.copyGlobal();
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/security/user/UserStateTest.java
+++ b/core/common/src/test/java/alluxio/security/user/UserStateTest.java
@@ -14,13 +14,12 @@ package alluxio.security.user;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.security.User;
 import alluxio.security.authentication.AuthType;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -28,12 +27,7 @@ import org.junit.Test;
  * Unit test for {@link UserState}.
  */
 public final class UserStateTest {
-  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
-
-  @After
-  public void after() {
-    mConfiguration = ConfigurationTestUtils.copyDefaults();
-  }
+  private final InstancedConfiguration mConfiguration = Configuration.copyGlobal();
 
   /**
    * Tests whether we can get login user with conf in SIMPLE mode.

--- a/core/common/src/test/java/alluxio/underfs/UnderFileSystemConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/underfs/UnderFileSystemConfigurationTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 
@@ -34,7 +34,7 @@ public final class UnderFileSystemConfigurationTest {
 
   @Before
   public void before() {
-    mConfiguration = ConfigurationTestUtils.copyDefaults();
+    mConfiguration = Configuration.copyGlobal();
   }
 
   @Test
@@ -46,11 +46,11 @@ public final class UnderFileSystemConfigurationTest {
       boolean readOnly = random.nextBoolean();
       boolean shared = random.nextBoolean();
       UnderFileSystemConfiguration conf = UnderFileSystemConfiguration
-          .defaults(ConfigurationTestUtils.copyDefaults()).setReadOnly(readOnly).setShared(shared);
+          .defaults(Configuration.global()).setReadOnly(readOnly).setShared(shared);
       assertEquals(readOnly, conf.isReadOnly());
       assertEquals(shared, conf.isShared());
       assertEquals("bar", mConfiguration.get(PropertyKey.S3A_ACCESS_KEY));
-      conf = UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults())
+      conf = UnderFileSystemConfiguration.defaults(Configuration.global())
           .setReadOnly(readOnly).setShared(shared)
           .createMountSpecificConf(ImmutableMap.of(PropertyKey.S3A_ACCESS_KEY.toString(), "foo"));
       assertEquals(readOnly, conf.isReadOnly());

--- a/core/common/src/test/java/alluxio/underfs/UnderFileSystemTest.java
+++ b/core/common/src/test/java/alluxio/underfs/UnderFileSystemTest.java
@@ -13,11 +13,10 @@ package alluxio.underfs;
 
 import static org.junit.Assert.assertNull;
 
-import alluxio.ConfigurationTestUtils;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 
 import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -25,12 +24,7 @@ import org.junit.Test;
  */
 public final class UnderFileSystemTest {
 
-  private InstancedConfiguration mConfiguration;
-
-  @Before
-  public void before() {
-    mConfiguration = ConfigurationTestUtils.copyDefaults();
-  }
+  private final AlluxioConfiguration mConfiguration = Configuration.global();
 
   /**
    * Tests the

--- a/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/CommonUtilsTest.java
@@ -19,9 +19,9 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.security.group.CachedGroupMapping;
 import alluxio.security.group.GroupMappingService;
 
@@ -299,7 +299,7 @@ public class CommonUtilsTest {
    */
   @Test
   public void getGroups() throws Throwable {
-    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    AlluxioConfiguration conf = Configuration.global();
 
     String userName = "alluxio-user1";
     String userGroup1 = "alluxio-user1-group1";

--- a/core/common/src/test/java/alluxio/util/ConfigurationUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/ConfigurationUtilsTest.java
@@ -155,7 +155,7 @@ public final class ConfigurationUtilsTest {
   }
 
   private AlluxioConfiguration createConf(Map<PropertyKey, Object> properties) {
-    AlluxioProperties props = Configuration.global().copyProperties();
+    AlluxioProperties props = Configuration.copyProperties();
     for (PropertyKey key : properties.keySet()) {
       props.set(key, properties.get(key));
     }

--- a/core/common/src/test/java/alluxio/util/SecurityUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/SecurityUtilsTest.java
@@ -13,27 +13,21 @@ package alluxio.util;
 
 import static org.junit.Assert.assertEquals;
 
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.security.authentication.AuthType;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.group.provider.IdentityUserGroupsMapping;
 
-import org.junit.Before;
 import org.junit.Test;
 
 public final class SecurityUtilsTest {
 
-  private InstancedConfiguration mConfiguration;
-
-  @Before
-  public void before() {
-    mConfiguration = ConfigurationTestUtils.copyDefaults();
-  }
+  private final InstancedConfiguration mConfiguration = Configuration.copyGlobal();
 
   /**
-   * Tests the {@link SecurityUtils#getOwnerFromGrpcClient()} ()} method.
+   * Tests the {@link SecurityUtils#getOwnerFromGrpcClient} method.
    */
   @Test
   public void getOwnerFromGrpcClient() throws Exception {
@@ -49,7 +43,7 @@ public final class SecurityUtilsTest {
   }
 
   /**
-   * Tests the {@link SecurityUtils#getGroupFromGrpcClient()} ()} method.
+   * Tests the {@link SecurityUtils#getGroupFromGrpcClient} method.
    */
   @Test
   public void getGroupFromGrpcClient() throws Exception {

--- a/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
+++ b/core/common/src/test/java/alluxio/util/network/GetMasterWorkerAddressTest.java
@@ -13,7 +13,7 @@ package alluxio.util.network;
 
 import static org.junit.Assert.assertEquals;
 
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.network.NetworkAddressUtils.ServiceType;
@@ -35,7 +35,7 @@ public class GetMasterWorkerAddressTest {
    */
   @Test
   public void getMasterAddress() {
-    InstancedConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    InstancedConfiguration conf = Configuration.copyGlobal();
 
     // connect host and port
     conf.set(PropertyKey.MASTER_HOSTNAME, "RemoteMaster1");
@@ -46,19 +46,19 @@ public class GetMasterWorkerAddressTest {
     InetSocketAddress masterAddress =
         NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
     assertEquals(InetSocketAddress.createUnresolved("RemoteMaster1", 10000), masterAddress);
-    conf = ConfigurationTestUtils.copyDefaults();
+    conf = Configuration.copyGlobal();
 
     // port only
     conf.set(PropertyKey.MASTER_RPC_PORT, 20000);
     masterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
     assertEquals(InetSocketAddress.createUnresolved(defaultHostname, 20000), masterAddress);
-    conf = ConfigurationTestUtils.copyDefaults();
+    conf = Configuration.copyGlobal();
 
     // connect host only
     conf.set(PropertyKey.MASTER_HOSTNAME, "RemoteMaster3");
     masterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
     assertEquals(InetSocketAddress.createUnresolved("RemoteMaster3", defaultPort), masterAddress);
-    conf = ConfigurationTestUtils.copyDefaults();
+    conf = Configuration.copyGlobal();
 
     // all default
     masterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);

--- a/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/network/NetworkAddressUtilsTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.CommonUtils;
@@ -40,11 +40,11 @@ import java.util.List;
  */
 public class NetworkAddressUtilsTest {
 
-  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConfiguration = Configuration.copyGlobal();
 
   @After
   public void after() {
-    mConfiguration = ConfigurationTestUtils.copyDefaults();
+    mConfiguration = Configuration.copyGlobal();
   }
 
   @Test

--- a/core/common/src/test/java/alluxio/wire/TieredIdentityTest.java
+++ b/core/common/src/test/java/alluxio/wire/TieredIdentityTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.grpc.GrpcUtils;
 import alluxio.network.TieredIdentityFactory;
@@ -26,7 +25,6 @@ import alluxio.util.TieredIdentityUtils;
 import alluxio.wire.TieredIdentity.LocalityTier;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -39,12 +37,7 @@ import java.util.Random;
  */
 public class TieredIdentityTest {
 
-  private InstancedConfiguration mConfiguration = ConfigurationTestUtils.copyDefaults();
-
-  @Before
-  public void before() {
-    mConfiguration = ConfigurationTestUtils.copyDefaults();
-  }
+  private final InstancedConfiguration mConfiguration = alluxio.conf.Configuration.copyGlobal();
 
   @Test
   public void nearest() throws Exception {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -377,11 +377,11 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     RaftServerConfigKeys.Snapshot.setAutoTriggerEnabled(
         properties, true);
     int snapshotAutoTriggerThreshold =
-        Configuration.global().getInt(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES);
+        Configuration.getInt(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES);
     RaftServerConfigKeys.Snapshot.setAutoTriggerThreshold(properties,
         snapshotAutoTriggerThreshold);
 
-    if (Configuration.global().getBoolean(PropertyKey.MASTER_JOURNAL_LOCAL_LOG_COMPACTION)) {
+    if (Configuration.getBoolean(PropertyKey.MASTER_JOURNAL_LOCAL_LOG_COMPACTION)) {
       // purges log files after taking a snapshot successfully
       RaftServerConfigKeys.Log.setPurgeUptoSnapshotIndex(properties, true);
       // leaves no gap between log file purges: all log files included in a newly installed
@@ -417,7 +417,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     RaftServerConfigKeys.LeaderElection.setLeaderStepDownWaitTime(properties,
         TimeDuration.valueOf(Long.MAX_VALUE, TimeUnit.MILLISECONDS));
 
-    long messageSize = Configuration.global().getBytes(
+    long messageSize = Configuration.getBytes(
         PropertyKey.MASTER_EMBEDDED_JOURNAL_TRANSPORT_MAX_INBOUND_MESSAGE_SIZE);
     GrpcConfigKeys.setMessageSizeMax(properties,
         SizeInBytes.valueOf(messageSize));

--- a/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
@@ -220,7 +220,7 @@ public class BackupWorkerRole extends AbstractBackupRole {
     // Update current backup status with given backup id.
     mBackupTracker.update(new BackupStatus(requestMsg.getBackupId(), BackupState.Initiating));
     mBackupTracker.updateHostname(NetworkAddressUtils.getLocalHostName(
-        (int) Configuration.global().getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS)));
+        (int) Configuration.getMs(PropertyKey.NETWORK_HOST_RESOLUTION_TIMEOUT_MS)));
 
     // Start sending backup progress to leader.
     startHeartbeatThread();

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -479,8 +479,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     getExecutorService().submit(new HeartbeatThread(
           HeartbeatContext.MASTER_WORKER_REGISTER_SESSION_CLEANER,
             new WorkerRegisterStreamGCExecutor(),
-            (int) Configuration.global().getMs(
-                PropertyKey.MASTER_WORKER_REGISTER_STREAM_RESPONSE_TIMEOUT),
+            (int) Configuration.getMs(PropertyKey.MASTER_WORKER_REGISTER_STREAM_RESPONSE_TIMEOUT),
             Configuration.global(), mMasterContext.getUserState()));
   }
 

--- a/core/server/master/src/main/java/alluxio/master/block/RegisterLeaseManager.java
+++ b/core/server/master/src/main/java/alluxio/master/block/RegisterLeaseManager.java
@@ -44,13 +44,12 @@ public class RegisterLeaseManager {
    */
   public RegisterLeaseManager() {
     int maxConcurrency =
-        Configuration.global().getInt(PropertyKey.MASTER_WORKER_REGISTER_LEASE_COUNT);
+        Configuration.getInt(PropertyKey.MASTER_WORKER_REGISTER_LEASE_COUNT);
     Preconditions.checkState(maxConcurrency > 0, "%s should be greater than 0",
         PropertyKey.MASTER_WORKER_REGISTER_LEASE_COUNT.toString());
     mSemaphore = new Semaphore(maxConcurrency);
 
-    if (Configuration.getBoolean(
-        PropertyKey.MASTER_WORKER_REGISTER_LEASE_RESPECT_JVM_SPACE)) {
+    if (Configuration.getBoolean(PropertyKey.MASTER_WORKER_REGISTER_LEASE_RESPECT_JVM_SPACE)) {
       mJvmChecker = new JvmSpaceReviewer(Runtime.getRuntime());
     }
 

--- a/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
+++ b/core/server/master/src/main/java/alluxio/web/MasterWebServer.java
@@ -62,7 +62,7 @@ public final class MasterWebServer extends WebServer {
     ResourceConfig config = new ResourceConfig()
         .packages("alluxio.master", "alluxio.master.block", "alluxio.master.file")
         .register(JacksonProtobufObjectMapperProvider.class);
-    mFileSystem = FileSystem.Factory.create(Configuration.global());
+    mFileSystem = FileSystem.Factory.create();
     // Override the init method to inject a reference to AlluxioMaster into the servlet context.
     // ServletContext may not be modified until after super.init() is called.
     ServletContainer servlet = new ServletContainer(config) {

--- a/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.AlluxioURI;
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Configuration;
 import alluxio.grpc.MountPOptions;
@@ -74,7 +73,7 @@ public class AsyncUfsAbsentPathCacheTest {
     mMountId = IdUtils.getRandomNonNegativeLong();
     MountPOptions options = MountContext.defaults().getOptions().build();
     mUfsManager.addMount(mMountId, new AlluxioURI(mLocalUfsPath),
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults())
+        UnderFileSystemConfiguration.defaults(Configuration.global())
             .setReadOnly(options.getReadOnly()).setShared(options.getShared())
             .createMountSpecificConf(Collections.<String, String>emptyMap()));
     mMountTable.add(NoopJournalContext.INSTANCE, new AlluxioURI("/mnt"),
@@ -203,7 +202,7 @@ public class AsyncUfsAbsentPathCacheTest {
     long newMountId = IdUtils.getRandomNonNegativeLong();
     MountPOptions options = MountContext.defaults().getOptions().build();
     mUfsManager.addMount(newMountId, new AlluxioURI(mLocalUfsPath),
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults())
+        UnderFileSystemConfiguration.defaults(Configuration.global())
             .setReadOnly(options.getReadOnly()).setShared(options.getShared())
             .createMountSpecificConf(Collections.<String, String>emptyMap()));
     mMountTable.add(NoopJournalContext.INSTANCE, new AlluxioURI("/mnt"),

--- a/core/server/worker/src/main/java/alluxio/web/WorkerWebServer.java
+++ b/core/server/worker/src/main/java/alluxio/web/WorkerWebServer.java
@@ -62,7 +62,7 @@ public final class WorkerWebServer extends WebServer {
     // REST configuration
     ResourceConfig config = new ResourceConfig().packages("alluxio.worker", "alluxio.worker.block")
         .register(JacksonProtobufObjectMapperProvider.class);
-    mFileSystem = FileSystem.Factory.create(Configuration.global());
+    mFileSystem = FileSystem.Factory.create();
 
     // Override the init method to inject a reference to AlluxioWorker into the servlet context.
     // ServletContext may not be modified until after super.init() is called.

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioFuseFileSystemTest.java
@@ -29,13 +29,13 @@ import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioURI;
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.block.BlockMasterClient;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.FileAlreadyExistsException;
@@ -83,7 +83,7 @@ public class AlluxioFuseFileSystemTest {
   private AlluxioFuseFileSystem mFuseFs;
   private FileSystem mFileSystem;
   private FuseFileInfo mFileInfo;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConf = Configuration.copyGlobal();
 
   @Rule
   public ConfigurationRule mConfiguration =

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioURI;
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.client.block.BlockMasterClient;
 import alluxio.client.file.FileInStream;
@@ -37,6 +36,7 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.FileAlreadyExistsException;
@@ -85,7 +85,7 @@ public class AlluxioJniFuseFileSystemTest {
   private FileSystemContext mFileSystemContext;
   private FileSystem mFileSystem;
   private FuseFileInfo mFileInfo;
-  private InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private InstancedConfiguration mConf = Configuration.copyGlobal();
 
   @Rule
   public ConfigurationRule mConfiguration =

--- a/integration/fuse/src/test/java/alluxio/fuse/cli/FuseShellTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/cli/FuseShellTest.java
@@ -19,13 +19,13 @@ import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioURI;
 import alluxio.ClientContext;
-import alluxio.ConfigurationTestUtils;
 import alluxio.cli.FuseShell;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.FileSystemMasterClient;
 import alluxio.client.file.MetadataCachingBaseFileSystem;
 import alluxio.client.file.URIStatus;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.AlluxioStatusException;
@@ -53,7 +53,7 @@ public class FuseShellTest {
   private FuseShell mFuseShell;
   private Map<AlluxioURI, URIStatus> mFileStatusMap;
   private FileSystem mFileSystem;
-  private final InstancedConfiguration mConf = ConfigurationTestUtils.copyDefaults();
+  private final InstancedConfiguration mConf = Configuration.copyGlobal();
   private FileSystemMasterClient mFileSystemMasterClient;
 
   private static final AlluxioURI DIR = new AlluxioURI("/dir");

--- a/job/client/src/test/java/alluxio/client/job/JobContextTest.java
+++ b/job/client/src/test/java/alluxio/client/job/JobContextTest.java
@@ -14,7 +14,7 @@ package alluxio.client.job;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.security.user.UserState;
@@ -27,7 +27,7 @@ import org.junit.Test;
  * Unit tests for {@link JobContext}.
  */
 public final class JobContextTest {
-  private static InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
+  private static InstancedConfiguration sConf = Configuration.copyGlobal();
 
   @Rule
   public ConfigurationRule mConf = new ConfigurationRule(ImmutableMap.of(

--- a/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
+++ b/job/server/src/test/java/alluxio/job/plan/migrate/MigrateDefinitionRunTaskTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioURI;
 import alluxio.ClientContext;
-import alluxio.ConfigurationTestUtils;
 import alluxio.client.WriteType;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
@@ -29,6 +28,7 @@ import alluxio.client.file.MockFileInStream;
 import alluxio.client.file.MockFileOutStream;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
@@ -65,7 +65,7 @@ public final class MigrateDefinitionRunTaskTest {
 
   @Before
   public void before() throws Exception {
-    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    AlluxioConfiguration conf = Configuration.global();
     mMockFileSystem = mock(FileSystem.class);
     mMockFileSystemContext = mock(FileSystemContext.class);
     when(mMockFileSystemContext.getClientContext())

--- a/minicluster/src/main/java/alluxio/master/ClientPool.java
+++ b/minicluster/src/main/java/alluxio/master/ClientPool.java
@@ -13,7 +13,6 @@ package alluxio.master;
 
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
-import alluxio.conf.Configuration;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -30,7 +29,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class ClientPool implements Closeable {
   private final List<FileSystem> mClients =
-      Collections.synchronizedList(new ArrayList<FileSystem>());
+      Collections.synchronizedList(new ArrayList<>());
 
   ClientPool(Supplier<String> uriSupplier) {}
 
@@ -41,7 +40,7 @@ public final class ClientPool implements Closeable {
    * @return a {@link FileSystem} client
    */
   public FileSystem getClient() throws IOException {
-    final FileSystem fs = FileSystem.Factory.create(Configuration.global());
+    final FileSystem fs = FileSystem.Factory.create();
     mClients.add(fs);
     return fs;
   }

--- a/shell/src/main/java/alluxio/cli/docgen/ConfigurationDocGenerator.java
+++ b/shell/src/main/java/alluxio/cli/docgen/ConfigurationDocGenerator.java
@@ -207,8 +207,8 @@ public final class ConfigurationDocGenerator {
    */
   public static void generate() throws IOException {
     Collection<? extends PropertyKey> defaultKeys = PropertyKey.defaultKeys();
-    defaultKeys.removeIf(key -> key.isHidden());
-    String homeDir = Configuration.global().getString(PropertyKey.HOME);
+    defaultKeys.removeIf(PropertyKey::isHidden);
+    String homeDir = Configuration.getString(PropertyKey.HOME);
     // generate CSV files
     String filePath = PathUtils.concatPath(homeDir, CSV_FILE_DIR);
     writeCSVFile(defaultKeys, filePath);

--- a/shell/src/main/java/alluxio/cli/docgen/MetricsDocGenerator.java
+++ b/shell/src/main/java/alluxio/cli/docgen/MetricsDocGenerator.java
@@ -56,7 +56,7 @@ public final class MetricsDocGenerator {
     List<MetricKey> defaultKeys = new ArrayList<>(MetricKey.allMetricKeys());
     Collections.sort(defaultKeys);
 
-    String homeDir = Configuration.global().getString(PropertyKey.HOME);
+    String homeDir = Configuration.getString(PropertyKey.HOME);
 
     // Map from metric key prefix to metric category
     Map<String, String> metricTypeMap = new HashMap<>();

--- a/stress/shell/src/main/java/alluxio/stress/cli/client/CompactionBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/CompactionBench.java
@@ -231,7 +231,7 @@ public class CompactionBench extends Benchmark<CompactionTaskResult> {
   }
 
   private static AlluxioProperties getCustomProperties(List<String> propertyList) {
-    AlluxioProperties properties = Configuration.global().copyProperties();
+    AlluxioProperties properties = Configuration.copyProperties();
     for (String property : propertyList) {
       String[] parts = property.split("=", 2);
       Preconditions.checkArgument(parts.length == 2,

--- a/table/server/common/src/main/java/alluxio/table/common/udb/UnderDatabaseRegistry.java
+++ b/table/server/common/src/main/java/alluxio/table/common/udb/UnderDatabaseRegistry.java
@@ -54,8 +54,7 @@ public class UnderDatabaseRegistry {
   public void refresh() {
     Map<String, UnderDatabaseFactory> map = new HashMap<>();
 
-    String libDir =
-        PathUtils.concatPath(Configuration.global().get(PropertyKey.HOME), "lib");
+    String libDir = PathUtils.concatPath(Configuration.get(PropertyKey.HOME), "lib");
     LOG.info("Loading udb jars from {}", libDir);
     List<File> files = new ArrayList<>();
     try (DirectoryStream<Path> stream = Files

--- a/table/server/common/src/test/java/alluxio/table/common/CatalogPathUtilsTest.java
+++ b/table/server/common/src/test/java/alluxio/table/common/CatalogPathUtilsTest.java
@@ -29,7 +29,7 @@ public class CatalogPathUtilsTest {
     String udbType = "udbType";
     AlluxioURI path = CatalogPathUtils.getTablePathUdb(dbName, tableName, udbType);
 
-    assertEquals(path.getPath(), PathUtils.concatPath(Configuration.global().get(
+    assertEquals(path.getPath(), PathUtils.concatPath(Configuration.get(
         PropertyKey.TABLE_CATALOG_PATH), dbName, "tables", tableName, udbType));
   }
 
@@ -39,7 +39,7 @@ public class CatalogPathUtilsTest {
     String tableName = "tableName";
     AlluxioURI path = CatalogPathUtils.getTablePathInternal(dbName, tableName);
 
-    assertEquals(path.getPath(), PathUtils.concatPath(Configuration.global().get(
+    assertEquals(path.getPath(), PathUtils.concatPath(Configuration.get(
         PropertyKey.TABLE_CATALOG_PATH), dbName, "tables", tableName, "_internal_"));
   }
 }

--- a/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
+++ b/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
@@ -13,7 +13,6 @@ package alluxio.master.table;
 
 import alluxio.client.file.FileSystem;
 import alluxio.collections.Pair;
-import alluxio.conf.Configuration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.table.ColumnStatisticsInfo;
@@ -70,7 +69,7 @@ public class AlluxioCatalog implements Journaled {
    * Creates an instance.
    */
   public AlluxioCatalog() {
-    mFileSystem = FileSystem.Factory.create(Configuration.global());
+    mFileSystem = FileSystem.Factory.create();
     mUdbRegistry = new UnderDatabaseRegistry();
     mUdbRegistry.refresh();
     mLayoutRegistry = new LayoutRegistry();

--- a/table/server/master/src/test/java/alluxio/master/table/TestDatabase.java
+++ b/table/server/master/src/test/java/alluxio/master/table/TestDatabase.java
@@ -13,7 +13,6 @@ package alluxio.master.table;
 
 import alluxio.client.file.FileSystem;
 import alluxio.collections.ConcurrentHashSet;
-import alluxio.conf.Configuration;
 import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.table.PrincipalType;
 import alluxio.table.common.udb.UdbBypassSpec;
@@ -129,7 +128,7 @@ public class TestDatabase implements UnderDatabase {
     DATABASE.mUdbTables.clear();
     FileSystem fs = null;
     if (generateFiles) {
-      fs = FileSystem.Factory.create(Configuration.global());
+      fs = FileSystem.Factory.create();
     }
     for (int i = 0; i < numOfTable; i++) {
       DATABASE.mUdbTables.put(getTableName(i),

--- a/tests/src/test/java/alluxio/client/cli/fs/FileSystemShellUtilsTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/FileSystemShellUtilsTest.java
@@ -14,7 +14,6 @@ package alluxio.client.cli.fs;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.AlluxioURI;
-import alluxio.ConfigurationTestUtils;
 import alluxio.Constants;
 import alluxio.cli.Command;
 import alluxio.cli.fs.FileSystemShell;
@@ -76,7 +75,7 @@ public final class FileSystemShellUtilsTest {
         new String[] {Constants.HEADER + "localhost:19998/dir", "/dir", "dir"};
     String expected = "/dir";
     for (String path : paths) {
-      String result = FileSystemShellUtils.getFilePath(path, ConfigurationTestUtils.copyDefaults());
+      String result = FileSystemShellUtils.getFilePath(path, Configuration.global());
       assertEquals(expected, result);
     }
   }

--- a/tests/src/test/java/alluxio/client/cli/fs/JobServiceFaultToleranceShellTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/JobServiceFaultToleranceShellTest.java
@@ -70,7 +70,7 @@ public final class JobServiceFaultToleranceShellTest extends BaseIntegrationTest
 
   @Test
   public void distributedCp() throws Exception {
-    FileSystem fs = FileSystem.Factory.create(Configuration.global());
+    FileSystem fs = FileSystem.Factory.create();
     try (OutputStream out = fs.createFile(new AlluxioURI("/test"))) {
       out.write("Hello".getBytes());
     }

--- a/tests/src/test/java/alluxio/client/fs/BlockMasterRegisterStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/BlockMasterRegisterStreamIntegrationTest.java
@@ -100,7 +100,7 @@ public class BlockMasterRegisterStreamIntegrationTest {
 
   private static final int MASTER_WORKER_TIMEOUT = 1_000_000;
   private static final long BLOCK_SIZE =
-      Configuration.global().getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);
+      Configuration.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);
   private static final Map<String, StorageList> NO_LOST_STORAGE = ImmutableMap.of();
   private static final Command EMPTY_CMD =
       Command.newBuilder().setCommandType(CommandType.Nothing).build();

--- a/tests/src/test/java/alluxio/client/fs/CheckConsistencyIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/CheckConsistencyIntegrationTest.java
@@ -63,7 +63,7 @@ public class CheckConsistencyIntegrationTest extends BaseIntegrationTest {
     mFileSystemMaster =
         mLocalAlluxioClusterResource.get().getLocalAlluxioMaster().getMasterProcess()
             .getMaster(FileSystemMaster.class);
-    mFileSystem = FileSystem.Factory.create(Configuration.global());
+    mFileSystem = FileSystem.Factory.create();
     CreateDirectoryPOptions dirOptions =
         CreateDirectoryPOptions.newBuilder().setWriteType(WritePType.CACHE_THROUGH).build();
     CreateFilePOptions fileOptions =

--- a/tests/src/test/java/alluxio/client/fs/ImpersonationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/ImpersonationIntegrationTest.java
@@ -79,7 +79,7 @@ public final class ImpersonationIntegrationTest extends BaseIntegrationTest {
   public void before() throws Exception {
     // Give the root dir 777, to write files as different users. This must be run as the user
     // that starts the master process
-    FileSystem.Factory.create(Configuration.global()).setAttribute(new AlluxioURI("/"),
+    FileSystem.Factory.create().setAttribute(new AlluxioURI("/"),
         SetAttributePOptions.newBuilder().setMode(new Mode((short) 0777).toProto()).build());
     // Enable client impersonation by default
     Configuration

--- a/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LoadMetadataIntegrationTest.java
@@ -101,7 +101,7 @@ public class LoadMetadataIntegrationTest extends BaseIntegrationTest {
   @Before
   public void before() throws Exception {
     mLocalUfsPath = mTempFolder.getRoot().getAbsolutePath();
-    mFileSystem = FileSystem.Factory.create(Configuration.global());
+    mFileSystem = FileSystem.Factory.create();
     mFileSystem.mount(new AlluxioURI("/mnt/"), new AlluxioURI("sleep://" + mLocalUfsPath));
 
     new File(mLocalUfsPath + "/dir1/dirA/").mkdirs();

--- a/tests/src/test/java/alluxio/client/fs/LocalFirstPolicyIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/LocalFirstPolicyIntegrationTest.java
@@ -90,7 +90,7 @@ public class LocalFirstPolicyIntegrationTest extends BaseIntegrationTest {
     TestUtils.waitForReady(worker1);
     TestUtils.waitForReady(worker2);
 
-    FileSystem fs = FileSystem.Factory.create(Configuration.global());
+    FileSystem fs = FileSystem.Factory.create();
 
     // Write to the worker in node1
     {

--- a/tests/src/test/java/alluxio/client/fs/TtlIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/TtlIntegrationTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertTrue;
 import alluxio.AlluxioURI;
 import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.WritePType;
@@ -52,7 +51,7 @@ public class TtlIntegrationTest extends BaseIntegrationTest {
 
   @Before
   public void before() {
-    mFileSystem = FileSystem.Factory.create(Configuration.global());
+    mFileSystem = FileSystem.Factory.create();
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -118,7 +118,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
 
   @Before
   public void before() throws Exception {
-    mFileSystem = FileSystem.Factory.create(Configuration.global());
+    mFileSystem = FileSystem.Factory.create();
     mFileSystem.mount(new AlluxioURI("/mnt/"), new AlluxioURI(mLocalUfsPath));
 
     new File(ufsPath(EXISTING_DIR)).mkdirs();

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentDeleteIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentDeleteIntegrationTest.java
@@ -85,7 +85,7 @@ public class ConcurrentDeleteIntegrationTest extends BaseIntegrationTest {
 
   @Before
   public void before() {
-    mFileSystem = FileSystem.Factory.create(Configuration.global());
+    mFileSystem = FileSystem.Factory.create();
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterCreateIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterCreateIntegrationTest.java
@@ -91,7 +91,7 @@ public class ConcurrentFileSystemMasterCreateIntegrationTest extends BaseIntegra
 
   @Before
   public void before() {
-    mFileSystem = FileSystem.Factory.create(Configuration.global());
+    mFileSystem = FileSystem.Factory.create();
     Configuration.set(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, "2b");
   }
 

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterLoadMetadataIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterLoadMetadataIntegrationTest.java
@@ -51,7 +51,7 @@ public final class ConcurrentFileSystemMasterLoadMetadataIntegrationTest {
 
   @Before
   public void before() {
-    mFileSystem = FileSystem.Factory.create(Configuration.global());
+    mFileSystem = FileSystem.Factory.create();
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
@@ -92,7 +92,7 @@ public class ConcurrentFileSystemMasterSetTtlIntegrationTest extends BaseIntegra
 
   @Before
   public void before() {
-    mFileSystem = FileSystem.Factory.create(Configuration.global());
+    mFileSystem = FileSystem.Factory.create();
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentRenameIntegrationTest.java
@@ -96,7 +96,7 @@ public class ConcurrentRenameIntegrationTest extends BaseIntegrationTest {
 
   @Before
   public void before() {
-    mFileSystem = FileSystem.Factory.create(Configuration.global());
+    mFileSystem = FileSystem.Factory.create();
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/fs/io/FileInStreamRehydrationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileInStreamRehydrationIntegrationTest.java
@@ -17,7 +17,6 @@ import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
-import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.master.MasterProcess;
@@ -49,7 +48,7 @@ public class FileInStreamRehydrationIntegrationTest extends AbstractFileOutStrea
 
   @Test
   public void testRehydration() throws Exception {
-    FileSystem fs = FileSystem.Factory.create(Configuration.global());
+    FileSystem fs = FileSystem.Factory.create();
 
     // Create a file with 10 blocks.
     AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());

--- a/tests/src/test/java/alluxio/client/fs/io/UfsFallbackFileOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/UfsFallbackFileOutStreamIntegrationTest.java
@@ -93,7 +93,7 @@ public class UfsFallbackFileOutStreamIntegrationTest extends AbstractFileOutStre
         put(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT, mBlockSize);
       }
     }, Configuration.modifiableGlobal()).toResource()) {
-      FileSystem fs = FileSystem.Factory.create(Configuration.global());
+      FileSystem fs = FileSystem.Factory.create();
       AlluxioURI filePath = new AlluxioURI(PathUtils.uniqPath());
       CreateFilePOptions op = CreateFilePOptions.newBuilder()
           .setWriteType(WritePType.ASYNC_THROUGH).setRecursive(true).build();

--- a/tests/src/test/java/alluxio/server/ft/journal/ufs/RenameFailureJournalTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/ufs/RenameFailureJournalTest.java
@@ -75,7 +75,7 @@ public class RenameFailureJournalTest {
 
   @Before
   public void before() throws Exception {
-    mFs = FileSystem.Factory.create(Configuration.global());
+    mFs = FileSystem.Factory.create();
   }
 
   @Test

--- a/underfs/abfs/src/test/java/alluxio/underfs/abfs/AbfsUnderFileSystemFactoryTest.java
+++ b/underfs/abfs/src/test/java/alluxio/underfs/abfs/AbfsUnderFileSystemFactoryTest.java
@@ -11,8 +11,8 @@
 
 package alluxio.underfs.abfs;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 
@@ -30,7 +30,7 @@ public class AbfsUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
-    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    AlluxioConfiguration conf = Configuration.global();
     UnderFileSystemFactory factory =
         UnderFileSystemFactoryRegistry.find("abfs://localhost/test/path", conf);
     Assert.assertNotNull(

--- a/underfs/adl/src/test/java/alluxio/underfs/adl/AdlUnderFileSystemFactoryTest.java
+++ b/underfs/adl/src/test/java/alluxio/underfs/adl/AdlUnderFileSystemFactoryTest.java
@@ -11,8 +11,8 @@
 
 package alluxio.underfs.adl;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 
@@ -30,7 +30,7 @@ public class AdlUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
-    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    AlluxioConfiguration conf = Configuration.global();
     UnderFileSystemFactory factory =
         UnderFileSystemFactoryRegistry.find("adl://localhost/test/path", conf);
     Assert.assertNotNull(

--- a/underfs/cosn/src/test/java/alluxio/underfs/cosn/CosNUnderFileSystemFactoryTest.java
+++ b/underfs/cosn/src/test/java/alluxio/underfs/cosn/CosNUnderFileSystemFactoryTest.java
@@ -11,8 +11,8 @@
 
 package alluxio.underfs.cosn;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 
@@ -29,7 +29,7 @@ public class CosNUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
-    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    AlluxioConfiguration conf = Configuration.global();
     UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry
                             .find("cosn://test-bucket/path", conf);
 

--- a/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemFactoryTest.java
+++ b/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemFactoryTest.java
@@ -11,7 +11,7 @@
 
 package alluxio.underfs.gcs;
 
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 
@@ -29,7 +29,7 @@ public final class GCSUnderFileSystemFactoryTest {
   @Test
   public void factory() {
     UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry.find("gs://test-bucket/path",
-        ConfigurationTestUtils.copyDefaults());
+        Configuration.global());
 
     Assert.assertNotNull(
         "A UnderFileSystemFactory should exist for gs paths when using this module", factory);

--- a/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemTest.java
+++ b/underfs/gcs/src/test/java/alluxio/underfs/gcs/GCSUnderFileSystemTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioURI;
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.DeleteOptions;
 
@@ -40,18 +40,16 @@ public class GCSUnderFileSystemTest {
   private static final String DST = "dst";
 
   private static final String BUCKET_NAME = "bucket";
-  private static final short BUCKET_MODE = 0;
-  private static final String ACCOUNT_OWNER = "account owner";
 
   /**
    * Set up.
    */
   @Before
-  public void before() throws InterruptedException, ServiceException {
+  public void before() {
     mClient = mock(GoogleStorageService.class);
 
     mGCSUnderFileSystem = new GCSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME,
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults()));
+        UnderFileSystemConfiguration.defaults(Configuration.global()));
   }
 
   /**

--- a/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactoryTest.java
+++ b/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemFactoryTest.java
@@ -11,7 +11,8 @@
 
 package alluxio.underfs.hdfs;
 
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 
@@ -28,24 +29,21 @@ public class HdfsUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
+    AlluxioConfiguration conf = Configuration.global();
     UnderFileSystemFactory factory =
-        UnderFileSystemFactoryRegistry.find("hdfs://localhost/test/path",
-            ConfigurationTestUtils.copyDefaults());
+        UnderFileSystemFactoryRegistry.find("hdfs://localhost/test/path", conf);
     Assert.assertNotNull(
         "A UnderFileSystemFactory should exist for HDFS paths when using this module", factory);
 
-    factory = UnderFileSystemFactoryRegistry.find("s3://localhost/test/path",
-        ConfigurationTestUtils.copyDefaults());
+    factory = UnderFileSystemFactoryRegistry.find("s3://localhost/test/path", conf);
     Assert.assertNull(
         "A UnderFileSystemFactory should not exist for S3 paths when using this module", factory);
 
-    factory = UnderFileSystemFactoryRegistry.find("s3n://localhost/test/path",
-        ConfigurationTestUtils.copyDefaults());
+    factory = UnderFileSystemFactoryRegistry.find("s3n://localhost/test/path", conf);
     Assert.assertNull(
         "A UnderFileSystemFactory should not exist for S3 paths when using this module", factory);
 
-    factory = UnderFileSystemFactoryRegistry.find("alluxio://localhost:19999/test",
-        ConfigurationTestUtils.copyDefaults());
+    factory = UnderFileSystemFactoryRegistry.find("alluxio://localhost:19999/test", conf);
     Assert.assertNull("A UnderFileSystemFactory should not exist for non supported paths when "
         + "using this module", factory);
   }

--- a/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemTest.java
+++ b/underfs/hdfs/src/test/java/alluxio/underfs/hdfs/HdfsUnderFileSystemTest.java
@@ -22,8 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import alluxio.AlluxioURI;
-import alluxio.ConfigurationTestUtils;
-import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.underfs.SeekableUnderFileInputStream;
 import alluxio.underfs.UnderFileSystemConfiguration;
@@ -47,15 +46,14 @@ import java.io.File;
 public final class HdfsUnderFileSystemTest {
 
   private HdfsUnderFileSystem mHdfsUnderFileSystem;
-  private final AlluxioConfiguration mAlluxioConf = ConfigurationTestUtils.copyDefaults();
 
   @Rule
   public TemporaryFolder mTemporaryFolder = new TemporaryFolder();
 
   @Before
-  public final void before() throws Exception {
+  public void before() throws Exception {
     UnderFileSystemConfiguration conf =
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults())
+        UnderFileSystemConfiguration.defaults(Configuration.global())
             .createMountSpecificConf(ImmutableMap.of("hadoop.security.group.mapping",
                 "org.apache.hadoop.security.ShellBasedUnixGroupsMapping", "fs.hdfs.impl",
             PropertyKey.UNDERFS_HDFS_IMPL.getDefaultValue()));
@@ -80,7 +78,7 @@ public final class HdfsUnderFileSystemTest {
   @Test
   public void prepareConfiguration() throws Exception {
     UnderFileSystemConfiguration ufsConf =
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults());
+        UnderFileSystemConfiguration.defaults(Configuration.global());
     org.apache.hadoop.conf.Configuration conf = HdfsUnderFileSystem.createConfiguration(ufsConf);
     Assert.assertEquals(ufsConf.get(PropertyKey.UNDERFS_HDFS_IMPL), conf.get("fs.hdfs.impl"));
     Assert.assertTrue(conf.getBoolean("fs.hdfs.impl.disable.cache", false));

--- a/underfs/kodo/src/test/java/alluxio/underfs/kodo/KodoOutputStreamTest.java
+++ b/underfs/kodo/src/test/java/alluxio/underfs/kodo/KodoOutputStreamTest.java
@@ -11,8 +11,7 @@
 
 package alluxio.underfs.kodo;
 
-import alluxio.ConfigurationTestUtils;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 
 import org.junit.Before;
@@ -39,9 +38,7 @@ import java.util.List;
  */
 @RunWith(PowerMockRunner.class)
 public class KodoOutputStreamTest {
-
-  private static InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
-  private static List<String> sTmpDirs = sConf.getList(PropertyKey.TMP_DIRS);
+  private static final List<String> TMP_DIRS = Configuration.getList(PropertyKey.TMP_DIRS);
 
   /**
    * The exception expected to be thrown.
@@ -74,7 +71,7 @@ public class KodoOutputStreamTest {
         .thenThrow(new IOException(errorMessage));
     mThrown.expect(IOException.class);
     mThrown.expectMessage(errorMessage);
-    new KodoOutputStream("testKey", mKodoClient, sTmpDirs).close();
+    new KodoOutputStream("testKey", mKodoClient, TMP_DIRS).close();
   }
 
   /**
@@ -87,7 +84,7 @@ public class KodoOutputStreamTest {
         .withArguments(Mockito.any(DigestOutputStream.class)).thenReturn(mLocalOutputStream);
     PowerMockito.whenNew(BufferedOutputStream.class)
         .withArguments(Mockito.any(FileOutputStream.class)).thenReturn(mLocalOutputStream);
-    KodoOutputStream stream = new KodoOutputStream("testKey", mKodoClient, sTmpDirs);
+    KodoOutputStream stream = new KodoOutputStream("testKey", mKodoClient, TMP_DIRS);
     stream.write(1);
     stream.close();
     Mockito.verify(mLocalOutputStream).write(1);
@@ -104,7 +101,7 @@ public class KodoOutputStreamTest {
         .withArguments(Mockito.any(DigestOutputStream.class)).thenReturn(mLocalOutputStream);
     PowerMockito.whenNew(BufferedOutputStream.class)
         .withArguments(Mockito.any(FileOutputStream.class)).thenReturn(mLocalOutputStream);
-    KodoOutputStream stream = new KodoOutputStream("testKey", mKodoClient, sTmpDirs);
+    KodoOutputStream stream = new KodoOutputStream("testKey", mKodoClient, TMP_DIRS);
     byte[] b = new byte[1];
     stream.write(b, 0, 1);
     stream.close();
@@ -118,7 +115,7 @@ public class KodoOutputStreamTest {
         .withArguments(Mockito.any(DigestOutputStream.class)).thenReturn(mLocalOutputStream);
     PowerMockito.whenNew(BufferedOutputStream.class)
         .withArguments(Mockito.any(FileOutputStream.class)).thenReturn(mLocalOutputStream);
-    KodoOutputStream stream = new KodoOutputStream("testKey", mKodoClient, sTmpDirs);
+    KodoOutputStream stream = new KodoOutputStream("testKey", mKodoClient, TMP_DIRS);
     byte[] b = new byte[1];
     stream.write(b);
     stream.close();
@@ -136,7 +133,7 @@ public class KodoOutputStreamTest {
     PowerMockito.whenNew(FileOutputStream.class).withArguments(mFile).thenReturn(outputStream);
     FileInputStream inputStream = PowerMockito.mock(FileInputStream.class);
     PowerMockito.whenNew(FileInputStream.class).withArguments(mFile).thenReturn(inputStream);
-    KodoOutputStream stream = new KodoOutputStream("testKey", mKodoClient, sTmpDirs);
+    KodoOutputStream stream = new KodoOutputStream("testKey", mKodoClient, TMP_DIRS);
     stream.close();
     Mockito.verify(mFile).delete();
   }
@@ -149,7 +146,7 @@ public class KodoOutputStreamTest {
   public void testFlush() throws Exception {
     PowerMockito.whenNew(BufferedOutputStream.class)
         .withArguments(Mockito.any(DigestOutputStream.class)).thenReturn(mLocalOutputStream);
-    KodoOutputStream stream = new KodoOutputStream("testKey", mKodoClient, sTmpDirs);
+    KodoOutputStream stream = new KodoOutputStream("testKey", mKodoClient, TMP_DIRS);
     stream.flush();
     stream.close();
     Mockito.verify(mLocalOutputStream).flush();

--- a/underfs/kodo/src/test/java/alluxio/underfs/kodo/KodoUnderFileSystemFactoryTest.java
+++ b/underfs/kodo/src/test/java/alluxio/underfs/kodo/KodoUnderFileSystemFactoryTest.java
@@ -11,7 +11,7 @@
 
 package alluxio.underfs.kodo;
 
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 
@@ -29,7 +29,7 @@ public class KodoUnderFileSystemFactoryTest {
   @Test
   public void factory() {
     UnderFileSystemFactory factory = UnderFileSystemFactoryRegistry.find("kodo://test-bucket/path",
-        ConfigurationTestUtils.copyDefaults());
+        Configuration.global());
 
     Assert.assertNotNull(
         "A UnderFileSystemFactory should exist for oss paths when using this module", factory);

--- a/underfs/kodo/src/test/java/alluxio/underfs/kodo/KodoUnderFileSystemTest.java
+++ b/underfs/kodo/src/test/java/alluxio/underfs/kodo/KodoUnderFileSystemTest.java
@@ -12,8 +12,7 @@
 package alluxio.underfs.kodo;
 
 import alluxio.AlluxioURI;
-import alluxio.ConfigurationTestUtils;
-import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.DeleteOptions;
 
@@ -31,8 +30,6 @@ import java.io.IOException;
  */
 public class KodoUnderFileSystemTest {
 
-  private static InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
-
   private KodoUnderFileSystem mKodoUnderFileSystem;
   private KodoClient mClient;
 
@@ -48,7 +45,7 @@ public class KodoUnderFileSystemTest {
     mClient = Mockito.mock(KodoClient.class);
 
     mKodoUnderFileSystem = new KodoUnderFileSystem(new AlluxioURI(""), mClient,
-        UnderFileSystemConfiguration.defaults(sConf));
+        UnderFileSystemConfiguration.defaults(Configuration.copyGlobal()));
   }
 
   /**

--- a/underfs/obs/src/test/java/alluxio/underfs/obs/OBSUnderFileSystemTest.java
+++ b/underfs/obs/src/test/java/alluxio/underfs/obs/OBSUnderFileSystemTest.java
@@ -12,7 +12,7 @@
 package alluxio.underfs.obs;
 
 import alluxio.AlluxioURI;
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.DeleteOptions;
 
@@ -51,7 +51,7 @@ public class OBSUnderFileSystemTest {
   public void before() throws InterruptedException, ObsException {
     mClient = Mockito.mock(ObsClient.class);
     mOBSUnderFileSystem = new OBSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME,
-        BUCKET_TYPE, UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults()));
+        BUCKET_TYPE, UnderFileSystemConfiguration.defaults(Configuration.global()));
   }
 
   /**
@@ -123,7 +123,7 @@ public class OBSUnderFileSystemTest {
 
     // PFS Bucket
     mOBSUnderFileSystem = new OBSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME, "pfs",
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults()));
+        UnderFileSystemConfiguration.defaults(Configuration.global()));
     Assert.assertNotNull(mOBSUnderFileSystem.getObjectStatus("pfs_file1"));
     Assert.assertNull(mOBSUnderFileSystem.getObjectStatus("pfs_file1/"));
     Assert.assertNull(mOBSUnderFileSystem.getObjectStatus("dir1"));
@@ -132,7 +132,7 @@ public class OBSUnderFileSystemTest {
 
     // OBS Bucket
     mOBSUnderFileSystem = new OBSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME, "obs",
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults()));
+        UnderFileSystemConfiguration.defaults(Configuration.global()));
     Mockito.when(mClient.getObjectMetadata(BUCKET_NAME, "dir1"))
         .thenReturn(null);
     Assert.assertNotNull(mOBSUnderFileSystem.getObjectStatus("obs_file1"));
@@ -159,7 +159,7 @@ public class OBSUnderFileSystemTest {
         .thenReturn(dirMeta);
 
     mOBSUnderFileSystem = new OBSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME, "obs",
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults()));
+        UnderFileSystemConfiguration.defaults(Configuration.global()));
     Assert.assertNotNull(mOBSUnderFileSystem.getObjectStatus("pfs_file1"));
     Assert.assertNotNull(mOBSUnderFileSystem.getObjectStatus("dir1"));
   }

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSUnderFileSystemTest.java
@@ -12,7 +12,7 @@
 package alluxio.underfs.oss;
 
 import alluxio.AlluxioURI;
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.DeleteOptions;
 
@@ -49,7 +49,7 @@ public class OSSUnderFileSystemTest {
     mClient = Mockito.mock(OSSClient.class);
 
     mOSSUnderFileSystem = new OSSUnderFileSystem(new AlluxioURI(""), mClient, BUCKET_NAME,
-        UnderFileSystemConfiguration.defaults(ConfigurationTestUtils.copyDefaults()));
+        UnderFileSystemConfiguration.defaults(Configuration.global()));
   }
 
   /**

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemFactoryTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemFactoryTest.java
@@ -17,33 +17,27 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 
-import org.junit.Before;
 import org.junit.Test;
 
 /**
  * Unit tests for the {@link S3AUnderFileSystemFactory}.
  */
 public class S3AUnderFileSystemFactoryTest {
-  private String mS3APath = "s3a://test-bucket/path";
-  private String mS3Path = "s3://test-bucket/path";
-  private String mS3NPath = "s3n://test-bucket/path";
-  private AlluxioConfiguration mAlluxioConf;
-  private UnderFileSystemConfiguration mConf;
-  private UnderFileSystemFactory mFactory1;
-
-  @Before
-  public void before() {
-    mAlluxioConf = ConfigurationTestUtils.copyDefaults();
-    mConf = UnderFileSystemConfiguration.defaults(mAlluxioConf);
-    mFactory1 = UnderFileSystemFactoryRegistry.find(mS3APath, mAlluxioConf);
-  }
+  private final String mS3APath = "s3a://test-bucket/path";
+  private final String mS3Path = "s3://test-bucket/path";
+  private final String mS3NPath = "s3n://test-bucket/path";
+  private final AlluxioConfiguration mAlluxioConf = Configuration.global();
+  private final UnderFileSystemConfiguration mConf =
+      UnderFileSystemConfiguration.defaults(mAlluxioConf);
+  private final UnderFileSystemFactory mFactory1 =
+      UnderFileSystemFactoryRegistry.find(mS3APath, mAlluxioConf);
 
   @Test
   public void factory() {

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
@@ -13,7 +13,7 @@ package alluxio.underfs.s3a;
 
 import alluxio.AlluxioURI;
 import alluxio.ConfigurationRule;
-import alluxio.ConfigurationTestUtils;
+import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.underfs.ObjectUnderFileSystem;
@@ -54,7 +54,7 @@ public class S3AUnderFileSystemTest {
   private static final String PATH = "path";
   private static final String SRC = "src";
   private static final String DST = "dst";
-  private static  InstancedConfiguration sConf = ConfigurationTestUtils.copyDefaults();
+  private static  InstancedConfiguration sConf = Configuration.copyGlobal();
 
   private static final String BUCKET_NAME = "bucket";
   private static final String DEFAULT_OWNER = "";

--- a/underfs/swift/src/test/java/alluxio/underfs/swift/SwiftUnderFileSystemFactoryTest.java
+++ b/underfs/swift/src/test/java/alluxio/underfs/swift/SwiftUnderFileSystemFactoryTest.java
@@ -11,8 +11,8 @@
 
 package alluxio.underfs.swift;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 
@@ -29,7 +29,7 @@ public class SwiftUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
-    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    AlluxioConfiguration conf = Configuration.global();
     UnderFileSystemFactory factory =
         UnderFileSystemFactoryRegistry.find("swift://localhost/test/path", conf);
     UnderFileSystemFactory factory2 =

--- a/underfs/wasb/src/test/java/alluxio/underfs/wasb/WasbUnderFileSystemFactoryTest.java
+++ b/underfs/wasb/src/test/java/alluxio/underfs/wasb/WasbUnderFileSystemFactoryTest.java
@@ -11,8 +11,8 @@
 
 package alluxio.underfs.wasb;
 
-import alluxio.ConfigurationTestUtils;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
 import alluxio.underfs.UnderFileSystemFactory;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 
@@ -30,7 +30,7 @@ public class WasbUnderFileSystemFactoryTest {
    */
   @Test
   public void factory() {
-    AlluxioConfiguration conf = ConfigurationTestUtils.copyDefaults();
+    AlluxioConfiguration conf = Configuration.global();
     UnderFileSystemFactory factory =
         UnderFileSystemFactoryRegistry.find("wasb://localhost/test/path", conf);
     Assert.assertNotNull(


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove unnecessary Configuration.global() since FileSystem.Factory.create() == FileSystem.Factory.create(Configuration.global())
also configuration.global().getXX can be replaced by configuration.getXX
Remove ConfigurationTestUtils.copyDefaults since it's just duplicate
### Why are the changes needed?
clean code

### Does this PR introduce any user facing changes?
na