### PR TITLE
Revert "Allow Docker image file permissions to be modified at runtime"

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -28,7 +28,6 @@ RUN cd /alluxio-csi && \
 FROM alpine:3.10.2 AS alluxio-extractor
 # Note that downloads for *-SNAPSHOT tarballs are not available.
 ARG ALLUXIO_TARBALL=http://downloads.alluxio.io/downloads/files/2.9.0-SNAPSHOT/alluxio-2.9.0-SNAPSHOT-bin.tar.gz
-
 # (Alert):It's not recommended to set this Argument to true, unless you know exactly what you are doing
 ARG ENABLE_DYNAMIC_USER=false
 
@@ -66,11 +65,11 @@ RUN \
 
 ENV LD_LIBRARY_PATH "/usr/local/lib:${LD_LIBRARY_PATH}"
 
-ENV ALLUXIO_USERNAME=alluxio
-ENV ALLUXIO_GROUP=alluxio
-ENV ALLUXIO_UID=1000
-ENV ALLUXIO_GID=1000
-ENV ENABLE_DYNAMIC_USER=true
+ARG ALLUXIO_USERNAME=alluxio
+ARG ALLUXIO_GROUP=alluxio
+ARG ALLUXIO_UID=1000
+ARG ALLUXIO_GID=1000
+ARG ENABLE_DYNAMIC_USER=true
 
 # Add Tini for Alluxio helm charts (https://github.com/Alluxio/alluxio/pull/12233)
 # - https://github.com/krallin/tini
@@ -88,14 +87,19 @@ RUN echo "networkaddress.cache.ttl=0" >> ${JAVA_HOME}/jre/lib/security/java.secu
 # Add the following for native libraries needed by rocksdb
 ENV LD_LIBRARY_PATH /lib64:${LD_LIBRARY_PATH}
 
+# If Alluxio user, group, gid, and uid aren't root|0, create the alluxio user and set file permissions accordingly
+RUN ./dockerfile-common.sh user-operation ${ALLUXIO_USERNAME} ${ALLUXIO_GROUP} ${ALLUXIO_UID} ${ALLUXIO_GID} alpine
+
 # Docker 19.03+ required to expand variables in --chown argument
 # https://github.com/moby/buildkit/pull/926#issuecomment-503943557
-COPY --from=alluxio-extractor /opt /opt/
-COPY conf /opt/alluxio/conf/
-COPY entrypoint.sh /
+COPY --from=alluxio-extractor --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} /opt /opt/
+COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} conf /opt/alluxio/conf/
+COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} entrypoint.sh /
 COPY --from=csi-dev /usr/local/bin/alluxio-csi /usr/local/bin/
 
 RUN ./dockerfile-common.sh enable-dynamic-user ${ENABLE_DYNAMIC_USER}
+
+USER ${ALLUXIO_UID}
 
 WORKDIR /opt/alluxio
 

--- a/integration/docker/Dockerfile-dev
+++ b/integration/docker/Dockerfile-dev
@@ -71,11 +71,11 @@ RUN \
 
 ENV LD_LIBRARY_PATH "/usr/local/lib:${LD_LIBRARY_PATH}"
 
-ENV ALLUXIO_USERNAME=alluxio
-ENV ALLUXIO_GROUP=alluxio
-ENV ALLUXIO_UID=1000
-ENV ALLUXIO_GID=1000
-ENV ENABLE_DYNAMIC_USER=true
+ARG ALLUXIO_USERNAME=alluxio
+ARG ALLUXIO_GROUP=alluxio
+ARG ALLUXIO_UID=1000
+ARG ALLUXIO_GID=1000
+ARG ENABLE_DYNAMIC_USER=true
 
 # Add Tini for alluxio helm charts (https://github.com/Alluxio/alluxio/pull/12233)
 # - https://github.com/krallin/tini
@@ -108,14 +108,19 @@ RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-11-openjdk/conf/secur
 # Add the following for native libraries needed by rocksdb
 ENV LD_LIBRARY_PATH /lib64:${LD_LIBRARY_PATH}
 
+# If Alluxio user, group, gid, and uid aren't root|0, create the alluxio user and set file permissions accordingly
+RUN ./dockerfile-common.sh user-operation ${ALLUXIO_USERNAME} ${ALLUXIO_GROUP} ${ALLUXIO_UID} ${ALLUXIO_GID} centos
+
 # Docker 19.03+ required to expand variables in --chown argument
 # https://github.com/moby/buildkit/pull/926#issuecomment-503943557
-COPY --from=alluxio-extractor /opt /opt/
-COPY conf /opt/alluxio/conf/
-COPY entrypoint.sh /
+COPY --from=alluxio-extractor --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} /opt /opt/
+COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} conf /opt/alluxio/conf/
+COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} entrypoint.sh /
 COPY --from=csi-dev /usr/local/bin/alluxio-csi /usr/local/bin/
 
 RUN ./dockerfile-common.sh enable-dynamic-user ${ENABLE_DYNAMIC_USER}
+
+USER ${ALLUXIO_UID}
 
 WORKDIR /opt/alluxio
 

--- a/integration/docker/README.md
+++ b/integration/docker/README.md
@@ -52,7 +52,6 @@ when the image starts.
 
 ```console
 $ docker run -e ALLUXIO_MASTER_HOSTNAME=ec2-203-0-113-25.compute-1.amazonaws.com \
--e ALLUXIO_USERNAME=your_username -e ALLUXIO_GROUP=your_group -e ALLUXIO_UID=1012 -e ALLUXIO_GID=1012 \
 alluxio/alluxio-[
 |dev] [master|worker|proxy|fuse]
 ```
@@ -67,7 +66,6 @@ to launch a standalone Fuse container:
 
 ```console
 $ docker run -e ALLUXIO_MASTER_HOSTNAME=alluxio-master \
--e ALLUXIO_USERNAME=your_username -e ALLUXIO_GROUP=your_group -e ALLUXIO_UID=1012 -e ALLUXIO_GID=1012 \
 --cap-add SYS_ADMIN --device /dev/fuse alluxio/alluxio fuse --fuse-opts=allow_other
 ```
 

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -169,12 +169,11 @@ function setup_for_dynamic_non_root {
       if [ "$alp" == "1" ];then
         addgroup -g ${ALLUXIO_GID} ${ALLUXIO_GROUP}
         adduser -u ${ALLUXIO_UID}  -G ${ALLUXIO_GROUP} --disabled-password ${ALLUXIO_USERNAME}
-        addgroup ${ALLUXIO_USERNAME} root
       else
         groupadd -g ${ALLUXIO_GID} ${ALLUXIO_GROUP} && \
         useradd -u ${ALLUXIO_UID} -g ${ALLUXIO_GROUP} ${ALLUXIO_USERNAME}
-        usermod -a -G root ${ALLUXIO_USERNAME}
       fi
+      usermod -a -G root ${ALLUXIO_USERNAME}
       mkdir -p /journal
       chown -R ${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} /opt/* /journal
       chmod -R g=u /opt/* /journal
@@ -192,7 +191,6 @@ function setup_for_dynamic_non_root {
           grep -Ev "^$" | \
           xargs -I {} chmod -R 777 {}
       fi
-      chown ${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} /entrypoint.sh
       exec su ${ALLUXIO_USERNAME} -c "/entrypoint.sh $*"
   fi
 }


### PR DESCRIPTION
This reverts commit 0cc44736fd533b2b1d452f36dd23ba92eabf3088.

### Why are the changes needed?

We need to further discuss on whether we should/want to let root be the default user because of security concerns. It is also breaking k8s, so reverting it 