### PR TITLE
Remove System.exit() calls in ufs journal catchup and propagate errors

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/JournalUtils.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalUtils.java
@@ -13,8 +13,8 @@ package alluxio.master.journal;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
-import alluxio.conf.PropertyKey;
 import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.CheckpointOutputStream;
 import alluxio.master.journal.checkpoint.CheckpointType;
@@ -186,7 +186,6 @@ public final class JournalUtils {
     }
     logger.error(message);
     if (!Configuration.getBoolean(PropertyKey.MASTER_JOURNAL_TOLERATE_CORRUPTION)) {
-      System.exit(-1);
       throw new RuntimeException(t);
     }
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalUtils.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalUtils.java
@@ -181,9 +181,6 @@ public final class JournalUtils {
     if (t != null) {
       message += "\n" + Throwables.getStackTraceAsString(t);
     }
-    if (Configuration.getBoolean(PropertyKey.TEST_MODE)) {
-      throw new RuntimeException(message);
-    }
     logger.error(message);
     if (!Configuration.getBoolean(PropertyKey.MASTER_JOURNAL_TOLERATE_CORRUPTION)) {
       throw new RuntimeException(t);

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
@@ -626,7 +626,13 @@ public class UfsJournal implements Journal {
       mWriter = null;
     }
     if (mTailerThread != null) {
-      mTailerThread.interrupt();
+      try {
+        mTailerThread.awaitTermination(false);
+      } catch (Throwable t) {
+        // We want to let the thread finish normally, however this call might throw if it already
+        // finished exceptionally. We do not rethrow as ww want the shutdown sequence to be smooth
+        // (aka not throw exceptions).
+      }
       mTailerThread = null;
     }
     mState.set(State.CLOSED);

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
@@ -630,8 +630,9 @@ public class UfsJournal implements Journal {
         mTailerThread.awaitTermination(false);
       } catch (Throwable t) {
         // We want to let the thread finish normally, however this call might throw if it already
-        // finished exceptionally. We do not rethrow as ww want the shutdown sequence to be smooth
+        // finished exceptionally. We do not rethrow as we want the shutdown sequence to be smooth
         // (aka not throw exceptions).
+        LOG.warn("exception caught when closing {}'s journal", mMaster.getName(), t);
       }
       mTailerThread = null;
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
@@ -237,6 +237,8 @@ public final class UfsJournalCheckpointThread extends Thread {
                 JournalUtils.handleJournalReplayFailure(LOG, null,
                     "%s: Unrecognized journal entry: %s", mMaster.getName(), entry);
               }
+            } catch (RuntimeException e) {
+              throw e;
             } catch (Throwable t) {
               JournalUtils.handleJournalReplayFailure(LOG, t,
                   "%s: Failed to read or process journal entry %s.", mMaster.getName(), entry);

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
@@ -84,7 +84,7 @@ public final class UfsJournalCheckpointThread extends Thread {
 
   /** The last sequence number applied to the journal. */
   private volatile long mLastAppliedSN;
-
+  // this throwable gets set if the thread completes exceptionally
   private Throwable mThrowable = null;
 
   /**

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
@@ -127,7 +127,12 @@ public final class UfsJournalCheckpointThread extends Thread {
     mCheckpointPeriodEntries =
         Configuration.getInt(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES);
     mJournalSinks = journalSinks;
-    setUncaughtExceptionHandler((thread, t) -> mThrowable = t);
+    setUncaughtExceptionHandler((thread, t) -> {
+      mThrowable = t;
+      // if the catchup thread terminates exceptionally, it has caught up as much as it can and
+      // is done
+      mCatchupState = CatchupState.DONE;
+    });
   }
 
   /**

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
@@ -91,7 +91,7 @@ public final class UfsJournalCheckpointThread extends Thread {
    * The state of the journal catchup.
    */
   public enum CatchupState {
-    NOT_STARTED, IN_PROGRESS, DONE;
+    NOT_STARTED, IN_PROGRESS, DONE
   }
 
   private volatile CatchupState mCatchupState = CatchupState.NOT_STARTED;
@@ -134,6 +134,8 @@ public final class UfsJournalCheckpointThread extends Thread {
    * Initiates the shutdown of this checkpointer thread, and also waits for it to finish.
    *
    * @param waitQuietPeriod whether to wait for a quiet period to pass before terminating the thread
+   * @throws RuntimeException if {@link #join()} throws an InterruptedException or if
+   * {@link #run()} completed exceptionally
    */
   public void awaitTermination(boolean waitQuietPeriod) {
     LOG.info("{}: Journal checkpointer shutdown has been initiated.", mMaster.getName());

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
@@ -12,8 +12,8 @@
 package alluxio.master.journal.ufs;
 
 import alluxio.RuntimeConstants;
-import alluxio.conf.PropertyKey;
 import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.JournalClosedException;
 import alluxio.exception.JournalClosedException.IOJournalClosedException;
@@ -52,7 +52,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * writer is closed.
  */
 @ThreadSafe
-final class UfsJournalLogWriter implements JournalWriter {
+public final class UfsJournalLogWriter implements JournalWriter {
   private static final Logger LOG = LoggerFactory.getLogger(UfsJournalLogWriter.class);
 
   private final UfsJournal mJournal;
@@ -72,7 +72,7 @@ final class UfsJournalLogWriter implements JournalWriter {
    */
   private JournalOutputStream mJournalOutputStream;
   /** The garbage collector. */
-  private UfsJournalGarbageCollector mGarbageCollector;
+  private final UfsJournalGarbageCollector mGarbageCollector;
   /** Whether the journal log writer is closed. */
   private boolean mClosed;
 
@@ -87,7 +87,7 @@ final class UfsJournalLogWriter implements JournalWriter {
    * before flush, {@code UfsJournalLogWriter} is able to retry writing the
    * journal entries.
    */
-  private Queue<JournalEntry> mEntriesToFlush;
+  private final Queue<JournalEntry> mEntriesToFlush;
 
   /**
    * Creates a new instance of {@link UfsJournalLogWriter}.
@@ -95,7 +95,7 @@ final class UfsJournalLogWriter implements JournalWriter {
    * @param journal the handle to the journal
    * @param nextSequenceNumber the sequence number to begin writing at
    */
-  UfsJournalLogWriter(UfsJournal journal, long nextSequenceNumber) throws IOException {
+  public UfsJournalLogWriter(UfsJournal journal, long nextSequenceNumber) throws IOException {
     mJournal = Preconditions.checkNotNull(journal, "journal");
     mUfs = mJournal.getUfs();
     mNextSequenceNumber = nextSequenceNumber;
@@ -228,7 +228,7 @@ final class UfsJournalLogWriter implements JournalWriter {
     UfsJournalFile currentLog = snapshot.getCurrentLog(mJournal);
     if (currentLog != null) {
       LOG.info("Recovering from previous UFS journal write failure."
-          + " Scanning for the last persisted journal entry. currentLog: " + currentLog.toString());
+          + " Scanning for the last persisted journal entry. currentLog: " + currentLog);
       try (JournalEntryStreamReader reader =
           new JournalEntryStreamReader(mUfs.open(currentLog.getLocation().toString(),
               OpenOptions.defaults().setRecoverFailedOpen(true)))) {
@@ -238,8 +238,6 @@ final class UfsJournalLogWriter implements JournalWriter {
             lastPersistSeq = entry.getSequenceNumber();
           }
         }
-      } catch (IOException e) {
-        throw e;
       }
       if (lastPersistSeq != -1) { // If the current log is an empty file, do not complete with SN: 0
         completeLog(currentLog, lastPersistSeq + 1);
@@ -426,7 +424,7 @@ final class UfsJournalLogWriter implements JournalWriter {
     private final DataOutputStream mOutputStream;
     private final UfsJournalFile mCurrentLog;
 
-    JournalOutputStream(UfsJournalFile currentLog, OutputStream stream) throws IOException {
+    JournalOutputStream(UfsJournalFile currentLog, OutputStream stream) {
       mOutputStream = wrapDataOutputStream(stream);
       mCurrentLog = currentLog;
     }

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -153,6 +153,9 @@ public class AlluxioMasterProcess extends MasterProcess {
 
   @Override
   public void stop() throws Exception {
+    if (mIsStopped) {
+      return;
+    }
     LOG.info("Stopping...");
     stopCommonHAAndNonHAServices();
     mIsStopped = true;

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -159,13 +159,13 @@ public class AlluxioMasterProcess extends MasterProcess {
         return;
       }
       LOG.info("Stopping...");
-      stopCommonHAAndNonHAServices();
+      stopCommonServices();
       mIsStopped.set(true);
       LOG.info("Stopped.");
     }
   }
 
-  protected void stopCommonHAAndNonHAServices() throws Exception {
+  protected void stopCommonServices() throws Exception {
     stopRejectingServers();
     stopServing();
     mJournalSystem.stop();

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -425,6 +425,8 @@ public class AlluxioMasterProcess extends MasterProcess {
 
   /**
    * Indicates if all master resources have been successfully released when stopping.
+   * An assumption made here is that a first call to {@link #stop()} might fail while a second call
+   * might succeed.
    * @return whether {@link #stop()} has concluded successfully at least once
    */
   public boolean isStopped() {

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -217,7 +217,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       }
       LOG.info("Stopping...");
       mRunning = false;
-      stopCommonHAAndNonHAServices();
+      stopCommonServices();
       if (mLeaderSelector != null) {
         mLeaderSelector.stop();
       }

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -211,6 +211,9 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
 
   @Override
   public void stop() throws Exception {
+    if (mIsStopped) {
+      return;
+    }
     LOG.info("Stopping...");
     mRunning = false;
     stopCommonHAAndNonHAServices();

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -13,8 +13,8 @@ package alluxio.master;
 
 import alluxio.Constants;
 import alluxio.ProcessUtils;
-import alluxio.conf.PropertyKey;
 import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.PrimarySelector.State;
 import alluxio.master.journal.JournalSystem;
@@ -50,7 +50,7 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
   private final PrimarySelector mLeaderSelector;
   private Thread mServingThread = null;
 
-  /** An indicator for whether the process is running (after start() and before stop()). */
+  /** See {@link #isRunning()}. */
   private volatile boolean mRunning = false;
 
   /**
@@ -213,14 +213,17 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
   public void stop() throws Exception {
     LOG.info("Stopping...");
     mRunning = false;
-    super.stop();
+    stopCommonHAAndNonHAServices();
     if (mLeaderSelector != null) {
       mLeaderSelector.stop();
     }
+    mIsStopped = true;
+    LOG.info("Stopped.");
   }
 
   /**
-   * @return whether the master is running
+   * @return {@code true} when {@link #start()} has been called and {@link #stop()} has not yet
+   * been called, {@code false} otherwise
    */
   boolean isRunning() {
     return mRunning;

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -211,17 +211,19 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
 
   @Override
   public void stop() throws Exception {
-    if (mIsStopped) {
-      return;
+    synchronized (mIsStopped) {
+      if (mIsStopped.get()) {
+        return;
+      }
+      LOG.info("Stopping...");
+      mRunning = false;
+      stopCommonHAAndNonHAServices();
+      if (mLeaderSelector != null) {
+        mLeaderSelector.stop();
+      }
+      mIsStopped.set(true);
+      LOG.info("Stopped.");
     }
-    LOG.info("Stopping...");
-    mRunning = false;
-    stopCommonHAAndNonHAServices();
-    if (mLeaderSelector != null) {
-      mLeaderSelector.stop();
-    }
-    mIsStopped = true;
-    LOG.info("Stopped.");
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
+++ b/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
@@ -48,7 +48,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -221,15 +220,16 @@ public final class AlluxioMasterProcessTest {
     masterProcess.mJournalSystem.format();
     // corrupt the journal
     UfsJournal fsMaster =
-        Mockito.spy(new UfsJournal(URIUtils.appendPathOrDie(journalLocation, "FileSystemMaster"),
-            new NoopMaster(), 0, Collections::emptySet));
-    Mockito.when(fsMaster.isWritable()).thenReturn(true);
+        new UfsJournal(URIUtils.appendPathOrDie(journalLocation, "FileSystemMaster"),
+            new NoopMaster(), 0, Collections::emptySet);
+    fsMaster.start();
+    fsMaster.gainPrimacy();
     long nextSN = 0;
     try (UfsJournalLogWriter writer = new UfsJournalLogWriter(fsMaster, nextSN)) {
       Journal.JournalEntry entry = Journal.JournalEntry.newBuilder()
           .setSequenceNumber(nextSN)
           .setDeleteFile(File.DeleteFileEntry.newBuilder()
-              .setId(4563728)
+              .setId(4563728) // random non-zero ID number (zero would delete the root)
               .setPath("/nonexistant")
               .build())
           .build();


### PR DESCRIPTION
### What changes are proposed in this pull request?
The `UfsJournalCheckpointThread` calls `System.exit(-1)` when encountering journal corruption. This causes a deadlock between the `UfsJournalCheckpointThread` and the shutdown hook calling `AlluxioMasterProcess.stop()`.
This PR removes the `System.exit()` calls in favor of propagating exceptions when the thread completes. 
The net effect is that the master process completely releases its resources when shutting down and terminates without having to be issued `kill -9`.

### Why are the changes needed?
For clean master process termination on errors.

### Does this PR introduce any user facing changes?
No.
