### PR TITLE
Remove exception from journal method signatures

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/AbstractJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/AbstractJournalSystem.java
@@ -20,7 +20,6 @@ import alluxio.resource.LockResource;
 
 import com.google.common.base.Preconditions;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -42,14 +41,14 @@ public abstract class AbstractJournalSystem implements JournalSystem {
   private final Set<JournalSink> mAllJournalSinks = new ConcurrentHashSet<>();
 
   @Override
-  public synchronized void start() throws InterruptedException, IOException {
+  public synchronized void start() {
     Preconditions.checkState(!mRunning, "Journal is already running");
     startInternal();
     mRunning = true;
   }
 
   @Override
-  public synchronized void stop() throws InterruptedException, IOException {
+  public synchronized void stop() {
     Preconditions.checkState(mRunning, "Journal is not running");
     mAllJournalSinks.forEach(JournalSink::beforeShutdown);
     mRunning = false;
@@ -96,12 +95,12 @@ public abstract class AbstractJournalSystem implements JournalSystem {
   /**
    * Starts the journal system.
    */
-  protected abstract void startInternal() throws InterruptedException, IOException;
+  protected abstract void startInternal();
 
   /**
    * Stops the journal system.
    */
-  protected abstract void stopInternal() throws InterruptedException, IOException;
+  protected abstract void stopInternal();
 
   protected void registerMetrics() {
     Map<String, Long> sequenceNumber = getCurrentSequenceNumbers();

--- a/core/server/common/src/main/java/alluxio/master/journal/JournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalSystem.java
@@ -121,12 +121,12 @@ public interface JournalSystem {
    * All journals must be created before starting the journal system. This method will block until
    * the journal system is successfully started. The journal always starts in standby mode.
    */
-  void start() throws InterruptedException, IOException;
+  void start();
 
   /**
    * Stops the journal system.
    */
-  void stop() throws InterruptedException, IOException;
+  void stop();
 
   /**
    * Transitions the journal to primary mode.

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -751,6 +751,10 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     }
   }
 
+  /**
+   * Throws {@link AlluxioRuntimeException} when it cannot start a RaftCluster and therefore
+   * cannot join the quorum.
+   */
   @Override
   public synchronized void startInternal() {
     LOG.info("Initializing Raft Journal System");

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -537,11 +537,14 @@ public class RaftJournalSystem extends AbstractJournalSystem {
       return;
     }
     mTransferLeaderAllowed.set(false);
+    try {
       // Close async writer first to flush pending entries.
-    mAsyncJournalWriter.get().close();
-    mRaftJournalWriter.close();
-    mAsyncJournalWriter.set(null);
-    mRaftJournalWriter = null;
+      mAsyncJournalWriter.get().close();
+      mRaftJournalWriter.close();
+    } finally {
+      mAsyncJournalWriter.set(null);
+      mRaftJournalWriter = null;
+    }
     LOG.info("Shutting down Raft server");
     try {
       mServer.close();
@@ -769,7 +772,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
       LOG.info("Started Raft Journal System in {}ms", System.currentTimeMillis() - startTime);
     } catch (IOException e) {
       String errorMessage = MessageFormat.format("Failed to bootstrap raft cluster "
-              + "with addresses {}", mClusterAddresses);
+          + "with addresses {}", mClusterAddresses);
       throw new AlluxioRuntimeException(Status.UNAVAILABLE, errorMessage, e, ErrorType.Internal,
           true);
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -14,9 +14,11 @@ package alluxio.master.journal.raft;
 import alluxio.Constants;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.runtime.AlluxioRuntimeException;
 import alluxio.exception.status.CancelledException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.AddQuorumServerRequest;
+import alluxio.grpc.ErrorType;
 import alluxio.grpc.GrpcService;
 import alluxio.grpc.JournalQueryRequest;
 import alluxio.grpc.NetAddress;
@@ -45,6 +47,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.net.HostAndPort;
+import io.grpc.Status;
 import org.apache.commons.io.FileUtils;
 import org.apache.ratis.RaftConfigKeys;
 import org.apache.ratis.client.RaftClient;
@@ -85,7 +88,6 @@ import java.net.URI;
 import java.nio.file.AccessDeniedException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -766,11 +768,10 @@ public class RaftJournalSystem extends AbstractJournalSystem {
       mServer.start();
       LOG.info("Started Raft Journal System in {}ms", System.currentTimeMillis() - startTime);
     } catch (IOException e) {
-      String errorMessage =
-          MessageFormat.format("Failed to bootstrap raft cluster with addresses {0}: {1}",
-              Arrays.toString(mClusterAddresses.toArray()),
-              e.getCause() == null ? e : e.getCause().toString());
-      throw new RuntimeException(errorMessage, e.getCause());
+      String errorMessage = MessageFormat.format("Failed to bootstrap raft cluster "
+              + "with addresses {}", mClusterAddresses);
+      throw new AlluxioRuntimeException(Status.UNAVAILABLE, errorMessage, e, ErrorType.Internal,
+          true);
     }
     joinQuorum();
   }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalWriter.java
@@ -133,7 +133,7 @@ public class RaftJournalWriter implements JournalWriter {
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() {
     if (mClosed) {
       return;
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
@@ -248,7 +248,7 @@ public class UfsJournal implements Journal {
   /**
    * Starts the journal in standby mode.
    */
-  public synchronized void start() throws IOException {
+  public synchronized void start() {
     mMaster.resetState();
     mTailerThread = new UfsJournalCheckpointThread(mMaster, this, mJournalSinks);
     mTailerThread.start();

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
@@ -187,7 +187,7 @@ public class UfsJournalSystem extends AbstractJournalSystem {
   }
 
   @Override
-  public void startInternal() throws IOException {
+  public void startInternal() {
     for (UfsJournal journal : mJournals.values()) {
       journal.start();
     }

--- a/tests/src/test/java/alluxio/testutils/master/FsMasterResource.java
+++ b/tests/src/test/java/alluxio/testutils/master/FsMasterResource.java
@@ -55,11 +55,7 @@ public class FsMasterResource implements Closeable {
 
   @Override
   public void close() throws IOException {
-    try {
-      mRegistry.close();
-      mJournal.stop();
-    } catch (InterruptedException e) {
-      throw new IOException(e);
-    }
+    mRegistry.close();
+    mJournal.stop();
   }
 }


### PR DESCRIPTION
Some key journal method have exceptions in their method signatures where it is not necessary, and in most cases where the method does not even throw said exception.
This PR removes those.