### PR TITLE
Add invalidation client interface

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
@@ -335,4 +335,11 @@ public interface FileSystemMasterClient extends Client {
    * @return the state lock waiters and holders thread identifiers
    */
   List<String> getStateLockHolders() throws AlluxioStatusException;
+
+  /**
+   * Mark a path as needed synchronization with the UFS, when this path or any
+   * of its children are accessed, a sync with the UFS will be performed.
+   * @param path the path to invalidate
+   */
+  void invalidateSyncPath(AlluxioURI path) throws AlluxioStatusException;
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -42,6 +42,7 @@ import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.GetStatusPRequest;
 import alluxio.grpc.GetSyncPathListPRequest;
 import alluxio.grpc.GrpcUtils;
+import alluxio.grpc.InvalidateSyncPathRequest;
 import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.ListStatusPRequest;
 import alluxio.grpc.ListStatusPartialPOptions;
@@ -407,6 +408,14 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
           .forEach((thread) -> result.add(thread));
       return result;
     }, RPC_LOG, "GetStateLockHolders", "");
+  }
+
+  @Override
+  public void invalidateSyncPath(AlluxioURI path) throws AlluxioStatusException {
+    retryRPC(
+        () -> mClient.invalidateSyncPath(
+            InvalidateSyncPathRequest.newBuilder().setPath(getTransportPath(path)).build()),
+        RPC_LOG, "InvalidateSyncPath", "path=%s", path);
   }
 
   /**

--- a/core/client/fs/src/test/java/alluxio/client/file/MockFileSystemMasterClient.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/MockFileSystemMasterClient.java
@@ -230,4 +230,8 @@ class MockFileSystemMasterClient implements FileSystemMasterClient {
   @Override
   public void close() throws IOException {
   }
+
+  @Override
+  public void invalidateSyncPath(AlluxioURI path) throws AlluxioStatusException {
+  }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -48,6 +48,8 @@ import alluxio.grpc.GetStatusPResponse;
 import alluxio.grpc.GetSyncPathListPRequest;
 import alluxio.grpc.GetSyncPathListPResponse;
 import alluxio.grpc.GrpcUtils;
+import alluxio.grpc.InvalidateSyncPathRequest;
+import alluxio.grpc.InvalidateSyncPathResponse;
 import alluxio.grpc.ListStatusPRequest;
 import alluxio.grpc.ListStatusPResponse;
 import alluxio.grpc.ListStatusPartialPRequest;
@@ -459,6 +461,15 @@ public final class FileSystemMasterClientServiceHandler
       final List<String> holders = mFileSystemMaster.getStateLockSharedWaitersAndHolders();
       return GetStateLockHoldersPResponse.newBuilder().addAllThreads(holders).build();
     }, "getStateLockHolders", "request=%s", responseObserver, request);
+  }
+
+  @Override
+  public void invalidateSyncPath(InvalidateSyncPathRequest request,
+                                 StreamObserver<InvalidateSyncPathResponse> responseObserver) {
+    RpcUtils.call(LOG, () -> {
+      mFileSystemMaster.invalidateSyncPath(new AlluxioURI(request.getPath()));
+      return InvalidateSyncPathResponse.getDefaultInstance();
+    }, "InvalidateSyncPath", true, "request=%s", responseObserver, request);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/SyncCheck.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/SyncCheck.java
@@ -58,6 +58,11 @@ public class SyncCheck {
     mLastSyncTime = lastSyncTime;
   }
 
+  @Override
+  public String toString() {
+    return String.format("{Should sync: %b, Last sync time: %d}", mShouldSync, mLastSyncTime);
+  }
+
   /**
    * @return true if a sync is necessary
    */

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -573,6 +573,12 @@ message GetStateLockHoldersPRequest {
   optional GetStateLockHoldersPOptions options = 1;
 }
 
+message InvalidateSyncPathRequest {
+  required string path = 1;
+}
+
+message InvalidateSyncPathResponse {}
+
 
 /**
  * This interface contains file system master service endpoints for Alluxio clients.
@@ -717,6 +723,8 @@ service FileSystemMasterClientService {
   rpc UpdateUfsMode(UpdateUfsModePRequest) returns (UpdateUfsModePResponse);
 
   rpc GetStateLockHolders(GetStateLockHoldersPRequest) returns (GetStateLockHoldersPResponse);
+
+  rpc InvalidateSyncPath(InvalidateSyncPathRequest) returns (InvalidateSyncPathResponse);
 }
 
 message FileSystemHeartbeatPResponse {

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -3588,6 +3588,19 @@
             ]
           },
           {
+            "name": "InvalidateSyncPathRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "path",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "InvalidateSyncPathResponse"
+          },
+          {
             "name": "FileSystemHeartbeatPResponse",
             "fields": [
               {
@@ -3849,6 +3862,11 @@
                 "name": "GetStateLockHolders",
                 "in_type": "GetStateLockHoldersPRequest",
                 "out_type": "GetStateLockHoldersPResponse"
+              },
+              {
+                "name": "InvalidateSyncPath",
+                "in_type": "InvalidateSyncPathRequest",
+                "out_type": "InvalidateSyncPathResponse"
               }
             ]
           },

--- a/integration/fuse/src/test/java/alluxio/fuse/cli/MockFuseFileSystemMasterClient.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/cli/MockFuseFileSystemMasterClient.java
@@ -198,6 +198,10 @@ class MockFuseFileSystemMasterClient implements FileSystemMasterClient {
   }
 
   @Override
+  public void invalidateSyncPath(AlluxioURI path) throws AlluxioStatusException {
+  }
+
+  @Override
   public void connect() throws IOException {
   }
 


### PR DESCRIPTION
Add the client interface to mark a path as needing synchronization with the UFS.

`void invalidateSyncPath(AlluxioURI path) throws AlluxioStatusException`