### PR TITLE
Disable cuckoo filter UTs

### DIFF
--- a/core/client/fs/src/test/java/alluxio/client/file/cache/cuckoofilter/ConcurrentClockCuckooFilterTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/cuckoofilter/ConcurrentClockCuckooFilterTest.java
@@ -22,6 +22,7 @@ import alluxio.test.util.ConcurrencyUtils;
 
 import com.google.common.hash.Funnels;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
+@Ignore("Ignored since there is a deadlock in the impl. See alluxio#15935.")
 public class ConcurrentClockCuckooFilterTest {
   private static final int EXPECTED_INSERTIONS = Constants.KB;
   private static final int BITS_PER_CLOCK = 4;

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/cuckoofilter/SegmentedLockTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/cuckoofilter/SegmentedLockTest.java
@@ -16,12 +16,14 @@ import static org.junit.Assert.assertEquals;
 import alluxio.test.util.ConcurrencyUtils;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
+@Ignore("Ignored since there is a deadlock in the impl. See alluxio#15935.")
 public class SegmentedLockTest {
   private static final int NUM_BUCKETS = 1024;
   private static final int NUM_LOCKS = 128;

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/cuckoofilter/SimpleCuckooTableTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/cuckoofilter/SimpleCuckooTableTest.java
@@ -17,12 +17,14 @@ import static org.junit.Assert.assertTrue;
 import alluxio.collections.BitSet;
 import alluxio.collections.BuiltinBitSet;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 
+@Ignore("Ignored since there is a deadlock in the impl. See alluxio#15935.")
 public class SimpleCuckooTableTest {
   private static final int NUM_BUCKETS = 16;
   private static final int TAGS_PER_BUCKET = 4;


### PR DESCRIPTION
Temporarily disable cuckoo filter UTs as the implementation has a deadlock issue, causing the test to fail randomly. See #15935.
