### PR TITLE
Add direct mem used metrics

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -2373,6 +2373,7 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("The used direct memory")
           .setMetricType(MetricType.GAUGE)
           .build();
+
   /**
    * A nested class to hold named string constants for their corresponding metrics.
    */

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -2367,6 +2367,12 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setIsClusterAggregated(false)
           .build();
 
+  // Other system related metrics
+  public static final MetricKey POOL_DIRECT_MEM_USED =
+      new Builder("pool.direct.mem.used")
+          .setDescription("The used direct memory")
+          .setMetricType(MetricType.GAUGE)
+          .build();
   /**
    * A nested class to hold named string constants for their corresponding metrics.
    */

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -151,6 +151,10 @@ public final class MetricsSystem {
     METRIC_REGISTRY.registerAll(new ClassLoadingGaugeSet());
     METRIC_REGISTRY.registerAll(new CachedThreadStatesGaugeSet(5, TimeUnit.SECONDS));
     METRIC_REGISTRY.registerAll(new OperationSystemGaugeSet());
+
+    MetricsSystem.registerGaugeIfAbsent(
+        MetricsSystem.getMetricName(MetricKey.POOL_DIRECT_MEM_USED.getName()),
+        MetricsSystem::getDirectMemUsed);
   }
 
   public static final BufferPoolMXBean DIRECT_BUFFER_POOL;

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -141,6 +141,7 @@ public final class MetricsSystem {
   // Supported special instance names.
   public static final String CLUSTER = "Cluster";
 
+  public static final BufferPoolMXBean DIRECT_BUFFER_POOL;
   public static final MetricRegistry METRIC_REGISTRY;
 
   static {
@@ -152,15 +153,10 @@ public final class MetricsSystem {
     METRIC_REGISTRY.registerAll(new CachedThreadStatesGaugeSet(5, TimeUnit.SECONDS));
     METRIC_REGISTRY.registerAll(new OperationSystemGaugeSet());
 
+    DIRECT_BUFFER_POOL = getDirectBufferPool();
     MetricsSystem.registerGaugeIfAbsent(
         MetricsSystem.getMetricName(MetricKey.POOL_DIRECT_MEM_USED.getName()),
         MetricsSystem::getDirectMemUsed);
-  }
-
-  public static final BufferPoolMXBean DIRECT_BUFFER_POOL;
-
-  static {
-    DIRECT_BUFFER_POOL = getDirectBufferPool();
   }
 
   private static BufferPoolMXBean getDirectBufferPool() {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add direct mem used metrics

### Why are the changes needed?

Sometimes the direct mem used is helpful for troubleshooting.

The metrics would look like:
    "Master.pool.direct.mem.used" : {
      "value" : 1138778
    },

### Does this PR introduce any user facing changes?
NA
