### PR TITLE
Fix snapshot from follower thread leak

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2738,6 +2738,21 @@ public final class PropertyKey implements Comparable<PropertyKey> {
                   .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
                   .setScope(Scope.MASTER)
                   .build();
+  public static final PropertyKey MASTER_JOURNAL_REQUEST_DATA_TIMEOUT =
+      durationBuilder(Name.MASTER_JOURNAL_REQUEST_DATA_TIMEOUT)
+          .setDefaultValue(20000)
+          .setDescription("Time to wait for follower to respond to request to send a new snapshot")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_JOURNAL_REQUEST_INFO_TIMEOUT =
+      durationBuilder(Name.MASTER_JOURNAL_REQUEST_INFO_TIMEOUT)
+          .setDefaultValue(20000)
+          .setDescription("Time to wait for follower to respond to request to get information"
+              + " about its latest snapshot")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_JOURNAL_SPACE_MONITOR_INTERVAL =
       durationBuilder(Name.MASTER_JOURNAL_SPACE_MONITOR_INTERVAL)
       .setDefaultValue("10min")
@@ -6969,6 +6984,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.journal.log.size.bytes.max";
     public static final String MASTER_JOURNAL_LOG_CONCURRENCY_MAX =
         "alluxio.master.journal.log.concurrency.max";
+    public static final String MASTER_JOURNAL_REQUEST_DATA_TIMEOUT =
+        "alluxio.master.journal.request.data.timeout";
+    public static final String MASTER_JOURNAL_REQUEST_INFO_TIMEOUT =
+        "alluxio.master.journal.request.info.timeout";
     public static final String MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS =
         "alluxio.master.journal.tailer.shutdown.quiet.wait.time";
     public static final String MASTER_JOURNAL_TAILER_SLEEP_TIME_MS =

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -87,7 +87,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class JournalStateMachine extends BaseStateMachine {
   private static final Logger LOG = LoggerFactory.getLogger(JournalStateMachine.class);
-  private static final Logger SAMPLING_LOG = new SamplingLogger(LOG, 10L * Constants.MINUTE_MS);
+  private static final Logger SAMPLING_LOG = new SamplingLogger(LOG, 10L * Constants.SECOND_MS);
 
   private static final CompletableFuture<Message> EMPTY_FUTURE =
       CompletableFuture.completedFuture(Message.EMPTY);

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -458,8 +458,11 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   }
 
   private RaftClient createClient() {
-    long timeoutMs =
-        Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT);
+    return createClient(Configuration.getMs(
+        PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT));
+  }
+
+  private RaftClient createClient(long timeoutMs) {
     long retryBaseMs =
         Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_INTERVAL);
     long maxSleepTimeMs =
