### PR TITLE
Optimizing reading and writing performance(patch 1)

### DIFF
--- a/core/common/src/main/java/alluxio/exception/ShuttleRpcException.java
+++ b/core/common/src/main/java/alluxio/exception/ShuttleRpcException.java
@@ -1,0 +1,45 @@
+package alluxio.exception;
+
+/**
+ * Exception thrown when error occurs using ShuttleRpc protocol
+ */
+public class ShuttleRpcException extends AlluxioException {
+    private static final long serialVersionUID = 305829608542844656L;
+
+    /**
+     * Constructs a new exception with the specified detail cause.
+     *
+     * @param cause the cause
+     */
+    protected ShuttleRpcException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    public ShuttleRpcException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause the cause
+     */
+    public ShuttleRpcException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the input exception.
+     *
+     * @param e the exception
+     */
+    public ShuttleRpcException(Exception e) {
+        super(e);
+    }
+}

--- a/core/common/src/main/java/alluxio/exception/ShuttleRpcExecutorException.java
+++ b/core/common/src/main/java/alluxio/exception/ShuttleRpcExecutorException.java
@@ -1,0 +1,43 @@
+package alluxio.exception;
+
+/**
+ *
+ */
+public class ShuttleRpcExecutorException extends AlluxioException {
+    /**
+     * Constructs a new exception with the specified detail cause.
+     *
+     * @param cause the cause
+     */
+    protected ShuttleRpcExecutorException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    public ShuttleRpcExecutorException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause the cause
+     */
+    public ShuttleRpcExecutorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the input exception.
+     *
+     * @param e the exception
+     */
+    public ShuttleRpcExecutorException(Exception e) {
+        super(e);
+    }
+}

