### PR TITLE
Add encoding-type support for S3 ListObjects and more logging

### DIFF
--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -43,6 +43,15 @@ public final class ThreadUtils {
     Throwable t = new Throwable(String.format("Stack trace for thread %s (State: %s):",
         thread.getName(), thread.getState()));
     t.setStackTrace(thread.getStackTrace());
+    return formatStackTrace(t);
+  }
+
+  /**
+   * Return formatted stacktrace of Throwable instance.
+   * @param t - a Throwable instance
+   * @return a human-readable representation of the Throwable's stack trace
+   */
+  public static String formatStackTrace(Throwable t) {
     StringWriter sw = new StringWriter();
     t.printStackTrace(new PrintWriter(sw));
     return sw.toString();

--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -75,6 +75,7 @@ public abstract class WebServer {
 
     QueuedThreadPool threadPool = new QueuedThreadPool();
     int webThreadCount = ServerConfiguration.getInt(PropertyKey.WEB_THREADS);
+    threadPool.setName(mServiceName.replace(" ", "-").toUpperCase());
 
     // Jetty needs at least (1 + selectors + acceptors) threads.
     threadPool.setMinThreads(webThreadCount * 2 + 1);

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
@@ -50,7 +50,7 @@ public final class ListBucketOptions {
     mPrefix = "";
     mMaxKeys = DEFAULT_MAX_KEYS;
     mDelimiter = null;
-    mEncodingType = DEFAULT_ENCODING_TYPE;
+    mEncodingType = null;
     // listObject parameter
     mMarker = null;
     // listObjectV2 parameter

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -284,7 +284,8 @@ public class ListBucketResult {
     on these fields for now:
     Prefix, Key, and StartAfter
      */
-    if (getEncodingType().equals(ListBucketOptions.DEFAULT_ENCODING_TYPE)) {
+    if (getEncodingType() != null
+            && getEncodingType().equals(ListBucketOptions.DEFAULT_ENCODING_TYPE)) {
       mContents.stream().forEach(content -> {
         try {
           content.mKey = URLEncoder.encode(content.mKey, "UTF-8");

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -284,7 +284,7 @@ public class ListBucketResult {
     on these fields for now:
     Prefix, Key, and StartAfter
      */
-    if (StringUtils.equals(getEncodingType(), ListBucketOptions.DEFAULT_ENCODING_TYPE)) {
+    if (getEncodingType().equals(ListBucketOptions.DEFAULT_ENCODING_TYPE)) {
       mContents.stream().forEach(content -> {
         try {
           content.mKey = URLEncoder.encode(content.mKey, "UTF-8");

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -357,6 +357,13 @@ public final class S3RestServiceHandler {
       }
       // Otherwise, this is ListObjects(v2)
       int maxKeys = maxKeysParam == null ? ListBucketOptions.DEFAULT_MAX_KEYS : maxKeysParam;
+      if (encodingTypeParam != null
+              && !StringUtils.equals(encodingTypeParam, ListBucketOptions.DEFAULT_ENCODING_TYPE)) {
+        throw new S3Exception(bucket, new S3ErrorCode(
+                S3ErrorCode.INVALID_ARGUMENT.getCode(),
+                "Invalid Encoding Method specified in Request.",
+                S3ErrorCode.INVALID_ARGUMENT.getStatus()));
+      }
       ListBucketOptions listBucketOptions = ListBucketOptions.defaults()
           .setMarker(markerParam)
           .setPrefix(prefixParam)


### PR DESCRIPTION
1. respect encoding-type flag in list-objects ( list-objects-v2 equivalent) and url-encoding the following return fields: Prefix, Key, and StartAfter
2. add util to print stacktrace of throwable in existing print thread stack trace util func
3. add service name in the webservice serving threads when starting for better tracing purpose
4. add access log in CompleteMultipartUploadHandler as well
5. add logging in CompleteMultipartUploadTask for better exception tracking.

1. to fix the bug where + in object names is shown as space when using aws s3 clit -> respect encoding-type flag fixed this
2. track completemultipartupload exception for better debugging purpose.

N/A

pr-link: Alluxio/alluxio#16530
change-id: cid-bf4356a4e308d22df3f57b8901b6b0106e2af120

### What changes are proposed in this pull request?

Please outline the changes and how this PR fixes the issue.

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
