### PR TITLE
Refactor s3 low level output stream and support OSS and OBS

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1223,6 +1223,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_OBJECT_STORE_STREAMING_UPLOAD_PART_TIMEOUT =
+      durationBuilder(Name.UNDERFS_OBJECT_STORE_STREAMING_UPLOAD_PART_TIMEOUT)
+          .setDescription("Timeout for uploading part when using streaming uploads.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_OBJECT_STORE_BREADCRUMBS_ENABLED =
       booleanBuilder(Name.UNDERFS_OBJECT_STORE_BREADCRUMBS_ENABLED)
           .setDefaultValue(true)
@@ -1755,6 +1761,41 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       .setScope(Scope.SERVER)
       .setDisplayType(DisplayType.CREDENTIALS)
       .build();
+  public static final PropertyKey UNDERFS_OSS_INTERMEDIATE_UPLOAD_CLEAN_AGE =
+      durationBuilder(Name.UNDERFS_OSS_INTERMEDIATE_UPLOAD_CLEAN_AGE)
+          .setDefaultValue("3day")
+          .setDescription("Streaming uploads may not have been completed/aborted correctly "
+              + "and need periodical ufs cleanup. If ufs cleanup is enabled, "
+              + "intermediate multipart uploads in all non-readonly OSS mount points "
+              + "older than this age will be cleaned. This may impact other "
+              + "ongoing upload operations, so a large clean age is encouraged.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_STREAMING_UPLOAD_ENABLED =
+      booleanBuilder(Name.UNDERFS_OSS_STREAMING_UPLOAD_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("(Experimental) If true, using streaming upload to write to OSS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_STREAMING_UPLOAD_PARTITION_SIZE =
+      dataSizeBuilder(Name.UNDERFS_OSS_STREAMING_UPLOAD_PARTITION_SIZE)
+          .setDefaultValue("64MB")
+          .setDescription("Maximum allowable size of a single buffer file when using "
+              + "OSS streaming upload. When the buffer file reaches the partition size, "
+              + "it will be uploaded and the upcoming data will write to other buffer files."
+              + "If the partition size is too small, OSS upload speed might be affected. ")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_STREAMING_UPLOAD_THREADS =
+      intBuilder(Name.UNDERFS_OSS_STREAMING_UPLOAD_THREADS)
+          .setDefaultValue(20)
+          .setDescription("the number of threads to use for streaming upload data to OSS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey S3A_ACCESS_KEY = stringBuilder(Name.S3A_ACCESS_KEY)
       .setAlias(Name.AWS_ACCESS_KEY)
       .setDescription("The access key of S3 bucket.")
@@ -1904,6 +1945,41 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue("obs")
           .setDescription("The type of bucket (obs/pfs).")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OBS_INTERMEDIATE_UPLOAD_CLEAN_AGE =
+      durationBuilder(Name.UNDERFS_OBS_INTERMEDIATE_UPLOAD_CLEAN_AGE)
+          .setDefaultValue("3day")
+          .setDescription("Streaming uploads may not have been completed/aborted correctly "
+              + "and need periodical ufs cleanup. If ufs cleanup is enabled, "
+              + "intermediate multipart uploads in all non-readonly OBS mount points "
+              + "older than this age will be cleaned. This may impact other "
+              + "ongoing upload operations, so a large clean age is encouraged.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OBS_STREAMING_UPLOAD_ENABLED =
+      booleanBuilder(Name.UNDERFS_OBS_STREAMING_UPLOAD_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("(Experimental) If true, using streaming upload to write to OBS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OBS_STREAMING_UPLOAD_PARTITION_SIZE =
+      dataSizeBuilder(Name.UNDERFS_OBS_STREAMING_UPLOAD_PARTITION_SIZE)
+          .setDefaultValue("64MB")
+          .setDescription("Maximum allowable size of a single buffer file when using "
+              + "S3A streaming upload. When the buffer file reaches the partition size, "
+              + "it will be uploaded and the upcoming data will write to other buffer files."
+              + "If the partition size is too small, OBS upload speed might be affected. ")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OBS_STREAMING_UPLOAD_THREADS =
+      intBuilder(Name.UNDERFS_OBS_STREAMING_UPLOAD_THREADS)
+          .setDefaultValue(20)
+          .setDescription("the number of threads to use for streaming upload data to OBS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
   //
@@ -7412,6 +7488,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_WEB_PARENT_NAMES = "alluxio.underfs.web.parent.names";
     public static final String UNDERFS_WEB_TITLES = "alluxio.underfs.web.titles";
     public static final String UNDERFS_VERSION = "alluxio.underfs.version";
+    public static final String UNDERFS_OBJECT_STORE_STREAMING_UPLOAD_PART_TIMEOUT =
+        "alluxio.underfs.object.store.streaming.upload.part.timeout";
     public static final String UNDERFS_OBJECT_STORE_BREADCRUMBS_ENABLED =
         "alluxio.underfs.object.store.breadcrumbs.enabled";
     public static final String UNDERFS_OBJECT_STORE_SERVICE_THREADS =
@@ -7434,6 +7512,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_OSS_STS_ENABLED = "alluxio.underfs.oss.sts.enabled";
     public static final String UNDERFS_OSS_STS_TOKEN_REFRESH_INTERVAL_MS =
         "alluxio.underfs.oss.sts.token.refresh.interval.ms";
+    public static final String UNDERFS_OSS_INTERMEDIATE_UPLOAD_CLEAN_AGE =
+        "alluxio.underfs.oss.intermediate.upload.clean.age";
+    public static final String UNDERFS_OSS_STREAMING_UPLOAD_ENABLED =
+        "alluxio.underfs.oss.streaming.upload.enabled";
+    public static final String UNDERFS_OSS_STREAMING_UPLOAD_PARTITION_SIZE =
+        "alluxio.underfs.oss.streaming.upload.partition.size";
+    public static final String UNDERFS_OSS_STREAMING_UPLOAD_THREADS =
+        "alluxio.underfs.oss.streaming.upload.threads";
     public static final String UNDERFS_S3_BULK_DELETE_ENABLED =
         "alluxio.underfs.s3.bulk.delete.enabled";
     public static final String UNDERFS_S3_DEFAULT_MODE = "alluxio.underfs.s3.default.mode";
@@ -7505,6 +7591,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.cephfs.mount.point";
     public static final String UNDERFS_CEPHFS_LOCALIZE_READS =
         "alluxio.underfs.cephfs.localize.reads";
+    public static final String UNDERFS_OBS_INTERMEDIATE_UPLOAD_CLEAN_AGE =
+        "alluxio.underfs.obs.intermediate.upload.clean.age";
+    public static final String UNDERFS_OBS_STREAMING_UPLOAD_ENABLED =
+        "alluxio.underfs.obs.streaming.upload.enabled";
+    public static final String UNDERFS_OBS_STREAMING_UPLOAD_PARTITION_SIZE =
+        "alluxio.underfs.obs.streaming.upload.partition.size";
+    public static final String UNDERFS_OBS_STREAMING_UPLOAD_THREADS =
+        "alluxio.underfs.obs.streaming.upload.threads";
 
     //
     // UFS access control related properties

--- a/core/common/src/main/java/alluxio/underfs/ObjectLowLevelOutputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectLowLevelOutputStream.java
@@ -1,0 +1,402 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs;
+
+import alluxio.Constants;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.retry.CountingRetry;
+import alluxio.retry.RetryPolicy;
+import alluxio.retry.RetryUtils;
+import alluxio.util.CommonUtils;
+import alluxio.util.io.PathUtils;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import org.apache.commons.codec.binary.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+/**
+ * [Experimental] A stream for writing a file into object storage using streaming upload.
+ * The data transfer is done using object storage low-level multipart upload.
+ * <p>
+ * We upload data in partitions. When write(), the data will be persisted to
+ * a temporary file {@link #mFile} on the local disk. When the data {@link #mPartitionOffset}
+ * in this temporary file reaches the {@link #mPartitionSize}, the file will be submitted
+ * to the upload executor {@link #mExecutor} and we do not wait for uploads to finish.
+ * A new temp file will be created for the future write and the {@link #mPartitionOffset}
+ * will be reset to zero. The process goes until all the data has been written to temp files.
+ * <p>
+ * In flush(), we upload the buffered data if they are bigger than 5MB
+ * and wait for all uploads to finish. The temp files will be deleted after uploading successfully.
+ * <p>
+ * In close(), we upload the last part of data (if exists), wait for all uploads to finish,
+ * and complete the multipart upload.
+ * <p>
+ * close() will not be retried, but all the multipart upload
+ * related operations(init, upload, complete, and abort) will be retried.
+ * <p>
+ * If an error occurs and we have no way to recover, we abort the multipart uploads.
+ * Some multipart uploads may not be completed/aborted in normal ways and need periodical cleanup
+ * by enabling the {@link PropertyKey#UNDERFS_CLEANUP_ENABLED}.
+ * When a leader master starts or a cleanup interval is reached, all the multipart uploads
+ * older than clean age will be cleaned.
+ */
+public abstract class ObjectLowLevelOutputStream extends OutputStream {
+  protected static final Logger LOG = LoggerFactory.getLogger(ObjectLowLevelOutputStream.class);
+
+  protected final List<String> mTmpDirs;
+
+  /**
+   * Only parts bigger than 5MB could be uploaded through multipart upload,
+   * except the last part.
+   */
+  protected static final long UPLOAD_THRESHOLD = 5L * Constants.MB;
+
+  /** Bucket name of the object storage bucket. */
+  protected final String mBucketName;
+
+  /** Key of the file when it is uploaded to object storage. */
+  protected final String mKey;
+
+  /** The retry policy of this multipart upload. */
+  protected final RetryPolicy mRetryPolicy = new CountingRetry(5);
+
+  /** Pre-allocated byte buffer for writing single characters. */
+  protected final byte[] mSingleCharWrite = new byte[1];
+
+  /** The MD5 hash of the file. */
+  protected MessageDigest mHash;
+
+  /** Flag to indicate this stream has been closed, to ensure close is only done once. */
+  protected boolean mClosed = false;
+
+  /** When the offset reaches the partition size, we upload the temp file. */
+  protected long mPartitionOffset;
+  /** The maximum allowed size of a partition. */
+  protected final long mPartitionSize;
+
+  /**
+   * The local temp file that will be uploaded when reaches the partition size
+   * or when flush() is called and this file is bigger than {@link #UPLOAD_THRESHOLD}.
+   */
+  protected File mFile;
+  /** The output stream to the local temp file. */
+  protected OutputStream mLocalOutputStream;
+
+  /**
+   * Give each upload request a unique and continuous id
+   * so that object storage knows the part sequence to concatenate the parts to a single object.
+   */
+  private final AtomicInteger mPartNumber;
+
+  /** Executing the upload tasks. */
+  private final ListeningExecutorService mExecutor;
+
+  /** Store the future of tags. */
+  private final List<ListenableFuture<?>> mFutures = new ArrayList<>();
+
+  /** upload part timeout, null means no timeout. */
+  @Nullable
+  private Duration mUploadPartTimeout;
+
+  /**
+   * Constructs a new stream for writing a file.
+   *
+   * @param bucketName the name of the bucket
+   * @param key the key of the file
+   * @param streamingUploadPartitionSize the size in bytes for partitions of streaming uploads
+   * @param executor executor
+   * @param ufsConf the object store under file system configuration
+   */
+  public ObjectLowLevelOutputStream(
+      String bucketName,
+      String key,
+      ListeningExecutorService executor,
+      long streamingUploadPartitionSize,
+      AlluxioConfiguration ufsConf) {
+    Preconditions.checkArgument(bucketName != null && !bucketName.isEmpty(),
+        "Bucket name must not be null or empty.");
+    mBucketName = bucketName;
+    mTmpDirs = ufsConf.getList(PropertyKey.TMP_DIRS);
+    mExecutor = executor;
+    mKey = key;
+    initHash();
+    mPartitionSize = Math.max(UPLOAD_THRESHOLD, streamingUploadPartitionSize);
+    mPartNumber = new AtomicInteger(1);
+    if (ufsConf.isSet(PropertyKey.UNDERFS_OBJECT_STORE_STREAMING_UPLOAD_PART_TIMEOUT)) {
+      mUploadPartTimeout =
+          ufsConf.getDuration(PropertyKey.UNDERFS_OBJECT_STORE_STREAMING_UPLOAD_PART_TIMEOUT);
+    }
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    mSingleCharWrite[0] = (byte) b;
+    write(mSingleCharWrite);
+  }
+
+  @Override
+  public void write(byte[] b) throws IOException {
+    write(b, 0, b.length);
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    if (b == null || len == 0) {
+      return;
+    }
+    validateWriteArgs(b, off, len);
+    if (mFile == null) {
+      initNewFile();
+    }
+    if (mPartitionOffset + len <= mPartitionSize) {
+      mLocalOutputStream.write(b, off, len);
+      mPartitionOffset += len;
+    } else {
+      int firstLen = (int) (mPartitionSize - mPartitionOffset);
+      mLocalOutputStream.write(b, off, firstLen);
+      mPartitionOffset += firstLen;
+      uploadPart();
+      write(b, off + firstLen, len - firstLen);
+    }
+  }
+
+  @Override
+  public void flush() throws IOException {
+    if (!isMultiPartUploadInitialized()) {
+      return;
+    }
+    // We try to minimize the time use to close()
+    // because Fuse release() method which calls close() is async.
+    // In flush(), we upload the current writing file if it is bigger than 5 MB,
+    // and wait for all current upload to complete.
+    if (mLocalOutputStream != null) {
+      mLocalOutputStream.flush();
+    }
+    if (mPartitionOffset > UPLOAD_THRESHOLD) {
+      uploadPart();
+    }
+    waitForAllPartsUpload();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (mClosed) {
+      return;
+    }
+
+    // Set the closed flag, we never retry close() even if exception occurs
+    mClosed = true;
+
+    // Multi-part upload has not been initialized
+    if (!isMultiPartUploadInitialized()) {
+      if (mFile == null) {
+        LOG.debug("Streaming upload output stream closed without uploading any data.");
+        RetryUtils.retry("put empty object for key" + mKey, () -> createEmptyObject(mKey),
+            mRetryPolicy);
+      } else {
+        try {
+          mLocalOutputStream.close();
+          final String md5;
+          if (mHash != null) {
+            md5 = Base64.encodeBase64String(mHash.digest());
+          } else {
+            md5 = null;
+          }
+          RetryUtils.retry("put object for key" + mKey, () -> putObject(mKey, mFile, md5),
+              mRetryPolicy);
+        } finally {
+          if (!mFile.delete()) {
+            LOG.error("Failed to delete temporary file @ {}", mFile.getPath());
+          }
+        }
+      }
+      return;
+    }
+
+    try {
+      if (mFile != null) {
+        mLocalOutputStream.close();
+        int partNumber = mPartNumber.getAndIncrement();
+        uploadPart(mFile, partNumber, true);
+      }
+
+      waitForAllPartsUpload();
+      RetryUtils.retry("complete multipart upload",
+          this::completeMultiPartUploadInternal, mRetryPolicy);
+    } catch (Exception e) {
+      LOG.error("Failed to upload {}", mKey, e);
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * Validates the arguments of write operation.
+   *
+   * @param b the data
+   * @param off the start offset in the data
+   * @param len the number of bytes to write
+   */
+  private void validateWriteArgs(byte[] b, int off, int len) {
+    Preconditions.checkNotNull(b);
+    if (off < 0 || off > b.length || len < 0
+        || (off + len) > b.length || (off + len) < 0) {
+      throw new IndexOutOfBoundsException("write(b[" + b.length + "], " + off + ", " + len + ")");
+    }
+  }
+
+  /**
+   * Creates a new temp file to write to.
+   */
+  private void initNewFile() throws IOException {
+    mFile = new File(PathUtils.concatPath(CommonUtils.getTmpDir(mTmpDirs), UUID.randomUUID()));
+    initHash();
+    if (mHash != null) {
+      mLocalOutputStream =
+          new BufferedOutputStream(new DigestOutputStream(new FileOutputStream(mFile), mHash));
+    } else {
+      mLocalOutputStream = new BufferedOutputStream(new FileOutputStream(mFile));
+    }
+    mPartitionOffset = 0;
+    LOG.debug("Init new temp file @ {}", mFile.getPath());
+  }
+
+  private void initHash() {
+    try {
+      mHash = MessageDigest.getInstance("MD5");
+    } catch (NoSuchAlgorithmException e) {
+      LOG.warn("Algorithm not available for MD5 hash.", e);
+      mHash = null;
+    }
+  }
+
+  /**
+   * Uploads part async.
+   */
+  protected void uploadPart() throws IOException {
+    if (mFile == null) {
+      return;
+    }
+    if (!isMultiPartUploadInitialized()) {
+      RetryUtils.retry("init multipart upload", this::initMultiPartUploadInternal, mRetryPolicy);
+    }
+    mLocalOutputStream.close();
+    int partNumber = mPartNumber.getAndIncrement();
+    File newFileToUpload = new File(mFile.getPath());
+    mFile = null;
+    mLocalOutputStream = null;
+    uploadPart(newFileToUpload, partNumber, false);
+  }
+
+  protected void uploadPart(File file, int partNumber, boolean lastPart) throws IOException {
+    final String md5;
+    if (mHash != null) {
+      md5 = Base64.encodeBase64String(mHash.digest());
+    } else {
+      md5 = null;
+    }
+    Callable<?> callable = () -> {
+      try {
+        RetryUtils.retry("upload part for key " + mKey + " and part number " + partNumber,
+            () -> uploadPartInternal(file, partNumber, lastPart, md5), mRetryPolicy);
+        return null;
+      } finally {
+        // Delete the uploaded or failed to upload file
+        if (!file.delete()) {
+          LOG.error("Failed to delete temporary file @ {}", file.getPath());
+        }
+      }
+    };
+    ListenableFuture<?> futureTag = mExecutor.submit(callable);
+    mFutures.add(futureTag);
+    LOG.debug(
+        "Submit upload part request. key={}, partNum={}, file={}, fileSize={}, lastPart={}.",
+        mKey, partNumber, file.getPath(), file.length(), lastPart);
+  }
+
+  protected void abortMultiPartUpload() throws IOException {
+    RetryUtils.retry("abort multipart upload for key " + mKey, this::abortMultiPartUploadInternal,
+        mRetryPolicy);
+  }
+
+  protected void waitForAllPartsUpload() throws IOException {
+    try {
+      for (ListenableFuture<?> future : mFutures) {
+        if (mUploadPartTimeout == null) {
+          future.get();
+        } else {
+          future.get(mUploadPartTimeout.toMillis(), TimeUnit.MILLISECONDS);
+        }
+      }
+    } catch (ExecutionException e) {
+      // No recover ways so that we need to cancel all the upload tasks
+      // and abort the multipart upload
+      Futures.allAsList(mFutures).cancel(true);
+      abortMultiPartUpload();
+      throw new IOException(
+          "Part upload failed in multipart upload with to " + mKey, e);
+    } catch (InterruptedException e) {
+      LOG.warn("Interrupted object upload.", e);
+      Futures.allAsList(mFutures).cancel(true);
+      abortMultiPartUpload();
+      Thread.currentThread().interrupt();
+    } catch (TimeoutException e) {
+      LOG.error("timeout when upload part");
+      Futures.allAsList(mFutures).cancel(true);
+      abortMultiPartUpload();
+      throw new IOException("timeout when upload part " + mKey, e);
+    }
+    mFutures.clear();
+  }
+
+  protected abstract void uploadPartInternal(
+      File file,
+      int partNumber,
+      boolean isLastPart,
+      @Nullable String md5)
+      throws IOException;
+
+  protected abstract void initMultiPartUploadInternal() throws IOException;
+
+  protected abstract void completeMultiPartUploadInternal() throws IOException;
+
+  protected abstract void abortMultiPartUploadInternal() throws IOException;
+
+  protected abstract void createEmptyObject(String key) throws IOException;
+
+  protected abstract void putObject(String key, File file, String md5) throws IOException;
+
+  protected abstract boolean isMultiPartUploadInitialized();
+}

--- a/core/common/src/main/java/alluxio/underfs/ObjectLowLevelOutputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectLowLevelOutputStream.java
@@ -37,7 +37,6 @@ import java.io.OutputStream;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;

--- a/core/common/src/main/java/alluxio/underfs/ObjectLowLevelOutputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectLowLevelOutputStream.java
@@ -391,5 +391,5 @@ public abstract class ObjectLowLevelOutputStream extends OutputStream {
 
   protected abstract void createEmptyObject(String key) throws IOException;
 
-  protected abstract void putObject(String key, File file, String md5) throws IOException;
+  protected abstract void putObject(String key, File file, @Nullable String md5) throws IOException;
 }

--- a/core/common/src/main/java/alluxio/underfs/ObjectLowLevelOutputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectLowLevelOutputStream.java
@@ -99,6 +99,7 @@ public abstract class ObjectLowLevelOutputStream extends OutputStream {
   protected final byte[] mSingleCharWrite = new byte[1];
 
   /** The MD5 hash of the file. */
+  @Nullable
   protected MessageDigest mHash;
 
   /** Flag to indicate this stream has been closed, to ensure close is only done once. */
@@ -113,8 +114,10 @@ public abstract class ObjectLowLevelOutputStream extends OutputStream {
    * The local temp file that will be uploaded when reaches the partition size
    * or when flush() is called and this file is bigger than {@link #UPLOAD_THRESHOLD}.
    */
+  @Nullable
   protected File mFile;
   /** The output stream to the local temp file. */
+  @Nullable
   protected OutputStream mLocalOutputStream;
 
   /**

--- a/core/common/src/main/java/alluxio/underfs/ObjectLowLevelOutputStream.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectLowLevelOutputStream.java
@@ -389,5 +389,4 @@ public abstract class ObjectLowLevelOutputStream extends OutputStream {
   protected abstract void createEmptyObject(String key) throws IOException;
 
   protected abstract void putObject(String key, File file, String md5) throws IOException;
-
 }

--- a/underfs/obs/src/main/java/alluxio/underfs/obs/OBSLowLevelOutputStream.java
+++ b/underfs/obs/src/main/java/alluxio/underfs/obs/OBSLowLevelOutputStream.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * {@link ObjectLowLevelOutputStream} implement for OBS.
@@ -76,7 +77,11 @@ public class OBSLowLevelOutputStream extends ObjectLowLevelOutputStream {
   }
 
   @Override
-  protected void uploadPartInternal(File file, int partNumber, boolean isLastPart, String md5)
+  protected void uploadPartInternal(
+      File file,
+      int partNumber,
+      boolean isLastPart,
+      @Nullable String md5)
       throws IOException {
     try {
       final UploadPartRequest uploadRequest = new UploadPartRequest();
@@ -157,7 +162,7 @@ public class OBSLowLevelOutputStream extends ObjectLowLevelOutputStream {
   }
 
   @Override
-  protected void putObject(String key, File file, String md5) throws IOException {
+  protected void putObject(String key, File file, @Nullable String md5) throws IOException {
     try {
       ObjectMetadata meta = new ObjectMetadata();
       meta.setContentLength(file.length());

--- a/underfs/obs/src/test/java/alluxio/underfs/obs/OBSLowLevelOutputStreamTest.java
+++ b/underfs/obs/src/test/java/alluxio/underfs/obs/OBSLowLevelOutputStreamTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.underfs.s3a;
+package alluxio.underfs.obs;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -21,19 +21,18 @@ import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.util.FormatUtils;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
-import com.amazonaws.services.s3.model.CompleteMultipartUploadResult;
-import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
-import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
-import com.amazonaws.services.s3.model.PartETag;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.UploadPartRequest;
-import com.amazonaws.services.s3.model.UploadPartResult;
-import com.amazonaws.services.s3.transfer.TransferManager;
-import com.amazonaws.services.s3.transfer.Upload;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
+import com.obs.services.IObsClient;
+import com.obs.services.model.CompleteMultipartUploadRequest;
+import com.obs.services.model.CompleteMultipartUploadResult;
+import com.obs.services.model.InitiateMultipartUploadRequest;
+import com.obs.services.model.InitiateMultipartUploadResult;
+import com.obs.services.model.PartEtag;
+import com.obs.services.model.PutObjectRequest;
+import com.obs.services.model.PutObjectResult;
+import com.obs.services.model.UploadPartRequest;
+import com.obs.services.model.UploadPartResult;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,43 +46,38 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.security.DigestOutputStream;
+import java.util.HashMap;
 import java.util.concurrent.Callable;
 
 /**
- * Unit tests for the {@link S3ALowLevelOutputStream}.
+ * Unit tests for the {@link OBSLowLevelOutputStream}.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(S3ALowLevelOutputStream.class)
+@PrepareForTest(OBSLowLevelOutputStream.class)
 @SuppressWarnings("unchecked")
-public class S3ALowLevelOutputStreamTest {
+public class OBSLowLevelOutputStreamTest {
   private static final String BUCKET_NAME = "testBucket";
   private static final String PARTITION_SIZE = "8MB";
   private static final String KEY = "testKey";
   private static final String UPLOAD_ID = "testUploadId";
   private static InstancedConfiguration sConf = Configuration.modifiableGlobal();
 
-  private AmazonS3 mMockS3Client;
+  private IObsClient mMockObsClient;
   private ListeningExecutorService mMockExecutor;
   private BufferedOutputStream mMockOutputStream;
-  private ListenableFuture<PartETag> mMockTag;
+  private ListenableFuture<PartEtag> mMockTag;
 
-  private S3ALowLevelOutputStream mStream;
-  private TransferManager mTransferManager;
+  private OBSLowLevelOutputStream mStream;
 
   /**
    * Sets the properties and configuration before each test runs.
    */
   @Before
   public void before() throws Exception {
-    mockS3ClientAndExecutor();
+    mockOSSClientAndExecutor();
     mockFileAndOutputStream();
-    mTransferManager = Mockito.mock(TransferManager.class);
-    Upload result = Mockito.mock(Upload.class);
-    Mockito.when(mTransferManager.upload(Mockito.any(PutObjectRequest.class))).thenReturn(result);
-
-    sConf.set(PropertyKey.UNDERFS_S3_STREAMING_UPLOAD_PARTITION_SIZE, PARTITION_SIZE);
-    mStream = new S3ALowLevelOutputStream(BUCKET_NAME, KEY, mMockS3Client, mTransferManager,
-        mMockExecutor, sConf);
+    sConf.set(PropertyKey.UNDERFS_OBS_STREAMING_UPLOAD_PARTITION_SIZE, PARTITION_SIZE);
+    mStream = new OBSLowLevelOutputStream(BUCKET_NAME, KEY, mMockObsClient, mMockExecutor, sConf);
   }
 
   @Test
@@ -93,10 +87,10 @@ public class S3ALowLevelOutputStreamTest {
     mStream.close();
     Mockito.verify(mMockOutputStream).write(new byte[] {1}, 0, 1);
     Mockito.verify(mMockExecutor, never()).submit(any(Callable.class));
-    Mockito.verify(mTransferManager).upload(any(PutObjectRequest.class));
-    Mockito.verify(mMockS3Client, never())
+    Mockito.verify(mMockObsClient).putObject(any(PutObjectRequest.class));
+    Mockito.verify(mMockObsClient, never())
         .initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
-    Mockito.verify(mMockS3Client, never())
+    Mockito.verify(mMockObsClient, never())
         .completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
   }
 
@@ -110,10 +104,10 @@ public class S3ALowLevelOutputStreamTest {
 
     mStream.close();
     Mockito.verify(mMockExecutor, never()).submit(any(Callable.class));
-    Mockito.verify(mTransferManager).upload(any(PutObjectRequest.class));
-    Mockito.verify(mMockS3Client, never())
+    Mockito.verify(mMockObsClient).putObject(any(PutObjectRequest.class));
+    Mockito.verify(mMockObsClient, never())
         .initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
-    Mockito.verify(mMockS3Client, never())
+    Mockito.verify(mMockObsClient, never())
         .completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
   }
 
@@ -123,14 +117,14 @@ public class S3ALowLevelOutputStreamTest {
     byte[] b = new byte[partSize + 1];
 
     mStream.write(b, 0, b.length);
-    Mockito.verify(mMockS3Client)
+    Mockito.verify(mMockObsClient)
         .initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
     Mockito.verify(mMockOutputStream).write(b, 0, b.length - 1);
     Mockito.verify(mMockOutputStream).write(b, b.length - 1, 1);
     Mockito.verify(mMockExecutor).submit(any(Callable.class));
 
     mStream.close();
-    Mockito.verify(mMockS3Client)
+    Mockito.verify(mMockObsClient)
         .completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
   }
 
@@ -138,12 +132,11 @@ public class S3ALowLevelOutputStreamTest {
   public void createEmptyFile() throws Exception {
     mStream.close();
     Mockito.verify(mMockExecutor, never()).submit(any(Callable.class));
-    Mockito.verify(mTransferManager, never()).upload(any(PutObjectRequest.class));
-    Mockito.verify(mMockS3Client, never())
+    Mockito.verify(mMockObsClient, never())
         .initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
-    Mockito.verify(mMockS3Client, never())
+    Mockito.verify(mMockObsClient, never())
         .completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
-    Mockito.verify(mMockS3Client).putObject(any());
+    Mockito.verify(mMockObsClient).putObject(any());
   }
 
   @Test
@@ -152,7 +145,7 @@ public class S3ALowLevelOutputStreamTest {
     byte[] b = new byte[2 * partSize - 1];
 
     mStream.write(b, 0, b.length);
-    Mockito.verify(mMockS3Client)
+    Mockito.verify(mMockObsClient)
         .initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
     Mockito.verify(mMockOutputStream).write(b, 0, partSize);
     Mockito.verify(mMockOutputStream).write(b, partSize, partSize - 1);
@@ -163,31 +156,33 @@ public class S3ALowLevelOutputStreamTest {
     Mockito.verify(mMockTag, times(2)).get();
 
     mStream.close();
-    Mockito.verify(mMockS3Client)
+    Mockito.verify(mMockObsClient)
         .completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
   }
 
   @Test
   public void close() throws Exception {
     mStream.close();
-    Mockito.verify(mMockS3Client, never())
+    Mockito.verify(mMockObsClient, never())
         .initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
-    Mockito.verify(mMockS3Client, never())
+    Mockito.verify(mMockObsClient, never())
         .completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
   }
 
   /**
-   * Mocks the S3 client and executor.
+   * Mocks the OSS client and executor.
    */
-  private void mockS3ClientAndExecutor() throws Exception {
-    mMockS3Client = PowerMockito.mock(AmazonS3.class);
+  private void mockOSSClientAndExecutor() throws Exception {
+    mMockObsClient = PowerMockito.mock(IObsClient.class);
 
-    InitiateMultipartUploadResult initResult = new InitiateMultipartUploadResult();
-    when(mMockS3Client.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class)))
+    InitiateMultipartUploadResult initResult =
+        new InitiateMultipartUploadResult(BUCKET_NAME, KEY, UPLOAD_ID);
+    when(mMockObsClient.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class)))
         .thenReturn(initResult);
+    when(mMockObsClient.putObject(any(PutObjectRequest.class)))
+        .thenReturn(new PutObjectResult(BUCKET_NAME, KEY, "", "", "", new HashMap<>(), 200));
 
-    initResult.setUploadId(UPLOAD_ID);
-    when(mMockS3Client.uploadPart(any(UploadPartRequest.class)))
+    when(mMockObsClient.uploadPart(any(UploadPartRequest.class)))
         .thenAnswer((InvocationOnMock invocation) -> {
           Object[] args = invocation.getArguments();
           UploadPartResult uploadResult = new UploadPartResult();
@@ -195,11 +190,11 @@ public class S3ALowLevelOutputStreamTest {
           return uploadResult;
         });
 
-    when(mMockS3Client.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
-        .thenReturn(new CompleteMultipartUploadResult());
+    when(mMockObsClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+        .thenReturn(new CompleteMultipartUploadResult(BUCKET_NAME, KEY, "", "", "", ""));
 
-    mMockTag = (ListenableFuture<PartETag>) PowerMockito.mock(ListenableFuture.class);
-    when(mMockTag.get()).thenReturn(new PartETag(1, "someTag"));
+    mMockTag = (ListenableFuture<PartEtag>) PowerMockito.mock(ListenableFuture.class);
+    when(mMockTag.get()).thenReturn(new PartEtag("someTag", 1));
     mMockExecutor = Mockito.mock(ListeningExecutorService.class);
     when(mMockExecutor.submit(any(Callable.class))).thenReturn(mMockTag);
   }

--- a/underfs/obs/src/test/java/alluxio/underfs/obs/OBSLowLevelOutputStreamTest.java
+++ b/underfs/obs/src/test/java/alluxio/underfs/obs/OBSLowLevelOutputStreamTest.java
@@ -33,6 +33,7 @@ import com.obs.services.model.PutObjectRequest;
 import com.obs.services.model.PutObjectResult;
 import com.obs.services.model.UploadPartRequest;
 import com.obs.services.model.UploadPartResult;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -115,8 +116,9 @@ public class OBSLowLevelOutputStreamTest {
   public void writeByteArrayForLargeFile() throws Exception {
     int partSize = (int) FormatUtils.parseSpaceSize(PARTITION_SIZE);
     byte[] b = new byte[partSize + 1];
-
+    Assert.assertEquals(mStream.getPartNumber(), 1);
     mStream.write(b, 0, b.length);
+    Assert.assertEquals(mStream.getPartNumber(), 2);
     Mockito.verify(mMockObsClient)
         .initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
     Mockito.verify(mMockOutputStream).write(b, 0, b.length - 1);
@@ -124,6 +126,7 @@ public class OBSLowLevelOutputStreamTest {
     Mockito.verify(mMockExecutor).submit(any(Callable.class));
 
     mStream.close();
+    Assert.assertEquals(mStream.getPartNumber(), 3);
     Mockito.verify(mMockObsClient)
         .completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
   }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelOutputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelOutputStream.java
@@ -1,0 +1,160 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.oss;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.underfs.ObjectLowLevelOutputStream;
+
+import com.aliyun.oss.ClientException;
+import com.aliyun.oss.OSS;
+import com.aliyun.oss.OSSException;
+import com.aliyun.oss.internal.Mimetypes;
+import com.aliyun.oss.model.AbortMultipartUploadRequest;
+import com.aliyun.oss.model.CompleteMultipartUploadRequest;
+import com.aliyun.oss.model.InitiateMultipartUploadRequest;
+import com.aliyun.oss.model.ObjectMetadata;
+import com.aliyun.oss.model.PartETag;
+import com.aliyun.oss.model.PutObjectRequest;
+import com.aliyun.oss.model.UploadPartRequest;
+import com.google.common.util.concurrent.ListeningExecutorService;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * {@link ObjectLowLevelOutputStream} implement for OSS.
+ */
+public class OSSLowLevelOutputStream extends ObjectLowLevelOutputStream {
+  /** The OSS client to interact with OSS. */
+  private final OSS mClient;
+  /** Tags for the uploaded part, provided by OSS after uploading. */
+  private final List<PartETag> mTags =
+      Collections.synchronizedList(new ArrayList<>());
+
+  /** The upload id of this multipart upload. */
+  protected volatile String mUploadId;
+
+  /**
+   * Constructs a new stream for writing a file.
+   *
+   * @param bucketName the name of the bucket
+   * @param key the key of the file
+   * @param oss the OSS client to upload the file with
+   * @param executor a thread pool executor
+   * @param ufsConf the object store under file system configuration
+   */
+  public OSSLowLevelOutputStream(
+      String bucketName,
+      String key,
+      OSS oss,
+      ListeningExecutorService executor,
+      AlluxioConfiguration ufsConf) {
+    super(bucketName, key, executor,
+        ufsConf.getBytes(PropertyKey.UNDERFS_OSS_STREAMING_UPLOAD_PARTITION_SIZE), ufsConf);
+    mClient = oss;
+  }
+
+  @Override
+  protected void abortMultiPartUploadInternal() throws IOException {
+    try {
+      getClient().abortMultipartUpload(new AbortMultipartUploadRequest(mBucketName,
+          mKey, mUploadId));
+    } catch (OSSException | ClientException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  protected void uploadPartInternal(File file, int partNumber, boolean isLastPart, String md5)
+      throws IOException {
+    try {
+      try (InputStream inputStream = new BufferedInputStream(new FileInputStream(file))) {
+        final UploadPartRequest uploadRequest =
+            new UploadPartRequest(mBucketName, mKey, mUploadId, partNumber, inputStream,
+                file.length());
+        if (md5 != null) {
+          uploadRequest.setMd5Digest(md5);
+        }
+        PartETag partETag = getClient().uploadPart(uploadRequest).getPartETag();
+        mTags.add(partETag);
+      }
+    } catch (OSSException | ClientException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  protected void initMultiPartUploadInternal() throws IOException {
+    try {
+      ObjectMetadata meta = new ObjectMetadata();
+      meta.setContentType(Mimetypes.DEFAULT_MIMETYPE);
+      InitiateMultipartUploadRequest initRequest =
+          new InitiateMultipartUploadRequest(mBucketName, mKey, meta);
+      mUploadId = getClient().initiateMultipartUpload(initRequest).getUploadId();
+    } catch (OSSException | ClientException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  protected void completeMultiPartUploadInternal() throws IOException {
+    try {
+      CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
+          mBucketName, mKey, mUploadId, mTags);
+      getClient().completeMultipartUpload(completeRequest);
+    } catch (OSSException | ClientException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  protected boolean isMultiPartUploadInitialized() {
+    return mUploadId != null;
+  }
+
+  @Override
+  protected void createEmptyObject(String key) throws IOException {
+    try {
+      ObjectMetadata objMeta = new ObjectMetadata();
+      objMeta.setContentLength(0);
+      getClient().putObject(mBucketName, key, new ByteArrayInputStream(new byte[0]), objMeta);
+    } catch (OSSException | ClientException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  protected void putObject(String key, File file, String md5) throws IOException {
+    try {
+      ObjectMetadata objMeta = new ObjectMetadata();
+      if (md5 != null) {
+        objMeta.setContentMD5(md5);
+      }
+      PutObjectRequest request = new PutObjectRequest(mBucketName, key, file, objMeta);
+      getClient().putObject(request);
+    } catch (OSSException | ClientException e) {
+      throw new IOException(e);
+    }
+  }
+
+  protected OSS getClient() {
+    return mClient;
+  }
+}

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelOutputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSLowLevelOutputStream.java
@@ -38,6 +38,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * {@link ObjectLowLevelOutputStream} implement for OSS.
@@ -86,7 +87,11 @@ public class OSSLowLevelOutputStream extends ObjectLowLevelOutputStream {
   }
 
   @Override
-  protected void uploadPartInternal(File file, int partNumber, boolean isLastPart, String md5)
+  protected void uploadPartInternal(
+      File file,
+      int partNumber,
+      boolean isLastPart,
+      @Nullable String md5)
       throws IOException {
     try {
       try (InputStream inputStream = new BufferedInputStream(new FileInputStream(file))) {
@@ -148,7 +153,7 @@ public class OSSLowLevelOutputStream extends ObjectLowLevelOutputStream {
   }
 
   @Override
-  protected void putObject(String key, File file, String md5) throws IOException {
+  protected void putObject(String key, File file, @Nullable String md5) throws IOException {
     try {
       ObjectMetadata objMeta = new ObjectMetadata();
       if (md5 != null) {

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/OSSLowLevelOutputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/OSSLowLevelOutputStreamTest.java
@@ -34,6 +34,7 @@ import com.aliyun.oss.model.UploadPartRequest;
 import com.aliyun.oss.model.UploadPartResult;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -116,8 +117,9 @@ public class OSSLowLevelOutputStreamTest {
   public void writeByteArrayForLargeFile() throws Exception {
     int partSize = (int) FormatUtils.parseSpaceSize(PARTITION_SIZE);
     byte[] b = new byte[partSize + 1];
-
+    Assert.assertEquals(mStream.getPartNumber(), 1);
     mStream.write(b, 0, b.length);
+    Assert.assertEquals(mStream.getPartNumber(), 2);
     Mockito.verify(mMockOssClient)
         .initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
     Mockito.verify(mMockOutputStream).write(b, 0, b.length - 1);
@@ -125,6 +127,7 @@ public class OSSLowLevelOutputStreamTest {
     Mockito.verify(mMockExecutor).submit(any(Callable.class));
 
     mStream.close();
+    Assert.assertEquals(mStream.getPartNumber(), 3);
     Mockito.verify(mMockOssClient)
         .completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
   }

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -406,12 +406,11 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   @Override
   protected OutputStream createObject(String key) throws IOException {
     if (mStreamingUploadEnabled) {
-      return new S3ALowLevelOutputStream(mBucketName, key, mClient, mManager, mExecutor, mUfsConf);
+      return new S3ALowLevelOutputStream(mBucketName, key, mClient, mExecutor, mUfsConf);
     }
     return new S3AOutputStream(mBucketName, key, mManager,
         mUfsConf.getList(PropertyKey.TMP_DIRS),
-        mUfsConf
-            .getBoolean(PropertyKey.UNDERFS_S3_SERVER_SIDE_ENCRYPTION_ENABLED));
+        mUfsConf.getBoolean(PropertyKey.UNDERFS_S3_SERVER_SIDE_ENCRYPTION_ENABLED));
   }
 
   @Override

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -406,10 +406,7 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
   @Override
   protected OutputStream createObject(String key) throws IOException {
     if (mStreamingUploadEnabled) {
-      return new S3ALowLevelOutputStream(mBucketName, key, mClient, mExecutor,
-          mUfsConf.getBytes(PropertyKey.UNDERFS_S3_STREAMING_UPLOAD_PARTITION_SIZE),
-          mUfsConf.getList(PropertyKey.TMP_DIRS),
-          mUfsConf.getBoolean(PropertyKey.UNDERFS_S3_SERVER_SIDE_ENCRYPTION_ENABLED));
+      return new S3ALowLevelOutputStream(mBucketName, key, mClient, mManager, mExecutor, mUfsConf);
     }
     return new S3AOutputStream(mBucketName, key, mManager,
         mUfsConf.getList(PropertyKey.TMP_DIRS),

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3ALowLevelOutputStreamTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3ALowLevelOutputStreamTest.java
@@ -34,6 +34,7 @@ import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -121,8 +122,9 @@ public class S3ALowLevelOutputStreamTest {
   public void writeByteArrayForLargeFile() throws Exception {
     int partSize = (int) FormatUtils.parseSpaceSize(PARTITION_SIZE);
     byte[] b = new byte[partSize + 1];
-
+    Assert.assertEquals(mStream.getPartNumber(), 1);
     mStream.write(b, 0, b.length);
+    Assert.assertEquals(mStream.getPartNumber(), 2);
     Mockito.verify(mMockS3Client)
         .initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
     Mockito.verify(mMockOutputStream).write(b, 0, b.length - 1);
@@ -130,6 +132,7 @@ public class S3ALowLevelOutputStreamTest {
     Mockito.verify(mMockExecutor).submit(any(Callable.class));
 
     mStream.close();
+    Assert.assertEquals(mStream.getPartNumber(), 3);
     Mockito.verify(mMockS3Client)
         .completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Refactor s3 low level output stream and support OSS and OBS.

### Why are the changes needed?

1. extract the generic logic to `ObjectLowLevelOutputStream` to make it easy to support new object storage.
2. Support streaming uploads for OBS and OSS.
3. fix the bug that empty files cannot be persisted to UFS.
4. specify MD5 when upload parts.

### Does this PR introduce any user facing changes?

`alluxio.underfs.oss.intermediate.upload.clean.age`: clean incomplete multi abort age for OSS.
`alluxio.underfs.oss.streaming.upload.enabled`: Whether to enable stream upload for OSS.
`alluxio.underfs.oss.streaming.upload.partition.size`: straming upload partition size for OSS.
`alluxio.underfs.oss.streaming.upload.threads`: thread pool size for OSS streaming upload.
`alluxio.underfs.obs.intermediate.upload.clean.age`: clean incomplete multi abort age for obs.
`alluxio.underfs.obs.streaming.upload.enabled`:  Whether to enable stream upload for OBS.
`alluxio.underfs.obs.streaming.upload.partition.size`: straming upload partition size for OBS.
`alluxio.underfs.obs.streaming.upload.threads`: thread pool size for OBS streaming upload.
