### PR TITLE
Add go dependency caching to github actions workflow

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          key: ${{ runner.os }}-gomod-checkstyle-${{ hashFiles('**/go.mod') }}
           restore-keys: |
             ${{ runner.os }}-gomod-
             ${{ runner.os }}-

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -28,6 +28,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Cache local Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod-
+            ${{ runner.os }}-
+
       - name: Execute license check, checkstyle, findbugs
         run: |
           mkdir -p ~/.m2

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -35,7 +35,6 @@ jobs:
           key: ${{ runner.os }}-gomod-checkstyle-${{ hashFiles('**/go.mod') }}
           restore-keys: |
             ${{ runner.os }}-gomod-
-            ${{ runner.os }}-
 
       - name: Execute license check, checkstyle, findbugs
         run: |

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -32,9 +32,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-checkstyle-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod-
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
 
       - name: Execute license check, checkstyle, findbugs
         run: |

--- a/.github/workflows/fuse_integration_tests.yml
+++ b/.github/workflows/fuse_integration_tests.yml
@@ -35,10 +35,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-java${{ matrix.java }}-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod-java${{ matrix.java }}-
-            ${{ runner.os }}-gomod-
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
 
       - name: Run tests
         id: test0

--- a/.github/workflows/fuse_integration_tests.yml
+++ b/.github/workflows/fuse_integration_tests.yml
@@ -31,6 +31,15 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-java${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
 
+      - name: Cache local Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod-
+            ${{ runner.os }}-
+
       - name: Run tests
         id: test0
         run: |

--- a/.github/workflows/fuse_integration_tests.yml
+++ b/.github/workflows/fuse_integration_tests.yml
@@ -37,6 +37,7 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-gomod-java${{ matrix.java }}-${{ hashFiles('**/go.mod') }}
           restore-keys: |
+            ${{ runner.os }}-gomod-java${{ matrix.java }}-
             ${{ runner.os }}-gomod-
 
       - name: Run tests

--- a/.github/workflows/fuse_integration_tests.yml
+++ b/.github/workflows/fuse_integration_tests.yml
@@ -38,7 +38,6 @@ jobs:
           key: ${{ runner.os }}-gomod-java${{ matrix.java }}-${{ hashFiles('**/go.mod') }}
           restore-keys: |
             ${{ runner.os }}-gomod-
-            ${{ runner.os }}-
 
       - name: Run tests
         id: test0

--- a/.github/workflows/fuse_integration_tests.yml
+++ b/.github/workflows/fuse_integration_tests.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          key: ${{ runner.os }}-gomod-java${{ matrix.java }}-${{ hashFiles('**/go.mod') }}
           restore-keys: |
             ${{ runner.os }}-gomod-
             ${{ runner.os }}-

--- a/.github/workflows/java11_integration_tests.yml
+++ b/.github/workflows/java11_integration_tests.yml
@@ -52,10 +52,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-java11-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod-java11-
-            ${{ runner.os }}-gomod-
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
 
       - name: Run tests
         id: test0

--- a/.github/workflows/java11_integration_tests.yml
+++ b/.github/workflows/java11_integration_tests.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          key: ${{ runner.os }}-gomod-java11-${{ hashFiles('**/go.mod') }}
           restore-keys: |
             ${{ runner.os }}-gomod-
             ${{ runner.os }}-

--- a/.github/workflows/java11_integration_tests.yml
+++ b/.github/workflows/java11_integration_tests.yml
@@ -54,8 +54,8 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-gomod-java11-${{ hashFiles('**/go.mod') }}
           restore-keys: |
+            ${{ runner.os }}-gomod-java11-
             ${{ runner.os }}-gomod-
-            ${{ runner.os }}-
 
       - name: Run tests
         id: test0

--- a/.github/workflows/java11_integration_tests.yml
+++ b/.github/workflows/java11_integration_tests.yml
@@ -48,6 +48,15 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-java11-${{ hashFiles('**/pom.xml') }}
 
+      - name: Cache local Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod-
+            ${{ runner.os }}-
+
       - name: Run tests
         id: test0
         run: |

--- a/.github/workflows/java11_integration_tests_webui.yml
+++ b/.github/workflows/java11_integration_tests_webui.yml
@@ -38,8 +38,8 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-gomod-java11-${{ hashFiles('**/go.mod') }}
           restore-keys: |
+            ${{ runner.os }}-gomod-java11-
             ${{ runner.os }}-gomod-
-            ${{ runner.os }}-
 
       - name: Run tests
         id: test0

--- a/.github/workflows/java11_integration_tests_webui.yml
+++ b/.github/workflows/java11_integration_tests_webui.yml
@@ -32,6 +32,15 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-java11-${{ hashFiles('**/pom.xml') }}
 
+      - name: Cache local Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod-
+            ${{ runner.os }}-
+
       - name: Run tests
         id: test0
         run: |

--- a/.github/workflows/java11_integration_tests_webui.yml
+++ b/.github/workflows/java11_integration_tests_webui.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          key: ${{ runner.os }}-gomod-java11-${{ hashFiles('**/go.mod') }}
           restore-keys: |
             ${{ runner.os }}-gomod-
             ${{ runner.os }}-

--- a/.github/workflows/java11_integration_tests_webui.yml
+++ b/.github/workflows/java11_integration_tests_webui.yml
@@ -36,10 +36,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-java11-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod-java11-
-            ${{ runner.os }}-gomod-
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
 
       - name: Run tests
         id: test0

--- a/.github/workflows/java11_unit_tests.yml
+++ b/.github/workflows/java11_unit_tests.yml
@@ -43,8 +43,8 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-gomod-java11-${{ hashFiles('**/go.mod') }}
           restore-keys: |
+            ${{ runner.os }}-gomod-java11-
             ${{ runner.os }}-gomod-
-            ${{ runner.os }}-
 
       - name: Run tests
         id: test0

--- a/.github/workflows/java11_unit_tests.yml
+++ b/.github/workflows/java11_unit_tests.yml
@@ -41,10 +41,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-java11-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod-java11-
-            ${{ runner.os }}-gomod-
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
 
       - name: Run tests
         id: test0

--- a/.github/workflows/java11_unit_tests.yml
+++ b/.github/workflows/java11_unit_tests.yml
@@ -37,6 +37,15 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-java11-${{ hashFiles('**/pom.xml') }}
 
+      - name: Cache local Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod-
+            ${{ runner.os }}-
+
       - name: Run tests
         id: test0
         run: |

--- a/.github/workflows/java11_unit_tests.yml
+++ b/.github/workflows/java11_unit_tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          key: ${{ runner.os }}-gomod-java11-${{ hashFiles('**/go.mod') }}
           restore-keys: |
             ${{ runner.os }}-gomod-
             ${{ runner.os }}-

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -51,6 +51,15 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-java8-${{ hashFiles('**/pom.xml') }}
 
+      - name: Cache local Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod-
+            ${{ runner.os }}-
+
       - name: Run tests
         id: test0
         run: |

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          key: ${{ runner.os }}-gomod-java8-${{ hashFiles('**/go.mod') }}
           restore-keys: |
             ${{ runner.os }}-gomod-
             ${{ runner.os }}-

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -57,8 +57,8 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-gomod-java8-${{ hashFiles('**/go.mod') }}
           restore-keys: |
+            ${{ runner.os }}-gomod-java8-
             ${{ runner.os }}-gomod-
-            ${{ runner.os }}-
 
       - name: Run tests
         id: test0

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -55,10 +55,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-java8-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod-java8-
-            ${{ runner.os }}-gomod-
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
 
       - name: Run tests
         id: test0

--- a/.github/workflows/java8_integration_tests_webui.yml
+++ b/.github/workflows/java8_integration_tests_webui.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          key: ${{ runner.os }}-gomod-java8-${{ hashFiles('**/go.mod') }}
           restore-keys: |
             ${{ runner.os }}-gomod-
             ${{ runner.os }}-

--- a/.github/workflows/java8_integration_tests_webui.yml
+++ b/.github/workflows/java8_integration_tests_webui.yml
@@ -41,8 +41,8 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-gomod-java8-${{ hashFiles('**/go.mod') }}
           restore-keys: |
+            ${{ runner.os }}-gomod-java8-
             ${{ runner.os }}-gomod-
-            ${{ runner.os }}-
 
       - name: Run tests
         id: test0

--- a/.github/workflows/java8_integration_tests_webui.yml
+++ b/.github/workflows/java8_integration_tests_webui.yml
@@ -35,6 +35,15 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-java8-${{ hashFiles('**/pom.xml') }}
 
+      - name: Cache local Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod-
+            ${{ runner.os }}-
+
       - name: Run tests
         id: test0
         run: |

--- a/.github/workflows/java8_integration_tests_webui.yml
+++ b/.github/workflows/java8_integration_tests_webui.yml
@@ -39,10 +39,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-java8-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod-java8-
-            ${{ runner.os }}-gomod-
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
 
       - name: Run tests
         id: test0

--- a/.github/workflows/java8_unit_tests.yml
+++ b/.github/workflows/java8_unit_tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          key: ${{ runner.os }}-gomod-java8-${{ hashFiles('**/go.mod') }}
           restore-keys: |
             ${{ runner.os }}-gomod-
             ${{ runner.os }}-

--- a/.github/workflows/java8_unit_tests.yml
+++ b/.github/workflows/java8_unit_tests.yml
@@ -43,8 +43,8 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-gomod-java8-${{ hashFiles('**/go.mod') }}
           restore-keys: |
+            ${{ runner.os }}-gomod-java8-
             ${{ runner.os }}-gomod-
-            ${{ runner.os }}-
 
       - name: Run tests
         id: test0

--- a/.github/workflows/java8_unit_tests.yml
+++ b/.github/workflows/java8_unit_tests.yml
@@ -37,6 +37,15 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-java8-${{ hashFiles('**/pom.xml') }}
 
+      - name: Cache local Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod-
+            ${{ runner.os }}-
+
       - name: Run tests
         id: test0
         run: |

--- a/.github/workflows/java8_unit_tests.yml
+++ b/.github/workflows/java8_unit_tests.yml
@@ -41,10 +41,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-java8-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod-java8-
-            ${{ runner.os }}-gomod-
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.mod') }}
 
       - name: Run tests
         id: test0


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add caching under github runners to reduce the need for go module downloads for every build

### Why are the changes needed?

Go downloads occasionally fail to download due to external factors. Caching reduces the need to download and thus reduce frequency of build failures.

### Does this PR introduce any user facing changes?

No
