### PR TITLE
[DOCFIX] Fix typo in deployment of Alluxio Cluster

### DIFF
--- a/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
+++ b/docs/en/deploy/Running-Alluxio-On-a-Cluster.md
@@ -72,7 +72,7 @@ alluxio.master.mount.table.root.ufs=<STORAGE_URI>
 
 Append the hostname of each node into `conf/masters` and `conf/workers` accordingly.
 Append the hostname of each Alluxio master node to a new line into `conf/masters`,
-and the hostname of each worker node to a new line into `conf/worers`.
+and the hostname of each worker node to a new line into `conf/workers`.
 Comment out `localhost` if necessary.
 For example, in `conf/masters`, we can add the hostnames of two master nodes in the following format:
 ```


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix the typo: from `conf/worers` to `conf/workers`

### Why are the changes needed?

To make our doc more accurate

### Does this PR introduce any user facing changes?

Nope
