### PR TITLE
Implement unbuffer interface for HdfsFileInputStream

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/CanUnbuffer.java
+++ b/core/client/fs/src/main/java/alluxio/client/CanUnbuffer.java
@@ -1,0 +1,23 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client;
+
+/**
+ * indicate that InputStream can clear their buffers on request.
+ */
+public interface CanUnbuffer {
+  /**
+   * Reduce the buffering. This will also free sockets and file descriptors held by the stream,
+   * if possible.
+   */
+  void unbuffer();
+}

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -420,6 +420,9 @@ public class AlluxioFileInStream extends FileInStream {
       if (stream == mBlockInStream) { // if stream is instance variable, set to null
         mBlockInStream = null;
       }
+      if (stream == mCachedPositionedReadStream) {
+        mCachedPositionedReadStream = null;
+      }
       if (blockSource == BlockInStream.BlockInStreamSource.NODE_LOCAL
           || blockSource == BlockInStream.BlockInStreamSource.PROCESS_LOCAL) {
         return;
@@ -510,6 +513,16 @@ public class AlluxioFileInStream extends FileInStream {
     // TODO(lu) consider recovering failed workers
     if (!causedByClientOOM) {
       mFailedWorkers.put(workerAddress, System.currentTimeMillis());
+    }
+  }
+
+  @Override
+  public void unbuffer() {
+    if (mBlockInStream != null) {
+      mBlockInStream.unbuffer();
+    }
+    if (mCachedPositionedReadStream != null) {
+      mCachedPositionedReadStream.unbuffer();
     }
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileInStream.java
@@ -13,6 +13,7 @@ package alluxio.client.file;
 
 import alluxio.Seekable;
 import alluxio.client.BoundedStream;
+import alluxio.client.CanUnbuffer;
 import alluxio.client.PositionedReadable;
 import alluxio.exception.PreconditionMessage;
 import alluxio.util.io.BufferUtils;
@@ -29,7 +30,7 @@ import java.nio.ByteBuffer;
  * into a given offset of the stream to read.
  */
 public abstract class FileInStream extends InputStream
-    implements BoundedStream, PositionedReadable, Seekable {
+    implements BoundedStream, PositionedReadable, Seekable, CanUnbuffer {
   private final byte[] mSingleByte = new byte[1];
 
   @Override
@@ -100,5 +101,9 @@ public abstract class FileInStream extends InputStream
       byteBuffer.put(dest, 0, nread);
     }
     return nread;
+  }
+
+  @Override
+  public void unbuffer() {
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -309,6 +309,13 @@ public class LocalCacheFileInStream extends FileInStream {
     mPosition = pos;
   }
 
+  @Override
+  public void unbuffer() {
+    if (mExternalFileInStream != null) {
+      mExternalFileInStream.unbuffer();
+    }
+  }
+
   /**
    * Convenience method to ensure the stream is not closed.
    */

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/TestBlockInStream.java
@@ -11,7 +11,10 @@
 
 package alluxio.client.block.stream;
 
+import alluxio.network.protocol.databuffer.DataBuffer;
 import alluxio.wire.WorkerNetAddress;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -54,6 +57,16 @@ public class TestBlockInStream extends BlockInStream {
 
   public boolean isClosed() {
     return mClosed;
+  }
+
+  @VisibleForTesting
+  public DataReader getDataReader() {
+    return mDataReader;
+  }
+
+  @VisibleForTesting
+  public DataBuffer getCurrentChunk() {
+    return mCurrentChunk;
   }
 
   @Override

--- a/core/client/fs/src/test/java/alluxio/client/block/stream/TestDataReader.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/stream/TestDataReader.java
@@ -14,6 +14,8 @@ package alluxio.client.block.stream;
 import alluxio.network.protocol.databuffer.DataBuffer;
 import alluxio.network.protocol.databuffer.NioDataBuffer;
 
+import com.google.common.base.Preconditions;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import javax.annotation.Nullable;
@@ -38,6 +40,7 @@ public class TestDataReader implements DataReader {
   @Override
   @Nullable
   public DataBuffer readChunk() {
+    Preconditions.checkState(!mClosed, "reader is closed");
     if (mPos >= mEnd || mPos >= mData.length) {
       return null;
     }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -524,6 +524,38 @@ public class LocalCacheFileInStreamTest {
     Assert.assertEquals(timeSource.get(StepTicker.Type.CACHE_MISS), timeReadExternal);
   }
 
+  @Test
+  public void testUnbuffer() throws Exception {
+    int fileSize = mPageSize;
+    byte[] testData = BufferUtils.getIncreasingByteArray(fileSize);
+    ByteArrayCacheManager manager = new ByteArrayCacheManager();
+    LocalCacheFileInStream stream = setupWithSingleFile(testData, manager);
+
+    int partialReadSize = fileSize / 5;
+    int offset = fileSize / 5;
+
+    byte[] cacheMiss = new byte[partialReadSize];
+    stream.unbuffer();
+    stream.seek(offset);
+    stream.unbuffer();
+    Assert.assertEquals(partialReadSize, stream.read(cacheMiss));
+    stream.unbuffer();
+    Assert.assertArrayEquals(
+        Arrays.copyOfRange(testData, offset, offset + partialReadSize), cacheMiss);
+    Assert.assertEquals(0, manager.mPagesServed);
+    Assert.assertEquals(1, manager.mPagesCached);
+
+    byte[] cacheHit = new byte[partialReadSize];
+    stream.unbuffer();
+    stream.seek(offset);
+    stream.unbuffer();
+    Assert.assertEquals(partialReadSize, stream.read(cacheHit));
+    stream.unbuffer();
+    Assert.assertArrayEquals(
+        Arrays.copyOfRange(testData, offset, offset + partialReadSize), cacheHit);
+    Assert.assertEquals(1, manager.mPagesServed);
+  }
+
   private LocalCacheFileInStream setupWithSingleFile(byte[] data, CacheManager manager)
       throws Exception {
     Map<AlluxioURI, byte[]> files = new HashMap<>();

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsInputStream.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioHdfsInputStream.java
@@ -104,4 +104,9 @@ public class AlluxioHdfsInputStream extends FileInStream {
       throws IOException {
     return mInput.read(position, buffer, offset, length);
   }
+
+  @Override
+  public void unbuffer() {
+    mInput.unbuffer();
+  }
 }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/BaseHdfsFileInputStream.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/BaseHdfsFileInputStream.java
@@ -1,0 +1,206 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.hadoop;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.FileSystem;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.ExceptionMessage;
+import alluxio.exception.FileDoesNotExistException;
+
+import org.apache.hadoop.fs.ByteBufferReadable;
+import org.apache.hadoop.fs.FileSystem.Statistics;
+import org.apache.hadoop.fs.PositionedReadable;
+import org.apache.hadoop.fs.Seekable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.EOFException;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * An input stream for reading a file from HDFS. This is just a wrapper around
+ * {@link FileInStream} with additional statistics gathering in a {@link Statistics} object.
+ */
+@NotThreadSafe
+public class BaseHdfsFileInputStream extends InputStream implements Seekable, PositionedReadable,
+    ByteBufferReadable {
+  private static final Logger LOG = LoggerFactory.getLogger(BaseHdfsFileInputStream.class);
+
+  private final Statistics mStatistics;
+  protected final FileInStream mInputStream;
+
+  private boolean mClosed = false;
+
+  /**
+   * Constructs a new stream for reading a file from HDFS.
+   *
+   * @param fs the file system
+   * @param uri the Alluxio file URI
+   * @param stats filesystem statistics
+   */
+  public BaseHdfsFileInputStream(FileSystem fs, AlluxioURI uri, Statistics stats)
+      throws IOException {
+    LOG.debug("HdfsFileInputStream({}, {})", uri, stats);
+
+    mStatistics = stats;
+    try {
+      mInputStream = fs.openFile(uri);
+    } catch (FileDoesNotExistException e) {
+      // Transform the Alluxio exception to a Java exception to satisfy the HDFS API contract.
+      throw new FileNotFoundException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(uri));
+    } catch (AlluxioException e) {
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * Constructs a new stream for reading a file from HDFS.
+   *
+   * @param inputStream the input stream
+   * @param stats filesystem statistics
+   */
+  public BaseHdfsFileInputStream(FileInStream inputStream, Statistics stats) {
+    mInputStream = inputStream;
+    mStatistics = stats;
+  }
+
+  @Override
+  public int available() throws IOException {
+    if (mClosed) {
+      throw new IOException("Cannot query available bytes from a closed stream.");
+    }
+    return (int) mInputStream.remaining();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (mClosed) {
+      return;
+    }
+    mInputStream.close();
+    mClosed = true;
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return mInputStream.getPos();
+  }
+
+  @Override
+  public int read() throws IOException {
+    if (mClosed) {
+      throw new IOException(ExceptionMessage.READ_CLOSED_STREAM.getMessage());
+    }
+
+    int data = mInputStream.read();
+    if (data != -1 && mStatistics != null) {
+      mStatistics.incrementBytesRead(1);
+    }
+    return data;
+  }
+
+  @Override
+  public int read(byte[] buffer) throws IOException {
+    return read(buffer, 0, buffer.length);
+  }
+
+  @Override
+  public int read(byte[] buffer, int offset, int length) throws IOException {
+    if (mClosed) {
+      throw new IOException(ExceptionMessage.READ_CLOSED_STREAM.getMessage());
+    }
+
+    int bytesRead = mInputStream.read(buffer, offset, length);
+    if (bytesRead != -1 && mStatistics != null) {
+      mStatistics.incrementBytesRead(bytesRead);
+    }
+    return bytesRead;
+  }
+
+  @Override
+  public int read(ByteBuffer buf) throws IOException {
+    if (mClosed) {
+      throw new IOException(ExceptionMessage.READ_CLOSED_STREAM.getMessage());
+    }
+    int bytesRead = mInputStream.read(buf);
+    if (bytesRead != -1 && mStatistics != null) {
+      mStatistics.incrementBytesRead(bytesRead);
+    }
+    return bytesRead;
+  }
+
+  @Override
+  public int read(long position, byte[] buffer, int offset, int length) throws IOException {
+    if (mClosed) {
+      throw new IOException(ExceptionMessage.READ_CLOSED_STREAM.getMessage());
+    }
+
+    int bytesRead = mInputStream.positionedRead(position, buffer, offset, length);
+    if (bytesRead != -1 && mStatistics != null) {
+      mStatistics.incrementBytesRead(bytesRead);
+    }
+    return bytesRead;
+  }
+
+  @Override
+  public void readFully(long position, byte[] buffer) throws IOException {
+    readFully(position, buffer, 0, buffer.length);
+  }
+
+  @Override
+  public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
+    int totalBytesRead = 0;
+    while (totalBytesRead < length) {
+      int bytesRead =
+          read(position + totalBytesRead, buffer, offset + totalBytesRead, length - totalBytesRead);
+      if (bytesRead == -1) {
+        throw new EOFException();
+      }
+      totalBytesRead += bytesRead;
+    }
+  }
+
+  @Override
+  public void seek(long pos) throws IOException {
+    try {
+      mInputStream.seek(pos);
+    } catch (IllegalArgumentException e) { // convert back to IOException
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * This method is not supported in {@link BaseHdfsFileInputStream}.
+   *
+   * @param targetPos N/A
+   * @return N/A
+   * @throws IOException always
+   */
+  @Override
+  public boolean seekToNewSource(long targetPos) throws IOException {
+    throw new IOException("This method is not supported.");
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    if (mClosed) {
+      throw new IOException("Cannot skip bytes in a closed stream.");
+    }
+    return mInputStream.skip(n);
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Implement unbuffer interface for HdfsFileInputStream. Fix #16016.

### Why are the changes needed?

If the unbuffer method is not implemented, then impala will not be able to use the file handle cache.

### Does this PR introduce any user facing changes?

Implement CanUnbuffer and StreamCapabilities for HdfsFileInputStream.