### PR TITLE
Remove the unused parameter in DefaultBlockWorker

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockWorkerFactory.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockWorkerFactory.java
@@ -67,7 +67,7 @@ public final class BlockWorkerFactory implements WorkerFactory {
     BlockWorker blockWorker = new DefaultBlockWorker(blockMasterClientPool,
         new FileSystemMasterClient(
             MasterClientContext.newBuilder(ClientContext.create(Configuration.global())).build()),
-        new Sessions(), blockStore, ufsManager, workerId);
+        new Sessions(), blockStore, workerId);
     registry.add(BlockWorker.class, blockWorker);
     return blockWorker;
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -43,7 +43,6 @@ import alluxio.metrics.MetricsSystem;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.retry.RetryUtils;
 import alluxio.security.user.ServerUserState;
-import alluxio.underfs.UfsManager;
 import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerNetAddress;
@@ -126,13 +125,12 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
    * @param fileSystemMasterClient a client for talking to the file system master
    * @param sessions an object for tracking and cleaning up client sessions
    * @param blockStore an Alluxio block store
-   * @param ufsManager ufs manager
    * @param workerId worker id
    */
   @VisibleForTesting
   public DefaultBlockWorker(BlockMasterClientPool blockMasterClientPool,
       FileSystemMasterClient fileSystemMasterClient, Sessions sessions, BlockStore blockStore,
-      UfsManager ufsManager, AtomicReference<Long> workerId) {
+      AtomicReference<Long> workerId) {
     super(ExecutorServiceFactories.fixedThreadPool("block-worker-executor", 5));
     mBlockMasterClientPool = mResourceCloser.register(blockMasterClientPool);
     mFileSystemMasterClient = mResourceCloser.register(fileSystemMasterClient);

--- a/core/server/worker/src/test/java/alluxio/worker/block/CacheRequestManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/CacheRequestManagerTest.java
@@ -114,7 +114,7 @@ public class CacheRequestManagerTest {
     BlockStore blockStore =
         new MonoBlockStore(tieredBlockStore, blockMasterClientPool, ufsManager, workerId);
     mBlockWorker = spy(new DefaultBlockWorker(blockMasterClientPool, fileSystemMasterClient,
-        sessions, blockStore, ufsManager, workerId));
+        sessions, blockStore, workerId));
     mBlockStore = mBlockWorker.getBlockStore();
     FileSystemContext context = mock(FileSystemContext.class);
     mCacheRequestManager =

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
@@ -100,7 +100,7 @@ public class DefaultBlockWorkerTest {
     mFileSystemMasterClient = mock(FileSystemMasterClient.class);
     Sessions sessions = mock(Sessions.class);
     mBlockWorker = new DefaultBlockWorker(blockMasterClientPool, mFileSystemMasterClient,
-        sessions, mBlockStore, ufsManager, workerId);
+        sessions, mBlockStore, workerId);
   }
 
   @Test

--- a/core/server/worker/src/test/java/alluxio/worker/block/stream/BlockWorkerDataReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/stream/BlockWorkerDataReaderTest.java
@@ -117,7 +117,7 @@ public class BlockWorkerDataReaderTest {
     MonoBlockStore blockStore =
         new MonoBlockStore(tieredBlockStore, blockMasterClientPool, ufsManager, workerId);
     mBlockWorker = new DefaultBlockWorker(blockMasterClientPool, fileSystemMasterClient,
-        sessions, blockStore, ufsManager, workerId);
+        sessions, blockStore, workerId);
 
     URIStatus dummyStatus =
         new URIStatus(new FileInfo().setBlockIds(Collections.singletonList(BLOCK_ID)));

--- a/tests/src/test/java/alluxio/client/fs/BlockWorkerRegisterStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/BlockWorkerRegisterStreamIntegrationTest.java
@@ -185,7 +185,7 @@ public class BlockWorkerRegisterStreamIntegrationTest {
     Sessions sessions = mock(Sessions.class);
 
     mBlockWorker = new DefaultBlockWorker(mBlockMasterClientPool, fileSystemMasterClient,
-            sessions, blockStore, ufsManager, workerId);
+            sessions, blockStore, workerId);
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?
Remove the unused parameter in DefaultBlockWorker

### Why are the changes needed?

ufsManager is no longer used in blockworker

### Does this PR introduce any user facing changes?

no
