### PR TITLE
Eliminate race condition in completempupload and support overwrite

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/UnderFileSystemFileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/UnderFileSystemFileOutStream.java
@@ -17,6 +17,7 @@ import alluxio.grpc.RequestType;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.wire.WorkerNetAddress;
+
 import com.codahale.metrics.Timer;
 
 import java.io.IOException;

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/UnderFileSystemFileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/UnderFileSystemFileOutStream.java
@@ -14,7 +14,10 @@ package alluxio.client.block.stream;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.options.OutStreamOptions;
 import alluxio.grpc.RequestType;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.wire.WorkerNetAddress;
+import com.codahale.metrics.Timer;
 
 import java.io.IOException;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -48,5 +51,13 @@ public class UnderFileSystemFileOutStream extends BlockOutStream {
    */
   protected UnderFileSystemFileOutStream(DataWriter dataWriter, WorkerNetAddress address) {
     super(dataWriter, Long.MAX_VALUE, address);
+  }
+
+  @Override
+  public void close() throws IOException {
+    try (Timer.Context ctx = MetricsSystem
+            .uniformTimer(MetricKey.CLOSE_UFS_OUTSTREAM_LATENCY.getName()).time()) {
+      super.close();
+    }
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileOutStream.java
@@ -39,6 +39,7 @@ import alluxio.wire.OperationId;
 import alluxio.wire.WorkerNetAddress;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
 import com.google.common.io.Closer;
 import org.slf4j.Logger;
@@ -154,7 +155,8 @@ public class AlluxioFileOutStream extends FileOutStream {
     if (mClosed) {
       return;
     }
-    try {
+    try (Timer.Context ctx = MetricsSystem
+            .uniformTimer(MetricKey.CLOSE_ALLUXIO_OUTSTREAM_LATENCY.getName()).time()){
       if (mCurrentBlockOutStream != null) {
         mPreviousBlockOutStreams.add(mCurrentBlockOutStream);
       }

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileOutStream.java
@@ -156,7 +156,7 @@ public class AlluxioFileOutStream extends FileOutStream {
       return;
     }
     try (Timer.Context ctx = MetricsSystem
-            .uniformTimer(MetricKey.CLOSE_ALLUXIO_OUTSTREAM_LATENCY.getName()).time()){
+            .uniformTimer(MetricKey.CLOSE_ALLUXIO_OUTSTREAM_LATENCY.getName()).time()) {
       if (mCurrentBlockOutStream != null) {
         mPreviousBlockOutStreams.add(mCurrentBlockOutStream);
       }

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -8131,6 +8131,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String PROXY_WEB_PORT = "alluxio.proxy.web.port";
     public static final String PROXY_AUDIT_LOGGING_ENABLED =
         "alluxio.proxy.audit.logging.enabled";
+    public static final String S3_UPLOADS_ID_XATTR_KEY = "s3_uploads_mulitpartupload_id";
 
     //
     // Locality related properties

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -661,6 +661,29 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setIsClusterAggregated(false)
           .build();
 
+  public static final MetricKey PROXY_CHECK_UPLOADID_STATUS_LATENCY =
+          new Builder("Proxy.CheckUploadIDStatusLatency")
+                  .setDescription("Latency of check uploadId status in CompleteMultipartUpload")
+                  .setMetricType(MetricType.TIMER)
+                  .build();
+  public static final MetricKey PROXY_COMPLETE_MP_UPLOAD_MERGE_LATENCY =
+          new Builder("Proxy.CompleteMPUploadMergeLatency")
+                  .setDescription("Latency of merging parts into one object in CompleteMultipartUpload")
+                  .setMetricType(MetricType.TIMER)
+                  .build();
+
+  public static final MetricKey PROXY_CLEANUP_MULTIPART_UPLOAD_LATENCY =
+          new Builder("Proxy.CleanupMultipartUploadLatency")
+                  .setDescription("Latency of cleaning up temp folder and meta file from CompleteMultipartUpload")
+                  .setMetricType(MetricType.TIMER)
+                  .build();
+
+  public static final MetricKey PROXY_CLEANUP_TEMP_MULTIPART_UPLOAD_OBJ_LATENCY =
+          new Builder("Proxy.CleanupTempMultipartUploadObjectLatency")
+                  .setDescription("Latency of cleaning up temp target obj during CompleteMultipartUpload")
+                  .setMetricType(MetricType.TIMER)
+                  .build();
+
   // Metadata sync metrics
   public static final MetricKey MASTER_METADATA_SYNC_UFS_MOUNT =
       new Builder("Master.MetadataSyncUfsMount.")
@@ -2360,6 +2383,18 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+
+  public static final MetricKey CLOSE_UFS_OUTSTREAM_LATENCY =
+          new Builder("Client.CloseUFSOutStreamLatency")
+                  .setDescription("Latency of close UFS outstream latency")
+                  .setMetricType(MetricType.TIMER)
+                  .build();
+
+  public static final MetricKey CLOSE_ALLUXIO_OUTSTREAM_LATENCY =
+          new Builder("Client.CloseAlluxioOutStreamLatency")
+                  .setDescription("Latency of close Alluxio outstream latency")
+                  .setMetricType(MetricType.TIMER)
+                  .build();
 
   // Fuse operation timer and failure counter metrics are added dynamically.
   // Other Fuse related metrics are added here

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -668,19 +668,22 @@ public final class MetricKey implements Comparable<MetricKey> {
                   .build();
   public static final MetricKey PROXY_COMPLETE_MP_UPLOAD_MERGE_LATENCY =
           new Builder("Proxy.CompleteMPUploadMergeLatency")
-                  .setDescription("Latency of merging parts into one object in CompleteMultipartUpload")
+                  .setDescription("Latency of merging parts into one object"
+                          + "in CompleteMultipartUpload")
                   .setMetricType(MetricType.TIMER)
                   .build();
 
   public static final MetricKey PROXY_CLEANUP_MULTIPART_UPLOAD_LATENCY =
           new Builder("Proxy.CleanupMultipartUploadLatency")
-                  .setDescription("Latency of cleaning up temp folder and meta file from CompleteMultipartUpload")
+                  .setDescription("Latency of cleaning up temp folder and meta"
+                          + "file from CompleteMultipartUpload")
                   .setMetricType(MetricType.TIMER)
                   .build();
 
   public static final MetricKey PROXY_CLEANUP_TEMP_MULTIPART_UPLOAD_OBJ_LATENCY =
           new Builder("Proxy.CleanupTempMultipartUploadObjectLatency")
-                  .setDescription("Latency of cleaning up temp target obj during CompleteMultipartUpload")
+                  .setDescription("Latency of cleaning up temp target obj during"
+                          + "CompleteMultipartUpload")
                   .setMetricType(MetricType.TIMER)
                   .build();
 

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -26,6 +26,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.UniformReservoir;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.jvm.CachedThreadStatesGaugeSet;
 import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
@@ -624,6 +625,14 @@ public final class MetricsSystem {
    */
   public static Timer timer(String name) {
     return METRIC_REGISTRY.timer(getMetricName(name));
+  }
+
+  public static Timer uniformTimer(String name) {
+    return METRIC_REGISTRY.timer(getMetricName(name),
+            () -> {
+              Timer timer = new Timer(new UniformReservoir());
+              return timer;
+            });
   }
 
   /**

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -26,8 +26,8 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.UniformReservoir;
 import com.codahale.metrics.Timer;
+import com.codahale.metrics.UniformReservoir;
 import com.codahale.metrics.jvm.CachedThreadStatesGaugeSet;
 import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
@@ -627,6 +627,12 @@ public final class MetricsSystem {
     return METRIC_REGISTRY.timer(getMetricName(name));
   }
 
+  /**
+   * Same with {@link #timer} but with UnirformReservoir for sampling.
+   *
+   * @param name the name of the metric
+   * @return a timer object with the qualified metric name
+   */
   public static Timer uniformTimer(String name) {
     return METRIC_REGISTRY.timer(getMetricName(name),
             () -> {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2852,10 +2852,12 @@ public class DefaultFileSystemMaster extends CoreMaster
       boolean failOnExist = true;
       if (context.getOptions().hasS3SyntaxOptions()) {
         // For object overwrite
-        String mpUploadIdDst = new String(dstInodePath.getInodeFile().getXAttr()
-                .getOrDefault(PropertyKey.Name.S3_UPLOADS_ID_XATTR_KEY, new byte[0]));
-        String mpUploadIdSrc = new String(srcInodePath.getInodeFile().getXAttr()
-                .getOrDefault(PropertyKey.Name.S3_UPLOADS_ID_XATTR_KEY, new byte[0]));
+        String mpUploadIdDst = new String(dstInodePath.getInodeFile().getXAttr() != null ?
+                dstInodePath.getInodeFile().getXAttr().getOrDefault(PropertyKey.Name.S3_UPLOADS_ID_XATTR_KEY, new byte[0])
+                : new byte[0]);
+        String mpUploadIdSrc = new String(srcInodePath.getInodeFile().getXAttr() != null ?
+                srcInodePath.getInodeFile().getXAttr().getOrDefault(PropertyKey.Name.S3_UPLOADS_ID_XATTR_KEY, new byte[0])
+                : new byte[0]);
         if (StringUtils.isNotEmpty(mpUploadIdSrc) && StringUtils.isNotEmpty(mpUploadIdDst)
                 && StringUtils.equals(mpUploadIdSrc, mpUploadIdDst)) {
           LOG.info("Object with same upload exists, bail and claim success.");
@@ -2872,6 +2874,7 @@ public class DefaultFileSystemMaster extends CoreMaster
             deleteInternal(rpcContext, dstInodePath, DeleteContext
                     .mergeFrom(DeletePOptions.newBuilder()
                             .setRecursive(true).setAlluxioOnly(context.getPersist())), true);
+            dstInodePath.removeLastInode();
           } catch (DirectoryNotEmptyException ex) {
             // IGNORE, this will never happen
           }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -20,7 +20,13 @@ import alluxio.client.file.URIStatus;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
-import alluxio.grpc.*;
+import alluxio.grpc.Bits;
+import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.DeletePOptions;
+import alluxio.grpc.RenamePOptions;
+import alluxio.grpc.S3SyntaxOptions;
+import alluxio.grpc.XAttrPropagationStrategy;
+import alluxio.grpc.PMode;
 import alluxio.util.ThreadUtils;
 import alluxio.web.ProxyWebServer;
 
@@ -241,7 +247,8 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
           metaStatus = S3RestUtils.checkStatusesForUploadId(mMetaFs, mUserFs,
                   multipartTemporaryDir, mUploadId).get(1);
         } catch (Exception e) {
-          LOG.warn("checkStatusesForUploadId uploadId:{} failed", mUploadId, ThreadUtils.formatStackTrace(e));
+          LOG.warn("checkStatusesForUploadId uploadId:{} failed. {}", mUploadId,
+                  ThreadUtils.formatStackTrace(e));
           throw new S3Exception(objectPath, S3ErrorCode.NO_SUCH_UPLOAD);
         }
         // Parse the HTTP request body to get the intended list of parts

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -208,7 +208,6 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
     private final String mBody;
     private final boolean mMultipartCleanerEnabled = Configuration.getBoolean(
         PropertyKey.PROXY_S3_MULTIPART_UPLOAD_CLEANER_ENABLED);
-    private AlluxioURI mMultipartTemporaryDir;
 
     /**
      * Creates a new instance of {@link CompleteMultipartUploadTask}.
@@ -438,7 +437,7 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
     }
 
     /**
-     * On any exception, check with Master on if the there's a object file.
+     * On any exception, check with Master on if the there's an object file.
      * bearing the same upload id already got completed.
      * @param objectPath
      * @return the status of the existing object through CompleteMultipartUpload call
@@ -453,6 +452,8 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
         }
       } catch (IOException | AlluxioException ex) {
         // can't validate if any previous attempt has succeeded
+        LOG.warn("Check for objectPath:{} failed:{}, unsure if the complete status.",
+                objectPath, ex.getMessage());
         return null;
       }
       return null;

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -21,7 +21,6 @@ import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.grpc.*;
-import alluxio.master.file.meta.PersistenceState;
 import alluxio.util.ThreadUtils;
 import alluxio.web.ProxyWebServer;
 
@@ -320,7 +319,7 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
                       .setOwnerBits(Bits.ALL)
                       .setGroupBits(Bits.ALL)
                       .setOtherBits(Bits.NONE).build())
-              .putXattr(S3Constants.UPLOADS_ID_XATTR_KEY, ByteString.copyFrom(mUploadId, StandardCharsets.UTF_8))
+              .putXattr(PropertyKey.Name.S3_UPLOADS_ID_XATTR_KEY, ByteString.copyFrom(mUploadId, StandardCharsets.UTF_8))
               .setXattrPropStrat(XAttrPropagationStrategy.LEAF_NODE)
               .setWriteType(S3RestUtils.getS3WriteType());
       // Copy Tagging xAttr if it exists
@@ -397,7 +396,7 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
         try {
           mUserFs.delete(new AlluxioURI(objTempPath), DeletePOptions.newBuilder().build());
         } catch (Exception e) {
-          LOG.warn("Failed to clean up temp path:{}", objTempPath, e.getMessage());
+          LOG.warn("Failed to clean up temp path:{}, {}", objTempPath, e.getMessage());
         }
       }
     }
@@ -406,7 +405,7 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
       try {
         URIStatus objStatus = mUserFs.getStatus(new AlluxioURI(objectPath));
         String uploadId = new String(objStatus.getXAttr()
-                .getOrDefault(S3Constants.UPLOADS_ID_XATTR_KEY, new byte[0]));
+                .getOrDefault(PropertyKey.Name.S3_UPLOADS_ID_XATTR_KEY, new byte[0]));
         if (objStatus.isCompleted() && StringUtils.equals(uploadId, mUploadId)) {
           return objStatus;
         }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -250,12 +250,6 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
         // Check if the requested parts are available
         List<URIStatus> uploadedParts = validateParts(request, objectPath, multipartTemporaryDir);
 
-        // Only overwrite at final step to commit/complete the file (AKA rename)
-//        try {
-//          S3RestUtils.deleteExistObject(mUserFs, objectUri);
-//        } catch (IOException | AlluxioException e) {
-//          throw S3RestUtils.toObjectS3Exception(e, objectUri.getPath());
-//        }
         // (re)create the merged object to a temporary object path
         LOG.debug("CompleteMultipartUploadTask (bucket: {}, object: {}, uploadId: {}) "
             + "combining {} parts...", mBucket, mObject, mUploadId, uploadedParts.size());
@@ -292,7 +286,7 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
         achieve idempotency: when a race caused by retry(most cases), the commit of
         this object happens at time of rename op, check DefaultFileSystemMaster.rename for more info.
          * */
-        LOG.warn("[LUCYINFO] Exception during CompleteMultipartUpload:{}", ThreadUtils.formatStackTrace(e));
+        LOG.warn("Exception during CompleteMultipartUpload:{}", ThreadUtils.formatStackTrace(e));
         if (objectPath != null) {
           URIStatus objStatus = checkIfComplete(objectPath);
           if (objStatus != null) {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -250,12 +250,10 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
           metaStatus = S3RestUtils.checkStatusesForUploadId(mMetaFs, mUserFs,
                   multipartTemporaryDir, mUploadId).get(1);
         } catch (Exception e) {
-          LOG.warn("checkStatusesForUploadId uploadId:{} failed. {}", mUploadId,
+            LOG.warn("checkStatusesForUploadId uploadId:{} failed. {}", mUploadId,
                   ThreadUtils.formatStackTrace(e));
           throw new S3Exception(objectPath, S3ErrorCode.NO_SUCH_UPLOAD);
         }
-
-
 
         // Parse the HTTP request body to get the intended list of parts
         CompleteMultipartUploadRequest request = parseCompleteMultipartUploadRequest(objectPath);
@@ -274,7 +272,8 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
 
         try (DigestOutputStream digestOutputStream = new DigestOutputStream(os, md5);
              Timer.Context ctx = MetricsSystem
-                     .uniformTimer(MetricKey.PROXY_COMPLETE_MP_UPLOAD_MERGE_LATENCY.getName()).time()) {
+                     .uniformTimer(MetricKey.PROXY_COMPLETE_MP_UPLOAD_MERGE_LATENCY
+                             .getName()).time()) {
           for (URIStatus part : uploadedParts) {
             try (FileInStream is = mUserFs.openFile(new AlluxioURI(part.getPath()))) {
               ByteStreams.copy(is, digestOutputStream);
@@ -441,7 +440,8 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
     public void cleanupTempPath(String objTempPath) {
       if (objTempPath != null) {
         try (Timer.Context ctx = MetricsSystem
-                .uniformTimer(MetricKey.PROXY_CLEANUP_TEMP_MULTIPART_UPLOAD_OBJ_LATENCY.getName()).time()) {
+                .uniformTimer(MetricKey.PROXY_CLEANUP_TEMP_MULTIPART_UPLOAD_OBJ_LATENCY
+                        .getName()).time()) {
           mUserFs.delete(new AlluxioURI(objTempPath), DeletePOptions.newBuilder().build());
         } catch (Exception e) {
           LOG.warn("Failed to clean up temp path:{}, {}", objTempPath, e.getMessage());

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -250,7 +250,7 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
           metaStatus = S3RestUtils.checkStatusesForUploadId(mMetaFs, mUserFs,
                   multipartTemporaryDir, mUploadId).get(1);
         } catch (Exception e) {
-            LOG.warn("checkStatusesForUploadId uploadId:{} failed. {}", mUploadId,
+          LOG.warn("checkStatusesForUploadId uploadId:{} failed. {}", mUploadId,
                   ThreadUtils.formatStackTrace(e));
           throw new S3Exception(objectPath, S3ErrorCode.NO_SUCH_UPLOAD);
         }
@@ -288,7 +288,10 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
         AlluxioURI objectUri = new AlluxioURI(objectPath);
         mUserFs.rename(objectTempUri, objectUri, RenamePOptions.newBuilder()
                 .setPersist(WriteType.fromProto(createFileOption.getWriteType()).isThrough())
-                .setS3SyntaxOptions(S3SyntaxOptions.newBuilder().setOverwrite(true).build())
+                .setS3SyntaxOptions(S3SyntaxOptions.newBuilder()
+                        .setOverwrite(true)
+                        .setIsMultipartUpload(true)
+                        .build())
                 .build());
 
         // Remove the temporary directory containing the uploaded parts and the

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Constants.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Constants.java
@@ -62,7 +62,6 @@ public final class S3Constants {
   public static final String UPLOADS_BUCKET_XATTR_KEY = "s3_uploads_bucket";
   public static final String UPLOADS_OBJECT_XATTR_KEY = "s3_uploads_object";
   public static final String UPLOADS_FILE_ID_XATTR_KEY = "s3_uploads_file_id";
-  public static final String UPLOADS_ID_XATTR_KEY = "s3_uploads_mulitpartupload_id";
 
   /* Alluxio UFS metadata */
   public static final String S3_METADATA_ROOT_DIR = ".alluxio_s3_api_metadata";

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Constants.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Constants.java
@@ -62,6 +62,7 @@ public final class S3Constants {
   public static final String UPLOADS_BUCKET_XATTR_KEY = "s3_uploads_bucket";
   public static final String UPLOADS_OBJECT_XATTR_KEY = "s3_uploads_object";
   public static final String UPLOADS_FILE_ID_XATTR_KEY = "s3_uploads_file_id";
+  public static final String UPLOADS_ID_XATTR_KEY = "s3_uploads_mulitpartupload_id";
 
   /* Alluxio UFS metadata */
   public static final String S3_METADATA_ROOT_DIR = ".alluxio_s3_api_metadata";

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -432,10 +432,15 @@ message FileSystemCommand {
   optional FileSystemCommandOptions commandOptions = 2;
 }
 
+message S3SyntaxOptions {
+  optional bool overwrite = 1;
+}
+
 message RenamePResponse {}
 message RenamePOptions {
   optional FileSystemMasterCommonPOptions commonOptions = 1;
   optional bool persist = 2;
+  optional S3SyntaxOptions s3SyntaxOptions = 3;
 }
 message RenamePRequest {
   /** the source path of the file or directory */

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -434,6 +434,7 @@ message FileSystemCommand {
 
 message S3SyntaxOptions {
   optional bool overwrite = 1;
+  optional bool isMultipartUpload = 2;
 }
 
 message RenamePResponse {}

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -1500,6 +1500,12 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
   @Test
   public void duplicateMultipartUpload() throws Exception {
+    /*
+    1) Test for two mp uploads with diff upload id for creating same object,
+    one should overwrite the other
+    2) Test for CompleteMultipartUpload call should be idempotent, AKA
+    CompleteMultipartUpload made for the same uploadId should return the same result.
+     */
     final String bucketName = "bucket";
     createBucketRestCall(bucketName);
 
@@ -1542,6 +1548,8 @@ public final class S3ClientRestApiTest extends RestApiTest {
     partList1.add(new CompleteMultipartUploadRequest.Part("", 2));
     result1 = completeMultipartUploadRestCall(objectKey, uploadId1,
         new CompleteMultipartUploadRequest(partList1));
+    String result1Retry = completeMultipartUploadRestCall(objectKey, uploadId1,
+            new CompleteMultipartUploadRequest(partList1));
 
     // Verify that the response is expected.
     String expectedCombinedObject = object1 + object2;
@@ -1555,6 +1563,9 @@ public final class S3ClientRestApiTest extends RestApiTest {
         result1.trim());
     Assert.assertEquals(XML_MAPPER.readValue(result1, CompleteMultipartUploadResult.class),
         completeMultipartUploadResult1);
+
+    // Verify the response is idempotent for upload1
+    Assert.assertEquals(result1, result1Retry);
 
     // Verify that only the corresponding temporary directory is deleted.
     Assert.assertFalse(mFileSystem.exists(tmpDir1));
@@ -1571,6 +1582,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
     partList2.add(new CompleteMultipartUploadRequest.Part("", 1));
     result2 = completeMultipartUploadRestCall(objectKey, uploadId2,
         new CompleteMultipartUploadRequest(partList2));
+    String result2Retry = completeMultipartUploadRestCall(objectKey, uploadId2,
+            new CompleteMultipartUploadRequest(partList2));
+
+    // Verify the response is idempotent for upload2
+    Assert.assertEquals(result2, result2Retry);
 
     // Verify that the response is expected.
     digest = md5.digest(object3.getBytes());
@@ -1590,6 +1606,15 @@ public final class S3ClientRestApiTest extends RestApiTest {
       String newObject = IOUtils.toString(is);
       Assert.assertEquals(object3, newObject);
     }
+
+    // Now if CompleteMultipartUpload is called for upload1
+    // It should say NoSuchUpload
+    HttpURLConnection connection = completeMultipartUploadRestCallWithResponse(objectKey, uploadId1,
+            new CompleteMultipartUploadRequest(partList1));
+    Assert.assertEquals(404, connection.getResponseCode());
+    S3Error response =
+            new XmlMapper().readerFor(S3Error.class).readValue(connection.getErrorStream());
+    Assert.assertEquals(S3ErrorCode.Name.NO_SUCH_UPLOAD, response.getCode());
   }
 
   @Test
@@ -2096,16 +2121,28 @@ public final class S3ClientRestApiTest extends RestApiTest {
         options).runAndGetResponse();
   }
 
-  private String completeMultipartUploadRestCall(
-      String objectUri, String uploadId, CompleteMultipartUploadRequest request)
-      throws Exception {
+  private TestCase getCompleteMultipartUploadReadCallTestCase(
+          String objectUri, String uploadId, CompleteMultipartUploadRequest request) {
     Map<String, String> params = ImmutableMap.of("uploadId", uploadId);
     return new TestCase(mHostname, mPort, mBaseUri,
-        objectUri, params, HttpMethod.POST,
-        getDefaultOptionsWithAuth()
-            .setBody(request)
-            .setContentType(TestCaseOptions.XML_CONTENT_TYPE))
-        .runAndGetResponse();
+            objectUri, params, HttpMethod.POST,
+            getDefaultOptionsWithAuth()
+                    .setBody(request)
+                    .setContentType(TestCaseOptions.XML_CONTENT_TYPE));
+  }
+
+  private String completeMultipartUploadRestCall(
+          String objectUri, String uploadId, CompleteMultipartUploadRequest request)
+          throws Exception {
+    TestCase testCase = getCompleteMultipartUploadReadCallTestCase(objectUri, uploadId, request);
+    return testCase.runAndGetResponse();
+  }
+
+  private HttpURLConnection completeMultipartUploadRestCallWithResponse(
+          String objectUri, String uploadId, CompleteMultipartUploadRequest request)
+          throws Exception {
+    TestCase testCase = getCompleteMultipartUploadReadCallTestCase(objectUri, uploadId, request);
+    return testCase.execute();
   }
 
   private HttpURLConnection abortMultipartUploadRestCall(String objectUri, String uploadId)


### PR DESCRIPTION
### What changes are proposed in this pull request?

Make CompleteMultipartUpload call idempotent
Support Overwrite now only for createobject from s3client thru multipart upload 

### Why are the changes needed?

When use  Spark + hadoop s3a to write to Alluxio, spark will retry if CompleteMultipartUpload took too long, since alluxio doesnt allow overwrite, s3 proxy does a delete and create in an non-atomic way which causes race condition, rendering the retry fail, and as a result failing the entire spark write.

### Does this PR introduce any user facing changes?
1) New timer (with uniformTimer call)using UniformReservoir is introduced in the MetricsSystem
2) the uniformTimer is added to measure different parts of CompleteMultipartUpload call, as well as common places such as UFS and AlluxioOutstream close call.
