### PR TITLE
Add the replica number feature through heartbeat

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3602,6 +3602,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
+  public static final PropertyKey MAINTAIN_REPLICA_INFO =
+          booleanBuilder(Name.MAINTAIN_REPLICA_INFO)
+                  .setDefaultValue(false)
+                  .setDescription("Whether maintain the replica info of each block for each worker")
+                  .setScope(Scope.MASTER)
+                  .build();
   public static final PropertyKey WORKER_FUSE_ENABLED =
       booleanBuilder(Name.WORKER_FUSE_ENABLED)
           .setDefaultValue(false)
@@ -7315,6 +7321,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.block.annotator.lrfu.attenuation.factor";
     public static final String WORKER_BLOCK_ANNOTATOR_LRFU_STEP_FACTOR =
         "alluxio.worker.block.annotator.lrfu.step.factor";
+    public static final String MAINTAIN_REPLICA_INFO =
+            "alluxio.master.maintain.replica.info";
     public static final String WORKER_FUSE_ENABLED =
         "alluxio.worker.fuse.enabled";
     public static final String WORKER_FUSE_MOUNT_ALLUXIO_PATH =

--- a/core/common/src/main/java/alluxio/wire/HeartBeatResponseMessage.java
+++ b/core/common/src/main/java/alluxio/wire/HeartBeatResponseMessage.java
@@ -26,15 +26,13 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class HeartBeatResponseMessage implements Serializable {
 
   private static final long serialVersionUID = -8936215337909224255L;
-  Command mCommand;
-  Map<Long, Long> mReplicaInfo;
+  Command mCommand = null;
+  Map<Long, Long> mReplicaInfo = null;
 
   /**
   * Creates a new instance of {@link HeartBeatResponseMessage}.
   */
   public HeartBeatResponseMessage() {
-    mCommand = null;
-    mReplicaInfo = null;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/wire/HeartBeatResponseMessage.java
+++ b/core/common/src/main/java/alluxio/wire/HeartBeatResponseMessage.java
@@ -75,17 +75,6 @@ public final class HeartBeatResponseMessage implements Serializable {
             .putAllReplicaInfo(mReplicaInfo).build();
   }
 
-  /**
-   * Creates a new instance of {@link HeartBeatResponseMessage} from a proto representation.
-   *
-   * @param info the proto representation of HeartBeatResponse
-   * @return the instance
-   */
-  public static HeartBeatResponseMessage fromProto(alluxio.grpc.BlockHeartbeatPResponse info) {
-    return new HeartBeatResponseMessage().setCommand(info.getCommand())
-             .setReplicaInfo(info.getReplicaInfoMap());
-  }
-
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/core/common/src/main/java/alluxio/wire/HeartBeatResponseMessage.java
+++ b/core/common/src/main/java/alluxio/wire/HeartBeatResponseMessage.java
@@ -1,0 +1,107 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.wire;
+
+import alluxio.grpc.Command;
+
+import com.google.common.base.Objects;
+
+import java.io.Serializable;
+import java.util.Map;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * The Alluxio HeartBeat Response Message.
+ */
+@NotThreadSafe
+public final class HeartBeatResponseMessage implements Serializable {
+
+  private static final long serialVersionUID = -8936215337909224255L;
+  Command mCommand;
+  Map<Long, Long> mReplicaInfo;
+
+  /**
+  * Creates a new instance of {@link HeartBeatResponseMessage}.
+  */
+  public HeartBeatResponseMessage() {
+    mCommand = null;
+    mReplicaInfo = null;
+  }
+
+  /**
+  * @return the blocks to be added
+  */
+  public Command getCommand() {
+    return mCommand;
+  }
+
+  /**
+  * @return the replica info of blocks to be changed for worker
+  */
+  public Map<Long, Long> getReplicaInfo() {
+    return mReplicaInfo;
+  }
+
+  /**
+   * @param command
+   * @return Set the command for heartbeat Response
+   */
+  public HeartBeatResponseMessage setCommand(Command command) {
+    mCommand = command;
+    return this;
+  }
+
+  /**
+   * @param ReplicaInfo
+   * @return set the replica Info to be changed
+   */
+  public HeartBeatResponseMessage setReplicaInfo(Map<Long, Long> ReplicaInfo) {
+    mReplicaInfo = ReplicaInfo;
+    return this;
+  }
+
+  /**
+   * @return proto representation of the heartbeat information from master to worker
+   */
+  protected alluxio.grpc.BlockHeartbeatPResponse toProto() {
+    return alluxio.grpc.BlockHeartbeatPResponse.newBuilder().setCommand(mCommand)
+            .putAllReplicaInfo(mReplicaInfo).build();
+  }
+
+  /**
+   * Creates a new instance of {@link HeartBeatResponseMessage} from a proto representation.
+   *
+   * @param info the proto representation of HeartBeatResponse
+   * @return the instance
+   */
+  public static HeartBeatResponseMessage fromProto(alluxio.grpc.BlockHeartbeatPResponse info) {
+    return new HeartBeatResponseMessage().setCommand(info.getCommand())
+             .setReplicaInfo(info.getReplicaInfoMap());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof HeartBeatResponseMessage)) {
+      return false;
+    }
+    HeartBeatResponseMessage that = (HeartBeatResponseMessage) o;
+    return mCommand == that.mCommand && Objects.equal(mReplicaInfo, that.mReplicaInfo);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(mCommand, mReplicaInfo);
+  }
+}

--- a/core/common/src/main/java/alluxio/wire/HeartBeatResponseMessage.java
+++ b/core/common/src/main/java/alluxio/wire/HeartBeatResponseMessage.java
@@ -16,6 +16,7 @@ import alluxio.grpc.Command;
 import com.google.common.base.Objects;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -27,7 +28,7 @@ public final class HeartBeatResponseMessage implements Serializable {
 
   private static final long serialVersionUID = -8936215337909224255L;
   Command mCommand = null;
-  Map<Long, Long> mReplicaInfo = null;
+  Map<Long, Long> mReplicaInfo = new HashMap<>();
 
   /**
   * Creates a new instance of {@link HeartBeatResponseMessage}.

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -246,10 +246,10 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
    * @return an optional command for the worker to execute
    */
   HeartBeatResponseMessage workerHeartbeat(long workerId, Map<String, Long> capacityBytesOnTiers,
-                                           Map<String, Long> usedBytesOnTiers, List<Long> removedBlockIds,
-                                           Map<Block.BlockLocation, List<Long>> addedBlocks,
-                                           Map<String, StorageList> lostStorage,
-                                           List<Metric> metrics);
+      Map<String, Long> usedBytesOnTiers, List<Long> removedBlockIds,
+      Map<Block.BlockLocation, List<Long>> addedBlocks,
+      Map<String, StorageList> lostStorage,
+      List<Metric> metrics);
 
   /**
    * @param blockId the block ID

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -17,7 +17,6 @@ import alluxio.exception.BlockInfoException;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.exception.status.NotFoundException;
 import alluxio.exception.status.UnavailableException;
-import alluxio.grpc.Command;
 import alluxio.grpc.ConfigProperty;
 import alluxio.grpc.GetRegisterLeasePRequest;
 import alluxio.grpc.RegisterWorkerPOptions;
@@ -28,11 +27,7 @@ import alluxio.master.Master;
 import alluxio.master.block.meta.MasterWorkerInfo;
 import alluxio.metrics.Metric;
 import alluxio.proto.meta.Block;
-import alluxio.wire.Address;
-import alluxio.wire.BlockInfo;
-import alluxio.wire.RegisterLease;
-import alluxio.wire.WorkerInfo;
-import alluxio.wire.WorkerNetAddress;
+import alluxio.wire.*;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -250,11 +245,11 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
    * @param metrics worker metrics
    * @return an optional command for the worker to execute
    */
