### PR TITLE
Add context for if operation is from metadata load

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -825,7 +825,7 @@ public class InodeSyncStream {
               builder.setGroup(group);
             }
             SetAttributeContext ctx = SetAttributeContext.mergeFrom(builder)
-                .setUfsFingerprint(ufsFpParsed.serialize());
+                .setUfsFingerprint(ufsFpParsed.serialize()).setMetadataLoad(true);
             mFsMaster.setAttributeSingleFile(mRpcContext, inodePath, false, opTimeMs, ctx);
           }
         }
@@ -838,7 +838,7 @@ public class InodeSyncStream {
                 DeletePOptions.newBuilder()
                 .setRecursive(true)
                 .setAlluxioOnly(true)
-                .setUnchecked(true));
+                .setUnchecked(true)).setMetadataLoad(true);
             mFsMaster.deleteInternal(mRpcContext, inodePath, syncDeleteContext, true);
           } catch (DirectoryNotEmptyException | IOException e) {
             // Should not happen, since it is an unchecked delete.
@@ -1185,7 +1185,7 @@ public class InodeSyncStream {
       fsMaster.createFileInternal(wrapRpcContext, writeLockedPath, createFileContext);
       CompleteFileContext completeContext =
           CompleteFileContext.mergeFrom(CompleteFilePOptions.newBuilder().setUfsLength(ufsLength))
-              .setUfsStatus(context.getUfsStatus());
+              .setUfsStatus(context.getUfsStatus()).setMetadataLoad(true);
       if (ufsLastModified != null) {
         completeContext.setOperationTimeMs(ufsLastModified);
       }

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CompleteFileContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CompleteFileContext.java
@@ -26,6 +26,7 @@ public class CompleteFileContext
 
   private long mOperationTimeMs;
   private UfsStatus mUfsStatus;
+  private boolean mMetadataLoad = false;
 
   /**
    * Creates rename context with given option data.
@@ -36,6 +37,23 @@ public class CompleteFileContext
     super(mergedOptionsBuilder);
     mOperationTimeMs = System.currentTimeMillis();
     mUfsStatus = null;
+  }
+
+  /**
+   * @param metadataLoad the flag value to use; if true, the operation is a result of a metadata
+   *        load
+   * @return the updated context
+   */
+  public CompleteFileContext setMetadataLoad(boolean metadataLoad) {
+    mMetadataLoad = metadataLoad;
+    return this;
+  }
+
+  /**
+   * @return the metadataLoad flag; if true, the operation is a result of a metadata load
+   */
+  public boolean isMetadataLoad() {
+    return mMetadataLoad;
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/DeleteContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/DeleteContext.java
@@ -22,6 +22,7 @@ import com.google.common.base.MoreObjects;
  * Used to merge and wrap {@link DeletePOptions}.
  */
 public class DeleteContext extends OperationContext<DeletePOptions.Builder, DeleteContext> {
+  private boolean mMetadataLoad = false;
 
   /**
    * Creates context with given option data.
@@ -68,6 +69,23 @@ public class DeleteContext extends OperationContext<DeletePOptions.Builder, Dele
       return OperationId.fromFsProto(getOptions().getCommonOptions().getOperationId());
     }
     return super.getOperationId();
+  }
+
+  /**
+   * @param metadataLoad the flag value to use; if true, the operation is a result of a metadata
+   *        load
+   * @return the updated context
+   */
+  public DeleteContext setMetadataLoad(boolean metadataLoad) {
+    mMetadataLoad = metadataLoad;
+    return this;
+  }
+
+  /**
+   * @return the metadataLoad flag; if true, the operation is a result of a metadata load
+   */
+  public boolean isMetadataLoad() {
+    return mMetadataLoad;
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/SetAttributeContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/SetAttributeContext.java
@@ -26,6 +26,7 @@ public class SetAttributeContext
 
   private long mOperationTimeMs;
   private String mUfsFingerprint;
+  private boolean mMetadataLoad = false;
 
   /**
    * Creates context with given option data.
@@ -83,6 +84,23 @@ public class SetAttributeContext
   public SetAttributeContext setOperationTimeMs(long operationTimeMs) {
     mOperationTimeMs = operationTimeMs;
     return this;
+  }
+
+  /**
+   * @param metadataLoad the flag value to use; if true, the operation is a result of a metadata
+   *        load
+   * @return the updated context
+   */
+  public SetAttributeContext setMetadataLoad(boolean metadataLoad) {
+    mMetadataLoad = metadataLoad;
+    return this;
+  }
+
+  /**
+   * @return the metadataLoad flag; if true, the operation is a result of a metadata load
+   */
+  public boolean isMetadataLoad() {
+    return mMetadataLoad;
   }
 
   /**


### PR DESCRIPTION
When performing a file system operation, add information to the context if is was performed by a metadata sync or not.
