### PR TITLE
Use formatJournal instead of formatMaster

### DIFF
--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -87,7 +87,7 @@ function formatMasterIfSpecified {
     exit 1
   fi
   if [[ ${OPTIONS} != ${NO_FORMAT} ]]; then
-    bin/alluxio formatMaster
+    bin/alluxio formatJournal
   fi
 }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Use formatJournal instead of formatMaster in docker's entry-script

### Why are the changes needed?

formatMaster is deprecated

### Does this PR introduce any user facing changes?
