### PR TITLE
Add test for LoadManager

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/loadmanager/LoadManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/loadmanager/LoadManager.java
@@ -90,7 +90,7 @@ public final class LoadManager {
   void start() {
     mLoadScheduler.scheduleAtFixedRate(this::updateWorkers,
         0, WORKER_UPDATE_INTERVAL, TimeUnit.MILLISECONDS);
-    mLoadScheduler.scheduleAtFixedRate(this::processJobs, 0, 1, TimeUnit.SECONDS);
+    mLoadScheduler.scheduleWithFixedDelay(this::processJobs, 0, 100, TimeUnit.MILLISECONDS);
   }
 
   /**


### PR DESCRIPTION
Add a test for 1000 worker with 100 jobs. Change the processJob task to run more
frequently to shorten test wall time. The CPU for each run is small except for
the first run when a job is submitted so the overhead is negligible.