### PR TITLE
Refactor watch-metrics.sh script

### DIFF
--- a/dev/scripts/watch-metrics.sh
+++ b/dev/scripts/watch-metrics.sh
@@ -22,52 +22,49 @@
 # Alluxio-related arguments
 host=""
 port=""
-metrics_file_prefix=""
+metrics_filename=""
 metrics_dir="/tmp/alluxio_metrics"
 
 # Misc. arguments
 time_step=2  # 2s is the default interval for `watch`
 watch=""
-jq_filter=""
+filter=""
 
 USAGE="This script is used as a convenience method for monitoring &
 periodically capturing the HTTP JSON sink for Alluxio metrics.
+Metric names and descriptions are available at
+https://docs.alluxio.io/os/user/stable/en/reference/Metrics-List.html
 
 Usage:
 Required:
   -H hostname              the host of the metrics HTTP server
   -p port                  the port of the metrics HTTP server
-  -f metrics_file_prefix   the prefix prepended to the output metrics files
 
 Optional:
-  -w [WDIFF_OPTS]          setting this flag will use 'watch' to display the output
-                           in the console, and appends the results to a single file
-  -d metrics_dir           the directory to output the metrics files to (default: ${metrics_dir})
+  -f metrics_filename      the name of the output metrics file(s)
+  -d [WDIFF_OPTS]          set this flag to control diff highlighting in 'watch'
   -n time_step             the time in seconds between iterations (default: ${time_step}s)
-  -F filter                a 'jq' compatible filter for filtering metrics
-                           - eg: '.gauges."Cluster.BytesReadDirectThroughput"'
+
+  -F filter                a JSON array of metric names/prefixes to filter on
+                           - eg: '["Master.Rocks", "Master.TotalRpcs"]'
 
 Misc:
-  -h                         display this message
+  -h                       display this message
 
 
 WDIFF_OPTS is required, and is one of:
   permanent      will run 'watch --differences=permanent'
   successive     will run 'watch --differences'
-  none           will run 'watch' without '--differences'
 "
 
 # argument parsing
 OPTIND=1
-while getopts ":hH:d:p:f:F:n:w:" opt; do
+while getopts ":hH:p:f:F:n:d:" opt; do
     case ${opt} in
-        d )
-            metrics_dir="${OPTARG}"
-            ;;
         f )
-            metrics_file_prefix="${OPTARG}"
+            metrics_filename="${OPTARG}"
             ;;
-        F ) jq_filter="${OPTARG}"
+        F ) filter="${OPTARG}"
             ;;
         h )
             echo "${USAGE}"
@@ -82,8 +79,8 @@ while getopts ":hH:d:p:f:F:n:w:" opt; do
         p )
             port=${OPTARG}
             ;;
-        w )
-            watch="${OPTARG}"
+        d )
+            diffs="${OPTARG}"
             ;;
         * )
             echo "ERROR: Unknown argument"
@@ -94,14 +91,7 @@ while getopts ":hH:d:p:f:F:n:w:" opt; do
 done
 shift $((OPTIND -1))
 
-# argument checking
-if [[ -z "${host}" || -z "${port}" || -z "${metrics_file_prefix}" || -z "${metrics_dir}" ]]; then
-    echo "ERROR: Must provide non-empty strings for arguments"
-    echo "${USAGE}"
-    exit 1
-fi
-
-# check if command `nslookup` exists
+# check if command `nslookup` exists, required for curl
 if ! command -v nslookup > /dev/null 2>&1; then
   echo "ERROR: nslookup command not found"
   exit 1
@@ -111,6 +101,13 @@ fi
 if ! command -v jq > /dev/null 2>&1; then
   echo "ERROR: jq command not found"
   exit 1
+fi
+
+# argument checking
+if [[ -z "${host}" || -z "${port}" ]]; then
+    echo "ERROR: Must provide non-empty strings for arguments"
+    echo "${USAGE}"
+    exit 1
 fi
 
 if [[ ${port} -le 0 ]]; then
@@ -123,63 +120,69 @@ if [[ ${time_step} -le 0 ]]; then
     exit 1
 fi
 
-if [[ ! ( -z ${watch} ) ]]; then
-    case ${watch} in
+if [[ ! ( -z ${diffs} ) ]]; then
+    case ${diffs} in
         "permanent" )   ;;
         "successive" )  ;;
-        "none" )        ;;
         * )
