### PR TITLE
Change FUSE readwriteLock to session based lock

### DIFF
--- a/core/common/src/main/java/alluxio/concurrent/ClientRWLock.java
+++ b/core/common/src/main/java/alluxio/concurrent/ClientRWLock.java
@@ -26,11 +26,6 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class ClientRWLock implements ReadWriteLock {
-  /**
-   * Uses the unfair lock to prevent a read lock that fails to release from locking the block
-   * forever and thus blocking all the subsequent write access.
-   * See https://alluxio.atlassian.net/browse/ALLUXIO-2636.
-   */
   private final Semaphore mAvailable;
   /** Reference count. */
   private final AtomicInteger mReferences = new AtomicInteger();
@@ -43,6 +38,9 @@ public final class ClientRWLock implements ReadWriteLock {
    */
   public ClientRWLock(int maxReaders) {
     mMaxReaders = maxReaders;
+    // Uses the unfair lock to prevent a read lock
+    // that fails to release from locking the block forever
+    // and thus blocking all the subsequent write access.
     mAvailable = new Semaphore(maxReaders, false);
   }
 

--- a/core/common/src/main/java/alluxio/concurrent/ClientRWLock.java
+++ b/core/common/src/main/java/alluxio/concurrent/ClientRWLock.java
@@ -9,10 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.worker.block;
-
-import alluxio.conf.Configuration;
-import alluxio.conf.PropertyKey;
+package alluxio.concurrent;
 
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -29,22 +26,25 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class ClientRWLock implements ReadWriteLock {
-  /** Total number of permits. This value decides the max number of concurrent readers. */
-  private static final int MAX_AVAILABLE =
-          Configuration.getInt(PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCK_READERS);
   /**
    * Uses the unfair lock to prevent a read lock that fails to release from locking the block
    * forever and thus blocking all the subsequent write access.
    * See https://alluxio.atlassian.net/browse/ALLUXIO-2636.
    */
-  private final Semaphore mAvailable = new Semaphore(MAX_AVAILABLE, false);
+  private final Semaphore mAvailable;
   /** Reference count. */
   private final AtomicInteger mReferences = new AtomicInteger();
+  private final int mMaxReaders;
 
   /**
    * Constructs a new {@link ClientRWLock}.
+   *
+   * @param maxReaders total number of permits, decides the max number of concurrent readers
    */
-  public ClientRWLock() {}
+  public ClientRWLock(int maxReaders) {
+    mMaxReaders = maxReaders;
+    mAvailable = new Semaphore(maxReaders, false);
+  }
 
   @Override
   public Lock readLock() {
@@ -53,7 +53,7 @@ public final class ClientRWLock implements ReadWriteLock {
 
   @Override
   public Lock writeLock() {
-    return new SessionLock(MAX_AVAILABLE);
+    return new SessionLock(mMaxReaders);
   }
 
   /**

--- a/core/common/src/test/java/alluxio/concurrent/ClientRWLockTest.java
+++ b/core/common/src/test/java/alluxio/concurrent/ClientRWLockTest.java
@@ -9,7 +9,7 @@
  * See the NOTICE file distributed with this work for information regarding copyright ownership.
  */
 
-package alluxio.worker.block;
+package alluxio.concurrent;
 
 import static junit.framework.TestCase.assertNotSame;
 import static org.junit.Assert.assertEquals;
@@ -35,7 +35,7 @@ public final class ClientRWLockTest {
    */
   @Before
   public void before() {
-    mClientRWLock = new ClientRWLock();
+    mClientRWLock = new ClientRWLock(20);
     mReadLock = mClientRWLock.readLock();
     mWriteLock = mClientRWLock.writeLock();
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockLockManager.java
@@ -14,6 +14,7 @@ package alluxio.worker.block;
 import alluxio.collections.IndexDefinition;
 import alluxio.collections.IndexedSet;
 import alluxio.collections.Pair;
+import alluxio.concurrent.ClientRWLock;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.resource.ResourcePool;
@@ -48,6 +49,8 @@ public final class BlockLockManager {
 
   /** The unique id of each lock. */
   private static final AtomicLong LOCK_ID_GEN = new AtomicLong(0);
+  private static final int MAX_READERS = Configuration.getInt(
+      PropertyKey.WORKER_TIERED_STORE_BLOCK_LOCK_READERS);
 
  /** A pool of read write locks. */
   private final ResourcePool<ClientRWLock> mLockPool = new ResourcePool<ClientRWLock>(
@@ -57,7 +60,7 @@ public final class BlockLockManager {
 
     @Override
     public ClientRWLock createNewResource() {
-      return new ClientRWLock();
+      return new ClientRWLock(MAX_READERS);
     }
   };
 

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -100,7 +100,6 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
   private final FuseShell mFuseShell;
   private static final IndexDefinition<FuseFileEntry<FuseFileStream>, Long>
       ID_INDEX = IndexDefinition.ofUnique(FuseFileEntry::getId);
-
   // Add a PATH_INDEX to know getattr() been called when writing this file
   private static final IndexDefinition<FuseFileEntry<FuseFileStream>, String>
       PATH_INDEX = IndexDefinition.ofUnique(FuseFileEntry::getPath);

--- a/integration/fuse/src/main/java/alluxio/fuse/lock/FuseReadWriteLockManager.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/lock/FuseReadWriteLockManager.java
@@ -1,0 +1,79 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.fuse.lock;
+
+import alluxio.Constants;
+import alluxio.concurrent.ClientRWLock;
+import alluxio.concurrent.LockMode;
+import alluxio.exception.runtime.CancelledRuntimeException;
+import alluxio.exception.runtime.DeadlineExceededRuntimeException;
+import alluxio.resource.CloseableResource;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+
+/**
+ * The lock manager to guard Fuse read/write operations.
+ */
+public class FuseReadWriteLockManager {
+  private static final long TRY_LOCK_TIMEOUT = 20 * Constants.SECOND_MS;
+
+  private final LoadingCache<String, ClientRWLock> mLockCache
+      = CacheBuilder.newBuilder().weakValues()
+      .build(new CacheLoader<String, ClientRWLock>() {
+        @Override
+        public ClientRWLock load(String key) {
+          return new ClientRWLock(64);
+        }
+      });
+
+  /**
+   * Constructs a new {@link FuseReadWriteLockManager}.
+   */
+  public FuseReadWriteLockManager() {}
+
+  /**
+   * Tries to lock the given poth with read/write mode.
+   *
+   * @param path the path to lock
+   * @param mode the lock mode
+   * @return the lock resource to unlock the locked lock
+   */
+  public CloseableResource<Lock> tryLock(String path, LockMode mode) {
+    ClientRWLock pathLock = mLockCache.getUnchecked(path);
+    Lock lock = mode == LockMode.READ ? pathLock.readLock() : pathLock.writeLock();
+    try {
+      if (!lock.tryLock(TRY_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
+        throw new DeadlineExceededRuntimeException(String.format(
+            "Failed to acquire lock for path %s after %s ms. "
+                + "LockMode: %s, lock reference count = %s",
+            path, TRY_LOCK_TIMEOUT, mode, pathLock.getReferenceCount()));
+      }
+      return new CloseableResource<Lock>(lock) {
+        @Override
+        public void closeResource() {
+          lock.unlock();
+        }
+      };
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new CancelledRuntimeException(String.format(
+          "Failed to acquire lock for path %s after %s ms. "
+              + "LockMode: %s, lock reference count = %s",
+          path, TRY_LOCK_TIMEOUT, mode, pathLock.getReferenceCount()));
+    }
+  }
+}

--- a/tests/src/test/java/alluxio/client/fuse/file/AbstractFuseFileStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/AbstractFuseFileStreamIntegrationTest.java
@@ -16,7 +16,6 @@ import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.URIStatus;
-import alluxio.collections.LockPool;
 import alluxio.conf.PropertyKey;
 import alluxio.fuse.auth.AuthPolicy;
 import alluxio.fuse.auth.LaunchUserGroupAuthPolicy;
@@ -34,7 +33,6 @@ import org.junit.Before;
 import org.junit.Rule;
 
 import java.util.Optional;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Abstract classes for all integration tests of {@link FuseFileStream}.
@@ -52,7 +50,6 @@ public abstract class AbstractFuseFileStreamIntegrationTest extends BaseIntegrat
 
   protected FileSystem mFileSystem = null;
   protected AuthPolicy mAuthPolicy = null;
-  protected LockPool<String> mPathLocks = null;
   protected FuseFileStream.Factory mStreamFactory = null;
 
   @Before
@@ -61,9 +58,7 @@ public abstract class AbstractFuseFileStreamIntegrationTest extends BaseIntegrat
     mAuthPolicy = LaunchUserGroupAuthPolicy.create(mFileSystem,
         mLocalAlluxioClusterResource.get().getClient().getConf(), Optional.empty());
     mAuthPolicy.init();
-    mPathLocks = new LockPool<>((key) -> new ReentrantReadWriteLock(),
-        8, 16, 128, 8);
-    mStreamFactory = new FuseFileStream.Factory(mFileSystem, mAuthPolicy, mPathLocks);
+    mStreamFactory = new FuseFileStream.Factory(mFileSystem, mAuthPolicy);
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/fuse/file/FuseFileInOrOutStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/FuseFileInOrOutStreamIntegrationTest.java
@@ -14,7 +14,6 @@ package alluxio.client.fuse.file;
 import alluxio.AlluxioURI;
 import alluxio.client.file.URIStatus;
 import alluxio.exception.runtime.UnimplementedRuntimeException;
-import alluxio.fuse.file.FuseFileInOrOutStream;
 import alluxio.fuse.file.FuseFileStream;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.util.io.BufferUtils;
@@ -107,8 +106,8 @@ public class FuseFileInOrOutStreamIntegrationTest extends AbstractFuseFileStream
         CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
     int newFileLength = 30;
-    try (FuseFileInOrOutStream stream = FuseFileInOrOutStream.create(mFileSystem, mAuthPolicy,
-        mPathLocks, alluxioURI, OpenFlags.O_RDWR.intValue() | OpenFlags.O_TRUNC.intValue(), MODE)) {
+    try (FuseFileStream stream = mStreamFactory.create(
+        alluxioURI, OpenFlags.O_RDWR.intValue() | OpenFlags.O_TRUNC.intValue(), MODE)) {
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(0, newFileLength);
       stream.write(buffer, newFileLength, 0);
     }

--- a/tests/src/test/java/alluxio/client/fuse/file/FuseFileInStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/FuseFileInStreamIntegrationTest.java
@@ -15,7 +15,6 @@ import alluxio.AlluxioURI;
 import alluxio.client.file.URIStatus;
 import alluxio.exception.runtime.NotFoundRuntimeException;
 import alluxio.exception.runtime.UnimplementedRuntimeException;
-import alluxio.fuse.file.FuseFileInStream;
 import alluxio.fuse.file.FuseFileStream;
 import alluxio.util.io.BufferUtils;
 import alluxio.util.io.PathUtils;
@@ -48,7 +47,7 @@ public class FuseFileInStreamIntegrationTest extends AbstractFuseFileStreamInteg
   @Test (expected = NotFoundRuntimeException.class)
   public void createNonexisting() {
     AlluxioURI alluxioURI = new AlluxioURI(PathUtils.uniqPath());
-    FuseFileInStream.create(mFileSystem, mPathLocks, alluxioURI);
+    mStreamFactory.create(alluxioURI, OpenFlags.O_RDONLY.intValue(), MODE).close();
   }
 
   @Test


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix the bug introduced by https://github.com/Alluxio/alluxio/pull/16377.
Change thread based lock to session based lock to avoid IllegalMonitorException when a thread tries to unlock a lock locked by another thread.

### Why are the changes needed?

Fuse stream operations can be called by different threads. stream creation (lock the path) can be called by one thread while stream close (unlock the path) may be called by another thread. Use the previous ReadWriteLock, unlock will throw IllegalMonitorException.

### Does this PR introduce any user facing changes?

NA