### PR TITLE
Refactor file system options

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -30,7 +30,7 @@ import alluxio.resource.CloseableResource;
 import alluxio.retry.ExponentialTimeBoundedRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.BlockLocation;
 import alluxio.wire.WorkerNetAddress;
@@ -235,7 +235,7 @@ public class AlluxioFileInStream extends FileInStream {
               FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(0).build())
           .setLoadMetadataOnly(true)
           .build();
-      ListStatusPOptions mergedOptions = FileSystemOptions.listStatusDefaults(
+      ListStatusPOptions mergedOptions = FileSystemOptionsUtils.listStatusDefaults(
           mContext.getPathConf(path)).toBuilder().mergeFrom(refreshPathOptions).build();
       mContext.acquireMasterClientResource().get().listStatus(path, mergedOptions);
       LOG.info("Notified the master that {} should be sync-ed with UFS on the next access",

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileOutStream.java
@@ -33,7 +33,7 @@ import alluxio.resource.CloseableResource;
 import alluxio.retry.ExponentialTimeBoundedRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.OperationId;
 import alluxio.wire.WorkerNetAddress;
@@ -193,7 +193,8 @@ public class AlluxioFileOutStream extends FileOutStream {
       if (!mCanceled && mUnderStorageType.isAsyncPersist()
           && mOptions.getPersistenceWaitTime() != Constants.NO_AUTO_PERSIST) {
         optionsBuilder.setAsyncPersistOptions(
-            FileSystemOptions.scheduleAsyncPersistDefaults(mContext.getPathConf(mUri)).toBuilder()
+            FileSystemOptionsUtils.scheduleAsyncPersistDefaults(
+                mContext.getPathConf(mUri)).toBuilder()
                 .setCommonOptions(mOptions.getCommonOptions())
                 .setPersistenceWaitTime(mOptions.getPersistenceWaitTime()));
       }

--- a/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/BaseFileSystem.java
@@ -60,7 +60,7 @@ import alluxio.master.MasterInquireClient;
 import alluxio.resource.CloseableResource;
 import alluxio.security.authorization.AclEntry;
 import alluxio.uri.Authority;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.wire.BlockLocation;
 import alluxio.wire.BlockLocationInfo;
 import alluxio.wire.FileBlockInfo;
@@ -135,7 +135,7 @@ public class BaseFileSystem implements FileSystem {
       throws InvalidPathException, IOException, AlluxioException {
     checkUri(path);
     rpc(client -> {
-      CheckAccessPOptions mergedOptions = FileSystemOptions
+      CheckAccessPOptions mergedOptions = FileSystemOptionsUtils
           .checkAccessDefaults(mFsContext.getPathConf(path))
           .toBuilder().mergeFrom(options).build();
       client.checkAccess(path, mergedOptions);
@@ -149,7 +149,7 @@ public class BaseFileSystem implements FileSystem {
       throws FileAlreadyExistsException, InvalidPathException, IOException, AlluxioException {
     checkUri(path);
     rpc(client -> {
-      CreateDirectoryPOptions mergedOptions = FileSystemOptions.createDirectoryDefaults(
+      CreateDirectoryPOptions mergedOptions = FileSystemOptionsUtils.createDirectoryDefaults(
           mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
       client.createDirectory(path, mergedOptions);
       LOG.debug("Created directory {}, options: {}", path.getPath(), mergedOptions);
@@ -162,7 +162,7 @@ public class BaseFileSystem implements FileSystem {
       throws FileAlreadyExistsException, InvalidPathException, IOException, AlluxioException {
     checkUri(path);
     return rpc(client -> {
-      CreateFilePOptions mergedOptions = FileSystemOptions.createFileDefaults(
+      CreateFilePOptions mergedOptions = FileSystemOptionsUtils.createFileDefaults(
           mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
       URIStatus status = client.createFile(path, mergedOptions);
       LOG.debug("Created file {}, options: {}", path.getPath(), mergedOptions);
@@ -186,7 +186,7 @@ public class BaseFileSystem implements FileSystem {
       throws DirectoryNotEmptyException, FileDoesNotExistException, IOException, AlluxioException {
     checkUri(path);
     rpc(client -> {
-      DeletePOptions mergedOptions = FileSystemOptions.deleteDefaults(
+      DeletePOptions mergedOptions = FileSystemOptionsUtils.deleteDefaults(
           mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
       client.delete(path, mergedOptions);
       LOG.debug("Deleted {}, options: {}", path.getPath(), mergedOptions);
@@ -199,7 +199,7 @@ public class BaseFileSystem implements FileSystem {
       throws IOException, AlluxioException {
     checkUri(path);
     return rpc(client -> {
-      ExistsPOptions mergedOptions = FileSystemOptions.existsDefaults(
+      ExistsPOptions mergedOptions = FileSystemOptionsUtils.existsDefaults(
           mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
       return client.exists(path, mergedOptions);
     });
@@ -210,7 +210,7 @@ public class BaseFileSystem implements FileSystem {
       throws FileDoesNotExistException, IOException, AlluxioException {
     checkUri(path);
     rpc(client -> {
-      FreePOptions mergedOptions = FileSystemOptions.freeDefaults(mFsContext.getPathConf(path))
+      FreePOptions mergedOptions = FileSystemOptionsUtils.freeDefaults(mFsContext.getPathConf(path))
           .toBuilder().mergeFrom(options).build();
       client.free(path, mergedOptions);
       LOG.debug("Freed {}, options: {}", path.getPath(), mergedOptions);
@@ -265,7 +265,7 @@ public class BaseFileSystem implements FileSystem {
       throws FileDoesNotExistException, IOException, AlluxioException {
     checkUri(path);
     URIStatus status = rpc(client -> {
-      GetStatusPOptions mergedOptions = FileSystemOptions.getStatusDefaults(
+      GetStatusPOptions mergedOptions = FileSystemOptionsUtils.getStatusDefaults(
           mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
       return client.getStatus(path, mergedOptions);
     });
@@ -281,7 +281,7 @@ public class BaseFileSystem implements FileSystem {
     checkUri(path);
     return rpc(client -> {
       // TODO(calvin): Fix the exception handling in the master
-      ListStatusPOptions mergedOptions = FileSystemOptions.listStatusDefaults(
+      ListStatusPOptions mergedOptions = FileSystemOptionsUtils.listStatusDefaults(
           mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
       return client.listStatus(path, mergedOptions);
     });
@@ -294,7 +294,7 @@ public class BaseFileSystem implements FileSystem {
     checkUri(path);
     rpc(client -> {
       // TODO(calvin): Fix the exception handling in the master
-      ListStatusPOptions mergedOptions = FileSystemOptions.listStatusDefaults(
+      ListStatusPOptions mergedOptions = FileSystemOptionsUtils.listStatusDefaults(
           mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
       client.iterateStatus(path, mergedOptions, action);
       return null;
@@ -307,7 +307,7 @@ public class BaseFileSystem implements FileSystem {
       throws AlluxioException, IOException {
     checkUri(path);
     return rpc(client -> {
-      ListStatusPartialPOptions mergedOptions = FileSystemOptions.listStatusPartialDefaults(
+      ListStatusPartialPOptions mergedOptions = FileSystemOptionsUtils.listStatusPartialDefaults(
           mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
       return client.listStatusPartial(path, mergedOptions);
     });
@@ -318,7 +318,7 @@ public class BaseFileSystem implements FileSystem {
       throws FileDoesNotExistException, IOException, AlluxioException {
     checkUri(path);
     rpc(client -> {
-      ListStatusPOptions mergedOptions = FileSystemOptions.listStatusDefaults(
+      ListStatusPOptions mergedOptions = FileSystemOptionsUtils.listStatusDefaults(
           mFsContext.getPathConf(path)).toBuilder().mergeFrom(options)
           .setLoadMetadataType(LoadMetadataPType.ALWAYS).setLoadMetadataOnly(true).build();
       client.listStatus(path, mergedOptions);
@@ -331,7 +331,7 @@ public class BaseFileSystem implements FileSystem {
       throws IOException, AlluxioException {
     checkUri(alluxioPath);
     rpc(client -> {
-      MountPOptions mergedOptions = FileSystemOptions.mountDefaults(
+      MountPOptions mergedOptions = FileSystemOptionsUtils.mountDefaults(
           mFsContext.getPathConf(alluxioPath)).toBuilder().mergeFrom(options).build();
       // TODO(calvin): Make this fail on the master side
       client.mount(alluxioPath, ufsPath, mergedOptions);
@@ -345,7 +345,7 @@ public class BaseFileSystem implements FileSystem {
       throws IOException, AlluxioException {
     checkUri(alluxioPath);
     rpc(client -> {
-      MountPOptions mergedOptions = FileSystemOptions.mountDefaults(
+      MountPOptions mergedOptions = FileSystemOptionsUtils.mountDefaults(
           mFsContext.getPathConf(alluxioPath)).toBuilder().mergeFrom(options).build();
       client.updateMount(alluxioPath, mergedOptions);
       LOG.debug("UpdateMount on {}", alluxioPath.getPath());
@@ -370,7 +370,8 @@ public class BaseFileSystem implements FileSystem {
     checkUri(path);
     rpc(client -> {
       ScheduleAsyncPersistencePOptions mergedOptions =
-          FileSystemOptions.scheduleAsyncPersistDefaults(mFsContext.getPathConf(path)).toBuilder()
+          FileSystemOptionsUtils
+              .scheduleAsyncPersistDefaults(mFsContext.getPathConf(path)).toBuilder()
               .mergeFrom(options).build();
       client.scheduleAsyncPersist(path, mergedOptions);
       LOG.debug("Scheduled persist for {}, options: {}", path.getPath(), mergedOptions);
@@ -385,7 +386,7 @@ public class BaseFileSystem implements FileSystem {
     checkUri(path);
     AlluxioConfiguration conf = mFsContext.getPathConf(path);
     URIStatus status = getStatus(path,
-        FileSystemOptions.getStatusDefaults(conf).toBuilder()
+        FileSystemOptionsUtils.getStatusDefaults(conf).toBuilder()
             .setAccessMode(Bits.READ)
             .setUpdateTimestamps(options.getUpdateLastAccessTime())
             .build());
@@ -404,7 +405,7 @@ public class BaseFileSystem implements FileSystem {
       throw new FileIncompleteException(path);
     }
     AlluxioConfiguration conf = mFsContext.getPathConf(path);
-    OpenFilePOptions mergedOptions = FileSystemOptions.openFileDefaults(conf)
+    OpenFilePOptions mergedOptions = FileSystemOptionsUtils.openFileDefaults(conf)
         .toBuilder().mergeFrom(options).build();
     InStreamOptions inStreamOptions = new InStreamOptions(status, mergedOptions, conf, mFsContext);
     return new AlluxioFileInStream(status, inStreamOptions, mFsContext);
@@ -416,7 +417,8 @@ public class BaseFileSystem implements FileSystem {
     checkUri(src);
     checkUri(dst);
     rpc(client -> {
-      RenamePOptions mergedOptions = FileSystemOptions.renameDefaults(mFsContext.getPathConf(dst))
+      RenamePOptions mergedOptions = FileSystemOptionsUtils
+          .renameDefaults(mFsContext.getPathConf(dst))
           .toBuilder().mergeFrom(options).build();
       // TODO(calvin): Update this code on the master side.
       client.rename(src, dst, mergedOptions);
@@ -439,7 +441,7 @@ public class BaseFileSystem implements FileSystem {
       SetAclPOptions options) throws FileDoesNotExistException, IOException, AlluxioException {
     checkUri(path);
     rpc(client -> {
-      SetAclPOptions mergedOptions = FileSystemOptions.setAclDefaults(
+      SetAclPOptions mergedOptions = FileSystemOptionsUtils.setAclDefaults(
           mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
       client.setAcl(path, action, entries, mergedOptions);
       LOG.debug("Set ACL for {}, entries: {} options: {}", path.getPath(), entries,
@@ -453,7 +455,7 @@ public class BaseFileSystem implements FileSystem {
       throws FileDoesNotExistException, IOException, AlluxioException {
     checkUri(path);
     SetAttributePOptions mergedOptions =
-        FileSystemOptions.setAttributeClientDefaults(mFsContext.getPathConf(path))
+        FileSystemOptionsUtils.setAttributeClientDefaults(mFsContext.getPathConf(path))
             .toBuilder().mergeFrom(options).build();
     rpc(client -> {
       client.setAttribute(path, mergedOptions);
@@ -496,7 +498,7 @@ public class BaseFileSystem implements FileSystem {
       throws IOException, AlluxioException {
     checkUri(path);
     rpc(client -> {
-      UnmountPOptions mergedOptions = FileSystemOptions.unmountDefaults(
+      UnmountPOptions mergedOptions = FileSystemOptionsUtils.unmountDefaults(
           mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
       client.unmount(path);
       LOG.debug("Unmounted {}, options: {}", path.getPath(), mergedOptions);

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -16,6 +16,7 @@ import alluxio.ClientContext;
 import alluxio.annotation.PublicApi;
 import alluxio.client.file.cache.CacheManager;
 import alluxio.client.file.cache.LocalCacheFileSystem;
+import alluxio.client.file.options.FileSystemOptions;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
@@ -150,16 +151,24 @@ public interface FileSystem extends Closeable {
      * @return a new FileSystem instance
      */
     public static FileSystem create(FileSystemContext context) {
+      return create(context, FileSystemOptions.create(context.getClusterConf()));
+    }
+
+    /**
+     * @param context the FileSystemContext to use with the FileSystem
+     * @return a new FileSystem instance
+     */
+    public static FileSystem create(FileSystemContext context, FileSystemOptions options) {
       AlluxioConfiguration conf = context.getClusterConf();
       checkSortConf(conf);
       if (CommonUtils.PROCESS_TYPE.get() != CommonUtils.ProcessType.CLIENT) {
         return new BaseFileSystem(context);
       }
       FileSystem fs = new BaseFileSystem(context);
-      if (conf.getBoolean(PropertyKey.USER_METADATA_CACHE_ENABLED)) {
+      if (options.isMetadataCacheEnabled()) {
         fs = new MetadataCachingFileSystem(fs, context);
       }
-      if (conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_ENABLED)) {
+      if (options.isDataCacheEnabled()) {
         try {
           CacheManager cacheManager = CacheManager.Factory.get(conf);
           return new LocalCacheFileSystem(cacheManager, fs, conf);

--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCachingFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCachingFileSystem.java
@@ -30,7 +30,7 @@ import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.RenamePOptions;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.util.ThreadUtils;
 import alluxio.wire.BlockLocationInfo;
 import alluxio.wire.FileInfo;
@@ -205,7 +205,7 @@ public class MetadataCachingFileSystem extends DelegatingFileSystem {
       throws FileDoesNotExistException, OpenDirectoryException, FileIncompleteException,
       IOException, AlluxioException {
     URIStatus status = getStatus(path,
-        FileSystemOptions.getStatusDefaults(mFsContext.getPathConf(path)).toBuilder()
+        FileSystemOptionsUtils.getStatusDefaults(mFsContext.getPathConf(path)).toBuilder()
             .setAccessMode(Bits.READ)
             .setUpdateTimestamps(options.getUpdateLastAccessTime())
             .build());
@@ -226,7 +226,8 @@ public class MetadataCachingFileSystem extends DelegatingFileSystem {
       mAccessTimeUpdater.submit(() -> {
         try {
           AlluxioConfiguration conf = mFsContext.getPathConf(path);
-          GetStatusPOptions getStatusOptions = FileSystemOptions.getStatusDefaults(conf).toBuilder()
+          GetStatusPOptions getStatusOptions = FileSystemOptionsUtils
+              .getStatusDefaults(conf).toBuilder()
               .setAccessMode(Bits.READ)
               .setUpdateTimestamps(true)
               .build();

--- a/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/RetryHandlingFileSystemMasterClient.java
@@ -70,7 +70,7 @@ import alluxio.grpc.UpdateUfsModePRequest;
 import alluxio.master.MasterClientContext;
 import alluxio.retry.CountingRetry;
 import alluxio.security.authorization.AclEntry;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.wire.SyncPointInfo;
 
 import org.slf4j.Logger;
@@ -320,7 +320,7 @@ public final class RetryHandlingFileSystemMasterClient extends AbstractMasterCli
   @Override
   public void rename(final AlluxioURI src, final AlluxioURI dst)
       throws AlluxioStatusException {
-    rename(src, dst, FileSystemOptions.renameDefaults(mContext.getClusterConf()));
+    rename(src, dst, FileSystemOptionsUtils.renameDefaults(mContext.getClusterConf()));
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/options/FileSystemOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/FileSystemOptions.java
@@ -1,0 +1,118 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file.options;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+
+/**
+ * Options for creating the {@link alluxio.client.file.FileSystem}.
+ */
+public class FileSystemOptions {
+  private final boolean mMetadataCacheEnabled;
+  private final boolean mDataCacheEnabled;
+
+  /**
+   * Creates the file system options.
+   *
+   * @param conf alluxio configuration
+   * @return the file system options
+   */
+  public static FileSystemOptions create(AlluxioConfiguration conf) {
+    return Builder.create(conf).build();
+  }
+
+  /**
+   * Creates the default file system options.
+   *
+   * @return the file system options
+   */
+  public static FileSystemOptions defaults() {
+    return new Builder().build();
+  }
+
+  /**
+   * Creates a new instance of {@link FileSystemOptions}.
+   *
+   * @param metadaCacheEnabled whether metadata cache is enabled
+   * @param dataCacheEnabled whether data cache is enabled
+   */
+  private FileSystemOptions(boolean metadaCacheEnabled, boolean dataCacheEnabled) {
+    mMetadataCacheEnabled = metadaCacheEnabled;
+    mDataCacheEnabled = dataCacheEnabled;
+  }
+
+  /**
+   * @return true if metadata cache is enabled, false otherwise
+   */
+  public boolean isMetadataCacheEnabled() {
+    return mMetadataCacheEnabled;
+  }
+
+  /**
+   * @return true if data cache is enabled, false otherwise
+   */
+  public boolean isDataCacheEnabled() {
+    return mDataCacheEnabled;
+  }
+
+  /**
+   * Builder class for {@link FileSystemOptions}.
+   */
+  public static final class Builder {
+    private boolean mMetadataCacheEnabled;
+    private boolean mDataCacheEnabled;
+
+    /**
+     * Creates a new Builder based on configuration.
+     *
+     * @param conf the alluxio conf
+     * @return the created builder
+     */
+    public static Builder create(AlluxioConfiguration conf) {
+      return new Builder()
+          .setMetadataCacheEnabled(conf.getBoolean(PropertyKey.USER_METADATA_CACHE_ENABLED))
+          .setDataCacheEnabled(conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_ENABLED));
+    }
+
+    /**
+     * Constructor.
+     */
+    public Builder() {}
+
+    /**
+     * @param metadataCacheEnabled metadata cache enabled
+     * @return the builder
+     */
+    public Builder setMetadataCacheEnabled(boolean metadataCacheEnabled) {
+      mMetadataCacheEnabled = metadataCacheEnabled;
+      return this;
+    }
+
+    /**
+     * @param dataCacheEnabled data cache enabled
+     * @return the builder
+     */
+    public Builder setDataCacheEnabled(boolean dataCacheEnabled) {
+      mDataCacheEnabled = dataCacheEnabled;
+      return this;
+    }
+
+    /**
+     * @return the worker net address
+     */
+    public FileSystemOptions build() {
+      return new FileSystemOptions(mMetadataCacheEnabled, mDataCacheEnabled);
+    }
+  }
+}
+

--- a/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
@@ -21,7 +21,7 @@ import alluxio.grpc.OpenFilePOptions;
 import alluxio.master.block.BlockId;
 import alluxio.master.file.meta.PersistenceState;
 import alluxio.proto.dataserver.Protocol;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.FileBlockInfo;
 
@@ -54,7 +54,7 @@ public final class InStreamOptions {
    * @param alluxioConf Alluxio configuration
    */
   public InStreamOptions(URIStatus status, @Nonnull AlluxioConfiguration alluxioConf) {
-    this(status, FileSystemOptions.openFileDefaults(alluxioConf), alluxioConf,
+    this(status, FileSystemOptionsUtils.openFileDefaults(alluxioConf), alluxioConf,
         FileSystemContext.create(alluxioConf));
   }
 
@@ -67,7 +67,7 @@ public final class InStreamOptions {
    */
   public InStreamOptions(URIStatus status, @Nonnull AlluxioConfiguration alluxioConf,
       @Nonnull FileSystemContext context) {
-    this(status, FileSystemOptions.openFileDefaults(alluxioConf), alluxioConf, context);
+    this(status, FileSystemOptionsUtils.openFileDefaults(alluxioConf), alluxioConf, context);
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/options/OutStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/OutStreamOptions.java
@@ -24,7 +24,7 @@ import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.security.authorization.AccessControlList;
 import alluxio.security.authorization.Mode;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.util.IdUtils;
 import alluxio.util.ModeUtils;
 
@@ -116,7 +116,7 @@ public final class OutStreamOptions {
   }
 
   private OutStreamOptions(FileSystemContext context, AlluxioConfiguration alluxioConf) {
-    mCommonOptions = FileSystemOptions.commonDefaults(alluxioConf);
+    mCommonOptions = FileSystemOptionsUtils.commonDefaults(alluxioConf);
     mBlockSizeBytes = alluxioConf.getBytes(PropertyKey.USER_BLOCK_SIZE_BYTES_DEFAULT);
     mLocationPolicy = context.getWriteBlockLocationPolicy(alluxioConf);
     mWriteTier = alluxioConf.getInt(PropertyKey.USER_FILE_WRITE_TIER_DEFAULT);

--- a/core/client/fs/src/main/java/alluxio/util/FileSystemOptionsUtils.java
+++ b/core/client/fs/src/main/java/alluxio/util/FileSystemOptionsUtils.java
@@ -46,7 +46,7 @@ import java.util.UUID;
  * This class contains static methods which can be passed Alluxio configuration objects that
  * will populate the gRPC options objects with the proper values based on the given configuration.
  */
-public class FileSystemOptions {
+public class FileSystemOptionsUtils {
   /**
    * @param conf Alluxio configuration
    * @return options based on the configuration

--- a/core/client/fs/src/test/java/alluxio/client/block/BlockStoreClientTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/BlockStoreClientTest.java
@@ -47,7 +47,7 @@ import alluxio.grpc.OpenLocalBlockRequest;
 import alluxio.grpc.OpenLocalBlockResponse;
 import alluxio.network.TieredIdentityFactory;
 import alluxio.resource.DummyCloseableResource;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.BlockLocation;
@@ -339,7 +339,7 @@ public final class BlockStoreClientTest {
     URIStatus dummyStatus =
         new URIStatus(new FileInfo().setPersisted(true).setBlockIds(Collections.singletonList(0L)));
     InStreamOptions options =
-        new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(S_CONF),
+        new InStreamOptions(dummyStatus, FileSystemOptionsUtils.openFileDefaults(S_CONF),
             S_CONF, mContext);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
     when(mContext.getCachedWorkers()).thenReturn(Collections.emptyList());
@@ -353,7 +353,7 @@ public final class BlockStoreClientTest {
     URIStatus dummyStatus = new URIStatus(
         new FileInfo().setPersisted(false).setBlockIds(Collections.singletonList(0L)));
     InStreamOptions options =
-        new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(S_CONF),
+        new InStreamOptions(dummyStatus, FileSystemOptionsUtils.openFileDefaults(S_CONF),
             S_CONF, mContext);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(new BlockInfo());
     Exception e = assertThrows(UnavailableException.class, () ->
@@ -540,7 +540,7 @@ public final class BlockStoreClientTest {
         .getArgument(0, GetWorkerOptions.class).getBlockWorkerInfos().iterator().next()
         .getNetAddress());
     InStreamOptions options =
-        new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(S_CONF),
+        new InStreamOptions(dummyStatus, FileSystemOptionsUtils.openFileDefaults(S_CONF),
             S_CONF, mContext);
     options.setUfsReadLocationPolicy(mockPolicy);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(info);
@@ -581,7 +581,7 @@ public final class BlockStoreClientTest {
         .getArgument(0, GetWorkerOptions.class).getBlockWorkerInfos().iterator().next()
         .getNetAddress()));
     InStreamOptions options =
-        new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(S_CONF),
+        new InStreamOptions(dummyStatus, FileSystemOptionsUtils.openFileDefaults(S_CONF),
             S_CONF, mContext);
     options.setUfsReadLocationPolicy(mockPolicy);
     when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(info);

--- a/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/BaseFileSystemTest.java
@@ -42,7 +42,7 @@ import alluxio.grpc.RenamePOptions;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.UnmountPOptions;
 import alluxio.resource.CloseableResource;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.wire.FileInfo;
 
 import org.junit.After;
@@ -130,7 +130,8 @@ public final class BaseFileSystemTest {
     when(mFileSystemMasterClient.createFile(any(AlluxioURI.class), any(CreateFilePOptions.class)))
         .thenReturn(status);
     mFileSystem.createFile(file, CreateFilePOptions.getDefaultInstance());
-    verify(mFileSystemMasterClient).createFile(file, FileSystemOptions.createFileDefaults(mConf)
+    verify(mFileSystemMasterClient).createFile(file,
+        FileSystemOptionsUtils.createFileDefaults(mConf)
             .toBuilder().mergeFrom(CreateFilePOptions.getDefaultInstance()).build());
 
     verifyFilesystemContextAcquiredAndReleased();
@@ -162,7 +163,7 @@ public final class BaseFileSystemTest {
     DeletePOptions deleteOptions = DeletePOptions.newBuilder().setRecursive(true).build();
     mFileSystem.delete(file, deleteOptions);
     verify(mFileSystemMasterClient).delete(file,
-        FileSystemOptions.deleteDefaults(mConf).toBuilder().mergeFrom(deleteOptions).build());
+        FileSystemOptionsUtils.deleteDefaults(mConf).toBuilder().mergeFrom(deleteOptions).build());
 
     verifyFilesystemContextAcquiredAndReleased();
   }
@@ -175,7 +176,7 @@ public final class BaseFileSystemTest {
     AlluxioURI file = new AlluxioURI("/file");
     DeletePOptions deleteOptions = DeletePOptions.newBuilder().setRecursive(true).build();
     doThrow(EXCEPTION).when(mFileSystemMasterClient).delete(file,
-        FileSystemOptions.deleteDefaults(mConf)
+        FileSystemOptionsUtils.deleteDefaults(mConf)
             .toBuilder().mergeFrom(deleteOptions).build());
     try {
       mFileSystem.delete(file, deleteOptions);
@@ -195,7 +196,7 @@ public final class BaseFileSystemTest {
     AlluxioURI file = new AlluxioURI("/file");
     FreePOptions freeOptions = FreePOptions.newBuilder().setRecursive(true).build();
     mFileSystem.free(file, freeOptions);
-    verify(mFileSystemMasterClient).free(file, FileSystemOptions.freeDefaults(mConf)
+    verify(mFileSystemMasterClient).free(file, FileSystemOptionsUtils.freeDefaults(mConf)
         .toBuilder().mergeFrom(freeOptions).build());
 
     verifyFilesystemContextAcquiredAndReleased();
@@ -209,7 +210,7 @@ public final class BaseFileSystemTest {
     AlluxioURI file = new AlluxioURI("/file");
     FreePOptions freeOptions = FreePOptions.newBuilder().setRecursive(true).build();
     doThrow(EXCEPTION).when(mFileSystemMasterClient).free(file,
-        FileSystemOptions.freeDefaults(mConf).toBuilder().mergeFrom(freeOptions).build());
+        FileSystemOptionsUtils.freeDefaults(mConf).toBuilder().mergeFrom(freeOptions).build());
     try {
       mFileSystem.free(file, freeOptions);
       fail(SHOULD_HAVE_PROPAGATED_MESSAGE);
@@ -228,10 +229,10 @@ public final class BaseFileSystemTest {
     AlluxioURI file = new AlluxioURI("/file");
     URIStatus status = new URIStatus(new FileInfo());
     GetStatusPOptions getStatusOptions = GetStatusPOptions.getDefaultInstance();
-    when(mFileSystemMasterClient.getStatus(file, FileSystemOptions.getStatusDefaults(mConf)
+    when(mFileSystemMasterClient.getStatus(file, FileSystemOptionsUtils.getStatusDefaults(mConf)
         .toBuilder().mergeFrom(getStatusOptions).build())).thenReturn(status);
     assertSame(status, mFileSystem.getStatus(file, getStatusOptions));
-    verify(mFileSystemMasterClient).getStatus(file, FileSystemOptions.getStatusDefaults(mConf)
+    verify(mFileSystemMasterClient).getStatus(file, FileSystemOptionsUtils.getStatusDefaults(mConf)
         .toBuilder().mergeFrom(getStatusOptions).build());
 
     verifyFilesystemContextAcquiredAndReleased();
@@ -244,7 +245,7 @@ public final class BaseFileSystemTest {
   public void getStatusException() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
     GetStatusPOptions getStatusOptions = GetStatusPOptions.getDefaultInstance();
-    when(mFileSystemMasterClient.getStatus(file, FileSystemOptions.getStatusDefaults(mConf)
+    when(mFileSystemMasterClient.getStatus(file, FileSystemOptionsUtils.getStatusDefaults(mConf)
         .toBuilder().mergeFrom(getStatusOptions).build())).thenThrow(EXCEPTION);
     try {
       mFileSystem.getStatus(file, getStatusOptions);
@@ -265,10 +266,11 @@ public final class BaseFileSystemTest {
     List<URIStatus> infos = new ArrayList<>();
     infos.add(new URIStatus(new FileInfo()));
     ListStatusPOptions listStatusOptions = ListStatusPOptions.getDefaultInstance();
-    when(mFileSystemMasterClient.listStatus(file, FileSystemOptions.listStatusDefaults(mConf)
+    when(mFileSystemMasterClient.listStatus(file, FileSystemOptionsUtils.listStatusDefaults(mConf)
         .toBuilder().mergeFrom(listStatusOptions).build())).thenReturn(infos);
     assertSame(infos, mFileSystem.listStatus(file, listStatusOptions));
-    verify(mFileSystemMasterClient).listStatus(file, FileSystemOptions.listStatusDefaults(mConf)
+    verify(mFileSystemMasterClient).listStatus(file,
+        FileSystemOptionsUtils.listStatusDefaults(mConf)
         .toBuilder().mergeFrom(listStatusOptions).build());
 
     verifyFilesystemContextAcquiredAndReleased();
@@ -280,7 +282,7 @@ public final class BaseFileSystemTest {
   @Test
   public void listStatusException() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
-    when(mFileSystemMasterClient.listStatus(file, FileSystemOptions.listStatusDefaults(mConf)
+    when(mFileSystemMasterClient.listStatus(file, FileSystemOptionsUtils.listStatusDefaults(mConf)
         .toBuilder().mergeFrom(ListStatusPOptions.getDefaultInstance()).build()))
         .thenThrow(EXCEPTION);
     try {
@@ -336,11 +338,11 @@ public final class BaseFileSystemTest {
     AlluxioURI dir = new AlluxioURI("/dir");
     CreateDirectoryPOptions createDirectoryOptions = CreateDirectoryPOptions.getDefaultInstance();
     doNothing().when(mFileSystemMasterClient).createDirectory(dir,
-        FileSystemOptions.createDirectoryDefaults(mConf)
+        FileSystemOptionsUtils.createDirectoryDefaults(mConf)
             .toBuilder().mergeFrom(createDirectoryOptions).build());
     mFileSystem.createDirectory(dir, createDirectoryOptions);
     verify(mFileSystemMasterClient).createDirectory(dir,
-        FileSystemOptions.createDirectoryDefaults(mConf)
+        FileSystemOptionsUtils.createDirectoryDefaults(mConf)
             .toBuilder().mergeFrom(createDirectoryOptions).build());
 
     verifyFilesystemContextAcquiredAndReleased();
@@ -354,7 +356,7 @@ public final class BaseFileSystemTest {
     AlluxioURI dir = new AlluxioURI("/dir");
     CreateDirectoryPOptions createDirectoryOptions = CreateDirectoryPOptions.getDefaultInstance();
     doThrow(EXCEPTION).when(mFileSystemMasterClient).createDirectory(dir,
-        FileSystemOptions.createDirectoryDefaults(mConf)
+        FileSystemOptionsUtils.createDirectoryDefaults(mConf)
             .toBuilder().mergeFrom(createDirectoryOptions).build());
     try {
       mFileSystem.createDirectory(dir, createDirectoryOptions);
@@ -375,10 +377,10 @@ public final class BaseFileSystemTest {
     AlluxioURI ufsPath = new AlluxioURI("/u");
     MountPOptions mountOptions = MountPOptions.getDefaultInstance();
     doNothing().when(mFileSystemMasterClient).mount(alluxioPath, ufsPath,
-        FileSystemOptions.mountDefaults(mConf).toBuilder().mergeFrom(mountOptions).build());
+        FileSystemOptionsUtils.mountDefaults(mConf).toBuilder().mergeFrom(mountOptions).build());
     mFileSystem.mount(alluxioPath, ufsPath, mountOptions);
     verify(mFileSystemMasterClient).mount(alluxioPath, ufsPath,
-        FileSystemOptions.mountDefaults(mConf).toBuilder().mergeFrom(mountOptions).build());
+        FileSystemOptionsUtils.mountDefaults(mConf).toBuilder().mergeFrom(mountOptions).build());
 
     verifyFilesystemContextAcquiredAndReleased();
   }
@@ -392,8 +394,8 @@ public final class BaseFileSystemTest {
     AlluxioURI ufsPath = new AlluxioURI("/u");
     MountPOptions mountOptions = MountPOptions.getDefaultInstance();
     doThrow(EXCEPTION).when(mFileSystemMasterClient)
-        .mount(alluxioPath, ufsPath,
-            FileSystemOptions.mountDefaults(mConf).toBuilder().mergeFrom(mountOptions).build());
+        .mount(alluxioPath, ufsPath, FileSystemOptionsUtils.mountDefaults(mConf)
+            .toBuilder().mergeFrom(mountOptions).build());
     try {
       mFileSystem.mount(alluxioPath, ufsPath, mountOptions);
       fail(SHOULD_HAVE_PROPAGATED_MESSAGE);
@@ -450,10 +452,10 @@ public final class BaseFileSystemTest {
     AlluxioURI dst = new AlluxioURI("/file2");
     RenamePOptions renameOptions = RenamePOptions.getDefaultInstance();
     doNothing().when(mFileSystemMasterClient).rename(src, dst,
-        FileSystemOptions.renameDefaults(mConf).toBuilder().mergeFrom(renameOptions).build());
+        FileSystemOptionsUtils.renameDefaults(mConf).toBuilder().mergeFrom(renameOptions).build());
     mFileSystem.rename(src, dst, renameOptions);
     verify(mFileSystemMasterClient).rename(src, dst,
-        FileSystemOptions.renameDefaults(mConf).toBuilder().mergeFrom(renameOptions).build());
+        FileSystemOptionsUtils.renameDefaults(mConf).toBuilder().mergeFrom(renameOptions).build());
   }
 
   /**
@@ -465,7 +467,7 @@ public final class BaseFileSystemTest {
     AlluxioURI dst = new AlluxioURI("/file2");
     RenamePOptions renameOptions = RenamePOptions.getDefaultInstance();
     doThrow(EXCEPTION).when(mFileSystemMasterClient).rename(src, dst,
-        FileSystemOptions.renameDefaults(mConf)
+        FileSystemOptionsUtils.renameDefaults(mConf)
         .toBuilder().mergeFrom(renameOptions).build());
     try {
       mFileSystem.rename(src, dst, renameOptions);
@@ -482,7 +484,7 @@ public final class BaseFileSystemTest {
   public void setAttribute() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
     SetAttributePOptions setAttributeOptions =
-        FileSystemOptions.setAttributeClientDefaults(mFileContext.getPathConf(file));
+        FileSystemOptionsUtils.setAttributeClientDefaults(mFileContext.getPathConf(file));
     mFileSystem.setAttribute(file, setAttributeOptions);
     verify(mFileSystemMasterClient).setAttribute(file, setAttributeOptions);
   }
@@ -494,7 +496,7 @@ public final class BaseFileSystemTest {
   public void setAttributeSyncMetadataInterval() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
     SetAttributePOptions opt =
-        FileSystemOptions.setAttributeClientDefaults(mFileContext.getPathConf(file));
+        FileSystemOptionsUtils.setAttributeClientDefaults(mFileContext.getPathConf(file));
     // Check that metadata sync interval from configuration is used when options are omitted
     mFileSystem.setAttribute(file);
     verify(mFileSystemMasterClient).setAttribute(file, opt);
@@ -507,7 +509,7 @@ public final class BaseFileSystemTest {
   public void setStateException() throws Exception {
     AlluxioURI file = new AlluxioURI("/file");
     SetAttributePOptions setAttributeOptions =
-        FileSystemOptions.setAttributeClientDefaults(mFileContext.getPathConf(file));
+        FileSystemOptionsUtils.setAttributeClientDefaults(mFileContext.getPathConf(file));
     doThrow(EXCEPTION).when(mFileSystemMasterClient).setAttribute(file, setAttributeOptions);
     try {
       mFileSystem.setAttribute(file, setAttributeOptions);
@@ -626,7 +628,7 @@ public final class BaseFileSystemTest {
   }
 
   private GetStatusPOptions getOpenOptions(GetStatusPOptions getStatusOptions) {
-    return FileSystemOptions.getStatusDefaults(mConf)
+    return FileSystemOptionsUtils.getStatusDefaults(mConf)
         .toBuilder().setAccessMode(Bits.READ).setUpdateTimestamps(true)
         .mergeFrom(getStatusOptions).build();
   }

--- a/core/client/fs/src/test/java/alluxio/util/FileSystemOptionsUtilsTest.java
+++ b/core/client/fs/src/test/java/alluxio/util/FileSystemOptionsUtilsTest.java
@@ -25,13 +25,13 @@ import alluxio.grpc.SetAclPOptions;
 
 import org.junit.Test;
 
-public class FileSystemOptionsTest {
+public class FileSystemOptionsUtilsTest {
 
   private InstancedConfiguration mConf = Configuration.copyGlobal();
 
   @Test
   public void loadMetadataOptionsDefaults() {
-    LoadMetadataPOptions options = FileSystemOptions.loadMetadataDefaults(mConf);
+    LoadMetadataPOptions options = FileSystemOptionsUtils.loadMetadataDefaults(mConf);
     assertNotNull(options);
     assertFalse(options.getCreateAncestors());
     assertFalse(options.getRecursive());
@@ -40,7 +40,7 @@ public class FileSystemOptionsTest {
 
   @Test
   public void deleteOptionsDefaults() {
-    DeletePOptions options = FileSystemOptions.deleteDefaults(mConf);
+    DeletePOptions options = FileSystemOptionsUtils.deleteDefaults(mConf);
     assertNotNull(options);
     assertFalse(options.getRecursive());
     assertFalse(options.getAlluxioOnly());
@@ -49,7 +49,7 @@ public class FileSystemOptionsTest {
 
   @Test
   public void mountOptionsDefaults() {
-    MountPOptions options = FileSystemOptions.mountDefaults(mConf);
+    MountPOptions options = FileSystemOptionsUtils.mountDefaults(mConf);
     assertNotNull(options);
     assertFalse(options.getShared());
     assertFalse(options.getReadOnly());
@@ -58,7 +58,7 @@ public class FileSystemOptionsTest {
 
   @Test
   public void setAclOptionsDefaults() {
-    SetAclPOptions options = FileSystemOptions.setAclDefaults(mConf);
+    SetAclPOptions options = FileSystemOptionsUtils.setAclDefaults(mConf);
     assertNotNull(options);
     assertFalse(options.getRecursive());
   }

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterOptions.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterOptions.java
@@ -13,7 +13,7 @@ package alluxio.master.file;
 
 import alluxio.conf.Configuration;
 import alluxio.grpc.CompleteFilePOptions;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -28,7 +28,7 @@ public final class FileSystemMasterOptions {
    */
   public static CompleteFilePOptions completeFileDefaults() {
     return CompleteFilePOptions.newBuilder()
-        .setCommonOptions(FileSystemOptions.commonDefaults(Configuration.global()))
+        .setCommonOptions(FileSystemOptionsUtils.commonDefaults(Configuration.global()))
         .setUfsLength(0)
         .build();
   }

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CheckAccessContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CheckAccessContext.java
@@ -13,7 +13,7 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.Configuration;
 import alluxio.grpc.CheckAccessPOptions;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import com.google.common.base.MoreObjects;
 
@@ -49,7 +49,7 @@ public class CheckAccessContext
    */
   public static CheckAccessContext mergeFrom(CheckAccessPOptions.Builder optionsBuilder) {
     CheckAccessPOptions masterOptions =
-        FileSystemOptions.checkAccessDefaults(Configuration.global());
+        FileSystemOptionsUtils.checkAccessDefaults(Configuration.global());
     CheckAccessPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -59,7 +59,7 @@ public class CheckAccessContext
    * @return the instance of {@link CheckAccessContext} with default values for master
    */
   public static CheckAccessContext defaults() {
-    return create(FileSystemOptions
+    return create(FileSystemOptionsUtils
         .checkAccessDefaults(Configuration.global()).toBuilder());
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CheckConsistencyContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CheckConsistencyContext.java
@@ -13,7 +13,7 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.Configuration;
 import alluxio.grpc.CheckConsistencyPOptions;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import com.google.common.base.MoreObjects;
 
@@ -49,7 +49,7 @@ public class CheckConsistencyContext
    */
   public static CheckConsistencyContext mergeFrom(CheckConsistencyPOptions.Builder optionsBuilder) {
     CheckConsistencyPOptions masterOptions =
-        FileSystemOptions.checkConsistencyDefaults(Configuration.global());
+        FileSystemOptionsUtils.checkConsistencyDefaults(Configuration.global());
     CheckConsistencyPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -59,7 +59,7 @@ public class CheckConsistencyContext
    * @return the instance of {@link CheckConsistencyContext} with default values for master
    */
   public static CheckConsistencyContext defaults() {
-    return create(FileSystemOptions
+    return create(FileSystemOptionsUtils
         .checkConsistencyDefaults(Configuration.global()).toBuilder());
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CreateDirectoryContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CreateDirectoryContext.java
@@ -15,7 +15,7 @@ import alluxio.conf.Configuration;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.security.authorization.AclEntry;
 import alluxio.underfs.UfsStatus;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.wire.OperationId;
 
 import com.google.common.base.MoreObjects;
@@ -61,7 +61,7 @@ public class CreateDirectoryContext
    */
   public static CreateDirectoryContext mergeFrom(CreateDirectoryPOptions.Builder optionsBuilder) {
     CreateDirectoryPOptions masterOptions =
-        FileSystemOptions.createDirectoryDefaults(Configuration.global(), false);
+        FileSystemOptionsUtils.createDirectoryDefaults(Configuration.global(), false);
     CreateDirectoryPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -71,7 +71,7 @@ public class CreateDirectoryContext
    * @return the instance of {@link CreateDirectoryContext} with default values for master
    */
   public static CreateDirectoryContext defaults() {
-    return create(FileSystemOptions
+    return create(FileSystemOptionsUtils
         .createDirectoryDefaults(Configuration.global(), false).toBuilder());
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CreateFileContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CreateFileContext.java
@@ -13,7 +13,7 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.Configuration;
 import alluxio.grpc.CreateFilePOptions;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.wire.OperationId;
 
 import com.google.common.base.MoreObjects;
@@ -52,7 +52,7 @@ public class CreateFileContext
    */
   public static CreateFileContext mergeFrom(CreateFilePOptions.Builder optionsBuilder) {
     CreateFilePOptions masterOptions =
-        FileSystemOptions.createFileDefaults(Configuration.global(), false);
+        FileSystemOptionsUtils.createFileDefaults(Configuration.global(), false);
     CreateFilePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return new CreateFileContext(mergedOptionsBuilder);
@@ -63,7 +63,7 @@ public class CreateFileContext
    */
   public static CreateFileContext defaults() {
     return create(
-        FileSystemOptions.createFileDefaults(Configuration.global(), false).toBuilder());
+        FileSystemOptionsUtils.createFileDefaults(Configuration.global(), false).toBuilder());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/DeleteContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/DeleteContext.java
@@ -13,7 +13,7 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.Configuration;
 import alluxio.grpc.DeletePOptions;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.wire.OperationId;
 
 import com.google.common.base.MoreObjects;
@@ -49,7 +49,7 @@ public class DeleteContext extends OperationContext<DeletePOptions.Builder, Dele
    */
   public static DeleteContext mergeFrom(DeletePOptions.Builder optionsBuilder) {
     DeletePOptions masterOptions =
-        FileSystemOptions.deleteDefaults(Configuration.global(), false);
+        FileSystemOptionsUtils.deleteDefaults(Configuration.global(), false);
     DeletePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -60,7 +60,7 @@ public class DeleteContext extends OperationContext<DeletePOptions.Builder, Dele
    */
   public static DeleteContext defaults() {
     return create(
-        FileSystemOptions.deleteDefaults(Configuration.global(), false).toBuilder());
+        FileSystemOptionsUtils.deleteDefaults(Configuration.global(), false).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/ExistsContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/ExistsContext.java
@@ -13,7 +13,7 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.Configuration;
 import alluxio.grpc.ExistsPOptions;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import com.google.common.base.MoreObjects;
 
@@ -49,7 +49,7 @@ public class ExistsContext
    */
   public static ExistsContext mergeFrom(ExistsPOptions.Builder optionsBuilder) {
     ExistsPOptions masterOptions =
-        FileSystemOptions.existsDefaults(Configuration.global());
+        FileSystemOptionsUtils.existsDefaults(Configuration.global());
     ExistsPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -59,7 +59,7 @@ public class ExistsContext
    * @return the instance of {@link ExistsContext} with default values for master
    */
   public static ExistsContext defaults() {
-    return create(FileSystemOptions
+    return create(FileSystemOptionsUtils
         .existsDefaults(Configuration.global()).toBuilder());
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/FreeContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/FreeContext.java
@@ -13,7 +13,7 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.Configuration;
 import alluxio.grpc.FreePOptions;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import com.google.common.base.MoreObjects;
 
@@ -46,7 +46,7 @@ public class FreeContext extends OperationContext<FreePOptions.Builder, FreeCont
    * @return the instance of {@link FreeContext} with default values for master
    */
   public static FreeContext mergeFrom(FreePOptions.Builder optionsBuilder) {
-    FreePOptions masterOptions = FileSystemOptions.freeDefaults(Configuration.global());
+    FreePOptions masterOptions = FileSystemOptionsUtils.freeDefaults(Configuration.global());
     FreePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -56,7 +56,7 @@ public class FreeContext extends OperationContext<FreePOptions.Builder, FreeCont
    * @return the instance of {@link FreeContext} with default values for master
    */
   public static FreeContext defaults() {
-    return create(FileSystemOptions.freeDefaults(Configuration.global()).toBuilder());
+    return create(FileSystemOptionsUtils.freeDefaults(Configuration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/GetStatusContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/GetStatusContext.java
@@ -13,7 +13,7 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.Configuration;
 import alluxio.grpc.GetStatusPOptions;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import com.google.common.base.MoreObjects;
 
@@ -47,7 +47,7 @@ public class GetStatusContext
    */
   public static GetStatusContext mergeFrom(GetStatusPOptions.Builder optionsBuilder) {
     GetStatusPOptions masterOptions =
-        FileSystemOptions.getStatusDefaults(Configuration.global());
+        FileSystemOptionsUtils.getStatusDefaults(Configuration.global());
     GetStatusPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -57,7 +57,7 @@ public class GetStatusContext
    * @return the instance of {@link GetStatusContext} with default values for master
    */
   public static GetStatusContext defaults() {
-    return create(FileSystemOptions.getStatusDefaults(Configuration.global()).toBuilder());
+    return create(FileSystemOptionsUtils.getStatusDefaults(Configuration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/ListStatusContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/ListStatusContext.java
@@ -14,7 +14,7 @@ package alluxio.master.file.contexts;
 import alluxio.conf.Configuration;
 import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.ListStatusPartialPOptions;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import com.google.common.base.MoreObjects;
 
@@ -102,7 +102,7 @@ public class ListStatusContext
    */
   public static ListStatusContext mergeFrom(ListStatusPOptions.Builder optionsBuilder) {
     ListStatusPOptions masterOptions =
-        FileSystemOptions.listStatusDefaults(Configuration.global());
+        FileSystemOptionsUtils.listStatusDefaults(Configuration.global());
     ListStatusPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -118,7 +118,7 @@ public class ListStatusContext
    */
   public static ListStatusContext mergeFrom(ListStatusPartialPOptions.Builder optionsBuilder) {
     return create(
-        FileSystemOptions.listStatusPartialDefaults(
+        FileSystemOptionsUtils.listStatusPartialDefaults(
             Configuration.global()).toBuilder().mergeFrom(optionsBuilder.build()));
   }
 
@@ -126,7 +126,7 @@ public class ListStatusContext
    * @return the instance of {@link ListStatusContext} with default values for master
    */
   public static ListStatusContext defaults() {
-    return create(FileSystemOptions.listStatusDefaults(Configuration.global()).toBuilder());
+    return create(FileSystemOptionsUtils.listStatusDefaults(Configuration.global()).toBuilder());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/LoadMetadataContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/LoadMetadataContext.java
@@ -14,7 +14,7 @@ package alluxio.master.file.contexts;
 import alluxio.conf.Configuration;
 import alluxio.grpc.LoadMetadataPOptions;
 import alluxio.underfs.UfsStatus;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import com.google.common.base.MoreObjects;
 
@@ -53,7 +53,7 @@ public class LoadMetadataContext
    */
   public static LoadMetadataContext mergeFrom(LoadMetadataPOptions.Builder optionsBuilder) {
     LoadMetadataPOptions masterOptions =
-        FileSystemOptions.loadMetadataDefaults(Configuration.global());
+        FileSystemOptionsUtils.loadMetadataDefaults(Configuration.global());
     LoadMetadataPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -63,7 +63,7 @@ public class LoadMetadataContext
    * @return the instance of {@link LoadMetadataContext} with default values for master
    */
   public static LoadMetadataContext defaults() {
-    return create(FileSystemOptions
+    return create(FileSystemOptionsUtils
         .loadMetadataDefaults(Configuration.global()).toBuilder());
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/MountContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/MountContext.java
@@ -13,7 +13,7 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.Configuration;
 import alluxio.grpc.MountPOptions;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import com.google.common.base.MoreObjects;
 
@@ -46,7 +46,7 @@ public class MountContext extends OperationContext<MountPOptions.Builder, MountC
    * @return the instance of {@link MountContext} with default values for master
    */
   public static MountContext mergeFrom(MountPOptions.Builder optionsBuilder) {
-    MountPOptions masterOptions = FileSystemOptions.mountDefaults(Configuration.global());
+    MountPOptions masterOptions = FileSystemOptionsUtils.mountDefaults(Configuration.global());
     MountPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -56,7 +56,7 @@ public class MountContext extends OperationContext<MountPOptions.Builder, MountC
    * @return the instance of {@link MountContext} with default values for master
    */
   public static MountContext defaults() {
-    return create(FileSystemOptions.mountDefaults(Configuration.global()).toBuilder());
+    return create(FileSystemOptionsUtils.mountDefaults(Configuration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/RenameContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/RenameContext.java
@@ -13,7 +13,7 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.Configuration;
 import alluxio.grpc.RenamePOptions;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.wire.OperationId;
 
 import com.google.common.base.MoreObjects;
@@ -53,7 +53,7 @@ public class RenameContext extends OperationContext<RenamePOptions.Builder, Rena
    */
   public static RenameContext mergeFrom(RenamePOptions.Builder optionsBuilder) {
     RenamePOptions masterOptions =
-        FileSystemOptions.renameDefaults(Configuration.global(), false);
+        FileSystemOptionsUtils.renameDefaults(Configuration.global(), false);
     RenamePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -64,7 +64,7 @@ public class RenameContext extends OperationContext<RenamePOptions.Builder, Rena
    */
   public static RenameContext defaults() {
     return create(
-        FileSystemOptions.renameDefaults(Configuration.global(), false).toBuilder());
+        FileSystemOptionsUtils.renameDefaults(Configuration.global(), false).toBuilder());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/ScheduleAsyncPersistenceContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/ScheduleAsyncPersistenceContext.java
@@ -13,7 +13,7 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.Configuration;
 import alluxio.grpc.ScheduleAsyncPersistencePOptions;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import com.google.common.base.MoreObjects;
 
@@ -55,7 +55,7 @@ public class ScheduleAsyncPersistenceContext
   public static ScheduleAsyncPersistenceContext mergeFrom(
       ScheduleAsyncPersistencePOptions.Builder optionsBuilder) {
     ScheduleAsyncPersistencePOptions masterOptions =
-        FileSystemOptions.scheduleAsyncPersistenceDefaults(Configuration.global());
+        FileSystemOptionsUtils.scheduleAsyncPersistenceDefaults(Configuration.global());
     ScheduleAsyncPersistencePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -65,7 +65,7 @@ public class ScheduleAsyncPersistenceContext
    * @return the instance of {@link LoadMetadataContext} with default values for master
    */
   public static ScheduleAsyncPersistenceContext defaults() {
-    return create(FileSystemOptions
+    return create(FileSystemOptionsUtils
         .scheduleAsyncPersistenceDefaults(Configuration.global()).toBuilder());
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/SetAclContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/SetAclContext.java
@@ -13,7 +13,7 @@ package alluxio.master.file.contexts;
 
 import alluxio.conf.Configuration;
 import alluxio.grpc.SetAclPOptions;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import com.google.common.base.MoreObjects;
 
@@ -46,7 +46,7 @@ public class SetAclContext extends OperationContext<SetAclPOptions.Builder, SetA
    * @return the instance of {@link SetAclContext} with default values for master
    */
   public static SetAclContext mergeFrom(SetAclPOptions.Builder optionsBuilder) {
-    SetAclPOptions masterOptions = FileSystemOptions.setAclDefaults(Configuration.global());
+    SetAclPOptions masterOptions = FileSystemOptionsUtils.setAclDefaults(Configuration.global());
     SetAclPOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -56,7 +56,7 @@ public class SetAclContext extends OperationContext<SetAclPOptions.Builder, SetA
    * @return the instance of {@link SetAclContext} with default values for master
    */
   public static SetAclContext defaults() {
-    return create(FileSystemOptions.setAclDefaults(Configuration.global()).toBuilder());
+    return create(FileSystemOptionsUtils.setAclDefaults(Configuration.global()).toBuilder());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/SetAttributeContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/SetAttributeContext.java
@@ -14,7 +14,7 @@ package alluxio.master.file.contexts;
 import alluxio.Constants;
 import alluxio.conf.Configuration;
 import alluxio.grpc.SetAttributePOptions;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import com.google.common.base.MoreObjects;
 
@@ -55,7 +55,7 @@ public class SetAttributeContext
    */
   public static SetAttributeContext mergeFrom(SetAttributePOptions.Builder optionsBuilder) {
     SetAttributePOptions masterOptions =
-        FileSystemOptions.setAttributeDefaults(Configuration.global());
+        FileSystemOptionsUtils.setAttributeDefaults(Configuration.global());
     SetAttributePOptions.Builder mergedOptionsBuilder =
         masterOptions.toBuilder().mergeFrom(optionsBuilder.build());
     return create(mergedOptionsBuilder);
@@ -65,7 +65,7 @@ public class SetAttributeContext
    * @return the instance of {@link SetAttributeContext} with default values for master
    */
   public static SetAttributeContext defaults() {
-    return create(FileSystemOptions.setAttributeDefaults(Configuration.global()).toBuilder());
+    return create(FileSystemOptionsUtils.setAttributeDefaults(Configuration.global()).toBuilder());
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -75,7 +75,7 @@ import alluxio.master.journal.JournalContext;
 import alluxio.proto.journal.Journal;
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.Mode;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.util.IdUtils;
 import alluxio.util.io.FileUtils;
 import alluxio.wire.FileBlockInfo;
@@ -661,7 +661,7 @@ public final class FileSystemMasterTest extends FileSystemMasterTestBase {
     assertEquals(1, mBlockMaster.getBlockInfo(blockId).getLocations().size());
     // Set ttl & operation.
     mFileSystemMaster.setAttribute(NESTED_FILE_URI, SetAttributeContext.mergeFrom(
-        SetAttributePOptions.newBuilder().setCommonOptions(FileSystemOptions
+        SetAttributePOptions.newBuilder().setCommonOptions(FileSystemOptionsUtils
             .commonDefaults(Configuration.global()).toBuilder().setTtl(0)
             .setTtlAction(alluxio.grpc.TtlAction.FREE))));
     Command heartbeat = mBlockMaster.workerHeartbeat(mWorkerId1, null,
@@ -681,7 +681,7 @@ public final class FileSystemMasterTest extends FileSystemMasterTestBase {
     assertEquals(1, mBlockMaster.getBlockInfo(blockId).getLocations().size());
     // Set ttl & operation.
     mFileSystemMaster.setAttribute(NESTED_FILE_URI, SetAttributeContext.mergeFrom(
-        SetAttributePOptions.newBuilder().setCommonOptions(FileSystemOptions
+        SetAttributePOptions.newBuilder().setCommonOptions(FileSystemOptionsUtils
             .commonDefaults(Configuration.global()).toBuilder().setTtl(0)
             .setTtlAction(alluxio.grpc.TtlAction.FREE))));
     // Simulate restart.
@@ -731,7 +731,7 @@ public final class FileSystemMasterTest extends FileSystemMasterTestBase {
     assertEquals(1, mBlockMaster.getBlockInfo(blockId).getLocations().size());
     // Set ttl & operation.
     mFileSystemMaster.setAttribute(NESTED_URI, SetAttributeContext.mergeFrom(
-        SetAttributePOptions.newBuilder().setCommonOptions(FileSystemOptions
+        SetAttributePOptions.newBuilder().setCommonOptions(FileSystemOptionsUtils
             .commonDefaults(Configuration.global()).toBuilder().setTtl(0)
             .setTtlAction(alluxio.grpc.TtlAction.FREE))));
 

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
@@ -57,7 +57,7 @@ import alluxio.security.GroupMappingServiceTestUtils;
 import alluxio.security.authorization.Mode;
 import alluxio.security.group.GroupMappingService;
 import alluxio.security.user.TestUserState;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.util.SecurityUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.wire.FileInfo;
@@ -702,7 +702,7 @@ public final class PermissionCheckTest {
 
       FileInfo fileInfo = mFileSystemMaster.getFileInfo(new AlluxioURI(path),
           GetStatusContext.defaults());
-      return FileSystemOptions.setAttributeDefaults(Configuration.global()).toBuilder()
+      return FileSystemOptionsUtils.setAttributeDefaults(Configuration.global()).toBuilder()
           .setPinned(fileInfo.isPinned()).setCommonOptions(FileSystemMasterCommonPOptions
               .newBuilder().setTtl(fileInfo.getTtl()).build())
           .setPersisted(fileInfo.isPersisted()).build();

--- a/core/server/worker/src/test/java/alluxio/worker/block/CacheRequestManagerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/CacheRequestManagerTest.java
@@ -35,7 +35,7 @@ import alluxio.underfs.UfsManager;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.wire.BlockInfo;
@@ -129,7 +129,7 @@ public class CacheRequestManagerTest {
         .setBlockIds(Collections.singletonList(BLOCK_ID)).setLength(CHUNK_SIZE)
         .setBlockSizeBytes(CHUNK_SIZE)
         .setFileBlockInfos(Collections.singletonList(new FileBlockInfo().setBlockInfo(info))));
-    OpenFilePOptions readOptions = FileSystemOptions.openFileDefaults(mConf);
+    OpenFilePOptions readOptions = FileSystemOptionsUtils.openFileDefaults(mConf);
     InStreamOptions options = new InStreamOptions(dummyStatus, readOptions, mConf, context);
     mOpenUfsBlockOptions = options.getOpenUfsBlockOptions(BLOCK_ID);
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/stream/BlockWorkerDataReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/stream/BlockWorkerDataReaderTest.java
@@ -38,7 +38,7 @@ import alluxio.network.protocol.databuffer.DataBuffer;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.util.io.BufferUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.FileBlockInfo;
@@ -123,7 +123,7 @@ public class BlockWorkerDataReaderTest {
     URIStatus dummyStatus =
         new URIStatus(new FileInfo().setBlockIds(Collections.singletonList(BLOCK_ID)));
     InStreamOptions options =
-        new InStreamOptions(dummyStatus, FileSystemOptions.openFileDefaults(mConf), mConf,
+        new InStreamOptions(dummyStatus, FileSystemOptionsUtils.openFileDefaults(mConf), mConf,
             FileSystemContext.create(mConf));
     mDataReaderFactory =
         new BlockWorkerDataReader.Factory(mBlockWorker, BLOCK_ID, CHUNK_SIZE, options);
@@ -153,7 +153,7 @@ public class BlockWorkerDataReaderTest {
       mBlockWorker.commitBlock(SESSION_ID, blockId, true);
       InStreamOptions inStreamOptions = new InStreamOptions(
           new URIStatus(new FileInfo().setBlockIds(Collections.singletonList(blockId))),
-          FileSystemOptions.openFileDefaults(mConf), mConf, FileSystemContext.create(mConf));
+          FileSystemOptionsUtils.openFileDefaults(mConf), mConf, FileSystemContext.create(mConf));
       mDataReaderFactory =
           new BlockWorkerDataReader.Factory(mBlockWorker, blockId, CHUNK_SIZE, inStreamOptions);
       DataReader dataReader = mDataReaderFactory.create(0, 100);

--- a/shell/src/main/java/alluxio/cli/fs/command/CheckConsistencyCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/CheckConsistencyCommand.java
@@ -24,7 +24,7 @@ import alluxio.exception.status.InvalidArgumentException;
 import alluxio.grpc.CheckConsistencyPOptions;
 import alluxio.grpc.DeletePOptions;
 import alluxio.resource.CloseableResource;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -139,7 +139,7 @@ public class CheckConsistencyCommand extends AbstractFileSystemCommand {
   private void runConsistencyCheck(AlluxioURI path, boolean repairConsistency, int repairThreads)
       throws AlluxioException, IOException {
     List<AlluxioURI> inconsistentUris =
-        checkConsistency(path, FileSystemOptions.checkConsistencyDefaults(
+        checkConsistency(path, FileSystemOptionsUtils.checkConsistencyDefaults(
             mFsContext.getPathConf(path)));
     if (inconsistentUris.isEmpty()) {
       System.out.println(path + " is consistent with the under storage system.");

--- a/shell/src/main/java/alluxio/cli/fs/command/LoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LoadCommand.java
@@ -30,7 +30,7 @@ import alluxio.grpc.CacheRequest;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.resource.CloseableResource;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.WorkerNetAddress;
 
@@ -126,7 +126,7 @@ public final class LoadCommand extends AbstractFileSystemCommand {
   private void runLoadTask(AlluxioURI filePath, URIStatus status, boolean local)
       throws IOException {
     AlluxioConfiguration conf = mFsContext.getPathConf(filePath);
-    OpenFilePOptions options = FileSystemOptions.openFileDefaults(conf);
+    OpenFilePOptions options = FileSystemOptionsUtils.openFileDefaults(conf);
     BlockLocationPolicy policy = Preconditions.checkNotNull(
         BlockLocationPolicy.Factory
             .create(conf.getClass(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY), conf),

--- a/tests/src/main/java/alluxio/master/backcompat/ops/PersistFile.java
+++ b/tests/src/main/java/alluxio/master/backcompat/ops/PersistFile.java
@@ -21,7 +21,7 @@ import alluxio.master.backcompat.TestOp;
 import alluxio.master.backcompat.Utils;
 import alluxio.multi.process.Clients;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.util.WaitForOptions;
 
 import java.util.Arrays;
@@ -38,10 +38,10 @@ public final class PersistFile implements TestOp {
     FileSystem fs = clients.getFileSystemClient();
     Utils.createFile(fs, PATH);
     clients.getFileSystemMasterClient().scheduleAsyncPersist(PATH,
-        FileSystemOptions.scheduleAsyncPersistDefaults(Configuration.global()));
+        FileSystemOptionsUtils.scheduleAsyncPersistDefaults(Configuration.global()));
     Utils.createFile(fs, NESTED_PATH);
     clients.getFileSystemMasterClient().scheduleAsyncPersist(NESTED_PATH,
-        FileSystemOptions.scheduleAsyncPersistDefaults(Configuration.global()));
+        FileSystemOptionsUtils.scheduleAsyncPersistDefaults(Configuration.global()));
     CommonUtils.waitFor("file to be async persisted", () -> {
       try {
         return fs.getStatus(PATH).isPersisted() && fs.getStatus(NESTED_PATH).isPersisted();

--- a/tests/src/test/java/alluxio/client/fs/FileSystemMasterClientIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemMasterClientIntegrationTest.java
@@ -23,7 +23,7 @@ import alluxio.grpc.GetStatusPOptions;
 import alluxio.master.MasterClientContext;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import com.google.common.base.Throwables;
 import org.junit.Assert;
@@ -37,7 +37,7 @@ import java.io.IOException;
  */
 public final class FileSystemMasterClientIntegrationTest extends BaseIntegrationTest {
   private static final GetStatusPOptions GET_STATUS_OPTIONS =
-      FileSystemOptions.getStatusDefaults(Configuration.global());
+      FileSystemOptionsUtils.getStatusDefaults(Configuration.global());
 
   @Rule
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
@@ -53,7 +53,7 @@ public final class FileSystemMasterClientIntegrationTest extends BaseIntegration
     fsMasterClient.connect();
     Assert.assertTrue(fsMasterClient.isConnected());
     fsMasterClient.createFile(file,
-        FileSystemOptions.createFileDefaults(Configuration.global()));
+        FileSystemOptionsUtils.createFileDefaults(Configuration.global()));
     Assert.assertNotNull(fsMasterClient.getStatus(file, GET_STATUS_OPTIONS));
     fsMasterClient.disconnect();
     Assert.assertFalse(fsMasterClient.isConnected());

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -47,7 +47,7 @@ import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.FileUtils;
 import alluxio.util.io.PathUtils;
@@ -692,7 +692,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
           try {
             return mFileSystem.listStatus(new AlluxioURI("/"), ListStatusPOptions.newBuilder()
                 .setRecursive(true)
-                .setCommonOptions(FileSystemOptions.commonDefaults(
+                .setCommonOptions(FileSystemOptionsUtils.commonDefaults(
                     mFileSystem.getConf()).toBuilder().setSyncIntervalMs(0).build()).build());
           } catch (Exception e) {
             return Collections.<URIStatus>emptyList();
@@ -708,7 +708,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
     assertEquals(0, status.size());
     status = mFileSystem.listStatus(new AlluxioURI("/"), ListStatusPOptions.newBuilder()
         .setRecursive(true)
-        .setCommonOptions(FileSystemOptions.commonDefaults(
+        .setCommonOptions(FileSystemOptionsUtils.commonDefaults(
             mFileSystem.getConf()).toBuilder().setSyncIntervalMs(-1).build()).build());
     final int TOTAL_FILE_COUNT = 20103;
     // verify that the previous sync did not complete
@@ -740,7 +740,7 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
 
     // Should not exist, since no loading or syncing
     assertFalse(mFileSystem.exists(new AlluxioURI(alluxioPath(fileA)), ExistsPOptions.newBuilder()
-        .setCommonOptions(FileSystemOptions.commonDefaults(mFileSystem.getConf()).toBuilder()
+        .setCommonOptions(FileSystemOptionsUtils.commonDefaults(mFileSystem.getConf()).toBuilder()
             .setSyncIntervalMs(-1).build()).build()));
 
     try {

--- a/tests/src/test/java/alluxio/job/plan/persist/PersistIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/plan/persist/PersistIntegrationTest.java
@@ -32,7 +32,7 @@ import alluxio.security.authorization.Mode;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.PathUtils;
 
@@ -132,7 +132,7 @@ public final class PersistIntegrationTest extends JobIntegrationTest {
     try (CloseableResource<FileSystemMasterClient> client =
         mFsContext.acquireMasterClientResource()) {
       client.get().scheduleAsyncPersist(new AlluxioURI(TEST_URI),
-          FileSystemOptions.scheduleAsyncPersistDefaults(Configuration.global()));
+          FileSystemOptionsUtils.scheduleAsyncPersistDefaults(Configuration.global()));
     }
     CommonUtils.waitFor("persist timeout", () -> {
       try {
@@ -171,7 +171,7 @@ public final class PersistIntegrationTest extends JobIntegrationTest {
     try (CloseableResource<FileSystemMasterClient> client =
         mFsContext.acquireMasterClientResource()) {
       client.get().scheduleAsyncPersist(path,
-          FileSystemOptions.scheduleAsyncPersistDefaults(Configuration.global()));
+          FileSystemOptionsUtils.scheduleAsyncPersistDefaults(Configuration.global()));
       Assert.fail("Should not be able to schedule persistence for incomplete file");
     } catch (Exception e) {
       // expected

--- a/tests/src/test/java/alluxio/server/auth/MasterClientAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/auth/MasterClientAuthenticationIntegrationTest.java
@@ -25,7 +25,7 @@ import alluxio.security.user.TestUserState;
 import alluxio.security.user.UserState;
 import alluxio.testutils.BaseIntegrationTest;
 import alluxio.testutils.LocalAlluxioClusterResource;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -147,10 +147,10 @@ public final class MasterClientAuthenticationIntegrationTest extends BaseIntegra
     masterClient.connect();
     Assert.assertTrue(masterClient.isConnected());
     masterClient.createFile(new AlluxioURI(filename),
-        FileSystemOptions.createFileDefaults(Configuration.global()));
+        FileSystemOptionsUtils.createFileDefaults(Configuration.global()));
     Assert.assertNotNull(
         masterClient.getStatus(new AlluxioURI(filename),
-            FileSystemOptions.getStatusDefaults(Configuration.global())));
+            FileSystemOptionsUtils.getStatusDefaults(Configuration.global())));
     masterClient.disconnect();
     masterClient.close();
   }

--- a/tests/src/test/java/alluxio/testutils/IntegrationTestUtils.java
+++ b/tests/src/test/java/alluxio/testutils/IntegrationTestUtils.java
@@ -29,7 +29,7 @@ import alluxio.master.journal.JournalUtils;
 import alluxio.master.journal.ufs.UfsJournal;
 import alluxio.master.journal.ufs.UfsJournalSnapshot;
 import alluxio.util.CommonUtils;
-import alluxio.util.FileSystemOptions;
+import alluxio.util.FileSystemOptionsUtils;
 import alluxio.util.URIUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.worker.block.BlockHeartbeatReporter;
@@ -77,7 +77,7 @@ public final class IntegrationTestUtils {
       CommonUtils.waitFor(uri + " to be persisted", () -> {
         try {
           return client.getStatus(uri,
-              FileSystemOptions.getStatusDefaults(Configuration.global())).isPersisted();
+              FileSystemOptionsUtils.getStatusDefaults(Configuration.global())).isPersisted();
         } catch (Exception e) {
           throw Throwables.propagate(e);
         }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Refactor file system options
rename original "FileSystemOptions" to "FileSystemOptionsUtils"
add a new "FileSystemOptions" with field metadataCacheEnabled and dataCacheEnabled

### Why are the changes needed?

Avoid overloading Alluxio property key when need to add new filesystem options.
Some path has deterministic file system options.
e.g. FUSE sdk will take user CLI input and set file system options directly. no need to expose global configuration. This can also prevent users use UFSBaseFileSystem when going through clients other than FUSE SDK.

### Does this PR introduce any user facing changes?
na
