### PR TITLE
[DOCFIX] Remove usage of InstanceConfiguration.defaults() in FS-API.md

### DIFF
--- a/docs/en/api/FS-API.md
+++ b/docs/en/api/FS-API.md
@@ -156,7 +156,7 @@ FileOutStream normalOut = normalFs.createFile(normalPath);
 normalOut.close();
 
 // Create a file system with custom configuration
-InstancedConfiguration conf = InstancedConfiguration.defaults();
+InstancedConfiguration conf = Configuration.copyGlobal();
 conf.set(PropertyKey.SECURITY_LOGIN_USERNAME, "alice");
 FileSystem customizedFs = FileSystem.Factory.create(conf);
 AlluxioURI customizedPath = new AlluxioURI("/customizedFile");


### PR DESCRIPTION
Minor docfix to help deprecate `InstancedConfiguration.defaults()`, which was removed in https://github.com/Alluxio/alluxio/pull/15712