### PR TITLE
Fix bug for read when persist

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -23,9 +23,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.exception.PreconditionMessage;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.OutOfRangeException;
-import alluxio.grpc.CacheRequest;
-import alluxio.grpc.FileSystemMasterCommonPOptions;
-import alluxio.grpc.ListStatusPOptions;
+import alluxio.grpc.*;
 import alluxio.resource.CloseableResource;
 import alluxio.retry.ExponentialTimeBoundedRetry;
 import alluxio.retry.RetryPolicy;
@@ -75,7 +73,7 @@ public class AlluxioFileInStream extends FileInStream {
   private static final Logger LOG = LoggerFactory.getLogger(AlluxioFileInStream.class);
 
   private Supplier<RetryPolicy> mRetryPolicySupplier;
-  private final URIStatus mStatus;
+  private URIStatus mStatus;
   private final InStreamOptions mOptions;
   private final BlockStoreClient mBlockStore;
   private final FileSystemContext mContext;
@@ -172,6 +170,7 @@ public class AlluxioFileInStream extends FileInStream {
         if (e instanceof OutOfRangeException) {
           refreshMetadataOnMismatchedLength((OutOfRangeException) e);
         }
+        refreshUriStatusIfNeeded(e);
       }
     }
     throw lastException;
@@ -215,6 +214,7 @@ public class AlluxioFileInStream extends FileInStream {
         if (e instanceof OutOfRangeException) {
           refreshMetadataOnMismatchedLength((OutOfRangeException) e);
         }
+        refreshUriStatusIfNeeded(e);
       }
     }
     if (lastException != null) {
@@ -329,6 +329,7 @@ public class AlluxioFileInStream extends FileInStream {
           handleRetryableException(mCachedPositionedReadStream, e);
           mCachedPositionedReadStream = null;
         }
+        refreshUriStatusIfNeeded(e);
       }
     }
     if (lastException != null) {
@@ -509,6 +510,28 @@ public class AlluxioFileInStream extends FileInStream {
     // TODO(lu) consider recovering failed workers
     if (!causedByClientOOM) {
       mFailedWorkers.put(workerAddress, System.currentTimeMillis());
+    }
+  }
+
+  public void refreshUriStatusIfNeeded(IOException e) throws IOException {
+    if (!mOptions.getOptions().getUpdateURIStatusWhenRetry()) {
+      return;
+    }
+    try (CloseableResource<FileSystemMasterClient> client = mContext.acquireMasterClientResource()) {
+      client.close();
+      URIStatus update = client.get().getStatus(new AlluxioURI(mOptions.getStatus().getPath()),
+              FileSystemOptionsUtils.getStatusDefaults(mContext.getClusterConf()).toBuilder()
+                      .setAccessMode(Bits.READ)
+                      .setLoadMetadataType(LoadMetadataPType.NEVER)
+                      .setUpdateTimestamps(mOptions.getOptions().getUpdateLastAccessTime())
+                      .build());
+      if (!update.equals(mOptions.getStatus())) {
+        LOG.info("refresh status because some exception occurs: {}, new: {}, old: {}", e.getMessage(), update, mStatus);
+        mOptions.setStatus(update);
+        mStatus = update;
+      }
+    } catch (Throwable throwable) {
+      LOG.warn("try to refresh status for {} but failed!", mStatus.getPath(), throwable);
     }
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
@@ -136,11 +136,11 @@ public final class InStreamOptions {
   }
 
   /**
-   * refresh URIStatus for options
+   * refresh URIStatus for options.
    * @param status current status for this file
    */
   public void setStatus(URIStatus status) {
-    this.mStatus = status;
+    mStatus = status;
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/InStreamOptions.java
@@ -42,7 +42,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 // TODO(calvin, jianjian): Rename this class since it's not used by InStream
 public final class InStreamOptions {
-  private final URIStatus mStatus;
+  private URIStatus mStatus;
   private final OpenFilePOptions mProtoOptions;
   private BlockLocationPolicy mUfsReadLocationPolicy;
   private boolean mPositionShort;
@@ -133,6 +133,14 @@ public final class InStreamOptions {
    */
   public URIStatus getStatus() {
     return mStatus;
+  }
+
+  /**
+   * refresh URIStatus for options
+   * @param status current status for this file
+   */
+  public void setStatus(URIStatus status) {
+    this.mStatus = status;
   }
 
   /**

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -94,6 +94,7 @@ message OpenFilePOptions {
   optional int32 maxUfsReadConcurrency = 2;
   optional FileSystemMasterCommonPOptions commonOptions = 3;
   optional bool updateLastAccessTime = 4 [default = true];
+  optional bool updateURIStatusWhenRetry = 5 [default =false];
 }
 
 // XAttrPropagationStrategy controls the behaviour for assigning xAttr

--- a/tests/src/test/java/alluxio/job/plan/persist/ReadWhenPersistIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/plan/persist/ReadWhenPersistIntegrationTest.java
@@ -1,0 +1,165 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.job.plan.persist;
+
+import alluxio.AlluxioURI;
+import alluxio.Constants;
+import alluxio.Sessions;
+import alluxio.client.file.*;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.AlluxioException;
+import alluxio.exception.status.NotFoundException;
+import alluxio.exception.status.UnavailableException;
+import alluxio.grpc.OpenFilePOptions;
+import alluxio.grpc.WritePType;
+import alluxio.job.JobIntegrationTest;
+import alluxio.master.file.meta.PersistenceState;
+import alluxio.retry.ExponentialBackoffRetry;
+import alluxio.retry.RetryUtils;
+import alluxio.testutils.LocalAlluxioClusterResource;
+import alluxio.worker.block.BlockWorker;
+import alluxio.worker.block.DefaultBlockWorker;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests for {@link AlluxioFileInStream#refreshUriStatusIfNeeded(IOException)}.
+ */
+public final class ReadWhenPersistIntegrationTest extends JobIntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReadWhenPersistIntegrationTest.class);
+
+    private final String FILE_PATH = "/file";
+    private DefaultBlockWorker blockWorker;
+
+    @Before
+    public void before() throws Exception {
+        super.before();
+        blockWorker = (DefaultBlockWorker) mLocalAlluxioClusterResource.get()
+                .getWorkerProcess().getWorker(BlockWorker.class);
+    }
+
+    @Test
+    @LocalAlluxioClusterResource.Config(confParams = {
+            PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "64MB",
+            PropertyKey.Name.USER_BLOCK_READ_RETRY_MAX_DURATION, "10s"
+    })
+    public void testFailIfOpenFileInStreamBeforePersist() throws Exception {
+        FileSystemTestUtils.createByteFile(mFileSystem, FILE_PATH, WritePType.MUST_CACHE, Constants.KB);
+
+        FileInStream in = mFileSystem.openFile(new AlluxioURI(FILE_PATH));
+
+        // do persist after open
+        mFileSystem.persist(new AlluxioURI(FILE_PATH));
+        waitForPersisted(mFileSystem, FILE_PATH);
+
+        // simulate that block is evicted
+        Long blockId = mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getBlockIds().get(0);
+        blockWorker.removeBlock(Sessions.createInternalSessionId(), blockId);
+
+        try {
+            in.positionedRead(0, new byte[10], 0, 10);
+            fail("should throw UnavailableException: Block .* is unavailable in both Alluxio and UFS," +
+                    " or NotFoundException: BlockMeta not found for blockId");
+        } catch (UnavailableException | NotFoundException expected) {}
+    }
+
+    @Test
+    @LocalAlluxioClusterResource.Config(confParams = {
+            PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "64MB",
+            PropertyKey.Name.USER_BLOCK_READ_RETRY_MAX_DURATION, "10s"
+    })
+    public void testSuccessIfOpenFileInStreamBeforePersist() throws Exception {
+        FileSystemTestUtils.createByteFile(mFileSystem, FILE_PATH, WritePType.MUST_CACHE, Constants.KB);
+
+        FileInStream in = mFileSystem.openFile(new AlluxioURI(FILE_PATH),
+                OpenFilePOptions.newBuilder().setUpdateURIStatusWhenRetry(true).build());
+
+        // do persist after open
+        mFileSystem.persist(new AlluxioURI(FILE_PATH));
+        waitForPersisted(mFileSystem, FILE_PATH);
+
+        // simulate that block is evicted
+        Long blockId = mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getBlockIds().get(0);
+        blockWorker.removeBlock(Sessions.createInternalSessionId(), blockId);
+
+        assertEquals(10, in.positionedRead(0, new byte[10], 0, 10));
+    }
+
+    @Test
+    @LocalAlluxioClusterResource.Config(confParams = {
+            PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "64MB",
+            PropertyKey.Name.USER_BLOCK_READ_RETRY_MAX_DURATION, "10s"
+    })
+    public void testFailIfOpenFileInStreamWhenPersisting() throws Exception {
+        FileSystemTestUtils.createByteFile(mFileSystem, FILE_PATH, WritePType.MUST_CACHE, Constants.KB);
+
+        // schedule async persist and open
+        mFileSystem.persist(new AlluxioURI(FILE_PATH));
+        FileInStream in = mFileSystem.openFile(new AlluxioURI(FILE_PATH));
+        if (!PersistenceState.TO_BE_PERSISTED.name().equals(
+                mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getPersistenceState())) {
+            LOG.warn("Ineffective test: current status should be TO_BE_PERSISTED");
+            return;
+        }
+        waitForPersisted(mFileSystem, FILE_PATH);
+
+        // simulate that block is evicted
+        Long blockId = mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getBlockIds().get(0);
+        blockWorker.removeBlock(Sessions.createInternalSessionId(), blockId);
+
+        try {
+            assertEquals(10, in.positionedRead(0, new byte[10], 0, 10));
+            fail("should throw NotFoundException: Failed to read from UFS");
+        } catch (NotFoundException expected) {}
+    }
+
+    @Test
+    @LocalAlluxioClusterResource.Config(confParams = {
+            PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "64MB",
+            PropertyKey.Name.USER_BLOCK_READ_RETRY_MAX_DURATION, "10s"
+    })
+    public void testSuccessIfOpenFileInStreamWhenPersisting() throws Exception {
+        FileSystemTestUtils.createByteFile(mFileSystem, FILE_PATH, WritePType.MUST_CACHE, Constants.KB);
+
+        // schedule async persist and open
+        mFileSystem.persist(new AlluxioURI(FILE_PATH));
+        FileInStream in = mFileSystem.openFile(new AlluxioURI(FILE_PATH),
+                OpenFilePOptions.newBuilder().setUpdateURIStatusWhenRetry(true).build());
+        waitForPersisted(mFileSystem, FILE_PATH);
+
+        // simulate that block is evicted
+        Long blockId = mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getBlockIds().get(0);
+        blockWorker.removeBlock(Sessions.createInternalSessionId(), blockId);
+
+        assertEquals(10, in.positionedRead(0, new byte[10], 0, 10));
+    }
+
+    private void waitForPersisted(FileSystem fileSystem, String filePath) throws IOException {
+        RetryUtils.retry("wait for persisted", () -> {
+            try {
+                URIStatus status = fileSystem.getStatus(new AlluxioURI(filePath));
+                if (!status.isPersisted()) {
+                    throw new IOException(String.format("%s is not persisted", filePath));
+                }
+            } catch (AlluxioException e) {
+                throw new IOException(e);
+            }
+        }, new ExponentialBackoffRetry(100, 1000, 20));
+    }
+}

--- a/tests/src/test/java/alluxio/job/plan/persist/ReadWhenPersistIntegrationTest.java
+++ b/tests/src/test/java/alluxio/job/plan/persist/ReadWhenPersistIntegrationTest.java
@@ -11,10 +11,17 @@
 
 package alluxio.job.plan.persist;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.Sessions;
-import alluxio.client.file.*;
+import alluxio.client.file.AlluxioFileInStream;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemTestUtils;
+import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.status.NotFoundException;
@@ -28,6 +35,7 @@ import alluxio.retry.RetryUtils;
 import alluxio.testutils.LocalAlluxioClusterResource;
 import alluxio.worker.block.BlockWorker;
 import alluxio.worker.block.DefaultBlockWorker;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -35,131 +43,134 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-import static org.junit.Assert.*;
-
 /**
  * Integration tests for {@link AlluxioFileInStream#refreshUriStatusIfNeeded(IOException)}.
  */
 public final class ReadWhenPersistIntegrationTest extends JobIntegrationTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ReadWhenPersistIntegrationTest.class);
+  private static final Logger LOG = LoggerFactory.getLogger(
+      ReadWhenPersistIntegrationTest.class);
 
-    private final String FILE_PATH = "/file";
-    private DefaultBlockWorker blockWorker;
+  private static final String FILE_PATH = "/file";
+  private DefaultBlockWorker mBlockWorker;
 
-    @Before
-    public void before() throws Exception {
-        super.before();
-        blockWorker = (DefaultBlockWorker) mLocalAlluxioClusterResource.get()
-                .getWorkerProcess().getWorker(BlockWorker.class);
+  @Before
+  public void before() throws Exception {
+    super.before();
+    mBlockWorker = (DefaultBlockWorker) mLocalAlluxioClusterResource.get()
+        .getWorkerProcess().getWorker(BlockWorker.class);
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(confParams = {
+      PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "64MB",
+      PropertyKey.Name.USER_BLOCK_READ_RETRY_MAX_DURATION, "10s"
+  })
+  public void testFailIfOpenFileInStreamBeforePersist() throws Exception {
+    FileSystemTestUtils.createByteFile(
+        mFileSystem, FILE_PATH, WritePType.MUST_CACHE, Constants.KB);
+
+    FileInStream in = mFileSystem.openFile(new AlluxioURI(FILE_PATH));
+
+    // do persist after open
+    mFileSystem.persist(new AlluxioURI(FILE_PATH));
+    waitForPersisted(mFileSystem, FILE_PATH);
+
+    // simulate that block is evicted
+    Long blockId = mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getBlockIds().get(0);
+    mBlockWorker.removeBlock(Sessions.createInternalSessionId(), blockId);
+
+    try {
+      in.positionedRead(0, new byte[10], 0, 10);
+      fail("should throw UnavailableException: Block .* is unavailable in both Alluxio and "
+          + "UFS, or NotFoundException: BlockMeta not found for blockId");
+    } catch (UnavailableException | NotFoundException ignored) { /* ignored */ }
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(confParams = {
+      PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "64MB",
+      PropertyKey.Name.USER_BLOCK_READ_RETRY_MAX_DURATION, "10s"
+  })
+  public void testSuccessIfOpenFileInStreamBeforePersist() throws Exception {
+    FileSystemTestUtils.createByteFile(
+        mFileSystem, FILE_PATH, WritePType.MUST_CACHE, Constants.KB);
+
+    FileInStream in = mFileSystem.openFile(new AlluxioURI(FILE_PATH),
+        OpenFilePOptions.newBuilder().setUpdateURIStatusWhenRetry(true).build());
+
+    // do persist after open
+    mFileSystem.persist(new AlluxioURI(FILE_PATH));
+    waitForPersisted(mFileSystem, FILE_PATH);
+
+    // simulate that block is evicted
+    Long blockId = mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getBlockIds().get(0);
+    mBlockWorker.removeBlock(Sessions.createInternalSessionId(), blockId);
+
+    assertEquals(10, in.positionedRead(0, new byte[10], 0, 10));
+  }
+
+  @Test
+  @LocalAlluxioClusterResource.Config(confParams = {
+      PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "64MB",
+      PropertyKey.Name.USER_BLOCK_READ_RETRY_MAX_DURATION, "10s"
+  })
+  public void testFailIfOpenFileInStreamWhenPersisting() throws Exception {
+    FileSystemTestUtils.createByteFile(
+        mFileSystem, FILE_PATH, WritePType.MUST_CACHE, Constants.KB);
+
+    // schedule async persist and open
+    mFileSystem.persist(new AlluxioURI(FILE_PATH));
+    FileInStream in = mFileSystem.openFile(new AlluxioURI(FILE_PATH));
+    if (!PersistenceState.TO_BE_PERSISTED.name().equals(
+        mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getPersistenceState())) {
+      LOG.warn("Ineffective test: current status should be TO_BE_PERSISTED");
+      return;
     }
+    waitForPersisted(mFileSystem, FILE_PATH);
 
-    @Test
-    @LocalAlluxioClusterResource.Config(confParams = {
-            PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "64MB",
-            PropertyKey.Name.USER_BLOCK_READ_RETRY_MAX_DURATION, "10s"
-    })
-    public void testFailIfOpenFileInStreamBeforePersist() throws Exception {
-        FileSystemTestUtils.createByteFile(mFileSystem, FILE_PATH, WritePType.MUST_CACHE, Constants.KB);
+    // simulate that block is evicted
+    Long blockId = mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getBlockIds().get(0);
+    mBlockWorker.removeBlock(Sessions.createInternalSessionId(), blockId);
 
-        FileInStream in = mFileSystem.openFile(new AlluxioURI(FILE_PATH));
+    try {
+      assertEquals(10, in.positionedRead(0, new byte[10], 0, 10));
+      fail("should throw NotFoundException: Failed to read from UFS");
+    } catch (NotFoundException ignored) { /* ignored */ }
+  }
 
-        // do persist after open
-        mFileSystem.persist(new AlluxioURI(FILE_PATH));
-        waitForPersisted(mFileSystem, FILE_PATH);
+  @Test
+  @LocalAlluxioClusterResource.Config(confParams = {
+      PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "64MB",
+      PropertyKey.Name.USER_BLOCK_READ_RETRY_MAX_DURATION, "10s"
+  })
+  public void testSuccessIfOpenFileInStreamWhenPersisting() throws Exception {
+    FileSystemTestUtils.createByteFile(
+        mFileSystem, FILE_PATH, WritePType.MUST_CACHE, Constants.KB);
 
-        // simulate that block is evicted
-        Long blockId = mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getBlockIds().get(0);
-        blockWorker.removeBlock(Sessions.createInternalSessionId(), blockId);
+    // schedule async persist and open
+    mFileSystem.persist(new AlluxioURI(FILE_PATH));
+    FileInStream in = mFileSystem.openFile(new AlluxioURI(FILE_PATH),
+        OpenFilePOptions.newBuilder().setUpdateURIStatusWhenRetry(true).build());
+    waitForPersisted(mFileSystem, FILE_PATH);
 
-        try {
-            in.positionedRead(0, new byte[10], 0, 10);
-            fail("should throw UnavailableException: Block .* is unavailable in both Alluxio and UFS," +
-                    " or NotFoundException: BlockMeta not found for blockId");
-        } catch (UnavailableException | NotFoundException expected) {}
-    }
+    // simulate that block is evicted
+    Long blockId = mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getBlockIds().get(0);
+    mBlockWorker.removeBlock(Sessions.createInternalSessionId(), blockId);
 
-    @Test
-    @LocalAlluxioClusterResource.Config(confParams = {
-            PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "64MB",
-            PropertyKey.Name.USER_BLOCK_READ_RETRY_MAX_DURATION, "10s"
-    })
-    public void testSuccessIfOpenFileInStreamBeforePersist() throws Exception {
-        FileSystemTestUtils.createByteFile(mFileSystem, FILE_PATH, WritePType.MUST_CACHE, Constants.KB);
+    assertEquals(10, in.positionedRead(0, new byte[10], 0, 10));
+  }
 
-        FileInStream in = mFileSystem.openFile(new AlluxioURI(FILE_PATH),
-                OpenFilePOptions.newBuilder().setUpdateURIStatusWhenRetry(true).build());
-
-        // do persist after open
-        mFileSystem.persist(new AlluxioURI(FILE_PATH));
-        waitForPersisted(mFileSystem, FILE_PATH);
-
-        // simulate that block is evicted
-        Long blockId = mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getBlockIds().get(0);
-        blockWorker.removeBlock(Sessions.createInternalSessionId(), blockId);
-
-        assertEquals(10, in.positionedRead(0, new byte[10], 0, 10));
-    }
-
-    @Test
-    @LocalAlluxioClusterResource.Config(confParams = {
-            PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "64MB",
-            PropertyKey.Name.USER_BLOCK_READ_RETRY_MAX_DURATION, "10s"
-    })
-    public void testFailIfOpenFileInStreamWhenPersisting() throws Exception {
-        FileSystemTestUtils.createByteFile(mFileSystem, FILE_PATH, WritePType.MUST_CACHE, Constants.KB);
-
-        // schedule async persist and open
-        mFileSystem.persist(new AlluxioURI(FILE_PATH));
-        FileInStream in = mFileSystem.openFile(new AlluxioURI(FILE_PATH));
-        if (!PersistenceState.TO_BE_PERSISTED.name().equals(
-                mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getPersistenceState())) {
-            LOG.warn("Ineffective test: current status should be TO_BE_PERSISTED");
-            return;
+  private void waitForPersisted(FileSystem fileSystem, String filePath) throws IOException {
+    RetryUtils.retry("wait for persisted", () -> {
+      try {
+        URIStatus status = fileSystem.getStatus(new AlluxioURI(filePath));
+        if (!status.isPersisted()) {
+          throw new IOException(String.format("%s is not persisted", filePath));
         }
-        waitForPersisted(mFileSystem, FILE_PATH);
-
-        // simulate that block is evicted
-        Long blockId = mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getBlockIds().get(0);
-        blockWorker.removeBlock(Sessions.createInternalSessionId(), blockId);
-
-        try {
-            assertEquals(10, in.positionedRead(0, new byte[10], 0, 10));
-            fail("should throw NotFoundException: Failed to read from UFS");
-        } catch (NotFoundException expected) {}
-    }
-
-    @Test
-    @LocalAlluxioClusterResource.Config(confParams = {
-            PropertyKey.Name.USER_BLOCK_SIZE_BYTES_DEFAULT, "64MB",
-            PropertyKey.Name.USER_BLOCK_READ_RETRY_MAX_DURATION, "10s"
-    })
-    public void testSuccessIfOpenFileInStreamWhenPersisting() throws Exception {
-        FileSystemTestUtils.createByteFile(mFileSystem, FILE_PATH, WritePType.MUST_CACHE, Constants.KB);
-
-        // schedule async persist and open
-        mFileSystem.persist(new AlluxioURI(FILE_PATH));
-        FileInStream in = mFileSystem.openFile(new AlluxioURI(FILE_PATH),
-                OpenFilePOptions.newBuilder().setUpdateURIStatusWhenRetry(true).build());
-        waitForPersisted(mFileSystem, FILE_PATH);
-
-        // simulate that block is evicted
-        Long blockId = mFileSystem.getStatus(new AlluxioURI(FILE_PATH)).getBlockIds().get(0);
-        blockWorker.removeBlock(Sessions.createInternalSessionId(), blockId);
-
-        assertEquals(10, in.positionedRead(0, new byte[10], 0, 10));
-    }
-
-    private void waitForPersisted(FileSystem fileSystem, String filePath) throws IOException {
-        RetryUtils.retry("wait for persisted", () -> {
-            try {
-                URIStatus status = fileSystem.getStatus(new AlluxioURI(filePath));
-                if (!status.isPersisted()) {
-                    throw new IOException(String.format("%s is not persisted", filePath));
-                }
-            } catch (AlluxioException e) {
-                throw new IOException(e);
-            }
-        }, new ExponentialBackoffRetry(100, 1000, 20));
-    }
+      } catch (AlluxioException e) {
+        throw new IOException(e);
+      }
+    }, new ExponentialBackoffRetry(100, 1000, 20));
+  }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix bug for read when persist.

### Why are the changes needed?

There are at least 2 conditions for this bug:

open FileInStream before persist, and read after persisted and blocks are evicted, the exception is one of the following:
1.1. UnavailableException: Block .* is unavailable in both Alluxio and UFS.
1.2. NotFoundException: BlockMeta not found for blockId
open FileInStream when TO_BE_PERSISTED, and read after persisted and blocks are evicted, the exception is:
2.1. NotFoundException: Failed to read from UFS
So, a new option for OpenFilePOptions is added, user can choose whether to refresh uristatus if IOException occurs in AlluxioFileInStream

### Does this PR introduce any user facing changes?

a new option named "updateURIStatusWhenRetry" is added to OpenFilePOptions

#16509 