### PR TITLE
[DOCFIX] Fix `logLevel` command doc

### DIFF
--- a/docs/en/operation/Basic-Logging.md
+++ b/docs/en/operation/Basic-Logging.md
@@ -113,19 +113,19 @@ for the command options.
 For example, the following command sets the logger level of the class `alluxio.underfs.hdfs.HdfsUnderFileSystem` to
 `DEBUG` on master as well as a worker at `192.168.100.100:30000`:
 
-```console
+```shell
 $ ./bin/alluxio logLevel --logName=alluxio.underfs.hdfs.HdfsUnderFileSystem \
   --target=master,192.168.100.100:30000 --level=DEBUG
 ```
 
 And the following command returns the log level of the class `alluxio.underfs.hdfs.HdfsUnderFileSystem` among all the workers:
-```console
+```shell
 $ ./bin/alluxio logLevel --logName=alluxio.underfs.hdfs.HdfsUnderFileSystem --target=workers
 ```
 
 You can also update the log level at a package level.
 For example, you can update the log level of all classes in `alluxio.underfs` package with the following command:
-```console
+```shell
 $ ./bin/alluxio logLevel --logName=alluxio.underfs --target=workers --level=DEBUG
 ```
 This works because log4j loggers will inherit the log level from their ancestors.
@@ -134,12 +134,25 @@ In this case `alluxio.underfs.hdfs.HdfsUnderFileSystem` inherits the log level i
 
 Furthermore, you can turn on Alluxio debug logging when you are troubleshooting a certain issue
 in a running cluster, and turn it off when you are done.
-```console
+```shell
 # Turn on Alluxio debug logging and start debugging
 $ ./bin/alluxio logLevel --logName=alluxio --level=DEBUG
 
 # Turn off Alluxio debug logging when you are done
 $ ./bin/alluxio logLevel --logName=alluxio --level=INFO
+```
+
+Finally, if your Alluxio deployment uses custom web ports (e.g. `alluxio.master.web.port` is different from 19999, or
+`alluxio.worker.web.port` is different from 30000), you can use the format `host:port:role` for your target.
+`role` can be one of `master` or `worker` or `job_master` or `job_worker`.
+For example, if your master running on `10.10.10.10` has `alluxio.master.web.port=2181` configured, you would use:
+```shell
+$ ./bin/alluxio logLevel --logName=alluxio --target=10.10.10.10:2181:master --level=DEBUG
+```
+
+If your worker is running on `127.0.0.1` with `alluxio.worker.web.port=25252` configured, you would use:
+```shell
+$ ./bin/alluxio logLevel --logName=alluxio --target=127.0.0.1:25252:worker --level=DEBUG
 ```
 
 ## Enabling Advanced Logging

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -229,12 +229,12 @@ Status: CANCELED
 The `logLevel` command returns the current value of or updates the log level of a particular class
 on specific instances. Users are able to change Alluxio server-side log levels at runtime.
 
-The command follows the format `alluxio logLevel --logName=NAME [--target=<master|workers|job_master|job_workers|host:port>] [--level=LEVEL]`,
+The command follows the format `alluxio logLevel --logName=NAME [--target=<master|workers|job_master|job_workers|host:webPort[:role]>] [--level=LEVEL]`,
 where:
 * `--logName <arg>` indicates the logger's class (e.g. `alluxio.master.file.DefaultFileSystemMaster`)
 * `--target <arg>` lists the Alluxio master or workers to set.
-The target could be of the form `<master|workers|job_master|job_workers|host:webPort>` and multiple targets can be listed as comma-separated entries.
-The `host:webPort` format can only be used when referencing a worker.
+The target could be of the form `<master|workers|job_master|job_workers|host:webPort[:role]>` and multiple targets can be listed as comma-separated entries.
+Role can be one of `master|worker|job_master|job_worker`.
 The default target value is the primary master, primary job master, all workers and job workers.
 * `--level <arg>` If provided, the command changes to the given logger level,
 otherwise it returns the current logger level.

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -234,7 +234,8 @@ where:
 * `--logName <arg>` indicates the logger's class (e.g. `alluxio.master.file.DefaultFileSystemMaster`)
 * `--target <arg>` lists the Alluxio master or workers to set.
 The target could be of the form `<master|workers|job_master|job_workers|host:webPort[:role]>` and multiple targets can be listed as comma-separated entries.
-Role can be one of `master|worker|job_master|job_worker`.
+`role` can be one of `master|worker|job_master|job_worker`. Using the `role` option is useful when an Alluxio process
+is configured to use a non-standard web port (e.g. if an Alluxio master does not use 19999 as its web port).
 The default target value is the primary master, primary job master, all workers and job workers.
 * `--level <arg>` If provided, the command changes to the given logger level,
 otherwise it returns the current logger level.


### PR DESCRIPTION
Represent the `logLevel` command capabilities accurately.