### PR TITLE
Allow Docker image file permissions to be modified at runtime

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -25,9 +25,9 @@ RUN cd /alluxio-csi && \
 #       - https://github.com/moby/moby/issues/6119
 # ADD with chown doesn't chown the files inside tarball
 #   See - https://github.com/moby/moby/issues/35525
-FROM alpine:3.10.8 AS alluxio-extractor
+FROM alpine:3.10.2 AS alluxio-extractor
 # Note that downloads for *-SNAPSHOT tarballs are not available.
-ARG ALLUXIO_TARBALL=https://downloads.alluxio.io/downloads/files/2.8.0/alluxio-2.8.0-bin.tar.gz
+ARG ALLUXIO_TARBALL=http://downloads.alluxio.io/downloads/files/2.9.0-SNAPSHOT/alluxio-2.9.0-SNAPSHOT-bin.tar.gz
 
 # (Alert):It's not recommended to set this Argument to true, unless you know exactly what you are doing
 ARG ENABLE_DYNAMIC_USER=false
@@ -44,7 +44,7 @@ RUN if [ ${ENABLE_DYNAMIC_USER} = "true" ] ; then \
     fi
 
 # For production use, we use alpine as base image to minimize alluxio image size.
-FROM alpine:3.10.8 AS final
+FROM alpine:3.10.2 AS final
 
 ADD dockerfile-common.sh /
 

--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -13,6 +13,7 @@
 # Make sure any changes to CSI installation are made in Dockerfile-dev as well
 FROM golang:1.15.13-alpine AS csi-dev
 ENV GO111MODULE=on
+RUN go env -w GOPROXY=https://goproxy.cn,direct
 RUN mkdir -p /alluxio-csi
 COPY ./csi /alluxio-csi
 RUN cd /alluxio-csi && \
@@ -25,9 +26,10 @@ RUN cd /alluxio-csi && \
 #       - https://github.com/moby/moby/issues/6119
 # ADD with chown doesn't chown the files inside tarball
 #   See - https://github.com/moby/moby/issues/35525
-FROM alpine:3.10.2 AS alluxio-extractor
+FROM alpine:3.10.8 AS alluxio-extractor
 # Note that downloads for *-SNAPSHOT tarballs are not available.
-ARG ALLUXIO_TARBALL=http://downloads.alluxio.io/downloads/files/2.9.0-SNAPSHOT/alluxio-2.9.0-SNAPSHOT-bin.tar.gz
+ARG ALLUXIO_TARBALL=https://downloads.alluxio.io/downloads/files/2.8.0/alluxio-2.8.0-bin.tar.gz
+
 # (Alert):It's not recommended to set this Argument to true, unless you know exactly what you are doing
 ARG ENABLE_DYNAMIC_USER=false
 
@@ -43,7 +45,7 @@ RUN if [ ${ENABLE_DYNAMIC_USER} = "true" ] ; then \
     fi
 
 # For production use, we use alpine as base image to minimize alluxio image size.
-FROM alpine:3.10.2 AS final
+FROM alpine:3.10.8 AS final
 
 ADD dockerfile-common.sh /
 
@@ -65,11 +67,11 @@ RUN \
 
 ENV LD_LIBRARY_PATH "/usr/local/lib:${LD_LIBRARY_PATH}"
 
-ARG ALLUXIO_USERNAME=alluxio
-ARG ALLUXIO_GROUP=alluxio
-ARG ALLUXIO_UID=1000
-ARG ALLUXIO_GID=1000
-ARG ENABLE_DYNAMIC_USER=true
+ENV ALLUXIO_USERNAME=alluxio
+ENV ALLUXIO_GROUP=alluxio
+ENV ALLUXIO_UID=1000
+ENV ALLUXIO_GID=1000
+ENV ENABLE_DYNAMIC_USER=true
 
 # Add Tini for Alluxio helm charts (https://github.com/Alluxio/alluxio/pull/12233)
 # - https://github.com/krallin/tini
@@ -87,19 +89,14 @@ RUN echo "networkaddress.cache.ttl=0" >> ${JAVA_HOME}/jre/lib/security/java.secu
 # Add the following for native libraries needed by rocksdb
 ENV LD_LIBRARY_PATH /lib64:${LD_LIBRARY_PATH}
 
