### PR TITLE
Support method-level set for ConfigurationRule

### DIFF
--- a/core/common/src/test/java/alluxio/ConfigurationRule.java
+++ b/core/common/src/test/java/alluxio/ConfigurationRule.java
@@ -48,6 +48,29 @@ public final class ConfigurationRule extends AbstractResourceRule {
     }, conf);
   }
 
+  /**
+   * Set a specific PropertyKey of the global configuration,
+   * change is only visible in the scope of the calling method.
+   *
+   * @param key the key of the configuration property to set
+   * @param value the value to set it to, can be null to unset
+   */
+  public void set(final PropertyKey key, final Object value) {
+    if (!mStashedProperties.containsKey(key)) {
+      if (mConfiguration.isSet(key)) {
+        mStashedProperties.put(key, mConfiguration.get(key));
+      } else {
+        mStashedProperties.put(key, null);
+      }
+    }
+
+    if (value != null) {
+      mConfiguration.set(key, value);
+    } else {
+      mConfiguration.unset(key);
+    }
+  }
+
   @Override
   public void before() {
     for (Map.Entry<PropertyKey, Object> entry : mKeyValuePairs.entrySet()) {

--- a/core/common/src/test/java/alluxio/ConfigurationRule.java
+++ b/core/common/src/test/java/alluxio/ConfigurationRule.java
@@ -55,7 +55,7 @@ public final class ConfigurationRule extends AbstractResourceRule {
    * @param key the key of the configuration property to set
    * @param value the value to set it to, can be null to unset
    */
-  public void set(final PropertyKey key, final Object value) {
+  public ConfigurationRule set(final PropertyKey key, final Object value) {
     if (!mStashedProperties.containsKey(key)) {
       if (mConfiguration.isSet(key)) {
         mStashedProperties.put(key, mConfiguration.get(key));
@@ -69,6 +69,8 @@ public final class ConfigurationRule extends AbstractResourceRule {
     } else {
       mConfiguration.unset(key);
     }
+
+    return this;
   }
 
   @Override

--- a/core/common/src/test/java/alluxio/ConfigurationRuleTest.java
+++ b/core/common/src/test/java/alluxio/ConfigurationRuleTest.java
@@ -55,4 +55,47 @@ public final class ConfigurationRuleTest {
         .apply(statement, null).evaluate();
     assertFalse(conf.isSet(PropertyKey.SECURITY_LOGIN_USERNAME));
   }
+
+  @Test
+  public void setConfiguration() throws Throwable {
+    InstancedConfiguration conf = Configuration.copyGlobal();
+
+    ConfigurationRule configurationRule = new ConfigurationRule(
+        ImmutableMap.of(PropertyKey.MASTER_HOSTNAME, "testHostName1"),
+        conf
+    );
+
+    // before rule is in effect, none of the property is set
+    assertFalse(conf.isSet(PropertyKey.MASTER_HOSTNAME));
+    assertFalse(conf.isSet(PropertyKey.SECURITY_LOGIN_USERNAME));
+
+    Statement statementWithSet = new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        // calling set overrides the initial value of configuration rule
+        configurationRule
+            .set(PropertyKey.MASTER_HOSTNAME, "testHostName2")
+            .set(PropertyKey.SECURITY_LOGIN_USERNAME, "testUserName");
+        assertEquals("testHostName2", conf.get(PropertyKey.MASTER_HOSTNAME));
+        assertEquals("testUserName", conf.get(PropertyKey.SECURITY_LOGIN_USERNAME));
+      }
+    };
+    configurationRule
+        .apply(statementWithSet, null)
+        .evaluate();
+
+    // calling set will have no effect to another
+    // life cycle of a ConfigurationRule
+    Statement statementWithoutSet = new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        assertEquals("testHostName1", conf.get(PropertyKey.MASTER_HOSTNAME));
+        assertFalse(conf.isSet(PropertyKey.SECURITY_LOGIN_USERNAME));
+      }
+    };
+
+    configurationRule
+        .apply(statementWithoutSet, null)
+        .evaluate();
+  }
 }

--- a/docs/cn/contributor/Unit-Testing.md
+++ b/docs/cn/contributor/Unit-Testing.md
@@ -100,18 +100,24 @@ public ConfigurationRule mConfigurationRule = new ConfigurationRule(ImmutableMap
     PropertyKey.key1, "value1",
     PropertyKey.key2, "value2"));
 ```
-对于一个单独测试需要的配置更改，请使用`Configuration.set(key, value)`，并创建一个`@After`方法来清理测试后的配置更改：
+对于一个单独测试需要的配置更改，请使用`ConfigurationRule#set(key, value)`, 这个方法造成的变化局限在调用方法的范围内：
 
 ```java
-@After
-public void after() {
-  ConfigurationTestUtils.resetConfiguration();
-}
+@Rule
+public ConfigurationRule mConfigurationRule = new ConfigurationRule(ImmutableMap.of(
+    PropertyKey.key1, "value1",
+    PropertyKey.key2, "value2"));
 
 @Test
 public void testSomething() {
-  Configuration.set(PropertyKey.key, "value");
+  mConfigurationRule.set(PropertyKey.key1, "value3");
+  // Now PropertyKey.key1 = "value3"
   ...
+}
+
+@Test
+public void testAnotherThing() {
+  // Now PropertyKey.key1 = "value1"
 }
 ```
 

