### PR TITLE
Support OSS multipart upload

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1275,6 +1275,30 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey UNDERFS_OSS_MULTIPART_UPLOAD_ENABLED =
+      booleanBuilder(Name.UNDERFS_OSS_MULTIPART_UPLOAD_ENABLED)
+          .setAlias("alluxio.underfs.oss.multipart.upload.enabled")
+          .setDefaultValue(false)
+          .setDescription("Whether to enable OSS multipart upload")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_MULTIPART_UPLOAD_PARTITION_SIZE =
+      dataSizeBuilder(Name.UNDERFS_OSS_MULTIPART_UPLOAD_PARTITION_SIZE)
+          .setAlias("alluxio.underfs.oss.multipart.upload.partition.size")
+          .setDefaultValue("64MB")
+          .setDescription("The partition size when use OSS multipart upload")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey UNDERFS_OSS_MULTIPART_UPLOAD_POOL_SIZE =
+      intBuilder(Name.UNDERFS_OSS_MULTIPART_UPLOAD_POOL_SIZE)
+          .setAlias("alluxio.underfs.oss.multipart.upload.pool.size")
+          .setDefaultValue(5)
+          .setDescription("The pool size of each file when use OSS multipart upload")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey UNDERFS_S3_ADMIN_THREADS_MAX =
       intBuilder(Name.UNDERFS_S3_ADMIN_THREADS_MAX)
           .setDefaultValue(20)
@@ -7261,6 +7285,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.underfs.oss.connection.timeout";
     public static final String UNDERFS_OSS_CONNECT_TTL = "alluxio.underfs.oss.connection.ttl";
     public static final String UNDERFS_OSS_SOCKET_TIMEOUT = "alluxio.underfs.oss.socket.timeout";
