### PR TITLE
Support config ratis configurations through alluxio config

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -8569,11 +8569,16 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     MASTER_IMPERSONATION_GROUPS_OPTION("alluxio.master.security.impersonation.%s.groups",
         "alluxio\\.master\\.security\\.impersonation\\.([a-zA-Z_0-9-\\.@]+)\\.groups",
         PropertyType.STRING),
+
     MASTER_IMPERSONATION_USERS_OPTION("alluxio.master.security.impersonation.%s.users",
         "alluxio\\.master\\.security\\.impersonation\\.([a-zA-Z_0-9-\\.@]+)\\.users",
         PropertyType.STRING),
     MASTER_JOURNAL_UFS_OPTION_PROPERTY("alluxio.master.journal.ufs.option.%s",
         "alluxio\\.master\\.journal\\.ufs\\.option\\.(?<nested>(\\w+\\.)*+\\w+)",
+        PropertyCreators.NESTED_JOURNAL_PROPERTY_CREATOR),
+    MASTER_EMBEDDED_JOURNAL_RATIS_CONFIG_PROPERTY(
+        "alluxio.master.embedded.journal.ratis.config.%s",
+        "alluxio\\.master\\.embedded\\.journal\\.ratis\\.config\\.(?<nested>(\\w+\\.)*+\\w+)",
         PropertyCreators.NESTED_JOURNAL_PROPERTY_CREATOR),
     MASTER_LOGICAL_NAMESERVICES("alluxio.master.nameservices.%s",
         String.format("alluxio\\.master\\.nameservices\\.%s",

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2228,11 +2228,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_RATIS_CONFIG =
       stringBuilder(Name.MASTER_EMBEDDED_JOURNAL_RATIS_CONFIG)
-          .setDescription("Prefix for Apache Ratis internal configuration options. For example, setting alluxio.master.embedded.journal.ratis.config.raft.server.rpc.request.timeout will set ratis.config.raft.server.rpc.request.timeout on the Ratis service in the Alluxio master.")
+          .setDescription("Prefix for Apache Ratis internal configuration options. For example, "
+              + "setting " + Name.MASTER_EMBEDDED_JOURNAL_RATIS_CONFIG
+              + ".raft.server.rpc.request.timeout will set "
+              + "ratis.config.raft.server.rpc.request.timeout "
+              + "on the Ratis service in the Alluxio master.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
-
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_TRANSPORT_REQUEST_TIMEOUT_MS =
       durationBuilder(Name.MASTER_EMBEDDED_JOURNAL_TRANSPORT_REQUEST_TIMEOUT_MS)
           .setDefaultValue("5sec")

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -8569,7 +8569,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     MASTER_IMPERSONATION_GROUPS_OPTION("alluxio.master.security.impersonation.%s.groups",
         "alluxio\\.master\\.security\\.impersonation\\.([a-zA-Z_0-9-\\.@]+)\\.groups",
         PropertyType.STRING),
-
     MASTER_IMPERSONATION_USERS_OPTION("alluxio.master.security.impersonation.%s.users",
         "alluxio\\.master\\.security\\.impersonation\\.([a-zA-Z_0-9-\\.@]+)\\.users",
         PropertyType.STRING),

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2226,6 +2226,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_RATIS_CONFIG =
+      stringBuilder(Name.MASTER_EMBEDDED_JOURNAL_RATIS_CONFIG)
+          .setDescription("The configuration to use for the ratis.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.MASTER)
+          .build();
+
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_TRANSPORT_REQUEST_TIMEOUT_MS =
       durationBuilder(Name.MASTER_EMBEDDED_JOURNAL_TRANSPORT_REQUEST_TIMEOUT_MS)
           .setDefaultValue("5sec")
@@ -7526,6 +7533,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.embedded.journal.raft.client.request.timeout";
     public static final String MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_INTERVAL =
         "alluxio.master.embedded.journal.raft.client.request.interval";
+    public static final String MASTER_EMBEDDED_JOURNAL_RATIS_CONFIG =
+        "alluxio.master.embedded.journal.ratis.config";
     public static final String MASTER_EMBEDDED_JOURNAL_TRANSPORT_REQUEST_TIMEOUT_MS =
         "alluxio.master.embedded.journal.transport.request.timeout.ms";
     public static final String MASTER_EMBEDDED_JOURNAL_TRANSPORT_MAX_INBOUND_MESSAGE_SIZE =

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -427,6 +427,16 @@ public class RaftJournalSystem extends AbstractJournalSystem {
         SizeInBytes.valueOf(messageSize));
     RatisDropwizardExports.registerRatisMetricReporters(mRatisMetricsMap);
 
+    Map<String, Object> ratisConf =
+        Configuration.getNestedProperties(PropertyKey.MASTER_EMBEDDED_JOURNAL_RATIS_CONFIG);
+
+    for (Map.Entry<String, Object> entry : ratisConf.entrySet()) {
+      if (entry.getValue() != null) {
+        properties.set(entry.getKey(), entry.getValue().toString());
+        LOG.info("set ratis config {}={}", entry.getKey(), entry.getValue());
+      }
+    }
+
     // TODO(feng): clean up embedded journal configuration
     // build server
     mServer = RaftServer.newBuilder()

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -427,15 +427,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
         SizeInBytes.valueOf(messageSize));
     RatisDropwizardExports.registerRatisMetricReporters(mRatisMetricsMap);
 
-    Map<String, Object> ratisConf =
-        Configuration.getNestedProperties(PropertyKey.MASTER_EMBEDDED_JOURNAL_RATIS_CONFIG);
-
-    for (Map.Entry<String, Object> entry : ratisConf.entrySet()) {
-      if (entry.getValue() != null) {
-        properties.set(entry.getKey(), entry.getValue().toString());
-        LOG.info("set ratis config {}={}", entry.getKey(), entry.getValue());
-      }
-    }
+    mergeAlluxioRatisConfig(properties);
 
     // TODO(feng): clean up embedded journal configuration
     // build server
@@ -451,6 +443,19 @@ public class RaftJournalSystem extends AbstractJournalSystem {
         this::getLeaderIndex);
     MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_ROLE_ID.getName(), this::getRoleId);
     MetricsSystem.registerGaugeIfAbsent(MetricKey.CLUSTER_LEADER_ID.getName(), this::getLeaderId);
+  }
+
+  @VisibleForTesting
+  void mergeAlluxioRatisConfig(RaftProperties properties) {
+    Map<String, Object> ratisConf =
+        Configuration.getNestedProperties(PropertyKey.MASTER_EMBEDDED_JOURNAL_RATIS_CONFIG);
+
+    for (Map.Entry<String, Object> entry : ratisConf.entrySet()) {
+      if (entry.getValue() != null) {
+        properties.set(entry.getKey(), entry.getValue().toString());
+        LOG.info("set ratis config {}={}", entry.getKey(), entry.getValue());
+      }
+    }
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -25,7 +25,9 @@ import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.RaftServerConfigKeys;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -502,6 +504,23 @@ public class RaftJournalTest {
 
     Assert.assertTrue(exception.getMessage()
         .contains(CountingNoopFileSystemMaster.ENTRY_DOES_NOT_EXIST));
+  }
+
+  @Test
+  public void testMergeAlluxioConfig() {
+    RaftProperties properties = new RaftProperties();
+    try {
+      Configuration.set(PropertyKey.fromString(
+          PropertyKey.MASTER_EMBEDDED_JOURNAL_RATIS_CONFIG.getName()
+              + ".raft.server.rpc.request.timeout"), 123456);
+      mLeaderJournalSystem.mergeAlluxioRatisConfig(properties);
+      Assert.assertEquals(123456,
+          RaftServerConfigKeys.Rpc.requestTimeout(properties).getDuration());
+    } finally {
+      Configuration.unset(PropertyKey.fromString(
+          PropertyKey.MASTER_EMBEDDED_JOURNAL_RATIS_CONFIG.getName()
+              + ".raft.server.rpc.request.timeout"));
+    }
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

Without this PR, we have to modify alluxio code to support a new coming ratis config key.

The way to config ratis related configures something like the following:

```
alluxio.master.embedded.journal.ratis.config.raft.server.rpc.slowness.timeout=1000
alluxio.master.embedded.journal.ratis.config.raft.server.snapshot.auto.trigger.threshold=1000
```

### Why are the changes needed?

Without this PR, we have to modify alluxio code to support a new coming ratis config key.


### Does this PR introduce any user facing changes?

Add alluxio config prefix 

`alluxio.master.embedded.journal.ratis.config`