### PR TITLE
Port changes of [#15698] to branch-2.6

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -43,7 +43,6 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -2187,6 +2186,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "This property should be used sparingly.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setIsHidden(true)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED =
+      new Builder(Name.MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED)
+          .setDefaultValue(true)
+          .setDescription("Takes a backup automatically when encountering journal corruption")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_JOURNAL_TYPE =
@@ -5618,6 +5624,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         = "alluxio.master.journal.space.monitor.percent.free.threshold";
     public static final String MASTER_JOURNAL_TOLERATE_CORRUPTION
         = "alluxio.master.journal.tolerate.corruption";
+    public static final String MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED
+        = "alluxio.master.journal.backup.when.corrupted";
     public static final String MASTER_JOURNAL_TYPE = "alluxio.master.journal.type";
     public static final String MASTER_JOURNAL_LOG_SIZE_BYTES_MAX =
         "alluxio.master.journal.log.size.bytes.max";

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalReader.java
@@ -102,7 +102,7 @@ public final class UfsJournalReader implements JournalReader {
    * @param journal the handle to the journal
    * @param readIncompleteLog whether to read incomplete logs
    */
-  UfsJournalReader(UfsJournal journal, boolean readIncompleteLog) {
+  public UfsJournalReader(UfsJournal journal, boolean readIncompleteLog) {
     this(journal, 0, readIncompleteLog);
   }
 

--- a/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
+++ b/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
@@ -120,6 +120,7 @@ public final class AlluxioMasterProcessTest {
   @Test
   public void failToGainPrimacyWhenJournalCorrupted() throws Exception {
     ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED, false);
     URI journalLocation = JournalUtils.getJournalLocation();
     JournalSystem journalSystem = new JournalSystem.Builder()
         .setLocation(journalLocation).build(CommonUtils.ProcessType.MASTER);
@@ -130,6 +131,7 @@ public final class AlluxioMasterProcessTest {
   @Test
   public void failToGainPrimacyWhenJournalCorruptedHA() throws Exception {
     ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED, false);
     URI journalLocation = JournalUtils.getJournalLocation();
     JournalSystem journalSystem = new JournalSystem.Builder()
         .setLocation(journalLocation).build(CommonUtils.ProcessType.MASTER);

--- a/docs/en/operation/Journal.md
+++ b/docs/en/operation/Journal.md
@@ -382,6 +382,11 @@ we recommend [taking regular journal backups](#automatically-backing-up-the-jour
 at a time when the cluster is under low load.
 Then if something happens to the journal, you can recover from one of the backups.
 
+By default, if a master encounters corruption when replaying a journal it will automatically
+take a backup of the state up to the corrupted entry in the configured backup directory. The master will notice the
+corruption when elected leader. The backup directory is configured by `alluxio.master.backup.directory`.
+This feature can be disabled by setting `alluxio.master.journal.backup.when.corrupted` to `false`.
+
 ### Get a human-readable journal
 
 Alluxio journal is serialized and not human-readable. The following command

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -66,6 +66,10 @@ public class PortCoordination {
   public static final List<ReservedPort> BACKUP_DELEGATION_EMBEDDED = allocate(2, 1);
   public static final List<ReservedPort> BACKUP_RESTORE_METASSTORE_HEAP = allocate(1, 1);
   public static final List<ReservedPort> BACKUP_RESTORE_METASSTORE_ROCKS = allocate(1, 1);
+  public static final List<ReservedPort> BACKUP_EMERGENCY_1 = allocate(1, 0);
+  public static final List<ReservedPort> BACKUP_EMERGENCY_2 = allocate(1, 0);
+  public static final List<ReservedPort> BACKUP_EMERGENCY_HA_1 = allocate(3, 0);
+  public static final List<ReservedPort> BACKUP_EMERGENCY_HA_2 = allocate(3, 0);
 
   public static final List<ReservedPort> ZOOKEEPER_FAILURE = allocate(2, 1);
   public static final List<ReservedPort> ZOOKEEPER_CONNECTION_POLICY_STANDARD = allocate(2, 0);

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
@@ -23,12 +23,12 @@ import alluxio.ConfigurationRule;
 import alluxio.Constants;
 import alluxio.client.block.BlockMasterClient;
 import alluxio.client.block.RetryHandlingBlockMasterClient;
+import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemTestUtils;
 import alluxio.client.file.URIStatus;
-import alluxio.conf.PropertyKey;
 import alluxio.client.meta.MetaMasterClient;
 import alluxio.client.meta.RetryHandlingMetaMasterClient;
-import alluxio.client.file.FileSystem;
+import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.BackupAbortedException;
 import alluxio.exception.status.FailedPreconditionException;
@@ -42,27 +42,42 @@ import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.LoadMetadataPType;
 import alluxio.grpc.WritePType;
 import alluxio.master.MasterClientContext;
+import alluxio.master.NoopMaster;
+import alluxio.master.journal.JournalReader;
 import alluxio.master.journal.JournalType;
+import alluxio.master.journal.ufs.UfsJournal;
+import alluxio.master.journal.ufs.UfsJournalLogWriter;
+import alluxio.master.journal.ufs.UfsJournalReader;
+import alluxio.master.metastore.MetastoreType;
 import alluxio.multi.process.MultiProcessCluster;
 import alluxio.multi.process.PortCoordination;
+import alluxio.proto.journal.Journal;
 import alluxio.testutils.AlluxioOperationThread;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.util.CommonUtils;
+import alluxio.util.URIUtils;
 import alluxio.util.WaitForOptions;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
  * Integration test for backing up and restoring alluxio master.
@@ -126,6 +141,103 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
         .addProperty(PropertyKey.MASTER_METASTORE, "ROCKS")
         .build();
     backupRestoreMetaStoreTest();
+  }
+
+  @Test
+  public void emergencyBackup() throws Exception {
+    emergencyBackupCore(1);
+  }
+
+  @Test
+  public void emergencyBackupHA() throws Exception {
+    emergencyBackupCore(3);
+  }
+
+  private void emergencyBackupCore(int numMasters) throws Exception {
+    TemporaryFolder backupFolder = new TemporaryFolder();
+    backupFolder.create();
+    List<PortCoordination.ReservedPort> ports1 = numMasters > 1
+        ? PortCoordination.BACKUP_EMERGENCY_HA_1 : PortCoordination.BACKUP_EMERGENCY_1;
+    String clusterName1 = numMasters > 1 ? "emergencyBackup_HA_1" : "emergencyBackup_1";
+    mCluster = MultiProcessCluster.newBuilder(ports1)
+        .setClusterName(clusterName1)
+        .setNumMasters(numMasters)
+        .setNumWorkers(0)
+        // Masters become primary faster, will be ignored in non HA case
+        .addProperty(PropertyKey.ZOOKEEPER_SESSION_TIMEOUT, "1sec")
+        .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS.toString())
+        .addProperty(PropertyKey.MASTER_METASTORE, MetastoreType.ROCKS.toString())
+        .addProperty(PropertyKey.MASTER_BACKUP_DIRECTORY, backupFolder.getRoot().toString())
+        .addProperty(PropertyKey.MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED, "true")
+        .build();
+    mCluster.start();
+    final int numFiles = 10;
+    // create normal uncorrupted journal
+    for (int i = 0; i < numFiles; i++) {
+      mCluster.getFileSystemClient().createFile(new AlluxioURI("/normal-file-" + i));
+    }
+    mCluster.stopMasters();
+    // corrupt journal
+    URI journalLocation = new URI(mCluster.getJournalDir());
+    UfsJournal fsMaster =
+        new UfsJournal(URIUtils.appendPathOrDie(journalLocation, "FileSystemMaster"),
+            new NoopMaster(), 0, Collections::emptySet);
+    fsMaster.start();
+    fsMaster.gainPrimacy();
+    long nextSN = 0;
+    try (UfsJournalReader reader = new UfsJournalReader(fsMaster, true)) {
+      while (reader.advance() != JournalReader.State.DONE) {
+        nextSN++;
+      }
+    }
+    try (UfsJournalLogWriter writer = new UfsJournalLogWriter(fsMaster, nextSN)) {
+      Journal.JournalEntry entry = Journal.JournalEntry.newBuilder()
+          .setSequenceNumber(nextSN)
+          .setDeleteFile(alluxio.proto.journal.File.DeleteFileEntry.newBuilder()
+              .setId(4563728) // random non-zero ID number (zero would delete the root)
+              .setPath("/nonexistant")
+              .build())
+          .build();
+      writer.write(entry);
+      writer.flush();
+    }
+    // this should fail and create backup(s)
+    mCluster.startMasters();
+    // wait for backup file(s) to be created
+    // successful backups leave behind one .gz file and one .gz.complete file
+    CommonUtils.waitFor("backup file(s) to be created automatically",
+        () -> 2 * numMasters == Objects.requireNonNull(backupFolder.getRoot().list()).length,
+        WaitForOptions.defaults().setInterval(500).setTimeoutMs(30_000));
+    List<String> backupFiles = Arrays.stream(Objects.requireNonNull(backupFolder.getRoot().list()))
+            .filter(s -> s.endsWith(".gz")).collect(Collectors.toList());
+    assertEquals(numMasters, backupFiles.size());
+    // create new cluster
+    List<PortCoordination.ReservedPort> ports2 = numMasters > 1
+        ? PortCoordination.BACKUP_EMERGENCY_HA_2 : PortCoordination.BACKUP_EMERGENCY_2;
+    String clusterName2 = numMasters > 1 ? "emergencyBackup_HA_2" : "emergencyBackup_2";
+    // verify that every backup contains all the entries
+    for (String backupFile : backupFiles) {
+      mCluster = MultiProcessCluster.newBuilder(ports2)
+          .setClusterName(String.format("%s_%s", clusterName2, backupFile))
+          .setNumMasters(numMasters)
+          .setNumWorkers(0)
+          .addProperty(PropertyKey.ZOOKEEPER_SESSION_TIMEOUT, "1sec")
+          .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS.toString())
+          // change metastore type to ensure backup is independent of metastore type
+          .addProperty(PropertyKey.MASTER_METASTORE, MetastoreType.HEAP.toString())
+          .addProperty(PropertyKey.MASTER_JOURNAL_INIT_FROM_BACKUP,
+              Paths.get(backupFolder.getRoot().toString(), backupFile).toString())
+          .build();
+      mCluster.start();
+      // test that the files were restored from the backup properly
+      for (int i = 0; i < numFiles; i++) {
+        boolean exists = mCluster.getFileSystemClient().exists(new AlluxioURI("/normal-file-" + i));
+        assertTrue(exists);
+      }
+      mCluster.stopMasters();
+      mCluster.notifySuccess();
+    }
+    backupFolder.delete();
   }
 
   // This test needs to stop and start master many times, so it can take up to a minute to complete.


### PR DESCRIPTION
### What changes are proposed in this pull request?
This PR adds the option of triggering a backup automatically when an Alluxio master shuts down.

### Why are the changes needed?
This helps trigger backups automatically when the master encounters unexpected journal corruption. 

### Does this PR introduce any user facing changes?
It adds a new `PropertyKey` to disable the feature (it is enabled by default).

[This is an manually generated PR to cherry-pick committed PR Alluxio/alluxio#15698 into target branch branch-2.6]