### PR TITLE
fix(sec): upgrade com.amazonaws:aws-java-sdk-s3 to 1.12.261

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
@@ -9,8 +10,7 @@
 
     See the NOTICE file distributed with this work for information regarding copyright ownership.
 
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.alluxio</groupId>
   <artifactId>alluxio-parent</artifactId>
@@ -122,9 +122,9 @@
   </repositories>
 
   <properties>
-    <argLine></argLine>
+    <argLine/>
     <apache.curator.version>4.2.0</apache.curator.version>
-    <aws.amazonaws.version>1.11.815</aws.amazonaws.version>
+    <aws.amazonaws.version>1.12.261</aws.amazonaws.version>
     <build.path>build</build.path>
     <catalyst.version>1.2.1</catalyst.version>
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.amazonaws:aws-java-sdk-s3 1.11.815
- [CVE-2022-31159](https://www.oscs1024.com/hd/CVE-2022-31159)


### What did I do？
Upgrade com.amazonaws:aws-java-sdk-s3 from 1.11.815 to 1.12.261 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS