### PR TITLE
Fix worker stream register forget release lease

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1249,6 +1249,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     mWorkerInfoCache.invalidate(WORKER_INFO_CACHE_KEY);
     LOG.info("Worker successfully registered: {}", workerInfo);
     mActiveRegisterContexts.remove(workerInfo.getId());
+    mRegisterLeaseManager.releaseLease(workerInfo.getId());
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

When we have a large cluster, we found that is very slowly to register all workers to master. Because of default 25 workers  register a time and the lease lasts for 1 minute since the worker have finished the register. And I found when not use stream register, it will release lease. So I think it should be the same as before.

### Why are the changes needed?
Greatly increase the worker registration speed when you have a large scale cluster.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
no
