### PR TITLE
Bump junit version again to fix the security vulerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <jaxb.version>2.3.3</jaxb.version>
     <jersey.version>2.34</jersey.version>
     <jetty.version>9.4.46.v20220331</jetty.version>
-    <junit.version>4.13</junit.version>
+    <junit.version>4.13.1</junit.version>
     <log4j.version>2.17.1</log4j.version>
     <maven.version>3.3.9</maven.version>
     <metrics.version>4.1.11</metrics.version>


### PR DESCRIPTION
### What changes are proposed in this pull request?

fix https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250
see [GHSA-269g-pwp5-87pp](https://github.com/junit-team/junit4/security/advisories/GHSA-269g-pwp5-87pp)

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
The JUnit4 test rule [TemporaryFolder](https://junit.org/junit4/javadoc/4.13/org/junit/rules/TemporaryFolder.html) contains a local information disclosure vulnerability.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
no
