### PR TITLE
Add posix api to StressClientIOBench

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
@@ -697,7 +697,10 @@ public class StressClientIOBench extends AbstractStressBench
       }
     }
 
-    protected void closeFile() {
+    @Override
+    protected void closeInStream() {}
+
+    private void closeFile() {
       try {
         if (mRandomAccessFile != null) {
           mRandomAccessFile.close();

--- a/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
@@ -665,7 +665,7 @@ public class StressClientIOBench extends AbstractStressBench
         case POS_READ: {
           int bytesRead = mRandomAccessFile.read(mBuffer);
           if (bytesRead < 0) {
-            closeInStream();
+            closeFile();
           }
           return bytesRead;
         }
@@ -675,7 +675,7 @@ public class StressClientIOBench extends AbstractStressBench
               mFileSize - mRandomAccessFile.getFilePointer());
           mRandomAccessFile.readFully(mBuffer, 0, toRead);
           if (mRandomAccessFile.getFilePointer() == mFileSize) {
-            closeInStream();
+            closeFile();
           }
           return toRead;
         }
@@ -686,7 +686,7 @@ public class StressClientIOBench extends AbstractStressBench
           int bytesToWrite = (int) Math.min(mFileSize - mRandomAccessFile.getFilePointer(),
               mBuffer.length);
           if (bytesToWrite == 0) {
-            mRandomAccessFile.close();
+            closeFile();
             return -1;
           }
           mRandomAccessFile.write(mBuffer, 0, bytesToWrite);
@@ -697,8 +697,7 @@ public class StressClientIOBench extends AbstractStressBench
       }
     }
 
-    @Override
-    protected void closeInStream() {
+    protected void closeFile() {
       try {
         if (mRandomAccessFile != null) {
           mRandomAccessFile.close();

--- a/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/StressClientIOBench.java
@@ -655,10 +655,8 @@ public class StressClientIOBench extends AbstractStressBench
         mCurrentOffset = 0;
       }
       if (ClientIOOperation.isRead(mParameters.mOperation) && mParameters.mReadRandom) {
-        if (mParameters.mReadRandom) {
-          mCurrentOffset = mLongs.next();
-          mRandomAccessFile.seek(mCurrentOffset);
-        }
+        mCurrentOffset = mLongs.next();
+        mRandomAccessFile.seek(mCurrentOffset);
       }
       switch (mParameters.mOperation) {
         case READ_ARRAY: // fall through


### PR DESCRIPTION
Add POSIX API to clientIO stressbench. Doc will be updated in the next pr.

To use the posix api, set `--base` to the alluxio fuse mount point.