### PR TITLE
Add empty string check for delimiter

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,7 +144,7 @@ public class ListBucketResult {
           S3ErrorCode.INVALID_ARGUMENT.getStatus()));
     }
     mDelimiter = options.getDelimiter();
-    if (mDelimiter != null) {
+    if (StringUtils.isNotEmpty(mDelimiter)) {
       mCommonPrefixes = new ArrayList<>();
     } // otherwise, mCommonPrefixes is null
     mEncodingType = options.getEncodingType() == null ? ListBucketOptions.DEFAULT_ENCODING_TYPE
@@ -218,7 +219,7 @@ public class ListBucketResult {
         })
         .filter(content -> {
           String path = content.getKey();
-          if (mDelimiter == null) {
+          if (StringUtils.isEmpty(mDelimiter)) {
             if (keyCount[0] == mMaxKeys) {
               mIsTruncated = true;
               return false;

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -404,7 +404,7 @@ public final class S3RestServiceHandler {
           // TODO(czhu): allow non-"/" delimiters by parsing the prefix & delimiter pair to
           //             determine what directory to list the contents of
           // only list the direct children if delimiter is not null
-          if (delimiterParam != null) {
+          if (StringUtils.isNotEmpty(delimiterParam)) {
             if (prefixParam == null) {
               path = parsePathWithDelimiter(path, "", delimiterParam);
             } else {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add empty string check for delimiter.

### Why are the changes needed?
For MinIO clients, commands such as' ls - r' will set the delimiter to an empty string.

### Does this PR introduce any user facing changes?
No.
