### PR TITLE
Avoid and dedup concurrent metadata sync

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3281,8 +3281,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
-  public static final PropertyKey MASTER_METADATA_SYNC_AVOID_SAME_PATH_CONCURRENT_SYNC =
-      booleanBuilder(Name.MASTER_METADATA_SYNC_AVOID_SAME_PATH_CONCURRENT_SYNC)
+  public static final PropertyKey MASTER_METADATA_CONCURRENT_SYNC_DEDUP =
+      booleanBuilder(Name.MASTER_METADATA_CONCURRENT_SYNC_DEDUP)
           .setDefaultValue(true)
           .setDescription("If set to true, a metadata sync request will be skipped and "
               + "doesn't trigger a UFS sync when there have already been other requests syncing "
@@ -7271,8 +7271,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_EMBEDDED_JOURNAL_TRANSPORT_MAX_INBOUND_MESSAGE_SIZE =
         "alluxio.master.embedded.journal.transport.max.inbound.message.size";
     public static final String MASTER_KEYTAB_KEY_FILE = "alluxio.master.keytab.file";
-    public static final String MASTER_METADATA_SYNC_AVOID_SAME_PATH_CONCURRENT_SYNC =
-        "alluxio.master.metadata.sync.avoid.same.path.concurrent.sync";
+    public static final String MASTER_METADATA_CONCURRENT_SYNC_DEDUP =
+        "alluxio.master.metadata.concurrent.sync.dedup";
     public static final String MASTER_METADATA_SYNC_CONCURRENCY_LEVEL =
         "alluxio.master.metadata.sync.concurrency.level";
     public static final String MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3283,13 +3283,41 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_METADATA_CONCURRENT_SYNC_DEDUP =
       booleanBuilder(Name.MASTER_METADATA_CONCURRENT_SYNC_DEDUP)
-          .setDefaultValue(true)
+          .setDefaultValue(false)
           .setDescription("If set to true, a metadata sync request will be skipped and "
               + "doesn't trigger a UFS sync when there have already been other requests syncing "
               + "the same path. The outstanding metadata sync request will wait until these syncs "
               + "are done and return SyncStatus.NOT_NEED.")
           .setScope(Scope.MASTER)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .build();
+  public static final PropertyKey MASTER_METADATA_SYNC_LOCK_POOL_INITSIZE =
+      intBuilder(Name.MASTER_METADATA_SYNC_LOCK_POOL_INITSIZE)
+          .setDefaultValue(1000)
+          .setDescription("Initial size of the lock pool for master metadata sync.")
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_METADATA_SYNC_LOCK_POOL_LOW_WATERMARK =
+      intBuilder(Name.MASTER_METADATA_SYNC_LOCK_POOL_LOW_WATERMARK)
+          .setDefaultValue(20000)
+          .setDescription("Low watermark of metadata sync lock pool size. "
+              + "When the size grows over the high watermark, a background thread will try to "
+              + "evict unused locks until the size reaches the low watermark.")
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_METADATA_SYNC_LOCK_POOL_HIGH_WATERMARK =
+      intBuilder(Name.MASTER_METADATA_SYNC_LOCK_POOL_HIGH_WATERMARK)
+          .setDefaultValue(50000)
+          .setDescription("High watermark of metadata sync lock pool size. "
+              + "When the size grows over the high watermark, a background thread starts evicting "
+              + "unused locks from the pool.")
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_METADATA_SYNC_LOCK_POOL_CONCURRENCY_LEVEL =
+      intBuilder(Name.MASTER_METADATA_SYNC_LOCK_POOL_CONCURRENCY_LEVEL)
+          .setDefaultValue(20)
+          .setDescription("Maximum concurrency level for the metadata sync lock pool")
+          .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_METADATA_SYNC_CONCURRENCY_LEVEL =
       intBuilder(Name.MASTER_METADATA_SYNC_CONCURRENCY_LEVEL)
@@ -7271,6 +7299,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_EMBEDDED_JOURNAL_TRANSPORT_MAX_INBOUND_MESSAGE_SIZE =
         "alluxio.master.embedded.journal.transport.max.inbound.message.size";
     public static final String MASTER_KEYTAB_KEY_FILE = "alluxio.master.keytab.file";
+    public static final String MASTER_METADATA_SYNC_LOCK_POOL_INITSIZE =
+        "alluxio.master.metadata.sync.lock.pool.initsize";
+    public static final String MASTER_METADATA_SYNC_LOCK_POOL_LOW_WATERMARK =
+        "alluxio.master.metadata.sync.lock.pool.low.watermark";
+    public static final String MASTER_METADATA_SYNC_LOCK_POOL_HIGH_WATERMARK =
+        "alluxio.master.metadata.sync.lock.pool.high.watermark";
+    public static final String MASTER_METADATA_SYNC_LOCK_POOL_CONCURRENCY_LEVEL =
+        "alluxio.master.metadata.sync.lock.pool.concurrency.level";
     public static final String MASTER_METADATA_CONCURRENT_SYNC_DEDUP =
         "alluxio.master.metadata.concurrent.sync.dedup";
     public static final String MASTER_METADATA_SYNC_CONCURRENCY_LEVEL =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3293,13 +3293,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_METADATA_SYNC_LOCK_POOL_INITSIZE =
       intBuilder(Name.MASTER_METADATA_SYNC_LOCK_POOL_INITSIZE)
-          .setDefaultValue(1000)
+          .setDefaultValue(1_000)
           .setDescription("Initial size of the lock pool for master metadata sync.")
           .setScope(Scope.MASTER)
           .build();
   public static final PropertyKey MASTER_METADATA_SYNC_LOCK_POOL_LOW_WATERMARK =
       intBuilder(Name.MASTER_METADATA_SYNC_LOCK_POOL_LOW_WATERMARK)
-          .setDefaultValue(20000)
+          .setDefaultValue(20_000)
           .setDescription("Low watermark of metadata sync lock pool size. "
               + "When the size grows over the high watermark, a background thread will try to "
               + "evict unused locks until the size reaches the low watermark.")
@@ -3307,7 +3307,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_METADATA_SYNC_LOCK_POOL_HIGH_WATERMARK =
       intBuilder(Name.MASTER_METADATA_SYNC_LOCK_POOL_HIGH_WATERMARK)
-          .setDefaultValue(50000)
+          .setDefaultValue(50_000)
           .setDescription("High watermark of metadata sync lock pool size. "
               + "When the size grows over the high watermark, a background thread starts evicting "
               + "unused locks from the pool.")

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3281,6 +3281,16 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_METADATA_SYNC_AVOID_SAME_PATH_CONCURRENT_SYNC =
+      booleanBuilder(Name.MASTER_METADATA_SYNC_AVOID_SAME_PATH_CONCURRENT_SYNC)
+          .setDefaultValue(true)
+          .setDescription("If set to true, a metadata sync request will be skipped and "
+              + "doesn't trigger a UFS sync when there have already been other requests syncing "
+              + "the same path. The outstanding metadata sync request will wait until these syncs "
+              + "are done and return SyncStatus.NOT_NEED.")
+          .setScope(Scope.MASTER)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .build();
   public static final PropertyKey MASTER_METADATA_SYNC_CONCURRENCY_LEVEL =
       intBuilder(Name.MASTER_METADATA_SYNC_CONCURRENCY_LEVEL)
           .setDefaultValue(6)
@@ -7261,6 +7271,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_EMBEDDED_JOURNAL_TRANSPORT_MAX_INBOUND_MESSAGE_SIZE =
         "alluxio.master.embedded.journal.transport.max.inbound.message.size";
     public static final String MASTER_KEYTAB_KEY_FILE = "alluxio.master.keytab.file";
+    public static final String MASTER_METADATA_SYNC_AVOID_SAME_PATH_CONCURRENT_SYNC =
+        "alluxio.master.metadata.sync.avoid.same.path.concurrent.sync";
     public static final String MASTER_METADATA_SYNC_CONCURRENCY_LEVEL =
         "alluxio.master.metadata.sync.concurrency.level";
     public static final String MASTER_METADATA_SYNC_EXECUTOR_POOL_SIZE =

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1450,6 +1450,7 @@ public class DefaultFileSystemMaster extends CoreMaster
   @Override
   public boolean exists(AlluxioURI path, ExistsContext context)
       throws AccessControlException, IOException {
+    boolean exists = false;
     try (RpcContext rpcContext = createRpcContext(context);
          FileSystemMasterAuditContext auditContext =
              createAuditContext("exists", path, null, null)) {
@@ -1458,40 +1459,51 @@ public class DefaultFileSystemMaster extends CoreMaster
           DescendantType.ONE, auditContext, LockedInodePath::getInodeOrNull,
           false);
 
-      try (LockedInodePath inodePath = mInodeTree.lockInodePath(
-          createLockingScheme(path, context.getOptions().getCommonOptions(), LockPattern.READ),
-          rpcContext.getJournalContext())
-      ) {
-        LoadMetadataContext lmCtx = LoadMetadataContext.create(
-            LoadMetadataPOptions.newBuilder()
-                .setCommonOptions(context.getOptions().getCommonOptions())
-                .setLoadType(context.getOptions().getLoadMetadataType()));
-        if (shouldLoadMetadataIfNotExists(inodePath, lmCtx)) {
-          checkLoadMetadataOptions(context.getOptions().getLoadMetadataType(), path);
+      LoadMetadataContext lmCtx = LoadMetadataContext.create(
+          LoadMetadataPOptions.newBuilder()
+              .setCommonOptions(context.getOptions().getCommonOptions())
+              .setLoadType(context.getOptions().getLoadMetadataType()));
+      /*
+      See the comments in #getFileIdInternal for an explanation on why the loop here is required.
+       */
+      boolean run = true;
+      boolean loadMetadata = false;
+      while (run) {
+        run = false;
+        if (loadMetadata) {
+          try {
+            checkLoadMetadataOptions(context.getOptions().getLoadMetadataType(), path);
+          } catch (FileDoesNotExistException e) {
+            return false;
+          }
           loadMetadataIfNotExist(rpcContext, path, lmCtx, false);
         }
-      } catch (FileDoesNotExistException e) {
-        // ignore exception
-      }
 
-      try (LockedInodePath inodePath = mInodeTree.lockInodePath(
-          createLockingScheme(path, context.getOptions().getCommonOptions(), LockPattern.READ),
-          rpcContext.getJournalContext())
-      ) {
-        try {
-          if (mPermissionChecker instanceof DefaultPermissionChecker) {
-            mPermissionChecker.checkParentPermission(Mode.Bits.EXECUTE, inodePath);
+        try (LockedInodePath inodePath = mInodeTree.lockInodePath(
+            createLockingScheme(path, context.getOptions().getCommonOptions(), LockPattern.READ),
+            rpcContext.getJournalContext())
+        ) {
+          if (!loadMetadata && shouldLoadMetadataIfNotExists(inodePath, lmCtx)) {
+            loadMetadata = true;
+            run = true;
+            continue;
           }
-        } catch (AccessControlException e) {
-          auditContext.setAllowed(false);
-          throw e;
+          try {
+            if (mPermissionChecker instanceof DefaultPermissionChecker) {
+              mPermissionChecker.checkParentPermission(Mode.Bits.EXECUTE, inodePath);
+            }
+          } catch (AccessControlException e) {
+            auditContext.setAllowed(false);
+            throw e;
+          }
+          auditContext.setSucceeded(true);
+          exists = inodePath.fullPathExists();
         }
-        auditContext.setSucceeded(true);
-        return inodePath.fullPathExists();
       }
     } catch (InvalidPathException e) {
       return false;
     }
+    return exists;
   }
 
   private void checkConsistencyRecursive(LockedInodePath inodePath,

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -69,6 +69,7 @@ import alluxio.underfs.UfsManager;
 import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UfsStatusCache;
 import alluxio.underfs.UnderFileSystem;
+import alluxio.util.CommonUtils;
 import alluxio.util.LogUtils;
 import alluxio.util.interfaces.Scoped;
 import alluxio.util.io.PathUtils;
@@ -262,6 +263,16 @@ public class InodeSyncStream {
       PropertyKey.MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS
   );
 
+  /** To determine whether we should only let the UFS sync happen once
+   * for the concurrent metadata sync requests syncing the same directory.
+   */
+  private static final boolean AVOID_CONCURRENT_SYNC_ON_THE_SAME_PATH = Configuration.getBoolean(
+      PropertyKey.MASTER_METADATA_SYNC_AVOID_SAME_PATH_CONCURRENT_SYNC
+  );
+
+  private static final MetadataSyncLockManager SYNC_METADATA_LOCK_MANAGER =
+      new MetadataSyncLockManager();
+
   /**
    * Whether the caller is {@link FileSystemMaster#getFileInfo(AlluxioURI, GetStatusContext)}.
    * This is used for the {@link #mUfsSyncPathCache}.
@@ -289,7 +300,6 @@ public class InodeSyncStream {
 
   private final FileSystemMasterAuditContext mAuditContext;
   private final Function<LockedInodePath, Inode> mAuditContextSrcInodeFunc;
-
   private final Clock mClock;
 
   /**
@@ -387,6 +397,20 @@ public class InodeSyncStream {
    * @return SyncStatus object
    */
   public SyncStatus sync() throws AccessControlException, InvalidPathException {
+    long syncStartTs = CommonUtils.getCurrentMs();
+    if (!AVOID_CONCURRENT_SYNC_ON_THE_SAME_PATH) {
+      return syncInternal(syncStartTs);
+    }
+    try (MetadataSyncLockManager.MetadataSyncPathList ignored = SYNC_METADATA_LOCK_MANAGER.lockPath(
+        mRootScheme.getPath())) {
+      return syncInternal(syncStartTs);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private SyncStatus syncInternal(long syncStartTs) throws
+      AccessControlException, InvalidPathException {
     // The high-level process for the syncing is:
     // 1. Given an Alluxio path, determine if it is not consistent with the corresponding UFS path.
     //     this means the UFS path does not exist, or has metadata which differs from Alluxio
@@ -401,6 +425,32 @@ public class InodeSyncStream {
     if (!mRootScheme.shouldSync().isShouldSync() && !mForceSync) {
       DefaultFileSystemMaster.Metrics.INODE_SYNC_STREAM_SKIPPED.inc();
       return SyncStatus.NOT_NEEDED;
+    }
+    if (AVOID_CONCURRENT_SYNC_ON_THE_SAME_PATH) {
+      /*
+       * If a sync had already started after the sync initialized by the current thread
+       * which has covered the targets this thread wants to sync,
+       * then there is no need to trigger another sync.
+       * * e.g.
+       * 1. [TS=100] the sync() method is called by thread A for path /aaa
+       * 2. [TS=110] the sync() method is called by thread B for path /aaa,
+       *    thread B is blocked by the new introduced metadata sync lock
+       * 3. [TS=180] thread A finishes the metadata sync, update the SyncPathCache,
+       *    setting the last sync timestamp to 180.
+       * 4. [TS=182] thread B acquired the lock and can start sync
+       * 5. [TS=182] thread B need to check if in the past (182-110=72) unit of time,
+       *    the same path has been synced by other thread,
+       *    if yes, just skip the sync and return NOT_NEEDED.
+       * Note that this still applies if A is to sync recursively path /aaa while B is to
+       * sync path /aaa/bbb as the sync scope of A covers B's.
+       */
+      long syncIntervalToPreventConcurrentSync = Instant.now().toEpochMilli() - syncStartTs;
+      boolean shouldSync = mUfsSyncPathCache.shouldSyncPath(mRootScheme.getPath().toString(),
+          syncIntervalToPreventConcurrentSync, mIsGetFileInfo).isShouldSync();
+      if (!shouldSync) {
+        DefaultFileSystemMaster.Metrics.INODE_SYNC_STREAM_SKIPPED.inc();
+        return SyncStatus.NOT_NEEDED;
+      }
     }
     Instant startTime = Instant.now();
     try (LockedInodePath path =

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -269,7 +269,6 @@ public class InodeSyncStream {
   private final boolean mDedupConcurrentSync = Configuration.getBoolean(
       PropertyKey.MASTER_METADATA_CONCURRENT_SYNC_DEDUP
   );
-
   private static final MetadataSyncLockManager SYNC_METADATA_LOCK_MANAGER =
       new MetadataSyncLockManager();
 
@@ -300,6 +299,7 @@ public class InodeSyncStream {
 
   private final FileSystemMasterAuditContext mAuditContext;
   private final Function<LockedInodePath, Inode> mAuditContextSrcInodeFunc;
+
   private final Clock mClock;
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/MetadataSyncLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/MetadataSyncLockManager.java
@@ -1,0 +1,88 @@
+package alluxio.master.file;
+
+import alluxio.AlluxioURI;
+import alluxio.collections.LockPool;
+import alluxio.concurrent.LockMode;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.resource.LockResource;
+
+import com.google.common.base.Preconditions;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Class for managing metadata　sync locking.
+ */
+public class MetadataSyncLockManager {
+  /**
+   * Pool for supplying metadata sync locks.
+   *
+   * We use weak values so that when nothing holds a reference to
+   * a lock, the garbage collector can remove the lock's entry from the pool.
+   */
+  private final LockPool<String> mLockPool =
+      new LockPool<>((key) -> new ReentrantReadWriteLock(),
+          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_INITSIZE),
+          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_LOW_WATERMARK),
+          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_HIGH_WATERMARK),
+          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_CONCURRENCY_LEVEL));
+
+  /**
+   * Acquire locks for a given path before metadata sync.
+   * Locks are for leading paths of a uri instead of inodes
+   * and hence paths will be locked regardless if they exist in alluxio or not.
+   * All locks but the last one will be read locks and the last lock acquired will be a write lock.
+   *
+   * For example, for path /a/b/c/d, this method will acquire the following locks sequentially
+   * 1. a read lock on /
+   * 2. a read lock on /a
+   * 3. a read lock on /a/b
+   * 4. a read lock on /a/b/c
+   * 5. a write lock on /a/b/c/d
+   *
+   * @param uri the alluxio uri to perform metadata sync
+   * @return the {@link MetadataSyncPathList} representing the locked paths
+   */
+  public MetadataSyncPathList lockPath(AlluxioURI uri) {
+    MetadataSyncPathList list = new MetadataSyncPathList();
+    int depth = uri.getDepth();
+    // TODO(elega) potential inefficient string operations
+    for (int i = 0; i <= depth; ++i) {
+      String lockKey = uri.getLeadingPath(i);
+      Preconditions.checkNotNull(lockKey);
+      LockMode lockMode = (i == depth) ? LockMode.WRITE : LockMode.READ;
+      list.add(mLockPool.get(lockKey, lockMode));
+    }
+    return list;
+  }
+
+  /**
+   * @return the size of the lock pool
+   */
+  public int getLockPoolSize() {
+    return mLockPool.size();
+  }
+
+  /**
+   * Represents a locked path for a metadata sync path.
+   */
+  public static class MetadataSyncPathList implements Closeable {
+    List<LockResource> mLockResources = new ArrayList<>();
+
+    private synchronized void add(LockResource lockResource) {
+      mLockResources.add(lockResource);
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+      for (int i = mLockResources.size() - 1; i >= 0; --i) {
+        mLockResources.get(i).close();
+      }
+    }
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/file/MetadataSyncLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/MetadataSyncLockManager.java
@@ -30,7 +30,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * Class for managing metadata　sync locking.
+ * Class for managing metadata sync locking.
  */
 public class MetadataSyncLockManager {
   /**
@@ -70,7 +70,7 @@ public class MetadataSyncLockManager {
     try {
       for (int i = 0; i < components.length; ++i) {
         sb.append(components[i]);
-        sb.append('/');
+        sb.append(AlluxioURI.SEPARATOR);
         String lockKey = sb.toString();
         Preconditions.checkNotNull(lockKey);
         LockMode lockMode = (i == components.length - 1) ? LockMode.WRITE : LockMode.READ;

--- a/core/server/master/src/main/java/alluxio/master/file/MetadataSyncLockManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/MetadataSyncLockManager.java
@@ -41,10 +41,10 @@ public class MetadataSyncLockManager {
    */
   private final LockPool<String> mLockPool =
       new LockPool<>((key) -> new ReentrantReadWriteLock(),
-          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_INITSIZE),
-          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_LOW_WATERMARK),
-          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_HIGH_WATERMARK),
-          Configuration.getInt(PropertyKey.MASTER_LOCK_POOL_CONCURRENCY_LEVEL));
+          Configuration.getInt(PropertyKey.MASTER_METADATA_SYNC_LOCK_POOL_INITSIZE),
+          Configuration.getInt(PropertyKey.MASTER_METADATA_SYNC_LOCK_POOL_LOW_WATERMARK),
+          Configuration.getInt(PropertyKey.MASTER_METADATA_SYNC_LOCK_POOL_HIGH_WATERMARK),
+          Configuration.getInt(PropertyKey.MASTER_METADATA_SYNC_LOCK_POOL_CONCURRENCY_LEVEL));
 
   /**
    * Acquire locks for a given path before metadata sync.

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataConcurrentTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataConcurrentTest.java
@@ -1,0 +1,192 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file;
+
+import static org.junit.Assert.assertEquals;
+
+import alluxio.AlluxioURI;
+import alluxio.collections.Pair;
+import alluxio.concurrent.jsr.CompletableFuture;
+import alluxio.exception.AccessControlException;
+import alluxio.exception.InvalidPathException;
+import alluxio.file.options.DescendantType;
+import alluxio.grpc.FileSystemMasterCommonPOptions;
+import alluxio.master.file.meta.InodeTree;
+import alluxio.master.file.meta.LockingScheme;
+import alluxio.underfs.UnderFileSystem;
+
+import com.google.common.math.IntMath;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({UnderFileSystem.Factory.class})
+public class FileSystemMasterSyncMetadataConcurrentTest
+    extends FileSystemMasterSyncMetadataTestBase {
+  private final int mNumDirsPerLevel = 2;
+  private final int mNumLevels = 3;
+  private final int mNumExpectedInodes = IntMath.pow(mNumDirsPerLevel, mNumLevels + 1) - 1;
+
+  @Override
+  public void before() throws Exception {
+    super.before();
+
+    createUFSHierarchy(0, mNumLevels, "", mNumDirsPerLevel);
+
+    mUfs.mIsSlow = true;
+    mUfs.mSlowTimeMs = 500;
+    // verify the files don't exist in alluxio
+    assertEquals(1, mFileSystemMaster.getInodeTree().getInodeCount());
+  }
+
+  @Test
+  public void syncTheSameDirectory() throws Exception {
+    InodeSyncStream iss1 = makeInodeSyncStream("/", false, true, 0);
+    InodeSyncStream iss2 = makeInodeSyncStream("/", false, true, 0);
+    assertTheSecondSyncSkipped(syncConcurrent(iss1, iss2));
+    // Only load 1 level metadata
+    assertEquals(1 + mNumDirsPerLevel, mFileSystemMaster.getInodeTree().getInodeCount());
+
+    iss1 = makeInodeSyncStream("/", true, false, 0);
+    iss2 = makeInodeSyncStream("/", true, false, 0);
+    assertTheSecondSyncSkipped(syncConcurrent(iss1, iss2));
+    assertEquals(mNumExpectedInodes, mFileSystemMaster.getInodeTree().getInodeCount());
+    assertSyncHappenTwice(syncSequential(iss1, iss2));
+
+    iss1 = makeInodeSyncStream("/0_1", true, false, 0);
+    iss2 = makeInodeSyncStream("/0_1", false, false, 0);
+    assertTheSecondSyncSkipped(syncConcurrent(iss1, iss2));
+
+    iss1 = makeInodeSyncStream("/0_1", true, false, -1);
+    iss2 = makeInodeSyncStream("/0_1", false, false, -1);
+    assertSyncNotHappen(syncConcurrent(iss1, iss2));
+  }
+
+  @Test
+  public void syncDirectoryAndItsSubdirectory() throws Exception {
+    InodeSyncStream iss1 = makeInodeSyncStream("/", true, false, 0);
+    InodeSyncStream iss2 = makeInodeSyncStream("/0_1", true, false, 0);
+    assertTheSecondSyncSkipped(syncConcurrent(iss1, iss2));
+    assertEquals(mNumExpectedInodes, mFileSystemMaster.getInodeTree().getInodeCount());
+    assertSyncHappenTwice(syncSequential(iss1, iss2));
+
+    iss1 = makeInodeSyncStream("/", false, false, 0);
+    iss2 = makeInodeSyncStream("/0_1", true, false, 0);
+    assertSyncHappenTwice(syncConcurrent(iss1, iss2));
+
+    iss1 = makeInodeSyncStream("/0_1", true, false, 0);
+    iss2 = makeInodeSyncStream("/", true, false, 0);
+    assertSyncHappenTwice(syncConcurrent(iss1, iss2));
+
+    iss1 = makeInodeSyncStream("/0_1", true, false, -1);
+    iss2 = makeInodeSyncStream("/", true, false, -1);
+    assertSyncNotHappen(syncConcurrent(iss1, iss2));
+  }
+
+  @Test
+  public void syncDifferentDirectories() throws Exception {
+    InodeSyncStream iss1 = makeInodeSyncStream("/0_0", true, true, 0);
+    InodeSyncStream iss2 = makeInodeSyncStream("/0_1", true, true, 0);
+    assertSyncHappenTwice(syncConcurrent(iss1, iss2));
+
+    iss1 = makeInodeSyncStream("/0_0", true, false, 0);
+    iss2 = makeInodeSyncStream("/0_1", true, false, 0);
+    assertSyncHappenTwice(syncConcurrent(iss1, iss2));
+    assertEquals(mNumExpectedInodes, mFileSystemMaster.getInodeTree().getInodeCount());
+  }
+
+  private void assertTheSecondSyncSkipped(
+      Pair<InodeSyncStream.SyncStatus, InodeSyncStream.SyncStatus> results) {
+    assertEquals(InodeSyncStream.SyncStatus.OK, results.getFirst());
+    assertEquals(InodeSyncStream.SyncStatus.NOT_NEEDED, results.getSecond());
+  }
+
+  private void assertSyncHappenTwice(
+      Pair<InodeSyncStream.SyncStatus, InodeSyncStream.SyncStatus> results) {
+    assertEquals(InodeSyncStream.SyncStatus.OK, results.getFirst());
+    assertEquals(InodeSyncStream.SyncStatus.OK, results.getSecond());
+  }
+
+  private void assertSyncNotHappen(
+      Pair<InodeSyncStream.SyncStatus, InodeSyncStream.SyncStatus> results) {
+    assertEquals(InodeSyncStream.SyncStatus.NOT_NEEDED, results.getFirst());
+    assertEquals(InodeSyncStream.SyncStatus.NOT_NEEDED, results.getSecond());
+  }
+
+  private InodeSyncStream makeInodeSyncStream(String path, boolean isRecursive, boolean loadOnly,
+                                              long syncInterval) {
+    FileSystemMasterCommonPOptions options = FileSystemMasterCommonPOptions.newBuilder()
+        .setSyncIntervalMs(syncInterval)
+        .build();
+    LockingScheme syncScheme =
+        new LockingScheme(new AlluxioURI(path), InodeTree.LockPattern.READ, options,
+            mFileSystemMaster.getSyncPathCache(), false); // shouldSync
+
+    return
+        new InodeSyncStream(syncScheme, mFileSystemMaster, RpcContext.NOOP,
+            isRecursive ? DescendantType.ALL : DescendantType.ONE, options,
+            false,
+            false,
+            loadOnly,
+            false);
+  }
+
+  private Pair<InodeSyncStream.SyncStatus, InodeSyncStream.SyncStatus> syncConcurrent(
+      InodeSyncStream iss1, InodeSyncStream iss2)
+      throws ExecutionException, InterruptedException {
+    Thread.sleep(10);
+    CompletableFuture<InodeSyncStream.SyncStatus> f1 = CompletableFuture.supplyAsync(() -> {
+      try {
+        return iss1.sync();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+    Thread.sleep(100);
+    CompletableFuture<InodeSyncStream.SyncStatus> f2 = CompletableFuture.supplyAsync(() -> {
+      try {
+        return iss2.sync();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+    return new Pair<>(f1.get(), f2.get());
+  }
+
+  private Pair<InodeSyncStream.SyncStatus, InodeSyncStream.SyncStatus> syncSequential(
+      InodeSyncStream iss1, InodeSyncStream iss2)
+      throws AccessControlException, InvalidPathException, InterruptedException {
+    Thread.sleep(10);
+    InodeSyncStream.SyncStatus result1 = iss1.sync();
+    Thread.sleep(10);
+    InodeSyncStream.SyncStatus result2 = iss2.sync();
+    return new Pair<>(result1, result2);
+  }
+
+  private void createUFSHierarchy(int level, int maxLevel, String prefix, int numPerLevel)
+      throws IOException {
+    if (level >= maxLevel) {
+      return;
+    }
+    for (int i = 0; i < numPerLevel; ++i) {
+      String dirPath = prefix + "/" + level + "_" + i;
+      createUfsDir(dirPath);
+      createUFSHierarchy(level + 1, maxLevel, dirPath, numPerLevel);
+    }
+  }
+}
+

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataConcurrentTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataConcurrentTest.java
@@ -48,7 +48,7 @@ public class FileSystemMasterSyncMetadataConcurrentTest
     super.before();
     Configuration.set(PropertyKey.MASTER_METADATA_CONCURRENT_SYNC_DEDUP, true);
 
-    createUFSHierarchy(0, mNumLevels, "", mNumDirsPerLevel);
+    createUfsHierarchy(0, mNumLevels, "", mNumDirsPerLevel);
 
     mUfs.mIsSlow = true;
     mUfs.mSlowTimeMs = 500;
@@ -177,8 +177,8 @@ public class FileSystemMasterSyncMetadataConcurrentTest
     assertEquals(InodeSyncStream.SyncStatus.NOT_NEEDED, results.getSecond());
   }
 
-  private InodeSyncStream makeInodeSyncStream(String path, boolean isRecursive, boolean loadOnly,
-                                              long syncInterval) {
+  private InodeSyncStream makeInodeSyncStream(
+      String path, boolean isRecursive, boolean loadOnly, long syncInterval) {
     FileSystemMasterCommonPOptions options = FileSystemMasterCommonPOptions.newBuilder()
         .setSyncIntervalMs(syncInterval)
         .build();
@@ -227,7 +227,7 @@ public class FileSystemMasterSyncMetadataConcurrentTest
     return new Pair<>(result1, result2);
   }
 
-  private void createUFSHierarchy(int level, int maxLevel, String prefix, int numPerLevel)
+  private void createUfsHierarchy(int level, int maxLevel, String prefix, int numPerLevel)
       throws IOException {
     if (level >= maxLevel) {
       return;
@@ -235,7 +235,7 @@ public class FileSystemMasterSyncMetadataConcurrentTest
     for (int i = 0; i < numPerLevel; ++i) {
       String dirPath = prefix + "/" + level + "_" + i;
       createUfsDir(dirPath);
-      createUFSHierarchy(level + 1, maxLevel, dirPath, numPerLevel);
+      createUfsHierarchy(level + 1, maxLevel, dirPath, numPerLevel);
     }
   }
 }

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataConcurrentTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataConcurrentTest.java
@@ -16,6 +16,8 @@ import static org.junit.Assert.assertEquals;
 import alluxio.AlluxioURI;
 import alluxio.collections.Pair;
 import alluxio.concurrent.jsr.CompletableFuture;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.AccessControlException;
 import alluxio.exception.InvalidPathException;
 import alluxio.file.options.DescendantType;
@@ -44,6 +46,7 @@ public class FileSystemMasterSyncMetadataConcurrentTest
   @Override
   public void before() throws Exception {
     super.before();
+    Configuration.set(PropertyKey.MASTER_METADATA_CONCURRENT_SYNC_DEDUP, true);
 
     createUFSHierarchy(0, mNumLevels, "", mNumDirsPerLevel);
 

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataMetricsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataMetricsTest.java
@@ -17,128 +17,35 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 
 import alluxio.AlluxioURI;
-import alluxio.Constants;
-import alluxio.conf.Configuration;
-import alluxio.conf.PropertyKey;
 import alluxio.file.options.DescendantType;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
-import alluxio.master.CoreMasterContext;
-import alluxio.master.MasterRegistry;
-import alluxio.master.MasterTestUtils;
-import alluxio.master.block.BlockMaster;
-import alluxio.master.block.BlockMasterFactory;
 import alluxio.master.file.contexts.ListStatusContext;
 import alluxio.master.file.meta.InodeTree;
 import alluxio.master.file.meta.LockingScheme;
 import alluxio.master.file.meta.MountTable;
 import alluxio.master.file.meta.NoopUfsAbsentPathCache;
 import alluxio.master.file.meta.UfsAbsentPathCache;
-import alluxio.master.journal.JournalSystem;
-import alluxio.master.journal.JournalTestUtils;
-import alluxio.master.journal.JournalType;
-import alluxio.master.metrics.MetricsMasterFactory;
-import alluxio.metrics.MetricsSystem;
-import alluxio.security.authentication.AuthenticatedClientUser;
-import alluxio.security.user.UserState;
-import alluxio.underfs.UfsFileStatus;
 import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UfsStatusCache;
 import alluxio.underfs.UnderFileSystem;
-import alluxio.underfs.UnderFileSystemConfiguration;
-import alluxio.underfs.local.LocalUnderFileSystem;
-import alluxio.util.ThreadFactoryUtils;
-import alluxio.util.executor.ExecutorServiceFactories;
-import alluxio.util.io.PathUtils;
 
 import com.codahale.metrics.Counter;
 import com.google.common.collect.ImmutableList;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.io.IOException;
 import java.io.OutputStream;
-import java.time.Clock;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({UnderFileSystem.Factory.class})
-public class FileSystemMasterSyncMetadataMetricsTest {
-  private static final AlluxioURI ROOT = new AlluxioURI("/");
-  private static final String TEST_DIR_PREFIX = "/dir";
-  private static final String TEST_FILE_PREFIX = "/file";
-  @Rule
-  public TemporaryFolder mTempDir = new TemporaryFolder();
-  private String mUfsUri;
-  private FlakyLocalUnderFileSystem mUfs;
-  private ExecutorService mFileSystemExecutorService;
-  private ExecutorService mUfsStateCacheExecutorService;
-  private MasterRegistry mRegistry;
-  private DefaultFileSystemMaster mFileSystemMaster;
-
-  private InodeTree mInodeTree;
-
-  @Before
-  public void before() throws Exception {
-    UserState us = UserState.Factory.create(Configuration.global());
-    AuthenticatedClientUser.set(us.getUser().getName());
-
-    mTempDir.create();
-    mUfsUri = mTempDir.newFolder().getAbsolutePath();
-
-    mUfs = new FlakyLocalUnderFileSystem(new AlluxioURI(mUfsUri),
-        UnderFileSystemConfiguration.defaults(Configuration.global()));
-    PowerMockito.mockStatic(UnderFileSystem.Factory.class);
-    Mockito.when(UnderFileSystem.Factory.create(anyString(), any())).thenReturn(mUfs);
-
-    Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
-    Configuration.set(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, mUfsUri);
-    String journalFolderUri = mTempDir.newFolder().getAbsolutePath();
-
-    mFileSystemExecutorService = Executors
-        .newFixedThreadPool(4, ThreadFactoryUtils.build("FileSystemMaster-%d", true));
-    mUfsStateCacheExecutorService = Executors
-        .newFixedThreadPool(4, ThreadFactoryUtils.build("UfsStateCache-%d", true));
-    mRegistry = new MasterRegistry();
-    JournalSystem journalSystem =
-        JournalTestUtils.createJournalSystem(journalFolderUri);
-    CoreMasterContext context = MasterTestUtils.testMasterContext(journalSystem);
-    new MetricsMasterFactory().create(mRegistry, context);
-    BlockMaster blockMaster = new BlockMasterFactory().create(mRegistry, context);
-    mFileSystemMaster = new DefaultFileSystemMaster(blockMaster, context,
-        ExecutorServiceFactories.constantExecutorServiceFactory(mFileSystemExecutorService),
-        Clock.systemUTC());
-    mInodeTree = mFileSystemMaster.getInodeTree();
-    mRegistry.add(FileSystemMaster.class, mFileSystemMaster);
-    journalSystem.start();
-    journalSystem.gainPrimacy();
-    mRegistry.start(true);
-
-    MetricsSystem.resetAllMetrics();
-  }
-
-  @After
-  public void after() throws Exception {
-    mRegistry.stop();
-    mFileSystemExecutorService.shutdown();
-    mUfsStateCacheExecutorService.shutdown();
-  }
-
+public class FileSystemMasterSyncMetadataMetricsTest extends FileSystemMasterSyncMetadataTestBase {
   @Test
   public void metadataSyncMetrics() throws Exception {
     final Counter streamCountCounter =
@@ -671,65 +578,6 @@ public class FileSystemMasterSyncMetadataMetricsTest {
     ufsStatusCache.remove(path2);
     assertEquals(0, cacheSizeTotal.getCount());
     assertEquals(0, cacheChildrenSizeTotal.getCount());
-  }
-
-  private void createUfsDir(String path) throws IOException {
-    mUfs.mkdirs(PathUtils.concatPath(mUfsUri, path));
-  }
-
-  private OutputStream createUfsFile(String path) throws IOException {
-    return mUfs.create(PathUtils.concatPath(mUfsUri, path));
-  }
-
-  private static UfsStatus createUfsStatusWithName(String name) {
-    return new UfsFileStatus(name, "hash", 0, 0L, "owner", "group", (short) 0, null, 0);
-  }
-
-  private static class FlakyLocalUnderFileSystem extends LocalUnderFileSystem {
-    public boolean mThrowIOException = false;
-    public boolean mThrowRuntimeException = false;
-    public boolean mIsSlow = false;
-    public long mSlowTime = 2L;
-
-    public FlakyLocalUnderFileSystem(AlluxioURI uri, UnderFileSystemConfiguration conf) {
-      super(uri, conf);
-    }
-
-    @Override
-    public UfsStatus getStatus(String path) throws IOException {
-      if (mThrowRuntimeException) {
-        throw new RuntimeException();
-      }
-      if (mThrowIOException) {
-        throw new IOException();
-      }
-      if (mIsSlow) {
-        try {
-          Thread.sleep(mSlowTime * Constants.SECOND);
-        } catch (InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-      }
-      return super.getStatus(path);
-    }
-
-    @Override
-    public UfsStatus[] listStatus(String path) throws IOException {
-      if (mThrowRuntimeException) {
-        throw new RuntimeException();
-      }
-      if (mThrowIOException) {
-        throw new IOException();
-      }
-      if (mIsSlow) {
-        try {
-          Thread.sleep(mSlowTime * Constants.SECOND);
-        } catch (InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-      }
-      return super.listStatus(path);
-    }
   }
 }
 

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTestBase.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTestBase.java
@@ -43,11 +43,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -55,8 +52,6 @@ import java.time.Clock;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({UnderFileSystem.Factory.class})
 public class FileSystemMasterSyncMetadataTestBase {
   protected static final AlluxioURI ROOT = new AlluxioURI("/");
   protected static final String TEST_DIR_PREFIX = "/dir";

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTestBase.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTestBase.java
@@ -1,0 +1,180 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import alluxio.AlluxioURI;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.master.CoreMasterContext;
+import alluxio.master.MasterRegistry;
+import alluxio.master.MasterTestUtils;
+import alluxio.master.block.BlockMaster;
+import alluxio.master.block.BlockMasterFactory;
+import alluxio.master.file.meta.InodeTree;
+import alluxio.master.journal.JournalSystem;
+import alluxio.master.journal.JournalTestUtils;
+import alluxio.master.journal.JournalType;
+import alluxio.master.metrics.MetricsMasterFactory;
+import alluxio.metrics.MetricsSystem;
+import alluxio.security.authentication.AuthenticatedClientUser;
+import alluxio.security.user.UserState;
+import alluxio.underfs.UfsFileStatus;
+import alluxio.underfs.UfsStatus;
+import alluxio.underfs.UnderFileSystem;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.local.LocalUnderFileSystem;
+import alluxio.util.ThreadFactoryUtils;
+import alluxio.util.executor.ExecutorServiceFactories;
+import alluxio.util.io.PathUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.Clock;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({UnderFileSystem.Factory.class})
+public class FileSystemMasterSyncMetadataTestBase {
+  protected static final AlluxioURI ROOT = new AlluxioURI("/");
+  protected static final String TEST_DIR_PREFIX = "/dir";
+  protected static final String TEST_FILE_PREFIX = "/file";
+  @Rule
+  public TemporaryFolder mTempDir = new TemporaryFolder();
+  protected String mUfsUri;
+  protected FlakyLocalUnderFileSystem mUfs;
+  protected ExecutorService mFileSystemExecutorService;
+  protected ExecutorService mUfsStateCacheExecutorService;
+  protected MasterRegistry mRegistry;
+  protected DefaultFileSystemMaster mFileSystemMaster;
+
+  protected InodeTree mInodeTree;
+
+  protected static UfsStatus createUfsStatusWithName(String name) {
+    return new UfsFileStatus(name, "hash", 0, 0L, "owner", "group", (short) 0, null, 0);
+  }
+
+  @Before
+  public void before() throws Exception {
+    UserState us = UserState.Factory.create(Configuration.global());
+    AuthenticatedClientUser.set(us.getUser().getName());
+
+    mTempDir.create();
+    mUfsUri = mTempDir.newFolder().getAbsolutePath();
+
+    mUfs = new FlakyLocalUnderFileSystem(new AlluxioURI(mUfsUri),
+        UnderFileSystemConfiguration.defaults(Configuration.global()));
+    PowerMockito.mockStatic(UnderFileSystem.Factory.class);
+    Mockito.when(UnderFileSystem.Factory.create(anyString(), any())).thenReturn(mUfs);
+
+    Configuration.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS);
+    Configuration.set(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, mUfsUri);
+    String journalFolderUri = mTempDir.newFolder().getAbsolutePath();
+
+    mFileSystemExecutorService = Executors
+        .newFixedThreadPool(4, ThreadFactoryUtils.build("FileSystemMaster-%d", true));
+    mUfsStateCacheExecutorService = Executors
+        .newFixedThreadPool(4, ThreadFactoryUtils.build("UfsStateCache-%d", true));
+    mRegistry = new MasterRegistry();
+    JournalSystem journalSystem =
+        JournalTestUtils.createJournalSystem(journalFolderUri);
+    CoreMasterContext context = MasterTestUtils.testMasterContext(journalSystem);
+    new MetricsMasterFactory().create(mRegistry, context);
+    BlockMaster blockMaster = new BlockMasterFactory().create(mRegistry, context);
+    mFileSystemMaster = new DefaultFileSystemMaster(blockMaster, context,
+        ExecutorServiceFactories.constantExecutorServiceFactory(mFileSystemExecutorService),
+        Clock.systemUTC());
+    mInodeTree = mFileSystemMaster.getInodeTree();
+    mRegistry.add(FileSystemMaster.class, mFileSystemMaster);
+    journalSystem.start();
+    journalSystem.gainPrimacy();
+    mRegistry.start(true);
+
+    MetricsSystem.resetAllMetrics();
+  }
+
+  @After
+  public void after() throws Exception {
+    mRegistry.stop();
+    mFileSystemExecutorService.shutdown();
+    mUfsStateCacheExecutorService.shutdown();
+  }
+
+  protected void createUfsDir(String path) throws IOException {
+    mUfs.mkdirs(PathUtils.concatPath(mUfsUri, path));
+  }
+
+  protected OutputStream createUfsFile(String path) throws IOException {
+    return mUfs.create(PathUtils.concatPath(mUfsUri, path));
+  }
+
+  protected static class FlakyLocalUnderFileSystem extends LocalUnderFileSystem {
+    public boolean mThrowIOException = false;
+    public boolean mThrowRuntimeException = false;
+    public boolean mIsSlow = false;
+    public long mSlowTimeMs = 2000L;
+
+    public FlakyLocalUnderFileSystem(AlluxioURI uri, UnderFileSystemConfiguration conf) {
+      super(uri, conf);
+    }
+
+    @Override
+    public UfsStatus getStatus(String path) throws IOException {
+      if (mThrowRuntimeException) {
+        throw new RuntimeException();
+      }
+      if (mThrowIOException) {
+        throw new IOException();
+      }
+      if (mIsSlow) {
+        try {
+          Thread.sleep(mSlowTimeMs);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+      return super.getStatus(path);
+    }
+
+    @Override
+    public UfsStatus[] listStatus(String path) throws IOException {
+      if (mThrowRuntimeException) {
+        throw new RuntimeException();
+      }
+      if (mThrowIOException) {
+        throw new IOException();
+      }
+      if (mIsSlow) {
+        try {
+          Thread.sleep(mSlowTimeMs);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+      return super.listStatus(path);
+    }
+  }
+}
+

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -1824,11 +1824,11 @@ public final class FileSystemMasterTest extends FileSystemMasterTestBase {
     AlluxioURI alluxioFileURI = new AlluxioURI("/hello/file");
 
     ExistsContext neverSyncContext = ExistsContext.create(
-        ExistsPOptions.newBuilder().setCommonOptions(
+        ExistsPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER).setCommonOptions(
             FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(-1).build()));
 
     ExistsContext alwaysSyncContext = ExistsContext.create(
-        ExistsPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.NEVER).setCommonOptions(
+        ExistsPOptions.newBuilder().setLoadMetadataType(LoadMetadataPType.ALWAYS).setCommonOptions(
         FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(0).build()));
 
     Assert.assertFalse(mFileSystemMaster.exists(alluxioFileURI, alwaysSyncContext));
@@ -1837,6 +1837,8 @@ public final class FileSystemMasterTest extends FileSystemMasterTestBase {
 
     Assert.assertFalse(mFileSystemMaster.exists(alluxioFileURI, neverSyncContext));
     Assert.assertTrue(mFileSystemMaster.exists(alluxioFileURI, alwaysSyncContext));
+    Assert.assertTrue(mFileSystemMaster.exists(alluxioFileURI, alwaysSyncContext));
+    Assert.assertTrue(mFileSystemMaster.exists(alluxioFileURI, neverSyncContext));
 
     mTestFolder.delete();
 

--- a/core/server/master/src/test/java/alluxio/master/file/MetadataSyncLockManagerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/MetadataSyncLockManagerTest.java
@@ -1,0 +1,75 @@
+package alluxio.master.file;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import alluxio.AlluxioURI;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.util.CommonUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class MetadataSyncLockManagerTest {
+  private MetadataSyncLockManager mMetadataSyncLockManager;
+
+  @Before
+  public void setup() {
+    Configuration.reloadProperties();
+    Configuration.set(PropertyKey.MASTER_LOCK_POOL_INITSIZE, 0);
+    Configuration.set(PropertyKey.MASTER_LOCK_POOL_LOW_WATERMARK, 0);
+    Configuration.set(PropertyKey.MASTER_LOCK_POOL_HIGH_WATERMARK, 0);
+    mMetadataSyncLockManager = new MetadataSyncLockManager();
+  }
+
+  @Test
+  public void lookPoolGC() throws IOException, InterruptedException, TimeoutException {
+    MetadataSyncLockManager.MetadataSyncPathList locks1 =
+        mMetadataSyncLockManager.lockPath(new AlluxioURI("/a/b/c/d"));
+    assertEquals(5, mMetadataSyncLockManager.getLockPoolSize());
+    MetadataSyncLockManager.MetadataSyncPathList locks2 =
+        mMetadataSyncLockManager.lockPath(new AlluxioURI("/e"));
+    assertEquals(6, mMetadataSyncLockManager.getLockPoolSize());
+    locks1.close();
+    CommonUtils.waitFor("Unused locks should be recycled.",
+        () -> mMetadataSyncLockManager.getLockPoolSize() == 2);
+    locks2.close();
+    CommonUtils.waitFor("Unused locks should be recycled.",
+        () -> mMetadataSyncLockManager.getLockPoolSize() == 0);
+  }
+
+  @Test
+  public void concurrentLock() throws IOException {
+    metadataSyncLockTest("/a", "/b", false);
+    metadataSyncLockTest("/a", "/a", true);
+    metadataSyncLockTest("/a/b", "/a/c", false);
+    metadataSyncLockTest("/a/b", "/a/b/c", true);
+  }
+
+  private void metadataSyncLockTest(String lockPath, String tryToLockPath, boolean expectBlocking)
+      throws IOException {
+    Closeable locks = mMetadataSyncLockManager.lockPath(new AlluxioURI(lockPath));
+    CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
+      try (Closeable ignored = mMetadataSyncLockManager.lockPath(new AlluxioURI(tryToLockPath))) {
+        return true;
+      } catch (Exception e) {
+        throw new RuntimeException();
+      }
+    });
+    try {
+      future.get(100, TimeUnit.MILLISECONDS);
+      assertFalse(expectBlocking);
+    } catch (Exception e) {
+      assertTrue(expectBlocking);
+    }
+    locks.close();
+  }
+}

--- a/core/server/master/src/test/java/alluxio/master/file/MetadataSyncLockManagerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/MetadataSyncLockManagerTest.java
@@ -38,9 +38,9 @@ public class MetadataSyncLockManagerTest {
   @Before
   public void setup() {
     Configuration.reloadProperties();
-    Configuration.set(PropertyKey.MASTER_LOCK_POOL_INITSIZE, 0);
-    Configuration.set(PropertyKey.MASTER_LOCK_POOL_LOW_WATERMARK, 0);
-    Configuration.set(PropertyKey.MASTER_LOCK_POOL_HIGH_WATERMARK, 0);
+    Configuration.set(PropertyKey.MASTER_METADATA_SYNC_LOCK_POOL_INITSIZE, 0);
+    Configuration.set(PropertyKey.MASTER_METADATA_SYNC_LOCK_POOL_LOW_WATERMARK, 0);
+    Configuration.set(PropertyKey.MASTER_METADATA_SYNC_LOCK_POOL_HIGH_WATERMARK, 0);
     mMetadataSyncLockManager = new MetadataSyncLockManager();
   }
 
@@ -103,9 +103,6 @@ public class MetadataSyncLockManagerTest {
     });
     try {
       future.get(200, TimeUnit.MILLISECONDS);
-      if (expectBlocking) {
-        System.out.println("cnm");
-      }
       assertFalse(expectBlocking);
     } catch (Exception e) {
       assertTrue(expectBlocking);

--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterIntegrationTest.java
@@ -1134,10 +1134,11 @@ public class FileSystemMasterIntegrationTest extends BaseIntegrationTest {
      * @param path the directory of files to be created in
      */
     public void exec(int depth, int concurrencyDepth, AlluxioURI path) throws Exception {
+      CreateFileContext context = CreateFileContext.create(mCreateFileContext.getOptions());
       if (depth < 1) {
         return;
       } else if (depth == 1) {
-        long fileId = mFsMaster.createFile(path, mCreateFileContext).getFileId();
+        long fileId = mFsMaster.createFile(path, context).getFileId();
         Assert.assertEquals(fileId, mFsMaster.getFileId(path));
         // verify the user permission for file
         FileInfo fileInfo = mFsMaster.getFileInfo(fileId);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Update the metadata sync logic to avoid concurrent metadata sync on the same path #16241

### Why are the changes needed?

If multiple requests attempt to sync the same directory, the metadata sync might happen over and over and bring huge load to UFS.

### Does this PR introduce any user facing changes?

1. Larger lock scope -> previously the Inode Path Lock will be RELEASED of the metadata sync of the sync uri root is done and the children are processed by worker threads which they will acquire locks separately. This means that once the root sync is done, another request can come in and trigger another sync. With this patch, this won't be available any more. If you do a sync /, the whole alluxio inode tree will be blocked from another sync until it's done. Though this doesn't block other threads read the directory (e.g. getFileInfo or ListStatus, because they don't use the metadata sync lock.) I think this is an expected behavior.
2. Two lock mechanisms -> which can potentially block each other. We acquire the metadata sync lock first and then add lock for the inode path tree. If the inode path is accessed by other threads and the metadata sync struggles to acquire the inode lock, this will blocks other metadata sync requests to acquire the metadata sync lock. Though I think this is still valid because these metadata sync threads should not trigger other metadata syncs before the current one is done anyways.
3. No timeout -> I really want to set some timeout here but seems like in alluxio, tryLock with a timeout is barely used and our Lock components don't have such interface at all. We might need to keep an eye on any potential issues caused by a path being locked by the metadata lock too long.
