### PR TITLE
Add more unit tests for DefaultBlockWorker

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -349,6 +349,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   }
 
   @Override
+  @Deprecated
   public void asyncCache(AsyncCacheRequest request) {
     CacheRequest cacheRequest =
         CacheRequest.newBuilder().setBlockId(request.getBlockId()).setLength(request.getLength())

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -194,6 +194,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
     mAddress = address;
 
     // Acquire worker Id.
+<<<<<<< HEAD
     BlockMasterClient blockMasterClient = mBlockMasterClientPool.acquire();
     try {
       RetryUtils.retry("create worker id", () -> mWorkerId.set(blockMasterClient.getId(address)),
@@ -204,6 +205,21 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
     } finally {
       mBlockMasterClientPool.release(blockMasterClient);
     }
+||||||| merged common ancestors
+    BlockMasterClient blockMasterClient = mBlockMasterClientPool.acquire();
+    try {
+      RetryUtils.retry("create worker id", () -> mWorkerId.set(blockMasterClient.getId(address)),
+          RetryUtils.defaultWorkerMasterClientRetry(Configuration
+              .getDuration(PropertyKey.WORKER_MASTER_CONNECT_RETRY_TIMEOUT)));
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create a worker id from block master: "
+          + e.getMessage());
+    } finally {
+      mBlockMasterClientPool.release(blockMasterClient);
+    }
+=======
+    askForWorkerId(address);
+>>>>>>> Remove heartbeat tests
 
     Preconditions.checkNotNull(mWorkerId, "mWorkerId");
     Preconditions.checkNotNull(mAddress, "mAddress");
@@ -241,6 +257,26 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
     // Mounts the embedded Fuse application
     if (Configuration.getBoolean(PropertyKey.WORKER_FUSE_ENABLED)) {
       mFuseManager.start();
+    }
+  }
+
+  /**
+   * Ask the master for a userId. Should not be called outside of testing
+   *
+   * @param address the address this worker operates on
+   */
+  @VisibleForTesting
+  public void askForWorkerId(WorkerNetAddress address) {
+    BlockMasterClient blockMasterClient = mBlockMasterClientPool.acquire();
+    try {
+      RetryUtils.retry("create worker id", () -> mWorkerId.set(blockMasterClient.getId(address)),
+              RetryUtils.defaultWorkerMasterClientRetry(Configuration
+                      .getDuration(PropertyKey.WORKER_MASTER_CONNECT_RETRY_TIMEOUT)));
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create a worker id from block master: "
+              + e.getMessage());
+    } finally {
+      mBlockMasterClientPool.release(blockMasterClient);
     }
   }
 
@@ -295,6 +331,12 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
               + "Tier:{}, Medium:{}, InitialBytes:{}, Error:{}",
           sessionId, blockId, tier,
           createBlockOptions.getMedium(), createBlockOptions.getInitialBytes(), e);
+
+      // mAddress is null if the worker is not started
+      if (mAddress == null) {
+        throw new WorkerOutOfSpaceException(ExceptionMessage.CANNOT_REQUEST_SPACE
+                .getMessage(mWorkerId.get(), blockId), e);
+      }
 
       InetSocketAddress address =
           InetSocketAddress.createUnresolved(mAddress.getHost(), mAddress.getRpcPort());

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -158,6 +158,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
    *
    * @return the LocalBlockStore that manages local blocks
    * */
+  @Override
   public BlockStore getBlockStore() {
     return mBlockStore;
   }
@@ -194,32 +195,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
     mAddress = address;
 
     // Acquire worker Id.
-<<<<<<< HEAD
-    BlockMasterClient blockMasterClient = mBlockMasterClientPool.acquire();
-    try {
-      RetryUtils.retry("create worker id", () -> mWorkerId.set(blockMasterClient.getId(address)),
-          RetryUtils.defaultWorkerMasterClientRetry());
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to create a worker id from block master: "
-          + e.getMessage());
-    } finally {
-      mBlockMasterClientPool.release(blockMasterClient);
-    }
-||||||| merged common ancestors
-    BlockMasterClient blockMasterClient = mBlockMasterClientPool.acquire();
-    try {
-      RetryUtils.retry("create worker id", () -> mWorkerId.set(blockMasterClient.getId(address)),
-          RetryUtils.defaultWorkerMasterClientRetry(Configuration
-              .getDuration(PropertyKey.WORKER_MASTER_CONNECT_RETRY_TIMEOUT)));
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to create a worker id from block master: "
-          + e.getMessage());
-    } finally {
-      mBlockMasterClientPool.release(blockMasterClient);
-    }
-=======
     askForWorkerId(address);
