### PR TITLE
Add Support for Azure Data Lake Gen2 MSI

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1598,6 +1598,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       .setScope(Scope.SERVER)
       .setDisplayType(DisplayType.CREDENTIALS)
       .build();
+  public static final PropertyKey ABFS_MSI_ENDPOINT = stringBuilder(Name.ABFS_MSI_ENDPOINT)
+      .setDescription("MSI endpoint")
+      .setDefaultValue("http://169.254.169.254/metadata/identity/oauth2/token")
+      .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+      .setScope(Scope.SERVER)
+      .build();
+  public static final PropertyKey ABFS_MSI_TENANT = stringBuilder(Name.ABFS_MSI_TENANT)
+      .setDescription("MSI Tenant ID")
+      .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+      .setScope(Scope.SERVER)
+      .build();
   public static final PropertyKey GCS_ACCESS_KEY = stringBuilder(Name.GCS_ACCESS_KEY)
       .setDescription(format("The access key of GCS bucket. This property key "
           + "is only valid when %s=1", Name.UNDERFS_GCS_VERSION))
@@ -6945,6 +6956,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String ABFS_CLIENT_ENDPOINT = "fs.azure.account.oauth2.client.endpoint";
     public static final String ABFS_CLIENT_ID = "fs.azure.account.oauth2.client.id";
     public static final String ABFS_CLIENT_SECRET = "fs.azure.account.oauth2.client.secret";
+    public static final String ABFS_MSI_ENDPOINT = "fs.azure.account.oauth2.msi.endpoint";
+    public static final String ABFS_MSI_TENANT = "fs.azure.account.oauth2.msi.tenant";
     public static final String COS_ACCESS_KEY = "fs.cos.access.key";
     public static final String COS_APP_ID = "fs.cos.app.id";
     public static final String COS_CONNECTION_MAX = "fs.cos.connection.max";

--- a/docs/en/ufs/Azure-Data-Lake-Gen2.md
+++ b/docs/en/ufs/Azure-Data-Lake-Gen2.md
@@ -106,6 +106,48 @@ $ ./bin/alluxio fs mount \
 
 After these changes, Alluxio should be configured to work with Azure Data Lake storage as its under storage system, and you can run Alluxio locally with it.
 
+## Setup with Azure Managed Identities
+
+### Root Mount
+
+To use Azure Data Lake Storage as the UFS of Alluxio root mount point,
+you need to configure Alluxio to use under storage systems by modifying
+`conf/alluxio-site.properties`. If it does not exist, create the configuration file from the
+template.
+
+```console
+$ cp conf/alluxio-site.properties.template conf/alluxio-site.properties
+```
+
+Specify the underfs address by modifying `conf/alluxio-site.properties` to include:
+
+```properties
+alluxio.master.mount.table.root.ufs=abfs://<AZURE_CONTAINER>@<AZURE_ACCOUNT>.dfs.core.windows.net/<AZURE_DIRECTORY>/
+```
+
+Specify the Azure Managed Identities by adding the following property in `conf/alluxio-site.properties`:
+
+```properties
+alluxio.master.mount.table.root.option.fs.azure.account.oauth2.msi.endpoint=<MSI_ENDPOINT>
+alluxio.master.mount.table.root.option.fs.azure.account.oauth2.client.id=<CLIENT_ID>
+alluxio.master.mount.table.root.option.fs.azure.account.oauth2.msi.tenant=<TENANT>
+```
+
+### Nested Mount
+An Azure Data Lake store location can be mounted at a nested directory in the Alluxio namespace to have unified access
+to multiple under storage systems. Alluxio's
+[Command Line Interface]({{ '/en/operation/User-CLI.html' | relativize_url }}) can be used for this purpose.
+
+```console
+$ ./bin/alluxio fs mount \
+  --option fs.azure.account.oauth2.msi.endpoint=<MSI_ENDPOINT> \
+  --option fs.azure.account.oauth2.client.id=<CLIENT_ID> \
+  --option fs.azure.account.oauth2.msi.tenant=<TENANT> \
+  /mnt/abfs abfs://<AZURE_CONTAINER>@<AZURE_ACCOUNT>.dfs.core.windows.net/<AZURE_DIRECTORY>/
+```
+
+After these changes, Alluxio should be configured to work with Azure Data Lake storage as its under storage system, and you can run Alluxio locally with it.
+
 ## Running Alluxio Locally with Data Lake Storage
 
 Start up Alluxio locally to see that everything works.

--- a/underfs/abfs/src/main/java/alluxio/underfs/abfs/AbfsUnderFileSystem.java
+++ b/underfs/abfs/src/main/java/alluxio/underfs/abfs/AbfsUnderFileSystem.java
@@ -87,8 +87,8 @@ public class AbfsUnderFileSystem extends HdfsUnderFileSystem {
         abfsConf.set(PropertyKey.ABFS_CLIENT_ID.getName(),
             conf.getString(PropertyKey.ABFS_CLIENT_ID));
       }
-
     }
+
     return abfsConf;
   }
 

--- a/underfs/abfs/src/main/java/alluxio/underfs/abfs/AbfsUnderFileSystem.java
+++ b/underfs/abfs/src/main/java/alluxio/underfs/abfs/AbfsUnderFileSystem.java
@@ -40,6 +40,7 @@ public class AbfsUnderFileSystem extends HdfsUnderFileSystem {
     Configuration abfsConf = HdfsUnderFileSystem.createConfiguration(conf);
 
     boolean sharedKey = false;
+    boolean clientCredentials = false;
 
     for (Map.Entry<String, Object> entry : conf.toMap().entrySet()) {
       String key = entry.getKey();
@@ -66,7 +67,27 @@ public class AbfsUnderFileSystem extends HdfsUnderFileSystem {
             conf.getString(PropertyKey.ABFS_CLIENT_ID));
         abfsConf.set(PropertyKey.ABFS_CLIENT_SECRET.getName(),
             conf.getString(PropertyKey.ABFS_CLIENT_SECRET));
+        clientCredentials = true;
       }
+    }
+
+    if (!clientCredentials && !sharedKey) {
+      abfsConf.set("fs.azure.account.auth.type", "OAuth");
+      abfsConf.set("fs.azure.account.oauth.provider.type",
+              "org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider<");
+      if (conf.isSet(PropertyKey.ABFS_MSI_ENDPOINT)) {
+        abfsConf.set(PropertyKey.ABFS_MSI_ENDPOINT.getName(),
+            conf.getString(PropertyKey.ABFS_MSI_ENDPOINT));
+      }
+      if (conf.isSet(PropertyKey.ABFS_MSI_TENANT)) {
+        abfsConf.set(PropertyKey.ABFS_MSI_TENANT.getName(),
+            conf.getString(PropertyKey.ABFS_MSI_TENANT));
+      }
+      if (conf.isSet(PropertyKey.ABFS_CLIENT_ID)) {
+        abfsConf.set(PropertyKey.ABFS_CLIENT_ID.getName(),
+            conf.getString(PropertyKey.ABFS_CLIENT_ID));
+      }
+
     }
     return abfsConf;
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add Support for Azure Data Lake Gen2 MSI

### Why are the changes needed?

Please clarify why the changes are needed. For instance,

when using ADLS Gen2, it's necessary to use Msi to auth

### Does this PR introduce any user facing changes?

 
change api
addition property keys
add doc
