### PR TITLE
Add configuration for kerberos authentication for Ufs HDFS

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6365,6 +6365,27 @@ public final class PropertyKey implements Comparable<PropertyKey> {
                   + "load option.")
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey HADOOP_SECURITY_AUTHENTICATION =
+          stringBuilder(Name.HADOOP_SECURITY_AUTHENTICATION)
+                  .setDescription("HDFS authentication method.")
+                  .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+                  .setScope(Scope.SERVER)
+                  .build();
+
+  public static final PropertyKey HADOOP_KRB5_CONF_FILE =
+          stringBuilder(Name.HADOOP_KRB5_CONF_KEY_FILE)
+                  .setDescription("Kerberos krb file for configuration of Kerberos.")
+                  .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+                  .setScope(Scope.SERVER)
+                  .setValueValidationFunction(CHECK_FILE_EXISTS)
+                  .build();
+
+  public static final PropertyKey HADOOP_KERBEROS_KEYTAB_LOGIN_AUTORENEWAL =
+          booleanBuilder(Name.HADOOP_KERBEROS_KEYTAB_LOGIN_AUTORENEWAL)
+                  .setDescription("Kerberos authentication keytab login auto renew.")
+                  .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+                  .setScope(Scope.SERVER)
+                  .build();
   /**
    * @deprecated This key is used for testing. It is always deprecated.
    */
@@ -7614,6 +7635,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.table.udb.hive.clientpool.MAX";
     public static final String TABLE_LOAD_DEFAULT_REPLICATION =
         "alluxio.table.load.default.replication";
+
+    public static final String HADOOP_SECURITY_AUTHENTICATION =
+            "alluxio.hadoop.security.authentication";
+
+    public static final String HADOOP_KRB5_CONF_KEY_FILE =
+            "alluxio.java.security.krb5.conf";
+
+    public static final String HADOOP_KERBEROS_KEYTAB_LOGIN_AUTORENEWAL =
+            "alluxio.hadoop.kerberos.keytab.login.autorenewal";
 
     private Name() {} // prevent instantiation
   }

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -7637,13 +7637,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.table.load.default.replication";
 
     public static final String HADOOP_SECURITY_AUTHENTICATION =
-            "alluxio.hadoop.security.authentication";
+        "alluxio.hadoop.security.authentication";
 
     public static final String HADOOP_KRB5_CONF_KEY_FILE =
-            "alluxio.java.security.krb5.conf";
+        "alluxio.hadoop.security.krb5.conf";
 
     public static final String HADOOP_KERBEROS_KEYTAB_LOGIN_AUTORENEWAL =
-            "alluxio.hadoop.kerberos.keytab.login.autorenewal";
+        "alluxio.hadoop.kerberos.keytab.login.autorenewal";
 
     private Name() {} // prevent instantiation
   }

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -100,6 +100,15 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
   private static final String JAVAX_WS_RS_CORE_MEDIA_TYPE =
       "javax.ws.rs.core.MediaType";
 
+  private static final String HADOOP_AUTH_METHOD =
+          "hadoop.security.authentication";
+
+  private static final String KRB5_CONF_FILE =
+          "java.security.krb5.conf";
+
+  private static final String KRB_KEYTAB_LOGIN_AUTO_RENEW =
+          "hadoop.kerberos.keytab.login.autorenewal.enabled";
+
   private final LoadingCache<String, FileSystem> mUserFs;
   private final HdfsAclProvider mHdfsAclProvider;
 
@@ -157,6 +166,18 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
     ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader(hdfsConf.getClassLoader());
+      if (mUfsConf.isSet(PropertyKey.HADOOP_SECURITY_AUTHENTICATION)) {
+        hdfsConf.set(HADOOP_AUTH_METHOD,
+                mUfsConf.getString(PropertyKey.HADOOP_SECURITY_AUTHENTICATION));
+      }
+      if (mUfsConf.isSet(PropertyKey.HADOOP_KRB5_CONF_FILE)) {
+        System.setProperty(KRB5_CONF_FILE,
+                mUfsConf.getString(PropertyKey.HADOOP_KRB5_CONF_FILE));
+      }
+      if (mUfsConf.isSet(PropertyKey.HADOOP_KERBEROS_KEYTAB_LOGIN_AUTORENEWAL)) {
+        hdfsConf.setBoolean(KRB_KEYTAB_LOGIN_AUTO_RENEW,
+                mUfsConf.getBoolean(PropertyKey.HADOOP_KERBEROS_KEYTAB_LOGIN_AUTORENEWAL));
+      }
       // Set Hadoop UGI configuration to ensure UGI can be initialized by the shaded classes for
       // group service.
       UserGroupInformation.setConfiguration(hdfsConf);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add configuration for Kerberos: 1) Allow user to specify Kerberos authentication Ufs HDFS. 2) Allow user to specify the location of krb5.conf file ; 3) allow user to enable autorenewal auth with keytab 

### Why are the changes needed?

Tested out with Kerberos auth for Ufs HDFS. It failed without the change. 

### Does this PR introduce any user facing changes?

no
