### PR TITLE
Fix out of bound error in parsing s3 Authorization header

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -592,7 +592,8 @@ public final class S3RestUtils {
     String credentials = fields[1];
     String[] creds = credentials.split("=");
     // only support version 4 signature
-    if (creds.length < 2 || !StringUtils.equals("Credential", creds[0])) {
+    if (creds.length < 2 || !StringUtils.equals("Credential", creds[0])
+        || !creds[1].contains("/")) {
       throw new S3Exception("The authorization header that you provided is not valid.",
           S3ErrorCode.AUTHORIZATION_HEADER_MALFORMED);
     }

--- a/core/server/proxy/src/test/java/alluxio/proxy/s3/S3RestServiceHandlerTest.java
+++ b/core/server/proxy/src/test/java/alluxio/proxy/s3/S3RestServiceHandlerTest.java
@@ -28,6 +28,12 @@ public class S3RestServiceHandlerTest {
   @Test
   public void userFromAuthorization() throws Exception {
     try {
+      S3RestUtils.getUserFromAuthorization("AWS-SHA256-HMAC Credential=xxx:asd", mConf);
+      Assert.fail();
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof S3Exception);
+    }
+    try {
       S3RestUtils.getUserFromAuthorization("AWS-SHA256-HMAC Credential=/asd", mConf);
       Assert.fail();
     } catch (Exception e) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

fix out of bound error in parsing s3 Authorization header

### Why are the changes needed?
if the authorization header have not the "/", the out of bound error will happen, and then Alluxio proxy will return an `500 Internal Error` to client.
