### PR TITLE
Reduce useless async cache request when read from remote worker

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -39,7 +39,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.io.Closer;
-import com.sun.org.apache.bcel.internal.generic.IF_ACMPEQ;
 import io.grpc.StatusRuntimeException;
 import io.netty.util.internal.OutOfDirectMemoryError;
 import org.slf4j.Logger;


### PR DESCRIPTION
### What changes are proposed in this pull request?

reduce useless async cache request when read from remote worker

### Why are the changes needed?

It is useless to trigger async cache when the remote worker has already cached block.

### Does this PR introduce any user facing changes?

No user facing changes.