### PR TITLE
Avoid CloseableIterator leak false alarms

### DIFF
--- a/core/common/src/main/java/alluxio/resource/CloseableIterator.java
+++ b/core/common/src/main/java/alluxio/resource/CloseableIterator.java
@@ -144,8 +144,11 @@ public abstract class CloseableIterator<T> extends CloseableResource<Iterator<T>
    */
   @VisibleForTesting
   public static int size(CloseableIterator<?> iter) {
-    int size = Iterators.size(iter);
-    iter.close();
-    return size;
+    try {
+      int size = Iterators.size(iter);
+      return size;
+    } finally {
+      iter.close();
+    }
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/metastore/ReadOnlyInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/ReadOnlyInodeStore.java
@@ -153,7 +153,7 @@ public interface ReadOnlyInodeStore extends Closeable {
         }
       }
     };
-    return CloseableIterator.create(iter, (any) -> it.closeResource());
+    return CloseableIterator.create(iter, (any) -> it.close());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
@@ -106,7 +106,7 @@ public class HeapInodeStore implements InodeStore {
         .map(this::get)
         .filter(Optional::isPresent)
         .map(Optional::get)
-        .map(Inode::wrap).iterator(), (any) -> childIter.closeResource());
+        .map(Inode::wrap).iterator(), (any) -> childIter.close());
   }
 
   @Override

--- a/core/server/master/src/test/java/alluxio/master/metastore/InodeStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/InodeStoreTest.java
@@ -39,6 +39,8 @@ import alluxio.master.metastore.rocks.RocksInodeStore;
 import alluxio.resource.CloseableIterator;
 import alluxio.resource.LockResource;
 
+import com.google.common.collect.ImmutableMap;
+import io.netty.util.ResourceLeakDetector;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -77,9 +79,12 @@ public class InodeStoreTest {
   }
 
   @Rule
-  public ConfigurationRule mConf =
-      new ConfigurationRule(PropertyKey.MASTER_METASTORE_INODE_CACHE_MAX_SIZE,
-          CACHE_SIZE, Configuration.modifiableGlobal());
+  public ConfigurationRule mConf = new ConfigurationRule(
+      ImmutableMap.of(PropertyKey.MASTER_METASTORE_INODE_CACHE_MAX_SIZE, CACHE_SIZE,
+          PropertyKey.MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE, 5,
+          PropertyKey.LEAK_DETECTOR_LEVEL, ResourceLeakDetector.Level.PARANOID,
+          PropertyKey.LEAK_DETECTOR_EXIT_ON_LEAK, true),
+      Configuration.modifiableGlobal());
 
   private final MutableInodeDirectory mRoot = inodeDir(0, -1, "");
 

--- a/core/server/master/src/test/java/alluxio/master/metastore/caching/CachingInodeStoreMockedBackingStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/caching/CachingInodeStoreMockedBackingStoreTest.java
@@ -37,7 +37,9 @@ import alluxio.master.metastore.ReadOption;
 import alluxio.master.metastore.heap.HeapInodeStore;
 import alluxio.resource.CloseableIterator;
 
+import alluxio.wire.Property;
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.ResourceLeakDetector;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -67,7 +69,9 @@ public class CachingInodeStoreMockedBackingStoreTest {
   @Rule
   public ConfigurationRule mConf = new ConfigurationRule(
       ImmutableMap.of(PropertyKey.MASTER_METASTORE_INODE_CACHE_MAX_SIZE, CACHE_SIZE,
-          PropertyKey.MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE, 5),
+          PropertyKey.MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE, 5,
+          PropertyKey.LEAK_DETECTOR_LEVEL, ResourceLeakDetector.Level.PARANOID,
+          PropertyKey.LEAK_DETECTOR_EXIT_ON_LEAK, true),
       Configuration.modifiableGlobal());
 
   @Before
@@ -151,7 +155,6 @@ public class CachingInodeStoreMockedBackingStoreTest {
       MutableInodeDirectory dir = createInodeDir(inodeId, 0);
       mStore.addChild(0, dir);
     }
-
     assertEquals(CACHE_SIZE * 2, CloseableIterator.size(mStore.getChildren(0L)));
   }
 

--- a/core/server/master/src/test/java/alluxio/master/metastore/caching/CachingInodeStoreMockedBackingStoreTest.java
+++ b/core/server/master/src/test/java/alluxio/master/metastore/caching/CachingInodeStoreMockedBackingStoreTest.java
@@ -37,7 +37,6 @@ import alluxio.master.metastore.ReadOption;
 import alluxio.master.metastore.heap.HeapInodeStore;
 import alluxio.resource.CloseableIterator;
 
-import alluxio.wire.Property;
 import com.google.common.collect.ImmutableMap;
 import io.netty.util.ResourceLeakDetector;
 import org.junit.After;


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix how `CloseableIterator` is closed to avoid false leak alarms.

### Why are the changes needed?

For places where an iterator is associated with some resources that need to be closed, we use `CloseableIterator` which requires explicit closing. Additionally we use the leak detector to catch unclosed ones (if they are enabled).

This change fixes below leak detection complaints:
```
2022-10-10 14:15:30,225 ERROR AlluxioResourceLeakDetector - LEAK: CloseableResource.close() was not called before resource is garbage-collected. See https://docs.alluxio.io/os/user/stable/en/operation/Troubleshooting.html#resource-leak-detection for more information about this message.
Recent access records: 
Created at:
	alluxio.resource.CloseableResource.<init>(CloseableResource.java:35)
	alluxio.resource.CloseableIterator.<init>(CloseableIterator.java:47)
	alluxio.resource.CloseableIterator$2.<init>(CloseableIterator.java:93)
	alluxio.resource.CloseableIterator.noopCloseable(CloseableIterator.java:93)
	alluxio.master.metastore.caching.CachingInodeStore$ListingCache.getChildIds(CachingInodeStore.java:734)
	alluxio.master.metastore.caching.CachingInodeStore.getChildIds(CachingInodeStore.java:214)
	alluxio.master.metastore.ReadOnlyInodeStore.getChildren(ReadOnlyInodeStore.java:127)
	alluxio.master.metastore.DelegatingReadOnlyInodeStore.getChildren(DelegatingReadOnlyInodeStore.java:56)
	alluxio.master.metastore.ReadOnlyInodeStore.getChildren(ReadOnlyInodeStore.java:182)
	alluxio.master.file.InodeSyncStream.syncExistingInodeMetadata(InodeSyncStream.java:869)
	alluxio.master.file.InodeSyncStream.syncInodeMetadata(InodeSyncStream.java:698)
	alluxio.master.file.InodeSyncStream.syncInternal(InodeSyncStream.java:464)
	alluxio.master.file.InodeSyncStream.sync(InodeSyncStream.java:404)
	alluxio.master.file.DefaultFileSystemMaster.loadMetadataIfNotExist(DefaultFileSystemMaster.java:3224)
	alluxio.master.file.DefaultFileSystemMaster.listStatus(DefaultFileSystemMaster.java:1102)
	alluxio.master.file.FileSystemMasterClientServiceHandler.lambda$listStatus$10(FileSystemMasterClientServiceHandler.java:257)
	alluxio.RpcUtils.callAndReturn(RpcUtils.java:125)
```

However, the "leaks" above are not really leaks. It is just we forgot to remove them from the tracker after we have done the close action. The so called "leak" is actually mild and misleading.

### Does this PR introduce any user facing changes?

NA