### PR TITLE
Fix inefficient use of keySet iterator

### DIFF
--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/activesync/SupportedHdfsActiveSyncProvider.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/activesync/SupportedHdfsActiveSyncProvider.java
@@ -132,9 +132,9 @@ public class SupportedHdfsActiveSyncProvider implements HdfsActiveSyncProvider {
    * unsynced syncpoints.
    */
   private void initNextWindow() {
-    for (String syncPoint : mActivity.keySet()) {
-      mActivity.put(syncPoint, mActivity.get(syncPoint) / 10);
-      mAge.put(syncPoint, mAge.get(syncPoint) + 1);
+    for (Map.Entry<String, Integer> syncPoint : mActivity.entrySet()) {
+      mActivity.put(syncPoint.getKey(), syncPoint.getValue() / 10);
+      mAge.put(syncPoint.getKey(), mAge.get(syncPoint) + 1);
     }
   }
 
@@ -417,15 +417,15 @@ public class SupportedHdfsActiveSyncProvider implements HdfsActiveSyncProvider {
         SyncInfo syncInfo = new SyncInfo(syncPointFiles, true, getLastTxId());
         return syncInfo;
       }
-      for (String syncPoint : mActivity.keySet()) {
-        AlluxioURI syncPointURI = new AlluxioURI(syncPoint);
+      for (Map.Entry<String, Integer> syncPoint : mActivity.entrySet()) {
+        AlluxioURI syncPointURI = new AlluxioURI(syncPoint.getKey());
         // if the activity level is below the threshold or the sync point is too old, we sync
-        if (mActivity.get(syncPoint) < mActiveUfsSyncMaxActivity
+        if (syncPoint.getValue() < mActiveUfsSyncMaxActivity
             || mAge.get(syncPoint) > mActiveUfsSyncMaxAge) {
           if (!syncPointFiles.containsKey(syncPointURI)) {
             syncPointFiles.put(syncPointURI, mChangedFiles.get(syncPoint));
           }
-          syncSyncPoint(syncPoint);
+          syncSyncPoint(syncPoint.getKey());
         }
       }
       txId = getLastTxId();


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix inefficient use of keySet iterator


### Why are the changes needed?
fix the `spotbugs` errors as below
```
Error: 7.323 [ERROR] Medium: alluxio.underfs.hdfs.activesync.SupportedHdfsActiveSyncProvider.getActivitySyncInfo() makes inefficient use of keySet iterator instead of entrySet iterator [alluxio.underfs.hdfs.activesync.SupportedHdfsActiveSyncProvider] At SupportedHdfsActiveSyncProvider.java:[line 423] WMI_WRONG_MAP_ITERATOR
Error: 7.354 [ERROR] Medium: alluxio.underfs.hdfs.activesync.SupportedHdfsActiveSyncProvider.initNextWindow() makes inefficient use of keySet iterator instead of entrySet iterator [alluxio.underfs.hdfs.activesync.SupportedHdfsActiveSyncProvider] At SupportedHdfsActiveSyncProvider.java:[line 136] WMI_WRONG_MAP_ITERATOR
```

these erros block the merge of https://github.com/Alluxio/alluxio/pull/15656

### Does this PR introduce any user facing changes?

NA