### PR TITLE
Fix the bug of 2GB File Size Limitation with S3 Rest API

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -741,13 +741,13 @@ public final class S3RestServiceHandler {
           // determine if it's encoded, and then which parts of the stream to read depending on
           // the encoding type.
           boolean isChunkedEncoding = decodedLength != null;
-          int toRead;
+          long toRead;
           InputStream readStream = is;
           if (isChunkedEncoding) {
-            toRead = Integer.parseInt(decodedLength);
+            toRead = Long.parseLong(decodedLength);
             readStream = new ChunkedEncodingInputStream(is);
           } else {
-            toRead = Integer.parseInt(contentLength);
+            toRead = Long.parseLong(contentLength);
           }
           FileOutStream os = fs.createFile(objectURI, filePOptions);
           try (DigestOutputStream digestOutputStream = new DigestOutputStream(os, md5)) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR changes the variable 'toRead' from Integer to Long.

### Why are the changes needed?

```
When we increase the size of a put to 2GB, we the get the following error that I see on the proxy side:
2022-05-17 20:55:00,782 WARN S3RestUtils - Unexpected error invoking REST endpoint: For input string: “2147483648”

/Users/t_bisson/Documents/scripts$aws --profile test-aiml-dp-dsc-admin --endpoint http://wiccan-lab.g.apple.com:39999/api/v1/s3/ s3api put-object --bucket=testbucket --key=2gfile_wiccan.txt --body=~/Documents/scripts/2g.img

An error occurred (InternalError) when calling the PutObject operation (reached max retries: 4): For input string: "2147483648"
```
our S3 REST API parses the Content-Length header as a signed Java Integer so it caps at ~2 GB.
If the file is larger than 2GB, some errors will occure.

