### PR TITLE
Fix worker swallow OOM

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -376,7 +376,7 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
         runInternal();
       } catch (Throwable e) {
         LOG.error("Failed to run DataReader.", e);
-        throw new RuntimeException(e);
+        throw e;
       }
     }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Throw Error when there's an Error so the worker could crash and let K8s restart the worker.

### Why are the changes needed?

Without this, Worker would still pretend to be functional if there's OOM.
### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
na
