### PR TITLE
Allocate buffer in load api

### DIFF
--- a/core/common/src/main/java/alluxio/exception/runtime/OutOfRangeRuntimeException.java
+++ b/core/common/src/main/java/alluxio/exception/runtime/OutOfRangeRuntimeException.java
@@ -1,0 +1,45 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.exception.runtime;
+
+import alluxio.grpc.ErrorType;
+
+import io.grpc.Status;
+
+/**
+ * Exception indicating that and operation was attempted past the valid range. E.g., seeking or
+ * reading past end of file.
+ *
+ * Unlike InvalidArgument, this error indicates a problem that may be fixed if the system
+ * state changes. For example, a 32-bit file system will generate InvalidArgument if asked
+ * to read at an offset that is not in the range [0,2^32-1], but it will generate
+ * OutOfRangeException if asked to read from an offset past the current file size.
+ *
+ * There is a fair bit of overlap between FailedPrecondition and OutOfRange. We
+ * recommend using OutOfRange (the more specific error) when it applies so that callers who
+ * are iterating through a space can easily look for an OutOfRange to detect when they are
+ * done.
+ */
+public class OutOfRangeRuntimeException extends AlluxioRuntimeException {
+  private static final Status STATUS = Status.OUT_OF_RANGE;
+  private static final ErrorType ERROR_TYPE = ErrorType.User;
+  private static final boolean RETRYABLE = false;
+
+  /**
+   * Constructor.
+   *
+   * @param message error message
+   */
+  public OutOfRangeRuntimeException(String message) {
+    super(STATUS, message, null, ERROR_TYPE, RETRYABLE);
+  }
+}

--- a/core/transport/src/main/proto/grpc/block_worker.proto
+++ b/core/transport/src/main/proto/grpc/block_worker.proto
@@ -141,7 +141,12 @@ message LoadRequest {
 
 message UfsReadOptions{
   required string tag = 1;
-  optional int64 bandwidth = 2;
+  // is position short or not, used for HDFS performance optimization.
+  // When the client buffer size is large ( > 2MB) and reads are guaranteed to be somewhat
+  // sequential, the `pread` API to HDFS is not as efficient as simple `read`.
+  // We introduce a heuristic to choose which API to use.
+  required bool position_short = 2;
+  optional int64 bandwidth = 3;
 }
 
 

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -1091,6 +1091,11 @@
               },
               {
                 "id": 2,
+                "name": "position_short",
+                "type": "bool"
+              },
+              {
+                "id": 3,
                 "name": "bandwidth",
                 "type": "int64"
               }
@@ -2359,6 +2364,11 @@
                 "id": 4,
                 "name": "commonOptions",
                 "type": "FileSystemMasterCommonPOptions"
+              },
+              {
+                "id": 6,
+                "name": "deleteMountPoint",
+                "type": "bool"
               }
             ]
           },
@@ -3061,7 +3071,14 @@
             ]
           },
           {
-            "name": "GetMountTablePRequest"
+            "name": "GetMountTablePRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "checkUfs",
+                "type": "bool"
+              }
+            ]
           },
           {
             "name": "MountPointInfo",


### PR DESCRIPTION
### What changes are proposed in this pull request?
make ufsiomanager take byterbuffer as input so we can allocate bytebuffer from buffer pool later on

### Why are the changes needed?
better memory usage
### Does this PR introduce any user facing changes?
na
