### PR TITLE
Fix typo in the name of CapacityBaseRandomPolicy

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/policy/CapacityBaseRandomPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/CapacityBaseRandomPolicy.java
@@ -11,119 +11,33 @@
 
 package alluxio.client.block.policy;
 
-import alluxio.client.block.BlockWorkerInfo;
-import alluxio.client.block.policy.options.GetWorkerOptions;
+import alluxio.Constants;
 import alluxio.conf.AlluxioConfiguration;
-import alluxio.conf.PropertyKey;
-import alluxio.wire.WorkerNetAddress;
+import alluxio.util.logging.SamplingLogger;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-
-import java.time.Duration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
-import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Randomly distribute workload based on the worker capacities so bigger workers get more requests.
- * The randomness is based on the capacity instead of availability because in the long run,
- * all workers will be filled up and have availability close to 0.
- * We do not want the policy to degenerate to all workers having the same chance.
+ * Alias for {@link CapacityBasedRandomPolicy} kept for backwards compatibility.
+ *
+ * @deprecated in favor of {@link CapacityBasedRandomPolicy}
  */
-@ThreadSafe
-public class CapacityBaseRandomPolicy implements BlockLocationPolicy {
-  private final Cache<Long, List<WorkerNetAddress>> mBlockLocationCache;
-
-  private final int mMaxReplicaSize;
+//todo(bowen): remove in 3.0
+@Deprecated
+public final class CapacityBaseRandomPolicy extends CapacityBasedRandomPolicy {
+  private static final Logger LOG = new SamplingLogger(
+      LoggerFactory.getLogger(CapacityBaseRandomPolicy.class), Constants.MINUTE_MS);
 
   /**
-   * Constructs a new {@link CapacityBaseRandomPolicy}
-   * needed for instantiation in {@link BlockLocationPolicy.Factory}.
+   * Alias for {@link CapacityBasedRandomPolicy#CapacityBasedRandomPolicy(AlluxioConfiguration)}.
    *
    * @param conf Alluxio configuration
+   * @deprecated in favor of {@link CapacityBasedRandomPolicy}
    */
+  @Deprecated
   public CapacityBaseRandomPolicy(AlluxioConfiguration conf) {
-    Duration expirationTime =
-        conf.getDuration(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_EXPIRATION_TIME);
-    int cacheSize = conf.getInt(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_SIZE);
-    mBlockLocationCache =
-        CacheBuilder.newBuilder().maximumSize(cacheSize).expireAfterWrite(expirationTime).build();
-    mMaxReplicaSize = conf.getInt(PropertyKey.USER_FILE_REPLICATION_MAX);
-  }
-
-  @Override
-  public Optional<WorkerNetAddress> getWorker(GetWorkerOptions options) {
-    WorkerNetAddress cacheAddress = findCacheWorker(options);
-    if (cacheAddress != null) {
-      return Optional.of(cacheAddress);
-    }
-
-    Iterable<BlockWorkerInfo> blockWorkerInfos = options.getBlockWorkerInfos();
-
-    // All the capacities will form a ring of continuous intervals
-    // And we throw a die in the ring and decide which worker to pick
-    // For example if worker1 has capacity 10, worker2 has 20, worker3 has 40,
-    // the ring will look like [0, 10), [10, 30), [30, 70).
-    // A key in the map is the LHS of a range.
-    // So the map will look like {0 -> w1, 10 -> w2, 30 -> w3}.
-    TreeMap<Long, BlockWorkerInfo> rangeStartMap = new TreeMap<>();
-    AtomicLong totalCapacity = new AtomicLong(0L);
-    blockWorkerInfos.forEach(workerInfo -> {
-      if (workerInfo.getCapacityBytes() > 0) {
-        long capacityRangeStart = totalCapacity.getAndAdd(workerInfo.getCapacityBytes());
-        rangeStartMap.put(capacityRangeStart, workerInfo);
-      }
-    });
-    if (totalCapacity.get() == 0L) {
-      return Optional.empty();
-    }
-    long randomLong = randomInCapacity(totalCapacity.get());
-    WorkerNetAddress targetWorker = rangeStartMap.floorEntry(randomLong).getValue().getNetAddress();
-    addWorkerToCache(options.getBlockInfo().getBlockId(), targetWorker);
-    return Optional.of(targetWorker);
-  }
-
-  protected long randomInCapacity(long totalCapacity) {
-    return ThreadLocalRandom.current().nextLong(totalCapacity);
-  }
-
-  protected WorkerNetAddress findCacheWorker(GetWorkerOptions options) {
-    List<WorkerNetAddress> cacheCandidateList =
-        mBlockLocationCache.getIfPresent(options.getBlockInfo().getBlockId());
-    if (cacheCandidateList != null && mMaxReplicaSize > 0) {
-      Set<WorkerNetAddress> eligibleAddresses = new HashSet<>();
-      for (BlockWorkerInfo info : options.getBlockWorkerInfos()) {
-        eligibleAddresses.add(info.getNetAddress());
-      }
-      List<WorkerNetAddress> eligibleCacheList =
-          cacheCandidateList.stream().filter(eligibleAddresses::contains)
-              .collect(Collectors.toList());
-      if (eligibleCacheList.size() >= mMaxReplicaSize) {
-        int index = ThreadLocalRandom.current().nextInt(eligibleCacheList.size());
-        return eligibleCacheList.get(index);
-      }
-    }
-    return null;
-  }
-
-  protected void addWorkerToCache(Long blockId, WorkerNetAddress targetWorker) {
-    if (mMaxReplicaSize <= 0) {
-      return;
-    }
-    List<WorkerNetAddress> cacheWorkers = mBlockLocationCache.getIfPresent(blockId);
-    if (cacheWorkers == null) {
-      cacheWorkers = new CopyOnWriteArrayList<>();
-      // guava cache is thread-safe
-      mBlockLocationCache.put(blockId, cacheWorkers);
-    }
-    cacheWorkers.add(targetWorker);
+    super(conf);
+    LOG.warn("This class name contains a typo. Use CapacityBasedRandomPolicy instead.");
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/block/policy/CapacityBaseRandomPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/CapacityBaseRandomPolicy.java
@@ -38,6 +38,7 @@ public final class CapacityBaseRandomPolicy extends CapacityBasedRandomPolicy {
   @Deprecated
   public CapacityBaseRandomPolicy(AlluxioConfiguration conf) {
     super(conf);
-    LOG.warn("This class name contains a typo. Use CapacityBasedRandomPolicy instead.");
+    LOG.warn("This class name contains a typo and will be removed in 3.0. "
+        + "Use {} instead.", CapacityBasedRandomPolicy.class.getName());
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/block/policy/CapacityBasedRandomPolicy.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/policy/CapacityBasedRandomPolicy.java
@@ -1,0 +1,129 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.block.policy;
+
+import alluxio.client.block.BlockWorkerInfo;
+import alluxio.client.block.policy.options.GetWorkerOptions;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.wire.WorkerNetAddress;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Randomly distribute workload based on the worker capacities so bigger workers get more requests.
+ * The randomness is based on the capacity instead of availability because in the long run,
+ * all workers will be filled up and have availability close to 0.
+ * We do not want the policy to degenerate to all workers having the same chance.
+ */
+@ThreadSafe
+public class CapacityBasedRandomPolicy implements BlockLocationPolicy {
+  private final Cache<Long, List<WorkerNetAddress>> mBlockLocationCache;
+
+  private final int mMaxReplicaSize;
+
+  /**
+   * Constructs a new {@link CapacityBasedRandomPolicy}
+   * needed for instantiation in {@link BlockLocationPolicy.Factory}.
+   *
+   * @param conf Alluxio configuration
+   */
+  public CapacityBasedRandomPolicy(AlluxioConfiguration conf) {
+    Duration expirationTime =
+        conf.getDuration(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_EXPIRATION_TIME);
+    int cacheSize = conf.getInt(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_SIZE);
+    mBlockLocationCache =
+        CacheBuilder.newBuilder().maximumSize(cacheSize).expireAfterWrite(expirationTime).build();
+    mMaxReplicaSize = conf.getInt(PropertyKey.USER_FILE_REPLICATION_MAX);
+  }
+
+  @Override
+  public Optional<WorkerNetAddress> getWorker(GetWorkerOptions options) {
+    WorkerNetAddress cacheAddress = findCacheWorker(options);
+    if (cacheAddress != null) {
+      return Optional.of(cacheAddress);
+    }
+
+    Iterable<BlockWorkerInfo> blockWorkerInfos = options.getBlockWorkerInfos();
+
+    // All the capacities will form a ring of continuous intervals
+    // And we throw a die in the ring and decide which worker to pick
+    // For example if worker1 has capacity 10, worker2 has 20, worker3 has 40,
+    // the ring will look like [0, 10), [10, 30), [30, 70).
+    // A key in the map is the LHS of a range.
+    // So the map will look like {0 -> w1, 10 -> w2, 30 -> w3}.
+    TreeMap<Long, BlockWorkerInfo> rangeStartMap = new TreeMap<>();
+    AtomicLong totalCapacity = new AtomicLong(0L);
+    blockWorkerInfos.forEach(workerInfo -> {
+      if (workerInfo.getCapacityBytes() > 0) {
+        long capacityRangeStart = totalCapacity.getAndAdd(workerInfo.getCapacityBytes());
+        rangeStartMap.put(capacityRangeStart, workerInfo);
+      }
+    });
+    if (totalCapacity.get() == 0L) {
+      return Optional.empty();
+    }
+    long randomLong = randomInCapacity(totalCapacity.get());
+    WorkerNetAddress targetWorker = rangeStartMap.floorEntry(randomLong).getValue().getNetAddress();
+    addWorkerToCache(options.getBlockInfo().getBlockId(), targetWorker);
+    return Optional.of(targetWorker);
+  }
+
+  protected long randomInCapacity(long totalCapacity) {
+    return ThreadLocalRandom.current().nextLong(totalCapacity);
+  }
+
+  protected WorkerNetAddress findCacheWorker(GetWorkerOptions options) {
+    List<WorkerNetAddress> cacheCandidateList =
+        mBlockLocationCache.getIfPresent(options.getBlockInfo().getBlockId());
+    if (cacheCandidateList != null && mMaxReplicaSize > 0) {
+      Set<WorkerNetAddress> eligibleAddresses = new HashSet<>();
+      for (BlockWorkerInfo info : options.getBlockWorkerInfos()) {
+        eligibleAddresses.add(info.getNetAddress());
+      }
+      List<WorkerNetAddress> eligibleCacheList =
+          cacheCandidateList.stream().filter(eligibleAddresses::contains)
+              .collect(Collectors.toList());
+      if (eligibleCacheList.size() >= mMaxReplicaSize) {
+        int index = ThreadLocalRandom.current().nextInt(eligibleCacheList.size());
+        return eligibleCacheList.get(index);
+      }
+    }
+    return null;
+  }
+
+  protected void addWorkerToCache(Long blockId, WorkerNetAddress targetWorker) {
+    if (mMaxReplicaSize <= 0) {
+      return;
+    }
+    List<WorkerNetAddress> cacheWorkers = mBlockLocationCache.getIfPresent(blockId);
+    if (cacheWorkers == null) {
+      cacheWorkers = new CopyOnWriteArrayList<>();
+      // guava cache is thread-safe
+      mBlockLocationCache.put(blockId, cacheWorkers);
+    }
+    cacheWorkers.add(targetWorker);
+  }
+}

--- a/core/client/fs/src/test/java/alluxio/client/block/policy/CapacityBasedRandomPolicyTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/block/policy/CapacityBasedRandomPolicyTest.java
@@ -29,7 +29,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
-public class CapacityBaseRandomPolicyTest {
+public class CapacityBasedRandomPolicyTest {
   private final InstancedConfiguration mNoCacheConf = Configuration.copyGlobal();
 
   @Before
@@ -133,7 +133,7 @@ public class CapacityBaseRandomPolicyTest {
         Duration.ofMinutes(1).toMillis());
     withCacheConf.set(PropertyKey.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_SIZE, 1000);
     GetWorkerOptions getWorkerOptions = mockOptions();
-    CapacityBaseRandomPolicy policy = new CapacityBaseRandomPolicy(withCacheConf);
+    CapacityBasedRandomPolicy policy = new CapacityBasedRandomPolicy(withCacheConf);
     Set<WorkerNetAddress> addressSet = new HashSet<>();
     for (int i = 0; i < 1000; i++) {
       policy.getWorker(getWorkerOptions).ifPresent(addressSet::add);
@@ -144,7 +144,7 @@ public class CapacityBaseRandomPolicyTest {
   @Test
   public void getWorkerWithoutCache() {
     GetWorkerOptions getWorkerOptions = mockOptions();
-    CapacityBaseRandomPolicy policy = new CapacityBaseRandomPolicy(mNoCacheConf);
+    CapacityBasedRandomPolicy policy = new CapacityBasedRandomPolicy(mNoCacheConf);
     Set<WorkerNetAddress> addressSet = new HashSet<>();
     for (int i = 0; i < 1000; i++) {
       policy.getWorker(getWorkerOptions).ifPresent(addressSet::add);
@@ -173,8 +173,8 @@ public class CapacityBaseRandomPolicyTest {
   /**
    * @param targetValue must be in [0,totalCapacity)
    */
-  private CapacityBaseRandomPolicy buildPolicyWithTarget(final int targetValue) {
-    return new CapacityBaseRandomPolicy(mNoCacheConf) {
+  private CapacityBasedRandomPolicy buildPolicyWithTarget(final int targetValue) {
+    return new CapacityBasedRandomPolicy(mNoCacheConf) {
       @Override
       protected long randomInCapacity(long totalCapacity) {
         return targetValue;

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6271,7 +6271,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       intBuilder(Name.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_SIZE)
           .setDefaultValue(10000)
           .setDescription("When alluxio.user.ufs.block.read.location.policy is set "
-              + "to alluxio.client.block.policy.CapacityBaseRandomPolicy, "
+              + "to alluxio.client.block.policy.CapacityBasedRandomPolicy, "
               + "this specifies cache size of block location.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
@@ -6280,7 +6280,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       durationBuilder(Name.USER_UFS_BLOCK_READ_LOCATION_POLICY_CACHE_EXPIRATION_TIME)
           .setDefaultValue("10min")
           .setDescription("When alluxio.user.ufs.block.read.location.policy is set "
-              + "to alluxio.client.block.policy.CapacityBaseRandomPolicy, "
+              + "to alluxio.client.block.policy.CapacityBasedRandomPolicy, "
               + "this specifies cache expire time of block location.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)


### PR DESCRIPTION
Fix typo in the name of CapacityBaseRandomPolicy.

Deprecate `CapacityBaseRandomPolicy` and add `CapacityBasedRandomPolicy`.