-  Command workerHeartbeat(long workerId, Map<String, Long> capacityBytesOnTiers,
-      Map<String, Long> usedBytesOnTiers, List<Long> removedBlockIds,
-      Map<Block.BlockLocation, List<Long>> addedBlocks,
-      Map<String, StorageList> lostStorage,
-      List<Metric> metrics);
+  HeartBeatResponseMessage workerHeartbeat(long workerId, Map<String, Long> capacityBytesOnTiers,
+                                           Map<String, Long> usedBytesOnTiers, List<Long> removedBlockIds,
+                                           Map<Block.BlockLocation, List<Long>> addedBlocks,
+                                           Map<String, StorageList> lostStorage,
+                                           List<Metric> metrics);
 
   /**
    * @param blockId the block ID

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -27,7 +27,12 @@ import alluxio.master.Master;
 import alluxio.master.block.meta.MasterWorkerInfo;
 import alluxio.metrics.Metric;
 import alluxio.proto.meta.Block;
-import alluxio.wire.*;
+import alluxio.wire.Address;
+import alluxio.wire.BlockInfo;
+import alluxio.wire.HeartBeatResponseMessage;
+import alluxio.wire.RegisterLease;
+import alluxio.wire.WorkerInfo;
+import alluxio.wire.WorkerNetAddress;
 
 import com.google.common.annotations.VisibleForTesting;
 

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1305,7 +1305,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
     // Update the TS again
     worker.updateLastUpdatedTimeMs();
-    mworkerReplicaInfo = worker.getReplicaInfo();
+    mworkerReplicaInfo = worker.getReplicaInfo(mBlockMetaStore);
     // Should not reach here
     Preconditions.checkNotNull(workerCommand, "Worker heartbeat response command is null!");
     return new HeartBeatResponseMessage().setCommand(workerCommand)

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -70,11 +70,7 @@ import alluxio.util.ThreadFactoryUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.util.executor.ExecutorServiceFactory;
 import alluxio.util.network.NetworkAddressUtils;
-import alluxio.wire.Address;
-import alluxio.wire.BlockInfo;
-import alluxio.wire.RegisterLease;
-import alluxio.wire.WorkerInfo;
-import alluxio.wire.WorkerNetAddress;
+import alluxio.wire.*;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -134,6 +130,12 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
    */
   private final long mContainerIdReservationSize = Configuration.getInt(
       PropertyKey.MASTER_CONTAINER_ID_RESERVATION_SIZE);
+
+  /**
+   * Whether we maintain the replica number of each block for each worker.
+   */
+  private final boolean mMaintainReplicaInfo = Configuration.getBoolean(
+          PropertyKey.MAINTAIN_REPLICA_INFO);
 
   /** The only valid key for {@link #mWorkerInfoCache}. */
   private static final String WORKER_INFO_CACHE_KEY = "WorkerInfoKey";
@@ -903,6 +905,9 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
           // TODO(binfan): when retry commitBlock on master is expected, make sure metrics are not
           // double counted.
           worker.addBlock(blockId);
+          if(mMaintainReplicaInfo) {
+            worker.updateReplica(blockId, 1);
+          }
           worker.updateUsedBytes(tierAlias, usedBytesOnTier);
         }
       }
@@ -1252,15 +1257,16 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
   }
 
   @Override
