### PR TITLE
Fix S3 API file mode bits to prevent unauthorized reads

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -19,8 +19,10 @@ import alluxio.client.file.URIStatus;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
+import alluxio.grpc.Bits;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
+import alluxio.grpc.PMode;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.io.ByteStreams;
@@ -288,6 +290,10 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
 
         CreateFilePOptions.Builder optionsBuilder = CreateFilePOptions.newBuilder()
             .setRecursive(true)
+            .setMode(PMode.newBuilder()
+                .setOwnerBits(Bits.ALL)
+                .setGroupBits(Bits.ALL)
+                .setOtherBits(Bits.NONE).build())
             .setWriteType(S3RestUtils.getS3WriteType());
         // Copy Tagging xAttr if it exists
         if (metaStatus.getXAttr().containsKey(S3Constants.TAGGING_XATTR_KEY)) {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -779,17 +779,20 @@ public final class S3RestServiceHandler {
         S3RestUtils.checkPathIsAlluxioDirectory(userFs, bucketPath, auditContext);
         String objectPath = bucketPath + AlluxioURI.SEPARATOR + object;
 
-        CreateDirectoryPOptions dirOptions = CreateDirectoryPOptions.newBuilder()
-            .setRecursive(true)
-            .setAllowExists(true)
-            .build();
-
         if (objectPath.endsWith(AlluxioURI.SEPARATOR)) {
           // Need to create a folder
           // TODO(czhu): verify S3 behaviour when ending an object path with a delimiter
           // - this is a convenience method for the Alluxio fs which does not have a
           //   direct counterpart for S3, since S3 does not have "folders" as actual objects
           try {
+            CreateDirectoryPOptions dirOptions = CreateDirectoryPOptions.newBuilder()
+                .setRecursive(true)
+                .setMode(PMode.newBuilder()
+                    .setOwnerBits(Bits.ALL)
+                    .setGroupBits(Bits.ALL)
+                    .setOtherBits(Bits.NONE).build())
+                .setAllowExists(true)
+                .build();
             userFs.createDirectory(new AlluxioURI(objectPath), dirOptions);
           } catch (FileAlreadyExistsException e) {
             // ok if directory already exists the user wanted to create it anyway
@@ -872,7 +875,12 @@ public final class S3RestServiceHandler {
               ByteString.copyFrom(contentTypeParam, S3Constants.HEADER_CHARSET));
         }
         CreateFilePOptions filePOptions =
-            CreateFilePOptions.newBuilder().setRecursive(true)
+            CreateFilePOptions.newBuilder()
+                .setRecursive(true)
+                .setMode(PMode.newBuilder()
+                    .setOwnerBits(Bits.ALL)
+                    .setGroupBits(Bits.ALL)
+                    .setOtherBits(Bits.NONE).build())
                 .setWriteType(S3RestUtils.getS3WriteType())
                 .putAllXattr(xattrMap).setXattrPropStrat(XAttrPropagationStrategy.LEAF_NODE)
                 .build();
@@ -939,8 +947,12 @@ public final class S3RestServiceHandler {
           String copySource = !copySourceParam.startsWith(AlluxioURI.SEPARATOR)
               ? AlluxioURI.SEPARATOR + copySourceParam : copySourceParam;
           URIStatus status = null;
-          CreateFilePOptions.Builder copyFilePOptionsBuilder =
-              CreateFilePOptions.newBuilder().setRecursive(true);
+          CreateFilePOptions.Builder copyFilePOptionsBuilder = CreateFilePOptions.newBuilder()
+              .setRecursive(true)
+              .setMode(PMode.newBuilder()
+                  .setOwnerBits(Bits.ALL)
+                  .setGroupBits(Bits.ALL)
+                  .setOtherBits(Bits.NONE).build());
           // Handle metadata directive
           if (metadataDirective == S3Constants.Directive.REPLACE
               && filePOptions.getXattrMap().containsKey(S3Constants.CONTENT_TYPE_XATTR_KEY)) {
@@ -1077,9 +1089,6 @@ public final class S3RestServiceHandler {
           LOG.debug("InitiateMultipartUpload tagData={}", tagData);
         }
 
-        CreateDirectoryPOptions options = CreateDirectoryPOptions.newBuilder()
-            .setRecursive(true)
-            .setWriteType(S3RestUtils.getS3WriteType()).build();
         try {
           // Find an unused UUID
           String uploadId;
@@ -1091,7 +1100,13 @@ public final class S3RestServiceHandler {
           // Create the directory containing the upload parts
           AlluxioURI multipartTemporaryDir = new AlluxioURI(
               S3RestUtils.getMultipartTemporaryDirForObject(bucketPath, object, uploadId));
-          userFs.createDirectory(multipartTemporaryDir, options);
+          userFs.createDirectory(multipartTemporaryDir, CreateDirectoryPOptions.newBuilder()
+              .setRecursive(true)
+              .setMode(PMode.newBuilder()
+                  .setOwnerBits(Bits.ALL)
+                  .setGroupBits(Bits.ALL)
+                  .setOtherBits(Bits.NONE).build())
+              .setWriteType(S3RestUtils.getS3WriteType()).build());
 
           // Create the Alluxio multipart upload metadata file
           if (contentType != null) {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -1106,16 +1106,16 @@ public final class S3RestServiceHandler {
               Longs.toByteArray(userFs.getStatus(multipartTemporaryDir).getFileId())));
           mMetaFS.createFile(
               new AlluxioURI(S3RestUtils.getMultipartMetaFilepathForUploadId(uploadId)),
-                  CreateFilePOptions.newBuilder()
-                      .setRecursive(true)
-                      .setMode(PMode.newBuilder()
-                          .setOwnerBits(Bits.ALL)
-                          .setGroupBits(Bits.ALL)
-                          .setOtherBits(Bits.NONE).build())
-                      .setWriteType(S3RestUtils.getS3WriteType())
-                      .putAllXattr(xattrMap)
-                      .setXattrPropStrat(XAttrPropagationStrategy.LEAF_NODE)
-                      .build()
+              CreateFilePOptions.newBuilder()
+                  .setRecursive(true)
+                  .setMode(PMode.newBuilder()
+                      .setOwnerBits(Bits.ALL)
+                      .setGroupBits(Bits.ALL)
+                      .setOtherBits(Bits.NONE).build())
+                  .setWriteType(S3RestUtils.getS3WriteType())
+                  .putAllXattr(xattrMap)
+                  .setXattrPropStrat(XAttrPropagationStrategy.LEAF_NODE)
+                  .build()
           );
           SetAttributePOptions attrPOptions = SetAttributePOptions.newBuilder()
               .setOwner(user)

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -1114,6 +1114,21 @@ public final class S3ClientRestApiTest extends RestApiTest {
   }
 
   @Test
+  public void getUnauthorizedObject() throws Exception {
+    putBucket("bucket");
+    createObject("bucket/object", "Hello World!".getBytes(), null, null);
+
+    TestCaseOptions options = getDefaultOptionsWithAuth("unauthorized");
+    HttpURLConnection connection = new TestCase(mHostname, mPort, mBaseUri,
+        "bucket/object", NO_PARAMS, HttpMethod.GET,
+        options).execute();
+    Assert.assertEquals(403, connection.getResponseCode());
+    S3Error response =
+        new XmlMapper().readerFor(S3Error.class).readValue(connection.getErrorStream());
+    Assert.assertEquals(S3ErrorCode.Name.ACCESS_DENIED_ERROR, response.getCode());
+  }
+
+  @Test
   public void getObjectMetadata() throws Exception {
     final String bucket = "bucket";
     createBucketRestCall(bucket);

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -96,6 +96,8 @@ public final class S3ClientRestApiTest extends RestApiTest {
   private static final GetStatusContext GET_STATUS_CONTEXT = GetStatusContext.defaults();
   private static final XmlMapper XML_MAPPER = new XmlMapper();
 
+  private static final String TEST_USER_NAME = "testuser";
+
   private FileSystem mFileSystem;
   private FileSystemMaster mFileSystemMaster;
 
@@ -799,7 +801,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
   }
 
   private void putBucket(String bucket) throws Exception {
-    putBucket(bucket, null);
+    putBucket(bucket, TEST_USER_NAME);
   }
 
   private void putBucket(String bucket, String user) throws Exception {
@@ -2015,7 +2017,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
   }
 
   private void createBucketRestCall(String bucketUri) throws Exception {
-    createBucketRestCall(bucketUri, null);
+    createBucketRestCall(bucketUri, TEST_USER_NAME);
   }
 
   private void createBucketRestCall(String bucketUri, String user) throws Exception {
@@ -2044,7 +2046,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
   }
 
   private String initiateMultipartUploadRestCall(String objectUri) throws Exception {
-    return initiateMultipartUploadRestCall(objectUri, null);
+    return initiateMultipartUploadRestCall(objectUri, TEST_USER_NAME);
   }
 
   private String initiateMultipartUploadRestCall(String objectUri, String user) throws Exception {
@@ -2084,7 +2086,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
   }
 
   private String listMultipartUploadsRestCall(String bucketUri) throws Exception {
-    return listMultipartUploadsRestCall(bucketUri, null);
+    return listMultipartUploadsRestCall(bucketUri, TEST_USER_NAME);
   }
 
   private String listMultipartUploadsRestCall(String bucketUri, String user) throws Exception {
@@ -2174,12 +2176,7 @@ public final class S3ClientRestApiTest extends RestApiTest {
   }
 
   private TestCaseOptions getDefaultOptionsWithAuth() {
-    if (System.getProperty("user.name").isEmpty()) {
-      throw new RuntimeException("No user available to set for Authorization header");
-    }
-    // Set the default user to the username used to launch the Java process
-    // TODO(czhu): Set the default user to a non-"root" user
-    return getDefaultOptionsWithAuth(System.getProperty("user.name"));
+    return getDefaultOptionsWithAuth("testuser");
   }
 
   private TestCaseOptions getDefaultOptionsWithAuth(@NotNull String user) {

--- a/tests/src/test/java/alluxio/client/rest/TestCaseOptions.java
+++ b/tests/src/test/java/alluxio/client/rest/TestCaseOptions.java
@@ -55,11 +55,6 @@ public final class TestCaseOptions {
    */
   public static TestCaseOptions defaults() {
     TestCaseOptions options =  new TestCaseOptions();
-    // Set the default user to the username used to launch the Java process
-    if (!System.getProperty("user.name").isEmpty()) {
-      options.setAuthorization("AWS4-HMAC-SHA256 Credential=" + System.getProperty("user.name")
-          + "/20220830");
-    }
     return options;
   }
 


### PR DESCRIPTION
This PR explicitly sets the mode bits for all S3 API gRPC writes instead of relying on implicit parent directory perms.

- Theoretically writes were supposed to inherit the parent folder's (bucket's) mode bits of `770` but in reality they were committed as `755` for directories and `644` for files.