### PR TITLE
Add efficient mount table data structures

### DIFF
--- a/core/common/src/main/java/alluxio/conf/path/TrieNode.java
+++ b/core/common/src/main/java/alluxio/conf/path/TrieNode.java
@@ -202,6 +202,29 @@ public final class TrieNode<V> {
     return Optional.of(current);
   }
 
+  /**
+   * Get the terminal node closest to the full path.
+   * @param path the path to check
+   * @return the terminal node
+   */
+  public Optional<TrieNode<V>> getClosestTerminal(String path) {
+    TrieNode<V> current = this;
+    String[] components = path.split("/");
+    TrieNode<V> result = current.isTerminal() ?  current : null;
+    int i;
+    for (i = 0; i < components.length; i++) {
+      if (current.mChildren.containsKey(components[i])) {
+        current = current.mChildren.get(components[i]);
+        if (current.mIsTerminal) {
+          result = current;
+        }
+      } else {
+        break;
+      }
+    }
+    return Optional.ofNullable(result);
+  }
+
   private boolean isTerminal() {
     return mIsTerminal;
   }
@@ -212,12 +235,19 @@ public final class TrieNode<V> {
   }
 
   /**
-   * Recursively removes all children.
+   * Recursively removes all children, removing terminal status
+   * from this and all children.
    */
   public void clear() {
+    mIsTerminal = false;
     for (TrieNode<V> child : mChildren.values()) {
       child.clear();
     }
     mChildren.clear();
+  }
+
+  @Override
+  public String toString() {
+    return "TrieNode: " + getValue();
   }
 }

--- a/core/common/src/test/java/alluxio/conf/path/TrieNodeTest.java
+++ b/core/common/src/test/java/alluxio/conf/path/TrieNodeTest.java
@@ -193,6 +193,45 @@ public class TrieNodeTest {
   }
 
   @Test
+  public void getClosetTerminal() {
+    TrieNode<Object> node = new TrieNode<>();
+    TrieNode<Object> a = node.insert("/a");
+    a.setValue("/a");
+    TrieNode<Object> b = node.insert("/a/b");
+    b.setValue("/a/b");
+    TrieNode<Object> f = node.insert("/a/e/f");
+    f.setValue("/a/e/f");
+    TrieNode<Object> d = node.insert("/c/d");
+    d.setValue("/c/d");
+    TrieNode<Object> g = node.insert("/c/g");
+    g.setValue("/c/g");
+    TrieNode<Object> h = node.insert("/u/h");
+    h.setValue("/u/h");
+
+    Assert.assertFalse(node.getClosestTerminal("/").isPresent());
+    Assert.assertFalse(node.getClosestTerminal("/none").isPresent());
+
+    TrieNode<Object> root = node.insert("/");
+    root.setValue("/");
+    Assert.assertEquals(root, node.getClosestTerminal("/").get());
+    Assert.assertEquals(root, node.getClosestTerminal("/none").get());
+
+    Assert.assertEquals(a, node.getClosestTerminal("/a").get());
+    Assert.assertEquals(a, node.getClosestTerminal("/a/none").get());
+    Assert.assertEquals(a, node.getClosestTerminal("/a/e").get());
+
+    Assert.assertEquals(f, node.getClosestTerminal("/a/e/f").get());
+    Assert.assertEquals(f, node.getClosestTerminal("/a/e/f/other").get());
+
+    Assert.assertEquals(d, node.getClosestTerminal("/c/d/a/b/c").get());
+
+    Assert.assertEquals(g, node.getClosestTerminal("/c/g/a/b/c").get());
+    Assert.assertEquals(g, node.getClosestTerminal("/c/g").get());
+
+    Assert.assertEquals(h, node.getClosestTerminal("/u/h/a").get());
+  }
+
+  @Test
   public void clearTrie() {
     TrieNode<Object> node = new TrieNode<>();
     TrieNode<Object> a = node.insert("/a");
@@ -203,9 +242,9 @@ public class TrieNodeTest {
     TrieNode<Object> h = node.insert("/u/h");
 
     node.clear();
-    // after clearing, each node should only contain itself
+    // after clearing, each node should have no children
     for (TrieNode<Object> nxt : ImmutableList.of(a, b, f, d, g, h)) {
-      Assert.assertEquals(Collections.singletonList(nxt),
+      Assert.assertEquals(Collections.emptyList(),
           nxt.getLeafChildren("/").collect(Collectors.toList()));
     }
   }


### PR DESCRIPTION
Efficient data structures for frequently used mount table operations (i.e. getting mount information about a path or resolving a path) are added.

This includes a path trie for resolution and reverse resolution, and a hash map from mount id to mount info.
