### PR TITLE
Change block worker load api's bandwidth to int64

### DIFF
--- a/core/common/src/main/java/alluxio/worker/block/BlockStore.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockStore.java
@@ -25,7 +25,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 
@@ -253,5 +252,5 @@ public interface BlockStore extends Closeable, SessionCleanable {
    * @param bandwidth limited bandwidth to ufs
    * @return load status for failed blocks
    */
-  List<BlockStatus> load(List<Block> fileBlocks, String tag, OptionalInt bandwidth);
+  List<BlockStatus> load(List<Block> fileBlocks, String tag, OptionalLong bandwidth);
 }

--- a/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -28,7 +28,7 @@ import alluxio.worker.block.io.BlockWriter;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -197,7 +197,7 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @param bandwidth limited bandwidth to ufs
    * @return load status for failed blocks
    */
-  List<BlockStatus> load(List<Block> fileBlocks, String tag, OptionalInt bandwidth);
+  List<BlockStatus> load(List<Block> fileBlocks, String tag, OptionalLong bandwidth);
 
   /**
    * Sets the pinlist for the underlying block store.

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -66,7 +66,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -386,7 +386,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   }
 
   @Override
-  public List<BlockStatus> load(List<Block> blocks, String tag, OptionalInt bandwidth) {
+  public List<BlockStatus> load(List<Block> blocks, String tag, OptionalLong bandwidth) {
     return mBlockStore.load(blocks, tag, bandwidth);
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/MonoBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/MonoBlockStore.java
@@ -46,7 +46,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -286,7 +285,7 @@ public class MonoBlockStore implements BlockStore {
   }
 
   @Override
-  public List<BlockStatus> load(List<Block> blocks, String tag, OptionalInt bandwidth) {
+  public List<BlockStatus> load(List<Block> blocks, String tag, OptionalLong bandwidth) {
     ArrayList<CompletableFuture<BlockStatus>> futures = new ArrayList<>();
     for (Block block : blocks) {
       CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
@@ -313,10 +312,10 @@ public class MonoBlockStore implements BlockStore {
   }
 
   private void loadInternal(long blockId, long blockSize, long mountId, String ufsPath, String tag,
-      OptionalInt bandwidth, long offsetInUfs) throws WorkerOutOfSpaceException, IOException {
+      OptionalLong bandwidth, long offsetInUfs) throws WorkerOutOfSpaceException, IOException {
     UfsIOManager manager = mUnderFileSystemBlockStore.getOrAddUfsIOManager(mountId);
     if (bandwidth.isPresent()) {
-      manager.setQuotaInMB(tag, bandwidth.getAsInt());
+      manager.setQuota(tag, bandwidth.getAsLong());
     }
     long sessionId = IdUtils.createSessionId();
     BlockStoreLocation loc = BlockStoreLocation.anyDirInTier(WORKER_STORAGE_TIER_ASSOC.getAlias(0));

--- a/core/server/worker/src/main/java/alluxio/worker/block/UfsIOManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UfsIOManager.java
@@ -12,7 +12,6 @@
 package alluxio.worker.block;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioRuntimeException;
@@ -48,7 +47,7 @@ import java.util.concurrent.RejectedExecutionException;
 public class UfsIOManager implements Closeable {
   private static final int READ_CAPACITY = 1024;
   private final UfsManager.UfsClient mUfsClient;
-  private final ConcurrentMap<String, Integer> mThroughputQuota = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, Long> mThroughputQuota = new ConcurrentHashMap<>();
   private final UfsInputStreamCache mUfsInstreamCache = new UfsInputStreamCache();
   private final LinkedBlockingQueue<ReadTask> mReadQueue = new LinkedBlockingQueue<>(READ_CAPACITY);
   private final ConcurrentMap<AlluxioURI, Meter> mUfsBytesReadThroughputMetrics =
@@ -85,9 +84,9 @@ public class UfsIOManager implements Closeable {
   /**
    * Set throughput quota for tag.
    * @param tag the client name or tag
-   * @param throughput throughput limit, MB/s
+   * @param throughput throughput limit in bytes
    */
