### PR TITLE
Fix snpashot replication test

### DIFF
--- a/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -469,7 +469,7 @@ public class SnapshotReplicationManagerTest {
           mSnapshotManager.wait(Configuration.global().getMs(
               PropertyKey.MASTER_JOURNAL_REQUEST_INFO_TIMEOUT));
         }
-        throw new IOException("get into disabled");
+        throw new IOException("get info disabled");
       }).when(mSnapshotManager)
           .handleRequest(argThat(JournalQueryRequest::hasSnapshotInfoRequest));
     }

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -466,9 +466,10 @@ public class SnapshotReplicationManagerTest {
       Mockito.doAnswer((args) -> {
         synchronized (mSnapshotManager) {
           // we sleep so nothing is returned
-          mSnapshotManager.wait();
+          mSnapshotManager.wait(Configuration.global().getMs(
+              PropertyKey.MASTER_JOURNAL_REQUEST_INFO_TIMEOUT));
         }
-        return null;
+        throw new IOException("get into disabled");
       }).when(mSnapshotManager)
           .handleRequest(argThat(JournalQueryRequest::hasSnapshotInfoRequest));
     }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fixes snapshot replication test which could block sometimes by adding a timeout when GetInfo requests are disabled by mocking (as would happen they were not being mocked).

### Does this PR introduce any user facing changes?

No
