### PR TITLE
Update raft group only on config change

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -396,8 +396,8 @@ public class JournalStateMachine extends BaseStateMachine {
   }
 
   @Override
-  public void notifyTermIndexUpdated(long term, long index) {
-    super.notifyTermIndexUpdated(term, index);
+  public void notifyConfigurationChanged(long term, long index,
+      RaftProtos.RaftConfigurationProto newRaftConfiguration) {
     CompletableFuture.runAsync(mJournalSystem::updateGroup, mJournalPool);
   }
 


### PR DESCRIPTION
Currently when using the embedded journal, on every journal entry committed, a task is submitted to the common thread pool to check if the journal group has changed. In certain experiments I have seen this resulting int up to a thousand threads being created to process these requests. I believe the group should only change when the configuration changes, so I have moved this operation to only be called on configuration changes.
