### PR TITLE
Determine the primary master address by calling GetNodeState endpoint

### DIFF
--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -19,18 +19,17 @@ import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.CancelledException;
 import alluxio.exception.status.DeadlineExceededException;
 import alluxio.exception.status.UnavailableException;
-import alluxio.grpc.GetServiceVersionPRequest;
+import alluxio.grpc.GetNodeStatePRequest;
 import alluxio.grpc.GrpcChannel;
 import alluxio.grpc.GrpcChannelBuilder;
 import alluxio.grpc.GrpcServerAddress;
-import alluxio.grpc.ServiceType;
-import alluxio.grpc.ServiceVersionClientServiceGrpc;
+import alluxio.grpc.JournalMasterClientServiceGrpc;
+import alluxio.grpc.NodeState;
 import alluxio.retry.RetryPolicy;
 import alluxio.retry.RetryUtils;
 import alluxio.security.user.UserState;
 import alluxio.uri.Authority;
 import alluxio.uri.MultiMasterAuthority;
-import alluxio.util.ConfigurationUtils;
 
 import com.google.common.collect.Lists;
 import io.grpc.StatusRuntimeException;
@@ -46,9 +45,8 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
- * PollingMasterInquireClient finds the address of the primary master by polling a list of master
- * addresses to see if their RPC servers are serving. This works because only primary masters serve
- * RPCs.
+ * PollingMasterInquireClient finds the address of the primary master by
+ * polling a list of master addresses to see if they respond as the leader.
  */
 public class PollingMasterInquireClient implements MasterInquireClient {
   private static final Logger LOG = LoggerFactory.getLogger(PollingMasterInquireClient.class);
@@ -126,9 +124,10 @@ public class PollingMasterInquireClient implements MasterInquireClient {
     for (InetSocketAddress address : addresses) {
       try {
         LOG.debug("Checking whether {} is listening for RPCs", address);
-        pingMetaService(address);
-        LOG.debug("Successfully connected to {}", address);
-        return address;
+        if (pingJournalMasterService(address)) {
+          LOG.debug("Successfully connected to {}", address);
+          return address;
+        }
       } catch (UnavailableException e) {
         LOG.debug("Failed to connect to {}", address);
       } catch (DeadlineExceededException e) {
@@ -144,22 +143,20 @@ public class PollingMasterInquireClient implements MasterInquireClient {
     return null;
   }
 
-  private void pingMetaService(InetSocketAddress address) throws AlluxioStatusException {
-    // disable authentication in the channel since version service does not require authentication
+  private boolean pingJournalMasterService(InetSocketAddress address)
+      throws AlluxioStatusException {
     GrpcChannel channel =
         GrpcChannelBuilder.newBuilder(GrpcServerAddress.create(address), mConfiguration)
             .setSubject(mUserState.getSubject())
-            .disableAuthentication().build();
-    ServiceVersionClientServiceGrpc.ServiceVersionClientServiceBlockingStub versionClient =
-        ServiceVersionClientServiceGrpc.newBlockingStub(channel)
+            .build();
+    JournalMasterClientServiceGrpc.JournalMasterClientServiceBlockingStub journalMasterClient =
+        JournalMasterClientServiceGrpc.newBlockingStub(channel)
             .withDeadlineAfter(mConfiguration.getMs(PropertyKey.USER_MASTER_POLLING_TIMEOUT),
                 TimeUnit.MILLISECONDS);
-    List<InetSocketAddress> addresses = ConfigurationUtils.getJobMasterRpcAddresses(mConfiguration);
-    ServiceType serviceType = addresses.contains(address)
-        ? ServiceType.JOB_MASTER_CLIENT_SERVICE : ServiceType.META_MASTER_CLIENT_SERVICE;
     try {
-      versionClient.getServiceVersion(GetServiceVersionPRequest.newBuilder()
-          .setServiceType(serviceType).build());
+      return journalMasterClient
+          .getNodeState(GetNodeStatePRequest.getDefaultInstance())
+          .getNodeState() == NodeState.PRIMARY;
     } catch (StatusRuntimeException e) {
       throw AlluxioStatusException.fromThrowable(e);
     } finally {

--- a/core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java
@@ -11,18 +11,30 @@
 
 package alluxio.master;
 
+import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.fail;
 
 import alluxio.Constants;
+import alluxio.conf.Configuration;
 import alluxio.conf.ConfigurationBuilder;
 import alluxio.exception.status.UnavailableException;
+import alluxio.grpc.GetNodeStatePRequest;
+import alluxio.grpc.GetNodeStatePResponse;
+import alluxio.grpc.GrpcServer;
+import alluxio.grpc.GrpcServerAddress;
+import alluxio.grpc.GrpcServerBuilder;
+import alluxio.grpc.GrpcService;
+import alluxio.grpc.JournalMasterClientServiceGrpc;
+import alluxio.grpc.NodeState;
 import alluxio.network.RejectingServer;
 import alluxio.retry.CountingRetry;
 import alluxio.util.network.NetworkAddressUtils;
 
+import io.grpc.stub.StreamObserver;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.List;
@@ -49,6 +61,41 @@ public class PollingMasterInquireClientTest {
       fail("Expected polling to fail");
     } catch (UnavailableException e) {
       // Expected
+    }
+  }
+
+  @Test(timeout = 10000)
+  public void testGetPrimaryRpcAddress() throws IOException {
+    int port = mPort.getPort();
+    InetSocketAddress serverAddress = new InetSocketAddress("127.0.0.1", port);
+
+    JournalMasterClientServiceGrpc.JournalMasterClientServiceImplBase handler =
+        new JournalMasterClientServiceGrpc.JournalMasterClientServiceImplBase() {
+          @Override
+          public void getNodeState(GetNodeStatePRequest request,
+              StreamObserver<GetNodeStatePResponse> responseObserver) {
+            responseObserver.onNext(
+                GetNodeStatePResponse.newBuilder().setNodeState(NodeState.PRIMARY).build());
+            responseObserver.onCompleted();
+          }
+        };
+
+    GrpcServer grpcServer = GrpcServerBuilder
+        .forAddress(
+            GrpcServerAddress.create("localhost", serverAddress), Configuration.global())
+        .addService(new GrpcService(handler))
+        .build();
+
+    try {
+      grpcServer.start();
+      List<InetSocketAddress> addrs = Arrays.asList(serverAddress);
+      PollingMasterInquireClient client = new PollingMasterInquireClient(addrs,
+          () -> new CountingRetry(0), new ConfigurationBuilder().build());
+      assertEquals(serverAddress, client.getPrimaryRpcAddress());
+    } catch (Exception e) {
+      throw e;
+    } finally {
+      grpcServer.shutdown();
     }
   }
 }

--- a/core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java
@@ -65,7 +65,7 @@ public class PollingMasterInquireClientTest {
   }
 
   @Test(timeout = 10000)
-  public void testGetPrimaryRpcAddress() throws IOException {
+  public void getPrimaryRpcAddress() throws IOException {
     int port = mPort.getPort();
     InetSocketAddress serverAddress = new InetSocketAddress("127.0.0.1", port);
 

--- a/core/server/common/src/main/java/alluxio/master/PrimarySelector.java
+++ b/core/server/common/src/main/java/alluxio/master/PrimarySelector.java
@@ -13,6 +13,7 @@ package alluxio.master;
 
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
+import alluxio.grpc.NodeState;
 import alluxio.master.journal.ufs.UfsJournalMultiMasterPrimarySelector;
 import alluxio.util.interfaces.Scoped;
 
@@ -23,17 +24,6 @@ import java.util.function.Consumer;
  * Interface for a class which can determine whether the local master is the primary.
  */
 public interface PrimarySelector {
-
-  /**
-   * The state for the primary selector.
-   */
-  enum State {
-    /** The current process is primary. */
-    PRIMARY,
-    /** The current process is standby. */
-    STANDBY,
-  }
-
   /**
    * Factory for creating primary selectors.
    */
@@ -77,7 +67,7 @@ public interface PrimarySelector {
   /**
    * @return the current state
    */
-  State getState();
+  NodeState getState();
 
   /**
    * Registers a listener to be executed whenever the selector's state updates.
@@ -88,12 +78,12 @@ public interface PrimarySelector {
    * @param listener the listener
    * @return an object which will unregister the listener when closed
    */
-  Scoped onStateChange(Consumer<State> listener);
+  Scoped onStateChange(Consumer<NodeState> listener);
 
   /**
    * Blocks until the primary selector enters the specified state.
    *
    * @param state the state to wait for
    */
-  void waitForState(State state) throws InterruptedException;
+  void waitForState(NodeState state) throws InterruptedException;
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/DefaultJournalMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/DefaultJournalMaster.java
@@ -11,10 +11,12 @@
 
 package alluxio.master.journal;
 
+import alluxio.grpc.GetNodeStatePResponse;
 import alluxio.grpc.GetQuorumInfoPResponse;
 import alluxio.grpc.GetTransferLeaderMessagePResponse;
 import alluxio.grpc.JournalDomain;
 import alluxio.grpc.NetAddress;
+import alluxio.master.PrimarySelector;
 import alluxio.master.journal.raft.RaftJournalSystem;
 
 import java.io.IOException;
@@ -26,20 +28,28 @@ import java.io.IOException;
 public class DefaultJournalMaster implements JournalMaster {
   private final JournalDomain mJournalDomain;
   private final JournalSystem mJournalSystem;
+  private final PrimarySelector mPrimarySelector;
 
   /**
    * @param journalDomain domain for the journal
    * @param journalSystem internal {@link JournalSystem} reference
+   * @param primarySelector the primary selector to get the node state
    */
-  public DefaultJournalMaster(JournalDomain journalDomain, JournalSystem journalSystem) {
+  public DefaultJournalMaster(
+      JournalDomain journalDomain, JournalSystem journalSystem, PrimarySelector primarySelector) {
     mJournalDomain = journalDomain;
     mJournalSystem = journalSystem;
+    mPrimarySelector = primarySelector;
   }
 
   private void checkQuorumOpSupported() {
     if (!(mJournalSystem instanceof RaftJournalSystem)) {
       throw new UnsupportedOperationException(
           "Quorum operations are supported for journal type: EMBEDDED");
+    }
+    if (!((RaftJournalSystem) (mJournalSystem)).isLeader()) {
+      throw new UnsupportedOperationException(
+          "Quorum operations are only supported on Raft leader");
     }
   }
 
@@ -74,5 +84,12 @@ public class DefaultJournalMaster implements JournalMaster {
     return GetTransferLeaderMessagePResponse.newBuilder()
            .setTransMsg(((RaftJournalSystem) mJournalSystem).getTransferLeaderMessage(transferId))
            .build();
+  }
+
+  @Override
+  public GetNodeStatePResponse getNodeState() {
+    return GetNodeStatePResponse.newBuilder()
+        .setNodeState(mPrimarySelector.getState())
+        .build();
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalMaster.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalMaster.java
@@ -11,6 +11,7 @@
 
 package alluxio.master.journal;
 
+import alluxio.grpc.GetNodeStatePResponse;
 import alluxio.grpc.GetQuorumInfoPResponse;
 import alluxio.grpc.GetTransferLeaderMessagePResponse;
 import alluxio.grpc.NetAddress;
@@ -61,4 +62,11 @@ public interface JournalMaster {
    * @return exception message
    */
   GetTransferLeaderMessagePResponse getTransferLeaderMessage(String transferId);
+
+  /**
+   * Gets the node state. This endpoint is available for both UFS and embedded journals.
+   * If HA mode is turn off, the node state will always be returned as PRIMARY.
+   * @return whether the node is a primary or standby
+   */
+  GetNodeStatePResponse getNodeState();
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalMasterClientServiceHandler.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalMasterClientServiceHandler.java
@@ -12,6 +12,8 @@
 package alluxio.master.journal;
 
 import alluxio.RpcUtils;
+import alluxio.grpc.GetNodeStatePRequest;
+import alluxio.grpc.GetNodeStatePResponse;
 import alluxio.grpc.GetQuorumInfoPRequest;
 import alluxio.grpc.GetQuorumInfoPResponse;
 import alluxio.grpc.GetTransferLeaderMessagePRequest;
@@ -86,5 +88,12 @@ public class JournalMasterClientServiceHandler
       StreamObserver<GetTransferLeaderMessagePResponse> responseObserver) {
     RpcUtils.call(LOG, () -> mJournalMaster.getTransferLeaderMessage(request.getTransferId()),
             "GetTransferLeaderMessage", "request=%s", responseObserver, request);
+  }
+
+  @Override
+  public void getNodeState(GetNodeStatePRequest request,
+       StreamObserver<GetNodeStatePResponse> responseObserver) {
+    RpcUtils.call(LOG, mJournalMaster::getNodeState,
+        "GetNodeState", "request=%s", responseObserver, request);
   }
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -20,6 +20,7 @@ import alluxio.grpc.AddQuorumServerRequest;
 import alluxio.grpc.GrpcService;
 import alluxio.grpc.JournalQueryRequest;
 import alluxio.grpc.NetAddress;
+import alluxio.grpc.NodeState;
 import alluxio.grpc.QuorumServerInfo;
 import alluxio.grpc.QuorumServerState;
 import alluxio.grpc.TransferLeaderMessage;
@@ -697,7 +698,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     //    will see that an entry was written after its ID, and double check that it is still the
     //    leader before trying again.
     while (true) {
-      if (mPrimarySelector.getState() != PrimarySelector.State.PRIMARY) {
+      if (mPrimarySelector.getState() != NodeState.PRIMARY) {
         return;
       }
       long lastAppliedSN = stateMachine.getLastAppliedSequenceNumber();
@@ -933,7 +934,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   public synchronized boolean isLeader() {
     return mServer != null
         && mServer.getLifeCycleState() == LifeCycle.State.RUNNING
-        && mPrimarySelector.getState() == PrimarySelector.State.PRIMARY;
+        && mPrimarySelector.getState() == NodeState.PRIMARY;
   }
 
   /**
@@ -1174,7 +1175,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
    */
   public void notifyLeadershipStateChanged(boolean isLeader) {
     mPrimarySelector.notifyStateChanged(
-        isLeader ? PrimarySelector.State.PRIMARY : PrimarySelector.State.STANDBY);
+        isLeader ? NodeState.PRIMARY : NodeState.STANDBY);
   }
 
   @VisibleForTesting

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftPrimarySelector.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftPrimarySelector.java
@@ -11,6 +11,7 @@
 
 package alluxio.master.journal.raft;
 
+import alluxio.grpc.NodeState;
 import alluxio.master.AbstractPrimarySelector;
 
 import java.net.InetSocketAddress;
@@ -26,7 +27,7 @@ public class RaftPrimarySelector extends AbstractPrimarySelector {
    * Notifies leadership state changed.
    * @param state the leadership state
    */
-  public void notifyStateChanged(State state) {
+  public void notifyStateChanged(NodeState state) {
     setState(state);
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSingleMasterPrimarySelector.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSingleMasterPrimarySelector.java
@@ -11,6 +11,7 @@
 
 package alluxio.master.journal.ufs;
 
+import alluxio.grpc.NodeState;
 import alluxio.master.AbstractPrimarySelector;
 
 import java.net.InetSocketAddress;
@@ -21,7 +22,7 @@ import java.net.InetSocketAddress;
 public class UfsJournalSingleMasterPrimarySelector extends AbstractPrimarySelector {
   @Override
   public void start(InetSocketAddress localAddress) {
-    setState(State.PRIMARY);
+    setState(NodeState.PRIMARY);
   }
 
   @Override

--- a/core/server/common/src/test/java/alluxio/master/AbstractPrimarySelectorTest.java
+++ b/core/server/common/src/test/java/alluxio/master/AbstractPrimarySelectorTest.java
@@ -14,7 +14,7 @@ package alluxio.master;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.Constants;
-import alluxio.master.PrimarySelector.State;
+import alluxio.grpc.NodeState;
 import alluxio.util.interfaces.Scoped;
 
 import org.junit.After;
@@ -49,21 +49,21 @@ public final class AbstractPrimarySelectorTest {
 
   @Test
   public void getState() {
-    assertEquals(State.STANDBY, mSelector.getState());
-    mSelector.setState(State.PRIMARY);
-    assertEquals(State.PRIMARY, mSelector.getState());
-    mSelector.setState(State.STANDBY);
-    assertEquals(State.STANDBY, mSelector.getState());
+    assertEquals(NodeState.STANDBY, mSelector.getState());
+    mSelector.setState(NodeState.PRIMARY);
+    assertEquals(NodeState.PRIMARY, mSelector.getState());
+    mSelector.setState(NodeState.STANDBY);
+    assertEquals(NodeState.STANDBY, mSelector.getState());
   }
 
   @Test(timeout = TIMEOUT)
   public void waitFor() throws Exception {
-    mExecutor.schedule(() -> mSelector.setState(State.PRIMARY), 30, TimeUnit.MILLISECONDS);
-    mSelector.waitForState(State.PRIMARY);
-    assertEquals(State.PRIMARY, mSelector.getState());
-    mExecutor.schedule(() -> mSelector.setState(State.STANDBY), 30, TimeUnit.MILLISECONDS);
-    mSelector.waitForState(State.STANDBY);
-    assertEquals(State.STANDBY, mSelector.getState());
+    mExecutor.schedule(() -> mSelector.setState(NodeState.PRIMARY), 30, TimeUnit.MILLISECONDS);
+    mSelector.waitForState(NodeState.PRIMARY);
+    assertEquals(NodeState.PRIMARY, mSelector.getState());
+    mExecutor.schedule(() -> mSelector.setState(NodeState.STANDBY), 30, TimeUnit.MILLISECONDS);
+    mSelector.waitForState(NodeState.STANDBY);
+    assertEquals(NodeState.STANDBY, mSelector.getState());
   }
 
   @Test(timeout = TIMEOUT)
@@ -71,21 +71,21 @@ public final class AbstractPrimarySelectorTest {
     AtomicInteger primaryCounter = new AtomicInteger(0);
     AtomicInteger standbyCounter = new AtomicInteger(0);
     Scoped listener = mSelector.onStateChange(state -> {
-      if (state.equals(State.PRIMARY)) {
+      if (state.equals(NodeState.PRIMARY)) {
         primaryCounter.incrementAndGet();
       } else {
         standbyCounter.incrementAndGet();
       }
     });
     for (int i = 0; i < 10; i++) {
-      mSelector.setState(State.PRIMARY);
-      mSelector.setState(State.STANDBY);
+      mSelector.setState(NodeState.PRIMARY);
+      mSelector.setState(NodeState.STANDBY);
     }
     assertEquals(10, primaryCounter.get());
     assertEquals(10, standbyCounter.get());
     listener.close();
-    mSelector.setState(State.PRIMARY);
-    mSelector.setState(State.STANDBY);
+    mSelector.setState(NodeState.PRIMARY);
+    mSelector.setState(NodeState.STANDBY);
     assertEquals(10, primaryCounter.get());
     assertEquals(10, standbyCounter.get());
   }

--- a/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
+++ b/core/server/master/src/test/java/alluxio/master/AlluxioMasterProcessTest.java
@@ -20,6 +20,7 @@ import alluxio.Constants;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.UnavailableException;
+import alluxio.grpc.NodeState;
 import alluxio.master.journal.JournalSystem;
 import alluxio.master.journal.JournalType;
 import alluxio.master.journal.JournalUtils;
@@ -168,7 +169,7 @@ public final class AlluxioMasterProcessTest {
   @Test
   public void startMastersThrowsUnavailableException() throws InterruptedException, IOException {
     ControllablePrimarySelector primarySelector = new ControllablePrimarySelector();
-    primarySelector.setState(PrimarySelector.State.PRIMARY);
+    primarySelector.setState(NodeState.PRIMARY);
     Configuration.set(PropertyKey.MASTER_JOURNAL_EXIT_ON_DEMOTION, true);
     AlluxioMasterProcess master = new AlluxioMasterProcess(
         new NoopJournalSystem(), primarySelector);
@@ -215,7 +216,7 @@ public final class AlluxioMasterProcessTest {
     ControllablePrimarySelector primarySelector = new ControllablePrimarySelector();
     AlluxioMasterProcess masterProcess =
         new AlluxioMasterProcess(journalSystem, primarySelector);
-    primarySelector.setState(PrimarySelector.State.PRIMARY);
+    primarySelector.setState(NodeState.PRIMARY);
     corruptJournalAndStartMasterProcess(masterProcess, journalLocation);
   }
 
@@ -253,7 +254,7 @@ public final class AlluxioMasterProcessTest {
   @Ignore
   public void stopAfterStandbyTransition() throws Exception {
     ControllablePrimarySelector primarySelector = new ControllablePrimarySelector();
-    primarySelector.setState(PrimarySelector.State.PRIMARY);
+    primarySelector.setState(NodeState.PRIMARY);
     Configuration.set(PropertyKey.MASTER_JOURNAL_EXIT_ON_DEMOTION, true);
     AlluxioMasterProcess master = new AlluxioMasterProcess(
         new NoopJournalSystem(), primarySelector);
@@ -269,7 +270,7 @@ public final class AlluxioMasterProcessTest {
     waitForSocketServing(ServiceType.MASTER_WEB);
     assertTrue(isBound(mRpcPort));
     assertTrue(isBound(mWebPort));
-    primarySelector.setState(PrimarySelector.State.STANDBY);
+    primarySelector.setState(NodeState.STANDBY);
     t.join(10000);
     CommonUtils.waitFor("Master to be stopped", () -> !master.isRunning(),
         WaitForOptions.defaults().setTimeoutMs(3 * Constants.MINUTE_MS));

--- a/core/server/master/src/test/java/alluxio/master/AlwaysStandbyPrimarySelector.java
+++ b/core/server/master/src/test/java/alluxio/master/AlwaysStandbyPrimarySelector.java
@@ -11,6 +11,7 @@
 
 package alluxio.master;
 
+import alluxio.grpc.NodeState;
 import alluxio.util.interfaces.Scoped;
 
 import java.net.InetSocketAddress;
@@ -31,18 +32,18 @@ public final class AlwaysStandbyPrimarySelector implements PrimarySelector {
   }
 
   @Override
-  public State getState() {
-    return State.STANDBY;
+  public NodeState getState() {
+    return NodeState.STANDBY;
   }
 
   @Override
-  public Scoped onStateChange(Consumer<State> listener) {
+  public Scoped onStateChange(Consumer<NodeState> listener) {
     // State never changes.
     return () -> { };
   }
 
   @Override
-  public void waitForState(State state) throws InterruptedException {
+  public void waitForState(NodeState state) throws InterruptedException {
     switch (state) {
       case PRIMARY:
         // Never happening

--- a/core/transport/src/main/proto/grpc/journal_master.proto
+++ b/core/transport/src/main/proto/grpc/journal_master.proto
@@ -72,6 +72,17 @@ message GetTransferLeaderMessagePResponse{
     required TransferLeaderMessage transMsg = 1;
 }
 
+message GetNodeStatePRequest {}
+
+message GetNodeStatePResponse {
+    optional NodeState node_state = 1;
+}
+
+enum NodeState {
+    STANDBY = 0;
+    PRIMARY = 1;
+}
+
 /**
   * This interface contains journal master service endpoints for Alluxio clients.
   */
@@ -101,4 +112,9 @@ service JournalMasterClientService {
      * Gets exception message throwing when transfer leader.
      */
     rpc GetTransferLeaderMessage(GetTransferLeaderMessagePRequest) returns (GetTransferLeaderMessagePResponse);
+
+    /**
+     * Gets the state of the current node and returns whether it is primary or standby.
+     */
+     rpc GetNodeState (GetNodeStatePRequest) returns (GetNodeStatePResponse);
 }

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -4893,6 +4893,18 @@
                 "integer": 2
               }
             ]
+          },
+          {
+            "name": "NodeState",
+            "enum_fields": [
+              {
+                "name": "STANDBY"
+              },
+              {
+                "name": "PRIMARY",
+                "integer": 1
+              }
+            ]
           }
         ],
         "messages": [
@@ -5047,6 +5059,19 @@
                 "type": "TransferLeaderMessage"
               }
             ]
+          },
+          {
+            "name": "GetNodeStatePRequest"
+          },
+          {
+            "name": "GetNodeStatePResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "node_state",
+                "type": "NodeState"
+              }
+            ]
           }
         ],
         "services": [
@@ -5077,6 +5102,11 @@
                 "name": "GetTransferLeaderMessage",
                 "in_type": "GetTransferLeaderMessagePRequest",
                 "out_type": "GetTransferLeaderMessagePResponse"
+              },
+              {
+                "name": "GetNodeState",
+                "in_type": "GetNodeStatePRequest",
+                "out_type": "GetNodeStatePResponse"
               }
             ]
           }


### PR DESCRIPTION
### What changes are proposed in this pull request?
1. In PollingMasterInquireClient, replace the current version service call with a new introduced GetNodeState grpc endpoint which returns if the node is primary or standby directly, which internally gets the node state from the PrimarySelector.  
2. Replace the PrimarySelector.State with a protobuf model NodeState.

### Why are the changes needed?

Currently PollingMasterInquireClient determines which master is the primary master by polling each client to see which one responds. This is a bit hacky and based on the assumption that standby masters don't have a gRPC server. So we replace the current call with a new call to GetNodeState endpoint that tells if the node is primary or not directly. 

### Does this PR introduce any user facing changes?

N/A