### PR TITLE
Fix generating proxy templates in helm-chart

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/helm-generate.sh
+++ b/integration/kubernetes/helm-chart/alluxio/helm-generate.sh
@@ -68,7 +68,7 @@ EOF
 }
 
 function generateConfigTemplates {
-  echo "Generating configmap templates into $(pwd)$dir"
+  echo "Generating configmap templates into $(pwd)/$dir"
   if [ "$workerFuse" = true ]; then
     helm template --name-template ${RELEASE_NAME} . --set worker.fuseEnabled=true --show-only templates/config/alluxio-conf.yaml -f $dir/config.yaml > "$dir/alluxio-configmap.yaml.template"
   else
@@ -77,13 +77,13 @@ function generateConfigTemplates {
 }
 
 function generateMasterTemplates {
-  echo "Generating master templates into $(pwd)$dir"
+  echo "Generating master templates into $(pwd)/$dir"
   helm template --name-template ${RELEASE_NAME} . --show-only templates/master/statefulset.yaml -f $dir/config.yaml > "$dir/master/alluxio-master-statefulset.yaml.template"
   helm template --name-template ${RELEASE_NAME} . --show-only templates/master/service.yaml -f $dir/config.yaml > "$dir/master/alluxio-master-service.yaml.template"
 }
 
 function generateWorkerTemplates {
-  echo "Generating worker templates into $(pwd)$dir"
+  echo "Generating worker templates into $(pwd)/$dir"
   if [ "$workerFuse" = true ]; then
     helm template --name-template ${RELEASE_NAME} . --set worker.fuseEnabled=true --show-only templates/worker/daemonset.yaml -f $dir/config.yaml > "$dir/worker/alluxio-worker-daemonset.yaml.template"
   else
@@ -93,12 +93,12 @@ function generateWorkerTemplates {
 }
 
 function generateProxyTemplates {
-  echo "Generating proxy templates"
-  helm template --name-template ${RELEASE_NAME} helm-chart/alluxio/ --set proxy.enabled=true --show-only templates/proxy/daemonset.yaml -f $dir/config.yaml > "$dir/proxy/alluxio-proxy-daemonset.yaml.template"
+  echo "Generating proxy templates into $(pwd)/$dir"
+  helm template --name-template ${RELEASE_NAME} . --set proxy.enabled=true --show-only templates/proxy/daemonset.yaml -f $dir/config.yaml > "$dir/proxy/alluxio-proxy-daemonset.yaml.template"
 }
 
 function generateFuseTemplates {
-  echo "Generating fuse templates into $(pwd)fuse/"
+  echo "Generating fuse templates into $(pwd)/fuse/"
   if [[ ! -d ./fuse ]]; then
     mkdir -p ./fuse
   fi
@@ -106,7 +106,7 @@ function generateFuseTemplates {
 }
 
 function generateLoggingTemplates {
-  echo "Generating remote logserver templates into $(pwd)$dir"
+  echo "Generating remote logserver templates into $(pwd)/$dir"
   helm template --name-template ${RELEASE_NAME} . --show-only templates/logserver/deployment.yaml -f $dir/config.yaml > "$dir/logserver/alluxio-logserver-deployment.yaml.template"
   helm template --name-template ${RELEASE_NAME} . --show-only templates/logserver/service.yaml -f $dir/config.yaml > "$dir/logserver/alluxio-logserver-service.yaml.template"
   helm template --name-template ${RELEASE_NAME} . --show-only templates/logserver/log-pvc.yaml -f $dir/config.yaml > "$dir/logserver/alluxio-logserver-pvc.yaml.template"
@@ -117,7 +117,7 @@ function generateMasterServiceTemplates {
 }
 
 function generateCsiTemplates {
-  echo "Generating csi templates into $(pwd)csi/"
+  echo "Generating csi templates into $(pwd)/csi/"
   if [[ ! -d ./csi ]]; then
     mkdir -p ./csi
   fi


### PR DESCRIPTION
`helm-generate.sh` failed to generate proxy template because of incorrect path. This PR fixes this.

The logging is missing `/`.