### PR TITLE
Fix misuse of variable in computeMaxThroughput

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/suite/AbstractMaxThroughput.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/suite/AbstractMaxThroughput.java
@@ -125,7 +125,7 @@ public abstract class AbstractMaxThroughput<Q extends TaskResult, T extends
       List<String> newArgs = new ArrayList<>(baseArgs);
       updateArgValue(newArgs, "--target-throughput", Integer.toString(perWorkerThroughput));
 
-      S mbr = runSingleTest(newArgs, perWorkerThroughput);
+      S mbr = runSingleTest(newArgs, next);
 
       int current = next;
       final float actualThroughput = mbr.getThroughput();


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix use of a wrong variable in `AbstractMaxThroughput.computeMaxThroughput`.

### Why are the changes needed?

Introduced in #14819, the number of test files prepared by the benchmark is controlled by `perWorkerThroughput`

https://github.com/Alluxio/alluxio/blob/4b43e50eb294542ab64687ab48e748feb2ad0b6f/stress/shell/src/main/java/alluxio/stress/cli/suite/AbstractMaxThroughput.java#L131


while it should have been `cluster-wide all-workers throughput`. Before the change:

https://github.com/Alluxio/alluxio/blob/bec0c356d0a4f3ecf9fcc7b504c55df06d353e4c/stress/shell/src/main/java/alluxio/stress/cli/suite/MaxThroughput.java#L100-L102

where `next` is the current throughput for all workers:

https://github.com/Alluxio/alluxio/blob/bec0c356d0a4f3ecf9fcc7b504c55df06d353e4c/stress/shell/src/main/java/alluxio/stress/cli/suite/MaxThroughput.java#L82-L87

### Does this PR introduce any user facing changes?

No.
