### PR TITLE
Fix client side config using wrong hash

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/ConfigHashSync.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ConfigHashSync.java
@@ -86,7 +86,7 @@ public final class ConfigHashSync implements HeartbeatExecutor {
       return;
     }
     boolean isClusterConfUpdated = !hash.getClusterConfigHash().equals(
-        mContext.getClusterConf().hash());
+        mContext.getClientContext().getClusterConfHash());
     boolean isPathConfUpdated = !hash.getPathConfigHash().equals(
         mContext.getClientContext().getPathConfHash());
     if (isClusterConfUpdated || isPathConfUpdated) {

--- a/core/common/src/main/java/alluxio/ClientContext.java
+++ b/core/common/src/main/java/alluxio/ClientContext.java
@@ -46,6 +46,7 @@ import javax.security.auth.Subject;
 @PublicApi
 public class ClientContext {
   private volatile AlluxioConfiguration mClusterConf;
+  private volatile String mClusterConfHash;
   private volatile PathConfiguration mPathConf = PathConfiguration.create(new HashMap<>());
   private volatile UserState mUserState;
   private volatile String mPathConfHash;
@@ -86,6 +87,7 @@ public class ClientContext {
     mClusterConf = ctx.getClusterConf();
     mPathConf = ctx.getPathConf();
     mUserState = ctx.getUserState();
+    mClusterConfHash = ctx.getClusterConfHash();
     mPathConfHash = ctx.getPathConfHash();
     mUriValidationEnabled = ctx.getUriValidationEnabled();
   }
@@ -93,6 +95,7 @@ public class ClientContext {
   private ClientContext(Subject subject, AlluxioConfiguration alluxioConf) {
     requireNonNull(subject, "subject is null");
     mClusterConf = requireNonNull(alluxioConf, "alluxioConf is null");
+    mClusterConfHash = alluxioConf.hash();
     mUserState = UserState.Factory.create(mClusterConf, subject);
   }
 
@@ -121,6 +124,7 @@ public class ClientContext {
         conf, !loadClusterConf, !loadPathConf);
     if (loadClusterConf) {
       mClusterConf = Configuration.getClusterConf(response, conf, Scope.CLIENT);
+      mClusterConfHash = response.getClusterConfigHash();
     }
     if (loadPathConf) {
       mPathConf = Configuration.getPathConf(response, conf);
@@ -172,6 +176,13 @@ public class ClientContext {
    */
   public PathConfiguration getPathConf() {
     return mPathConf;
+  }
+
+  /**
+   * @return hash of cluster level configuration
+   */
+  public String getClusterConfHash() {
+    return mClusterConfHash;
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/fs/FileSystemContextReinitIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemContextReinitIntegrationTest.java
@@ -203,10 +203,10 @@ public final class FileSystemContextReinitIntegrationTest extends BaseIntegratio
     // Use Equals and NotEquals so that when test fails, the hashes are printed out for comparison.
     if (clusterConfHashUpdated) {
       Assert.assertNotEquals(mClusterConfHash,
-          mContext.getClientContext().getClusterConf().hash());
+          mContext.getClientContext().getClusterConfHash());
     } else {
       Assert.assertEquals(mClusterConfHash,
-          mContext.getClientContext().getClusterConf().hash());
+          mContext.getClientContext().getClusterConfHash());
     }
 
     if (pathConfHashUpdated) {
@@ -219,7 +219,7 @@ public final class FileSystemContextReinitIntegrationTest extends BaseIntegratio
   }
 
   private void updateHash() {
-    mClusterConfHash = mContext.getClientContext().getClusterConf().hash();
+    mClusterConfHash = mContext.getClientContext().getClusterConfHash();
     mPathConfHash = mContext.getClientContext().getPathConfHash();
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?
Revert "Remove ClientContext.mClusterConfHash"
Use the clusterConfHash calculated by the master as the hash version of all the clients.
fix #16491


### Why are the changes needed?
The master uses Configuration.hash() to calculate the hash, while client uses clusterConf to calculate the hash version, which will cause the client to judge that the master and its own clusterConfHash are always unequal, thus updating the client configuration all the time.

