### PR TITLE
Reduce creation of unused strings

### DIFF
--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -197,9 +197,9 @@ public class InstancedConfiguration implements AlluxioConfiguration {
         throw new IllegalArgumentException(
             format("Invalid value for property key %s: %s", key, value));
       }
-      LOG.warn(format("The value %s for property key %s is invalid. PropertyKey are now typed "
+      LOG.warn("The value {} for property key {} is invalid. PropertyKey are now typed "
               + "and require values to be properly typed. Invalid PropertyKey values will not be "
-              + "accepted in 3.0", value, key));
+              + "accepted in 3.0", value, key);
       mProperties.put(key, key.parseValue(value), Source.RUNTIME);
     }
   }
@@ -255,9 +255,9 @@ public class InstancedConfiguration implements AlluxioConfiguration {
   @Override
   public String getString(PropertyKey key) {
     if (key.getType() != PropertyKey.PropertyType.STRING) {
-      LOG.warn(format("PropertyKey %s's type is %s, please use proper getter method for the type, "
+      LOG.warn("PropertyKey {}'s type is {}, please use proper getter method for the type, "
           + "getString will no longer work for non-STRING property types in 3.0",
-          key, key.getType()));
+          key, key.getType());
     }
     Object value = get(key);
     if (value instanceof String) {
@@ -475,9 +475,9 @@ public class InstancedConfiguration implements AlluxioConfiguration {
       String message = "%s cannot be specified when allowing multiple workers per host with "
           + PropertyKey.Name.INTEGRATION_YARN_WORKERS_PER_HOST_MAX + "=" + maxWorkersPerHost;
       checkState(System.getProperty(PropertyKey.Name.WORKER_RPC_PORT) == null,
-          String.format(message, PropertyKey.WORKER_RPC_PORT));
+          message, PropertyKey.WORKER_RPC_PORT);
       checkState(System.getProperty(PropertyKey.Name.WORKER_WEB_PORT) == null,
-          String.format(message, PropertyKey.WORKER_WEB_PORT));
+          message, PropertyKey.WORKER_WEB_PORT);
     }
   }
 

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -8930,7 +8930,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public Class<? extends Enum> getEnumType()
   {
     checkState(mType == PropertyType.ENUM && mEnumType.isPresent(),
-        format("PropertyKey %s is not of enum type", mName));
+        "PropertyKey %s is not of enum type", mName);
     return mEnumType.get();
   }
 
@@ -8939,7 +8939,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
    */
   public String getDelimiter() {
     checkState(mType == PropertyType.LIST && mDelimiter.isPresent(),
-        format("PropertyKey %s is not of list type", mName));
+        "PropertyKey %s is not of list type", mName);
     return mDelimiter.get();
   }
 