+    public static final String UNDERFS_OSS_MULTIPART_UPLOAD_ENABLED =
+            "alluxio.underfs.oss.multipart.upload.enabled";
+    public static final String UNDERFS_OSS_MULTIPART_UPLOAD_PARTITION_SIZE =
+        "alluxio.underfs.oss.multipart.upload.partition.size";
+    public static final String UNDERFS_OSS_MULTIPART_UPLOAD_POOL_SIZE =
+        "alluxio.underfs.oss.multipart.upload.pool.size";
     public static final String UNDERFS_S3_BULK_DELETE_ENABLED =
         "alluxio.underfs.s3.bulk.delete.enabled";
     public static final String UNDERFS_S3_DEFAULT_MODE = "alluxio.underfs.s3.default.mode";

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/MultipartOSSOutputStream.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/MultipartOSSOutputStream.java
@@ -1,0 +1,308 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.oss;
+
+import alluxio.Constants;
+import alluxio.retry.CountingRetry;
+import alluxio.retry.RetryPolicy;
+import alluxio.util.io.PathUtils;
+import com.aliyun.oss.OSS;
+import com.aliyun.oss.model.PartETag;
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class MultipartOSSOutputStream extends OutputStream {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MultipartOSSOutputStream.class);
+    private static final long UPLOAD_THRESHOLD = 5L * Constants.MB;
+
+    private final String mKey;
+    private final String mBucketName;
+    private final OSS mOssClient;
+    private final long mPartitionSize;
+    private final List<String> mTmpDirs;
+    private OutputStream mLocalOutputStream;
+    private String mUploadId;
+    private final AtomicInteger mPartNumber;
+    private List<Future<PartETag>> mTagFutures = new ArrayList<>();
+    private final ExecutorService mExecutor;
+    private long mPartitionOffset;
+    private final AtomicBoolean mClosed = new AtomicBoolean(false);
+    private final byte[] mSingleCharWrite = new byte[1];
+    private File mFile;
+    private final List<PartETag> mTags = new ArrayList<>();
+    private final RetryPolicy mRetryPolicy = new CountingRetry(3);
+
+    /**
+     * Creates a name instance of {@link OSSOutputStream}.
+     *
+     * @param bucketName the name of the bucket
+     * @param key        the key of the file
+     * @param client     the client for OSS
+     * @param tmpDirs    a list of temporary directories
+     */
+    public MultipartOSSOutputStream(String bucketName, String key, OSS client, List<String> tmpDirs,
+                                    long uploadPartitionSize, int poolSize) {
+        Preconditions.checkArgument(bucketName != null && !bucketName.isEmpty(),
+                "Bucket name must not be null or empty.");
+        Preconditions.checkArgument(key != null && !key.isEmpty(),
+                "OSS path must not be null or empty.");
+        Preconditions.checkArgument(client != null, "OSSClient must not be null.");
+        mBucketName = bucketName;
+        mKey = key;
+        mOssClient = client;
+        mExecutor = Executors.newFixedThreadPool(poolSize);
+        mTmpDirs = tmpDirs;
+        // Partition size should be at least 5 MB, since S3 low-level multipart upload does not
+        // accept intermediate part smaller than 5 MB.
+        mPartitionSize = Math.max(UPLOAD_THRESHOLD, uploadPartitionSize);
+        mPartNumber = new AtomicInteger(1);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        mSingleCharWrite[0] = (byte) b;
+        write(mSingleCharWrite);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        write(b, 0, b.length);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        if (b == null || len == 0) {
+            return;
+        }
+        validateWriteArgs(b, off, len);
+        if (mUploadId == null) {
+            mUploadId = OSSMultipartUploadHelper.initMultiPartUpload(
+                    mBucketName, mKey, mOssClient, mRetryPolicy);
+        }
+        if (mFile == null) {
+            initNewFile();
+        }
+        if (mPartitionOffset + len < mPartitionSize) {
+            mLocalOutputStream.write(b, off, len);
+            mPartitionOffset += len;
+        } else {
+            int firstLen = (int) (mPartitionSize - mPartitionOffset);
+            mLocalOutputStream.write(b, off, firstLen);
+            mPartitionOffset += firstLen;
+            uploadPart();
+            write(b, off + firstLen, len - firstLen);
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        if (mUploadId == null) {
+            return;
+        }
+        // We try to minimize the time use to close()
+        // because Fuse release() method which calls close() is async.
+        // In flush(), we upload the current writing file if it is bigger than 5 MB,
+        // and wait for all current upload to complete.
+        if (mLocalOutputStream != null) {
+            mLocalOutputStream.flush();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (mClosed.getAndSet(true)) {
+            return;
+        }
+
+        // Multipart upload has not been initialized
+        try {
+            if (mUploadId == null) {
+                LOG.info("OSS Streaming upload output stream closed without uploading any data.");
+                String tmpDir = prepareTmpDir();
+                File emptyFile = new File(PathUtils.concatPath(tmpDir, UUID.randomUUID()));
+                Files.newOutputStream(emptyFile.toPath()).close();
+                try (BufferedInputStream in = new BufferedInputStream(
+                        Files.newInputStream(emptyFile.toPath()))) {
+                    mOssClient.putObject(mBucketName, mKey, in);
+                } finally {
+                    emptyFile.delete();
+                }
+                return;
+            }
+
+            try {
+                if (mFile != null) {
+                    mLocalOutputStream.close();
+                    int partNumber = mPartNumber.getAndIncrement();
+                    final OSSMultipartUploadHelper.FileHoldUploadPartRequest uploadRequest =
+                            new OSSMultipartUploadHelper.FileHoldUploadPartRequest(
+                                    mBucketName, mKey, mUploadId, partNumber, mFile, mFile.length());
+                    execUpload(uploadRequest, mExecutor);
+                }
+
+                waitForAllPartsUpload();
+                completeMultiPartUpload();
+            } catch (Exception e) {
+                LOG.error("Failed to upload {}", mKey, e);
+                throw new IOException(e);
+            }
+        } finally {
+            mExecutor.shutdownNow();
+        }
+    }
+
+    private String prepareTmpDir() throws IOException {
+        String tmpDir = mTmpDirs.get(0);
+        String dir = PathUtils.concatPath(tmpDir, mKey);
+        Path dirPath = Paths.get(dir);
+        if (!Files.exists(dirPath)) {
+            Files.createDirectories(dirPath);
+        }
+        return dir;
+    }
+
+    /**
+     * Creates a new temp file to write to.
+     */
+    private void initNewFile() throws IOException {
+        String tmpDir = prepareTmpDir();
+        mFile = new File(PathUtils.concatPath(tmpDir, UUID.randomUUID()));
+        mLocalOutputStream = new BufferedOutputStream(Files.newOutputStream(mFile.toPath()));
+        mPartitionOffset = 0;
+        LOG.debug("Init new temp file @ {}", mFile.getPath());
+    }
+
+    /**
+     * Uploads part async.
+     */
+    private void uploadPart() throws IOException {
+        if (mFile == null) {
+            return;
+        }
+        mLocalOutputStream.close();
+        int partNumber = mPartNumber.getAndIncrement();
+        File newFileToUpload = new File(mFile.getPath());
+        mFile = null;
+        mLocalOutputStream = null;
+        OSSMultipartUploadHelper.FileHoldUploadPartRequest uploadRequest;
+        try {
+            uploadRequest = new OSSMultipartUploadHelper.FileHoldUploadPartRequest(
+                    mBucketName, mKey, mUploadId, partNumber, newFileToUpload,
+                    newFileToUpload.length());
+            execUpload(uploadRequest, mExecutor);
+        } catch (Exception e) {
+            throw new IOException(String.format("generate exception when submit upload task" +
+                    " bucket %s, file path %s, part No. %s", mBucketName, mKey, partNumber), e);
+        }
+    }
+
+    /**
+     * Executes the upload part request.
+     *
+     * @param request   the upload part request
+     * @param mExecutor
+     */
+    private void execUpload(OSSMultipartUploadHelper.FileHoldUploadPartRequest request,
+                            ExecutorService mExecutor) {
+        Future<PartETag> futureTag =
+                mExecutor.submit(() -> {
+                    try {
+                        return OSSMultipartUploadHelper.uploadPartFiles(
+                                request, mOssClient, mRetryPolicy);
+                    } finally {
+                        // Delete the uploaded or failed to upload file
+                        if (!request.getUploadFile().delete()) {
+                            LOG.error("Failed to delete temporary file @ {}",
+                                    request.getUploadFile().getPath());
+                        }
+                    }
+                });
+        mTagFutures.add(futureTag);
+    }
+
+    /**
+     * Waits for the submitted upload tasks to finish.
+     */
+    private void waitForAllPartsUpload() throws IOException {
+        int beforeSize = mTags.size();
+        try {
+            for (Future<PartETag> future : mTagFutures) {
+                mTags.add(future.get());
+            }
+        } catch (ExecutionException e) {
+            // No recover ways so that we need to cancel all the upload tasks
+            // and abort the multipart upload
+            mTagFutures.forEach(partETagFuture -> partETagFuture.cancel(true));
+            abortMultiPartUpload();
+            throw new IOException("Part upload failed in multipart upload with "
+                    + "id '" + mUploadId + "' to " + mKey, e);
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted object upload.", e);
+            mTagFutures.forEach(partETagFuture -> partETagFuture.cancel(true));
+            abortMultiPartUpload();
+            Thread.currentThread().interrupt();
+        }
+        mTagFutures = new ArrayList<>();
+        if (mTags.size() != beforeSize) {
+            LOG.debug("Uploaded {} partitions of id '{}' to {}.", mTags.size(), mUploadId, mKey);
+        }
+    }
+
+    /**
+     * Completes multipart upload.
+     */
+    private void completeMultiPartUpload() throws IOException {
+        OSSMultipartUploadHelper.completeMultiPartUpload(
+                mBucketName, mKey, mUploadId, mTags, mOssClient, mRetryPolicy);
+    }
+
+
+    /**
+     * Aborts multipart upload.
+     */
+    private void abortMultiPartUpload() throws IOException {
+        OSSMultipartUploadHelper.abortMultiPartUpload(
+                mOssClient, mBucketName, mKey, mUploadId, mRetryPolicy);
+    }
+
+    /**
+     * Validates the arguments of write operation.
+     *
+     * @param b   the data
+     * @param off the start offset in the data
+     * @param len the number of bytes to write
+     */
+    private void validateWriteArgs(byte[] b, int off, int len) {
+        Preconditions.checkNotNull(b);
+        if (off < 0 || off > b.length || len < 0
+                || (off + len) > b.length || (off + len) < 0) {
+            throw new IndexOutOfBoundsException(
+                    "write(b[" + b.length + "], " + off + ", " + len + ")");
+        }
+    }
+}

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSMultipartUploadHelper.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSMultipartUploadHelper.java
@@ -1,0 +1,163 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.oss;
+
+import alluxio.retry.RetryPolicy;
+import com.aliyun.oss.OSS;
+import com.aliyun.oss.OSSException;
+import com.aliyun.oss.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+public class OSSMultipartUploadHelper {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(OSSMultipartUploadHelper.class);
+    
+    public static class FileHoldUploadPartRequest {
+        private final String bucketName;
+        private final String key;
+        private final String uploadId;
+        private final int partNumber;
+        private final File uploadFile;
+        private final long partSize;
+
+        public FileHoldUploadPartRequest(String bucketName, String key, String uploadId,
+                                         int partNumber, File uploadFile, long partSize) {
+            this.bucketName = bucketName;
+            this.key = key;
+            this.uploadId = uploadId;
+            this.partNumber = partNumber;
+            this.uploadFile = uploadFile;
+            this.partSize = partSize;
+        }
+
+        public String getBucketName() {
+            return bucketName;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getUploadId() {
+            return uploadId;
+        }
+
+        public int getPartNumber() {
+            return partNumber;
+        }
+
+        public File getUploadFile() {
+            return uploadFile;
+        }
+
+        public long getPartSize() {
+            return partSize;
+        }
+    }
+
+    public static void abortMultiPartUpload(
+            OSS ossClient, String bucketName, String key, String uploadId, RetryPolicy retryPolicy)
+            throws IOException {
+        Exception lastException;
+        do {
+            try {
+                ossClient.abortMultipartUpload(
+                        new AbortMultipartUploadRequest(bucketName, key, uploadId));
+                LOG.warn("Aborted multipart upload for key {} and id '{}' to bucket {}",
+                        key, uploadId, bucketName);
+                return;
+            } catch (Exception e) {
+                lastException = e;
+            }
+        } while (retryPolicy.attempt());
+        String requestId = lastException instanceof OSSException ?
+                ((OSSException) lastException).getRequestId() : "NULL";
+        throw new IOException(String.format("generate exception when abort multipart upload id " +
+                "bucket %s, file path %s, upload id. %s, request id %s",
+                bucketName, key, uploadId, requestId), lastException);
+    }
+
+    public static void completeMultiPartUpload(
+            String bucketName, String key, String mUploadId, List<PartETag> mTags, OSS mOssClient,
+            RetryPolicy retryPolicy) throws IOException {
+        Exception lastException;
+        CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
+                bucketName, key, mUploadId, mTags);
+        do {
+            try {
+                mOssClient.completeMultipartUpload(completeRequest);
+                LOG.debug("Completed multipart upload for key {} and id '{}' with {} partitions.",
+                        key, mUploadId, mTags.size());
+                return;
+            } catch (Exception e) {
+                lastException = e;
+            }
+        } while (retryPolicy.attempt());
+        String requestId = lastException instanceof OSSException ?
+                ((OSSException) lastException).getRequestId() : "NULL";
+        throw new IOException(String.format("generate exception when complete upload id " +
+                "bucket %s, file path %s, part No. %s, request id %s",
+                bucketName, key, mUploadId, requestId), lastException);
+    }
+
+    public static String initMultiPartUpload(
+            String bucketName, String key, OSS ossClient, RetryPolicy retryPolicy)
+            throws IOException {
+        InitiateMultipartUploadRequest initiateMultipartUploadRequest =
+                new InitiateMultipartUploadRequest(bucketName, key);
+        Exception lastException;
+        do {
+            try {
+                return ossClient.initiateMultipartUpload(initiateMultipartUploadRequest).getUploadId();
+            } catch (Exception e) {
+                lastException = e;
+            }
+        } while (retryPolicy.attempt());
+        String requestId = lastException instanceof OSSException ?
+                ((OSSException) lastException).getRequestId() : "NULL";
+        throw new IOException(String.format("generate exception when get upload id" +
+                " bucket %s, file path %s, request id %s",
+                bucketName, key, requestId), lastException);
+    }
+
+    public static PartETag uploadPartFiles(
+            OSSMultipartUploadHelper.FileHoldUploadPartRequest request, OSS mOssClient,
+            RetryPolicy retryPolicy) throws IOException {
+        PartETag partETag;
+        Exception lastException;
+        do {
+            try (InputStream inputStream = new FileInputStream(request.getUploadFile())) {
+                UploadPartRequest uploadPartRequest = new UploadPartRequest(
+                        request.getBucketName(), request.getKey(), request.getUploadId(),
+                        request.getPartNumber(), inputStream, request.getPartSize());
+                UploadPartResult uploadPartResult = mOssClient.uploadPart(uploadPartRequest);
+                partETag = uploadPartResult.getPartETag();
+                return partETag;
+            } catch (Exception e) {
+                lastException = e;
+            }
+        } while (retryPolicy.attempt());
+        String requestId = lastException instanceof OSSException ?
+                ((OSSException) lastException).getRequestId() : "NULL";
+        throw new IOException(String.format("generate exception when get upload id" +
+                " bucket %s, file path %s, part No. %s, request id %s",
+                request.getBucketName(), request.getKey(), request.getPartNumber(), requestId),
+                lastException);
+    }
+}

--- a/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/alluxio/underfs/oss/OSSUnderFileSystem.java
@@ -140,6 +140,12 @@ public class OSSUnderFileSystem extends ObjectUnderFileSystem {
 
   @Override
   protected OutputStream createObject(String key) throws IOException {
+    if (mUfsConf.getBoolean(PropertyKey.UNDERFS_OSS_MULTIPART_UPLOAD_ENABLED)) {
+      return new MultipartOSSOutputStream(mBucketName, key, mClient,
+              mUfsConf.getList(PropertyKey.TMP_DIRS),
+              mUfsConf.getBytes(PropertyKey.UNDERFS_OSS_MULTIPART_UPLOAD_PARTITION_SIZE),
+              mUfsConf.getInt(PropertyKey.UNDERFS_OSS_MULTIPART_UPLOAD_POOL_SIZE));
+    }
     return new OSSOutputStream(mBucketName, key, mClient,
         mUfsConf.getList(PropertyKey.TMP_DIRS));
   }

--- a/underfs/oss/src/test/java/alluxio/underfs/oss/MultipartOSSOutputStreamTest.java
+++ b/underfs/oss/src/test/java/alluxio/underfs/oss/MultipartOSSOutputStreamTest.java
@@ -1,0 +1,166 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+package alluxio.underfs.oss;
+
+import alluxio.conf.Configuration;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.util.FormatUtils;
+import com.aliyun.oss.OSSClient;
+import com.aliyun.oss.model.*;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.util.concurrent.*;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ListenableFuture.class, Executors.class, OSSClient.class,
+        MultipartOSSOutputStreamTest.class, BufferedOutputStream.class,
+        MultipartOSSOutputStream.class, Files.class})
+public class MultipartOSSOutputStreamTest {
+    private static final String BUCKET_NAME = "testBucket";
+    private static final String PARTITION_SIZE = "8MB";
+    private static final String KEY = "testKey";
+    private static final String UPLOAD_ID = "testUploadId";
+    private static InstancedConfiguration sConf = Configuration.copyGlobal();
+
+    private OSSClient mOssClient;
+    private BufferedOutputStream mMockOutputStream;
+    private ListenableFuture<PartETag> mMockTag;
+    private ExecutorService mMockExecutor;
+    private MultipartOSSOutputStream mStream;
+
+    @Before
+    public void before() throws Exception {
+        mockOSSClient();
+        mockFileAndOutputStream();
+        sConf.set(PropertyKey.UNDERFS_OSS_MULTIPART_UPLOAD_PARTITION_SIZE, PARTITION_SIZE);
+        mStream = new MultipartOSSOutputStream(BUCKET_NAME, KEY, mOssClient,
+                sConf.getList(PropertyKey.TMP_DIRS),
+                sConf.getBytes(PropertyKey.UNDERFS_OSS_MULTIPART_UPLOAD_PARTITION_SIZE),
+                sConf.getInt(PropertyKey.UNDERFS_OSS_MULTIPART_UPLOAD_POOL_SIZE));
+    }
+
+    @Test
+    public void testWriteByte() throws Exception {
+        mStream.write(1);
+        Mockito.verify(mOssClient)
+                .initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+        Mockito.verify(mMockOutputStream).write(new byte[]{1}, 0, 1);
+        Mockito.verify(mMockExecutor, never()).submit(any(Callable.class));
+
+        mStream.close();
+        Mockito.verify(mMockExecutor).submit(any(Callable.class));
+        Mockito.verify(mOssClient)
+                .completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+    }
+
+    @Test
+    public void testWriteByteArray() throws Exception {
+        int partSize = (int) FormatUtils.parseSpaceSize(PARTITION_SIZE);
+        byte[] b = new byte[partSize + 1];
+
+        mStream.write(b, 0, b.length);
+        Mockito.verify(mOssClient)
+                .initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+        Mockito.verify(mMockOutputStream).write(b, 0, b.length - 1);
+        Mockito.verify(mMockOutputStream).write(b, b.length - 1, 1);
+        Mockito.verify(mMockExecutor).submit(any(Callable.class));
+
+        mStream.close();
+        Mockito.verify(mOssClient)
+                .completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+    }
+
+    @Test
+    public void testFlush() throws Exception {
+        int partSize = (int) FormatUtils.parseSpaceSize(PARTITION_SIZE);
+        byte[] b = new byte[2 * partSize - 1];
+
+        mStream.write(b, 0, b.length);
+        Mockito.verify(mOssClient)
+                .initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+        Mockito.verify(mMockOutputStream).write(b, 0, partSize);
+        Mockito.verify(mMockOutputStream).write(b, partSize, partSize - 1);
+        Mockito.verify(mMockExecutor).submit(any(Callable.class));
+
+        mStream.flush();
+        Mockito.verify(mMockExecutor, times(1)).submit(any(Callable.class));
+
+        mStream.close();
+        Mockito.verify(mOssClient)
+                .completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+    }
+
+    @Test
+    public void testClose() throws Exception {
+        mStream.close();
+        Mockito.verify(mOssClient, never())
+                .initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+        Mockito.verify(mOssClient, never())
+                .completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+    }
+
+    private void mockOSSClient() throws ExecutionException, InterruptedException {
+        mOssClient = Mockito.mock(OSSClient.class);
+        InitiateMultipartUploadResult initResult = new InitiateMultipartUploadResult();
+        when(mOssClient.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class)))
+                .thenReturn(initResult);
+        initResult.setUploadId(UPLOAD_ID);
+        when(mOssClient.uploadPart(any(UploadPartRequest.class)))
+                .thenAnswer((InvocationOnMock invocation) -> {
+                    Object[] args = invocation.getArguments();
+                    UploadPartResult uploadResult = new UploadPartResult();
+                    uploadResult.setPartNumber(((UploadPartRequest) args[0]).getPartNumber());
+                    return uploadResult;
+                });
+
+        when(mOssClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+                .thenReturn(new CompleteMultipartUploadResult());
+
+        mMockTag = (ListenableFuture<PartETag>) PowerMockito.mock(ListenableFuture.class);
+        when(mMockTag.get()).thenReturn(new PartETag(1, "someTag"));
+        mMockExecutor = Mockito.mock(ThreadPoolExecutor.class);
+        PowerMockito.mockStatic(Executors.class);
+        when(Executors.newFixedThreadPool(anyInt())).thenReturn(mMockExecutor);
+        when(mMockExecutor.submit(any(Callable.class))).thenReturn(mMockTag);
+    }
+
+    private void mockFileAndOutputStream() throws Exception {
+        File file = Mockito.mock(File.class);
+        PowerMockito.whenNew(File.class).withAnyArguments().thenReturn(file);
+
+        mMockOutputStream = Mockito.mock(BufferedOutputStream.class);
+        PowerMockito.whenNew(BufferedOutputStream.class)
+                .withArguments(Mockito.any(FileOutputStream.class)).thenReturn(mMockOutputStream);
+
+        FileOutputStream outputStream = PowerMockito.mock(FileOutputStream.class);
+        PowerMockito.whenNew(FileOutputStream.class).withArguments(file).thenReturn(outputStream);
+        PowerMockito.mockStatic(Files.class);
+        PowerMockito.when(Files.newOutputStream(any())).thenReturn(outputStream);
+    }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

OSS ufs support multipart upload

### Why are the changes needed?

For now, oss upload have a pool upload performance.
Multipart upload can speed up the upload of OSS ufs.
#16497 

### Does this PR introduce any user facing changes?

PropertyKey added:
1. UNDERFS_OSS_MULTIPART_UPLOAD_ENABLED
2. UNDERFS_OSS_MULTIPART_UPLOAD_PARTITION_SIZE
3. UNDERFS_OSS_MULTIPART_UPLOAD_POOL_SIZE