@@ -880,7 +883,8 @@ public class RaftJournalSystem extends AbstractJournalSystem {
    */
   public synchronized CompletableFuture<RaftClientReply> sendMessageAsync(
       RaftPeerId server, Message message) {
-    return sendMessageAsync(server, message, 0);
+    return sendMessageAsync(server, message, Configuration.getMs(
+        PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT));
   }
 
   /**
@@ -893,13 +897,12 @@ public class RaftJournalSystem extends AbstractJournalSystem {
    */
   public synchronized CompletableFuture<RaftClientReply> sendMessageAsync(
       RaftPeerId server, Message message, long timeoutMs) {
-    RaftClient client = createClient();
+    RaftClient client = createClient(timeoutMs);
     RaftClientRequest request = RaftClientRequest.newBuilder()
             .setClientId(mRawClientId)
             .setServerId(server)
             .setGroupId(RAFT_GROUP_ID)
             .setCallId(nextCallId())
-            .setTimeoutMs(timeoutMs)
             .setMessage(message)
             .setType(RaftClientRequest.staleReadRequestType(0))
             .setSlidingWindowEntry(null)

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -880,12 +880,26 @@ public class RaftJournalSystem extends AbstractJournalSystem {
    */
   public synchronized CompletableFuture<RaftClientReply> sendMessageAsync(
       RaftPeerId server, Message message) {
+    return sendMessageAsync(server, message, 0);
+  }
+
+  /**
+   * Sends a message to a raft server asynchronously.
+   *
+   * @param server the raft peer id of the target server
+   * @param message the message to send
+   * @param timeoutMs the message timeout in milliseconds
+   * @return a future to be completed with the client reply
+   */
+  public synchronized CompletableFuture<RaftClientReply> sendMessageAsync(
+      RaftPeerId server, Message message, long timeoutMs) {
     RaftClient client = createClient();
     RaftClientRequest request = RaftClientRequest.newBuilder()
             .setClientId(mRawClientId)
             .setServerId(server)
             .setGroupId(RAFT_GROUP_ID)
             .setCallId(nextCallId())
+            .setTimeoutMs(timeoutMs)
             .setMessage(message)
             .setType(RaftClientRequest.staleReadRequestType(0))
             .setSlidingWindowEntry(null)

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
@@ -348,9 +348,9 @@ public class SnapshotReplicationManager {
    */
   public Message handleRequest(JournalQueryRequest queryRequest) throws IOException {
     if (queryRequest.hasSnapshotInfoRequest()) {
-      SnapshotInfo latestSnapshot = mStorage.getLatestSnapshot();
       SnapshotMetadata requestSnapshot = queryRequest.getSnapshotInfoRequest().getSnapshotInfo();
       Instant start = Instant.now();
+      SnapshotInfo latestSnapshot = mStorage.getLatestSnapshot();
       synchronized (this) {
         // We may need to wait for a valid snapshot to be ready
         while ((latestSnapshot == null
@@ -368,9 +368,9 @@ public class SnapshotReplicationManager {
             LOG.debug("Interrupted while waiting for snapshot", e);
             break;
           }
+          latestSnapshot = mStorage.getLatestSnapshot();
         }
       }
-      latestSnapshot = mStorage.getLatestSnapshot();
       if (latestSnapshot == null) {
         LOG.debug("No snapshot to send");
         return toMessage(GetSnapshotInfoResponse.getDefaultInstance());

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -458,6 +458,7 @@ public class RaftJournalTest {
     // Override defaults for faster quorum formation.
     Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, 550);
     Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, 1100);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 10);
 
     List<InetSocketAddress> clusterAddresses = new ArrayList<>(journalSystemCount);
     List<Integer> freePorts = getFreePorts(journalSystemCount);

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -52,7 +52,6 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
@@ -259,8 +258,8 @@ public class SnapshotReplicationManagerTest {
 
     createSnapshotFile(firstFollower.mStore); // create default 0, 1 snapshot
     createSnapshotFile(secondFollower.mStore, 0, 2); // preferable to the default 0, 1 snapshot
-    // the second follower will not reply to the getInfo request, so the leader will request from the first
-    // after a timeout
+    // the second follower will not reply to the getInfo request, so the leader will request from
+    // the first after a timeout
     secondFollower.disableGetInfo();
 
     mLeaderSnapshotManager.maybeCopySnapshotFromFollower();
@@ -280,8 +279,8 @@ public class SnapshotReplicationManagerTest {
 
     createSnapshotFile(firstFollower.mStore); // create default 0, 1 snapshot
     createSnapshotFile(secondFollower.mStore, 0, 2); // preferable to the default 0, 1 snapshot
-    // the second follower will not start the snapshot upload, so the leader will request from the first
-    // after a timeout
+    // the second follower will not start the snapshot upload, so the leader will request from the
+    // first after a timeout
     secondFollower.disableFollowerUpload();
 
     mLeaderSnapshotManager.maybeCopySnapshotFromFollower();
@@ -291,7 +290,6 @@ public class SnapshotReplicationManagerTest {
     // verify that the leader still requests and get the snapshot from the first follower
     validateSnapshotFile(mLeaderStore, 0, 1);
   }
-
 
   @Test
   public void requestSnapshotHigherTermLowerIndex() throws Exception {
@@ -432,12 +430,12 @@ public class SnapshotReplicationManagerTest {
 
     void disableGetInfo() throws IOException {
       Mockito.doAnswer((args) -> {
-            synchronized (mSnapshotManager) {
-              // we sleep so nothing is returned
-              mSnapshotManager.wait();
-            }
-            return null;
-          }).when(mSnapshotManager)
+        synchronized (mSnapshotManager) {
+          // we sleep so nothing is returned
+          mSnapshotManager.wait();
+        }
+        return null;
+      }).when(mSnapshotManager)
           .handleRequest(argThat(JournalQueryRequest::hasSnapshotInfoRequest));
     }
 

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -12,6 +12,7 @@
 package alluxio.master.journal.raft;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 
 import alluxio.ConfigurationRule;
 import alluxio.conf.PropertyKey;
@@ -51,6 +52,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -123,7 +125,7 @@ public class SnapshotReplicationManagerTest {
     }).collect(Collectors.toList());
 
     Mockito.when(mLeader.getQuorumServerInfoList()).thenReturn(quorumServerInfos);
-    Mockito.when(mLeader.sendMessageAsync(any(), any())).thenAnswer((args) -> {
+    Answer<?> fn = (args) -> {
       RaftPeerId peerId = args.getArgument(0, RaftPeerId.class);
       Message message = args.getArgument(1, Message.class);
       JournalQueryRequest queryRequest = JournalQueryRequest.parseFrom(
@@ -132,7 +134,9 @@ public class SnapshotReplicationManagerTest {
       RaftClientReply reply = Mockito.mock(RaftClientReply.class);
       Mockito.when(reply.getMessage()).thenReturn(response);
       return CompletableFuture.completedFuture(reply);
-    });
+    };
+    Mockito.when(mLeader.sendMessageAsync(any(), any())).thenAnswer(fn);
+    Mockito.when(mLeader.sendMessageAsync(any(), any(), anyLong())).thenAnswer(fn);
   }
 
   private SimpleStateMachineStorage getSimpleStateMachineStorage() throws IOException {

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -290,7 +290,8 @@ public class SnapshotReplicationManagerTest {
     // verify that the leader still requests and get the snapshot from the first follower
     validateSnapshotFile(mLeaderStore, 0, 1);
   }
-@Test
+
+  @Test
   public void failFailThenSuccess() throws Exception {
     before(3);
     List<Follower> followers = new ArrayList<>(mFollowers.values());
@@ -322,6 +323,7 @@ public class SnapshotReplicationManagerTest {
         (num) -> num == 2, mWaitOptions);
     validateSnapshotFile(mLeaderStore, 0, 2);
   }
+
   @Test
   public void requestSnapshotHigherTermLowerIndex() throws Exception {
     before(2);

--- a/core/transport/src/main/proto/grpc/raft_journal.proto
+++ b/core/transport/src/main/proto/grpc/raft_journal.proto
@@ -23,6 +23,7 @@ message AddQuorumServerRequest {
 }
 
 message GetSnapshotInfoRequest {
+  optional SnapshotMetadata snapshotInfo = 1;
 }
 
 message GetSnapshotInfoResponse {

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -6048,7 +6048,14 @@
             ]
           },
           {
-            "name": "GetSnapshotInfoRequest"
+            "name": "GetSnapshotInfoRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "snapshotInfo",
+                "type": "SnapshotMetadata"
+              }
+            ]
           },
           {
             "name": "GetSnapshotInfoResponse",


### PR DESCRIPTION
### What changes are proposed in this pull request?

When using Ratis, the primary master does not take a snapshot itself, instead it requests a snapshot from a follower. This pull request fixes two issues with the current implementation of this.

1. Currently when a snapshot needs to be taken as given by `alluxio.master.journal.checkpoint.period.entries`, Ratis will call `takeSnapshot()` in the JournalStateMachine each time a journal entry is committed until a new snapshot is installed. On the primary master `takeSnapshot()` runs asynchronously by first requesting snapshot information from each follower, then downloading a snapshot form one of them if a valid snapshot is available. If no valid snapshot is available (which is likely since all nodes take snapshots at the same log index and it takes time to generate a snapshot) the request happens repeatedly until one is available, but each request allocates a new GRPC connection, eventually this may cause the master to crash or fail over from allocating too many threads. This is fixed by having the follower block until a valid snapshot is available before sending the reply (with a configurable timeout).

2. Currently when a primary master sends a request to a follower to start sending the snapshot it always expects the follower to start a new RPC to do this, but if the follower does not do this (for example due to any sort of failure or network issue) then the primary master will always be waiting for this RPC and never install a new snapshot. This is fixed by adding a timeout for the follower to start the RPC, and if the timeout runs out, a new follower is tried, or the snapshot request protocol starts again if none are available presently.

### Does this PR introduce any user facing changes?

No
