### PR TITLE
Install libfuse-dev and libfuse3-dev in alluxio-maven image

### DIFF
--- a/dev/jenkins/Dockerfile-jdk11
+++ b/dev/jenkins/Dockerfile-jdk11
@@ -138,7 +138,7 @@ RUN mkdir -p /home/jenkins && \
     chmod -R 777 /.config && \
     apt-get update -y && \
     apt-get upgrade -y ca-certificates && \
-    apt-get install -y build-essential fuse3 make ruby ruby-dev
+    apt-get install -y build-essential fuse3 libfuse3-dev libfuse-dev make ruby ruby-dev
 # jekyll for documentation
 RUN gem install jekyll bundler
 # golang for tooling

--- a/dev/jenkins/Dockerfile-jdk8
+++ b/dev/jenkins/Dockerfile-jdk8
@@ -21,7 +21,7 @@ RUN mkdir -p /home/jenkins && \
     chmod -R 777 /.config && \
     apt-get update -y && \
     apt-get upgrade -y ca-certificates && \
-    apt-get install -y build-essential fuse3 make ruby ruby-dev
+    apt-get install -y build-essential fuse3 libfuse3-dev libfuse-dev make ruby ruby-dev
 # jekyll for documentation
 RUN gem install jekyll bundler
 # golang for tooling


### PR DESCRIPTION
Deleted package libfuse-dev in PR https://github.com/Alluxio/alluxio/pull/15876. Turns out it is required. Add it back in along with the corresponding libfuse3-dev for fuse3.