### PR TITLE
Remove file from UfsAbsentPathCache after persisting

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4642,6 +4642,7 @@ public class DefaultFileSystemMaster extends CoreMaster
                 .setPersistenceState(PersistenceState.PERSISTED.name())
                 .build());
             propagatePersistedInternal(journalContext, inodePath);
+            mUfsAbsentPathCache.processExisting(inodePath.getUri());
             Metrics.FILES_PERSISTED.inc();
 
             // Save state for possible cleanup


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove the file from UfsAbsentPathCache after async persisting.

### Why are the changes needed?

To fix #16621

### Does this PR introduce any user facing changes?

No
