### PR TITLE
Run async write in caller thread when queue is full for local cache

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -136,13 +136,11 @@ public class LocalCacheManager implements CacheManager {
       mPageLocks[i] = new ReentrantReadWriteLock(true /* fair ordering */);
     }
     mPendingRequests = new ConcurrentHashSet<>();
-    mAsyncCacheExecutor =
-        mAsyncWrite
-            ? Optional.of(
-              new ThreadPoolExecutor(conf.getInt(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_THREADS),
-                conf.getInt(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_THREADS), 60,
-                TimeUnit.SECONDS, new SynchronousQueue<>()))
-            : Optional.empty();
+    mAsyncCacheExecutor = mAsyncWrite ? Optional.of(
+        new ThreadPoolExecutor(conf.getInt(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_THREADS),
+            conf.getInt(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_THREADS), 60, TimeUnit.SECONDS,
+            new SynchronousQueue<>(), new ThreadPoolExecutor.CallerRunsPolicy())) :
+        Optional.empty();
     mInitService =
         mAsyncRestore ? Optional.of(Executors.newSingleThreadExecutor()) : Optional.empty();
     mQuotaEnabled = conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_QUOTA_ENABLED);

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -794,9 +794,9 @@ public final class LocalCacheManagerTest {
       PageId pageId = new PageId("5", i);
       assertTrue(mCacheManager.put(pageId, page(i, PAGE_SIZE_BYTES)));
     }
-    // fail due to full queue
-    assertFalse(mCacheManager.put(PAGE_ID1, PAGE1));
     pageStore.setPutHanging(false);
+    //fallback to caller's thread when queue is full
+    assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
     while (pageStore.getPuts() < threads) {
       Thread.sleep(1000);
     }


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR will run the async write in call's thread when the queue is full.


### Why are the changes needed?
Prevent the rejection of the async write during busy time


### Does this PR introduce any user facing changes?
no
