### PR TITLE
Add encoding-type support for S3 ListObjects and more logging

### DIFF
--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -42,17 +42,18 @@ public final class ThreadUtils {
   public static String formatStackTrace(Thread thread) {
     Throwable t = new Throwable(String.format("Stack trace for thread %s (State: %s):",
         thread.getName(), thread.getState()));
+    t.setStackTrace(thread.getStackTrace());
     return formatStackTrace(t);
   }
 
   /**
    * Return formatted stacktrace of Throwable instance.
-   * @param th - a Throwable instance
+   * @param t - a Throwable instance
    * @return a human-readable representation of the Throwable's stack trace
    */
-  public static String formatStackTrace(Throwable th) {
+  public static String formatStackTrace(Throwable t) {
     StringWriter sw = new StringWriter();
-    th.printStackTrace(new PrintWriter(sw));
+    t.printStackTrace(new PrintWriter(sw));
     return sw.toString();
   }
 

--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -42,9 +42,17 @@ public final class ThreadUtils {
   public static String formatStackTrace(Thread thread) {
     Throwable t = new Throwable(String.format("Stack trace for thread %s (State: %s):",
         thread.getName(), thread.getState()));
-    t.setStackTrace(thread.getStackTrace());
+    return formatStackTrace(t);
+  }
+
+  /**
+   * Return formatted stacktrace of Throwable instance.
+   * @param th - a Throwable instance
+   * @return a human-readable representation of the Throwable's stack trace
+   */
+  public static String formatStackTrace(Throwable th) {
     StringWriter sw = new StringWriter();
-    t.printStackTrace(new PrintWriter(sw));
+    th.printStackTrace(new PrintWriter(sw));
     return sw.toString();
   }
 

--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -75,7 +75,7 @@ public abstract class WebServer {
     mServiceName = serviceName;
 
     QueuedThreadPool threadPool = new QueuedThreadPool();
-    threadPool.setName(mServiceName.replace(" ", "-").toLowerCase());
+    threadPool.setName(mServiceName.replace(" ", "-").toUpperCase());
     int webThreadCount = Configuration.getInt(PropertyKey.WEB_THREADS);
 
     // Jetty needs at least (1 + selectors + acceptors) threads.

--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -75,6 +75,7 @@ public abstract class WebServer {
     mServiceName = serviceName;
 
     QueuedThreadPool threadPool = new QueuedThreadPool();
+    threadPool.setName(mServiceName.replace(" ", "-").toLowerCase());
     int webThreadCount = Configuration.getInt(PropertyKey.WEB_THREADS);
 
     // Jetty needs at least (1 + selectors + acceptors) threads.

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -170,7 +170,7 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
             httpServletResponse.setStatus(s3Exception.getErrorCode().getStatus().getStatusCode());
           }
         }
-        LOG.error(ThreadUtils.formatStackTrace(e));
+        LOG.error(ThreadUtils.formatStackTrace(cause));
       }
       httpServletResponse.getWriter().flush();
       request.setHandled(true);

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -235,8 +235,7 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
           metaStatus = S3RestUtils.checkStatusesForUploadId(mMetaFs, mUserFs,
               multipartTemporaryDir, mUploadId).get(1);
         } catch (Exception e) {
-          LOG.error("checkStatusesForUploadId failed:{}:{}",
-                  e.getMessage(), ThreadUtils.formatStackTrace(e));
+          LOG.error("checkStatusesForUploadId failed:{}", ThreadUtils.formatStackTrace(e));
           throw new S3Exception(objectPath, S3ErrorCode.NO_SUCH_UPLOAD);
         }
 
@@ -246,8 +245,8 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
           request = new XmlMapper().readerFor(CompleteMultipartUploadRequest.class)
               .readValue(mBody);
         } catch (IllegalArgumentException e) {
-          LOG.error("Failed parsing CompleteMultipartUploadRequest {}:{}",
-                  e.getMessage(), ThreadUtils.formatStackTrace(e));
+          LOG.error("Failed parsing CompleteMultipartUploadRequest:{}",
+                  ThreadUtils.formatStackTrace(e));
           Throwable cause = e.getCause();
           if (cause instanceof S3Exception) {
             throw S3RestUtils.toObjectS3Exception((S3Exception) cause, objectPath);

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
@@ -50,7 +50,7 @@ public final class ListBucketOptions {
     mPrefix = "";
     mMaxKeys = DEFAULT_MAX_KEYS;
     mDelimiter = null;
-    mEncodingType = DEFAULT_ENCODING_TYPE;
+    mEncodingType = null;
     // listObject parameter
     mMarker = null;
     // listObjectV2 parameter

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -274,6 +274,17 @@ public class ListBucketResult {
         .filter(content -> !content.mIsCommonPrefix)
         .collect(Collectors.toList());
 
+    /*
+    As explained in:
+    https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#API_ListObjectsV2_ResponseElements
+    The encoding type, if specified, we will return encoded key name values in the
+    following response elements:
+      Delimiter, Prefix, Key, and StartAfter.
+    AWS S3 for some reason is not encoding every char,  / and * for example.
+    Since we are not supporting delimiter other than /, we will apply url encoding
+    on these fields for now:
+    Prefix, Key, and StartAfter
+     */
     if (StringUtils.equals(getEncodingType(), ListBucketOptions.DEFAULT_ENCODING_TYPE)) {
       mContents.stream().forEach(content -> {
         try {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -290,7 +290,7 @@ public class ListBucketResult {
         try {
           content.mKey = URLEncoder.encode(content.mKey, "UTF-8");
         } catch (UnsupportedEncodingException ex) {
-          // IGNORE
+          // IGNORE, return as is
         }
       });
 
@@ -299,7 +299,7 @@ public class ListBucketResult {
           try {
             commonPrefix.mPrefix = URLEncoder.encode(commonPrefix.mPrefix, "UTF-8");
           } catch (UnsupportedEncodingException ex) {
-            // IGNORE
+            // IGNORE, return as is
           }
         });
       }
@@ -308,7 +308,7 @@ public class ListBucketResult {
         try {
           mStartAfter = URLEncoder.encode(mStartAfter, "UTF-8");
         } catch (UnsupportedEncodingException ex) {
-          // IGNORE
+          // IGNORE, return as is
         }
       }
     }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -320,6 +320,13 @@ public final class S3RestServiceHandler {
         }
         // Otherwise, this is ListObjects(v2)
         int maxKeys = maxKeysParam == null ? ListBucketOptions.DEFAULT_MAX_KEYS : maxKeysParam;
+        if (encodingTypeParam != null
+            && !StringUtils.equals(encodingTypeParam, ListBucketOptions.DEFAULT_ENCODING_TYPE)) {
+          throw new S3Exception(bucket, new S3ErrorCode(
+                  S3ErrorCode.INVALID_ARGUMENT.getCode(),
+                  "Invalid Encoding Method specified in Request.",
+                  S3ErrorCode.INVALID_ARGUMENT.getStatus()));
+        }
         ListBucketOptions listBucketOptions = ListBucketOptions.defaults()
             .setMarker(markerParam)
             .setPrefix(prefixParam)

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -606,6 +606,14 @@ public final class S3RestUtils {
     return user;
   }
 
+  public static String throwableToString(Throwable th) {
+    StringBuilder sb = new StringBuilder();
+    for (StackTraceElement ste : th.getStackTrace()) {
+      sb.append(ste.toString() + "\n");
+    }
+    return sb.toString();
+  }
+
   /**
    * Comparator based on uri name， treat uri name as a Long number.
    */

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -606,14 +606,6 @@ public final class S3RestUtils {
     return user;
   }
 
-  public static String throwableToString(Throwable th) {
-    StringBuilder sb = new StringBuilder();
-    for (StackTraceElement ste : th.getStackTrace()) {
-      sb.append(ste.toString() + "\n");
-    }
-    return sb.toString();
-  }
-
   /**
    * Comparator based on uri name， treat uri name as a Long number.
    */


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. respect encoding-type flag in list-objects ( list-objects-v2 equivalent) and url-encoding the following return fields:
       Prefix, Key, and StartAfter
2. add util to print stacktrace of throwable in existing print thread stack trace util func
3. add service name in the webservice serving threads when starting for better tracing purpose
4. add access log in CompleteMultipartUploadHandler as well
5. add logging in CompleteMultipartUploadTask for better exception tracking.

### Why are the changes needed?

1. to fix the bug where  + in object names is shown as space when using aws s3 clit -> respect encoding-type flag fixed this
2. track completemultipartupload exception for better debugging purpose.

### Does this PR introduce any user facing changes?

N/A
