### PR TITLE
Merge journals & flush journals before lock release

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2851,6 +2851,24 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_MERGE_JOURNAL_CONTEXT_NUM_ENTRIES_LOGGING_THRESHOLD =
+      intBuilder(Name.MASTER_MERGE_JOURNAL_CONTEXT_NUM_ENTRIES_LOGGING_THRESHOLD)
+          .setDefaultValue(10000)
+          .setDescription("The logging threshold of number of journal entries which are held "
+              + "in a merge journal context. This log may help debug memory exhaustion issues.")
+          .build();
+
+  public static final PropertyKey MASTER_RECURSIVE_OPERATION_JOURNAL_FORCE_FLUSH_MAX_ENTRIES =
+      intBuilder(Name.MASTER_RECURSIVE_OPERATION_JOURNAL_FORCE_FLUSH_MAX_ENTRIES)
+          .setDefaultValue(100)
+          .setDescription("The threshold of the number of completed single operations in a "
+              + "recursive file system operation, e.g. delete file/set file attributes "
+              + "to trigger a force journal flush. Increasing the threshold decreases the "
+              + "possibility to see partial state of a recurisive operation on a standby master "
+              + "but increases the memory consumption as alluxio holds more journal entries "
+              + "in memory. This config is only available when "
+              + Name.MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS + "is enabled.")
+          .build();
   public static final PropertyKey MASTER_PERIODIC_BLOCK_INTEGRITY_CHECK_REPAIR =
       booleanBuilder(Name.MASTER_PERIODIC_BLOCK_INTEGRITY_CHECK_REPAIR)
           .setDefaultValue(true)
