### PR TITLE
Fix alluxio-fuse unmount to get the right pid when no options

### DIFF
--- a/integration/fuse/bin/alluxio-fuse
+++ b/integration/fuse/bin/alluxio-fuse
@@ -98,7 +98,7 @@ mount_fuse() {
     fi
     cmd="${JAVA} ${ALLUXIO_FUSE_ATTACH_OPTS} -cp ${CLASSPATH} ${JAVA_OPTS} ${ALLUXIO_FUSE_JAVA_OPTS} \
       alluxio.fuse.AlluxioFuse \
-      -m ${mount_point} -a ${mount_alluxio_path} ${mount_options}"
+      ${mount_options} -m ${mount_point} -a ${mount_alluxio_path}"
     message="Starting AlluxioFuse process: mounting alluxio path \"${mount_alluxio_path}\" to local mount point \"${mount_point}\""
   fi
   echo "${message}"
@@ -202,7 +202,7 @@ fuse_stat() {
   local fuse_info="$(ps aux | grep [A]lluxioFuse)"
   if [[ -n ${fuse_info} ]]; then
     echo -e "pid\tmount_point\talluxio_path"
-    echo -e "$(ps ax -o pid,args | grep [A]lluxioFuse | awk -F' ' '{print $1 "\t" $(NF-4) "\t" $NF}')"
+    echo -e "$(ps ax -o pid,args | grep [A]lluxioFuse | awk -F' ' '{print $1 "\t" $(NF-2) "\t" $NF}')"
     return 0
   fi
   fuse_info=$(ps ax -o pid,args | grep [A]lluxioWorker | grep alluxio\.worker\.fuse\.enabled=true)


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix alluxio-fuse unmount to get the right pid when no options provided during mounting. 

### Why are the changes needed?

I submitted a PR [Fix alluxio-fuse unmount to get the right pid](https://github.com/Alluxio/alluxio/pull/15897) about two months ago. For that PR, I was always testing with setting mount options. For example, `-o default_permissions`. 

Now I found that (with options)/(without options) made the matching pattern have different indexes, and the solution is to make the pattern has consistent indexes.

### Does this PR introduce any user facing changes?

No
