### PR TITLE
Remove S3 API ETag requirement & misc. cleanups

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4530,22 +4530,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
-  public static final PropertyKey PROXY_S3_MULTIPART_UPLOAD_MIN_PART_SIZE =
-      dataSizeBuilder(Name.PROXY_S3_MULTIPART_UPLOAD_MIN_PART_SIZE)
-          .setDefaultValue("5MB")
-          .setDescription("The minimum required file size of parts for multipart uploads. "
-              + "Parts which are smaller than this limit aside from the final part will result "
-              + "in an EntityTooSmall error code. Set to 0 to disable size requirements.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
-          .setScope(Scope.SERVER)
-          .build();
-  public static final PropertyKey PROXY_S3_COMPLETE_MULTIPART_UPLOAD_POOL_SIZE =
-      intBuilder(Name.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_POOL_SIZE)
-          .setDefaultValue(20)
-          .setDescription("The complete multipart upload thread pool size.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.SERVER)
-          .build();
   public static final PropertyKey PROXY_S3_COMPLETE_MULTIPART_UPLOAD_KEEPALIVE_ENABLED =
       booleanBuilder(Name.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_KEEPALIVE_ENABLED)
           .setDefaultValue(false)
@@ -4562,6 +4546,22 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("The complete multipart upload maximum keepalive time. "
               + "The keepalive whitespace characters will be sent after 1 second, "
               + "exponentially increasing in duration up to the configured value.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey PROXY_S3_COMPLETE_MULTIPART_UPLOAD_MIN_PART_SIZE =
+      dataSizeBuilder(Name.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_MIN_PART_SIZE)
+          .setDefaultValue("5MB")
+          .setDescription("The minimum required file size of parts for multipart uploads. "
+              + "Parts which are smaller than this limit aside from the final part will result "
+              + "in an EntityTooSmall error code. Set to 0 to disable size requirements.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey PROXY_S3_COMPLETE_MULTIPART_UPLOAD_POOL_SIZE =
+      intBuilder(Name.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_POOL_SIZE)
+          .setDefaultValue(20)
+          .setDescription("The complete multipart upload thread pool size.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
@@ -7458,14 +7458,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.proxy.s3.multipart.upload.cleaner.retry.delay";
     public static final String PROXY_S3_MULTIPART_UPLOAD_CLEANER_POOL_SIZE =
         "alluxio.proxy.s3.multipart.upload.cleaner.pool.size";
-    public static final String PROXY_S3_MULTIPART_UPLOAD_MIN_PART_SIZE =
-        "alluxio.proxy.s3.multipart.upload.min.part.size";
-    public static final String PROXY_S3_COMPLETE_MULTIPART_UPLOAD_POOL_SIZE =
-        "alluxio.proxy.s3.complete.multipart.upload.pool.size";
     public static final String PROXY_S3_COMPLETE_MULTIPART_UPLOAD_KEEPALIVE_ENABLED =
         "alluxio.proxy.s3.complete.multipart.upload.keepalive.enabled";
     public static final String PROXY_S3_COMPLETE_MULTIPART_UPLOAD_KEEPALIVE_TIME_INTERVAL =
         "alluxio.proxy.s3.complete.multipart.upload.keepalive.time.interval";
+    public static final String PROXY_S3_COMPLETE_MULTIPART_UPLOAD_MIN_PART_SIZE =
+        "alluxio.proxy.s3.complete.multipart.upload.min.part.size";
+    public static final String PROXY_S3_COMPLETE_MULTIPART_UPLOAD_POOL_SIZE =
+        "alluxio.proxy.s3.complete.multipart.upload.pool.size";
     public static final String PROXY_S3_HEADER_METADATA_MAX_SIZE =
         "alluxio.proxy.s3.header.metadata.max.size";
     public static final String PROXY_S3_BUCKET_NAMING_RESTRICTIONS_ENABLED =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4480,8 +4480,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "`CACHE_THROUGH` (try to cache, write to UnderFS synchronously), "
               + "`ASYNC_THROUGH` (try to cache, write to UnderFS asynchronously), "
               + "`THROUGH` (no cache, write to UnderFS synchronously).")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
-          .setScope(Scope.NONE)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_S3_DELETE_TYPE =
       stringBuilder(Name.PROXY_S3_DELETE_TYPE)
@@ -4491,8 +4491,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
                   + "`%s` (delete both in Alluxio and UFS), "
                   + "`%s` (delete only the buckets or objects in Alluxio namespace).",
               Constants.S3_DELETE_IN_ALLUXIO_AND_UFS, Constants.S3_DELETE_IN_ALLUXIO_ONLY))
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
-          .setScope(Scope.NONE)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_S3_MULTIPART_UPLOAD_CLEANER_ENABLED =
       booleanBuilder(Name.PROXY_S3_MULTIPART_UPLOAD_CLEANER_ENABLED)
@@ -4506,28 +4506,28 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       durationBuilder(Name.PROXY_S3_MULTIPART_UPLOAD_CLEANER_TIMEOUT)
           .setDefaultValue("10min")
           .setDescription("The timeout for aborting proxy s3 multipart upload automatically.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_COUNT =
       intBuilder(Name.PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_COUNT)
           .setDefaultValue(3)
           .setDescription("The retry count when aborting a multipart upload fails.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_DELAY =
       durationBuilder(Name.PROXY_S3_MULTIPART_UPLOAD_CLEANER_RETRY_DELAY)
           .setDefaultValue("10sec")
           .setDescription("The retry delay time when aborting a multipart upload fails.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_S3_MULTIPART_UPLOAD_CLEANER_POOL_SIZE =
       intBuilder(Name.PROXY_S3_MULTIPART_UPLOAD_CLEANER_POOL_SIZE)
           .setDefaultValue(1)
           .setDescription("The abort multipart upload cleaner pool size.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_S3_COMPLETE_MULTIPART_UPLOAD_KEEPALIVE_ENABLED =
@@ -4537,7 +4537,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "keepalive message during CompleteMultipartUpload. Enabling this will "
               + "cause any errors to be silently ignored. However, the errors will appear "
               + "in the Proxy logs.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_S3_COMPLETE_MULTIPART_UPLOAD_KEEPALIVE_TIME_INTERVAL =
@@ -4562,7 +4562,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       intBuilder(Name.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_POOL_SIZE)
           .setDefaultValue(20)
           .setDescription("The complete multipart upload thread pool size.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_S3_METADATA_HEADER_MAX_SIZE =
@@ -4570,7 +4570,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue("2KB")
           .setDescription("The maximum size to allow for user-defined metadata in S3 PUT"
               + "request headers. Set to 0 to disable size limits.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_S3_BUCKET_NAMING_RESTRICTIONS_ENABLED =
@@ -4579,7 +4579,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("Toggles whether or not the Alluxio S3 API will enforce "
               + "AWS S3 bucket naming restrictions. See "
               + "https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_S3_TAGGING_RESTRICTIONS_ENABLED =
@@ -4589,7 +4589,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
             + "AWS S3 tagging restrictions (10 tags, 128 character keys, 256 character "
             + "values) See "
             + "https://docs.aws.amazon.com/AmazonS3/latest/userguide/tagging-managing.html.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_STREAM_CACHE_TIMEOUT_MS =

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -229,7 +229,7 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
           }
           if (part.getPartNumber() != lastPartNum // size requirement not applicable to last part
               && uploadedPartsMap.get(part.getPartNumber()).getLength()
-                < Configuration.getBytes(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_MIN_PART_SIZE)) {
+                < Configuration.getBytes(PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_MIN_PART_SIZE)) {
             throw new S3Exception(objectPath, S3ErrorCode.ENTITY_TOO_SMALL);
           }
         }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -38,6 +38,8 @@ import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -72,8 +74,7 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
         PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_KEEPALIVE_ENABLED);
     mKeepAliveTime = Configuration.getMs(
         PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_KEEPALIVE_TIME_INTERVAL);
-    mS3Prefix = baseUri + AlluxioURI.SEPARATOR + S3RestServiceHandler.SERVICE_PREFIX
-        + AlluxioURI.SEPARATOR;
+    mS3Prefix = baseUri + AlluxioURI.SEPARATOR + S3RestServiceHandler.SERVICE_PREFIX;
   }
 
   /**
@@ -82,74 +83,103 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
   @Override
   public void handle(String s, Request request, HttpServletRequest httpServletRequest,
                      HttpServletResponse httpServletResponse) throws IOException {
-    if (!s.startsWith(mS3Prefix)) {
-      return;
-    }
-    LOG.info("Alluxio S3 API received request: {}", request);
-    if (!request.getMethod().equals("POST")
-        || request.getParameter("uploadId") == null) {
-      return;
-    } // Otherwise, handle CompleteMultipartUpload
-    s = s.substring(mS3Prefix.length());
-    final String bucket = s.substring(0, s.indexOf(AlluxioURI.SEPARATOR));
-    final String object = s.substring(s.indexOf(AlluxioURI.SEPARATOR) + 1);
-    final String uploadId = request.getParameter("uploadId");
-    LOG.debug("(bucket: {}, object: {}, uploadId: {}) queuing task...",
-        bucket, object, uploadId);
-
-    // Set headers before getting committed when flushing whitespaces
-    httpServletResponse.setContentType(MediaType.APPLICATION_XML);
-
-    Future<CompleteMultipartUploadResult> future =
-        mExecutor.submit(new CompleteMultipartUploadTask(mFileSystem, bucket, object, uploadId,
-            IOUtils.toString(request.getReader())));
-    if (mKeepAliveEnabled) {
-      // Set status before getting committed when flushing whitespaces
-      httpServletResponse.setStatus(HttpServletResponse.SC_OK);
-      long sleepMs = 1000;
-      while (!future.isDone()) {
-        LOG.debug("(bucket: {}, object: {}, uploadId: {}) sleeping for {}ms...",
-            bucket, object, uploadId, sleepMs);
-        try {
-          Thread.sleep(sleepMs);
-        } catch (InterruptedException e) {
-          LOG.error(e.toString());
-        }
-        // TODO(czhu): figure out how to send whitespace characters while still
-        // returning a correct status code
-        // - calling getWriter().flush() commits the response (headers, status code, etc.)
-        // - https://docs.oracle.com/javaee/7/api/javax/servlet/ServletResponse.html#getWriter--
-        // periodically sends white space characters to keep the connection from timing out
-        LOG.debug("(bucket: {}, object: {}, uploadId: {}) sending whitespace...",
-            bucket, object, uploadId);
-        httpServletResponse.getWriter().print(" ");
-        httpServletResponse.getWriter().flush();
-        sleepMs = Math.min(2 * sleepMs, mKeepAliveTime);
-      }
-    } // otherwise we perform a blocking call on future.get()
-
-    XmlMapper mapper = new XmlMapper();
     try {
-      CompleteMultipartUploadResult result = future.get();
-      httpServletResponse.getWriter().write(mapper.writeValueAsString(result));
-      if (!mKeepAliveEnabled) {
-        httpServletResponse.setStatus(HttpServletResponse.SC_OK);
+      if (!s.startsWith(mS3Prefix)) {
+        return;
       }
-    } catch (Exception e) {
-      Throwable cause = e.getCause();
-      if (cause instanceof S3Exception) {
-        S3Exception s3Exception = (S3Exception) cause;
-        httpServletResponse.getWriter().write(mapper.writeValueAsString(
-            new CompleteMultipartUploadResult(s3Exception.getErrorCode().getCode(),
-                s3Exception.getErrorCode().getDescription())));
-        if (!mKeepAliveEnabled) {
-          httpServletResponse.setStatus(s3Exception.getErrorCode().getStatus().getStatusCode());
+      // Build log message capturing the request details
+      StringBuilder sb = new StringBuilder();
+      sb.append("Alluxio S3 API received ");
+      sb.append(request.getMethod());
+      sb.append(" request: URI=");
+      sb.append(s);
+      if (request.getQueryString() != null) { sb.append("?").append(request.getQueryString()); }
+      sb.append(" User=");
+      String user = S3RestServiceHandler.getUserFromAuthorization(
+          request.getHeader("Authorization"));
+      if (user == null) { user = "N/A"; }
+      sb.append(user);
+      if (LOG.isDebugEnabled() && request.getHeaderNames() != null) {
+        // Using "DEBUG" log level to indicate verbosity of this message,
+        // but we keep it printed at the "INFO" level
+        sb.append(" Headers=");
+        Map<String, String> headerMap = new HashMap<>();
+        for (String headerName : Collections.list(request.getHeaderNames())) {
+          headerMap.put(headerName, request.getHeader(headerName));
         }
+        sb.append(headerMap);
       }
-      LOG.error(e.toString());
+      LOG.info(sb.toString());
+      if (!request.getMethod().equals("POST")
+          || request.getParameter("uploadId") == null) {
+        return;
+      } // Otherwise, handle CompleteMultipartUpload
+      s = s.substring(mS3Prefix.length() + 1); // substring the prefix + leading "/" character
+      final String bucket = s.substring(0, s.indexOf(AlluxioURI.SEPARATOR));
+      final String object = s.substring(s.indexOf(AlluxioURI.SEPARATOR) + 1);
+      final String uploadId = request.getParameter("uploadId");
+      LOG.debug("(bucket: {}, object: {}, uploadId: {}) queuing task...",
+          bucket, object, uploadId);
+
+      // Set headers before getting committed when flushing whitespaces
+      httpServletResponse.setContentType(MediaType.APPLICATION_XML);
+
+      Future<CompleteMultipartUploadResult> future =
+          mExecutor.submit(new CompleteMultipartUploadTask(mFileSystem, bucket, object, uploadId,
+              IOUtils.toString(request.getReader())));
+      if (mKeepAliveEnabled) {
+        // Set status before getting committed when flushing whitespaces
+        httpServletResponse.setStatus(HttpServletResponse.SC_OK);
+        long sleepMs = 1000;
+        while (!future.isDone()) {
+          LOG.debug("(bucket: {}, object: {}, uploadId: {}) sleeping for {}ms...",
+              bucket, object, uploadId, sleepMs);
+          try {
+            Thread.sleep(sleepMs);
+          } catch (InterruptedException e) {
+            LOG.error(e.toString());
+          }
+          // TODO(czhu): figure out how to send whitespace characters while still
+          // returning a correct status code
+          // - calling getWriter().flush() commits the response (headers, status code, etc.)
+          // - https://docs.oracle.com/javaee/7/api/javax/servlet/ServletResponse.html#getWriter--
+          // periodically sends white space characters to keep the connection from timing out
+          LOG.debug("(bucket: {}, object: {}, uploadId: {}) sending whitespace...",
+              bucket, object, uploadId);
+          httpServletResponse.getWriter().print(" ");
+          httpServletResponse.getWriter().flush();
+          sleepMs = Math.min(2 * sleepMs, mKeepAliveTime);
+        }
+      } // otherwise we perform a blocking call on future.get()
+
+      XmlMapper mapper = new XmlMapper();
+      try {
+        CompleteMultipartUploadResult result = future.get();
+        httpServletResponse.getWriter().write(mapper.writeValueAsString(result));
+        if (!mKeepAliveEnabled) {
+          httpServletResponse.setStatus(HttpServletResponse.SC_OK);
+        }
+      } catch (Exception e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof S3Exception) {
+          S3Exception s3Exception = (S3Exception) cause;
+          httpServletResponse.getWriter().write(mapper.writeValueAsString(
+              new CompleteMultipartUploadResult(s3Exception.getErrorCode().getCode(),
+                  s3Exception.getErrorCode().getDescription())));
+          if (!mKeepAliveEnabled) {
+            httpServletResponse.setStatus(s3Exception.getErrorCode().getStatus().getStatusCode());
+          }
+        }
+        LOG.error(e.toString());
+      }
+      httpServletResponse.getWriter().flush();
+      request.setHandled(true);
+    } catch (Exception e) {
+      // This try-catch is not intended to handle any exceptions, it is purely
+      // to ensure that encountered exceptions get logged.
+      LOG.error("Unhandled exception for {}. {}", s, e);
+      throw e;
     }
-    httpServletResponse.getWriter().flush();
-    request.setHandled(true);
   }
 
   /**
@@ -228,8 +258,8 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
             throw new S3Exception(objectPath, S3ErrorCode.INVALID_PART);
           }
           if (part.getPartNumber() != lastPartNum // size requirement not applicable to last part
-              && uploadedPartsMap.get(part.getPartNumber()).getLength()
-                < Configuration.getBytes(PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_MIN_PART_SIZE)) {
+              && uploadedPartsMap.get(part.getPartNumber()).getLength() < Configuration.getBytes(
+                  PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_MIN_PART_SIZE)) {
             throw new S3Exception(objectPath, S3ErrorCode.ENTITY_TOO_SMALL);
           }
         }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -108,13 +108,14 @@ public final class S3RestServiceHandler {
   @Context
   private ContainerRequestContext mRequestContext;
 
+  private final boolean mBucketNamingRestrictionsEnabled;
   private final int mMaxHeaderMetadataSize; // 0 means disabled
   private final boolean mMultipartCleanerEnabled;
-  private final boolean mBucketNamingRestrictionsEnabled;
-  private final Pattern mBucketValidNamePattern;
+
   private final Pattern mBucketAdjacentDotsDashesPattern;
   private final Pattern mBucketInvalidPrefixPattern;
   private final Pattern mBucketInvalidSuffixPattern;
+  private final Pattern mBucketValidNamePattern;
 
   /**
    * Constructs a new {@link S3RestServiceHandler}.
@@ -126,19 +127,20 @@ public final class S3RestServiceHandler {
         (FileSystem) context.getAttribute(ProxyWebServer.FILE_SYSTEM_SERVLET_RESOURCE_KEY);
     mSConf = (InstancedConfiguration)
         context.getAttribute(ProxyWebServer.SERVER_CONFIGURATION_RESOURCE_KEY);
+
+    mBucketNamingRestrictionsEnabled = Configuration.getBoolean(
+        PropertyKey.PROXY_S3_BUCKET_NAMING_RESTRICTIONS_ENABLED);
     mMaxHeaderMetadataSize = (int) Configuration.getBytes(
         PropertyKey.PROXY_S3_METADATA_HEADER_MAX_SIZE);
     mMultipartCleanerEnabled = Configuration.getBoolean(
         PropertyKey.PROXY_S3_MULTIPART_UPLOAD_CLEANER_ENABLED);
-    mBucketNamingRestrictionsEnabled = Configuration.getBoolean(
-        PropertyKey.PROXY_S3_BUCKET_NAMING_RESTRICTIONS_ENABLED);
 
     // https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
     // - Undocumented edge-case, no adjacent periods with hyphens, i.e: '.-' or '-.'
-    mBucketValidNamePattern = Pattern.compile("[a-z0-9][a-z0-9\\.-]{1,61}[a-z0-9]");
     mBucketAdjacentDotsDashesPattern = Pattern.compile("([-\\.]{2})");
     mBucketInvalidPrefixPattern = Pattern.compile("^xn--.*");
     mBucketInvalidSuffixPattern = Pattern.compile(".*-s3alias$");
+    mBucketValidNamePattern = Pattern.compile("[a-z0-9][a-z0-9\\.-]{1,61}[a-z0-9]");
   }
 
   /**

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -891,11 +891,7 @@ public final class S3RestServiceHandler {
             String entityTag = Hex.encodeHexString(digest);
             // persist the ETag via xAttr
             // TODO(czhu): compute the ETag prior to creating the file to reduce total RPC RTT
-            fs.setAttribute(objectUri, SetAttributePOptions.newBuilder()
-                .putXattr(S3Constants.ETAG_XATTR_KEY,
-                    ByteString.copyFrom(entityTag, S3Constants.XATTR_STR_CHARSET))
-                .setXattrUpdateStrategy(File.XAttrUpdateStrategy.UNION_REPLACE)
-                .build());
+            S3RestUtils.setEntityTag(fs, objectUri, entityTag);
             if (partNumber != null) { // UploadPartCopy
               return new CopyPartResult(entityTag);
             }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -465,6 +465,20 @@ public final class S3RestUtils {
   }
 
   /**
+   * This helper method is used to get the ETag xAttr on an object.
+   * @param status The {@link URIStatus} of the object
+   * @return the entityTag String, or null if it does not exist
+   */
+  public static String getEntityTag(URIStatus status) {
+    if (status.getXAttr() == null
+        || !status.getXAttr().containsKey(S3Constants.ETAG_XATTR_KEY)) {
+      return null;
+    }
+    return new String(status.getXAttr().get(S3Constants.ETAG_XATTR_KEY),
+        S3Constants.XATTR_STR_CHARSET);
+  }
+
+  /**
    * Comparator based on uri name， treat uri name as a Long number.
    */
   public static class URIStatusNameComparator implements Comparator<URIStatus>, Serializable {

--- a/docs/en/api/S3-API.md
+++ b/docs/en/api/S3-API.md
@@ -54,9 +54,10 @@ with if you used the AWS S3 console to create all parent folders for each object
 ### Tagging & Metadata Limits
 
 User-defined tags on buckets & objects are limited to 10 and obey the [S3 tag restrictions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html).
+- Set the property key `alluxio.proxy.s3.tagging.restrictions.enabled=false` to disable this behavior.
 
 The maximum size for user-defined metadata in PUT-requests is 2KB by default in accordance with [S3 object metadata restrictions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html).
-Set the property key `alluxio.proxy.s3.header.metadata.max.size` to change this behavior.
+- Set the property key `alluxio.proxy.s3.header.metadata.max.size` to change this behavior.
 
 ### Performance Implications
 
@@ -317,7 +318,8 @@ Server: Jetty(9.4.43.v20210629)
 {% navtab AWS CLI %}
 ```console
 $ aws --profile alluxio-s3 --endpoint "http://localhost:39999/api/v1/s3/" s3api complete-multipart-upload \
-  --bucket=testbucket --key=multipart.txt --upload-id=6367cf96-ea4e-4447-b931-c5bc91200375
+  --bucket=testbucket --key=multipart.txt --upload-id=6367cf96-ea4e-4447-b931-c5bc91200375 \
+  --multipart-upload="Parts=[{PartNumber=1},{PartNumber=2}]"
 {
     "Location": "/testbucket/multipart.txt",
     "Bucket": "testbucket",
@@ -338,7 +340,19 @@ $ aws --profile alluxio-s3 --endpoint "http://localhost:39999/api/v1/s3/" s3api 
 {% endnavtab %}
 {% navtab REST Clients %}
 ```console
+$ cat complete_upload.xml
+
+<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+   <Part>
+      <PartNumber>1</PartNumber>
+   </Part>
+   <Part>
+      <PartNumber>2</PartNumber>
+   </Part>
+</CompleteMultipartUpload>
+
 $ curl -i -H "Authorization: AWS4-HMAC-SHA256 Credential=testuser/... SignedHeaders=... Signature=..." \
+  -H "Content-Type: application/xml" -d "@complete_upload.xml" \
   -X POST "http://localhost:39999/api/v1/s3/testbucket/multipart.txt?uploadId=6367cf96-ea4e-4447-b931-c5bc91200375"
 
 Date: Tue, 03 May 2022 23:59:17 GMT

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -104,7 +104,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
       .setProperty(PropertyKey.SECURITY_AUTHORIZATION_PERMISSION_ENABLED, false)
       .setProperty(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.NOSASL)
       .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, "1KB")
-      .setProperty(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_MIN_PART_SIZE, "0")
+      .setProperty(PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_MIN_PART_SIZE, "0")
       .setProperty(PropertyKey.PROXY_S3_TAGGING_RESTRICTIONS_ENABLED, true) // default
       .setProperty(PropertyKey.PROXY_S3_BUCKET_NAMING_RESTRICTIONS_ENABLED, false) // default
       .setProperty(PropertyKey.PROXY_S3_MULTIPART_UPLOAD_CLEANER_ENABLED, false)


### PR DESCRIPTION
### What changes are proposed in this pull request?

- Rename a property key to align with prior naming scheme.
- Update S3 API docs to include `CompleteMultipartUpload` XML body.
- Update scope & consistency enforcement of S3 API `PropertyKey`s
- Remove requirement for objects to have prior ETags in `GetObject(Attributes)`
- Improved log messages for HTTP requests received

### Why are the changes needed?

Clarity/accuracy.

For the ETag requirement removal, this is to make the S3 API behaviour in line with before that ETag `xAttr` field existed. We unintentionally made it so that the S3 API was incompatible with files in Alluxio's FS which were not created via the S3 API. 

### Does this PR introduce any user facing changes?

Renamed `alluxio.proxy.s3.multipart.upload.min.part.size` to `alluxio.proxy.s3.complete.multipart.upload.min.part.size`
