### PR TITLE
Install fuse3 in jenkins image for github action

### DIFF
--- a/dev/jenkins/Dockerfile-jdk11
+++ b/dev/jenkins/Dockerfile-jdk11
@@ -105,7 +105,7 @@ RUN mkdir -p /home/jenkins && \
     chmod -R 777 /.config && \
     apt-get update -y && \
     apt-get upgrade -y ca-certificates && \
-    apt-get install -y build-essential fuse libfuse-dev make ruby ruby-dev
+    apt-get install -y build-essential fuse3 make ruby ruby-dev
 # jekyll for documentation
 RUN gem install jekyll bundler
 # golang for tooling

--- a/dev/jenkins/Dockerfile-jdk8
+++ b/dev/jenkins/Dockerfile-jdk8
@@ -21,7 +21,7 @@ RUN mkdir -p /home/jenkins && \
     chmod -R 777 /.config && \
     apt-get update -y && \
     apt-get upgrade -y ca-certificates && \
-    apt-get install -y build-essential fuse libfuse-dev make ruby ruby-dev
+    apt-get install -y build-essential fuse3 make ruby ruby-dev
 # jekyll for documentation
 RUN gem install jekyll bundler
 # golang for tooling


### PR DESCRIPTION
The current JNIFuseIntegrationTest is always running fuse2 even it claims it runs with fuse3. The PR https://github.com/Alluxio/alluxio/pull/15863 fixes this by replacing the existing incorrect loading libfuse process for the test with a correct one, but the jenkins image doesn't have fuse3, so the test hangs. 

This PR is to install Fuse3 on the jenkins image. On Ubuntu used by the jenkins image, package `fuse3` installs `fuse2` as well, which is why only `fuse3` is installed.