@@ -3458,6 +3476,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDescription("Size of fs operation retry cache.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS =
+      booleanBuilder(Name.MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS)
+          .setDefaultValue(false)
+          .setDescription("If enabled, the file system master inode related journals"
+              + "will be merged and submitted BEFORE the inode path lock is released.")
           .build();
 
   //
@@ -7179,6 +7203,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.persistence.blacklist";
     public static final String MASTER_LOG_CONFIG_REPORT_HEARTBEAT_INTERVAL =
         "alluxio.master.log.config.report.heartbeat.interval";
+    public static final String MASTER_MERGE_JOURNAL_CONTEXT_NUM_ENTRIES_LOGGING_THRESHOLD =
+        "alluxio.master.merge.journal.context.num.entries.logging.threshold";
+    public static final String MASTER_RECURSIVE_OPERATION_JOURNAL_FORCE_FLUSH_MAX_ENTRIES =
+        "alluxio.master.recursive.operation.journal.force.flush.max.entries";
     public static final String MASTER_PERIODIC_BLOCK_INTEGRITY_CHECK_REPAIR =
         "alluxio.master.periodic.block.integrity.check.repair";
     public static final String MASTER_PERIODIC_BLOCK_INTEGRITY_CHECK_INTERVAL =
@@ -7298,6 +7326,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.filesystem.operation.retry.cache.enabled";
     public static final String MASTER_FILE_SYSTEM_OPERATION_RETRY_CACHE_SIZE =
         "alluxio.master.filesystem.operation.retry.cache.size";
+    public static final String MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS =
+        "alluxio.master.filesystem.commit.journals.before.release.inode.path.lock";
 
     //
     // Secondary master related properties

--- a/core/server/common/src/main/java/alluxio/master/journal/FileSystemMergeJournalContext.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/FileSystemMergeJournalContext.java
@@ -1,0 +1,113 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.journal;
+
+import alluxio.Constants;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.status.UnavailableException;
+import alluxio.proto.journal.Journal.JournalEntry;
+import alluxio.util.logging.SamplingLogger;
+
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Context for merging journal entries together for a wrapped journal context.
+ *
+ * This is used so that we can combine several journal entries into one using a merge
+ * function. This helps us resolve the inconsistency between primary and standby and
+ * decrease the chance for a standby to see intermediate state of a file system operation.
+ */
+@NotThreadSafe
+public final class FileSystemMergeJournalContext implements JournalContext {
+  // It will log a warning if the number of buffered journal entries exceed 100
+  private static final int MAX_LOGGING_ENTRIES
+      = Configuration.getInt(
+          PropertyKey.MASTER_MERGE_JOURNAL_CONTEXT_NUM_ENTRIES_LOGGING_THRESHOLD);
+
+  private static final Logger SAMPLING_LOG = new SamplingLogger(
+      LoggerFactory.getLogger(FileSystemMergeJournalContext.class), 30L * Constants.SECOND_MS);
+
+  private final JournalContext mJournalContext;
+  private final JournalEntryMerger mJournalEntryMerger;
+
+  /**
+   * Constructs a {@link FileSystemMergeJournalContext}.
+   * @param journalContext the journal context to wrap
+   * @param journalEntryMerger the merger which merges multiple journal entries into one
+   */
+  public FileSystemMergeJournalContext(JournalContext journalContext,
+                             JournalEntryMerger journalEntryMerger) {
+    Preconditions.checkNotNull(journalContext, "journalContext is null");
+    Preconditions.checkNotNull(journalEntryMerger, "mergeOperator is null");
+    mJournalContext = journalContext;
+    mJournalEntryMerger = journalEntryMerger;
+  }
+
+  /**
+   * Adds the new journal entry into the journal entry merger.
+   * If the size of the outstanding journal entries are bigger than the threshold,
+   * we will flush them immediately into the async journal writer.
+   * This is used to prevent a recursive file system operation adding
+   * too many journal entries without being flushed and taking huge memory.
+   * Though it might create inconsistency between primary and standby if
+   * the primary crashes between two flushes.
+   * Tune PropertyKey.MASTER_MERGE_JOURNAL_CONTEXT_MAX_ENTRIES to trade off
+   * @param entry the {@link JournalEntry} to append to the journal
+   */
+  @Override
+  public void append(JournalEntry entry) {
+    mJournalEntryMerger.add(entry);
+    List<JournalEntry> journalEntries = mJournalEntryMerger.getMergedJournalEntries();
+    if (journalEntries.size() >= MAX_LOGGING_ENTRIES) {
+      SAMPLING_LOG.warn("MergeJournalContext has " + journalEntries.size()
+          + " entries, over the limit of " + MAX_LOGGING_ENTRIES);
+    }
+  }
+
+  @Override
+  public void close() throws UnavailableException {
+    try {
+      appendMergedJournals();
+    } finally {
+      mJournalContext.close();
+    }
+  }
+
+  /**
+   * Merges all journals and then flushes them.
+   * The journal writer will commit these journals synchronously.
+   */
+  @Override
+  public void flush() throws UnavailableException {
+    // Skip flushing the journal if no journal entries to append
+    if (appendMergedJournals()) {
+      mJournalContext.flush();
+    }
+  }
+
+  private boolean appendMergedJournals() {
+    List<JournalEntry> journalEntries = mJournalEntryMerger.getMergedJournalEntries();
+    if (journalEntries.size() == 0) {
+      return false;
+    }
+
+    journalEntries.forEach(mJournalContext::append);
+    mJournalEntryMerger.clear();
+    return true;
+  }
+}

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalContext.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalContext.java
@@ -26,6 +26,13 @@ public interface JournalContext extends Closeable, Supplier<JournalContext> {
    */
   void append(JournalEntry entry);
 
+  /**
+   * Flushes all the entries appended by the journal context so far and commits them.
+   * This method can be called multiple times within the life cycle of the
+   * journal context
+   */
+  void flush() throws UnavailableException;
+
   @Override
   default JournalContext get() {
     return this;

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalEntryMerger.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalEntryMerger.java
@@ -1,0 +1,39 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.journal;
+
+import alluxio.proto.journal.Journal;
+
+import java.util.List;
+
+/**
+ * The interface for a journal entry merge which merges multiple inode journals on the
+ * same inode object into one.
+ */
+public interface JournalEntryMerger {
+  /**
+   * Adds a new journal entry.
+   * @param entry the new journal entry to add
+   */
+  void add(Journal.JournalEntry entry);
+
+  /**
+   * Returns a list of journal entries which have been merged.
+   * @return the merged journal entries
+   */
+  List<Journal.JournalEntry> getMergedJournalEntries();
+
+  /**
+   * Clears the existing journal entries.
+   */
+  void clear();
+}

--- a/core/server/common/src/main/java/alluxio/master/journal/MasterJournalContext.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/MasterJournalContext.java
@@ -97,6 +97,11 @@ public final class MasterJournalContext implements JournalContext {
   }
 
   @Override
+  public void flush() throws UnavailableException {
+    waitForJournalFlush();
+  }
+
+  @Override
   public void close() throws UnavailableException {
     waitForJournalFlush();
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/MergeJournalContext.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/MergeJournalContext.java
@@ -94,13 +94,18 @@ public final class MergeJournalContext implements JournalContext {
   }
 
   @Override
-  public void close() throws UnavailableException {
+  public void flush() throws UnavailableException {
     if (mJournalEntries.size() > MAX_ENTRIES) {
       LOG.debug("MergeJournalContext has " + mJournalEntries.size()
           + " entries, over the limit of " + MAX_ENTRIES);
     }
     List<JournalEntry> mergedEntries = mMergeOperator.apply(mJournalEntries);
     mergedEntries.forEach(mJournalContext::append);
-    // Note that we do not close the enclosing journal context here
+    mJournalEntries.clear();
+  }
+
+  @Override
+  public void close() throws UnavailableException {
+    flush();
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/NoopJournalContext.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/NoopJournalContext.java
@@ -11,6 +11,7 @@
 
 package alluxio.master.journal;
 
+import alluxio.exception.status.UnavailableException;
 import alluxio.proto.journal.Journal.JournalEntry;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -29,6 +30,9 @@ public final class NoopJournalContext implements JournalContext {
 
   @Override
   public void append(JournalEntry entry) {}
+
+  @Override
+  public void flush() throws UnavailableException {}
 
   @Override
   public void close() {}

--- a/core/server/common/src/main/java/alluxio/master/journal/StateChangeJournalContext.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/StateChangeJournalContext.java
@@ -45,6 +45,11 @@ public final class StateChangeJournalContext implements JournalContext {
   }
 
   @Override
+  public void flush() throws UnavailableException {
+    mJournalContext.flush();
+  }
+
+  @Override
   public void close() throws UnavailableException {
     try {
       mJournalContext.close();

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemJournalEntryMerger.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemJournalEntryMerger.java
@@ -1,0 +1,112 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file;
+
+import alluxio.master.file.meta.MutableInodeDirectory;
+import alluxio.master.file.meta.MutableInodeFile;
+import alluxio.master.journal.JournalEntryMerger;
+import alluxio.proto.journal.Journal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A file system journal entry merger which merges inode creation and inode update journals
+ * on the same inode object into one.
+ * This class is not thread-safe and should not be shared across threads.
+ */
+@NotThreadSafe
+public class FileSystemJournalEntryMerger implements JournalEntryMerger {
+  /** Persists merged journal entries. */
+  private final List<Journal.JournalEntry> mJournalEntries = new ArrayList<>();
+  /** A map whose key is the inode id and value is the journal index in the mJournalEntries list.*/
+  private final Map<Long, Integer> mEntriesMap = new HashMap<>();
+
+  /**
+   * Adds a new journal entry and merges it on the fly.
+   * @param entry the new journal entry to add
+   */
+  @Override
+  public void add(Journal.JournalEntry entry) {
+    if (entry.hasInodeFile() || entry.hasInodeDirectory()) {
+      mJournalEntries.add(entry);
+      mEntriesMap.put(getInodeId(entry), mJournalEntries.size() - 1);
+    }
+    else if (
+        entry.hasUpdateInode() || entry.hasUpdateInodeFile() || entry.hasUpdateInodeDirectory()
+    ) {
+      if (!mEntriesMap.containsKey(getInodeId(entry))) {
+        mJournalEntries.add(entry);
+        return;
+      }
+      int index = mEntriesMap.get(getInodeId(entry));
+      Journal.JournalEntry existingEntry = mJournalEntries.get(index);
+      if (existingEntry.hasInodeFile()) {
+        MutableInodeFile inodeFile =
+            MutableInodeFile.fromJournalEntry(existingEntry.getInodeFile());
+        if (entry.hasUpdateInode()) {
+          inodeFile.updateFromEntry(entry.getUpdateInode());
+        } else if (entry.hasUpdateInodeFile()) {
+          inodeFile.updateFromEntry(entry.getUpdateInodeFile());
+        }
+        mJournalEntries.set(index, inodeFile.toJournalEntry());
+      }
+      if (existingEntry.hasInodeDirectory()) {
+        MutableInodeDirectory inodeDirectory =
+            MutableInodeDirectory.fromJournalEntry(existingEntry.getInodeDirectory());
+        if (entry.hasUpdateInode()) {
+          inodeDirectory.updateFromEntry(entry.getUpdateInode());
+        } else if (entry.hasUpdateInodeDirectory()) {
+          inodeDirectory.updateFromEntry(entry.getUpdateInodeDirectory());
+        }
+        mJournalEntries.set(index, inodeDirectory.toJournalEntry());
+      }
+    } else {
+      mJournalEntries.add(entry);
+    }
+  }
+
+  @Override
+  public List<Journal.JournalEntry> getMergedJournalEntries() {
+    return Collections.unmodifiableList(mJournalEntries);
+  }
+
+  @Override
+  public void clear() {
+    mEntriesMap.clear();
+    mJournalEntries.clear();
+  }
+
+  private long getInodeId(Journal.JournalEntry entry) {
+    if (entry.hasInodeDirectory()) {
+      return entry.getInodeDirectory().getId();
+    }
+    if (entry.hasInodeFile()) {
+      return entry.getInodeFile().getId();
+    }
+    if (entry.hasUpdateInode()) {
+      return entry.getUpdateInode().getId();
+    }
+    if (entry.hasUpdateInodeFile()) {
+      return entry.getUpdateInodeFile().getId();
+    }
+    if (entry.hasUpdateInodeDirectory()) {
+      return entry.getUpdateInodeDirectory().getId();
+    }
+    throw new RuntimeException("Unsupported JournalEntry type. The following entries are supported:"
+        + "InodeDirectory/InodeFile/UpdateInode/UpdateInodeFile/UpdateInodeDirectory");
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -51,7 +51,9 @@ import alluxio.master.file.meta.MutableInodeFile;
 import alluxio.master.file.meta.UfsAbsentPathCache;
 import alluxio.master.file.meta.UfsSyncPathCache;
 import alluxio.master.file.meta.UfsSyncUtils;
+import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.MergeJournalContext;
+import alluxio.master.journal.NoopJournalContext;
 import alluxio.master.metastore.ReadOnlyInodeStore;
 import alluxio.proto.journal.File;
 import alluxio.proto.journal.Journal;
@@ -176,6 +178,11 @@ public class InodeSyncStream {
 
   /** The sync options on the RPC.  */
   private final FileSystemMasterCommonPOptions mSyncOptions;
+
+  /** To determine if we should use the MergeJournalContext to merge journals. */
+  private static final boolean USE_FILE_SYSTEM_MERGE_JOURNAL_CONTEXT = Configuration.getBoolean(
+      PropertyKey.MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS
+  );
 
   /**
    * Whether the caller is {@link FileSystemMaster#getFileInfo(AlluxioURI, GetStatusContext)}.
@@ -309,7 +316,8 @@ public class InodeSyncStream {
       return SyncStatus.NOT_NEEDED;
     }
     Instant startTime = Instant.now();
-    try (LockedInodePath path = mInodeTree.lockInodePath(mRootScheme)) {
+    try (LockedInodePath path =
+             mInodeTree.lockInodePath(mRootScheme, mRpcContext.getJournalContext())) {
       if (mAuditContext != null && mAuditContextSrcInodeFunc != null) {
         mAuditContext.setSrcInode(mAuditContextSrcInodeFunc.apply(path));
       }
@@ -500,7 +508,8 @@ public class InodeSyncStream {
     if (!scheme.shouldSync() && !mForceSync) {
       return false;
     }
-    try (LockedInodePath inodePath = mInodeTree.tryLockInodePath(scheme)) {
+    try (LockedInodePath inodePath =
+             mInodeTree.tryLockInodePath(scheme, mRpcContext.getJournalContext())) {
       if (Thread.currentThread().isInterrupted()) {
         LOG.warn("Thread syncing {} was interrupted before completion", inodePath.getUri());
         return false;
@@ -984,12 +993,17 @@ public class InodeSyncStream {
     }
 
     try (LockedInodePath writeLockedPath = inodePath.lockFinalEdgeWrite();
-         MergeJournalContext merger = new MergeJournalContext(rpcContext.getJournalContext(),
+         JournalContext merger = USE_FILE_SYSTEM_MERGE_JOURNAL_CONTEXT
+             ? NoopJournalContext.INSTANCE
+             : new MergeJournalContext(rpcContext.getJournalContext(),
              writeLockedPath.getUri(),
-             InodeSyncStream::mergeCreateComplete)) {
+             InodeSyncStream::mergeCreateComplete)
+    ) {
       // We do not want to close this wrapRpcContext because it uses elements from another context
-      RpcContext wrapRpcContext = new RpcContext(
-          rpcContext.getBlockDeletionContext(), merger, rpcContext.getOperationContext());
+      RpcContext wrapRpcContext = USE_FILE_SYSTEM_MERGE_JOURNAL_CONTEXT
+          ? rpcContext
+          : new RpcContext(
+              rpcContext.getBlockDeletionContext(), merger, rpcContext.getOperationContext());
       fsMaster.createFileInternal(wrapRpcContext, writeLockedPath, createFileContext);
       CompleteFileContext completeContext =
           CompleteFileContext.mergeFrom(CompleteFilePOptions.newBuilder().setUfsLength(ufsLength))

--- a/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
@@ -28,6 +28,7 @@ import alluxio.master.file.meta.LockedInodePath;
 import alluxio.master.file.meta.TtlBucket;
 import alluxio.master.file.meta.TtlBucketList;
 import alluxio.master.journal.JournalContext;
+import alluxio.master.journal.NoopJournalContext;
 import alluxio.proto.journal.File.UpdateInodeEntry;
 
 import org.slf4j.Logger;
@@ -67,7 +68,9 @@ final class InodeTtlChecker implements HeartbeatExecutor {
         }
         AlluxioURI path = null;
         try (LockedInodePath inodePath =
-            mInodeTree.lockFullInodePath(inode.getId(), LockPattern.READ)) {
+            mInodeTree.lockFullInodePath(
+                inode.getId(), LockPattern.READ, NoopJournalContext.INSTANCE)
+        ) {
           path = inodePath.getUri();
         } catch (FileDoesNotExistException e) {
           // The inode has already been deleted, nothing needs to be done.

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -459,6 +459,12 @@ public class LockedInodePath implements Closeable {
    *
    * On return, all existing inodes in the path are added to mExistingInodes and the inodes are
    * locked according to {@link LockPattern}.
+   *
+   * Journals are not flushed in this method because:
+   * 1. When a LockedInodePath is created, it will be traversed first before any journal is written
+   * 2. The only use cases that call this method independently are in metadata sync
+   * {@link alluxio.master.file.InodeSyncStream}. Where traverse() is called right before the
+   * lock is released, where the journals will be flushed anyway.
    */
   public void traverse() throws InvalidPathException {
     // This locks the root edge and inode.

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -13,10 +13,14 @@ package alluxio.master.file.meta;
 
 import alluxio.AlluxioURI;
 import alluxio.concurrent.LockMode;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
+import alluxio.exception.status.UnavailableException;
 import alluxio.master.file.meta.InodeTree.LockPattern;
+import alluxio.master.journal.JournalContext;
 import alluxio.master.metastore.ReadOnlyInodeStore;
 import alluxio.resource.AlluxioResourceLeakDetectorFactory;
 import alluxio.util.io.PathUtils;
@@ -80,6 +84,53 @@ public class LockedInodePath implements Closeable {
   /** Tracker used for logging leaked resources. */
   @Nullable
   private final ResourceLeakTracker<LockedInodePath> mTracker;
+  /** To determine if we should flush the journals when lock is released or scope reduced. */
+  private final boolean mMergeInodeJournals = Configuration.getBoolean(
+      PropertyKey.MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS
+  );
+
+  /**
+   * Keeps a reference of JournalContext and flushes it before the lock is released.
+   * This is used to prevent inconsistency between primary and standby.
+   * A typical write operation in FileSystem looks like:
+   * <blockquote><pre>
+   * try (createJournalContext()) {
+   *   try (lockInodePath(uri)) {
+   *     // File System Operations
+   *     // ...
+   *   }
+   * }
+   * </pre></blockquote>
+   * *
+   * Because the inode path lock is released ahead of the close of the journal context,
+   * other requests can do other file system operations on the inode path we locked
+   * before the journals are actually flushed and committed.
+   * If the primary master crashes before the journals are flushed,
+   * the primary will be in an irreversible stale state because both the journals and metadata
+   * are corrupted.
+   *
+   * We keep the journal context instance in the LockedInodePath to mitigate the issue,
+   * by forcing to flush journals before the lock is released.
+   *
+   * This also helps keep the ordering of the committed journals
+   * if {@link alluxio.master.journal.FileSystemMergeJournalContext} is used because
+   * in its implement, journals will not be queued until the context is closed or the flush method
+   * is called. Given the LockedInodePath is closed ahead of the FileSystemMergeJournalContext,
+   * another request can potentially quickly do a file system operation on the same file
+   * and commits its journals, before the current thread commits its journal, which
+   * resulted in the disordering of the journals. Flushing journals before closing the
+   * LockedInodePath object solves this issue.
+   *
+   * Note that this still doesn't solve the inconsistency between primary and standby
+   * if the primary crashes when it has been doing a file system operation but hasn't committed
+   * journals to standby.
+   *
+   * When MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS is enabled, releasing inode tree locks
+   * will flush the entire journal context for the operation. Hence whenever a lock is released,
+   * the operation must be sure that it has made all necessary updates to
+   * any journal modifications that should be visible atomically.
+   */
+  private final JournalContext mJournalContext;
 
   /**
    * Creates a new locked inode path.
@@ -90,10 +141,11 @@ public class LockedInodePath implements Closeable {
    * @param root the root inode
    * @param lockPattern the pattern to lock in
    * @param tryLock whether or not use {@link Lock#tryLock()} or {@link Lock#lock()}
+   * @param journalContext the journal context to flush when the lock is released
    */
   public LockedInodePath(AlluxioURI uri, ReadOnlyInodeStore inodeStore,
       InodeLockManager inodeLockManager, InodeDirectory root, LockPattern lockPattern,
-      boolean tryLock)
+      boolean tryLock, JournalContext journalContext)
       throws InvalidPathException {
     mUri = uri;
     mPathComponents = PathUtils.getPathComponents(uri.getPath());
@@ -103,6 +155,7 @@ public class LockedInodePath implements Closeable {
     mUseTryLock = tryLock;
     mLockList = new SimpleInodeLockList(inodeLockManager, mUseTryLock);
     mTracker = DETECTOR.track(this);
+    mJournalContext = journalContext;
   }
 
   /**
@@ -124,6 +177,10 @@ public class LockedInodePath implements Closeable {
     mRoot = path.mLockList.get(0);
     mUseTryLock = tryLock;
     mTracker = DETECTOR.track(this);
+    // LockedInodePath is not thread safe and should not be shared across threads.
+    // So the new created LockInodePath instance must be on the same thread with
+    // the original one and hence they will use the same JournalContext.
+    mJournalContext = path.mJournalContext;
   }
 
   /**
@@ -259,6 +316,8 @@ public class LockedInodePath implements Closeable {
   public void removeLastInode() {
     Preconditions.checkState(fullPathExists());
 
+    maybeFlushJournals();
+
     mLockList.unlockLastInode();
   }
 
@@ -273,6 +332,10 @@ public class LockedInodePath implements Closeable {
     Preconditions.checkState(!fullPathExists());
     Preconditions.checkState(inode.getName().equals(mPathComponents[mLockList.numInodes()]));
 
+    // We need to flush the pending journals into the writer
+    // before the lock scope is reduced.
+    maybeFlushJournals();
+
     int nextInodeIndex = mLockList.numInodes() + 1;
     if (nextInodeIndex < mPathComponents.length) {
       mLockList.pushWriteLockedEdge(inode, mPathComponents[nextInodeIndex]);
@@ -285,6 +348,7 @@ public class LockedInodePath implements Closeable {
    * Downgrades all locks in this list to read locks.
    */
   public void downgradeToRead() {
+    maybeFlushJournals();
     mLockList.downgradeToReadLocks();
     mLockPattern = LockPattern.READ;
   }
@@ -472,6 +536,7 @@ public class LockedInodePath implements Closeable {
 
   @Override
   public void close() {
+    maybeFlushJournals();
     if (mTracker != null) {
       mTracker.close(this);
     }
@@ -481,5 +546,15 @@ public class LockedInodePath implements Closeable {
   @Override
   public String toString() {
     return mUri.toString();
+  }
+
+  private void maybeFlushJournals() {
+    if (mMergeInodeJournals) {
+      try {
+        mJournalContext.flush();
+      } catch (UnavailableException e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/replication/ReplicationChecker.java
@@ -32,6 +32,7 @@ import alluxio.master.file.meta.InodeTree;
 import alluxio.master.file.meta.InodeTree.LockPattern;
 import alluxio.master.file.meta.LockedInodePath;
 import alluxio.master.file.meta.PersistenceState;
+import alluxio.master.journal.NoopJournalContext;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.logging.SamplingLogger;
@@ -255,7 +256,9 @@ public final class ReplicationChecker implements HeartbeatExecutor {
       if (Thread.interrupted()) {
         throw new InterruptedException("ReplicationChecker interrupted.");
       }
-      try (LockedInodePath inodePath = mInodeTree.lockFullInodePath(inodeId, LockPattern.READ)) {
+      try (LockedInodePath inodePath =
+               mInodeTree.lockFullInodePath(inodeId, LockPattern.READ, NoopJournalContext.INSTANCE)
+      ) {
         InodeFile file = inodePath.getInodeFile();
         for (long blockId : file.getBlockIds()) {
           BlockInfo blockInfo = null;
@@ -313,7 +316,9 @@ public final class ReplicationChecker implements HeartbeatExecutor {
       // TODO(binfan): calling lockFullInodePath locks the entire path from root to the target
       // file and may increase lock contention in this tree. Investigate if we could avoid
       // locking the entire path but just the inode file since this access is read-only.
-      try (LockedInodePath inodePath = mInodeTree.lockFullInodePath(inodeId, LockPattern.READ)) {
+      try (LockedInodePath inodePath = mInodeTree.lockFullInodePath(
+          inodeId, LockPattern.READ, NoopJournalContext.INSTANCE)
+      ) {
         InodeFile file = inodePath.getInodeFile();
         for (long blockId : file.getBlockIds()) {
           BlockInfo blockInfo = null;

--- a/core/server/master/src/test/java/alluxio/master/file/AccessTimeUpdaterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/AccessTimeUpdaterTest.java
@@ -112,7 +112,11 @@ public final class AccessTimeUpdaterTest {
   private void createInode(String path, CreateFileContext context)
       throws Exception {
     try (LockedInodePath inodePath =
-             mInodeTree.lockInodePath(new AlluxioURI(path), InodeTree.LockPattern.WRITE_EDGE)) {
+             mInodeTree.lockInodePath(
+                 new AlluxioURI(path),
+                 InodeTree.LockPattern.WRITE_EDGE, NoopJournalContext.INSTANCE
+             )
+    ) {
       List<Inode> result = mInodeTree.createPath(RpcContext.NOOP, inodePath, context);
       MutableInode<?> inode = mInodeStore.getMutable(result.get(result.size() - 1).getId()).get();
       mInodeStore.writeInode(inode);
@@ -131,7 +135,7 @@ public final class AccessTimeUpdaterTest {
     long accessTime = CommonUtils.getCurrentMs() + 100L;
     long inodeId;
     try (LockedInodePath lockedInodes = mInodeTree.lockFullInodePath(new AlluxioURI(path),
-        InodeTree.LockPattern.READ)) {
+        InodeTree.LockPattern.READ, journalContext)) {
       mAccessTimeUpdater.updateAccessTime(journalContext, lockedInodes.getInode(), accessTime);
       inodeId = lockedInodes.getInode().getId();
     }
@@ -161,7 +165,7 @@ public final class AccessTimeUpdaterTest {
     long accessTime = CommonUtils.getCurrentMs() + 100L;
     long inodeId;
     try (LockedInodePath lockedInodes = mInodeTree.lockFullInodePath(new AlluxioURI(path),
-        InodeTree.LockPattern.READ)) {
+        InodeTree.LockPattern.READ, journalContext)) {
       mAccessTimeUpdater.updateAccessTime(journalContext, lockedInodes.getInode(), accessTime);
       inodeId = lockedInodes.getInode().getId();
     }
@@ -199,7 +203,7 @@ public final class AccessTimeUpdaterTest {
     long accessTime = CommonUtils.getCurrentMs() + 100L;
     long inodeId;
     try (LockedInodePath lockedInodes = mInodeTree.lockFullInodePath(new AlluxioURI(path),
-        InodeTree.LockPattern.READ)) {
+        InodeTree.LockPattern.READ, journalContext)) {
       mAccessTimeUpdater.updateAccessTime(journalContext, lockedInodes.getInode(), accessTime);
       inodeId = lockedInodes.getInode().getId();
     }
@@ -214,7 +218,7 @@ public final class AccessTimeUpdaterTest {
 
     // update access time with a much later timestamp
     try (LockedInodePath lockedInodes = mInodeTree.lockFullInodePath(new AlluxioURI(path),
-        InodeTree.LockPattern.READ)) {
+        InodeTree.LockPattern.READ, journalContext)) {
       mAccessTimeUpdater.updateAccessTime(journalContext, lockedInodes.getInode(), newAccessTime);
       inodeId = lockedInodes.getInode().getId();
     }
@@ -243,7 +247,7 @@ public final class AccessTimeUpdaterTest {
     long accessTime = CommonUtils.getCurrentMs() + 100L;
     long inodeId;
     try (LockedInodePath lockedInodes = mInodeTree.lockFullInodePath(new AlluxioURI(path),
-        InodeTree.LockPattern.READ)) {
+        InodeTree.LockPattern.READ, journalContext)) {
       mAccessTimeUpdater.updateAccessTime(journalContext, lockedInodes.getInode(), accessTime);
       inodeId = lockedInodes.getInode().getId();
     }
@@ -260,7 +264,7 @@ public final class AccessTimeUpdaterTest {
 
     // update access time with a much later timestamp
     try (LockedInodePath lockedInodes = mInodeTree.lockFullInodePath(new AlluxioURI(path),
-        InodeTree.LockPattern.READ)) {
+        InodeTree.LockPattern.READ, journalContext)) {
       mAccessTimeUpdater.updateAccessTime(journalContext, lockedInodes.getInode(), newAccessTime);
       inodeId = lockedInodes.getInode().getId();
     }
@@ -297,7 +301,7 @@ public final class AccessTimeUpdaterTest {
     long accessTime = CommonUtils.getCurrentMs() + 100L;
     long inodeId;
     try (LockedInodePath lockedInodes = mInodeTree.lockFullInodePath(new AlluxioURI(path),
-        InodeTree.LockPattern.READ)) {
+        InodeTree.LockPattern.READ, journalContext)) {
       mAccessTimeUpdater.updateAccessTime(journalContext, lockedInodes.getInode(), accessTime);
       inodeId = lockedInodes.getInode().getId();
     }

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemJournalEntryMergerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemJournalEntryMergerTest.java
@@ -1,0 +1,112 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import alluxio.AlluxioURI;
+import alluxio.master.block.BlockId;
+import alluxio.master.file.meta.PersistenceState;
+import alluxio.proto.journal.File;
+import alluxio.proto.journal.Journal;
+
+import org.junit.Test;
+
+import java.util.List;
+
+public class FileSystemJournalEntryMergerTest {
+  /**
+   * Tests if the FileSystemJournalEntryMerger is able to merge inode creations and updates.
+   */
+  @Test
+  public void testFileSystemJournalEntryMerger() {
+    AlluxioURI uri = new AlluxioURI("/dir/test1");
+
+    FileSystemJournalEntryMerger merger = new FileSystemJournalEntryMerger();
+
+    merger.add(Journal.JournalEntry.newBuilder().setInodeFile(
+        File.InodeFileEntry.newBuilder().setId(
+                BlockId.createBlockId(1, BlockId.getMaxSequenceNumber())).setLength(2)
+            .setPersistenceState(PersistenceState.PERSISTED.name())
+            .setName("test1").setPath(uri.getPath()).build()).build());
+
+    merger.add(Journal.JournalEntry.newBuilder().setInodeFile(
+        File.InodeFileEntry.newBuilder().setId(
+                BlockId.createBlockId(2, BlockId.getMaxSequenceNumber())).setLength(3)
+            .setPersistenceState(PersistenceState.PERSISTED.name())
+            .setName("test2").build()).build());
+
+    merger.add(Journal.JournalEntry.newBuilder().setUpdateInode(
+        File.UpdateInodeEntry.newBuilder().setId(
+                BlockId.createBlockId(3, BlockId.getMaxSequenceNumber()))
+            .setName("test3_unchanged").build()).build());
+
+    merger.add(Journal.JournalEntry.newBuilder().setUpdateInode(
+        File.UpdateInodeEntry.newBuilder().setId(
+                BlockId.createBlockId(2, BlockId.getMaxSequenceNumber()))
+            .setName("test2_updated").build()).build());
+
+    merger.add(Journal.JournalEntry.newBuilder().setUpdateInodeFile(
+        File.UpdateInodeFileEntry.newBuilder().setId(
+                BlockId.createBlockId(1, BlockId.getMaxSequenceNumber()))
+            .setLength(200).build()).build());
+
+    merger.add(Journal.JournalEntry.newBuilder().setInodeDirectory(
+        File.InodeDirectoryEntry.newBuilder().setId(1).setParentId(0)
+            .setPersistenceState(PersistenceState.PERSISTED.name())
+            .setName("test_dir").setPath(uri.getPath()).build()).build());
+
+    merger.add(Journal.JournalEntry.newBuilder().setUpdateInodeDirectory(
+        File.UpdateInodeDirectoryEntry.newBuilder().setId(1)
+            .setDirectChildrenLoaded(true).build()).build());
+
+    merger.add(Journal.JournalEntry.newBuilder().setUpdateInode(
+        File.UpdateInodeEntry.newBuilder().setId(1).setName("test_dir_updated").build()).build());
+
+    merger.add(Journal.JournalEntry.newBuilder().setAddMountPoint(
+        File.AddMountPointEntry.newBuilder().setMountId(1).build()
+    ).build());
+
+    List<Journal.JournalEntry> entries = merger.getMergedJournalEntries();
+    Journal.JournalEntry entry = entries.get(0);
+    assertNotNull(entry.getInodeFile());
+    assertEquals(BlockId.createBlockId(1, BlockId.getMaxSequenceNumber()),
+        entry.getInodeFile().getId());
+    assertEquals(200, entry.getInodeFile().getLength());
+    assertEquals("test1", entry.getInodeFile().getName());
+
+    Journal.JournalEntry entry2 = entries.get(1);
+    assertNotNull(entry2.getInodeFile());
+    assertEquals(BlockId.createBlockId(2, BlockId.getMaxSequenceNumber()),
+        entry2.getInodeFile().getId());
+    assertEquals("test2_updated", entry2.getInodeFile().getName());
+
+    Journal.JournalEntry entry3 = entries.get(2);
+    assertNotNull(entry3.getUpdateInode());
+    assertEquals(BlockId.createBlockId(3, BlockId.getMaxSequenceNumber()),
+        entry3.getUpdateInode().getId());
+    assertEquals("test3_unchanged", entry3.getUpdateInode().getName());
+
+    Journal.JournalEntry entry4 = entries.get(3);
+    assertNotNull(entry4.getInodeDirectory());
+    assertEquals(1, entry4.getInodeDirectory().getId());
+    assertEquals("test_dir_updated", entry4.getInodeDirectory().getName());
+
+    Journal.JournalEntry entry5 = entries.get(4);
+    assertNotNull(entry5.getAddMountPoint());
+    assertEquals(1, entry5.getAddMountPoint().getMountId());
+
+    merger.clear();
+    assertEquals(0, merger.getMergedJournalEntries().size());
+  }
+}

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -69,7 +69,6 @@ import alluxio.master.file.contexts.SetAttributeContext;
 import alluxio.master.file.contexts.WorkerHeartbeatContext;
 import alluxio.master.file.meta.PersistenceState;
 import alluxio.master.journal.JournalContext;
-import alluxio.master.journal.JournalType;
 import alluxio.proto.journal.Journal;
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.Mode;
@@ -1764,23 +1763,23 @@ public final class FileSystemMasterTest extends FileSystemMasterTestBase {
 
   @Test
   public void RecursiveDeleteForceFlushJournals() throws Exception {
-    FileSystemMaster mFileSystemMasterWithSpy = spy(mFileSystemMaster);
+    FileSystemMaster fileSystemMasterWithSpy = spy(mFileSystemMaster);
     AtomicInteger flushCount = new AtomicInteger();
     AtomicInteger closeCount = new AtomicInteger();
-    when(mFileSystemMasterWithSpy.createJournalContext()).thenReturn(
+    when(fileSystemMasterWithSpy.createJournalContext()).thenReturn(
         new JournalContext() {
-          private int numLogs = 0;
+          private int mNumLogs = 0;
 
           @Override
           public void append(Journal.JournalEntry entry) {
-            numLogs++;
+            mNumLogs++;
           }
 
           @Override
           public void flush() throws UnavailableException {
-            if (numLogs != 0) {
+            if (mNumLogs != 0) {
               flushCount.incrementAndGet();
-              numLogs = 0;
+              mNumLogs = 0;
             }
           }
 
@@ -1797,7 +1796,7 @@ public final class FileSystemMasterTest extends FileSystemMasterTestBase {
     mountPersistedDirectories(ufsMount);
     loadPersistedDirectories(level);
     // delete top-level directory
-    mFileSystemMasterWithSpy.delete(new AlluxioURI(MOUNT_URI).join(DIR_TOP_LEVEL),
+    fileSystemMasterWithSpy.delete(new AlluxioURI(MOUNT_URI).join(DIR_TOP_LEVEL),
         DeleteContext.mergeFrom(DeletePOptions.newBuilder().setRecursive(true)
             .setAlluxioOnly(false).setUnchecked(false)));
     checkPersistedDirectoriesDeleted(level, ufsMount, Collections.EMPTY_LIST);

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import alluxio.AlluxioURI;
 import alluxio.AuthenticatedClientUserResource;
@@ -28,11 +30,13 @@ import alluxio.AuthenticatedUserRule;
 import alluxio.Constants;
 import alluxio.client.WriteType;
 import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.UnexpectedAlluxioException;
+import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.Command;
 import alluxio.grpc.CommandType;
 import alluxio.grpc.CreateDirectoryPOptions;
@@ -64,6 +68,9 @@ import alluxio.master.file.contexts.SetAclContext;
 import alluxio.master.file.contexts.SetAttributeContext;
 import alluxio.master.file.contexts.WorkerHeartbeatContext;
 import alluxio.master.file.meta.PersistenceState;
+import alluxio.master.journal.JournalContext;
+import alluxio.master.journal.JournalType;
+import alluxio.proto.journal.Journal;
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.Mode;
 import alluxio.util.FileSystemOptions;
@@ -78,9 +85,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.math.IntMath;
 import com.google.protobuf.ByteString;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,17 +102,44 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /**
  * Unit tests for {@link FileSystemMaster}.
  */
+@RunWith(Parameterized.class)
 public final class FileSystemMasterTest extends FileSystemMasterTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(FileSystemMasterTest.class);
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        {new ImmutableMap.Builder<PropertyKey, Object>()
+            .put(PropertyKey.MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS, false)
+            .build()},
+        {new ImmutableMap.Builder<PropertyKey, Object>()
+            .put(PropertyKey.MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS, true)
+            .put(PropertyKey.MASTER_RECURSIVE_OPERATION_JOURNAL_FORCE_FLUSH_MAX_ENTRIES, 0)
+            .build()},
+    });
+  }
+
+  @Parameterized.Parameter
+  public ImmutableMap<PropertyKey, Object> mConfigMap;
+
+  @Override
+  public void before() throws Exception {
+    for (Map.Entry<PropertyKey, Object> entry : mConfigMap.entrySet()) {
+      Configuration.set(entry.getKey(), entry.getValue());
+    }
+    super.before();
+  }
 
   @Test
   public void createPathWithWhiteSpaces() throws Exception {
@@ -919,7 +956,7 @@ public final class FileSystemMasterTest extends FileSystemMasterTestBase {
     mFileSystemMaster.setAttribute(NESTED_FILE_URI,
         SetAttributeContext.mergeFrom(SetAttributePOptions.newBuilder().setPinned(false)
             .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
-            .setTtl(1))));
+                .setTtl(1))));
     fileInfo = mFileSystemMaster.getFileInfo(NESTED_FILE_URI, GET_STATUS_CONTEXT);
     assertFalse(fileInfo.isPinned());
     assertEquals(1, fileInfo.getTtl());
@@ -927,7 +964,7 @@ public final class FileSystemMasterTest extends FileSystemMasterTestBase {
     mFileSystemMaster.setAttribute(NESTED_URI,
         SetAttributeContext.mergeFrom(SetAttributePOptions.newBuilder()
             .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
-            .setTtl(1))));
+                .setTtl(1))));
   }
 
   /**
@@ -1722,6 +1759,53 @@ public final class FileSystemMasterTest extends FileSystemMasterTestBase {
       } catch (AccessControlException e) {
         // ignored
       }
+    }
+  }
+
+  @Test
+  public void RecursiveDeleteForceFlushJournals() throws Exception {
+    FileSystemMaster mFileSystemMasterWithSpy = spy(mFileSystemMaster);
+    AtomicInteger flushCount = new AtomicInteger();
+    AtomicInteger closeCount = new AtomicInteger();
+    when(mFileSystemMasterWithSpy.createJournalContext()).thenReturn(
+        new JournalContext() {
+          private int numLogs = 0;
+
+          @Override
+          public void append(Journal.JournalEntry entry) {
+            numLogs++;
+          }
+
+          @Override
+          public void flush() throws UnavailableException {
+            if (numLogs != 0) {
+              flushCount.incrementAndGet();
+              numLogs = 0;
+            }
+          }
+
+          @Override
+          public void close() throws UnavailableException {
+            closeCount.incrementAndGet();
+          }
+        }
+    );
+
+    int level = 2;
+    int numInodes = 4 * IntMath.pow(DIR_WIDTH, level) - 3;
+    AlluxioURI ufsMount = createPersistedDirectories(level);
+    mountPersistedDirectories(ufsMount);
+    loadPersistedDirectories(level);
+    // delete top-level directory
+    mFileSystemMasterWithSpy.delete(new AlluxioURI(MOUNT_URI).join(DIR_TOP_LEVEL),
+        DeleteContext.mergeFrom(DeletePOptions.newBuilder().setRecursive(true)
+            .setAlluxioOnly(false).setUnchecked(false)));
+    checkPersistedDirectoriesDeleted(level, ufsMount, Collections.EMPTY_LIST);
+    assertEquals(1, closeCount.get());
+    if (Configuration.getBoolean(PropertyKey.MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS)) {
+      assertEquals(numInodes, flushCount.get());
+    } else {
+      assertEquals(0, flushCount.get());
     }
   }
 }

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckerTest.java
@@ -235,7 +235,9 @@ public final class PermissionCheckerTest {
   private static void createAndSetPermission(String path, CreateFileContext context)
       throws Exception {
     try (LockedInodePath inodePath =
-        sTree.lockInodePath(new AlluxioURI(path), LockPattern.WRITE_EDGE)) {
+        sTree.lockInodePath(
+            new AlluxioURI(path), LockPattern.WRITE_EDGE, NoopJournalContext.INSTANCE)
+    ) {
       List<Inode> result = sTree.createPath(RpcContext.NOOP, inodePath, context);
       MutableInode<?> inode = sInodeStore.getMutable(result.get(result.size() - 1).getId()).get();
       inode.setOwner(context.getOwner())
@@ -262,19 +264,19 @@ public final class PermissionCheckerTest {
   @Test
   public void createFileAndDirs() throws Exception {
     try (LockedInodePath inodePath = sTree.lockInodePath(new AlluxioURI(TEST_DIR_FILE_URI),
-        LockPattern.READ)) {
+        LockPattern.READ, NoopJournalContext.INSTANCE)) {
       verifyInodesList(TEST_DIR_FILE_URI.split("/"), inodePath.getInodeList());
     }
     try (LockedInodePath inodePath = sTree.lockInodePath(new AlluxioURI(TEST_FILE_URI),
-        LockPattern.READ)) {
+        LockPattern.READ, NoopJournalContext.INSTANCE)) {
       verifyInodesList(TEST_FILE_URI.split("/"), inodePath.getInodeList());
     }
     try (LockedInodePath inodePath = sTree.lockInodePath(new AlluxioURI(TEST_WEIRD_FILE_URI),
-        LockPattern.READ)) {
+        LockPattern.READ, NoopJournalContext.INSTANCE)) {
       verifyInodesList(TEST_WEIRD_FILE_URI.split("/"), inodePath.getInodeList());
     }
     try (LockedInodePath inodePath = sTree.lockInodePath(new AlluxioURI(TEST_NOT_EXIST_URI),
-        LockPattern.READ)) {
+        LockPattern.READ, NoopJournalContext.INSTANCE)) {
       verifyInodesList(new String[]{"", "testDir"}, inodePath.getInodeList());
     }
   }
@@ -395,7 +397,7 @@ public final class PermissionCheckerTest {
   public void invalidPath() throws Exception {
     mThrown.expect(InvalidPathException.class);
     try (LockedInodePath inodePath = sTree
-        .lockInodePath(new AlluxioURI(""), LockPattern.READ)) {
+        .lockInodePath(new AlluxioURI(""), LockPattern.READ, NoopJournalContext.INSTANCE)) {
       mPermissionChecker.checkPermission(Mode.Bits.WRITE, inodePath);
     }
   }
@@ -403,7 +405,9 @@ public final class PermissionCheckerTest {
   @Test
   public void getPermission() throws Exception {
     try (LockedInodePath path =
-             sTree.lockInodePath(new AlluxioURI(TEST_WEIRD_FILE_URI), LockPattern.READ)) {
+             sTree.lockInodePath(
+                 new AlluxioURI(TEST_WEIRD_FILE_URI), LockPattern.READ, NoopJournalContext.INSTANCE)
+    ) {
       // user is admin
       AuthenticatedClientUser.set(TEST_USER_ADMIN.getUser());
       Mode.Bits perm = mPermissionChecker.getPermission(path);
@@ -433,7 +437,7 @@ public final class PermissionCheckerTest {
       throws Exception {
     AuthenticatedClientUser.set(user.getUser());
     try (LockedInodePath inodePath = sTree
-        .lockInodePath(new AlluxioURI(path), LockPattern.READ)) {
+        .lockInodePath(new AlluxioURI(path), LockPattern.READ, NoopJournalContext.INSTANCE)) {
       mPermissionChecker.checkPermission(action, inodePath);
     }
   }
@@ -450,7 +454,7 @@ public final class PermissionCheckerTest {
       throws Exception {
     AuthenticatedClientUser.set(user.getUser());
     try (LockedInodePath inodePath = sTree
-        .lockInodePath(new AlluxioURI(path), LockPattern.READ)) {
+        .lockInodePath(new AlluxioURI(path), LockPattern.READ, NoopJournalContext.INSTANCE)) {
       mPermissionChecker.checkParentPermission(action, inodePath);
     }
   }

--- a/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -587,7 +587,8 @@ public final class InodeTreeTest {
     int fileCount = files.size();
     int remain = fileCount;
     for (AlluxioURI nxt : files) {
-      try (LockedInodePath inodePath = mTree.lockFullInodePath(nxt, LockPattern.READ)) {
+      try (LockedInodePath inodePath = mTree.lockFullInodePath(
+          nxt, LockPattern.READ, NoopJournalContext.INSTANCE)) {
         long parentId = inodePath.getInode().getParentId();
         Inode childInode = inodePath.getInode();
         Inode[] childInodes;
@@ -613,7 +614,8 @@ public final class InodeTreeTest {
     String prefix = "afile";
     AlluxioURI file = new AlluxioURI("/" + prefix);
     createPath(mTree, file, sNestedDirectoryContext);
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(file, LockPattern.READ)) {
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(
+        file, LockPattern.READ, NoopJournalContext.INSTANCE)) {
       long parentId = inodePath.getInode().getParentId();
       Inode[] childInodes;
       try (CloseableIterator<? extends Inode> fromIter = mInodeStore.getChildrenPrefix(parentId,
@@ -639,7 +641,8 @@ public final class InodeTreeTest {
     files.add(new AlluxioURI(nestedPath));
     // add a file that does not match the prefix
     createPath(mTree, new AlluxioURI("/cfile"), sNestedFileContext);
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(file, LockPattern.READ)) {
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(
+        file, LockPattern.READ, NoopJournalContext.INSTANCE)) {
       long parentId = inodePath.getInode().getParentId();
       Inode[] childInodes;
       try (CloseableIterator<? extends Inode> fromIter = mInodeStore.getChildrenPrefix(parentId,
@@ -659,7 +662,8 @@ public final class InodeTreeTest {
     String prefix = "afile";
     AlluxioURI file = new AlluxioURI("/" + prefix);
     createPath(mTree, file, sNestedDirectoryContext);
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(file, LockPattern.READ)) {
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(
+        file, LockPattern.READ, NoopJournalContext.INSTANCE)) {
       long parentId = inodePath.getInode().getParentId();
       Inode[] childInodes;
       try (CloseableIterator<? extends Inode> fromIter = mInodeStore.getChildrenPrefixFrom(parentId,
@@ -685,7 +689,8 @@ public final class InodeTreeTest {
     files.add(new AlluxioURI(nestedPath));
     // add a file that does not match the prefix
     createPath(mTree, new AlluxioURI("/cfile"), sNestedFileContext);
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(file, LockPattern.READ)) {
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(
+        file, LockPattern.READ, NoopJournalContext.INSTANCE)) {
       long parentId = inodePath.getInode().getParentId();
       Inode[] childInodes;
       // read from "bfile1" with prefix
@@ -754,7 +759,8 @@ public final class InodeTreeTest {
           remain++;
         }
         AlluxioURI nxt = new AlluxioURI(String.format("%s/%d", parent, j));
-        try (LockedInodePath inodePath = mTree.lockFullInodePath(nxt, LockPattern.READ)) {
+        try (LockedInodePath inodePath = mTree.lockFullInodePath(
+            nxt, LockPattern.READ, NoopJournalContext.INSTANCE)) {
           long parentId = inodePath.getInode().getParentId();
           Inode childInode = inodePath.getInode();
           Inode[] childInodes;
@@ -784,7 +790,8 @@ public final class InodeTreeTest {
     // test nesting
     long id;
     createPath(mTree, NESTED_URI, sNestedDirectoryContext);
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(NESTED_URI, LockPattern.READ)) {
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(
+        NESTED_URI, LockPattern.READ, NoopJournalContext.INSTANCE)) {
       assertEquals(NESTED_URI, mTree.getPath(inodePath.getInode()));
       id = inodePath.getInode().getId();
     }
@@ -800,7 +807,8 @@ public final class InodeTreeTest {
     long id;
     ArrayList<String> pathIds;
     createPath(mTree, NESTED_URI, sNestedDirectoryContext);
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(NESTED_URI, LockPattern.READ)) {
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(
+        NESTED_URI, LockPattern.READ, NoopJournalContext.INSTANCE)) {
       pathIds = inodePath.getInodeList().stream().map(Inode::getName).collect(
           Collectors.toCollection(ArrayList::new));
       assertEquals(pathIds, mTree.getPathInodeNames(inodePath.getInode()));

--- a/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/InodeTreeTest.java
@@ -232,7 +232,9 @@ public final class InodeTreeTest {
 
     // pin nested folder
     try (
-        LockedInodePath inodePath = mTree.lockFullInodePath(NESTED_URI, LockPattern.WRITE_INODE)) {
+        LockedInodePath inodePath = mTree.lockFullInodePath(
+            NESTED_URI, LockPattern.WRITE_INODE, NoopJournalContext.INSTANCE)
+    ) {
       mTree.setPinned(RpcContext.NOOP, inodePath, true, Collections.emptyList(), 0);
     }
 
@@ -493,7 +495,8 @@ public final class InodeTreeTest {
     mThrown.expectMessage(ExceptionMessage.INODE_DOES_NOT_EXIST.getMessage(1));
 
     assertFalse(mTree.inodeIdExists(1));
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(1, LockPattern.READ)) {
+    try (LockedInodePath inodePath =
+             mTree.lockFullInodePath(1, LockPattern.READ, NoopJournalContext.INSTANCE)) {
       // inode exists
     }
   }
@@ -512,7 +515,8 @@ public final class InodeTreeTest {
    */
   @Test
   public void getPath() throws Exception {
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(0, LockPattern.READ)) {
+    try (LockedInodePath inodePath =
+             mTree.lockFullInodePath(0, LockPattern.READ, NoopJournalContext.INSTANCE)) {
       Inode root = inodePath.getInode();
       // test root path
       assertEquals(new AlluxioURI("/"), mTree.getPath(root));
@@ -520,13 +524,16 @@ public final class InodeTreeTest {
 
     // test one level
     createPath(mTree, TEST_URI, sDirectoryContext);
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(TEST_URI, LockPattern.READ)) {
+    try (LockedInodePath inodePath =
+             mTree.lockFullInodePath(TEST_URI, LockPattern.READ, NoopJournalContext.INSTANCE)) {
       assertEquals(new AlluxioURI("/test"), mTree.getPath(inodePath.getInode()));
     }
 
     // test nesting
     createPath(mTree, NESTED_URI, sNestedDirectoryContext);
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(NESTED_URI, LockPattern.READ)) {
+    try (LockedInodePath inodePath = mTree.lockFullInodePath(
+        NESTED_URI, LockPattern.READ, NoopJournalContext.INSTANCE)
+    ) {
       assertEquals(new AlluxioURI("/nested/test"), mTree.getPath(inodePath.getInode()));
     }
   }
@@ -539,7 +546,8 @@ public final class InodeTreeTest {
     createPath(mTree, NESTED_FILE_URI, sNestedFileContext);
 
     // all inodes under root
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(0, LockPattern.WRITE_INODE)) {
+    try (LockedInodePath inodePath =
+             mTree.lockFullInodePath(0, LockPattern.WRITE_INODE, NoopJournalContext.INSTANCE)) {
       // /test, /nested, /nested/test, /nested/test/file
       assertEquals(4, mTree.getDescendants(inodePath).getInodePathList().size());
     }
@@ -553,7 +561,8 @@ public final class InodeTreeTest {
     createPath(mTree, NESTED_URI, sNestedDirectoryContext);
 
     // all inodes under root
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(0, LockPattern.WRITE_INODE)) {
+    try (LockedInodePath inodePath =
+             mTree.lockFullInodePath(0, LockPattern.WRITE_INODE, NoopJournalContext.INSTANCE)) {
       // /nested, /nested/test
       assertEquals(2, mTree.getDescendants(inodePath).getInodePathList().size());
 
@@ -575,7 +584,9 @@ public final class InodeTreeTest {
 
     // pin nested folder
     try (
-        LockedInodePath inodePath = mTree.lockFullInodePath(NESTED_URI, LockPattern.WRITE_INODE)) {
+        LockedInodePath inodePath = mTree.lockFullInodePath(
+            NESTED_URI, LockPattern.WRITE_INODE, NoopJournalContext.INSTANCE)
+    ) {
       mTree.setPinned(RpcContext.NOOP, inodePath, true, Collections.emptyList(), 0);
     }
     // nested file pinned
@@ -583,7 +594,9 @@ public final class InodeTreeTest {
 
     // unpin nested folder
     try (
-        LockedInodePath inodePath = mTree.lockFullInodePath(NESTED_URI, LockPattern.WRITE_INODE)) {
+        LockedInodePath inodePath = mTree.lockFullInodePath(
+            NESTED_URI, LockPattern.WRITE_INODE, NoopJournalContext.INSTANCE)
+    ) {
       mTree.setPinned(RpcContext.NOOP, inodePath, false, Collections.emptyList(), 0);
     }
     assertEquals(0, mTree.getPinIdSet().size());
@@ -623,7 +636,9 @@ public final class InodeTreeTest {
     // re-init the root since the tree was reset above
     mTree.getRoot();
     try (LockedInodePath inodePath =
-             mTree.lockFullInodePath(new AlluxioURI("/"), LockPattern.WRITE_INODE)) {
+             mTree.lockFullInodePath(
+                 new AlluxioURI("/"), LockPattern.WRITE_INODE, NoopJournalContext.INSTANCE)
+    ) {
       assertEquals(0, mTree.getDescendants(inodePath).getInodePathList().size());
       mTree.processJournalEntry(nested.toJournalEntry());
       verifyChildrenNames(mTree, inodePath, Sets.newHashSet("nested"));
@@ -657,7 +672,9 @@ public final class InodeTreeTest {
     // re-init the root since the tree was reset above
     mTree.getRoot();
     try (LockedInodePath inodePath =
-             mTree.lockFullInodePath(new AlluxioURI("/"), LockPattern.WRITE_INODE)) {
+             mTree.lockFullInodePath(
+                 new AlluxioURI("/"), LockPattern.WRITE_INODE, NoopJournalContext.INSTANCE)
+    ) {
       assertEquals(0, mTree.getDescendants(inodePath).getInodePathList().size());
       mTree.processJournalEntry(nested.toJournalEntry());
       mTree.processJournalEntry(test.toJournalEntry());
@@ -676,7 +693,8 @@ public final class InodeTreeTest {
 
   @Test
   public void getInodePathById() throws Exception {
-    try (LockedInodePath rootPath = mTree.lockFullInodePath(0, LockPattern.READ)) {
+    try (LockedInodePath rootPath
+             = mTree.lockFullInodePath(0, LockPattern.READ, NoopJournalContext.INSTANCE)) {
       assertEquals(0, rootPath.getInode().getId());
     }
 
@@ -684,7 +702,8 @@ public final class InodeTreeTest {
 
     for (Inode inode : created) {
       long id = inode.getId();
-      try (LockedInodePath inodePath = mTree.lockFullInodePath(id, LockPattern.READ)) {
+      try (LockedInodePath inodePath
+               = mTree.lockFullInodePath(id, LockPattern.READ, NoopJournalContext.INSTANCE)) {
         assertEquals(id, inodePath.getInode().getId());
       }
     }
@@ -693,7 +712,9 @@ public final class InodeTreeTest {
   @Test
   public void getInodePathByPath() throws Exception {
     try (LockedInodePath rootPath =
-        mTree.lockFullInodePath(new AlluxioURI("/"), LockPattern.READ)) {
+        mTree.lockFullInodePath(
+            new AlluxioURI("/"), LockPattern.READ, NoopJournalContext.INSTANCE)
+    ) {
       assertTrue(mTree.isRootId(rootPath.getInode().getId()));
     }
 
@@ -701,17 +722,20 @@ public final class InodeTreeTest {
     createPath(mTree, NESTED_FILE_URI, sNestedFileContext);
 
     AlluxioURI uri = new AlluxioURI("/nested");
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(uri, LockPattern.READ)) {
+    try (LockedInodePath inodePath =
+             mTree.lockFullInodePath(uri, LockPattern.READ, NoopJournalContext.INSTANCE)) {
       assertEquals(uri.getName(), inodePath.getInode().getName());
     }
 
     uri = NESTED_URI;
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(uri, LockPattern.READ)) {
+    try (LockedInodePath inodePath =
+             mTree.lockFullInodePath(uri, LockPattern.READ, NoopJournalContext.INSTANCE)) {
       assertEquals(uri.getName(), inodePath.getInode().getName());
     }
 
     uri = NESTED_FILE_URI;
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(uri, LockPattern.READ)) {
+    try (LockedInodePath inodePath =
+             mTree.lockFullInodePath(uri, LockPattern.READ, NoopJournalContext.INSTANCE)) {
       assertEquals(uri.getName(), inodePath.getInode().getName());
     }
   }
@@ -720,7 +744,8 @@ public final class InodeTreeTest {
   private List<Inode> createPath(InodeTree root, AlluxioURI path, CreatePathContext<?, ?> context)
       throws FileAlreadyExistsException, BlockInfoException, InvalidPathException, IOException,
       FileDoesNotExistException {
-    try (LockedInodePath inodePath = root.lockInodePath(path, LockPattern.WRITE_EDGE)) {
+    try (LockedInodePath inodePath =
+             root.lockInodePath(path, LockPattern.WRITE_EDGE, NoopJournalContext.INSTANCE)) {
       return root.createPath(RpcContext.NOOP, inodePath, context);
     }
   }
@@ -736,14 +761,16 @@ public final class InodeTreeTest {
 
   // Helper to get an inode by path. The inode is unlocked before returning.
   private MutableInode<?> getInodeByPath(AlluxioURI path) throws Exception {
-    try (LockedInodePath inodePath = mTree.lockFullInodePath(path, LockPattern.READ)) {
+    try (LockedInodePath inodePath =
+             mTree.lockFullInodePath(path, LockPattern.READ, NoopJournalContext.INSTANCE)) {
       return mInodeStore.getMutable(inodePath.getInode().getId()).get();
     }
   }
 
   // Helper to delete an inode by path.
   private static void deleteInodeByPath(InodeTree root, AlluxioURI path) throws Exception {
-    try (LockedInodePath inodePath = root.lockFullInodePath(path, LockPattern.WRITE_EDGE)) {
+    try (LockedInodePath inodePath
+             = root.lockFullInodePath(path, LockPattern.WRITE_EDGE, NoopJournalContext.INSTANCE)) {
       root.deleteInode(RpcContext.NOOP, inodePath, System.currentTimeMillis());
     }
   }

--- a/core/server/master/src/test/java/alluxio/master/file/replication/ReplicationCheckerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/replication/ReplicationCheckerTest.java
@@ -205,7 +205,9 @@ public final class ReplicationCheckerTest {
    */
   private long createBlockHelper(AlluxioURI path, CreatePathContext<?, ?> context,
       String pinLocation) throws Exception {
-    try (LockedInodePath inodePath = mInodeTree.lockInodePath(path, LockPattern.WRITE_EDGE)) {
+    try (LockedInodePath inodePath = mInodeTree.lockInodePath(
+        path, LockPattern.WRITE_EDGE, NoopJournalContext.INSTANCE)
+    ) {
       List<Inode> created = mInodeTree.createPath(RpcContext.NOOP, inodePath, context);
       if (!pinLocation.equals("")) {
         mInodeTree.setPinned(RpcContext.NOOP, inodePath, true, ImmutableList.of(pinLocation), 0);

--- a/core/server/master/src/test/java/alluxio/master/journal/JournalContextTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/JournalContextTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
@@ -31,6 +32,7 @@ import alluxio.master.StateLockOptions;
 import alluxio.master.block.BlockId;
 import alluxio.master.block.BlockMaster;
 import alluxio.master.block.BlockMasterFactory;
+import alluxio.master.file.FileSystemJournalEntryMerger;
 import alluxio.master.file.InodeSyncStream;
 import alluxio.master.file.meta.PersistenceState;
 import alluxio.master.metrics.MetricsMasterFactory;
@@ -306,5 +308,47 @@ public class JournalContextTest {
         entry4.getInodeFile().getId());
     assertEquals(200, entry4.getInodeFile().getLength());
     assertEquals("test1", entry4.getInodeFile().getName());
+  }
+
+  @Test
+  public void testFileSystemMergeJournalContext() throws Exception {
+    JournalContext journalContext = Mockito.mock(JournalContext.class);
+    List<Journal.JournalEntry> entries = new ArrayList<>();
+    doAnswer(invocationOnMock -> {
+      entries.add(invocationOnMock.getArgument(0));
+      return null;
+    }).when(journalContext).append(any(Journal.JournalEntry.class));
+
+    doNothing().when(journalContext).flush();
+    doNothing().when(journalContext).close();
+
+    JournalContext mergeContext = new FileSystemMergeJournalContext(journalContext,
+        new FileSystemJournalEntryMerger());
+
+    mergeContext.append(Journal.JournalEntry.newBuilder().getDefaultInstanceForType());
+    assertEquals(0, entries.size());
+
+    mergeContext.flush();
+    // Flush should flush all journals held by the JournalContext into the writer
+    assertEquals(1, entries.size());
+
+    // Test merge journal entries. Detailed test can be found in FileSystemJournalEntryMergerTest
+    mergeContext.append(Journal.JournalEntry.newBuilder().setInodeFile(
+        File.InodeFileEntry.newBuilder().setId(
+                BlockId.createBlockId(2, BlockId.getMaxSequenceNumber())).setLength(3)
+            .setPersistenceState(PersistenceState.PERSISTED.name())
+            .setName("test2").build()).build());
+
+    mergeContext.append(Journal.JournalEntry.newBuilder().setUpdateInode(
+        File.UpdateInodeEntry.newBuilder().setId(
+                BlockId.createBlockId(2, BlockId.getMaxSequenceNumber()))
+            .setName("test2_updated").build()).build());
+    mergeContext.flush();
+    assertEquals(2, entries.size());
+
+    mergeContext.append(Journal.JournalEntry.newBuilder().getDefaultInstanceForType());
+    mergeContext.close();
+    // Close should also flush all journals held by the JournalContext into the writer
+    assertEquals(3, entries.size());
   }
 }

--- a/microbench/src/main/java/alluxio/inode/InodeBenchBase.java
+++ b/microbench/src/main/java/alluxio/inode/InodeBenchBase.java
@@ -123,7 +123,9 @@ class InodeBenchBase {
   private void createPath(InodeTree root, AlluxioURI path)
       throws FileAlreadyExistsException, BlockInfoException, InvalidPathException, IOException,
       FileDoesNotExistException {
-    try (LockedInodePath inodePath = root.lockInodePath(path, InodeTree.LockPattern.WRITE_EDGE)) {
+    try (LockedInodePath inodePath = root.lockInodePath(
+        path, InodeTree.LockPattern.WRITE_EDGE, NoopJournalContext.INSTANCE)
+    ) {
       root.createPath(RpcContext.NOOP, inodePath, InodeBenchBase.DIRECTORY_CONTEXT);
     }
   }
@@ -146,7 +148,7 @@ class InodeBenchBase {
 
   Inode getFile(int depth, long nxtFileId) throws Exception {
     try (LockedInodePath path = mTree.lockFullInodePath(
-        getPath(0, depth, nxtFileId), InodeTree.LockPattern.READ)) {
+        getPath(0, depth, nxtFileId), InodeTree.LockPattern.READ, NoopJournalContext.INSTANCE)) {
       return path.getInode();
     }
   }
@@ -157,7 +159,8 @@ class InodeBenchBase {
 
   void listDir(int depth, Consumer<Inode> consumeFun) throws Exception {
     try (LockedInodePath path = mTree.lockInodePath(
-        new AlluxioURI(mBasePath.get(depth)), InodeTree.LockPattern.READ)) {
+        new AlluxioURI(mBasePath.get(depth)),
+        InodeTree.LockPattern.READ, NoopJournalContext.INSTANCE)) {
       mInodeStore.getChildren(path.getInode().asDirectory()).forEachRemaining(
           consumeFun);
     }

--- a/tests/src/test/java/alluxio/server/ft/FileSystemMasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/FileSystemMasterFaultToleranceIntegrationTest.java
@@ -38,15 +38,22 @@ import alluxio.testutils.IntegrationTestUtils;
 import alluxio.wire.FileInfo;
 import alluxio.wire.OperationId;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
 
+@RunWith(Parameterized.class)
 public final class FileSystemMasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
   private static final int CLUSTER_WAIT_TIMEOUT_MS = 120 * Constants.SECOND_MS;
   private static final String TEST_USER = "test";
@@ -60,6 +67,21 @@ public final class FileSystemMasterFaultToleranceIntegrationTest extends BaseInt
   public AuthenticatedUserRule mAuthenticatedUser =
       new AuthenticatedUserRule(TEST_USER, Configuration.global());
 
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        {new ImmutableMap.Builder<PropertyKey, Object>()
+            .put(PropertyKey.MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS, false)
+            .build()},
+        {new ImmutableMap.Builder<PropertyKey, Object>()
+            .put(PropertyKey.MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS, true)
+            .build()},
+    });
+  }
+
+  @Parameterized.Parameter
+  public ImmutableMap<PropertyKey, Object> mParameterizedConfigMap;
+
   @Before
   public final void before() throws Exception {
     mMultiMasterLocalAlluxioCluster = new MultiMasterLocalAlluxioCluster(2, 0);
@@ -70,12 +92,17 @@ public final class FileSystemMasterFaultToleranceIntegrationTest extends BaseInt
     Configuration.set(PropertyKey.NETWORK_CONNECTION_SERVER_SHUTDOWN_TIMEOUT, "30sec");
     Configuration.set(PropertyKey.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS, "0sec");
     Configuration.set(PropertyKey.SECURITY_LOGIN_USERNAME, TEST_USER);
+    Configuration.set(PropertyKey.MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS, false);
+    for (Map.Entry<PropertyKey, Object> entry : mParameterizedConfigMap.entrySet()) {
+      Configuration.set(entry.getKey(), entry.getValue());
+    }
     mMultiMasterLocalAlluxioCluster.start();
   }
 
   @After
   public final void after() throws Exception {
     mMultiMasterLocalAlluxioCluster.stop();
+    Configuration.reloadProperties();
   }
 
   @Test

--- a/tests/src/test/java/alluxio/server/ft/FileSystemMasterMergeJournalContextIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/FileSystemMasterMergeJournalContextIntegrationTest.java
@@ -1,0 +1,110 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.server.ft;
+
+import static org.junit.Assert.assertEquals;
+
+import alluxio.AlluxioURI;
+import alluxio.Constants;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.URIStatus;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.grpc.SetAttributePOptions;
+import alluxio.master.file.contexts.CreateDirectoryContext;
+import alluxio.master.file.contexts.CreateFileContext;
+import alluxio.master.file.contexts.ListStatusContext;
+import alluxio.master.journal.JournalType;
+import alluxio.multi.process.MultiProcessCluster;
+import alluxio.multi.process.PortCoordination;
+import alluxio.security.authorization.Mode;
+import alluxio.server.ft.journal.raft.EmbeddedJournalIntegrationTestBase;
+
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * A test class to test the file system master fault toleration when MergeJournalContext is used.
+ */
+public class FileSystemMasterMergeJournalContextIntegrationTest
+    extends EmbeddedJournalIntegrationTestBase {
+
+  private static final int GET_MASTER_TIMEOUT_MS = 1 * Constants.MINUTE_MS;
+  private static final int NUM_MASTERS = 3;
+  private static final int NUM_WORKERS = 0;
+
+  @Test
+  public void testForceFlush() throws Exception {
+    mCluster = MultiProcessCluster.newBuilder(PortCoordination.EMBEDDED_JOURNAL_FAILOVER)
+        .setClusterName("EmbeddedJournalFaultTolerance_failover")
+        .setNumMasters(NUM_MASTERS)
+        .setNumWorkers(NUM_WORKERS)
+        .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.EMBEDDED)
+        .addProperty(PropertyKey.MASTER_JOURNAL_FLUSH_TIMEOUT_MS, "5min")
+        .addProperty(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, "750ms")
+        .addProperty(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, "1500ms")
+        .build();
+    mCluster.start();
+
+    // Create paths for the test.
+    AlluxioURI testPath1 = new AlluxioURI("/testPath1");
+
+    SetAttributePOptions setAttributeContext =
+        SetAttributePOptions.newBuilder().setRecursive(true)
+            .setMode(new Mode((short) 0777).toProto()).build();
+    int mergeJournalContextMaxEntries =
+        Configuration.getInt(
+            PropertyKey.MASTER_RECURSIVE_OPERATION_JOURNAL_FORCE_FLUSH_MAX_ENTRIES);
+
+    // Run partition tolerance test on leading master.
+    {
+      // Acquire file-system-master of leading master.
+      FileSystem fileSystem = mCluster.getFileSystemClient();
+
+      fileSystem.createDirectory(testPath1, CreateDirectoryContext.defaults().getOptions().build());
+
+      // Create files to change attributes.
+      for (int i = 0; i < mergeJournalContextMaxEntries * 3; ++i) {
+        AlluxioURI path = new AlluxioURI("/testPath1/" + i);
+        fileSystem.createFile(path, CreateFileContext.defaults().getOptions().build()).close();
+      }
+
+      // Change the attribute recursively, this will trigger a InodeTree.getDescendants call.
+      fileSystem.setAttribute(testPath1, setAttributeContext);
+
+      List<URIStatus> fileInfo =
+          fileSystem.listStatus(testPath1, ListStatusContext.defaults().getOptions()
+          .build());
+      assertEquals(mergeJournalContextMaxEntries * 3, fileInfo.size());
+      fileInfo.forEach(
+          (it) -> assertEquals(0777, it.getMode())
+      );
+    }
+
+    mCluster.waitForAndKillPrimaryMaster(GET_MASTER_TIMEOUT_MS);
+    mCluster.getPrimaryMasterIndex(GET_MASTER_TIMEOUT_MS);
+    {
+      // Acquire file-system-master of leading master.
+      FileSystem fileSystem = mCluster.getFileSystemClient();
+
+      List<URIStatus> fileInfo =
+          fileSystem.listStatus(testPath1, ListStatusContext.defaults().getOptions()
+          .build());
+      assertEquals(mergeJournalContextMaxEntries * 3, fileInfo.size());
+      fileInfo.forEach(
+          (it) -> assertEquals(0777, it.getMode())
+      );
+    }
+    mCluster.notifySuccess();
+  }
+}

--- a/tests/src/test/java/alluxio/server/health/BlockMasterIntegrityIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/health/BlockMasterIntegrityIntegrationTest.java
@@ -107,8 +107,9 @@ public class BlockMasterIntegrityIntegrationTest {
     FileSystemMaster fsm =
         mCluster.getLocalAlluxioMaster().getMasterProcess().getMaster(FileSystemMaster.class);
     InodeTree tree = Whitebox.getInternalState(fsm, "mInodeTree");
-    LockedInodePath path = tree.lockInodePath(uri, LockPattern.WRITE_EDGE);
     RpcContext rpcContext = ((DefaultFileSystemMaster) fsm).createRpcContext();
+    LockedInodePath path
+        = tree.lockInodePath(uri, LockPattern.WRITE_EDGE, rpcContext.getJournalContext());
     ((DefaultFileSystemMaster) fsm).deleteInternal(
         rpcContext, path, DeleteContext.defaults(), false);
     path.close();


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. Created a new FileSystemMergeJournalContext to merge journals on a single inode object together before they get flushed.
2. Force flush journals before the locked inode path is closed.

### Why are the changes needed?

Today our current journal are applied different between primary and standby and this creates inconsistencies. The goal of this PR is to mitigate it.
Change 1 reduces the change on a standby master to see partial changes & intermediate metadata. 
Change 2 slightly reduces the race condition and ensures the ordering of journals after FileSystemMergeJournalContext is introduced. 

There will be a following PR to add locks on the standby master side.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  3. addition or removal of property keys
  4. webui
