### PR TITLE
Fix bug for ufs journal dumper when read regular checkpoint

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/journal/tool/UfsJournalDumper.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/UfsJournalDumper.java
@@ -68,7 +68,6 @@ public class UfsJournalDumper extends AbstractJournalDumper {
           case CHECKPOINT:
             try (CheckpointInputStream checkpoint = reader.getCheckpoint()) {
               Path dir = Paths.get(mCheckpointsDir + "-" + reader.getNextSequenceNumber());
-              Files.createDirectories(dir);
               readCheckpoint(checkpoint, dir);
             }
             break;

--- a/core/server/master/src/main/java/alluxio/master/journal/tool/UfsJournalDumper.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/UfsJournalDumper.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 

--- a/core/server/master/src/main/java/alluxio/master/journal/tool/UfsJournalDumper.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/UfsJournalDumper.java
@@ -67,8 +67,8 @@ public class UfsJournalDumper extends AbstractJournalDumper {
         switch (state) {
           case CHECKPOINT:
             try (CheckpointInputStream checkpoint = reader.getCheckpoint()) {
-              Path dir = Paths.get(mCheckpointsDir + "-" + reader.getNextSequenceNumber());
-              readCheckpoint(checkpoint, dir);
+              Path path = Paths.get(mCheckpointsDir + "-" + reader.getNextSequenceNumber());
+              readCheckpoint(checkpoint, path);
             }
             break;
           case LOG:


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix `UfsJournalDumper.dumpJournal()`, which shouldn't call `Files.createDirectories(dir)`.

### Why are the changes needed?

bug: when using UfsJournal, if you use JournalTool to dump the ufs journal of a regular checkpoint(like BlockMaster), it will throws FileNotFoundException: /path-to-output/checkpoints-106 (Is a directory).
like this: 
<img width="944" alt="截屏2022-11-15 11 15 58" src="https://user-images.githubusercontent.com/5937168/201818808-9264ffb6-f5ff-491c-9a52-cbdada78bb8c.png">

Because in `AbstractJournalDumper.readCheckpoint(checkpoint, path)`, path is a file or dir. For regular checkpoint, it is a file; and for compound checkpoint, it is a dir. But `UfsJournalDumper` calls `Files.createDirectories(dir)`, which should be called in `AbstractJournalDumper.readCompoundCheckpoint`.

### Does this PR introduce any user facing changes?

None
