### PR TITLE
[DOCFIX] Fix typo in LockResource comment

### DIFF
--- a/core/common/src/main/java/alluxio/resource/LockResource.java
+++ b/core/common/src/main/java/alluxio/resource/LockResource.java
@@ -63,7 +63,7 @@ public class LockResource implements Closeable {
    * This method may use the {@link Lock#tryLock()} method to gain ownership of the locks. The
    * reason one might want to use this is to avoid the fairness heuristics within the
    * {@link java.util.concurrent.locks.ReentrantReadWriteLock}'s NonFairSync which may block reader
-   * threads if a writer if the first in the queue.
+   * threads if a writer is the first in the queue.
    *
    * @param lock the lock to acquire
    * @param acquireLock whether to lock the lock
@@ -79,7 +79,7 @@ public class LockResource implements Closeable {
    * This method may use the {@link Lock#tryLock()} method to gain ownership of the locks. The
    * reason one might want to use this is to avoid the fairness heuristics within the
    * {@link java.util.concurrent.locks.ReentrantReadWriteLock}'s NonFairSync which may block reader
-   * threads if a writer if the first in the queue.
+   * threads if a writer is the first in the queue.
    *
    * @param lock the lock to acquire
    * @param acquireLock whether to lock the lock


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix the typo: from `if` to `is`

### Why are the changes needed?

Fixed typo

### Does this PR introduce any user facing changes?

Not at all
