### PR TITLE
Fix unwanted message for empty job of distributedLoad

### DIFF
--- a/job/server/src/main/java/alluxio/master/job/tracker/CmdJobTracker.java
+++ b/job/server/src/main/java/alluxio/master/job/tracker/CmdJobTracker.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -143,9 +144,9 @@ public class CmdJobTracker {
 
     CmdInfo cmdInfo = mInfoMap.get(jobControlId);
 
-    if (cmdInfo.getCmdRunAttempt().isEmpty()) { // If no attempts created, throws an Exception
-      throw new JobDoesNotExistException(
-              ExceptionMessage.JOB_DEFINITION_DOES_NOT_EXIST.getMessage(jobControlId));
+    if (cmdInfo.getCmdRunAttempt().isEmpty()) { // If no attempts created,
+      // that means the files are loaded already, set status to complete
+      return Status.COMPLETED;
     }
 
     int completed = 0;
@@ -254,9 +255,10 @@ public class CmdJobTracker {
 
     CmdInfo cmdInfo = mInfoMap.get(jobControlId);
 
-    if (cmdInfo.getCmdRunAttempt().isEmpty()) { // If no attempts are created, throws an Exception
-      throw new JobDoesNotExistException(
-              ExceptionMessage.JOB_DEFINITION_DOES_NOT_EXIST.getMessage(jobControlId));
+    if (cmdInfo.getCmdRunAttempt().isEmpty()) { // If no attempts are created,
+      // that means the files are loaded already, set status to complete
+      return new CmdStatusBlock(cmdInfo.getJobControlId(), Collections.EMPTY_LIST,
+              cmdInfo.getOperationType());
     }
 
     List<SimpleJobStatusBlock> blockList = cmdInfo.getCmdRunAttempt().stream()

--- a/job/server/src/main/java/alluxio/master/job/tracker/DistLoadCliRunner.java
+++ b/job/server/src/main/java/alluxio/master/job/tracker/DistLoadCliRunner.java
@@ -88,7 +88,7 @@ public class DistLoadCliRunner extends AbstractCmdRunner {
       load(filePath, batchSize, replication, workerSet, excludedWorkerSet, localityIds,
               excludedLocalityIds, directCache, filePool, cmdInfo);
     } catch (IOException | AlluxioException e) {
-      LOG.warn("failing in distcp!");
+      LOG.warn(String.format("DistributedLoad job is failing for path = %s!", filePath.getPath()));
       LOG.error(e.getMessage());
       throw new IOException(e.getMessage());
     }

--- a/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/AbstractDistributedJobCommand.java
@@ -149,10 +149,7 @@ public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCo
         }
       } catch (IOException e) {
         System.out.println(String.format("Unable to get running status for command %s."
-                + " For distributedLoad, the files may already be loaded in Alluxio."
-                + " For distributedCp, please check file source contains files or not."
-                + " Please retry using `getCmdStatus` to check command detailed status,"
-                + " or using `fs ls` command to check if the files are already loaded.",
+                + " Please retry using `getCmdStatus` to check command detailed status,",
                 jobControlId));
         break;
       }
@@ -176,7 +173,6 @@ public abstract class AbstractDistributedJobCommand extends AbstractFileSystemCo
               jobControlId);
     } catch (IOException e) {
       System.out.println(String.format("Unable to get detailed command information for command %s,"
-              + " the files may already be loaded in Alluxio or file souce may not contain files"
               + "%n", jobControlId));
     }
   }

--- a/shell/src/main/java/alluxio/cli/job/command/GetCmdStatusCommand.java
+++ b/shell/src/main/java/alluxio/cli/job/command/GetCmdStatusCommand.java
@@ -88,10 +88,7 @@ public class GetCmdStatusCommand extends AbstractFileSystemCommand {
     } catch (Exception e) {
       LOG.error("Failed to get detailed status of the command", e);
       System.out.println(String.format("Unable to get detailed information for command %s."
-                      + " For distributedLoad, the files may already be loaded in Alluxio."
-                      + " For distributedCp, please check file source contains files or not."
-                      + " Please retry using `getCmdStatus` to check command detailed status,"
-                      + " or using `fs ls` command to check if the files are already loaded.",
+                      + " Please retry using `getCmdStatus` to check command detailed status,",
               jobControlId));
       return -1;
     }

