### PR TITLE
Fix Integration test

### DIFF
--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterRestartIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterRestartIntegrationTest.java
@@ -306,6 +306,7 @@ public class FileSystemMasterRestartIntegrationTest extends BaseIntegrationTest 
         .createLeaderFileSystemMasterFromJournal()) {
       FileSystemMaster newFsMaster = masterResource.getRegistry().get(FileSystemMaster.class);
 
+      AuthenticatedClientUser.set(TEST_USER);
       files = newFsMaster.listStatus(new AlluxioURI("/mnt/"),
           ListStatusContext.defaults());
       Assert.assertTrue(files.isEmpty());


### PR DESCRIPTION
In FileSystemMasterRestartIntegrationTest.unavailableUfsRecursiveCreate,
when we call stopFS, the authenticated client user might be cleared, in
which case the following listStatus can fail. Always set the user before
calling listStatus explicitly.
