### PR TITLE
Improve MasterProcess#mStartTimeMs initialization

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/MasterProcess.java
+++ b/core/server/common/src/main/java/alluxio/master/MasterProcess.java
@@ -65,7 +65,7 @@ public abstract class MasterProcess implements Process {
   final InetSocketAddress mWebBindAddress;
 
   /** The start time for when the master started. */
-  final long mStartTimeMs = System.currentTimeMillis();
+  final long mStartTimeMs;
 
   /**
    * Rejecting servers for used by backup masters to reserve ports but reject connection requests.
@@ -101,6 +101,7 @@ public abstract class MasterProcess implements Process {
     mLeaderSelector = Preconditions.checkNotNull(leaderSelector, "leaderSelector");
     mRpcBindAddress = configureAddress(rpcService);
     mWebBindAddress = configureAddress(webService);
+    mStartTimeMs = System.currentTimeMillis();
   }
 
   private static InetSocketAddress configureAddress(ServiceType service) {


### PR DESCRIPTION
### What changes are proposed in this pull request?
In Alluxio, AlluxioMaster, AlluxioJobMaster, AlluxioWorker, AlluxioJobWorker, and AlluxioProxy are equal. They all use mStartTimeMs to record the time when the service starts. But the way they initialize mStartTimeMs is different. MasterProcess does not directly initialize mStartTimeMs through the constructor:
MasterProcess :
`
final long mStartTimeMs = System.currentTimeMillis();
`
But AlluxioProxyProcess, AlluxioWorkerProcess, AlluxioJobWorkerProcess are initialized in the constructor. Details:
`
AlluxioProxyProcess() { mStartTimeMs = System. currentTimeMillis(); … }
`
`
AlluxioWorkerProcess(TieredIdentity tieredIdentity) { mStartTimeMs = System. currentTimeMillis(); … }
`
`
AlluxioJobWorkerProcess() { mStartTimeMs = System. currentTimeMillis(); … }
`

The goal of this PR is to keep them as consistent as possible.

### Why are the changes needed?
When the Master, JobMaster, Worker, JobWorker, and Proxy services start, the way of recording mStartTimeMs should be consistent.

### Does this PR introduce any user facing changes?
There will be no impact on users.
