### PR TITLE
Add getUnsafe() interface for PrimarySelector

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/AbstractPrimarySelector.java
+++ b/core/server/common/src/main/java/alluxio/master/AbstractPrimarySelector.java
@@ -47,7 +47,7 @@ public abstract class AbstractPrimarySelector implements PrimarySelector {
   private final Lock mStateLock = new ReentrantLock();
   private final Condition mStateCond = mStateLock.newCondition();
   @GuardedBy("mStateLock")
-  private NodeState mState = NodeState.STANDBY;
+  private volatile NodeState mState = NodeState.STANDBY;
 
   protected final void setState(NodeState state) {
     try (LockResource lr = new LockResource(mStateLock)) {
@@ -65,6 +65,11 @@ public abstract class AbstractPrimarySelector implements PrimarySelector {
     try (LockResource lr = new LockResource(mStateLock)) {
       return mState;
     }
+  }
+
+  @Override
+  public final NodeState getStateUnsafe() {
+    return mState;
   }
 
   @Override

--- a/core/server/common/src/main/java/alluxio/master/PrimarySelector.java
+++ b/core/server/common/src/main/java/alluxio/master/PrimarySelector.java
@@ -70,6 +70,11 @@ public interface PrimarySelector {
   NodeState getState();
 
   /**
+   * @return the current state without the lock acquired
+   */
+  NodeState getStateUnsafe();
+
+  /**
    * Registers a listener to be executed whenever the selector's state updates.
    *
    * The listener will be executed synchronously in the state update thread, so it should run

--- a/core/server/common/src/test/java/alluxio/master/AbstractPrimarySelectorTest.java
+++ b/core/server/common/src/test/java/alluxio/master/AbstractPrimarySelectorTest.java
@@ -49,10 +49,13 @@ public final class AbstractPrimarySelectorTest {
 
   @Test
   public void getState() {
+    assertEquals(NodeState.STANDBY, mSelector.getStateUnsafe());
     assertEquals(NodeState.STANDBY, mSelector.getState());
     mSelector.setState(NodeState.PRIMARY);
+    assertEquals(NodeState.PRIMARY, mSelector.getStateUnsafe());
     assertEquals(NodeState.PRIMARY, mSelector.getState());
     mSelector.setState(NodeState.STANDBY);
+    assertEquals(NodeState.STANDBY, mSelector.getStateUnsafe());
     assertEquals(NodeState.STANDBY, mSelector.getState());
   }
 
@@ -61,8 +64,10 @@ public final class AbstractPrimarySelectorTest {
     mExecutor.schedule(() -> mSelector.setState(NodeState.PRIMARY), 30, TimeUnit.MILLISECONDS);
     mSelector.waitForState(NodeState.PRIMARY);
     assertEquals(NodeState.PRIMARY, mSelector.getState());
+    assertEquals(NodeState.PRIMARY, mSelector.getStateUnsafe());
     mExecutor.schedule(() -> mSelector.setState(NodeState.STANDBY), 30, TimeUnit.MILLISECONDS);
     mSelector.waitForState(NodeState.STANDBY);
+    assertEquals(NodeState.STANDBY, mSelector.getStateUnsafe());
     assertEquals(NodeState.STANDBY, mSelector.getState());
   }
 

--- a/core/server/master/src/test/java/alluxio/master/AlwaysStandbyPrimarySelector.java
+++ b/core/server/master/src/test/java/alluxio/master/AlwaysStandbyPrimarySelector.java
@@ -37,6 +37,11 @@ public final class AlwaysStandbyPrimarySelector implements PrimarySelector {
   }
 
   @Override
+  public NodeState getStateUnsafe() {
+    return NodeState.STANDBY;
+  }
+
+  @Override
   public Scoped onStateChange(Consumer<NodeState> listener) {
     // State never changes.
     return () -> { };


### PR DESCRIPTION
### What changes are proposed in this pull request?

Replace the lock with volatile for the state variable in PrimarySelector because the state assignment is atomic and doesn't depend on any previous values.

Provide a getUnsafe() method to read the variable without adding a lock.

### Why are the changes needed?

Improve the read performance of the primary selector.  

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
N/A