### PR TITLE
Set direct_io as the default fuse mount option for JNIFuse

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5762,6 +5762,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey FUSE_MOUNT_OPTIONS =
       listBuilder(Name.FUSE_MOUNT_OPTIONS)
           .setAlias(Name.WORKER_FUSE_MOUNT_OPTIONS)
+          .setDefaultValue("direct_io")
           .setDescription("The platform specific Fuse mount options "
               + "to mount the given Fuse mount point. "
               + "If multiple mount options are provided, separate them with comma.")

--- a/docs/en/api/POSIX-API.md
+++ b/docs/en/api/POSIX-API.md
@@ -199,13 +199,13 @@ alluxio.fuse.mount.options=<list of mount options separated by comma>
 ```
 
 For example, one can mount Alluxio path `/people` to local path `/mnt/people`
-with `kernel_cache,entry_timeout=7200,attr_timeout=7200` mount options when starting the Alluxio worker process:
+with `direct_io,entry_timeout=7200,attr_timeout=7200` mount options when starting the Alluxio worker process:
 
 ```config
 alluxio.worker.fuse.enabled=true
 alluxio.fuse.mount.alluxio.path=/people
 alluxio.fuse.mount.point=/mnt/people
-alluxio.fuse.mount.options=kernel_cache,entry_timeout=7200,attr_timeout=7200
+alluxio.fuse.mount.options=direct_io,entry_timeout=7200,attr_timeout=7200
 ```
 
 Fuse on worker also uses `alluxio.fuse.jnifuse.libfuse.version` configuration to determine which libfuse version to use. 
@@ -266,21 +266,21 @@ $ ${ALLUXIO_HOME}/integration/fuse/bin/alluxio-fuse mount \
     </tr>
     <tr>
         <td>direct_io</td>
-        <td>set by default in JNR-Fuse</td>
-        <td>don't set in JNI-Fuse</td>
-        <td>When `direct_io` is enabled, kernel will not cache data and read-ahead. `direct_io` is enabled by default in JNR-Fuse but is recommended not to be set in JNI-Fuse cause it may have stability issue under high I/O load.</td>
+        <td>set by default in JNR-Fuse and JNI-FUSE</td>
+        <td>set when deploying AlluxioFuse in Kubernetes environment</td>
+        <td>When `direct_io` is enabled, kernel will not cache data and read-ahead. `direct_io` is enabled by default in AlluxioFuse. It eliminates the use of system buffer cache and improves pod stability in kubernetes environment</td>
     </tr>
     <tr>
         <td>kernel_cache</td>
         <td></td>
-        <td>Unable to set in JNR-Fuse, recommend to set in JNI-Fuse based on workloads</td>
-        <td>`kernel_cache` utilizes kernel system caching and improves read performance. This should only be enabled on filesystems, where the file data is never changed externally (not through the mounted FUSE filesystem).</td>
+        <td>Unable to set in JNR-Fuse</td>
+        <td>`kernel_cache` utilizes kernel system caching and improves read performance. This should only be enabled on filesystems, where the file data is never changed externally (not through the mounted FUSE filesystem). It should not be enabled when launching AlluxioFuse in kubernetes. See https://github.com/Alluxio/alluxio/issues/14485 for more details. </td>
     </tr>
     <tr>
         <td>auto_cache</td>
         <td></td>
         <td>This option is an alternative to `kernel_cache`. Unable to set in JNR-Fuse.</td>
-        <td>`auto_cache` utilizes kernel system caching and improves read performance. Instead of unconditionally keeping cached data, the cached data is invalidated if the modification time or the size of the file has changed since it was last opened. See [libfuse documentation](https://libfuse.github.io/doxygen/structfuse__config.html#a9db154b1f75284dd4fccc0248be71f66) for more info. </td>
+        <td>`auto_cache` utilizes kernel system caching and improves read performance. Instead of unconditionally keeping cached data, the cached data is invalidated if the modification time or the size of the file has changed since it was last opened. See [libfuse documentation](https://libfuse.github.io/doxygen/structfuse__config.html#a9db154b1f75284dd4fccc0248be71f66) for more info. It should not be enabled when launching AlluxioFuse in kubernetes. See https://github.com/Alluxio/alluxio/issues/14485 for more details. </td>
     </tr>
     <tr>
         <td>attr_timeout=N</td>

--- a/docs/en/deploy/Running-Alluxio-On-Docker.md
+++ b/docs/en/deploy/Running-Alluxio-On-Docker.md
@@ -439,7 +439,7 @@ $ docker run -d --rm \
     -e ALLUXIO_FUSE_JAVA_OPTS=" \
         -Dalluxio.fuse.mount.point=/mnt/alluxio-fuse \
         -Dalluxio.fuse.mount.alluxio.path=/ \
-        -Dalluxio.fuse.mount.options=kernel_cache" \
+        -Dalluxio.fuse.mount.options=direct_io" \
     --cap-add SYS_ADMIN \
     --device /dev/fuse \
     --security-opt apparmor:unconfined \

--- a/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
+++ b/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
@@ -1378,7 +1378,7 @@ fuse:
 - Alluxio fuse mount options
 ```properties
 fuse:
-  mountOptions: kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200
+  mountOptions: direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200
 ```
 - Alluxio fuse environment variables
 ```properties
@@ -1422,7 +1422,7 @@ across multiple containers.
   ALLUXIO_FUSE_JAVA_OPTS: |-
     -Dalluxio.fuse.mount.point=/mnt/alluxio-fuse 
     -Dalluxio.fuse.mount.alluxio.path=/ 
-    -Dalluxio.fuse.mount.options=kernel_cache,max_read=131072,entry_timeout=7200,attr_timeout=7200 
+    -Dalluxio.fuse.mount.options=direct_io,max_read=131072,entry_timeout=7200,attr_timeout=7200 
     -Dalluxio.user.hostname=${ALLUXIO_CLIENT_HOSTNAME} 
     -Dalluxio.user.metadata.cache.enabled=true 
     -Dalluxio.user.metadata.cache.expiration.time=40min 

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -687,7 +687,7 @@ csi:
   mountPath: /data
   alluxioPath: /
   mountOptions:
-    - kernel_cache
+    - direct_io
     - allow_other
     - entry_timeout=36000
     - attr_timeout=36000


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fixes https://github.com/Alluxio/alluxio/issues/14485

### Why are the changes needed?
Change from kernel_cache to direct_io fuse mount mode by default for JNI-FUSE.

### Does this PR introduce any user facing changes?
Yeah, read performance may be impacted but Fuse pod stability will be improved in kubernetes environment