### PR TITLE
Fix helm-chart-related tarball generation

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -318,9 +318,8 @@ func generateTarball(skipUI, skipHelm bool) error {
 	run("adding Alluxio FUSE jar", "mv", fmt.Sprintf("integration/fuse/target/alluxio-integration-fuse-%v-jar-with-dependencies.jar", version), filepath.Join(dstPath, "integration", "fuse", fmt.Sprintf("alluxio-fuse-%v.jar", version)))
 	// Generate Helm templates in the dstPath
 	run("adding Helm chart", "cp", "-r", filepath.Join(srcPath, "integration/kubernetes/helm-chart"), filepath.Join(dstPath, "integration/kubernetes/helm-chart"))
-	run("adding YAML generator script", "cp", filepath.Join(srcPath, "integration/kubernetes/helm-generate.sh"), filepath.Join(dstPath, "integration/kubernetes/helm-generate.sh"))
 	if !skipHelm {
-		chdir(filepath.Join(dstPath, "integration/kubernetes/"))
+		chdir(filepath.Join(dstPath, "integration/kubernetes/helm-chart/alluxio/"))
 		run("generate Helm templates", "bash", "helm-generate.sh", "all")
 		chdir(srcPath)
 	}


### PR DESCRIPTION
helm-generate.sh has been moved into the helm-chart. Fix the related tarball generation process.