### PR TITLE
Allow dot in chown username or group

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/ChownCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/ChownCommand.java
@@ -85,7 +85,7 @@ public final class ChownCommand extends AbstractFileSystemCommand {
    * valid POSIX usernames.
    */
   private static final Pattern USER_GROUP_PATTERN =
-      Pattern.compile("(?<user>[\\w][\\w-]*\\$?)(:(?<group>[\\w][\\w-]*\\$?))?");
+      Pattern.compile("(?<user>[\\w][\\w-.]*\\$?)(:(?<group>[\\w][\\w-.]*\\$?))?");
 
   /**
    * Changes the owner for the path specified in args.

--- a/shell/src/test/java/alluxio/cli/fs/command/ChownCommandTest.java
+++ b/shell/src/test/java/alluxio/cli/fs/command/ChownCommandTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.cli.fs.command;
 
+import alluxio.AlluxioURI;
 import alluxio.exception.AlluxioException;
 
 import org.apache.commons.cli.CommandLine;
@@ -18,6 +19,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -43,17 +45,14 @@ public class ChownCommandTest {
   public void chownPanicIllegalOwnerName() throws AlluxioException, IOException {
     ChownCommand command = new ChownCommand(null);
 
-    String expectedOutput =
-        String.format("Failed to parse user.1:group1 as user or user:group%n");
-    verifyChownCommandReturnValueAndOutput(command, -1, expectedOutput,
-        "user.1:group1", "/testFile");
-
-    String[] args2 = {"user#1:group1", "/testFile"};
-    expectedOutput = String.format("Failed to parse user#1:group1 as user or user:group%n");
+    String expectedOutput = String.format("Failed to parse user#1:group1 as user or user:group%n");
     verifyChownCommandReturnValueAndOutput(command, -1, expectedOutput,
         "user#1:group1", "/testFile");
 
-    String[] args3 = {"6user^$group$", "/testFile"};
+    expectedOutput = String.format("Failed to parse user@1:group1 as user or user:group%n");
+    verifyChownCommandReturnValueAndOutput(command, -1, expectedOutput,
+        "user@1:group1", "/testFile");
+
     expectedOutput = String.format("Failed to parse 6user^$group$ as user or user:group%n");
     verifyChownCommandReturnValueAndOutput(command, -1, expectedOutput,
         "6user^$group$", "/testFile");
@@ -63,13 +62,18 @@ public class ChownCommandTest {
   public void chownPanicIllegalGroupName() throws AlluxioException, IOException {
     ChownCommand command = new ChownCommand(null);
 
-    String expectedOutput = String.format("Failed to parse user1:group.1 as user or user:group%n");
-    verifyChownCommandReturnValueAndOutput(command, -1, expectedOutput,
-        "user1:group.1", "/testFile");
-
-    expectedOutput = String.format("Failed to parse user1:^6group$ as user or user:group%n");
+    String expectedOutput = String.format("Failed to parse user1:^6group$ as user or user:group%n");
     verifyChownCommandReturnValueAndOutput(command, -1, expectedOutput,
         "user1:^6group$", "/testFile");
+  }
+
+  @Test
+  public void chownLegalCases() throws AlluxioException, IOException {
+    ChownCommand command = Mockito.spy(new ChownCommand(null));
+    Mockito.doNothing().when(command).runWildCardCmd(
+        Mockito.any(AlluxioURI.class), Mockito.any(CommandLine.class));
+    verifyChownCommandReturnValueAndOutput(command, 0, "", "user-1:group-1", "/testFile");
+    verifyChownCommandReturnValueAndOutput(command, 0, "", "user.1:group.1", "/testFile");
   }
 
   private void verifyChownCommandReturnValueAndOutput(ChownCommand command,


### PR DESCRIPTION
### What changes are proposed in this pull request?

Allow dot in chown username or groupname.

### Why are the changes needed?

Reasons
1. "chown" in hdfs supports a user/group with a dot
2. alluxio internal also supports it, such as "alluxio fs ls"
3. Dot is also allowed in gmail's account, which is registered as usernames in many cases

Otherwise the following behaviour is strange
<img width="997" alt="2022-09-24_17-32-39" src="https://user-images.githubusercontent.com/7149512/192091203-cfac62be-3007-4302-bc21-543edb211cfd.png">


### Does this PR introduce any user facing changes?

No
