### PR TITLE
Enable java 11 in alluxio base image

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -10,6 +10,7 @@
 #
 
 # ARG defined before the first FROM can be used in FROM lines
+# Only 8 and 11 are supported.
 ARG JAVA_VERSION=8
 
 # Setup CSI

--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -9,6 +9,9 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
+# ARG defined before the first FROM can be used in FROM lines
+ARG JAVA_VERSION=8
+
 # Setup CSI
 FROM golang:1.15.13-alpine AS csi-dev
 ENV GO111MODULE=on
@@ -41,13 +44,31 @@ RUN if [ ${ENABLE_DYNAMIC_USER} = "true" ] ; then \
        chmod -R 777 /opt/* ; \
     fi
 
-FROM centos:7 as final
+# Configure Java
+FROM centos:7 as build_java8
+RUN \
+    yum update -y && yum upgrade -y && \
+    yum install -y java-1.8.0-openjdk-devel java-1.8.0-openjdk && \
+    yum clean all
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk
+# Disable JVM DNS cache in java8 (https://github.com/Alluxio/alluxio/pull/9452)
+RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-1.8.0-openjdk/jre/lib/security/java.security
+
+FROM centos:7 as build_java11
+RUN \
+    yum update -y && yum upgrade -y && \
+    yum install -y java-11-openjdk-devel java-11-openjdk && \
+    yum clean all
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
+# Disable JVM DNS cache in java11 (https://github.com/Alluxio/alluxio/pull/9452)
+RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-11-openjdk/conf/security/java.security
+
+FROM build_java${JAVA_VERSION} AS final
 
 WORKDIR /
 
 # Install libfuse2 and libfuse3. Libfuse2 setup is modified from cheyang/fuse2:ubuntu1604-customize to be applied on centOS
 RUN \
-    yum update -y && yum upgrade -y && \
     yum install -y ca-certificates pkgconfig wget udev git && \
     yum install -y gcc gcc-c++ make cmake gettext-devel libtool autoconf && \
     git clone https://github.com/Alluxio/libfuse.git && \
@@ -87,14 +108,6 @@ ARG ENABLE_DYNAMIC_USER=true
 ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /usr/local/bin/tini
 RUN chmod +x /usr/local/bin/tini
-
-RUN yum install -y java-1.8.0-openjdk-devel java-1.8.0-openjdk && \
-    yum clean all
-
-ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk
-
-# Disable JVM DNS cache in java8 (https://github.com/Alluxio/alluxio/pull/9452)
-RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-1.8.0-openjdk/jre/lib/security/java.security
 
 # If Alluxio user, group, gid, and uid aren't root|0, create the alluxio user and set file permissions accordingly
 RUN if [ ${ALLUXIO_USERNAME} != "root" ] \


### PR DESCRIPTION
By adding an argument to specify the java version, users will be able to launch Alluxio with java 11 in containers.

Only java 8 and java 11 are supported. If users try build with other versions, the build would fail with error `failed to solve with frontend dockerfile.v0: failed to create LLB definition: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed`. It is not intuitive at all but there is no way to print an custom error message because the error happens when it's trying to load the metadata for all images used in the dockerfile, before any script runs, where we can put our custom error message.

This is the first step of a series of updates of the images. The documentation will be updated later.