### PR TITLE
Use async journals for block id journal entries in metadata sync

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -170,7 +170,11 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
    * @param blockId the id of the block to commit
    * @param length the length of the block
    */
-  void commitBlockInUFS(long blockId, long length) throws UnavailableException;
+  default void commitBlockInUFS(long blockId, long length) throws UnavailableException {
+    try (JournalContext journalContext = createJournalContext()) {
+      commitBlockInUFS(blockId, length, journalContext);
+    }
+  }
 
   /**
    * Marks a block as committed, but without a worker location. This means the block is only in ufs.

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -26,6 +26,7 @@ import alluxio.grpc.StorageList;
 import alluxio.grpc.WorkerLostStorageInfo;
 import alluxio.master.Master;
 import alluxio.master.block.meta.MasterWorkerInfo;
+import alluxio.master.journal.JournalContext;
 import alluxio.metrics.Metric;
 import alluxio.proto.meta.Block;
 import alluxio.wire.Address;
@@ -170,6 +171,15 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
    * @param length the length of the block
    */
   void commitBlockInUFS(long blockId, long length) throws UnavailableException;
+
+  /**
+   * Marks a block as committed, but without a worker location. This means the block is only in ufs.
+   * Append any created journal entries to the included context.
+   * @param blockId the id of the block to commit
+   * @param length the length of the block
+   * @param context the journal context
+   */
+  void commitBlockInUFS(long blockId, long length, JournalContext context);
 
   /**
    * @param blockId the block id to get information for

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -941,13 +941,6 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
   }
 
   @Override
-  public void commitBlockInUFS(long blockId, long length) throws UnavailableException {
-    try (JournalContext journalContext = createJournalContext()) {
-      commitBlockInUFS(blockId, length, journalContext);
-    }
-  }
-
-  @Override
   public void commitBlockInUFS(long blockId, long length, JournalContext journalContext) {
     LOG.debug("Commit block in ufs. blockId: {}, length: {}", blockId, length);
     try (LockResource r = lockBlock(blockId)) {

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -942,9 +942,15 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
   @Override
   public void commitBlockInUFS(long blockId, long length) throws UnavailableException {
+    try (JournalContext journalContext = createJournalContext()) {
+      commitBlockInUFS(blockId, length, journalContext);
+    }
+  }
+
+  @Override
+  public void commitBlockInUFS(long blockId, long length, JournalContext journalContext) {
     LOG.debug("Commit block in ufs. blockId: {}, length: {}", blockId, length);
-    try (JournalContext journalContext = createJournalContext();
-         LockResource r = lockBlock(blockId)) {
+    try (LockResource r = lockBlock(blockId)) {
       if (mBlockMetaStore.getBlock(blockId).isPresent()) {
         // Block metadata already exists, so do not need to create a new one.
         return;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/AsyncUfsAbsentPathCache.java
@@ -82,7 +82,8 @@ public class AsyncUfsAbsentPathCache implements UfsAbsentPathCache {
     mMountTable = mountTable;
     mClock = clock;
     mCurrentPaths = new ConcurrentHashMap<>(8, 0.95f, 8);
-    mCache = CacheBuilder.newBuilder().maximumSize(MAX_PATHS).recordStats().build();
+    mCache = CacheBuilder.newBuilder().maximumSize(MAX_PATHS).concurrencyLevel(Configuration.getInt(
+        PropertyKey.MASTER_UFS_PATH_CACHE_THREADS)).recordStats().build();
     /* Number of threads for the async pool. */
 
     mPool = new ThreadPoolExecutor(numThreads, numThreads, THREAD_KEEP_ALIVE_SECONDS,

--- a/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncPathCache.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/UfsSyncPathCache.java
@@ -90,7 +90,8 @@ public class UfsSyncPathCache {
   @VisibleForTesting
   UfsSyncPathCache(Clock clock, @Nullable BiConsumer<String, SyncState> onRemoval) {
     mClock = Preconditions.checkNotNull(clock);
-    mItems = CacheBuilder.newBuilder()
+    mItems = CacheBuilder.newBuilder().concurrencyLevel(
+            Configuration.getInt(PropertyKey.MASTER_UFS_PATH_CACHE_THREADS))
         .removalListener(
             (removal) -> {
               if (removal.wasEvicted() && removal.getKey() != null && removal.getValue() != null) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Currently when metadata is created during metadata sync, when creating journal entries for block ids, they will be journaled synchronously. All other metadata updates are journaled asynchronously then flushed as a group.

This PR makes the block id journal entries also be flushed asynchronously using the same journal context.

Additionally it add higher concurrency defaults on some of the caches used by metadata sync which reduces the locking overhead.

### Does this PR introduce any user facing changes?

No