### PR TITLE
Fix stale buildVersion when downgrade workers

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1129,9 +1129,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
       throw new NotFoundException(ExceptionMessage.NO_WORKER_FOUND.getMessage(workerId));
     }
 
-    if (options.hasBuildVersion()) {
-      worker.setBuildVersion(options.getBuildVersion());
-    }
+    worker.setBuildVersion(options.getBuildVersion());
 
     // Gather all blocks on this worker.
     int totalSize = currentBlocksOnLocation.values().stream().mapToInt(List::size).sum();
@@ -1224,9 +1222,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     processWorkerAddedBlocks(workerInfo, currentBlocksOnLocation);
     processWorkerOrphanedBlocks(workerInfo);
     workerInfo.addLostStorage(lostStorage);
-    if (options.hasBuildVersion()) {
-      workerInfo.setBuildVersion(options.getBuildVersion());
-    }
+    workerInfo.setBuildVersion(options.getBuildVersion());
 
     // TODO(jiacheng): This block can be moved to a non-locked section
     if (options.getConfigsCount() > 0) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Clear worker.buildVersion when it's not set in proto.

Note: Since we are using protobuf3 to compile proto2, it's OK to omit `hasField` check.
If the field is not set, the default instance will be returned.

Steps to reproduce:

1. Start a new cluster (master and worker).
2. Stop the new worker.
3. Start a old worker (prior to 7d8ad9b12ab366ef85c05a7cedfa3a60a562de12) using the same config.
4. Check workers in web UI.

### Why are the changes needed?

Previously, if we downgrade a worker to a versions prior to 7d8ad9b12ab366ef85c05a7cedfa3a60a562de12,
the buildVersion is stale.

### Does this PR introduce any user facing changes?

It fixes a bug in which the buildVersion could be stale.