### PR TITLE
Fix master down when master change to leader

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -158,6 +158,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       startMasters(true);
     } catch (UnavailableException e) {
       LOG.warn("Error starting masters: {}", e.toString());
+      mJournalSystem.losePrimacy();
       stopMasters();
       return false;
     }


### PR DESCRIPTION
Fix master down when master change to leader but last time failed because of startMasters

### What changes are proposed in this pull request?
Fix master down when master change to leader but last time failed because of startMasters
### Why are the changes needed?
The master change leader failed because of startMasters, but it is not set mRaftJournalWriter = null; The next time the master change to leader , it will check `Preconditions.checkState(mRaftJournalWriter == null);`, so the master will exit.

### Does this PR introduce any user facing changes?
no
