### PR TITLE
Add IO rate limit

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4883,6 +4883,27 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
+  public static final PropertyKey WORKER_LOCAL_BLOCK_QOS_ENABLE =
+      booleanBuilder(Name.WORKER_LOCAL_BLOCK_QOS_ENABLE)
+          .setDefaultValue(false)
+          .setDescription("Whether to enable local block qos.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.WORKER)
+          .build();
+  public static final PropertyKey WORKER_LOCAL_BLOCK_READ_THROUGHPUT =
+      dataSizeBuilder(Name.WORKER_LOCAL_BLOCK_READ_THROUGHPUT)
+          .setDefaultValue("200MB")
+          .setDescription("Read throughput limit access block store.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.WORKER)
+          .build();
+  public static final PropertyKey WORKER_LOCAL_BLOCK_WRITE_THROUGHPUT =
+      dataSizeBuilder(Name.WORKER_LOCAL_BLOCK_WRITE_THROUGHPUT)
+          .setDefaultValue("200MB")
+          .setDescription("Write throughput limit access block store.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.WORKER)
+          .build();
 
   //
   // Proxy related properties
@@ -8036,6 +8057,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String WORKER_UFS_INSTREAM_CACHE_MAX_SIZE =
         "alluxio.worker.ufs.instream.cache.max.size";
     public static final String WORKER_WHITELIST = "alluxio.worker.whitelist";
+    public static final String WORKER_LOCAL_BLOCK_QOS_ENABLE =
+        "alluxio.worker.local.block.qos.enabled";
+    public static final String WORKER_LOCAL_BLOCK_READ_THROUGHPUT =
+        "alluxio.worker.local.block.read.throughput";
+    public static final String WORKER_LOCAL_BLOCK_WRITE_THROUGHPUT =
+        "alluxio.worker.local.block.write.throughput";
 
     //
     // Proxy related properties

--- a/core/common/src/main/java/alluxio/qos/RateLimiter.java
+++ b/core/common/src/main/java/alluxio/qos/RateLimiter.java
@@ -1,0 +1,41 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.qos;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Rate Limiter Interface.
+ */
+public interface RateLimiter {
+  /**
+   * A blocked method to acquire resources.
+   * @param permits num of requested resource
+   */
+  public void acquire(int permits);
+
+  /**
+   * An un-blocked method to acquire resources.
+   * @param permits num of requested resource
+   * @return true if resource is acquired otherwise false
+   */
+  public boolean tryAcquire(int permits);
+
+  /**
+   * An un-blocked method to acquire resources.
+   * @param permits num of requested resource
+   * @param timeOut try to acquire resources until times up
+   * @param timeUnit time unit of timeout
+   * @return true if resource is acquired otherwise false
+   */
+  public boolean tryAcquire(int permits, long timeOut, TimeUnit timeUnit);
+}

--- a/core/common/src/main/java/alluxio/worker/block/io/RateLimitedBlockReader.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/RateLimitedBlockReader.java
@@ -1,0 +1,122 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block.io;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.qos.RateLimiter;
+import alluxio.worker.block.qos.BlockStoreRateLimiter;
+
+import io.netty.buffer.ByteBuf;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+
+/**
+ * A {@link BlockReader} with RateLimit.
+ */
+public class RateLimitedBlockReader extends BlockReader {
+
+  private final BlockReader mDelegate;
+  private final RateLimiter mRateLimiter;
+
+  /**
+   * Constructs a new instance for {@link RateLimitedBlockReader}.
+   * @param delegate real BlockReader
+   * @param configuration conf
+   */
+  public RateLimitedBlockReader(BlockReader delegate, AlluxioConfiguration configuration) {
+    mDelegate = delegate;
+    mRateLimiter = BlockStoreRateLimiter.getReadLimiter(configuration);
+  }
+
+  @Override
+  public ByteBuffer read(long offset, long length) throws IOException {
+    mRateLimiter.acquire((int) length);
+    return mDelegate.read(offset, length);
+  }
+
+  @Override
+  public long getLength() {
+    return mDelegate.getLength();
+  }
+
+  @Override
+  public ReadableByteChannel getChannel() {
+    return new RateLimitedReadableByteChannel(mDelegate.getChannel(), mRateLimiter);
+  }
+
+  @Override
+  public int transferTo(ByteBuf buf) throws IOException {
+    mRateLimiter.acquire(buf.writableBytes());
+    return mDelegate.transferTo(buf);
+  }
+
+  @Override
+  public boolean isClosed() {
+    return mDelegate.isClosed();
+  }
+
+  @Override
+  public String getLocation() {
+    return mDelegate.getLocation();
+  }
+
+  @Override
+  public void close() throws IOException {
+    mDelegate.close();
+  }
+
+  /**
+   * Returns the delegated BlockReader.
+   * @return block reader
+   */
+  public BlockReader getDelegate() {
+    return mDelegate;
+  }
+
+  /**
+   * A {@link ReadableByteChannel} with RateLimit.
+   */
+  public static class RateLimitedReadableByteChannel implements ReadableByteChannel {
+
+    private final ReadableByteChannel mDelegate;
+
+    private final RateLimiter mRateLimiter;
+
+    /**
+     * Constructs a new instance for {@link RateLimitedReadableByteChannel}.
+     * @param delegate
+     * @param rateLimiter
+     */
+    public RateLimitedReadableByteChannel(ReadableByteChannel delegate, RateLimiter rateLimiter) {
+      mDelegate = delegate;
+      mRateLimiter = rateLimiter;
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+      mRateLimiter.acquire(dst.remaining());
+      return mDelegate.read(dst);
+    }
+
+    @Override
+    public boolean isOpen() {
+      return mDelegate.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+      mDelegate.close();
+    }
+  }
+}

--- a/core/common/src/main/java/alluxio/worker/block/io/RateLimitedBlockWriter.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/RateLimitedBlockWriter.java
@@ -1,0 +1,110 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block.io;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.network.protocol.databuffer.DataBuffer;
+import alluxio.qos.RateLimiter;
+import alluxio.worker.block.qos.BlockStoreRateLimiter;
+
+import io.netty.buffer.ByteBuf;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * A {@link BlockWriter} with RateLimit.
+ */
+public class RateLimitedBlockWriter extends BlockWriter {
+
+  private final BlockWriter mDelegate;
+  private final RateLimiter mRateLimiter;
+
+  /**
+   * Constructs a new instance for {@link RateLimitedBlockWriter}.
+   * @param blockWriter the real BlockWriter
+   * @param configuration conf
+   */
+  public RateLimitedBlockWriter(BlockWriter blockWriter, AlluxioConfiguration configuration) {
+    mDelegate = blockWriter;
+    mRateLimiter = BlockStoreRateLimiter.getWriteLimiter(configuration);
+  }
+
+  @Override
+  public long append(ByteBuffer inputBuf) {
+    mRateLimiter.acquire(inputBuf.remaining());
+    return mDelegate.append(inputBuf);
+  }
+
+  @Override
+  public long append(ByteBuf buf) throws IOException {
+    mRateLimiter.acquire(buf.readableBytes());
+    return mDelegate.append(buf);
+  }
+
+  @Override
+  public long append(DataBuffer buffer) throws IOException {
+    mRateLimiter.acquire(buffer.readableBytes());
+    return mDelegate.append(buffer);
+  }
+
+  @Override
+  public long getPosition() {
+    return mDelegate.getPosition();
+  }
+
+  @Override
+  public WritableByteChannel getChannel() {
+    return new RateLimitedWritableByteChannel(mDelegate.getChannel(), mRateLimiter);
+  }
+
+  @Override
+  public void close() throws IOException {
+    mDelegate.close();
+  }
+
+  /**
+   * A {@link WritableByteChannel} with RateLimit.
+   */
+  public static class RateLimitedWritableByteChannel implements WritableByteChannel {
+
+    private final WritableByteChannel mDelegate;
+    private final RateLimiter mRateLimiter;
+
+    /**
+     * Constructs a new instance for {@link RateLimitedWritableByteChannel}.
+     * @param delegate
+     * @param rateLimiter
+     */
+    public RateLimitedWritableByteChannel(WritableByteChannel delegate, RateLimiter rateLimiter) {
+      mDelegate = delegate;
+      mRateLimiter = rateLimiter;
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+      mRateLimiter.acquire(src.remaining());
+      return mDelegate.write(src);
+    }
+
+    @Override
+    public boolean isOpen() {
+      return mDelegate.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+      mDelegate.close();
+    }
+  }
+}

--- a/core/common/src/main/java/alluxio/worker/block/qos/BlockStoreRateLimiter.java
+++ b/core/common/src/main/java/alluxio/worker/block/qos/BlockStoreRateLimiter.java
@@ -1,0 +1,124 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block.qos;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.qos.RateLimiter;
+import alluxio.resource.LockResource;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A {@link RateLimiter} For BlockStore.
+ */
+public class BlockStoreRateLimiter implements RateLimiter {
+  private static final Lock READ_LIMITER_INIT_LOCK = new ReentrantLock();
+  private static final Lock WRITE_LIMITER_INIT_LOCK = new ReentrantLock();
+  private static BlockStoreRateLimiter sReadLimiter;
+  private static BlockStoreRateLimiter sWriteLimiter;
+
+  private final com.google.common.util.concurrent.RateLimiter mRateLimiter;
+
+  /**
+   * Constructs or get read limiter.
+   * @param conf conf
+   * @return read limiter
+   */
+  public static BlockStoreRateLimiter getReadLimiter(AlluxioConfiguration conf) {
+    if (sReadLimiter == null) {
+      try (LockResource ignored = new LockResource(READ_LIMITER_INIT_LOCK)) {
+        if (sReadLimiter == null) {
+          sReadLimiter = new BlockStoreRateLimiter(getThroughputLimit(conf, TpsLimitType.READ));
+        }
+      }
+    }
+    return sReadLimiter;
+  }
+
+  /**
+   * Constructs or get write limiter.
+   * @param conf conf
+   * @return write limiter
+   */
+  public static BlockStoreRateLimiter getWriteLimiter(AlluxioConfiguration conf) {
+    if (sWriteLimiter == null) {
+      try (LockResource ignored = new LockResource(WRITE_LIMITER_INIT_LOCK)) {
+        if (sWriteLimiter == null) {
+          sWriteLimiter = new BlockStoreRateLimiter(getThroughputLimit(conf, TpsLimitType.WRITE));
+        }
+      }
+    }
+    return sWriteLimiter;
+  }
+
+  private BlockStoreRateLimiter(double limits) {
+    mRateLimiter = com.google.common.util.concurrent.RateLimiter.create(limits);
+  }
+
+  /**
+   * Clear the read limiter & write limiter.
+   */
+  public static void clear() {
+    if (sReadLimiter != null) {
+      try (LockResource ignored = new LockResource(READ_LIMITER_INIT_LOCK)) {
+        if (sReadLimiter != null) {
+          sReadLimiter = null;
+        }
+      }
+    }
+    if (sWriteLimiter != null) {
+      try (LockResource ignored = new LockResource(WRITE_LIMITER_INIT_LOCK)) {
+        if (sWriteLimiter != null) {
+          sWriteLimiter = null;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void acquire(int permits) {
+    mRateLimiter.acquire(permits);
+  }
+
+  @Override
+  public boolean tryAcquire(int permits) {
+    return mRateLimiter.tryAcquire(permits);
+  }
+
+  @Override
+  public boolean tryAcquire(int permits, long timeOut, TimeUnit timeUnit) {
+    return mRateLimiter.tryAcquire(permits, timeOut, timeUnit);
+  }
+
+  private static double getThroughputLimit(AlluxioConfiguration conf, TpsLimitType type) {
+    long throughput;
+    switch (type) {
+      case READ:
+        throughput = conf.getBytes(PropertyKey.WORKER_LOCAL_BLOCK_READ_THROUGHPUT);
+        break;
+      case WRITE:
+        throughput = conf.getBytes(PropertyKey.WORKER_LOCAL_BLOCK_WRITE_THROUGHPUT);
+        break;
+      default:
+        throw new IllegalArgumentException("UNKNOWN TpsLimitType!");
+    }
+    return throughput;
+  }
+
+  private enum TpsLimitType {
+    READ,
+    WRITE
+  }
+}

--- a/core/common/src/test/java/alluxio/worker/block/io/RateLimitedBlockReaderTest.java
+++ b/core/common/src/test/java/alluxio/worker/block/io/RateLimitedBlockReaderTest.java
@@ -1,0 +1,204 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block.io;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class RateLimitedBlockReaderTest {
+
+  private RateLimitedBlockReader mReader;
+  private MockBlockReader mBlockReader;
+  private AlluxioConfiguration mConf;
+
+  /**
+   * Sets up the file path and file block reader before a test runs.
+   */
+  @Before
+  public void before() throws Exception {
+    InstancedConfiguration configuration = Configuration.copyGlobal();
+    configuration.set(PropertyKey.WORKER_LOCAL_BLOCK_QOS_ENABLE, true);
+    configuration.set(PropertyKey.WORKER_LOCAL_BLOCK_READ_THROUGHPUT, "1MB");
+    mConf = configuration;
+    mBlockReader = new MockBlockReader(new byte[16 * 1024 * 1024]);
+    mReader = new RateLimitedBlockReader(mBlockReader, configuration);
+  }
+
+  @After
+  public void after() throws IOException {
+    mReader.close();
+    Assert.assertTrue(mBlockReader.isClosed());
+  }
+
+  @Test
+  public void testSingleReadLimit() throws Exception {
+    long start = System.currentTimeMillis();
+    long len = mReader.getLength();
+    int currentOff = 0;
+    while (len > 0) {
+      int current = mReader.read(currentOff, 2048).remaining();
+      len -= current;
+      currentOff += current;
+    }
+    long cost = System.currentTimeMillis() - start;
+    Assert.assertTrue(cost >= 15000);
+  }
+
+  @Test
+  public void testSingleTransLimit() throws Exception {
+    long start = System.currentTimeMillis();
+    long len = mReader.getLength();
+    ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer(2048, 2048);
+    while (len > 0) {
+      mReader.transferTo(buf);
+      int current = buf.readableBytes();
+      len -= current;
+      if (buf.writableBytes() <= 0) {
+        buf.clear();
+      }
+    }
+    buf.release();
+    long cost = System.currentTimeMillis() - start;
+    Assert.assertTrue(cost >= 15000);
+  }
+
+  @Test
+  public void testSingleChannelLimit() throws Exception {
+    long start = System.currentTimeMillis();
+    long len = mReader.getLength();
+    ReadableByteChannel channel = mReader.getChannel();
+    while (len > 0) {
+      ByteBuffer buffer = ByteBuffer.allocate(2048);
+      int current = channel.read(buffer);
+      len -= current;
+    }
+    long cost = System.currentTimeMillis() - start;
+    Assert.assertTrue(cost >= 15000);
+  }
+
+  @Test
+  public void testMultiReadLimit() throws Exception {
+    MockBlockReader blockReader1 = new MockBlockReader(new byte[16 * 1024 * 1024]);
+    RateLimitedBlockReader reader1 = new RateLimitedBlockReader(blockReader1, mConf);
+    ExecutorService service = Executors.newFixedThreadPool(2);
+    long start = System.currentTimeMillis();
+    Future<Long> future1 = service.submit(() -> {
+      long len = mReader.getLength();
+      int currentOff = 0;
+      while (len > 0) {
+        int current = mReader.read(currentOff, 2048).remaining();
+        len -= current;
+        currentOff += current;
+      }
+      return null;
+    });
+    Future<Long> future2 = service.submit(() -> {
+      long len = reader1.getLength();
+      int currentOff = 0;
+      while (len > 0) {
+        int current = reader1.read(currentOff, 2048).remaining();
+        len -= current;
+        currentOff += current;
+      }
+      return null;
+    });
+    future1.get();
+    future2.get();
+    Assert.assertTrue(System.currentTimeMillis() - start >= 30000);
+  }
+
+  @Test
+  public void testMultiTransLimit() throws Exception {
+    MockBlockReader blockReader1 = new MockBlockReader(new byte[16 * 1024 * 1024]);
+    RateLimitedBlockReader reader1 = new RateLimitedBlockReader(blockReader1, mConf);
+    ExecutorService service = Executors.newFixedThreadPool(2);
+    long start = System.currentTimeMillis();
+    Future<Long> future1 = service.submit(() -> {
+      long len = mReader.getLength();
+      ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer(2048, 2048);
+      while (len > 0) {
+        mReader.transferTo(buf);
+        int current = buf.readableBytes();
+        len -= current;
+        if (buf.writableBytes() <= 0) {
+          buf.clear();
+        }
+      }
+      buf.release();
+      return null;
+    });
+    Future<Long> future2 = service.submit(() -> {
+      long len = reader1.getLength();
+      ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer(2048, 2048);
+      while (len > 0) {
+        reader1.transferTo(buf);
+        int current = buf.readableBytes();
+        len -= current;
+        if (buf.writableBytes() <= 0) {
+          buf.clear();
+        }
+      }
+      buf.release();
+      return null;
+    });
+    future1.get();
+    future2.get();
+    Assert.assertTrue(System.currentTimeMillis() - start >= 30000);
+  }
+
+  @Test
+  public void testMultiChannelLimit() throws Exception {
+    MockBlockReader blockReader1 = new MockBlockReader(new byte[16 * 1024 * 1024]);
+    RateLimitedBlockReader reader1 = new RateLimitedBlockReader(blockReader1, mConf);
+    ExecutorService service = Executors.newFixedThreadPool(2);
+    long start = System.currentTimeMillis();
+    Future<Long> future1 = service.submit(() -> {
+      long len = mReader.getLength();
+      ReadableByteChannel channel = mReader.getChannel();
+      while (len > 0) {
+        ByteBuffer buffer = ByteBuffer.allocate(2048);
+        int current = channel.read(buffer);
+        len -= current;
+      }
+      return null;
+    });
+    Future<Long> future2 = service.submit(() -> {
+      long len = reader1.getLength();
+      ReadableByteChannel channel = reader1.getChannel();
+      while (len > 0) {
+        ByteBuffer buffer = ByteBuffer.allocate(2048);
+        int current = channel.read(buffer);
+        len -= current;
+      }
+      return null;
+    });
+    future1.get();
+    future2.get();
+    Assert.assertTrue(System.currentTimeMillis() - start >= 30000);
+  }
+}

--- a/core/common/src/test/java/alluxio/worker/block/io/RateLimitedBlockWriterTest.java
+++ b/core/common/src/test/java/alluxio/worker/block/io/RateLimitedBlockWriterTest.java
@@ -1,0 +1,257 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block.io;
+
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.Configuration;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.network.protocol.databuffer.DataBuffer;
+import alluxio.network.protocol.databuffer.NioDataBuffer;
+import alluxio.util.io.BufferUtils;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class RateLimitedBlockWriterTest {
+
+  private RateLimitedBlockWriter mWriter;
+  private MockBlockWriter mBlockWriter;
+  private AlluxioConfiguration mConf;
+
+  /**
+   * Sets up the file path and file block reader before a test runs.
+   */
+  @Before
+  public void before() throws Exception {
+    InstancedConfiguration configuration = Configuration.copyGlobal();
+    configuration.set(PropertyKey.WORKER_LOCAL_BLOCK_QOS_ENABLE, true);
+    configuration.set(PropertyKey.WORKER_LOCAL_BLOCK_WRITE_THROUGHPUT, "1MB");
+    mConf = configuration;
+    mBlockWriter = new MockBlockWriter();
+    mWriter = new RateLimitedBlockWriter(mBlockWriter, configuration);
+  }
+
+  @After
+  public void after() throws IOException {
+    mWriter.close();
+  }
+
+  @Test
+  public void testSingleAppendByteBuf() throws IOException {
+    long start = System.currentTimeMillis();
+    long len = 17 * 1024 * 1024;
+    while (len > 0) {
+      ByteBuf buffer = Unpooled.wrappedBuffer(
+          BufferUtils.getIncreasingByteBuffer(2048));
+      long current = mWriter.append(buffer);
+      len -= current;
+      buffer.release();
+    }
+    long cost = System.currentTimeMillis() - start;
+    Assert.assertTrue(cost >= 15000);
+  }
+
+  @Test
+  public void testSingleAppendByteBuffer() throws IOException {
+    long start = System.currentTimeMillis();
+    long len = 17 * 1024 * 1024;
+    while (len > 0) {
+      ByteBuffer buf = BufferUtils.getIncreasingByteBuffer(2048);
+      long current = mWriter.append(buf);
+      len -= current;
+    }
+    long cost = System.currentTimeMillis() - start;
+    Assert.assertTrue(cost >= 15000);
+  }
+
+  @Test
+  public void testSingleAppendDataBuffer() throws IOException {
+    long start = System.currentTimeMillis();
+    long len = 17 * 1024 * 1024;
+    while (len > 0) {
+      ByteBuffer buf = BufferUtils.getIncreasingByteBuffer(2048);
+      DataBuffer dataBuffer = new NioDataBuffer(buf, 2048);
+      long current = mWriter.append(dataBuffer);
+      len -= current;
+      dataBuffer.release();
+    }
+    long cost = System.currentTimeMillis() - start;
+    Assert.assertTrue(cost >= 15000);
+  }
+
+  @Test
+  public void testSingleChannel() throws IOException {
+    long start = System.currentTimeMillis();
+    long len = 17 * 1024 * 1024;
+    WritableByteChannel channel = mWriter.getChannel();
+    while (len > 0) {
+      ByteBuffer buf = BufferUtils.getIncreasingByteBuffer(2048);
+      long current = channel.write(buf);
+      len -= current;
+    }
+    channel.close();
+    long cost = System.currentTimeMillis() - start;
+    Assert.assertTrue(cost >= 15000);
+  }
+
+  @Test
+  public void testMultiAppendByteBuf() throws Exception {
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    MockBlockWriter blockWriter1 = new MockBlockWriter();
+    BlockWriter writer1 = new RateLimitedBlockWriter(blockWriter1, mConf);
+    List<Future<Boolean>> futureList = new ArrayList<>();
+    futureList.add(executorService.submit(() -> {
+      long len = 16 * 1024 * 1024;
+      while (len > 0) {
+        ByteBuf buffer = Unpooled.wrappedBuffer(
+            BufferUtils.getIncreasingByteBuffer(2048));
+        long current = mWriter.append(buffer);
+        len -= current;
+        buffer.release();
+      }
+      return true;
+    }));
+    futureList.add(executorService.submit(() -> {
+      long len = 16 * 1024 * 1024;
+      while (len > 0) {
+        ByteBuf buffer = Unpooled.wrappedBuffer(
+            BufferUtils.getIncreasingByteBuffer(2048));
+        long current = writer1.append(buffer);
+        len -= current;
+        buffer.release();
+      }
+      return true;
+    }));
+    long start = System.currentTimeMillis();
+    for (Future<Boolean> future : futureList) {
+      future.get();
+    }
+    long cost = System.currentTimeMillis() - start;
+    Assert.assertTrue(cost >= 30000);
+  }
+
+  @Test
+  public void testMultiAppendByteBuffer() throws Exception {
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    MockBlockWriter blockWriter1 = new MockBlockWriter();
+    BlockWriter writer1 = new RateLimitedBlockWriter(blockWriter1, mConf);
+    List<Future<Boolean>> futureList = new ArrayList<>();
+    futureList.add(executorService.submit(() -> {
+      long len = 16 * 1024 * 1024;
+      while (len > 0) {
+        ByteBuffer buf = BufferUtils.getIncreasingByteBuffer(2048);
+        long current = mWriter.append(buf);
+        len -= current;
+      }
+      return true;
+    }));
+    futureList.add(executorService.submit(() -> {
+      long len = 16 * 1024 * 1024;
+      while (len > 0) {
+        ByteBuffer buf = BufferUtils.getIncreasingByteBuffer(2048);
+        long current = writer1.append(buf);
+        len -= current;
+      }
+      return true;
+    }));
+    long start = System.currentTimeMillis();
+    for (Future<Boolean> future : futureList) {
+      future.get();
+    }
+    long cost = System.currentTimeMillis() - start;
+    Assert.assertTrue(cost >= 30000);
+  }
+
+  @Test
+  public void testMultiAppendDataBuffer() throws Exception {
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    MockBlockWriter blockWriter1 = new MockBlockWriter();
+    BlockWriter writer1 = new RateLimitedBlockWriter(blockWriter1, mConf);
+    List<Future<Boolean>> futureList = new ArrayList<>();
+    futureList.add(executorService.submit(() -> {
+      long len = 16 * 1024 * 1024;
+      while (len > 0) {
+        ByteBuffer buf = BufferUtils.getIncreasingByteBuffer(2048);
+        DataBuffer dataBuffer = new NioDataBuffer(buf, 2048);
+        long current = mWriter.append(dataBuffer);
+        len -= current;
+        dataBuffer.release();
+      }
+      return true;
+    }));
+    futureList.add(executorService.submit(() -> {
+      long len = 16 * 1024 * 1024;
+      while (len > 0) {
+        ByteBuffer buf = BufferUtils.getIncreasingByteBuffer(2048);
+        DataBuffer dataBuffer = new NioDataBuffer(buf, 2048);
+        long current = writer1.append(dataBuffer);
+        len -= current;
+        dataBuffer.release();
+      }
+      return true;
+    }));
+    long start = System.currentTimeMillis();
+    for (Future<Boolean> future : futureList) {
+      future.get();
+    }
+    long cost = System.currentTimeMillis() - start;
+    Assert.assertTrue(cost >= 30000);
+  }
+
+  @Test
+  public void testMultiChannel() throws Exception {
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    MockBlockWriter blockWriter1 = new MockBlockWriter();
+    BlockWriter writer1 = new RateLimitedBlockWriter(blockWriter1, mConf);
+    List<Future<Boolean>> futureList = new ArrayList<>();
+    futureList.add(executorService.submit(() -> {
+      WritableByteChannel channel = mWriter.getChannel();
+      long len = 16 * 1024 * 1024;
+      while (len > 0) {
+        ByteBuffer buf = BufferUtils.getIncreasingByteBuffer(2048);
+        long current = channel.write(buf);
+        len -= current;
+      }
+      return true;
+    }));
+    futureList.add(executorService.submit(() -> {
+      WritableByteChannel channel = writer1.getChannel();
+      long len = 16 * 1024 * 1024;
+      while (len > 0) {
+        ByteBuffer buf = BufferUtils.getIncreasingByteBuffer(2048);
+        long current = channel.write(buf);
+        len -= current;
+      }
+      return true;
+    }));
+    long start = System.currentTimeMillis();
+    for (Future<Boolean> future : futureList) {
+      future.get();
+    }
+    long cost = System.currentTimeMillis() - start;
+    Assert.assertTrue(cost >= 30000);
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support IO rate limit for BlockReader & BlockWriter

### Why are the changes needed?

If Alluxio Worker is deployed with another process, IO rate limit is necessary to protect the other process.

### Does this PR introduce any user facing changes?

3 PropertyKey added
1. WORKER_LOCAL_BLOCK_QOS_ENABLE
2. WORKER_LOCAL_BLOCK_READ_THROUGHPUT
3. WORKER_LOCAL_BLOCK_WRITE_THROUGHPUT
