### PR TITLE
Avoid canceling duplicate metadata sync prefetch job

### DIFF
--- a/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
+++ b/core/server/master/src/main/java/alluxio/underfs/UfsStatusCache.java
@@ -387,11 +387,15 @@ public class UfsStatusCache {
     if (mPrefetchExecutor == null) {
       return null;
     }
+    Future<Collection<UfsStatus>> prev = mActivePrefetchJobs.get(path);
+    if (prev != null) {
+      return prev;
+    }
     try {
       Future<Collection<UfsStatus>> job =
           mPrefetchExecutor.submit(() -> getChildrenIfAbsent(path, mountTable));
       DefaultFileSystemMaster.Metrics.METADATA_SYNC_PREFETCH_OPS_COUNT.inc();
-      Future<Collection<UfsStatus>> prev = mActivePrefetchJobs.put(path, job);
+      prev = mActivePrefetchJobs.put(path, job);
       if (prev != null) {
         prev.cancel(true);
         DefaultFileSystemMaster.Metrics.METADATA_SYNC_PREFETCH_CANCEL.inc();

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataMetricsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataMetricsTest.java
@@ -431,15 +431,15 @@ public class FileSystemMasterSyncMetadataMetricsTest extends FileSystemMasterSyn
     assertTrue(0 < prefetchRetriesCounter.getCount());
     ufsStatusCache.remove(ROOT);
 
-    // the 1st prefetch is cancelled because of double submission
+    // the 1st prefetch waits for the second to finish
     ufsStatusCache.prefetchChildren(ROOT, mountTable);
     ufsStatusCache.prefetchChildren(ROOT, mountTable);
     ufsStatusCollection =
         ufsStatusCache.fetchChildrenIfAbsent(null, ROOT, mountTable, false);
     assertNotNull(ufsStatusCollection);
     assertEquals(2, ufsStatusCollection.size());
-    assertEquals(prefetchOpsCount + 2, prefetchOpsCountCounter.getCount());
-    prefetchOpsCount += 2;
+    assertEquals(prefetchOpsCount + 1, prefetchOpsCountCounter.getCount());
+    prefetchOpsCount += 1;
     assertEquals(succeededPrefetches + 1, succeededPrefetchCounter.getCount());
     succeededPrefetches += 1;
     assertEquals(failedPrefetches + 0, failedPrefetchCounter.getCount());
@@ -447,8 +447,8 @@ public class FileSystemMasterSyncMetadataMetricsTest extends FileSystemMasterSyn
     // "/dir0" , "/dir1"
     assertEquals(prefetchPaths + 2, prefetchPathsCounter.getCount());
     prefetchPaths += 2;
-    assertEquals(cancelPrefetches + 1, canceledPrefetchCounter.getCount());
-    cancelPrefetches += 1;
+    assertEquals(cancelPrefetches + 0, canceledPrefetchCounter.getCount());
+    cancelPrefetches += 0;
     ufsStatusCache.remove(ROOT);
 
     mUfs.mIsSlow = false;
@@ -464,9 +464,9 @@ public class FileSystemMasterSyncMetadataMetricsTest extends FileSystemMasterSyn
     assertEquals(9, mInodeTree.getInodeCount());
     // getFromUfs: "/" , "/dir0" , "/dir0/file0" , "/dir0/file1" ,"/dir0/file2"
     //                  "/dir1" , "/dir1/file0" , "/dir1/file1" , "/dir1/file2"
-    // prefetchChildren: "/" , "/dir0" , "/dir0" , "/dir1" , "/dir1"
-    assertEquals(prefetchOpsCount + 14, prefetchOpsCountCounter.getCount());
-    prefetchOpsCount += 14;
+    // prefetchChildren: "/" , "/dir0" , "/dir1"
+    assertEquals(prefetchOpsCount + 12, prefetchOpsCountCounter.getCount());
+    prefetchOpsCount += 12;
     // getFromUfs: "/" , "/dir0" , "/dir0/file0" , "/dir0/file1" ,"/dir0/file2"
     //                  "/dir1" , "/dir1/file0" , "/dir1/file1" , "/dir1/file2"
     // prefetchChildren: "/" , "/dir0" , "/dir1"
@@ -480,9 +480,9 @@ public class FileSystemMasterSyncMetadataMetricsTest extends FileSystemMasterSyn
     prefetchPaths += 17;
     assertEquals(failedPrefetches + 0, failedPrefetchCounter.getCount());
     failedPrefetches += 0;
-    // "/dir0" and "/dir1" in prefetchChildren are canceled because of double commits
-    assertEquals(cancelPrefetches + 2, canceledPrefetchCounter.getCount());
-    cancelPrefetches += 2;
+    // no prefetches are cancelled as they wait for others to complete
+    assertEquals(cancelPrefetches + 0, canceledPrefetchCounter.getCount());
+    cancelPrefetches += 0;
 
     // When UFS throw IOException
     mUfs.mThrowIOException = true;

--- a/core/server/master/src/test/java/alluxio/underfs/UfsStatusCacheTest.java
+++ b/core/server/master/src/test/java/alluxio/underfs/UfsStatusCacheTest.java
@@ -356,7 +356,8 @@ public class UfsStatusCacheTest {
     Future<?> f1 = mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable);
     Future<?> f2 = mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable);
     assertNotNull(f1);
-    assertTrue("first future is cancelled", f1.isCancelled());
+    assertFalse("first future is not cancelled", f1.isCancelled());
+    assertEquals("the same job is running on the same path", f1, f2);
     Collection<UfsStatus> statuses =
         mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/dir0/dir0"), mMountTable, true);
     assertEquals(1, statuses.size());
@@ -396,11 +397,16 @@ public class UfsStatusCacheTest {
         l.unlock();
       }
     }).when(mCache).getChildrenIfAbsent(any(AlluxioURI.class), any(MountTable.class));
-    assertNotNull(mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable));
-    assertNull(mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable)); // rejected
-    assertNull(mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable)); // rejected
-    assertNull(mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable)); // rejected
-    assertNull(mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable)); // rejected
+    Future<Collection<UfsStatus>> job = mCache.prefetchChildren(new AlluxioURI("/dir0"),
+        mMountTable);
+    assertNotNull(job);
+    // the same job should still be running
+    assertEquals(job, mCache.prefetchChildren(new AlluxioURI("/dir0"), mMountTable));
+    // the following will be rejected as there is no available thread to execute them
+    assertNull(mCache.prefetchChildren(new AlluxioURI("/dir1"), mMountTable));
+    assertNull(mCache.prefetchChildren(new AlluxioURI("/dir1"), mMountTable));
+    assertNull(mCache.prefetchChildren(new AlluxioURI("/dir1"), mMountTable));
+    assertNull(mCache.prefetchChildren(new AlluxioURI("/dir1"), mMountTable));
     l.unlock();
     Collection<UfsStatus> statuses =
         mCache.fetchChildrenIfAbsent(null, new AlluxioURI("/dir0"), mMountTable, false);


### PR DESCRIPTION
### What changes are proposed in this pull request?

During a recursive meta data sync, when a child directory is set to be fetched from the UFS it will be done in a separate thread. Another thread will then use this perfected data to sync the path. Currently if this thread starts running before the prefetch is complete, it will cancel the prefetch and relaunch it. This PR changes this so it will instead wait for the thread to complete.
