### PR TITLE
Run fault tolerant tests as single fork

### DIFF
--- a/.github/workflows/java8_integration_tests_ft.yml
+++ b/.github/workflows/java8_integration_tests_ft.yml
@@ -11,19 +11,9 @@ jobs:
       matrix:
         modules:
           - >-
-            alluxio.client.cli.**,!alluxio.client.cli.fs.**
+            alluxio.server.ft.**,!alluxio.server.ft.journal.raft.**,!alluxio.server.ft.journal.ufs.**
           - >-
-            alluxio.client.cli.fs.**
-          - >-
-            alluxio.client.fs.**,!alluxio.client.fs.concurrent.**,!alluxio.client.fs.io.**
-          - >-
-            alluxio.client.fs.concurrent.**,alluxio.client.fs.io.**
-          - >-
-            alluxio.client.**,!alluxio.client.fs.**,!alluxio.client.cli.**,!alluxio.client.fuse.**
-          - >-
-            alluxio.job.**,alluxio.master.**,alluxio.stress.**
-          - >-
-            alluxio.server.**,!alluxio.server.ft.**
+            alluxio.server.ft.journal.raft.**,alluxio.server.ft.journal.ufs.**
 
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.title, 'DOCFIX') &&
@@ -54,6 +44,7 @@ jobs:
         id: test0
         run: |
           mkdir -p ~/.m2
+          ALLUXIO_DOCKER_FORK_COUNT=1 \
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \

--- a/.github/workflows/java8_integration_tests_ft.yml
+++ b/.github/workflows/java8_integration_tests_ft.yml
@@ -1,4 +1,4 @@
-name: Java 8 Integration Tests
+name: Java 8 Fault Tolerant Integration Tests
 
 on: [pull_request]
 
@@ -44,6 +44,7 @@ jobs:
         id: test0
         run: |
           mkdir -p ~/.m2
+          # Set fork count to 1 so that fault tolerant tests are run sequentially as these tests have high overhead, starting and stopping multiple Alluxio processes
           ALLUXIO_DOCKER_FORK_COUNT=1 \
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \

--- a/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/JournalBackupIntegrationTest.java
@@ -391,6 +391,7 @@ public final class JournalBackupIntegrationTest extends BaseIntegrationTest {
     mCluster.updateMasterConf(PropertyKey.MASTER_JOURNAL_INIT_FROM_BACKUP,
         backup.getBackupUri().getPath());
     mCluster.startMasters();
+    mCluster.waitForAllNodesRegistered(WAIT_NODES_REGISTERED_MS);
 
     try (FileInStream inStream = mCluster.getFileSystemClient().openFile(f)) {
       byte[] bytes = new byte[modifiedData.length()];


### PR DESCRIPTION
This should improve test reliability for the fault tolerant tests as it runs a single test at a time (see ALLUXIO_DOCKER_FORK_COUNT=1). These tests are costly as they are starting and stopping Alluxio processes frequently, which may cause the tests to timeout.

It also adds a wait command to the JournalBackupIntegrationTest to ensure the cluster is ready after being restarted.