### PR TITLE
Support create empty file and open for write/RW workloads

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -65,7 +65,9 @@ public class FuseFileOutStream implements FuseFileStream {
     }
     long fileLen = status.map(URIStatus::getLength).orElse(0L);
     if (status.isPresent()) {
-      if (AlluxioFuseOpenUtils.containsTruncate(flags)) {
+      if (AlluxioFuseOpenUtils.containsTruncate(flags) || fileLen == 0) {
+        // support create file then open with truncate flag to write workload
+        // support create empty file then open for write/read_write workload
         AlluxioFuseUtils.deleteFile(fileSystem, uri);
         fileLen = 0;
         LOG.debug(String.format("Open path %s with flag 0x%x for overwriting. "

--- a/tests/src/test/java/alluxio/client/fuse/JNIFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNIFuseIntegrationTest.java
@@ -222,6 +222,33 @@ public class JNIFuseIntegrationTest extends AbstractFuseIntegrationTest {
   }
 
   /**
+   * Tests opening file with O_RDWR on existing empty for write-only workloads.
+   */
+  @Test
+  public void openReadWriteEmptyFile() throws Exception {
+    String testFile = "/openReadWriteEmptyFile";
+    try (CloseableFuseFileInfo closeableFuseFileInfo = new CloseableFuseFileInfo()) {
+      FuseFileInfo info = closeableFuseFileInfo.getFuseFileInfo();
+      // Create empty file
+      info.flags.set(OpenFlags.O_WRONLY.intValue());
+      Assert.assertEquals(0, mFuseFileSystem.create(testFile, 100644, info));
+      Assert.assertEquals(0, mFuseFileSystem.release(testFile, info));
+      // Open empty file for write
+      info.flags.set(OpenFlags.O_RDWR.intValue());
+      Assert.assertEquals(0, mFuseFileSystem.open(testFile, info));
+      try {
+        ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(FILE_LEN);
+        Assert.assertEquals(FILE_LEN, mFuseFileSystem.write(testFile, buffer, FILE_LEN, 0, info));
+        buffer.clear();
+        Assert.assertTrue(mFuseFileSystem.read(testFile, buffer, FILE_LEN, 0, info) < 0);
+      } finally {
+        Assert.assertEquals(0, mFuseFileSystem.release(testFile, info));
+      }
+      readAndValidateTestFile(testFile, info, FILE_LEN);
+    }
+  }
+
+  /**
    * Tests opening file with O_RDWR and O_TRUNC flags on existing file
    * for write-only workloads.
    */


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fixes #15569
Support FIO sequential write test
fio --name=sequential-write --directory=/mnt/alluxio-fuse --rw=write --refill_buffers --bs=4M --size=4G --end_fsync=1

### Why are the changes needed?

The sequential write workload failed with 
```
Fuse.Create(path=/sequential-write.0.0,mode=100644)
Fuse.Flush(path=/sequential-write.0.0,fd=1)
Fuse.Release(path=/sequential-write.0.0,fd=1)
Fuse.Open(path=/sequential-write.0.0,flags=0x8002(READ_WRITE))
Fuse.Write(path=/sequential-write.0.0,fd=2,size=131056,offset=0)
Cannot overwrite existing file /sequential-write.0.0 without O_TRUNC flag or fuse.truncate(size=0), flag 0x8002
```
and Alluxio do not support create empty file then open for write

### Does this PR introduce any user facing changes?
Support create empty file and open for write or open for readOrWrite
