### PR TITLE
Port changes of [#15699] to branch-2.8

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
@@ -11,7 +11,6 @@
 
 package alluxio.master.journal.ufs;
 
-import alluxio.ProcessUtils;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.master.Master;
@@ -85,12 +84,14 @@ public final class UfsJournalCheckpointThread extends Thread {
 
   /** The last sequence number applied to the journal. */
   private volatile long mLastAppliedSN;
+  // this throwable gets set if the thread completes exceptionally
+  private Throwable mThrowable = null;
 
   /**
    * The state of the journal catchup.
    */
   public enum CatchupState {
-    NOT_STARTED, IN_PROGRESS, DONE;
+    NOT_STARTED, IN_PROGRESS, DONE
   }
 
   private volatile CatchupState mCatchupState = CatchupState.NOT_STARTED;
@@ -126,12 +127,20 @@ public final class UfsJournalCheckpointThread extends Thread {
     mCheckpointPeriodEntries =
         ServerConfiguration.getInt(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES);
     mJournalSinks = journalSinks;
+    setUncaughtExceptionHandler((thread, t) -> {
+      mThrowable = t;
+      // if the catchup thread terminates exceptionally, it has caught up as much as it can and
+      // is done
+      mCatchupState = CatchupState.DONE;
+    });
   }
 
   /**
    * Initiates the shutdown of this checkpointer thread, and also waits for it to finish.
    *
    * @param waitQuietPeriod whether to wait for a quiet period to pass before terminating the thread
+   * @throws RuntimeException if {@link #join()} throws an InterruptedException or if
+   * {@link #run()} completed exceptionally
    */
   public void awaitTermination(boolean waitQuietPeriod) {
     LOG.info("{}: Journal checkpointer shutdown has been initiated.", mMaster.getName());
@@ -147,7 +156,10 @@ public final class UfsJournalCheckpointThread extends Thread {
     try {
       // Wait for the thread to finish.
       join();
-      LOG.info("{}: Journal shutdown complete", mMaster.getName());
+      if (mThrowable != null) {
+        throw new RuntimeException(mThrowable);
+      }
+      LOG.info("{}: Journal checkpointer shutdown complete", mMaster.getName());
     } catch (InterruptedException e) {
       LOG.error("{}: journal checkpointer shutdown is interrupted.", mMaster.getName(), e);
       // Kills the master. This can happen in the following two scenarios:
@@ -187,11 +199,6 @@ public final class UfsJournalCheckpointThread extends Thread {
     try {
       t.start();
       runInternal();
-    } catch (Throwable e) {
-      t.interrupt();
-      ProcessUtils.fatalError(LOG, e, "%s: Failed to run journal checkpoint thread, crashing.",
-          mMaster.getName());
-      System.exit(-1);
     } finally {
       t.interrupt();
       try {
@@ -224,13 +231,14 @@ public final class UfsJournalCheckpointThread extends Thread {
           case LOG:
             entry = mJournalReader.getEntry();
             try {
-              if (!mMaster.processJournalEntry(entry)) {
-                JournalUtils
-                    .handleJournalReplayFailure(LOG, null, "%s: Unrecognized journal entry: %s",
-                        mMaster.getName(), entry);
-              } else {
+              if (mMaster.processJournalEntry(entry)) {
                 JournalUtils.sinkAppend(mJournalSinks, entry);
+              } else {
+                JournalUtils.handleJournalReplayFailure(LOG, null,
+                    "%s: Unrecognized journal entry: %s", mMaster.getName(), entry);
               }
+            } catch (RuntimeException e) {
+              throw e;
             } catch (Throwable t) {
               JournalUtils.handleJournalReplayFailure(LOG, t,
                   "%s: Failed to read or process journal entry %s.", mMaster.getName(), entry);

--- a/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
+++ b/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
@@ -12,16 +12,25 @@
 package alluxio.master;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.Constants;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.ServerConfiguration;
 import alluxio.exception.status.UnavailableException;
+import alluxio.master.journal.JournalSystem;
+import alluxio.master.journal.JournalType;
+import alluxio.master.journal.JournalUtils;
 import alluxio.master.journal.noop.NoopJournalSystem;
 import alluxio.master.journal.raft.RaftJournalConfiguration;
 import alluxio.master.journal.raft.RaftJournalSystem;
+import alluxio.master.journal.ufs.UfsJournal;
+import alluxio.master.journal.ufs.UfsJournalLogWriter;
+import alluxio.proto.journal.File;
+import alluxio.proto.journal.Journal;
 import alluxio.util.CommonUtils;
+import alluxio.util.URIUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.FileUtils;
 import alluxio.util.io.PathUtils;
@@ -40,8 +49,8 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
@@ -51,10 +60,13 @@ import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -180,6 +192,58 @@ public final class AlluxioMasterProcessTest {
     t.join(WAIT_TIME_TO_THROW_EXC);
     t.interrupt();
     Assert.assertTrue(success.get());
+  }
+
+  @Test
+  public void failToGainPrimacyWhenJournalCorrupted() throws Exception {
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    URI journalLocation = JournalUtils.getJournalLocation();
+    JournalSystem journalSystem = new JournalSystem.Builder()
+        .setLocation(journalLocation).build(CommonUtils.ProcessType.MASTER);
+    AlluxioMasterProcess masterProcess = new AlluxioMasterProcess(journalSystem);
+    corruptJournalAndStartMasterProcess(masterProcess, journalLocation);
+  }
+
+  @Test
+  public void failToGainPrimacyWhenJournalCorruptedHA() throws Exception {
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    URI journalLocation = JournalUtils.getJournalLocation();
+    JournalSystem journalSystem = new JournalSystem.Builder()
+        .setLocation(journalLocation).build(CommonUtils.ProcessType.MASTER);
+    ControllablePrimarySelector primarySelector = new ControllablePrimarySelector();
+    FaultTolerantAlluxioMasterProcess masterProcess =
+        new FaultTolerantAlluxioMasterProcess(journalSystem, primarySelector);
+    primarySelector.setState(PrimarySelector.State.PRIMARY);
+    corruptJournalAndStartMasterProcess(masterProcess, journalLocation);
+  }
+
+  private void corruptJournalAndStartMasterProcess(AlluxioMasterProcess masterProcess,
+      URI journalLocation) throws Exception {
+    masterProcess.mJournalSystem.format();
+    // corrupt the journal
+    UfsJournal fsMaster =
+        new UfsJournal(URIUtils.appendPathOrDie(journalLocation, "FileSystemMaster"),
+            new NoopMaster(), 0, Collections::emptySet);
+    fsMaster.start();
+    fsMaster.gainPrimacy();
+    long nextSN = 0;
+    try (UfsJournalLogWriter writer = new UfsJournalLogWriter(fsMaster, nextSN)) {
+      Journal.JournalEntry entry = Journal.JournalEntry.newBuilder()
+          .setSequenceNumber(nextSN)
+          .setDeleteFile(File.DeleteFileEntry.newBuilder()
+              .setId(4563728) // random non-zero ID number (zero would delete the root)
+              .setPath("/nonexistant")
+              .build())
+          .build();
+      writer.write(entry);
+      writer.flush();
+    }
+    // comes from mJournalSystem#gainPrimacy
+    RuntimeException exception = assertThrows(RuntimeException.class, masterProcess::start);
+    assertTrue(exception.getMessage().contains(NoSuchElementException.class.getName()));
+    // if AlluxioMasterProcess#start throws an exception, then #stop will get called
+    masterProcess.stop();
+    assertTrue(masterProcess.isStopped());
   }
 
   @Test


### PR DESCRIPTION
### What changes are proposed in this pull request?
The `UfsJournalCheckpointThread` calls `System.exit(-1)` when encountering journal corruption. This causes a deadlock between the `UfsJournalCheckpointThread` and the shutdown hook calling `AlluxioMasterProcess.stop()`.
This PR removes the `System.exit()` calls in favor of propagating exceptions when the thread completes. 
The net effect is that the master process completely releases its resources when shutting down and terminates without having to be issued `kill -9`.

### Why are the changes needed?
For clean master process termination on errors.

### Does this PR introduce any user facing changes?
No.

[This is an manually generated PR to cherry-pick committed PR Alluxio/alluxio#15699 into target branch branch-2.6]