### PR TITLE
Fix gauges when creating a new rpc server

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -626,6 +626,17 @@ public final class MetricsSystem {
   }
 
   /**
+   * Registers a gauge, replacing an existing one if necessary.
+   *
+   * @param name the gauge name
+   * @param metric the gauge
+   * @param <T> the type
+   */
+  public static synchronized <T> void registerGauge(String name, Gauge<T> metric) {
+    METRIC_REGISTRY.register(name, metric);
+  }
+
+  /**
    * Registers a gauge if it has not been registered.
    *
    * @param name the gauge name

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -626,17 +626,6 @@ public final class MetricsSystem {
   }
 
   /**
-   * Registers a gauge, replacing an existing one if necessary.
-   *
-   * @param name the gauge name
-   * @param metric the gauge
-   * @param <T> the type
-   */
-  public static synchronized <T> void registerGauge(String name, Gauge<T> metric) {
-    METRIC_REGISTRY.register(name, metric);
-  }
-
-  /**
    * Registers a gauge if it has not been registered.
    *
    * @param name the gauge name

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -519,11 +519,14 @@ public class AlluxioMasterProcess extends MasterProcess {
     // Create an executor for Master RPC server.
     mRPCExecutor = ExecutorServiceBuilder.buildExecutorService(
         ExecutorServiceBuilder.RpcExecutorHost.MASTER);
-    MetricsSystem.registerGauge(MetricKey.MASTER_RPC_QUEUE_LENGTH.getName(),
+    MetricsSystem.removeMetrics(MetricKey.MASTER_RPC_QUEUE_LENGTH.getName());
+    MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_RPC_QUEUE_LENGTH.getName(),
         mRPCExecutor::getRpcQueueLength);
-    MetricsSystem.registerGauge(MetricKey.MASTER_RPC_THREAD_ACTIVE_COUNT.getName(),
+    MetricsSystem.removeMetrics(MetricKey.MASTER_RPC_THREAD_ACTIVE_COUNT.getName());
+    MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_RPC_THREAD_ACTIVE_COUNT.getName(),
         mRPCExecutor::getActiveCount);
-    MetricsSystem.registerGauge(MetricKey.MASTER_RPC_THREAD_CURRENT_COUNT.getName(),
+    MetricsSystem.removeMetrics(MetricKey.MASTER_RPC_THREAD_CURRENT_COUNT.getName());
+    MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_RPC_THREAD_CURRENT_COUNT.getName(),
         mRPCExecutor::getPoolSize);
     // Create underlying gRPC server.
     GrpcServerBuilder builder = GrpcServerBuilder

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -519,11 +519,11 @@ public class AlluxioMasterProcess extends MasterProcess {
     // Create an executor for Master RPC server.
     mRPCExecutor = ExecutorServiceBuilder.buildExecutorService(
         ExecutorServiceBuilder.RpcExecutorHost.MASTER);
-    MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_RPC_QUEUE_LENGTH.getName(),
+    MetricsSystem.registerGauge(MetricKey.MASTER_RPC_QUEUE_LENGTH.getName(),
         mRPCExecutor::getRpcQueueLength);
-    MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_RPC_THREAD_ACTIVE_COUNT.getName(),
+    MetricsSystem.registerGauge(MetricKey.MASTER_RPC_THREAD_ACTIVE_COUNT.getName(),
         mRPCExecutor::getActiveCount);
-    MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_RPC_THREAD_CURRENT_COUNT.getName(),
+    MetricsSystem.registerGauge(MetricKey.MASTER_RPC_THREAD_CURRENT_COUNT.getName(),
         mRPCExecutor::getPoolSize);
     // Create underlying gRPC server.
     GrpcServerBuilder builder = GrpcServerBuilder


### PR DESCRIPTION
When master gain/regain primacy they create a new RPC server and executor related metrics along with it. These metrics do not get reregistered when a master is promoted to leader for a second time. This PR fixes this problem.