### PR TITLE
Bump up maven frontend plugin for m1 arm support

### DIFF
--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -33,7 +33,7 @@
         <artifactId>frontend-maven-plugin</artifactId>
         <!-- Use the latest released version:
         https://repo1.maven.org/maven2/com/github/eirslett/frontend-maven-plugin/ -->
-        <version>1.6</version>
+        <version>1.12.1</version>
         <executions>
           <execution>
             <id>install node and npm</id>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Bump up maven frontend plugin to fix the "cannot download node.js" issues on osx m1.  See the discussion here https://github.com/eirslett/frontend-maven-plugin/issues/952

### Why are the changes needed?
Enable the development on macbook m1

### Does this PR introduce any user facing changes?
no
