### PR TITLE
Fix timeouts for DistributedCpCancel and DistributedCommandsStats tests

### DIFF
--- a/tests/src/test/java/alluxio/client/cli/fs/command/DistributedCpCancelTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/DistributedCpCancelTest.java
@@ -38,7 +38,7 @@ import java.io.FileWriter;
  */
 public final class DistributedCpCancelTest extends AbstractFileSystemShellTest {
   private static final long SLEEP_MS = Constants.SECOND_MS * 30;
-  private static final int TEST_TIMEOUT = 20;
+  private static final int TEST_TIMEOUT = Constants.SECOND_MS * 90;
 
   @ClassRule
   public static UnderFileSystemFactoryRegistryRule sUnderfilesystemfactoryregistry =

--- a/tests/src/test/java/alluxio/client/cli/job/DistributedCommandsStatsTest.java
+++ b/tests/src/test/java/alluxio/client/cli/job/DistributedCommandsStatsTest.java
@@ -214,7 +214,7 @@ public class DistributedCommandsStatsTest extends JobShellTest {
   @Test
   public void testAsyncPersistCancelStats() throws Exception {
     FileSystemTestUtils.createByteFile(sFileSystem,  "/mnt/testFile",
-            WritePType.MUST_CACHE, 10);
+            WritePType.MUST_CACHE, 10000);
 
     long jobId = sJobMaster.run(new PersistConfig("/mnt/testFile",
             0, false, "/mnt/testUfsPath"));


### PR DESCRIPTION
### What changes are proposed in this pull request?
1. For DistributedCommandsStats, increase file size to persist to allow enough time for the cancel to happen.
2. For DistributedCpCancel, increase test timeout to exceed (90s) local cluster start timeout (1 min).
