### PR TITLE
Add BLOCK_COUNT in gRPC WorkerInfoField

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/options/GetWorkerReportOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/options/GetWorkerReportOptions.java
@@ -188,7 +188,6 @@ public final class GetWorkerReportOptions implements Serializable {
    */
   public enum WorkerInfoField {
     ADDRESS,
-    BLOCK_COUNT,
     WORKER_CAPACITY_BYTES,
     WORKER_CAPACITY_BYTES_ON_TIERS,
     ID,
@@ -196,7 +195,8 @@ public final class GetWorkerReportOptions implements Serializable {
     START_TIME_MS,
     STATE,
     WORKER_USED_BYTES,
-    WORKER_USED_BYTES_ON_TIERS;
+    WORKER_USED_BYTES_ON_TIERS,
+    BLOCK_COUNT;
 
     public static final Set<WorkerInfoField> ALL = EnumSet.allOf(WorkerInfoField.class);
 

--- a/core/transport/src/main/proto/grpc/block_master.proto
+++ b/core/transport/src/main/proto/grpc/block_master.proto
@@ -88,6 +88,7 @@ enum WorkerInfoField {
   STATE = 7;
   WORKER_USED_BYTES = 8;
   WORKER_USED_BYTES_ON_TIERS = 9;
+  BLOCK_COUNT = 10;
 }
 
 message GetWorkerReportPOptions {

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -104,6 +104,10 @@
               {
                 "name": "WORKER_USED_BYTES_ON_TIERS",
                 "integer": 9
+              },
+              {
+                "name": "BLOCK_COUNT",
+                "integer": 10
               }
             ]
           }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Enum variant `BLOCK_COUNT` of `WorkerInfoField` in `GetWorkerReportOptions.java` was introduced in  #14126, but its gRPC counterpart was not updated accordingly.
This PR adds the missing variant, and reorders the fields of the java enum. 

### Why are the changes needed?

The field cannot be retrieved via RPC, only via internal function call, because gRPC will fail to serialize that java enum variant.

### Does this PR introduce any user facing changes?

No.
