### PR TITLE
Increase the timeout for waiting for the master to start in minicluster

### DIFF
--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -56,7 +56,7 @@ public abstract class AbstractLocalAlluxioCluster {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractLocalAlluxioCluster.class);
 
   private static final Random RANDOM_GENERATOR = new Random();
-  private static final int WAIT_MASTER_START_TIMEOUT_MS = 30_000;
+  private static final int WAIT_MASTER_START_TIMEOUT_MS = 90_000;
 
   protected ProxyProcess mProxyProcess;
   protected Thread mProxyThread;


### PR DESCRIPTION
### What changes are proposed in this pull request?
![image](https://user-images.githubusercontent.com/26576419/192249471-7dbba49b-5529-42a1-93f6-dbb1910f6148.png)
Similar errors are often reported when running test classes. 

### Why are the changes needed?

You can avoid running some test case errors by increasing the timeout period for waiting for the master to start in minicluster.


### Does this PR introduce any user facing changes?
No.
