### PR TITLE
Fix metric description of 'Cluster.BytesReadDirectThroughput'

### DIFF
--- a/docs/_data/table/en/cluster-metrics.yml
+++ b/docs/_data/table/en/cluster-metrics.yml
@@ -5,7 +5,7 @@ Cluster.ActiveRpcWriteCount:
 Cluster.BytesReadDirect:
   'Total number of bytes read from Alluxio storage managed by workers and underlying UFS if data cannot be found in the Alluxio storage without external RPC involved. This records data read by worker internal calls (e.g. clients embedded in workers).'
 Cluster.BytesReadDirectThroughput:
-  'Total number of bytes read from Alluxio storage managed by workers and underlying UFS if data cannot be found in the Alluxio storage without external RPC involved. This records data read by worker internal calls (e.g. clients embedded in workers).'
+  'Bytes read per minute throughput from Alluxio storage managed by workers and underlying UFS if data cannot be found in the Alluxio storage without external RPC involved. This records data read by worker internal calls (e.g. clients embedded in workers).'
 Cluster.BytesReadDomain:
   'Total number of bytes read from Alluxio storage via domain socket reported by all workers'
 Cluster.BytesReadDomainThroughput:


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix incorrect description of 'Cluster.BytesReadDirectThroughput' in docs.

### Why are the changes needed?

Description of metric 'Cluster.BytesReadDirectThroughput' in docs is incorrect.

### Does this PR introduce any user facing changes?

No.
