### PR TITLE
Fix listStatus on empty MinIO bucket return 400 Error

### DIFF
--- a/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/ObjectUnderFileSystem.java
@@ -981,7 +981,7 @@ public abstract class ObjectUnderFileSystem extends BaseUnderFileSystem {
     ObjectListingChunk chunk = getObjectListingChunkForPath(path, options.isRecursive());
     if (chunk == null) {
       String keyAsFolder = convertToFolderName(stripPrefixIfPresent(path));
-      if (getObjectStatus(keyAsFolder) != null) {
+      if (isRoot(keyAsFolder) || getObjectStatus(keyAsFolder) != null) {
         // Path is an empty directory
         return new UfsStatus[0];
       }


### PR DESCRIPTION
Fix #16147
### What changes are proposed in this pull request?

When execute listStatus on empty bucket, there is no need to execute getObjectStatus method through S3 client.

### Why are the changes needed?

When UFS is MinIO and bucket is empty, execute getObjectStatus on key '/' will return 400 Error.

### Does this PR introduce any user facing changes?
No
