### PR TITLE
Refactor abstract master client with master selection policy

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -15,8 +15,11 @@ import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.GrpcServerAddress;
 import alluxio.master.MasterClientContext;
 import alluxio.master.MasterInquireClient;
+import alluxio.master.selectionpolicy.MasterSelectionPolicy;
 import alluxio.retry.RetryPolicy;
 
+import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -28,30 +31,63 @@ public abstract class AbstractMasterClient extends AbstractClient {
   /** Client for determining the master RPC address. */
   private final MasterInquireClient mMasterInquireClient;
 
+  private final MasterSelectionPolicy mMasterSelectionPolicy;
+
   /**
-   * Creates a new master client base.
+   * Creates a new master client base and default the selection policy to primary master.
    *
    * @param clientConf master client configuration
    */
   public AbstractMasterClient(MasterClientContext clientConf) {
-    super(clientConf);
-    mMasterInquireClient = clientConf.getMasterInquireClient();
+    this(clientConf, MasterSelectionPolicy.Factory.primaryMaster());
   }
 
   /**
    * Creates a new master client base.
    *
    * @param clientConf master client configuration
+   * @param selectionPolicy master selection policy: which master the client should connect to
+   */
+  public AbstractMasterClient(
+      MasterClientContext clientConf, MasterSelectionPolicy selectionPolicy) {
+    super(clientConf);
+    mMasterInquireClient = clientConf.getMasterInquireClient();
+    mMasterSelectionPolicy = selectionPolicy;
+  }
+
+  /**
+   * Creates a new master client without a specific address.
+   * The client defaults to connect to the primary master.
+   * @param clientConf master client configuration
    * @param retryPolicySupplier retry policy to use
    */
-  public AbstractMasterClient(MasterClientContext clientConf,
-      Supplier<RetryPolicy> retryPolicySupplier) {
+  public AbstractMasterClient(
+      MasterClientContext clientConf, Supplier<RetryPolicy> retryPolicySupplier) {
     super(clientConf, retryPolicySupplier);
     mMasterInquireClient = clientConf.getMasterInquireClient();
+    mMasterSelectionPolicy = MasterSelectionPolicy.Factory.primaryMaster();
+  }
+
+  @Override
+  public synchronized InetSocketAddress getConfAddress() throws UnavailableException {
+    return mMasterSelectionPolicy.getPrimaryMasterAddressCached(mMasterInquireClient);
+  }
+
+  @Override
+  protected void beforeConnect() throws IOException {
+    mMasterSelectionPolicy.resetPrimaryMasterAddressCache();
+    super.beforeConnect();
+  }
+
+  @Override
+  protected void afterDisconnect() {
+    super.afterDisconnect();
+    mMasterSelectionPolicy.resetPrimaryMasterAddressCache();
   }
 
   @Override
   protected synchronized GrpcServerAddress queryGrpcServerAddress() throws UnavailableException {
-    return GrpcServerAddress.create(mMasterInquireClient.getPrimaryRpcAddress());
+    return GrpcServerAddress.create(
+        mMasterSelectionPolicy.getGrpcMasterAddress(mMasterInquireClient));
   }
 }

--- a/core/common/src/main/java/alluxio/master/selectionpolicy/AbstractMasterSelectionPolicy.java
+++ b/core/common/src/main/java/alluxio/master/selectionpolicy/AbstractMasterSelectionPolicy.java
@@ -1,0 +1,45 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.selectionpolicy;
+
+import alluxio.exception.status.UnavailableException;
+import alluxio.master.MasterInquireClient;
+
+import java.net.InetSocketAddress;
+import javax.annotation.Nullable;
+
+/**
+ * Base class of master selection policy that
+ * determines which master node a client should connect to.
+ */
+public abstract class AbstractMasterSelectionPolicy implements MasterSelectionPolicy {
+  @Nullable
+  protected volatile InetSocketAddress mPrimaryMasterAddress;
+
+  @Override
+  public synchronized InetSocketAddress getPrimaryMasterAddressCached(
+      MasterInquireClient masterInquireClient) throws UnavailableException {
+    if (mPrimaryMasterAddress == null) {
+      mPrimaryMasterAddress = masterInquireClient.getPrimaryRpcAddress();
+    }
+    return mPrimaryMasterAddress;
+  }
+
+  @Override
+  public abstract InetSocketAddress getGrpcMasterAddress(MasterInquireClient masterInquireClient)
+      throws UnavailableException;
+
+  @Override
+  public synchronized void resetPrimaryMasterAddressCache() {
+    mPrimaryMasterAddress = null;
+  }
+}

--- a/core/common/src/main/java/alluxio/master/selectionpolicy/MasterSelectionPolicy.java
+++ b/core/common/src/main/java/alluxio/master/selectionpolicy/MasterSelectionPolicy.java
@@ -1,0 +1,97 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.selectionpolicy;
+
+import alluxio.exception.status.UnavailableException;
+import alluxio.master.MasterInquireClient;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Interface for master selection policy that
+ * determines which master node a client should connect to.
+ */
+public interface MasterSelectionPolicy {
+  /**
+   * Get and cache the primary master address.
+   *
+   * @param masterInquireClient master inquire client
+   *
+   * @return the remote address of primary master gRPC server
+   * @throws UnavailableException if address cannot be determined
+   */
+  InetSocketAddress getPrimaryMasterAddressCached(MasterInquireClient masterInquireClient)
+      throws UnavailableException;
+
+  /**
+   * Gets the master address the client makes gRPC request to.
+   *
+   * @param masterInquireClient master inquire client
+   *
+   * @return the remote address of master gRPC server
+   * @throws UnavailableException if address cannot be determined
+   */
+  InetSocketAddress getGrpcMasterAddress(MasterInquireClient masterInquireClient)
+      throws UnavailableException;
+
+  /**
+   * Resets the cached primary master address.
+   */
+  void resetPrimaryMasterAddressCache();
+
+  /**
+   * Factory for {@link MasterSelectionPolicy}.
+   */
+  class Factory {
+    /**
+     * Creates a MasterSelectionPolicy that selects the primary master to connect.
+     * @return the MasterSelectionPolicy
+     */
+    public static MasterSelectionPolicy primaryMaster() {
+      return new SelectionPolicyPrimaryMaster();
+    }
+
+    /**
+     * Creates a MasterSelectionPolicy that selects a standby master to connect.
+     * @return the MasterSelectionPolicy
+     */
+    public static MasterSelectionPolicy anyStandbyMaster() {
+      return new SelectionPolicyAnyStandbyMaster();
+    }
+
+    /**
+     * Creates a MasterSelectionPolicy that selects a standby master to connect.
+     * @param randomSeed a random seed to do the deterministic random selection
+     * @return the MasterSelectionPolicy
+     */
+    public static MasterSelectionPolicy anyStandbyMaster(long randomSeed) {
+      return new SelectionPolicyAnyStandbyMaster(randomSeed);
+    }
+
+    /**
+     * Creates a MasterSelectionPolicy that selects a random master to connect.
+     * @return the MasterSelectionPolicy
+     */
+    public static MasterSelectionPolicy anyMaster() {
+      return new SelectionPolicyAnyMaster();
+    }
+
+    /**
+     * Creates a MasterSelectionPolicy that selects a specified master to connect.
+     * @param masterAddress the master address to connect
+     * @return the MasterSelectionPolicy
+     */
+    public static MasterSelectionPolicy specifiedMaster(InetSocketAddress masterAddress) {
+      return new SelectionPolicySpecifiedMaster(masterAddress);
+    }
+  }
+}

--- a/core/common/src/main/java/alluxio/master/selectionpolicy/SelectionPolicyAnyMaster.java
+++ b/core/common/src/main/java/alluxio/master/selectionpolicy/SelectionPolicyAnyMaster.java
@@ -1,0 +1,39 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.selectionpolicy;
+
+import alluxio.exception.status.UnavailableException;
+import alluxio.master.MasterInquireClient;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The master selection policy that connects to a random master.
+ */
+public class SelectionPolicyAnyMaster extends AbstractMasterSelectionPolicy {
+  protected SelectionPolicyAnyMaster() {}
+
+  @Override
+  public synchronized InetSocketAddress getGrpcMasterAddress(
+      MasterInquireClient masterInquireClient) throws UnavailableException {
+    List<InetSocketAddress> masterAddresses =
+        new ArrayList<>(masterInquireClient.getMasterRpcAddresses());
+    if (masterAddresses.size() == 0) {
+      throw new UnavailableException("No master available");
+    }
+    Collections.shuffle(masterAddresses);
+    return masterAddresses.get(0);
+  }
+}

--- a/core/common/src/main/java/alluxio/master/selectionpolicy/SelectionPolicyAnyStandbyMaster.java
+++ b/core/common/src/main/java/alluxio/master/selectionpolicy/SelectionPolicyAnyStandbyMaster.java
@@ -1,0 +1,68 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.selectionpolicy;
+
+import alluxio.exception.status.UnavailableException;
+import alluxio.master.MasterInquireClient;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+import javax.annotation.Nullable;
+
+/**
+ * The master connection mode that connects to a random standby master.
+ */
+public class SelectionPolicyAnyStandbyMaster extends AbstractMasterSelectionPolicy {
+  @Nullable
+  private final Random mRandom;
+
+  /**
+   * Creates a new standby connection mode that picks the standby master randomly.
+   */
+  protected SelectionPolicyAnyStandbyMaster() {
+    mRandom = null;
+  }
+
+  /**
+   * Creates a new standby connection mode that
+   * picks the standby master deterministically with a random seed.
+   *
+   * @param shuffleSeed the random seed to shuffle the master client list
+   */
+  protected SelectionPolicyAnyStandbyMaster(long shuffleSeed) {
+    mRandom = new Random(shuffleSeed);
+  }
+
+  @Override
+  public synchronized InetSocketAddress getGrpcMasterAddress(
+      MasterInquireClient masterInquireClient) throws UnavailableException {
+    List<InetSocketAddress> masterAddresses =
+        new ArrayList<>(masterInquireClient.getMasterRpcAddresses());
+
+    if (mRandom != null) {
+      masterAddresses.sort(Comparator.comparing(InetSocketAddress::toString));
+      Collections.shuffle(masterAddresses, mRandom);
+    } else {
+      Collections.shuffle(masterAddresses);
+    }
+    for (InetSocketAddress address : masterAddresses) {
+      if (!address.equals(getPrimaryMasterAddressCached(masterInquireClient))) {
+        return address;
+      }
+    }
+    throw new UnavailableException("No standby masters available");
+  }
+}

--- a/core/common/src/main/java/alluxio/master/selectionpolicy/SelectionPolicyPrimaryMaster.java
+++ b/core/common/src/main/java/alluxio/master/selectionpolicy/SelectionPolicyPrimaryMaster.java
@@ -1,0 +1,31 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.selectionpolicy;
+
+import alluxio.exception.status.UnavailableException;
+import alluxio.master.MasterInquireClient;
+
+import java.net.InetSocketAddress;
+
+/**
+ * The master selection policy that connects to the primary master.
+ */
+public class SelectionPolicyPrimaryMaster extends AbstractMasterSelectionPolicy {
+  protected SelectionPolicyPrimaryMaster() {}
+
+  @Override
+  public synchronized InetSocketAddress getGrpcMasterAddress(
+      MasterInquireClient masterInquireClient) throws UnavailableException {
+    mPrimaryMasterAddress = masterInquireClient.getPrimaryRpcAddress();
+    return mPrimaryMasterAddress;
+  }
+}

--- a/core/common/src/main/java/alluxio/master/selectionpolicy/SelectionPolicySpecifiedMaster.java
+++ b/core/common/src/main/java/alluxio/master/selectionpolicy/SelectionPolicySpecifiedMaster.java
@@ -1,0 +1,40 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.selectionpolicy;
+
+import alluxio.exception.status.UnavailableException;
+import alluxio.master.MasterInquireClient;
+
+import java.net.InetSocketAddress;
+
+/**
+ * The master selection policy that connects to the specified master.
+ */
+public class SelectionPolicySpecifiedMaster extends AbstractMasterSelectionPolicy {
+  final InetSocketAddress mMasterAddressToConnect;
+
+  /**
+   * Creates a new selection policy that specifies a master address to client.
+   *
+   * @param masterAddressToConnect the master address to connect
+   */
+  protected SelectionPolicySpecifiedMaster(InetSocketAddress masterAddressToConnect) {
+    mMasterAddressToConnect = masterAddressToConnect;
+  }
+
+  @Override
+  public synchronized InetSocketAddress getGrpcMasterAddress(
+      MasterInquireClient masterInquireClient) throws UnavailableException {
+    return mMasterAddressToConnect;
+  }
+}
+

--- a/core/common/src/test/java/alluxio/AbstractMasterClientTest.java
+++ b/core/common/src/test/java/alluxio/AbstractMasterClientTest.java
@@ -1,0 +1,147 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio;
+
+import alluxio.conf.Configuration;
+import alluxio.exception.status.UnavailableException;
+import alluxio.grpc.ServiceType;
+import alluxio.master.MasterClientContext;
+import alluxio.master.MasterInquireClient;
+import alluxio.master.selectionpolicy.MasterSelectionPolicy;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Unit tests for {@link AbstractMasterClientTest}.
+ */
+public class AbstractMasterClientTest {
+  static class TestAbstractClient extends AbstractMasterClient {
+
+    public TestAbstractClient(MasterClientContext clientConf, MasterSelectionPolicy connectMode) {
+      super(clientConf, connectMode);
+    }
+
+    @Override
+    protected ServiceType getRemoteServiceType() {
+      return ServiceType.FILE_SYSTEM_MASTER_CLIENT_SERVICE;
+    }
+
+    @Override
+    protected String getServiceName() {
+      return "SERVICE_NAME";
+    }
+
+    @Override
+    protected long getServiceVersion() {
+      return 0;
+    }
+  }
+
+  MasterInquireClient mMockMasterInquireClient;
+  MasterClientContext mMockMasterClientContext;
+
+  List<InetSocketAddress> mAddress = Arrays.asList(
+      new InetSocketAddress("114.5.1.4", 810),
+      new InetSocketAddress("114.5.1.4", 811),
+      new InetSocketAddress("114.5.1.4", 812)
+  );
+  int mPrimaryMasterIndex = 0;
+
+  @Before
+  public void setup() throws UnavailableException {
+    mPrimaryMasterIndex = 0;
+    mMockMasterInquireClient = Mockito.mock(MasterInquireClient.class);
+    mMockMasterClientContext = Mockito.mock(MasterClientContext.class);
+    Mockito.when(mMockMasterClientContext.getMasterInquireClient())
+        .thenReturn(mMockMasterInquireClient);
+    Mockito.when(mMockMasterClientContext.getConfMasterInquireClient())
+        .thenReturn(mMockMasterInquireClient);
+    Mockito.when(mMockMasterClientContext.getClusterConf()).thenReturn(
+        Configuration.modifiableGlobal());
+    Mockito.when(mMockMasterInquireClient.getMasterRpcAddresses()).thenReturn(mAddress);
+    Mockito.when(mMockMasterInquireClient.getPrimaryRpcAddress()).thenAnswer(
+        (invocation) -> mAddress.get(mPrimaryMasterIndex)
+    );
+  }
+
+  @Test
+  public void primaryMaster() throws UnavailableException {
+    AbstractMasterClient client = new TestAbstractClient(
+        mMockMasterClientContext,
+        MasterSelectionPolicy.Factory.primaryMaster()
+    );
+    Assert.assertEquals(mAddress.get(mPrimaryMasterIndex), client.getRemoteSockAddress());
+    Assert.assertEquals(mAddress.get(mPrimaryMasterIndex), client.getConfAddress());
+
+    mPrimaryMasterIndex = 1;
+
+    // To simulate the client.disconnect() then client.connect()
+    client.afterDisconnect();
+    client.mServerAddress = null;
+
+    Assert.assertEquals(mAddress.get(mPrimaryMasterIndex), client.getRemoteSockAddress());
+    Assert.assertEquals(mAddress.get(mPrimaryMasterIndex), client.getConfAddress());
+  }
+
+  @Test
+  public void anyStandbyMaster() throws UnavailableException {
+    AbstractMasterClient client =
+        new TestAbstractClient(
+            mMockMasterClientContext, MasterSelectionPolicy.Factory.anyStandbyMaster());
+    Assert.assertNotEquals(mAddress.get(mPrimaryMasterIndex), client.getRemoteSockAddress());
+    Assert.assertEquals(mAddress.get(mPrimaryMasterIndex), client.getConfAddress());
+
+    mPrimaryMasterIndex = 1;
+
+    // To simulate the client.disconnect() then client.connect()
+    client.afterDisconnect();
+    client.mServerAddress = null;
+
+    Assert.assertNotEquals(mAddress.get(mPrimaryMasterIndex), client.getRemoteSockAddress());
+    Assert.assertEquals(mAddress.get(mPrimaryMasterIndex), client.getConfAddress());
+  }
+
+  @Test
+  public void anyMaster() throws UnavailableException {
+    AbstractMasterClient client =
+        new TestAbstractClient(mMockMasterClientContext, MasterSelectionPolicy.Factory.anyMaster());
+    Assert.assertTrue(mAddress.contains(client.getRemoteSockAddress()));
+    Assert.assertEquals(mAddress.get(mPrimaryMasterIndex), client.getConfAddress());
+
+    mPrimaryMasterIndex = 1;
+
+    // To simulate the client.disconnect() then client.connect()
+    client.afterDisconnect();
+    client.mServerAddress = null;
+
+    Assert.assertTrue(mAddress.contains(client.getRemoteSockAddress()));
+    Assert.assertEquals(mAddress.get(mPrimaryMasterIndex), client.getConfAddress());
+  }
+
+  @Test
+  public void specificMaster() throws UnavailableException {
+    int masterIndex = 2;
+    AbstractMasterClient client = new TestAbstractClient(
+        mMockMasterClientContext,
+        MasterSelectionPolicy.Factory.specifiedMaster(mAddress.get(masterIndex))
+    );
+    Assert.assertEquals(mAddress.get(masterIndex), client.getRemoteSockAddress());
+    Assert.assertEquals(mAddress.get(mPrimaryMasterIndex), client.getConfAddress());
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Enhance the abstract master client with the master selection policy that allows a client to connect to primary master / standby master or a specific master. This refactoring is a prerequisite for the following master side works. 

### Why are the changes needed?

Introduced different types of MasterSelectionPolicy(/ies)

### Does this PR introduce any user facing changes?

N/A