### PR TITLE
Add cli for marking a path as needing sync with UFS

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -504,6 +504,16 @@ public class BaseFileSystem implements FileSystem {
     });
   }
 
+  @Override
+  public void needsSync(AlluxioURI path)
+      throws IOException, AlluxioException {
+    checkUri(path);
+    rpc(client -> {
+      client.needsSync(path);
+      return null;
+    });
+  }
+
   /**
    * Checks an {@link AlluxioURI} for scheme and authority information. Warn the user and throw an
    * exception if necessary.

--- a/core/client/fs/src/main/java/alluxio/client/file/DelegatingFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DelegatingFileSystem.java
@@ -237,6 +237,11 @@ public class DelegatingFileSystem implements FileSystem {
   }
 
   @Override
+  public void needsSync(AlluxioURI path) throws IOException, AlluxioException {
+    mDelegatedFileSystem.needsSync(path);
+  }
+
+  @Override
   public void close() throws IOException {
     mDelegatedFileSystem.close();
   }

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -720,4 +720,11 @@ public interface FileSystem extends Closeable {
    * @param options options to associate with this operation
    */
   void unmount(AlluxioURI path, UnmountPOptions options) throws IOException, AlluxioException;
+
+  /**
+   * Marks the path in Alluxio as needing sync with the UFS. The next time the
+   * path or any of its children are accessed they will be synced with the UFS.
+   * @param path the path needing synchronization
+   */
+  void needsSync(AlluxioURI path) throws IOException, AlluxioException;
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemMasterClient.java
@@ -341,5 +341,5 @@ public interface FileSystemMasterClient extends Client {
    * of its children are accessed, a sync with the UFS will be performed.
    * @param path the path to invalidate
    */
-  void invalidateSyncPath(AlluxioURI path) throws AlluxioStatusException;
+  void needsSync(AlluxioURI path) throws AlluxioStatusException;
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -42,13 +42,13 @@ import alluxio.grpc.GetStatusPOptions;
 import alluxio.grpc.GetStatusPRequest;
 import alluxio.grpc.GetSyncPathListPRequest;
 import alluxio.grpc.GrpcUtils;
-import alluxio.grpc.InvalidateSyncPathRequest;
 import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.ListStatusPRequest;
 import alluxio.grpc.ListStatusPartialPOptions;
 import alluxio.grpc.ListStatusPartialPRequest;
 import alluxio.grpc.MountPOptions;
 import alluxio.grpc.MountPRequest;
+import alluxio.grpc.NeedsSyncRequest;
 import alluxio.grpc.RenamePOptions;
 import alluxio.grpc.RenamePRequest;
 import alluxio.grpc.ReverseResolvePRequest;
@@ -411,11 +411,11 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
   }
 
   @Override
-  public void invalidateSyncPath(AlluxioURI path) throws AlluxioStatusException {
+  public void needsSync(AlluxioURI path) throws AlluxioStatusException {
     retryRPC(
-        () -> mClient.invalidateSyncPath(
-            InvalidateSyncPathRequest.newBuilder().setPath(getTransportPath(path)).build()),
-        RPC_LOG, "InvalidateSyncPath", "path=%s", path);
+        () -> mClient.needsSync(
+            NeedsSyncRequest.newBuilder().setPath(getTransportPath(path)).build()),
+        RPC_LOG, "NeedsSync", "path=%s", path);
   }
 
   /**

--- a/core/client/fs/src/test/java/alluxio/client/file/MockFileSystemMasterClient.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/MockFileSystemMasterClient.java
@@ -232,6 +232,6 @@ class MockFileSystemMasterClient implements FileSystemMasterClient {
   }
 
   @Override
-  public void invalidateSyncPath(AlluxioURI path) throws AlluxioStatusException {
+  public void needsSync(AlluxioURI path) throws AlluxioStatusException {
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -858,6 +858,11 @@ public class LocalCacheFileInStreamTest {
     }
 
     @Override
+    public void needsSync(AlluxioURI path) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void close() throws IOException {
       throw new UnsupportedOperationException();
     }

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -344,7 +344,7 @@ public class AlluxioMasterProcess extends MasterProcess {
     // When restoring from backup, some fs modifications exist only in UFS. We invalidate the root
     // to force new accesses to sync with UFS first to update our picture of the UFS.
     try {
-      mRegistry.get(FileSystemMaster.class).invalidateSyncPath(new AlluxioURI("/"));
+      mRegistry.get(FileSystemMaster.class).needsSync(new AlluxioURI("/"));
     } catch (InvalidPathException e) {
       LOG.warn("Failed to mark root as needing syncing after backup restore");
     }

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -5255,7 +5255,7 @@ public class DefaultFileSystemMaster extends CoreMaster
   }
 
   @Override
-  public void invalidateSyncPath(AlluxioURI path) throws InvalidPathException {
+  public void needsSync(AlluxioURI path) throws InvalidPathException {
     getSyncPathCache().notifyInvalidation(path);
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -634,5 +634,5 @@ public interface FileSystemMaster extends Master {
    * of its children are accessed, a sync with the UFS will be performed.
    * @param path the path to invalidate
    */
