### PR TITLE
Enable journal merger by default for operation atomicity

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3701,9 +3701,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS =
       booleanBuilder(Name.MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS)
-          .setDefaultValue(false)
+          .setDefaultValue(true)
           .setDescription("If enabled, the file system master inode related journals"
-              + "will be merged and submitted BEFORE the inode path lock is released.")
+              + "will be merged and submitted BEFORE the inode path lock is released. "
+              + "This provides a better atomicity guarantee to Alluxio especially in HA.")
           .build();
 
   //
@@ -7600,7 +7601,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_FILE_SYSTEM_OPERATION_RETRY_CACHE_SIZE =
         "alluxio.master.filesystem.operation.retry.cache.size";
     public static final String MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS =
-        "alluxio.master.filesystem.commit.journals.before.release.inode.path.lock";
+        "alluxio.master.filesystem.merge.inode.journals";
 
     //
     // Throttle


### PR DESCRIPTION
### What changes are proposed in this pull request?

This change enables the journal merger by default. Also it corrects a typo in the property key name.

### Why are the changes needed?

Fixes https://github.com/Alluxio/alluxio/issues/16310

### Does this PR introduce any user facing changes?

When a failover happens, there should no longer be chance that a standby master starts with parts of an operation seen and other parts lost. The user should not experience anything but the absence of atomicity errors.