### PR TITLE
Fix S3 API writing objects yields BucketNotFound 404

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -360,7 +360,6 @@ public final class S3RestServiceHandler {
           }
         }
         // Otherwise, this is ListObjects(v2)
-        LOG.info("[czhu] ListObjectsV2({}) for user: {}", path, user);
         int maxKeys = maxKeysParam == null ? ListBucketOptions.DEFAULT_MAX_KEYS : maxKeysParam;
         ListBucketOptions listBucketOptions = ListBucketOptions.defaults()
             .setMarker(markerParam)
@@ -383,11 +382,9 @@ public final class S3RestServiceHandler {
             } else {
               path = parsePathWithDelimiter(path, prefixParam, delimiterParam);
             }
-            LOG.info("[czhu] ListObjectsV2 - ListStatus({})", path);
             children = fs.listStatus(new AlluxioURI(path));
           } else {
             ListStatusPOptions options = ListStatusPOptions.newBuilder().setRecursive(true).build();
-            LOG.info("[czhu] ListObjectsV2 - ListStatus({}, recursive=true)", path);
             children = fs.listStatus(new AlluxioURI(path), options);
           }
         } catch (FileDoesNotExistException e) {
@@ -398,15 +395,10 @@ public final class S3RestServiceHandler {
             auditContext.setSucceeded(false);
             throw new S3Exception(e, bucket, S3ErrorCode.NO_SUCH_BUCKET);
           } // otherwise, the prefix path does not exist
-          LOG.info("[czhu] ListObjectsV2 - FileDoesNotExistException: {}", e.toString());
           children = new ArrayList<>(); // return empty results because the prefix DNE
         } catch (IOException | AlluxioException e) {
-          LOG.info("[czhu] ListObjectsV2 - Other caught exception: {}", e.toString());
           auditContext.setSucceeded(false);
           throw new RuntimeException(e);
-        } catch (Exception e) {
-          LOG.info("[czhu] ListObjectsV2 - Other \"uncaught\" exception: {}", e.toString());
-          throw e;
         }
         return new ListBucketResult(
             bucket,
@@ -1114,14 +1106,11 @@ public final class S3RestServiceHandler {
       String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
       AlluxioURI objectUri = new AlluxioURI(objectPath);
 
-      LOG.info("[czhu] GetObjectAttributes({}) for user {}", objectPath, user);
-
       try (S3AuditContext auditContext =
           createAuditContext("getObjectMetadata", user, bucket, object)) {
         try {
           URIStatus status = fs.getStatus(objectUri);
           if (status.isFolder() && !object.endsWith(AlluxioURI.SEPARATOR)) {
-            LOG.info("[czhu] GetObjectAttributes - throwing DNE error: status={}", status.toString());
             throw new FileDoesNotExistException(status.getPath() + " is a directory");
           }
           Response.ResponseBuilder res = Response.ok()
@@ -1142,10 +1131,8 @@ public final class S3RestServiceHandler {
           return res.build();
         } catch (FileDoesNotExistException e) {
           // must be null entity (content length 0) for S3A Filesystem
-          LOG.info("[czhu] GetObjectAttributes - FileDoesNotExistException: {}", e.toString());
           return Response.status(404).entity(null).header("Content-Length", "0").build();
         } catch (Exception e) {
-          LOG.info("[czhu] GetObjectAttributes - Other caught exception: {}", e.toString());
           throw S3RestUtils.toObjectS3Exception(e, objectPath, auditContext);
         }
       }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -388,14 +388,9 @@ public final class S3RestServiceHandler {
             children = fs.listStatus(new AlluxioURI(path), options);
           }
         } catch (FileDoesNotExistException e) {
-          // return the proper error code if the bucket doesn't exist. Previously a 500 error was
-          // returned which does not match the S3 response behavior
-          // - this should never happen since we've called S3RestUtils.checkPathIsAlluxioDirectory()
-          if (prefixParam == null || prefixParam.isEmpty()) {
-            auditContext.setSucceeded(false);
-            throw new S3Exception(e, bucket, S3ErrorCode.NO_SUCH_BUCKET);
-          } // otherwise, the prefix path does not exist
-          children = new ArrayList<>(); // return empty results because the prefix DNE
+          // Since we've called S3RestUtils.checkPathIsAlluxioDirectory() on the bucket path
+          // already, this indicates that the prefix was unable to be found in the Alluxio FS
+          children = new ArrayList<>();
         } catch (IOException | AlluxioException e) {
           auditContext.setSucceeded(false);
           throw new RuntimeException(e);

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -391,7 +391,7 @@ public final class S3RestServiceHandler {
           // return the proper error code if the bucket doesn't exist. Previously a 500 error was
           // returned which does not match the S3 response behavior
           // - this should never happen since we've called S3RestUtils.checkPathIsAlluxioDirectory()
-          if (prefixParam == null) {
+          if (prefixParam == null || prefixParam.isEmpty()) {
             auditContext.setSucceeded(false);
             throw new S3Exception(e, bucket, S3ErrorCode.NO_SUCH_BUCKET);
           } // otherwise, the prefix path does not exist

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -699,10 +699,10 @@ public final class S3ClientRestApiTest extends RestApiTest {
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE))
         .runAndCheckResult(expected);
 
-    //parameters with non-existent prefix="foo"
+    //parameters with non-existent prefix="file_store/file2"
     try {
       expected = new ListBucketResult("bucket", statuses,
-          ListBucketOptions.defaults().setPrefix("foo"));
+          ListBucketOptions.defaults().setPrefix("file_store/file2"));
     } catch (Exception e) {
       // expected
       // TODO(czhu): with the current implementation of prefixes w/o delimiters,
@@ -712,7 +712,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
     }
     assertEquals(0, expected.getContents().size());
 
-    parameters.put("prefix", "foo");
+    parameters.put("prefix", "file_store/file2");
     new TestCase(mHostname, mPort, mBaseUri,
         "bucket", parameters, HttpMethod.GET,
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE))

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -699,20 +699,20 @@ public final class S3ClientRestApiTest extends RestApiTest {
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE))
         .runAndCheckResult(expected);
 
-    //parameters with non-existent prefix="file_store/file2"
+    //parameters with non-existent prefix="dne_folder/file"
     try {
       expected = new ListBucketResult("bucket", statuses,
-          ListBucketOptions.defaults().setPrefix("file_store/file2"));
+          ListBucketOptions.defaults().setPrefix("dne_folder/file"));
     } catch (Exception e) {
       // expected
-      // TODO(czhu): with the current implementation of prefixes w/o delimiters,
-      // this is never an error because we just list the entire bucket recursively
+      // TODO(czhu): with the current implementation of prefixes w/o delimiters, there is
+      // never a FileDoesNotExistException because we just list the entire bucket recursively
       statuses = new ArrayList<>();
       return;
     }
     assertEquals(0, expected.getContents().size());
 
-    parameters.put("prefix", "file_store/file2");
+    parameters.put("prefix", "dne_folder/file");
     new TestCase(mHostname, mPort, mBaseUri,
         "bucket", parameters, HttpMethod.GET,
         TestCaseOptions.defaults().setContentType(TestCaseOptions.XML_CONTENT_TYPE))

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -748,8 +748,8 @@ public final class S3ClientRestApiTest extends RestApiTest {
       statuses = new ArrayList<>();
       return;
     }
-    expected = new ListBucketResult("bucket", statuses,
-        ListBucketOptions.defaults().setPrefix("file_store/file1/").setDelimiter(AlluxioURI.SEPARATOR));
+    expected = new ListBucketResult("bucket", statuses, ListBucketOptions.defaults()
+        .setPrefix("file_store/file1/").setDelimiter(AlluxioURI.SEPARATOR));
     assertEquals(0, expected.getContents().size());
     assertEquals(0, expected.getCommonPrefixes().size());
 
@@ -768,8 +768,8 @@ public final class S3ClientRestApiTest extends RestApiTest {
       statuses = new ArrayList<>();
       return;
     }
-    expected = new ListBucketResult("bucket", statuses,
-        ListBucketOptions.defaults().setPrefix("file_store/file2").setDelimiter(AlluxioURI.SEPARATOR));
+    expected = new ListBucketResult("bucket", statuses, ListBucketOptions.defaults()
+        .setPrefix("file_store/file2").setDelimiter(AlluxioURI.SEPARATOR));
     assertEquals(0, expected.getContents().size());
     assertEquals(0, expected.getCommonPrefixes().size());
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Resolves https://github.com/Alluxio/alluxio/issues/15844

### Why are the changes needed?

There was an outdated `catch (FileNotFoundException e)` which returned a `BucketNotFound` S3 Error code (HTTP 404). It was outdated because a check that the bucket path exists was added since that code had been written. Furthermore, we needed to return an empty list for the `children` to `ListBucketResults`.

### Does this PR introduce any user facing changes?

No user facing changes.
