### PR TITLE
Add a configurable temp ufs dir

### DIFF
--- a/core/common/src/main/java/alluxio/Constants.java
+++ b/core/common/src/main/java/alluxio/Constants.java
@@ -214,7 +214,6 @@ public final class Constants {
   public static final int NO_AUTO_PERSIST = -1;
   public static final int PERSISTENCE_INVALID_JOB_ID = -1;
   public static final String PERSISTENCE_INVALID_UFS_PATH = "";
-  public static final String PERSISTENCE_ASYNC_TEMP_PATH_ROOT_DIR = ".alluxio_ufs_persistence";
 
   // Table service
   public static final String TABLE_MASTER_NAME = "TableMaster";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1111,6 +1111,11 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_PERSISTENCE_ASYNC_TEMP_DIR =
+      stringBuilder(Name.UNDERFS_PERSISTENCE_ASYNC_TEMP_DIR)
+          .setDescription("The temporary directory used for async persistence in the ufs")
+          .setDefaultValue(".alluxio_ufs_persistence")
+          .build();
   public static final PropertyKey UNDERFS_WEB_HEADER_LAST_MODIFIED =
       stringBuilder(Name.UNDERFS_WEB_HEADER_LAST_MODIFIED)
           .setDefaultValue("EEE, dd MMM yyyy HH:mm:ss zzz")
@@ -6828,6 +6833,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_IO_THREADS = "alluxio.underfs.io.threads";
     public static final String UNDERFS_LOCAL_SKIP_BROKEN_SYMLINKS =
         "alluxio.underfs.local.skip.broken.symlinks";
+    public static final String UNDERFS_PERSISTENCE_ASYNC_TEMP_DIR =
+        "alluxio.underfs.persistence.async.temp.dir";
     public static final String UNDERFS_WEB_HEADER_LAST_MODIFIED =
         "alluxio.underfs.web.header.last.modified";
     public static final String UNDERFS_WEB_CONNECTION_TIMEOUT =

--- a/core/common/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/PathUtils.java
@@ -13,10 +13,10 @@ package alluxio.util.io;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidPathException;
-import alluxio.underfs.UnderFileSystem;
 import alluxio.util.OSUtils;
 
 import com.google.common.base.CharMatcher;
@@ -222,22 +222,21 @@ public final class PathUtils {
   /**
    * Get temp path for async persistence job.
    *
-   * @param ufs the ufs
+   * @param ufsConfiguration the ufs configuration
    * @param path ufs path
    * @return ufs temp path with UUID
    */
-  public static String getPersistentTmpPath(@Nullable UnderFileSystem ufs, String path)
-      throws IOException {
+  public static String getPersistentTmpPath(AlluxioConfiguration ufsConfiguration,
+      String path) {
     StringBuilder tempFilePath = new StringBuilder();
     StringBuilder tempFileName = new StringBuilder();
     String fileName = FilenameUtils.getName(path);
     String timeStamp = String.valueOf(System.currentTimeMillis());
     String uuid = UUID.randomUUID().toString();
     String tempDir = Constants.PERSISTENCE_ASYNC_TEMP_PATH_ROOT_DIR;
-    if (ufs != null && ufs.getConfiguration() != null
-        && ufs.getConfiguration()
+    if (ufsConfiguration
         .isSet(PropertyKey.UNDERFS_PERSISTENCE_ASYNC_TEMP_DIR)) {
-      tempDir = ufs.getConfiguration()
+      tempDir = ufsConfiguration
           .getString(alluxio.conf.PropertyKey.UNDERFS_PERSISTENCE_ASYNC_TEMP_DIR);
     }
     tempFilePath.append(tempDir);

--- a/core/common/src/main/java/alluxio/util/io/PathUtils.java
+++ b/core/common/src/main/java/alluxio/util/io/PathUtils.java
@@ -12,7 +12,6 @@
 package alluxio.util.io;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.ExceptionMessage;
@@ -23,14 +22,12 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Preconditions;
 import org.apache.commons.io.FilenameUtils;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -233,12 +230,8 @@ public final class PathUtils {
     String fileName = FilenameUtils.getName(path);
     String timeStamp = String.valueOf(System.currentTimeMillis());
     String uuid = UUID.randomUUID().toString();
-    String tempDir = Constants.PERSISTENCE_ASYNC_TEMP_PATH_ROOT_DIR;
-    if (ufsConfiguration
-        .isSet(PropertyKey.UNDERFS_PERSISTENCE_ASYNC_TEMP_DIR)) {
-      tempDir = ufsConfiguration
-          .getString(alluxio.conf.PropertyKey.UNDERFS_PERSISTENCE_ASYNC_TEMP_DIR);
-    }
+    String tempDir = ufsConfiguration
+          .getString(PropertyKey.UNDERFS_PERSISTENCE_ASYNC_TEMP_DIR);
     tempFilePath.append(tempDir);
     tempFilePath.append(AlluxioURI.SEPARATOR);
     tempFileName.append(fileName);

--- a/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
@@ -21,8 +21,10 @@ import static org.junit.Assert.fail;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.InvalidPathException;
+import alluxio.underfs.UnderFileSystemConfiguration;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -269,7 +271,9 @@ public final class PathUtilsTest {
     // Get temporary path
     Pattern pattern = Pattern.compile(
         "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
-    String tempPersistencePath = PathUtils.getPersistentTmpPath(null, "s3://test/test.parquet");
+    AlluxioConfiguration alluxioConfiguration = UnderFileSystemConfiguration.emptyConfig();
+    String tempPersistencePath = PathUtils.getPersistentTmpPath(alluxioConfiguration,
+        "s3://test/test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
     pattern = Pattern.compile(
         "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
@@ -280,12 +284,13 @@ public final class PathUtilsTest {
     // Get temporary path with root path
     pattern = Pattern.compile(
         "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
-    tempPersistencePath = PathUtils.getPersistentTmpPath(null, "s3://test.parquet");
+    tempPersistencePath = PathUtils.getPersistentTmpPath(alluxioConfiguration,
+        "s3://test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
     pattern = Pattern.compile(
         "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
     tempPersistencePath = PathUtils
-        .getPersistentTmpPath(null, "hdfs://localhost:9010/test.parquet");
+        .getPersistentTmpPath(alluxioConfiguration, "hdfs://localhost:9010/test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
   }
 

--- a/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
@@ -273,7 +273,8 @@ public final class PathUtilsTest {
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
     pattern = Pattern.compile(
         "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
-    tempPersistencePath = PathUtils.getPersistentTmpPath(null, "hdfs://localhost:9010/test/test.parquet");
+    tempPersistencePath = PathUtils
+        .getPersistentTmpPath(null, "hdfs://localhost:9010/test/test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
 
     // Get temporary path with root path
@@ -283,7 +284,8 @@ public final class PathUtilsTest {
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
     pattern = Pattern.compile(
         "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
-    tempPersistencePath = PathUtils.getPersistentTmpPath(null, "hdfs://localhost:9010/test.parquet");
+    tempPersistencePath = PathUtils
+        .getPersistentTmpPath(null, "hdfs://localhost:9010/test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
   }
 

--- a/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
@@ -267,7 +267,7 @@ public final class PathUtilsTest {
   }
 
   @Test
-  public void getPersistentTmpPath() throws IOException {
+  public void getPersistentTmpPath() {
     // Get temporary path
     Pattern pattern = Pattern.compile(
         "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
@@ -278,7 +278,7 @@ public final class PathUtilsTest {
     pattern = Pattern.compile(
         "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
     tempPersistencePath = PathUtils
-        .getPersistentTmpPath(null, "hdfs://localhost:9010/test/test.parquet");
+        .getPersistentTmpPath(alluxioConfiguration, "hdfs://localhost:9010/test/test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
 
     // Get temporary path with root path

--- a/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
@@ -30,7 +30,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
+++ b/core/common/src/test/java/alluxio/util/io/PathUtilsTest.java
@@ -28,6 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -264,25 +265,25 @@ public final class PathUtilsTest {
   }
 
   @Test
-  public void getPersistentTmpPath() {
+  public void getPersistentTmpPath() throws IOException {
     // Get temporary path
     Pattern pattern = Pattern.compile(
         "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
-    String tempPersistencePath = PathUtils.getPersistentTmpPath("s3://test/test.parquet");
+    String tempPersistencePath = PathUtils.getPersistentTmpPath(null, "s3://test/test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
     pattern = Pattern.compile(
         "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
-    tempPersistencePath = PathUtils.getPersistentTmpPath("hdfs://localhost:9010/test/test.parquet");
+    tempPersistencePath = PathUtils.getPersistentTmpPath(null, "hdfs://localhost:9010/test/test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
 
     // Get temporary path with root path
     pattern = Pattern.compile(
         "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
-    tempPersistencePath = PathUtils.getPersistentTmpPath("s3://test.parquet");
+    tempPersistencePath = PathUtils.getPersistentTmpPath(null, "s3://test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
     pattern = Pattern.compile(
         "\\.alluxio_ufs_persistence\\/test\\.parquet\\.alluxio\\.\\d+\\.\\S+\\.tmp");
-    tempPersistencePath = PathUtils.getPersistentTmpPath("hdfs://localhost:9010/test.parquet");
+    tempPersistencePath = PathUtils.getPersistentTmpPath(null, "hdfs://localhost:9010/test.parquet");
     assertEquals(pattern.matcher(tempPersistencePath).matches(), true);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4350,7 +4350,7 @@ public class DefaultFileSystemMaster extends CoreMaster
           // error reading (failure of temp file clean up)
           String mountPointUri = resolution.getUfsMountPointUri().toString();
           tempUfsPath = PathUtils.concatUfsPath(mountPointUri,
-              PathUtils.getPersistentTmpPath(resolution.getUri().toString()));
+              PathUtils.getPersistentTmpPath(ufsResource.get(), resolution.getUri().toString()));
           LOG.debug("Generate tmp ufs path {} from ufs path {} for persistence.",
               tempUfsPath, resolution.getUri());
         }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4350,7 +4350,8 @@ public class DefaultFileSystemMaster extends CoreMaster
           // error reading (failure of temp file clean up)
           String mountPointUri = resolution.getUfsMountPointUri().toString();
           tempUfsPath = PathUtils.concatUfsPath(mountPointUri,
-              PathUtils.getPersistentTmpPath(ufsResource.get(), resolution.getUri().toString()));
+              PathUtils.getPersistentTmpPath(ufsResource.get().getConfiguration(),
+                  resolution.getUri().toString()));
           LOG.debug("Generate tmp ufs path {} from ufs path {} for persistence.",
               tempUfsPath, resolution.getUri());
         }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add a configurable temp ufs dir.

### Why are the changes needed?
Add a configurable temp ufs dir. So far the dir is a fixed one under "/", some users may have concerns about that.

### Does this PR introduce any user facing changes?
The configurable dir config item:
alluxio.underfs.persistence.async.temp.dir

eg:
alluxio.underfs.persistence.async.temp.dir=.ufs_persistence_temp_dir