### PR TITLE
Delete temporary files when uploading files to OBS fails

### DIFF
--- a/underfs/obs/src/main/java/alluxio/underfs/obs/OBSOutputStream.java
+++ b/underfs/obs/src/main/java/alluxio/underfs/obs/OBSOutputStream.java
@@ -173,10 +173,15 @@ public final class OBSOutputStream extends OutputStream {
         objMeta.setContentMd5(new String(Base64.encodeBase64(hashBytes)));
       }
       mObsClient.putObject(mBucketName, mKey, in, objMeta);
-      mFile.delete();
     } catch (ObsException e) {
       LOG.error("Failed to upload {}. Temporary file @ {}", mKey, mFile.getPath());
       throw new IOException(e);
+    } finally {
+      // Delete the temporary file on the local machine if the GCS client completed the
+      // upload or if the upload failed.
+      if (!mFile.delete()) {
+        LOG.error("Failed to delete temporary file @ {}", mFile.getPath());
+      }
     }
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

delete temporary files when uploading files to OBS fails.

### Why are the changes needed?

Currently does not delete temporary files when obs delete fails.

### Does this PR introduce any user facing changes?

No user facing changes.
