### PR TITLE
Fix user alluxio doesn't exist in k8s containers

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -21,9 +21,9 @@ imageTag: 2.9.0-SNAPSHOT
 imagePullPolicy: IfNotPresent
 
 # Security Context
-user: 1000
-group: 1000
-fsGroup: 1000
+user: 0
+group: 0
+fsGroup: 0
 
 # Service Account
 #   If not specified, Kubernetes will assign the 'default'


### PR DESCRIPTION
### What changes are proposed in this pull request?

Change default user of the containers of Alluxio to root.

### Why are the changes needed?

Addresses https://github.com/Alluxio/alluxio/issues/15979. 

PR https://github.com/Alluxio/alluxio/pull/15898 makes the dockerfile able to run as any user at runtime, in exchange of the user is created in `entrypoint.sh`. Only user `root` has the permission to create user, so if in k8s we set `runAsUser` to be a a non-root user, it can't create this new user. Therefore the user under security context has to be `root`.

### Does this PR introduce any user facing changes?

For users who explicitly set user/group/fsgroup in their helm chart values file, they need to reset them to 0. For users using yaml files, they need to reset the security context but it's more because of https://github.com/Alluxio/alluxio/pull/15898