### PR TITLE
Fix AbstractFileSystem URI parsing

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -273,6 +273,11 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
   }
 
   @Override
+  protected URI canonicalizeUri(URI uri) {
+    return uri;
+  }
+
+  @Override
   public long getDefaultBlockSize() {
     return mFileSystem.getConf()
         .getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);


### PR DESCRIPTION
When implementing `org.apache.hadoop.fs.FileSystem` we are provided with a default implementation for `#canonicalizeUri(URI)` (found [here](https://github.com/apache/hadoop/blob/454157a3844cdd6c92ef650af6c3b323cbec88af/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java#L400)). This default implementation leaves the URI unaltered if the implementation has default port of 0. 
#16207 changed the default port from 0 to 1998. This PR overrides `#canonicalizeUri(URI)` so that it can continue to be unaltered as it was before #16207.