### PR TITLE
Increase worker heartbeat time for asyncCache tests

### DIFF
--- a/tests/src/test/java/alluxio/client/fs/io/FileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileInStreamIntegrationTest.java
@@ -565,6 +565,8 @@ public final class FileInStreamIntegrationTest extends BaseIntegrationTest {
   }
 
   @Test(timeout = 10000)
+  @LocalAlluxioClusterResource.Config(
+          confParams = {PropertyKey.Name.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "2000"})
   public void asyncCacheAfterSeek() throws Exception {
     String filename = mTestPath + "/file_" + MAX_LEN + "_" + mWriteUnderStore.hashCode();
     AlluxioURI uri = new AlluxioURI(filename);

--- a/tests/src/test/java/alluxio/client/fs/io/FileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/io/FileInStreamIntegrationTest.java
@@ -514,7 +514,7 @@ public final class FileInStreamIntegrationTest extends BaseIntegrationTest {
 
   @Test(timeout = 10000)
   @LocalAlluxioClusterResource.Config(
-      confParams = {PropertyKey.Name.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "1000"})
+      confParams = {PropertyKey.Name.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS, "2000"})
   public void asyncCacheFirstBlock() throws Exception {
     String filename = mTestPath + "/file_" + MAX_LEN + "_" + mWriteUnderStore.hashCode();
     AlluxioURI uri = new AlluxioURI(filename);


### PR DESCRIPTION
Currently the test asyncCacheFirstBlock is flaky, when the test is running extremely slow, and after the worker reports the newly cached blocks to master, the test will fail. The original time interval is 1000ms and may be small. Increasing the worker heartbeat in the test to 2000ms may allow the test to pass before worker reporting to master.
