### PR TITLE
Fix documentation surrounding `backup` command

### DIFF
--- a/docs/en/operation/Admin-CLI.md
+++ b/docs/en/operation/Admin-CLI.md
@@ -60,6 +60,16 @@ Backup URI         : file:///opt/alluxio/backups/alluxio-backup-2020-10-13-16026
 Backup Entry Count : 4
 ```
 
+Allow the leading master to take a backup if no standby masters are available.
+```shell
+$ ./bin/alluxio fsadmin backup --allow-leader
+```
+
+Force the leading master to take the backup even if standby masters are available.
+```shell
+$ bin/alluxio fsadmin backup --bypass-delegation
+```
+
 ### journal
 The `journal` command provides several sub-commands for journal management.
 

--- a/docs/en/operation/Journal.md
+++ b/docs/en/operation/Journal.md
@@ -218,9 +218,8 @@ Since it is uncertain which host will take the backup, it is suggested to use sh
 A backup attempt will fail if delegation fails to find a standby master, thus favoring service availability.
 For manual backups, you can pass `--allow-leader` option to allow the leading master to take a backup when there are no standby masters to delegate the backup.
 
-You can also pass `--bypass-delegation` flag to disable delegation all together.
-
-Disabling backup delegation using above flags will revert backup behavior to local and will cause temporary service unavailability while the leading master is writing a backup.
+You can also pass `--bypass-delegation` flag to disable delegation altogether.
+Disabling backup delegation will cause temporary service unavailability while the leading master is writing a backup.
 
 ### Restoring from a backup
 

--- a/shell/src/main/java/alluxio/cli/fsadmin/command/BackupCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/command/BackupCommand.java
@@ -77,7 +77,8 @@ public class BackupCommand extends AbstractFsAdminCommand {
   public Options getOptions() {
     return new Options()
         .addOption(LOCAL_OPTION)
-        .addOption(ALLOW_LEADER_OPTION);
+        .addOption(ALLOW_LEADER_OPTION)
+        .addOption(BYPASS_DELEGATION_OPTION);
   }
 
   @Override
@@ -146,7 +147,7 @@ public class BackupCommand extends AbstractFsAdminCommand {
 
   @Override
   public String getUsage() {
-    return "backup [directory] [--local] [--allow-leader]";
+    return "backup [directory] [--local] [--allow-leader] [--bypass-delegation]";
   }
 
   @Override
@@ -157,7 +158,8 @@ public class BackupCommand extends AbstractFsAdminCommand {
         + " master, use --local and specify a filesystem path. Backing up metadata"
         + " will be delegated to standby masters in HA cluster. Use --allow-leader for"
         + " leader to take the backup when there are no standby masters.(This will pause"
-        + " metadata changes during the backup.";
+        + " metadata changes during the backup). Use --bypass-delegation to take the backup on"
+        + " the leader even if there are standby masters.";
   }
 
   @Override


### PR DESCRIPTION
Some of the documentation on the website and in the CLI is missing information about `--bypass-delegation`.
Followup to #15110.