### PR TITLE
Fix shaded client dependencies for prestodb's alluxio connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,7 @@
     <module>shaded</module>
     <module>shell</module>
     <module>stress</module>
+    <module>table</module>
     <module>tests</module>
     <module>underfs</module>
     <module>webui</module>

--- a/shaded/client/pom.xml
+++ b/shaded/client/pom.xml
@@ -87,6 +87,11 @@
       <artifactId>alluxio-core-client-fs</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-table-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix shaded client dependencies for prestodb's alluxio connector

### Why are the changes needed?

There is some code in prestodb are still using the alluxio-table-client

### Does this PR introduce any user facing changes?
no
