### PR TITLE
Refactor the address API of alluxio client

### DIFF
--- a/core/client/fs/src/test/java/alluxio/client/file/MockFileSystemMasterClient.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/MockFileSystemMasterClient.java
@@ -194,7 +194,12 @@ class MockFileSystemMasterClient implements FileSystemMasterClient {
   }
 
   @Override
-  public InetSocketAddress getAddress() throws UnavailableException {
+  public InetSocketAddress getRemoteSockAddress() throws UnavailableException {
+    return null;
+  }
+
+  @Override
+  public String getRemoteHostName() throws UnavailableException {
     return null;
   }
 

--- a/core/client/fs/src/test/java/alluxio/client/file/MockFileSystemMasterClient.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/MockFileSystemMasterClient.java
@@ -37,6 +37,7 @@ import alluxio.wire.SyncPointInfo;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -194,7 +195,7 @@ class MockFileSystemMasterClient implements FileSystemMasterClient {
   }
 
   @Override
-  public InetSocketAddress getRemoteSockAddress() throws UnavailableException {
+  public SocketAddress getRemoteSockAddress() throws UnavailableException {
     return null;
   }
 

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -360,9 +360,11 @@ public abstract class AbstractClient implements Client {
       return (InetSocketAddress) sockAddress;
     }
 
-    // We would reach here when the client talks to an Alluxio Worker through
-    // domain socket. Such client doesn't load configuration anyway. So this line
-    // currently should not be reached.
+    // We would reach here if a child's implementation provided a socket address
+    // that is not a TCP/IP socket, e.g. a block worker client that talks to a
+    // a worker via Unix domain socket. But client configuration is only provided 
+    // by meta master via a TCP/IP socket, so reaching here indicates a bug in
+    // the implementation of the child.
     throw new UnavailableException("Remote is not an InetSockAddress");
   }
 

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -347,6 +347,10 @@ public abstract class AbstractClient implements Client {
 
   @Override
   public synchronized InetSocketAddress getConfAddress() throws UnavailableException {
+    if (mServerAddress == null) {
+      mServerAddress = queryGrpcServerAddress();
+    }
+
     SocketAddress sockAddress = mServerAddress.getSocketAddress();
     if (sockAddress instanceof InetSocketAddress) {
       return (InetSocketAddress) sockAddress;

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -349,6 +349,15 @@ public abstract class AbstractClient implements Client {
     return mServerAddress.getHostName();
   }
 
+  /**
+   * By default, return the same underlying address as
+   * {@link AbstractClient#getRemoteSockAddress()}.
+   * Child classes should override this implementation if they intend to have different
+   * address to fetch configuration.
+   *
+   * @return the remote address of the configuration server
+   * @throws UnavailableException if address cannot be determined
+   */
   @Override
   public synchronized InetSocketAddress getConfAddress() throws UnavailableException {
     if (mServerAddress == null) {
@@ -361,8 +370,8 @@ public abstract class AbstractClient implements Client {
     }
 
     // We would reach here if a child's implementation provided a socket address
-    // that is not a TCP/IP socket, e.g. a block worker client that talks to a
-    // a worker via Unix domain socket. But client configuration is only provided 
+    // that is not a TCP/IP socket, e.g. a block worker client that talks to
+    // a worker via Unix domain socket. But client configuration is only provided
     // by meta master via a TCP/IP socket, so reaching here indicates a bug in
     // the implementation of the child.
     throw new UnavailableException("Remote is not an InetSockAddress");

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -268,6 +268,10 @@ public abstract class AbstractClient implements Client {
       }
     }
     // Reaching here indicates that we did not successfully connect.
+    if (mChannel != null) {
+      mChannel.shutdown();
+    }
+
     if (mServerAddress == null) {
       throw new UnavailableException(
           String.format("Failed to determine address for %s after %s attempts", getServiceName(),

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -87,16 +87,18 @@ public abstract class AbstractClient implements Client {
   protected volatile boolean mClosed = false;
 
   /**
-   * Stores the service version; used for detecting incompatible client-server pairs.
+   * Stores the actual remote service version, used to compare with expected local version.
    */
   protected long mServiceVersion;
 
+  /** Context of the client. */
   protected ClientContext mContext;
 
+  /** If rpc call takes more than this duration, signal warning. */
   private final long mRpcThreshold;
 
   /**
-   * Creates a new client base.
+   * Creates a new client base with default retry policy supplier.
    *
    * @param context information required to connect to Alluxio
    */
@@ -105,7 +107,7 @@ public abstract class AbstractClient implements Client {
   }
 
   /**
-   * Creates a new client base.
+   * Creates a new client base with specified retry policy supplier.
    *
    * @param context information required to connect to Alluxio
    * @param retryPolicySupplier factory for retry policies to be used when performing RPCs
@@ -118,10 +120,14 @@ public abstract class AbstractClient implements Client {
   }
 
   /**
-   * @return the type of remote service
+   * @return the expected type of remote service
    */
   protected abstract ServiceType getRemoteServiceType();
 
+  /**
+   * @return the actual remote service version
+   * @throws AlluxioStatusException if query rpc failed
+   */
   protected long getRemoteServiceVersion() throws AlluxioStatusException {
     // Calling directly as this method is subject to an encompassing retry loop.
     try {
@@ -357,6 +363,7 @@ public abstract class AbstractClient implements Client {
    *
    * @param <V> the return value of {@link #call()}
    */
+  @FunctionalInterface
   protected interface RpcCallable<V> {
     /**
      * The task where RPC happens.

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -66,7 +66,11 @@ public abstract class AbstractClient implements Client {
 
   private final Supplier<RetryPolicy> mRetryPolicySupplier;
 
-  /**Grpc Address of the remote server. */
+  /**
+   * Grpc Address of the remote server.
+   * This field is lazily initialized by {@link AbstractClient#queryGrpcServerAddress},
+   * and could only be null right after instantiation and before use.
+   */
   protected GrpcServerAddress mServerAddress = null;
 
   /** Underlying channel to the target service. */

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -324,7 +324,7 @@ public abstract class AbstractClient implements Client {
   protected abstract GrpcServerAddress queryGrpcServerAddress() throws UnavailableException;
 
   @Override
-  public SocketAddress getRemoteSockAddress() throws UnavailableException {
+  public synchronized SocketAddress getRemoteSockAddress() throws UnavailableException {
     if (mServerAddress == null) {
       mServerAddress = queryGrpcServerAddress();
     }
@@ -332,7 +332,7 @@ public abstract class AbstractClient implements Client {
   }
 
   @Override
-  public String getRemoteHostName() throws UnavailableException {
+  public synchronized String getRemoteHostName() throws UnavailableException {
     if (mServerAddress == null) {
       mServerAddress = queryGrpcServerAddress();
     }

--- a/core/common/src/main/java/alluxio/AbstractJobMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractJobMasterClient.java
@@ -49,9 +49,9 @@ public abstract class AbstractJobMasterClient extends AbstractMasterClient {
    * @param address address to connect to
    * @param retryPolicySupplier retry policy to use
    */
-  public AbstractJobMasterClient(MasterClientContext clientConf, InetSocketAddress address,
+  public AbstractJobMasterClient(MasterClientContext clientConf,
                               Supplier<RetryPolicy> retryPolicySupplier) {
-    super(clientConf, address, retryPolicySupplier);
+    super(clientConf, retryPolicySupplier);
     mConfMasterInquireClient = clientConf.getConfMasterInquireClient();
   }
 

--- a/core/common/src/main/java/alluxio/AbstractJobMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractJobMasterClient.java
@@ -46,7 +46,6 @@ public abstract class AbstractJobMasterClient extends AbstractMasterClient {
    * Creates a new master client base.
    *
    * @param clientConf master client configuration
-   * @param address address to connect to
    * @param retryPolicySupplier retry policy to use
    */
   public AbstractJobMasterClient(MasterClientContext clientConf,

--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -45,7 +45,7 @@ public abstract class AbstractMasterClient extends AbstractClient {
    * @param retryPolicySupplier retry policy to use
    */
   public AbstractMasterClient(MasterClientContext clientConf,
-                              Supplier<RetryPolicy> retryPolicySupplier) {
+      Supplier<RetryPolicy> retryPolicySupplier) {
     super(clientConf, retryPolicySupplier);
     mMasterInquireClient = clientConf.getMasterInquireClient();
   }

--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -51,7 +51,7 @@ public abstract class AbstractMasterClient extends AbstractClient {
   }
 
   @Override
-  public synchronized GrpcServerAddress queryGrpcServerAddress() throws UnavailableException {
+  protected synchronized GrpcServerAddress queryGrpcServerAddress() throws UnavailableException {
     return GrpcServerAddress.create(mMasterInquireClient.getPrimaryRpcAddress());
   }
 }

--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -12,11 +12,11 @@
 package alluxio;
 
 import alluxio.exception.status.UnavailableException;
+import alluxio.grpc.GrpcServerAddress;
 import alluxio.master.MasterClientContext;
 import alluxio.master.MasterInquireClient;
 import alluxio.retry.RetryPolicy;
 
-import java.net.InetSocketAddress;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -42,26 +42,16 @@ public abstract class AbstractMasterClient extends AbstractClient {
    * Creates a new master client base.
    *
    * @param clientConf master client configuration
-   * @param address address to connect to
    * @param retryPolicySupplier retry policy to use
    */
-  public AbstractMasterClient(MasterClientContext clientConf, InetSocketAddress address,
-      Supplier<RetryPolicy> retryPolicySupplier) {
-    super(clientConf, address, retryPolicySupplier);
+  public AbstractMasterClient(MasterClientContext clientConf,
+                              Supplier<RetryPolicy> retryPolicySupplier) {
+    super(clientConf, retryPolicySupplier);
     mMasterInquireClient = clientConf.getMasterInquireClient();
   }
 
   @Override
-  public synchronized InetSocketAddress getAddress() throws UnavailableException {
-    return mMasterInquireClient.getPrimaryRpcAddress();
-  }
-
-  @Override
-  public synchronized InetSocketAddress getConfAddress() throws UnavailableException {
-    if (mAddress != null) {
-      return mAddress;
-    }
-
-    return mMasterInquireClient.getPrimaryRpcAddress();
+  public synchronized GrpcServerAddress queryGrpcServerAddress() throws UnavailableException {
+    return GrpcServerAddress.create(mMasterInquireClient.getPrimaryRpcAddress());
   }
 }

--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -34,7 +34,7 @@ public abstract class AbstractMasterClient extends AbstractClient {
    * @param clientConf master client configuration
    */
   public AbstractMasterClient(MasterClientContext clientConf) {
-    super(clientConf, null);
+    super(clientConf);
     mMasterInquireClient = clientConf.getMasterInquireClient();
   }
 

--- a/core/common/src/main/java/alluxio/Client.java
+++ b/core/common/src/main/java/alluxio/Client.java
@@ -16,6 +16,7 @@ import alluxio.exception.status.UnavailableException;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 
 /**
  * Interface for a client in the Alluxio system.
@@ -34,10 +35,16 @@ public interface Client extends Closeable {
   void disconnect();
 
   /**
-   * @return the {@link InetSocketAddress} of the remote
+   * @return the {@link SocketAddress} of the remote
    * @throws UnavailableException if the primary address cannot be determined
    */
-  InetSocketAddress getAddress() throws UnavailableException;
+  SocketAddress getRemoteSockAddress() throws UnavailableException;
+
+  /**
+   * @return the host name of the remote
+   * @throws UnavailableException if the primary address cannot be determined
+   */
+  String getRemoteHostName() throws UnavailableException;
 
   /**
    * @return the {@link InetSocketAddress} of the configuration remote

--- a/core/common/src/test/java/alluxio/AbstractClientTest.java
+++ b/core/common/src/test/java/alluxio/AbstractClientTest.java
@@ -31,7 +31,6 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 
 /**
  * Unit tests for {@link AbstractClient}.
@@ -75,7 +74,7 @@ public final class AbstractClientTest {
     }
 
     @Override
-    protected GrpcServerAddress queryGrpcServerAddress() throws UnavailableException {
+    protected synchronized GrpcServerAddress queryGrpcServerAddress() throws UnavailableException {
       throw new UnavailableException("Unavailable");
     }
 
@@ -140,8 +139,8 @@ public final class AbstractClientTest {
     InetSocketAddress confAddress = new InetSocketAddress("0.0.0.0", 2000);
     final alluxio.Client client = new BaseTestClient(context) {
       @Override
-      public synchronized SocketAddress getRemoteSockAddress() {
-        return baseAddress;
+      public synchronized GrpcServerAddress queryGrpcServerAddress() {
+        return GrpcServerAddress.create(baseAddress);
       }
 
       @Override

--- a/core/common/src/test/java/alluxio/AbstractClientTest.java
+++ b/core/common/src/test/java/alluxio/AbstractClientTest.java
@@ -139,7 +139,7 @@ public final class AbstractClientTest {
     InetSocketAddress confAddress = new InetSocketAddress("0.0.0.0", 2000);
     final alluxio.Client client = new BaseTestClient(context) {
       @Override
-      public synchronized GrpcServerAddress queryGrpcServerAddress() {
+      protected synchronized GrpcServerAddress queryGrpcServerAddress() {
         return GrpcServerAddress.create(baseAddress);
       }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
@@ -192,7 +192,7 @@ public class SnapshotReplicationManager {
     }
     try {
       RaftJournalServiceClient client = createJournalServiceClient();
-      String address = String.valueOf(client.getAddress());
+      String address = String.valueOf(client.getRemoteSockAddress());
       SnapshotDownloader<DownloadSnapshotPRequest, DownloadSnapshotPResponse> observer =
           SnapshotDownloader.forFollower(mStorage, address);
       Timer.Context ctx = MetricsSystem
@@ -245,7 +245,7 @@ public class SnapshotReplicationManager {
     SnapshotUploader<UploadSnapshotPRequest, UploadSnapshotPResponse> snapshotUploader =
         SnapshotUploader.forFollower(mStorage, snapshot);
     RaftJournalServiceClient client = createJournalServiceClient();
-    LOG.info("Sending stream request to leader {} for snapshot {}", client.getAddress(),
+    LOG.info("Sending stream request to leader {} for snapshot {}", client.getRemoteSockAddress(),
         snapshot.getTermIndex());
     StreamObserver<UploadSnapshotPRequest> requestObserver =
         client.uploadSnapshot(snapshotUploader);

--- a/integration/fuse/src/test/java/alluxio/fuse/cli/MockFuseFileSystemMasterClient.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/cli/MockFuseFileSystemMasterClient.java
@@ -39,6 +39,7 @@ import alluxio.wire.SyncPointInfo;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -196,7 +197,12 @@ class MockFuseFileSystemMasterClient implements FileSystemMasterClient {
   }
 
   @Override
-  public InetSocketAddress getAddress() throws UnavailableException {
+  public SocketAddress getRemoteSockAddress() throws UnavailableException {
+    return null;
+  }
+
+  @Override
+  public String getRemoteHostName() throws UnavailableException {
     return null;
   }
 

--- a/shell/src/main/java/alluxio/cli/LogLevel.java
+++ b/shell/src/main/java/alluxio/cli/LogLevel.java
@@ -202,7 +202,7 @@ public final class LogLevel {
           jobClient = JobMasterClient.Factory.create(JobMasterClientContext
                   .newBuilder(clientContext).build());
         }
-        String jobMasterHost = jobClient.getAddress().getHostName();
+        String jobMasterHost = jobClient.getRemoteHostName();
         int jobMasterPort = NetworkAddressUtils.getPort(ServiceType.JOB_MASTER_WEB, conf);
         TargetInfo jobMaster = new TargetInfo(jobMasterHost, jobMasterPort, ROLE_JOB_MASTER);
         targetInfoList.add(jobMaster);

--- a/shell/src/main/java/alluxio/cli/fs/command/LeaderCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LeaderCommand.java
@@ -62,7 +62,7 @@ public final class LeaderCommand extends AbstractFileSystemCommand {
     try (CloseableResource<FileSystemMasterClient> client =
         mFsContext.acquireMasterClientResource()) {
       try {
-        InetSocketAddress address = client.get().getAddress();
+        InetSocketAddress address = (InetSocketAddress) client.get().getRemoteSockAddress();
         System.out.println(address.getHostName());
 
         List<InetSocketAddress> addresses = Arrays.asList(address);

--- a/shell/src/main/java/alluxio/cli/fsadmin/FileSystemAdminShellUtils.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/FileSystemAdminShellUtils.java
@@ -59,7 +59,9 @@ public final class FileSystemAdminShellUtils {
   public static void checkMasterClientService(AlluxioConfiguration alluxioConf) throws IOException {
     try (FileSystemContext context = FileSystemContext.create(ClientContext.create(alluxioConf));
         CloseableResource<FileSystemMasterClient> client = context.acquireMasterClientResource()) {
-      InetSocketAddress address = client.get().getAddress();
+      // MasterClient is guaranteed to have an InetSocketAddress remote
+      // so the cast is safe here.
+      InetSocketAddress address = (InetSocketAddress) client.get().getRemoteSockAddress();
 
       List<InetSocketAddress> addresses = Arrays.asList(address);
       MasterInquireClient inquireClient = new PollingMasterInquireClient(addresses,

--- a/shell/src/test/java/alluxio/cli/LogLevelTest.java
+++ b/shell/src/test/java/alluxio/cli/LogLevelTest.java
@@ -161,7 +161,7 @@ public class LogLevelTest {
     try (MockedStatic<JobMasterClient.Factory> mockFactory =
         mockStatic(JobMasterClient.Factory.class)) {
       JobMasterClient mockJobClient = mock(JobMasterClient.class);
-      when(mockJobClient.getAddress()).thenReturn(new InetSocketAddress("masters-2",
+      when(mockJobClient.getRemoteSockAddress()).thenReturn(new InetSocketAddress("masters-2",
           mConf.getInt(PropertyKey.JOB_MASTER_RPC_PORT)));
       mockFactory.when(() -> JobMasterClient.Factory.create(any())).thenReturn(mockJobClient);
 
@@ -184,7 +184,7 @@ public class LogLevelTest {
     try (MockedStatic<JobMasterClient.Factory> mockFactory =
         mockStatic(JobMasterClient.Factory.class)) {
       JobMasterClient mockJobClient = mock(JobMasterClient.class);
-      when(mockJobClient.getAddress()).thenReturn(new InetSocketAddress("masters-2",
+      when(mockJobClient.getRemoteSockAddress()).thenReturn(new InetSocketAddress("masters-2",
           mConf.getInt(PropertyKey.JOB_MASTER_RPC_PORT)));
       mockFactory.when(() -> JobMasterClient.Factory.create(any())).thenReturn(mockJobClient);
 

--- a/shell/src/test/java/alluxio/cli/LogLevelTest.java
+++ b/shell/src/test/java/alluxio/cli/LogLevelTest.java
@@ -163,6 +163,7 @@ public class LogLevelTest {
       JobMasterClient mockJobClient = mock(JobMasterClient.class);
       when(mockJobClient.getRemoteSockAddress()).thenReturn(new InetSocketAddress("masters-2",
           mConf.getInt(PropertyKey.JOB_MASTER_RPC_PORT)));
+      when(mockJobClient.getRemoteHostName()).thenReturn("masters-2");
       mockFactory.when(() -> JobMasterClient.Factory.create(any())).thenReturn(mockJobClient);
 
       List<LogLevel.TargetInfo> targets = LogLevel.parseOptTarget(mockCommandLine, mConf);
@@ -186,6 +187,7 @@ public class LogLevelTest {
       JobMasterClient mockJobClient = mock(JobMasterClient.class);
       when(mockJobClient.getRemoteSockAddress()).thenReturn(new InetSocketAddress("masters-2",
           mConf.getInt(PropertyKey.JOB_MASTER_RPC_PORT)));
+      when(mockJobClient.getRemoteHostName()).thenReturn("masters-2");
       mockFactory.when(() -> JobMasterClient.Factory.create(any())).thenReturn(mockJobClient);
 
       List<LogLevel.TargetInfo> targets = LogLevel.parseOptTarget(mockCommandLine, mConf);


### PR DESCRIPTION
### What changes are proposed in this pull request?
Refactor the `Client` API to:
- replace the original `InetSocketAddress getAddress` method with `SocketAddress getRemoteSockAddress` and `String getRemoteHostName`

Refactor the `AbstractClient`:
- Work with a `GrpcServerAddress` instead of a raw `InetSocketAddress` to be compatible with `BlockWorkerClient`, which might not have an IP-remote. 
- Clarify the semantics of the methods: `getRemoteSockAddress` and `getRemoteHostName` inherited from `Client` are supposed to be idempotent getters, i.e., they should not perform network queries each time they are called. Provide a new abstract method `queryGrpcServerAddress` that queries the address each time it's called. Child classes now override this method to implement whatever address query logic they need, and `connect` uses this method to query a new address on each iteration.

### Why are the changes needed?
- To better support integrating with `DefaultBlockWorkerClient`, which might uses a `DomainSocketAddress`. Related to https://github.com/Alluxio/alluxio/pull/15837

### Does this PR introduce any user facing changes?
No
