### PR TITLE
Fix S3 UFS executor service thread leak

### DIFF
--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -362,6 +362,11 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   }
 
   @Override
+  public void close() {
+    mExecutor.shutdown();
+  }
+
+  @Override
   protected boolean copyObject(String src, String dst) {
     LOG.debug("Copying {} to {}", src, dst);
     // Retry copy for a few times, in case some AWS internal errors happened during copy.


### PR DESCRIPTION
### What changes are proposed in this pull request?

Calls shutdown on the executor service in the S3 UFS class.

### Why are the changes needed?

If shutdown is not called the threads will not be garbage collected.

### Does this PR introduce any user facing changes?

No