-            echo "ERROR: Invalid WDIFF_OPTS - ${watch}"
+            echo "ERROR: Invalid WDIFF_OPTS - ${diffs}"
             exit 1
             ;;
     esac
 fi
 
-function main() {
-    mkdir -p "${metrics_dir}"
+if [[ ! ( -z "${metrics_filename}" ) ]]; then
+    # attempt to create the file at the start,
+    # will propagate permission/filepath errors to user
 
-    echo "Collecting metrics from http://${host}:${port}/metrics/json/ to ${metrics_dir}"
+    # TODO(czhu): add flags to control whether or not to separate output into
+    #             individual files, whether to truncate the file first
+    touch "${metrics_filename}"
+fi
+
+function main() {
+    echo "Collecting metrics from http://${host}:${port}/metrics/json/ to ${metrics_filename}"
     echo "Press CTRL-C to stop collecting..."
 
     # trap ctrl-c and call cleanup()
     trap cleanup INT
     function cleanup() {
-        echo -e "\nMetrics collected from http://${host}:${port}/metrics/json/ to ${metrics_dir}"
+        echo -e "\nMetrics collected from http://${host}:${port}/metrics/json/ to ${metrics_filename}"
         exit 0
     }
 
-    # We need to surround jq_filter with literal single-quotes
-    # since we have special characters (i.e: '.') in our key names
-    # - Method used: https://stackoverflow.com/a/1315213
-    jq_filter=$(printf $'\'%s\'' "${jq_filter}")
+    # This cmd feeds the output of the curl request into jq to flatten the metrics
+    # from different sources (gauges, counters, meters, and timers) into a single array.
+    cmd="curl --silent -XGET \"http://${host}:${port}/metrics/json/\" | jq '[.gauges, .counters, .meters, .timers] | reduce .[] as \$metric ({}; . + \$metric)'"
 
-    if [[ ${watch} ]]; then
-        # default behaviour is to have no --differences flag
-        differences_flag=""
-        case "${watch}" in
-            "permanent" )
-                differences_flag='--differences=permanent'
-                ;;
-            "successive" )
-                differences_flag='--differences'
-                ;;
-        esac
-
-        # one-liner which appends to a single file
-        watch ${differences_flag} --no-title --interval=${time_step} "curl --silent -XGET \"http://${host}:${port}/metrics/json/\" | jq ${jq_filter} | tee \"${metrics_dir}/${metrics_file_prefix}.json\""
-    else
-        # loop which outputs to new files for each iteration
-        i=0
-        while true; do
-            metrics_file="${metrics_dir}/${metrics_file_prefix}.${i}.json"
-
-            # need to wrap this with `bash -c` due to quoting issues with ${jq_filter}
-            bash -c "curl --silent -XGET \"http://${host}:${port}/metrics/json/\" | jq ${jq_filter}" > "${metrics_file}"
-            echo "Collected metrics to ${metrics_file}"
-            i=$((i+1))
-            sleep ${time_step}
+    # if a filter is provided, filter the metrics by their key name
+    if [[ ! ( -z "${filter}" ) ]]; then
+        select_keys=""
+        for key in `echo "${filter}" | jq -r '. | join(" ")'`; do
+            echo "Parsed metric key: ${key}"
+            if [[ ! ( -z $select_keys ) ]]; then
+                select_keys+=" or "
+            fi
+            # using `startswith` since some of our metrics append metadata into the key name
+            # eg: Worker.BlocksCached.<WORKER_IP>
+            select_keys+="(.key | startswith(\"${key}\"))"
         done
+        cmd+=" | jq 'with_entries(select( ${select_keys} ))'"
     fi
+
+    # determine the differences flag to pass to `diffs`
+    differences_flag=""
+    case ${diffs} in
+        "permanent" )
+            differences_flag='--differences=permanent'
+            ;;
+        "successive" )
+            differences_flag='--differences'
+            ;;
+    esac
+
+    # one-liner which appends to a single file
+    watch ${differences_flag} --no-title --interval=${time_step} "${cmd} | tee -a \"${metrics_filename}\""
 }
 
 main


### PR DESCRIPTION
### What changes are proposed in this pull request?

Refactor the `watch-metrics.sh` script to be more useable, and to increase its flexibility.

### Why are the changes needed?

The previous script required knowledge about the format of the JSON returned by the Alluxio metrics JSON sink. This version of the script only requires the metrics keys.

### Does this PR introduce any user facing changes?

Developers using the script will see changed flags & functionality.
