### PR TITLE
Make client send version to server and audit log contain version

### DIFF
--- a/core/common/src/main/java/alluxio/RuntimeConstants.java
+++ b/core/common/src/main/java/alluxio/RuntimeConstants.java
@@ -36,7 +36,7 @@ public final class RuntimeConstants {
     }
   }
 
-  public static final String SHORT_REVISION = ProjectConstants.REVISION.substring(0, 8);
+  public static final String REVISION_SHORT = ProjectConstants.REVISION.substring(0, 8);
 
   /** The relative path to the Alluxio target jar. */
   public static final String ALLUXIO_JAR = "target/alluxio-" + VERSION

--- a/core/common/src/main/java/alluxio/RuntimeConstants.java
+++ b/core/common/src/main/java/alluxio/RuntimeConstants.java
@@ -36,6 +36,8 @@ public final class RuntimeConstants {
     }
   }
 
+  public static final String SHORT_REVISION = ProjectConstants.REVISION.substring(0, 8);
+
   /** The relative path to the Alluxio target jar. */
   public static final String ALLUXIO_JAR = "target/alluxio-" + VERSION
       + "-jar-with-dependencies.jar";

--- a/core/common/src/main/java/alluxio/RuntimeConstants.java
+++ b/core/common/src/main/java/alluxio/RuntimeConstants.java
@@ -37,6 +37,8 @@ public final class RuntimeConstants {
   }
 
   public static final String REVISION_SHORT = ProjectConstants.REVISION.substring(0, 8);
+  public static final String VERSION_AND_REVISION_SHORT =
+      VERSION + "-" + REVISION_SHORT;
 
   /** The relative path to the Alluxio target jar. */
   public static final String ALLUXIO_JAR = "target/alluxio-" + VERSION

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5826,7 +5826,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
 
   public static final PropertyKey USER_CLIENT_REPORT_VERSION_ENABLED =
       booleanBuilder(Name.USER_CLIENT_REPORT_VERSION_ENABLED)