->>>>>>> Remove heartbeat tests
 
     Preconditions.checkNotNull(mWorkerId, "mWorkerId");
     Preconditions.checkNotNull(mAddress, "mAddress");
@@ -270,8 +246,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
     BlockMasterClient blockMasterClient = mBlockMasterClientPool.acquire();
     try {
       RetryUtils.retry("create worker id", () -> mWorkerId.set(blockMasterClient.getId(address)),
-              RetryUtils.defaultWorkerMasterClientRetry(Configuration
-                      .getDuration(PropertyKey.WORKER_MASTER_CONNECT_RETRY_TIMEOUT)));
+              RetryUtils.defaultWorkerMasterClientRetry());
     } catch (Exception e) {
       throw new RuntimeException("Failed to create a worker id from block master: "
               + e.getMessage());

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -237,7 +237,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   }
 
   /**
-   * Ask the master for a userId. Should not be called outside of testing
+   * Ask the master for a workerId. Should not be called outside of testing
    *
    * @param address the address this worker operates on
    */

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
@@ -17,9 +17,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -239,12 +242,12 @@ public class DefaultBlockWorkerTest {
     doThrow(new RuntimeException())
         .when(mBlockMasterClient)
         .commitBlock(
-            any(long.class),
-            any(long.class),
-            any(String.class),
-            any(String.class),
-            any(long.class),
-            any(long.class));
+            anyLong(),
+            anyLong(),
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyLong());
 
     mBlockWorker.createBlock(
         sessionId,
@@ -271,7 +274,7 @@ public class DefaultBlockWorkerTest {
 
     doThrow(new IOException("Failed to commit block in ufs"))
         .when(mBlockMasterClient)
-        .commitBlockInUfs(any(long.class), any(long.class));
+        .commitBlockInUfs(anyLong(), anyLong());
 
     assertThrows(IOException.class, () -> mBlockWorker.commitBlockInUfs(blockId, ufsBlockLength));
   }
@@ -571,21 +574,19 @@ public class DefaultBlockWorkerTest {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void blockMasterSync() throws Exception {
     // verify that syncing heartbeat is working properly
     Thread.sleep(10 * Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS));
     // BlockWorker should have fired 10 calls of heartbeat during this interval
     // check that at least 5 calls are made to make room for some scheduling issues.
     verify(mBlockMasterClient, atLeast(5)).heartbeat(
-        eq(WORKER_ID),
-        any(Map.class),
-        any(Map.class),
-        any(List.class),
-        any(Map.class),
-        any(Map.class),
-        any(List.class)
-    );
+            eq(WORKER_ID),
+            anyMap(),
+            anyMap(),
+            anyList(),
+            anyMap(),
+            anyMap(),
+            anyList());
   }
 
   @Test
@@ -637,7 +638,7 @@ public class DefaultBlockWorkerTest {
   }
 
   private void cacheBlock(boolean async) throws Exception {
-    // flush 1MB block data to ufs
+    // flush 1MB block data to ufs so that caching will take a while
     long ufsBlockSize = 1024 * 1024;
     byte[] data = new byte[(int) ufsBlockSize];
     Arrays.fill(data, (byte) 7);
@@ -680,7 +681,6 @@ public class DefaultBlockWorkerTest {
 
   // create a BlockMasterClient that simulates reasonable default
   // interactions with the block master
-  @SuppressWarnings("unchecked")
   private BlockMasterClient createMockBlockMasterClient() throws Exception {
     BlockMasterClient client = mock(BlockMasterClient.class);
 
@@ -693,13 +693,13 @@ public class DefaultBlockWorkerTest {
     doReturn(Command.newBuilder().setCommandType(CommandType.Nothing).build())
         .when(client)
         .heartbeat(
-            any(long.class),
-            any(Map.class),
-            any(Map.class),
-            any(List.class),
-            any(Map.class),
-            any(Map.class),
-            any(List.class)
+            anyLong(),
+            anyMap(),
+            anyMap(),
+            anyList(),
+            anyMap(),
+            anyMap(),
+            anyList()
         );
     return client;
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?
Added more unit tests for DefaultBlockWorker that:
- tested for various failure scenarios
- tested the behavior of ufs fallback block reader
- tested cache behavior
- tested DefaultBlockWorker's heartbeat tasks are executing properly

### Why are the changes needed?
Give more confidence on the correctness of `DefaultBlockWorker`, improve unit-test coverage(60% -> 83%)

### Does this PR introduce any user facing changes?
No
