### PR TITLE
Fix Fuse remove dir not empty error code

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseUtils.java
@@ -106,16 +106,16 @@ public final class AlluxioFuseUtils {
   }
 
   /**
-   * Deletes a file in alluxio namespace.
+   * Deletes a file or a directory in alluxio namespace.
    *
    * @param fileSystem the file system
    * @param uri the alluxio uri
    */
-  public static void deleteFile(FileSystem fileSystem, AlluxioURI uri) {
+  public static void deletePath(FileSystem fileSystem, AlluxioURI uri) {
     try {
       fileSystem.delete(uri);
     } catch (IOException | AlluxioException e) {
-      throw new RuntimeException(String.format("Failed to delete file %s", uri), e);
+      throw new RuntimeException(String.format("Failed to delete path %s", uri), e);
     }
   }
 

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -23,6 +23,7 @@ import alluxio.collections.IndexedSet;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.AlluxioException;
+import alluxio.exception.DirectoryNotEmptyException;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.fuse.auth.AuthPolicy;
 import alluxio.fuse.auth.AuthPolicyFactory;
@@ -445,7 +446,18 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
    * @return 0 on success, a negative value on error
    */
   private int rmInternal(String path) {
-    AlluxioFuseUtils.deleteFile(mFileSystem, mPathResolverCache.getUnchecked(path));
+    try {
+      mFileSystem.delete(mPathResolverCache.getUnchecked(path));
+    } catch (DirectoryNotEmptyException de) {
+      LOG.error("Failed to remove {}: directory not empty", path, de);
+      return -ErrorCodes.EEXIST() | ErrorCodes.ENOTEMPTY();
+    } catch (FileDoesNotExistException fe) {
+      LOG.error("Failed to remove {}: path does not exist", path, fe);
+      return -ErrorCodes.ENOENT();
+    } catch (IOException | AlluxioException e) {
+      LOG.error("Failed to remove {}: ", path, e);
+      return -ErrorCodes.EIO();
+    }
     return 0;
   }
 
@@ -581,7 +593,7 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
         return 0;
       }
       if (size == 0) {
-        AlluxioFuseUtils.deleteFile(mFileSystem, uri);
+        AlluxioFuseUtils.deletePath(mFileSystem, uri);
       }
       LOG.error("Failed to truncate file {}({} bytes) to {} bytes: not supported.",
           path, fileLen, size);

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
@@ -67,7 +67,7 @@ public class FuseFileInOrOutStream implements FuseFileStream {
     boolean truncate = AlluxioFuseOpenUtils.containsTruncate(flags);
     Optional<URIStatus> currentStatus = status;
     if (status.isPresent() && truncate) {
-      AlluxioFuseUtils.deleteFile(fileSystem, uri);
+      AlluxioFuseUtils.deletePath(fileSystem, uri);
       currentStatus = Optional.empty();
       LOG.debug(String.format("Open path %s with flag 0x%x for overwriting. "
           + "Alluxio deleted the old file and created a new file for writing", uri, flags));
@@ -162,7 +162,7 @@ public class FuseFileInOrOutStream implements FuseFileStream {
       return;
     }
     if (size == 0) {
-      AlluxioFuseUtils.deleteFile(mFileSystem, mUri);
+      AlluxioFuseUtils.deletePath(mFileSystem, mUri);
       mOutStream = Optional.of(FuseFileOutStream.create(mFileSystem, mAuthPolicy, mUri,
           OpenFlags.O_WRONLY.intValue(), mMode, Optional.empty()));
     }

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -76,7 +76,7 @@ public class FuseFileOutStream implements FuseFileStream {
       if (AlluxioFuseOpenUtils.containsTruncate(flags) || fileLen == 0) {
         // support create file then open with truncate flag to write workload
         // support create empty file then open for write/read_write workload
-        AlluxioFuseUtils.deleteFile(fileSystem, uri);
+        AlluxioFuseUtils.deletePath(fileSystem, uri);
         fileLen = 0;
         LOG.debug(String.format("Open path %s with flag 0x%x for overwriting. "
             + "Alluxio deleted the old file and created a new file for writing", uri, flags));
@@ -166,7 +166,7 @@ public class FuseFileOutStream implements FuseFileStream {
     }
     if (size == 0) {
       close();
-      AlluxioFuseUtils.deleteFile(mFileSystem, mURI);
+      AlluxioFuseUtils.deletePath(mFileSystem, mURI);
       mOutStream = Optional.of(AlluxioFuseUtils.createFile(mFileSystem, mAuthPolicy, mURI, mMode));
       mExtendedFileLen = 0L;
       return;


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove directory return correct error code when failed to delete directory because directory not empty

### Why are the changes needed?

Pjdfstest
expect 0 mkdir ${n0} 0755
create_file ${type} ${n0}/${n1}
expect "EEXIST|ENOTEMPTY" rmdir ${n0}
### Does this PR introduce any user facing changes?
Clear error message