### PR TITLE
Set longer timeout for localAlluxioCluster to get ready

### DIFF
--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -56,7 +56,7 @@ public abstract class AbstractLocalAlluxioCluster {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractLocalAlluxioCluster.class);
 
   private static final Random RANDOM_GENERATOR = new Random();
-  private static final int WAIT_MASTER_START_TIMEOUT_MS = 20_000;
+  private static final int WAIT_MASTER_START_TIMEOUT_MS = 30_000;
 
   protected ProxyProcess mProxyProcess;
   protected Thread mProxyThread;


### PR DESCRIPTION
Introduced in https://github.com/Alluxio/alluxio/pull/16067/, the timeout for the master in `AbstractLocalAlluxioCluster` is set to 20s. This brings about >75% failure rate of the test `updateConfIntegrationTest` in github actions. 

Tested on different machines, running same tests the slower machine can be 5x slower than the faster machine. Since Github actions machines are not considered powerful, set the timeout to 30s.