### PR TITLE
Fix github actions from running cron

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -1,11 +1,6 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Checkstyle, Findbugs, Doc Check, etc.
 
-on:
-  pull_request:
-  schedule:
-    - cron: 0 0 * * *
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/java8_integration_tests.yml
+++ b/.github/workflows/java8_integration_tests.yml
@@ -1,9 +1,6 @@
 name: Java 8 Integration Tests
 
-on:
-  pull_request:
-  schedule:
-    - cron: 0 0 * * *
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/java8_integration_tests_webui.yml
+++ b/.github/workflows/java8_integration_tests_webui.yml
@@ -1,9 +1,6 @@
 name: Java 8 Integration Tests (w/ webui)
 
-on:
-  pull_request:
-  schedule:
-    - cron: 0 0 * * *
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/java8_unit_tests.yml
+++ b/.github/workflows/java8_unit_tests.yml
@@ -1,9 +1,6 @@
 name: Java 8 Unit Tests
 
-on:
-  pull_request:
-  schedule:
-    - cron: 0 0 * * *
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
none of the workflows should be scheduled via cron. this also wastes github action minutes on individual forks of the repo