### PR TITLE
Fix AlluxioFuseUtils getUserName

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -205,7 +205,7 @@ public final class AlluxioFuseUtils {
    */
   public static String getUserName(long uid) {
     try {
-      return ShellUtils.execCommand("bash", "-c", "id -nu", Long.toString(uid)).trim();
+      return ShellUtils.execCommand("bash", "-c", "id -nu " + uid).trim();
     } catch (IOException e) {
       LOG.error("Failed to get user name of uid {}", uid, e);
       return INVALID_USER_GROUP_NAME;


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix AlluxioFuseUtils.getUserName bug

### Why are the changes needed?

Currently alluxio-fuse chown always set the user to the user that mounts the path.

```
alluxio# touch test_chown
alluxio# ll test_chown
-rw-r--r-- 1 alluxio alluxio 0 Jun  8 14:53 test_chown
alluxio# chown test test_chown
alluxio# ll test_chown
-rw-r--r-- 1 alluxio alluxio 0 Jun  8 14:39 test_chown
```

The cause is here https://github.com/Alluxio/alluxio/blob/master/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java#L208

As the below test demonstrated

```
$ id -nu 1008
test

$ bash -c id -nu 1008
uid=1071(alluxio) gid=1071(alluxio) groups=1071(alluxio)

$ bash -c "id -nu 1008"
test
```

### Does this PR introduce any user facing changes?

No
