### PR TITLE
Make journal context thread safe

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/MasterJournalContext.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/MasterJournalContext.java
@@ -28,12 +28,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Context for storing master journal information.
+ *
+ * This journal context is made thread-safe because metadata sync creates worker threads to fetch
+ * metadata and reuses the same journal context.
  */
-@NotThreadSafe
+@ThreadSafe
 public final class MasterJournalContext implements JournalContext {
   private static final Logger LOG = LoggerFactory.getLogger(MasterJournalContext.class);
   private static final long INVALID_FLUSH_COUNTER = -1;
@@ -57,7 +60,7 @@ public final class MasterJournalContext implements JournalContext {
   }
 
   @Override
-  public void append(JournalEntry entry) {
+  public synchronized void append(JournalEntry entry) {
     mFlushCounter = mAsyncJournalWriter.appendEntry(entry);
   }
 
@@ -97,12 +100,12 @@ public final class MasterJournalContext implements JournalContext {
   }
 
   @Override
-  public void flush() throws UnavailableException {
+  public synchronized void flush() throws UnavailableException {
     waitForJournalFlush();
   }
 
   @Override
-  public void close() throws UnavailableException {
+  public synchronized void close() throws UnavailableException {
     waitForJournalFlush();
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemJournalEntryMerger.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemJournalEntryMerger.java
@@ -21,14 +21,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A file system journal entry merger which merges inode creation and inode update journals
  * on the same inode object into one.
  * This class is not thread-safe and should not be shared across threads.
  */
-@NotThreadSafe
+@ThreadSafe
 public class FileSystemJournalEntryMerger implements JournalEntryMerger {
   /** Persists merged journal entries. */
   private final List<Journal.JournalEntry> mJournalEntries = new ArrayList<>();
@@ -40,7 +40,7 @@ public class FileSystemJournalEntryMerger implements JournalEntryMerger {
    * @param entry the new journal entry to add
    */
   @Override
-  public void add(Journal.JournalEntry entry) {
+  public synchronized void add(Journal.JournalEntry entry) {
     if (entry.hasInodeFile() || entry.hasInodeDirectory()) {
       mJournalEntries.add(entry);
       mEntriesMap.put(getInodeId(entry), mJournalEntries.size() - 1);
@@ -80,12 +80,12 @@ public class FileSystemJournalEntryMerger implements JournalEntryMerger {
   }
 
   @Override
-  public List<Journal.JournalEntry> getMergedJournalEntries() {
+  public synchronized List<Journal.JournalEntry> getMergedJournalEntries() {
     return Collections.unmodifiableList(mJournalEntries);
   }
 
   @Override
-  public void clear() {
+  public synchronized void clear() {
     mEntriesMap.clear();
     mJournalEntries.clear();
   }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockedInodePath.java
@@ -556,11 +556,15 @@ public class LockedInodePath implements Closeable {
 
   @Override
   public void close() {
-    maybeFlushJournals();
-    if (mTracker != null) {
-      mTracker.close(this);
+    try {
+      maybeFlushJournals();
+    } finally {
+      // releases the locks in case journal flush failed
+      if (mTracker != null) {
+        mTracker.close(this);
+      }
+      mLockList.close();
     }
-    mLockList.close();
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

Make journal context thread safe to address potential data race issues. During metadata sync, the journal context is shared across multiple metadata sync inode threads.

### Why are the changes needed?

To address potential data race issues.

### Does this PR introduce any user facing changes?

N/A