### PR TITLE
Use try-with-resource on FSMClient to avoid leak

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -227,7 +227,8 @@ public class AlluxioFileInStream extends FileInStream {
   // force a sync to update the latest metadata, then abort the current stream
   // The user should restart the stream and read the updated file
   private void refreshMetadataOnMismatchedLength(OutOfRangeException e) {
-    try (CloseableResource<FileSystemMasterClient> client = mContext.acquireMasterClientResource()) {
+    try (CloseableResource<FileSystemMasterClient> client =
+        mContext.acquireMasterClientResource()) {
       // Force refresh the file metadata by loadMetadata
       AlluxioURI path = new AlluxioURI(mStatus.getPath());
       ListStatusPOptions refreshPathOptions = ListStatusPOptions.newBuilder()


### PR DESCRIPTION
### What changes are proposed in this pull request?

fix usage for acquireMasterClientResource() in AlluxioFileInStream with try-with-resource

### Why are the changes needed?

resource leak


### Does this PR introduce any user facing changes?

none
