### PR TITLE
Refactor UnderFileSystemConfiguration

### DIFF
--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -85,6 +85,14 @@ public class InstancedConfiguration implements AlluxioConfiguration {
     mClusterDefaultsLoaded = clusterDefaultsLoaded;
   }
 
+  /**
+   * Return reference to mProperties.
+   * @return mProperties
+   */
+  public AlluxioProperties getProperties() {
+    return mProperties;
+  }
+
   @Override
   public AlluxioProperties copyProperties() {
     return mProperties.copy();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1756,6 +1756,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
+  @Deprecated
   public static final PropertyKey MASTER_MOUNT_TABLE_ROOT_SHARED =
       new Builder(PropertyType.BOOLEAN, Template.MASTER_MOUNT_TABLE_SHARED, "root")
           .setDefaultValue(true)

--- a/core/common/src/main/java/alluxio/conf/path/PrefixPathConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/path/PrefixPathConfiguration.java
@@ -15,7 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -40,13 +39,6 @@ public final class PrefixPathConfiguration implements PathConfiguration {
    * Matches path patterns.
    */
   private final PathMatcher mMatcher;
-
-  /**
-   * Constructs an empty path level configuration.
-   */
-  public PrefixPathConfiguration() {
-    mMatcher = new PrefixPathMatcher(Collections.emptySet());
-  }
 
   /**
    * Constructs a new path level configuration.

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -130,11 +130,10 @@ public interface UnderFileSystem extends Closeable {
     public static UnderFileSystem createForRoot(AlluxioConfiguration conf) {
       String ufsRoot = conf.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
       boolean readOnly = conf.getBoolean(PropertyKey.MASTER_MOUNT_TABLE_ROOT_READONLY);
-      boolean shared = conf.getBoolean(PropertyKey.MASTER_MOUNT_TABLE_ROOT_SHARED);
       Map<String, Object> ufsConf =
           conf.getNestedProperties(PropertyKey.MASTER_MOUNT_TABLE_ROOT_OPTION);
-      return create(ufsRoot, UnderFileSystemConfiguration.defaults(conf).setReadOnly(readOnly)
-          .setShared(shared).createMountSpecificConf(ufsConf));
+      return create(ufsRoot, new UnderFileSystemConfiguration(conf, readOnly)
+          .createMountSpecificConf(ufsConf));
     }
   }
 

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactoryRegistry.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemFactoryRegistry.java
@@ -12,6 +12,7 @@
 package alluxio.underfs;
 
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.extensions.ExtensionFactoryRegistry;
 
@@ -114,7 +115,6 @@ public final class UnderFileSystemFactoryRegistry {
             StringUtils.join(supportedVersions, ","), path,
             configuredVersion);
       }
-      ufsConf.set(PropertyKey.UNDERFS_VERSION, configuredVersion);
     }
     return eligibleFactories;
   }
@@ -128,13 +128,14 @@ public final class UnderFileSystemFactoryRegistry {
    *         not support setting a version on the mount.
    */
   public static List<String> getSupportedVersions(String path,
-      UnderFileSystemConfiguration ufsConf) {
+      AlluxioConfiguration ufsConf) {
     // copy properties to not modify the original conf.
-    UnderFileSystemConfiguration ufsConfCopy = UnderFileSystemConfiguration.defaults(ufsConf);
+    InstancedConfiguration confCopy = new InstancedConfiguration(ufsConf.copyProperties());
     // unset the configuration to make sure any supported factories for the path are returned.
-    ufsConfCopy.unset(PropertyKey.UNDERFS_VERSION);
+    confCopy.unset(PropertyKey.UNDERFS_VERSION);
     // Check if any versioned factory supports the default configuration
-    List<UnderFileSystemFactory> factories = sRegistryInstance.findAll(path, ufsConfCopy);
+    List<UnderFileSystemFactory> factories = sRegistryInstance
+        .findAll(path, UnderFileSystemConfiguration.defaults(confCopy));
     List<String> supportedVersions = new ArrayList<>();
     for (UnderFileSystemFactory factory : factories) {
       if (!factory.getVersion().isEmpty()) {

--- a/core/common/src/test/java/alluxio/conf/PropertyKeyTest.java
+++ b/core/common/src/test/java/alluxio/conf/PropertyKeyTest.java
@@ -167,8 +167,6 @@ public final class PropertyKeyTest {
         PropertyKey.Template.MASTER_MOUNT_TABLE_UFS.format("root"));
     assertEquals(PropertyKey.MASTER_MOUNT_TABLE_ROOT_READONLY,
         PropertyKey.Template.MASTER_MOUNT_TABLE_READONLY.format("root"));
-    assertEquals(PropertyKey.MASTER_MOUNT_TABLE_ROOT_SHARED,
-        PropertyKey.Template.MASTER_MOUNT_TABLE_SHARED.format("root"));
     assertEquals(PropertyKey.MASTER_MOUNT_TABLE_ROOT_OPTION,
         PropertyKey.Template.MASTER_MOUNT_TABLE_OPTION.format("root"));
   }

--- a/core/common/src/test/java/alluxio/underfs/UnderFileSystemConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/underfs/UnderFileSystemConfigurationTest.java
@@ -44,17 +44,13 @@ public final class UnderFileSystemConfigurationTest {
         .toResource()) {
       Random random = new Random();
       boolean readOnly = random.nextBoolean();
-      boolean shared = random.nextBoolean();
-      UnderFileSystemConfiguration conf = UnderFileSystemConfiguration
-          .defaults(Configuration.global()).setReadOnly(readOnly).setShared(shared);
+      UnderFileSystemConfiguration conf =
+          new UnderFileSystemConfiguration(Configuration.global(), readOnly);
       assertEquals(readOnly, conf.isReadOnly());
-      assertEquals(shared, conf.isShared());
       assertEquals("bar", mConfiguration.get(PropertyKey.S3A_ACCESS_KEY));
-      conf = UnderFileSystemConfiguration.defaults(Configuration.global())
-          .setReadOnly(readOnly).setShared(shared)
+      conf = new UnderFileSystemConfiguration(Configuration.global(), readOnly)
           .createMountSpecificConf(ImmutableMap.of(PropertyKey.S3A_ACCESS_KEY.toString(), "foo"));
       assertEquals(readOnly, conf.isReadOnly());
-      assertEquals(shared, conf.isShared());
       assertEquals("foo", conf.get(PropertyKey.S3A_ACCESS_KEY));
     }
   }
@@ -77,11 +73,8 @@ public final class UnderFileSystemConfigurationTest {
         .toResource()) {
       Random random = new Random();
       boolean readOnly = random.nextBoolean();
-      boolean shared = random.nextBoolean();
       UnderFileSystemConfiguration conf =
-          UnderFileSystemConfiguration.defaults(mConfiguration)
-              .setReadOnly(readOnly)
-              .setShared(shared);
+          new UnderFileSystemConfiguration(mConfiguration, readOnly);
       try {
         conf.get(PropertyKey.S3A_ACCESS_KEY);
         fail("this key should not exist");
@@ -92,7 +85,6 @@ public final class UnderFileSystemConfigurationTest {
           conf.createMountSpecificConf(ImmutableMap.of(PropertyKey.S3A_ACCESS_KEY.toString(),
               "foo"));
       assertEquals(readOnly, conf2.isReadOnly());
-      assertEquals(shared, conf2.isShared());
       assertEquals("foo", conf2.get(PropertyKey.S3A_ACCESS_KEY));
     }
   }
@@ -104,14 +96,11 @@ public final class UnderFileSystemConfigurationTest {
         .toResource()) {
       Random random = new Random();
       boolean readOnly = random.nextBoolean();
-      boolean shared = random.nextBoolean();
       UnderFileSystemConfiguration conf =
-          UnderFileSystemConfiguration.defaults(mConfiguration).setReadOnly(readOnly)
-              .setShared(shared);
+          new UnderFileSystemConfiguration(mConfiguration, readOnly);
       assertTrue(conf.isSet(PropertyKey.S3A_ACCESS_KEY));
       conf.createMountSpecificConf(ImmutableMap.of(PropertyKey.S3A_ACCESS_KEY.toString(), "foo"));
       assertEquals(readOnly, conf.isReadOnly());
-      assertEquals(shared, conf.isShared());
       assertTrue(conf.isSet(PropertyKey.S3A_ACCESS_KEY));
     }
   }
@@ -123,22 +112,19 @@ public final class UnderFileSystemConfigurationTest {
         .toResource()) {
       Random random = new Random();
       boolean readOnly = random.nextBoolean();
-      boolean shared = random.nextBoolean();
       UnderFileSystemConfiguration conf =
-          UnderFileSystemConfiguration.defaults(mConfiguration)
-              .setReadOnly(readOnly).setShared(shared);
+          new UnderFileSystemConfiguration(mConfiguration, readOnly);
       assertFalse(conf.isSet(PropertyKey.S3A_ACCESS_KEY));
       UnderFileSystemConfiguration conf2 =
           conf.createMountSpecificConf(ImmutableMap.of(PropertyKey.S3A_ACCESS_KEY.toString(),
               "foo"));
       assertEquals(readOnly, conf2.isReadOnly());
-      assertEquals(shared, conf2.isShared());
       assertTrue(conf2.isSet(PropertyKey.S3A_ACCESS_KEY));
     }
   }
 
   @Test
-  public void setUserSpecifiedConfRepeatedly() throws Exception {
+  public void setUserSpecifiedConfRepeatedly() {
     UnderFileSystemConfiguration conf = UnderFileSystemConfiguration.defaults(mConfiguration);
     UnderFileSystemConfiguration conf2 =
         conf.createMountSpecificConf(ImmutableMap.of(PropertyKey.S3A_ACCESS_KEY.toString(),

--- a/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
+++ b/core/server/common/src/main/java/alluxio/underfs/AbstractUfsManager.java
@@ -196,13 +196,11 @@ public abstract class AbstractUfsManager implements UfsManager {
         String rootUri = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
         boolean rootReadOnly =
             Configuration.getBoolean(PropertyKey.MASTER_MOUNT_TABLE_ROOT_READONLY);
-        boolean rootShared = Configuration
-            .getBoolean(PropertyKey.MASTER_MOUNT_TABLE_ROOT_SHARED);
         Map<String, Object> rootConf =
             Configuration.getNestedProperties(PropertyKey.MASTER_MOUNT_TABLE_ROOT_OPTION);
         addMount(IdUtils.ROOT_MOUNT_ID, new AlluxioURI(rootUri),
-            UnderFileSystemConfiguration.defaults(Configuration.global())
-                .setReadOnly(rootReadOnly).setShared(rootShared).createMountSpecificConf(rootConf));
+            new UnderFileSystemConfiguration(Configuration.global(), rootReadOnly)
+                .createMountSpecificConf(rootConf));
         try {
           mRootUfsClient = get(IdUtils.ROOT_MOUNT_ID);
         } catch (NotFoundException | UnavailableException e) {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -610,11 +610,9 @@ public class DefaultFileSystemMaster extends CoreMaster
           continue;
         }
         MountInfo mountInfo = mMountTable.getMountTable().get(key);
-        UnderFileSystemConfiguration ufsConf =
-            UnderFileSystemConfiguration.defaults(Configuration.global())
-                .createMountSpecificConf(mountInfo.getOptions().getPropertiesMap())
-                .setReadOnly(mountInfo.getOptions().getReadOnly())
-                .setShared(mountInfo.getOptions().getShared());
+        UnderFileSystemConfiguration ufsConf = new UnderFileSystemConfiguration(
+            Configuration.global(), mountInfo.getOptions().getReadOnly())
+            .createMountSpecificConf(mountInfo.getOptions().getPropertiesMap());
         mUfsManager.addMount(mountInfo.getMountId(), mountInfo.getUfsUri(), ufsConf);
       }
       // Startup Checks and Periodic Threads.
@@ -3047,9 +3045,8 @@ public class DefaultFileSystemMaster extends CoreMaster
       AlluxioURI alluxioPath = inodePath.getUri();
       // validate new UFS client before updating the mount table
       mUfsManager.addMount(newMountId, new AlluxioURI(ufsPath.toString()),
-          UnderFileSystemConfiguration.defaults(Configuration.global())
-              .setReadOnly(context.getOptions().getReadOnly())
-              .setShared(context.getOptions().getShared())
+          new UnderFileSystemConfiguration(
+              Configuration.global(), context.getOptions().getReadOnly())
               .createMountSpecificConf(context.getOptions().getPropertiesMap()));
       prepareForMount(ufsPath, newMountId, context);
       // old ufsClient is removed as part of the mount table update process
@@ -3180,9 +3177,8 @@ public class DefaultFileSystemMaster extends CoreMaster
     AlluxioURI alluxioPath = inodePath.getUri();
     // Adding the mount point will not create the UFS instance and thus not connect to UFS
     mUfsManager.addMount(mountId, new AlluxioURI(ufsPath.toString()),
-        UnderFileSystemConfiguration.defaults(Configuration.global())
-            .setReadOnly(context.getOptions().getReadOnly())
-            .setShared(context.getOptions().getShared())
+        new UnderFileSystemConfiguration(
+            Configuration.global(), context.getOptions().getReadOnly())
             .createMountSpecificConf(context.getOptions().getPropertiesMap()));
     try {
       prepareForMount(ufsPath, mountId, context);

--- a/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
@@ -73,8 +73,7 @@ public class AsyncUfsAbsentPathCacheTest {
     mMountId = IdUtils.getRandomNonNegativeLong();
     MountPOptions options = MountContext.defaults().getOptions().build();
     mUfsManager.addMount(mMountId, new AlluxioURI(mLocalUfsPath),
-        UnderFileSystemConfiguration.defaults(Configuration.global())
-            .setReadOnly(options.getReadOnly()).setShared(options.getShared())
+        new UnderFileSystemConfiguration(Configuration.global(), options.getReadOnly())
             .createMountSpecificConf(Collections.<String, String>emptyMap()));
     mMountTable.add(NoopJournalContext.INSTANCE, new AlluxioURI("/mnt"),
         new AlluxioURI(mLocalUfsPath), mMountId, options);
@@ -202,8 +201,7 @@ public class AsyncUfsAbsentPathCacheTest {
     long newMountId = IdUtils.getRandomNonNegativeLong();
     MountPOptions options = MountContext.defaults().getOptions().build();
     mUfsManager.addMount(newMountId, new AlluxioURI(mLocalUfsPath),
-        UnderFileSystemConfiguration.defaults(Configuration.global())
-            .setReadOnly(options.getReadOnly()).setShared(options.getShared())
+        new UnderFileSystemConfiguration(Configuration.global(), options.getReadOnly())
             .createMountSpecificConf(Collections.<String, String>emptyMap()));
     mMountTable.add(NoopJournalContext.INSTANCE, new AlluxioURI("/mnt"),
         new AlluxioURI(mLocalUfsPath), newMountId, options);

--- a/core/server/master/src/test/java/alluxio/master/file/meta/LazyUfsBlockLocationCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/LazyUfsBlockLocationCacheTest.java
@@ -55,8 +55,7 @@ public class LazyUfsBlockLocationCacheTest {
     mUfsManager = new MasterUfsManager();
     MountPOptions options = MountContext.defaults().getOptions().build();
     mUfsManager.addMount(mMountId, new AlluxioURI(mLocalUfsPath),
-        UnderFileSystemConfiguration.defaults(Configuration.global())
-            .setReadOnly(options.getReadOnly()).setShared(options.getShared())
+        new UnderFileSystemConfiguration(Configuration.global(), options.getReadOnly())
             .createMountSpecificConf(Collections.<String, String>emptyMap()));
 
     mMountTable = new MountTable(mUfsManager, new MountInfo(new AlluxioURI("/"),

--- a/core/server/worker/src/main/java/alluxio/underfs/WorkerUfsManager.java
+++ b/core/server/worker/src/main/java/alluxio/underfs/WorkerUfsManager.java
@@ -68,9 +68,8 @@ public final class WorkerUfsManager extends AbstractUfsManager {
     }
     Preconditions.checkState((info.hasUri() && info.hasProperties()), "unknown mountId");
     super.addMount(mountId, new AlluxioURI(info.getUri()),
-        UnderFileSystemConfiguration.defaults(Configuration.global())
-            .setReadOnly(info.getProperties().getReadOnly())
-            .setShared(info.getProperties().getShared())
+        new UnderFileSystemConfiguration(
+            Configuration.global(), info.getProperties().getReadOnly())
             .createMountSpecificConf(info.getProperties().getPropertiesMap()));
     return super.get(mountId);
   }

--- a/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
@@ -167,7 +167,7 @@ public final class UnderFileSystemContractTest {
 
   private UnderFileSystemConfiguration getUfsConf() {
     return UnderFileSystemConfiguration.defaults(mConf)
-        .createMountSpecificConf(mConf.copyProperties().entrySet().stream()
+        .createMountSpecificConf(mConf.getProperties().entrySet().stream()
             .filter(entry -> mConf.getSource(entry.getKey()) == Source.SYSTEM_PROPERTY)
             .filter(entry -> mConf.isSet(entry.getKey()) && (entry.getKey().getType() != STRING
                 || !((String) entry.getValue()).isEmpty()))

--- a/job/server/src/main/java/alluxio/underfs/JobUfsManager.java
+++ b/job/server/src/main/java/alluxio/underfs/JobUfsManager.java
@@ -72,9 +72,8 @@ public final class JobUfsManager extends AbstractUfsManager {
     }
     Preconditions.checkState((info.hasUri() && info.hasProperties()), "unknown mountId");
     super.addMount(mountId, new AlluxioURI(info.getUri()),
-        UnderFileSystemConfiguration.defaults(Configuration.global())
-            .setReadOnly(info.getProperties().getReadOnly())
-            .setShared(info.getProperties().getShared())
+        new UnderFileSystemConfiguration(
+            Configuration.global(), info.getProperties().getReadOnly())
             .createMountSpecificConf(info.getProperties().getPropertiesMap()));
     UfsClient ufsClient = super.get(mountId);
     try (CloseableResource<UnderFileSystem> ufsResource = ufsClient.acquireUfsResource()) {

--- a/shell/src/main/java/alluxio/cli/ValidateHdfsMount.java
+++ b/shell/src/main/java/alluxio/cli/ValidateHdfsMount.java
@@ -12,6 +12,7 @@
 package alluxio.cli;
 
 import alluxio.conf.Configuration;
+import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.Source;
 import alluxio.underfs.UnderFileSystemConfiguration;
 
@@ -113,20 +114,14 @@ public class ValidateHdfsMount {
 
     String ufsPath = args[0];
     // Merge options from the command line option
-    UnderFileSystemConfiguration ufsConf = UnderFileSystemConfiguration.defaults(
-        Configuration.global());
-    if (cmd.hasOption(READONLY_OPTION.getLongOpt())) {
-      ufsConf.setReadOnly(true);
-    }
-    if (cmd.hasOption(SHARED_OPTION.getLongOpt())) {
-      ufsConf.setShared(true);
-    }
+    InstancedConfiguration config = Configuration.copyGlobal();
     if (cmd.hasOption(OPTION_OPTION.getLongOpt())) {
       Properties properties = cmd.getOptionProperties(OPTION_OPTION.getLongOpt());
-      ufsConf.merge(properties, Source.MOUNT_OPTION);
+      config.merge(properties, Source.MOUNT_OPTION);
       LOG.debug("Options from cmdline: {}", properties);
     }
-
+    UnderFileSystemConfiguration ufsConf = new UnderFileSystemConfiguration(
+        config, cmd.hasOption(READONLY_OPTION.getLongOpt()));
     ValidationToolRegistry registry
             = new ValidationToolRegistry(Configuration.global());
     // Load hdfs validation tool from alluxio lib directory

--- a/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
@@ -169,7 +169,7 @@ public class StressClientIOBench extends AbstractStressBench
       LOG.info("Using ALLUXIO Native API to perform the test.");
 
       alluxio.conf.AlluxioProperties alluxioProperties = alluxio.conf.Configuration
-          .global().copyProperties();
+          .copyProperties();
       alluxioProperties.merge(HadoopConfigurationUtils.getConfigurationFromHadoop(hdfsConf),
           Source.RUNTIME);
 

--- a/tests/src/test/java/alluxio/server/ft/journal/ufs/UfsConfigurationJournalTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/ufs/UfsConfigurationJournalTest.java
@@ -84,7 +84,6 @@ public class UfsConfigurationJournalTest {
         assertEquals(entry.getValue(), ufsConf.getMountSpecificConf().get(entry.getKey()));
       }
       assertTrue(ufsConf.isReadOnly());
-      assertTrue(ufsConf.isShared());
     }
   }
 }

--- a/tests/src/test/java/alluxio/testutils/underfs/sleeping/SleepingUnderFileSystemFactory.java
+++ b/tests/src/test/java/alluxio/testutils/underfs/sleeping/SleepingUnderFileSystemFactory.java
@@ -12,6 +12,7 @@
 package alluxio.testutils.underfs.sleeping;
 
 import alluxio.AlluxioURI;
+import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
@@ -48,10 +49,12 @@ public class SleepingUnderFileSystemFactory implements UnderFileSystemFactory {
   @Override
   public UnderFileSystem create(String path, UnderFileSystemConfiguration conf) {
     // Managed blocking should be enabled when using Sleeping UFS.
-    conf.set(PropertyKey.MASTER_UFS_MANAGED_BLOCKING_ENABLED, true);
+    InstancedConfiguration confCopy = new InstancedConfiguration(conf.copyProperties());
+    confCopy.set(PropertyKey.MASTER_UFS_MANAGED_BLOCKING_ENABLED, true);
     if (mUfs == null) {
       Preconditions.checkArgument(path != null, "path may not be null");
-      return new SleepingUnderFileSystem(new AlluxioURI(path), mOptions, conf);
+      return new SleepingUnderFileSystem(new AlluxioURI(path), mOptions,
+          new UnderFileSystemConfiguration(confCopy, conf.isReadOnly()));
     } else {
       return mUfs;
     }

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemTest.java
@@ -54,7 +54,7 @@ public class S3AUnderFileSystemTest {
   private static final String PATH = "path";
   private static final String SRC = "src";
   private static final String DST = "dst";
-  private static  InstancedConfiguration sConf = Configuration.copyGlobal();
+  private static final InstancedConfiguration CONF = Configuration.copyGlobal();
 
   private static final String BUCKET_NAME = "bucket";
   private static final String DEFAULT_OWNER = "";
@@ -69,13 +69,13 @@ public class S3AUnderFileSystemTest {
   public final ExpectedException mThrown = ExpectedException.none();
 
   @Before
-  public void before() throws InterruptedException, AmazonClientException {
+  public void before() throws AmazonClientException {
     mClient = Mockito.mock(AmazonS3Client.class);
     mExecutor = Mockito.mock(ListeningExecutorService.class);
     mManager = Mockito.mock(TransferManager.class);
     mS3UnderFileSystem =
         new S3AUnderFileSystem(new AlluxioURI("s3a://" + BUCKET_NAME), mClient, BUCKET_NAME,
-            mExecutor, mManager, UnderFileSystemConfiguration.defaults(sConf), false);
+            mExecutor, mManager, UnderFileSystemConfiguration.defaults(CONF), false);
   }
 
   @Test
@@ -134,8 +134,8 @@ public class S3AUnderFileSystemTest {
     Map<PropertyKey, Object> conf = new HashMap<>();
     conf.put(PropertyKey.S3A_ACCESS_KEY, "key1");
     conf.put(PropertyKey.S3A_SECRET_KEY, "key2");
-    try (Closeable c = new ConfigurationRule(conf, sConf).toResource()) {
-      UnderFileSystemConfiguration ufsConf = UnderFileSystemConfiguration.defaults(sConf);
+    try (Closeable c = new ConfigurationRule(conf, CONF).toResource()) {
+      UnderFileSystemConfiguration ufsConf = UnderFileSystemConfiguration.defaults(CONF);
       AWSCredentialsProvider credentialsProvider =
           S3AUnderFileSystem.createAwsCredentialsProvider(ufsConf);
       Assert.assertEquals("key1", credentialsProvider.getCredentials().getAWSAccessKeyId());
@@ -150,8 +150,8 @@ public class S3AUnderFileSystemTest {
     Map<PropertyKey, Object> conf = new HashMap<>();
     conf.put(PropertyKey.S3A_ACCESS_KEY, null);
     conf.put(PropertyKey.S3A_SECRET_KEY, null);
-    try (Closeable c = new ConfigurationRule(conf, sConf).toResource()) {
-      UnderFileSystemConfiguration ufsConf = UnderFileSystemConfiguration.defaults(sConf);
+    try (Closeable c = new ConfigurationRule(conf, CONF).toResource()) {
+      UnderFileSystemConfiguration ufsConf = UnderFileSystemConfiguration.defaults(CONF);
       AWSCredentialsProvider credentialsProvider =
           S3AUnderFileSystem.createAwsCredentialsProvider(ufsConf);
       Assert.assertTrue(credentialsProvider instanceof DefaultAWSCredentialsProviderChain);
@@ -159,7 +159,7 @@ public class S3AUnderFileSystemTest {
   }
 
   @Test
-  public void getPermissionsCached() throws Exception {
+  public void getPermissionsCached() {
     Mockito.when(mClient.getS3AccountOwner()).thenReturn(new Owner("0", "test"));
     Mockito.when(mClient.getBucketAcl(Mockito.anyString())).thenReturn(new AccessControlList());
     mS3UnderFileSystem.getPermissions();
@@ -169,7 +169,7 @@ public class S3AUnderFileSystemTest {
   }
 
   @Test
-  public void getPermissionsDefault() throws Exception {
+  public void getPermissionsDefault() {
     Mockito.when(mClient.getS3AccountOwner()).thenThrow(AmazonClientException.class);
     ObjectUnderFileSystem.ObjectPermissions permissions = mS3UnderFileSystem.getPermissions();
     Assert.assertEquals(DEFAULT_OWNER, permissions.getGroup());
@@ -181,44 +181,42 @@ public class S3AUnderFileSystemTest {
   public void getPermissionsWithMapping() throws Exception {
     Map<PropertyKey, Object> conf = new HashMap<>();
     conf.put(PropertyKey.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING, "111=altname");
-    try (Closeable c = new ConfigurationRule(conf, sConf).toResource()) {
-      UnderFileSystemConfiguration ufsConf = UnderFileSystemConfiguration.defaults(sConf);
-      mS3UnderFileSystem =
+    try (Closeable c = new ConfigurationRule(conf, CONF).toResource()) {
+      S3AUnderFileSystem s3UnderFileSystem =
               new S3AUnderFileSystem(new AlluxioURI("s3a://" + BUCKET_NAME), mClient, BUCKET_NAME,
-                      mExecutor, mManager, UnderFileSystemConfiguration.defaults(sConf), false);
+                      mExecutor, mManager, UnderFileSystemConfiguration.defaults(CONF), false);
+
+      Mockito.when(mClient.getS3AccountOwner()).thenReturn(new Owner("111", "test"));
+      Mockito.when(mClient.getBucketAcl(Mockito.anyString())).thenReturn(new AccessControlList());
+      ObjectUnderFileSystem.ObjectPermissions permissions = s3UnderFileSystem.getPermissions();
+
+      Assert.assertEquals("altname", permissions.getOwner());
+      Assert.assertEquals("altname", permissions.getGroup());
+      Assert.assertEquals(0, permissions.getMode());
     }
-
-    Mockito.when(mClient.getS3AccountOwner()).thenReturn(new Owner("111", "test"));
-    Mockito.when(mClient.getBucketAcl(Mockito.anyString())).thenReturn(new AccessControlList());
-    ObjectUnderFileSystem.ObjectPermissions permissions = mS3UnderFileSystem.getPermissions();
-
-    Assert.assertEquals("altname", permissions.getOwner());
-    Assert.assertEquals("altname", permissions.getGroup());
-    Assert.assertEquals(0, permissions.getMode());
   }
 
   @Test
   public void getPermissionsNoMapping() throws Exception {
     Map<PropertyKey, Object> conf = new HashMap<>();
     conf.put(PropertyKey.UNDERFS_S3_OWNER_ID_TO_USERNAME_MAPPING, "111=userid");
-    try (Closeable c = new ConfigurationRule(conf, sConf).toResource()) {
-      UnderFileSystemConfiguration ufsConf = UnderFileSystemConfiguration.defaults(sConf);
-      mS3UnderFileSystem =
+    try (Closeable c = new ConfigurationRule(conf, CONF).toResource()) {
+      S3AUnderFileSystem s3UnderFileSystem =
               new S3AUnderFileSystem(new AlluxioURI("s3a://" + BUCKET_NAME), mClient, BUCKET_NAME,
-                      mExecutor, mManager, UnderFileSystemConfiguration.defaults(sConf), false);
+                      mExecutor, mManager, UnderFileSystemConfiguration.defaults(CONF), false);
+
+      Mockito.when(mClient.getS3AccountOwner()).thenReturn(new Owner("0", "test"));
+      Mockito.when(mClient.getBucketAcl(Mockito.anyString())).thenReturn(new AccessControlList());
+      ObjectUnderFileSystem.ObjectPermissions permissions = s3UnderFileSystem.getPermissions();
+
+      Assert.assertEquals("test", permissions.getOwner());
+      Assert.assertEquals("test", permissions.getGroup());
+      Assert.assertEquals(0, permissions.getMode());
     }
-
-    Mockito.when(mClient.getS3AccountOwner()).thenReturn(new Owner("0", "test"));
-    Mockito.when(mClient.getBucketAcl(Mockito.anyString())).thenReturn(new AccessControlList());
-    ObjectUnderFileSystem.ObjectPermissions permissions = mS3UnderFileSystem.getPermissions();
-
-    Assert.assertEquals("test", permissions.getOwner());
-    Assert.assertEquals("test", permissions.getGroup());
-    Assert.assertEquals(0, permissions.getMode());
   }
 
   @Test
-  public void getOperationMode() throws Exception {
+  public void getOperationMode() {
     Map<String, UfsMode> physicalUfsState = new Hashtable<>();
     // Check default
     Assert.assertEquals(UfsMode.READ_WRITE,
@@ -245,7 +243,7 @@ public class S3AUnderFileSystemTest {
   }
 
   @Test
-  public void stripPrefixIfPresent() throws Exception {
+  public void stripPrefixIfPresent() {
     Assert.assertEquals("", mS3UnderFileSystem.stripPrefixIfPresent("s3a://" + BUCKET_NAME));
     Assert.assertEquals("", mS3UnderFileSystem.stripPrefixIfPresent("s3a://" + BUCKET_NAME + "/"));
     Assert.assertEquals("test/",


### PR DESCRIPTION
### What changes are proposed in this pull request?

1) Implements AlluxioConfiguration instead of extends InstancedConfiguration
This will remove set capabilities of UnderFileSystemConfiguration, thus removing
the need of copying when constructing. When set is needed, a new InstancedConfiguration
is explicitly created with copyProperties.
2) Remove mShared / isShared / setShared. This is only used in unit test.
