### PR TITLE
Create inode before updating the MountTable

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3349,7 +3349,8 @@ public class DefaultFileSystemMaster extends CoreMaster
           ExceptionMessage.MOUNT_POINT_ALREADY_EXISTS.getMessage(inodePath.getUri()));
     }
     // validate the Mount operation first
-    mMountTable.validateMountPoint(inodePath.getUri(), ufsPath);
+    MountTable.ValidatedPathPair validatedMountPair = mMountTable
+        .validateMountPoint(inodePath.getUri(), ufsPath);
     long mountId = IdUtils.createMountId();
     // get UfsManager prepared
     mUfsManager.addMount(mountId, new AlluxioURI(ufsPath.toString()),
@@ -3372,8 +3373,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       if (loadMetadataSucceeded) {
         // As we have verified the mount operation by calling MountTable.verifyMount, there won't
         // be any error thrown when doing MountTable.add
-        mMountTable.add(rpcContext, inodePath.getUri(), ufsPath, mountId,
-            context.getOptions().build());
+        mMountTable.add(rpcContext, validatedMountPair, mountId, context.getOptions().build());
       } else {
         mUfsManager.removeMount(mountId);
       }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3368,10 +3368,11 @@ public class DefaultFileSystemMaster extends CoreMaster
             this);
         // As we have verified the mount operation by calling MountTable.verifyMount, there won't
         // be any error thrown when doing MountTable.add
-        mMountTable.add(rpcContext, new Pair<>(inodePath.getUri(), ufsPath), mountId,
+        mMountTable.addValidated(rpcContext, inodePath.getUri(), ufsPath, mountId,
             context.getOptions().build());
       } catch (Exception e) {
         // if exception happens, it indicates the failure of loadMetadata
+        LOG.error("Failed to mount {} at {}: ", ufsPath, inodePath.getUri(), e);
         mUfsManager.removeMount(mountId);
         throw e;
       }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3330,7 +3330,8 @@ public class DefaultFileSystemMaster extends CoreMaster
           ExceptionMessage.MOUNT_POINT_ALREADY_EXISTS.getMessage(inodePath.getUri()));
     }
     // validate the Mount operation first
-    mMountTable.validateMountPoint(inodePath.getUri(), ufsPath);
+    MountTable.ValidatedPathPair validatedMountPair = mMountTable
+        .validateMountPoint(inodePath.getUri(), ufsPath);
     long mountId = IdUtils.createMountId();
     // get UfsManager prepared
     mUfsManager.addMount(mountId, new AlluxioURI(ufsPath.toString()),
@@ -3353,8 +3354,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       if (loadMetadataSucceeded) {
         // As we have verified the mount operation by calling MountTable.verifyMount, there won't
         // be any error thrown when doing MountTable.add
-        mMountTable.add(rpcContext, inodePath.getUri(), ufsPath, mountId,
-            context.getOptions().build());
+        mMountTable.add(rpcContext, validatedMountPair, mountId, context.getOptions().build());
       } else {
         mUfsManager.removeMount(mountId);
       }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3250,7 +3250,6 @@ public class DefaultFileSystemMaster extends CoreMaster
               Configuration.global(), context.getOptions().getReadOnly())
               .createMountSpecificConf(context.getOptions().getPropertiesMap()));
       prepareForMount(ufsPath, newMountId, context);
-
       // old ufsClient is removed as part of the mount table update process
       mMountTable.update(journalContext, alluxioPath, newMountId, context.getOptions().build());
     } catch (FileAlreadyExistsException | InvalidPathException | IOException e) {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3338,19 +3338,29 @@ public class DefaultFileSystemMaster extends CoreMaster
           inodePath,
           LoadMetadataContext.mergeFrom(
               LoadMetadataPOptions.newBuilder().setCreateAncestors(false)),
-          true, context.getOptions().getShared(), ufsPath, mUfsManager.get(mountId),
+          context.getOptions().getShared(), ufsPath, mUfsManager.get(mountId),
           this);
       loadMetadataSucceeded = true;
     } finally {
       if (loadMetadataSucceeded) {
-        mMountTable.add(rpcContext, inodePath.getUri(), ufsPath, mountId, context.getOptions().build());
+        // As we have verified the mount operation by calling MountTable.verifyMount, there won't
+        // be any error thrown when doing MountTable.add
+        mMountTable.add(rpcContext, inodePath.getUri(), ufsPath, mountId,
+            context.getOptions().build());
       } else {
         mUfsManager.removeMount(mountId);
       }
     }
   }
 
