### PR TITLE
Improve job command manager utilisation 

### DIFF
--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -551,10 +551,12 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
         }
         mWorkerHealth.remove(deadWorker.getId());
         mWorkers.remove(deadWorker);
+        mCommandManager.removeWorkerLock(deadWorker.getId());
       }
       // Generate a new worker id.
       long workerId = mNextWorkerId.getAndIncrement();
       mWorkers.add(new MasterWorkerInfo(workerId, workerNetAddress));
+      mCommandManager.createWorkerLock(workerId);
       LOG.info("registerWorker(): WorkerNetAddress: {} id: {}", workerNetAddress, workerId);
       return workerId;
     }

--- a/job/server/src/main/java/alluxio/master/job/command/CommandManager.java
+++ b/job/server/src/main/java/alluxio/master/job/command/CommandManager.java
@@ -25,8 +25,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -39,6 +45,9 @@ public final class CommandManager {
 
   // TODO(yupeng) add retry support
   private final Map<Long, List<JobCommand>> mWorkerIdToPendingCommands = Maps.newHashMap();
+  // TODO replace lock per worker with guava striped lock once it is unstable
+  private final Map<Long, ReadWriteLock> mWorkerLocks = new ConcurrentHashMap<>();
+
 
   /**
    * Constructs a new {@link CommandManager}.
@@ -54,8 +63,8 @@ public final class CommandManager {
    * @param taskArgs the arguments passed to the executor on the worker
    * @param workerId the id of the worker
    */
-  public synchronized void submitRunTaskCommand(long jobId, long taskId, JobConfig jobConfig,
-      Object taskArgs, long workerId) {
+  public void submitRunTaskCommand(long jobId, long taskId, JobConfig jobConfig,
+                                   Object taskArgs, long workerId) {
     RunTaskCommand.Builder runTaskCommand = RunTaskCommand.newBuilder();
     runTaskCommand.setJobId(jobId);
     runTaskCommand.setTaskId(taskId);
@@ -81,7 +90,7 @@ public final class CommandManager {
    * @param taskId the task id
    * @param workerId the worker id
    */
-  public synchronized void submitCancelTaskCommand(long jobId, long taskId, long workerId) {
+  public void submitCancelTaskCommand(long jobId, long taskId, long workerId) {
     CancelTaskCommand.Builder cancelTaskCommand = CancelTaskCommand.newBuilder();
     cancelTaskCommand.setJobId(jobId);
     cancelTaskCommand.setTaskId(taskId);
@@ -96,7 +105,7 @@ public final class CommandManager {
    * @param workerId the worker id
    * @param taskPoolSize the task pool size
    */
-  public synchronized void submitSetTaskPoolSizeCommand(long workerId, int taskPoolSize) {
+  public void submitSetTaskPoolSizeCommand(long workerId, int taskPoolSize) {
     SetTaskPoolSizeCommand.Builder setTaskPoolSizeCommand = SetTaskPoolSizeCommand.newBuilder();
     setTaskPoolSizeCommand.setTaskPoolSize(taskPoolSize);
 
@@ -105,11 +114,18 @@ public final class CommandManager {
     submit(workerId, command);
   }
 
-  private synchronized void submit(long workerId, JobCommand.Builder command) {
-    if (!mWorkerIdToPendingCommands.containsKey(workerId)) {
-      mWorkerIdToPendingCommands.put(workerId, Lists.newArrayList());
+  private void submit(long workerId, JobCommand.Builder command) {
+    Objects.requireNonNull(mWorkerLocks.get(workerId), String.format("Worker,%d,not holding the lock.", workerId));
+    Lock writeLock = mWorkerLocks.get(workerId).writeLock();
+    writeLock.lock();
+    try{
+      if (!mWorkerIdToPendingCommands.containsKey(workerId)) {
+        mWorkerIdToPendingCommands.put(workerId, Lists.newArrayList());
+      }
+      mWorkerIdToPendingCommands.get(workerId).add(command.build());
+    } finally {
+      writeLock.unlock();
     }
-    mWorkerIdToPendingCommands.get(workerId).add(command.build());
   }
 
   /**
@@ -118,13 +134,46 @@ public final class CommandManager {
    * @param workerId id of the worker to send the commands to
    * @return the list of the commends polled
    */
-  public synchronized List<alluxio.grpc.JobCommand> pollAllPendingCommands(long workerId) {
-    if (!mWorkerIdToPendingCommands.containsKey(workerId)) {
-      return Lists.newArrayList();
+  public List<alluxio.grpc.JobCommand> pollAllPendingCommands(long workerId) {
+    Objects.requireNonNull(mWorkerLocks.get(workerId), String.format("Worker,%d,not holding the lock.", workerId));
+    List<JobCommand> commands = null;
+    Lock writeLock = mWorkerLocks.get(workerId).writeLock();
+    writeLock.lock();
+    try{
+      List<JobCommand> workerIdToPendingCommandList = mWorkerIdToPendingCommands.getOrDefault(workerId, Lists.newArrayList());
+      commands = Lists.newArrayList(workerIdToPendingCommandList);
+      workerIdToPendingCommandList.clear();
+    } finally {
+      writeLock.unlock();
     }
-    List<JobCommand> commands =
-        Lists.newArrayList(mWorkerIdToPendingCommands.get(workerId));
-    mWorkerIdToPendingCommands.get(workerId).clear();
     return commands;
+  }
+
+  /**
+   * Register the lock for worker
+   *
+   * @param workerId id of the worker
+   */
+  public void createWorkerLock(long workerId){
+    if (!mWorkerLocks.containsKey(workerId)) {
+      this.mWorkerLocks.put(workerId, new ReentrantReadWriteLock(true));
+    }
+  }
+
+  /**
+   * Remove the lock of the worker.
+   *
+   * @param workerId id of the worker
+   */
+  public void removeWorkerLock(long workerId){
+    if (!mWorkerLocks.containsKey(workerId)) {
+      Lock writeLock = mWorkerLocks.get(workerId).writeLock();
+      writeLock.lock();
+      try{
+        this.mWorkerLocks.remove(workerId);
+      }finally {
+        writeLock.unlock();
+      }
+    }
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?
Instead of the implicit java lock, applied the java exclusive lock on each individual worker. I have opted for trade off solution like creating the map for worker to its lock, it provides the better performance from existing one and the proposed one can be enhanced with guava striped lock once it is stable.

### Why are the changes needed?
The current implementation of the job command manager uses implicit java locking on each methods for submitting new command and polling the command for the worker; the job workers send the heartbeat in every 10 secs and acquire the lock due to that, user submitted commands have to wait/poll for longer duration to acquire the lock which makes the commands' execution time longer.

### Does this PR introduce any user facing changes?
No