### PR TITLE
Support prefer the worker with the same UFS location when read from ufs

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
@@ -11,6 +11,8 @@
 
 package alluxio.client.file.options;
 
+import static alluxio.conf.PropertyKey.USER_UFS_BLOCK_READ_LOCATION_PREFER_UFS_LOCATION;
+
 import alluxio.client.ReadType;
 import alluxio.client.block.policy.BlockLocationPolicy;
 import alluxio.client.file.FileSystemContext;
@@ -46,6 +48,7 @@ public final class InStreamOptions {
   private final OpenFilePOptions mProtoOptions;
   private BlockLocationPolicy mUfsReadLocationPolicy;
   private boolean mPositionShort;
+  private final boolean mReadPreferUfsLocation;
 
   /**
    * Creates with the default {@link OpenFilePOptions}.
@@ -92,6 +95,8 @@ public final class InStreamOptions {
     mStatus = status;
     mProtoOptions = openOptions;
     mUfsReadLocationPolicy = context.getReadBlockLocationPolicy(alluxioConf);
+    mReadPreferUfsLocation =
+        alluxioConf.getBoolean(USER_UFS_BLOCK_READ_LOCATION_PREFER_UFS_LOCATION);
     mPositionShort = false;
   }
 
@@ -140,6 +145,13 @@ public final class InStreamOptions {
    */
   public boolean getPositionShort() {
     return mPositionShort;
+  }
+
+  /**
+   * @return true, if prefer the worker in the same location in ufs when need to read from ufs
+   */
+  public boolean getReadPreferUfsLocation() {
+    return mReadPreferUfsLocation;
   }
 
   /**

--- a/core/common/src/main/java/alluxio/client/file/URIStatus.java
+++ b/core/common/src/main/java/alluxio/client/file/URIStatus.java
@@ -88,6 +88,16 @@ public class URIStatus {
   }
 
   /**
+   * @param blockId the block ID
+   * @return the ufs location
+   */
+  @Nullable
+  public List<String> getUfsLocations(long blockId) {
+    FileBlockInfo info = mInfo.getFileBlockInfo(blockId);
+    return info == null ? null : info.getUfsLocations();
+  }
+
+  /**
    * @return a list of block ids belonging to the file, empty for directories, immutable
    */
   public List<Long> getBlockIds() {

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6106,6 +6106,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_UFS_BLOCK_READ_LOCATION_PREFER_UFS_LOCATION =
+      booleanBuilder(Name.USER_UFS_BLOCK_READ_LOCATION_PREFER_UFS_LOCATION)
+          .setDefaultValue(false)
+          .setDescription("When data needs to be read from the UFS, "
+              + "Whether to choose the worker based on its location in the UFS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_UFS_BLOCK_READ_LOCATION_POLICY =
       classBuilder(Name.USER_UFS_BLOCK_READ_LOCATION_POLICY)
           .setDefaultValue("alluxio.client.block.policy.LocalFirstPolicy")
@@ -8142,6 +8150,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.ufs.block.location.all.fallback.enabled";
     public static final String USER_UFS_BLOCK_READ_LOCATION_POLICY =
         "alluxio.user.ufs.block.read.location.policy";
+    public static final String USER_UFS_BLOCK_READ_LOCATION_PREFER_UFS_LOCATION =
+        "alluxio.user.ufs.block.read.location.prefer.ufs.location";
     public static final String USER_UFS_BLOCK_READ_LOCATION_POLICY_DETERMINISTIC_HASH_SHARDS =
         "alluxio.user.ufs.block.read.location.policy.deterministic.hash.shards";
     public static final String USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_SIZE =

--- a/job/server/src/main/java/alluxio/job/util/JobUtils.java
+++ b/job/server/src/main/java/alluxio/job/util/JobUtils.java
@@ -28,6 +28,7 @@ import alluxio.collections.IndexedSet;
 import alluxio.collections.Pair;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.ExceptionMessage;
 import alluxio.exception.status.NotFoundException;
@@ -202,7 +203,8 @@ public final class JobUtils {
     BlockInfo info = Preconditions.checkNotNull(status.getBlockInfo(blockId));
     long blockLength = info.getLength();
     Pair<WorkerNetAddress, BlockInStream.BlockInStreamSource> dataSourceAndType = blockStore
-        .getDataSourceAndType(status.getBlockInfo(blockId), status, policy, ImmutableMap.of());
+        .getDataSourceAndType(status.getBlockInfo(blockId), status, policy, conf.getBoolean(
+            PropertyKey.USER_UFS_BLOCK_READ_LOCATION_PREFER_UFS_LOCATION), ImmutableMap.of());
     WorkerNetAddress dataSource = dataSourceAndType.getFirst();
     String host = dataSource.getHost();
     // issues#11172: If the worker is in a container, use the container hostname

--- a/shell/src/main/java/alluxio/cli/fs/command/LoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LoadCommand.java
@@ -139,7 +139,9 @@ public final class LoadCommand extends AbstractFileSystemCommand {
       } else { // send request to data source
         BlockStoreClient blockStore = BlockStoreClient.create(mFsContext);
         Pair<WorkerNetAddress, BlockInStream.BlockInStreamSource> dataSourceAndType = blockStore
-            .getDataSourceAndType(status.getBlockInfo(blockId), status, policy, ImmutableMap.of());
+            .getDataSourceAndType(status.getBlockInfo(blockId), status, policy,
+                conf.getBoolean(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_PREFER_UFS_LOCATION),
+                ImmutableMap.of());
         dataSource = dataSourceAndType.getFirst();
       }
       Protocol.OpenUfsBlockOptions openUfsBlockOptions =


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support prefer the worker with the same UFS location when read from ufs.

### Why are the changes needed?

Reading from the UFS will be faster if prefer a worker with the same location as the UFS.

### Does this PR introduce any user facing changes?

add config `alluxio.user.ufs.block.read.location.prefer.ufs.location`