-  public void prepareUfsForMount(long mountId, AlluxioURI ufsPath, MountContext context)
+  /**
+   * Get UfsManager prepared before add/update MountTable.
+   * @param mountId the mountId of this new mount operation
+   * @param ufsPath the ufs path to be mounted
+   * @param context the mounting context
+   * @throws IOException can be thrown when the ufsPath doesn't exist
+   */
+  private void prepareUfsForMount(long mountId, AlluxioURI ufsPath, MountContext context)
       throws IOException {
     // Adding the mount point will not create the UFS instance and thus not connect to UFS
     mUfsManager.addMount(mountId, new AlluxioURI(ufsPath.toString()),
@@ -3369,7 +3379,7 @@ public class DefaultFileSystemMaster extends CoreMaster
   private void mountPathValidation(LockedInodePath inodePath, AlluxioURI ufsPath)
       throws FileAlreadyExistsException, InvalidPathException, IOException {
     AlluxioURI alluxioPath = inodePath.getUri();
-    mMountTable.validateMount(alluxioPath, ufsPath);
+    mMountTable.verifyMount(alluxioPath, ufsPath);
       // Check that the alluxioPath we're creating doesn't shadow a path in the parent UFS
     MountTable.Resolution resolution = mMountTable.resolve(alluxioPath);
     try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2624,59 +2624,6 @@ public class DefaultFileSystemMaster extends CoreMaster
     }
   }
 
-  /**
-   * Implementation of the directory creation. Before creating by this function, the
-   * corresponding UFS client and UFS uri of the inodePath have to be settle down.
-   *
-   * @param rpcContext the rpc context
-   * @param inodePath the path of the directory
-   * @param ufsClient the corresponding ufsClient of the given inodePath
-   * @param ufsUri the corresponding ufsPath of the given inodePath
-   * @param context method context
-   * @return a list of created inodes
-   */
-  List<Inode> createDirectoryInternal(RpcContext rpcContext, LockedInodePath inodePath,
-      UfsManager.UfsClient ufsClient, AlluxioURI ufsUri, CreateDirectoryContext context) throws
-      InvalidPathException, FileAlreadyExistsException, IOException, FileDoesNotExistException {
-    Preconditions.checkState(inodePath.getLockPattern() == LockPattern.WRITE_EDGE);
-
-    try {
-      List<Inode> createResult = mInodeTree.createPath(rpcContext, inodePath, context);
-      InodeDirectory inodeDirectory = inodePath.getInode().asDirectory();
-
-      String ufsFingerprint = Constants.INVALID_UFS_FINGERPRINT;
-      if (inodeDirectory.isPersisted()) {
-        UfsStatus ufsStatus = context.getUfsStatus();
-        // Retrieve the UFS fingerprint for this file.
-        try (CloseableResource<UnderFileSystem> ufsResource = ufsClient.acquireUfsResource()) {
-          UnderFileSystem ufs = ufsResource.get();
-          if (ufsStatus == null) {
-            ufsFingerprint = ufs.getParsedFingerprint(ufsUri.toString()).serialize();
-          } else {
-            ufsFingerprint = Fingerprint.create(ufs.getUnderFSType(), ufsStatus).serialize();
-          }
-        }
-      }
-
-      mInodeTree.updateInode(rpcContext, UpdateInodeEntry.newBuilder()
-          .setId(inodeDirectory.getId())
-          .setUfsFingerprint(ufsFingerprint)
-          .build());
-
-      if (context.isPersisted()) {
-        // The path exists in UFS, so it is no longer absent.
-        mUfsAbsentPathCache.processExisting(inodePath.getUri());
-      }
-
-      Metrics.DIRECTORIES_CREATED.inc();
-      return createResult;
-    } catch (BlockInfoException e) {
-      // Since we are creating a directory, the block size is ignored, no such exception should
-      // happen.
-      throw new RuntimeException(e);
-    }
-  }
-
   List<Inode> createDirectoryInternal(RpcContext rpcContext, LockedInodePath inodePath,
       UfsManager.UfsClient ufsClient, AlluxioURI ufsUri, CreateDirectoryContext context) throws
       InvalidPathException, FileAlreadyExistsException, IOException, FileDoesNotExistException {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3349,7 +3349,7 @@ public class DefaultFileSystemMaster extends CoreMaster
           ExceptionMessage.MOUNT_POINT_ALREADY_EXISTS.getMessage(inodePath.getUri()));
     }
     // validate the Mount operation first
-    try(MountTable.ValidatedPathPair validatedMountPair = mMountTable
+    try (MountTable.ValidatedPathPair validatedMountPair = mMountTable
         .validateMountPoint(inodePath.getUri(), ufsPath)) {
       long mountId = IdUtils.createMountId();
       // get UfsManager prepared

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2624,6 +2624,17 @@ public class DefaultFileSystemMaster extends CoreMaster
     }
   }
 
+  /**
+   * Implementation of the directory creation. Before creating by this function, the
+   * corresponding UFS client and UFS uri of the inodePath have to be settle down.
+   *
+   * @param rpcContext the rpc context
+   * @param inodePath the path of the directory
+   * @param ufsClient the corresponding ufsClient of the given inodePath
+   * @param ufsUri the corresponding ufsPath of the given inodePath
+   * @param context method context
+   * @return a list of created inodes
+   */
   List<Inode> createDirectoryInternal(RpcContext rpcContext, LockedInodePath inodePath,
       UfsManager.UfsClient ufsClient, AlluxioURI ufsUri, CreateDirectoryContext context) throws
       InvalidPathException, FileAlreadyExistsException, IOException, FileDoesNotExistException {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3349,7 +3349,7 @@ public class DefaultFileSystemMaster extends CoreMaster
           ExceptionMessage.MOUNT_POINT_ALREADY_EXISTS.getMessage(inodePath.getUri()));
     }
     // validate the Mount operation first
