### PR TITLE
Optimize the access speed of the inAlluxioData UI page

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2980,9 +2980,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
-  public static final PropertyKey MASTER_IN_ALLUXIO_DATA_PAGE_COUNT =
-      Builder.intBuilder(Name.MASTER_IN_ALLUXIO_DATA_PAGE_COUNT)
-          .setDescription("The count of uri showing in the inAlluxioData ui page.")
+  public static final PropertyKey MASTER_WEB_IN_ALLUXIO_DATA_PAGE_COUNT =
+      Builder.intBuilder(Name.MASTER_WEB_IN_ALLUXIO_DATA_PAGE_COUNT)
+          .setDescription("The number of URIs showing in the In-Alluxio Data Web UI page.")
           .setDefaultValue(1000)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
@@ -6928,8 +6928,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_WEB_PORT = "alluxio.master.web.port";
     public static final String MASTER_WEB_JOURNAL_CHECKPOINT_WARNING_THRESHOLD_TIME =
         "alluxio.master.journal.checkpoint.warning.threshold.time";
-    public static final String MASTER_IN_ALLUXIO_DATA_PAGE_COUNT =
-        "alluxio.master.in.alluxio.data.page.count";
+    public static final String MASTER_WEB_IN_ALLUXIO_DATA_PAGE_COUNT =
+        "alluxio.master.web.in.alluxio.data.page.count";
     public static final String MASTER_WHITELIST = "alluxio.master.whitelist";
     public static final String MASTER_WORKER_CONNECT_WAIT_TIME =
         "alluxio.master.worker.connect.wait.time";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2980,6 +2980,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_IN_ALLUXIO_DATA_PAGE_COUNT =
+      Builder.intBuilder(Name.MASTER_IN_ALLUXIO_DATA_PAGE_COUNT)
+          .setDescription("The count of uri showing in the inAlluxioData ui page.")
+          .setDefaultValue(1000)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_WHITELIST =
       listBuilder(Name.MASTER_WHITELIST)
           .setDefaultValue("/")
@@ -6921,6 +6928,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_WEB_PORT = "alluxio.master.web.port";
     public static final String MASTER_WEB_JOURNAL_CHECKPOINT_WARNING_THRESHOLD_TIME =
         "alluxio.master.journal.checkpoint.warning.threshold.time";
+    public static final String MASTER_IN_ALLUXIO_DATA_PAGE_COUNT =
+        "alluxio.master.in.alluxio.data.page.count";
     public static final String MASTER_WHITELIST = "alluxio.master.whitelist";
     public static final String MASTER_WORKER_CONNECT_WAIT_TIME =
         "alluxio.master.worker.connect.wait.time";

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2227,7 +2227,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       // Root should always exist.
       throw new RuntimeException(e);
     }
-    int fileCount = Configuration.getInt(PropertyKey.MASTER_IN_ALLUXIO_DATA_PAGE_COUNT);
+    int fileCount = Configuration.getInt(PropertyKey.MASTER_WEB_IN_ALLUXIO_DATA_PAGE_COUNT);
 
     try (LockedInodePath inodePath = rootPath) {
       getInAlluxioFilesInternal(inodePath, files, fileCount);

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2227,10 +2227,10 @@ public class DefaultFileSystemMaster extends CoreMaster
       // Root should always exist.
       throw new RuntimeException(e);
     }
-    int fileCount = Configuration.getInt(PropertyKey.MASTER_WEB_IN_ALLUXIO_DATA_PAGE_COUNT);
 
     try (LockedInodePath inodePath = rootPath) {
-      getInAlluxioFilesInternal(inodePath, files, fileCount);
+      getInAlluxioFilesInternal(inodePath, files,
+          Configuration.getInt(PropertyKey.MASTER_WEB_IN_ALLUXIO_DATA_PAGE_COUNT));
     }
     return files;
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

To optimize the access speed of the inAlluxioData UI page

### Why are the changes needed?

When there are many files in alluxio, if we open the inAlluxio web ui of the Alluxio master, it will take a long time and cause the Alluxio master to freeze. We may specify a certain number of file information to be displayed on the inAlluxio web through configuration items to avoid the above situation.

### Does this PR introduce any user facing changes?
No