### PR TITLE
Remove unnecessary exception from `PrimarySelector`

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/PrimarySelector.java
+++ b/core/server/common/src/main/java/alluxio/master/PrimarySelector.java
@@ -15,7 +15,6 @@ import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.interfaces.Scoped;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.function.Consumer;
 
@@ -67,12 +66,12 @@ public interface PrimarySelector {
    *
    * @param localAddress the address of the local master
    */
-  void start(InetSocketAddress localAddress) throws IOException;
+  void start(InetSocketAddress localAddress);
 
   /**
    * Stops the primary selector.
    */
-  void stop() throws IOException;
+  void stop();
 
   /**
    * @return the current state

--- a/core/server/common/src/main/java/alluxio/master/PrimarySelectorClient.java
+++ b/core/server/common/src/main/java/alluxio/master/PrimarySelectorClient.java
@@ -29,7 +29,6 @@ import org.apache.zookeeper.CreateMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
@@ -92,7 +91,7 @@ public final class PrimarySelectorClient extends AbstractPrimarySelector
   }
 
   @Override
-  public synchronized void stop() throws IOException {
+  public synchronized void stop() {
     if (mLifecycleState == LifecycleState.STARTED) {
       mLeaderSelector.close();
     }
@@ -128,7 +127,7 @@ public final class PrimarySelectorClient extends AbstractPrimarySelector
    * gets closed, the calling thread will be interrupted.
    */
   @Override
-  public synchronized void start(InetSocketAddress address) throws IOException {
+  public synchronized void start(InetSocketAddress address) {
     Preconditions.checkState(mLifecycleState == LifecycleState.INIT,
         "Failed to transition from INIT to STARTED: current state is " + mLifecycleState);
     mLifecycleState = LifecycleState.STARTED;

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftPrimarySelector.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftPrimarySelector.java
@@ -13,7 +13,6 @@ package alluxio.master.journal.raft;
 
 import alluxio.master.AbstractPrimarySelector;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -32,12 +31,12 @@ public class RaftPrimarySelector extends AbstractPrimarySelector {
   }
 
   @Override
-  public void start(InetSocketAddress address) throws IOException {
+  public void start(InetSocketAddress address) {
     // The Ratis cluster is owned by the outer {@link RaftJournalSystem}.
   }
 
   @Override
-  public void stop() throws IOException {
+  public void stop() {
     // The Ratis cluster is owned by the outer {@link RaftJournalSystem}.
   }
 }

--- a/core/server/common/src/test/java/alluxio/master/AbstractPrimarySelectorTest.java
+++ b/core/server/common/src/test/java/alluxio/master/AbstractPrimarySelectorTest.java
@@ -21,7 +21,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -93,9 +92,9 @@ public final class AbstractPrimarySelectorTest {
 
   static class TestSelector extends AbstractPrimarySelector {
     @Override
-    public void start(InetSocketAddress localAddress) throws IOException {}
+    public void start(InetSocketAddress localAddress) {}
 
     @Override
-    public void stop() throws IOException {}
+    public void stop() {}
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/FaultTolerantAlluxioMasterProcess.java
@@ -31,7 +31,6 @@ import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -83,13 +82,8 @@ final class FaultTolerantAlluxioMasterProcess extends AlluxioMasterProcess {
       mJournalSystem.waitForCatchup();
     }
 
-    try {
-      LOG.info("Starting leader selector.");
-      mLeaderSelector.start(getRpcAddress());
-    } catch (IOException e) {
-      LOG.error(e.getMessage(), e);
-      throw new RuntimeException(e);
-    }
+    LOG.info("Starting leader selector.");
+    mLeaderSelector.start(getRpcAddress());
 
     while (!Thread.interrupted()) {
       if (!mRunning) {

--- a/core/server/master/src/test/java/alluxio/master/AlwaysStandbyPrimarySelector.java
+++ b/core/server/master/src/test/java/alluxio/master/AlwaysStandbyPrimarySelector.java
@@ -13,7 +13,6 @@ package alluxio.master;
 
 import alluxio.util.interfaces.Scoped;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.function.Consumer;
 
@@ -22,12 +21,12 @@ import java.util.function.Consumer;
  */
 public final class AlwaysStandbyPrimarySelector implements PrimarySelector {
   @Override
-  public void start(InetSocketAddress localAddress) throws IOException {
+  public void start(InetSocketAddress localAddress) {
     // Nothing to do.
   }
 
   @Override
-  public void stop() throws IOException {
+  public void stop() {
     // Nothing to do.
   }
 

--- a/core/server/master/src/test/java/alluxio/master/ControllablePrimarySelector.java
+++ b/core/server/master/src/test/java/alluxio/master/ControllablePrimarySelector.java
@@ -11,7 +11,6 @@
 
 package alluxio.master;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 
 /**
@@ -22,12 +21,12 @@ import java.net.InetSocketAddress;
  */
 public class ControllablePrimarySelector extends AbstractPrimarySelector {
   @Override
-  public void start(InetSocketAddress localAddress) throws IOException {
+  public void start(InetSocketAddress localAddress) {
       // nothing to do
   }
 
   @Override
-  public void stop() throws IOException {
+  public void stop() {
     // nothing to do
   }
 }

--- a/job/server/src/main/java/alluxio/master/FaultTolerantAlluxioJobMasterProcess.java
+++ b/job/server/src/main/java/alluxio/master/FaultTolerantAlluxioJobMasterProcess.java
@@ -20,7 +20,6 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -52,12 +51,7 @@ final class FaultTolerantAlluxioJobMasterProcess extends AlluxioJobMasterProcess
   @Override
   public void start() throws Exception {
     mJournalSystem.start();
-    try {
-      mLeaderSelector.start(getRpcAddress());
-    } catch (IOException e) {
-      LOG.error(e.getMessage(), e);
-      throw new RuntimeException(e);
-    }
+    mLeaderSelector.start(getRpcAddress());
 
     while (!Thread.interrupted()) {
       if (mServingThread == null) {


### PR DESCRIPTION
`PrimarySelector` and its implementations never throw in `start` or `stop`. I removed the Exception from the method signatures.