### PR TITLE
Use specialized PageId for pages of a block

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/page/BlockPageId.java
+++ b/core/server/worker/src/main/java/alluxio/worker/page/BlockPageId.java
@@ -39,7 +39,7 @@ public final class BlockPageId extends PageId {
    * @param pageIndex index of the page in the block
    */
   public BlockPageId(long blockId, long pageIndex) {
-    super(String.valueOf(blockId), pageIndex);
+    super(String.valueOf(blockId).intern(), pageIndex);
     mBlockId = blockId;
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/page/BlockPageId.java
+++ b/core/server/worker/src/main/java/alluxio/worker/page/BlockPageId.java
@@ -50,6 +50,7 @@ public final class BlockPageId extends PageId {
     return mBlockId;
   }
 
+  @SuppressWarnings("checkstyle:EqualsHashCode")
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -69,10 +70,5 @@ public final class BlockPageId extends PageId {
     return o.equals(this);
   }
 
-  @Override
-  public int hashCode() {
-    return Long.hashCode(mBlockId) * 7 + Long.hashCode(getPageIndex());
-  }
-
-  // toString impl is intentionally not overridden
+  // hashCode and toString impls are intentionally not overridden
 }

--- a/core/server/worker/src/main/java/alluxio/worker/page/BlockPageId.java
+++ b/core/server/worker/src/main/java/alluxio/worker/page/BlockPageId.java
@@ -58,16 +58,15 @@ public final class BlockPageId extends PageId {
     if (!(o instanceof PageId)) {
       return false;
     }
-    if (getClass() == o.getClass()) {
-      // a fast path comparing longs instead of strings when both are BlockPageIds
+    // a fast path comparing longs instead of strings when both are BlockPageIds
+    if (o instanceof BlockPageId) { // we are final so instanceof check is ok
       BlockPageId that = (BlockPageId) o;
       return mBlockId == that.mBlockId && getPageIndex() == that.getPageIndex();
-    } else {
-      // otherwise, compare by parent equals
-      // note that mBlockId does not need to be compared as it's merely PageId.mFileId in a
-      // different representation
-      return super.equals(o);
     }
+    // otherwise o is either the super class PageId or some other subclass of PageId.
+    // super.equals(o) does not work here because if o is a subclass of PageId,
+    // it may have its own unique fields, so need to call their equals method
+    return o.equals(this);
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/page/BlockPageId.java
+++ b/core/server/worker/src/main/java/alluxio/worker/page/BlockPageId.java
@@ -50,8 +50,6 @@ public final class BlockPageId extends PageId {
     return mBlockId;
   }
 
-  // CHECKSTYLE OFF: EqualsHashCode
-  // hashCode and toString impls are intentionally not overridden
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -70,5 +68,11 @@ public final class BlockPageId extends PageId {
     // it may have its own unique fields, so need to call their equals method
     return o.equals(this);
   }
-  // CHECKSTYLE ON: EqualsHashCode
+
+  // hashCode impl is intentionally not overridden to preserve compatibility
+  // with parent class
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/page/BlockPageId.java
+++ b/core/server/worker/src/main/java/alluxio/worker/page/BlockPageId.java
@@ -1,0 +1,79 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.page;
+
+import alluxio.client.file.cache.PageId;
+
+/**
+ * Specialized {@link PageId} when it's part of a block.
+ */
+public final class BlockPageId extends PageId {
+  /**
+   * this is constructed from {@link PageId#getFileId()} and cached to avoid parsing the string
+   * multiple times.
+   */
+  private final long mBlockId;
+
+  /**
+   * @param blockId the block ID
+   * @param pageIndex index of the page in the block
+   * @throws NumberFormatException when {@code blockId} cannot be parsed as a {@code long}
+   */
+  public BlockPageId(String blockId, long pageIndex) {
+    super(blockId, pageIndex);
+    mBlockId = Long.parseLong(blockId);
+  }
+
+  /**
+   * Creates an instance with a block ID as a {@code long}.
+   * @param blockId the block ID
+   * @param pageIndex index of the page in the block
+   */
+  public BlockPageId(long blockId, long pageIndex) {
+    super(String.valueOf(blockId), pageIndex);
+    mBlockId = blockId;
+  }
+
+  /**
+   * @return the block ID
+   */
+  public long getBlockId() {
+    return mBlockId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PageId)) {
+      return false;
+    }
+    if (getClass() == o.getClass()) {
+      // a fast path comparing longs instead of strings when both are BlockPageIds
+      BlockPageId that = (BlockPageId) o;
+      return mBlockId == that.mBlockId && getPageIndex() == that.getPageIndex();
+    } else {
+      // otherwise, compare by parent equals
+      // note that mBlockId does not need to be compared as it's merely PageId.mFileId in a
+      // different representation
+      return super.equals(o);
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Long.hashCode(mBlockId) * 7 + Long.hashCode(getPageIndex());
+  }
+
+  // toString impl is intentionally not overridden
+}

--- a/core/server/worker/src/main/java/alluxio/worker/page/BlockPageId.java
+++ b/core/server/worker/src/main/java/alluxio/worker/page/BlockPageId.java
@@ -50,7 +50,8 @@ public final class BlockPageId extends PageId {
     return mBlockId;
   }
 
-  @SuppressWarnings("checkstyle:EqualsHashCode")
+  // CHECKSTYLE OFF: EqualsHashCode
+  // hashCode and toString impls are intentionally not overridden
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -69,6 +70,5 @@ public final class BlockPageId extends PageId {
     // it may have its own unique fields, so need to call their equals method
     return o.equals(this);
   }
-
-  // hashCode and toString impls are intentionally not overridden
+  // CHECKSTYLE ON: EqualsHashCode
 }

--- a/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockReader.java
@@ -91,7 +91,7 @@ public class PagedBlockReader extends BlockReader {
     while (bytesRead < length) {
       long pos = offset + bytesRead;
       long pageIndex = pos / mPageSize;
-      PageId pageId = new PageId(String.valueOf(mBlockId), pageIndex);
+      PageId pageId = new BlockPageId(mBlockId, pageIndex);
       int currentPageOffset = (int) (pos % mPageSize);
       int bytesLeftInPage =
           (int) Math.min(mPageSize - currentPageOffset, length - bytesRead);

--- a/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockWriter.java
+++ b/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockWriter.java
@@ -104,7 +104,7 @@ public class PagedBlockWriter extends BlockWriter {
 
   private PageId getPageId(long bytesWritten) {
     long pageIndex = (mPosition + bytesWritten) / mPageSize;
-    return new PageId(mBlockId, pageIndex);
+    return new BlockPageId(mBlockId, pageIndex);
   }
 
   private int getCurrentPageOffset(long bytesWritten) {

--- a/core/server/worker/src/test/java/alluxio/worker/page/BlockPageIdTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/page/BlockPageIdTest.java
@@ -1,0 +1,84 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.page;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import alluxio.client.file.cache.PageId;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.apache.curator.shaded.com.google.common.collect.Sets;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+public class BlockPageIdTest {
+  @Test
+  public void equality() {
+    BlockPageId id1 = new BlockPageId(1, 1);
+    BlockPageId id2 = new BlockPageId("1", 1);
+    BlockPageId id3 = new BlockPageId(1, 1);
+    // reflexive
+    assertEquals(id1, id1);
+    assertEquals(id2, id2);
+    assertEquals(id3, id3);
+    // symmetric
+    assertEquals(id1, id2);
+    assertEquals(id2, id1);
+    // transitive
+    assertEquals(id1, id2);
+    assertEquals(id2, id3);
+    assertEquals(id3, id1);
+  }
+
+  @Test
+  public void equalityWithParentClass() {
+    BlockPageId id1 = new BlockPageId("1", 1);
+    PageId id2 = new PageId("1", 1);
+    assertEquals(id1, id2);
+    assertEquals(id2, id1);
+  }
+
+  @Test
+  public void inequality() {
+    Set<Object> pageIds = ImmutableSet.of(
+        new BlockPageId(1, 1),
+        new BlockPageId(2, 1),
+        new BlockPageId(1, 2),
+        new BlockPageId(2, 2),
+        new Object());
+
+    for (Set<Object> set : Sets.combinations(pageIds, 2)) {
+      List<Object> pair = ImmutableList.copyOf(set);
+      assertNotEquals(pair.get(0), pair.get(1));
+      assertNotEquals(pair.get(1), pair.get(0));
+    }
+  }
+
+  @Test
+  public void testHashCode() {
+    PageId id1 = new BlockPageId(1, 1);
+    PageId id2 = new BlockPageId("1", 1);
+    assertEquals(id1, id2);
+    assertEquals(id1.hashCode(), id2.hashCode());
+  }
+
+  @Test
+  public void getBlockId() {
+    long blockId = 2;
+    BlockPageId pageId = new BlockPageId(blockId, 0);
+    assertEquals(blockId, pageId.getBlockId());
+  }
+}

--- a/core/server/worker/src/test/java/alluxio/worker/page/BlockPageIdTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/page/BlockPageIdTest.java
@@ -22,6 +22,7 @@ import org.apache.curator.shaded.com.google.common.collect.Sets;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class BlockPageIdTest {
@@ -49,6 +50,14 @@ public class BlockPageIdTest {
     PageId id2 = new PageId("1", 1);
     assertEquals(id1, id2);
     assertEquals(id2, id1);
+  }
+
+  @Test
+  public void inequalityWithOtherSubclass() {
+    PageId id = new BlockPageId("1", 1);
+    PageId otherSubclassId = new MoreFieldsPageId("1", 1, 1);
+    assertNotEquals(id, otherSubclassId);
+    assertNotEquals(otherSubclassId, id);
   }
 
   @Test
@@ -80,5 +89,34 @@ public class BlockPageIdTest {
     long blockId = 2;
     BlockPageId pageId = new BlockPageId(blockId, 0);
     assertEquals(blockId, pageId.getBlockId());
+  }
+
+  private static class MoreFieldsPageId extends PageId {
+    private final int mSomeField;
+
+    public MoreFieldsPageId(String fileId, long pageIndex, int value) {
+      super(fileId, pageIndex);
+      mSomeField = value;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), mSomeField);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      if (!super.equals(o)) {
+        return false;
+      }
+      MoreFieldsPageId that = (MoreFieldsPageId) o;
+      return mSomeField == that.mSomeField;
+    }
   }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/page/BlockPageIdTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/page/BlockPageIdTest.java
@@ -82,6 +82,10 @@ public class BlockPageIdTest {
     PageId id2 = new BlockPageId("1", 1);
     assertEquals(id1, id2);
     assertEquals(id1.hashCode(), id2.hashCode());
+
+    PageId id3 = new PageId("1", 1);
+    assertEquals(id1, id3);
+    assertEquals(id1.hashCode(), id3.hashCode());
   }
 
   @Test


### PR DESCRIPTION
### What changes are proposed in this pull request?

A specialized `PageId` when it's part of a block.

### Why are the changes needed?

Faster comparison of block ID as `long` instead of `String`.

### Does this PR introduce any user facing changes?

No.