### PR TITLE
Fix typo ActiveSyncManager.java，Syntax error in comments

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
+++ b/core/server/master/src/main/java/alluxio/master/file/activesync/ActiveSyncManager.java
@@ -113,7 +113,7 @@ public class ActiveSyncManager implements Journaled {
           .build();
 
   /**
-   * Constructs a Active Sync Manager.
+   * Constructs an Active Sync Manager.
    *
    * @param mountTable mount table
    * @param fileSystemMaster file system master


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Syntax error in comments
Modify the comments in the ActiveSyncManager.java file, and change a to an
**Why are the changes needed?**
Please clarify why the changes are needed. For instance,

Fix typo.
**Does this PR introduce any user facing changes?**
none

Fixed #623 https://github.com/Alluxio/new-contributor-tasks/issues/623