### PR TITLE
Fix Fuse open read_write then truncate to extend file length

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
@@ -158,14 +158,21 @@ public class FuseFileInOrOutStream implements FuseFileStream {
       mOutStream.get().truncate(size);
       return;
     }
-    if (size == getFileLength()) {
+    long currentSize = getFileLength();
+    if (size == currentSize) {
       return;
     }
-    if (size == 0) {
+    if (size == 0 || currentSize == 0) {
       AlluxioFuseUtils.deletePath(mFileSystem, mUri);
       mOutStream = Optional.of(FuseFileOutStream.create(mFileSystem, mAuthPolicy, mUri,
           OpenFlags.O_WRONLY.intValue(), mMode, Optional.empty()));
+      if (currentSize == 0) {
+        mOutStream.get().truncate(size);
+      }
+      return;
     }
+    throw new UnsupportedOperationException(
+        String.format("Cannot truncate file %s from size %s to size %s", mUri, currentSize, size));
   }
 
   @Override

--- a/tests/src/test/java/alluxio/client/fuse/file/FuseFileInOrOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/FuseFileInOrOutStreamIntegrationTest.java
@@ -59,6 +59,24 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
   }
 
   @Test
+  public void openTruncate() throws Exception {
+    AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
+    mFileSystem.createFile(alluxioURI).close();
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    try (FuseFileInOrOutStream stream
+        = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy, alluxioURI,
+        OpenFlags.O_RDWR.intValue(), MODE, Optional.of(uriStatus))) {
+      stream.truncate(DEFAULT_FILE_LEN);
+    }
+    URIStatus status = mFileSystem.getStatus(alluxioURI);
+    Assert.assertNotNull(status);
+    Assert.assertTrue(status.isCompleted());
+    Assert.assertEquals(DEFAULT_FILE_LEN, status.getLength());
+  }
+
+  @Test
   public void createTruncateFlagClose() throws Exception {
     AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
     mFileSystem.createDirectory(alluxioURI.getParent(),


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fixes #15852 support create empty file -> open(rdwr) -> truncate() workload

