### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: 0 0 * * *
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuse_integration_tests.yml
+++ b/.github/workflows/fuse_integration_tests.yml
@@ -2,6 +2,9 @@ name: Fuse Integration Tests
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "modules: fuse"

--- a/.github/workflows/java11_integration_tests.yml
+++ b/.github/workflows/java11_integration_tests.yml
@@ -2,6 +2,9 @@ name: Java 11 Integration Tests
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "modules: "

--- a/.github/workflows/java11_integration_tests_webui.yml
+++ b/.github/workflows/java11_integration_tests_webui.yml
@@ -2,6 +2,9 @@ name: Java 11 Integration Tests (w/ webui)
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "modules: "

--- a/.github/workflows/java11_unit_tests.yml
+++ b/.github/workflows/java11_unit_tests.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: 0 0 * * *
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "modules: "

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: 0 0 * * *
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "modules: "

--- a/.github/workflows/java8_integration_tests_webui.yml
+++ b/.github/workflows/java8_integration_tests_webui.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: 0 0 * * *
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "modules: "

--- a/.github/workflows/java8_unit_tests.yml
+++ b/.github/workflows/java8_unit_tests.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: 0 0 * * *
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "modules: "


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
