### PR TITLE
Use no fallback options for cache test in DefaultBlockWorkerTest

### DIFF
--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
@@ -668,8 +668,12 @@ public class DefaultBlockWorkerTest {
 
     long sessionId = mRandom.nextLong();
     // check that we can read the block locally
+    // note: this time we use an OpenUfsOption without ufsPath and blockInUfsTier so
+    // that the worker can't fall back to ufs read.
+    Protocol.OpenUfsBlockOptions noFallbackOptions = Protocol.OpenUfsBlockOptions.newBuilder()
+        .setBlockInUfsTier(false).build();
     try (BlockReader reader = mBlockWorker.createBlockReader(
-            sessionId, blockId, 0, false, options)) {
+            sessionId, blockId, 0, false, noFallbackOptions)) {
       ByteBuffer buf = reader.read(0, ufsBlockSize);
       // alert: LocalFileBlockReader uses a MappedByteBuffer, which does not
       // support the array operation. So we need to compare ByteBuffer manually


### PR DESCRIPTION
### What changes are proposed in this pull request?
Change `OpenUfsOptions` in `DefaultBlockWorkerTest#cacheBlock` to disable fall back behavior.

### Why are the changes needed?
Once the cache succeeded, we should find the block locally without falling back. This ensures correct test expectations.

### Does this PR introduce any user facing changes?
No
