### PR TITLE
Set log4j.additivity of the audit log to false

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -20,6 +20,8 @@ log4j.logger.AUDIT_LOG=INFO, ${alluxio.master.audit.logger.type}
 log4j.logger.JOB_MASTER_AUDIT_LOG=INFO, ${alluxio.job.master.audit.logger.type}
 log4j.logger.PROXY_AUDIT_LOG=INFO, ${alluxio.proxy.audit.logger.type}
 log4j.additivity.AUDIT_LOG=false
+log4j.additivity.JOB_MASTER_AUDIT_LOG=false
+log4j.additivity.PROXY_AUDIT_LOG=false
 
 # Configures an appender whose name is "" (empty string) to be NullAppender.
 # By default, if a Java class does not specify a particular appender, log4j will


### PR DESCRIPTION
### What changes are proposed in this pull request?

Set the log4j.additivity of the audit log to false.

### Why are the changes needed?

Audit logs do not need to be appended to service logs.

### Does this PR introduce any user facing changes?
no.
