### PR TITLE
Ensure the HadoopFS default port is the same across all hadoop fs

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -268,6 +268,11 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
   }
 
   @Override
+  protected int getDefaultPort() {
+    return (Integer) PropertyKey.MASTER_RPC_PORT.getDefaultValue();
+  }
+
+  @Override
   public long getDefaultBlockSize() {
     return mFileSystem.getConf()
         .getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AlluxioFileSystem.java
@@ -12,7 +12,6 @@
 package alluxio.hadoop;
 
 import alluxio.Constants;
-import alluxio.conf.PropertyKey;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.DelegateToFileSystem;
@@ -38,7 +37,7 @@ import java.net.URISyntaxException;
 public class AlluxioFileSystem extends DelegateToFileSystem {
   /**
    * This constructor has the signature needed by
-   * {@link AbstractFileSystem#createFileSystem(URI, Configuration)}
+   * {@link org.apache.hadoop.fs.AbstractFileSystem#createFileSystem(URI, Configuration)}
    * in Hadoop 2.x.
    *
    * @param uri the uri for this Alluxio filesystem
@@ -48,10 +47,5 @@ public class AlluxioFileSystem extends DelegateToFileSystem {
   AlluxioFileSystem(final URI uri, final Configuration conf)
       throws IOException, URISyntaxException {
     super(uri, new FileSystem(), conf, Constants.SCHEME, false);
-  }
-
-  @Override
-  public int getUriDefaultPort() {
-    return (Integer) PropertyKey.MASTER_RPC_PORT.getDefaultValue();
   }
 }

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -676,6 +676,27 @@ public class AbstractFileSystemTest {
     }
   }
 
+  @Test
+  public void defaultPortTest() throws Exception {
+    // this test ensures that that default port for Alluxio Hadoop file system is the same
+    // whether in Hadoop 1.x or Hadoop 2.x
+    int defaultRpcPort = (int) PropertyKey.MASTER_RPC_PORT.getDefaultValue();
+
+    Configuration conf = new Configuration();
+    conf.set("fs.AbstractFileSystem.alluxio.impl", "alluxio.hadoop.AlluxioFileSystem");
+    conf.set("fs.alluxio.impl", "alluxio.hadoop.FileSystem");
+    URI uri = new URI("alluxio:///test");
+    org.apache.hadoop.fs.AbstractFileSystem system = org.apache.hadoop.fs.AbstractFileSystem
+        .createFileSystem(uri, conf);
+    assertTrue(system instanceof AlluxioFileSystem);
+    assertEquals(defaultRpcPort, system.getUriDefaultPort());
+
+    org.apache.hadoop.fs.FileSystem system2 = org.apache.hadoop.fs.FileSystem.get(uri, conf);
+    assertTrue(system2 instanceof FileSystem);
+    // casting is required as org.apache.hadoop.fs.FileSystem#getDefaultPort is protected
+    assertEquals(defaultRpcPort, ((FileSystem) system2).getDefaultPort());
+  }
+
   void verifyBlockLocations(List<WorkerNetAddress> blockWorkers, List<String> ufsLocations,
       List<WorkerNetAddress> allWorkers, List<WorkerNetAddress> expectedWorkers) throws Exception {
     FileBlockInfo blockInfo = new FileBlockInfo().setBlockInfo(


### PR DESCRIPTION
Fix #14648.
Followup to #14649.

Currently, the `alluxio.hadoop.AlluxioFileSystem` (that offers compatibility with Hadoop 2.x) reports its default port as 19998 through its method `#getUriDefaultPort`. This contrasts with the `alluxio.hadoop.AbstractFileSystem` and `alluxio.hadoop.FileSystem`  who have default port 0 (as they do not override the `#getDefaultPort` method).

This mismatch causes yarn jobs to fail when using Alluxio logical URIs.
We can see [here](https://github.com/apache/hadoop/blob/a3b9c37a397ad4188041dd80621bdeefc46885f2/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/DelegateToFileSystem.java#L170) that `org.apache.hadoop.fs.DelegateToFileSystem#getUriDefaultPort` calls `org.apache.hadoop.fs.FileSystem#getDefaultPort` by default. 
This PR therefore aligns `alluxio.hadoop.AlluxioFileSystem`, `alluxio.hadoop.AbstractFileSystem`, and `alluxio.hadoop.FileSystem` to all use 19998 as their default port, eliminating the mismatch and allowing yarn jobs to be used with Alluxio logical URIs. 