--- a/shell/src/main/java/alluxio/cli/util/DistributedCommandUtil.java
+++ b/shell/src/main/java/alluxio/cli/util/DistributedCommandUtil.java
@@ -85,9 +85,7 @@ public class DistributedCommandUtil {
     }
 
     if (cmdStatus.getJobStatusBlock().isEmpty()) {
-      System.out.format("Unable to get command status for jobControlId=%s, please retry"
-             + " or use `fs ls` command to check if files are already loaded in Alluxio.%n",
-              jobControlId);
+      System.out.format("Job is completed successfully.%n");
     } else {
       System.out.format("Get command status information below: %n");
 

--- a/shell/src/main/java/alluxio/cli/util/DistributedCommandUtil.java
+++ b/shell/src/main/java/alluxio/cli/util/DistributedCommandUtil.java
@@ -85,7 +85,7 @@ public class DistributedCommandUtil {
     }
 
     if (cmdStatus.getJobStatusBlock().isEmpty()) {
-      System.out.format("Job is completed successfully.%n");
+      System.out.format("Job is completed successfully, 0 files are loaded and 0 files failed.%n");
     } else {
       System.out.format("Get command status information below: %n");
 

--- a/shell/src/main/java/alluxio/cli/util/DistributedCommandUtil.java
+++ b/shell/src/main/java/alluxio/cli/util/DistributedCommandUtil.java
@@ -84,11 +84,10 @@ public class DistributedCommandUtil {
       printKeyWord = "processed";
     }
 
+    System.out.format("Get command status information below: %n");
     if (cmdStatus.getJobStatusBlock().isEmpty()) {
-      System.out.format("Job is completed successfully, 0 files are loaded and 0 files failed.%n");
+      System.out.format("Total completed file count is 0, failed file count is 0%n");
     } else {
-      System.out.format("Get command status information below: %n");
-
       completedFiles.forEach(file -> {
         System.out.format("Successfully %s path %s%n", printKeyWord, file);
       });

--- a/shell/src/main/java/alluxio/cli/util/DistributedCommandUtil.java
+++ b/shell/src/main/java/alluxio/cli/util/DistributedCommandUtil.java
@@ -96,4 +96,6 @@ public class DistributedCommandUtil {
               completedCount, failedCount);
     }
   }
+
+  private DistributedCommandUtil() {} // prevent instantiation
 }

--- a/shell/src/main/java/alluxio/cli/util/DistributedCommandUtil.java
+++ b/shell/src/main/java/alluxio/cli/util/DistributedCommandUtil.java
@@ -84,7 +84,7 @@ public class DistributedCommandUtil {
       printKeyWord = "processed";
     }
 
-    System.out.format("Get command status information below: %n");
+    System.out.println("Get command status information below:");
     if (cmdStatus.getJobStatusBlock().isEmpty()) {
       System.out.format("Total completed file count is 0, failed file count is 0%n");
     } else {

--- a/tests/src/test/java/alluxio/client/cli/job/GetCmdStatusCommandTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/GetCmdStatusCommandTest.java
@@ -78,7 +78,7 @@ public class GetCmdStatusCommandTest extends AbstractFileSystemShellTest  {
 
     mOutput.reset();
     sJobShell.run("getCmdStatus", jobControlId);
-    Assert.assertTrue(mOutput.toString().contains("Get command status information below: "));
+    Assert.assertTrue(mOutput.toString().contains("Get command status information below:"));
     Assert.assertTrue(mOutput.toString().contains(
             "Successfully loaded path /testRoot/testFileA\n"));
     Assert.assertTrue(mOutput.toString().contains(


### PR DESCRIPTION
### What changes are proposed in this pull request?
If no actual load happens on the server side, then the command just outputs "Job is completed successfully." as its default 
success state.

An example is below:
**Example 1:**
➜  alluxio git:(patch-fix) bin/alluxio fs distributedLoad /dir3
Please wait for command submission to finish..
Submitted successfully, jobControlId = 1665695558406
Waiting for the command to finish ...
Get command status information below:
Total completed file count is 0, failed file count is 0
Finished running the command, jobControlId = 1665695558406

➜  alluxio git:(patch-fix) bin/alluxio job getCmdStatus  1665695558406
Get command status information below:
Total completed file count is 0, failed file count is 0

**Example 2:**
Create an empty dir and check the output.
➜  alluxio git:(patch-fix) ✗ bin/alluxio fs mkdir /zzz
Successfully created directory /zzz

➜  alluxio git:(patch-fix) bin/alluxio fs distributedLoad /zzz
Please wait for command submission to finish..
Submitted successfully, jobControlId = 1665695558407
Waiting for the command to finish ...
Get command status information below:
Total completed file count is 0, failed file count is 0
Finished running the command, jobControlId = 1665695558407

➜  alluxio git:(patch-fix) bin/alluxio job getCmdStatus  1665695558407
Get command status information below:
Total completed file count is 0, failed file count is 0
`
