### PR TITLE
Make worker error propagate to client

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -454,9 +454,6 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
               mContext.getRequest(), mContext.getRequest().getSessionId(),
               e);
           setError(new Error(AlluxioStatusException.fromThrowable(e), true));
-          if (e instanceof java.lang.Error) {
-            throw (java.lang.Error) e;
-          }
         }
         continue;
       }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -448,12 +448,15 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
               }
             });
           }
-        } catch (Exception e) {
+        } catch (Throwable e) {
           LogUtils.warnWithException(LOG,
               "Exception occurred while reading data for read request {}. session {}",
               mContext.getRequest(), mContext.getRequest().getSessionId(),
               e);
           setError(new Error(AlluxioStatusException.fromThrowable(e), true));
+          if (e instanceof java.lang.Error) {
+            throw (java.lang.Error) e;
+          }
         }
         continue;
       }


### PR DESCRIPTION
### What changes are proposed in this pull request?
This PR can fix the OOM Error no longer reply to client issue.

```
2022-10-19 11:41:38,397 WARN  GrpcBlockingStream - Client did not receive message from stream, will wait again. totalWaitMs: 60006 clientClosed: false clientCancelled: false serverClosed: false description: Zero Copy GrpcDataReader
2022-10-19 11:42:38,404 WARN  GrpcBlockingStream - Client did not receive message from stream, will wait again. totalWaitMs: 120013 clientClosed: false clientCancelled: false serverClosed: false description: Zero Copy GrpcDataReader
2022-10-19 11:43:38,409 WARN  GrpcBlockingStream - Client did not receive message from stream, will wait again. totalWaitMs: 180018 clientClosed: false clientCancelled: false serverClosed: false description: Zero Copy GrpcDataReader
2022-10-19 11:44:38,415 WARN  GrpcBlockingStream - Client did not receive message from stream, will wait again. totalWaitMs: 240024 clientClosed: false clientCancelled: false serverClosed: false description: Zero Copy GrpcDataReader
2022-10-19 11:45:38,418 WARN  GrpcBlockingStream - Client did not receive message from stream, will wait again. totalWaitMs: 300027 clientClosed: false clientCancelled: false serverClosed: false description: Zero Copy GrpcDataReader
2022-10-19 11:46:38,424 WARN  GrpcBlockingStream - Client did not receive message from stream, will wait again. totalWaitMs: 360033 clientClosed: false clientCancelled: false serverClosed: false description: Zero Copy GrpcDataReader
2022-10-19 11:47:38,428 WARN  GrpcBlockingStream - Client did not receive message from stream, will wait again. totalWaitMs: 420037 clientClosed: false clientCancelled: false serverClosed: false description: Zero Copy GrpcDataReader
2022-10-19 11:48:38,418 WARN  GrpcBlockingStream - Client did not receive message from stream, will wait again. totalWaitMs: 480027 clientClosed: false clientCancelled: false serverClosed: false description: Zero Copy GrpcDataReader
2022-10-19 11:49:38,427 WARN  GrpcBlockingStream - Client did not receive message from stream, will wait again. totalWaitMs: 540036 clientClosed: false clientCancelled: false serverClosed: false description: Zero Copy GrpcDataReader
2022-10-19 11:50:38,436 WARN  GrpcBlockingStream - Client did not receive message from stream, will wait again. totalWaitMs: 600045 clientClosed: false clientCancelled: false serverClosed: false description: Zero Copy GrpcDataReader
2022-10-19 11:51:38,446 WARN  GrpcBlockingStream - Client did not receive message from stream, will wait again. totalWaitMs: 660055 clientClosed: false clientCancelled: false serverClosed: false description: Zero Copy GrpcDataReader
2022-10-19 11:52:38,451 WARN  GrpcBlockingStream - Client did not receive message from stream, will wait again. totalWaitMs: 720060 clientClosed: false clientCancelled: false serverClosed: false description: Zero Copy GrpcDataReader
```

I did the following changes

<img width="859" alt="image" src="https://user-images.githubusercontent.com/17329931/196597200-ce910820-2066-4dab-8fb5-37433a0791a4.png">




After patched this PR, client will receive the error and choose another worker


```
2022-10-19 12:07:56,324 WARN  GrpcBlockingStream - Received error io.grpc.StatusRuntimeException: INTERNAL: XXX for stream (Zero Copy GrpcDataReader)
2022-10-19 12:07:56,338 WARN  AlluxioFileInStream - Failed to read block 268435456 of file /NOTICE4 from worker WorkerNetAddress{host=localhost, containerHost=, rpcPort=29999, dataPort=29999, webPort=30000, domainSocketPath=, tieredIdentity=TieredIdentity(node=localhost, rack=null)}. This worker will be skipped for future read operations, will retry: alluxio.exception.status.InternalException: XXX (Zero Copy GrpcDataReader).

```
