### PR TITLE
Improve the PollingMasterInquireClient logic

### DIFF
--- a/core/common/src/main/java/alluxio/master/MasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/MasterInquireClient.java
@@ -89,7 +89,8 @@ public interface MasterInquireClient {
       } else {
         List<InetSocketAddress> addresses = ConfigurationUtils.getMasterRpcAddresses(conf);
         if (addresses.size() > 1) {
-          return new PollingMasterInquireClient(addresses, conf, userState);
+          return new PollingMasterInquireClient(addresses, conf, userState,
+              alluxio.grpc.ServiceType.META_MASTER_CLIENT_SERVICE);
         } else {
           return new SingleMasterInquireClient(addresses.get(0));
         }
@@ -105,7 +106,8 @@ public interface MasterInquireClient {
     public static MasterInquireClient createForAddresses(
         List<InetSocketAddress> addresses, AlluxioConfiguration conf, UserState userState) {
       if (addresses.size() > 1) {
-        return new PollingMasterInquireClient(addresses, conf, userState);
+        return new PollingMasterInquireClient(addresses, conf, userState,
+            alluxio.grpc.ServiceType.META_MASTER_CLIENT_SERVICE);
       } else {
         return new SingleMasterInquireClient(addresses.get(0));
       }
@@ -127,7 +129,8 @@ public interface MasterInquireClient {
       } else {
         List<InetSocketAddress> addresses = ConfigurationUtils.getJobMasterRpcAddresses(conf);
         if (addresses.size() > 1) {
-          return new PollingMasterInquireClient(addresses, conf, userState);
+          return new PollingMasterInquireClient(addresses, conf, userState,
+              alluxio.grpc.ServiceType.JOB_MASTER_CLIENT_SERVICE);
         } else {
           return new SingleMasterInquireClient(addresses.get(0));
         }

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -186,7 +186,8 @@ public class PollingMasterInquireClient implements MasterInquireClient {
                 TimeUnit.MILLISECONDS);
     ServiceType serviceType = mServiceType;
     if (serviceType == null) {
-      List<InetSocketAddress> addresses = ConfigurationUtils.getJobMasterRpcAddresses(mConfiguration);
+      List<InetSocketAddress> addresses =
+          ConfigurationUtils.getJobMasterRpcAddresses(mConfiguration);
       serviceType = addresses.contains(address)
           ? ServiceType.JOB_MASTER_CLIENT_SERVICE : ServiceType.META_MASTER_CLIENT_SERVICE;
     }

--- a/core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.fail;
 import alluxio.Constants;
 import alluxio.conf.ConfigurationBuilder;
 import alluxio.exception.status.UnavailableException;
+import alluxio.grpc.ServiceType;
 import alluxio.network.RejectingServer;
 import alluxio.retry.CountingRetry;
 import alluxio.util.network.NetworkAddressUtils;
@@ -43,7 +44,8 @@ public class PollingMasterInquireClientTest {
     List<InetSocketAddress> addrs = Arrays.asList(InetSocketAddress
         .createUnresolved(NetworkAddressUtils.getLocalHostName(Constants.SECOND_MS), port));
     PollingMasterInquireClient client = new PollingMasterInquireClient(addrs,
-        () -> new CountingRetry(0), new ConfigurationBuilder().build());
+        () -> new CountingRetry(0), new ConfigurationBuilder().build(),
+        ServiceType.META_MASTER_CLIENT_SERVICE);
     try {
       client.getPrimaryRpcAddress();
       fail("Expected polling to fail");

--- a/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
+++ b/minicluster/src/main/java/alluxio/multi/process/MultiProcessCluster.java
@@ -34,6 +34,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
 import alluxio.exception.status.UnavailableException;
 import alluxio.grpc.MasterInfo;
+import alluxio.grpc.ServiceType;
 import alluxio.master.LocalAlluxioCluster;
 import alluxio.master.MasterClientContext;
 import alluxio.master.MasterInquireClient;
@@ -770,7 +771,7 @@ public final class MultiProcessCluster {
                 InetSocketAddress.createUnresolved(address.getHostname(), address.getRpcPort()));
           }
           return new PollingMasterInquireClient(addresses, Configuration.global(),
-              ServerUserState.global());
+              ServerUserState.global(), ServiceType.META_MASTER_CLIENT_SERVICE);
         } else {
           return new SingleMasterInquireClient(InetSocketAddress.createUnresolved(
               mMasterAddresses.get(0).getHostname(), mMasterAddresses.get(0).getRpcPort()));

--- a/shell/src/main/java/alluxio/cli/fs/command/LeaderCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LeaderCommand.java
@@ -17,6 +17,7 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.FileSystemMasterClient;
 import alluxio.exception.status.InvalidArgumentException;
 import alluxio.exception.status.UnavailableException;
+import alluxio.grpc.ServiceType;
 import alluxio.master.MasterInquireClient;
 import alluxio.master.PollingMasterInquireClient;
 import alluxio.resource.CloseableResource;
@@ -67,7 +68,8 @@ public final class LeaderCommand extends AbstractFileSystemCommand {
 
         List<InetSocketAddress> addresses = Arrays.asList(address);
         MasterInquireClient inquireClient = new PollingMasterInquireClient(addresses, () ->
-                new ExponentialBackoffRetry(50, 100, 2), mFsContext.getClusterConf()
+                new ExponentialBackoffRetry(50, 100, 2), mFsContext.getClusterConf(),
+            ServiceType.META_MASTER_CLIENT_SERVICE
         );
         try {
           inquireClient.getPrimaryRpcAddress();

--- a/shell/src/main/java/alluxio/cli/fsadmin/FileSystemAdminShellUtils.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/FileSystemAdminShellUtils.java
@@ -17,6 +17,7 @@ import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.FileSystemMasterClient;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.exception.status.UnavailableException;
+import alluxio.grpc.ServiceType;
 import alluxio.master.MasterInquireClient;
 import alluxio.master.PollingMasterInquireClient;
 import alluxio.resource.CloseableResource;
@@ -65,7 +66,8 @@ public final class FileSystemAdminShellUtils {
 
       List<InetSocketAddress> addresses = Arrays.asList(address);
       MasterInquireClient inquireClient = new PollingMasterInquireClient(addresses,
-          () -> new ExponentialBackoffRetry(50, 100, 2), alluxioConf);
+          () -> new ExponentialBackoffRetry(50, 100, 2), alluxioConf,
+          ServiceType.META_MASTER_CLIENT_SERVICE);
       inquireClient.getPrimaryRpcAddress();
     } catch (UnavailableException e) {
       throw new IOException("Cannot connect to Alluxio leader master.");


### PR DESCRIPTION
### What changes are proposed in this pull request?

Previously the service type in polling master inquire client was deduced by looking up the master ip address. This is an unnecessary step because when the client is initialized, the caller knows what exact type of master it talks too. So we add this as a constructor param and let every caller to pass it in, to improve the code readability. 

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
To improve the code readability.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
N/A
