### PR TITLE
Add root cache for inode tree

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -252,7 +252,7 @@ public class InodeTree implements DelegatingJournaled {
    */
   public void initializeRoot(String owner, String group, Mode mode, JournalContext context)
       throws UnavailableException {
-    if (mState.getRoot() == null) {
+    if (mState.getRootFromStore() == null) {
       MutableInodeDirectory root = MutableInodeDirectory.create(
           mDirectoryIdGenerator.getNewDirectoryId(context), NO_PARENT, ROOT_INODE_NAME,
           CreateDirectoryContext


### PR DESCRIPTION
### What changes are proposed in this pull request?
Add root cache for inode tree

### Why are the changes needed?
As the most commonly used node, the root node can be cached, saving a query of rocksdb

### Does this PR introduce any user facing changes?
No
