### PR TITLE
Add jobName into audit log for run command

### DIFF
--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -264,6 +264,7 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
     try (JobMasterAuditContext auditContext =
         createAuditContext("run")) {
       auditContext.setJobId(jobId);
+      auditContext.setJobName(jobConfig.getName());
       if (jobConfig instanceof PlanConfig) {
         mPlanTracker.run((PlanConfig) jobConfig, mCommandManager, mJobServerContext,
             getWorkerInfoList(), jobId);

--- a/job/server/src/main/java/alluxio/master/job/JobMasterAuditContext.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMasterAuditContext.java
@@ -146,7 +146,7 @@ public class JobMasterAuditContext implements AuditContext {
   @Override
   public String toString() {
     return String.format(
-        "succeeded=%b\tallowed=%b\tugi=%s (AUTH=%s)\tip=%s\tcmd=%s\tmJobId=%d\tmJobName=%s\t"
+        "succeeded=%b\tallowed=%b\tugi=%s (AUTH=%s)\tip=%s\tcmd=%s\tjobId=%d\tjobName=%s\t"
             + "perm=null\texecutionTimeUs=%d",
         mSucceeded, mAllowed, mUgi, mAuthType, mIp, mCommand, mJobId, mJobName,
         mExecutionTimeNs / 1000);

--- a/job/server/src/main/java/alluxio/master/job/JobMasterAuditContext.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMasterAuditContext.java
@@ -114,7 +114,7 @@ public class JobMasterAuditContext implements AuditContext {
   }
 
   /**
-   * Sets mCreationTimeNs field.
+   * Sets mJobName field.
    *
    * @param jobName the job name
    * @return this {@link AuditContext} instance


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add jobName into audit log for run command.

### Why are the changes needed?

The audit log of the run command has no jobName record.
```
2022-11-02 18:20:47,690 INFO  JOB_MASTER_AUDIT_LOG (AsyncUserAccessAuditLogWriter.java:run) - succeeded=true    allowed=true    ugi=alluxio,alluxio (AUTH=RPC)  ip=null cmd=run mJobId=1666765197501    mJobName=null   perm=null       executionTimeUs=2700
```
