### PR TITLE
Require valid "Authorization" header in S3 API Proxy

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -19,10 +19,8 @@ import alluxio.client.file.URIStatus;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
-import alluxio.grpc.Bits;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
-import alluxio.grpc.PMode;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.io.ByteStreams;
@@ -290,10 +288,6 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
 
         CreateFilePOptions.Builder optionsBuilder = CreateFilePOptions.newBuilder()
             .setRecursive(true)
-            .setMode(PMode.newBuilder()
-                .setOwnerBits(Bits.ALL)
-                .setGroupBits(Bits.ALL)
-                .setOtherBits(Bits.NONE).build())
             .setWriteType(S3RestUtils.getS3WriteType());
         // Copy Tagging xAttr if it exists
         if (metaStatus.getXAttr().containsKey(S3Constants.TAGGING_XATTR_KEY)) {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -95,9 +95,17 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
       sb.append(s);
       if (request.getQueryString() != null) { sb.append("?").append(request.getQueryString()); }
       sb.append(" User=");
-      String user = S3RestServiceHandler.getUserFromAuthorization(
-          request.getHeader("Authorization"));
-      if (user == null) { user = "N/A"; }
+      String user = null;
+      try {
+        user = S3RestServiceHandler.getUserFromAuthorization(
+            request.getHeader("Authorization"));
+      } catch (S3Exception e) {
+        XmlMapper mapper = new XmlMapper();
+        S3Error errorResponse = new S3Error("Authorization", e.getErrorCode());
+        httpServletResponse.setStatus(e.getErrorCode().getStatus().getStatusCode());
+        httpServletResponse.getOutputStream().print(mapper.writeValueAsString(errorResponse));
+        return;
+      }
       sb.append(user);
       if (LOG.isDebugEnabled() && request.getHeaderNames() != null) {
         // Using "DEBUG" log level to indicate verbosity of this message,

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -104,6 +104,7 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
         S3Error errorResponse = new S3Error("Authorization", e.getErrorCode());
         httpServletResponse.setStatus(e.getErrorCode().getStatus().getStatusCode());
         httpServletResponse.getOutputStream().print(mapper.writeValueAsString(errorResponse));
+        request.setHandled(true); // Prevent other handlers from processing this request\
         return;
       }
       sb.append(user);
@@ -118,8 +119,7 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
         sb.append(headerMap);
       }
       LOG.info(sb.toString());
