### PR TITLE
Support setting sleep time for alluxio-fuse mount

### DIFF
--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -28,7 +28,7 @@ Usage:\talluxio-fuse mount [-n] [-o <mount option>] [-t <sleep seconds>] [mount_
 -o \tmount options for the fuse daemon,separated by comma
 -n \tno-daemon. This launches the process in the foreground and logs to stdout
 -s \tstackFS. This launches StackFS process for testing purpose
--t \tsleep time(seconds) before checking the AlluxioFuse process, default value is 2"
+-t \tsleep time(seconds) before checking whether the AlluxioFuse process is alive, default value is 2"
 
 readonly UMOUNT_USAGE="
 Umounts a given fuse mount point (defaults to \"alluxio.fuse.mount.point\"), use mount stat to show mount points.

--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -22,12 +22,13 @@ readonly MOUNT_USAGE="
 Mounts a path in Alluxio namespace (defaults to \"alluxio.fuse.mount.point\") 
 to mount point on local file system (defaults to \"alluxio.fuse.mount.alluxio.path\").
 
-Usage:\talluxio-fuse mount [-n] [-o <mount option>] [mount_point] [alluxio_path]
+Usage:\talluxio-fuse mount [-n] [-o <mount option>] [-t <sleep seconds>] [mount_point] [alluxio_path]
 \talluxio-fuse mount
 
 -o \tmount options for the fuse daemon,separated by comma
 -n \tno-daemon. This launches the process in the foreground and logs to stdout
--s \tstackFS. This launches StackFS process for testing purpose"
+-s \tstackFS. This launches StackFS process for testing purpose
+-t \tsleep time(seconds) before checking the AlluxioFuse process, default value is 2"
 
 readonly UMOUNT_USAGE="
 Umounts a given fuse mount point (defaults to \"alluxio.fuse.mount.point\"), use mount stat to show mount points.
@@ -108,7 +109,7 @@ mount_fuse() {
   else
     (nohup ${cmd} > ${ALLUXIO_LOGS_DIR}/fuse.out 2>&1) &
     # sleep: workaround to let the bg java process exit on errors, if any
-    sleep 2s
+    sleep ${mount_sleep_seconds}s
     if kill -0 $! > /dev/null 2>&1 ; then
       echo "Successfully mounted Alluxio to ${mount_point}."
       echo "See ${ALLUXIO_LOGS_DIR}/fuse.log for logging messages"
@@ -254,6 +255,7 @@ main() {
   
   NO_DAEMON=false
   STACK_FS=false
+  mount_sleep_seconds=2
   FORCE_KILL_OPT=false
   mount_point=''
   wait_time=120
@@ -261,7 +263,7 @@ main() {
   case "${command}" in
     mount)
       shift
-      while getopts 'o:ns' option; do
+      while getopts 'o:nst:' option; do
         case "${option}" in
           o)
             mount_options="${OPTARG}"
@@ -271,6 +273,9 @@ main() {
             ;;
           s)
             STACK_FS=true
+            ;;
+          t)
+            mount_sleep_seconds=${OPTARG}
             ;;
           *)
             err "Invalid mount option"


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add a parameter "-t" to set the sleep time before checking the AlluxioFuse process.

### Why are the changes needed?

Sometimes `alluxio-fuse mount` outputs `Successfully mounted` and returns `0` even failed, for example

```
$ integration/fuse/bin/alluxio-fuse mount /mnt/not_exist/projects /projects
Path /mnt/not_exist/projects is not mounted
Starting AlluxioFuse process: mounting alluxio path "/projects" to local mount point "/mnt/not_exist/projects"
Successfully mounted Alluxio to /mnt/not_exist/projects.
See /opt/alluxio-2.7.1-sdi-016/logs/fuse.log for logging messages

$ echo $?
0

$ jps -m |grep -i fuse
$
```

With the added option `-t`, the issue can be solved by setting a bigger value as below

```
$ integration/fuse/bin/alluxio-fuse mount -t 5 /mnt/not_exist/projects /projects
Path /mnt/not_exist/projects is not mounted
Starting AlluxioFuse process: mounting alluxio path "/projects" to local mount point "/mnt/not_exist/projects"
Failed to mount Alluxio to /mnt/not_exist/projects.
See /opt/alluxio-2.7.1/logs/fuse.out for more details

$ echo $?
1
```

### Does this PR introduce any user facing changes?

Added an optional parameter `-t` to set the sleep time before checking the AlluxioFuse process.
