### PR TITLE
[SMALLFIX] Fix incorrect error message template in UfsInputStreamCache

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamCache.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UfsInputStreamCache.java
@@ -275,7 +275,7 @@ public final class UfsInputStreamCache {
      * @param id the id of the input stream
      */
     synchronized void acquire(long id) {
-      Preconditions.checkArgument(!mInUseStreamIds.contains(id), "%d is already in use", id);
+      Preconditions.checkArgument(!mInUseStreamIds.contains(id), "%s is already in use", id);
       mAvailableStreamIds.remove(id);
       mInUseStreamIds.add(id);
     }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix string format specifier `%d` in `Preconditions.checkArgument` error message template.

### Why are the changes needed?

any other format specifiers like `%d` are not recognized at the method of `Preconditions.checkArgument`, only `%s` is accepted.

### Does this PR introduce any user facing changes?
none

Fixed https://github.com/Alluxio/alluxio/pull/642 https://github.com/Alluxio/new-contributor-tasks/issues/642