-  public Command workerHeartbeat(long workerId, Map<String, Long> capacityBytesOnTiers,
-      Map<String, Long> usedBytesOnTiers, List<Long> removedBlockIds,
-      Map<BlockLocation, List<Long>> addedBlocks,
-      Map<String, StorageList> lostStorage,
-      List<Metric> metrics) {
+  public HeartBeatResponseMessage workerHeartbeat(long workerId, Map<String, Long> capacityBytesOnTiers,
+                                                  Map<String, Long> usedBytesOnTiers, List<Long> removedBlockIds,
+                                                  Map<BlockLocation, List<Long>> addedBlocks,
+                                                  Map<String, StorageList> lostStorage,
+                                                  List<Metric> metrics) {
     MasterWorkerInfo worker = mWorkers.getFirstByField(ID_INDEX, workerId);
     if (worker == null) {
       LOG.warn("Could not find worker id: {} for heartbeat.", workerId);
-      return Command.newBuilder().setCommandType(CommandType.Register).build();
+      Command workerCommand = Command.newBuilder().setCommandType(CommandType.Register).build();
+      return new HeartBeatResponseMessage().setCommand(workerCommand);
     }
 
     // Update the TS before the heartbeat so even if the worker heartbeat processing
@@ -1272,6 +1278,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     processWorkerMetrics(worker.getWorkerAddress().getHost(), metrics);
 
     Command workerCommand = null;
+    Map<java.lang.Long, java.lang.Long> mworkerReplicaInfo = new HashMap<>();
     try (LockResource r = worker.lockWorkerMeta(
         EnumSet.of(WorkerMetaLockSection.USAGE, WorkerMetaLockSection.BLOCKS), false)) {
       worker.addLostStorage(lostStorage);
@@ -1298,11 +1305,11 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
     // Update the TS again
     worker.updateLastUpdatedTimeMs();
-
+    mworkerReplicaInfo = worker.getReplicaInfo();
     // Should not reach here
     Preconditions.checkNotNull(workerCommand, "Worker heartbeat response command is null!");
-
-    return workerCommand;
+    return new HeartBeatResponseMessage().setCommand(workerCommand)
+            .setReplicaInfo(mworkerReplicaInfo);
   }
 
   @Override
@@ -1334,6 +1341,12 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
         Optional<BlockMeta> block = mBlockMetaStore.getBlock(removedBlockId);
         if (block.isPresent()) {
           LOG.debug("Block {} is removed on worker {}.", removedBlockId, workerInfo.getId());
+          if(mMaintainReplicaInfo) {
+            for (BlockLocation relatedWorkers : mBlockMetaStore.getLocations(removedBlockId)) {
+              MasterWorkerInfo worker = mWorkers.getFirstByField(ID_INDEX, relatedWorkers.getWorkerId());
+              worker.updateReplica(removedBlockId, -1);
+            }
+          }
           mBlockMetaStore.removeLocation(removedBlockId, workerInfo.getId());
           if (mBlockMetaStore.getLocations(removedBlockId).size() == 0) {
             mLostBlocks.add(removedBlockId);
@@ -1374,6 +1387,16 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
                 location.getWorkerId(), workerInfo.getId());
             mBlockMetaStore.addLocation(blockId, location);
             mLostBlocks.remove(blockId);
+            if(mMaintainReplicaInfo) {
+              for (BlockLocation relatedWorkers : mBlockMetaStore.getLocations(blockId)) {
+                MasterWorkerInfo worker = mWorkers.getFirstByField(ID_INDEX, relatedWorkers.getWorkerId());
+                if (worker != workerInfo) {
+                  worker.updateReplica(blockId, 1);
+                } else {
+                  worker.updateReplica(blockId, mBlockMetaStore.getLocations(blockId).size());
+                }
+              }
+            }
           } else {
             invalidBlockCount++;
             // The block is not recognized and should therefore be purged from the worker

--- a/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -450,7 +450,8 @@ public class BlockMasterTest {
             ImmutableMap.of(Constants.MEDIUM_MEM, 0L), NO_BLOCKS,
             ImmutableMap.of(blockOnWorker3, addedBlocks),
             NO_LOST_STORAGE, mMetrics).getReplicaInfo();
-    assertEquals(ImmutableMap.copyOf(worker3Info), ImmutableMap.of(blockId1, 3L, blockId2, 2L, blockId3, 1L));
+    assertEquals(ImmutableMap.copyOf(worker3Info),
+        ImmutableMap.of(blockId1, 3L, blockId2, 2L, blockId3, 1L));
 
     //worker2 delete block1 and heartbeat
     Map<Long, Long> worker2Info3 = mBlockMaster.workerHeartbeat(worker2, null,
@@ -476,7 +477,8 @@ public class BlockMasterTest {
 
   @Test
   public void unknownWorkerHeartbeatTriggersRegisterRequest() {
-    Command heartBeat = mBlockMaster.workerHeartbeat(0, null, null, null, null, null, mMetrics).getCommand();
+    Command heartBeat =
+        mBlockMaster.workerHeartbeat(0, null, null, null, null, null, mMetrics).getCommand();
     assertEquals(Command.newBuilder().setCommandType(CommandType.Register).build(), heartBeat);
   }
 

--- a/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -72,6 +72,8 @@ public class BlockMasterTest {
       .setRpcPort(80).setDataPort(81).setWebPort(82);
   private static final WorkerNetAddress NET_ADDRESS_2 = new WorkerNetAddress().setHost("localhost")
       .setRpcPort(83).setDataPort(84).setWebPort(85);
+  private static final WorkerNetAddress NET_ADDRESS_3 = new WorkerNetAddress().setHost("localhost")
+          .setRpcPort(86).setDataPort(87).setWebPort(88);
 
   private static final List<Long> NO_BLOCKS = ImmutableList.of();
   private static final Map<Block.BlockLocation, List<Long>> NO_BLOCKS_ON_LOCATION
@@ -103,6 +105,7 @@ public class BlockMasterTest {
    */
   @Before
   public void before() throws Exception {
+    Configuration.set(PropertyKey.MAINTAIN_REPLICA_INFO, true);
     mRegistry = new MasterRegistry();
     mMetrics = Lists.newArrayList();
     JournalSystem journalSystem = new NoopJournalSystem();
@@ -227,7 +230,7 @@ public class BlockMasterTest {
     // Check that the worker heartbeat tells the worker to remove the block.
     Map<String, Long> memUsage = ImmutableMap.of(Constants.MEDIUM_MEM, 0L);
     alluxio.grpc.Command heartBeat = mBlockMaster.workerHeartbeat(worker1, null, memUsage,
-        NO_BLOCKS, NO_BLOCKS_ON_LOCATION, NO_LOST_STORAGE, mMetrics);
+        NO_BLOCKS, NO_BLOCKS_ON_LOCATION, NO_LOST_STORAGE, mMetrics).getCommand();
     assertEquals(ImmutableList.of(1L), heartBeat.getDataList());
   }
 
@@ -248,7 +251,7 @@ public class BlockMasterTest {
 
     // Check that the worker heartbeat tells the worker to remove the blocks.
     alluxio.grpc.Command heartBeat = mBlockMaster.workerHeartbeat(workerId, null,
-        memUsage, NO_BLOCKS, NO_BLOCKS_ON_LOCATION, NO_LOST_STORAGE, mMetrics);
+        memUsage, NO_BLOCKS, NO_BLOCKS_ON_LOCATION, NO_LOST_STORAGE, mMetrics).getCommand();
     assertEquals(orphanedBlocks, heartBeat.getDataList());
   }
 
@@ -367,8 +370,113 @@ public class BlockMasterTest {
   }
 
   @Test
+  public void replicaInfoUpdateTest() throws Exception {
+    long blockId1 = 1L;
+    long blockId2 = 101L;
+    long blockId3 = 201L;
+    // Create  worker 1.
+    long worker1 = mBlockMaster.getWorkerId(NET_ADDRESS_1);
+    Block.BlockLocation blockOnWorker1 = Block.BlockLocation.newBuilder()
+            .setWorkerId(worker1).setTier(Constants.MEDIUM_MEM)
+            .setMediumType(Constants.MEDIUM_MEM).build();
+    mBlockMaster.workerRegister(worker1, Arrays.asList(Constants.MEDIUM_MEM, Constants.MEDIUM_SSD),
+            ImmutableMap.of(Constants.MEDIUM_MEM, 100L, Constants.MEDIUM_SSD, 200L),
+            ImmutableMap.of(Constants.MEDIUM_MEM, 0L, Constants.MEDIUM_SSD, 0L),
+            NO_BLOCKS_ON_LOCATION, NO_LOST_STORAGE,
+            RegisterWorkerPOptions.getDefaultInstance());
+    //Create worker 2
+    long worker2 = mBlockMaster.getWorkerId(NET_ADDRESS_2);
+    Block.BlockLocation blockOnWorker2 = Block.BlockLocation.newBuilder()
+            .setWorkerId(worker2).setTier(Constants.MEDIUM_MEM)
+            .setMediumType(Constants.MEDIUM_MEM).build();
+    mBlockMaster.workerRegister(worker2, Arrays.asList(Constants.MEDIUM_MEM, Constants.MEDIUM_HDD),
+            ImmutableMap.of(Constants.MEDIUM_MEM, 100L, Constants.MEDIUM_HDD, 300L),
+            ImmutableMap.of(Constants.MEDIUM_MEM, 0L, Constants.MEDIUM_HDD, 0L),
+            NO_BLOCKS_ON_LOCATION, NO_LOST_STORAGE,
+            RegisterWorkerPOptions.getDefaultInstance());
+    //Create Worker 3
+    long worker3 = mBlockMaster.getWorkerId(NET_ADDRESS_3);
+    Block.BlockLocation blockOnWorker3 = Block.BlockLocation.newBuilder()
+            .setWorkerId(worker3).setTier(Constants.MEDIUM_MEM)
+            .setMediumType(Constants.MEDIUM_MEM).build();
+    mBlockMaster.workerRegister(worker3, Arrays.asList(Constants.MEDIUM_MEM, Constants.MEDIUM_HDD),
+            ImmutableMap.of(Constants.MEDIUM_MEM, 100L, Constants.MEDIUM_HDD, 300L),
+            ImmutableMap.of(Constants.MEDIUM_MEM, 0L, Constants.MEDIUM_HDD, 0L),
+            NO_BLOCKS_ON_LOCATION, NO_LOST_STORAGE,
+            RegisterWorkerPOptions.getDefaultInstance());
+    //Commit block3 with worker 3
+    //Current State: worker1:{}, worker2:{}. worker3:{block3}
+    mBlockMaster.commitBlock(worker3, 50L, Constants.MEDIUM_MEM,
+            Constants.MEDIUM_MEM, blockId3, 20L);
+
+    //Commit block1 with worker1
+    //Current State: worker1:{block1}, worker2:{}, worker3:{}
+    mBlockMaster.commitBlock(worker1, 50L, Constants.MEDIUM_MEM,
+            Constants.MEDIUM_MEM, blockId1, 20L);
+    Map<Long, Long> worker1Info = mBlockMaster.workerHeartbeat(worker1, null,
+            ImmutableMap.of(Constants.MEDIUM_MEM, 0L), NO_BLOCKS,
+            NO_BLOCKS_ON_LOCATION,
+            NO_LOST_STORAGE, mMetrics).getReplicaInfo();
+    //worker1 heartbeat
+    assertEquals(ImmutableMap.copyOf(worker1Info), ImmutableMap.of(blockId1, 1L));
+
+    //worker2 add block1 and heartbeat
+    List<Long> addedBlocks = ImmutableList.of(blockId1);
+    Map<Long, Long> worker2Info = mBlockMaster.workerHeartbeat(worker2, null,
+            ImmutableMap.of(Constants.MEDIUM_MEM, 0L), NO_BLOCKS,
+            ImmutableMap.of(blockOnWorker2, addedBlocks),
+            NO_LOST_STORAGE, mMetrics).getReplicaInfo();
+    assertEquals(ImmutableMap.copyOf(worker2Info), ImmutableMap.of(blockId1, 2L));
+
+    //worker1 heartbeat
+    Map<Long, Long> worker1Info2 = mBlockMaster.workerHeartbeat(worker1, null,
+            ImmutableMap.of(Constants.MEDIUM_MEM, 0L), NO_BLOCKS,
+            NO_BLOCKS_ON_LOCATION,
+            NO_LOST_STORAGE, mMetrics).getReplicaInfo();
+    assertEquals(ImmutableMap.copyOf(worker1Info2), ImmutableMap.of(blockId1, 1L));
+
+    //block2 commit by worker2 and worker2 heartbeat
+    mBlockMaster.commitBlock(worker2, 50L, Constants.MEDIUM_MEM,
+            Constants.MEDIUM_MEM, blockId2, 20L);
+    Map<Long, Long> worker2Info2 = mBlockMaster.workerHeartbeat(worker2, null,
+            ImmutableMap.of(Constants.MEDIUM_MEM, 0L), NO_BLOCKS,
+            NO_BLOCKS_ON_LOCATION,
+            NO_LOST_STORAGE, mMetrics).getReplicaInfo();
+    assertEquals(ImmutableMap.copyOf(worker2Info2), ImmutableMap.of(blockId2, 1L));
+
+    //worker3 add block1 and block2 and heartbeat
+    addedBlocks = ImmutableList.of(blockId1, blockId2);
+    Map<Long, Long> worker3Info = mBlockMaster.workerHeartbeat(worker3, null,
+            ImmutableMap.of(Constants.MEDIUM_MEM, 0L), NO_BLOCKS,
+            ImmutableMap.of(blockOnWorker3, addedBlocks),
+            NO_LOST_STORAGE, mMetrics).getReplicaInfo();
+    assertEquals(ImmutableMap.copyOf(worker3Info), ImmutableMap.of(blockId1, 3L, blockId2, 2L, blockId3, 1L));
+
+    //worker2 delete block1 and heartbeat
+    Map<Long, Long> worker2Info3 = mBlockMaster.workerHeartbeat(worker2, null,
+            ImmutableMap.of(Constants.MEDIUM_MEM, 0L), ImmutableList.of(blockId1),
+            NO_BLOCKS_ON_LOCATION,
+            NO_LOST_STORAGE, mMetrics).getReplicaInfo();
+    assertEquals(ImmutableMap.copyOf(worker2Info3), ImmutableMap.of(blockId2, 1L));
+
+    //worker1 delete block1 and heartbeat
+    Map<Long, Long> worker1Info3 = mBlockMaster.workerHeartbeat(worker1, null,
+            ImmutableMap.of(Constants.MEDIUM_MEM, 0L), ImmutableList.of(blockId1),
+            NO_BLOCKS_ON_LOCATION,
+            NO_LOST_STORAGE, mMetrics).getReplicaInfo();
+    assertEquals(ImmutableMap.copyOf(worker1Info3), ImmutableMap.of(blockId1, -1L));
+
+    //worker2 add block1 and heartbeat
+    Map<Long, Long> worker2Info4 = mBlockMaster.workerHeartbeat(worker2, null,
+            ImmutableMap.of(Constants.MEDIUM_MEM, 0L), NO_BLOCKS,
+            ImmutableMap.of(blockOnWorker2, ImmutableList.of(blockId1)),
+            NO_LOST_STORAGE, mMetrics).getReplicaInfo();
+    assertEquals(ImmutableMap.copyOf(worker2Info4), ImmutableMap.of(blockId1, 2L));
+  }
+
+  @Test
   public void unknownWorkerHeartbeatTriggersRegisterRequest() {
-    Command heartBeat = mBlockMaster.workerHeartbeat(0, null, null, null, null, null, mMetrics);
+    Command heartBeat = mBlockMaster.workerHeartbeat(0, null, null, null, null, null, mMetrics).getCommand();
     assertEquals(Command.newBuilder().setCommandType(CommandType.Register).build(), heartBeat);
   }
 

--- a/core/server/master/src/test/java/alluxio/master/block/ConcurrentBlockMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/ConcurrentBlockMasterTest.java
@@ -425,7 +425,7 @@ public class ConcurrentBlockMasterTest {
               ImmutableList.of(BLOCK1_ID),
               ImmutableMap.of(),
               NO_LOST_STORAGE,
-              ImmutableList.of());
+              ImmutableList.of()).getCommand();
 
           // The block has been removed, nothing from command
           assertEquals(EMPTY_CMD, cmd);
@@ -475,7 +475,7 @@ public class ConcurrentBlockMasterTest {
               ImmutableList.of(BLOCK2_ID),
               ImmutableMap.of(),
               NO_LOST_STORAGE,
-              ImmutableList.of());
+              ImmutableList.of()).getCommand();
 
           // The block has been removed, nothing from command
           assertEquals(EMPTY_CMD, cmd);
@@ -526,7 +526,7 @@ public class ConcurrentBlockMasterTest {
               ImmutableList.of(BLOCK1_ID),
               ImmutableMap.of(),
               NO_LOST_STORAGE,
-              ImmutableList.of());
+              ImmutableList.of()).getCommand();
 
           // The block has been removed, nothing from command
           assertEquals(EMPTY_CMD, cmd);
@@ -588,7 +588,7 @@ public class ConcurrentBlockMasterTest {
               ImmutableList.of(BLOCK2_ID),
               ImmutableMap.of(),
               NO_LOST_STORAGE,
-              ImmutableList.of());
+              ImmutableList.of()).getCommand();
 
           // The block has been removed, nothing from command
           assertEquals(EMPTY_CMD, cmd);
@@ -680,7 +680,7 @@ public class ConcurrentBlockMasterTest {
                 ImmutableList.of(),
                 ImmutableMap.of(),
                 NO_LOST_STORAGE,
-                ImmutableList.of());
+                ImmutableList.of()).getCommand();
             assertEquals(FREE_BLOCK1_CMD, worker1HeartbeatCmd);
 
             if (deleteMetadata) {
@@ -693,7 +693,7 @@ public class ConcurrentBlockMasterTest {
                   ImmutableList.of(),
                   ImmutableMap.of(),
                   NO_LOST_STORAGE,
-                  ImmutableList.of());
+                  ImmutableList.of()).getCommand();
               // Block on worker 2 will be freed because the block is already removed
               // Unrecognized blocks will be freed
               assertEquals(FREE_BLOCK1_CMD, worker2HeartbeatCmd);
@@ -711,7 +711,7 @@ public class ConcurrentBlockMasterTest {
                   ImmutableList.of(),
                   ImmutableMap.of(),
                   NO_LOST_STORAGE,
-                  ImmutableList.of());
+                  ImmutableList.of()).getCommand();
               assertTrue(worker2HeartbeatCmd.equals(FREE_BLOCK1_CMD)
                   || worker2HeartbeatCmd.equals(EMPTY_CMD));
             }
