### PR TITLE
Respect prefix param to avoid recursive ls on root dir

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -320,6 +320,9 @@ public final class S3RestServiceHandler {
             }
             children = userFs.listStatus(new AlluxioURI(path));
           } else {
+            if (prefixParam != null) {
+              path = parsePathWithDelimiter(path, prefixParam, AlluxioURI.SEPARATOR);
+            }
             ListStatusPOptions options = ListStatusPOptions.newBuilder().setRecursive(true).build();
             children = userFs.listStatus(new AlluxioURI(path), options);
           }


### PR DESCRIPTION
### What changes are proposed in this pull request?

respect prefix param to avoid recursive ls on root dir

### Why are the changes needed?

when s3 client issues list-objects with --prefix flag on a particular subfolder  ( /bucket/folder1/) but without no --delimiter flag, this should be a recursive listing on  /bucket/folder1/   but instead s3 proxy is ignoring this flag and end up shooting recursive listing on /bucket, with ramification of generating unnecessary metadata sync in the backend. 

### Does this PR introduce any user facing changes?
N/A
