### PR TITLE
Fix the getCachedPageIdsByFileId for small or empty files

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -625,7 +625,7 @@ public class LocalCacheManager implements CacheManager {
 
   @Override
   public List<PageId> getCachedPageIdsByFileId(String fileId, long fileLength) {
-    int numOfPages = (int) (fileLength / mPageSize);
+    int numOfPages = (int) ((fileLength - 1) / mPageSize) + 1; //ceiling round the result
     List<PageId> pageIds = new ArrayList<>(numOfPages);
     try (LockResource r = new LockResource(mMetaLock.readLock())) {
       for (long pageIndex = 0; pageIndex < numOfPages; pageIndex++) {

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -910,6 +910,24 @@ public final class LocalCacheManagerTest {
         mCacheManager.getCachedPageIdsByFileId(PAGE_ID1.getFileId(), 64 * PAGE_SIZE_BYTES).get(0));
     assertEquals(pageId5,
         mCacheManager.getCachedPageIdsByFileId(PAGE_ID1.getFileId(), 64 * PAGE_SIZE_BYTES).get(1));
+    //Store a page smaller than full size
+    PageId pageId6 = new PageId(PAGE_ID1.getFileId(), 6);
+    mCacheManager.put(pageId6, BufferUtils.getIncreasingByteArray(135));
+    assertEquals(pageId6,
+        mCacheManager.getCachedPageIdsByFileId(PAGE_ID1.getFileId(),
+            6 * PAGE_SIZE_BYTES + 135).get(2));
+    //Store a file smaller than one page
+    PageId smallFilePageId = new PageId("small_file", 0);
+    mCacheManager.put(smallFilePageId, BufferUtils.getIncreasingByteArray(135));
+    assertEquals(smallFilePageId,
+        mCacheManager.getCachedPageIdsByFileId(smallFilePageId.getFileId(),
+            135).get(0));
+    //Store a zero length file
+    PageId zeroLenFilePageId = new PageId("zero_len_file", 0);
+    mCacheManager.put(zeroLenFilePageId, BufferUtils.getIncreasingByteArray(0));
+    assertEquals(zeroLenFilePageId,
+        mCacheManager.getCachedPageIdsByFileId(zeroLenFilePageId.getFileId(),
+            0).get(0));
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix the getCachedPageIdsByFileId for small or empty files

### Why are the changes needed?
The existing impl is missing the ceiling round when calculate the num of pages for a file, so it will exclude the last the page for the files whose length is not divisible by the page length.

### Does this PR introduce any user facing changes?
No
