### PR TITLE
Ignore AlluxioJniFuseFileSystemTest

### DIFF
--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
@@ -59,6 +59,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -74,6 +75,7 @@ import java.util.Optional;
 /**
  * Isolation tests for {@link AlluxioJniFuseFileSystem}.
  */
+@Ignore
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({BlockMasterClient.Factory.class})
 public class AlluxioJniFuseFileSystemTest {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Ignore AlluxioJniFuseFileSystemTest

### Why are the changes needed?

AlluxioJniFuseFileSystemTest is enabled in https://github.com/Alluxio/alluxio/pull/15983.
Before merging, it had rebased on the latest `master` branch at that time and passed all tests.

But now there are test cases failing in  https://github.com/Alluxio/alluxio/runs/7668865525?check_suite_focus=true

### Does this PR introduce any user facing changes?

No
