### PR TITLE
Optimize MasterWorkerInfo memory usage by introducing fastutil Set

### DIFF
--- a/core/server/master/pom.xml
+++ b/core/server/master/pom.xml
@@ -79,6 +79,10 @@
       <artifactId>jersey-media-json-jackson</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil-core</artifactId>
+    </dependency>
 
     <!-- Internal dependencies -->
     <dependency>

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -83,6 +83,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Striped;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1087,7 +1088,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
     // Gather all blocks on this worker.
     int totalSize = currentBlocksOnLocation.values().stream().mapToInt(List::size).sum();
-    HashSet<Long> blocks = new HashSet<>(totalSize);
+    Set<Long> blocks = new LongOpenHashSet(totalSize);
     for (List<Long> blockIds : currentBlocksOnLocation.values()) {
       blocks.addAll(blockIds);
     }

--- a/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
+++ b/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
@@ -26,6 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -161,8 +161,8 @@ public final class MasterWorkerInfo {
   public MasterWorkerInfo(long id, WorkerNetAddress address) {
     mMeta = new StaticWorkerMeta(id, address);
     mUsage = new WorkerUsageMeta();
-    mBlocks = new HashSet<>();
-    mToRemoveBlocks = new HashSet<>();
+    mBlocks = new LongOpenHashSet();
+    mToRemoveBlocks = new LongOpenHashSet();
     mLastUpdatedTimeMs = new AtomicLong(CommonUtils.getCurrentMs());
 
     // Init all locks
@@ -375,7 +375,7 @@ public final class MasterWorkerInfo {
    * @return ids of all blocks the worker contains
    */
   public Set<Long> getBlocks() {
-    return new HashSet<>(mBlocks);
+    return new LongOpenHashSet(mBlocks);
   }
 
   /**
@@ -426,7 +426,7 @@ public final class MasterWorkerInfo {
    * @return ids of blocks the worker should remove
    */
   public Set<Long> getToRemoveBlocks() {
-    return new HashSet<>(mToRemoveBlocks);
+    return new LongOpenHashSet(mToRemoveBlocks);
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -63,6 +63,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * Unit tests for {@link BlockMaster}.
@@ -249,7 +250,8 @@ public class BlockMasterTest {
     // Check that the worker heartbeat tells the worker to remove the blocks.
     alluxio.grpc.Command heartBeat = mBlockMaster.workerHeartbeat(workerId, null,
         memUsage, NO_BLOCKS, NO_BLOCKS_ON_LOCATION, NO_LOST_STORAGE, mMetrics);
-    assertEquals(orphanedBlocks, heartBeat.getDataList());
+    assertEquals(orphanedBlocks,
+        heartBeat.getDataList().stream().sorted().collect(Collectors.toList()));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
     <libcephfs.version>0.0.1</libcephfs.version>
     <jnr-fuse.version>0.5.5</jnr-fuse.version>
     <kerby.version>1.0.1</kerby.version>
+    <fastutil.version>8.5.9</fastutil.version>
   </properties>
 
   <modules>
@@ -692,6 +693,11 @@
         <groupId>org.apache.kerby</groupId>
         <artifactId>kerby-util</artifactId>
         <version>${kerby.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>it.unimi.dsi</groupId>
+        <artifactId>fastutil-core</artifactId>
+        <version>${fastutil.version}</version>
       </dependency>
       <!-- Test scope -->
       <dependency>


### PR DESCRIPTION
### What changes are proposed in this pull request?

Introduce the HashSet from fastutil (https://fastutil.di.unimi.it/) to replace the current java HashSet in MasterWorkerInfo

### Why are the changes needed?

MasterWorkerInfo persisted in heap, has become a bottleneck for persisting more metadata in alluxio masters. This is mainly because it contains a block id set. If there are too many workers and too many blocks, this set will exhaust the memory.

A Long object in a java HashSet will take about 64 bytes memory. However, there are some third party collection libraries for primitive types. By getting rid of the boxing and unboxing, tons of memories can be saved and we can also achieve some performance boost. 

By using the LongOpenHashSet, we cut down the size of the hash map to a quarter and save 75% memory.     

Fastutil is one of the most used java alternatives .

There are a couple of benchmarks shows the collection components outperformance the java native one and the size of the collection components are also significantly smaller. 

A couple of benchmarks
https://collection-libs-comparison.develar.org/
https://github.com/Speiger/Primitive-Collections-Benchmarks/blob/master/BENCHMARKS.md

I tested it locally too and I got the same result. Memory size is 75% smaller. Read is 2x faster, write is 3-5x faster depending on the operations (put/remove) while the performance of getSize() is almost on par.

### Does this PR introduce any user facing changes?

N/A