### PR TITLE
Implement SharedResourcePool

### DIFF
--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelPool.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelPool.java
@@ -18,6 +18,7 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.network.ChannelType;
+import alluxio.resource.CountingReference;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.network.NettyUtils;
@@ -40,7 +41,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -311,49 +311,5 @@ public class GrpcChannelPool
       }
       return ref;
     });
-  }
-
-  /**
-   * Used as reference counting wrapper over instance of type {@link T}.
-   */
-  private static class CountingReference<T> {
-    private final T mObject;
-    private final AtomicInteger mRefCount;
-
-    private CountingReference(T object, int initialRefCount) {
-      mObject = object;
-      mRefCount = new AtomicInteger(initialRefCount);
-    }
-
-    /**
-     * @return the underlying object after increasing ref-count
-     */
-    private CountingReference<T> reference() {
-      mRefCount.incrementAndGet();
-      return this;
-    }
-
-    /**
-     * Decrement the ref-count for underlying object.
-     *
-     * @return the current ref count after dereference
-     */
-    private int dereference() {
-      return mRefCount.decrementAndGet();
-    }
-
-    /**
-     * @return current ref-count
-     */
-    private int getRefCount() {
-      return mRefCount.get();
-    }
-
-    /**
-     * @return the underlying object without changing the ref-count
-     */
-    private T get() {
-      return mObject;
-    }
   }
 }

--- a/core/common/src/main/java/alluxio/resource/CountingReference.java
+++ b/core/common/src/main/java/alluxio/resource/CountingReference.java
@@ -1,0 +1,77 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.resource;
+
+import com.google.common.base.Objects;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A reference counting wrapper around any resource type. It typically works with
+ * a ResourcePool to keep track of which resource is owned.
+ * @param <T> The wrapped resource type
+ */
+public class CountingReference<T> {
+  private final T mObject;
+  private final AtomicInteger mRefCount;
+
+  /**
+   * Create counting reference wrapper.
+   * @param object the inner resource
+   * @param initialRefCount initial reference count
+   */
+  public CountingReference(T object, int initialRefCount) {
+    mObject = object;
+    mRefCount = new AtomicInteger(initialRefCount);
+  }
+
+  /**
+   * @return the underlying object after increasing ref-count
+   */
+  public CountingReference<T> reference() {
+    mRefCount.incrementAndGet();
+    return this;
+  }
+
+  /**
+   * Decrement the ref-count for underlying object.
+   *
+   * @return the current ref count after dereference
+   */
+  public int dereference() {
+    return mRefCount.decrementAndGet();
+  }
+
+  /**
+   * @return current ref-count
+   */
+  public int getRefCount() {
+    return mRefCount.get();
+  }
+
+  /**
+   * @return the underlying object without changing the ref-count
+   */
+  public T get() {
+    return mObject;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(mObject, mRefCount);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return this == other;
+  }
+}

--- a/core/common/src/main/java/alluxio/resource/SharableResource.java
+++ b/core/common/src/main/java/alluxio/resource/SharableResource.java
@@ -1,0 +1,36 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.resource;
+
+/**
+ * {@link SharableResource} is a marker interface for sharable resources.
+ * Such resource can be safely pooled in a {@link SharedResourcePool} without
+ * compromising correctness of the system.
+ * <p></p>
+ * The requirements on a sharable resource is that:
+ * 1. Thread safe
+ * 2. The correct working of its public API methods don't depend on each other, i.e., the public
+ * methods should have orthogonal functionalities. This is a slightly lighter requirements than
+ * "stateless": a purely stateless class is sharable, but statelessness is not strictly required.
+ * For example: a thread-safe Counter class that provides "increment" and "get" APIs are sharable by
+ * this standard. It maintains internal states, but the correctness promise of its public APIs don't
+ * rely on any ordering of method calls.
+ * Also, {@link io.grpc.ManagedChannel} is another example of sharable resources.
+ * <p></p>
+ * This is only a marker, and it is the implementor's responsibility to make sure the constraints
+ * are satisfied.
+ * <p></p>
+ * Examples of in-use sharable resources include various kinds of {@link alluxio.Client} in alluxio,
+ * which serve as functional layers on top of the grpc communication channel.
+ */
+public interface SharableResource {
+}