@@ -790,7 +790,7 @@ public class ConcurrentBlockMasterTest {
                 ImmutableList.of(),
                 ImmutableMap.of(),
                 NO_LOST_STORAGE,
-                ImmutableList.of());
+                ImmutableList.of()).getCommand();
             assertEquals(FREE_BLOCK1_CMD, worker1HeartbeatCmd);
 
             Command worker2HeartbeatCmd = mBlockMaster.workerHeartbeat(worker2,
@@ -801,7 +801,7 @@ public class ConcurrentBlockMasterTest {
                 ImmutableList.of(),
                 ImmutableMap.of(),
                 NO_LOST_STORAGE,
-                ImmutableList.of());
+                ImmutableList.of()).getCommand();
             // Blocks on worker 2 are unaffected
             assertEquals(EMPTY_CMD, worker2HeartbeatCmd);
             return null;
@@ -838,7 +838,7 @@ public class ConcurrentBlockMasterTest {
                 ImmutableList.of(BLOCK1_ID),
                 ImmutableMap.of(),
                 NO_LOST_STORAGE,
-                ImmutableList.of());
+                ImmutableList.of()).getCommand();
 
             // The block has been removed, nothing from command
             assertEquals(EMPTY_CMD, cmd);
@@ -904,7 +904,7 @@ public class ConcurrentBlockMasterTest {
                 ImmutableList.of(BLOCK2_ID),
                 ImmutableMap.of(),
                 NO_LOST_STORAGE,
-                ImmutableList.of());
+                ImmutableList.of()).getCommand();
 
             // The heartbeat contends on the block lock of block 2, worker usage lock and
             // worker block list lock
