### PR TITLE
Mark root as needing sync on backup restore

### DIFF
--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -676,14 +676,11 @@ public final class MultiProcessCluster {
     File metastoreDir = new File(mWorkDir, "metastore-master" + extension);
     File logsDir = new File(mWorkDir, "logs-master" + extension);
     logsDir.mkdirs();
-    File underFsDir = new File(mWorkDir, "underFSStorage-master" + extension);
-    underFsDir.mkdirs();
     Map<PropertyKey, Object> conf = new HashMap<>();
     conf.put(PropertyKey.LOGGER_TYPE, "MASTER_LOGGER");
     conf.put(PropertyKey.CONF_DIR, confDir.getAbsolutePath());
     conf.put(PropertyKey.MASTER_METASTORE_DIR, metastoreDir.getAbsolutePath());
     conf.put(PropertyKey.LOGS_DIR, logsDir.getAbsolutePath());
-    conf.put(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, underFsDir);
     conf.put(PropertyKey.MASTER_HOSTNAME, address.getHostname());
     conf.put(PropertyKey.MASTER_RPC_PORT, address.getRpcPort());
     conf.put(PropertyKey.MASTER_WEB_PORT, address.getWebPort());

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -676,11 +676,14 @@ public final class MultiProcessCluster {
     File metastoreDir = new File(mWorkDir, "metastore-master" + extension);
     File logsDir = new File(mWorkDir, "logs-master" + extension);
     logsDir.mkdirs();
+    File underFsDir = new File(mWorkDir, "underFSStorage-master" + extension);
+    underFsDir.mkdirs();
     Map<PropertyKey, Object> conf = new HashMap<>();
     conf.put(PropertyKey.LOGGER_TYPE, "MASTER_LOGGER");
     conf.put(PropertyKey.CONF_DIR, confDir.getAbsolutePath());
     conf.put(PropertyKey.MASTER_METASTORE_DIR, metastoreDir.getAbsolutePath());
     conf.put(PropertyKey.LOGS_DIR, logsDir.getAbsolutePath());
+    conf.put(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, underFsDir);
     conf.put(PropertyKey.MASTER_HOSTNAME, address.getHostname());
     conf.put(PropertyKey.MASTER_RPC_PORT, address.getRpcPort());
     conf.put(PropertyKey.MASTER_WEB_PORT, address.getWebPort());

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -60,6 +60,7 @@ public class PortCoordination {
   public static final List<ReservedPort> JOURNAL_MIGRATION = allocate(3, 1);
 
   public static final List<ReservedPort> BACKUP_RESTORE_EMBEDDED = allocate(3, 1);
+  public static final List<ReservedPort> BACKUP_SYNC_ON_RESTORE = allocate(1, 1);
 
   public static final List<ReservedPort> CONFIG_CHECKER_MULTI_WORKERS = allocate(1, 2);
   public static final List<ReservedPort> CONFIG_CHECKER_MULTI_NODES = allocate(2, 2);


### PR DESCRIPTION
When restoring from a backup, some modifications exist in UFS that are not present in Alluxio namespace. This PR marks the root (and in turn all subdirectories) as needed to be synced with UFS after restoring from a backup. This amortizes the cost of recovering information from UFS over the course of the subsequent accesses.