### PR TITLE
Port changes of [#15699] to branch-2.6

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/JournalUtils.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalUtils.java
@@ -181,12 +181,8 @@ public final class JournalUtils {
     if (t != null) {
       message += "\n" + Throwables.getStackTraceAsString(t);
     }
-    if (ServerConfiguration.getBoolean(PropertyKey.TEST_MODE)) {
-      throw new RuntimeException(message);
-    }
     logger.error(message);
     if (!ServerConfiguration.getBoolean(PropertyKey.MASTER_JOURNAL_TOLERATE_CORRUPTION)) {
-      System.exit(-1);
       throw new RuntimeException(t);
     }
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.journal.ufs;
 
-import alluxio.ProcessUtils;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.master.Master;
@@ -31,7 +30,6 @@ import java.io.IOException;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Supplier;
-
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -86,12 +84,14 @@ public final class UfsJournalCheckpointThread extends Thread {
 
   /** The last sequence number applied to the journal. */
   private volatile long mLastAppliedSN;
+  // this throwable gets set if the thread completes exceptionally
+  private Throwable mThrowable = null;
 
   /**
    * The state of the journal catchup.
    */
   public enum CatchupState {
-    NOT_STARTED, IN_PROGRESS, DONE;
+    NOT_STARTED, IN_PROGRESS, DONE
   }
 
   private volatile CatchupState mCatchupState = CatchupState.NOT_STARTED;
@@ -127,12 +127,20 @@ public final class UfsJournalCheckpointThread extends Thread {
     mCheckpointPeriodEntries =
         ServerConfiguration.getLong(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES);
     mJournalSinks = journalSinks;
+    setUncaughtExceptionHandler((thread, t) -> {
+      mThrowable = t;
+      // if the catchup thread terminates exceptionally, it has caught up as much as it can and
+      // is done
+      mCatchupState = CatchupState.DONE;
+    });
   }
 
   /**
    * Initiates the shutdown of this checkpointer thread, and also waits for it to finish.
    *
    * @param waitQuietPeriod whether to wait for a quiet period to pass before terminating the thread
+   * @throws RuntimeException if {@link #join()} throws an InterruptedException or if
+   * {@link #run()} completed exceptionally
    */
   public void awaitTermination(boolean waitQuietPeriod) {
     LOG.info("{}: Journal checkpointer shutdown has been initiated.", mMaster.getName());
@@ -148,7 +156,10 @@ public final class UfsJournalCheckpointThread extends Thread {
     try {
       // Wait for the thread to finish.
       join();
-      LOG.info("{}: Journal shutdown complete", mMaster.getName());
+      if (mThrowable != null) {
+        throw new RuntimeException(mThrowable);
+      }
+      LOG.info("{}: Journal checkpointer shutdown complete", mMaster.getName());
     } catch (InterruptedException e) {
       LOG.error("{}: journal checkpointer shutdown is interrupted.", mMaster.getName(), e);
       // Kills the master. This can happen in the following two scenarios:
@@ -188,11 +199,6 @@ public final class UfsJournalCheckpointThread extends Thread {
     try {
       t.start();
       runInternal();
-    } catch (Throwable e) {
-      t.interrupt();
-      ProcessUtils.fatalError(LOG, e, "%s: Failed to run journal checkpoint thread, crashing.",
-          mMaster.getName());
-      System.exit(-1);
     } finally {
       t.interrupt();
       try {
@@ -225,13 +231,14 @@ public final class UfsJournalCheckpointThread extends Thread {
           case LOG:
             entry = mJournalReader.getEntry();
             try {
-              if (!mMaster.processJournalEntry(entry)) {
-                JournalUtils
-                    .handleJournalReplayFailure(LOG, null, "%s: Unrecognized journal entry: %s",
-                        mMaster.getName(), entry);
-              } else {
+              if (mMaster.processJournalEntry(entry)) {
                 JournalUtils.sinkAppend(mJournalSinks, entry);
+              } else {
+                JournalUtils.handleJournalReplayFailure(LOG, null,
+                    "%s: Unrecognized journal entry: %s", mMaster.getName(), entry);
               }
+            } catch (RuntimeException e) {
+              throw e;
             } catch (Throwable t) {
               JournalUtils.handleJournalReplayFailure(LOG, t,
                   "%s: Failed to read or process journal entry %s.", mMaster.getName(), entry);

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
@@ -41,7 +41,6 @@ import java.net.URI;
 import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
-
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -54,7 +53,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * writer is closed.
  */
 @ThreadSafe
-final class UfsJournalLogWriter implements JournalWriter {
+public final class UfsJournalLogWriter implements JournalWriter {
   private static final Logger LOG = LoggerFactory.getLogger(UfsJournalLogWriter.class);
 
   private final UfsJournal mJournal;
@@ -74,7 +73,7 @@ final class UfsJournalLogWriter implements JournalWriter {
    */
   private JournalOutputStream mJournalOutputStream;
   /** The garbage collector. */
-  private UfsJournalGarbageCollector mGarbageCollector;
+  private final UfsJournalGarbageCollector mGarbageCollector;
   /** Whether the journal log writer is closed. */
   private boolean mClosed;
 
@@ -89,7 +88,7 @@ final class UfsJournalLogWriter implements JournalWriter {
    * before flush, {@code UfsJournalLogWriter} is able to retry writing the
    * journal entries.
    */
-  private Queue<JournalEntry> mEntriesToFlush;
+  private final Queue<JournalEntry> mEntriesToFlush;
 
   /**
    * Creates a new instance of {@link UfsJournalLogWriter}.
@@ -97,7 +96,7 @@ final class UfsJournalLogWriter implements JournalWriter {
    * @param journal the handle to the journal
    * @param nextSequenceNumber the sequence number to begin writing at
    */
-  UfsJournalLogWriter(UfsJournal journal, long nextSequenceNumber) throws IOException {
+  public UfsJournalLogWriter(UfsJournal journal, long nextSequenceNumber) throws IOException {
     mJournal = Preconditions.checkNotNull(journal, "journal");
     mUfs = mJournal.getUfs();
     mNextSequenceNumber = nextSequenceNumber;
@@ -112,6 +111,7 @@ final class UfsJournalLogWriter implements JournalWriter {
     mEntriesToFlush = new ArrayDeque<>();
   }
 
+  @Override
   public synchronized void write(JournalEntry entry) throws IOException, JournalClosedException {
     checkIsWritable();
     try {
@@ -229,7 +229,7 @@ final class UfsJournalLogWriter implements JournalWriter {
     UfsJournalFile currentLog = snapshot.getCurrentLog(mJournal);
     if (currentLog != null) {
       LOG.info("Recovering from previous UFS journal write failure."
-          + " Scanning for the last persisted journal entry. currentLog: " + currentLog.toString());
+          + " Scanning for the last persisted journal entry. currentLog: " + currentLog);
       try (JournalEntryStreamReader reader =
           new JournalEntryStreamReader(mUfs.open(currentLog.getLocation().toString(),
               OpenOptions.defaults().setRecoverFailedOpen(true)))) {
@@ -239,8 +239,6 @@ final class UfsJournalLogWriter implements JournalWriter {
             lastPersistSeq = entry.getSequenceNumber();
           }
         }
-      } catch (IOException e) {
-        throw e;
       }
       if (lastPersistSeq != -1) { // If the current log is an empty file, do not complete with SN: 0
         completeLog(currentLog, lastPersistSeq + 1);
@@ -358,6 +356,7 @@ final class UfsJournalLogWriter implements JournalWriter {
     }
   }
 
+  @Override
   public synchronized void flush() throws IOException, JournalClosedException {
     checkIsWritable();
     maybeRecoverFromUfsFailures();
@@ -420,7 +419,7 @@ final class UfsJournalLogWriter implements JournalWriter {
     private final DataOutputStream mOutputStream;
     private final UfsJournalFile mCurrentLog;
 
-    JournalOutputStream(UfsJournalFile currentLog, OutputStream stream) throws IOException {
+    JournalOutputStream(UfsJournalFile currentLog, OutputStream stream) {
       mOutputStream = wrapDataOutputStream(stream);
       mCurrentLog = currentLog;
     }


### PR DESCRIPTION
### What changes are proposed in this pull request?
The `UfsJournalCheckpointThread` calls `System.exit(-1)` when encountering journal corruption. This causes a deadlock between the `UfsJournalCheckpointThread` and the shutdown hook calling `AlluxioMasterProcess.stop()`.
This PR removes the `System.exit()` calls in favor of propagating exceptions when the thread completes. 
The net effect is that the master process completely releases its resources when shutting down and terminates without having to be issued `kill -9`.

### Why are the changes needed?
For clean master process termination on errors.

### Does this PR introduce any user facing changes?
No.

[This is an manually generated PR to cherry-pick committed PR Alluxio/alluxio#15699 into target branch branch-2.7]