### PR TITLE
Throw Error after reply error to client

### DIFF
--- a/core/common/src/main/java/alluxio/util/CommonUtils.java
+++ b/core/common/src/main/java/alluxio/util/CommonUtils.java
@@ -908,5 +908,18 @@ public final class CommonUtils {
     return Objects.toString(obj);
   }
 
+  /**
+   * @param e error
+   * @return whether it's fatal error
+   */
+  public static boolean isFatalError(Throwable e) {
+    // StackOverflowError ok even though it is a VirtualMachineError
+    if (e instanceof StackOverflowError) {
+      return false;
+    }
+    // VirtualMachineError includes OutOfMemoryError and other fatal errors
+    return e instanceof VirtualMachineError || e instanceof LinkageError;
+  }
+
   private CommonUtils() {} // prevent instantiation
 }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -465,6 +465,10 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
           LOG.error("Failed to close the request.", e);
         }
         replyError(error);
+        Throwable rootCause = error.getCause().getCause();
+        if (rootCause != null && rootCause instanceof java.lang.Error) {
+          throw (java.lang.Error) rootCause;
+        }
       } else if (eof || cancel) {
         try {
           completeRequest(mContext);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -11,9 +11,11 @@
 
 package alluxio.worker.grpc;
 
+import static alluxio.util.CommonUtils.isFatalError;
 import static alluxio.worker.block.BlockMetadataManager.WORKER_STORAGE_TIER_ASSOC;
 
 import alluxio.Constants;
+import alluxio.ProcessUtils;
 import alluxio.RpcSensitiveConfigMask;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
@@ -449,6 +451,9 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
             });
           }
         } catch (Throwable e) {
+          if (isFatalError(e)) {
+            ProcessUtils.fatalError(LOG, e, "Error while reading");
+          }
           LogUtils.warnWithException(LOG,
               "Exception occurred while reading data for read request {}. session {}",
               mContext.getRequest(), mContext.getRequest().getSessionId(),
@@ -457,7 +462,6 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
         }
         continue;
       }
-
       if (error != null) {
         try {
           completeRequest(mContext);
@@ -465,10 +469,6 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
           LOG.error("Failed to close the request.", e);
         }
         replyError(error);
-        Throwable rootCause = error.getCause().getCause();
-        if (rootCause != null && rootCause instanceof java.lang.Error) {
-          throw (java.lang.Error) rootCause;
-        }
       } else if (eof || cancel) {
         try {
           completeRequest(mContext);


### PR DESCRIPTION
### What changes are proposed in this pull request?
Throw Error after reply error to client so worker would crash because of Error and k8s can restart unhealthy worker

### Why are the changes needed?

na

### Does this PR introduce any user facing changes?

na
