### PR TITLE
Remove dockerfile-common.sh from generating tarball

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -207,7 +207,6 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 		"integration/docker/csi/main.go",
 		"integration/docker/Dockerfile",
 		"integration/docker/Dockerfile-dev",
-		"integration/docker/dockerfile-common.sh",
 		"integration/docker/entrypoint.sh",
 		"integration/fuse/bin/alluxio-fuse",
 		"integration/metrics/docker-compose-master.yaml",


### PR DESCRIPTION
dockerfile-common.sh is removed by #16101. Remove it from generate tarball script.