### PR TITLE
Create automatic backup when shutting down Alluxio master

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2545,7 +2545,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED =
       booleanBuilder(Name.MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED)
-          .setDefaultValue(false)
+          .setDefaultValue(true)
           .setDescription("Takes a backup automatically when encountering journal corruption")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2543,6 +2543,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setIsHidden(true)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED =
+      booleanBuilder(Name.MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED)
+          .setDefaultValue(false)
+          .setDescription("Takes a backup automatically when encountering journal corruption")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_JOURNAL_TYPE =
       enumBuilder(Name.MASTER_JOURNAL_TYPE, JournalType.class)
           .setDefaultValue(JournalType.EMBEDDED)
@@ -6729,6 +6736,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         = "alluxio.master.journal.space.monitor.percent.free.threshold";
     public static final String MASTER_JOURNAL_TOLERATE_CORRUPTION
         = "alluxio.master.journal.tolerate.corruption";
+    public static final String MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED
+        = "alluxio.master.journal.backup.when.corrupted";
     public static final String MASTER_JOURNAL_TYPE = "alluxio.master.journal.type";
     public static final String MASTER_JOURNAL_LOG_SIZE_BYTES_MAX =
         "alluxio.master.journal.log.size.bytes.max";

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalReader.java
@@ -101,7 +101,7 @@ public final class UfsJournalReader implements JournalReader {
    * @param journal the handle to the journal
    * @param readIncompleteLog whether to read incomplete logs
    */
-  UfsJournalReader(UfsJournal journal, boolean readIncompleteLog) {
+  public UfsJournalReader(UfsJournal journal, boolean readIncompleteLog) {
     this(journal, 0, readIncompleteLog);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -17,7 +17,9 @@ import alluxio.AlluxioURI;
 import alluxio.RuntimeConstants;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.AlluxioException;
 import alluxio.executor.ExecutorServiceBuilder;
+import alluxio.grpc.BackupStatusPRequest;
 import alluxio.grpc.GrpcServer;
 import alluxio.grpc.GrpcServerAddress;
 import alluxio.grpc.GrpcServerBuilder;
@@ -28,6 +30,8 @@ import alluxio.master.journal.JournalMasterClientServiceHandler;
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.JournalUtils;
 import alluxio.master.journal.raft.RaftJournalSystem;
+import alluxio.master.meta.DefaultMetaMaster;
+import alluxio.master.meta.MetaMaster;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.resource.CloseableResource;
@@ -42,6 +46,7 @@ import alluxio.util.URIUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.web.MasterWebServer;
+import alluxio.wire.BackupStatus;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -147,7 +152,14 @@ public class AlluxioMasterProcess extends MasterProcess {
   public void start() throws Exception {
     LOG.info("Starting...");
     mJournalSystem.start();
-    mJournalSystem.gainPrimacy();
+    try {
+      mJournalSystem.gainPrimacy();
+    } catch (Throwable t) {
+      if (Configuration.getBoolean(PropertyKey.MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED)) {
+        takeEmergencyBackup();
+      }
+      throw t;
+    }
     startMasters(true);
     startServing();
   }
@@ -191,6 +203,27 @@ public class AlluxioMasterProcess extends MasterProcess {
       LOG.info("Initializing metadata from backup {}", backup);
       mBackupManager.initFromBackup(ufsIn);
     }
+  }
+
+  protected void takeEmergencyBackup() throws AlluxioException, InterruptedException,
+      TimeoutException {
+    LOG.warn("Emergency backup triggered");
+    DefaultMetaMaster metaMaster = (DefaultMetaMaster) mRegistry.get(MetaMaster.class);
+    BackupStatus backup = metaMaster.takeEmergencyBackup();
+    BackupStatusPRequest statusRequest =
+        BackupStatusPRequest.newBuilder().setBackupId(backup.getBackupId().toString()).build();
+    final int requestIntervalMs = 2_000;
+    CommonUtils.waitFor("emergency backup to complete", () -> {
+      try {
+        BackupStatus status = metaMaster.getBackupStatus(statusRequest);
+        LOG.info("Auto backup state: {} | Entries processed: {}.", status.getState(),
+            status.getEntryCount());
+        return status.isCompleted();
+      } catch (AlluxioException e) {
+        return false;
+      }
+      // no need for timeout on shutdown, we must wait until the backup is complete
+    }, WaitForOptions.defaults().setInterval(requestIntervalMs).setTimeoutMs(Integer.MAX_VALUE));
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -106,16 +106,24 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       if (!mRunning) {
         break;
       }
-      if (gainPrimacy()) {
-        mLeaderSelector.waitForState(State.STANDBY);
-        if (Configuration.getBoolean(PropertyKey.MASTER_JOURNAL_EXIT_ON_DEMOTION)) {
-          stop();
-        } else {
-          if (!mRunning) {
-            break;
-          }
-          losePrimacy();
+      try {
+        if (!gainPrimacy()) {
+          continue;
         }
+      } catch (Throwable t) {
+        if (Configuration.getBoolean(PropertyKey.MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED)) {
+          takeEmergencyBackup();
+        }
+        throw t;
+      }
+      mLeaderSelector.waitForState(State.STANDBY);
+      if (Configuration.getBoolean(PropertyKey.MASTER_JOURNAL_EXIT_ON_DEMOTION)) {
+        stop();
+      } else {
+        if (!mRunning) {
+          break;
+        }
+        losePrimacy();
       }
     }
   }

--- a/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
+++ b/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
@@ -194,6 +194,7 @@ public final class AlluxioMasterProcessTest {
   @Test
   public void failToGainPrimacyWhenJournalCorrupted() throws Exception {
     Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED, false);
     URI journalLocation = JournalUtils.getJournalLocation();
     JournalSystem journalSystem = new JournalSystem.Builder()
         .setLocation(journalLocation).build(CommonUtils.ProcessType.MASTER);
@@ -204,6 +205,7 @@ public final class AlluxioMasterProcessTest {
   @Test
   public void failToGainPrimacyWhenJournalCorruptedHA() throws Exception {
     Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED, false);
     URI journalLocation = JournalUtils.getJournalLocation();
     JournalSystem journalSystem = new JournalSystem.Builder()
         .setLocation(journalLocation).build(CommonUtils.ProcessType.MASTER);

--- a/docs/en/operation/Journal.md
+++ b/docs/en/operation/Journal.md
@@ -394,6 +394,11 @@ we recommend [taking regular journal backups](#automatically-backing-up-the-jour
 at a time when the cluster is under low load.
 Then if something happens to the journal, you can recover from one of the backups.
 
+By default, if a master encounters corruption when replaying a journal it will automatically
+take a backup of the state up to the corrupted entry in the configured backup directory. The master will notice the
+corruption when elected leader. The backup directory is configured by `alluxio.master.backup.directory`.
+This feature can be disabled by setting `alluxio.master.journal.backup.when.corrupted` to `false`.
+
 ### Get a human-readable journal
 
 Alluxio journal is serialized and not human-readable. The following command

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -80,6 +80,8 @@ public class PortCoordination {
   public static final List<ReservedPort> BACKUP_DELEGATION_EMBEDDED = allocate(2, 1);
   public static final List<ReservedPort> BACKUP_RESTORE_METASSTORE_HEAP = allocate(1, 1);
   public static final List<ReservedPort> BACKUP_RESTORE_METASSTORE_ROCKS = allocate(1, 1);
+  public static final List<ReservedPort> BACKUP_EMERGENCY_1 = allocate(1, 0);
+  public static final List<ReservedPort> BACKUP_EMERGENCY_2 = allocate(1, 0);
 
   public static final List<ReservedPort> ZOOKEEPER_FAILURE = allocate(2, 1);
   public static final List<ReservedPort> ZOOKEEPER_CONNECTION_POLICY_STANDARD = allocate(2, 0);

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -82,6 +82,8 @@ public class PortCoordination {
   public static final List<ReservedPort> BACKUP_RESTORE_METASSTORE_ROCKS = allocate(1, 1);
   public static final List<ReservedPort> BACKUP_EMERGENCY_1 = allocate(1, 0);
   public static final List<ReservedPort> BACKUP_EMERGENCY_2 = allocate(1, 0);
+  public static final List<ReservedPort> BACKUP_EMERGENCY_HA_1 = allocate(3, 0);
+  public static final List<ReservedPort> BACKUP_EMERGENCY_HA_2 = allocate(3, 0);
 
   public static final List<ReservedPort> ZOOKEEPER_FAILURE = allocate(2, 1);
   public static final List<ReservedPort> ZOOKEEPER_CONNECTION_POLICY_STANDARD = allocate(2, 0);


### PR DESCRIPTION
### What changes are proposed in this pull request?
This PR adds the option of triggering a backup automatically when an Alluxio master shuts down.

### Why are the changes needed?
This helps trigger backups automatically when the master encounters unexpected journal corruption. 

### Does this PR introduce any user facing changes?
It adds a new `PropertyKey` to enable the feature (it is disabled by default).