@@ -953,7 +953,7 @@ public class ConcurrentBlockMasterTest {
                   ImmutableList.of(BLOCK2_ID),
                   ImmutableMap.of(),
                   NO_LOST_STORAGE,
-                  ImmutableList.of());
+                  ImmutableList.of()).getCommand();
               assertEquals(FREE_BLOCK1_CMD, cmd);
             }
             return null;
@@ -991,7 +991,7 @@ public class ConcurrentBlockMasterTest {
                 ImmutableList.of(BLOCK1_ID),
                 ImmutableMap.of(),
                 NO_LOST_STORAGE,
-                ImmutableList.of());
+                ImmutableList.of()).getCommand();
 
             // The block has been removed, nothing from command
             assertEquals(EMPTY_CMD, cmd);
@@ -1027,7 +1027,7 @@ public class ConcurrentBlockMasterTest {
                 ImmutableList.of(),
                 ImmutableMap.of(),
                 NO_LOST_STORAGE,
-                ImmutableList.of());
+                ImmutableList.of()).getCommand();
             assertEquals(FREE_BLOCK1_CMD, cmd);
             return null;
           });
@@ -1065,7 +1065,7 @@ public class ConcurrentBlockMasterTest {
                 ImmutableList.of(BLOCK2_ID),
                 ImmutableMap.of(),
                 NO_LOST_STORAGE,
-                ImmutableList.of());
+                ImmutableList.of()).getCommand();
 
             // Nothing for worker 2 to do because it does not have block 1
             assertEquals(EMPTY_CMD, cmd);

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -316,7 +316,7 @@ public final class FileSystemMasterTest {
     // Update the heartbeat of removedBlockId received from worker 1.
     Command heartbeat1 = mBlockMaster.workerHeartbeat(mWorkerId1, null,
         ImmutableMap.of(Constants.MEDIUM_MEM, (long) Constants.KB), ImmutableList.of(blockId),
-        ImmutableMap.of(), ImmutableMap.of(), mMetrics);
+        ImmutableMap.of(), ImmutableMap.of(), mMetrics).getCommand();
     // Verify the muted Free command on worker1.
     assertEquals(Command.newBuilder().setCommandType(CommandType.Nothing).build(), heartbeat1);
     assertFalse(mBlockMaster.isBlockLost(blockId));
