### PR TITLE
Fix aws s3 cp with source object having special characters in it

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -718,7 +718,9 @@ public final class S3RestServiceHandler {
           try {
             S3RestUtils.checkStatusesForUploadId(mMetaFS, userFs, new AlluxioURI(tmpDir), uploadId);
           } catch (Exception e) {
-            throw S3RestUtils.toObjectS3Exception(e, object, auditContext);
+            throw S3RestUtils.toObjectS3Exception((e instanceof FileDoesNotExistException) ?
+                            new S3Exception(object, S3ErrorCode.NO_SUCH_UPLOAD) : e,
+                    object, auditContext);
           }
           objectPath = tmpDir + AlluxioURI.SEPARATOR + partNumber;
           // eg: /bucket/folder/object_<uploadId>/<partNumber>
@@ -1169,7 +1171,9 @@ public final class S3RestServiceHandler {
         try {
           S3RestUtils.checkStatusesForUploadId(mMetaFS, userFs, tmpDir, uploadId);
         } catch (Exception e) {
-          throw S3RestUtils.toObjectS3Exception(e, object, auditContext);
+          throw S3RestUtils.toObjectS3Exception((e instanceof FileDoesNotExistException) ?
+                          new S3Exception(object, S3ErrorCode.NO_SUCH_UPLOAD) : e,
+                  object, auditContext);
         }
 
         try {
@@ -1316,7 +1320,9 @@ public final class S3RestServiceHandler {
       try {
         S3RestUtils.checkStatusesForUploadId(mMetaFS, userFs, multipartTemporaryDir, uploadId);
       } catch (Exception e) {
-        throw S3RestUtils.toObjectS3Exception(e, object, auditContext);
+        throw S3RestUtils.toObjectS3Exception((e instanceof FileDoesNotExistException) ?
+                        new S3Exception(object, S3ErrorCode.NO_SUCH_UPLOAD) : e,
+                object, auditContext);
       }
 
       try {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -56,7 +56,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.util.ArrayList;
@@ -718,8 +717,8 @@ public final class S3RestServiceHandler {
           try {
             S3RestUtils.checkStatusesForUploadId(mMetaFS, userFs, new AlluxioURI(tmpDir), uploadId);
           } catch (Exception e) {
-            throw S3RestUtils.toObjectS3Exception((e instanceof FileDoesNotExistException) ?
-                            new S3Exception(object, S3ErrorCode.NO_SUCH_UPLOAD) : e,
+            throw S3RestUtils.toObjectS3Exception((e instanceof FileDoesNotExistException)
+                            ? new S3Exception(object, S3ErrorCode.NO_SUCH_UPLOAD) : e,
                     object, auditContext);
           }
           objectPath = tmpDir + AlluxioURI.SEPARATOR + partNumber;
@@ -1171,8 +1170,8 @@ public final class S3RestServiceHandler {
         try {
           S3RestUtils.checkStatusesForUploadId(mMetaFS, userFs, tmpDir, uploadId);
         } catch (Exception e) {
-          throw S3RestUtils.toObjectS3Exception((e instanceof FileDoesNotExistException) ?
-                          new S3Exception(object, S3ErrorCode.NO_SUCH_UPLOAD) : e,
+          throw S3RestUtils.toObjectS3Exception((e instanceof FileDoesNotExistException)
+                          ? new S3Exception(object, S3ErrorCode.NO_SUCH_UPLOAD) : e,
                   object, auditContext);
         }
 
@@ -1320,8 +1319,8 @@ public final class S3RestServiceHandler {
       try {
         S3RestUtils.checkStatusesForUploadId(mMetaFS, userFs, multipartTemporaryDir, uploadId);
       } catch (Exception e) {
-        throw S3RestUtils.toObjectS3Exception((e instanceof FileDoesNotExistException) ?
-                        new S3Exception(object, S3ErrorCode.NO_SUCH_UPLOAD) : e,
+        throw S3RestUtils.toObjectS3Exception((e instanceof FileDoesNotExistException)
+                        ? new S3Exception(object, S3ErrorCode.NO_SUCH_UPLOAD) : e,
                 object, auditContext);
       }
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -54,6 +54,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.util.ArrayList;
@@ -849,6 +852,11 @@ public final class S3RestServiceHandler {
         } else { // CopyObject or UploadPartCopy
           String copySource = !copySourceParam.startsWith(AlluxioURI.SEPARATOR)
               ? AlluxioURI.SEPARATOR + copySourceParam : copySourceParam;
+          try {
+            copySource = URLDecoder.decode(copySource, "UTF-8");
+          } catch (UnsupportedEncodingException ex) {
+            throw S3RestUtils.toObjectS3Exception(ex, objectPath, auditContext);
+          }
           URIStatus status = null;
           CreateFilePOptions.Builder copyFilePOptionsBuilder = CreateFilePOptions.newBuilder()
               .setRecursive(true)

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -152,7 +152,7 @@ public final class ProxyWebServer extends WebServer {
       String responseHeaders = response.getHeaderNames().stream()
               .map(x -> x + ":" + response.getHeader(x))
               .collect(Collectors.joining("\n"));
-      String moreInfoStr = String.format("\n[RequestHeader]:\n%s\n[ResponseHeader]:\n%s",
+      String moreInfoStr = String.format("%n[RequestHeader]:%n%s%n[ResponseHeader]:%n%s",
               requestHeaders, responseHeaders);
       LOG.debug(accessLog + " " + moreInfoStr);
     } else {

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -129,8 +129,10 @@ public final class ProxyWebServer extends WebServer {
 
   public static void logAccess(HttpServletRequest request, HttpServletResponse response, Stopwatch stopWatch)
   {
-    String accessLog = String.format("[ACCESSLOG] Request:%s - Status:%d - Elapsed(ms):%d",
-            request, response.getStatus(), stopWatch.elapsed(TimeUnit.MILLISECONDS));
+    String contentLenStr = request.getHeader("x-amz-decoded-content-length") != null ?
+            request.getHeader("x-amz-decoded-content-length") : request.getHeader("Content-Length");
+    String accessLog = String.format("[ACCESSLOG] Request:%s - Status:%d - ContentLength:%s - Elapsed(ms):%d",
+            request, response.getStatus(), contentLenStr, stopWatch.elapsed(TimeUnit.MILLISECONDS));
     if (LOG.isDebugEnabled()) {
       String requestHeaders = Collections.list(request.getHeaderNames()).stream().map(x -> x + ":" + request.getHeader(x))
               .collect(Collectors.joining("\n"));

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -106,7 +106,7 @@ public final class ProxyWebServer extends WebServer {
       public void service(final ServletRequest req, final ServletResponse res)
               throws ServletException, IOException {
         Stopwatch stopWatch = Stopwatch.createStarted();
-        super.service(req,res);
+        super.service(req, res);
         logAccess((HttpServletRequest) req, (HttpServletResponse) res, stopWatch);
       }
     };
@@ -127,19 +127,30 @@ public final class ProxyWebServer extends WebServer {
     super.stop();
   }
 
-  public static void logAccess(HttpServletRequest request, HttpServletResponse response, Stopwatch stopWatch)
-  {
+  /**
+   * Log the access of every single http request.
+   * @param request
+   * @param response
+   * @param stopWatch
+   */
+  public static void logAccess(HttpServletRequest request, HttpServletResponse response,
+                               Stopwatch stopWatch) {
     String contentLenStr = "None";
-    if (request.getHeader("x-amz-decoded-content-length") != null)
+    if (request.getHeader("x-amz-decoded-content-length") != null) {
       contentLenStr = request.getHeader("x-amz-decoded-content-length");
-    else if (request.getHeader("Content-Length") != null)
+    } else if (request.getHeader("Content-Length") != null) {
       contentLenStr = request.getHeader("Content-Length");
-    String accessLog = String.format("[ACCESSLOG] Request:%s - Status:%d - ContentLength:%s - Elapsed(ms):%d",
-            request, response.getStatus(), contentLenStr, stopWatch.elapsed(TimeUnit.MILLISECONDS));
+    }
+    String accessLog = String.format("[ACCESSLOG] Request:%s - Status:%d "
+                    + "- ContentLength:%s - Elapsed(ms):%d",
+            request, response.getStatus(),
+            contentLenStr, stopWatch.elapsed(TimeUnit.MILLISECONDS));
     if (LOG.isDebugEnabled()) {
-      String requestHeaders = Collections.list(request.getHeaderNames()).stream().map(x -> x + ":" + request.getHeader(x))
+      String requestHeaders = Collections.list(request.getHeaderNames()).stream()
+              .map(x -> x + ":" + request.getHeader(x))
               .collect(Collectors.joining("\n"));
-      String responseHeaders = response.getHeaderNames().stream().map(x -> x + ":" + response.getHeader(x))
+      String responseHeaders = response.getHeaderNames().stream()
+              .map(x -> x + ":" + response.getHeader(x))
               .collect(Collectors.joining("\n"));
       String moreInfoStr = String.format("\n[RequestHeader]:\n%s\n[ResponseHeader]:\n%s",
               requestHeaders, responseHeaders);
@@ -148,5 +159,4 @@ public final class ProxyWebServer extends WebServer {
       LOG.info(accessLog);
     }
   }
-
 }

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -129,8 +129,11 @@ public final class ProxyWebServer extends WebServer {
 
   public static void logAccess(HttpServletRequest request, HttpServletResponse response, Stopwatch stopWatch)
   {
-    String contentLenStr = request.getHeader("x-amz-decoded-content-length") != null ?
-            request.getHeader("x-amz-decoded-content-length") : request.getHeader("Content-Length");
+    String contentLenStr = "None";
+    if (request.getHeader("x-amz-decoded-content-length") != null)
+      contentLenStr = request.getHeader("x-amz-decoded-content-length");
+    else if (request.getHeader("Content-Length") != null)
+      contentLenStr = request.getHeader("Content-Length");
     String accessLog = String.format("[ACCESSLOG] Request:%s - Status:%d - ContentLength:%s - Elapsed(ms):%d",
             request, response.getStatus(), contentLenStr, stopWatch.elapsed(TimeUnit.MILLISECONDS));
     if (LOG.isDebugEnabled()) {
@@ -138,7 +141,7 @@ public final class ProxyWebServer extends WebServer {
               .collect(Collectors.joining("\n"));
       String responseHeaders = response.getHeaderNames().stream().map(x -> x + ":" + response.getHeader(x))
               .collect(Collectors.joining("\n"));
-      String moreInfoStr = String.format("ReqHeader:\n%s - RespHeader:\n%s",
+      String moreInfoStr = String.format("\n[RequestHeader]:\n%s\n[ResponseHeader]:\n%s",
               requestHeaders, responseHeaders);
       LOG.debug(accessLog + " " + moreInfoStr);
     } else {

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -108,7 +108,9 @@ public final class ProxyWebServer extends WebServer {
         Stopwatch stopWatch = Stopwatch.createStarted();
         super.service(req, res);
         if ((req instanceof HttpServletRequest) && (res instanceof HttpServletResponse)) {
-          logAccess((HttpServletRequest) req, (HttpServletResponse) res, stopWatch);
+          HttpServletRequest httpReq = (HttpServletRequest) req;
+          HttpServletResponse httpRes = (HttpServletResponse) res;
+          logAccess(httpReq, httpRes, stopWatch);
         }
       }
     };

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -24,20 +24,31 @@ import alluxio.proxy.s3.CompleteMultipartUploadHandler;
 import alluxio.proxy.s3.S3RestExceptionMapper;
 import alluxio.util.io.PathUtils;
 
+import com.google.common.base.Stopwatch;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * The Alluxio proxy web server.
  */
 @NotThreadSafe
 public final class ProxyWebServer extends WebServer {
-
+  private static final Logger LOG = LoggerFactory.getLogger(ProxyWebServer.class);
   public static final String ALLUXIO_PROXY_SERVLET_RESOURCE_KEY = "Alluxio Proxy";
   public static final String FILE_SYSTEM_SERVLET_RESOURCE_KEY = "File System";
   public static final String STREAM_CACHE_SERVLET_RESOURCE_KEY = "Stream Cache";
@@ -85,10 +96,18 @@ public final class ProxyWebServer extends WebServer {
         super.init();
         getServletContext().setAttribute(ALLUXIO_PROXY_SERVLET_RESOURCE_KEY, proxyProcess);
         getServletContext()
-            .setAttribute(FILE_SYSTEM_SERVLET_RESOURCE_KEY, mFileSystem);
+                .setAttribute(FILE_SYSTEM_SERVLET_RESOURCE_KEY, mFileSystem);
         getServletContext().setAttribute(STREAM_CACHE_SERVLET_RESOURCE_KEY,
-            new StreamCache(Configuration.getMs(PropertyKey.PROXY_STREAM_CACHE_TIMEOUT_MS)));
+                new StreamCache(Configuration.getMs(PropertyKey.PROXY_STREAM_CACHE_TIMEOUT_MS)));
         getServletContext().setAttribute(ALLUXIO_PROXY_AUDIT_LOG_WRITER_KEY, mAsyncAuditLogWriter);
+      }
+
+      @Override
+      public void service(final ServletRequest req, final ServletResponse res)
+              throws ServletException, IOException {
+        Stopwatch stopWatch = Stopwatch.createStarted();
+        super.service(req,res);
+        logAccess((HttpServletRequest) req, (HttpServletResponse) res, stopWatch);
       }
     };
     ServletHolder servletHolder = new ServletHolder("Alluxio Proxy Web Service", servlet);
@@ -107,4 +126,22 @@ public final class ProxyWebServer extends WebServer {
     mFileSystem.close();
     super.stop();
   }
+
+  public static void logAccess(HttpServletRequest request, HttpServletResponse response, Stopwatch stopWatch)
+  {
+    String accessLog = String.format("[ACCESSLOG] Request:%s - Status:%d - Elapsed(ms):%d",
+            request, response.getStatus(), stopWatch.elapsed(TimeUnit.MILLISECONDS));
+    if (LOG.isDebugEnabled()) {
+      String requestHeaders = Collections.list(request.getHeaderNames()).stream().map(x -> x + ":" + request.getHeader(x))
+              .collect(Collectors.joining("\n"));
+      String responseHeaders = response.getHeaderNames().stream().map(x -> x + ":" + response.getHeader(x))
+              .collect(Collectors.joining("\n"));
+      String moreInfoStr = String.format("ReqHeader:\n%s - RespHeader:\n%s",
+              requestHeaders, responseHeaders);
+      LOG.debug(accessLog + " " + moreInfoStr);
+    } else {
+      LOG.info(accessLog);
+    }
+  }
+
 }

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -107,7 +107,9 @@ public final class ProxyWebServer extends WebServer {
               throws ServletException, IOException {
         Stopwatch stopWatch = Stopwatch.createStarted();
         super.service(req, res);
-        logAccess((HttpServletRequest) req, (HttpServletResponse) res, stopWatch);
+        if ((req instanceof HttpServletRequest) && (res instanceof HttpServletResponse)) {
+          logAccess((HttpServletRequest) req, (HttpServletResponse) res, stopWatch);
+        }
       }
     };
     ServletHolder servletHolder = new ServletHolder("Alluxio Proxy Web Service", servlet);


### PR DESCRIPTION
### What changes are proposed in this pull request?

1) Fixed the issue of unable to do aws s3 cp when the source objects has special characters in it. The source object are specified in the header x-amz-copy-source which is url encoded, it should be decoded to give the correct source object name.
2) Add access log to display req http verb / path / query / http body content length / time for processing the request. As well in the debug mode the request and response headers will be displayed.
3) Fixed when the uploadId is not found in multipart upload, it should return NoSuchUpload error code instead of NoSuchKey.

### Why are the changes needed?

To fix incorrect behavior in aws cp and multipart upload APIs.

### Does this PR introduce any user facing changes?

No. 
