### PR TITLE
Make RocksDB problem crash master

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreePersistentState.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTreePersistentState.java
@@ -203,17 +203,6 @@ public class InodeTreePersistentState implements Journaled {
     return Collections.unmodifiableSet(mToBePersistedIds);
   }
 
-  ////
-  /// The applyAndJournal() methods make sure the in-memory metadata state and the journal are
-  /// BOTH updated. Any exception seen here will crash the master! So if an exception should be
-  /// tolerated, make sure it is caught and handled properly.
-  /// However, the journal flushing is async and happens when the JournalContext is closed.
-  /// That means when applyAndJournal() returns, the metadata states are updated but the
-  /// journal entries are not necessarily persisted or sent to standby masters.
-  /// Therefore, to ensure atomicity, callers should make sure the JournalContext is closed
-  /// after calling the applyAndJournal() methods.
-  ////
-
   /**
    * Deletes an inode (may be either a file or directory).
    *
@@ -395,7 +384,6 @@ public class InodeTreePersistentState implements Journaled {
   ////
   /// Apply Implementations. These methods are used for journal replay, so they are not allowed to
   /// fail. They are also used when making metadata changes during regular operation.
-  /// If the method throws an exception, the caller applyAndJournal() method will crash the master.
   ////
 
   private void applyDelete(DeleteFileEntry entry) {

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockMetaStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksBlockMetaStore.java
@@ -13,6 +13,7 @@ package alluxio.master.metastore.rocks;
 
 import static alluxio.master.metastore.rocks.RocksStore.checkSetTableConfig;
 
+import alluxio.ProcessUtils;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.master.metastore.BlockMetaStore;
@@ -275,7 +276,8 @@ public class RocksBlockMetaStore implements BlockMetaStore {
     try {
       meta = db().get(mBlockMetaColumn.get(), Longs.toByteArray(id));
     } catch (RocksDBException e) {
-      throw new RuntimeException(e);
+      ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+      throw new RuntimeException(e); // fatalError will usually system.exit
     }
     if (meta == null) {
       return Optional.empty();
@@ -283,7 +285,8 @@ public class RocksBlockMetaStore implements BlockMetaStore {
     try {
       return Optional.of(BlockMeta.parseFrom(meta));
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+      throw new RuntimeException(e); // fatalError will usually system.exit
     }
   }
 
@@ -298,7 +301,8 @@ public class RocksBlockMetaStore implements BlockMetaStore {
         mSize.increment();
       }
     } catch (RocksDBException e) {
-      throw new RuntimeException(e);
+      ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+      throw new RuntimeException(e); // fatalError will usually system.exit
     }
   }
 
@@ -312,7 +316,8 @@ public class RocksBlockMetaStore implements BlockMetaStore {
         mSize.decrement();
       }
     } catch (RocksDBException e) {
-      throw new RuntimeException(e);
+      ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+      throw new RuntimeException(e); // fatalError will usually system.exit
     }
   }
 
@@ -358,7 +363,8 @@ public class RocksBlockMetaStore implements BlockMetaStore {
         try {
           locations.add(BlockLocation.parseFrom(iter.value()));
         } catch (Exception e) {
-          throw new RuntimeException(e);
+          ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+          throw new RuntimeException(e); // fatalError will usually system.exit
         }
       }
       return locations;
@@ -371,7 +377,8 @@ public class RocksBlockMetaStore implements BlockMetaStore {
     try {
       db().put(mBlockLocationsColumn.get(), mDisableWAL, key, location.toByteArray());
     } catch (RocksDBException e) {
-      throw new RuntimeException(e);
+      ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+      throw new RuntimeException(e); // fatalError will usually system.exit
     }
   }
 
@@ -381,7 +388,8 @@ public class RocksBlockMetaStore implements BlockMetaStore {
     try {
       db().delete(mBlockLocationsColumn.get(), mDisableWAL, key);
     } catch (RocksDBException e) {
-      throw new RuntimeException(e);
+      ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+      throw new RuntimeException(e); // fatalError will usually system.exit
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksInodeStore.java
@@ -13,6 +13,7 @@ package alluxio.master.metastore.rocks;
 
 import static alluxio.master.metastore.rocks.RocksStore.checkSetTableConfig;
 
+import alluxio.ProcessUtils;
 import alluxio.collections.Pair;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
@@ -290,7 +291,8 @@ public class RocksInodeStore implements InodeStore {
       byte[] id = Longs.toByteArray(inodeId);
       db().delete(mInodesColumn.get(), mDisableWAL, id);
     } catch (RocksDBException e) {
-      throw new RuntimeException(e);
+      ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+      throw new RuntimeException(e); // fatalError will usually system.exit
     }
   }
 
@@ -300,7 +302,8 @@ public class RocksInodeStore implements InodeStore {
       db().put(mInodesColumn.get(), mDisableWAL, Longs.toByteArray(inode.getId()),
           inode.toProto().toByteArray());
     } catch (RocksDBException e) {
-      throw new RuntimeException(e);
+      ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+      throw new RuntimeException(e); // fatalError will usually system.exit
     }
   }
 
@@ -320,7 +323,8 @@ public class RocksInodeStore implements InodeStore {
       db().put(mEdgesColumn.get(), mDisableWAL, RocksUtils.toByteArray(parentId, childName),
           Longs.toByteArray(childId));
     } catch (RocksDBException e) {
-      throw new RuntimeException(e);
+      ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+      throw new RuntimeException(e); // fatalError will usually system.exit
     }
   }
 
@@ -329,7 +333,8 @@ public class RocksInodeStore implements InodeStore {
     try {
       db().delete(mEdgesColumn.get(), mDisableWAL, RocksUtils.toByteArray(parentId, name));
     } catch (RocksDBException e) {
-      throw new RuntimeException(e);
+      ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+      throw new RuntimeException(e); // fatalError will usually system.exit
     }
   }
 
@@ -339,7 +344,8 @@ public class RocksInodeStore implements InodeStore {
     try {
       inode = db().get(mInodesColumn.get(), Longs.toByteArray(id));
     } catch (RocksDBException e) {
-      throw new RuntimeException(e);
+      ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+      throw new RuntimeException(e); // fatalError will usually system.exit
     }
     if (inode == null) {
       return Optional.empty();
@@ -347,7 +353,8 @@ public class RocksInodeStore implements InodeStore {
     try {
       return Optional.of(MutableInode.fromProto(InodeMeta.Inode.parseFrom(inode)));
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+      throw new RuntimeException(e); // fatalError will usually system.exit
     }
   }
 
@@ -386,7 +393,8 @@ public class RocksInodeStore implements InodeStore {
     try {
       id = db().get(mEdgesColumn.get(), RocksUtils.toByteArray(inodeId, name));
     } catch (RocksDBException e) {
-      throw new RuntimeException(e);
+      ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+      throw new RuntimeException(e); // fatalError will usually system.exit
     }
     if (id == null) {
       return Optional.empty();
@@ -531,7 +539,8 @@ public class RocksInodeStore implements InodeStore {
         mBatch.put(mInodesColumn.get(), Longs.toByteArray(inode.getId()),
             inode.toProto().toByteArray());
       } catch (RocksDBException e) {
-        throw new RuntimeException(e);
+        ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+        throw new RuntimeException(e); // fatalError will usually system.exit
       }
     }
 
@@ -540,7 +549,8 @@ public class RocksInodeStore implements InodeStore {
       try {
         mBatch.delete(mInodesColumn.get(), Longs.toByteArray(key));
       } catch (RocksDBException e) {
-        throw new RuntimeException(e);
+        ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+        throw new RuntimeException(e); // fatalError will usually system.exit
       }
     }
 
@@ -550,7 +560,8 @@ public class RocksInodeStore implements InodeStore {
         mBatch.put(mEdgesColumn.get(), RocksUtils.toByteArray(parentId, childName),
             Longs.toByteArray(childId));
       } catch (RocksDBException e) {
-        throw new RuntimeException(e);
+        ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+        throw new RuntimeException(e); // fatalError will usually system.exit
       }
     }
 
@@ -559,7 +570,8 @@ public class RocksInodeStore implements InodeStore {
       try {
         mBatch.delete(mEdgesColumn.get(), RocksUtils.toByteArray(parentId, childName));
       } catch (RocksDBException e) {
-        throw new RuntimeException(e);
+        ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+        throw new RuntimeException(e); // fatalError will usually system.exit
       }
     }
 
@@ -568,7 +580,8 @@ public class RocksInodeStore implements InodeStore {
       try {
         db().write(mDisableWAL, mBatch);
       } catch (RocksDBException e) {
-        throw new RuntimeException(e);
+        ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+        throw new RuntimeException(e); // fatalError will usually system.exit
       }
     }
 
@@ -608,7 +621,8 @@ public class RocksInodeStore implements InodeStore {
         try {
           inode = MutableInode.fromProto(InodeMeta.Inode.parseFrom(inodeIter.value()));
         } catch (Exception e) {
-          throw new RuntimeException(e);
+          ProcessUtils.fatalError(LOG, e, "RocksDB failed");
+          throw new RuntimeException(e); // fatalError will usually system.exit
         }
         sb.append("Inode ").append(Longs.fromByteArray(inodeIter.key())).append(": ").append(inode)
             .append("\n");


### PR DESCRIPTION
### What changes are proposed in this pull request?

Currently the `RuntimeException` from `RocksInodeStore` will crash the master from `InodeTreePersistentState`. But the same exception from `RocksBlockStore` will only make RPCs fail instead of crashing the master.