@@ -1961,7 +1961,7 @@ public final class FileSystemMasterTest {
             .setTtlAction(alluxio.grpc.TtlAction.FREE))));
     Command heartbeat = mBlockMaster.workerHeartbeat(mWorkerId1, null,
         ImmutableMap.of(Constants.MEDIUM_MEM, (long) Constants.KB), ImmutableList.of(blockId),
-        ImmutableMap.of(), ImmutableMap.of(), mMetrics);
+        ImmutableMap.of(), ImmutableMap.of(), mMetrics).getCommand();
     // Verify the muted Free command on worker1.
     assertEquals(Command.newBuilder().setCommandType(CommandType.Nothing).build(), heartbeat);
     assertEquals(0, mBlockMaster.getBlockInfo(blockId).getLocations().size());
@@ -1985,7 +1985,7 @@ public final class FileSystemMasterTest {
 
     Command heartbeat = mBlockMaster.workerHeartbeat(mWorkerId1, null,
         ImmutableMap.of(Constants.MEDIUM_MEM, (long) Constants.KB), ImmutableList.of(blockId),
-        ImmutableMap.of(), ImmutableMap.<String, StorageList>of(), mMetrics);
+        ImmutableMap.of(), ImmutableMap.<String, StorageList>of(), mMetrics).getCommand();
     // Verify the muted Free command on worker1.
     assertEquals(Command.newBuilder().setCommandType(CommandType.Nothing).build(), heartbeat);
     assertEquals(0, mBlockMaster.getBlockInfo(blockId).getLocations().size());
@@ -2008,7 +2008,7 @@ public final class FileSystemMasterTest {
             .newBuilder().setTtl(0).setTtlAction(alluxio.grpc.TtlAction.FREE))));
     Command heartbeat = mBlockMaster.workerHeartbeat(mWorkerId1, null,
         ImmutableMap.of(Constants.MEDIUM_MEM, (long) Constants.KB), ImmutableList.of(blockId),
-        ImmutableMap.of(), ImmutableMap.<String, StorageList>of(), mMetrics);
+        ImmutableMap.of(), ImmutableMap.<String, StorageList>of(), mMetrics).getCommand();
     // Verify the muted Free command on worker1.
     assertEquals(Command.newBuilder().setCommandType(CommandType.Nothing).build(), heartbeat);
     assertEquals(0, mBlockMaster.getBlockInfo(blockId).getLocations().size());
@@ -2036,7 +2036,7 @@ public final class FileSystemMasterTest {
 
     Command heartbeat = mBlockMaster.workerHeartbeat(mWorkerId1, null,
         ImmutableMap.of(Constants.MEDIUM_MEM, (long) Constants.KB), ImmutableList.of(blockId),
-        ImmutableMap.of(), ImmutableMap.of(), mMetrics);
+        ImmutableMap.of(), ImmutableMap.of(), mMetrics).getCommand();
     // Verify the muted Free command on worker1.
     assertEquals(Command.newBuilder().setCommandType(CommandType.Nothing).build(), heartbeat);
     assertEquals(0, mBlockMaster.getBlockInfo(blockId).getLocations().size());
@@ -2405,7 +2405,7 @@ public final class FileSystemMasterTest {
     // Update the heartbeat of removedBlockId received from worker 1.
     Command heartbeat2 = mBlockMaster.workerHeartbeat(mWorkerId1, null,
         ImmutableMap.of(Constants.MEDIUM_MEM, (long) Constants.KB), ImmutableList.of(blockId),
-        ImmutableMap.of(), ImmutableMap.of(), mMetrics);
+        ImmutableMap.of(), ImmutableMap.of(), mMetrics).getCommand();
     // Verify the muted Free command on worker1.
     assertEquals(Command.newBuilder().setCommandType(CommandType.Nothing).build(), heartbeat2);
     assertEquals(0, mBlockMaster.getBlockInfo(blockId).getLocations().size());
@@ -2458,7 +2458,7 @@ public final class FileSystemMasterTest {
     // Update the heartbeat of removedBlockId received from worker 1.
     Command heartbeat = mBlockMaster.workerHeartbeat(mWorkerId1, null,
         ImmutableMap.of(Constants.MEDIUM_MEM, (long) Constants.KB), ImmutableList.of(blockId),
-        ImmutableMap.of(), ImmutableMap.of(), mMetrics);
+        ImmutableMap.of(), ImmutableMap.of(), mMetrics).getCommand();
     // Verify the muted Free command on worker1.
     assertEquals(Command.newBuilder().setCommandType(CommandType.Nothing).build(), heartbeat);
     assertEquals(0, mBlockMaster.getBlockInfo(blockId).getLocations().size());
@@ -2493,7 +2493,7 @@ public final class FileSystemMasterTest {
     // Update the heartbeat of removedBlockId received from worker 1.
     Command heartbeat3 = mBlockMaster.workerHeartbeat(mWorkerId1, null,
         ImmutableMap.of(Constants.MEDIUM_MEM, (long) Constants.KB), ImmutableList.of(blockId),
-        ImmutableMap.of(), ImmutableMap.of(), mMetrics);
+        ImmutableMap.of(), ImmutableMap.of(), mMetrics).getCommand();
     // Verify the muted Free command on worker1.
     assertEquals(Command.newBuilder().setCommandType(CommandType.Nothing).build(), heartbeat3);
     assertEquals(0, mBlockMaster.getBlockInfo(blockId).getLocations().size());