-    mountPathValidation(inodePath, ufsPath);
+    mMountTable.validateMountPoint(inodePath.getUri(), ufsPath);
     long mountId = IdUtils.createMountId();
     // get UfsManager prepared
     mUfsManager.addMount(mountId, new AlluxioURI(ufsPath.toString()),
@@ -3376,45 +3376,6 @@ public class DefaultFileSystemMaster extends CoreMaster
             context.getOptions().build());
       } else {
         mUfsManager.removeMount(mountId);
-      }
-    }
-  }
-
-  /**
-   * Get UfsManager prepared before add/update MountTable.
-   * @param mountId the mountId of this new mount operation
-   * @param ufsPath the ufs path to be mounted
-   * @param context the mounting context
-   * @throws IOException can be thrown when the ufsPath doesn't exist
-   */
-  private void prepareUfsForMount(long mountId, AlluxioURI ufsPath, MountContext context)
-      throws IOException {
-    // Adding the mount point will not create the UFS instance and thus not connect to UFS
-    mUfsManager.addMount(mountId, new AlluxioURI(ufsPath.toString()),
-        new UnderFileSystemConfiguration(
-            Configuration.global(), context.getOptions().getReadOnly())
-            .createMountSpecificConf(context.getOptions().getPropertiesMap()));
-    prepareForMount(ufsPath, mountId, context);
-  }
-
-  /**
-   * Updates the mount table with the specified mount point. The mount options may be updated during
-   * this method.
-   *
-   * @param inodePath the Alluxio mount point
-   */
-  private void mountPathValidation(LockedInodePath inodePath, AlluxioURI ufsPath)
-      throws FileAlreadyExistsException, InvalidPathException, IOException {
-    AlluxioURI alluxioPath = inodePath.getUri();
-    mMountTable.validateMountPoint(alluxioPath, ufsPath);
-      // Check that the alluxioPath we're creating doesn't shadow a path in the parent UFS
-    MountTable.Resolution resolution = mMountTable.resolve(alluxioPath);
-    try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
-      String ufsResolvedPath = resolution.getUri().getPath();
-      if (ufsResource.get().exists(ufsResolvedPath)) {
-        throw new IOException(MessageFormat.format(
-            "Mount path {0} shadows an existing path {1} in the parent underlying filesystem",
-            alluxioPath, ufsResolvedPath));
       }
     }
   }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3231,7 +3231,6 @@ public class DefaultFileSystemMaster extends CoreMaster
               Configuration.global(), context.getOptions().getReadOnly())
               .createMountSpecificConf(context.getOptions().getPropertiesMap()));
       prepareForMount(ufsPath, newMountId, context);
-
       // old ufsClient is removed as part of the mount table update process
       mMountTable.update(journalContext, alluxioPath, newMountId, context.getOptions().build());
     } catch (FileAlreadyExistsException | InvalidPathException | IOException e) {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3349,8 +3349,9 @@ public class DefaultFileSystemMaster extends CoreMaster
           ExceptionMessage.MOUNT_POINT_ALREADY_EXISTS.getMessage(inodePath.getUri()));
     }
     // validate the Mount operation first
