### PR TITLE
Fix ActiveSync timeout retry

### DIFF
--- a/core/common/src/main/java/alluxio/retry/RetryUtils.java
+++ b/core/common/src/main/java/alluxio/retry/RetryUtils.java
@@ -100,6 +100,19 @@ public final class RetryUtils {
   }
 
   /**
+   * @param activeUfsPollTimeoutMs the max time in milliseconds to wait for active ufs sync retries
+   * @return the default active sync retry behavior
+   */
+  public static RetryPolicy defaultActiveSyncClientRetry(long activeUfsPollTimeoutMs) {
+    return ExponentialTimeBoundedRetry.builder()
+        .withMaxDuration(Duration
+            .ofMillis(activeUfsPollTimeoutMs))
+        .withInitialSleep(Duration.ofMillis(100))
+        .withMaxSleep(Duration.ofSeconds(60))
+        .build();
+  }
+
+  /**
    * Interface for methods which return nothing and may throw IOException.
    */
   @FunctionalInterface

--- a/core/common/src/main/java/alluxio/retry/RetryUtils.java
+++ b/core/common/src/main/java/alluxio/retry/RetryUtils.java
@@ -100,19 +100,6 @@ public final class RetryUtils {
   }
 
   /**
-   * @param activeUfsPollTimeoutMs the max time in milliseconds to wait for active ufs sync retries
-   * @return the default active sync retry behavior
-   */
-  public static RetryPolicy defaultActiveSyncClientRetry(long activeUfsPollTimeoutMs) {
-    return ExponentialTimeBoundedRetry.builder()
-        .withMaxDuration(Duration
-            .ofMillis(activeUfsPollTimeoutMs))
-        .withInitialSleep(Duration.ofMillis(100))
-        .withMaxSleep(Duration.ofSeconds(60))
-        .build();
-  }
-
-  /**
    * Interface for methods which return nothing and may throw IOException.
    */
   @FunctionalInterface

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -82,8 +82,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public class ActiveSyncManager implements Journaled {
   private static final Logger LOG = LoggerFactory.getLogger(ActiveSyncManager.class);
-  private static final long RETRY_TIMEOUT = Configuration.getMs(
-      PropertyKey.MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT);
 
   // a reference to the mount table
   private final MountTable mMountTable;
@@ -108,7 +106,8 @@ public class ActiveSyncManager implements Journaled {
   private final Supplier<RetryPolicy> mRetryPolicy = () ->
       ExponentialTimeBoundedRetry.builder()
           .withMaxDuration(Duration
-              .ofMillis(RETRY_TIMEOUT))
+              .ofMillis(Configuration.getMs(
+                  PropertyKey.MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT)))
           .withInitialSleep(Duration.ofMillis(100))
           .withMaxSleep(Duration.ofSeconds(60))
           .build();

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -150,7 +150,8 @@ public class ActiveSyncManager implements Journaled {
    * @return retry policy
    */
   public RetryPolicy getRetryPolicy() {
-    return mRetryPolicy;
+    return RetryUtils.defaultActiveSyncClientRetry(Configuration
+        .getMs(PropertyKey.MASTER_UFS_ACTIVE_SYNC_RETRY_TIMEOUT));
   }
 
   /**
@@ -550,7 +551,7 @@ public class ActiveSyncManager implements Journaled {
 
                 RetryUtils.retry("active sync during start",
                     () -> mFileSystemMaster.activeSyncMetadata(syncPoint,
-                        null, getExecutor()), mRetryPolicy);
+                        null, getExecutor()), getRetryPolicy());
               }
             } catch (IOException e) {
               LOG.info(MessageFormat.format(

--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -105,6 +105,13 @@ public class ActiveSyncManager implements Journaled {
   // a local executor service used to launch polling threads
   private final ThreadPoolExecutor mExecutorService;
   private boolean mStarted;
+  private final Supplier<RetryPolicy> mRetryPolicy = () ->
+      ExponentialTimeBoundedRetry.builder()
+          .withMaxDuration(Duration
+              .ofMillis(RETRY_TIMEOUT))
+          .withInitialSleep(Duration.ofMillis(100))
+          .withMaxSleep(Duration.ofSeconds(60))
+          .build();
 
   /**
    * Constructs a Active Sync Manager.
@@ -146,12 +153,7 @@ public class ActiveSyncManager implements Journaled {
    * @return retry policy
    */
   public RetryPolicy getRetryPolicy() {
-    return ExponentialTimeBoundedRetry.builder()
-        .withMaxDuration(Duration
-            .ofMillis(RETRY_TIMEOUT))
-        .withInitialSleep(Duration.ofMillis(100))
-        .withMaxSleep(Duration.ofSeconds(60))
-        .build();
+    return mRetryPolicy.get();
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

https://github.com/Alluxio/alluxio/pull/15765 changed the ActiveSync retry mechanism to use reuse a single RetryPolicy object for every call. This caused the ActiveSync calls to not work correctly as the timer object in this single object was always expired after every call. This reverts the change, but keeps the cleanup restructuring from that PR.

### Why are the changes needed?

This fixes ActiveSync calls timing out unnecessarily.

### Does this PR introduce any user facing changes?

No