### PR TITLE
Add unsafe flush option to embedded journal

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2187,6 +2187,19 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_EMBEDDED_JOURNAL_UNSAFE_FLUSH_ENABLED =
+      booleanBuilder(Name.MASTER_EMBEDDED_JOURNAL_UNSAFE_FLUSH_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("If true, embedded journal entries will be committed without "
+              + "waiting for the entry to be flushed to disk. This may improve performance "
+              + "of write operations on the Alluxio master if the journal is written to a "
+              + "slow or contested disk. WARNING: enabling this property may result in metadata "
+              + "loss if half or more of the master nodes fail. See Ratis property "
+              + "raft.server.log.unsafe-flush.enabled at "
+              + "https://github.com/apache/ratis/blob/master/ratis-docs/src/site/markdown/configuraions.md.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED =
       booleanBuilder(Name.MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED)
           .setDefaultValue(false)
@@ -7564,6 +7577,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.embedded.journal.port";
     public static final String MASTER_EMBEDDED_JOURNAL_RETRY_CACHE_EXPIRY_TIME =
         "alluxio.master.embedded.journal.retry.cache.expiry.time";
+    public static final String MASTER_EMBEDDED_JOURNAL_UNSAFE_FLUSH_ENABLED =
+        "alluxio.master.embedded.journal.unsafe.flush.enabled";
     public static final String MASTER_EMBEDDED_JOURNAL_WRITE_LOCAL_FIRST_ENABLED =
         "alluxio.master.embedded.journal.write.local.first.enabled";
     public static final String MASTER_EMBEDDED_JOURNAL_WRITE_REMOTE_ENABLED =

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -375,6 +375,10 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     // snapshot retention
     RaftServerConfigKeys.Snapshot.setRetentionFileNum(properties, 3);
 
+    // unsafe flush
+    RaftServerConfigKeys.Log.setUnsafeFlushEnabled(properties,
+        Configuration.getBoolean(PropertyKey.MASTER_EMBEDDED_JOURNAL_UNSAFE_FLUSH_ENABLED));
+
     // snapshot interval
     RaftServerConfigKeys.Snapshot.setAutoTriggerEnabled(
         properties, true);

--- a/docs/en/administration/Performance-Tuning.md
+++ b/docs/en/administration/Performance-Tuning.md
@@ -182,7 +182,7 @@ alive if the journal writing location is unavailable for an extended duration.
 When using the embedded journal, before each update operation in Alluxio is committed, a journal
 entry corresponding to the operation must be written and flushed to disk in a write-ahead-log (WAL) at all masters.
 If the WAL is located on a disk that is frequently accessed by other processes, the performance of
-update operations in Alluxio may suffer. This may be the case if, for example, if the WAL shares a disk with the
+update operations in Alluxio may suffer. This may be the case if, for example, the WAL shares a disk with the
 [basic logging]({{ '/en/administration/Basic-Logging.html' | relativize_url }}) operations.
 
 For optimal performance it may be useful to dedicate a disk specifically to the journal.

--- a/docs/en/administration/Performance-Tuning.md
+++ b/docs/en/administration/Performance-Tuning.md
@@ -178,6 +178,21 @@ increase the latency for those update/write RPCs.
 Setting a larger timeout value for `alluxio.master.journal.flush.timeout` helps keep the master
 alive if the journal writing location is unavailable for an extended duration.
 
+### Embedded journal write performance
+When using the embedded journal, before each update operation in Alluxio is committed, a journal
+entry corresponding to the operation must be written and flushed to disk in a write-ahead-log (WAL) at all masters.
+If the WAL is located on a disk that is frequently accessed by other processes, the performance of
+update operations in Alluxio may suffer. This may be the case if, for example, if the WAL shares a disk with the
+[basic logging]({{ '/en/administration/Basic-Logging.html' | relativize_url }}) operations.
+
+For optimal performance it may be useful to dedicate a disk specifically to the journal.
+The location of the journal folder can be set by the property key `alluxio.master.journal.folder`.
+
+Alternatively, by setting the property key `alluxio.master.embedded.journal.unsafe.flush.enabled`
+to true, operations will be committed without waiting for the flush to disk to complete.
+> Warning: enabling this property may lead to metadata loss on the Alluxio masters if half
+or more of the master nodes fail.
+
 ### Journal garbage collection
 
 <table class="table table-striped">


### PR DESCRIPTION
### What changes are proposed in this pull request?

This adds the option to allow journal entries to be committed without waiting for them to be flushed to disk. It can improve performance greatly in the case of slow or busy disks with the risk of metadata loss. It also adds performance tuning discussions on how to improve journal write performance.

### Does this PR introduce any user facing changes?

This adds the property key alluxio.master.embedded.journal.unsafe.flush.enabled