### PR TITLE
Add consistency check for ufs versions against their compiled modules

### DIFF
--- a/dev/github/run_checks.sh
+++ b/dev/github/run_checks.sh
@@ -37,3 +37,5 @@ mvn -Duser.home=/home/jenkins -T 4C clean install -Pdeveloper -DskipTests -Dmave
 -Dsurefire.forkCount=2 ${mvn_args}
 
 ./dev/scripts/check-docs.sh
+./dev/scripts/generate-tarballs checkUfsVersions
+

--- a/dev/jenkins/build.sh
+++ b/dev/jenkins/build.sh
@@ -101,3 +101,7 @@ if [ "${RUN_DOC_CHECK}" == "true" ]; then
 else
   echo "RUN_DOC_CHECK was not set to true, skipping doc check"
 fi
+
+# Check UFS version consistency
+./dev/scripts/generate-tarballs checkUfsVersions
+

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/check-ufs-versions.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/check-ufs-versions.go
@@ -1,3 +1,13 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
 package cmd
 
 import (

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/check-ufs-versions.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/check-ufs-versions.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+type UfsVersionDetails struct {
+	VersionProp         string
+	VersionEnumFilePath string
+}
+
+var (
+	ufsTypeToVersionDetails = map[string]*UfsVersionDetails{
+		"hdfs": {
+			VersionProp:         "ufs.hadoop.version",
+			VersionEnumFilePath: "underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsVersion.java",
+		},
+	}
+)
+
+func CheckUfsVersions() error {
+	parsedFiles := map[string]map[string]string{} // mapping of file path to version to regex pattern
+
+	for _, m := range ufsModules {
+		u, ok := ufsTypeToVersionDetails[m.ufsType]
+		if !ok {
+			continue
+		}
+		mavenVersionRe, err := regexp.Compile(fmt.Sprintf(`.*\-D%s=(?P<version>\S+).*`, regexp.QuoteMeta(u.VersionProp)))
+		if err != nil {
+			return fmt.Errorf("error compiling regex pattern from version property %v", u.VersionProp)
+		}
+		match := mavenVersionRe.FindStringSubmatch(m.mavenArgs)
+		if len(match) != 2 {
+			return fmt.Errorf("did not find the correct number of regex matches within %v for %v",
+				m.mavenArgs, u.VersionProp)
+		}
+		// first match is the full string match, second is the named match
+		compiledVersion := match[1]
+
+		parsedVersions, ok := parsedFiles[u.VersionEnumFilePath]
+		if !ok {
+			parsed, err := parseEnumFile(u.VersionEnumFilePath)
+			if err != nil {
+				return err
+			}
+			parsedFiles[u.VersionEnumFilePath] = parsed
+			parsedVersions = parsed
+		}
+		regexPattern, ok := parsedVersions[m.name]
+		if !ok {
+			return fmt.Errorf("versions file %v does not contain an enum for %v", u.VersionEnumFilePath, m.name)
+		}
+		enumVersionRe, err := regexp.Compile(regexPattern)
+		if err != nil {
+			return fmt.Errorf("could not compile regex pattern %v for version %v in file %v",
+				regexPattern, compiledVersion, u.VersionEnumFilePath)
+		}
+		// the regex pattern defined in the enum file should match on version being used to compile the ufs jar
+		if !enumVersionRe.MatchString(compiledVersion) {
+			return fmt.Errorf("regex %v defined for version %v in file %v does not match version defined in maven args %v",
+				regexPattern, m.name, u.VersionEnumFilePath, compiledVersion)
+		}
+	}
+	return nil
+}
+
+var (
+	negativeLookaheadRe = regexp.MustCompile(`\(\?\![\w|]+\)`)
+	versionEnumRe       = regexp.MustCompile(`\S+\("(?P<version>\S+)", "(?P<regex>\S+)"\),`)
+)
+
+func parseEnumFile(filePath string) (map[string]string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening file at %v: %v", filePath, err)
+	}
+	defer f.Close()
+
+	foundHeader := false
+	ret := map[string]string{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		// the parsing assumes that
+		// - all enums are defined immediately after the definition header of the enum, comments allowed
+		// - each enum line contains 2 parts, the version and regex pattern, comma separated and encapsulated within parenthesis
+		// - the list of enums end with when encountering ;
+		l := strings.TrimSpace(scanner.Text())
+		if !foundHeader {
+			if strings.HasPrefix(l, "public enum") {
+				foundHeader = true
+			}
+			// skip lines until header is found
+			continue
+		} else if strings.HasPrefix(l, "//") {
+			// ignore comments
+			continue
+		} else if l == ";" {
+			// terminating line
+			break
+		} else {
+			// parse matching line
+			match := versionEnumRe.FindStringSubmatch(l)
+			if len(match) != 3 {
+				return nil, fmt.Errorf("did not find the correct number of regex matches within %v for pattern %v in file %v",
+					filePath, l, versionEnumRe.String())
+			}
+			// first match is the full string match, subsequent are the named matches
+			regexString := match[2]
+			// unescape regex by replacing \\ with \
+			regexString = strings.ReplaceAll(regexString, `\\`, `\`)
+			// java regex supports negative lookahead via '?!' but golang does not, remove such expressions
+			regexString = negativeLookaheadRe.ReplaceAllString(regexString, "")
+			ret[match[1]] = regexString
+		}
+	}
+	return ret, nil
+}

--- a/dev/scripts/src/alluxio.org/build-distribution/main.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/main.go
@@ -19,6 +19,7 @@ import (
 )
 
 const (
+	checkUfsVersions       = "checkUfsVersions"
 	generateTarball        = "single"
 	generateReleaseTarball = "release"
 )
@@ -30,17 +31,19 @@ func main() {
 }
 
 func runSubcmd(args []string) error {
-	subcmdNames := []string{generateTarball, generateReleaseTarball}
+	subcmdNames := []string{checkUfsVersions, generateTarball, generateReleaseTarball}
 	if len(args) < 2 {
 		return fmt.Errorf("expected a subcommand in arguments. use one of %v", subcmdNames)
 	}
 	subcmd := args[1]
-	if subcmd == generateTarball {
+	switch subcmd {
+	case generateTarball:
 		return cmd.Single(args)
-	} else if subcmd == generateReleaseTarball {
+	case generateReleaseTarball:
 		return cmd.Release(args)
-	} else {
+	case checkUfsVersions:
+		return cmd.CheckUfsVersions()
+	default:
 		return fmt.Errorf("unknown subcommand %q. use one of %v", args[1], subcmdNames)
 	}
-	return nil
 }


### PR DESCRIPTION
For new HDFS UFS versions, a new enum describing the version needs to be added to HdfsVersion.java as well as adding a new ufs module to compile the jar when building the tarball. It is easy to check for the UFS modules in a tarball by inspecting the lib directory of a tarball, but it is not easy to check that the corresponding version enum is defined. This check ensures that each HDFS UFS module has a corresponding HdfsVersion by checking that the compilation version matches version enum regex.