### PR TITLE
Support truncate to extend file length

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -96,7 +96,9 @@ public final class AlluxioFuseUtils {
       authPolicy.setUserGroupIfNeeded(uri);
       return out;
     } catch (IOException | AlluxioException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException(String.format(
+          "Failed to create file %s [mode: %s, auth policy: %s]",
+          uri, mode, authPolicy.getClass().getName()), e);
     }
   }
 
@@ -110,7 +112,7 @@ public final class AlluxioFuseUtils {
     try {
       fileSystem.delete(uri);
     } catch (IOException | AlluxioException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException(String.format("Failed to delete file %s", uri), e);
     }
   }
 

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -173,7 +173,7 @@ public class FuseFileOutStream implements FuseFileStream {
       return;
     }
     throw new UnsupportedOperationException(
-        String.format("Cannot truncate file %s to size %s", mURI, size));
+        String.format("Cannot truncate file %s from size %s to size %s", mURI, currentSize, size));
   }
 
   @Override

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -134,9 +134,10 @@ public class FuseFileOutStream implements FuseFileStream {
 
   @Override
   public synchronized long getFileLength() {
-    return mOutStream.map(
-        fileOutStream -> Math.max(fileOutStream.getBytesWritten(), mExtendedFileLen))
-        .orElse(mOriginalFileLen);
+    if (mOutStream.isPresent()) {
+      return Math.max(mOutStream.get().getBytesWritten(), mExtendedFileLen);
+    }
+    return mOriginalFileLen;
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fixes #15569
Support Fuse.truncate() to set the file to a bigger size before writing to it.

### Why are the changes needed?
Support running FIO sequential read test.
Support Fuse.truncate() to change file to a file size bigger than the current bytes written.

### Does this PR introduce any user facing changes?

Support user Fuse.truncate() to actual file size - sequential write to actual file size use case.