### PR TITLE
Fix jekyll installation in alluxio-maven dockerfiles

### DIFF
--- a/dev/jenkins/Dockerfile-jdk11
+++ b/dev/jenkins/Dockerfile-jdk11
@@ -140,7 +140,7 @@ RUN mkdir -p /home/jenkins && \
     apt-get upgrade -y ca-certificates && \
     apt-get install -y build-essential fuse3 libfuse3-dev libfuse-dev make ruby ruby-dev
 # jekyll for documentation
-RUN gem install jekyll bundler
+RUN gem install public_suffix:4.0.7 jekyll:4.2.2 bundler:2.3.18
 # golang for tooling
 RUN ARCH=$(dpkg --print-architecture) && \
     wget https://go.dev/dl/go1.18.1.linux-${ARCH}.tar.gz && \

--- a/dev/jenkins/Dockerfile-jdk8
+++ b/dev/jenkins/Dockerfile-jdk8
@@ -23,7 +23,7 @@ RUN mkdir -p /home/jenkins && \
     apt-get upgrade -y ca-certificates && \
     apt-get install -y build-essential fuse3 libfuse3-dev libfuse-dev make ruby ruby-dev
 # jekyll for documentation
-RUN gem install jekyll bundler
+RUN gem install public_suffix:4.0.7 jekyll:4.2.2 bundler:2.3.18
 # golang for tooling
 RUN ARCH=$(dpkg --print-architecture) && \
     wget https://go.dev/dl/go1.18.1.linux-${ARCH}.tar.gz && \


### PR DESCRIPTION
to address the following error

ERROR:  Error installing jekyll:
	The last version of public_suffix (< 6.0, >= 2.0.2) to support your Ruby & RubyGems was 4.0.7. Try installing it with `gem install public_suffix -v 4.0.7` and then running the current command again
	public_suffix requires Ruby version >= 2.6. The current ruby version is 2.5.0

### What changes are proposed in this pull request?

Please outline the changes and how this PR fixes the issue.

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