--- a/docs/en/contributor/Code-Conventions.md
+++ b/docs/en/contributor/Code-Conventions.md
@@ -39,8 +39,8 @@ for details.
 ## Coding Style
 
 - Please follow the style of the existing codebase. We mainly follow the
-[Google Java style](https://google.github.io/styleguide/javaguide.html),
-with the following deviations:
+  [Google Java style](https://google.github.io/styleguide/javaguide.html),
+  with the following deviations:
   - Maximum line length of **100** characters.
   - Third-party imports are grouped together to make IDE formatting much simpler.
   - Class member variable names should be prefixed with `m`
@@ -60,9 +60,9 @@ must be compatible with Bash 3.x
     settings [as such]({{ '/resources/style_scheme.png' | relativize_url }}).
 - If you use Eclipse:
     - You can download our
-[Eclipse formatter]({{ '/resources/alluxio-code-formatter-eclipse.xml' | relativize_url }})
+    [Eclipse formatter]({{ '/resources/alluxio-code-formatter-eclipse.xml' | relativize_url }})
     - To organize your imports correctly, configure "Organize Imports" to look like
-[this]({{ '/resources/eclipse_imports.png' | relativize_url }})
+    [this]({{ '/resources/eclipse_imports.png' | relativize_url }})
 - To automatically reorder methods alphabetically, try the
 [Rearranger Plugin](http://plugins.jetbrains.com/plugin/173), open Preferences, search for
 rearranger, remove the unnecessary comments, then right click, choose "Rearrange", codes
@@ -771,19 +771,24 @@ public ConfigurationRule mConfigurationRule = new ConfigurationRule(ImmutableMap
     PropertyKey.key1, "value1",
     PropertyKey.key2, "value2"));
 ```
-For configuration changes needed for an individual test, use `Configuration.set(key, value)`, and
-create an `@After` method to clean up the configuration changes after the test:
+For configuration changes needed for an individual test, use `ConfigurationRule#set(key, value)` on the instance created by your test class. The resulting change of this method is only visible for the calling test.
 
 ```java
-@After
-public void after() {
-  ConfigurationTestUtils.resetConfiguration();
-}
+@Rule
+public ConfigurationRule mConfigurationRule = new ConfigurationRule(ImmutableMap.of(
+    PropertyKey.key1, "value1",
+    PropertyKey.key2, "value2"));
 
 @Test
 public void testSomething() {
-  Configuration.set(PropertyKey.key, "value");
+  mConfigurationRule.set(PropertyKey.key1, "value3");
+  // Now PropertyKey.key1 = "value3"
   ...
+}
+
+@Test
+public void testAnotherThing() {
+  // Now PropertyKey.key1 = "value1"
 }
 ```
 


### PR DESCRIPTION
### What changes are proposed in this pull request?
I propose to add a `set` method in `ConfigurationRule` to let unit-tests change configurations in the scope of a single method.

### Why are the changes needed?
Fix #15683 

### Does this PR introduce any user facing changes?
No