-# If Alluxio user, group, gid, and uid aren't root|0, create the alluxio user and set file permissions accordingly
-RUN ./dockerfile-common.sh user-operation ${ALLUXIO_USERNAME} ${ALLUXIO_GROUP} ${ALLUXIO_UID} ${ALLUXIO_GID} alpine
-
 # Docker 19.03+ required to expand variables in --chown argument
 # https://github.com/moby/buildkit/pull/926#issuecomment-503943557
-COPY --from=alluxio-extractor --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} /opt /opt/
-COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} conf /opt/alluxio/conf/
-COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} entrypoint.sh /
+COPY --from=alluxio-extractor /opt /opt/
+COPY conf /opt/alluxio/conf/
+COPY entrypoint.sh /
 COPY --from=csi-dev /usr/local/bin/alluxio-csi /usr/local/bin/
 
 RUN ./dockerfile-common.sh enable-dynamic-user ${ENABLE_DYNAMIC_USER}
-
-USER ${ALLUXIO_UID}
 
 WORKDIR /opt/alluxio
 

--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -13,7 +13,6 @@
 # Make sure any changes to CSI installation are made in Dockerfile-dev as well
 FROM golang:1.15.13-alpine AS csi-dev
 ENV GO111MODULE=on
-RUN go env -w GOPROXY=https://goproxy.cn,direct
 RUN mkdir -p /alluxio-csi
 COPY ./csi /alluxio-csi
 RUN cd /alluxio-csi && \

--- a/integration/docker/Dockerfile-dev
+++ b/integration/docker/Dockerfile-dev
@@ -28,9 +28,9 @@ RUN cd /alluxio-csi && \
 #       - https://github.com/moby/moby/issues/6119
 # ADD with chown doesn't chown the files inside tarball
 #   See - https://github.com/moby/moby/issues/35525
-FROM alpine:3.10.2 AS alluxio-extractor
+FROM alpine:3.10.8 AS alluxio-extractor
 # Note that downloads for *-SNAPSHOT tarballs are not available.
-ARG ALLUXIO_TARBALL=http://downloads.alluxio.io/downloads/files/2.9.0-SNAPSHOT/alluxio-2.9.0-SNAPSHOT-bin.tar.gz
+ARG ALLUXIO_TARBALL=https://downloads.alluxio.io/downloads/files/2.8.0/alluxio-2.8.0-bin.tar.gz
 # (Alert):It's not recommended to set this Argument to true, unless you know exactly what you are doing
 ARG ENABLE_DYNAMIC_USER=false
 
@@ -71,11 +71,11 @@ RUN \
 
 ENV LD_LIBRARY_PATH "/usr/local/lib:${LD_LIBRARY_PATH}"
 
-ARG ALLUXIO_USERNAME=alluxio
-ARG ALLUXIO_GROUP=alluxio
-ARG ALLUXIO_UID=1000
-ARG ALLUXIO_GID=1000
-ARG ENABLE_DYNAMIC_USER=true
+ENV ALLUXIO_USERNAME=alluxio
+ENV ALLUXIO_GROUP=alluxio
+ENV ALLUXIO_UID=1000
+ENV ALLUXIO_GID=1000
+ENV ENABLE_DYNAMIC_USER=true
 
 # Add Tini for alluxio helm charts (https://github.com/Alluxio/alluxio/pull/12233)
 # - https://github.com/krallin/tini
@@ -108,19 +108,14 @@ RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-11-openjdk/conf/secur
 # Add the following for native libraries needed by rocksdb
 ENV LD_LIBRARY_PATH /lib64:${LD_LIBRARY_PATH}
 
-# If Alluxio user, group, gid, and uid aren't root|0, create the alluxio user and set file permissions accordingly
-RUN ./dockerfile-common.sh user-operation ${ALLUXIO_USERNAME} ${ALLUXIO_GROUP} ${ALLUXIO_UID} ${ALLUXIO_GID} centos
-
 # Docker 19.03+ required to expand variables in --chown argument
 # https://github.com/moby/buildkit/pull/926#issuecomment-503943557
-COPY --from=alluxio-extractor --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} /opt /opt/
-COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} conf /opt/alluxio/conf/
-COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} entrypoint.sh /
+COPY --from=alluxio-extractor /opt /opt/
+COPY conf /opt/alluxio/conf/
+COPY entrypoint.sh /
 COPY --from=csi-dev /usr/local/bin/alluxio-csi /usr/local/bin/
 
 RUN ./dockerfile-common.sh enable-dynamic-user ${ENABLE_DYNAMIC_USER}
