### PR TITLE
Support parsing resolved InetSocketAddress string

### DIFF
--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -666,11 +666,11 @@ public final class NetworkAddressUtils {
     if (strArr.length != 2) {
       throw new IOException("Invalid InetSocketAddress " + address);
     }
-    // a typical resolved InetSocketAddress has a string representation of form <hostname>/<address>:port,
-    // e.g., "localhost/127.0.0.1:9000".
+    // a typical resolved InetSocketAddress has a string representation of form
+    // <hostname>/<address>:port, e.g., "localhost/127.0.0.1:9000".
     // extract the <hostname> part by splitting at "/"
-    String[] hostname = strArr[0].split("/");
-    return InetSocketAddress.createUnresolved(hostname[0], Integer.parseInt(strArr[1]));
+    String hostname = strArr[0].split("/")[0];
+    return InetSocketAddress.createUnresolved(hostname, Integer.parseInt(strArr[1]));
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -666,7 +666,7 @@ public final class NetworkAddressUtils {
     if (strArr.length != 2) {
       throw new IOException("Invalid InetSocketAddress " + address);
     }
-    // a typical resolved InetSocketAddress will have hostname part <hostname>/<address>,
+    // a typical resolved InetSocketAddress has a string representation of form <hostname>/<address>:port,
     // e.g., "localhost/127.0.0.1:9000".
     // extract the <hostname> part by splitting at "/"
     String[] hostname = strArr[0].split("/");

--- a/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
+++ b/core/common/src/main/java/alluxio/util/network/NetworkAddressUtils.java
@@ -666,7 +666,11 @@ public final class NetworkAddressUtils {
     if (strArr.length != 2) {
       throw new IOException("Invalid InetSocketAddress " + address);
     }
-    return InetSocketAddress.createUnresolved(strArr[0], Integer.parseInt(strArr[1]));
+    // a typical resolved InetSocketAddress will have hostname part <hostname>/<address>,
+    // e.g., "localhost/127.0.0.1:9000".
+    // extract the <hostname> part by splitting at "/"
+    String[] hostname = strArr[0].split("/");
+    return InetSocketAddress.createUnresolved(hostname[0], Integer.parseInt(strArr[1]));
   }
 
   /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockMasterClientTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockMasterClientTest.java
@@ -77,17 +77,14 @@ import java.util.stream.Collectors;
 
 public class BlockMasterClientTest {
 
-  // alert: you CANNOT just set TEST_SOCKET_ADDRESS to
-  // configuration, because it will get turned to string "localhost/127.0.0.1:9999"
-  // This string cannot be parsed accurately by the current parsing algorithm
+  // test socket address
   private static final InetSocketAddress TEST_SOCKET_ADDRESS =
       new InetSocketAddress("localhost", 9999);
-  private static final String TEST_SOCKET_ADDRESS_STRING = "localhost:9999";
 
   @Rule
   public ConfigurationRule mConfiguration = new ConfigurationRule(ImmutableMap
       .of(
-          PropertyKey.MASTER_RPC_ADDRESSES, ImmutableList.of(TEST_SOCKET_ADDRESS_STRING),
+          PropertyKey.MASTER_RPC_ADDRESSES, ImmutableList.of(TEST_SOCKET_ADDRESS),
           // set retry durations shorter to ensure that tests don't take too long
           PropertyKey.USER_RPC_RETRY_MAX_DURATION, "5s",
           PropertyKey.USER_RPC_RETRY_BASE_SLEEP_MS, "100ms",


### PR DESCRIPTION
### What changes are proposed in this pull request?
Modify `NetworkAddressUtils#parseInetSocketAddress` to handle resolved address strings correctly.

### Why are the changes needed?
As mentioned in https://github.com/Alluxio/alluxio/pull/15670#discussion_r891870760 A resolved `InetSocketAddress` has the following `toString()` representation: "<hostname>/<resolved_address>:<port>". It is handy that `NetworkAddressUtils#parseInetSocketAddress` can process such strings correctly, so that we can pass an `InetSocketAddress` directly to the configuration.

### Does this PR introduce any user facing changes?
No
