### PR TITLE
Ignore no_cache setting for "load" command

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/LoadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LoadCommand.java
@@ -144,6 +144,11 @@ public final class LoadCommand extends AbstractFileSystemCommand {
       }
       Protocol.OpenUfsBlockOptions openUfsBlockOptions =
           new InStreamOptions(status, options, conf, mFsContext).getOpenUfsBlockOptions(blockId);
+      if (openUfsBlockOptions.getNoCache()) {
+        // ignore "NO_CACHE" setting for "load"
+        openUfsBlockOptions = Protocol.OpenUfsBlockOptions.newBuilder(openUfsBlockOptions)
+            .setNoCache(false).build();
+      }
       cacheBlock(blockId, dataSource, status, openUfsBlockOptions);
     }
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Ignore no_cache setting for "load" command.

### Why are the changes needed?

Currently the "load" command behaviours strangely if the corresponding node/client has the setting

```
alluxio.user.file.readtype.default=NO_CACHE
```

It reports "loaded" every time repeatedly

```
$ ./bin/alluxio fs load /test/file.01
/test/file.01 loaded

$ ./bin/alluxio fs load /test/file.01
/test/file.01 loaded
```

After applying this PR, the behaviour changes to

```
$ ./bin/alluxio fs load /test/file.01
/test/file.01 loaded

$ ./bin/alluxio fs load /test/file.01
/test/file.01 already in Alluxio fully
```

### Does this PR introduce any user facing changes?

No
