### PR TITLE
Fix leaking threads in backup

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/BackupManager.java
+++ b/core/server/common/src/main/java/alluxio/master/BackupManager.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -106,8 +107,9 @@ public class BackupManager {
     GzipCompressorOutputStream zipStream = new GzipCompressorOutputStream(os);
 
     // Executor for taking backup.
-    CompletionService<Boolean> completionService = new ExecutorCompletionService<>(
-        Executors.newFixedThreadPool(4, ThreadFactoryUtils.build("master-backup-%d", true)));
+    ExecutorService es = Executors.newFixedThreadPool(
+        2, ThreadFactoryUtils.build("master-backup-%d", true));
+    CompletionService<Boolean> completionService = new ExecutorCompletionService<>(es);
 
     // List of active tasks.
     Set<Future<?>> activeTasks = new HashSet<>();
@@ -196,6 +198,7 @@ public class BackupManager {
 
     // finish() instead of close() since close would close os, which is owned by the caller.
     zipStream.finish();
+    es.shutdown();
     LOG.info("Created backup with {} entries", entryCount.get());
   }
 
@@ -210,8 +213,9 @@ public class BackupManager {
       List<Master> masters = mRegistry.getServers();
 
       // Executor for applying backup.
-      CompletionService<Boolean> completionService = new ExecutorCompletionService<>(
-          Executors.newFixedThreadPool(2, ThreadFactoryUtils.build("master-backup-%d", true)));
+      ExecutorService es = Executors.newFixedThreadPool(
+          2, ThreadFactoryUtils.build("master-backup-%d", true));
+      CompletionService<Boolean> completionService = new ExecutorCompletionService<>(es);
 
       // List of active tasks.
       Set<Future<?>> activeTasks = new HashSet<>();
@@ -332,6 +336,7 @@ public class BackupManager {
         mRestoreTimeMs = System.currentTimeMillis() - startRestoreTime;
         mRestoreEntriesCount = appliedEntryCount.get();
         traceExecutor.shutdownNow();
+        es.shutdown();
       }
 
       LOG.info("Restored {} entries from backup", appliedEntryCount.get());

--- a/core/server/common/src/main/java/alluxio/master/BackupManager.java
+++ b/core/server/common/src/main/java/alluxio/master/BackupManager.java
@@ -108,7 +108,7 @@ public class BackupManager {
 
     // Executor for taking backup.
     ExecutorService es = Executors.newFixedThreadPool(
-        2, ThreadFactoryUtils.build("master-backup-%d", true));
+        4, ThreadFactoryUtils.build("master-backup-%d", true));
     CompletionService<Boolean> completionService = new ExecutorCompletionService<>(es);
 
     // List of active tasks.


### PR DESCRIPTION
### What changes are proposed in this pull request?

This closes the thread pools used during backup and restore from backup.

### Why are the changes needed?

Since the thread pools were not being closed, the threads were being leaked and not garbage collected.

### Does this PR introduce any user facing changes?

No