-  public void setQuotaInMB(String tag, int throughput) {
+  public void setQuota(String tag, long throughput) {
     Preconditions.checkArgument(throughput > 0, "throughput should be positive");
     mThroughputQuota.put(tag, throughput);
   }
@@ -97,7 +96,7 @@ public class UfsIOManager implements Closeable {
       try {
         ReadTask task = mReadQueue.take();
         if (mThroughputQuota.containsKey(task.mTag)
-            && mThroughputQuota.get(task.mTag) * Constants.MB < getUsedThroughput(task.mMeter)) {
+            && mThroughputQuota.get(task.mTag) < getUsedThroughput(task.mMeter)) {
           // resubmit to queue
           mReadQueue.put(task);
         } else {

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockWorkerClientServiceHandler.java
@@ -62,7 +62,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalInt;
+import java.util.OptionalLong;
 
 /**
  * Server side implementation of the gRPC BlockWorker interface.
@@ -175,9 +175,9 @@ public class BlockWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorker
   public void load(LoadRequest request, StreamObserver<LoadResponse> responseObserver) {
     RpcUtils.call(LOG, () -> {
       LoadResponse.Builder response = LoadResponse.newBuilder();
-      OptionalInt bandwidth = OptionalInt.empty();
+      OptionalLong bandwidth = OptionalLong.empty();
       if (request.hasBandwidth()) {
-        bandwidth = OptionalInt.of(request.getBandwidth());
+        bandwidth = OptionalLong.of(request.getBandwidth());
       }
       List<BlockStatus> failures =
           mBlockWorker.load(request.getBlocksList(), request.getTag(), bandwidth);

--- a/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockStore.java
@@ -46,7 +46,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -186,7 +185,7 @@ public class PagedBlockStore implements BlockStore {
   }
 
   @Override
-  public List<BlockStatus> load(List<Block> fileBlocks, String tag, OptionalInt bandwidth) {
+  public List<BlockStatus> load(List<Block> fileBlocks, String tag, OptionalLong bandwidth) {
     return null;
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
@@ -78,7 +78,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -479,7 +479,7 @@ public class DefaultBlockWorkerTest {
         .setUfsPath(mTestLoadFilePath).build();
 
     List<BlockStatus> res =
-        mBlockWorker.load(Arrays.asList(block, block2), "test", OptionalInt.empty());
+        mBlockWorker.load(Arrays.asList(block, block2), "test", OptionalLong.empty());
     assertEquals(res.size(), 0);
     assertTrue(mBlockStore.hasBlockMeta(0));
     assertTrue(mBlockStore.hasBlockMeta(1));
@@ -500,10 +500,10 @@ public class DefaultBlockWorkerTest {
     Block blocks = Block.newBuilder().setBlockId(blockId).setBlockSize(BLOCK_SIZE)
         .setMountId(UFS_LOAD_MOUNT_ID).setOffsetInFile(0).setUfsPath(mTestLoadFilePath).build();
     List<BlockStatus> res =
-        mBlockWorker.load(Collections.singletonList(blocks), "test", OptionalInt.empty());
+        mBlockWorker.load(Collections.singletonList(blocks), "test", OptionalLong.empty());
     assertEquals(res.size(), 0);
     List<BlockStatus> failure =
-        mBlockWorker.load(Collections.singletonList(blocks), "test", OptionalInt.empty());
+        mBlockWorker.load(Collections.singletonList(blocks), "test", OptionalLong.empty());
     assertEquals(failure.size(), 1);
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerUfsExceptionTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerUfsExceptionTest.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -98,7 +98,7 @@ public class DefaultBlockWorkerUfsExceptionTest {
     Block blocks = Block.newBuilder().setBlockId(blockId).setBlockSize(BLOCK_SIZE).setMountId(0)
         .setOffsetInFile(0).setUfsPath(FILE_NAME).build();
     List<BlockStatus> failure =
-        mBlockWorker.load(Collections.singletonList(blocks), "test", OptionalInt.empty());
+        mBlockWorker.load(Collections.singletonList(blocks), "test", OptionalLong.empty());
     assertEquals(failure.size(), 1);
     assertEquals("alluxio.underfs.hdfs.AlluxioHdfsException", failure.get(0).getMessage());
     assertEquals(exception.getStatus().getCode().value(), failure.get(0).getCode());

--- a/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
@@ -30,7 +30,7 @@ import alluxio.worker.block.io.BlockWriter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -118,7 +118,7 @@ public class NoopBlockWorker implements BlockWorker {
   }
 
   @Override
-  public List<BlockStatus> load(List<Block> fileBlocks, String tag, OptionalInt bandwidth) {
+  public List<BlockStatus> load(List<Block> fileBlocks, String tag, OptionalLong bandwidth) {
     return null;
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/UfsIoManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UfsIoManagerTest.java
@@ -124,14 +124,14 @@ public final class UfsIoManagerTest {
 
   @Test
   public void readWithQuota() throws Exception {
-    mUfsIOManager.setQuotaInMB("quotaTest", 2); // magic number for proper test time
+    mUfsIOManager.setQuota("quotaTest", 2 * Constants.MB); // magic number for proper test time
     CompletableFuture<byte[]> data =
         mUfsIOManager.read(FIRST_BLOCK_ID, 2, TEST_BLOCK_SIZE - 2, mTestFilePath, false,
             "quotaTest");
     // sleep to make sure future is not done because of quota instead of get future too soon
     Thread.sleep(3000);
     assertFalse(data.isDone());
-    mUfsIOManager.setQuotaInMB("quotaTest", 5);
+    mUfsIOManager.setQuota("quotaTest", 5 * Constants.MB);
     assertTrue(BufferUtils.equalIncreasingByteArray(2, (int) TEST_BLOCK_SIZE - 2, data.get()));
   }
 }

--- a/core/transport/src/main/proto/grpc/block_worker.proto
+++ b/core/transport/src/main/proto/grpc/block_worker.proto
@@ -137,7 +137,7 @@ message CacheRequest {
 message LoadRequest {
   repeated Block blocks = 1;
   optional string tag = 2;
-  optional int32 bandwidth = 3;
+  optional int64 bandwidth = 3;
 }
 
 message Block{

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -1082,7 +1082,7 @@
               {
                 "id": 3,
                 "name": "bandwidth",
-                "type": "int32"
+                "type": "int64"
               }
             ]
           },

--- a/microbench/src/main/java/alluxio/worker/WorkerBenchLoad.java
+++ b/microbench/src/main/java/alluxio/worker/WorkerBenchLoad.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Random;
 
 public class WorkerBenchLoad {
@@ -72,7 +72,7 @@ public class WorkerBenchLoad {
               .setOffsetInFile(0).setUfsPath(param.mFiles.get(i)).build();
       blocks.add(block);
     }
-    bh.consume(param.mBase.mBlockStore.load(blocks, "test", OptionalInt.empty()));
+    bh.consume(param.mBase.mBlockStore.load(blocks, "test", OptionalLong.empty()));
   }
 
   public static void main(String[] args) throws RunnerException {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Use bytes instead of MB as the unit for bandwidth
