### PR TITLE
Fuse create should create file out stream

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -187,25 +187,39 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
 
   @Override
   public int create(String path, long mode, FuseFileInfo fi) {
-    return AlluxioFuseUtils.call(LOG, () -> createOrOpenInternal(path, fi, mode),
+    return AlluxioFuseUtils.call(LOG, () -> createInternal(path, fi, mode),
         "Fuse.Create", "path=%s,mode=%o", path, mode);
   }
 
-  @Override
-  public int open(String path, FuseFileInfo fi) {
-    return AlluxioFuseUtils.call(LOG,
-        () -> createOrOpenInternal(path, fi, AlluxioFuseUtils.MODE_NOT_SET_VALUE),
-        "Fuse.Open", "path=%s,flags=0x%x", path, fi.flags.get());
-  }
-
-  private int createOrOpenInternal(String path, FuseFileInfo fi, long mode) {
+  private int createInternal(String path, FuseFileInfo fi, long mode) {
     final AlluxioURI uri = mPathResolverCache.getUnchecked(path);
     if (uri.getName().length() > MAX_NAME_LENGTH) {
       LOG.error("Failed to create/open {}: file name longer than {} characters",
           path, MAX_NAME_LENGTH);
       return -ErrorCodes.ENAMETOOLONG();
     }
-    FuseFileStream stream = mStreamFactory.create(uri, fi.flags.get(), mode);
+    FuseFileStream stream = mStreamFactory.createFile(uri, fi.flags.get(), mode);
+    long fd = mNextOpenFileId.getAndIncrement();
+    mFileEntries.add(new FuseFileEntry<>(fd, path, stream));
+    fi.fh.set(fd);
+    return 0;
+  }
+
+  @Override
+  public int open(String path, FuseFileInfo fi) {
+    return AlluxioFuseUtils.call(LOG,
+        () -> openInternal(path, fi, AlluxioFuseUtils.MODE_NOT_SET_VALUE),
+        "Fuse.Open", "path=%s,flags=0x%x", path, fi.flags.get());
+  }
+
+  private int openInternal(String path, FuseFileInfo fi, long mode) {
+    final AlluxioURI uri = mPathResolverCache.getUnchecked(path);
+    if (uri.getName().length() > MAX_NAME_LENGTH) {
+      LOG.error("Failed to create/open {}: file name longer than {} characters",
+          path, MAX_NAME_LENGTH);
+      return -ErrorCodes.ENAMETOOLONG();
+    }
+    FuseFileStream stream = mStreamFactory.openFile(uri, fi.flags.get(), mode);
     long fd = mNextOpenFileId.getAndIncrement();
     mFileEntries.add(new FuseFileEntry<>(fd, path, stream));
     fi.fh.set(fd);

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
@@ -94,16 +94,17 @@ public interface FuseFileStream extends AutoCloseable {
     }
 
     /**
-     * Factory method for creating an implementation of {@link FuseFileStream}.
+     * Factory method for opening a file
+     * and creating an implementation of {@link FuseFileStream}.
      *
      * @param uri the Alluxio URI
      * @param flags the create/open flags
      * @param mode the create file mode, -1 if not set
-     * @param status the uri status
      * @return the created fuse file stream
      */
-    public FuseFileStream create(
-        AlluxioURI uri, int flags, long mode, Optional<URIStatus> status) {
+    public FuseFileStream openFile(
+        AlluxioURI uri, int flags, long mode) {
+      Optional<URIStatus> status = AlluxioFuseUtils.getPathStatus(mFileSystem, uri);
       switch (OpenFlags.valueOf(flags & O_ACCMODE.intValue())) {
         case O_RDONLY:
           return FuseFileInStream.create(mFileSystem, uri, flags, status);
@@ -119,16 +120,16 @@ public interface FuseFileStream extends AutoCloseable {
     }
 
     /**
-     * Factory method for creating an implementation of {@link FuseFileStream}.
+     * Factory method for creating a file.
      *
      * @param uri the Alluxio URI
      * @param flags the create/open flags
      * @param mode the create file mode, -1 if not set
-     * @return the created fuse file stream
+     * @return the created fuse file out stream
      */
-    public FuseFileStream create(AlluxioURI uri, int flags, long mode) {
-      return create(uri, flags, mode,
-          AlluxioFuseUtils.getPathStatus(mFileSystem, uri));
+    public FuseFileOutStream createFile(
+        AlluxioURI uri, int flags, long mode) {
+      return FuseFileOutStream.create(mFileSystem, mAuthPolicy, uri, flags, mode, Optional.empty());
     }
   }
 }


### PR DESCRIPTION
Fixes #15773
### What changes are proposed in this pull request?

Fuse create will create a file
### Why are the changes needed?

Fuse create failed because create flag was detected as read-only flags

### Does this PR introduce any user facing changes?
Support creating file with more flags
