### PR TITLE
Fix typo in SegmentedLock

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/cuckoofilter/SegmentedLock.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/cuckoofilter/SegmentedLock.java
@@ -112,7 +112,7 @@ public class SegmentedLock {
     int segmentIndex2 = getSegmentIndex(bucket2);
     int segmentIndex3 = getSegmentIndex(bucket3);
     int maxIndex = Math.max(segmentIndex1, Math.max(segmentIndex2, segmentIndex3));
-    int minIndex = Math.min(segmentIndex1, Math.max(segmentIndex2, segmentIndex3));
+    int minIndex = Math.min(segmentIndex1, Math.min(segmentIndex2, segmentIndex3));
     int midIndex = segmentIndex1 + segmentIndex2 + segmentIndex3 - maxIndex - minIndex;
     mLocks[minIndex].writeLock();
     if (midIndex != minIndex) {


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix a typo in `SegmentedLock` that probably caused the deadlock described in https://github.com/Alluxio/alluxio/issues/15935

### Why are the changes needed?
Fix https://github.com/Alluxio/alluxio/issues/15935

### Does this PR introduce any user facing changes?
No