--- a/core/common/src/main/java/alluxio/resource/SharedResourcePool.java
+++ b/core/common/src/main/java/alluxio/resource/SharedResourcePool.java
@@ -1,0 +1,284 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.resource;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.PriorityQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * This class implements a SharedResourcePool. It manages resources under a different
+ * model than an exclusive {@link Pool}: in a pool, resources are owned exclusively,
+ * and the workflow is: user acquires a resource from the pool, owns it and works on it
+ * exclusively for a time, and then return it back to the pool so that others can acquire it.
+ * <p></p>
+ * A shared pool manages {@link SharableResource}, i.e., a pool of resources shared among all
+ * users. When users acquire a resource from queue, they might get a new one, or they might get
+ * a used one to share with other users. The idea is that the underlying resources can be safely
+ * shared so that acquire never needs to wait or fail.
+ * <p></p>
+ * {@link SharedResourcePool} implements the shared pool model by maintaining a priority queue
+ * of resources ordered by current reference count.
+ *
+ * @param <T> The inner resource type. It has to implement {@link SharableResource}, see the docs
+ *           there for the requirements of this interface.
+ */
+@ThreadSafe
+public abstract class SharedResourcePool<T extends Closeable & SharableResource>
+    implements AutoCloseable {
+  private static final Logger LOG = LoggerFactory.getLogger(SharedResourcePool.class);
+
+  /** Max number of resources the pool can hold. */
+  private final int mMaxCapacity;
+
+  /** Min number of resources to avoid the pool being too cold. */
+  private final int mMinCapacity;
+
+  /** Lock protects internal mutation of resource tree. */
+  private final ReentrantLock mLock = new ReentrantLock();
+
+  /** Close flag. */
+  private boolean mClosed = false;
+
+  /**
+   * Resources are wrapped in a {@link CountingReference} to keep track of its holders.
+   * All the resources are managed in a priority queue, so that users acquire the
+   * least referenced resource if possible.
+   */
+  private final PriorityQueue<CountingReference<T>> mResources =
+      new PriorityQueue<>((o1, o2) -> {
+        // note: this is only partial order, but it works fine with
+        // priority queue
+        if (o1.equals(o2)) {
+          return 0;
+        }
+        if (o1.getRefCount() <= o2.getRefCount()) {
+          return -1;
+        }
+        return 1;
+      });
+
+  /** GC executor that closes unused resources periodically. */
+  private final ScheduledExecutorService mExecutor;
+
+  /** GC task future. */
+  private final ScheduledFuture<?> mGcFuture;
+
+  /**
+   * Create a new resource queue.
+   * @param options construction options
+   */
+  public SharedResourcePool(DynamicResourcePool.Options options) {
+    mExecutor = Preconditions.checkNotNull(options.getGcExecutor());
+    mMaxCapacity = options.getMaxCapacity();
+    mMinCapacity = options.getMinCapacity();
+    mGcFuture = mExecutor.scheduleAtFixedRate(
+        () -> gcUnusedResources(true),
+        options.getInitialDelayMs(),
+        options.getGcIntervalMs(),
+        TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Acquire a {@link CloseableResource} from the queue, intending
+   * not to share.
+   *
+   * @return a closable resource
+   * @throws IOException when the resource pool is empty whereas we failed to create a new one
+   */
+  public CloseableResource<T> acquire() throws IOException {
+    return acquire(0);
+  }
+
+  /**
+   * Acquire a {@link CloseableResource} from the resource tree.
+   * This method accepts a best-effort based `maxAcceptableRefCount` parameter, which
+   * follows the following behavior in decreasing priority:
+   * 1. There is a resource in the tree that is current referenced less than
+   * `maxAcceptableRefCount`, then we reuse the resource.
+   * 2. If the current size of the resource pool is less than `maxCapacity`, then we
+   * try to create a new resource and use the new one.
+   * 3. If the resource pool is full or creating new one fails, then we fall back to sharing
+   * the least-referenced resource in the pool.
+   * 4. If the resource pool is empty and creating new resource fails, then we throw exception.
+   *
+   * @param maxAcceptableRefCount the maximum degree of acceptable sharing
+   * @return the closeable resource
+   * @throws IOException when the resource pool is empty whereas we failed to create a new one
+   */
+  public CloseableResource<T> acquire(int maxAcceptableRefCount) throws IOException {
+    try (LockResource r = new LockResource(mLock)) {
+      Preconditions.checkState(!mClosed);
+
+      // firstly try to reuse an eligible resource
+      CountingReference<T> ref = mResources.poll();
+      if (ref != null
+          && (ref.getRefCount() <= maxAcceptableRefCount
+              || mResources.size() + 1 >= mMaxCapacity)) {
+        ref.reference();
+        mResources.add(ref);
+        return makeResource(ref);
+      } else if (ref != null) {
+        mResources.add(ref);
+      }
+
+      // secondly try to create a new one
+      try {
+        CountingReference<T> newResource = new CountingReference<>(createNewResource(), 1);
+        mResources.add(newResource);
+        return makeResource(newResource);
+      } catch (Exception e) {
+        if (ref != null) {
+          // create new resource failed, but can fall back to use
+          // shared resource
+          LOG.warn("Reuse shared resource as creating new resource failed", e);
+          mResources.remove(ref);
+          ref.reference();
+          mResources.add(ref);
+          return makeResource(ref);
+        }
+        // can't fall back, error out
+        throw new IOException(e);
+      }
+    }
+  }
+
+  /**
+   * Wraps the inner {@link CountingReference} in a {@link CloseableResource} for return.
+   * @param ref the inner shared reference of the resource
+   * @return the closeable resource for public use
+   */
+  private CloseableResource<T> makeResource(CountingReference<T> ref) {
+    return new CloseableResource<T>(ref.get()) {
+      @Override
+      public void closeResource() {
+        try (LockResource r = new LockResource(mLock)) {
+          mResources.remove(ref);
+          ref.dereference();
+          mResources.add(ref);
+        }
+      }
+    };
+  }
+
+  /**
+   * @return the number of resources the queue currently holds
+   */
+  public int size() {
+    try (LockResource r = new LockResource(mLock)) {
+      Preconditions.checkState(!mClosed);
+
+      return mResources.size();
+    }
+  }
+
+  /**
+   * Create new resource.
+   * Note that this method could be called inside critical sections when acquiring
+   * new resources from the pool. So it is generally advisable to avoid expensive
+   * operations here, as that might compromise the performance during contention
+   * scenarios.
+   *
+   * @return newly created resource
+   * @throws IOException if error occurs during creation
+   */
+  protected abstract T createNewResource() throws Exception;
+
+  protected void closeResource(T resource) throws IOException {
+    resource.close();
+  }
+
+  /**
+   * Garbage collects unused resources.
+   * @param onlyGcWhenFull if true, then the routine won't do anything if
+   *                       the resource pool hasn't reached full capacity,
+   *                       also it will abort once the pool has reached min
+   *                       capacity.
+   *                       Otherwise, it gcs all unused resources.
+   */
+  @VisibleForTesting
+  void gcUnusedResources(boolean onlyGcWhenFull) {
+    ArrayList<T> resourceToGc = new ArrayList<>();
+    try (LockResource r = new LockResource(mLock)) {
+      if (onlyGcWhenFull && mResources.size() < mMaxCapacity) {
+        return;
+      }
+
+      int curSize = mResources.size();
+      Iterator<CountingReference<T>> iterator = mResources.iterator();
+      while (iterator.hasNext()) {
+        CountingReference<T> nxt = iterator.next();
+        if (nxt.getRefCount() == 0) {
+          resourceToGc.add(nxt.get());
+          iterator.remove();
+          curSize -= 1;
+
+          // abort since the pool is cold enough
+          if (onlyGcWhenFull && curSize <= mMinCapacity) {
+            break;
+          }
+        }
+      }
+    }
+
+    for (T resource: resourceToGc) {
+      try {
+        closeResource(resource);
+      } catch (IOException e) {
+        LOG.debug("Resource {} failed to be closed: {}", resource, e);
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    try (LockResource r = new LockResource(mLock)) {
+      if (mClosed) {
+        return;
+      }
+
+      mClosed = true;
+      int resourceInUse = 0;
+
+      for (CountingReference<T> resource: mResources) {
+        if (resource.getRefCount() != 0) {
+          resourceInUse++;
+        }
+
+        try {
+          closeResource(resource.get());
+        } catch (IOException e) {
+          // log and continue closing other resources
+          LOG.warn("Resource {} cannot be closed: {}", resource, e);
+        }
+      }
+
+      if (resourceInUse != 0) {
+        LOG.warn("{} resources are not released when closing the resource queue.", resourceInUse);
+      }
+      mResources.clear();
+      mGcFuture.cancel(true);
+    }
+  }
+}

--- a/core/common/src/test/java/alluxio/resource/SharedResourcePoolTest.java
+++ b/core/common/src/test/java/alluxio/resource/SharedResourcePoolTest.java
@@ -1,0 +1,250 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import alluxio.util.ThreadFactoryUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+public class SharedResourcePoolTest {
+  private static final class TestResource implements Closeable, SharableResource {
+    int mResourceId;
+    boolean mClosed;
+
+    private TestResource(int id) {
+      mResourceId = id;
+      mClosed = false;
+    }
+
+    @Override
+    public void close() {
+      mClosed = true;
+    }
+  }
+
+  private static final class SharedTestResourcePool extends SharedResourcePool<TestResource> {
+
+    // Monotonically increasing resource id generator
+    private int mNextId = 0;
+
+    // Fail to create after some number of creations,
+    // used to simulation error scenarios
+    // -1 if never fails
+    private final int mFailAfterNumCreate;
+
+    private int mNumCreate = 0;
+
+    /**
+     * Create a new resource queue.
+     *
+     * @param options construction options
+     */
+    public SharedTestResourcePool(DynamicResourcePool.Options options, int failAfterNumCreate) {
+      super(options);
+      mFailAfterNumCreate = failAfterNumCreate;
+    }
+
+    @Override
+    protected TestResource createNewResource() throws IOException {
+      if (mNumCreate == mFailAfterNumCreate) {
+        throw new IOException();
+      }
+      mNumCreate += 1;
+      int id = mNextId;
+      mNextId++;
+      return new TestResource(id);
+    }
+  }
+
+  // max capacity in test cases
+  private static final int MAX_CAPACITY = 100;
+
+  private static final ScheduledExecutorService GC_EXECUTOR =
+      new ScheduledThreadPoolExecutor(5,
+          ThreadFactoryUtils.build("TestPool-%d", true));
+
+  // set gc delay high so that it will not be triggered.
+  private static final DynamicResourcePool.Options DEFAULT_OPTIONS =
+      DynamicResourcePool.Options.defaultOptions()
+          .setGcExecutor(GC_EXECUTOR).setInitialDelayMs(100000).setMaxCapacity(MAX_CAPACITY);
+
+  private SharedResourcePool<TestResource> mResourcePool;
+
+  @Before
+  public void before() {
+    mResourcePool = new SharedTestResourcePool(DEFAULT_OPTIONS, -1);
+  }
+
+  @After
+  public void after() throws Exception {
+    mResourcePool.close();
+  }
+
+  @Test
+  public void acquireUnderMaxCapacity() throws Exception {
+    // should all succeed and return a different resource
+    for (int i = 0; i < MAX_CAPACITY; ++i) {
+      CloseableResource<TestResource> resource = mResourcePool.acquire();
+      assertEquals(i, resource.get().mResourceId);
+      assertEquals(i + 1, mResourcePool.size());
+    }
+  }
+
+  @Test
+  public void acquireExceedMaxCapacity() throws Exception {
+    // maps resourceId to numberOfReference
+    // #keys should <= MAX_CAPACITY, sum of values should equal total
+    // number of acquire calls
+    Map<Integer, Integer> resourceIdToRefCount = new HashMap<>();
+
+    int numAcquireCalls = 2 * MAX_CAPACITY;
+    for (int i = 0; i < numAcquireCalls; ++i) {
+      // should all succeed without blocking
+      CloseableResource<TestResource> resource = mResourcePool.acquire();
+
+      int resourceId = resource.get().mResourceId;
+      // should not create more than MAX_CAPACITY resources
+      assertTrue(resourceId < MAX_CAPACITY);
+      resourceIdToRefCount.compute(resourceId, (key, old) -> old == null ? 1 : old + 1);
+    }
+
+    // we should not allocate more resources than MAX_CAPACITY
+    assertTrue(resourceIdToRefCount.size() <= MAX_CAPACITY);
+    assertEquals(numAcquireCalls,
+        resourceIdToRefCount.values().stream().mapToInt(Integer::intValue).sum());
+  }
+
+  @Test
+  public void gcInternal() throws Exception {
+    List<CloseableResource<TestResource>> resourceList = new ArrayList<>();
+    for (int i = 0; i < MAX_CAPACITY; i++) {
+      CloseableResource<TestResource> resource = mResourcePool.acquire();
+      assertFalse(resource.get().mClosed);
+      resourceList.add(resource);
+    }
+
+    // this gc should do nothing as all resources are being held
+    mResourcePool.gcUnusedResources(false);
+    for (CloseableResource<TestResource> ref: resourceList) {
+      assertFalse(ref.get().mClosed);
+    }
+
+    // now we close all references manually, which should make next gc collect all
+    // the resources
+    for (CloseableResource<TestResource> ref: resourceList) {
+      ref.close();
+    }
+    mResourcePool.gcUnusedResources(false);
+
+    // now all the resource should be closed
+    for (CloseableResource<TestResource> ref: resourceList) {
+      assertTrue(ref.get().mClosed);
+    }
+    assertEquals(0, mResourcePool.size());
+  }
+
+  @Test
+  public void concurrentAcquireAndClose() throws Exception {
+    ConcurrentMap<Integer, Integer> resourceIdToRefCount = new ConcurrentHashMap<>();
+
+    int numAcquireCallsPerThread = 50;
+    int numThread = 10;
+    Thread[] threads = new Thread[10];
+    for (int i = 0; i < numThread; i++) {
+      Thread thread = new Thread(() -> {
+        for (int j = 0; j < numAcquireCallsPerThread; j++) {
+          try (CloseableResource<TestResource> resource = mResourcePool.acquire()) {
+            // resource should be working
+            assertFalse(resource.get().mClosed);
+            // keep track of resource id
+            int id = resource.get().mResourceId;
+            assertTrue(id <= MAX_CAPACITY);
+            resourceIdToRefCount.compute(id, (key, old) -> old == null ? 1 : old + 1);
+          } catch (IOException e) {
+            // nothing to do
+          }
+        }
+      });
+      thread.start();
+      threads[i] = thread;
+    }
+
+    for (Thread t: threads) {
+      // all threads should succeed
+      t.join();
+    }
+
+    // first sanity check: we allocated no more than MAX_CAPACITY resources
+    // and the ref count matches up
+    assertTrue(resourceIdToRefCount.size() <= MAX_CAPACITY);
+    assertEquals(numAcquireCallsPerThread * numThread,
+        resourceIdToRefCount.values().stream().mapToInt(Integer::intValue).sum());
+
+    // second sanity check: after all the concurrent threads closed their resource, now
+    // all the resource should have reference count 0 and should be garbage collected in the
+    // next gc round
+    mResourcePool.gcUnusedResources(false);
+    assertEquals(0, mResourcePool.size());
+  }
+
+  @Test
+  public void failCreateFallback() throws Exception {
+    // first create will succeed, second will fail
+    mResourcePool = new SharedTestResourcePool(DEFAULT_OPTIONS, 1);
+    CloseableResource<TestResource> firstResource = mResourcePool.acquire();
+    CloseableResource<TestResource> secondResource = mResourcePool.acquire();
+
+    // should fall back to shared resource
+    assertEquals(firstResource.get(), secondResource.get());
+  }
+
+  @Test
+  public void failCreateErrOut() throws Exception {
+    // first create will fail
+    mResourcePool = new SharedTestResourcePool(DEFAULT_OPTIONS, 0);
+    assertThrows(IOException.class, () -> mResourcePool.acquire());
+  }
+
+  @Test
+  public void reuseResourceWhenPossible() throws Exception {
+    TestResource shouldBeReused;
+    try (CloseableResource<TestResource> first = mResourcePool.acquire()) {
+      shouldBeReused = first.get();
+      assertFalse(shouldBeReused.mClosed);
+    }
+
+    // since we released the last reference, we should reuse existing
+    // resource
+    try (CloseableResource<TestResource> second = mResourcePool.acquire()) {
+      assertSame(shouldBeReused, second.get());
+    }
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?
Implemented `SharedResourcePool`, which unlike `DynamicResourcePool`, shares resources across multiple acquire calls and never blocks. 

### Why are the changes needed?
We might want to replace the current `ClientPool` model to share clients within the same `FileSystemContext`, which might help with issues like https://github.com/Alluxio/alluxio/issues/15893

Also, sharing client makes sense as clients are pretty much stateless and already synchronized. There's very little benefit creating many instances of the client anyway, since the underlying connection channels are already shared.

### Does this PR introduce any user facing changes?
No
