### PR TITLE
Port changes of [#15698] to branch-2.8

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2512,6 +2512,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setIsHidden(true)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED =
+      booleanBuilder(Name.MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED)
+          .setDefaultValue(true)
+          .setDescription("Takes a backup automatically when encountering journal corruption")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_JOURNAL_TYPE =
       enumBuilder(Name.MASTER_JOURNAL_TYPE, JournalType.class)
           .setDefaultValue(JournalType.EMBEDDED)
@@ -6661,6 +6668,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         = "alluxio.master.journal.space.monitor.percent.free.threshold";
     public static final String MASTER_JOURNAL_TOLERATE_CORRUPTION
         = "alluxio.master.journal.tolerate.corruption";
+    public static final String MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED
+        = "alluxio.master.journal.backup.when.corrupted";
     public static final String MASTER_JOURNAL_TYPE = "alluxio.master.journal.type";
     public static final String MASTER_JOURNAL_LOG_SIZE_BYTES_MAX =
         "alluxio.master.journal.log.size.bytes.max";

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalReader.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalReader.java
@@ -101,7 +101,7 @@ public final class UfsJournalReader implements JournalReader {
    * @param journal the handle to the journal
    * @param readIncompleteLog whether to read incomplete logs
    */
-  UfsJournalReader(UfsJournal journal, boolean readIncompleteLog) {
+  public UfsJournalReader(UfsJournal journal, boolean readIncompleteLog) {
     this(journal, 0, readIncompleteLog);
   }
 

--- a/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
+++ b/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
@@ -197,6 +197,7 @@ public final class AlluxioMasterProcessTest {
   @Test
   public void failToGainPrimacyWhenJournalCorrupted() throws Exception {
     ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED, false);
     URI journalLocation = JournalUtils.getJournalLocation();
     JournalSystem journalSystem = new JournalSystem.Builder()
         .setLocation(journalLocation).build(CommonUtils.ProcessType.MASTER);
@@ -207,6 +208,7 @@ public final class AlluxioMasterProcessTest {
   @Test
   public void failToGainPrimacyWhenJournalCorruptedHA() throws Exception {
     ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED, false);
     URI journalLocation = JournalUtils.getJournalLocation();
     JournalSystem journalSystem = new JournalSystem.Builder()
         .setLocation(journalLocation).build(CommonUtils.ProcessType.MASTER);

--- a/docs/en/operation/Journal.md
+++ b/docs/en/operation/Journal.md
@@ -393,6 +393,11 @@ we recommend [taking regular journal backups](#automatically-backing-up-the-jour
 at a time when the cluster is under low load.
 Then if something happens to the journal, you can recover from one of the backups.
 
+By default, if a master encounters corruption when replaying a journal it will automatically
+take a backup of the state up to the corrupted entry in the configured backup directory. The master will notice the
+corruption when elected leader. The backup directory is configured by `alluxio.master.backup.directory`.
+This feature can be disabled by setting `alluxio.master.journal.backup.when.corrupted` to `false`.
+
 ### Get a human-readable journal
 
 Alluxio journal is serialized and not human-readable. The following command

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -76,6 +76,10 @@ public class PortCoordination {
   public static final List<ReservedPort> BACKUP_DELEGATION_EMBEDDED = allocate(2, 1);
   public static final List<ReservedPort> BACKUP_RESTORE_METASSTORE_HEAP = allocate(1, 1);
   public static final List<ReservedPort> BACKUP_RESTORE_METASSTORE_ROCKS = allocate(1, 1);
+  public static final List<ReservedPort> BACKUP_EMERGENCY_1 = allocate(1, 0);
+  public static final List<ReservedPort> BACKUP_EMERGENCY_2 = allocate(1, 0);
+  public static final List<ReservedPort> BACKUP_EMERGENCY_HA_1 = allocate(3, 0);
+  public static final List<ReservedPort> BACKUP_EMERGENCY_HA_2 = allocate(3, 0);
 
   public static final List<ReservedPort> ZOOKEEPER_FAILURE = allocate(2, 1);
   public static final List<ReservedPort> ZOOKEEPER_CONNECTION_POLICY_STANDARD = allocate(2, 0);


### PR DESCRIPTION
### What changes are proposed in this pull request?
This PR adds the option of triggering a backup automatically when an Alluxio master shuts down.

### Why are the changes needed?
This helps trigger backups automatically when the master encounters unexpected journal corruption. 

### Does this PR introduce any user facing changes?
It adds a new `PropertyKey` to disable the feature (it is enabled by default).

[This is an manually generated PR to cherry-pick committed PR Alluxio/alluxio#15698 into target branch branch-2.6]