### PR TITLE
Add flag sync root

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2800,8 +2800,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey MASTER_JOURNAL_SYNC_ROOT_AFTER_INIT_FROM_BACKUP =
       booleanBuilder(Name.MASTER_JOURNAL_SYNC_ROOT_AFTER_INIT_FROM_BACKUP)
           .setDefaultValue(true)
-          .setDescription("Controls whether to automatically invalidate the root of the UFS after"
-              + " restoring from backup")
+          .setDescription("Controls whether to automatically mark the root of the UFS as "
+              + "needing synchronization after restoring from backup.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setIsHidden(true)
           .setScope(Scope.MASTER)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2797,6 +2797,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_JOURNAL_SYNC_ROOT_AFTER_INIT_FROM_BACKUP =
+      booleanBuilder(Name.MASTER_JOURNAL_SYNC_ROOT_AFTER_INIT_FROM_BACKUP)
+          .setDefaultValue(true)
+          .setDescription("Controls whether to automatically invalidate the root of the UFS after"
+              + " restoring from backup")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setIsHidden(true)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_JOURNAL_SPACE_MONITOR_PERCENT_FREE_THRESHOLD =
       intBuilder(Name.MASTER_JOURNAL_SPACE_MONITOR_PERCENT_FREE_THRESHOLD)
           .setDefaultValue(10)
@@ -7473,6 +7482,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String MASTER_JOURNAL_FOLDER = "alluxio.master.journal.folder";
     public static final String MASTER_JOURNAL_INIT_FROM_BACKUP =
         "alluxio.master.journal.init.from.backup";
+    public static final String MASTER_JOURNAL_SYNC_ROOT_AFTER_INIT_FROM_BACKUP =
+        "alluxio.master.journal.sync.root.after.init.from.backup";
     public static final String MASTER_JOURNAL_SPACE_MONITOR_INTERVAL =
         "alluxio.master.journal.space.monitor.interval";
     public static final String MASTER_JOURNAL_SPACE_MONITOR_PERCENT_FREE_THRESHOLD

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -343,10 +343,13 @@ public class AlluxioMasterProcess extends MasterProcess {
     }
     // When restoring from backup, some fs modifications exist only in UFS. We invalidate the root
     // to force new accesses to sync with UFS first to update our picture of the UFS.
-    try {
-      mRegistry.get(FileSystemMaster.class).needsSync(new AlluxioURI("/"));
-    } catch (InvalidPathException e) {
-      LOG.warn("Failed to mark root as needing syncing after backup restore");
+    if (Configuration.getBoolean(PropertyKey.MASTER_JOURNAL_SYNC_ROOT_AFTER_INIT_FROM_BACKUP)) {
+      try {
+        mRegistry.get(FileSystemMaster.class).needsSync(new AlluxioURI("/"));
+        LOG.info("Marked root as needing sync after backup restore");
+      } catch (InvalidPathException e) {
+        LOG.warn("Failed to mark root as needing syncing after backup restore");
+      }
     }
   }
 


### PR DESCRIPTION
Add flag to control whether to trigger metadata sync on UFS root after a backup restore or not. 