### PR TITLE
Disable delegated backup in irrelevant UTs

### DIFF
--- a/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
@@ -115,6 +115,8 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
         .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS)
         // Masters become primary faster
         .addProperty(PropertyKey.ZOOKEEPER_SESSION_TIMEOUT, "3sec")
+        // Disable backup delegation
+        .addProperty(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, false)
         .build();
     backupRestoreTest(true);
   }
@@ -129,6 +131,8 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
         // Masters become primary faster
         .addProperty(PropertyKey.ZOOKEEPER_SESSION_TIMEOUT, "1sec")
         .addProperty(PropertyKey.MASTER_METASTORE, MetastoreType.HEAP)
+        // Disable backup delegation
+        .addProperty(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, false)
         .build();
     backupRestoreMetaStoreTest();
   }
@@ -143,6 +147,8 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
         // Masters become primary faster
         .addProperty(PropertyKey.ZOOKEEPER_SESSION_TIMEOUT, "1sec")
         .addProperty(PropertyKey.MASTER_METASTORE, MetastoreType.ROCKS)
+        // Disable backup delegation
+        .addProperty(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, false)
         .build();
     backupRestoreMetaStoreTest();
   }
@@ -158,6 +164,8 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
         .addProperty(PropertyKey.ZOOKEEPER_SESSION_TIMEOUT, "1sec")
         .addProperty(PropertyKey.MASTER_INODE_METASTORE, MetastoreType.ROCKS)
         .addProperty(PropertyKey.MASTER_BLOCK_METASTORE, MetastoreType.HEAP)
+        // Disable backup delegation
+        .addProperty(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, false)
         .build();
     backupRestoreMetaStoreTest();
   }
@@ -173,6 +181,8 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
         .addProperty(PropertyKey.ZOOKEEPER_SESSION_TIMEOUT, "1sec")
         .addProperty(PropertyKey.MASTER_INODE_METASTORE, MetastoreType.HEAP)
         .addProperty(PropertyKey.MASTER_BLOCK_METASTORE, MetastoreType.ROCKS)
+        // Disable backup delegation
+        .addProperty(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, false)
         .build();
     backupRestoreMetaStoreTest();
   }
@@ -203,6 +213,8 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
         .addProperty(PropertyKey.MASTER_METASTORE, MetastoreType.ROCKS)
         .addProperty(PropertyKey.MASTER_BACKUP_DIRECTORY, backupFolder.getRoot())
         .addProperty(PropertyKey.MASTER_JOURNAL_BACKUP_WHEN_CORRUPTED, true)
+        // Disable backup delegation
+        .addProperty(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, false)
         .build();
     mCluster.start();
     final int numFiles = 10;
@@ -288,6 +300,8 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
         // performed due to the invalidation associated with restoring a backup, as opposed to
         // performed automatically under some other metadata load types
         .addProperty(PropertyKey.USER_FILE_METADATA_LOAD_TYPE, LoadMetadataPType.NEVER)
+        // Disable backup delegation
+        .addProperty(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, false)
         .build();
     mCluster.start();
 
@@ -324,6 +338,8 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
         .setNumWorkers(1)
         .addProperty(PropertyKey.MASTER_BACKUP_DIRECTORY, temporaryFolder.getRoot())
         .addProperty(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.CACHE_THROUGH)
+        // Disable backup delegation
+        .addProperty(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, false)
         .build();
     mCluster.start();
 
@@ -373,6 +389,8 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
         .setClusterName("backupRestoreEmbedded")
         .setNumMasters(3)
         .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.EMBEDDED)
+        // Disable backup delegation
+        .addProperty(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, false)
         .build();
     backupRestoreTest(true);
   }
@@ -383,6 +401,8 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
         .setClusterName("backupRestoreSingle")
         .setNumMasters(1)
         .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS)
+        // Disable backup delegation
+        .addProperty(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, false)
         .build();
     backupRestoreTest(false);
   }

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalMigrationIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalMigrationIntegrationTest.java
@@ -48,6 +48,8 @@ public final class JournalMigrationIntegrationTest extends BaseIntegrationTest {
         .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS)
         // Masters become primary faster
         .addProperty(PropertyKey.ZOOKEEPER_SESSION_TIMEOUT, "1sec")
+        // Disable backup delegation
+        .addProperty(PropertyKey.MASTER_BACKUP_DELEGATION_ENABLED, false)
         .build();
     try {
       cluster.start();


### PR DESCRIPTION
### What changes are proposed in this pull request?
After we changed delegated backup to enabled by default, a few UTs are automatically running on delegated backup and that affected the stability (in some tests the cluster is not fully mocked so delegated backup might not even work). This change disables delegated backup in UTs that are irrelevant.

A few tests are updated and the numbers are from my local runs:

JournalBackupIntegrationTest#backupRestoreZk
enabled - 1 out of 10 success
disabled - 10 out of 10 success

JournalBackupIntegrationTest#backupRestoreEmbedded
enabled - 0 out of 10 success
disabled - 0 out of 10 success
// The flakiness in this test is irrelevant to backup but to election

JournalMigrationIntegrationTest#migrate
enabled - 0 out of 10 success
disabled - 10 out of 10 success