-
-USER ${ALLUXIO_UID}
 
 WORKDIR /opt/alluxio
 

--- a/integration/docker/Dockerfile-dev
+++ b/integration/docker/Dockerfile-dev
@@ -28,9 +28,9 @@ RUN cd /alluxio-csi && \
 #       - https://github.com/moby/moby/issues/6119
 # ADD with chown doesn't chown the files inside tarball
 #   See - https://github.com/moby/moby/issues/35525
-FROM alpine:3.10.8 AS alluxio-extractor
+FROM alpine:3.10.2 AS alluxio-extractor
 # Note that downloads for *-SNAPSHOT tarballs are not available.
-ARG ALLUXIO_TARBALL=https://downloads.alluxio.io/downloads/files/2.8.0/alluxio-2.8.0-bin.tar.gz
+ARG ALLUXIO_TARBALL=http://downloads.alluxio.io/downloads/files/2.9.0-SNAPSHOT/alluxio-2.9.0-SNAPSHOT-bin.tar.gz
 # (Alert):It's not recommended to set this Argument to true, unless you know exactly what you are doing
 ARG ENABLE_DYNAMIC_USER=false
 

--- a/integration/docker/README.md
+++ b/integration/docker/README.md
@@ -52,6 +52,7 @@ when the image starts.
 
 ```console
 $ docker run -e ALLUXIO_MASTER_HOSTNAME=ec2-203-0-113-25.compute-1.amazonaws.com \
+-e ALLUXIO_USERNAME=your_username -e ALLUXIO_GROUP=your_group -e ALLUXIO_UID=1012 -e ALLUXIO_GID=1012 \
 alluxio/alluxio-[
 |dev] [master|worker|proxy|fuse]
 ```
@@ -66,6 +67,7 @@ to launch a standalone Fuse container:
 
 ```console
 $ docker run -e ALLUXIO_MASTER_HOSTNAME=alluxio-master \
+-e ALLUXIO_USERNAME=your_username -e ALLUXIO_GROUP=your_group -e ALLUXIO_UID=1012 -e ALLUXIO_GID=1012 \
 --cap-add SYS_ADMIN --device /dev/fuse alluxio/alluxio fuse --fuse-opts=allow_other
 ```
 

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -169,11 +169,12 @@ function setup_for_dynamic_non_root {
       if [ "$alp" == "1" ];then
         addgroup -g ${ALLUXIO_GID} ${ALLUXIO_GROUP}
         adduser -u ${ALLUXIO_UID}  -G ${ALLUXIO_GROUP} --disabled-password ${ALLUXIO_USERNAME}
+        addgroup ${ALLUXIO_USERNAME} root
       else
         groupadd -g ${ALLUXIO_GID} ${ALLUXIO_GROUP} && \
         useradd -u ${ALLUXIO_UID} -g ${ALLUXIO_GROUP} ${ALLUXIO_USERNAME}
+        usermod -a -G root ${ALLUXIO_USERNAME}
       fi
-      usermod -a -G root ${ALLUXIO_USERNAME}
       mkdir -p /journal
       chown -R ${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} /opt/* /journal
       chmod -R g=u /opt/* /journal
@@ -191,6 +192,7 @@ function setup_for_dynamic_non_root {
           grep -Ev "^$" | \
           xargs -I {} chmod -R 777 {}
       fi
+      chown ${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} /entrypoint.sh
       exec su ${ALLUXIO_USERNAME} -c "/entrypoint.sh $*"
   fi
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Rrefactor the Dockerfile's entrypoint script so that we can set permissions on a provided env/argument instead.

### Why are the changes needed?

Please clarify why the changes are needed. For instance,

Currently in the Alluxio Dockerfile the USER, UID and GID are all hard-coded. Thus only way to change the file permissions is to recompile a Docker image with new values for the arguments.

This creates a problem for users of the Helm chart who try to modify the user / UID used to run the Docker container in k8s. The corresponding file permissions do not get updated to the new UID.

I suggest we should consider refactoring the Dockerfile's entrypoint script so that we can set permissions on a provided env/argument instead.

### Does this PR introduce any user facing changes?

No, it doesn't. 
