### PR TITLE
Remove unneeded auto-boxing in AsyncJournalWriter

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AsyncJournalWriter.java
@@ -125,7 +125,7 @@ public final class AsyncJournalWriter {
    * This counter is only accessed by the dedicated journal thread.
    * Invariant: {@code mWriteCounter >= mFlushCounter}
    */
-  private Long mWriteCounter;
+  private long mWriteCounter;
   /** Maximum number of nanoseconds for a batch flush. */
   private final long mFlushBatchTimeNs;
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove unneeded auto-boxing in `AsyncJournalWriter`.

### Why are the changes needed?

The `mWriteCounter` member only needs to be a primitive `long` type.

### Does this PR introduce any user facing changes?

No.