### PR TITLE
Support random buffer size for worker stress benchmark

### DIFF
--- a/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
@@ -86,6 +86,10 @@ public final class WorkerBenchParameters extends FileSystemParameters {
       description = "The random max length upper bound")
   public String mRandomMinReadLength = "1m";
 
+  @Parameter(names = {"--random-min-buffer-size"},
+      description = "The buffer size for random IO operations. (1k, 16k, etc.)")
+  public String mRandomMinBufferSize = "1k";
+
   @Parameter(names = {"--free"},
       description = "If true, free the data from Alluxio before reading. Only applies to Alluxio "
           + "paths")

--- a/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
+++ b/stress/common/src/main/java/alluxio/stress/worker/WorkerBenchParameters.java
@@ -87,8 +87,12 @@ public final class WorkerBenchParameters extends FileSystemParameters {
   public String mRandomMinReadLength = "1m";
 
   @Parameter(names = {"--random-min-buffer-size"},
-      description = "The buffer size for random IO operations. (1k, 16k, etc.)")
+      description = "The min buffer size for random IO operations. (1k, 16k, etc.)")
   public String mRandomMinBufferSize = "1k";
+
+  @Parameter(names = {"--random-max-buffer-size"},
+      description = "The max buffer size for random IO operations. (1k, 16k, etc.)")
+  public String mRandomMaxBufferSize = "4k";
 
   @Parameter(names = {"--free"},
       description = "If true, free the data from Alluxio before reading. Only applies to Alluxio "

--- a/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -230,7 +230,6 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
     return (int) longFileSize;
   }
 
-
   private static final class BenchContext {
     private final long mStartMs;
     private final long mEndMs;

--- a/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/worker/StressWorkerBench.java
@@ -59,7 +59,6 @@ public class StressWorkerBench extends AbstractStressBench<WorkerBenchTaskResult
   private Integer[] mOffsets;
   private Integer[] mLengths;
 
-
   /** generate random number in range [min, max] (include both min and max).*/
   private Integer randomNumInRange(Random rand, int min, int max) {
     return rand.nextInt(max - min + 1) + min;


### PR DESCRIPTION
### What changes are proposed in this pull request?
Make read buffer size random to support test direct memory pool.

### Why are the changes needed?

Fix buffer size for each read operation can't simulation real world request well. 
Use random size of read buffer to support benchmark.

### Does this PR introduce any user facing changes?
add one parameter "--random-min-buffer-size"
