### PR TITLE
Fix the time used to calculate the gap between two heartbeats

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/throttle/SystemMonitor.java
+++ b/core/server/master/src/main/java/alluxio/master/throttle/SystemMonitor.java
@@ -417,7 +417,7 @@ public class SystemMonitor {
       }
     }
 
-    mLastHeartBeatTimeMS = System.nanoTime();
+    mLastHeartBeatTimeMS = System.currentTimeMillis();
   }
 }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix the time used to calculate the gap between two heartbeats

### Why are the changes needed?

The time unit should be mini seconds, it was using nano seconds.

### Does this PR introduce any user facing changes?
NA