-    try (MountTable.ValidatedPathPair validatedMountPair = mMountTable
-        .validateMountPoint(inodePath.getUri(), ufsPath)) {
+    try (LockResource r = new LockResource(mMountTable.getWriteLock())) {
+      MountTable.ValidatedPathPair validatedMountPair = mMountTable
+          .validateMountPoint(inodePath.getUri(), ufsPath);
       long mountId = IdUtils.createMountId();
       // get UfsManager prepared
       mUfsManager.addMount(mountId, new AlluxioURI(ufsPath.toString()),

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3321,7 +3321,7 @@ public class DefaultFileSystemMaster extends CoreMaster
         }
         mMountTable.checkUnderWritableMountPoint(alluxioPath);
 
-        mountPathValidation(rpcContext, inodePath, ufsPath, context);
+        mountInternal(rpcContext, inodePath, ufsPath, context);
         auditContext.setSucceeded(true);
         Metrics.PATHS_MOUNTED.inc();
       }
@@ -3336,8 +3336,8 @@ public class DefaultFileSystemMaster extends CoreMaster
    * @param ufsPath the UFS path to mount
    * @param context the mount context
    */
-  private void mountPathValidation(RpcContext rpcContext, LockedInodePath inodePath, AlluxioURI ufsPath,
-                                   MountContext context) throws InvalidPathException, FileAlreadyExistsException,
+  private void mountInternal(RpcContext rpcContext, LockedInodePath inodePath, AlluxioURI ufsPath,
+      MountContext context) throws InvalidPathException, FileAlreadyExistsException,
       FileDoesNotExistException, IOException, AccessControlException {
     // Check that the Alluxio Path does not exist
     if (inodePath.fullPathExists()) {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2626,7 +2626,7 @@ public class DefaultFileSystemMaster extends CoreMaster
 
   /**
    * Implementation of the directory creation. Before creating by this function, the
-   * corresponding UFS client and UFS uri of the inodePath have to be settle down.
+   * corresponding UFS client and UFS uri of the inodePath have to be prepared.
    *
    * @param rpcContext the rpc context
    * @param inodePath the path of the directory

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3302,7 +3302,7 @@ public class DefaultFileSystemMaster extends CoreMaster
         }
         mMountTable.checkUnderWritableMountPoint(alluxioPath);
 
-        mountPathValidation(rpcContext, inodePath, ufsPath, context);
+        mountInternal(rpcContext, inodePath, ufsPath, context);
         auditContext.setSucceeded(true);
         Metrics.PATHS_MOUNTED.inc();
       }
@@ -3317,8 +3317,8 @@ public class DefaultFileSystemMaster extends CoreMaster
    * @param ufsPath the UFS path to mount
    * @param context the mount context
    */
-  private void mountPathValidation(RpcContext rpcContext, LockedInodePath inodePath, AlluxioURI ufsPath,
-                                   MountContext context) throws InvalidPathException, FileAlreadyExistsException,
+  private void mountInternal(RpcContext rpcContext, LockedInodePath inodePath, AlluxioURI ufsPath,
+      MountContext context) throws InvalidPathException, FileAlreadyExistsException,
       FileDoesNotExistException, IOException, AccessControlException {
     // Check that the Alluxio Path does not exist
     if (inodePath.fullPathExists()) {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2677,6 +2677,48 @@ public class DefaultFileSystemMaster extends CoreMaster
     }
   }
 
+  List<Inode> createDirectoryInternal(RpcContext rpcContext, LockedInodePath inodePath,
+      UfsManager.UfsClient ufsClient, AlluxioURI ufsUri, CreateDirectoryContext context) throws
+      InvalidPathException, FileAlreadyExistsException, IOException, FileDoesNotExistException {
+    Preconditions.checkState(inodePath.getLockPattern() == LockPattern.WRITE_EDGE);
+
+    try {
+      List<Inode> createResult = mInodeTree.createPath(rpcContext, inodePath, context);
+      InodeDirectory inodeDirectory = inodePath.getInode().asDirectory();
+
+      String ufsFingerprint = Constants.INVALID_UFS_FINGERPRINT;
+      if (inodeDirectory.isPersisted()) {
+        UfsStatus ufsStatus = context.getUfsStatus();
+        // Retrieve the UFS fingerprint for this file.
+        try (CloseableResource<UnderFileSystem> ufsResource = ufsClient.acquireUfsResource()) {
+          UnderFileSystem ufs = ufsResource.get();
+          if (ufsStatus == null) {
+            ufsFingerprint = ufs.getParsedFingerprint(ufsUri.toString()).serialize();
+          } else {
+            ufsFingerprint = Fingerprint.create(ufs.getUnderFSType(), ufsStatus).serialize();
+          }
+        }
+      }
+
+      mInodeTree.updateInode(rpcContext, UpdateInodeEntry.newBuilder()
+          .setId(inodeDirectory.getId())
+          .setUfsFingerprint(ufsFingerprint)
+          .build());
+
+      if (context.isPersisted()) {
+        // The path exists in UFS, so it is no longer absent.
+        mUfsAbsentPathCache.processExisting(inodePath.getUri());
+      }
+
+      Metrics.DIRECTORIES_CREATED.inc();
+      return createResult;
+    } catch (BlockInfoException e) {
+      // Since we are creating a directory, the block size is ignored, no such exception should
+      // happen.
+      throw new RuntimeException(e);
+    }
+  }
+
   /**
    * Implementation of directory creation for a given path.
    *

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3245,7 +3245,11 @@ public class DefaultFileSystemMaster extends CoreMaster
       }
       AlluxioURI alluxioPath = inodePath.getUri();
       // validate new UFS client before updating the mount table
-      prepareUfsForMount(newMountId, ufsPath, context);
+      mUfsManager.addMount(newMountId, new AlluxioURI(ufsPath.toString()),
+          new UnderFileSystemConfiguration(
+              Configuration.global(), context.getOptions().getReadOnly())
+              .createMountSpecificConf(context.getOptions().getPropertiesMap()));
+      prepareForMount(ufsPath, newMountId, context);
 
       // old ufsClient is removed as part of the mount table update process
       mMountTable.update(journalContext, alluxioPath, newMountId, context.getOptions().build());
@@ -3349,7 +3353,12 @@ public class DefaultFileSystemMaster extends CoreMaster
     mountPathValidation(inodePath, ufsPath);
     long mountId = IdUtils.createMountId();
     // get UfsManager prepared
-    prepareUfsForMount(mountId, ufsPath, context);
+    mUfsManager.addMount(mountId, new AlluxioURI(ufsPath.toString()),
+        new UnderFileSystemConfiguration(
+            Configuration.global(), context.getOptions().getReadOnly())
+            .createMountSpecificConf(context.getOptions().getPropertiesMap()));
+    prepareForMount(ufsPath, mountId, context);
+
     boolean loadMetadataSucceeded = false;
     try {
       // This will create the directory at alluxioPath
@@ -3398,7 +3407,7 @@ public class DefaultFileSystemMaster extends CoreMaster
   private void mountPathValidation(LockedInodePath inodePath, AlluxioURI ufsPath)
       throws FileAlreadyExistsException, InvalidPathException, IOException {
     AlluxioURI alluxioPath = inodePath.getUri();
-    mMountTable.verifyMount(alluxioPath, ufsPath);
+    mMountTable.validateMountPoint(alluxioPath, ufsPath);
       // Check that the alluxioPath we're creating doesn't shadow a path in the parent UFS
     MountTable.Resolution resolution = mMountTable.resolve(alluxioPath);
     try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -1043,8 +1043,8 @@ public class InodeSyncStream {
     MountTable.Resolution resolution = mountTable.resolve(inodePath.getUri());
     // create the actual metadata
     loadDirectoryMetadataInternal(rpcContext, context, inodePath, resolution.getUri(),
-        resolution.getUfsClient(), fsMaster, resolution.getShared(),
-        mountTable.isMountPoint(inodePath.getUri()));
+        resolution.getUfsClient(), fsMaster, mountTable.isMountPoint(inodePath.getUri()),
+            resolution.getShared());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -1048,7 +1048,8 @@ public class InodeSyncStream {
   }
 
   /**
-   * Loads metadata for a mount point. This method acquires a write-edge lock on the target mount path.
+   * Loads metadata for a mount point. This method acquires a write-edge lock on
+   * the target mount path.
    */
   static void loadMountPointDirectoryMetadata(RpcContext rpcContext, LockedInodePath inodePath,
       LoadMetadataContext context, boolean isShared, AlluxioURI ufsUri,

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -1123,7 +1123,8 @@ public class InodeSyncStream {
     }
 
     try (LockedInodePath writeLockedPath = inodePath.lockFinalEdgeWrite()) {
-      fsMaster.createDirectoryInternal(rpcContext, writeLockedPath, createDirectoryContext);
+      fsMaster.createDirectoryInternal(rpcContext, writeLockedPath, ufsClient, ufsUri,
+          createDirectoryContext);
     } catch (FileAlreadyExistsException e) {
       // This may occur if a thread created or loaded the directory before we got the write lock.
       // The directory already exists, so nothing needs to be loaded.

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -64,6 +64,7 @@ import alluxio.security.authorization.DefaultAccessControlList;
 import alluxio.security.authorization.Mode;
 import alluxio.underfs.Fingerprint;
 import alluxio.underfs.UfsFileStatus;
+import alluxio.underfs.UfsManager;
 import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UfsStatusCache;
 import alluxio.underfs.UnderFileSystem;
@@ -1016,6 +1017,70 @@ public class InodeSyncStream {
       // This may occur if a thread created or loaded the file before we got the write lock.
       // The file already exists, so nothing needs to be loaded.
       LOG.debug("Failed to load file metadata: {}", e.toString());
+    }
+    // Re-traverse the path to pick up any newly created inodes.
+    inodePath.traverse();
+  }
+
+  static void loadMountPointDirectoryMetadata(RpcContext rpcContext, LockedInodePath inodePath,
+      LoadMetadataContext context, boolean isMountPoint, boolean isShared, AlluxioURI ufsUri,
+      UfsManager.UfsClient ufsClient, DefaultFileSystemMaster fsMaster) throws
+      FileDoesNotExistException, IOException, InvalidPathException {
+    if (inodePath.fullPathExists()) {
+      return;
+    }
+    CreateDirectoryContext createDirectoryContext = CreateDirectoryContext.defaults();
+    createDirectoryContext.getOptions()
+        .setRecursive(context.getOptions().getCreateAncestors()).setAllowExists(false)
+        .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
+            .setTtl(context.getOptions().getCommonOptions().getTtl())
+            .setTtlAction(context.getOptions().getCommonOptions().getTtlAction()));
+    createDirectoryContext.setMountPoint(isMountPoint);
+    createDirectoryContext.setMetadataLoad(true);
+    createDirectoryContext.setWriteType(WriteType.THROUGH);
+
+    AccessControlList acl = null;
+    DefaultAccessControlList defaultAcl = null;
+    try (CloseableResource<UnderFileSystem> ufsResource = ufsClient.acquireUfsResource()) {
+      UnderFileSystem ufs = ufsResource.get();
+      if (context.getUfsStatus() == null) {
+        context.setUfsStatus(ufs.getExistingDirectoryStatus(ufsUri.toString()));
+      }
+      Pair<AccessControlList, DefaultAccessControlList> aclPair =
+          ufs.getAclPair(ufsUri.toString());
+      if (aclPair != null) {
+        acl = aclPair.getFirst();
+        defaultAcl = aclPair.getSecond();
+      }
+    }
+    String ufsOwner = context.getUfsStatus().getOwner();
+    String ufsGroup = context.getUfsStatus().getGroup();
+    short ufsMode = context.getUfsStatus().getMode();
+    Long lastModifiedTime = context.getUfsStatus().getLastModifiedTime();
+    Mode mode = new Mode(ufsMode);
+    if (isShared) {
+      mode.setOtherBits(mode.getOtherBits().or(mode.getOwnerBits()));
+    }
+    createDirectoryContext.getOptions().setMode(mode.toProto());
+    createDirectoryContext.setOwner(ufsOwner).setGroup(ufsGroup)
+        .setUfsStatus(context.getUfsStatus());
+    createDirectoryContext.setXAttr(context.getUfsStatus().getXAttr());
+    if (acl != null) {
+      createDirectoryContext.setAcl(acl.getEntries());
+    }
+
+    if (defaultAcl != null) {
+      createDirectoryContext.setDefaultAcl(defaultAcl.getEntries());
+    }
+    if (lastModifiedTime != null) {
+      createDirectoryContext.setOperationTimeMs(lastModifiedTime);
+    }
+
+    try (LockedInodePath writeLockedPath = inodePath.lockFinalEdgeWrite()) {
+      fsMaster.createDirectoryInternal(rpcContext, writeLockedPath, createDirectoryContext);
+    } catch (FileAlreadyExistsException e) {
+      // This may occur if a thread created or loaded the directory before we got the write lock.
+      // The directory already exists, so nothing needs to be loaded.
     }
     // Re-traverse the path to pick up any newly created inodes.
     inodePath.traverse();

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -1048,12 +1048,7 @@ public class InodeSyncStream {
   }
 
   /**
-   * Loads metadata for the directory that will be the mount point.
-   *
-   * This difference between this method and
-   * {@link InodeSyncStream#loadDirectoryMetadata(RpcContext, LockedInodePath, LoadMetadataContext,
-   * MountTable, DefaultFileSystemMaster)} is that it accepts more specific parameters(i.e
-   * . isShared, ufsUri and ufsClient) and doesn't require the MountTable as its parameter.
+   * Loads metadata for a mount point. This method acquires a write-edge lock on the target mount path.
    */
   static void loadMountPointDirectoryMetadata(RpcContext rpcContext, LockedInodePath inodePath,
       LoadMetadataContext context, boolean isShared, AlluxioURI ufsUri,

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -1050,7 +1050,7 @@ public class InodeSyncStream {
   }
 
   /**
-   * Loads metadata for a mount point. This method acquires a write-edge lock on
+   * Loads metadata for a mount point. This method acquires a WRITE_EDGE lock on
    * the target mount path.
    */
   static void loadMountPointDirectoryMetadata(RpcContext rpcContext, LockedInodePath inodePath,

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -1141,13 +1141,14 @@ public class InodeSyncStream {
         .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
             .setTtl(context.getOptions().getCommonOptions().getTtl())
             .setTtlAction(context.getOptions().getCommonOptions().getTtlAction()));
-    createDirectoryContext.setMountPoint(isMountPoint);
+    createDirectoryContext.setMountPoint(mountTable.isMountPoint(inodePath.getUri()));
     createDirectoryContext.setMetadataLoad(true);
     createDirectoryContext.setWriteType(WriteType.THROUGH);
+    MountTable.Resolution resolution = mountTable.resolve(inodePath.getUri());
 
     AccessControlList acl = null;
     DefaultAccessControlList defaultAcl = null;
-    try (CloseableResource<UnderFileSystem> ufsResource = ufsClient.acquireUfsResource()) {
+    try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
       UnderFileSystem ufs = ufsResource.get();
       if (context.getUfsStatus() == null) {
         context.setUfsStatus(ufs.getExistingDirectoryStatus(ufsUri.toString()));

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -1037,6 +1037,8 @@ public class InodeSyncStream {
   static void loadDirectoryMetadata(RpcContext rpcContext, LockedInodePath inodePath,
       LoadMetadataContext context, MountTable mountTable, DefaultFileSystemMaster fsMaster)
       throws FileDoesNotExistException, InvalidPathException, AccessControlException, IOException {
+    // Return if the full path exists because the sync cares only about keeping up with the UFS
+    // If the mount point target path exists, the later mount logic will complain.
     if (inodePath.fullPathExists()) {
       return;
     }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -156,6 +156,7 @@ public final class MountTable implements DelegatingJournaled {
       throws FileAlreadyExistsException, InvalidPathException, IOException {
     String alluxioPath = alluxioUri.getPath().isEmpty() ? "/" : alluxioUri.getPath();
     LOG.info("Validating Mounting {} at {}", ufsUri, alluxioPath);
+
     try (LockResource r = new LockResource(mReadLock)) {
       if (mState.getMountTable().containsKey(alluxioPath)) {
         throw new FileAlreadyExistsException(
@@ -190,7 +191,7 @@ public final class MountTable implements DelegatingJournaled {
             alluxioPath, ufsResolvedPath));
       }
     }
-    return new ValidatedPathPair(alluxioUri, ufsUri);
+    return new ValidatedPathPair(alluxioUri, ufsUri, mReadLock);
   }
 
   /**
@@ -508,10 +509,12 @@ public final class MountTable implements DelegatingJournaled {
   public final class ValidatedPathPair {
     private final AlluxioURI mAlluxioPath;
     private final AlluxioURI mUfsPath;
+    private final Lock mLock;
 
-    private ValidatedPathPair(AlluxioURI alluxioPath, AlluxioURI ufsPath) {
+    private ValidatedPathPair(AlluxioURI alluxioPath, AlluxioURI ufsPath, Lock lock) {
       mAlluxioPath = alluxioPath;
       mUfsPath = ufsPath;
+      mLock = lock;
     }
 
     /**
@@ -526,6 +529,13 @@ public final class MountTable implements DelegatingJournaled {
      */
     public AlluxioURI getUfsPath() {
       return mUfsPath;
+    }
+
+    /**
+     * @return the lock held by the current mount operation
+     */
+    public Lock getLock() {
+      return mLock;
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -126,10 +126,16 @@ public final class MountTable implements DelegatingJournaled {
   }
 
   /**
-   * Mounts based on the given ValidatedPathPair. It will directly insert a new entry into
-   * MountTable via the mState. This method is NOT ThreadSafe. When calling this add, lockResource
-   * will not be applied and the
-   * caller MUST hold the write lock resource.
+   * Inserts an entry into the mount table.
+   * Before calling this method, the caller must hold the write lock to the mount table.
+   * The caller must also have validated the mount information to make sure the mount will succeed.
+   * <blockquote><pre>
+   * try (LockResource mountTableLock = new LockResource(mMountTable.getWriteLock()) {
+   *     mMountTable.validateMountPoint(alluxioPath, ufsPath);
+   *     mMountTable.add(alluxioPath, ufsPath);
+   *     ...
+   *  }
+   * </pre></blockquote>
    * @param journalContext the journal context
    * @param validatedPair the validated mount entry
    * @param mountId the mount id

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -157,7 +157,6 @@ public final class MountTable implements DelegatingJournaled {
       throws FileAlreadyExistsException, InvalidPathException, IOException {
     String alluxioPath = alluxioUri.getPath().isEmpty() ? "/" : alluxioUri.getPath();
     LOG.info("Validating Mounting {} at {}", ufsUri, alluxioPath);
-    // acquire the writelock resource
     LockResource r = new LockResource(mWriteLock);
 
     try {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -200,7 +200,7 @@ public final class MountTable implements DelegatingJournaled {
     try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
       String ufsResolvedPath = resolution.getUri().getPath();
       if (ufsResource.get().exists(ufsResolvedPath)) {
-        throw new IOException(MessageFormat.format(
+        throw new InvalidPathException(MessageFormat.format(
             "Mount path {0} shadows an existing path {1} in the parent underlying filesystem",
             alluxioPath, ufsResolvedPath));
       }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -106,7 +106,7 @@ public final class MountTable implements DelegatingJournaled {
   public void add(Supplier<JournalContext> journalContext, AlluxioURI alluxioUri, AlluxioURI ufsUri,
       long mountId, MountPOptions options) throws FileAlreadyExistsException, InvalidPathException {
     // validate the Mount operation first, error will be thrown if the operation is invalid
-    verifyMount(alluxioUri, ufsUri);
+    validateMountPoint(alluxioUri, ufsUri);
 
     String alluxioPath = alluxioUri.getPath().isEmpty() ? "/" : alluxioUri.getPath();
     LOG.info("Mounting {} at {}", ufsUri, alluxioPath);
@@ -134,7 +134,7 @@ public final class MountTable implements DelegatingJournaled {
    * @throws FileAlreadyExistsException
    * @throws InvalidPathException
    */
-  public void verifyMount(AlluxioURI alluxioUri, AlluxioURI ufsUri)
+  public void validateMountPoint(AlluxioURI alluxioUri, AlluxioURI ufsUri)
       throws FileAlreadyExistsException, InvalidPathException {
     String alluxioPath = alluxioUri.getPath().isEmpty() ? "/" : alluxioUri.getPath();
     LOG.info("Validating Mounting {} at {}", ufsUri, alluxioPath);

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -106,7 +106,7 @@ public final class MountTable implements DelegatingJournaled {
   public void add(Supplier<JournalContext> journalContext, AlluxioURI alluxioUri, AlluxioURI ufsUri,
       long mountId, MountPOptions options) throws FileAlreadyExistsException, InvalidPathException {
     // validate the Mount operation first, error will be thrown if the operation is invalid
-    validateMount(alluxioUri, ufsUri);
+    verifyMount(alluxioUri, ufsUri);
 
     String alluxioPath = alluxioUri.getPath().isEmpty() ? "/" : alluxioUri.getPath();
     LOG.info("Mounting {} at {}", ufsUri, alluxioPath);
@@ -127,7 +127,14 @@ public final class MountTable implements DelegatingJournaled {
     }
   }
 
-  public void validateMount(AlluxioURI alluxioUri, AlluxioURI ufsUri)
+  /**
+   * Verify if the given (alluxioPath, ufsPath) can be inserted into MountTable.
+   * @param alluxioUri the alluxio path that is about to be the mountpoint
+   * @param ufsUri the UFS path that is about to mount
+   * @throws FileAlreadyExistsException
+   * @throws InvalidPathException
+   */
+  public void verifyMount(AlluxioURI alluxioUri, AlluxioURI ufsUri)
       throws FileAlreadyExistsException, InvalidPathException {
     String alluxioPath = alluxioUri.getPath().isEmpty() ? "/" : alluxioUri.getPath();
     LOG.info("Validating Mounting {} at {}", ufsUri, alluxioPath);
@@ -514,6 +521,13 @@ public final class MountTable implements DelegatingJournaled {
      */
     public long getMountId() {
       return mMountId;
+    }
+
+    /**
+     * @return the ufsClient corresponding to this ufs
+     */
+    public UfsManager.UfsClient getUfsClient() {
+      return mUfsClient;
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -514,35 +514,6 @@ public final class MountTable implements DelegatingJournaled {
   }
 
   /**
-   * ValidatedPathPair is used to store the [alluxioPath: ufsPath] pair that has been validated as
-   * a legal MountTable Entry. ValidatedPathPair can only be constructed and returned by
-   * {@link MountTable#validateMountPoint(AlluxioURI, AlluxioURI)}.
-   */
-  public static final class ValidatedPathPair {
-    private final AlluxioURI mAlluxioPath;
-    private final AlluxioURI mUfsPath;
-
-    private ValidatedPathPair(AlluxioURI alluxioPath, AlluxioURI ufsPath) {
-      mAlluxioPath = alluxioPath;
-      mUfsPath = ufsPath;
-    }
-
-    /**
-     * @return the validated alluxioPath
-     */
-    public AlluxioURI getAlluxioPath() {
-      return mAlluxioPath;
-    }
-
-    /**
-     * @return the validated ufsPath
-     */
-    public AlluxioURI getUfsPath() {
-      return mUfsPath;
-    }
-  }
-
-  /**
    * This class represents a UFS path after resolution. The UFS URI and the {@link UnderFileSystem}
    * for the UFS path are available.
    */

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -161,6 +161,7 @@ public final class MountTable implements DelegatingJournaled {
     LockResource r = new LockResource(mWriteLock);
 
     if (mState.getMountTable().containsKey(alluxioPath)) {
+      r.close();
       throw new FileAlreadyExistsException(
           ExceptionMessage.MOUNT_POINT_ALREADY_EXISTS.getMessage(alluxioPath));
     }
@@ -173,10 +174,12 @@ public final class MountTable implements DelegatingJournaled {
         String ufsPath = ufsUri.getPath().isEmpty() ? "/" : ufsUri.getPath();
         String mountedUfsPath = mountedUfsUri.getPath().isEmpty() ? "/" : mountedUfsUri.getPath();
         if (PathUtils.hasPrefix(ufsPath, mountedUfsPath)) {
+          r.close();
           throw new InvalidPathException(ExceptionMessage.MOUNT_POINT_PREFIX_OF_ANOTHER
               .getMessage(mountedUfsUri.toString(), ufsUri.toString()));
         }
         if (PathUtils.hasPrefix(mountedUfsPath, ufsPath)) {
+          r.close();
           throw new InvalidPathException(ExceptionMessage.MOUNT_POINT_PREFIX_OF_ANOTHER
               .getMessage(ufsUri.toString(), mountedUfsUri.toString()));
         }
@@ -188,6 +191,7 @@ public final class MountTable implements DelegatingJournaled {
     try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
       String ufsResolvedPath = resolution.getUri().getPath();
       if (ufsResource.get().exists(ufsResolvedPath)) {
+        r.close();
         throw new IOException(MessageFormat.format(
             "Mount path {0} shadows an existing path {1} in the parent underlying filesystem",
             alluxioPath, ufsResolvedPath));

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -1297,7 +1297,7 @@ public final class FileSystemMasterTest extends FileSystemMasterTestBase {
     AlluxioURI notShadowUfsURI = createTempUfsDir("ufs/notshadowhi");
     mFileSystemMaster.mount(notShadowAlluxioURI, notShadowUfsURI,
         MountContext.defaults());
-    mThrown.expect(IOException.class);
+    mThrown.expect(InvalidPathException.class);
     mFileSystemMaster.mount(shadowAlluxioURI, shadowUfsURI,
         MountContext.defaults());
   }

--- a/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/AsyncUfsAbsentPathCacheTest.java
@@ -66,12 +66,16 @@ public class AsyncUfsAbsentPathCacheTest {
   public void before() throws Exception {
     mLocalUfsPath = mTemp.getRoot().getAbsolutePath();
     mUfsManager = new MasterUfsManager();
+    MountPOptions options = MountContext.defaults().getOptions().build();
+
+    mUfsManager.addMount(1, new AlluxioURI("/ufs"),
+        new UnderFileSystemConfiguration(Configuration.global(), options.getReadOnly())
+            .createMountSpecificConf(Collections.<String, String>emptyMap()));
     mMountTable = new MountTable(mUfsManager, new MountInfo(new AlluxioURI("/"),
         new AlluxioURI("/ufs"), 1, MountContext.defaults().getOptions().build()));
     mUfsAbsentPathCache = new AsyncUfsAbsentPathCache(mMountTable, THREADS);
 
     mMountId = IdUtils.getRandomNonNegativeLong();
-    MountPOptions options = MountContext.defaults().getOptions().build();
     mUfsManager.addMount(mMountId, new AlluxioURI(mLocalUfsPath),
         new UnderFileSystemConfiguration(Configuration.global(), options.getReadOnly())
             .createMountSpecificConf(Collections.<String, String>emptyMap()));

--- a/core/server/master/src/test/java/alluxio/master/file/meta/LazyUfsBlockLocationCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/LazyUfsBlockLocationCacheTest.java
@@ -34,7 +34,7 @@ import java.util.List;
 /**
  * Unit tests for {@link LazyUfsBlockLocationCache}.
  */
-public class LazyUfsBlockLocationCacheTest {
+public class LazyUfsBlockLocationCacheTest extends BaseInodeLockingTest {
   private String mLocalUfsPath;
   private UnderFileSystem mLocalUfs;
   private long mMountId;
@@ -57,6 +57,9 @@ public class LazyUfsBlockLocationCacheTest {
     mUfsManager.addMount(mMountId, new AlluxioURI(mLocalUfsPath),
         new UnderFileSystemConfiguration(Configuration.global(), options.getReadOnly())
             .createMountSpecificConf(Collections.<String, String>emptyMap()));
+    mUfsManager.addMount(1, new AlluxioURI("/ufs"),
+        new UnderFileSystemConfiguration(Configuration.global(), options.getReadOnly())
+        .createMountSpecificConf(Collections.<String, String>emptyMap()));
 
     mMountTable = new MountTable(mUfsManager, new MountInfo(new AlluxioURI("/"),
         new AlluxioURI("/ufs"), 1, MountContext.defaults().getOptions().build()));

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -39,8 +39,6 @@ if [[ -e "${ALLUXIO_CONF_DIR}/alluxio-env.sh" ]]; then
   . "${ALLUXIO_CONF_DIR}/alluxio-env.sh"
 fi
 
-JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_321.jdk/Contents/Home
-
 # Check if java is found
 if [[ -z "${JAVA}" ]]; then
   if [[ -n "${JAVA_HOME}" ]] && [[ -x "${JAVA_HOME}/bin/java" ]];  then

--- a/libexec/alluxio-config.sh
+++ b/libexec/alluxio-config.sh
@@ -39,6 +39,8 @@ if [[ -e "${ALLUXIO_CONF_DIR}/alluxio-env.sh" ]]; then
   . "${ALLUXIO_CONF_DIR}/alluxio-env.sh"
 fi
 
+JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_321.jdk/Contents/Home
+
 # Check if java is found
 if [[ -z "${JAVA}" ]]; then
   if [[ -n "${JAVA_HOME}" ]] && [[ -x "${JAVA_HOME}/bin/java" ]];  then


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. Add method `validateMount` in `MountTable` 
2. When doing mount in `DefaultFileSystemMaster`, load the directory metadata first, then modify the `MountTable` 

### Why are the changes needed?
One major challenge we face in #15578 is that when the mount point is added to `MountTable`, the corresponding inodes don't exist yet. That makes our proposed change in #15578 hard because by using a `Trie<Inode>` data structure the inode must exist first. 

In this change we propose creating the inode before updating the MountTable, so when we update the MountTable, we can just update the `MountTableTrie` with the correct Inode.

### Does this PR introduce any user facing changes?
Nope