-          .setDefaultValue(true)
+          .setDefaultValue(false)
           .setDescription("Whether the client reports version information to the server.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5823,6 +5823,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+
+  public static final PropertyKey USER_CLIENT_REPORT_VERSION =
+      booleanBuilder(Name.USER_CLIENT_REPORT_VERSION)
+          .setDefaultValue(true)
+          .setDescription("Whether the client reports version information to the server.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
+
   public static final PropertyKey USER_FILE_WRITE_TYPE_DEFAULT =
       enumBuilder(Name.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.class)
           .setDefaultValue(WriteType.ASYNC_THROUGH)
@@ -8322,6 +8331,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.client.cache.timeout.duration";
     public static final String USER_CLIENT_CACHE_TIMEOUT_THREADS =
         "alluxio.user.client.cache.timeout.threads";
+    public static final String USER_CLIENT_REPORT_VERSION =
+        "alluxio.user.client.report.version";
     public static final String USER_CONF_CLUSTER_DEFAULT_ENABLED =
         "alluxio.user.conf.cluster.default.enabled";
     public static final String USER_CONF_SYNC_INTERVAL = "alluxio.user.conf.sync.interval";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5824,8 +5824,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.CLIENT)
           .build();
 
-  public static final PropertyKey USER_CLIENT_REPORT_VERSION =
-      booleanBuilder(Name.USER_CLIENT_REPORT_VERSION)
+  public static final PropertyKey USER_CLIENT_REPORT_VERSION_ENABLED =
+      booleanBuilder(Name.USER_CLIENT_REPORT_VERSION_ENABLED)
           .setDefaultValue(true)
           .setDescription("Whether the client reports version information to the server.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
@@ -8331,8 +8331,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.client.cache.timeout.duration";
     public static final String USER_CLIENT_CACHE_TIMEOUT_THREADS =
         "alluxio.user.client.cache.timeout.threads";
-    public static final String USER_CLIENT_REPORT_VERSION =
-        "alluxio.user.client.report.version";
+    public static final String USER_CLIENT_REPORT_VERSION_ENABLED =
+        "alluxio.user.client.report.version.enabled";
     public static final String USER_CONF_CLUSTER_DEFAULT_ENABLED =
         "alluxio.user.conf.cluster.default.enabled";
     public static final String USER_CONF_SYNC_INTERVAL = "alluxio.user.conf.sync.interval";

--- a/core/common/src/main/java/alluxio/grpc/ClientVersionClientInjector.java
+++ b/core/common/src/main/java/alluxio/grpc/ClientVersionClientInjector.java
@@ -41,7 +41,7 @@ public class ClientVersionClientInjector implements ClientInterceptor {
       public void start(Listener<RespT> responseListener, Metadata headers) {
         // Put version to headers.
         headers.put(S_CLIENT_VERSION_KEY, ProjectConstants.VERSION);
-        headers.put(S_CLIENT_REVISION_KEY, RuntimeConstants.SHORT_REVISION);
+        headers.put(S_CLIENT_REVISION_KEY, RuntimeConstants.REVISION_SHORT);
         super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(
             responseListener) {
           @Override

--- a/core/common/src/main/java/alluxio/grpc/ClientVersionClientInjector.java
+++ b/core/common/src/main/java/alluxio/grpc/ClientVersionClientInjector.java
@@ -11,7 +11,6 @@
 
 package alluxio.grpc;
 
-import alluxio.ProjectConstants;
 import alluxio.RuntimeConstants;
 
 import io.grpc.CallOptions;
@@ -29,8 +28,6 @@ import io.grpc.MethodDescriptor;
 public class ClientVersionClientInjector implements ClientInterceptor {
   public static final Metadata.Key<String> S_CLIENT_VERSION_KEY =
       Metadata.Key.of("alluxio-version", Metadata.ASCII_STRING_MARSHALLER);
-  public static final Metadata.Key<String> S_CLIENT_REVISION_KEY =
-      Metadata.Key.of("alluxio-revision", Metadata.ASCII_STRING_MARSHALLER);
 
   @Override
   public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
@@ -40,8 +37,7 @@ public class ClientVersionClientInjector implements ClientInterceptor {
       @Override
       public void start(Listener<RespT> responseListener, Metadata headers) {
         // Put version to headers.
-        headers.put(S_CLIENT_VERSION_KEY, ProjectConstants.VERSION);
-        headers.put(S_CLIENT_REVISION_KEY, RuntimeConstants.REVISION_SHORT);
+        headers.put(S_CLIENT_VERSION_KEY, RuntimeConstants.VERSION_AND_REVISION_SHORT);
         super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(
             responseListener) {
           @Override

--- a/core/common/src/main/java/alluxio/grpc/ClientVersionClientInjector.java
+++ b/core/common/src/main/java/alluxio/grpc/ClientVersionClientInjector.java
@@ -12,6 +12,7 @@
 package alluxio.grpc;
 
 import alluxio.ProjectConstants;
+import alluxio.RuntimeConstants;
 
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -27,17 +28,9 @@ import io.grpc.MethodDescriptor;
  */
 public class ClientVersionClientInjector implements ClientInterceptor {
   public static final Metadata.Key<String> S_CLIENT_VERSION_KEY =
-      Metadata.Key.of("alluxio-version", new Metadata.AsciiMarshaller<String>() {
-        @Override
-        public String toAsciiString(String value) {
-          return value;
-        }
-
-        @Override
-        public String parseAsciiString(String serialized) {
-          return serialized;
-        }
-      });
+      Metadata.Key.of("alluxio-version", Metadata.ASCII_STRING_MARSHALLER);
+  public static final Metadata.Key<String> S_CLIENT_REVISION_KEY =
+      Metadata.Key.of("alluxio-revision", Metadata.ASCII_STRING_MARSHALLER);
 
   @Override
   public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
@@ -48,6 +41,7 @@ public class ClientVersionClientInjector implements ClientInterceptor {
       public void start(Listener<RespT> responseListener, Metadata headers) {
         // Put version to headers.
         headers.put(S_CLIENT_VERSION_KEY, ProjectConstants.VERSION);
+        headers.put(S_CLIENT_REVISION_KEY, RuntimeConstants.SHORT_REVISION);
         super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(
             responseListener) {
           @Override

--- a/core/common/src/main/java/alluxio/grpc/ClientVersionClientInjector.java
+++ b/core/common/src/main/java/alluxio/grpc/ClientVersionClientInjector.java
@@ -1,0 +1,61 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.grpc;
+
+import alluxio.ProjectConstants;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+
+/**
+ * Client side interceptor that is used to set the request header for the client version.
+ */
+public class ClientVersionClientInjector implements ClientInterceptor {
+  public static final Metadata.Key<String> S_CLIENT_VERSION_KEY =
+      Metadata.Key.of("alluxio-version", new Metadata.AsciiMarshaller<String>() {
+        @Override
+        public String toAsciiString(String value) {
+          return value;
+        }
+
+        @Override
+        public String parseAsciiString(String serialized) {
+          return serialized;
+        }
+      });
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+      CallOptions callOptions, Channel next) {
+    return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+        next.newCall(method, callOptions)) {
+      @Override
+      public void start(Listener<RespT> responseListener, Metadata headers) {
+        // Put version to headers.
+        headers.put(S_CLIENT_VERSION_KEY, ProjectConstants.VERSION);
+        super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(
+            responseListener) {
+          @Override
+          public void onHeaders(Metadata headers) {
+            super.onHeaders(headers);
+          }
+        }, headers);
+      }
+    };
+  }
+}

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -104,7 +104,9 @@ public final class GrpcChannelBuilder {
       }
       throw AlluxioStatusException.fromThrowable(t);
     }
-    channel.intercept(new ClientVersionClientInjector());
+    if (mConfiguration.getBoolean(PropertyKey.USER_CLIENT_REPORT_VERSION)) {
+      channel.intercept(new ClientVersionClientInjector());
+    }
     return channel;
   }
 }

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -104,7 +104,7 @@ public final class GrpcChannelBuilder {
       }
       throw AlluxioStatusException.fromThrowable(t);
     }
-    if (mConfiguration.getBoolean(PropertyKey.USER_CLIENT_REPORT_VERSION)) {
+    if (mConfiguration.getBoolean(PropertyKey.USER_CLIENT_REPORT_VERSION_ENABLED)) {
       channel.intercept(new ClientVersionClientInjector());
     }
     return channel;

--- a/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcChannelBuilder.java
@@ -104,6 +104,7 @@ public final class GrpcChannelBuilder {
       }
       throw AlluxioStatusException.fromThrowable(t);
     }
+    channel.intercept(new ClientVersionClientInjector());
     return channel;
   }
 }

--- a/core/common/src/main/java/alluxio/security/authentication/ClientContextServerInjector.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ClientContextServerInjector.java
@@ -11,6 +11,8 @@
 
 package alluxio.security.authentication;
 
+import alluxio.grpc.ClientVersionClientInjector;
+
 import io.grpc.ForwardingServerCallListener;
 import io.grpc.Grpc;
 import io.grpc.Metadata;
@@ -18,32 +20,48 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 
+import javax.annotation.Nullable;
+
 /**
  * Server side interceptor that is used to put remote client's IP Address to thread local storage.
  */
-public class ClientIpAddressInjector implements ServerInterceptor {
+public class ClientContextServerInjector implements ServerInterceptor {
 
   /**
    * A {@link ThreadLocal} variable to maintain the client's IP address along with a specific
    * thread.
    */
-  private static ThreadLocal<String> sIpAddressThreadLocal = new ThreadLocal<>();
-
+  private static final ThreadLocal<String> IP_ADDRESS_THREAD_LOCAL = new ThreadLocal<>();
+  /**
+   * A {@link ThreadLocal} variable to maintain the client's version along with a specific
+   * thread.
+   */
+  private static final ThreadLocal<String> CLIENT_VERSION_THREAD_LOCAL =
+      new ThreadLocal<>();
   /**
    * @return IP address of the gRPC client that is making the call
    */
+  @Nullable
   public static String getIpAddress() {
-    return sIpAddressThreadLocal.get();
+    return IP_ADDRESS_THREAD_LOCAL.get();
   }
 
+  /**
+   * @return the client version
+   */
+  @Nullable
+  public static String getClientVersion() {
+    return CLIENT_VERSION_THREAD_LOCAL.get();
+  }
   @Override
   public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
       Metadata headers, ServerCallHandler<ReqT, RespT> next) {
     /**
-     * For streaming calls, below will make sure remote IP address is injected prior to creating the
-     * stream.
+     * For streaming calls, below will make sure remote IP address and client version are
+     * injected prior to creating the stream.
      */
     setRemoteIpAddress(call);
+    setClientVersion(headers);
 
     /**
      * For non-streaming calls to server, below listener will be invoked in the same thread that is
@@ -54,6 +72,7 @@ public class ClientIpAddressInjector implements ServerInterceptor {
       @Override
       public void onHalfClose() {
         setRemoteIpAddress(call);
+        setClientVersion(headers);
         super.onHalfClose();
       }
     };
@@ -61,6 +80,11 @@ public class ClientIpAddressInjector implements ServerInterceptor {
 
   private <ReqT, RespT> void setRemoteIpAddress(ServerCall<ReqT, RespT> call) {
     String remoteIpAddress = call.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR).toString();
-    sIpAddressThreadLocal.set(remoteIpAddress);
+    IP_ADDRESS_THREAD_LOCAL.set(remoteIpAddress);
+  }
+
+  private void setClientVersion(Metadata headers) {
+    String version = headers.get(ClientVersionClientInjector.S_CLIENT_VERSION_KEY);
+    CLIENT_VERSION_THREAD_LOCAL.set(version);
   }
 }

--- a/core/common/src/main/java/alluxio/security/authentication/ClientContextServerInjector.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ClientContextServerInjector.java
@@ -38,12 +38,6 @@ public class ClientContextServerInjector implements ServerInterceptor {
    */
   private static final ThreadLocal<String> CLIENT_VERSION_THREAD_LOCAL =
       new ThreadLocal<>();
-  /**
-   * A {@link ThreadLocal} variable to maintain the client's revision along with a specific
-   * thread.
-   */
-  private static final ThreadLocal<String> CLIENT_REVISION_THREAD_LOCAL =
-      new ThreadLocal<>();
 
   /**
    * @return IP address of the gRPC client that is making the call
@@ -59,14 +53,6 @@ public class ClientContextServerInjector implements ServerInterceptor {
   @Nullable
   public static String getClientVersion() {
     return CLIENT_VERSION_THREAD_LOCAL.get();
-  }
-
-  /**
-   * @return the client revision
-   */
-  @Nullable
-  public static String getClientRevision() {
-    return CLIENT_REVISION_THREAD_LOCAL.get();
   }
 
   @Override
@@ -102,7 +88,5 @@ public class ClientContextServerInjector implements ServerInterceptor {
   private void setClientVersion(Metadata headers) {
     String version = headers.get(ClientVersionClientInjector.S_CLIENT_VERSION_KEY);
     CLIENT_VERSION_THREAD_LOCAL.set(version);
-    String revision = headers.get(ClientVersionClientInjector.S_CLIENT_REVISION_KEY);
-    CLIENT_REVISION_THREAD_LOCAL.set(revision);
   }
 }

--- a/core/common/src/main/java/alluxio/security/authentication/ClientContextServerInjector.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ClientContextServerInjector.java
@@ -38,6 +38,12 @@ public class ClientContextServerInjector implements ServerInterceptor {
    */
   private static final ThreadLocal<String> CLIENT_VERSION_THREAD_LOCAL =
       new ThreadLocal<>();
+  /**
+   * A {@link ThreadLocal} variable to maintain the client's revision along with a specific
+   * thread.
+   */
+  private static final ThreadLocal<String> CLIENT_REVISION_THREAD_LOCAL =
+      new ThreadLocal<>();
 
   /**
    * @return IP address of the gRPC client that is making the call
@@ -53,6 +59,14 @@ public class ClientContextServerInjector implements ServerInterceptor {
   @Nullable
   public static String getClientVersion() {
     return CLIENT_VERSION_THREAD_LOCAL.get();
+  }
+
+  /**
+   * @return the client revision
+   */
+  @Nullable
+  public static String getClientRevision() {
+    return CLIENT_REVISION_THREAD_LOCAL.get();
   }
 
   @Override
@@ -88,5 +102,7 @@ public class ClientContextServerInjector implements ServerInterceptor {
   private void setClientVersion(Metadata headers) {
     String version = headers.get(ClientVersionClientInjector.S_CLIENT_VERSION_KEY);
     CLIENT_VERSION_THREAD_LOCAL.set(version);
+    String revision = headers.get(ClientVersionClientInjector.S_CLIENT_REVISION_KEY);
+    CLIENT_REVISION_THREAD_LOCAL.set(revision);
   }
 }

--- a/core/common/src/main/java/alluxio/security/authentication/ClientContextServerInjector.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ClientContextServerInjector.java
@@ -38,6 +38,7 @@ public class ClientContextServerInjector implements ServerInterceptor {
    */
   private static final ThreadLocal<String> CLIENT_VERSION_THREAD_LOCAL =
       new ThreadLocal<>();
+
   /**
    * @return IP address of the gRPC client that is making the call
    */
@@ -53,6 +54,7 @@ public class ClientContextServerInjector implements ServerInterceptor {
   public static String getClientVersion() {
     return CLIENT_VERSION_THREAD_LOCAL.get();
   }
+
   @Override
   public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
       Metadata headers, ServerCallHandler<ReqT, RespT> next) {

--- a/core/server/common/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/common/src/main/java/alluxio/RpcUtils.java
@@ -21,7 +21,7 @@ import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.security.User;
 import alluxio.security.authentication.AuthenticatedClientUser;
-import alluxio.security.authentication.ClientIpAddressInjector;
+import alluxio.security.authentication.ClientContextServerInjector;
 
 import com.codahale.metrics.Timer;
 import io.grpc.StatusException;
@@ -122,7 +122,10 @@ public final class RpcUtils {
         MetricsSystem.timer(MetricKey.MASTER_TOTAL_RPCS.getName()),
         MetricsSystem.timer(getQualifiedMetricName(methodName)))) {
       MetricsSystem.counter(getQualifiedInProgressMetricName(methodName)).inc();
-      logger.debug("Enter: {} from {}: {}", methodName, ClientIpAddressInjector.getIpAddress(),
+      logger.debug("Enter: {} from {}: {} client version: {}, revision: {}", methodName,
+          ClientContextServerInjector.getIpAddress(),
+          ClientContextServerInjector.getClientVersion(),
+          ClientContextServerInjector.getClientRevision(),
           debugDesc);
       T res = callable.call();
       logger.debug("Exit: {}: {}", methodName, debugDesc);

--- a/core/server/common/src/main/java/alluxio/RpcUtils.java
+++ b/core/server/common/src/main/java/alluxio/RpcUtils.java
@@ -122,10 +122,9 @@ public final class RpcUtils {
         MetricsSystem.timer(MetricKey.MASTER_TOTAL_RPCS.getName()),
         MetricsSystem.timer(getQualifiedMetricName(methodName)))) {
       MetricsSystem.counter(getQualifiedInProgressMetricName(methodName)).inc();
-      logger.debug("Enter: {} from {}: {} client version: {}, revision: {}", methodName,
+      logger.debug("Enter: {} from {}: {} client version: {}", methodName,
           ClientContextServerInjector.getIpAddress(),
           ClientContextServerInjector.getClientVersion(),
-          ClientContextServerInjector.getClientRevision(),
           debugDesc);
       T res = callable.call();
       logger.debug("Exit: {}: {}", methodName, debugDesc);

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
@@ -35,7 +35,7 @@ import alluxio.master.MasterClientContext;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.resource.LockResource;
-import alluxio.security.authentication.ClientIpAddressInjector;
+import alluxio.security.authentication.ClientContextServerInjector;
 import alluxio.util.FormatUtils;
 import alluxio.util.LogUtils;
 import alluxio.util.logging.SamplingLogger;
@@ -293,7 +293,7 @@ public class SnapshotReplicationManager {
    */
   public StreamObserver<UploadSnapshotPRequest> receiveSnapshotFromFollower(
       StreamObserver<UploadSnapshotPResponse> responseStreamObserver) {
-    String followerIp = ClientIpAddressInjector.getIpAddress();
+    String followerIp = ClientContextServerInjector.getIpAddress();
     LOG.info("Received upload snapshot request from follower {}", followerIp);
 
     SnapshotDownloader<UploadSnapshotPResponse, UploadSnapshotPRequest> observer =
@@ -389,7 +389,7 @@ public class SnapshotReplicationManager {
   public StreamObserver<DownloadSnapshotPRequest> sendSnapshotToFollower(
       StreamObserver<DownloadSnapshotPResponse> responseObserver) {
     SnapshotInfo snapshot = mStorage.getLatestSnapshot();
-    LOG.debug("Received snapshot download request from {}", ClientIpAddressInjector.getIpAddress());
+    LOG.debug("Received snapshot download request from {}", ClientContextServerInjector.getIpAddress());
     SnapshotUploader<DownloadSnapshotPResponse, DownloadSnapshotPRequest> requestStreamObserver =
         SnapshotUploader.forLeader(mStorage, snapshot, responseObserver);
     if (snapshot == null) {

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
@@ -389,7 +389,8 @@ public class SnapshotReplicationManager {
   public StreamObserver<DownloadSnapshotPRequest> sendSnapshotToFollower(
       StreamObserver<DownloadSnapshotPResponse> responseObserver) {
     SnapshotInfo snapshot = mStorage.getLatestSnapshot();
-    LOG.debug("Received snapshot download request from {}", ClientContextServerInjector.getIpAddress());
+    LOG.debug("Received snapshot download request from {}",
+        ClientContextServerInjector.getIpAddress());
     SnapshotUploader<DownloadSnapshotPResponse, DownloadSnapshotPRequest> requestStreamObserver =
         SnapshotUploader.forLeader(mStorage, snapshot, responseObserver);
     if (snapshot == null) {

--- a/core/server/common/src/main/java/alluxio/master/transport/GrpcMessagingServer.java
+++ b/core/server/common/src/main/java/alluxio/master/transport/GrpcMessagingServer.java
@@ -16,7 +16,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.grpc.GrpcServerAddress;
 import alluxio.grpc.GrpcServerBuilder;
 import alluxio.grpc.GrpcService;
-import alluxio.security.authentication.ClientIpAddressInjector;
+import alluxio.security.authentication.ClientContextServerInjector;
 import alluxio.security.user.UserState;
 
 import io.grpc.ServerInterceptors;
@@ -105,7 +105,7 @@ public class GrpcMessagingServer {
           .addService(new GrpcService(ServerInterceptors.intercept(
               new GrpcMessagingServiceClientHandler(address, listener::accept, threadContext,
                   mExecutor, mConf.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT)),
-              new ClientIpAddressInjector())))
+              new ClientContextServerInjector())))
           .build();
 
       try {

--- a/core/server/common/src/main/java/alluxio/master/transport/GrpcMessagingServiceClientHandler.java
+++ b/core/server/common/src/main/java/alluxio/master/transport/GrpcMessagingServiceClientHandler.java
@@ -13,7 +13,7 @@ package alluxio.master.transport;
 
 import alluxio.grpc.MessagingServiceGrpc;
 import alluxio.grpc.TransportMessage;
-import alluxio.security.authentication.ClientIpAddressInjector;
+import alluxio.security.authentication.ClientContextServerInjector;
 
 import com.google.common.base.MoreObjects;
 import io.grpc.stub.StreamObserver;
@@ -74,7 +74,7 @@ public class GrpcMessagingServiceClientHandler
     // Transport level identifier for this connection.
     String transportId = MoreObjects.toStringHelper(this)
         .add("ServerAddress", mServerAddress)
-        .add("ClientAddress", ClientIpAddressInjector.getIpAddress())
+        .add("ClientAddress", ClientContextServerInjector.getIpAddress())
         .toString();
     LOG.debug("Creating a messaging server connection: {}", transportId);
 

--- a/core/server/master/src/main/java/alluxio/master/backup/BackupLeaderRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupLeaderRole.java
@@ -30,7 +30,7 @@ import alluxio.master.StateLockOptions;
 import alluxio.master.transport.GrpcMessagingConnection;
 import alluxio.master.transport.GrpcMessagingServiceClientHandler;
 import alluxio.resource.LockResource;
-import alluxio.security.authentication.ClientIpAddressInjector;
+import alluxio.security.authentication.ClientContextServerInjector;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.network.NetworkAddressUtils;
 import alluxio.wire.BackupStatus;
@@ -144,7 +144,7 @@ public class BackupLeaderRole extends AbstractBackupRole {
                             Configuration.global()),
                         (conn) -> activateWorkerConnection(conn), mGrpcMessagingContext,
                         mExecutorService, mCatalystRequestTimeout),
-                    new ClientIpAddressInjector())).withCloseable(this));
+                    new ClientContextServerInjector())).withCloseable(this));
     return services;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -63,7 +63,7 @@ import alluxio.proto.meta.Block.BlockLocation;
 import alluxio.proto.meta.Block.BlockMeta;
 import alluxio.resource.CloseableIterator;
 import alluxio.resource.LockResource;
-import alluxio.security.authentication.ClientIpAddressInjector;
+import alluxio.security.authentication.ClientContextServerInjector;
 import alluxio.util.CommonUtils;
 import alluxio.util.IdUtils;
 import alluxio.util.ThreadFactoryUtils;
@@ -341,11 +341,11 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     services.put(ServiceType.BLOCK_MASTER_CLIENT_SERVICE,
         new GrpcService(ServerInterceptors
             .intercept(new BlockMasterClientServiceHandler(this),
-                new ClientIpAddressInjector())));
+                new ClientContextServerInjector())));
     services.put(ServiceType.BLOCK_MASTER_WORKER_SERVICE,
         new GrpcService(ServerInterceptors
             .intercept(new BlockMasterWorkerServiceHandler(this),
-                new ClientIpAddressInjector())));
+                new ClientContextServerInjector())));
     return services;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -5225,7 +5225,6 @@ public class DefaultFileSystemMaster extends CoreMaster
           .setAuthType(authType)
           .setIp(ClientContextServerInjector.getIpAddress())
           .setClientVersion(ClientContextServerInjector.getClientVersion())
-          .setClientRevision(ClientContextServerInjector.getClientRevision())
           .setCommand(command).setSrcPath(srcPath).setDstPath(dstPath)
           .setSrcInode(srcInode).setAllowed(true)
           .setCreationTimeNs(System.nanoTime());

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -5225,6 +5225,7 @@ public class DefaultFileSystemMaster extends CoreMaster
           .setAuthType(authType)
           .setIp(ClientContextServerInjector.getIpAddress())
           .setClientVersion(ClientContextServerInjector.getClientVersion())
+          .setClientRevision(ClientContextServerInjector.getClientRevision())
           .setCommand(command).setSrcPath(srcPath).setDstPath(dstPath)
           .setSrcInode(srcInode).setAllowed(true)
           .setCreationTimeNs(System.nanoTime());

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -144,7 +144,7 @@ import alluxio.retry.CountingRetry;
 import alluxio.retry.RetryPolicy;
 import alluxio.security.authentication.AuthType;
 import alluxio.security.authentication.AuthenticatedClientUser;
-import alluxio.security.authentication.ClientIpAddressInjector;
+import alluxio.security.authentication.ClientContextServerInjector;
 import alluxio.security.authorization.AclEntry;
 import alluxio.security.authorization.AclEntryType;
 import alluxio.security.authorization.Mode;
@@ -562,13 +562,13 @@ public class DefaultFileSystemMaster extends CoreMaster
     Map<ServiceType, GrpcService> services = new HashMap<>();
     services.put(ServiceType.FILE_SYSTEM_MASTER_CLIENT_SERVICE, new GrpcService(ServerInterceptors
         .intercept(new FileSystemMasterClientServiceHandler(this),
-            new ClientIpAddressInjector())));
+            new ClientContextServerInjector())));
     services.put(ServiceType.FILE_SYSTEM_MASTER_JOB_SERVICE, new GrpcService(ServerInterceptors
         .intercept(new FileSystemMasterJobServiceHandler(this),
-            new ClientIpAddressInjector())));
+            new ClientContextServerInjector())));
     services.put(ServiceType.FILE_SYSTEM_MASTER_WORKER_SERVICE, new GrpcService(ServerInterceptors
         .intercept(new FileSystemMasterWorkerServiceHandler(this),
-            new ClientIpAddressInjector())));
+            new ClientContextServerInjector())));
     return services;
   }
 
