### PR TITLE
Fix getDb-in-RocksStore performance

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.StampedLock;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -60,6 +61,7 @@ public final class RocksStore implements Closeable {
   private Checkpoint mCheckpoint;
   // When we create the database, we must set these handles.
   private final List<AtomicReference<ColumnFamilyHandle>> mColumnHandles;
+  private final StampedLock mStampedLock = new StampedLock();
 
   /**
    * @param name a name to distinguish what store this is
@@ -94,20 +96,30 @@ public final class RocksStore implements Closeable {
    * @return the underlying rocksdb instance. The instance changes when clear() is called, so if the
    *         caller caches the returned db, they must reset it after calling clear()
    */
-  public synchronized RocksDB getDb() {
-    return mDb;
+  public RocksDB getDb() {
+    long stamp = mStampedLock.readLock();
+    try {
+      return mDb;
+    } finally {
+      mStampedLock.unlockRead(stamp);
+    }
   }
 
   /**
    * Clears and re-initializes the database.
    */
-  public synchronized void clear() {
+  public void clear() {
+    long stamp = mStampedLock.writeLock();
     try {
-      resetDb();
-    } catch (RocksDBException e) {
-      throw new RuntimeException(e);
+      try {
+        resetDb();
+      } catch (RocksDBException e) {
+        throw new RuntimeException(e);
+      }
+      LOG.info("Cleared store at {}", mDbPath);
+    } finally {
+      mStampedLock.unlockWrite(stamp);
     }
-    LOG.info("Cleared store at {}", mDbPath);
   }
 
   private void resetDb() throws RocksDBException {
@@ -181,24 +193,29 @@ public final class RocksStore implements Closeable {
    *
    * @param output the stream to write to
    */
-  public synchronized void writeToCheckpoint(OutputStream output)
+  public void writeToCheckpoint(OutputStream output)
       throws IOException, InterruptedException {
-    LOG.info("Creating rocksdb checkpoint at {}", mDbCheckpointPath);
-    long startNano = System.nanoTime();
-
-    CheckpointOutputStream out = new CheckpointOutputStream(output, CheckpointType.ROCKS);
+    long stamp = mStampedLock.writeLock();
     try {
-      // createCheckpoint requires that the directory not already exist.
+      LOG.info("Creating rocksdb checkpoint at {}", mDbCheckpointPath);
+      long startNano = System.nanoTime();
+
+      CheckpointOutputStream out = new CheckpointOutputStream(output, CheckpointType.ROCKS);
+      try {
+        // createCheckpoint requires that the directory not already exist.
+        FileUtils.deletePathRecursively(mDbCheckpointPath);
+        mCheckpoint.createCheckpoint(mDbCheckpointPath);
+      } catch (RocksDBException e) {
+        throw new IOException(e);
+      }
+      LOG.info("Checkpoint complete, creating tarball");
+      TarUtils.writeTarGz(Paths.get(mDbCheckpointPath), out);
+      LOG.info("Completed rocksdb checkpoint in {}ms", (System.nanoTime() - startNano) / 1_000_000);
+      // Checkpoint is no longer needed, delete to save space.
       FileUtils.deletePathRecursively(mDbCheckpointPath);
-      mCheckpoint.createCheckpoint(mDbCheckpointPath);
-    } catch (RocksDBException e) {
-      throw new IOException(e);
+    } finally {
+      mStampedLock.unlockWrite(stamp);
     }
-    LOG.info("Checkpoint complete, creating tarball");
-    TarUtils.writeTarGz(Paths.get(mDbCheckpointPath), out);
-    LOG.info("Completed rocksdb checkpoint in {}ms", (System.nanoTime() - startNano) / 1_000_000);
-    // Checkpoint is no longer needed, delete to save space.
-    FileUtils.deletePathRecursively(mDbCheckpointPath);
   }
 
   /**
@@ -206,27 +223,37 @@ public final class RocksStore implements Closeable {
    *
    * @param input the checkpoint stream to restore from
    */
-  public synchronized void restoreFromCheckpoint(CheckpointInputStream input) throws IOException {
-    LOG.info("Restoring rocksdb from checkpoint");
-    long startNano = System.nanoTime();
-    Preconditions.checkState(input.getType() == CheckpointType.ROCKS,
-        "Unexpected checkpoint type in RocksStore: " + input.getType());
-    stopDb();
-    FileUtils.deletePathRecursively(mDbPath);
-    TarUtils.readTarGz(Paths.get(mDbPath), input);
+  public void restoreFromCheckpoint(CheckpointInputStream input) throws IOException {
+    long stamp = mStampedLock.writeLock();
     try {
-      createDb();
-    } catch (RocksDBException e) {
-      throw new IOException(e);
+      LOG.info("Restoring rocksdb from checkpoint");
+      long startNano = System.nanoTime();
+      Preconditions.checkState(input.getType() == CheckpointType.ROCKS,
+          "Unexpected checkpoint type in RocksStore: " + input.getType());
+      stopDb();
+      FileUtils.deletePathRecursively(mDbPath);
+      TarUtils.readTarGz(Paths.get(mDbPath), input);
+      try {
+        createDb();
+      } catch (RocksDBException e) {
+        throw new IOException(e);
+      }
+      LOG.info("Restored rocksdb checkpoint in {}ms",
+          (System.nanoTime() - startNano) / Constants.MS_NANO);
+    } finally {
+      mStampedLock.unlockWrite(stamp);
     }
-    LOG.info("Restored rocksdb checkpoint in {}ms",
-        (System.nanoTime() - startNano) / Constants.MS_NANO);
   }
 
   @Override
-  public synchronized void close() {
-    stopDb();
-    mDbOpts.close();
-    LOG.info("Closed store at {}", mDbPath);
+  public void close() {
+    long stamp = mStampedLock.writeLock();
+    try {
+      stopDb();
+      mDbOpts.close();
+      LOG.info("Closed store at {}", mDbPath);
+    } finally {
+      mStampedLock.unlockWrite(stamp);
+    }
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?
Each get db instance operation must be synchronized, which has a great impact on performance

### Why are the changes needed?
Performance
When I debug alluxio, try to store 10 billion data in alluxio, and sort out some performance fixes that can be give back to alluxio, this is one of them

https://github.com/Alluxio/alluxio/pull/15657
The problem with AtomicRef solution is that it is possible to pass out a db instance that has been closed, the read-write lock solution can at least ensure that the db instance is not closed when getDb() is returned, It may cost a long time for rocksdb shutdown, in this time window, the AtomicRef solution may encounter many exceptions
@tcrain @yuzhu 

### Does this PR introduce any user facing changes?
No
