### PR TITLE
Fix alluxio-fuse unmount to get the right pid

### DIFF
--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -202,7 +202,7 @@ fuse_stat() {
   local fuse_info="$(ps aux | grep [A]lluxioFuse)"
   if [[ -n ${fuse_info} ]]; then
     echo -e "pid\tmount_point\talluxio_path"
-    echo -e "$(ps ax -o pid,args | grep [A]lluxioFuse | awk -F' ' '{print $1 "\t" $(NF-2) "\t" $NF}')"
+    echo -e "$(ps ax -o pid,args | grep [A]lluxioFuse | awk -F' ' '{print $1 "\t" $(NF-4) "\t" $(NF-2) "\t" $NF}')"
     return 0
   fi
   fuse_info=$(ps ax -o pid,args | grep [A]lluxioWorker | grep alluxio\.worker\.fuse\.enabled=true)

--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -202,7 +202,7 @@ fuse_stat() {
   local fuse_info="$(ps aux | grep [A]lluxioFuse)"
   if [[ -n ${fuse_info} ]]; then
     echo -e "pid\tmount_point\talluxio_path"
-    echo -e "$(ps ax -o pid,args | grep [A]lluxioFuse | awk -F' ' '{print $1 "\t" $(NF-4) "\t" $(NF-2) "\t" $NF}')"
+    echo -e "$(ps ax -o pid,args | grep [A]lluxioFuse | awk -F' ' '{print $1 "\t" $(NF-4) "\t" $NF}')"
     return 0
   fi
   fuse_info=$(ps ax -o pid,args | grep [A]lluxioWorker | grep alluxio\.worker\.fuse\.enabled=true)


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix alluxio-fuse unmount to get the right pid to kill.

### Why are the changes needed?

Currently even the "-f" option cannot kill the AlluxioFuse process, below is a demo

```
$ jps -m
42757 AlluxioFuse -m /mnt/projects -a /projects -o allow_other

$ integration/fuse/bin/alluxio-fuse unmount -f /mnt/projects
Successfully unmount fuse at /mnt/projects

$ jps -m
42757 AlluxioFuse -m /mnt/projects -a /projects -o allow_other
```

The cause is:
- https://github.com/Alluxio/alluxio/blob/master/integration/fuse/bin/alluxio-fuse#L101

    ```
      alluxio.fuse.AlluxioFuse \
      -m ${mount_point} -a ${mount_alluxio_path} ${mount_options}"
    ```

- https://github.com/Alluxio/alluxio/blob/master/integration/fuse/bin/alluxio-fuse#L205, `fuse_stat` outputs the `mount_alluxio_path` instead of `mount_point` here

### Does this PR introduce any user facing changes?

No
