### PR TITLE
Make Alluxio parse KiB and more

### DIFF
--- a/core/common/src/main/java/alluxio/util/FormatUtils.java
+++ b/core/common/src/main/java/alluxio/util/FormatUtils.java
@@ -190,15 +190,15 @@ public final class FormatUtils {
     end = end.toLowerCase();
     if (end.isEmpty() || end.equals("b")) {
       return (long) (ret + alpha);
-    } else if (end.equals("kb") || end.equals("k")) {
+    } else if (end.equals("kb") || end.equals("k") || end.equals("kib") || end.equals("ki")) {
       return (long) (ret * Constants.KB + alpha);
-    } else if (end.equals("mb") || end.equals("m")) {
+    } else if (end.equals("mb") || end.equals("m") || end.equals("mib") || end.equals("mi")) {
       return (long) (ret * Constants.MB + alpha);
-    } else if (end.equals("gb") || end.equals("g")) {
+    } else if (end.equals("gb") || end.equals("g") || end.equals("gib") || end.equals("gi")) {
       return (long) (ret * Constants.GB + alpha);
-    } else if (end.equals("tb") || end.equals("t")) {
+    } else if (end.equals("tb") || end.equals("t") || end.equals("tib") || end.equals("ti")) {
       return (long) (ret * Constants.TB + alpha);
-    } else if (end.equals("pb") || end.equals("p")) {
+    } else if (end.equals("pb") || end.equals("p") || end.equals("pib") || end.equals("pi")) {
       // When parsing petabyte values, we can't multiply with doubles and longs, since that will
       // lose presicion with such high numbers. Therefore we use a BigDecimal.
       BigDecimal pBDecimal = new BigDecimal(Constants.PB);

--- a/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
+++ b/docs/en/deploy/Running-Alluxio-On-Kubernetes.md
@@ -2159,4 +2159,11 @@ You should check the Java version in the container you are using to ensure the
 correct memory limits are respected. Also it is recommended to go to the 
 running container and double check the JVM process is running with the correct memory consumption.
   {% endcollapsible %}
+  {% collapsible tmpfs is smaller than the configured size %}
+In Kubernetes context, g or GB means 1000^3 and gi or GiB means 1024^3. However, in Alluxio context, g or GB means 1024^3.
+So when we use g and pass the quota to Alluxio and K8s, K8s grants 1000^3 but Alluxio tries to utilize 1024^3.
+For example if it is an emptyDir, then the pod using the emptyDir will be killed for overusing resources.
+
+Therefore, we recommend using Gi whenever possible in helm chart or yaml files to avoid such issue.
+  {% endcollapsible %}
 {% endaccordion %}

--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -291,4 +291,9 @@
 - Support ConfigMap mounts and allow users to mount ConfigMap volumes similar to Secrets
 
 0.6.47
+
 - Support alluxio proxy
+
+0.6.48
+
+- Replace all default space size to "i" unit to avoid the unit discrepancy between Alluxio and Kubernetes

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.47
+version: 0.6.48
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -89,10 +89,10 @@ master:
     # The default xmx is 8G
     limits:
       cpu: "4"
-      memory: "8G"
+      memory: "8Gi"
     requests:
       cpu: "1"
-      memory: "1G"
+      memory: "1Gi"
   ports:
     embedded: 19200
     rpc: 19998
@@ -164,10 +164,10 @@ jobMaster:
   resources:
     limits:
       cpu: "4"
-      memory: "8G"
+      memory: "8Gi"
     requests:
       cpu: "1"
-      memory: "1G"
+      memory: "1Gi"
   ports:
     embedded: 20003
     rpc: 20001
@@ -271,10 +271,10 @@ worker:
   resources:
     limits:
       cpu: "4"
-      memory: "4G"
+      memory: "4Gi"
     requests:
       cpu: "1"
-      memory: "2G"
+      memory: "2Gi"
   ports:
     rpc: 29999
     web: 30000
@@ -330,10 +330,10 @@ jobWorker:
   resources:
     limits:
       cpu: "4"
-      memory: "4G"
+      memory: "4Gi"
     requests:
       cpu: "1"
-      memory: "1G"
+      memory: "1Gi"
   ports:
     rpc: 30001
     data: 30002
@@ -367,7 +367,7 @@ jobWorker:
 #    mediumtype: MEM
 #    path: /dev/shm
 #    type: emptyDir
-#    quota: 1G
+#    quota: 1Gi
 #
 # hostPath example
 #  - level: 0
@@ -375,7 +375,7 @@ jobWorker:
 #    mediumtype: MEM
 #    path: /dev/shm
 #    type: hostPath
-#    quota: 1G
+#    quota: 1Gi
 #
 # persistentVolumeClaim example
 #  - level: 1
@@ -384,7 +384,7 @@ jobWorker:
 #    type: persistentVolumeClaim
 #    name: alluxio-ssd
 #    path: /dev/ssd
-#    quota: 10G
+#    quota: 10Gi
 #
 # multi-part mediumtype example
 #  - level: 1
@@ -393,7 +393,7 @@ jobWorker:
 #    type: persistentVolumeClaim
 #    name: alluxio-ssd,alluxio-hdd
 #    path: /dev/ssd,/dev/hdd
-#    quota: 10G,10G
+#    quota: 10Gi,10Gi
 tieredstore:
   levels:
   - level: 0
@@ -401,7 +401,7 @@ tieredstore:
     mediumtype: MEM
     path: /dev/shm
     type: emptyDir
-    quota: 1G
+    quota: 1Gi
     high: 0.95
     low: 0.7
 
@@ -419,10 +419,10 @@ proxy:
   resources:
     requests:
       cpu: "0.5"
-      memory: "1G"
+      memory: "1Gi"
     limits:
       cpu: "4"
-      memory: "4G"
+      memory: "4Gi"
   ports:
     web: 39999
   hostNetwork: false
@@ -497,10 +497,10 @@ fuse:
   resources:
     requests:
       cpu: "0.5"
-      memory: "1G"
+      memory: "1Gi"
     limits:
       cpu: "4"
-      memory: "4G"
+      memory: "4Gi"
   nodeSelector: {}
   tolerations: []
   podAnnotations: {}
@@ -609,10 +609,10 @@ logserver:
     # The default xmx is 8G
     limits:
       cpu: "4"
-      memory: "8G"
+      memory: "8Gi"
     requests:
       cpu: "1"
-      memory: "1G"
+      memory: "1Gi"
   ports:
     logging: 45600
   hostPID: false
@@ -718,10 +718,10 @@ csi:
         # fuse in nodeserver container needs more resources
         limits:
           cpu: "4"
-          memory: "8G"
+          memory: "8Gi"
         requests:
           cpu: "1"
-          memory: "1G"
+          memory: "1Gi"
     driverRegistrar:
       image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.0
       resources:


### PR DESCRIPTION
### What changes are proposed in this pull request?

Make Alluxio able to recognize KiB, MiB,... that are used by Kubernetes configs. Making use of the "i" format default in helm chart.

### Why are the changes needed?

Addresses https://github.com/Alluxio/alluxio/issues/12277. This solution is mentioned at https://github.com/Alluxio/alluxio/issues/12277#issuecomment-1058572008 and I also think it has the minimal impact.

### Does this PR introduce any user facing changes?
No. 