-  void invalidateSyncPath(AlluxioURI path) throws InvalidPathException;
+  void needsSync(AlluxioURI path) throws InvalidPathException;
 }

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -48,14 +48,14 @@ import alluxio.grpc.GetStatusPResponse;
 import alluxio.grpc.GetSyncPathListPRequest;
 import alluxio.grpc.GetSyncPathListPResponse;
 import alluxio.grpc.GrpcUtils;
-import alluxio.grpc.InvalidateSyncPathRequest;
-import alluxio.grpc.InvalidateSyncPathResponse;
 import alluxio.grpc.ListStatusPRequest;
 import alluxio.grpc.ListStatusPResponse;
 import alluxio.grpc.ListStatusPartialPRequest;
 import alluxio.grpc.ListStatusPartialPResponse;
 import alluxio.grpc.MountPRequest;
 import alluxio.grpc.MountPResponse;
+import alluxio.grpc.NeedsSyncRequest;
+import alluxio.grpc.NeedsSyncResponse;
 import alluxio.grpc.RenamePRequest;
 import alluxio.grpc.RenamePResponse;
 import alluxio.grpc.ReverseResolvePRequest;
@@ -464,12 +464,12 @@ public final class FileSystemMasterClientServiceHandler
   }
 
   @Override
-  public void invalidateSyncPath(InvalidateSyncPathRequest request,
-                                 StreamObserver<InvalidateSyncPathResponse> responseObserver) {
+  public void needsSync(NeedsSyncRequest request,
+                        StreamObserver<NeedsSyncResponse> responseObserver) {
     RpcUtils.call(LOG, () -> {
-      mFileSystemMaster.invalidateSyncPath(new AlluxioURI(request.getPath()));
-      return InvalidateSyncPathResponse.getDefaultInstance();
-    }, "InvalidateSyncPath", true, "request=%s", responseObserver, request);
+      mFileSystemMaster.needsSync(new AlluxioURI(request.getPath()));
+      return NeedsSyncResponse.getDefaultInstance();
+    }, "NeedsSync", true, "request=%s", responseObserver, request);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncPathCache.java
@@ -61,7 +61,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * appropriate invalidation times updated. Validation times are updated on the path
  * when {@link #notifySyncedPath} is called on the root sync path after a successful sync.
  * An invalidation is received either when a client calls
- * {@link alluxio.master.file.DefaultFileSystemMaster#invalidateSyncPath} to notify that a path
+ * {@link alluxio.master.file.DefaultFileSystemMaster#needsSync} to notify that a path
  * needs synchronization, or when a file is updated by an external Alluxio cluster, and
  * cross cluster sync is enabled.
  *

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncTest.java
@@ -408,7 +408,7 @@ public class FileSystemMasterSyncTest extends FileSystemMasterTestBase {
     assertEquals(InodeSyncStream.SyncStatus.NOT_NEEDED, syncStatus);
 
     // invalidate f1 at time 1
-    mFileSystemMaster.invalidateSyncPath(f1);
+    mFileSystemMaster.needsSync(f1);
     // move to time 2
     currentTime[0] = 2L;
     // dir1 should still not need a sync with interval 2

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -573,11 +573,11 @@ message GetStateLockHoldersPRequest {
   optional GetStateLockHoldersPOptions options = 1;
 }
 
-message InvalidateSyncPathRequest {
+message NeedsSyncRequest {
   required string path = 1;
 }
 
-message InvalidateSyncPathResponse {}
+message NeedsSyncResponse {}
 
 
 /**
@@ -724,7 +724,7 @@ service FileSystemMasterClientService {
 
   rpc GetStateLockHolders(GetStateLockHoldersPRequest) returns (GetStateLockHoldersPResponse);
 
-  rpc InvalidateSyncPath(InvalidateSyncPathRequest) returns (InvalidateSyncPathResponse);
+  rpc NeedsSync(NeedsSyncRequest) returns (NeedsSyncResponse);
 }
 
 message FileSystemHeartbeatPResponse {

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -3588,7 +3588,7 @@
             ]
           },
           {
-            "name": "InvalidateSyncPathRequest",
+            "name": "NeedsSyncRequest",
             "fields": [
               {
                 "id": 1,
@@ -3598,7 +3598,7 @@
             ]
           },
           {
-            "name": "InvalidateSyncPathResponse"
+            "name": "NeedsSyncResponse"
           },
           {
             "name": "FileSystemHeartbeatPResponse",
@@ -3864,9 +3864,9 @@
                 "out_type": "GetStateLockHoldersPResponse"
               },
               {
-                "name": "InvalidateSyncPath",
-                "in_type": "InvalidateSyncPathRequest",
-                "out_type": "InvalidateSyncPathResponse"
+                "name": "NeedsSync",
+                "in_type": "NeedsSyncRequest",
+                "out_type": "NeedsSyncResponse"
               }
             ]
           },

--- a/docs/en/operation/User-CLI.md
+++ b/docs/en/operation/User-CLI.md
@@ -1258,6 +1258,23 @@ For example, `mv` can be used to re-organize your files.
 $ ./bin/alluxio fs mv /data/2014 /data/archives/2014
 ```
 
+### needsSync
+
+The `needsSync` command marks a path in Alluxio as needing synchronization with the UFS.
+The next time the path or any child path is accessed by a file system operation the
+metadata for that path will be synchronized with the UFS. Note that the metadata will not
+be synchronized immediately, the synchronization will only happen on each path when it
+is accessed.
+
+Usage `needsSync <path>`
+
+For example, `needsSync` can be used after a set of files have been modified on the UFS
+outside Alluxio and those changes should be visible the next time the files are accessed.
+
+```console
+$ ./bin/alluxio fs needsSync /data
+```
+
 ### persist
 
 The `persist` command persists data in Alluxio storage into the under storage system.

--- a/integration/fuse/src/test/java/alluxio/fuse/auth/AbstractAuthPolicyTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/auth/AbstractAuthPolicyTest.java
@@ -292,6 +292,11 @@ public abstract class AbstractAuthPolicyTest {
     }
 
     @Override
+    public void needsSync(AlluxioURI path) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void close() throws IOException {
       throw new UnsupportedOperationException();
     }

--- a/integration/fuse/src/test/java/alluxio/fuse/cli/MockFuseFileSystemMasterClient.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/cli/MockFuseFileSystemMasterClient.java
@@ -198,7 +198,7 @@ class MockFuseFileSystemMasterClient implements FileSystemMasterClient {
   }
 
   @Override
-  public void invalidateSyncPath(AlluxioURI path) throws AlluxioStatusException {
+  public void needsSync(AlluxioURI path) throws AlluxioStatusException {
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/NeedsSyncCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/NeedsSyncCommand.java
@@ -1,0 +1,88 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.cli.fs.command;
+
+import alluxio.AlluxioURI;
+import alluxio.annotation.PublicApi;
+import alluxio.cli.CommandUtils;
+import alluxio.client.file.FileSystemContext;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.status.InvalidArgumentException;
+
+import org.apache.commons.cli.CommandLine;
+
+import java.io.IOException;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Marks a path in Alluxio as needing metadata synchronization with the UFS.
+ * The next time the path or any child path is accessed a metadata sync for
+ * that path will be performed.
+ */
+@ThreadSafe
+@PublicApi
+public class NeedsSyncCommand extends AbstractFileSystemCommand {
+
+  /**
+   * Constructs a new instance of a needsSync command for the given Alluxio path.
+   *
+   * @param fsContext the filesystem of Alluxio
+   */
+  public NeedsSyncCommand(FileSystemContext fsContext) {
+    super(fsContext);
+  }
+
+  @Override
+  public String getCommandName() {
+    return "needsSync";
+  }
+
+  @Override
+  protected void runPlainPath(AlluxioURI plainPath, CommandLine cl)
+      throws AlluxioException, IOException {
+    needsSync(plainPath);
+  }
+
+  @Override
+  public int run(CommandLine cl) throws AlluxioException, IOException {
+    String[] args = cl.getArgs();
+    AlluxioURI path = new AlluxioURI(args[0]);
+    runWildCardCmd(path, cl);
+
+    return 0;
+  }
+
+  private void needsSync(AlluxioURI path) throws IOException {
+    try {
+      mFileSystem.needsSync(path);
+    } catch (AlluxioException e) {
+      throw new IOException(e.getMessage());
+    }
+  }
+
+  @Override
+  public String getUsage() {
+    return "needsSync <path>";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Marks the path in Alluxio as needing synchronization with the under file system. "
+        + "The next time the path or any of its children are accessed a metadata synchronization"
+        + " will be performed.";
+  }
+
+  @Override
+  public void validateArgs(CommandLine cl) throws InvalidArgumentException {
+    CommandUtils.checkNumOfArgsEquals(this, cl, 1);
+  }
+}

--- a/tests/src/test/java/alluxio/client/cli/fs/command/NeedsSyncCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/NeedsSyncCommandIntegrationTest.java
@@ -1,0 +1,137 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.cli.fs.command;
+
+import alluxio.AlluxioURI;
+import alluxio.client.cli.fs.AbstractFileSystemShellTest;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.URIStatus;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.AlluxioException;
+import alluxio.grpc.CreateDirectoryPOptions;
+import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.ListStatusPOptions;
+import alluxio.grpc.WritePType;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Tests for needsSync command.
+ */
+public final class NeedsSyncCommandIntegrationTest extends AbstractFileSystemShellTest {
+  @Test
+  public void needsSyncDir() throws IOException, AlluxioException {
+    CreateFilePOptions createOptions = CreateFilePOptions.newBuilder()
+        .setWriteType(WritePType.CACHE_THROUGH).build();
+    AlluxioURI dir = new AlluxioURI("/dir");
+    sFileSystem.createDirectory(dir);
+    AlluxioURI file1 = dir.join("file1");
+    sFileSystem.createFile(file1, createOptions).close();
+    Assert.assertEquals(ImmutableList.of(file1.getPath()),
+        sFileSystem.listStatus(dir).stream().map(URIStatus::getPath).collect(Collectors.toList()));
+    // Create a file outside Alluxio
+    AlluxioURI file2 = dir.join("file2");
+    String ufsPath = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    Files.createFile(Paths.get(ufsPath, file2.getPath()));
+    // It should not be synced since we already synced dir
+    Assert.assertEquals(ImmutableList.of(file1.getPath()),
+        sFileSystem.listStatus(dir).stream().map(URIStatus::getPath).collect(Collectors.toList()));
+    // marking the path as needed sync should mean that the new file is synced on the next listing
+    sFsShell.run("needsSync", dir.getPath());
+    Assert.assertEquals(ImmutableList.of(file1.getPath(), file2.getPath()),
+        sFileSystem.listStatus(dir).stream().map(URIStatus::getPath).collect(Collectors.toList()));
+  }
+
+  @Test
+  public void needsSyncFile() throws IOException, AlluxioException {
+    CreateFilePOptions createOptions = CreateFilePOptions.newBuilder()
+        .setWriteType(WritePType.CACHE_THROUGH).build();
+    AlluxioURI dir = new AlluxioURI("/dir");
+    sFileSystem.createDirectory(dir);
+    AlluxioURI file1 = dir.join("file1");
+    String fileContents = "some bytes";
+    try (FileOutStream f = sFileSystem.createFile(file1, createOptions)) {
+      f.write(fileContents.getBytes());
+    }
+    Assert.assertEquals(fileContents, new String(IOUtils.toByteArray(sFileSystem.openFile(file1))));
+
+    // modify the file outside Alluxio
+    String newFileContents = "a new file write that is longer";
+    String ufsPath = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    Files.write(Paths.get(ufsPath, file1.getPath()), newFileContents.getBytes());
+
+    // we should not see the updated file
+    Assert.assertEquals(fileContents, new String(IOUtils.toByteArray(sFileSystem.openFile(file1))));
+    // marking the path as needed sync should mean that the new file is synced on the next listing
+    sFsShell.run("needsSync", file1.getPath());
+    Assert.assertEquals(newFileContents, new String(IOUtils.toByteArray(
+        sFileSystem.openFile(file1))));
+  }
+
+  @Test
+  public void needsSyncWithWildcard() throws IOException, AlluxioException {
+    CreateFilePOptions createOptions = CreateFilePOptions.newBuilder()
+        .setWriteType(WritePType.CACHE_THROUGH).build();
+    ListStatusPOptions listStatusOptions = ListStatusPOptions.newBuilder()
+        .setRecursive(true).build();
+    CreateDirectoryPOptions createDirectoryOptions = CreateDirectoryPOptions.newBuilder()
+        .setRecursive(true).build();
+
+    // Create a directory with a file outside alluxio
+    AlluxioURI dir2 = new AlluxioURI("/dir1/dir2");
+    sFileSystem.createDirectory(dir2, createDirectoryOptions);
+    AlluxioURI file1 = dir2.join("file1");
+    sFileSystem.createFile(file1, createOptions).close();
+    List<String> listing = ImmutableList.of(file1.getPath());
+    Assert.assertEquals(listing, sFileSystem.listStatus(dir2, listStatusOptions).stream()
+            .map(URIStatus::getPath).collect(Collectors.toList()));
+    // Create a file outside Alluxio
+    AlluxioURI file2 = dir2.join("file2");
+    String ufsPath = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
+    Files.createFile(Paths.get(ufsPath, file2.getPath()));
+    Assert.assertEquals(listing, sFileSystem.listStatus(dir2, listStatusOptions).stream()
+        .map(URIStatus::getPath).collect(Collectors.toList()));
+
+    // Repeat the process for a separate path
+    AlluxioURI dir3 = new AlluxioURI("/dir1/dir3");
+    sFileSystem.createDirectory(dir3, createDirectoryOptions);
+    AlluxioURI file3 = dir3.join("file3");
+    sFileSystem.createFile(file3, createOptions).close();
+    listing = ImmutableList.of(file3.getPath());
+    Assert.assertEquals(listing, sFileSystem.listStatus(dir3, listStatusOptions).stream()
+        .map(URIStatus::getPath).collect(Collectors.toList()));
+    // Create a file outside Alluxio
+    AlluxioURI file4 = dir3.join("file4");
+    Files.createFile(Paths.get(ufsPath, file4.getPath()));
+    Assert.assertEquals(listing, sFileSystem.listStatus(dir3, listStatusOptions).stream()
+        .map(URIStatus::getPath).collect(Collectors.toList()));
+
+    // marking the path as needed sync should mean that the new file is synced on the next listing
+    sFsShell.run("needsSync", "/dir*/*/file*");
+    Assert.assertEquals(ImmutableList.of(file1.getPath(), file2.getPath()),
+        sFileSystem.listStatus(dir2, listStatusOptions).stream().map(URIStatus::getPath)
+            .collect(Collectors.toList()));
+    Assert.assertEquals(ImmutableList.of(file3.getPath(), file4.getPath()),
+        sFileSystem.listStatus(dir3, listStatusOptions).stream().map(URIStatus::getPath)
+            .collect(Collectors.toList()));
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Adds cli for marking a path as needing sync with the UFS.

### Does this PR introduce any user facing changes?

New cli as follows

`bin/alluxio fs needsSync {path}`
