### PR TITLE
Disable master heap estimation until we find a more accurate way

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2563,7 +2563,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_METRICS_HEAP_ENABLED =
       booleanBuilder(Name.MASTER_METRICS_HEAP_ENABLED)
-          .setDefaultValue(true)
+          .setDefaultValue(false)
           .setDescription("Enable master heap estimate metrics")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)


### PR DESCRIPTION
### What changes are proposed in this pull request?

Disable master heap estimation until we find a more accurate way

### Why are the changes needed?
The current estimation method is inaccurate and has some overhead.
Disable until we find better way. 