### PR TITLE
Optimize FUSE mount options

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6467,7 +6467,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey FUSE_MOUNT_OPTIONS =
       listBuilder(Name.FUSE_MOUNT_OPTIONS)
           .setAlias(Name.WORKER_FUSE_MOUNT_OPTIONS)
-          .setDefaultValue("direct_io")
+          .setDefaultValue("attr_timeout=600,entry_timeout=600")
           .setDescription("The platform specific Fuse mount options "
               + "to mount the given Fuse mount point. "
               + "If multiple mount options are provided, separate them with comma.")

--- a/integration/fuse/src/main/java/alluxio/fuse/options/FuseOptions.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/options/FuseOptions.java
@@ -14,6 +14,8 @@ package alluxio.fuse.options;
 import alluxio.client.file.options.FileSystemOptions;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.runtime.InvalidArgumentRuntimeException;
+import alluxio.exception.runtime.UnimplementedRuntimeException;
 import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.jnifuse.utils.LibfuseVersion;
 
@@ -21,7 +23,6 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -59,34 +60,49 @@ public class FuseOptions {
    * Creates the FUSE options.
    *
    * @param conf alluxio configuration
-   * @param options the file system options
+   * @param fileSystemOptions the file system options
    * @param updateCheckEnabled whether to enable update check
    * @return the file system options
    */
   public static FuseOptions create(AlluxioConfiguration conf,
-      FileSystemOptions options, boolean updateCheckEnabled) {
-    return new FuseOptions(options, constructFuseMountOptions(conf), updateCheckEnabled);
-  }
-
-  private static Set<String> constructFuseMountOptions(AlluxioConfiguration conf) {
-    Set<String> options = conf.getList(PropertyKey.FUSE_MOUNT_OPTIONS)
+      FileSystemOptions fileSystemOptions, boolean updateCheckEnabled) {
+    Set<String> mountOptions = conf.getList(PropertyKey.FUSE_MOUNT_OPTIONS)
         .stream().filter(a -> !a.isEmpty()).collect(Collectors.toSet());
-    if (AlluxioFuseUtils.getLibfuseVersion(conf) == LibfuseVersion.VERSION_2) {
+    LibfuseVersion version = AlluxioFuseUtils.getLibfuseVersion(conf);
+    if (!conf.getBoolean(PropertyKey.FUSE_JNIFUSE_ENABLED)
+        && version == LibfuseVersion.VERSION_3) {
+      throw new InvalidArgumentRuntimeException("Cannot use JNR-FUSE with libfuse 3");
+    }
+    if (version == LibfuseVersion.VERSION_2) {
       // Without option big_write, the kernel limits a single writing request to 4k.
       // With option big_write, maximum of a single writing request is 128k.
       // See https://github.com/libfuse/libfuse/blob/fuse_2_9_3/ChangeLog#L655-L659,
       // and https://github.com/torvalds/linux/commit/78bb6cb9a890d3d50ca3b02fce9223d3e734ab9b.
       // Libfuse3 dropped this option because it's default
       String bigWritesOptions = "big_writes";
-      options.add(bigWritesOptions);
-      LOG.info("Added fuse mount option {} to enlarge single write request size", bigWritesOptions);
+      if (mountOptions.add(bigWritesOptions)) {
+        LOG.info("Added fuse mount option {} to enlarge single write request size",
+            bigWritesOptions);
+      }
+      if (!conf.getBoolean(PropertyKey.FUSE_JNIFUSE_ENABLED)) {
+        String directIOOptions = "direct_io";
+        if (mountOptions.add(directIOOptions)) {
+          LOG.info("Added fuse mount option {} for JNR FUSE", directIOOptions);
+        }
+      }
+    } else {
+      if (mountOptions.remove("direct_io")) {
+        // TODO(lu) implement direct_io with libfuse3
+        throw new UnimplementedRuntimeException(
+            "Option direct_io with libfuse 3 is not implemented in Alluxio FUSE");
+      }
+      if (mountOptions.stream().noneMatch(a -> a.startsWith("max_idle_threads"))) {
+        String idleThreadsOption = "max_idle_threads=64";
+        mountOptions.add(idleThreadsOption);
+        LOG.info("Added fuse mount option {} for FUSE 3", idleThreadsOption);
+      }
     }
-    if (!conf.getBoolean(PropertyKey.FUSE_JNIFUSE_ENABLED)) {
-      String directIOOptions = "direct_io";
-      options.add(directIOOptions);
-      LOG.info("Added fuse mount option {} for JNR FUSE", directIOOptions);
-    }
-    return Collections.unmodifiableSet(options);
+    return new FuseOptions(fileSystemOptions, mountOptions, updateCheckEnabled);
   }
 
   /**

--- a/integration/fuse/src/main/java/alluxio/fuse/options/FuseOptions.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/options/FuseOptions.java
@@ -15,7 +15,6 @@ import alluxio.client.file.options.FileSystemOptions;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.runtime.InvalidArgumentRuntimeException;
-import alluxio.exception.runtime.UnimplementedRuntimeException;
 import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.jnifuse.utils.LibfuseVersion;
 
@@ -93,8 +92,7 @@ public class FuseOptions {
     } else {
       if (mountOptions.remove("direct_io")) {
         // TODO(lu) implement direct_io with libfuse3
-        throw new UnimplementedRuntimeException(
-            "Option direct_io with libfuse 3 is not implemented in Alluxio FUSE");
+        LOG.error("FUSE 3 does not support direct_io mount option");
       }
       if (mountOptions.stream().noneMatch(a -> a.startsWith("max_idle_threads"))) {
         String idleThreadsOption = "max_idle_threads=64";

--- a/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
@@ -17,6 +17,7 @@ import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.fuse.AlluxioJnrFuseFileSystem;
 import alluxio.fuse.options.FuseOptions;
+
 import org.junit.Assume;
 
 import java.nio.file.Paths;

--- a/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
@@ -17,6 +17,7 @@ import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.fuse.AlluxioJnrFuseFileSystem;
 import alluxio.fuse.options.FuseOptions;
+import org.junit.Assume;
 
 import java.nio.file.Paths;
 
@@ -34,6 +35,7 @@ public class JNRFuseIntegrationTest extends AbstractFuseIntegrationTest {
   @Override
   public void mountFuse(FileSystemContext context,
       FileSystem fileSystem, String mountPoint, String alluxioRoot) {
+    Assume.assumeTrue(Configuration.getInt(PropertyKey.FUSE_JNIFUSE_LIBFUSE_VERSION) == 2);
     Configuration.set(PropertyKey.FUSE_MOUNT_ALLUXIO_PATH, alluxioRoot);
     Configuration.set(PropertyKey.FUSE_MOUNT_POINT, mountPoint);
     Configuration.set(PropertyKey.FUSE_USER_GROUP_TRANSLATION_ENABLED, true);


### PR DESCRIPTION
### What changes are proposed in this pull request?
Remove direct_io mount option when using libfuse 3.
Add -o max_idle_threads=64 when using FUSE with libfuse 3.
Change default mount option to "attr_timeout=600,entry_timeout=600"

### Why are the changes needed?
Fix and optimize mount options.
Improve performance when using libfuse 3 and remove not working default mount options.


