### PR TITLE
Avoid allocating new page for read in case of MEM Cache on client

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -209,13 +209,13 @@ public interface CacheManager extends AutoCloseable {
 
   /**
    * Acquires an empty page from the cache manager with scope and quota respected. This is intended
-   * to be used by MEM cache manager to avoid alloc/copy a page. Other cache manager may return null.
-   * The returned empty page can be used to read from InputStream, and then this page will be
+   * to be used by MEM cache manager to avoid alloc/copy a page. Other cache manager may return
+   * null. The returned empty page can be used to read from InputStream, and then this page will be
    * put to cache manager.
    *
    * @param pageId the PageId of this page
-   * @param pageSize the size of this page. Usually this is the configured in global configuration.
-   * @return an empty page if success, otherwise null.
+   * @param pageSize the size of this page. Usually this is the configured in global configuration
+   * @return an empty page if success, otherwise null
    */
   byte[] acquire(PageId pageId, long pageSize);
 

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -208,6 +208,18 @@ public interface CacheManager extends AutoCloseable {
   boolean put(PageId pageId, ByteBuffer page, CacheContext cacheContext);
 
   /**
+   * Acquires an empty page from the cache manager with scope and quota respected. This is intended
+   * to be used by MEM cache manager to avoid alloc/copy a page. Other cache manager may return null.
+   * The returned empty page can be used to read from InputStream, and then this page will be
+   * put to cache manager.
+   *
+   * @param pageId the PageId of this page
+   * @param pageSize the size of this page. Usually this is the configured in global configuration.
+   * @return an empty page if success, otherwise null.
+   */
+  byte[] acquire(PageId pageId, long pageSize);
+
+  /**
    * Reads the entire page if the queried page is found in the cache, stores the result in buffer.
    *
    * @param pageId page identifier

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManagerWithShadowCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManagerWithShadowCache.java
@@ -53,6 +53,9 @@ public class CacheManagerWithShadowCache implements CacheManager {
   }
 
   @Override
+  public byte[] acquire(PageId pageId, long pageSize) { return null; }
+
+  @Override
   public int get(PageId pageId, int pageOffset, int bytesToRead, PageReadTargetBuffer target,
       CacheContext cacheContext) {
     int nread = mShadowCacheManager.get(pageId, bytesToRead, getCacheScope(cacheContext));

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/NoExceptionCacheManager.java
@@ -61,6 +61,17 @@ public class NoExceptionCacheManager implements CacheManager {
   }
 
   @Override
+  public byte[] acquire(PageId pageId, long pageSize) {
+    try {
+      return mCacheManager.acquire(pageId, pageSize);
+    } catch (Exception e) {
+      LOG.error("Failed to acquire page {}, size {}", pageId, pageSize, e);
+      Metrics.PUT_ERRORS.inc();
+      return null;
+    }
+  }
+
+  @Override
   public int get(PageId pageId, int bytesToRead, byte[] buffer, int offsetInBuffer) {
     try {
       return mCacheManager.get(pageId, bytesToRead, buffer, offsetInBuffer);

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -118,7 +118,15 @@ public interface PageStore extends AutoCloseable {
       ByteBuffer page,
       boolean isTemporary) throws ResourceExhaustedException, IOException;
 
+  /**
+   * Acquires a new/empty page from this page store. The new page is used by
+   * caller for read or write, and then this page will be put back to be a cache.
+   *
+   * @param pageId the identifier
+   * @return the page (in the format of byte array)
+   */
   byte[] acquire(PageId pageId);
+
   /**
    * Gets a page from the store to the destination buffer.
    *

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageStore.java
@@ -118,6 +118,7 @@ public interface PageStore extends AutoCloseable {
       ByteBuffer page,
       boolean isTemporary) throws ResourceExhaustedException, IOException;
 
+  byte[] acquire(PageId pageId);
   /**
    * Gets a page from the store to the destination buffer.
    *

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/TimeBoundPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/TimeBoundPageStore.java
@@ -88,6 +88,11 @@ public class TimeBoundPageStore implements PageStore {
   }
 
   @Override
+  public byte[] acquire(PageId pageId) {
+    return null;
+  }
+
+  @Override
   public int get(PageId pageId, int pageOffset, int bytesToRead, PageReadTargetBuffer target,
       boolean isTemporary) throws IOException, PageNotFoundException {
     Callable<Integer> callable = () ->

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -86,6 +86,11 @@ public class LocalPageStore implements PageStore {
   }
 
   @Override
+  public byte[] acquire(PageId pageId) {
+    return null;
+  }
+
+  @Override
   public int get(PageId pageId, int pageOffset, int bytesToRead, PageReadTargetBuffer target,
       boolean isTemporary) throws IOException, PageNotFoundException {
     Preconditions.checkArgument(pageOffset >= 0, "page offset should be non-negative");

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/MemoryPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/MemoryPageStore.java
@@ -48,13 +48,20 @@ public class MemoryPageStore implements PageStore {
     //TODO(beinan): support temp page for memory page store
     PageId pageKey = getKeyFromPageId(pageId);
     try {
-      MemPage pageCopy = mPagePool.acquire(page.remaining());
-      page.get(pageCopy.getPage(), 0, pageCopy.getPageLength());
-      mPageStoreMap.put(pageKey, pageCopy);
+      // This is to wrap the page to a MemPage, not allocating new memory.
+      MemPage pageToPut = new MemPage(page.array(), page.remaining());
+      mPageStoreMap.put(pageKey, pageToPut);
     } catch (Exception e) {
       throw new IOException("Failed to put cached data in memory for page " + pageId);
     }
   }
+
+  public byte[] acquire(PageId pageId){
+    PageId pageKey = getKeyFromPageId(pageId);
+    MemPage tempPage = mPagePool.acquire(mPagePool.mPageSize);
+    return tempPage.getPage();
+  }
+
 
   @Override
   public int get(PageId pageId, int pageOffset, int bytesToRead, PageReadTargetBuffer target,

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/MemoryPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/MemoryPageStore.java
@@ -56,12 +56,18 @@ public class MemoryPageStore implements PageStore {
     }
   }
 
-  public byte[] acquire(PageId pageId){
+  /**
+   * Acquires a new/empty page from this page store. The returned page will be used
+   * to read or write data. After that, the page will be put back as a cache.
+   *
+   * @param pageId the page identifier
+   * @return a new/empty page (in the form of byte array)
+   */
+  public byte[] acquire(PageId pageId) {
     PageId pageKey = getKeyFromPageId(pageId);
     MemPage tempPage = mPagePool.acquire(mPagePool.mPageSize);
     return tempPage.getPage();
   }
-
 
   @Override
   public int get(PageId pageId, int pageOffset, int bytesToRead, PageReadTargetBuffer target,

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
@@ -177,6 +177,11 @@ public class RocksPageStore implements PageStore {
   }
 
   @Override
+  public byte[] acquire(PageId pageId) {
+    return null;
+  }
+
+  @Override
   public int get(PageId pageId, int pageOffset, int bytesToRead, PageReadTargetBuffer target,
       boolean isTemporary) throws IOException, PageNotFoundException {
     Preconditions.checkArgument(pageOffset >= 0, "page offset should be non-negative");

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
@@ -230,7 +230,6 @@ public final class CacheManagerWithShadowCacheTest {
     @Override
     public byte[] acquire(PageId pageId, long pageSize) { return null; }
 
-
     @Override
     public int get(PageId pageId, int pageOffset, int bytesToRead, PageReadTargetBuffer buffer,
         CacheContext cacheContext) {

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/CacheManagerWithShadowCacheTest.java
@@ -228,6 +228,10 @@ public final class CacheManagerWithShadowCacheTest {
     }
 
     @Override
+    public byte[] acquire(PageId pageId, long pageSize) { return null; }
+
+
+    @Override
     public int get(PageId pageId, int pageOffset, int bytesToRead, PageReadTargetBuffer buffer,
         CacheContext cacheContext) {
       if (!mCache.containsKey(pageId)) {

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -627,6 +627,9 @@ public class LocalCacheFileInStreamTest {
     }
 
     @Override
+    public byte[] acquire(PageId pageId, long pageSize) { return null; }
+
+    @Override
     public int get(PageId pageId, int pageOffset, int bytesToRead, PageReadTargetBuffer target,
         CacheContext cacheContext) {
       if (!mPages.containsKey(pageId)) {

--- a/core/server/worker/src/test/java/alluxio/worker/page/ByteArrayCacheManager.java
+++ b/core/server/worker/src/test/java/alluxio/worker/page/ByteArrayCacheManager.java
@@ -46,6 +46,9 @@ class ByteArrayCacheManager implements CacheManager {
   }
 
   @Override
+  public byte[] acquire(PageId pageId, long pageSize) { return null; }
+
+  @Override
   public int get(PageId pageId, int pageOffset, int bytesToRead, PageReadTargetBuffer target,
       CacheContext cacheContext) {
     if (!mPages.containsKey(pageId)) {


### PR DESCRIPTION
### What changes are proposed in this pull request?
When MEM cache is used on client, we try to acquire an new/empty page from the cache manager before reading from external UFS. When the external read request completes, the data is copied to user-provided buffer, and this page is added back to cache manager. So, this will avoid allocating new page for every read.
Please outline the changes and how this PR fixes the issue.

### Why are the changes needed?

This will improve the read performance when MEM cache is used on client.

### Does this PR introduce any user facing changes?

Performance Improvement is expected.

Original-author: Huang Hua <huanghua78@msn.com>