### PR TITLE
Add ufs_path and block_size to BlockStatus

### DIFF
--- a/core/transport/src/main/proto/grpc/block_worker.proto
+++ b/core/transport/src/main/proto/grpc/block_worker.proto
@@ -166,6 +166,7 @@ message BlockStatus {
   optional string message = 3;
   optional bool retryable = 4;
   optional string ufs_path = 5;
+  optional int64 block_size = 6;
 }
 
 // Response for an async cache request

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -1150,6 +1150,11 @@
                 "id": 5,
                 "name": "ufs_path",
                 "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "block_size",
+                "type": "int64"
               }
             ]
           },


### PR DESCRIPTION
### What changes are proposed in this pull request?
Add ufs_path and block_size to BlockStatus to simplify response handling in cases when many lookups for ufs_path and block_size by block_id are needed.