@@ -5223,7 +5223,8 @@ public class DefaultFileSystemMaster extends CoreMaster
           Configuration.getEnum(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.class);
       auditContext.setUgi(ugi)
           .setAuthType(authType)
-          .setIp(ClientIpAddressInjector.getIpAddress())
+          .setIp(ClientContextServerInjector.getIpAddress())
+          .setClientVersion(ClientContextServerInjector.getClientVersion())
           .setCommand(command).setSrcPath(srcPath).setDstPath(dstPath)
           .setSrcInode(srcInode).setAllowed(true)
           .setCreationTimeNs(System.nanoTime());

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterAuditContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterAuditContext.java
@@ -203,7 +203,7 @@ public final class FileSystemMasterAuditContext implements AuditContext {
           mSucceeded, mAllowed, mUgi, mAuthType, mIp, mCommand, mSrcPath, mDstPath,
           mExecutionTimeNs / 1000);
     }
-    if (Configuration.global().getBoolean(PropertyKey.USER_CLIENT_REPORT_VERSION)) {
+    if (Configuration.global().getBoolean(PropertyKey.USER_CLIENT_REPORT_VERSION_ENABLED)) {
       auditLog.append(
           String.format("\tclientVersion=%s\tclientRevision=%s", mClientVersion, mClientRevision));
     }

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterAuditContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterAuditContext.java
@@ -40,7 +40,6 @@ public final class FileSystemMasterAuditContext implements AuditContext {
   private long mCreationTimeNs;
   private long mExecutionTimeNs;
   private String mClientVersion;
-  private String mClientRevision;
 
   @Override
   public FileSystemMasterAuditContext setAllowed(boolean allowed) {
@@ -155,17 +154,6 @@ public final class FileSystemMasterAuditContext implements AuditContext {
   }
 
   /**
-   * set client revision.
-   *
-   * @param revision client revision
-   * @return this {@link AuditContext} instance
-   */
-  public FileSystemMasterAuditContext setClientRevision(String revision) {
-    mClientRevision = revision;
-    return this;
-  }
-
-  /**
    * Constructor of {@link FileSystemMasterAuditContext}.
    *
    * @param asyncAuditLogWriter async audit log writer
@@ -197,15 +185,15 @@ public final class FileSystemMasterAuditContext implements AuditContext {
           Mode.extractOwnerBits(mode), Mode.extractGroupBits(mode), Mode.extractOtherBits(mode),
           mExecutionTimeNs / 1000));
     } else {
-      return String.format(
+      auditLog.append(String.format(
           "succeeded=%b\tallowed=%b\tugi=%s (AUTH=%s)\tip=%s\tcmd=%s\tsrc=%s\tdst=%s\t"
               + "perm=null\texecutionTimeUs=%d",
           mSucceeded, mAllowed, mUgi, mAuthType, mIp, mCommand, mSrcPath, mDstPath,
-          mExecutionTimeNs / 1000);
+          mExecutionTimeNs / 1000));
     }
     if (Configuration.global().getBoolean(PropertyKey.USER_CLIENT_REPORT_VERSION_ENABLED)) {
       auditLog.append(
-          String.format("\tclientVersion=%s\tclientRevision=%s", mClientVersion, mClientRevision));
+          String.format("\tclientVersion=%s\t", mClientVersion));
     }
     auditLog.append("\tproto=rpc");
     return auditLog.toString();

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterAuditContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterAuditContext.java
@@ -37,6 +37,7 @@ public final class FileSystemMasterAuditContext implements AuditContext {
   private Inode mSrcInode;
   private long mCreationTimeNs;
   private long mExecutionTimeNs;
+  private String mClientVersion;
 
   @Override
   public FileSystemMasterAuditContext setAllowed(boolean allowed) {
@@ -140,6 +141,16 @@ public final class FileSystemMasterAuditContext implements AuditContext {
   }
 
   /**
+   * set client version.
+   * @param version client version
+   * @return this {@link AuditContext} instance
+   */
+  public FileSystemMasterAuditContext setClientVersion(String version) {
+    mClientVersion = version;
+    return this;
+  }
+
+  /**
    * Constructor of {@link FileSystemMasterAuditContext}.
    *
    * @param asyncAuditLogWriter async audit log writer
@@ -164,17 +175,17 @@ public final class FileSystemMasterAuditContext implements AuditContext {
       short mode = mSrcInode.getMode();
       return String.format(
           "succeeded=%b\tallowed=%b\tugi=%s (AUTH=%s)\tip=%s\tcmd=%s\tsrc=%s\tdst=%s\t"
-              + "perm=%s:%s:%s%s%s\texecutionTimeUs=%d",
+              + "perm=%s:%s:%s%s%s\texecutionTimeUs=%d\tclientVersion=%s\tproto=rpc",
           mSucceeded, mAllowed, mUgi, mAuthType, mIp, mCommand, mSrcPath, mDstPath,
           mSrcInode.getOwner(), mSrcInode.getGroup(),
           Mode.extractOwnerBits(mode), Mode.extractGroupBits(mode), Mode.extractOtherBits(mode),
-          mExecutionTimeNs / 1000);
+          mExecutionTimeNs / 1000, mClientVersion);
     } else {
       return String.format(
           "succeeded=%b\tallowed=%b\tugi=%s (AUTH=%s)\tip=%s\tcmd=%s\tsrc=%s\tdst=%s\t"
-              + "perm=null\texecutionTimeUs=%d",
+              + "perm=null\texecutionTimeUs=%d\tclientVersion=%s\tproto=rpc",
           mSucceeded, mAllowed, mUgi, mAuthType, mIp, mCommand, mSrcPath, mDstPath,
-          mExecutionTimeNs / 1000);
+          mExecutionTimeNs / 1000, mClientVersion);
     }
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterAuditContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterAuditContext.java
@@ -199,9 +199,9 @@ public final class FileSystemMasterAuditContext implements AuditContext {
     } else {
       return String.format(
           "succeeded=%b\tallowed=%b\tugi=%s (AUTH=%s)\tip=%s\tcmd=%s\tsrc=%s\tdst=%s\t"
-              + "perm=null\texecutionTimeUs=%d\tclientVersion=%s\tclientRevision=%s",
+              + "perm=null\texecutionTimeUs=%d",
           mSucceeded, mAllowed, mUgi, mAuthType, mIp, mCommand, mSrcPath, mDstPath,
-          mExecutionTimeNs / 1000, mClientVersion, mClientRevision);
+          mExecutionTimeNs / 1000);
     }
     if (Configuration.global().getBoolean(PropertyKey.USER_CLIENT_REPORT_VERSION)) {
       auditLog.append(

--- a/core/server/master/src/main/java/alluxio/master/journal/DefaultJournalMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/DefaultJournalMaster.java
@@ -24,7 +24,7 @@ import alluxio.master.AbstractMaster;
 import alluxio.master.MasterContext;
 import alluxio.master.PrimarySelector;
 import alluxio.master.journal.raft.RaftJournalSystem;
-import alluxio.security.authentication.ClientIpAddressInjector;
+import alluxio.security.authentication.ClientContextServerInjector;
 import alluxio.util.executor.ExecutorServiceFactories;
 
 import io.grpc.ServerInterceptors;
@@ -116,7 +116,7 @@ public class DefaultJournalMaster extends AbstractMaster implements JournalMaste
     services.put(alluxio.grpc.ServiceType.JOURNAL_MASTER_CLIENT_SERVICE,
         new GrpcService(ServerInterceptors.intercept(
             new JournalMasterClientServiceHandler(this),
-            new ClientIpAddressInjector())));
+            new ClientContextServerInjector())));
     return services;
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -52,7 +52,7 @@ import alluxio.master.meta.checkconf.ConfigurationStore;
 import alluxio.proto.journal.Journal;
 import alluxio.proto.journal.Meta;
 import alluxio.resource.CloseableIterator;
-import alluxio.security.authentication.ClientIpAddressInjector;
+import alluxio.security.authentication.ClientContextServerInjector;
 import alluxio.underfs.UfsManager;
 import alluxio.util.ConfigurationUtils;
 import alluxio.util.IdUtils;
@@ -260,15 +260,15 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
     services.put(ServiceType.META_MASTER_CONFIG_SERVICE,
         new GrpcService(ServerInterceptors.intercept(
             new MetaMasterConfigurationServiceHandler(this),
-            new ClientIpAddressInjector())).disableAuthentication());
+            new ClientContextServerInjector())).disableAuthentication());
     services.put(ServiceType.META_MASTER_CLIENT_SERVICE,
         new GrpcService(ServerInterceptors.intercept(
             new MetaMasterClientServiceHandler(this),
-            new ClientIpAddressInjector())));
+            new ClientContextServerInjector())));
     services.put(ServiceType.META_MASTER_MASTER_SERVICE,
         new GrpcService(ServerInterceptors.intercept(
             new MetaMasterMasterServiceHandler(this),
-            new ClientIpAddressInjector())));
+            new ClientContextServerInjector())));
     // Add backup role services.
     services.putAll(mBackupRole.getRoleServices());
     services.putAll(mJournalSystem.getJournalServices());

--- a/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/DefaultMetricsMaster.java
@@ -30,7 +30,7 @@ import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.metrics.MultiValueMetricsAggregator;
 import alluxio.metrics.aggregator.SingleTagValueAggregator;
-import alluxio.security.authentication.ClientIpAddressInjector;
+import alluxio.security.authentication.ClientContextServerInjector;
 import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.util.executor.ExecutorServiceFactory;
 
@@ -168,7 +168,7 @@ public class DefaultMetricsMaster extends CoreMaster implements MetricsMaster, N
     services.put(ServiceType.METRICS_MASTER_CLIENT_SERVICE,
         new GrpcService(ServerInterceptors.intercept(
             getMasterServiceHandler(),
-            new ClientIpAddressInjector())));
+            new ClientContextServerInjector())));
     return services;
   }
 

--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -60,7 +60,7 @@ import alluxio.metrics.MetricsSystem;
 import alluxio.resource.LockResource;
 import alluxio.security.authentication.AuthType;
 import alluxio.security.authentication.AuthenticatedClientUser;
-import alluxio.security.authentication.ClientIpAddressInjector;
+import alluxio.security.authentication.ClientContextServerInjector;
 import alluxio.underfs.UfsManager;
 import alluxio.util.CommonUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
@@ -222,7 +222,8 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
     Map<ServiceType, GrpcService> services = Maps.newHashMap();
     services.put(ServiceType.JOB_MASTER_CLIENT_SERVICE,
         new GrpcService(ServerInterceptors
-            .intercept(new JobMasterClientServiceHandler(this), new ClientIpAddressInjector())));
+            .intercept(new JobMasterClientServiceHandler(this),
+                new ClientContextServerInjector())));
     services.put(ServiceType.JOB_MASTER_WORKER_SERVICE,
         new GrpcService(new JobMasterWorkerServiceHandler(this)));
     return services;
@@ -669,7 +670,8 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
           Configuration.getEnum(PropertyKey.SECURITY_AUTHENTICATION_TYPE, AuthType.class);
       auditContext.setUgi(ugi)
           .setAuthType(authType)
-          .setIp(ClientIpAddressInjector.getIpAddress())
+          .setIp(ClientContextServerInjector.getIpAddress())
+          .setClientVersion(ClientContextServerInjector.getClientVersion())
           .setCommand(command)
           .setAllowed(true)
           .setCreationTimeNs(System.nanoTime());

--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -672,7 +672,6 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
           .setAuthType(authType)
           .setIp(ClientContextServerInjector.getIpAddress())
           .setClientVersion(ClientContextServerInjector.getClientVersion())
-          .setClientRevision(ClientContextServerInjector.getClientRevision())
           .setCommand(command)
           .setAllowed(true)
           .setCreationTimeNs(System.nanoTime());

--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -672,6 +672,7 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
           .setAuthType(authType)
           .setIp(ClientContextServerInjector.getIpAddress())
           .setClientVersion(ClientContextServerInjector.getClientVersion())
+          .setClientRevision(ClientContextServerInjector.getClientRevision())
           .setCommand(command)
           .setAllowed(true)
           .setCreationTimeNs(System.nanoTime());

--- a/job/server/src/main/java/alluxio/master/job/JobMasterAuditContext.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMasterAuditContext.java
@@ -176,7 +176,7 @@ public class JobMasterAuditContext implements AuditContext {
             + "perm=null\texecutionTimeUs=%d",
         mSucceeded, mAllowed, mUgi, mAuthType, mIp, mCommand, mJobId, mJobName,
         mExecutionTimeNs / 1000));
-    if (Configuration.global().getBoolean(PropertyKey.USER_CLIENT_REPORT_VERSION)) {
+    if (Configuration.global().getBoolean(PropertyKey.USER_CLIENT_REPORT_VERSION_ENABLED)) {
       auditLog.append(
           String.format("\tclientVersion=%s\tclientRevision=%s", mClientVersion, mClientRevision));
     }

--- a/job/server/src/main/java/alluxio/master/job/JobMasterAuditContext.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMasterAuditContext.java
@@ -11,6 +11,8 @@
 
 package alluxio.master.job;
 
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 import alluxio.master.audit.AsyncUserAccessAuditLogWriter;
 import alluxio.master.audit.AuditContext;
 import alluxio.security.authentication.AuthType;
@@ -34,6 +36,7 @@ public class JobMasterAuditContext implements AuditContext {
   private long mCreationTimeNs;
   private long mExecutionTimeNs;
   private String mClientVersion;
+  private String mClientRevision;
 
   @Override
   public JobMasterAuditContext setAllowed(boolean allowed) {
@@ -137,6 +140,16 @@ public class JobMasterAuditContext implements AuditContext {
   }
 
   /**
+   * set client revision.
+   * @param revision client revision
+   * @return this {@link AuditContext} instance
+   */
+  public JobMasterAuditContext setClientRevision(String revision) {
+    mClientRevision = revision;
+    return this;
+  }
+
+  /**
    * Constructor of {@link JobMasterAuditContext}.
    *
    * @param asyncAuditLogWriter async audit log writer
@@ -157,10 +170,16 @@ public class JobMasterAuditContext implements AuditContext {
 
   @Override
   public String toString() {
-    return String.format(
+    StringBuilder auditLog = new StringBuilder();
+    auditLog.append(String.format(
         "succeeded=%b\tallowed=%b\tugi=%s (AUTH=%s)\tip=%s\tcmd=%s\tjobId=%d\tjobName=%s\t"
-            + "perm=null\texecutionTimeUs=%d\tclientVersion=%s",
+            + "perm=null\texecutionTimeUs=%d",
         mSucceeded, mAllowed, mUgi, mAuthType, mIp, mCommand, mJobId, mJobName,
-        mExecutionTimeNs / 1000, mClientVersion);
+        mExecutionTimeNs / 1000));
+    if (Configuration.global().getBoolean(PropertyKey.USER_CLIENT_REPORT_VERSION)) {
+      auditLog.append(
+          String.format("\tclientVersion=%s\tclientRevision=%s", mClientVersion, mClientRevision));
+    }
+    return auditLog.toString();
   }
 }

--- a/job/server/src/main/java/alluxio/master/job/JobMasterAuditContext.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMasterAuditContext.java
@@ -36,7 +36,6 @@ public class JobMasterAuditContext implements AuditContext {
   private long mCreationTimeNs;
   private long mExecutionTimeNs;
   private String mClientVersion;
-  private String mClientRevision;
 
   @Override
   public JobMasterAuditContext setAllowed(boolean allowed) {
@@ -139,15 +138,6 @@ public class JobMasterAuditContext implements AuditContext {
     return this;
   }
 
-  /**
-   * set client revision.
-   * @param revision client revision
-   * @return this {@link AuditContext} instance
-   */
-  public JobMasterAuditContext setClientRevision(String revision) {
-    mClientRevision = revision;
-    return this;
-  }
 
   /**
    * Constructor of {@link JobMasterAuditContext}.
@@ -177,8 +167,7 @@ public class JobMasterAuditContext implements AuditContext {
         mSucceeded, mAllowed, mUgi, mAuthType, mIp, mCommand, mJobId, mJobName,
         mExecutionTimeNs / 1000));
     if (Configuration.global().getBoolean(PropertyKey.USER_CLIENT_REPORT_VERSION_ENABLED)) {
-      auditLog.append(
-          String.format("\tclientVersion=%s\tclientRevision=%s", mClientVersion, mClientRevision));
+      auditLog.append(String.format("\tclientVersion=%s\t", mClientVersion));
     }
     return auditLog.toString();
   }

--- a/job/server/src/main/java/alluxio/master/job/JobMasterAuditContext.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMasterAuditContext.java
@@ -33,6 +33,7 @@ public class JobMasterAuditContext implements AuditContext {
   private String mJobName;
   private long mCreationTimeNs;
   private long mExecutionTimeNs;
+  private String mClientVersion;
 
   @Override
   public JobMasterAuditContext setAllowed(boolean allowed) {
@@ -125,9 +126,20 @@ public class JobMasterAuditContext implements AuditContext {
   }
 
   /**
+   * Sets client version.
+   *
+   * @param clientVersion the client version
+   * @return this {@link AuditContext} instance
+   */
+  public JobMasterAuditContext setClientVersion(String clientVersion) {
+    mClientVersion = clientVersion;
+    return this;
+  }
+
+  /**
    * Constructor of {@link JobMasterAuditContext}.
    *
-   * @param asyncAuditLogWriter
+   * @param asyncAuditLogWriter async audit log writer
    */
   protected JobMasterAuditContext(AsyncUserAccessAuditLogWriter asyncAuditLogWriter) {
     mAsyncAuditLogWriter = asyncAuditLogWriter;
@@ -147,8 +159,8 @@ public class JobMasterAuditContext implements AuditContext {
   public String toString() {
     return String.format(
         "succeeded=%b\tallowed=%b\tugi=%s (AUTH=%s)\tip=%s\tcmd=%s\tjobId=%d\tjobName=%s\t"
-            + "perm=null\texecutionTimeUs=%d",
+            + "perm=null\texecutionTimeUs=%d\tclientVersion=%s",
         mSucceeded, mAllowed, mUgi, mAuthType, mIp, mCommand, mJobId, mJobName,
-        mExecutionTimeNs / 1000);
+        mExecutionTimeNs / 1000, mClientVersion);
   }
 }

--- a/job/server/src/main/java/alluxio/master/job/JobMasterAuditContext.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMasterAuditContext.java
@@ -138,7 +138,6 @@ public class JobMasterAuditContext implements AuditContext {
     return this;
   }
 
-
   /**
    * Constructor of {@link JobMasterAuditContext}.
    *

--- a/table/server/master/src/main/java/alluxio/master/table/DefaultTableMaster.java
+++ b/table/server/master/src/main/java/alluxio/master/table/DefaultTableMaster.java
@@ -33,7 +33,7 @@ import alluxio.master.journal.JournaledGroup;
 import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.master.table.transform.TransformJobInfo;
 import alluxio.master.table.transform.TransformManager;
-import alluxio.security.authentication.ClientIpAddressInjector;
+import alluxio.security.authentication.ClientContextServerInjector;
 import alluxio.table.common.transform.TransformDefinition;
 import alluxio.util.executor.ExecutorServiceFactories;
 
@@ -181,7 +181,7 @@ public class DefaultTableMaster extends AbstractMaster
     services.put(ServiceType.TABLE_MASTER_CLIENT_SERVICE,
         new GrpcService(ServerInterceptors.intercept(
             new TableMasterClientServiceHandler(this),
-            new ClientIpAddressInjector())));
+            new ClientContextServerInjector())));
     return services;
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. The client will use an injector to send version and revision to the server
2. Displaying client version in audit log

### Why are the changes needed?

This allows us to know the version of the client connected to alluxio.

### Does this PR introduce any user facing changes?

Display client version information in the audit log like
```
2022-11-30 18:08:57,038 INFO AUDIT_LOG: succeeded=true	allowed=true	ugi=xxx,xxx(AUTH=SIMPLE)	ip=/xxx:52912	cmd=mkdirs	src=xxx	dst=null	perm=xxx:xxx:rwxrwxrwx	executionTimeUs=160770	clientVersion=xxx	proto=rpc
```
