### PR TITLE
Support dynamic configuration of alluxio master max heap size

### DIFF
--- a/bin/launch-process
+++ b/bin/launch-process
@@ -122,7 +122,7 @@ launch_master() {
   fi
 
   # use a default Xmx value for the master
-  local res="$(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "Xmx")"
+  local res="$(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "Xmx") + $(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "MaxRAMPercentage")"
   if [[ "${res}" -eq "0" ]]; then
     ALLUXIO_MASTER_JAVA_OPTS+=" -Xmx8g "
   fi


### PR DESCRIPTION
### What changes are proposed in this pull request?

Enable set alluxio master max heap size based on `-XX:MaxRAMPercentage`

### Why are the changes needed?

Currently, the max heap size of the alluxio master must be a specific value and does not support proportional setting according to the container limits.

### Does this PR introduce any user facing changes?

No.
