### PR TITLE
Fix worker fuse metadata cache

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -166,7 +166,7 @@ public interface FileSystem extends Closeable {
         fs = new MetadataCachingFileSystem(fs, context);
       }
       if (options.isDataCacheEnabled()
-          && CommonUtils.PROCESS_TYPE.get() != CommonUtils.ProcessType.CLIENT) {
+          && CommonUtils.PROCESS_TYPE.get() == CommonUtils.ProcessType.CLIENT) {
         try {
           CacheManager cacheManager = CacheManager.Factory.get(conf);
           return new LocalCacheFileSystem(cacheManager, fs, conf);

--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -161,14 +161,12 @@ public interface FileSystem extends Closeable {
     public static FileSystem create(FileSystemContext context, FileSystemOptions options) {
       AlluxioConfiguration conf = context.getClusterConf();
       checkSortConf(conf);
-      if (CommonUtils.PROCESS_TYPE.get() != CommonUtils.ProcessType.CLIENT) {
-        return new BaseFileSystem(context);
-      }
       FileSystem fs = new BaseFileSystem(context);
       if (options.isMetadataCacheEnabled()) {
         fs = new MetadataCachingFileSystem(fs, context);
       }
-      if (options.isDataCacheEnabled()) {
+      if (options.isDataCacheEnabled()
+          && CommonUtils.PROCESS_TYPE.get() != CommonUtils.ProcessType.CLIENT) {
         try {
           CacheManager cacheManager = CacheManager.Factory.get(conf);
           return new LocalCacheFileSystem(cacheManager, fs, conf);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Allow metadata cache used in process other than alluxio client, e.g. alluxio fuse inside alluxio worker

### Why are the changes needed?
Worker fuse performance with metadata cache option enabled has worse performance because no actual metadata cache happening

### Does this PR introduce any user facing changes?
Performance