### PR TITLE
Increase default timeout for local cluster

### DIFF
--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -56,7 +56,7 @@ public abstract class AbstractLocalAlluxioCluster {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractLocalAlluxioCluster.class);
 
   private static final Random RANDOM_GENERATOR = new Random();
-  private static final int WAIT_MASTER_START_TIMEOUT_MS = 90_000;
+  private static final int WAIT_MASTER_START_TIMEOUT_MS = 200_000;
 
   protected ProxyProcess mProxyProcess;
   protected Thread mProxyThread;


### PR DESCRIPTION
### What changes are proposed in this pull request?
Currently alluxio.server.auth.CapabilityTokenExpirationIntegrationTest.testCapabilityExpiration is flakey because of timeout waiting for local cluster to start, increase default timeout for local cluster from 90000 to 200000ms to allow for longer waiting time.
