### PR TITLE
Support STS for OSS ufs through RAMRole

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1275,19 +1275,19 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
-  public static final PropertyKey UNDERFS_OSS_STS_ENABLED =
-      booleanBuilder(Name.UNDERFS_OSS_STS_ENABLED)
-          .setAlias("alluxio.underfs.oss.sts.enabled")
-          .setDefaultValue(false)
-          .setDescription("Whether to enable oss STS(Security Token Service).")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.SERVER)
-          .build();
   public static final PropertyKey UNDERFS_OSS_RETRY_MAX =
       intBuilder(Name.UNDERFS_OSS_RETRY_MAX)
           .setAlias("alluxio.underfs.oss.retry.max")
           .setDefaultValue(3)
           .setDescription("The maximum number of OSS error retry.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_STS_ENABLED =
+      booleanBuilder(Name.UNDERFS_OSS_STS_ENABLED)
+          .setAlias("alluxio.underfs.oss.sts.enabled")
+          .setDefaultValue(false)
+          .setDescription("Whether to enable oss STS(Security Token Service).")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
@@ -1306,12 +1306,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
-  public static final PropertyKey UNDERFS_OSS_STS_TOKEN_TIMEOUT_MS =
-      durationBuilder(Name.UNDERFS_OSS_STS_TOKEN_TIMEOUT_MS)
-          .setAlias("alluxio.underfs.oss.sts.token.timeout.ms")
+  public static final PropertyKey UNDERFS_OSS_STS_TOKEN_REFRESH_INTERVAL_MS =
+      durationBuilder(Name.UNDERFS_OSS_STS_TOKEN_REFRESH_INTERVAL_MS)
+          .setAlias("alluxio.underfs.oss.sts.token.refresh.interval.ms")
           .setDefaultValue("30m")
-          .setDescription("The token timeout for OSS STS. How long before the token expires, "
-              + "it will refresh the token automatically")
+          .setDescription("Time before an OSS Security Token is considered expired "
+              + "and will be automatically renewed")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
@@ -7278,13 +7278,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.oss.connection.timeout";
     public static final String UNDERFS_OSS_CONNECT_TTL = "alluxio.underfs.oss.connection.ttl";
     public static final String UNDERFS_OSS_SOCKET_TIMEOUT = "alluxio.underfs.oss.socket.timeout";
-    public static final String UNDERFS_OSS_STS_ENABLED = "alluxio.underfs.oss.sts.enabled";
-    public static final String UNDERFS_OSS_RETRY_MAX = "alluxio.underfs.oss.retry.max";
     public static final String UNDERFS_OSS_ECS_RAM_ROLE = "alluxio.underfs.oss.ecs.ram.role";
+    public static final String UNDERFS_OSS_RETRY_MAX = "alluxio.underfs.oss.retry.max";
     public static final String UNDERFS_OSS_STS_ECS_METADATA_SERVICE_ENDPOINT =
         "alluxio.underfs.oss.sts.ecs.metadata.service.endpoint";
-    public static final String UNDERFS_OSS_STS_TOKEN_TIMEOUT_MS =
-        "alluxio.underfs.oss.sts.token.timeout.ms";
+    public static final String UNDERFS_OSS_STS_ENABLED = "alluxio.underfs.oss.sts.enabled";
+    public static final String UNDERFS_OSS_STS_TOKEN_REFRESH_INTERVAL_MS =
+        "alluxio.underfs.oss.sts.token.refresh.interval.ms";
     public static final String UNDERFS_S3_BULK_DELETE_ENABLED =
         "alluxio.underfs.s3.bulk.delete.enabled";
     public static final String UNDERFS_S3_DEFAULT_MODE = "alluxio.underfs.s3.default.mode";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1275,6 +1275,29 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_OSS_STS_ENABLED =
+      booleanBuilder(Name.UNDERFS_OSS_STS_ENABLED)
+          .setAlias("alluxio.underfs.oss.sts.enabled")
+          .setDefaultValue(false)
+          .setDescription("Whether to enable oss STS(Security Token Service).")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_RETRY_MAX =
+      intBuilder(Name.UNDERFS_OSS_RETRY_MAX)
+          .setAlias("alluxio.underfs.oss.retry.max")
+          .setDefaultValue(3)
+          .setDescription("The maximum number of OSS error retry.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_ECS_RAM_ROLE =
+      stringBuilder(Name.UNDERFS_OSS_ECS_RAM_ROLE)
+          .setAlias("alluxio.underfs.oss.ecs.ram.role")
+          .setDescription("The RAM role of current owner of ECS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_S3_ADMIN_THREADS_MAX =
       intBuilder(Name.UNDERFS_S3_ADMIN_THREADS_MAX)
           .setDefaultValue(20)
@@ -7238,6 +7261,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.oss.connection.timeout";
     public static final String UNDERFS_OSS_CONNECT_TTL = "alluxio.underfs.oss.connection.ttl";
     public static final String UNDERFS_OSS_SOCKET_TIMEOUT = "alluxio.underfs.oss.socket.timeout";
+    public static final String UNDERFS_OSS_STS_ENABLED = "alluxio.underfs.oss.sts.enabled";
+    public static final String UNDERFS_OSS_RETRY_MAX = "alluxio.underfs.oss.retry.max";
+    public static final String UNDERFS_OSS_ECS_RAM_ROLE = "alluxio.underfs.oss.ecs.ram.role";
     public static final String UNDERFS_S3_BULK_DELETE_ENABLED =
         "alluxio.underfs.s3.bulk.delete.enabled";
     public static final String UNDERFS_S3_DEFAULT_MODE = "alluxio.underfs.s3.default.mode";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1275,6 +1275,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_OSS_ECS_RAM_ROLE =
+      stringBuilder(Name.UNDERFS_OSS_ECS_RAM_ROLE)
+          .setAlias("alluxio.underfs.oss.ecs.ram.role")
+          .setDescription("The RAM role of current owner of ECS.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_OSS_RETRY_MAX =
       intBuilder(Name.UNDERFS_OSS_RETRY_MAX)
           .setAlias("alluxio.underfs.oss.retry.max")
@@ -1283,26 +1290,19 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
-  public static final PropertyKey UNDERFS_OSS_STS_ENABLED =
-      booleanBuilder(Name.UNDERFS_OSS_STS_ENABLED)
-          .setAlias("alluxio.underfs.oss.sts.enabled")
-          .setDefaultValue(false)
-          .setDescription("Whether to enable oss STS(Security Token Service).")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.SERVER)
-          .build();
-  public static final PropertyKey UNDERFS_OSS_ECS_RAM_ROLE =
-      stringBuilder(Name.UNDERFS_OSS_ECS_RAM_ROLE)
-          .setAlias("alluxio.underfs.oss.ecs.ram.role")
-          .setDescription("The RAM role of current owner of ECS.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.SERVER)
-          .build();
   public static final PropertyKey UNDERFS_OSS_STS_ECS_METADATA_SERVICE_ENDPOINT =
       stringBuilder(Name.UNDERFS_OSS_STS_ECS_METADATA_SERVICE_ENDPOINT)
           .setAlias("alluxio.underfs.oss.sts.ecs.metadata.service.endpoint")
           .setDefaultValue("http://100.100.100.200/latest/meta-data/ram/security-credentials/")
           .setDescription("The ECS metadata service endpoint for Aliyun STS")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_STS_ENABLED =
+      booleanBuilder(Name.UNDERFS_OSS_STS_ENABLED)
+          .setAlias("alluxio.underfs.oss.sts.enabled")
+          .setDefaultValue(false)
+          .setDescription("Whether to enable oss STS(Security Token Service).")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1298,6 +1298,23 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_OSS_STS_ECS_METADATA_SERVICE_ENDPOINT =
+      stringBuilder(Name.UNDERFS_OSS_STS_ECS_METADATA_SERVICE_ENDPOINT)
+          .setAlias("alluxio.underfs.oss.sts.ecs.metadata.service.endpoint")
+          .setDefaultValue("http://100.100.100.200/latest/meta-data/ram/security-credentials/")
+          .setDescription("The ECS metadata service endpoint for Aliyun STS")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_STS_TOKEN_TIMEOUT_MS =
+      durationBuilder(Name.UNDERFS_OSS_STS_TOKEN_TIMEOUT_MS)
+          .setAlias("alluxio.underfs.oss.sts.token.timeout.ms")
+          .setDefaultValue("30m")
+          .setDescription("The token timeout for OSS STS. How long before the token expires, "
+              + "it will refresh the token automatically")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_S3_ADMIN_THREADS_MAX =
       intBuilder(Name.UNDERFS_S3_ADMIN_THREADS_MAX)
           .setDefaultValue(20)
@@ -7264,6 +7281,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String UNDERFS_OSS_STS_ENABLED = "alluxio.underfs.oss.sts.enabled";
     public static final String UNDERFS_OSS_RETRY_MAX = "alluxio.underfs.oss.retry.max";
     public static final String UNDERFS_OSS_ECS_RAM_ROLE = "alluxio.underfs.oss.ecs.ram.role";
+    public static final String UNDERFS_OSS_STS_ECS_METADATA_SERVICE_ENDPOINT =
+        "alluxio.underfs.oss.sts.ecs.metadata.service.endpoint";
+    public static final String UNDERFS_OSS_STS_TOKEN_TIMEOUT_MS =
+        "alluxio.underfs.oss.sts.token.timeout.ms";
     public static final String UNDERFS_S3_BULK_DELETE_ENABLED =
         "alluxio.underfs.s3.bulk.delete.enabled";
     public static final String UNDERFS_S3_DEFAULT_MODE = "alluxio.underfs.s3.default.mode";

--- a/underfs/oss/pom.xml
+++ b/underfs/oss/pom.xml
@@ -54,6 +54,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -284,7 +284,7 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
 
   /**
    * Creates an OSS {@code ClientConfiguration} using an Alluxio Configuration.
-   *
+   * @param alluxioConf the OSS Configuration
    * @return the OSS {@link ClientBuilderConfiguration}
    */
   public static ClientBuilderConfiguration initializeOSSClientConfig(

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -41,6 +41,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Date;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -59,7 +60,6 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
   /** Bucket name of user's configured Alluxio bucket. */
   private final String mBucketName;
 
-  private boolean mStsEnabled;
   private StsOssClientProvider mClientProvider;
 
   /**
@@ -83,12 +83,11 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
    * @param bucketName bucket name of user's configured Alluxio bucket
    * @param conf configuration for this UFS
    */
-  protected OSSUnderFileSystem(AlluxioURI uri, OSS ossClient, String bucketName,
-      UnderFileSystemConfiguration conf) {
+  protected OSSUnderFileSystem(AlluxioURI uri, @Nullable OSS ossClient, String bucketName,
+                               UnderFileSystemConfiguration conf) {
     super(uri, conf);
 
-    mStsEnabled = conf.getBoolean(PropertyKey.UNDERFS_OSS_STS_ENABLED);
-    if (mStsEnabled) {
+    if (conf.getBoolean(PropertyKey.UNDERFS_OSS_STS_ENABLED)) {
       try {
         mClientProvider = new StsOssClientProvider(conf);
         mClientProvider.init();
@@ -288,7 +287,7 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
    *
    * @return the OSS {@link ClientBuilderConfiguration}
    */
-  private static ClientBuilderConfiguration initializeOSSClientConfig(
+  public static ClientBuilderConfiguration initializeOSSClientConfig(
       AlluxioConfiguration alluxioConf) {
     ClientBuilderConfiguration ossClientConf = new ClientBuilderConfiguration();
     ossClientConf
@@ -296,6 +295,7 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
     ossClientConf.setSocketTimeout((int) alluxioConf.getMs(PropertyKey.UNDERFS_OSS_SOCKET_TIMEOUT));
     ossClientConf.setConnectionTTL(alluxioConf.getMs(PropertyKey.UNDERFS_OSS_CONNECT_TTL));
     ossClientConf.setMaxConnections(alluxioConf.getInt(PropertyKey.UNDERFS_OSS_CONNECT_MAX));
+    ossClientConf.setMaxErrorRetry(alluxioConf.getInt(PropertyKey.UNDERFS_OSS_RETRY_MAX));
     return ossClientConf;
   }
 

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -62,7 +62,6 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
   private boolean mStsEnabled;
   private StsOssClientProvider mClientProvider;
 
-
   /**
    * Constructs a new instance of {@link OSSUnderFileSystem}.
    *

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystemFactory.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystemFactory.java
@@ -62,6 +62,10 @@ public class OSSUnderFileSystemFactory implements UnderFileSystemFactory {
    * @return true if both access, secret and endpoint keys are present, false otherwise
    */
   private boolean checkOSSCredentials(UnderFileSystemConfiguration conf) {
+    if (conf.getBoolean(PropertyKey.UNDERFS_OSS_STS_ENABLED)) {
+      return conf.isSet(PropertyKey.UNDERFS_OSS_ECS_RAM_ROLE);
+    }
+
     return conf.isSet(PropertyKey.OSS_ACCESS_KEY)
         && conf.isSet(PropertyKey.OSS_SECRET_KEY)
         && conf.isSet(PropertyKey.OSS_ENDPOINT_KEY);

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/StsOssClientProvider.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/StsOssClientProvider.java
@@ -17,6 +17,7 @@ import alluxio.retry.RetryPolicy;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.util.ThreadFactoryUtils;
 import alluxio.util.network.HttpUtils;
+
 import com.aliyun.oss.ClientBuilderConfiguration;
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.OSSClientBuilder;
@@ -36,176 +37,202 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-
+/**
+ * STS client provider for Aliyun OSS.
+ */
 public class StsOssClientProvider implements Closeable {
-    private static final Logger LOG = LoggerFactory.getLogger(StsOssClientProvider.class);
+  private static final Logger LOG = LoggerFactory.getLogger(StsOssClientProvider.class);
 
-    private static final int ECS_META_GET_TIMEOUT = 10000;
-    private static final int BASE_SLEEP_TIME_MS = 1000;
-    private static final int MAX_SLEEP_MS = 3000;
-    private static final int MAX_RETRIES = 5;
+  private static final int ECS_META_GET_TIMEOUT = 10000;
+  private static final int BASE_SLEEP_TIME_MS = 1000;
+  private static final int MAX_SLEEP_MS = 3000;
+  private static final int MAX_RETRIES = 5;
 
-    private volatile OSS ossClient = null;
-    private Date stsTokenExpiration = null;
+  private volatile OSS mOssClient = null;
+  private Date mStsTokenExpiration = null;
 
-    public static final String ECS_METADATA_SERVICE = "http://100.100.100.200/latest/meta-data/ram/security-credentials/";
+  public static final String ECS_METADATA_SERVICE =
+      "http://100.100.100.200/latest/meta-data/ram/security-credentials/";
 
-    private static final int IN_TOKEN_EXPIRED_MS = 1800000;
-    private static final String ACCESS_KEY_ID = "AccessKeyId";
-    private static final String ACCESS_KEY_SECRET = "AccessKeySecret";
-    private static final String SECURITY_TOKEN = "SecurityToken";
-    private static final String EXPIRATION = "Expiration";
+  private static final int IN_TOKEN_EXPIRED_MS = 1800000;
+  private static final String ACCESS_KEY_ID = "AccessKeyId";
+  private static final String ACCESS_KEY_SECRET = "AccessKeySecret";
+  private static final String SECURITY_TOKEN = "SecurityToken";
+  private static final String EXPIRATION = "Expiration";
 
-    private UnderFileSystemConfiguration ossConf;
-    private final ScheduledExecutorService refreshOssClientScheduledThread;
+  private UnderFileSystemConfiguration mOssConf;
+  private final ScheduledExecutorService mRefreshOssClientScheduledThread;
 
-    public StsOssClientProvider(UnderFileSystemConfiguration ossConfiguration) throws IOException {
-        RetryPolicy retryPolicy = new ExponentialBackoffRetry(BASE_SLEEP_TIME_MS, MAX_SLEEP_MS, MAX_RETRIES);
-        IOException lastException = null;
-        while (retryPolicy.attempt()) {
-            try {
-                initializeOssClient(ossConfiguration);
-                lastException = null;
-                break;
-            } catch (IOException e) {
-                LOG.warn("init oss client failed! has retry {} times", retryPolicy.getAttemptCount(), e);
-                lastException = e;
-            }
+  /**
+   * Constructs a new instance of {@link StsOssClientProvider}.
+   * @param ossConfiguration {@link UnderFileSystemConfiguration} for OSS
+   * @throws IOException if failed to init OSS STS client
+   */
+  public StsOssClientProvider(UnderFileSystemConfiguration ossConfiguration) throws IOException {
+    RetryPolicy retryPolicy = new ExponentialBackoffRetry(
+        BASE_SLEEP_TIME_MS, MAX_SLEEP_MS, MAX_RETRIES);
+    IOException lastException = null;
+    while (retryPolicy.attempt()) {
+      try {
+        initializeOssClient(ossConfiguration);
+        lastException = null;
+        break;
+      } catch (IOException e) {
+        LOG.warn("init oss client failed! has retry {} times", retryPolicy.getAttemptCount(), e);
+        lastException = e;
+      }
+    }
+    if (lastException != null) {
+      throw lastException;
+    }
+    mRefreshOssClientScheduledThread = Executors.newSingleThreadScheduledExecutor(
+        ThreadFactoryUtils.build("refresh_oss_client-%d", false));
+    mRefreshOssClientScheduledThread.scheduleAtFixedRate(() -> {
+      try {
+        if (null != mOssConf) {
+          refreshOssStsClient(mOssConf);
         }
-        if (lastException != null) {
-            throw lastException;
+      } catch (Exception e) {
+        //retry it
+        LOG.warn("throw exception when clear meta data cache", e);
+      }
+    }, 0, 60000, TimeUnit.MILLISECONDS);
+  }
+
+  protected void refreshOssStsClient(UnderFileSystemConfiguration ossConfiguration)
+      throws IOException {
+    ClientBuilderConfiguration ossClientConf = getClientBuilderConfiguration(ossConfiguration);
+    createOrRefreshStsOssClient(ossConfiguration, ossClientConf);
+  }
+
+  private ClientBuilderConfiguration getClientBuilderConfiguration(
+      UnderFileSystemConfiguration ossConfiguration) {
+    ClientBuilderConfiguration ossClientConf = new ClientBuilderConfiguration();
+    ossClientConf.setMaxConnections(ossConfiguration.getInt(PropertyKey.UNDERFS_OSS_CONNECT_MAX));
+    ossClientConf.setMaxErrorRetry(ossConfiguration.getInt(PropertyKey.UNDERFS_OSS_RETRY_MAX));
+    ossClientConf.setConnectionTimeout(
+        (int) ossConfiguration.getMs(PropertyKey.UNDERFS_OSS_CONNECT_TIMEOUT));
+    ossClientConf.setSocketTimeout(
+        (int) ossConfiguration.getMs(PropertyKey.UNDERFS_OSS_SOCKET_TIMEOUT));
+    ossClientConf.setSupportCname(false);
+    ossClientConf.setCrcCheckEnabled(true);
+    return ossClientConf;
+  }
+
+  /**
+   * Init the STS OSS client.
+   * @param ossConfiguration OSS {@link UnderFileSystemConfiguration}
+   * @throws IOException if failed to init OSS client
+   */
+  public void initializeOssClient(UnderFileSystemConfiguration ossConfiguration)
+      throws IOException {
+    mOssConf = ossConfiguration;
+    if (null != mOssClient) {
+      return;
+    }
+
+    ClientBuilderConfiguration clientConf = getClientBuilderConfiguration(ossConfiguration);
+    createOrRefreshStsOssClient(ossConfiguration, clientConf);
+
+    LOG.info("init ossClient success : {}", mOssClient.toString());
+  }
+
+  boolean isStsTokenExpired() {
+    boolean expired = true;
+    Date now = convertLongToDate(System.currentTimeMillis());
+    if (null != mStsTokenExpiration) {
+      if (mStsTokenExpiration.after(now)) {
+        expired = false;
+      }
+    }
+    return expired;
+  }
+
+  boolean isTokenWillExpired() {
+    boolean in = true;
+    Date now = convertLongToDate(System.currentTimeMillis());
+    long millisecond = mStsTokenExpiration.getTime() - now.getTime();
+    if (millisecond >= IN_TOKEN_EXPIRED_MS) {
+      in = false;
+    }
+    return in;
+  }
+
+  private void createOrRefreshStsOssClient(
+      UnderFileSystemConfiguration ossConfiguration,
+      ClientBuilderConfiguration clientConfiguration) throws IOException {
+    if (isStsTokenExpired() || isTokenWillExpired()) {
+      try {
+        String ecsRamRole = ossConfiguration.getString(PropertyKey.UNDERFS_OSS_ECS_RAM_ROLE);
+        String fullECSMetaDataServiceUrl = ECS_METADATA_SERVICE + ecsRamRole;
+        String jsonStringResponse = HttpUtils.get(fullECSMetaDataServiceUrl, ECS_META_GET_TIMEOUT);
+
+        JsonObject jsonObject = new Gson().fromJson(jsonStringResponse, JsonObject.class);
+        String accessKeyId = jsonObject.get(ACCESS_KEY_ID).getAsString();
+        String accessKeySecret = jsonObject.get(ACCESS_KEY_SECRET).getAsString();
+        String securityToken = jsonObject.get(SECURITY_TOKEN).getAsString();
+        mStsTokenExpiration = convertStringToDate(jsonObject.get(EXPIRATION).getAsString());
+
+        if (null == mOssClient) {
+          mOssClient = new OSSClientBuilder().build(
+              ossConfiguration.getString(PropertyKey.OSS_ENDPOINT_KEY),
+              accessKeyId, accessKeySecret, securityToken,
+              clientConfiguration);
+        } else {
+          mOssClient.switchCredentials((new DefaultCredentials(
+              accessKeyId, accessKeySecret, securityToken)));
         }
-        refreshOssClientScheduledThread = Executors.newSingleThreadScheduledExecutor(
-                ThreadFactoryUtils.build("refresh_oss_client-%d", false));
-        refreshOssClientScheduledThread.scheduleAtFixedRate(() -> {
-            try {
-                if (null != ossConf) {
-                    refreshOssStsClient(ossConf);
-                }
-            } catch (Exception e) {
-                //retry it
-                LOG.warn("throw exception when clear meta data cache", e);
-            }
-        }, 0, 60000, TimeUnit.MILLISECONDS);
+        LOG.info("oss sts client create success {} {} {}",
+            mOssClient, securityToken, mStsTokenExpiration);
+      } catch (IOException e) {
+        LOG.error("create stsOssClient exception", e);
+        throw new IOException("create stsOssClient exception", e);
+      }
     }
+  }
 
-    protected void refreshOssStsClient(UnderFileSystemConfiguration ossConfiguration) throws IOException {
-        ClientBuilderConfiguration ossClientConf = getClientBuilderConfiguration(ossConfiguration);
-        createOrRefreshStsOssClient(ossConfiguration, ossClientConf);
+  /**
+   * Returns the STS OSS client.
+   * @return oss client
+   */
+  public OSS getOSSClient() {
+    return mOssClient;
+  }
+
+  private Date convertLongToDate(long timeMs) {
+    TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    sdf.setTimeZone(zeroTimeZone);
+    Date date = null;
+    try {
+      date = sdf.parse(sdf.format(new Date(timeMs)));
+    } catch (ParseException e) {
+      LOG.error("convert String to Date type error", e);
     }
+    return date;
+  }
 
-    private ClientBuilderConfiguration getClientBuilderConfiguration(UnderFileSystemConfiguration ossConfiguration) {
-        ClientBuilderConfiguration ossClientConf = new ClientBuilderConfiguration();
-        ossClientConf.setMaxConnections(ossConfiguration.getInt(PropertyKey.UNDERFS_OSS_CONNECT_MAX));
-        ossClientConf.setMaxErrorRetry(ossConfiguration.getInt(PropertyKey.UNDERFS_OSS_RETRY_MAX));
-        ossClientConf.setConnectionTimeout((int) ossConfiguration.getMs(PropertyKey.UNDERFS_OSS_CONNECT_TIMEOUT));
-        ossClientConf.setSocketTimeout((int) ossConfiguration.getMs(PropertyKey.UNDERFS_OSS_SOCKET_TIMEOUT));
-        ossClientConf.setSupportCname(false);
-        ossClientConf.setCrcCheckEnabled(true);
-        return ossClientConf;
+  private Date convertStringToDate(String dateString) {
+    TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    sdf.setTimeZone(zeroTimeZone);
+    Date date = null;
+    try {
+      date = sdf.parse(dateString);
+    } catch (ParseException e) {
+      LOG.error("convert String to Date type error", e);
     }
+    return date;
+  }
 
-    public void initializeOssClient(UnderFileSystemConfiguration ossConfiguration) throws IOException {
-        ossConf = ossConfiguration;
-        if (null != ossClient) {
-            return;
-        }
-
-        ClientBuilderConfiguration clientConf = getClientBuilderConfiguration(ossConfiguration);
-        createOrRefreshStsOssClient(ossConfiguration, clientConf);
-
-        LOG.info("init ossClient success : {}", ossClient.toString());
+  @Override
+  public void close() throws IOException {
+    if (null != mRefreshOssClientScheduledThread) {
+      mRefreshOssClientScheduledThread.shutdown();
     }
-
-    boolean isStsTokenExpired() {
-        boolean expired = true;
-        Date now = convertLongToDate(System.currentTimeMillis());
-        if (null != stsTokenExpiration) {
-            if (stsTokenExpiration.after(now)) {
-                expired = false;
-            }
-        }
-        return expired;
+    if (null != mOssClient) {
+      mOssClient.shutdown();
+      mOssClient = null;
     }
-
-    boolean isTokenWillExpired() {
-        boolean in = true;
-        Date now = convertLongToDate(System.currentTimeMillis());
-        long millisecond = stsTokenExpiration.getTime() - now.getTime();
-        if (millisecond >= IN_TOKEN_EXPIRED_MS) {
-            in = false;
-        }
-        return in;
-    }
-
-    private void createOrRefreshStsOssClient(UnderFileSystemConfiguration ossConfiguration,
-                                             ClientBuilderConfiguration clientConfiguration) throws IOException {
-        if (isStsTokenExpired() || isTokenWillExpired()) {
-            try {
-                String ecsRamRole = ossConfiguration.getString(PropertyKey.UNDERFS_OSS_ECS_RAM_ROLE);
-                String fullECSMetaDataServiceUrl = ECS_METADATA_SERVICE + ecsRamRole;
-                String jsonStringResponse = HttpUtils.get(fullECSMetaDataServiceUrl, ECS_META_GET_TIMEOUT);
-
-                JsonObject jsonObject = new Gson().fromJson(jsonStringResponse, JsonObject.class);
-                String accessKeyId = jsonObject.get(ACCESS_KEY_ID).getAsString();
-                String accessKeySecret = jsonObject.get(ACCESS_KEY_SECRET).getAsString();
-                String securityToken = jsonObject.get(SECURITY_TOKEN).getAsString();
-                stsTokenExpiration = convertStringToDate(jsonObject.get(EXPIRATION).getAsString());
-
-                if (null == ossClient) {
-                    ossClient = new OSSClientBuilder().build(
-                            ossConfiguration.getString(PropertyKey.OSS_ENDPOINT_KEY),
-                            accessKeyId, accessKeySecret, securityToken,
-                            clientConfiguration);
-                } else {
-                    ossClient.switchCredentials((new DefaultCredentials(accessKeyId, accessKeySecret, securityToken)));
-                }
-                LOG.info("oss sts client create success {} {} {}", ossClient, securityToken, stsTokenExpiration);
-            } catch (IOException e) {
-                LOG.error("create stsOssClient exception", e);
-                throw new IOException("create stsOssClient exception", e);
-            }
-        }
-    }
-
-    public OSS getOSSClient() {
-        return ossClient;
-    }
-
-    private Date convertLongToDate(long timeMs) {
-        TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        sdf.setTimeZone(zeroTimeZone);
-        Date date = null;
-        try {
-            date = sdf.parse(sdf.format(new Date(timeMs)));
-        } catch (ParseException e) {
-            LOG.error("convert String to Date type error", e);
-        }
-        return date;
-    }
-
-    private Date convertStringToDate(String dateString) {
-        TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        sdf.setTimeZone(zeroTimeZone);
-        Date date = null;
-        try {
-            date = sdf.parse(dateString);
-        } catch (ParseException e) {
-            LOG.error("convert String to Date type error", e);
-        }
-        return date;
-    }
-
-    @Override
-    public void close() throws IOException {
-        if (null != refreshOssClientScheduledThread) {
-            refreshOssClientScheduledThread.shutdown();
-        }
-        if (null != ossClient) {
-            ossClient.shutdown();
-            ossClient = null;
-        }
-    }
+  }
 }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/StsOssClientProvider.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/StsOssClientProvider.java
@@ -22,6 +22,7 @@ import com.aliyun.oss.ClientBuilderConfiguration;
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.OSSClientBuilder;
 import com.aliyun.oss.common.auth.DefaultCredentials;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import org.slf4j.Logger;
@@ -51,7 +52,6 @@ public class StsOssClientProvider implements Closeable {
   private static final String ACCESS_KEY_SECRET = "AccessKeySecret";
   private static final String SECURITY_TOKEN = "SecurityToken";
   private static final String EXPIRATION = "Expiration";
-  protected static OSSClientBuilder sOssClientBuilder = new OSSClientBuilder();
 
   private volatile OSS mOssClient = null;
   private long mStsTokenExpiration = 0;
@@ -59,6 +59,7 @@ public class StsOssClientProvider implements Closeable {
   private final long mTokenTimeoutMs;
   private final UnderFileSystemConfiguration mOssConf;
   private final ScheduledExecutorService mRefreshOssClientScheduledThread;
+  private OSSClientBuilder mOssClientBuilder = new OSSClientBuilder();
 
   /**
    * Constructs a new instance of {@link StsOssClientProvider}.
@@ -138,7 +139,7 @@ public class StsOssClientProvider implements Closeable {
           convertStringToDate(jsonObject.get(EXPIRATION).getAsString()).getTime();
 
       if (null == mOssClient) {
-        mOssClient = sOssClientBuilder.build(
+        mOssClient = mOssClientBuilder.build(
             ossConfiguration.getString(PropertyKey.OSS_ENDPOINT_KEY),
             accessKeyId, accessKeySecret, securityToken,
             clientConfiguration);
@@ -180,5 +181,10 @@ public class StsOssClientProvider implements Closeable {
       mOssClient.shutdown();
       mOssClient = null;
     }
+  }
+
+  @VisibleForTesting
+  protected void setOssClientBuilder(OSSClientBuilder ossClientBuilder) {
+    mOssClientBuilder = ossClientBuilder;
   }
 }

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/StsOssClientProvider.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/StsOssClientProvider.java
@@ -51,6 +51,7 @@ public class StsOssClientProvider implements Closeable {
   private static final String ACCESS_KEY_SECRET = "AccessKeySecret";
   private static final String SECURITY_TOKEN = "SecurityToken";
   private static final String EXPIRATION = "Expiration";
+  protected static OSSClientBuilder mOssClientBuilder = new OSSClientBuilder();
 
   private volatile OSS mOssClient = null;
   private long mStsTokenExpiration = 0;
@@ -137,7 +138,7 @@ public class StsOssClientProvider implements Closeable {
           convertStringToDate(jsonObject.get(EXPIRATION).getAsString()).getTime();
 
       if (null == mOssClient) {
-        mOssClient = new OSSClientBuilder().build(
+        mOssClient = mOssClientBuilder.build(
             ossConfiguration.getString(PropertyKey.OSS_ENDPOINT_KEY),
             accessKeyId, accessKeySecret, securityToken,
             clientConfiguration);

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/StsOssClientProvider.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/StsOssClientProvider.java
@@ -146,12 +146,8 @@ public class StsOssClientProvider implements Closeable {
   }
 
   boolean tokenWillExpiredAfter(long after) {
-    boolean in = true;
-    Date now = convertLongToDate(System.currentTimeMillis());
-    if (null != mStsTokenExpiration && mStsTokenExpiration.getTime() - now.getTime() > after) {
-      in = false;
-    }
-    return in;
+    return null == mStsTokenExpiration
+        || mStsTokenExpiration.getTime() - System.currentTimeMillis() <= after;
   }
 
   private void createOrRefreshStsOssClient(
@@ -193,19 +189,6 @@ public class StsOssClientProvider implements Closeable {
    */
   public OSS getOSSClient() {
     return mOssClient;
-  }
-
-  private Date convertLongToDate(long timeMs) {
-    TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-    sdf.setTimeZone(zeroTimeZone);
-    Date date = null;
-    try {
-      date = sdf.parse(sdf.format(new Date(timeMs)));
-    } catch (ParseException e) {
-      LOG.error("convert String to Date type error", e);
-    }
-    return date;
   }
 
   private Date convertStringToDate(String dateString) {

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/StsOssClientProvider.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/StsOssClientProvider.java
@@ -51,7 +51,7 @@ public class StsOssClientProvider implements Closeable {
   private static final String ACCESS_KEY_SECRET = "AccessKeySecret";
   private static final String SECURITY_TOKEN = "SecurityToken";
   private static final String EXPIRATION = "Expiration";
-  protected static OSSClientBuilder mOssClientBuilder = new OSSClientBuilder();
+  protected static OSSClientBuilder sOssClientBuilder = new OSSClientBuilder();
 
   private volatile OSS mOssClient = null;
   private long mStsTokenExpiration = 0;
@@ -138,7 +138,7 @@ public class StsOssClientProvider implements Closeable {
           convertStringToDate(jsonObject.get(EXPIRATION).getAsString()).getTime();
 
       if (null == mOssClient) {
-        mOssClient = mOssClientBuilder.build(
+        mOssClient = sOssClientBuilder.build(
             ossConfiguration.getString(PropertyKey.OSS_ENDPOINT_KEY),
             accessKeyId, accessKeySecret, securityToken,
             clientConfiguration);

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/StsOssClientProvider.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/StsOssClientProvider.java
@@ -1,0 +1,211 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.oss;
+
+import alluxio.conf.PropertyKey;
+import alluxio.retry.ExponentialBackoffRetry;
+import alluxio.retry.RetryPolicy;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.util.ThreadFactoryUtils;
+import alluxio.util.network.HttpUtils;
+import com.aliyun.oss.ClientBuilderConfiguration;
+import com.aliyun.oss.OSS;
+import com.aliyun.oss.OSSClientBuilder;
+import com.aliyun.oss.common.auth.DefaultCredentials;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+
+public class StsOssClientProvider implements Closeable {
+    private static final Logger LOG = LoggerFactory.getLogger(StsOssClientProvider.class);
+
+    private static final int ECS_META_GET_TIMEOUT = 10000;
+    private static final int BASE_SLEEP_TIME_MS = 1000;
+    private static final int MAX_SLEEP_MS = 3000;
+    private static final int MAX_RETRIES = 5;
+
+    private volatile OSS ossClient = null;
+    private Date stsTokenExpiration = null;
+
+    public static final String ECS_METADATA_SERVICE = "http://100.100.100.200/latest/meta-data/ram/security-credentials/";
+
+    private static final int IN_TOKEN_EXPIRED_MS = 1800000;
+    private static final String ACCESS_KEY_ID = "AccessKeyId";
+    private static final String ACCESS_KEY_SECRET = "AccessKeySecret";
+    private static final String SECURITY_TOKEN = "SecurityToken";
+    private static final String EXPIRATION = "Expiration";
+
+    private UnderFileSystemConfiguration ossConf;
+    private final ScheduledExecutorService refreshOssClientScheduledThread;
+
+    public StsOssClientProvider(UnderFileSystemConfiguration ossConfiguration) throws IOException {
+        RetryPolicy retryPolicy = new ExponentialBackoffRetry(BASE_SLEEP_TIME_MS, MAX_SLEEP_MS, MAX_RETRIES);
+        IOException lastException = null;
+        while (retryPolicy.attempt()) {
+            try {
+                initializeOssClient(ossConfiguration);
+                lastException = null;
+                break;
+            } catch (IOException e) {
+                LOG.warn("init oss client failed! has retry {} times", retryPolicy.getAttemptCount(), e);
+                lastException = e;
+            }
+        }
+        if (lastException != null) {
+            throw lastException;
+        }
+        refreshOssClientScheduledThread = Executors.newSingleThreadScheduledExecutor(
+                ThreadFactoryUtils.build("refresh_oss_client-%d", false));
+        refreshOssClientScheduledThread.scheduleAtFixedRate(() -> {
+            try {
+                if (null != ossConf) {
+                    refreshOssStsClient(ossConf);
+                }
+            } catch (Exception e) {
+                //retry it
+                LOG.warn("throw exception when clear meta data cache", e);
+            }
+        }, 0, 60000, TimeUnit.MILLISECONDS);
+    }
+
+    protected void refreshOssStsClient(UnderFileSystemConfiguration ossConfiguration) throws IOException {
+        ClientBuilderConfiguration ossClientConf = getClientBuilderConfiguration(ossConfiguration);
+        createOrRefreshStsOssClient(ossConfiguration, ossClientConf);
+    }
+
+    private ClientBuilderConfiguration getClientBuilderConfiguration(UnderFileSystemConfiguration ossConfiguration) {
+        ClientBuilderConfiguration ossClientConf = new ClientBuilderConfiguration();
+        ossClientConf.setMaxConnections(ossConfiguration.getInt(PropertyKey.UNDERFS_OSS_CONNECT_MAX));
+        ossClientConf.setMaxErrorRetry(ossConfiguration.getInt(PropertyKey.UNDERFS_OSS_RETRY_MAX));
+        ossClientConf.setConnectionTimeout((int) ossConfiguration.getMs(PropertyKey.UNDERFS_OSS_CONNECT_TIMEOUT));
+        ossClientConf.setSocketTimeout((int) ossConfiguration.getMs(PropertyKey.UNDERFS_OSS_SOCKET_TIMEOUT));
+        ossClientConf.setSupportCname(false);
+        ossClientConf.setCrcCheckEnabled(true);
+        return ossClientConf;
+    }
+
+    public void initializeOssClient(UnderFileSystemConfiguration ossConfiguration) throws IOException {
+        ossConf = ossConfiguration;
+        if (null != ossClient) {
+            return;
+        }
+
+        ClientBuilderConfiguration clientConf = getClientBuilderConfiguration(ossConfiguration);
+        createOrRefreshStsOssClient(ossConfiguration, clientConf);
+
+        LOG.info("init ossClient success : {}", ossClient.toString());
+    }
+
+    boolean isStsTokenExpired() {
+        boolean expired = true;
+        Date now = convertLongToDate(System.currentTimeMillis());
+        if (null != stsTokenExpiration) {
+            if (stsTokenExpiration.after(now)) {
+                expired = false;
+            }
+        }
+        return expired;
+    }
+
+    boolean isTokenWillExpired() {
+        boolean in = true;
+        Date now = convertLongToDate(System.currentTimeMillis());
+        long millisecond = stsTokenExpiration.getTime() - now.getTime();
+        if (millisecond >= IN_TOKEN_EXPIRED_MS) {
+            in = false;
+        }
+        return in;
+    }
+
+    private void createOrRefreshStsOssClient(UnderFileSystemConfiguration ossConfiguration,
+                                             ClientBuilderConfiguration clientConfiguration) throws IOException {
+        if (isStsTokenExpired() || isTokenWillExpired()) {
+            try {
+                String ecsRamRole = ossConfiguration.getString(PropertyKey.UNDERFS_OSS_ECS_RAM_ROLE);
+                String fullECSMetaDataServiceUrl = ECS_METADATA_SERVICE + ecsRamRole;
+                String jsonStringResponse = HttpUtils.get(fullECSMetaDataServiceUrl, ECS_META_GET_TIMEOUT);
+
+                JsonObject jsonObject = new Gson().fromJson(jsonStringResponse, JsonObject.class);
+                String accessKeyId = jsonObject.get(ACCESS_KEY_ID).getAsString();
+                String accessKeySecret = jsonObject.get(ACCESS_KEY_SECRET).getAsString();
+                String securityToken = jsonObject.get(SECURITY_TOKEN).getAsString();
+                stsTokenExpiration = convertStringToDate(jsonObject.get(EXPIRATION).getAsString());
+
+                if (null == ossClient) {
+                    ossClient = new OSSClientBuilder().build(
+                            ossConfiguration.getString(PropertyKey.OSS_ENDPOINT_KEY),
+                            accessKeyId, accessKeySecret, securityToken,
+                            clientConfiguration);
+                } else {
+                    ossClient.switchCredentials((new DefaultCredentials(accessKeyId, accessKeySecret, securityToken)));
+                }
+                LOG.info("oss sts client create success {} {} {}", ossClient, securityToken, stsTokenExpiration);
+            } catch (IOException e) {
+                LOG.error("create stsOssClient exception", e);
+                throw new IOException("create stsOssClient exception", e);
+            }
+        }
+    }
+
+    public OSS getOSSClient() {
+        return ossClient;
+    }
+
+    private Date convertLongToDate(long timeMs) {
+        TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        sdf.setTimeZone(zeroTimeZone);
+        Date date = null;
+        try {
+            date = sdf.parse(sdf.format(new Date(timeMs)));
+        } catch (ParseException e) {
+            LOG.error("convert String to Date type error", e);
+        }
+        return date;
+    }
+
+    private Date convertStringToDate(String dateString) {
+        TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        sdf.setTimeZone(zeroTimeZone);
+        Date date = null;
+        try {
+            date = sdf.parse(dateString);
+        } catch (ParseException e) {
+            LOG.error("convert String to Date type error", e);
+        }
+        return date;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (null != refreshOssClientScheduledThread) {
+            refreshOssClientScheduledThread.shutdown();
+        }
+        if (null != ossClient) {
+            ossClient.shutdown();
+            ossClient = null;
+        }
+    }
+}

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
@@ -67,7 +67,6 @@ public class StsOssClientProviderTest {
 
     // init
     OSSClientBuilder ossClientBuilder = Mockito.mock(OSSClientBuilder.class);
-    StsOssClientProvider.sOssClientBuilder = ossClientBuilder;
     OSSClient ossClient = Mockito.mock(OSSClient.class);
     Mockito.when(ossClientBuilder.build(
         Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
@@ -76,6 +75,7 @@ public class StsOssClientProviderTest {
       mockedHttpUtils.when(() -> HttpUtils.get(mEcsMetadataService, 10000))
           .thenReturn(MOCK_ECS_META_RESPONSE);
       try (StsOssClientProvider clientProvider = new StsOssClientProvider(ossConfiguration)) {
+        clientProvider.setOssClientBuilder(ossClientBuilder);
         clientProvider.init();
         // refresh
         String responseBodyString = "{\n"

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
@@ -67,7 +67,7 @@ public class StsOssClientProviderTest {
 
     // init
     OSSClientBuilder ossClientBuilder = Mockito.mock(OSSClientBuilder.class);
-    StsOssClientProvider.mOssClientBuilder = ossClientBuilder;
+    StsOssClientProvider.sOssClientBuilder = ossClientBuilder;
     OSSClient ossClient = Mockito.mock(OSSClient.class);
     Mockito.when(ossClientBuilder.build(
         Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
@@ -55,7 +55,7 @@ public class StsOssClientProviderTest {
 
   @Test
   public void testInitAndRefresh() throws Exception {
-    Date dateExpiration = toUtcDateString(System.currentTimeMillis() + 21600000);
+    Date dateExpiration = toUtcDateString(System.currentTimeMillis() +  6 * Constants.HOUR_MS);
     Date dateLastUpdated = toUtcDateString(System.currentTimeMillis());
     String expiration = toUtcString(dateExpiration);
     String lastUpdated = toUtcString(dateLastUpdated);

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
@@ -91,9 +91,9 @@ public class StsOssClientProviderTest {
         + "}";
     PowerMockito.mockStatic(HttpUtils.class);
     when(HttpUtils.get(mEcsMetadataService, 10000)).thenReturn(responseBodyString);
-    assertTrue(clientProvider.isStsTokenExpired());
+    assertTrue(clientProvider.tokenWillExpiredAfter(0));
     clientProvider.refreshOssStsClient(ossConfiguration);
-    assertFalse(clientProvider.isStsTokenExpired());
+    assertFalse(clientProvider.tokenWillExpiredAfter(0));
   }
 
   private Date toUtcDateString(long dateInMills) throws ParseException {

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
@@ -42,8 +42,7 @@ public class StsOssClientProviderTest {
 
   InstancedConfiguration mConf;
   private static final String ECS_RAM_ROLE = "snapshot-role-test";
-  private static final String ECS_METADATA_SERVICE =
-      StsOssClientProvider.ECS_METADATA_SERVICE + ECS_RAM_ROLE;
+  private String mEcsMetadataService;
   public static final String MOCK_ECS_META_RESPONSE = "{\n"
       + "  'AccessKeyId' : 'STS.mockAK',\n"
       + "  'AccessKeySecret' : 'mockSK',\n"
@@ -56,6 +55,8 @@ public class StsOssClientProviderTest {
   @Before
   public void before() {
     mConf = Configuration.copyGlobal();
+    mEcsMetadataService = mConf.getString(
+        PropertyKey.UNDERFS_OSS_STS_ECS_METADATA_SERVICE_ENDPOINT) + ECS_RAM_ROLE;
   }
 
   @Test
@@ -76,7 +77,7 @@ public class StsOssClientProviderTest {
     OSSClient ossClient = Mockito.mock(OSSClient.class);
     PowerMockito.whenNew(OSSClient.class).withAnyArguments().thenReturn(ossClient);
     PowerMockito.mockStatic(HttpUtils.class);
-    when(HttpUtils.get(ECS_METADATA_SERVICE, 10000)).thenReturn(MOCK_ECS_META_RESPONSE);
+    when(HttpUtils.get(mEcsMetadataService, 10000)).thenReturn(MOCK_ECS_META_RESPONSE);
     StsOssClientProvider clientProvider = new StsOssClientProvider(ossConfiguration);
 
     // refresh
@@ -89,7 +90,7 @@ public class StsOssClientProviderTest {
         + "  'Code' : 'Success'\n"
         + "}";
     PowerMockito.mockStatic(HttpUtils.class);
-    when(HttpUtils.get(ECS_METADATA_SERVICE, 10000)).thenReturn(responseBodyString);
+    when(HttpUtils.get(mEcsMetadataService, 10000)).thenReturn(responseBodyString);
     assertTrue(clientProvider.isStsTokenExpired());
     clientProvider.refreshOssStsClient(ossConfiguration);
     assertFalse(clientProvider.isStsTokenExpired());

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
@@ -78,7 +78,7 @@ public class StsOssClientProviderTest {
     PowerMockito.whenNew(OSSClient.class).withAnyArguments().thenReturn(ossClient);
     PowerMockito.mockStatic(HttpUtils.class);
     when(HttpUtils.get(mEcsMetadataService, 10000)).thenReturn(MOCK_ECS_META_RESPONSE);
-    try(StsOssClientProvider clientProvider = new StsOssClientProvider(ossConfiguration)) {
+    try (StsOssClientProvider clientProvider = new StsOssClientProvider(ossConfiguration)) {
       clientProvider.init();
       // refresh
       String responseBodyString = "{\n"

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
@@ -14,6 +14,7 @@ package alluxio.underfs.oss;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import alluxio.Constants;
 import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
@@ -27,7 +28,6 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
@@ -55,10 +55,8 @@ public class StsOssClientProviderTest {
 
   @Test
   public void testInitAndRefresh() throws Exception {
-    Date dateExpiration = toUtcDateString(System.currentTimeMillis() +  6 * Constants.HOUR_MS);
-    Date dateLastUpdated = toUtcDateString(System.currentTimeMillis());
-    String expiration = toUtcString(dateExpiration);
-    String lastUpdated = toUtcString(dateLastUpdated);
+    String expiration = toUtcString(new Date(System.currentTimeMillis() +  6 * Constants.HOUR_MS));
+    String lastUpdated = toUtcString(new Date(System.currentTimeMillis()));
 
     mConf.set(PropertyKey.OSS_ENDPOINT_KEY, "http://oss-cn-qingdao.aliyuncs.com");
     mConf.set(PropertyKey.UNDERFS_OSS_ECS_RAM_ROLE, ECS_RAM_ROLE);
@@ -93,13 +91,6 @@ public class StsOssClientProviderTest {
         assertFalse(clientProvider.tokenWillExpiredAfter(0));
       }
     }
-  }
-
-  private Date toUtcDateString(long dateInMills) throws ParseException {
-    TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-    sdf.setTimeZone(zeroTimeZone);
-    return sdf.parse(sdf.format(new Date(dateInMills)));
   }
 
   private String toUtcString(Date date) {

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
@@ -1,0 +1,107 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.oss;
+
+import alluxio.conf.Configuration;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.util.network.HttpUtils;
+import com.aliyun.oss.OSSClient;
+import com.aliyun.oss.common.comm.DefaultServiceClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({HttpUtils.class, OSSClient.class, OSSUnderFileSystemTest.class})
+public class StsOssClientProviderTest {
+
+    InstancedConfiguration conf;
+    private final String ECS_RAM_ROLE = "snapshot-role-test";
+    private final String ECS_METADATA_SERVICE = StsOssClientProvider.ECS_METADATA_SERVICE + ECS_RAM_ROLE;
+    public static final String MOCK_ECS_META_RESPONSE = "{\n" +
+            "  'AccessKeyId' : 'STS.mockAK',\n" +
+            "  'AccessKeySecret' : 'mockSK',\n" +
+            "  'Expiration' : '2018-04-23T09:45:05Z',\n" +
+            "  'SecurityToken' : 'mockSecurityToken',\n" +
+            "  'LastUpdated' : '2018-04-23T03:45:05Z',\n" +
+            "  'Code' : 'Success'\n" +
+            "}";
+
+    @Before
+    public void before() {
+        conf = Configuration.copyGlobal();
+    }
+
+    @Test
+    public void testInitAndRefresh() throws Exception {
+        Date dateExpiration = toUtcDateString(System.currentTimeMillis() + 21600000);
+        Date dateLastUpdated = toUtcDateString(System.currentTimeMillis());
+        String expiration = toUtcString(dateExpiration);
+        String lastUpdated = toUtcString(dateLastUpdated);
+
+        conf.set(PropertyKey.OSS_ENDPOINT_KEY, "http://oss-cn-qingdao.aliyuncs.com");
+        conf.set(PropertyKey.UNDERFS_OSS_ECS_RAM_ROLE, ECS_RAM_ROLE);
+        final UnderFileSystemConfiguration ossConfiguration = UnderFileSystemConfiguration.defaults(conf);
+
+        // init
+        DefaultServiceClient client = Mockito.mock(DefaultServiceClient.class);
+        PowerMockito.whenNew(DefaultServiceClient.class).withAnyArguments().thenReturn(client);
+        OSSClient ossClient = Mockito.mock(OSSClient.class);
+        PowerMockito.whenNew(OSSClient.class).withAnyArguments().thenReturn(ossClient);
+        PowerMockito.mockStatic(HttpUtils.class);
+        when(HttpUtils.get(ECS_METADATA_SERVICE, 10000)).thenReturn(MOCK_ECS_META_RESPONSE);
+        StsOssClientProvider mClientProvider = new StsOssClientProvider(ossConfiguration);
+
+        // refresh
+        String responseBodyString = "{\n" +
+                "  'AccessKeyId' : 'STS.mockAK',\n" +
+                "  'AccessKeySecret' : 'mockSK',\n" +
+                "  'Expiration' : '" + expiration + "',\n" +
+                "  'SecurityToken' : 'mockSecurityToken',\n" +
+                "  'LastUpdated' : '" + lastUpdated + "',\n" +
+                "  'Code' : 'Success'\n" +
+                "}";
+        PowerMockito.mockStatic(HttpUtils.class);
+        when(HttpUtils.get(ECS_METADATA_SERVICE, 10000)).thenReturn(responseBodyString);
+        assertTrue(mClientProvider.isStsTokenExpired());
+        mClientProvider.refreshOssStsClient(ossConfiguration);
+        assertFalse(mClientProvider.isStsTokenExpired());
+    }
+
+    private Date toUtcDateString(long dateInMills) throws ParseException {
+        TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        sdf.setTimeZone(zeroTimeZone);
+        return sdf.parse(sdf.format(new Date(dateInMills)));
+    }
+
+    private String toUtcString(Date date) {
+        TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        sdf.setTimeZone(zeroTimeZone);
+        return sdf.format(date);
+    }
+}

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/StsOssClientProviderTest.java
@@ -11,11 +11,16 @@
 
 package alluxio.underfs.oss;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
 import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.util.network.HttpUtils;
+
 import com.aliyun.oss.OSSClient;
 import com.aliyun.oss.common.comm.DefaultServiceClient;
 import org.junit.Before;
@@ -31,77 +36,76 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.when;
-
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({HttpUtils.class, OSSClient.class, OSSUnderFileSystemTest.class})
 public class StsOssClientProviderTest {
 
-    InstancedConfiguration conf;
-    private final String ECS_RAM_ROLE = "snapshot-role-test";
-    private final String ECS_METADATA_SERVICE = StsOssClientProvider.ECS_METADATA_SERVICE + ECS_RAM_ROLE;
-    public static final String MOCK_ECS_META_RESPONSE = "{\n" +
-            "  'AccessKeyId' : 'STS.mockAK',\n" +
-            "  'AccessKeySecret' : 'mockSK',\n" +
-            "  'Expiration' : '2018-04-23T09:45:05Z',\n" +
-            "  'SecurityToken' : 'mockSecurityToken',\n" +
-            "  'LastUpdated' : '2018-04-23T03:45:05Z',\n" +
-            "  'Code' : 'Success'\n" +
-            "}";
+  InstancedConfiguration mConf;
+  private static final String ECS_RAM_ROLE = "snapshot-role-test";
+  private static final String ECS_METADATA_SERVICE =
+      StsOssClientProvider.ECS_METADATA_SERVICE + ECS_RAM_ROLE;
+  public static final String MOCK_ECS_META_RESPONSE = "{\n"
+      + "  'AccessKeyId' : 'STS.mockAK',\n"
+      + "  'AccessKeySecret' : 'mockSK',\n"
+      + "  'Expiration' : '2018-04-23T09:45:05Z',\n"
+      + "  'SecurityToken' : 'mockSecurityToken',\n"
+      + "  'LastUpdated' : '2018-04-23T03:45:05Z',\n"
+      + "  'Code' : 'Success'\n"
+      + "}";
 
-    @Before
-    public void before() {
-        conf = Configuration.copyGlobal();
-    }
+  @Before
+  public void before() {
+    mConf = Configuration.copyGlobal();
+  }
 
-    @Test
-    public void testInitAndRefresh() throws Exception {
-        Date dateExpiration = toUtcDateString(System.currentTimeMillis() + 21600000);
-        Date dateLastUpdated = toUtcDateString(System.currentTimeMillis());
-        String expiration = toUtcString(dateExpiration);
-        String lastUpdated = toUtcString(dateLastUpdated);
+  @Test
+  public void testInitAndRefresh() throws Exception {
+    Date dateExpiration = toUtcDateString(System.currentTimeMillis() + 21600000);
+    Date dateLastUpdated = toUtcDateString(System.currentTimeMillis());
+    String expiration = toUtcString(dateExpiration);
+    String lastUpdated = toUtcString(dateLastUpdated);
 
-        conf.set(PropertyKey.OSS_ENDPOINT_KEY, "http://oss-cn-qingdao.aliyuncs.com");
-        conf.set(PropertyKey.UNDERFS_OSS_ECS_RAM_ROLE, ECS_RAM_ROLE);
-        final UnderFileSystemConfiguration ossConfiguration = UnderFileSystemConfiguration.defaults(conf);
+    mConf.set(PropertyKey.OSS_ENDPOINT_KEY, "http://oss-cn-qingdao.aliyuncs.com");
+    mConf.set(PropertyKey.UNDERFS_OSS_ECS_RAM_ROLE, ECS_RAM_ROLE);
+    final UnderFileSystemConfiguration ossConfiguration =
+        UnderFileSystemConfiguration.defaults(mConf);
 
-        // init
-        DefaultServiceClient client = Mockito.mock(DefaultServiceClient.class);
-        PowerMockito.whenNew(DefaultServiceClient.class).withAnyArguments().thenReturn(client);
-        OSSClient ossClient = Mockito.mock(OSSClient.class);
-        PowerMockito.whenNew(OSSClient.class).withAnyArguments().thenReturn(ossClient);
-        PowerMockito.mockStatic(HttpUtils.class);
-        when(HttpUtils.get(ECS_METADATA_SERVICE, 10000)).thenReturn(MOCK_ECS_META_RESPONSE);
-        StsOssClientProvider mClientProvider = new StsOssClientProvider(ossConfiguration);
+    // init
+    DefaultServiceClient client = Mockito.mock(DefaultServiceClient.class);
+    PowerMockito.whenNew(DefaultServiceClient.class).withAnyArguments().thenReturn(client);
+    OSSClient ossClient = Mockito.mock(OSSClient.class);
+    PowerMockito.whenNew(OSSClient.class).withAnyArguments().thenReturn(ossClient);
+    PowerMockito.mockStatic(HttpUtils.class);
+    when(HttpUtils.get(ECS_METADATA_SERVICE, 10000)).thenReturn(MOCK_ECS_META_RESPONSE);
+    StsOssClientProvider clientProvider = new StsOssClientProvider(ossConfiguration);
 
-        // refresh
-        String responseBodyString = "{\n" +
-                "  'AccessKeyId' : 'STS.mockAK',\n" +
-                "  'AccessKeySecret' : 'mockSK',\n" +
-                "  'Expiration' : '" + expiration + "',\n" +
-                "  'SecurityToken' : 'mockSecurityToken',\n" +
-                "  'LastUpdated' : '" + lastUpdated + "',\n" +
-                "  'Code' : 'Success'\n" +
-                "}";
-        PowerMockito.mockStatic(HttpUtils.class);
-        when(HttpUtils.get(ECS_METADATA_SERVICE, 10000)).thenReturn(responseBodyString);
-        assertTrue(mClientProvider.isStsTokenExpired());
-        mClientProvider.refreshOssStsClient(ossConfiguration);
-        assertFalse(mClientProvider.isStsTokenExpired());
-    }
+    // refresh
+    String responseBodyString = "{\n"
+        + "  'AccessKeyId' : 'STS.mockAK',\n"
+        + "  'AccessKeySecret' : 'mockSK',\n"
+        + "  'Expiration' : '" + expiration + "',\n"
+        + "  'SecurityToken' : 'mockSecurityToken',\n"
+        + "  'LastUpdated' : '" + lastUpdated + "',\n"
+        + "  'Code' : 'Success'\n"
+        + "}";
+    PowerMockito.mockStatic(HttpUtils.class);
+    when(HttpUtils.get(ECS_METADATA_SERVICE, 10000)).thenReturn(responseBodyString);
+    assertTrue(clientProvider.isStsTokenExpired());
+    clientProvider.refreshOssStsClient(ossConfiguration);
+    assertFalse(clientProvider.isStsTokenExpired());
+  }
 
-    private Date toUtcDateString(long dateInMills) throws ParseException {
-        TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        sdf.setTimeZone(zeroTimeZone);
-        return sdf.parse(sdf.format(new Date(dateInMills)));
-    }
+  private Date toUtcDateString(long dateInMills) throws ParseException {
+    TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    sdf.setTimeZone(zeroTimeZone);
+    return sdf.parse(sdf.format(new Date(dateInMills)));
+  }
 
-    private String toUtcString(Date date) {
-        TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        sdf.setTimeZone(zeroTimeZone);
-        return sdf.format(date);
-    }
+  private String toUtcString(Date date) {
+    TimeZone zeroTimeZone = TimeZone.getTimeZone("ETC/GMT-0");
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    sdf.setTimeZone(zeroTimeZone);
+    return sdf.format(date);
+  }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support STS for OSS ufs

### Why are the changes needed?

1. Plaintext AccessKey/AccessSecret is not safe and not Recommended for Aliyun
2. STS(Security Token Service) for OSS is more safe. For details, see https://help.aliyun.com/document_detail/32016.html

### Does this PR introduce any user facing changes?

addition property keys
1. UNDERFS_OSS_STS_ENABLED
2. UNDERFS_OSS_RETRY_MAX
3. UNDERFS_OSS_ECS_RAM_ROLE

#16510 