--- a/core/common/src/main/java/alluxio/exception/ShuttleRpcRuntimeException.java
+++ b/core/common/src/main/java/alluxio/exception/ShuttleRpcRuntimeException.java
@@ -1,0 +1,22 @@
+package alluxio.exception;
+
+public class ShuttleRpcRuntimeException extends RuntimeException{
+    public ShuttleRpcRuntimeException() {
+    }
+
+    public ShuttleRpcRuntimeException(String message) {
+        super(message);
+    }
+
+    public ShuttleRpcRuntimeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ShuttleRpcRuntimeException(Throwable cause) {
+        super(cause);
+    }
+
+    public ShuttleRpcRuntimeException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/core/common/src/main/java/alluxio/shuttle/Constants.java
+++ b/core/common/src/main/java/alluxio/shuttle/Constants.java
@@ -1,0 +1,31 @@
+package alluxio.shuttle;
+
+public class Constants {
+    /**
+     *  Timeout ms for thread pause
+     */
+    public static final long PAUSE_TIMEOUT_MS = 300;
+
+    /**
+     * Status for thread of SingleThreadExecutor
+     */
+    public enum ThreadStatus {
+        INIT(1),
+        RUNNING(2),
+        SHUTDOWN(3),
+        STOP(4);
+
+        private int value;
+
+        ThreadStatus(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return this.value;
+        }
+    };
+
+    public static final int DEFAULT_MSG_QUEUE_SIZE = 1024;
+    public final static int DEFAULT_GROUP_THREAD_NUM = Math.max(4, 2 * Runtime.getRuntime().availableProcessors());
+}

--- a/core/common/src/main/java/alluxio/shuttle/Constants.java
+++ b/core/common/src/main/java/alluxio/shuttle/Constants.java
@@ -1,6 +1,11 @@
 package alluxio.shuttle;
 
 public class Constants {
+
+    public static final int SHUTTLE_RPC_CLIENT_CONN_TIMEOUT_MS = 120_000;
+    public static final int SHUTTLE_RPC_CLIENT_THREAD_NUM_DEFAULT = 16;
+    public static final int SHUTTLE_RPC_CLIENT_CONN_NUM_DEFAULT = 1;
+
     /**
      *  Timeout ms for thread pause
      */

--- a/core/common/src/main/java/alluxio/shuttle/client/ShuttleClientInfo.java
+++ b/core/common/src/main/java/alluxio/shuttle/client/ShuttleClientInfo.java
@@ -1,0 +1,155 @@
+package alluxio.shuttle.client;
+
+import alluxio.shuttle.handler.ShuttleRpcMessageProcessor;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import org.apache.commons.lang3.SystemUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Base info for Shuttle rpc protocol client
+ */
+public class ShuttleClientInfo {
+    private final int timeoutMs;
+    private final int ioThreads;
+    private final int numConnections;
+    private final boolean _closeIdleConnections;
+    private final Map<ChannelOption<?>, Object> channelOptions;
+    private final Supplier<ShuttleRpcMessageProcessor> msgProcessorSupplier;
+
+    public ShuttleClientInfo(
+            int timeoutMs,
+            int ioThreads,
+            int numConnections,
+            boolean closeIdleConnections,
+            Map<ChannelOption<?>, Object> channelOptions,
+            Supplier<ShuttleRpcMessageProcessor> msgProcessorSupplier) {
+        this.timeoutMs = timeoutMs;
+        this.ioThreads = ioThreads;
+        this.numConnections = numConnections;
+        this._closeIdleConnections = closeIdleConnections;
+        this.channelOptions = channelOptions;
+        this.msgProcessorSupplier = msgProcessorSupplier;
+    }
+
+    public int getTimeoutMs() {
+        return timeoutMs;
+    }
+
+    public int getIoThreads() {
+        return ioThreads;
+    }
+
+    public int getNumConnections() {
+        return numConnections;
+    }
+
+    public Map<ChannelOption<?>, Object> getChannelOptions() {
+        return channelOptions;
+    }
+
+    public Supplier<ShuttleRpcMessageProcessor> getMsgProcessorSupplier() {
+        return msgProcessorSupplier;
+    }
+
+    public Class<? extends SocketChannel> getChannelClass() {
+        if (SystemUtils.IS_OS_LINUX) {
+            return EpollSocketChannel.class;
+        } else {
+            return NioSocketChannel.class;
+        }
+    }
+
+
+    public boolean useEpoll() {
+        return SystemUtils.IS_OS_LINUX;
+    }
+
+    public boolean closeIdleConnections() {
+        return _closeIdleConnections;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ClientInfo{timeoutMs=%d, ioThreads=%d, channelClass=%s, numConnections=%d}",
+                timeoutMs,
+                ioThreads,
+                ioThreads,
+                getChannelClass().getSimpleName(),
+                numConnections);
+    }
+
+    public static class Builder {
+        private int timeoutMs;
+        private int ioThreads;
+        private boolean closeIdleConnections;
+        private int numConnections;
+        private final Map<ChannelOption<?>, Object> channelOptions = new HashMap<>();
+        private Supplier<ShuttleRpcMessageProcessor> msgProcessorSupplier;
+
+        public Builder() {
+            timeoutMs = 120_000;
+            ioThreads = 16;
+            numConnections = 1;
+            closeIdleConnections = true;
+
+            // Set system default parameters
+            channelOptions.put(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
+            channelOptions.put(ChannelOption.TCP_NODELAY, true);
+            channelOptions.put(ChannelOption.SO_KEEPALIVE, true);
+            channelOptions.put(ChannelOption.CONNECT_TIMEOUT_MILLIS, timeoutMs);
+        }
+
+        public Builder setTimeoutMs(int timeoutMs) {
+            this.timeoutMs = timeoutMs;
+            channelOptions.put(ChannelOption.CONNECT_TIMEOUT_MILLIS, timeoutMs);
+            return this;
+        }
+
+        public Builder setIoThreads(int ioThreads) {
+            this.ioThreads = ioThreads;
+            return this;
+        }
+
+        public Builder setNumConnections(int numConnections) {
+            this.numConnections = numConnections;
+            return this;
+        }
+
+        public Builder setHandlerSupplier(Supplier<ShuttleRpcMessageProcessor> msgProcessorSupplier) {
+            this.msgProcessorSupplier = msgProcessorSupplier;
+            return this;
+        }
+
+        public Builder addChannelOption(ChannelOption<?> key, Object value) {
+            channelOptions.put(key, value);
+            return this;
+        }
+
+        public Builder setCloseIdleConnections(boolean closeIdleConnections) {
+            this.closeIdleConnections = closeIdleConnections;
+            return this;
+        }
+
+        public ShuttleClientInfo build() {
+            assert  msgProcessorSupplier != null;
+            return new ShuttleClientInfo(
+                    timeoutMs,
+                    ioThreads,
+                    numConnections,
+                    closeIdleConnections,
+                    channelOptions,
+                    msgProcessorSupplier);
+        }
+    }
+}

--- a/core/common/src/main/java/alluxio/shuttle/client/ShuttleClientInfo.java
+++ b/core/common/src/main/java/alluxio/shuttle/client/ShuttleClientInfo.java
@@ -1,5 +1,6 @@
 package alluxio.shuttle.client;
 
+import alluxio.shuttle.Constants;
 import alluxio.shuttle.handler.ShuttleRpcMessageProcessor;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelOption;
@@ -98,9 +99,9 @@ public class ShuttleClientInfo {
         private Supplier<ShuttleRpcMessageProcessor> msgProcessorSupplier;
 
         public Builder() {
-            timeoutMs = 120_000;
-            ioThreads = 16;
-            numConnections = 1;
+            timeoutMs = Constants.SHUTTLE_RPC_CLIENT_CONN_TIMEOUT_MS;
+            ioThreads = Constants.SHUTTLE_RPC_CLIENT_THREAD_NUM_DEFAULT;
+            numConnections = Constants.SHUTTLE_RPC_CLIENT_CONN_NUM_DEFAULT;
             closeIdleConnections = true;
 
             // Set system default parameters

--- a/core/common/src/main/java/alluxio/shuttle/client/ShuttleRpcClient.java
+++ b/core/common/src/main/java/alluxio/shuttle/client/ShuttleRpcClient.java
@@ -17,19 +17,20 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 /**
- *  Underlying rpc client for msg transmit
+ *  Underlying rpc client for msg transmit.
+ *  Use netty channel to transmit msg.
  */
 public class ShuttleRpcClient implements Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(ShuttleRpcClient.class);
 
     private volatile boolean timeout;
     private final Channel channel;
-    private final ShuttleRpcMessageProcessor handler;
+    private final ShuttleRpcMessageProcessor msgProcessor;
     private final boolean server;
 
-    public ShuttleRpcClient(boolean server, Channel channel, ShuttleRpcMessageProcessor handler) {
+    public ShuttleRpcClient(boolean server, Channel channel, ShuttleRpcMessageProcessor msgProcessor) {
         this.channel = channel;
-        this.handler = handler;
+        this.msgProcessor = msgProcessor;
         this.server = server;
     }
 
@@ -82,7 +83,7 @@ public class ShuttleRpcClient implements Closeable {
     }
 
     public void sendRpc(Message msg, RpcCallback callback) {
-        handler.addRpc(msg.getReqId(), callback);
+        msgProcessor.addRpc(msg.getReqId(), callback);
         channel.writeAndFlush(msg);
     }
 
@@ -99,11 +100,11 @@ public class ShuttleRpcClient implements Closeable {
     }
 
     public void setCallback(long reqId, RpcCallback callback) throws ShuttleRpcException {
-        handler.setCallback(reqId, callback);
+        msgProcessor.setCallback(reqId, callback);
     }
 
     public void removeCallback(long reqId) throws ShuttleRpcException {
-        handler.removeCallback(reqId);
+        msgProcessor.removeCallback(reqId);
     }
 
     public Message sendSync(Message msg, long timeoutMs) throws ShuttleRpcException {

--- a/core/common/src/main/java/alluxio/shuttle/client/ShuttleRpcClient.java
+++ b/core/common/src/main/java/alluxio/shuttle/client/ShuttleRpcClient.java
@@ -1,0 +1,126 @@
+package alluxio.shuttle.client;
+
+import alluxio.exception.ShuttleRpcException;
+import alluxio.shuttle.handler.RpcCallback;
+import alluxio.shuttle.handler.ShuttleRpcMessageProcessor;
+import alluxio.shuttle.handler.ShuttleSyncRpcCallback;
+import alluxio.shuttle.message.Message;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.util.concurrent.DefaultPromise;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *  Underlying rpc client for msg transmit
+ */
+public class ShuttleRpcClient implements Closeable {
+    private static final Logger LOG = LoggerFactory.getLogger(ShuttleRpcClient.class);
+
+    private volatile boolean timeout;
+    private final Channel channel;
+    private final ShuttleRpcMessageProcessor handler;
+    private final boolean server;
+
+    public ShuttleRpcClient(boolean server, Channel channel, ShuttleRpcMessageProcessor handler) {
+        this.channel = channel;
+        this.handler = handler;
+        this.server = server;
+    }
+
+    public void timeout() {
+        timeout = true;
+    }
+
+    public boolean isActive() {
+        return !timeout && (channel.isOpen() || channel.isActive());
+    }
+
+    public boolean isWritable() {
+        return channel.isWritable();
+    }
+
+    public boolean isClosed() {
+        return !channel.isOpen() && !channel.isActive();
+    }
+
+    public boolean isServer() {
+        return server;
+    }
+
+    public String address() {
+        if (channel != null) {
+            return String.format("[%s -> %s]", channel.localAddress(), channel.remoteAddress());
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        close(null);
+    }
+
+    public void close(CountDownLatch latch) {
+        channel.close().addListener((future -> {
+            if (latch != null) {
+                latch.countDown();
+            }
+            if (!future.isSuccess()) {
+                LOG.warn("channel close fail", future.cause());
+            }
+        }));
+    }
+
+    public Channel getChannel() {
+        return channel;
+    }
+
+    public void sendRpc(Message msg, RpcCallback callback) {
+        handler.addRpc(msg.getReqId(), callback);
+        channel.writeAndFlush(msg);
+    }
+
+    public void sendRpc(Message msg) {
+        channel.writeAndFlush(msg);
+    }
+
+    public ChannelFuture writeAndFlush(Object msg) {
+        return channel.writeAndFlush(msg);
+    }
+
+    public ChannelFuture write(Object msg) {
+        return channel.write(msg);
+    }
+
+    public void setCallback(long reqId, RpcCallback callback) throws ShuttleRpcException {
+        handler.setCallback(reqId, callback);
+    }
+
+    public void removeCallback(long reqId) throws ShuttleRpcException {
+        handler.removeCallback(reqId);
+    }
+
+    public Message sendSync(Message msg, long timeoutMs) throws ShuttleRpcException {
+        DefaultPromise<Message> promise = new DefaultPromise<>(channel.eventLoop());
+        sendRpc(msg, new ShuttleSyncRpcCallback(promise));
+        try {
+            return promise.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            throw new ShuttleRpcException(e);
+        }
+    }
+
+    public Message sendSync(Message msg) throws ShuttleRpcException {
+        return sendSync(msg, Integer.MAX_VALUE);
+    }
+
+    public void execute(Runnable runnable) {
+        channel.eventLoop().execute(runnable);
+    }
+}

--- a/core/common/src/main/java/alluxio/shuttle/executor/DefaultThreadExecutor.java
+++ b/core/common/src/main/java/alluxio/shuttle/executor/DefaultThreadExecutor.java
@@ -18,7 +18,6 @@ public class DefaultThreadExecutor extends SingleThreadExecutor{
         queueRefer = (BlockingQueue<Runnable>) taskQueue;
     }
 
-
     public DefaultThreadExecutor(String name) {
         this(name, Constants.DEFAULT_MSG_QUEUE_SIZE, 0);
     }

--- a/core/common/src/main/java/alluxio/shuttle/executor/DefaultThreadExecutor.java
+++ b/core/common/src/main/java/alluxio/shuttle/executor/DefaultThreadExecutor.java
@@ -1,0 +1,45 @@
+package alluxio.shuttle.executor;
+
+import alluxio.shuttle.Constants;
+
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Use a bounded blocking queue to store tasks for one thread
+ */
+public class DefaultThreadExecutor extends SingleThreadExecutor{
+    private final BlockingQueue<Runnable> queueRefer;
+
+    public DefaultThreadExecutor(String name, int queueSize, int waitMs) {
+        super(name, queueSize, waitMs);
+        queueRefer = (BlockingQueue<Runnable>) taskQueue;
+    }
+
+
+    public DefaultThreadExecutor(String name) {
+        this(name, Constants.DEFAULT_MSG_QUEUE_SIZE, 0);
+    }
+
+    @Override
+    protected Queue<Runnable> createTaskQueue(int queueSize) {
+        return new ArrayBlockingQueue<>(queueSize);
+    }
+
+    @Override
+    protected Runnable pollTask() throws InterruptedException {
+       return queueRefer.poll(Constants.PAUSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected boolean offerTask(Runnable task) throws InterruptedException {
+        if (waitMs <= 0) {
+            queueRefer.put(task);
+            return true;
+        } else {
+            return queueRefer.offer(task, waitMs, TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/core/common/src/main/java/alluxio/shuttle/executor/GroupExecutor.java
+++ b/core/common/src/main/java/alluxio/shuttle/executor/GroupExecutor.java
@@ -138,18 +138,16 @@ public abstract class GroupExecutor extends AbstractExecutorService {
 
     @Override
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        long deadline = System.nanoTime() + unit.toNanos(timeout);
-        loop:
+        final long deadline = System.nanoTime() + unit.toNanos(timeout);
         for (Iterator<SingleThreadExecutor> it = allThreadsIterator(); it.hasNext(); ) {
             SingleThreadExecutor thread = it.next();
-            for (;;) {
-                long timeLeft = deadline - System.nanoTime();
-                if (timeLeft <= 0) {
-                    break loop;
-                }
-                if (thread.awaitTermination(timeLeft, TimeUnit.NANOSECONDS)) {
-                    break;
-                }
+            long timeLeft = deadline - System.nanoTime();
+            if (timeLeft <= 0) {
+                LOG.warn("Wait all threads terminate, after {} {} timeout.", timeout, unit.name());
+                break;
+            }
+            if (thread.awaitTermination(timeLeft, TimeUnit.NANOSECONDS)) {
+                continue;
             }
         }
 

--- a/core/common/src/main/java/alluxio/shuttle/executor/GroupExecutor.java
+++ b/core/common/src/main/java/alluxio/shuttle/executor/GroupExecutor.java
@@ -1,0 +1,182 @@
+package alluxio.shuttle.executor;
+
+import alluxio.exception.ShuttleRpcExecutorException;
+import alluxio.exception.ShuttleRpcRuntimeException;
+import alluxio.shuttle.Constants;
+import org.apache.commons.codec.digest.MurmurHash3;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Thread pool model as grouping tasks by specified thread id.
+ * The read / write tasks of same file will put the queue of one thread, et.
+ * Thread id depends on the hash value of label.
+ */
+public abstract class GroupExecutor extends AbstractExecutorService {
+    protected final Logger LOG = LoggerFactory.getLogger(this.getClass());
+
+    protected final List<SingleThreadExecutor> threadGroup;
+    protected final int threadNum;
+    protected final int queueSize;
+    protected final int waitMs;
+    protected volatile boolean stopped = false;
+
+    public GroupExecutor(
+            int threadNum,
+            int queueSize,
+            int waitMs) {
+        this.threadNum = threadNum > 0 ? threadNum : Constants.DEFAULT_GROUP_THREAD_NUM;
+        this.queueSize = queueSize > 0 ? queueSize : Constants.DEFAULT_MSG_QUEUE_SIZE;
+        this.waitMs = waitMs;
+        this.threadGroup = createThreadGroup();
+
+        LOG.info("{} create success, treadNum: {}, queueSize {}, waitMs {}",
+                getClass().getSimpleName(), this.threadNum, this.queueSize, this.waitMs);
+    }
+
+    public GroupExecutor() {
+        this(0, 0, 0);
+    }
+
+    public GroupExecutor(int threadNum) {
+        this(threadNum, 0, 0);
+    }
+
+    protected abstract List<SingleThreadExecutor> createThreadGroup();
+
+    protected abstract SingleThreadExecutor getThread(long value);
+
+    protected Iterator<SingleThreadExecutor> allThreadsIterator() {
+        return threadGroup.iterator();
+    }
+
+    public Thread getJavaThread(long value) {
+        return getThread(value).thread;
+    }
+
+    /**
+     * Put the runnable task into the queue of specified thread by threadId
+     * @param threadId specified thread
+     * @param command task
+     * @throws ShuttleRpcExecutorException
+     */
+    public void execute(long threadId, Runnable command) throws ShuttleRpcExecutorException {
+        checkStop();
+        getThread(threadId).execute(command);
+    }
+
+    @Override
+    public void execute(@Nonnull Runnable runnable) {
+        throw new ShuttleRpcRuntimeException("Execute thread index is required in GroupExecutor!");
+    }
+
+    /**
+     * Get thread id
+     * @param value
+     * @return
+     */
+    public long getIndex(long value) {
+        return Math.abs(MurmurHash3.hash32(value) % threadNum);
+    }
+
+    public String threadName(int i) {
+        return this.getClass().getSimpleName() + "-" + i;
+    }
+
+    public String threadName(long i) {
+        return this.getClass().getSimpleName() + "-" + i;
+    }
+
+    public String threadName(String name) {
+        return this.getClass().getSimpleName() + "-" + name;
+    }
+
+    public int getPendingTask(long value) {
+        return getThread(value).getPendingTask();
+    }
+
+    protected void checkStop() throws ShuttleRpcExecutorException {
+        if (stopped) {
+            throw new ShuttleRpcExecutorException("The thread pool has been stopped");
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        shutdown(0);
+    }
+
+    public synchronized void shutdown(long timeoutMs) {
+        if (stopped) {
+            return;
+        }
+
+        for (Iterator<SingleThreadExecutor> it = allThreadsIterator(); it.hasNext(); ) {
+            SingleThreadExecutor shareThread = it.next();
+            shareThread.shutdown(timeoutMs);
+        }
+        stopped = true;
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        shutdown();
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return stopped;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        long deadline = System.nanoTime() + unit.toNanos(timeout);
+        loop:
+        for (Iterator<SingleThreadExecutor> it = allThreadsIterator(); it.hasNext(); ) {
+            SingleThreadExecutor thread = it.next();
+            for (;;) {
+                long timeLeft = deadline - System.nanoTime();
+                if (timeLeft <= 0) {
+                    break loop;
+                }
+                if (thread.awaitTermination(timeLeft, TimeUnit.NANOSECONDS)) {
+                    break;
+                }
+            }
+        }
+
+        return isTerminated();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        for (Iterator<SingleThreadExecutor> it = allThreadsIterator(); it.hasNext(); ) {
+            SingleThreadExecutor thread = it.next();
+            if (!thread.isShutdown()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public int getThreadNum() {
+        return threadNum;
+    }
+
+    public int getQueueSize() {
+        return queueSize;
+    }
+
+    public int getWaitMs() {
+        return waitMs;
+    }
+}

--- a/core/common/src/main/java/alluxio/shuttle/executor/SingleThreadExecutor.java
+++ b/core/common/src/main/java/alluxio/shuttle/executor/SingleThreadExecutor.java
@@ -1,0 +1,193 @@
+package alluxio.shuttle.executor;
+
+import alluxio.exception.ShuttleRpcRuntimeException;
+import alluxio.shuttle.Constants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public abstract class SingleThreadExecutor extends AbstractExecutorService {
+    protected final Logger LOG = LoggerFactory.getLogger(this.getClass());
+
+    protected final String name;
+    protected final int queueSize;
+    protected final int waitMs;
+    protected final Thread thread;
+    protected final Queue<Runnable> taskQueue;
+
+    protected final AtomicInteger ctl = new AtomicInteger(Constants.ThreadStatus.INIT.getValue());
+
+    protected Callable<Boolean> END_TASK = () -> {
+        advanceRunState(Constants.ThreadStatus.STOP.getValue());
+        return true;
+    };
+
+    public SingleThreadExecutor(String name, int queueSize, int waitMs) {
+        this.name = name;
+        this.queueSize = queueSize;
+        this.waitMs = waitMs;
+        this.taskQueue = createTaskQueue(queueSize);
+        thread = new Thread(this::run);
+        thread.setName(name);
+        thread.setDaemon(true);
+        thread.start();
+        advanceRunState(Constants.ThreadStatus.RUNNING.getValue());
+    }
+
+    public SingleThreadExecutor(String name) {
+        this(name, Constants.DEFAULT_MSG_QUEUE_SIZE, 0);
+    }
+
+    protected abstract Queue<Runnable> createTaskQueue(int queueSize);
+
+    protected abstract Runnable pollTask() throws InterruptedException;
+
+    protected abstract boolean offerTask(Runnable task) throws InterruptedException;
+
+    @Override
+    public void execute(@Nonnull Runnable task) {
+        if (isShutdown()) {
+            throw new ShuttleRpcRuntimeException("The thread has been shutdown, cannot add tasks");
+        }
+
+        try {
+            boolean bool = offerTask(task);
+            if (!bool) {
+                String msg = String.format("thread %s queue is full(queueSize=%s)", name, queueSize);
+                throw new ShuttleRpcRuntimeException(msg);
+            }
+        } catch (InterruptedException e) {
+            LOG.info("thread {} quit", name);
+        }
+    }
+
+    public void run() {
+        Runnable task;
+        while (canRunTask()) {
+            try {
+                while ((task = pollTask()) != null) {
+                    task.run();
+                }
+            } catch (Throwable e) {
+                LOG.error("run fail", e);
+            }
+        }
+    }
+
+    public int getPendingTask() {
+        return taskQueue.size();
+    }
+
+    /**
+     * ST_SHUTDOWN is a transitional state, new tasks cannot be added,
+     * but tasks in the queue can continue to be executed
+     */
+    protected boolean canRunTask() {
+        return ctl.get() <= Constants.ThreadStatus.SHUTDOWN.getValue();
+    }
+
+    /**
+     * Must be in running state to add new tasks
+     */
+    protected boolean canAddTask() {
+        return ctl.get() <= Constants.ThreadStatus.RUNNING.getValue();
+    }
+
+    public boolean isStop() {
+        return ctl.get() == Constants.ThreadStatus.STOP.getValue();
+    }
+
+    private static boolean runStateAtLeast(int c, int s) {
+        return c >= s;
+    }
+
+    public void advanceRunState(int targetState) {
+        for (;;) {
+            int c = ctl.get();
+            if (runStateAtLeast(c, targetState) || ctl.compareAndSet(c, targetState)) {
+                break;
+            }
+        }
+    }
+
+    public void shutdown(long timeoutMs) {
+        if (isShutdown()) {
+            LOG.warn("The thread has been shutdown");
+            return;
+        }
+
+        advanceRunState(Constants.ThreadStatus.SHUTDOWN.getValue());
+
+        long wait = 0;
+        while(taskQueue.size() != 0) {
+            if (timeoutMs > 0 && wait >= waitMs) {
+                break;
+            }
+            long start = System.currentTimeMillis();
+            try {
+                Thread.sleep(Constants.PAUSE_TIMEOUT_MS);
+            } catch (InterruptedException e) {
+                LOG.warn("thread shutdown", e);
+            }
+            wait += System.currentTimeMillis() - start;
+        }
+
+        advanceRunState(Constants.ThreadStatus.STOP.getValue());
+
+        if (thread != Thread.currentThread()) {
+            try {
+                thread.join(timeoutMs);
+            } catch (InterruptedException e) {
+                // pass
+            }
+        }
+
+        if (thread.isAlive()) {
+            thread.interrupt();
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        shutdown(0);
+    }
+
+    public Future<Boolean> sendStop() {
+        return submit(END_TASK);
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        shutdown();
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return ctl.get() >= Constants.ThreadStatus.SHUTDOWN.getValue();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return ctl.get() >= Constants.ThreadStatus.STOP.getValue();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        thread.join(unit.toMillis(timeout));
+        return isTerminated();
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/core/common/src/main/java/alluxio/shuttle/handler/RpcCallback.java
+++ b/core/common/src/main/java/alluxio/shuttle/handler/RpcCallback.java
@@ -1,0 +1,21 @@
+package alluxio.shuttle.handler;
+
+
+import alluxio.shuttle.message.Message;
+
+public interface RpcCallback {
+    /**
+     * Request success callback
+     */
+    void onSuccess(Message message);
+
+    /**
+     * Request failure callback
+     */
+    void onFailure(long reqId, Throwable cause);
+
+    /**
+     * Channel exception callback, such as connection close, timeout, etc.
+     */
+    default void onChannelError(Throwable cause) {};
+}

--- a/core/common/src/main/java/alluxio/shuttle/handler/ShuttleRpcMessageProcessor.java
+++ b/core/common/src/main/java/alluxio/shuttle/handler/ShuttleRpcMessageProcessor.java
@@ -1,0 +1,177 @@
+package alluxio.shuttle.handler;
+
+import alluxio.exception.ShuttleRpcException;
+import alluxio.shuttle.client.ShuttleRpcClient;
+import alluxio.shuttle.executor.GroupExecutor;
+import alluxio.shuttle.message.Message;
+import io.netty.channel.ChannelHandlerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ShuttleRpcMessageProcessor {
+    protected final Logger LOG = LoggerFactory.getLogger(this.getClass());
+
+    protected GroupExecutor executor;
+    protected ShuttleRpcClient client;
+    private final Map<Long, RpcCallback> flightingRpc;
+
+    public ShuttleRpcMessageProcessor() {
+        flightingRpc = new ConcurrentHashMap<>();
+    }
+
+    public synchronized void setClientAndExecutor(GroupExecutor executor, ShuttleRpcClient client) {
+        this.client = client;
+        this.executor = executor;
+        this.init();
+    }
+
+    public void init() {
+    }
+
+    public void setClientAndExecutor(ShuttleRpcClient client) {
+        setClientAndExecutor(null, client);
+    }
+
+    public long getAssignId(Message msg) {
+        return msg.getReqId();
+    }
+
+    public void handle(ChannelHandlerContext ctx, Message msg) throws Exception {
+        if (executor == null) {
+            // If the executor is null, the handler does not release the buffer because there is no way
+            // to know when the data processing will end.
+            call(msg);
+        } else {
+            executor.execute(getAssignId(msg), () -> {
+                boolean isRelease = false;
+                try {
+                    isRelease = call(msg);
+                } catch (Exception e) {
+                    ctx.fireExceptionCaught(e);
+                } finally {
+                    if (!isRelease) {
+                        msg.releaseBody();
+                    }
+                }
+            });
+        }
+    }
+
+
+    public boolean call(Message msg) {
+        RpcCallback callback = getCallback(msg);
+        if (callback == null) {
+            LOG.warn("Ignoring response for reqId {} from {} since it is complete", msg.getReqId(), client.address());
+            msg.releaseBody();
+            return true;
+        }
+
+        if (!msg.isError()) {
+            callback.onSuccess(msg);
+            return false;
+        } else {
+            IOException ioException = new IOException(msg.getNettyBody().toString(Charset.defaultCharset()));
+            callback.onFailure(msg.getReqId(), new IOException(ioException));
+            msg.releaseBody();
+            return true;
+        }
+    }
+
+    public int getFlightingRpcCount() {
+        return flightingRpc.size();
+    }
+
+    public boolean hasFlightingRpc() {
+        return getFlightingRpcCount() > 0;
+    }
+
+
+    public void channelActive(ChannelHandlerContext ctx) {
+        // pass
+    }
+
+    public void channelInactive(ChannelHandlerContext ctx) throws IOException {
+        if (hasFlightingRpc()) {
+            LOG.error("Still have {} requests not completed when connection from {} is closed",
+                    getFlightingRpcCount(), client.address());
+            failFlightingRpc(new IOException("Connection " + client.address() + " closed"));
+        }
+    }
+
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable e) {
+        if (hasFlightingRpc()) {
+            LOG.error("Still have {} requests not completed when connection from {} is closed",
+                    getFlightingRpcCount(), client.address());
+            failFlightingRpc(e);
+        }
+    }
+
+
+    public void channelTimeout(ChannelHandlerContext ctx) {
+    }
+
+    public void failFlightingRpc(Throwable cause) {
+        for (Map.Entry<Long, RpcCallback> entry : flightingRpc.entrySet()) {
+            try {
+                entry.getValue().onFailure(entry.getKey(), cause);
+            } catch (Exception e) {
+                LOG.error("rpc.onFailure throws exception", e);
+            }
+        }
+
+        flightingRpc.clear();
+    }
+
+    public void addRpc(long reqId, RpcCallback callback) {
+        flightingRpc.put(reqId, callback);
+    }
+
+    private RpcCallback getCallback(Message msg) {
+        RpcCallback callback;
+        if (msg.isLastReq())  {
+            callback = flightingRpc.remove(msg.getReqId());
+        } else {
+            callback = flightingRpc.get(msg.getReqId());
+            if (callback instanceof ShuttleSyncRpcCallback) {
+                flightingRpc.remove(msg.getReqId());
+            }
+        }
+        return callback;
+    }
+
+
+
+    public synchronized void setCallback(long reqId, RpcCallback callback) throws ShuttleRpcException {
+        if (flightingRpc.containsKey(reqId)) {
+            LOG.warn("The reqId:{} callback already exists", reqId);
+            throw new ShuttleRpcException("The reqId " + reqId +
+                    " callback function already exists, it is not allowed to set it repeatedly");
+        } else {
+            flightingRpc.put(reqId, callback);
+        }
+    }
+
+    public void removeCallback(long reqId) throws ShuttleRpcException {
+        if (!flightingRpc.containsKey(reqId)) {
+            LOG.warn("The reqId:{} not exists in flighting rpc", reqId);
+            throw new ShuttleRpcException("The reqId " + reqId +
+                    " callback function does not exist");
+        } else {
+            flightingRpc.remove(reqId);
+        }
+    }
+
+    public void onSuccess(Message msg) {
+        getCallback(msg).onSuccess(msg);
+    }
+
+    public void onFailure(Message msg, Throwable cause) {
+        getCallback(msg).onFailure(msg.getReqId(), cause);
+    }
+
+}

--- a/core/common/src/main/java/alluxio/shuttle/handler/ShuttleSyncRpcCallback.java
+++ b/core/common/src/main/java/alluxio/shuttle/handler/ShuttleSyncRpcCallback.java
@@ -1,0 +1,22 @@
+package alluxio.shuttle.handler;
+
+import alluxio.shuttle.message.Message;
+import io.netty.util.concurrent.DefaultPromise;
+
+public class ShuttleSyncRpcCallback implements RpcCallback{
+    private final DefaultPromise<Message> promise;
+
+    public ShuttleSyncRpcCallback(DefaultPromise<Message> promise) {
+        this.promise = promise;
+    }
+
+    @Override
+    public void onSuccess(Message message) {
+        promise.setSuccess(message);
+    }
+
+    @Override
+    public void onFailure(long reqId, Throwable cause) {
+        promise.setFailure(cause);
+    }
+}

--- a/core/common/src/main/java/alluxio/shuttle/message/Message.java
+++ b/core/common/src/main/java/alluxio/shuttle/message/Message.java
@@ -1,0 +1,46 @@
+package alluxio.shuttle.message;
+
+import io.netty.buffer.ByteBuf;
+
+public abstract class Message {
+    public final static byte VERSION = 1;
+    public final static int CONTROL_LEN = 2 * Byte.BYTES + Long.BYTES + Integer.BYTES;
+    public final static int PROTOCOL_LEN = 2 * Integer.BYTES;
+    public final static int END_SEQ_ID = -100;
+    public final static int INIT_SEQ_ID = -99;
+
+    public abstract ByteBuf encode();
+    public abstract long getReqId();
+    public abstract boolean isLastReq();
+    public abstract void releaseBody();
+    public abstract boolean isError();
+    public abstract ByteBuf getNettyBody();
+
+    public enum Status {
+        HEARTBEAT((byte)20),
+        OPEN((byte)21),
+        RUNNING((byte)22),
+
+        SUCCESS((byte)23),
+        COMPLETE((byte)24),
+        CANCEL((byte)25),
+        ERROR((byte)26);
+
+        public final byte code;
+
+        Status(byte code) {
+            this.code = code;
+        }
+
+        private static final int FIRST_CODE = values()[0].code;
+
+        public static Status valueOf(byte code) {
+            final int i = (code & 0xff) - FIRST_CODE;
+            return i < 0 || i >= values().length ? null : values()[i];
+        }
+
+        public static Status read(ByteBuf buf) {
+            return valueOf(buf.readByte());
+        }
+    }
+}


### PR DESCRIPTION
As a popular distributed cache system, Alluxio has good performance in read and write scenarios with small amounts of data. However, in large-scale data read and write scenarios, Alluxio's performance is somewhat unsatisfactory.
We use Netty instead of GRPC as data transmitting underlying architecture to improve the performance of data reading and writing.
The data serialization of pb consumes too much cpu time, we take advantage zero-copy of off-heap memory to send and receive data, striping data byte from pb messages.
In addition, we propose a customized thread pool model which to assure pressing sequentially for one file or data block.
The detailed design is shown in the following document：
https://docs.google.com/document/d/1A63xwD_vQtsBYg2AG2iN6q2B0NMMk0how8cD75EurAE/edit#