### PR TITLE
Port changes of [#16365] to branch-2.8

### DIFF
--- a/core/server/common/src/main/java/alluxio/util/TarUtils.java
+++ b/core/server/common/src/main/java/alluxio/util/TarUtils.java
@@ -44,6 +44,8 @@ public final class TarUtils {
       throws IOException, InterruptedException {
     GzipCompressorOutputStream zipStream = new GzipCompressorOutputStream(output);
     TarArchiveOutputStream archiveStream = new TarArchiveOutputStream(zipStream);
+    archiveStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+    archiveStream.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
     try (final Stream<Path> stream = Files.walk(dirPath)) {
       for (Path subPath : stream.collect(toList())) {
         if (Thread.interrupted()) {

--- a/core/server/common/src/test/java/alluxio/util/TarUtilsTest.java
+++ b/core/server/common/src/test/java/alluxio/util/TarUtilsTest.java
@@ -11,23 +11,32 @@
 
 package alluxio.util;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
  * Units tests for {@link TarUtils}.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(TarUtils.class)
 public final class TarUtilsTest {
   @Rule
   public TemporaryFolder mFolder = new TemporaryFolder();
@@ -81,6 +90,28 @@ public final class TarUtilsTest {
     Files.write(file, "hello world".getBytes());
 
     tarUntarTest(dir);
+  }
+
+  @Test
+  public void testLargePosixUserAndGroupIds() throws Exception {
+    // when the TarArchiveEntry(File, String) constructor is called (as is used in
+    // TarUtils#writeTarGz), return a new instance of TarArchiveEntry that has a group id greater
+    // than the max id
+    Long largeId = TarArchiveEntry.MAXID + 100;
+    PowerMockito.whenNew(TarArchiveEntry.class)
+        .withParameterTypes(File.class, String.class)
+        .withArguments(any())
+        .thenAnswer(i -> {
+          TarArchiveEntry spy = PowerMockito.spy(
+              TarArchiveEntry.class.getConstructor(File.class, String.class)
+                  .newInstance(i.getArguments()));
+          PowerMockito.when(spy.getLongGroupId()).thenReturn(largeId);
+          PowerMockito.when(spy.getLongUserId()).thenReturn(largeId);
+          return spy;
+        });
+
+    Path empty = mFolder.newFolder("emptyDir").toPath();
+    tarUntarTest(empty);
   }
 
   private void tarUntarTest(Path path) throws Exception {


### PR DESCRIPTION
To store and distribute RocksDB snapshot files, we compress them into a `.tar.gz` file. This file fails to be written if the group id or user id being operated under is too large: `group id '__' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit` or `user id '__' is too big ( > 2097151 ).`
This PR resolves this issue.

[This is an manually-generated PR to cherry-pick committed PR Alluxio/alluxio#16365 into target branch branch-2.8]