-      if (!request.getMethod().equals("POST")
-          || request.getParameter("uploadId") == null) {
+      if (!request.getMethod().equals("POST") || request.getParameter("uploadId") == null) {
         return;
       } // Otherwise, handle CompleteMultipartUpload
       s = s.substring(mS3Prefix.length() + 1); // substring the prefix + leading "/" character

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -95,7 +95,7 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
       sb.append(s);
       if (request.getQueryString() != null) { sb.append("?").append(request.getQueryString()); }
       sb.append(" User=");
-      String user = null;
+      final String user;
       try {
         user = S3RestServiceHandler.getUserFromAuthorization(
             request.getHeader("Authorization"));

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Constants.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Constants.java
@@ -79,6 +79,9 @@ public final class S3Constants {
   public static final String S3_DATE_FORMAT_REGEXP = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
   public static final String S3_STANDARD_STORAGE_CLASS = "STANDARD";
 
+  // TODO(czhu): prefix multipart upload part file names with this
+  public static final String S3_MULTIPART_PART_PREFIX = "part_";
+
   /**
    * Directive specifies whether metadata/tag-set are copied from the source object
    * or replaced with metadata/tag-set provided in the request.

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -40,6 +40,7 @@ import alluxio.proxy.s3.auth.Authenticator;
 import alluxio.proxy.s3.auth.AwsAuthInfo;
 import alluxio.proxy.s3.signature.AwsSignatureProcessor;
 import alluxio.security.User;
+import alluxio.security.authentication.AuthType;
 import alluxio.util.CommonUtils;
 import alluxio.web.ProxyWebServer;
 
@@ -172,11 +173,20 @@ public final class S3RestServiceHandler {
    * @throws S3Exception
    */
   private String getUser(String authorization) throws S3Exception {
+    // TODO(czhu): refactor PropertyKey.S3_REST_AUTHENTICATION_ENABLED to an ENUM
+    //             to specify between using custom Authenticator class vs. Alluxio Master schemes
     if (S3RestUtils.isAuthenticationEnabled(mSConf)) {
       return getUserFromSignature();
-    } else {
-      return getUserFromAuthorization(authorization);
     }
+    try {
+      if (mSConf.get(PropertyKey.SECURITY_AUTHENTICATION_TYPE) != AuthType.NOSASL) {
+        return getUserFromAuthorization(authorization);
+      }
+    } catch (RuntimeException e) {
+      throw new S3Exception(new S3ErrorCode(S3ErrorCode.INTERNAL_ERROR.getCode(),
+          e.getMessage(), S3ErrorCode.INTERNAL_ERROR.getStatus()));
+    }
+    return null; // else, we apply no authentication scheme
   }
 
   /**
@@ -259,7 +269,7 @@ public final class S3RestServiceHandler {
   @GET
   public Response listAllMyBuckets(@HeaderParam("Authorization") final String authorization) {
     return S3RestUtils.call("", () -> {
-      String user = getUser(authorization);
+      final String user = getUser(authorization);
 
       List<URIStatus> objects;
       try (S3AuditContext auditContext = createAuditContext("listBuckets", user, null, null)) {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -192,6 +192,8 @@ public final class S3RestUtils {
       return new S3Exception(e, resource, S3ErrorCode.NO_SUCH_BUCKET);
     } catch (InvalidPathException e) {
       return new S3Exception(e, resource, S3ErrorCode.INVALID_BUCKET_NAME);
+    } catch (AccessControlException e) {
+      return new S3Exception(e, resource, S3ErrorCode.ACCESS_DENIED_ERROR);
     } catch (Exception e) {
       return new S3Exception(e, resource, S3ErrorCode.INTERNAL_ERROR);
     }
@@ -231,6 +233,8 @@ public final class S3RestUtils {
       return new S3Exception(e, resource, S3ErrorCode.PRECONDITION_FAILED);
     } catch (FileDoesNotExistException e) {
       return new S3Exception(e, resource, S3ErrorCode.NO_SUCH_KEY);
+    } catch (AccessControlException e) {
+      return new S3Exception(e, resource, S3ErrorCode.ACCESS_DENIED_ERROR);
     } catch (Exception e) {
       return new S3Exception(e, resource, S3ErrorCode.INTERNAL_ERROR);
     }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -28,6 +28,7 @@ import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.WritePType;
 import alluxio.proto.journal.File;
+import alluxio.security.User;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.user.ServerUserState;
 import alluxio.util.SecurityUtils;
@@ -52,6 +53,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.security.auth.Subject;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -284,7 +286,8 @@ public final class S3RestUtils {
   /**
    * Fetches and returns the corresponding {@link URIStatus} for both
    * the multipart upload temp directory and the Alluxio S3 metadata file.
-   * @param fs instance of {@link FileSystem}
+   * @param metaFs instance of {@link FileSystem} - used for metadata operations
+   * @param userFs instance of {@link FileSystem} - under the scope of a user agent
    * @param multipartTempDirUri multipart upload tmp directory URI
    * @param uploadId multipart upload Id
    * @return a list of file statuses:
@@ -292,10 +295,10 @@ public final class S3RestUtils {
    *         - second, the metadata file
    */
   public static List<URIStatus> checkStatusesForUploadId(
-      FileSystem fs, AlluxioURI multipartTempDirUri, String uploadId)
+      FileSystem metaFs, FileSystem userFs, AlluxioURI multipartTempDirUri, String uploadId)
       throws AlluxioException, IOException {
     // Verify the multipart upload dir exists and is a folder
-    URIStatus multipartTempDirStatus = fs.getStatus(multipartTempDirUri);
+    URIStatus multipartTempDirStatus = userFs.getStatus(multipartTempDirUri);
     if (!multipartTempDirStatus.isFolder()) {
       //TODO(czhu): determine intended behavior in this edge-case
       throw new RuntimeException(
@@ -306,7 +309,7 @@ public final class S3RestUtils {
     // Verify the multipart upload meta file exists and matches the file ID
     final AlluxioURI metaUri = new AlluxioURI(
         S3RestUtils.getMultipartMetaFilepathForUploadId(uploadId));
-    URIStatus metaStatus = fs.getStatus(metaUri);
+    URIStatus metaStatus = metaFs.getStatus(metaUri);
     if (metaStatus.getXAttr() == null
         || !metaStatus.getXAttr().containsKey(S3Constants.UPLOADS_FILE_ID_XATTR_KEY)) {
       //TODO(czhu): determine intended behavior in this edge-case
@@ -366,6 +369,23 @@ public final class S3RestUtils {
    */
   public static boolean isAuthenticationEnabled(AlluxioConfiguration conf) {
     return conf.getBoolean(PropertyKey.S3_REST_AUTHENTICATION_ENABLED);
+  }
+
+  /**
+   * @param user the {@link Subject} name of the filesystem user
+   * @param fs the source {@link FileSystem} to base off of
+   * @return A {@link FileSystem} with the subject set to the provided user
+   */
+  public static FileSystem createFileSystemForUser(
+      String user, FileSystem fs) {
+    if (user == null) {
+      // Used to return the top-level FileSystem view when not using Authentication
+      return fs;
+    }
+
+    final Subject subject = new Subject();
+    subject.getPrincipals().add(new User(user));
+    return FileSystem.Factory.get(subject, fs.getConf());
   }
 
   /**

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -14,7 +14,6 @@ package alluxio.web;
 import alluxio.Constants;
 import alluxio.StreamCache;
 import alluxio.client.file.FileSystem;
-import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.proxy.ProxyProcess;
@@ -39,11 +38,8 @@ public final class ProxyWebServer extends WebServer {
   public static final String ALLUXIO_PROXY_SERVLET_RESOURCE_KEY = "Alluxio Proxy";
   public static final String FILE_SYSTEM_SERVLET_RESOURCE_KEY = "File System";
   public static final String STREAM_CACHE_SERVLET_RESOURCE_KEY = "Stream Cache";
-  public static final String SERVER_CONFIGURATION_RESOURCE_KEY = "Server Configuration";
 
   private final FileSystem mFileSystem;
-
-  private final AlluxioConfiguration mSConf = Configuration.global();
 
   /**
    * Creates a new instance of {@link ProxyWebServer}.
@@ -61,7 +57,7 @@ public final class ProxyWebServer extends WebServer {
         .register(JacksonProtobufObjectMapperProvider.class)
         .register(S3RestExceptionMapper.class);
 
-    mFileSystem = FileSystem.Factory.create(mSConf);
+    mFileSystem = FileSystem.Factory.create(Configuration.global());
 
     ServletContainer servlet = new ServletContainer(config) {
       private static final long serialVersionUID = 7756010860672831556L;
@@ -74,13 +70,12 @@ public final class ProxyWebServer extends WebServer {
             .setAttribute(FILE_SYSTEM_SERVLET_RESOURCE_KEY, mFileSystem);
         getServletContext().setAttribute(STREAM_CACHE_SERVLET_RESOURCE_KEY,
             new StreamCache(Configuration.getMs(PropertyKey.PROXY_STREAM_CACHE_TIMEOUT_MS)));
-        getServletContext()
-            .setAttribute(SERVER_CONFIGURATION_RESOURCE_KEY, mSConf);
       }
     };
     ServletHolder servletHolder = new ServletHolder("Alluxio Proxy Web Service", servlet);
     mServletContextHandler
         .addServlet(servletHolder, PathUtils.concatPath(Constants.REST_API_PREFIX, "*"));
+    // TODO(czhu): Move S3 API logging out of CompleteMultipartUploadHandler into a logging handler
     addHandler(new CompleteMultipartUploadHandler(mFileSystem, Constants.REST_API_PREFIX));
   }
 

--- a/core/server/proxy/src/test/java/alluxio/proxy/s3/S3RestServiceHandlerTest.java
+++ b/core/server/proxy/src/test/java/alluxio/proxy/s3/S3RestServiceHandlerTest.java
@@ -16,16 +16,27 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class S3RestServiceHandlerTest {
 
   @Test
   public void userFromAuthorization() throws Exception {
-    assertNull(S3RestServiceHandler.getUserFromAuthorization("AWS-SHA256-HMAC Credential=/asd"));
+    try {
+      S3RestServiceHandler.getUserFromAuthorization("AWS-SHA256-HMAC Credential=/asd");
+      Assert.fail();
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof S3Exception);
+    }
+    try {
+      assertNull(S3RestServiceHandler.getUserFromAuthorization(""));
+      Assert.fail();
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof S3Exception);
+    }
     assertEquals("test", S3RestServiceHandler.getUserFromAuthorization(
         "AWS-SHA256-HMAC Credential=test/asd"));
-    assertNull(S3RestServiceHandler.getUserFromAuthorization(""));
   }
 
   @Test

--- a/core/server/proxy/src/test/java/alluxio/proxy/s3/S3RestServiceHandlerTest.java
+++ b/core/server/proxy/src/test/java/alluxio/proxy/s3/S3RestServiceHandlerTest.java
@@ -15,28 +15,32 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
+
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class S3RestServiceHandlerTest {
+  private final AlluxioConfiguration mConf = Configuration.global();
 
   @Test
   public void userFromAuthorization() throws Exception {
     try {
-      S3RestServiceHandler.getUserFromAuthorization("AWS-SHA256-HMAC Credential=/asd");
+      S3RestServiceHandler.getUserFromAuthorization("AWS-SHA256-HMAC Credential=/asd", mConf);
       Assert.fail();
     } catch (Exception e) {
       Assert.assertTrue(e instanceof S3Exception);
     }
     try {
-      assertNull(S3RestServiceHandler.getUserFromAuthorization(""));
+      assertNull(S3RestServiceHandler.getUserFromAuthorization("", mConf));
       Assert.fail();
     } catch (Exception e) {
       Assert.assertTrue(e instanceof S3Exception);
     }
     assertEquals("test", S3RestServiceHandler.getUserFromAuthorization(
-        "AWS-SHA256-HMAC Credential=test/asd"));
+        "AWS-SHA256-HMAC Credential=test/asd", mConf));
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -2071,4 +2071,28 @@ public final class S3ClientRestApiTest extends RestApiTest {
             .setBody(TaggingData.serialize(tags).toByteArray()))
         .runAndCheckResult();
   }
+
+  @Test
+  public void testMalformedAuthHeader() throws Exception {
+    // test with Null Authorization Header
+    String bucket = "test-bucket";
+    TestCaseOptions options = TestCaseOptions.defaults();
+    options.setAuthorization("");
+    HttpURLConnection connection = new TestCase(mHostname, mPort, mBaseUri,
+            bucket, NO_PARAMS, HttpMethod.GET, options).execute();;
+    Assert.assertEquals(400, connection.getResponseCode());
+    S3Error response =
+            new XmlMapper().readerFor(S3Error.class).readValue(connection.getErrorStream());
+    Assert.assertEquals(S3ErrorCode.Name.AUTHORIZATION_HEADER_MALFORMED, response.getCode());
+
+    // test with V2 Authorization Header
+    options = TestCaseOptions.defaults();
+    options.setAuthorization("AWS alluxio:3uRmVm7lWfvclsqfpPJN2Ftigi4=");
+    connection = new TestCase(mHostname, mPort, mBaseUri,
+            bucket, NO_PARAMS, HttpMethod.GET, options).execute();;
+    Assert.assertEquals(400, connection.getResponseCode());
+    response =
+            new XmlMapper().readerFor(S3Error.class).readValue(connection.getErrorStream());
+    Assert.assertEquals(S3ErrorCode.Name.AUTHORIZATION_HEADER_MALFORMED, response.getCode());
+  }
 }

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -2079,7 +2079,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
     TestCaseOptions options = TestCaseOptions.defaults();
     options.setAuthorization("");
     HttpURLConnection connection = new TestCase(mHostname, mPort, mBaseUri,
-            bucket, NO_PARAMS, HttpMethod.GET, options).execute();;
+            bucket, NO_PARAMS, HttpMethod.GET, options).execute();
     Assert.assertEquals(400, connection.getResponseCode());
     S3Error response =
             new XmlMapper().readerFor(S3Error.class).readValue(connection.getErrorStream());
@@ -2089,7 +2089,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
     options = TestCaseOptions.defaults();
     options.setAuthorization("AWS alluxio:3uRmVm7lWfvclsqfpPJN2Ftigi4=");
     connection = new TestCase(mHostname, mPort, mBaseUri,
-            bucket, NO_PARAMS, HttpMethod.GET, options).execute();;
+            bucket, NO_PARAMS, HttpMethod.GET, options).execute();
     Assert.assertEquals(400, connection.getResponseCode());
     response =
             new XmlMapper().readerFor(S3Error.class).readValue(connection.getErrorStream());

--- a/tests/src/test/java/alluxio/client/rest/TestCaseOptions.java
+++ b/tests/src/test/java/alluxio/client/rest/TestCaseOptions.java
@@ -54,7 +54,9 @@ public final class TestCaseOptions {
    * @return the default {@link TestCaseOptions}
    */
   public static TestCaseOptions defaults() {
-    return new TestCaseOptions();
+    TestCaseOptions options =  new TestCaseOptions();
+    options.setAuthorization("AWS4-HMAC-SHA256 Credential=alluxio/20220830");
+    return options;
   }
 
   private TestCaseOptions() {

--- a/tests/src/test/java/alluxio/client/rest/TestCaseOptions.java
+++ b/tests/src/test/java/alluxio/client/rest/TestCaseOptions.java
@@ -56,8 +56,10 @@ public final class TestCaseOptions {
   public static TestCaseOptions defaults() {
     TestCaseOptions options =  new TestCaseOptions();
     // Set the default user to the username used to launch the Java process
-    options.setAuthorization("AWS4-HMAC-SHA256 Credential=" + System.getProperty("user.name")
-        + "/20220830");
+    if (!System.getProperty("user.name").isEmpty()) {
+      options.setAuthorization("AWS4-HMAC-SHA256 Credential=" + System.getProperty("user.name")
+          + "/20220830");
+    }
     return options;
   }
 

--- a/tests/src/test/java/alluxio/client/rest/TestCaseOptions.java
+++ b/tests/src/test/java/alluxio/client/rest/TestCaseOptions.java
@@ -55,7 +55,9 @@ public final class TestCaseOptions {
    */
   public static TestCaseOptions defaults() {
     TestCaseOptions options =  new TestCaseOptions();
-    options.setAuthorization("AWS4-HMAC-SHA256 Credential=alluxio/20220830");
+    // Set the default user to the username used to launch the Java process
+    options.setAuthorization("AWS4-HMAC-SHA256 Credential=" + System.getProperty("user.name")
+        + "/20220830");
     return options;
   }
 

--- a/tests/src/test/java/alluxio/client/rest/TestCaseOptionsTest.java
+++ b/tests/src/test/java/alluxio/client/rest/TestCaseOptionsTest.java
@@ -31,7 +31,6 @@ public class TestCaseOptionsTest {
   public void defaults() {
     TestCaseOptions options = TestCaseOptions.defaults();
 
-    Assert.assertNull(options.getAuthorization());
     Assert.assertNull(options.getBody());
     Assert.assertEquals(TestCaseOptions.OCTET_STREAM_CONTENT_TYPE, options.getContentType());
     Assert.assertEquals(StandardCharsets.UTF_8, options.getCharset());


### PR DESCRIPTION
This PR is the successor of https://github.com/Alluxio/alluxio/pull/16135
---
Introduced on top of that PR is the following:

- Fixes how the S3 API sets ACL permissions and mode bits on files so that buckets and their objects are owned by a user corresponding to the "Authorization" header
- Disables requirement for "Authorization" header when `alluxio.security.authentication.type=NOSASL`