### PR TITLE
Revert PollingMasterInquireClient change and use MetaService again

### DIFF
--- a/core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java
@@ -11,30 +11,18 @@
 
 package alluxio.master;
 
-import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.fail;
 
 import alluxio.Constants;
-import alluxio.conf.Configuration;
 import alluxio.conf.ConfigurationBuilder;
 import alluxio.exception.status.UnavailableException;
-import alluxio.grpc.GetNodeStatePRequest;
-import alluxio.grpc.GetNodeStatePResponse;
-import alluxio.grpc.GrpcServer;
-import alluxio.grpc.GrpcServerAddress;
-import alluxio.grpc.GrpcServerBuilder;
-import alluxio.grpc.GrpcService;
-import alluxio.grpc.JournalMasterClientServiceGrpc;
-import alluxio.grpc.NodeState;
 import alluxio.network.RejectingServer;
 import alluxio.retry.CountingRetry;
 import alluxio.util.network.NetworkAddressUtils;
 
-import io.grpc.stub.StreamObserver;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.List;
@@ -61,41 +49,6 @@ public class PollingMasterInquireClientTest {
       fail("Expected polling to fail");
     } catch (UnavailableException e) {
       // Expected
-    }
-  }
-
-  @Test(timeout = 10000)
-  public void getPrimaryRpcAddress() throws IOException {
-    int port = mPort.getPort();
-    InetSocketAddress serverAddress = new InetSocketAddress("127.0.0.1", port);
-
-    JournalMasterClientServiceGrpc.JournalMasterClientServiceImplBase handler =
-        new JournalMasterClientServiceGrpc.JournalMasterClientServiceImplBase() {
-          @Override
-          public void getNodeState(GetNodeStatePRequest request,
-              StreamObserver<GetNodeStatePResponse> responseObserver) {
-            responseObserver.onNext(
-                GetNodeStatePResponse.newBuilder().setNodeState(NodeState.PRIMARY).build());
-            responseObserver.onCompleted();
-          }
-        };
-
-    GrpcServer grpcServer = GrpcServerBuilder
-        .forAddress(
-            GrpcServerAddress.create("localhost", serverAddress), Configuration.global())
-        .addService(new GrpcService(handler))
-        .build();
-
-    try {
-      grpcServer.start();
-      List<InetSocketAddress> addrs = Arrays.asList(serverAddress);
-      PollingMasterInquireClient client = new PollingMasterInquireClient(addrs,
-          () -> new CountingRetry(0), new ConfigurationBuilder().build());
-      assertEquals(serverAddress, client.getPrimaryRpcAddress());
-    } catch (Exception e) {
-      throw e;
-    } finally {
-      grpcServer.shutdown();
     }
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Revert the PollingMasterInquireClient change in https://github.com/Alluxio/alluxio/pull/16065

Command to revert:
git checkout 50a282e5f48aa00b6d3e83dd1b3d60079162dcea -- core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
git checkout 50a282e5f48aa00b6d3e83dd1b3d60079162dcea -- core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java 


### Why are the changes needed?

The previous PR introduced a new endpoint for polling primary master address, which introduces a backward compatibility issue.  If a 2.9 client tries to connect to a 2.8 master, then it will get an error because the endpoint it's calling isn't on 2.8.

Revert the change for now to solve the backward compatibility issue.  

### Does this PR introduce any user facing changes?

N/A