### PR TITLE
Fix clientIO stressbench throughput calculation

### DIFF
--- a/stress/common/src/main/java/alluxio/stress/client/ClientIOTaskResult.java
+++ b/stress/common/src/main/java/alluxio/stress/client/ClientIOTaskResult.java
@@ -262,8 +262,9 @@ public final class ClientIOTaskResult implements TaskResult, Summary {
       for (Map.Entry<Integer, Long> threadCountIOBytesEntry: threadCountIOBytes.entrySet()) {
         int numThreads = threadCountIOBytesEntry.getKey();
         long ioBytes = threadCountIOBytesEntry.getValue();
-        threadCountIoMbps.put(numThreads, (float) ioBytes / 1000
-            / (threadCountEndMs.get(numThreads) - threadCountRecordedStartMs.get(numThreads)));
+        threadCountIoMbps.put(numThreads, (float) ioBytes
+            / (threadCountEndMs.get(numThreads) - threadCountRecordedStartMs.get(numThreads))
+            * 1000.0f / Constants.MB);
       }
 
       return new ClientIOSummary(clientIOParameters, baseParameters, nodes, threadCountIoMbps);

--- a/stress/common/src/main/java/alluxio/stress/client/ClientIOTaskResult.java
+++ b/stress/common/src/main/java/alluxio/stress/client/ClientIOTaskResult.java
@@ -262,7 +262,7 @@ public final class ClientIOTaskResult implements TaskResult, Summary {
       for (Map.Entry<Integer, Long> threadCountIOBytesEntry: threadCountIOBytes.entrySet()) {
         int numThreads = threadCountIOBytesEntry.getKey();
         long ioBytes = threadCountIOBytesEntry.getValue();
-        threadCountIoMbps.put(numThreads, (float) ioBytes
+        threadCountIoMbps.put(numThreads, (float) ioBytes / 1000
             / (threadCountEndMs.get(numThreads) - threadCountRecordedStartMs.get(numThreads)));
       }
 


### PR DESCRIPTION
Divide 1000 to get megabytes per second instead of megabytes per millisecond.