### PR TITLE
Move jvm pause metrics names

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1487,13 +1487,13 @@ public final class MetricKey implements Comparable<MetricKey> {
           .build();
   // Server metrics shared by Master, Worker and other Alluxio servers
   public static final MetricKey TOTAL_EXTRA_TIME =
-      new Builder("Server.JvmPauseMonitorTotalExtraTime")
+      new Builder(Name.TOTAL_EXTRA_TIME)
           .setDescription("The total time that JVM slept and didn't do GC")
           .setMetricType(MetricType.GAUGE)
           .setIsClusterAggregated(false)
           .build();
   public static final MetricKey INFO_TIME_EXCEEDED =
-      new Builder("Server.JvmPauseMonitorInfoTimeExceeded")
+      new Builder(Name.INFO_TIME_EXCEEDED)
           .setDescription(String.format("The total number of times that JVM slept and the sleep"
                   + " period is larger than the info level threshold defined by %s",
               PropertyKey.JVM_MONITOR_INFO_THRESHOLD_MS.getName()))
@@ -1501,7 +1501,7 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setIsClusterAggregated(false)
           .build();
   public static final MetricKey WARN_TIME_EXCEEDED =
-      new Builder("Server.JvmPauseMonitorWarnTimeExceeded")
+      new Builder(Name.WARN_TIME_EXCEEDED)
           .setDescription(String.format("The total number of times that JVM slept and the sleep"
                   + " period is larger than the warn level threshold defined by %s",
               PropertyKey.JVM_MONITOR_WARN_THRESHOLD_MS.getName()))
@@ -2300,6 +2300,16 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.GAUGE)
           .setIsClusterAggregated(false)
           .build();
+
+  /**
+   * A nested class to hold named string constants for their corresponding metrics.
+   */
+  @ThreadSafe
+  public static final class Name {
+    public static final String TOTAL_EXTRA_TIME = "Server.JvmPauseMonitorTotalExtraTime";
+    public static final String INFO_TIME_EXCEEDED = "Server.JvmPauseMonitorInfoTimeExceeded";
+    public static final String WARN_TIME_EXCEEDED = "Server.JvmPauseMonitorWarnTimeExceeded";
+  }
 
   /**
    * Registers the given key to the global key map.

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -728,9 +728,10 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
   @Override
   public void validateBlocks(Function<Long, Boolean> validator, boolean repair)
       throws UnavailableException {
+    long limit = 100;
     List<Long> invalidBlocks = new ArrayList<>();
     try (CloseableIterator<Block> iter = mBlockMetaStore.getCloseableIterator()) {
-      while (iter.hasNext()) {
+      while (iter.hasNext() && invalidBlocks.size() < limit) {
         long id = iter.next().getId();
         if (!validator.apply(id)) {
           invalidBlocks.add(id);
@@ -738,7 +739,6 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
       }
     }
     if (!invalidBlocks.isEmpty()) {
-      long limit = 100;
       List<Long> loggedBlocks = invalidBlocks.stream().limit(limit).collect(Collectors.toList());
       LOG.warn("Found {} orphan blocks without corresponding file metadata.", invalidBlocks.size());
       if (invalidBlocks.size() > limit) {

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -728,10 +728,9 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
   @Override
   public void validateBlocks(Function<Long, Boolean> validator, boolean repair)
       throws UnavailableException {
-    long limit = 100;
     List<Long> invalidBlocks = new ArrayList<>();
     try (CloseableIterator<Block> iter = mBlockMetaStore.getCloseableIterator()) {
-      while (iter.hasNext() && invalidBlocks.size() < limit) {
+      while (iter.hasNext()) {
         long id = iter.next().getId();
         if (!validator.apply(id)) {
           invalidBlocks.add(id);
@@ -739,6 +738,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
       }
     }
     if (!invalidBlocks.isEmpty()) {
+      long limit = 100;
       List<Long> loggedBlocks = invalidBlocks.stream().limit(limit).collect(Collectors.toList());
       LOG.warn("Found {} orphan blocks without corresponding file metadata.", invalidBlocks.size());
       if (invalidBlocks.size() > limit) {


### PR DESCRIPTION
### What changes are proposed in this pull request?
Move jvm pause metrics names so that it can be used.

### Why are the changes needed?
This is for the jvm pause metrics name string reuse

### Does this PR introduce any user facing changes?
NA