@@ -2547,7 +2547,7 @@ public final class FileSystemMasterTest {
     // Update the heartbeat of removedBlockId received from worker 1.
     Command heartbeat = mBlockMaster.workerHeartbeat(mWorkerId1, null,
         ImmutableMap.of(Constants.MEDIUM_MEM, (long) Constants.KB), ImmutableList.of(blockId),
-        ImmutableMap.of(), ImmutableMap.of(), mMetrics);
+        ImmutableMap.of(), ImmutableMap.of(), mMetrics).getCommand();
     // Verify the muted Free command on worker1.
     assertEquals(Command.newBuilder().setCommandType(CommandType.Nothing).build(), heartbeat);
     assertEquals(0, mBlockMaster.getBlockInfo(blockId).getLocations().size());

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
@@ -21,7 +21,6 @@ import alluxio.grpc.BlockHeartbeatPRequest;
 import alluxio.grpc.BlockIdList;
 import alluxio.grpc.BlockMasterWorkerServiceGrpc;
 import alluxio.grpc.BlockStoreLocationProto;
-import alluxio.grpc.Command;
 import alluxio.grpc.CommitBlockInUfsPRequest;
 import alluxio.grpc.CommitBlockPRequest;
 import alluxio.grpc.ConfigProperty;
@@ -220,9 +219,10 @@ public class BlockMasterClient extends AbstractMasterClient {
         .addAllAddedBlocks(entryList).setOptions(options)
         .putAllLostStorage(lostStorageMap).build();
 
-    alluxio.grpc.BlockHeartbeatPResponse heartbeatReturn = retryRPC(() -> mClient.withDeadlineAfter(mContext.getClusterConf()
-                    .getMs(PropertyKey.WORKER_MASTER_PERIODICAL_RPC_TIMEOUT), TimeUnit.MILLISECONDS)
-            .blockHeartbeat(request), LOG, "Heartbeat", "workerId=%d", workerId);
+    alluxio.grpc.BlockHeartbeatPResponse heartbeatReturn = retryRPC(() -> mClient.withDeadlineAfter(
+        mContext.getClusterConf()
+        .getMs(PropertyKey.WORKER_MASTER_PERIODICAL_RPC_TIMEOUT), TimeUnit.MILLISECONDS)
+        .blockHeartbeat(request), LOG, "Heartbeat", "workerId=%d", workerId);
     return new HeartBeatResponseMessage().fromProto(heartbeatReturn);
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
@@ -223,7 +223,8 @@ public class BlockMasterClient extends AbstractMasterClient {
         mContext.getClusterConf()
         .getMs(PropertyKey.WORKER_MASTER_PERIODICAL_RPC_TIMEOUT), TimeUnit.MILLISECONDS)
         .blockHeartbeat(request), LOG, "Heartbeat", "workerId=%d", workerId);
-    return new HeartBeatResponseMessage().fromProto(heartbeatReturn);
+    return new HeartBeatResponseMessage().setCommand(heartbeatReturn.getCommand())
+            .setReplicaInfo(heartbeatReturn.getReplicaInfoMap());
   }
 
   private GetRegisterLeasePResponse acquireRegisterLease(

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
@@ -251,7 +251,8 @@ public final class BlockMasterSync implements HeartbeatExecutor {
     }
   }
 
-  private void handleMasterReplicaChange(Map<Long, Long> ReplicaInfo) throws IOException, ConnectionFailedException {
+  private void handleMasterReplicaChange(Map<Long, Long> ReplicaInfo)
+      throws IOException, ConnectionFailedException {
     if (ReplicaInfo == null) {
       return;
     }

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
@@ -182,6 +182,7 @@ public final class BlockMasterSync implements HeartbeatExecutor {
               storeMeta.getCapacityBytesOnTiers(),
               storeMeta.getUsedBytesOnTiers(), blockReport.getRemovedBlocks(),
               blockReport.getAddedBlocks(), blockReport.getLostStorage(), metrics);
+      cmdFromMaster = heartbeatReturn.getCommand();
       handleMasterCommand(heartbeatReturn.getCommand());
       handleMasterReplicaChange(heartbeatReturn.getReplicaInfo());
       mLastSuccessfulHeartbeatMs = System.currentTimeMillis();
@@ -259,6 +260,6 @@ public final class BlockMasterSync implements HeartbeatExecutor {
     if (ReplicaInfo.isEmpty()) {
       return;
     }
-    //TodoL to update the replica Info
+    //Todo to update the replica Info
   }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockMasterClientTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockMasterClientTest.java
@@ -316,7 +316,7 @@ public class BlockMasterClientTest {
         removedBlocks,
         addedBlocks,
         lostStorage,
-        metrics).getCommandType());
+        metrics).getCommand().getCommandType());
   }
 
   @Test

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTest.java
@@ -45,8 +45,6 @@ import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.Block;
 import alluxio.grpc.BlockStatus;
 import alluxio.grpc.CacheRequest;
-import alluxio.grpc.Command;
-import alluxio.grpc.CommandType;
 import alluxio.grpc.GetConfigurationPOptions;
 import alluxio.master.NoopUfsManager;
 import alluxio.proto.dataserver.Protocol;
@@ -56,6 +54,7 @@ import alluxio.util.IdUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.network.NetworkAddressUtils;
+import alluxio.wire.HeartBeatResponseMessage;
 import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
@@ -696,7 +695,7 @@ public class DefaultBlockWorkerTest {
         .getId(any(WorkerNetAddress.class));
 
     // return Command.Nothing for heartbeat
-    doReturn(Command.newBuilder().setCommandType(CommandType.Nothing).build())
+    doReturn(new HeartBeatResponseMessage())
         .when(client)
         .heartbeat(
             anyLong(),

--- a/core/transport/src/main/proto/grpc/block_master.proto
+++ b/core/transport/src/main/proto/grpc/block_master.proto
@@ -193,6 +193,7 @@ message BlockHeartbeatPRequest {
 
 message BlockHeartbeatPResponse {
   optional grpc.Command command = 1;
+  map<int64, int64> replicaInfo = 2;
 }
 
 message CommitBlockPResponse {}

--- a/core/transport/src/main/proto/grpc/block_master.proto
+++ b/core/transport/src/main/proto/grpc/block_master.proto
@@ -193,6 +193,7 @@ message BlockHeartbeatPRequest {
 
 message BlockHeartbeatPResponse {
   optional grpc.Command command = 1;
+  /** the map of changing replica number on the blocks **/
   map<int64, int64> replicaInfo = 2;
 }
 

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -482,6 +482,16 @@
                 "name": "command",
                 "type": "grpc.Command"
               }
+            ],
+            "maps": [
+              {
+                "key_type": "int64",
+                "field": {
+                  "id": 2,
+                  "name": "replicaInfo",
+                  "type": "int64"
+                }
+              }
             ]
           },
           {

--- a/stress/shell/src/main/java/alluxio/stress/cli/WorkerHeartbeatBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/WorkerHeartbeatBench.java
@@ -115,7 +115,7 @@ public class WorkerHeartbeatBench extends RpcBench<BlockMasterBenchParameters> {
             // So an empty map will be used here
             ImmutableMap.of(),
             LOST_STORAGE,
-            EMPTY_METRICS);
+            EMPTY_METRICS).getCommand();
         LOG.debug("Received command from heartbeat {}", cmd);
         Instant e = Instant.now();
         Duration d = Duration.between(s, e);

--- a/tests/src/test/java/alluxio/client/fs/BlockMasterRegisterStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/BlockMasterRegisterStreamIntegrationTest.java
@@ -874,6 +874,6 @@ public class BlockMasterRegisterStreamIntegrationTest {
         // list of added blockIds
         ImmutableMap.of(),
         NO_LOST_STORAGE,
-        ImmutableList.of());
+        ImmutableList.of()).getCommand();
   }
 }

