### PR TITLE
[DOCFIX] Use our own hosted strapdown script for REST docs

### DIFF
--- a/templates/strapdown.html.hbs
+++ b/templates/strapdown.html.hbs
@@ -5,6 +5,6 @@
 {{>markdown}}
 </xmp>
 
-<script src="https://strapdownjs.com/v/0.2/strapdown.js"></script>
+<script src="https://docs.alluxio.io/scripts/strapdown.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### What changes are proposed in this pull request?

[Hosting](https://docs.alluxio.io/scripts/strapdown.min.js) strapdown script ourselves since the link we were originally relying on is not available anymore. This script is used to help create styled doc pages in Markdown. 

### Why are the changes needed?

https://strapdownjs.com/v/0.2/strapdown.js is no longer available.

### Does this PR introduce any user facing changes?

REST docs
