### PR TITLE
Fix error in snapshot-taking when using large group ids

### DIFF
--- a/core/server/common/src/main/java/alluxio/util/TarUtils.java
+++ b/core/server/common/src/main/java/alluxio/util/TarUtils.java
@@ -44,6 +44,8 @@ public final class TarUtils {
       throws IOException, InterruptedException {
     GzipCompressorOutputStream zipStream = new GzipCompressorOutputStream(output);
     TarArchiveOutputStream archiveStream = new TarArchiveOutputStream(zipStream);
+    archiveStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+    archiveStream.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
     try (final Stream<Path> stream = Files.walk(dirPath)) {
       for (Path subPath : stream.collect(toList())) {
         if (Thread.interrupted()) {

--- a/core/server/common/src/test/java/alluxio/util/TarUtilsTest.java
+++ b/core/server/common/src/test/java/alluxio/util/TarUtilsTest.java
@@ -89,11 +89,11 @@ public final class TarUtilsTest {
   }
 
   @Test
-  public void testLargePosixGroupNumbers() throws Exception {
+  public void testLargePosixUserAndGroupIds() throws Exception {
     // when the TarArchiveEntry(File, String) constructor is called (as is used in
     // TarUtils#writeTarGz), return a new instance of TarArchiveEntry that has a group id greater
     // than the max id
-    Long groupId = TarArchiveEntry.MAXID + 100;
+    Long largeId = TarArchiveEntry.MAXID + 100;
     PowerMockito.whenNew(TarArchiveEntry.class)
         .withParameterTypes(File.class, String.class)
         .withArguments(any())
@@ -101,7 +101,8 @@ public final class TarUtilsTest {
           TarArchiveEntry spy = PowerMockito.spy(
               TarArchiveEntry.class.getConstructor(File.class, String.class)
                   .newInstance(i.getArguments()));
-          PowerMockito.when(spy.getLongGroupId()).thenReturn(groupId);
+          PowerMockito.when(spy.getLongGroupId()).thenReturn(largeId);
+          PowerMockito.when(spy.getLongUserId()).thenReturn(largeId);
           return spy;
         });
 

--- a/core/server/common/src/test/java/alluxio/util/TarUtilsTest.java
+++ b/core/server/common/src/test/java/alluxio/util/TarUtilsTest.java
@@ -11,18 +11,26 @@
 
 package alluxio.util;
 
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
  * Units tests for {@link TarUtils}.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(TarUtils.class)
 public final class TarUtilsTest {
   @Rule
   public TemporaryFolder mFolder = new TemporaryFolder();
@@ -76,6 +84,17 @@ public final class TarUtilsTest {
     Files.write(file, "hello world".getBytes());
 
     tarUntarTest(dir);
+  }
+
+  @Test
+  public void testLargePosixGroupNumbers() throws Exception {
+    File tempFile = mFolder.newFile("emptyFile");
+    TarArchiveEntry instance = PowerMockito.spy(new TarArchiveEntry(tempFile));
+    PowerMockito.doReturn(1234567890L).when(instance).getLongGroupId();
+    PowerMockito.whenNew(TarArchiveEntry.class).withAnyArguments().thenReturn(instance);
+
+    Path empty = mFolder.newFolder("emptyDir").toPath();
+    tarUntarTest(empty);
   }
 
   private void tarUntarTest(Path path) throws Exception {


### PR DESCRIPTION
To store and distribute RocksDB snapshot files, we compress them into a `.tar.gz` file. This file fails to be written if the group id or user id being operated under is too large: `group id '__' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit` or `user id '__' is too big ( > 2097151 ).`
This PR resolves this issue.