--- a/tests/src/test/java/alluxio/client/fs/BlockWorkerRegisterStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/BlockWorkerRegisterStreamIntegrationTest.java
@@ -59,6 +59,7 @@ import alluxio.stress.cli.RpcBenchPreparationUtils;
 import alluxio.stress.rpc.TierAlias;
 import alluxio.underfs.UfsManager;
 import alluxio.util.ThreadFactoryUtils;
+import alluxio.wire.HeartBeatResponseMessage;
 import alluxio.worker.block.BlockMasterClient;
 import alluxio.worker.block.BlockMasterClientPool;
 import alluxio.worker.block.BlockMasterSync;
@@ -505,14 +506,14 @@ public class BlockWorkerRegisterStreamIntegrationTest {
     }
 
     @Override
-    public synchronized Command heartbeat(
-        final long workerId, final Map<String, Long> capacityBytesOnTiers,
-        final Map<String, Long> usedBytesOnTiers,
-        final List<Long> removedBlocks, final Map<BlockStoreLocation, List<Long>> addedBlocks,
-        final Map<String, List<String>> lostStorage, final List<Metric> metrics) {
+    public synchronized HeartBeatResponseMessage heartbeat(
+            final long workerId, final Map<String, Long> capacityBytesOnTiers,
+            final Map<String, Long> usedBytesOnTiers,
+            final List<Long> removedBlocks, final Map<BlockStoreLocation, List<Long>> addedBlocks,
+            final Map<String, List<String>> lostStorage, final List<Metric> metrics) {
       assertEquals(mRemovedBlocks, removedBlocks);
       assertEquals(mAddedBlocks, addedBlocks);
-      return Command.getDefaultInstance();
+      return new HeartBeatResponseMessage();
     }
 
     @Override

--- a/tests/src/test/java/alluxio/client/fs/BlockWorkerRegisterStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/BlockWorkerRegisterStreamIntegrationTest.java
@@ -46,7 +46,6 @@ import alluxio.exception.status.DeadlineExceededException;
 import alluxio.exception.status.InternalException;
 import alluxio.exception.status.NotFoundException;
 import alluxio.grpc.BlockMasterWorkerServiceGrpc;
-import alluxio.grpc.Command;
 import alluxio.grpc.ConfigProperty;
 import alluxio.grpc.GrpcExceptionUtils;
 import alluxio.grpc.LocationBlockIdListEntry;

--- a/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
@@ -329,7 +329,8 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
       // Worker 2 tries to heartbeat (with original id), and should get "Register" in response.
       assertEquals(CommandType.Register, blockMaster2
           .workerHeartbeat(workerId2a, null, Collections.EMPTY_MAP, Collections.EMPTY_LIST,
-              Collections.EMPTY_MAP, Collections.EMPTY_MAP, Lists.newArrayList()).getCommand().getCommandType());
+          Collections.EMPTY_MAP, Collections.EMPTY_MAP,
+          Lists.newArrayList()).getCommand().getCommandType());
 
       // Worker 2 re-registers (and gets a new worker id)
       long workerId2b =

--- a/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/MasterFaultToleranceIntegrationTest.java
@@ -313,11 +313,11 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
       assertEquals(CommandType.Nothing,
           blockMaster1.workerHeartbeat(workerId1a, null, Collections.EMPTY_MAP,
               Collections.EMPTY_LIST, Collections.EMPTY_MAP, Collections.EMPTY_MAP,
-              Lists.newArrayList()).getCommandType());
+              Lists.newArrayList()).getCommand().getCommandType());
       assertEquals(CommandType.Nothing,
           blockMaster1.workerHeartbeat(workerId2a, null, Collections.EMPTY_MAP,
               Collections.EMPTY_LIST, Collections.EMPTY_MAP, Collections.EMPTY_MAP,
-              Lists.newArrayList()).getCommandType());
+              Lists.newArrayList()).getCommand().getCommandType());
 
       assertTrue(cluster.stopLeader());
       cluster.waitForNewMaster(CLUSTER_WAIT_TIMEOUT_MS);
@@ -329,7 +329,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
       // Worker 2 tries to heartbeat (with original id), and should get "Register" in response.
       assertEquals(CommandType.Register, blockMaster2
           .workerHeartbeat(workerId2a, null, Collections.EMPTY_MAP, Collections.EMPTY_LIST,
-              Collections.EMPTY_MAP, Collections.EMPTY_MAP, Lists.newArrayList()).getCommandType());
+              Collections.EMPTY_MAP, Collections.EMPTY_MAP, Lists.newArrayList()).getCommand().getCommandType());
 
       // Worker 2 re-registers (and gets a new worker id)
       long workerId2b =
@@ -342,7 +342,7 @@ public class MasterFaultToleranceIntegrationTest extends BaseIntegrationTest {
       assertEquals(CommandType.Register,
           blockMaster2.workerHeartbeat(workerId1a, null, Collections.EMPTY_MAP,
               Collections.EMPTY_LIST, Collections.EMPTY_MAP, Collections.EMPTY_MAP,
-              Lists.newArrayList()).getCommandType());
+              Lists.newArrayList()).getCommand().getCommandType());
 
       // Worker 1 re-registers (and gets a new worker id)
       long workerId1b =


### PR DESCRIPTION
The information of the number of replications of blocks in the clusters can help us optimize the evictor algorithm. For example, we can first delete the block with more replications in other workers to decrease the times to download data.

This PR has finished these things:
1. Original heartbeat just send a command to worker. We changed into a new class 'HeartbeatResponseMessage' to contain more messages. 
2. When heartbeat, the worker tells the master which blocks are added or removed, and the master tells the worker the how each block replication number have been changed from last heartbeat.  And the master send these messages to the worker.
