### PR TITLE
Support STS for OSS ufs

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1275,6 +1275,29 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_OSS_STS_ENABLED =
+      booleanBuilder(Name.UNDERFS_OSS_STS_ENABLED)
+          .setAlias("alluxio.underfs.oss.sts.enabled")
+          .setDefaultValue(false)
+          .setDescription("Whether to enable oss STS(Security Token Service).")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_RETRY_MAX =
+      intBuilder(Name.UNDERFS_OSS_RETRY_MAX)
+          .setAlias("alluxio.underfs.oss.retry.max")
+          .setDefaultValue(3)
+          .setDescription("The maximum number of OSS error retry.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_ECS_RAM_ROLE =
+      stringBuilder(Name.UNDERFS_OSS_ECS_RAM_ROLE)
+          .setAlias("alluxio.underfs.oss.ecs.ram.role")
+          .setDescription("The RAM role of current owner of ECS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_S3_ADMIN_THREADS_MAX =
       intBuilder(Name.UNDERFS_S3_ADMIN_THREADS_MAX)
           .setDefaultValue(20)
@@ -7238,6 +7261,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.oss.connection.timeout";
     public static final String UNDERFS_OSS_CONNECT_TTL = "alluxio.underfs.oss.connection.ttl";
     public static final String UNDERFS_OSS_SOCKET_TIMEOUT = "alluxio.underfs.oss.socket.timeout";
+    public static final String UNDERFS_OSS_STS_ENABLED = "alluxio.underfs.oss.sts.enabled";
+    public static final String UNDERFS_OSS_RETRY_MAX = "alluxio.underfs.oss.retry.max";
+    public static final String UNDERFS_OSS_ECS_RAM_ROLE = "alluxio.underfs.oss.ecs.ram.role";
     public static final String UNDERFS_S3_BULK_DELETE_ENABLED =
         "alluxio.underfs.s3.bulk.delete.enabled";
     public static final String UNDERFS_S3_DEFAULT_MODE = "alluxio.underfs.s3.default.mode";

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystemFactory.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystemFactory.java
@@ -62,6 +62,10 @@ public class OSSUnderFileSystemFactory implements UnderFileSystemFactory {
    * @return true if both access, secret and endpoint keys are present, false otherwise
    */
   private boolean checkOSSCredentials(UnderFileSystemConfiguration conf) {
+    if (conf.getBoolean(PropertyKey.UNDERFS_OSS_STS_ENABLED)) {
+      return conf.isSet(PropertyKey.UNDERFS_OSS_ECS_RAM_ROLE);
+    }
+
     return conf.isSet(PropertyKey.OSS_ACCESS_KEY)
         && conf.isSet(PropertyKey.OSS_SECRET_KEY)
         && conf.isSet(PropertyKey.OSS_ENDPOINT_KEY);

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/StsOssClientProvider.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/StsOssClientProvider.java
@@ -1,0 +1,211 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.oss;
+
+import alluxio.conf.PropertyKey;
+import alluxio.retry.ExponentialBackoffRetry;
+import alluxio.retry.RetryPolicy;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.util.ThreadFactoryUtils;
+import alluxio.util.network.HttpUtils;
+import com.aliyun.oss.ClientBuilderConfiguration;
+import com.aliyun.oss.OSS;
+import com.aliyun.oss.OSSClientBuilder;
+import com.aliyun.oss.common.auth.DefaultCredentials;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+
+public class StsOssClientProvider implements Closeable {
+    private static final Logger LOG = LoggerFactory.getLogger(StsOssClientProvider.class);
+
+    private static final int ECS_META_GET_TIMEOUT = 10000;
+    private static final int BASE_SLEEP_TIME_MS = 1000;
+    private static final int MAX_SLEEP_MS = 3000;
+    private static final int MAX_RETRIES = 5;
+
+    private volatile OSS ossClient = null;
+    private Date stsTokenExpiration = null;
+
+    public static final String ECS_METADATA_SERVICE = "http://100.100.100.200/latest/meta-data/ram/security-credentials/";
+
+    private static final int IN_TOKEN_EXPIRED_MS = 1800000;
+    private static final String ACCESS_KEY_ID = "AccessKeyId";
+    private static final String ACCESS_KEY_SECRET = "AccessKeySecret";
+    private static final String SECURITY_TOKEN = "SecurityToken";
+    private static final String EXPIRATION = "Expiration";
+
+    private UnderFileSystemConfiguration ossConf;
+    private final ScheduledExecutorService refreshOssClientScheduledThread;
+
+    public StsOssClientProvider(UnderFileSystemConfiguration ossConfiguration) throws IOException {
+        RetryPolicy retryPolicy = new ExponentialBackoffRetry(BASE_SLEEP_TIME_MS, MAX_SLEEP_MS, MAX_RETRIES);
+        IOException lastException = null;
+        while (retryPolicy.attempt()) {
+            try {
+                initializeOssClient(ossConfiguration);
+                lastException = null;
+                break;
+            } catch (IOException e) {
+                LOG.warn("init oss client failed! has retry {} times", retryPolicy.getAttemptCount(), e);
+                lastException = e;
+            }
+        }
+        if (lastException != null) {
+            throw lastException;
+        }
+        refreshOssClientScheduledThread = Executors.newSingleThreadScheduledExecutor(
+                ThreadFactoryUtils.build("refresh_oss_client-%d", false));
+        refreshOssClientScheduledThread.scheduleAtFixedRate(() -> {
+            try {
+                if (null != ossConf) {
+                    refreshOssStsClient(ossConf);
+                }
+            } catch (Exception e) {
+                //retry it
+                LOG.warn("throw exception when clear meta data cache", e);
+            }
+        }, 0, 60000, TimeUnit.MILLISECONDS);
+    }
+
+    protected void refreshOssStsClient(UnderFileSystemConfiguration ossConfiguration) throws IOException {
+        ClientBuilderConfiguration ossClientConf = getClientBuilderConfiguration(ossConfiguration);
+        createOrRefreshStsOssClient(ossConfiguration, ossClientConf);
+    }
+
+    private ClientBuilderConfiguration getClientBuilderConfiguration(UnderFileSystemConfiguration ossConfiguration) {
+        ClientBuilderConfiguration ossClientConf = new ClientBuilderConfiguration();
+        ossClientConf.setMaxConnections(ossConfiguration.getInt(PropertyKey.UNDERFS_OSS_CONNECT_MAX));
+        ossClientConf.setMaxErrorRetry(ossConfiguration.getInt(PropertyKey.UNDERFS_OSS_RETRY_MAX));
+        ossClientConf.setConnectionTimeout((int) ossConfiguration.getMs(PropertyKey.UNDERFS_OSS_CONNECT_TIMEOUT));
+        ossClientConf.setSocketTimeout((int) ossConfiguration.getMs(PropertyKey.UNDERFS_OSS_SOCKET_TIMEOUT));
+        ossClientConf.setSupportCname(false);
+        ossClientConf.setCrcCheckEnabled(true);
+        return ossClientConf;
+    }
+
+    public void initializeOssClient(UnderFileSystemConfiguration ossConfiguration) throws IOException {
+        ossConf = ossConfiguration;
+        if (null != ossClient) {
+            return;
+        }
+
+        ClientBuilderConfiguration clientConf = getClientBuilderConfiguration(ossConfiguration);
+        createOrRefreshStsOssClient(ossConfiguration, clientConf);
+
+        LOG.info("init ossClient success : {}", ossClient.toString());
+    }
+
+    boolean isStsTokenExpired() {
+        boolean expired = true;
+        Date now = convertLongToDate(System.currentTimeMillis());
+        if (null != stsTokenExpiration) {
+            if (stsTokenExpiration.after(now)) {
+                expired = false;
+            }
+        }
+        return expired;
+    }
+
+    boolean isTokenWillExpired() {
+        boolean in = true;
+        Date now = convertLongToDate(System.currentTimeMillis());
+        long millisecond = stsTokenExpiration.getTime() - now.getTime();
+        if (millisecond >= IN_TOKEN_EXPIRED_MS) {
+            in = false;
+        }
+        return in;
+    }
+
+    private void createOrRefreshStsOssClient(UnderFileSystemConfiguration ossConfiguration,
+                                             ClientBuilderConfiguration clientConfiguration) throws IOException {
+        if (isStsTokenExpired() || isTokenWillExpired()) {
+            try {
+                String ecsRamRole = ossConfiguration.getString(PropertyKey.UNDERFS_OSS_ECS_RAM_ROLE);
+                String fullECSMetaDataServiceUrl = ECS_METADATA_SERVICE + ecsRamRole;
+                String jsonStringResponse = HttpUtils.get(fullECSMetaDataServiceUrl, ECS_META_GET_TIMEOUT);
+
+                JsonObject jsonObject = new Gson().fromJson(jsonStringResponse, JsonObject.class);
+                String accessKeyId = jsonObject.get(ACCESS_KEY_ID).getAsString();
+                String accessKeySecret = jsonObject.get(ACCESS_KEY_SECRET).getAsString();
+                String securityToken = jsonObject.get(SECURITY_TOKEN).getAsString();
+                stsTokenExpiration = convertStringToDate(jsonObject.get(EXPIRATION).getAsString());
+
+                if (null == ossClient) {
+                    ossClient = new OSSClientBuilder().build(
+                            ossConfiguration.getString(PropertyKey.OSS_ENDPOINT_KEY),
+                            accessKeyId, accessKeySecret, securityToken,
+                            clientConfiguration);
+                } else {
+                    ossClient.switchCredentials((new DefaultCredentials(accessKeyId, accessKeySecret, securityToken)));
+                }
+                LOG.info("oss sts client create success {} {} {}", ossClient, securityToken, stsTokenExpiration);
+            } catch (IOException e) {
+                LOG.error("create stsOssClient exception", e);
+                throw new IOException("create stsOssClient exception", e);
+            }
+        }
+    }
+
+    public OSS getOSSClient() {
+        return ossClient;
+    }
+
+    private Date convertLongToDate(long timeMs) {
+        TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        sdf.setTimeZone(zeroTimeZone);
+        Date date = null;
+        try {
+            date = sdf.parse(sdf.format(new Date(timeMs)));
+        } catch (ParseException e) {
+            LOG.error("convert String to Date type error", e);
+        }
+        return date;
+    }
+
+    private Date convertStringToDate(String dateString) {
+        TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        sdf.setTimeZone(zeroTimeZone);
+        Date date = null;
+        try {
+            date = sdf.parse(dateString);
+        } catch (ParseException e) {
+            LOG.error("convert String to Date type error", e);
+        }
+        return date;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (null != refreshOssClientScheduledThread) {
+            refreshOssClientScheduledThread.shutdown();
+        }
+        if (null != ossClient) {
+            ossClient.shutdown();
+            ossClient = null;
+        }
+    }
+}

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
@@ -1,0 +1,107 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.oss;
+
+import alluxio.conf.Configuration;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.util.network.HttpUtils;
+import com.aliyun.oss.OSSClient;
+import com.aliyun.oss.common.comm.DefaultServiceClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({HttpUtils.class, OSSClient.class, OSSUnderFileSystemTest.class})
+public class StsOssClientProviderTest {
+
+    InstancedConfiguration conf;
+    private final String ECS_RAM_ROLE = "snapshot-role-test";
+    private final String ECS_METADATA_SERVICE = StsOssClientProvider.ECS_METADATA_SERVICE + ECS_RAM_ROLE;
+    public static final String MOCK_ECS_META_RESPONSE = "{\n" +
+            "  'AccessKeyId' : 'STS.mockAK',\n" +
+            "  'AccessKeySecret' : 'mockSK',\n" +
+            "  'Expiration' : '2018-04-23T09:45:05Z',\n" +
+            "  'SecurityToken' : 'mockSecurityToken',\n" +
+            "  'LastUpdated' : '2018-04-23T03:45:05Z',\n" +
+            "  'Code' : 'Success'\n" +
+            "}";
+
+    @Before
+    public void before() {
+        conf = Configuration.copyGlobal();
+    }
+
+    @Test
+    public void testInitAndRefresh() throws Exception {
+        Date dateExpiration = toUtcDateString(System.currentTimeMillis() + 21600000);
+        Date dateLastUpdated = toUtcDateString(System.currentTimeMillis());
+        String expiration = toUtcString(dateExpiration);
+        String lastUpdated = toUtcString(dateLastUpdated);
+
+        conf.set(PropertyKey.OSS_ENDPOINT_KEY, "http://oss-cn-qingdao.aliyuncs.com");
+        conf.set(PropertyKey.UNDERFS_OSS_ECS_RAM_ROLE, ECS_RAM_ROLE);
+        final UnderFileSystemConfiguration ossConfiguration = UnderFileSystemConfiguration.defaults(conf);
+
+        // init
+        DefaultServiceClient client = Mockito.mock(DefaultServiceClient.class);
+        PowerMockito.whenNew(DefaultServiceClient.class).withAnyArguments().thenReturn(client);
+        OSSClient ossClient = Mockito.mock(OSSClient.class);
+        PowerMockito.whenNew(OSSClient.class).withAnyArguments().thenReturn(ossClient);
+        PowerMockito.mockStatic(HttpUtils.class);
+        when(HttpUtils.get(ECS_METADATA_SERVICE, 10000)).thenReturn(MOCK_ECS_META_RESPONSE);
+        StsOssClientProvider mClientProvider = new StsOssClientProvider(ossConfiguration);
+
+        // refresh
+        String responseBodyString = "{\n" +
+                "  'AccessKeyId' : 'STS.mockAK',\n" +
+                "  'AccessKeySecret' : 'mockSK',\n" +
+                "  'Expiration' : '" + expiration + "',\n" +
+                "  'SecurityToken' : 'mockSecurityToken',\n" +
+                "  'LastUpdated' : '" + lastUpdated + "',\n" +
+                "  'Code' : 'Success'\n" +
+                "}";
+        PowerMockito.mockStatic(HttpUtils.class);
+        when(HttpUtils.get(ECS_METADATA_SERVICE, 10000)).thenReturn(responseBodyString);
+        assertTrue(mClientProvider.isStsTokenExpired());
+        mClientProvider.refreshOssStsClient(ossConfiguration);
+        assertFalse(mClientProvider.isStsTokenExpired());
+    }
+
+    private Date toUtcDateString(long dateInMills) throws ParseException {
+        TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        sdf.setTimeZone(zeroTimeZone);
+        return sdf.parse(sdf.format(new Date(dateInMills)));
+    }
+
+    private String toUtcString(Date date) {
+        TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        sdf.setTimeZone(zeroTimeZone);
+        return sdf.format(date);
+    }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?
Support STS for OSS ufs

### Why are the changes needed?
1. Plaintext AccessKey/AccessSecret is not safe and not Recommended for Aliyun
2. STS(Security Token Service) for OSS is more safe. For details, see https://help.aliyun.com/document_detail/32016.html

### Does this PR introduce any user facing changes?
addition  property keys
  1. UNDERFS_OSS_STS_ENABLED
  2. UNDERFS_OSS_RETRY_MAX
  3. UNDERFS_OSS_ECS_RAM_ROLE
