### PR TITLE
Set FREE as the default action when file's ttl is expired

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5018,9 +5018,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey USER_FILE_CREATE_TTL_ACTION =
       enumBuilder(Name.USER_FILE_CREATE_TTL_ACTION, TtlAction.class)
-          .setDefaultValue(TtlAction.DELETE)
+          .setDefaultValue(TtlAction.FREE)
           .setDescription("When file's ttl is expired, the action performs on it. Options: "
-              + "DELETE (default) or FREE")
+              + "FREE (default)")
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_FILE_UFS_TIER_ENABLED =


### PR DESCRIPTION
Hi all,

May I get reviews for this small patch?

### What changes are proposed in this pull request?

When file's ttl is expired, the default action performs on it was changed from `DELETE` to `FREE`.

### Why are the changes needed?

This is because the file may be used again even though the file's ttl is expired.
So it seems better to free it instead of deleting it.

### Does this PR introduce any user facing changes?

No.


Thanks.
Best regards,
Jie
