### PR TITLE
Remove unnecessary log in memory page store

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/MemoryPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/MemoryPageStore.java
@@ -17,8 +17,6 @@ import alluxio.exception.PageNotFoundException;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -30,8 +28,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class MemoryPageStore implements PageStore {
-  private static final Logger LOG = LoggerFactory.getLogger(MemoryPageStore.class);
-
   private ConcurrentHashMap<PageId, byte[]> mPageStoreMap = new ConcurrentHashMap<>();
 
   @Override
@@ -75,7 +71,6 @@ public class MemoryPageStore implements PageStore {
       throw new PageNotFoundException(pageId.getFileId() + "_" + pageId.getPageIndex());
     }
     mPageStoreMap.remove(pageKey);
-    LOG.info("Remove cached page, size: {}", mPageStoreMap.size());
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove unnecessary log in memory page store

### Why are the changes needed?

The log of the cache eviction is polluting the log on presto side 


### Does this PR introduce any user facing changes?

no