### PR TITLE
Support record audit log for getMountTable op

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1794,12 +1794,17 @@ public class DefaultFileSystemMaster extends CoreMaster
 
   @Override
   public Map<String, MountPointInfo> getMountPointInfoSummary(boolean invokeUfs) {
-    SortedMap<String, MountPointInfo> mountPoints = new TreeMap<>();
-    for (Map.Entry<String, MountInfo> mountPoint : mMountTable.getMountTable().entrySet()) {
-      mountPoints.put(mountPoint.getKey(),
-              getDisplayMountPointInfo(mountPoint.getValue(), invokeUfs));
+    String command = invokeUfs ? "getMountPointInfo(invokeUfs)" : "getMountPointInfo";
+    try (FileSystemMasterAuditContext auditContext =
+             createAuditContext(command, null, null, null)) {
+      SortedMap<String, MountPointInfo> mountPoints = new TreeMap<>();
+      for (Map.Entry<String, MountInfo> mountPoint : mMountTable.getMountTable().entrySet()) {
+        mountPoints.put(mountPoint.getKey(),
+            getDisplayMountPointInfo(mountPoint.getValue(), invokeUfs));
+      }
+      auditContext.setSucceeded(true);
+      return mountPoints;
     }
-    return mountPoints;
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support record the audit log for getMounttable operation.

### Why are the changes needed?

Just add auditlog context.

### Does this PR introduce any user facing changes?

No.



```
2022-08-03 22:53:40,239 INFO  AUDIT_LOG - succeeded=true	allowed=true	ugi=mbl,staff (AUTH=SIMPLE)	ip=/127.0.0.1:65311	cmd=getMountPointInfo(invokeUfs)	src=null	dst=null	perm=null	executionTimeUs=436
2022-08-03 22:53:51,628 INFO  AUDIT_LOG - succeeded=true	allowed=true	ugi=mbl,staff (AUTH=SIMPLE)	ip=/127.0.0.1:65332	cmd=getMountPointInfo(invokeUfs)	src=null	dst=null	perm=null	executionTimeUs=940
2022-08-03 22:54:00,779 INFO  AUDIT_LOG - succeeded=true	allowed=true	ugi=mbl,staff (AUTH=SIMPLE)	ip=/127.0.0.1:65348	cmd=getMountPointInfo(invokeUfs)	src=null	dst=null	perm=null	executionTimeUs=617
2022-08-03 22:54:14,247 INFO  AUDIT_LOG - succeeded=true	allowed=true	ugi=mbl,staff (AUTH=SIMPLE)	ip=/127.0.0.1:65439	cmd=getMountPointInfo	src=null	dst=null	perm=null	executionTimeUs=71
2022-08-03 22:54:24,869 INFO  AUDIT_LOG - succeeded=true	allowed=true	ugi=mbl,staff (AUTH=SIMPLE)	ip=/127.0.0.1:65451	cmd=getMountPointInfo	src=null	dst=null	perm=null	executionTimeUs=78
2022-08-03 22:54:32,817 INFO  AUDIT_LOG - succeeded=true	allowed=true	ugi=mbl,staff (AUTH=SIMPLE)	ip=/127.0.0.1:65475	cmd=getMountPointInfo	src=null	dst=null	perm=null	executionTimeUs=94
```
