### PR TITLE
Add supplement field to S3AuditContext

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3AuditContext.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3AuditContext.java
@@ -14,6 +14,8 @@ package alluxio.proxy.s3;
 import alluxio.master.audit.AsyncUserAccessAuditLogWriter;
 import alluxio.master.audit.AuditContext;
 
+import java.util.List;
+
 /**
  * An audit context for s3 rest service.
  */
@@ -28,7 +30,7 @@ public class S3AuditContext implements AuditContext {
   private String mObject;
   private long mCreationTimeNs;
   private long mExecutionTimeNs;
-  private String mComplement;
+  private List<String> mMetadata;
 
   /**
    * Constructor of {@link S3AuditContext}.
@@ -106,12 +108,12 @@ public class S3AuditContext implements AuditContext {
   }
 
   /**
-   * Sets mComplement field.
-   * @param complement complement to audit logs
+   * Sets mMetadata field.
+   * @param metadataList more metadata
    * @return this {@link AuditContext} instance
    */
-  public S3AuditContext setComplement(String complement) {
-    mComplement = complement;
+  public S3AuditContext setMetadata(List<String> metadataList) {
+    mMetadata = metadataList;
     return this;
   }
 
@@ -140,8 +142,8 @@ public class S3AuditContext implements AuditContext {
   public String toString() {
     return String.format(
       "succeeded=%b\tallowed=%b\tugi=%s\tip=%s\tcmd=%s\t"
-      + "bucket=%s\tobject=%s\tcomplement=%s\texecutionTimeUs=%d",
-      mSucceeded, mAllowed, mUgi, mIp, mCommand, mBucket, mObject, mComplement,
+      + "bucket=%s\tobject=%s\tmetadata=%s\texecutionTimeUs=%d",
+      mSucceeded, mAllowed, mUgi, mIp, mCommand, mBucket, mObject, mMetadata,
       mExecutionTimeNs / 1000);
   }
 }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3AuditContext.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3AuditContext.java
@@ -28,6 +28,7 @@ public class S3AuditContext implements AuditContext {
   private String mObject;
   private long mCreationTimeNs;
   private long mExecutionTimeNs;
+  private String mComplement;
 
   /**
    * Constructor of {@link S3AuditContext}.
@@ -104,6 +105,16 @@ public class S3AuditContext implements AuditContext {
     return this;
   }
 
+  /**
+   * Sets mComplement field.
+   * @param complement complement to audit logs
+   * @return this {@link AuditContext} instance
+   */
+  public S3AuditContext setComplement(String complement) {
+    mComplement = complement;
+    return this;
+  }
+
   @Override
   public S3AuditContext setAllowed(boolean allowed) {
     mAllowed = allowed;
@@ -129,8 +140,9 @@ public class S3AuditContext implements AuditContext {
   public String toString() {
     return String.format(
       "succeeded=%b\tallowed=%b\tugi=%s\tip=%s\tcmd=%s\t"
-      + "bucket=%s\tobject=%s\texecutionTimeUs=%d",
-      mSucceeded, mAllowed, mUgi, mIp, mCommand, mBucket, mObject, mExecutionTimeNs / 1000);
+      + "bucket=%s\tobject=%s\tcomplement=%s\texecutionTimeUs=%d",
+      mSucceeded, mAllowed, mUgi, mIp, mCommand, mBucket, mObject, mComplement,
+      mExecutionTimeNs / 1000);
   }
 }
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -354,7 +354,7 @@ public final class S3RestServiceHandler {
             .setListType(listTypeParam)
             .setContinuationToken(continuationTokenParam)
             .setStartAfter(startAfterParam);
-
+        auditContext.setComplement(listBucketOptions.toString());
         List<URIStatus> children;
         try {
           // TODO(czhu): allow non-"/" delimiters by parsing the prefix & delimiter pair to

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -314,6 +314,8 @@ public final class S3RestServiceHandler {
 
       try (S3AuditContext auditContext = createAuditContext("listObjects", user, bucket, null)) {
         S3RestUtils.checkPathIsAlluxioDirectory(userFs, path, auditContext, BUCKET_PATH_CACHE);
+        List<String> metadata = new ArrayList<>();
+        S3RestUtils.checkPathIsAlluxioDirectory(userFs, path, auditContext);
         if (tagging != null) { // GetBucketTagging
           AlluxioURI uri = new AlluxioURI(path);
           try {
@@ -354,7 +356,8 @@ public final class S3RestServiceHandler {
             .setListType(listTypeParam)
             .setContinuationToken(continuationTokenParam)
             .setStartAfter(startAfterParam);
-        auditContext.setComplement(listBucketOptions.toString());
+        metadata.add(listBucketOptions.toString());
+        auditContext.setMetadata(metadata);
         List<URIStatus> children;
         try {
           // TODO(czhu): allow non-"/" delimiters by parsing the prefix & delimiter pair to


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add supplement field to S3AuditContext.

### Why are the changes needed?

The audit log of the getBucket interface of s3 only records the bucket cannot know the specific operation path.

### Does this PR introduce any user facing changes?

no.
