### PR TITLE
Rename BlockStore interface to BlockMetaStore

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/CoreMasterContext.java
+++ b/core/server/master/src/main/java/alluxio/master/CoreMasterContext.java
@@ -12,7 +12,7 @@
 package alluxio.master;
 
 import alluxio.master.journal.JournalSystem;
-import alluxio.master.metastore.BlockStore;
+import alluxio.master.metastore.BlockMetaStore;
 import alluxio.master.metastore.InodeStore;
 import alluxio.security.user.UserState;
 import alluxio.underfs.MasterUfsManager;
@@ -25,7 +25,7 @@ import com.google.common.base.Preconditions;
 public class CoreMasterContext extends MasterContext<MasterUfsManager> {
   private final SafeModeManager mSafeModeManager;
   private final BackupManager mBackupManager;
-  private final BlockStore.Factory mBlockStoreFactory;
+  private final BlockMetaStore.Factory mBlockStoreFactory;
   private final InodeStore.Factory mInodeStoreFactory;
   private final JournalSystem mJournalSystem;
   private final long mStartTimeMs;
@@ -62,7 +62,7 @@ public class CoreMasterContext extends MasterContext<MasterUfsManager> {
   /**
    * @return the block store factory
    */
-  public BlockStore.Factory getBlockStoreFactory() {
+  public BlockMetaStore.Factory getBlockStoreFactory() {
     return mBlockStoreFactory;
   }
 
@@ -107,7 +107,7 @@ public class CoreMasterContext extends MasterContext<MasterUfsManager> {
     private UserState mUserState;
     private SafeModeManager mSafeModeManager;
     private BackupManager mBackupManager;
-    private BlockStore.Factory mBlockStoreFactory;
+    private BlockMetaStore.Factory mBlockStoreFactory;
     private InodeStore.Factory mInodeStoreFactory;
     private MasterUfsManager mUfsManager;
     private long mStartTimeMs;
@@ -153,7 +153,7 @@ public class CoreMasterContext extends MasterContext<MasterUfsManager> {
      * @param blockStoreFactory factory for creating a block store
      * @return the builder
      */
-    public Builder setBlockStoreFactory(BlockStore.Factory blockStoreFactory) {
+    public Builder setBlockStoreFactory(BlockMetaStore.Factory blockStoreFactory) {
       mBlockStoreFactory = blockStoreFactory;
       return this;
     }

--- a/core/server/master/src/main/java/alluxio/master/MasterUtils.java
+++ b/core/server/master/src/main/java/alluxio/master/MasterUtils.java
@@ -14,13 +14,13 @@ package alluxio.master;
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Configuration;
-import alluxio.master.metastore.BlockStore;
+import alluxio.master.metastore.BlockMetaStore;
 import alluxio.master.metastore.InodeStore;
 import alluxio.master.metastore.MetastoreType;
 import alluxio.master.metastore.caching.CachingInodeStore;
-import alluxio.master.metastore.heap.HeapBlockStore;
+import alluxio.master.metastore.heap.HeapBlockMetaStore;
 import alluxio.master.metastore.heap.HeapInodeStore;
-import alluxio.master.metastore.rocks.RocksBlockStore;
+import alluxio.master.metastore.rocks.RocksBlockMetaStore;
 import alluxio.master.metastore.rocks.RocksInodeStore;
 import alluxio.util.CommonUtils;
 
@@ -61,14 +61,14 @@ public final class MasterUtils {
    * @param baseDir the base directory in which to store on-disk metadata
    * @return a block store factory of the configured type
    */
-  public static BlockStore.Factory getBlockStoreFactory(String baseDir) {
+  public static BlockMetaStore.Factory getBlockStoreFactory(String baseDir) {
     MetastoreType type =
         Configuration.getEnum(PropertyKey.MASTER_METASTORE, MetastoreType.class);
     switch (type) {
       case HEAP:
-        return HeapBlockStore::new;
+        return HeapBlockMetaStore::new;
       case ROCKS:
-        return () -> new RocksBlockStore(baseDir);
+        return () -> new RocksBlockMetaStore(baseDir);
       default:
         throw new IllegalStateException("Unknown metastore type: " + type);
     }

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -49,8 +49,8 @@ import alluxio.master.block.meta.MasterWorkerInfo;
 import alluxio.master.block.meta.WorkerMetaLockSection;
 import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.checkpoint.CheckpointName;
-import alluxio.master.metastore.BlockStore;
-import alluxio.master.metastore.BlockStore.Block;
+import alluxio.master.metastore.BlockMetaStore;
+import alluxio.master.metastore.BlockMetaStore.Block;
 import alluxio.master.metrics.MetricsMaster;
 import alluxio.metrics.Metric;
 import alluxio.metrics.MetricInfo;
@@ -212,7 +212,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
    */
   private final Striped<Lock> mBlockLocks = Striped.lock(10_000);
   /** Manages block metadata and block locations. */
-  private final BlockStore mBlockStore;
+  private final BlockMetaStore mBlockMetaStore;
 
   /** Keeps track of blocks which are no longer in Alluxio storage. */
   private final ConcurrentHashSet<Long> mLostBlocks = new ConcurrentHashSet<>(64, 0.90f, 64);
@@ -284,11 +284,11 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
   }
 
   private DefaultBlockMaster(MetricsMaster metricsMaster, CoreMasterContext masterContext,
-      Clock clock, ExecutorServiceFactory executorServiceFactory, BlockStore blockStore) {
+      Clock clock, ExecutorServiceFactory executorServiceFactory, BlockMetaStore blockMetaStore) {
     super(masterContext, clock, executorServiceFactory);
     Preconditions.checkNotNull(metricsMaster, "metricsMaster");
 
-    mBlockStore = blockStore;
+    mBlockMetaStore = blockMetaStore;
     mMetricsMaster = metricsMaster;
     Metrics.registerGauges(this);
 
@@ -347,11 +347,11 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
       mJournaledNextContainerId = (entry.getBlockContainerIdGenerator()).getNextContainerId();
       mBlockContainerIdGenerator.setNextContainerId((mJournaledNextContainerId));
     } else if (entry.hasDeleteBlock()) {
-      mBlockStore.removeBlock(entry.getDeleteBlock().getBlockId());
+      mBlockMetaStore.removeBlock(entry.getDeleteBlock().getBlockId());
     } else if (entry.hasBlockInfo()) {
       BlockInfoEntry blockInfoEntry = entry.getBlockInfo();
       long length = blockInfoEntry.getLength();
-      Optional<BlockMeta> block = mBlockStore.getBlock(blockInfoEntry.getBlockId());
+      Optional<BlockMeta> block = mBlockMetaStore.getBlock(blockInfoEntry.getBlockId());
       if (block.isPresent()) {
         long oldLen = block.get().getLength();
         if (oldLen != Constants.UNKNOWN_SIZE) {
@@ -360,7 +360,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
           return true;
         }
       }
-      mBlockStore.putBlock(blockInfoEntry.getBlockId(),
+      mBlockMetaStore.putBlock(blockInfoEntry.getBlockId(),
           BlockMeta.newBuilder().setLength(blockInfoEntry.getLength()).build());
     } else {
       return false;
@@ -370,7 +370,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
   @Override
   public void resetState() {
-    mBlockStore.clear();
+    mBlockMetaStore.clear();
     mJournaledNextContainerId = 0;
     mBlockContainerIdGenerator.setNextContainerId(0);
   }
@@ -382,7 +382,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
   @Override
   public CloseableIterator<JournalEntry> getJournalEntryIterator() {
-    CloseableIterator<Block> blockStoreIterator = mBlockStore.getCloseableIterator();
+    CloseableIterator<Block> blockStoreIterator = mBlockMetaStore.getCloseableIterator();
     Iterator<JournalEntry> journalIterator = new Iterator<JournalEntry>() {
       @Override
       public boolean hasNext() {
@@ -491,7 +491,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
   @Override
   public void close() throws IOException {
     super.close();
-    mBlockStore.close();
+    mBlockMetaStore.close();
   }
 
   @Override
@@ -518,7 +518,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
   @Override
   public long getUniqueBlockCount() {
-    return mBlockStore.size();
+    return mBlockMetaStore.size();
   }
 
   @Override
@@ -682,11 +682,11 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
       for (long blockId : blockIds) {
         Set<Long> workerIds;
         try (LockResource r = lockBlock(blockId)) {
-          Optional<BlockMeta> block = mBlockStore.getBlock(blockId);
+          Optional<BlockMeta> block = mBlockMetaStore.getBlock(blockId);
           if (!block.isPresent()) {
             continue;
           }
-          List<BlockLocation> locations = mBlockStore.getLocations(blockId);
+          List<BlockLocation> locations = mBlockMetaStore.getLocations(blockId);
           workerIds = new HashSet<>(locations.size());
           for (BlockLocation loc : locations) {
             workerIds.add(loc.getWorkerId());
@@ -699,7 +699,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
             // Make sure blockId is removed from mLostBlocks when the block metadata is deleted.
             // Otherwise blockId in mLostBlock can be dangling index if the metadata is gone.
             mLostBlocks.remove(blockId);
-            mBlockStore.removeBlock(blockId);
+            mBlockMetaStore.removeBlock(blockId);
             JournalEntry entry = JournalEntry.newBuilder()
                 .setDeleteBlock(DeleteBlockEntry.newBuilder().setBlockId(blockId)).build();
             journalContext.append(entry);
@@ -729,7 +729,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
   public void validateBlocks(Function<Long, Boolean> validator, boolean repair)
       throws UnavailableException {
     List<Long> invalidBlocks = new ArrayList<>();
-    try (CloseableIterator<Block> iter = mBlockStore.getCloseableIterator()) {
+    try (CloseableIterator<Block> iter = mBlockMetaStore.getCloseableIterator()) {
       while (iter.hasNext()) {
         long id = iter.next().getId();
         if (!validator.apply(id)) {
@@ -820,20 +820,20 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
       try (LockResource lr = worker.lockWorkerMeta(
           EnumSet.of(WorkerMetaLockSection.USAGE, WorkerMetaLockSection.BLOCKS), false)) {
         try (LockResource r = lockBlock(blockId)) {
-          Optional<BlockMeta> block = mBlockStore.getBlock(blockId);
+          Optional<BlockMeta> block = mBlockMetaStore.getBlock(blockId);
           if (!block.isPresent() || block.get().getLength() != length) {
             if (block.isPresent() && block.get().getLength() != Constants.UNKNOWN_SIZE) {
               LOG.warn("Rejecting attempt to change block length from {} to {}",
                   block.get().getLength(), length);
             } else {
-              mBlockStore.putBlock(blockId, BlockMeta.newBuilder().setLength(length).build());
+              mBlockMetaStore.putBlock(blockId, BlockMeta.newBuilder().setLength(length).build());
               BlockInfoEntry blockInfo =
                   BlockInfoEntry.newBuilder().setBlockId(blockId).setLength(length).build();
               journalContext.append(JournalEntry.newBuilder().setBlockInfo(blockInfo).build());
             }
           }
           // Update the block metadata with the new worker location.
-          mBlockStore.addLocation(blockId, BlockLocation.newBuilder()
+          mBlockMetaStore.addLocation(blockId, BlockLocation.newBuilder()
               .setWorkerId(workerId)
               .setTier(tierAlias)
               .setMediumType(mediumType)
@@ -858,11 +858,11 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     LOG.debug("Commit block in ufs. blockId: {}, length: {}", blockId, length);
     try (JournalContext journalContext = createJournalContext();
          LockResource r = lockBlock(blockId)) {
-      if (mBlockStore.getBlock(blockId).isPresent()) {
+      if (mBlockMetaStore.getBlock(blockId).isPresent()) {
         // Block metadata already exists, so do not need to create a new one.
         return;
       }
-      mBlockStore.putBlock(blockId, BlockMeta.newBuilder().setLength(length).build());
+      mBlockMetaStore.putBlock(blockId, BlockMeta.newBuilder().setLength(length).build());
       BlockInfoEntry blockInfo =
           BlockInfoEntry.newBuilder().setBlockId(blockId).setLength(length).build();
       journalContext.append(JournalEntry.newBuilder().setBlockInfo(blockInfo).build());
@@ -1273,11 +1273,11 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
       Collection<Long> removedBlockIds, boolean sendCommand) {
     for (long removedBlockId : removedBlockIds) {
       try (LockResource r = lockBlock(removedBlockId)) {
-        Optional<BlockMeta> block = mBlockStore.getBlock(removedBlockId);
+        Optional<BlockMeta> block = mBlockMetaStore.getBlock(removedBlockId);
         if (block.isPresent()) {
           LOG.debug("Block {} is removed on worker {}.", removedBlockId, workerInfo.getId());
-          mBlockStore.removeLocation(removedBlockId, workerInfo.getId());
-          if (mBlockStore.getLocations(removedBlockId).size() == 0) {
+          mBlockMetaStore.removeLocation(removedBlockId, workerInfo.getId());
+          if (mBlockMetaStore.getLocations(removedBlockId).size() == 0) {
             mLostBlocks.add(removedBlockId);
           }
         }
@@ -1307,14 +1307,14 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     for (Map.Entry<BlockLocation, List<Long>> entry : addedBlockIds.entrySet()) {
       for (long blockId : entry.getValue()) {
         try (LockResource r = lockBlock(blockId)) {
-          Optional<BlockMeta> block = mBlockStore.getBlock(blockId);
+          Optional<BlockMeta> block = mBlockMetaStore.getBlock(blockId);
           if (block.isPresent()) {
             workerInfo.addBlock(blockId);
             BlockLocation location = entry.getKey();
             Preconditions.checkState(location.getWorkerId() == workerInfo.getId(),
                 "BlockLocation has a different workerId %s from the request sender's workerId %s",
                 location.getWorkerId(), workerInfo.getId());
-            mBlockStore.addLocation(blockId, location);
+            mBlockMetaStore.addLocation(blockId, location);
             mLostBlocks.remove(blockId);
           } else {
             invalidBlockCount++;
@@ -1346,7 +1346,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
   private void processWorkerOrphanedBlocks(MasterWorkerInfo workerInfo) {
     long orphanedBlockCount = 0;
     for (long block : workerInfo.getBlocks()) {
-      if (!mBlockStore.getBlock(block).isPresent()) {
+      if (!mBlockMetaStore.getBlock(block).isPresent()) {
         orphanedBlockCount++;
         LOG.debug("Requesting delete for orphaned block: {} from worker {}.", block,
             workerInfo.getWorkerAddress().getHost());
@@ -1401,12 +1401,12 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     BlockMeta block;
     List<BlockLocation> blockLocations;
     try (LockResource r = lockBlock(blockId)) {
-      Optional<BlockMeta> blockOpt = mBlockStore.getBlock(blockId);
+      Optional<BlockMeta> blockOpt = mBlockMetaStore.getBlock(blockId);
       if (!blockOpt.isPresent()) {
         return Optional.empty();
       }
       block = blockOpt.get();
-      blockLocations = new ArrayList<>(mBlockStore.getLocations(blockId));
+      blockLocations = new ArrayList<>(mBlockMetaStore.getLocations(blockId));
     }
 
     // Sort the block locations by their alias ordinal in the master storage tier mapping

--- a/core/server/master/src/main/java/alluxio/master/metastore/BlockMetaStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/BlockMetaStore.java
@@ -24,7 +24,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * The block store keeps track of block sizes and block locations.
  */
 @ThreadSafe
-public interface BlockStore {
+public interface BlockMetaStore {
   /**
    * @param id a block id
    * @return the block's metadata, or empty if the block does not exist
@@ -142,5 +142,5 @@ public interface BlockStore {
   /**
    * Factory for creating block stores.
    */
-  interface Factory extends Supplier<BlockStore> {}
+  interface Factory extends Supplier<BlockMetaStore> {}
 }

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapBlockMetaStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapBlockMetaStore.java
@@ -14,7 +14,7 @@ package alluxio.master.metastore.heap;
 import alluxio.collections.TwoKeyConcurrentMap;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Configuration;
-import alluxio.master.metastore.BlockStore;
+import alluxio.master.metastore.BlockMetaStore;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.proto.meta.Block.BlockLocation;
@@ -40,7 +40,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * different block ids can be performed concurrently.
  */
 @ThreadSafe
-public class HeapBlockStore implements BlockStore {
+public class HeapBlockMetaStore implements BlockMetaStore {
   // Map from block id to block metadata.
   public final Map<Long, BlockMeta> mBlocks = new ConcurrentHashMap<>();
   // Map from block id to block locations.
@@ -51,7 +51,7 @@ public class HeapBlockStore implements BlockStore {
    * constructor a HeapBlockStore.
    *
    */
-  public HeapBlockStore() {
+  public HeapBlockMetaStore() {
     super();
     if (Configuration.getBoolean(PropertyKey.MASTER_METRICS_HEAP_ENABLED)) {
       MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_BLOCK_HEAP_SIZE.getName(),

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockMetaStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockMetaStore.java
@@ -13,7 +13,7 @@ package alluxio.master.metastore.rocks;
 
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Configuration;
-import alluxio.master.metastore.BlockStore;
+import alluxio.master.metastore.BlockMetaStore;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.proto.meta.Block.BlockLocation;
@@ -52,8 +52,8 @@ import javax.annotation.concurrent.ThreadSafe;
  * Block store backed by RocksDB.
  */
 @ThreadSafe
-public class RocksBlockStore implements BlockStore {
-  private static final Logger LOG = LoggerFactory.getLogger(RocksBlockStore.class);
+public class RocksBlockMetaStore implements BlockMetaStore {
+  private static final Logger LOG = LoggerFactory.getLogger(RocksBlockMetaStore.class);
   private static final String BLOCKS_DB_NAME = "blocks";
   private static final String BLOCK_META_COLUMN = "block-meta";
   private static final String BLOCK_LOCATIONS_COLUMN = "block-locations";
@@ -75,7 +75,7 @@ public class RocksBlockStore implements BlockStore {
    *
    * @param baseDir the base directory in which to store block store metadata
    */
-  public RocksBlockStore(String baseDir) {
+  public RocksBlockMetaStore(String baseDir) {
     RocksDB.loadLibrary();
     mDisableWAL = new WriteOptions().setDisableWAL(true);
     mIteratorOption = new ReadOptions().setReadaheadSize(

--- a/core/server/master/src/test/java/alluxio/master/MasterTestUtils.java
+++ b/core/server/master/src/test/java/alluxio/master/MasterTestUtils.java
@@ -15,9 +15,9 @@ import static org.mockito.Mockito.mock;
 
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.noop.NoopJournalSystem;
-import alluxio.master.metastore.BlockStore;
+import alluxio.master.metastore.BlockMetaStore;
 import alluxio.master.metastore.InodeStore;
-import alluxio.master.metastore.heap.HeapBlockStore;
+import alluxio.master.metastore.heap.HeapBlockMetaStore;
 import alluxio.master.metastore.heap.HeapInodeStore;
 import alluxio.security.user.UserState;
 import alluxio.underfs.MasterUfsManager;
@@ -50,19 +50,19 @@ public final class MasterTestUtils {
   public static CoreMasterContext testMasterContext(JournalSystem journalSystem,
       UserState userState) {
     return testMasterContext(journalSystem, userState,
-        HeapBlockStore::new, x -> new HeapInodeStore());
+        HeapBlockMetaStore::new, x -> new HeapInodeStore());
   }
 
   /**
    * @return a basic master context for the purpose of testing
    * @param journalSystem a journal system to use in the context
    * @param userState the user state to use in the context
-   * @param blockStoreFactory a factory to create {@link BlockStore}
+   * @param blockStoreFactory a factory to create {@link BlockMetaStore}
    * @param inodeStoreFactory a factory to create {@link InodeStore}
    */
   public static CoreMasterContext testMasterContext(
       JournalSystem journalSystem, UserState userState,
-      BlockStore.Factory blockStoreFactory,
+      BlockMetaStore.Factory blockStoreFactory,
       InodeStore.Factory inodeStoreFactory) {
     return CoreMasterContext.newBuilder()
         .setJournalSystem(journalSystem)

--- a/table/server/master/src/test/java/alluxio/master/table/TableMasterFactoryTest.java
+++ b/table/server/master/src/test/java/alluxio/master/table/TableMasterFactoryTest.java
@@ -25,7 +25,7 @@ import alluxio.master.MasterRegistry;
 import alluxio.master.MasterUtils;
 import alluxio.master.TestSafeModeManager;
 import alluxio.master.journal.noop.NoopJournalSystem;
-import alluxio.master.metastore.heap.HeapBlockStore;
+import alluxio.master.metastore.heap.HeapBlockMetaStore;
 import alluxio.master.metastore.heap.HeapInodeStore;
 import alluxio.underfs.MasterUfsManager;
 
@@ -51,7 +51,7 @@ public class TableMasterFactoryTest {
         .setJournalSystem(new NoopJournalSystem())
         .setSafeModeManager(new TestSafeModeManager())
         .setBackupManager(mock(BackupManager.class))
-        .setBlockStoreFactory(HeapBlockStore::new)
+        .setBlockStoreFactory(HeapBlockMetaStore::new)
         .setInodeStoreFactory(x -> new HeapInodeStore())
         .setUfsManager(new MasterUfsManager())
         .build();


### PR DESCRIPTION
### What changes are proposed in this pull request?

Rename BlockStore interface to BlockMetaStore

### Why are the changes needed?
The blockStore interface actually is a store for the metadata of blocks rather than the data of blocks, so New name may reduce confusion.

Also I would like to use the name of BlockStore for the abstraction of pagedBlockStore and tieredBlockStore.

### Does this PR introduce any user facing changes?
N/A
