### PR TITLE
Upgrade Apache Ratis from 2.3.0 to 2.4.0

### DIFF
--- a/core/server/common/pom.xml
+++ b/core/server/common/pom.xml
@@ -26,7 +26,7 @@
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.parent.basedir}/build</build.path>
-    <alluxio.ratis.version>2.3.0</alluxio.ratis.version>
+    <alluxio.ratis.version>2.4.0</alluxio.ratis.version>
   </properties>
 
   <dependencies>

--- a/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
@@ -87,6 +87,7 @@ public class RaftJournalDumper extends AbstractJournalDumper {
             RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
             RaftStorage.StartupOption.RECOVER,
             RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize())) {
+      storage.initialize();
       List<LogSegmentPath> paths = LogSegmentPath.getLogSegmentPaths(storage);
       for (LogSegmentPath path : paths) {
         final int entryCount = LogSegment.readSegmentFile(path.getPath().toFile(),
@@ -119,6 +120,7 @@ public class RaftJournalDumper extends AbstractJournalDumper {
         RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
         RaftStorage.StartupOption.RECOVER,
         RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize())) {
+      storage.initialize();
       SimpleStateMachineStorage stateMachineStorage = new SimpleStateMachineStorage();
       stateMachineStorage.init(storage);
       SingleFileSnapshotInfo currentSnapshot = stateMachineStorage.getLatestSnapshot();

--- a/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
@@ -23,7 +23,7 @@ import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.raftlog.segmented.LogSegment;
 import org.apache.ratis.server.raftlog.segmented.LogSegmentPath;
 import org.apache.ratis.server.storage.RaftStorage;
-import org.apache.ratis.server.storage.RaftStorageImpl;
+import org.apache.ratis.server.storage.StorageImplUtils;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 import org.slf4j.Logger;
@@ -83,8 +83,9 @@ public class RaftJournalDumper extends AbstractJournalDumper {
     try (
         PrintStream out =
             new PrintStream(new BufferedOutputStream(new FileOutputStream(mJournalEntryFile)));
-        RaftStorage storage = new RaftStorageImpl(getJournalDir(),
+        RaftStorage storage = StorageImplUtils.newRaftStorage(getJournalDir(),
             RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
+            RaftStorage.StartupOption.RECOVER,
             RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize())) {
       List<LogSegmentPath> paths = LogSegmentPath.getLogSegmentPaths(storage);
       for (LogSegmentPath path : paths) {
@@ -114,8 +115,9 @@ public class RaftJournalDumper extends AbstractJournalDumper {
   }
 
   private void readRatisSnapshotFromDir() throws IOException {
-    try (RaftStorage storage = new RaftStorageImpl(getJournalDir(),
+    try (RaftStorage storage = StorageImplUtils.newRaftStorage(getJournalDir(),
         RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
+        RaftStorage.StartupOption.RECOVER,
         RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize())) {
       SimpleStateMachineStorage stateMachineStorage = new SimpleStateMachineStorage();
       stateMachineStorage.init(storage);

--- a/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -586,10 +586,10 @@ public class RaftJournalTest {
     long currentTermObj = (long) getCurrentTermMethod.invoke(serverStateObj);
 
     Method changeToFollowerMethod = raftServerImplClass.getDeclaredMethod("changeToFollower",
-        long.class, boolean.class, Object.class);
+        long.class, boolean.class, boolean.class, Object.class);
 
     changeToFollowerMethod.setAccessible(true);
-    changeToFollowerMethod.invoke(serverImplObj, currentTermObj, true, "test");
+    changeToFollowerMethod.invoke(serverImplObj, currentTermObj, true, false, "test");
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -44,7 +44,7 @@ import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.storage.RaftStorage;
-import org.apache.ratis.server.storage.RaftStorageImpl;
+import org.apache.ratis.server.storage.StorageImplUtils;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 import org.junit.After;
@@ -165,8 +165,10 @@ public class SnapshotReplicationManagerTest {
   }
 
   private SimpleStateMachineStorage getSimpleStateMachineStorage() throws IOException {
-    RaftStorage rs = new RaftStorageImpl(mFolder.newFolder(CommonUtils.randomAlphaNumString(6)),
+    RaftStorage rs = StorageImplUtils.newRaftStorage(
+        mFolder.newFolder(CommonUtils.randomAlphaNumString(6)),
         RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
+        RaftStorage.StartupOption.FORMAT,
         RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize());
     SimpleStateMachineStorage snapshotStore = new SimpleStateMachineStorage();
     snapshotStore.init(rs);

--- a/core/server/master/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -170,6 +170,7 @@ public class SnapshotReplicationManagerTest {
         RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
         RaftStorage.StartupOption.FORMAT,
         RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize());
+    rs.initialize();
     SimpleStateMachineStorage snapshotStore = new SimpleStateMachineStorage();
     snapshotStore.init(rs);
     return snapshotStore;

--- a/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
+++ b/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
@@ -224,6 +224,7 @@ public class JournalToolTest extends BaseIntegrationTest {
           RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
           RaftStorage.StartupOption.RECOVER,
           RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize())) {
+      storage.initialize();
       SimpleStateMachineStorage stateMachineStorage = new SimpleStateMachineStorage();
       stateMachineStorage.init(storage);
       SingleFileSnapshotInfo snapshot = stateMachineStorage.getLatestSnapshot();

--- a/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
+++ b/tests/src/test/java/alluxio/client/cli/JournalToolTest.java
@@ -42,7 +42,7 @@ import alluxio.util.io.PathUtils;
 
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.storage.RaftStorage;
-import org.apache.ratis.server.storage.RaftStorageImpl;
+import org.apache.ratis.server.storage.StorageImplUtils;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 import org.hamcrest.Matchers;
@@ -218,10 +218,11 @@ public class JournalToolTest extends BaseIntegrationTest {
   }
 
   private long getCurrentRatisSnapshotIndex(String journalFolder) throws Throwable {
-    try (RaftStorage storage = new RaftStorageImpl(
+    try (RaftStorage storage = StorageImplUtils.newRaftStorage(
         new File(RaftJournalUtils.getRaftJournalDir(new File(journalFolder)),
             RaftJournalSystem.RAFT_GROUP_UUID.toString()),
           RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
+          RaftStorage.StartupOption.RECOVER,
           RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize())) {
       SimpleStateMachineStorage stateMachineStorage = new SimpleStateMachineStorage();
       stateMachineStorage.init(storage);

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
@@ -106,11 +106,13 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
     waitForSnapshot(raftDir);
     mCluster.stopMasters();
 
-    SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
-    storage.init(StorageImplUtils.newRaftStorage(raftDir,
+    RaftStorage rs = StorageImplUtils.newRaftStorage(raftDir,
         RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
         RaftStorage.StartupOption.RECOVER,
-        RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize()));
+        RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize());
+    rs.initialize();
+    SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
+    storage.init(rs);
     SingleFileSnapshotInfo snapshot = storage.findLatestSnapshot();
     assertNotNull(snapshot);
     mCluster.notifySuccess();
@@ -151,11 +153,13 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
         RaftJournalSystem.RAFT_GROUP_UUID.toString());
     waitForSnapshot(raftDir);
     mCluster.stopMaster(catchUpMasterIndex);
-    SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
-    storage.init(StorageImplUtils.newRaftStorage(raftDir,
+    RaftStorage rs = StorageImplUtils.newRaftStorage(raftDir,
         RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
         RaftStorage.StartupOption.RECOVER,
-        RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize()));
+        RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize());
+    rs.initialize();
+    SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
+    storage.init(rs);
     SingleFileSnapshotInfo snapshot = storage.findLatestSnapshot();
     assertNotNull(snapshot);
     mCluster.notifySuccess();

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
@@ -31,7 +31,8 @@ import alluxio.util.WaitForOptions;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.storage.RaftStorageImpl;
+import org.apache.ratis.server.storage.RaftStorage;
+import org.apache.ratis.server.storage.StorageImplUtils;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 import org.junit.Assert;
@@ -106,8 +107,9 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
     mCluster.stopMasters();
 
     SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
-    storage.init(new RaftStorageImpl(raftDir,
+    storage.init(StorageImplUtils.newRaftStorage(raftDir,
         RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
+        RaftStorage.StartupOption.RECOVER,
         RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize()));
     SingleFileSnapshotInfo snapshot = storage.findLatestSnapshot();
     assertNotNull(snapshot);
@@ -150,8 +152,9 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
     waitForSnapshot(raftDir);
     mCluster.stopMaster(catchUpMasterIndex);
     SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
-    storage.init(new RaftStorageImpl(raftDir,
+    storage.init(StorageImplUtils.newRaftStorage(raftDir,
         RaftServerConfigKeys.Log.CorruptionPolicy.getDefault(),
+        RaftStorage.StartupOption.RECOVER,
         RaftServerConfigKeys.STORAGE_FREE_SPACE_MIN_DEFAULT.getSize()));
     SingleFileSnapshotInfo snapshot = storage.findLatestSnapshot();
     assertNotNull(snapshot);


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. Upgrade Apache Ratis to 2.4.0.
2. Fix issues caused by API change.  (Please double check the `RaftStorage.StartupOption` I used) 

Verified with CI: https://github.com/kaijchen/alluxio/pull/1/checks

### Why are the changes needed?

Apache Ratis has released 2.4.0 in Oct 18th and includes some bug fixes.
https://ratis.apache.org/post/2.4.0.html

Do note Apache Ratis 2.4.1 release is under discussion,
but we can just bump the dependency version when it's released.
https://lists.apache.org/thread/9yw80p20ds533wwn7jfcg1f76q56zogh

### Does this PR introduce any user facing changes?

No.