### PR TITLE
Support skipping root ufs meta sync

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2949,6 +2949,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setIsHidden(true)
           .setIgnoredSiteProperty(true)
           .build();
+  public static final PropertyKey MASTER_SKIP_ROOT_UFS_META_SYNC =
+      booleanBuilder(Name.MASTER_SKIP_ROOT_UFS_META_SYNC)
+          .setDefaultValue(false)
+          .setDescription("Skip meta sync for the path with a ufsPath under the root ufs.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_STARTUP_BLOCK_INTEGRITY_CHECK_ENABLED =
       booleanBuilder(Name.MASTER_STARTUP_BLOCK_INTEGRITY_CHECK_ENABLED)
           .setDefaultValue(true)
@@ -7187,6 +7194,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.serving.thread.timeout";
     public static final String MASTER_SKIP_ROOT_ACL_CHECK =
         "alluxio.master.skip.root.acl.check";
+    public static final String MASTER_SKIP_ROOT_UFS_META_SYNC =
+        "alluxio.master.skip.root.ufs.meta.sync";
     public static final String MASTER_STARTUP_BLOCK_INTEGRITY_CHECK_ENABLED =
         "alluxio.master.startup.block.integrity.check.enabled";
     public static final String MASTER_TIERED_STORE_GLOBAL_LEVEL0_ALIAS =

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3032,8 +3032,10 @@ public class DefaultFileSystemMaster extends CoreMaster
       try {
         Inode inode = inodePath.getInode();
         loadDirectChildren = inode.isDirectory()
-            && (context.getOptions().getLoadDescendantType() != LoadDescendantPType.NONE)
-            && !isRootUfsPath(inodePath);
+            && (context.getOptions().getLoadDescendantType() != LoadDescendantPType.NONE);
+        if (loadDirectChildren && mSkipRootUfsMetaSync) {
+          loadDirectChildren = !isRootUfsPath(inodePath);
+        }
       } catch (FileDoesNotExistException | InvalidPathException e) {
         // This should never happen.
         throw new RuntimeException(e);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support skipping root ufs meta sync.

### Why are the changes needed?

To reduce the impact of #16010

### Side effect of this feature

If there is something wrote to the root ufs directory not through Alluxio, AlluxioMaster cann't sync it. For example, writing to the under hdfs directory directly.

### Does this PR introduce any user facing changes?

No
