### PR TITLE
Add fork count option to alluxio github test scripts

### DIFF
--- a/dev/github/run_docker.sh
+++ b/dev/github/run_docker.sh
@@ -33,6 +33,11 @@ function main {
     run_args+=" -it"
   fi
 
+  if [ -n "${ALLUXIO_DOCKER_FORK_COUNT}" ]
+   then
+     run_args+=" -e ALLUXIO_FORK_COUNT=${ALLUXIO_DOCKER_FORK_COUNT}"
+  fi
+
   if [ -n "${ALLUXIO_DOCKER_GIT_CLEAN}" ]
   then
     run_args+=" -e ALLUXIO_GIT_CLEAN=true"

--- a/dev/github/run_tests.sh
+++ b/dev/github/run_tests.sh
@@ -15,6 +15,11 @@
 #
 set -ex
 
+if [ -z "${ALLUXIO_FORK_COUNT}" ]
+then
+  ALLUXIO_FORK_COUNT=2
+fi
+
 if [ -n "${ALLUXIO_GIT_CLEAN}" ]
 then
   git clean -fdx
@@ -55,4 +60,4 @@ PATH=${PATH_BACKUP}
 
 # Run tests
 mvn -Duser.home=/home/jenkins test -Pdeveloper -Dmaven.main.skip -Dskip.protoc=true -Dmaven.javadoc.skip -Dlicense.skip=true \
--Dcheckstyle.skip=true -Dfindbugs.skip=true -Dsurefire.forkCount=2 ${mvn_args} $@
+-Dcheckstyle.skip=true -Dfindbugs.skip=true -Dsurefire.forkCount=${ALLUXIO_FORK_COUNT} ${mvn_args} $@


### PR DESCRIPTION
Adds a fork count environment variable so that the number of concurrent forks to run during a test can be set in the GitHub tests yml file.