### PR TITLE
Fix journal shutdown deadlock

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -104,7 +104,8 @@ public class JournalStateMachine extends BaseStateMachine {
   @GuardedBy("this")
   private boolean mClosed = false;
 
-  private Lock mGroupLock = new ReentrantLock();
+  private final Lock mGroupLock = new ReentrantLock();
+  @GuardedBy("mGroupLock")
   private boolean mServerClosing = false;
 
   private volatile long mLastAppliedCommitIndex = -1;

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -817,10 +817,13 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     if (mRaftJournalWriter != null) {
       mRaftJournalWriter.close();
     }
+    mStateMachine.setServerClosing();
     try {
       mServer.close();
     } catch (IOException e) {
       throw new RuntimeException("Failed to shut down Raft server", e);
+    } finally {
+      mStateMachine.afterServerClosing();
     }
     LOG.info("Journal shutdown complete");
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

TakeSnapshot in JournalStateMachine calls a Ratis function that needs to acquire a lock in the RaftServerProxy.

When the raft server is shutting down it takes the lock in RaftServerProxy then waits for the state machine thread thread to finish while holding this lock. This causes a deadlock.

This PR fixes this by ensuring takeSnapshot will not take this lock once shutdown has started.

### Does this PR introduce any user facing changes?

No
