### PR TITLE
Change the default value of async write for local cache

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4813,7 +4813,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED =
       booleanBuilder(Name.USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED)
-          .setDefaultValue(true)
+          .setDefaultValue(false)
           .setDescription("If this is enabled, cache data asynchronously.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)


### PR DESCRIPTION
### What changes are proposed in this pull request?

Change the default value of async write for local cache to false

### Why are the changes needed?
Using async write in local cache might cause async rejection errors (the queue is full)

We recommend to disable the async write for local cache (the async write is disabled in Meta/Uber's production)

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
No
