### PR TITLE
Return the existing status when cannot access UFS

### DIFF
--- a/core/common/src/main/java/alluxio/concurrent/ManagedBlockingUfsForwarder.java
+++ b/core/common/src/main/java/alluxio/concurrent/ManagedBlockingUfsForwarder.java
@@ -279,12 +279,12 @@ public class ManagedBlockingUfsForwarder implements UnderFileSystem {
   }
 
   @Override
-  public String getFingerprint(String path) {
+  public String getFingerprint(String path) throws IOException {
     return mUfs.getFingerprint(path);
   }
 
   @Override
-  public Fingerprint getParsedFingerprint(String path) {
+  public Fingerprint getParsedFingerprint(String path) throws IOException {
     return mUfs.getParsedFingerprint(path);
   }
 

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystem.java
@@ -407,20 +407,23 @@ public interface UnderFileSystem extends Closeable {
    * Computes and returns a fingerprint for the path. The fingerprint is used to determine if two
    * UFS files are identical. The fingerprint must be deterministic, and must not change if a
    * file is only renamed (identical content and permissions). Returns
-   * {@link alluxio.Constants#INVALID_UFS_FINGERPRINT} if there is any error.
+   * {@link alluxio.Constants#INVALID_UFS_FINGERPRINT} if the path does not exist in UFS.
+   * Throws the exception if connection failed or other exceptions.
    *
    * @deprecated
    * @param path the path to compute the fingerprint for
    * @return the string representing the fingerprint
+   * @throws IOException when cannot determine the fingerprint of the path
    */
   @Deprecated
-  String getFingerprint(String path);
+  String getFingerprint(String path) throws IOException;
 
   /**
    * Computes and returns a fingerprint for the path. The fingerprint is used to determine if two
    * UFS files are identical. The fingerprint must be deterministic, and must not change if a
    * file is only renamed (identical content and permissions). Returns
-   * {@link Fingerprint#INVALID_FINGERPRINT} if there is any error.
+   * {@link alluxio.Constants#INVALID_UFS_FINGERPRINT} if the path does not exist in UFS.
+   * Throws the exception if connection failed or other exceptions.
    *
    * The default implementation relies on {@link #getFingerprint(String)} and there is one extra
    * parsing. This default implementation is mainly for backward compatibility.
@@ -428,8 +431,9 @@ public interface UnderFileSystem extends Closeable {
    *
    * @param path the path to compute the fingerprint for
    * @return the string representing the fingerprint
+   * @throws IOException when cannot determine the fingerprint of the path
    */
-  default Fingerprint getParsedFingerprint(String path) {
+  default Fingerprint getParsedFingerprint(String path) throws IOException {
     return Fingerprint.parse(getFingerprint(path));
   }
 

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -38,6 +38,7 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -560,7 +561,7 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
   }
 
   @Override
-  public String getFingerprint(String path) {
+  public String getFingerprint(String path) throws IOException {
     try {
       return call(new UfsCallable<String>() {
         @Override
@@ -578,14 +579,14 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
           return String.format("path=%s", path);
         }
       });
-    } catch (IOException e) {
+    } catch (FileNotFoundException e) {
       // This is not possible.
       return Constants.INVALID_UFS_FINGERPRINT;
     }
   }
 
   @Override
-  public Fingerprint getParsedFingerprint(String path) {
+  public Fingerprint getParsedFingerprint(String path) throws IOException {
     try {
       return call(new UfsCallable<Fingerprint>() {
         @Override
@@ -603,7 +604,7 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
           return String.format("path=%s", path);
         }
       });
-    } catch (IOException e) {
+    } catch (FileNotFoundException e) {
       // This is not possible.
       return Fingerprint.INVALID_FINGERPRINT;
     }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1695,7 +1695,12 @@ public class DefaultFileSystemMaster extends CoreMaster
       try (CloseableResource<UnderFileSystem> ufsResource = resolution.acquireUfsResource()) {
         UnderFileSystem ufs = ufsResource.get();
         if (ufsStatus == null) {
-          ufsFingerprint = ufs.getParsedFingerprint(resolvedUri.toString()).serialize();
+          try {
+            ufsFingerprint = ufs.getParsedFingerprint(resolvedUri.toString()).serialize();
+          } catch (IOException e) {
+            LOG.warn("Cannot determine the ufsFingerprint. uri: {}, exception: {}",
+                resolvedUri, e.toString());
+          }
         } else {
           ufsFingerprint = Fingerprint.create(ufs.getUnderFSType(), ufsStatus).serialize();
         }
@@ -4127,7 +4132,13 @@ public class DefaultFileSystemMaster extends CoreMaster
               context.setUfsFingerprint(fp.serialize());
             } else {
               // Need to retrieve the fingerprint from ufs.
-              context.setUfsFingerprint(ufs.getParsedFingerprint(ufsUri).serialize());
+              try {
+                context.setUfsFingerprint(ufs.getParsedFingerprint(ufsUri).serialize());
+              } catch (IOException e) {
+                LOG.warn("Cannot determine the ufsFingerprint. uri: {}, exception: {}",
+                    ufsUri, e.toString());
+                context.setUfsFingerprint(Constants.INVALID_UFS_FINGERPRINT);
+              }
             }
           }
         }

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -943,7 +943,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
     }
   }
 
-  private void checkUriStatus(URIStatus uriStatus) {
+  private void checkUriStatus(URIStatus uriStatus) throws IOException {
     File ufsFile = new File(uriStatus.getUfsPath());
     if (uriStatus.isFolder() != ufsFile.isDirectory()) {
       Assert.fail("Directory mismatch (Alluxio isDir: " + uriStatus.isFolder() + ") (ufs isDir: "

--- a/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
+++ b/tests/src/test/java/alluxio/testutils/underfs/delegating/DelegatingUnderFileSystem.java
@@ -173,12 +173,12 @@ public class DelegatingUnderFileSystem implements UnderFileSystem {
   }
 
   @Override
-  public String getFingerprint(String path) {
+  public String getFingerprint(String path) throws IOException {
     return mUfs.getFingerprint(path);
   }
 
   @Override
-  public Fingerprint getParsedFingerprint(String path) {
+  public Fingerprint getParsedFingerprint(String path) throws IOException {
     return mUfs.getParsedFingerprint(path);
   }
 

--- a/tests/src/test/java/alluxio/testutils/underfs/sleeping/SleepingUnderFileSystem.java
+++ b/tests/src/test/java/alluxio/testutils/underfs/sleeping/SleepingUnderFileSystem.java
@@ -144,13 +144,13 @@ public class SleepingUnderFileSystem extends LocalUnderFileSystem {
   }
 
   @Override
-  public String getFingerprint(String path) {
+  public String getFingerprint(String path) throws IOException {
     sleepIfNecessary(mOptions.getGetFingerprintMs());
     return super.getFingerprint(cleanPath(path));
   }
 
   @Override
-  public Fingerprint getParsedFingerprint(String path) {
+  public Fingerprint getParsedFingerprint(String path) throws IOException {
     sleepIfNecessary(mOptions.getGetFingerprintMs());
     return super.getParsedFingerprint(cleanPath(path));
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Return the existing status instead of FileDoesNotExistException to clients when cannot access UFS.

### Why are the changes needed?

Fix #16236 

### Does this PR introduce any user facing changes?

Yes
  1. change in user-facing APIs

