### PR TITLE
Add unchecked flag to AlluxioFuse rm

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6046,6 +6046,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "will drop the metadata cache of path '/mnt/alluxio-fuse/path/to/be/cleaned/'")
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey FUSE_DELETE_UNCHECKED =
+      booleanBuilder(Name.FUSE_DELETE_UNCHECKED)
+          .setDefaultValue(false)
+          .setDescription("If set, all paths will be deleted with the 'unchecked' option")
+          .setScope(Scope.CLIENT)
+          .build();
   //
   // Standalone FUSE process related properties
   //
@@ -7764,6 +7770,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.fuse.user.group.translation.enabled";
     public static final String FUSE_SPECIAL_COMMAND_ENABLED =
         "alluxio.fuse.special.command.enabled";
+    public static final String FUSE_DELETE_UNCHECKED =
+        "alluxio.fuse.delete.unchecked";
     //
     // Standalone FUSE process related properties
     //

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6049,7 +6049,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey FUSE_DELETE_UNCHECKED =
       booleanBuilder(Name.FUSE_DELETE_UNCHECKED)
           .setDefaultValue(false)
-          .setDescription("If set, all paths will be deleted with the 'unchecked' option")
+          .setDescription("Whether to check if the UFS contents are in sync with Alluxio "
+              + "before attempting to delete persisted directories recursively.")
           .setScope(Scope.CLIENT)
           .build();
   //

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystemOpts.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseFileSystemOpts.java
@@ -43,6 +43,7 @@ public final class AlluxioFuseFileSystemOpts {
   private final List<String> mLibfuseOptions;
   // general options
   private final boolean mIsDebug;
+  private final boolean mDeleteUnchecked;
 
   /**
    * Constructs an {@link AlluxioFuseFileSystemOpts} with only Alluxio cluster configuration.
@@ -111,14 +112,15 @@ public final class AlluxioFuseFileSystemOpts {
         mountPoint,
         conf.getBoolean(PropertyKey.FUSE_SPECIAL_COMMAND_ENABLED),
         conf.getMs(PropertyKey.FUSE_STAT_CACHE_REFRESH_INTERVAL),
-        conf.getBoolean(PropertyKey.FUSE_USER_GROUP_TRANSLATION_ENABLED));
+        conf.getBoolean(PropertyKey.FUSE_USER_GROUP_TRANSLATION_ENABLED),
+        conf.getBoolean(PropertyKey.FUSE_DELETE_UNCHECKED));
   }
 
   private AlluxioFuseFileSystemOpts(String alluxioPath, String fsName, Class fuseAuthPolicyClass,
         Optional<String> fuseAuthPolicyCustomGroup, Optional<String> fuseAuthPolicyCustomUser,
         int fuseMaxPathCached, int fuseUmountTimeout, boolean isDebug, List<String> libfuseOptions,
         boolean metaDataCacheEnabled, String mountPoint, boolean specialCommandEnabled,
-        long statCacheTimeout, boolean userGroupTranslationEnabled) {
+        long statCacheTimeout, boolean userGroupTranslationEnabled, boolean deleteUnchecked) {
     mAlluxioPath = Preconditions.checkNotNull(alluxioPath);
     mFsName = Preconditions.checkNotNull(fsName);
     mFuseAuthPolicyClass = Preconditions.checkNotNull(fuseAuthPolicyClass);
@@ -133,6 +135,7 @@ public final class AlluxioFuseFileSystemOpts {
     mSpecialCommandEnabled = specialCommandEnabled;
     mStatCacheTimeout = statCacheTimeout;
     mUserGroupTranslationEnabled = userGroupTranslationEnabled;
+    mDeleteUnchecked = deleteUnchecked;
   }
 
   /**
@@ -189,6 +192,13 @@ public final class AlluxioFuseFileSystemOpts {
    */
   public boolean isDebug() {
     return mIsDebug;
+  }
+
+  /**
+   * @return if enabling "unchecked" option for "rm"
+   */
+  public boolean deleteUnchecked() {
+    return mDeleteUnchecked;
   }
 
   /**

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -30,6 +30,7 @@ import alluxio.fuse.auth.AuthPolicyFactory;
 import alluxio.fuse.file.FuseFileEntry;
 import alluxio.fuse.file.FuseFileStream;
 import alluxio.grpc.CreateDirectoryPOptions;
+import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.jnifuse.AbstractFuseFileSystem;
 import alluxio.jnifuse.ErrorCodes;
@@ -456,7 +457,11 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
       return res;
     }
     try {
-      mFileSystem.delete(uri);
+      if (mFuseFsOpts.deleteUnchecked()) {
+        mFileSystem.delete(uri, DeletePOptions.newBuilder().setUnchecked(true).build());
+      } else {
+        mFileSystem.delete(uri);
+      }
     } catch (DirectoryNotEmptyException de) {
       LOG.error("Failed to remove {}: directory not empty", path, de);
       return -ErrorCodes.EEXIST() | ErrorCodes.ENOTEMPTY();


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add unchecked flag to AlluxioFuse rm

### Why are the changes needed?

1. [The doc](https://docs.alluxio.io/os/user/stable/en/operation/User-CLI.html#rm) has "We recommend always using the -U option for the best performance and resource efficiency."
2. Currently AlluxioFuse may fail to delete files which are not in sync with UFS. Below is an example

```
$ rm -rf alluxio-2.7.1/
rm: cannot remove ‘alluxio-2.7.1/webui/worker/build/static/css’: Input/output error
...
```

"fuse.log" has the following content

```
2022-06-12 16:08:52,308 ERROR AlluxioJniFuseFileSystem - Failed to delete /alluxio-2.7.1/integration/yarn/bin
alluxio.exception.DirectoryNotEmptyException: Failed to delete /.../alluxio-2.7.1/integration/yarn/bin (UFS dir not in sync. Sync UFS, or delete with unchecked flag.) from the under file system
        ...
```

### Does this PR introduce any user facing changes?

No
