### PR TITLE
Fix single master embedded journal checkpoint

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/JournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/JournalSystem.java
@@ -15,6 +15,7 @@ import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.GrpcService;
 import alluxio.master.Master;
+import alluxio.master.StateLockManager;
 import alluxio.master.journal.noop.NoopJournalSystem;
 import alluxio.master.journal.raft.RaftJournalSystem;
 import alluxio.master.journal.sink.JournalSink;
@@ -229,8 +230,10 @@ public interface JournalSystem {
 
   /**
    * Creates a checkpoint in the primary master journal system.
+   * @param stateLockManager used to prevent reads and writes while the journal system is
+   *                         checkpointing
    */
-  void checkpoint() throws IOException;
+  void checkpoint(StateLockManager stateLockManager) throws IOException;
 
   /**
    * @return RPC services for journal system

--- a/core/server/common/src/main/java/alluxio/master/journal/noop/NoopJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/noop/NoopJournalSystem.java
@@ -12,6 +12,7 @@
 package alluxio.master.journal.noop;
 
 import alluxio.master.Master;
+import alluxio.master.StateLockManager;
 import alluxio.master.journal.CatchupFuture;
 import alluxio.master.journal.Journal;
 import alluxio.master.journal.JournalSystem;
@@ -89,5 +90,5 @@ public final class NoopJournalSystem implements JournalSystem {
   public void stop() {}
 
   @Override
-  public void checkpoint() {}
+  public void checkpoint(StateLockManager stateLockManager) {}
 }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -102,7 +102,8 @@ public class JournalStateMachine extends BaseStateMachine {
   private final Map<String, RaftJournal> mJournals;
   private final RaftJournalSystem mJournalSystem;
   private final SnapshotReplicationManager mSnapshotManager;
-  private final AtomicReference<StateLockManager> mStateLockManagerRef = new AtomicReference<>(null);
+  private final AtomicReference<StateLockManager> mStateLockManagerRef
+      = new AtomicReference<>(null);
   @GuardedBy("this")
   private boolean mIgnoreApplys = false;
   @GuardedBy("this")

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -613,12 +613,12 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   @Override
   public synchronized void checkpoint(StateLockManager stateLockManager) throws IOException {
     try (RaftJournalAppender client = new RaftJournalAppender(mServer, this::createClient,
-        mRawClientId); RaftClient raftClient = createClient()) {
+        mRawClientId); RaftClient raftClt = createClient()) {
       catchUp(mStateMachine, client);
       mStateMachine.allowLeaderSnapshots(stateLockManager);
       // taking a manual checkpoint can take a long time, users are warned about this, so we set
       // a long timeout for the operation
-      RaftClientReply reply = raftClient.getSnapshotManagementApi(mPeerId).create(Integer.MAX_VALUE);
+      RaftClientReply reply = raftClt.getSnapshotManagementApi(mPeerId).create(Integer.MAX_VALUE);
       processReply(reply, "failed to take checkpoint");
     } catch (TimeoutException e) {
       LOG.warn("Timeout while performing snapshot: {}", e.toString());

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalSystem.java
@@ -15,11 +15,14 @@ import alluxio.Constants;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.master.Master;
+import alluxio.master.StateLockManager;
+import alluxio.master.StateLockOptions;
 import alluxio.master.journal.AbstractJournalSystem;
 import alluxio.master.journal.CatchupFuture;
 import alluxio.master.journal.sink.JournalSink;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
+import alluxio.resource.LockResource;
 import alluxio.retry.ExponentialTimeBoundedRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.util.CommonUtils;
@@ -247,9 +250,13 @@ public class UfsJournalSystem extends AbstractJournalSystem {
   }
 
   @Override
-  public void checkpoint() throws IOException {
-    for (UfsJournal journal : mJournals.values()) {
-      journal.checkpoint();
+  public void checkpoint(StateLockManager stateLockManager) throws IOException {
+    try (LockResource stateLock = stateLockManager.lockExclusive(StateLockOptions.defaults())) {
+      for (UfsJournal journal : mJournals.values()) {
+        journal.checkpoint();
+      }
+    } catch (Exception e) {
+      throw new IOException("Failed to take snapshot", e);
     }
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -52,7 +52,6 @@ import alluxio.master.meta.checkconf.ConfigurationStore;
 import alluxio.proto.journal.Journal;
 import alluxio.proto.journal.Meta;
 import alluxio.resource.CloseableIterator;
-import alluxio.resource.LockResource;
 import alluxio.underfs.UfsManager;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.IdUtils;
@@ -391,14 +390,9 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
 
   @Override
   public String checkpoint() throws IOException {
-    try (LockResource lr =
-        mMasterContext.getStateLockManager().lockExclusive(StateLockOptions.defaults())) {
-      mJournalSystem.checkpoint();
-      return NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.MASTER_RPC,
-          Configuration.global());
-    } catch (Exception e) {
-      throw new IOException("Failed to take a checkpoint.", e);
-    }
+    mJournalSystem.checkpoint(mMasterContext.getStateLockManager());
+    return NetworkAddressUtils.getConnectHost(NetworkAddressUtils.ServiceType.MASTER_RPC,
+        Configuration.global());
   }
 
   @Override

--- a/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -15,6 +15,7 @@ import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.QuorumServerInfo;
 import alluxio.master.NoopMaster;
+import alluxio.master.StateLockManager;
 import alluxio.master.journal.CatchupFuture;
 import alluxio.master.journal.CountingNoopFileSystemMaster;
 import alluxio.master.journal.JournalContext;
@@ -229,7 +230,7 @@ public class RaftJournalTest {
     }
 
     // Ask the follower to do a snapshot.
-    mFollowerJournalSystem.checkpoint();
+    mFollowerJournalSystem.checkpoint(new StateLockManager());
 
     // Restart the follower.
     mFollowerJournalSystem.stop();

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -42,6 +42,7 @@ public class PortCoordination {
   public static final List<ReservedPort> EMBEDDED_JOURNAL_SNAPSHOT_MASTER = allocate(3, 0);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_SNAPSHOT_FOLLOWER = allocate(3, 0);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_SNAPSHOT_TRANSFER_LOAD = allocate(3, 0);
+  public static final List<ReservedPort> EMBEDDED_JOURNAL_SNAPSHOT_SINGLE_MASTER = allocate(1, 0);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_RESTART = allocate(3, 0);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_RESTART_STRESS = allocate(3, 0);
   // for EmbeddedJournalIntegrationTestResizing

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
@@ -11,6 +11,7 @@
 
 package alluxio.server.ft.journal.raft;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -203,6 +204,55 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
       }
     }
     mCluster.notifySuccess();
+  }
+
+  @Test
+  public void singleMasterSnapshotPurgeLogFiles() throws Exception {
+    mCluster =
+        MultiProcessCluster.newBuilder(PortCoordination.EMBEDDED_JOURNAL_SNAPSHOT_SINGLE_MASTER)
+            .setClusterName("EmbeddedJournalTransferLeadership_singleMasterSnapshot")
+            .setNumMasters(1)
+            .setNumWorkers(NUM_WORKERS)
+            .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.EMBEDDED)
+            .addProperty(PropertyKey.MASTER_JOURNAL_FLUSH_TIMEOUT_MS, "5min")
+            .addProperty(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, "750ms")
+            .addProperty(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, "1500ms")
+            // very small log file size for test purposes
+            .addProperty(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, "1KB")
+            .build();
+    mCluster.start();
+    mCluster.waitForAllNodesRegistered(5_000);
+    File journalDir = new File(mCluster.getJournalDir(0));
+    Path raftDir = Paths.get(RaftJournalUtils.getRaftJournalDir(journalDir).toString(),
+        RaftJournalSystem.RAFT_GROUP_UUID.toString());
+    expectSnapshots(raftDir, 0);
+    expectLogFiles(raftDir, 1);
+    // create two files so that it closes the first log file and creates a new one
+    mCluster.getFileSystemClient().createFile(new AlluxioURI("/testfile0"));
+    mCluster.getFileSystemClient().createFile(new AlluxioURI("/testfile1"));
+    expectSnapshots(raftDir, 0);
+    expectLogFiles(raftDir, 2);
+    // take checkpoint aka snapshot, should purge log files
+    mCluster.getMetaMasterClient().checkpoint();
+    expectSnapshots(raftDir, 1);
+    expectLogFiles(raftDir, 1);
+    mCluster.notifySuccess();
+  }
+
+  private void expectSnapshots(Path raftDir, int numExpected) throws Exception {
+    try (Stream<Path> stream = Files.walk(raftDir, Integer.MAX_VALUE)) {
+      long countSnapshots = stream.filter(path -> path.toString().endsWith(".md5")).count();
+      assertEquals("Expected " + numExpected +  " snapshot(s) to be taken", numExpected,
+          countSnapshots);
+    }
+  }
+
+  private void expectLogFiles(Path raftDir, int numExpected) throws Exception {
+    try (Stream<Path> stream = Files.walk(raftDir, Integer.MAX_VALUE)) {
+      long countLogFiles =
+          stream.filter(path -> path.getFileName().toString().startsWith("log_")).count();
+      assertEquals("Expected " + numExpected +  " log file(s)", numExpected, countLogFiles);
+    }
   }
 
   @Test


### PR DESCRIPTION
Currently, when calling `bin/alluxio fsadmin journal checkpoint` on a cluster with a single embedded journal master, the information about the new snapshot does not get propagated back to Ratis. This in turn means that logs are not pruned and the snapshot is ignored on master restart. 
This fix makes sure the new snapshot is taken through Ratis so that all appropriate functions may be executed. 

Removed `mIsSnapshotAllowed` from `RaftJournalSystem` as it is functionally a duplicate of `mIsLeader` in `JournalStateMachine`.

Redo of #16117.