### PR TITLE
Remove the unnecessary buf duplicate call

### DIFF
--- a/core/common/src/main/java/alluxio/worker/block/io/LocalFileBlockWriter.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/LocalFileBlockWriter.java
@@ -55,7 +55,7 @@ public class LocalFileBlockWriter extends BlockWriter {
 
   @Override
   public long append(ByteBuffer inputBuf) throws IOException {
-    long bytesWritten = write(mLocalFileChannel.size(), inputBuf.duplicate());
+    long bytesWritten = write(mLocalFileChannel.size(), inputBuf);
     mPosition += bytesWritten;
     return bytesWritten;
   }

--- a/core/common/src/test/java/alluxio/worker/block/io/LocalFileBlockWriterTest.java
+++ b/core/common/src/test/java/alluxio/worker/block/io/LocalFileBlockWriterTest.java
@@ -74,9 +74,10 @@ public final class LocalFileBlockWriterTest {
 
   @Test
   public void append() throws Exception {
-    ByteBuffer buf = BufferUtils.getIncreasingByteBuffer(TEST_BLOCK_SIZE);
-    Assert.assertEquals(TEST_BLOCK_SIZE, mWriter.append(buf));
-    Assert.assertEquals(TEST_BLOCK_SIZE, mWriter.append(buf));
+    Assert.assertEquals(TEST_BLOCK_SIZE,
+        mWriter.append(BufferUtils.getIncreasingByteBuffer(TEST_BLOCK_SIZE)));
+    Assert.assertEquals(TEST_BLOCK_SIZE,
+        mWriter.append(BufferUtils.getIncreasingByteBuffer(TEST_BLOCK_SIZE)));
     mWriter.close();
     Assert.assertEquals(2 * TEST_BLOCK_SIZE, new File(mTestFilePath).length());
     ByteBuffer result = ByteBuffer.wrap(Files.readAllBytes(Paths.get(mTestFilePath)));


### PR DESCRIPTION
### What changes are proposed in this pull request?
Remove the unnecessary buf duplicate call

### Why are the changes needed?
we already call duplicated on the caller side.  https://github.com/Alluxio/alluxio/blob/70b6e77438ad22b876890e635a43d1520e83498b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java#L193

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
no
