### PR TITLE
Avoid chown if the file already has correct owner and group

### DIFF
--- a/integration/fuse/src/test/java/alluxio/fuse/auth/AbstractAuthPolicyTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/auth/AbstractAuthPolicyTest.java
@@ -82,7 +82,11 @@ public abstract class AbstractAuthPolicyTest {
     Assert.assertEquals(userName, status.getOwner());
     Assert.assertEquals(groupName, status.getGroup());
 
-    // do not call "setAttribute" if the file already has correct owner and group
+    // `setAttribute` should not be called once more as the file
+    // already has correct owner and group, as `UserGroupFileSystem.setAttribute`
+    // defined here creates a new `URIStatus` each time,
+    // `mFileSystem.getStatus` should return the same instance if
+    // `setAttribute` is not called once again.
     mAuthPolicy.setUserGroup(uri, uid, gid);
     URIStatus status2 = mFileSystem.getStatus(uri);
     Assert.assertSame(status, status2);

--- a/integration/fuse/src/test/java/alluxio/fuse/auth/AbstractAuthPolicyTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/auth/AbstractAuthPolicyTest.java
@@ -71,7 +71,7 @@ public abstract class AbstractAuthPolicyTest {
     long gid = 456;
     String userName = "myuser";
     String groupName = "mygroup";
-    PowerMockito.mockStatic(AlluxioFuseUtils.class);
+    PowerMockito.spy(AlluxioFuseUtils.class);
     PowerMockito.when(AlluxioFuseUtils.getUserName(eq(uid)))
         .thenReturn(Optional.of(userName));
     PowerMockito.when(AlluxioFuseUtils.getGroupName(eq(gid)))
@@ -81,6 +81,11 @@ public abstract class AbstractAuthPolicyTest {
     URIStatus status = mFileSystem.getStatus(uri);
     Assert.assertEquals(userName, status.getOwner());
     Assert.assertEquals(groupName, status.getGroup());
+
+    // do not call "setAttribute" if the file already has correct owner and group
+    mAuthPolicy.setUserGroup(uri, uid, gid);
+    URIStatus status2 = mFileSystem.getStatus(uri);
+    Assert.assertSame(status, status2);
   }
 
   static class CustomContextFuseFileSystem implements FuseFileSystem {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Avoid chown if the file already has correct owner and group

### Why are the changes needed?

- The client may send a request to change owner&group even the file already has correct values
- The request may be rejected because "chown" needs supergroup privilege

### Does this PR introduce any user facing changes?

No