--- a/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
+++ b/core/common/src/main/java/alluxio/underfs/UnderFileSystemWithLogging.java
@@ -1249,7 +1249,7 @@ public class UnderFileSystemWithLogging implements UnderFileSystem {
           methodName, callable, durationMs, e.toString());
       if (durationMs >= mLoggingThreshold) {
         LOG.warn("{}({}) returned \"{}\" in {} ms (>={} ms)", methodName,
-            callable, e.toString(), durationMs, mLoggingThreshold);
+            callable, e, durationMs, mLoggingThreshold);
       }
       throw e;
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -500,12 +500,14 @@ public class JournalStateMachine extends BaseStateMachine {
    * @param entry the entry to apply
    */
   private void applyEntry(JournalEntry entry) {
-    Preconditions.checkState(
-        entry.getAllFields().size() <= 2
-            || (entry.getAllFields().size() == 3 && entry.hasSequenceNumber()),
-        "Raft journal entries should never set multiple fields in addition to sequence "
-            + "number, but found %s",
-        entry);
+    if (LOG.isDebugEnabled()) {
+      Preconditions.checkState(
+          entry.getAllFields().size() <= 2
+              || (entry.getAllFields().size() == 3 && entry.hasSequenceNumber()),
+          "Raft journal entries should never set multiple fields in addition to sequence "
+              + "number, but found %s",
+          entry);
+    }
     if (entry.getJournalEntriesCount() > 0) {
       // This entry aggregates multiple entries.
       for (JournalEntry e : entry.getJournalEntriesList()) {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -501,6 +501,8 @@ public class JournalStateMachine extends BaseStateMachine {
    */
   private void applyEntry(JournalEntry entry) {
     if (LOG.isDebugEnabled()) {
+      // This check is put behind the debug flag as the call to getAllFields creates
+      // a map and is very expensive
       Preconditions.checkState(
           entry.getAllFields().size() <= 2
               || (entry.getAllFields().size() == 3 && entry.hasSequenceNumber()),

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -453,7 +453,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
       Preconditions.checkState(groupIter.hasNext(), "no group info found");
       RaftGroup group = groupIter.next();
       Preconditions.checkState(group.getGroupId() == RAFT_GROUP_ID,
-          String.format("Invalid group id %s, expecting %s", group.getGroupId(), RAFT_GROUP_ID));
+          "Invalid group id %s, expecting %s", group.getGroupId(), RAFT_GROUP_ID);
       return group;
     } catch (IOException | IllegalStateException e) {
       LogUtils.warnWithException(LOG, "Failed to get raft group, falling back to initial group", e);

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -666,11 +666,11 @@ public final class S3RestServiceHandler {
       Preconditions.checkArgument(!(partNumber != null && tagging != null),
           "Only one of 'partNumber' and 'tagging' can be set.");
       Preconditions.checkArgument(!(taggingHeader != null && tagging != null),
-          String.format("Only one of '%s' and 'tagging' can be set.",
-              S3Constants.S3_TAGGING_HEADER));
+          "Only one of '%s' and 'tagging' can be set.",
+              S3Constants.S3_TAGGING_HEADER);
       Preconditions.checkArgument(!(copySourceParam != null && tagging != null),
-          String.format("Only one of '%s' and 'tagging' can be set.",
-              S3Constants.S3_COPY_SOURCE_HEADER));
+          "Only one of '%s' and 'tagging' can be set.",
+              S3Constants.S3_COPY_SOURCE_HEADER);
       // Uncomment the following check when supporting ACLs
       // Preconditions.checkArgument(!(copySourceParam != null && acl != null),
       //     String.format("Must use the header \"%s\" to provide ACL for CopyObject.",

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
@@ -69,8 +69,10 @@ public class FuseFileInOrOutStream implements FuseFileStream {
     if (status.isPresent() && truncate) {
       AlluxioFuseUtils.deletePath(fileSystem, uri);
       currentStatus = Optional.empty();
-      LOG.debug(String.format("Open path %s with flag 0x%x for overwriting. "
-          + "Alluxio deleted the old file and created a new file for writing", uri, flags));
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(String.format("Open path %s with flag 0x%x for overwriting. "
+            + "Alluxio deleted the old file and created a new file for writing", uri, flags));
+      }
     }
     if (!currentStatus.isPresent()) {
       FuseFileOutStream outStream = FuseFileOutStream.create(fileSystem, authPolicy,

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileOutStream.java
@@ -78,8 +78,10 @@ public class FuseFileOutStream implements FuseFileStream {
         // support create empty file then open for write/read_write workload
         AlluxioFuseUtils.deletePath(fileSystem, uri);
         fileLen = 0;
-        LOG.debug(String.format("Open path %s with flag 0x%x for overwriting. "
-            + "Alluxio deleted the old file and created a new file for writing", uri, flags));
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(String.format("Open path %s with flag 0x%x for overwriting. "
+              + "Alluxio deleted the old file and created a new file for writing", uri, flags));
+        }
       } else {
         // Support open(O_WRONLY flag) - truncate(0) - write() workflow, otherwise error out
         return new FuseFileOutStream(fileSystem, authPolicy, Optional.empty(), fileLen, uri, mode);

--- a/shell/src/main/java/alluxio/cli/fs/command/CopyFromLocalCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CopyFromLocalCommand.java
@@ -51,9 +51,11 @@ public final class CopyFromLocalCommand extends AbstractFileSystemCommand {
         fsContext.getClusterConf().copyProperties());
     conf.set(PropertyKey.USER_BLOCK_WRITE_LOCATION_POLICY,
         conf.get(PropertyKey.USER_FILE_COPYFROMLOCAL_BLOCK_LOCATION_POLICY));
-    LOG.debug(String.format("copyFromLocal block write location policy is %s from property %s",
-        conf.get(PropertyKey.USER_BLOCK_WRITE_LOCATION_POLICY),
-        PropertyKey.USER_FILE_COPYFROMLOCAL_BLOCK_LOCATION_POLICY.getName()));
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(String.format("copyFromLocal block write location policy is %s from property %s",
+          conf.get(PropertyKey.USER_BLOCK_WRITE_LOCATION_POLICY),
+          PropertyKey.USER_FILE_COPYFROMLOCAL_BLOCK_LOCATION_POLICY.getName()));
+    }
     FileSystemContext updatedCtx = FileSystemContext.create(conf);
     mFsContext = updatedCtx;
     mFileSystem = FileSystem.Factory.create(updatedCtx);


### PR DESCRIPTION
When calling precondition or debug logs, avoid creating strings that are not used.

Also the precondition check on line 503 of JournalStateMachine is put behind a debug flag, as that operation is extremely expensive (it causes the most memory allocation of all operations on the standby master).