### PR TITLE
Port changes of [#16137] to branch-2.8

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1192,6 +1192,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     mWorkerInfoCache.invalidate(WORKER_INFO_CACHE_KEY);
     LOG.info("Worker successfully registered: {}", worker);
     mActiveRegisterContexts.remove(worker.getId());
+    mRegisterLeaseManager.releaseLease(worker.getId());
   }
 
   @Override


### PR DESCRIPTION
When we have a large cluster, we found that is very slowly to register
all workers to master. Because of default 25 workers register a time and
the lease lasts for 1 minute since the worker have finished the
register. And I found when not use stream register, it will release
lease. So I think it should be the same as before.

Greatly increase the worker registration speed when you have a large
scale cluster.

Please list the user-facing changes introduced by your change, including
no

pr-link: Alluxio/alluxio#16137
change-id: cid-20fd21e04cb74c5861cd692764a4b5f3db896178
