### PR TITLE
Refactor load libfuse library related logics

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6492,7 +6492,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey FUSE_JNIFUSE_LIBFUSE_VERSION =
       intBuilder(Name.FUSE_JNIFUSE_LIBFUSE_VERSION)
           .setDescription("The version of libfuse used by libjnifuse. "
-              + "Libfuse2 and Libfuse3 are supported.")
+              + "Libfuse2 (set by value \"2\") and Libfuse3 (set by value \"3\") are supported. "
+              + "If not configured, libfuse will be loaded dynamically. "
+              + "If both libfuse2 and libfuse3 are available, libfuse 3 will be loaded first.")
           .setScope(Scope.ALL)
           .build();
   public static final PropertyKey FUSE_SHARED_CACHING_READER_ENABLED =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6491,10 +6491,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey FUSE_JNIFUSE_LIBFUSE_VERSION =
       intBuilder(Name.FUSE_JNIFUSE_LIBFUSE_VERSION)
+          .setDefaultValue(2)
           .setDescription("The version of libfuse used by libjnifuse. "
-              + "Libfuse2 (set by value \"2\") and Libfuse3 (set by value \"3\") are supported. "
-              + "If not configured, libfuse will be loaded dynamically. "
-              + "If both libfuse2 and libfuse3 are available, libfuse 3 will be loaded first.")
+              + "Libfuse2 (set by value \"2\") and Libfuse3 (set by value \"3\") are supported.")
           .setScope(Scope.ALL)
           .build();
   public static final PropertyKey FUSE_SHARED_CACHING_READER_ENABLED =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6491,7 +6491,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey FUSE_JNIFUSE_LIBFUSE_VERSION =
       intBuilder(Name.FUSE_JNIFUSE_LIBFUSE_VERSION)
-          .setDefaultValue(2)
           .setDescription("The version of libfuse used by libjnifuse. "
               + "Libfuse2 and Libfuse3 are supported.")
           .setScope(Scope.ALL)

--- a/core/server/worker/src/main/java/alluxio/worker/block/FuseManager.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/FuseManager.java
@@ -14,11 +14,8 @@ package alluxio.worker.block;
 import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.fuse.AlluxioFuse;
-import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.fuse.FuseUmountable;
 import alluxio.fuse.options.FuseOptions;
-import alluxio.jnifuse.LibFuse;
-import alluxio.jnifuse.utils.LibfuseVersion;
 
 import com.google.common.io.Closer;
 import org.slf4j.Logger;
@@ -55,12 +52,9 @@ public class FuseManager implements Closeable {
     try {
       // TODO(lu) consider launching fuse in a separate thread as blocking operation
       // so that we can know about the fuse application status
-      FileSystem fileSystem = mResourceCloser.register(FileSystem.Factory.create(mFsContext));
-      LibfuseVersion loadedLibfuseVersion = LibFuse.loadLibrary(
-          AlluxioFuseUtils.getLibfuseLoadStrategy(mFsContext.getClusterConf()));
-      FuseOptions options = FuseOptions.create(loadedLibfuseVersion, mFsContext.getClusterConf());
       mFuseUmountable = AlluxioFuse.launchFuse(
-          mFsContext, fileSystem, options, false);
+          mFsContext, mResourceCloser.register(FileSystem.Factory.create(mFsContext)),
+          FuseOptions.create(mFsContext.getClusterConf()), false);
     } catch (Throwable throwable) {
       // TODO(lu) for already mounted application, unmount first and then remount
       LOG.error("Failed to launch worker internal Fuse application", throwable);

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -3270,6 +3270,21 @@
             ]
           },
           {
+            "name": "S3SyntaxOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "overwrite",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "isMultipartUpload",
+                "type": "bool"
+              }
+            ]
+          },
+          {
             "name": "RenamePResponse"
           },
           {
@@ -3284,6 +3299,11 @@
                 "id": 2,
                 "name": "persist",
                 "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "s3SyntaxOptions",
+                "type": "S3SyntaxOptions"
               }
             ]
           },

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -3270,21 +3270,6 @@
             ]
           },
           {
-            "name": "S3SyntaxOptions",
-            "fields": [
-              {
-                "id": 1,
-                "name": "overwrite",
-                "type": "bool"
-              },
-              {
-                "id": 2,
-                "name": "isMultipartUpload",
-                "type": "bool"
-              }
-            ]
-          },
-          {
             "name": "RenamePResponse"
           },
           {
@@ -3299,11 +3284,6 @@
                 "id": 2,
                 "name": "persist",
                 "type": "bool"
-              },
-              {
-                "id": 3,
-                "name": "s3SyntaxOptions",
-                "type": "S3SyntaxOptions"
               }
             ]
           },

--- a/integration/fuse/bin/alluxio-fuse-sdk
+++ b/integration/fuse/bin/alluxio-fuse-sdk
@@ -23,6 +23,7 @@ General options
 
 Alluxio mount options
 \t-o <ALLUXIO_PROPERTY_KEY>=<ALLUXIO_PROPERTY_VALUE> \tThe credentials of the target ufs address should be provided here so that alluxio fuse can access the target data set. Other alluxio common/user configuration can also be provided here
+\t-o fuse=<fuse_version> (Default=\"2\" which means fuse(libfuse2) is loaded) \tThe FUSE (and included libfuse) version to be used. Supported value includes 2 and 3.
 \t-o data_cache=<local_cache_directory> (Default=\"\" which means disabled) \tLocal folder to use for local data cache.
 \t-o data_cache_size=<size> (Default=\"512MB\") \tMaximum cache size for local data cache directory.  
 \t-o metadata_cache_size=<size> (Default=\"0\" which means disabled) \tMaximum number of entries in the metadata cache. Each 1000 entries cause about 2MB memory.

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -29,8 +29,7 @@ import alluxio.fuse.meta.UpdateChecker;
 import alluxio.fuse.options.FuseOptions;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatThread;
-import alluxio.jnifuse.LibFuse;
-import alluxio.jnifuse.utils.LibfuseVersion;
+import alluxio.jnifuse.utils.NativeLibraryLoader;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.security.user.UserState;
@@ -157,10 +156,7 @@ public final class AlluxioFuse {
     LOG.info("Alluxio version: {}-{}", RuntimeConstants.VERSION, ProjectConstants.REVISION);
     setConfigurationFromInput(cli, Configuration.modifiableGlobal());
     AlluxioConfiguration conf = Configuration.global();
-    LibfuseVersion loadedLibfuseVersion = LibFuse.loadLibrary(
-        AlluxioFuseUtils.getLibfuseLoadStrategy(conf));
-
-    FuseOptions fuseOptions = getFuseOptions(loadedLibfuseVersion, cli, conf);
+    FuseOptions fuseOptions = getFuseOptions(cli, conf);
 
     FileSystemContext fsContext = FileSystemContext.create(conf);
     if (!fuseOptions.getFileSystemOptions().getUfsFileSystemOptions().isPresent()) {
@@ -210,6 +206,7 @@ public final class AlluxioFuse {
        FuseOptions fuseOptions, boolean blocking) {
     AlluxioConfiguration conf = fsContext.getClusterConf();
     validateFuseConfAndOptions(conf, fuseOptions);
+    NativeLibraryLoader.getInstance().loadLibfuse(fuseOptions.getLibfuseVersion());
 
     String mountPoint = conf.getString(PropertyKey.FUSE_MOUNT_POINT);
     Path mountPath = Paths.get(mountPoint);
@@ -327,8 +324,7 @@ public final class AlluxioFuse {
     }
   }
 
-  private static FuseOptions getFuseOptions(LibfuseVersion libfuseVersion,
-      CommandLine cli, AlluxioConfiguration conf) {
+  private static FuseOptions getFuseOptions(CommandLine cli, AlluxioConfiguration conf) {
     boolean updateCheckEnabled = false;
     if (cli.hasOption(UPDATE_CHECK_OPTION_NAME)) {
       updateCheckEnabled = Boolean.parseBoolean(cli.getOptionValue(UPDATE_CHECK_OPTION_NAME));
@@ -336,9 +332,9 @@ public final class AlluxioFuse {
       updateCheckEnabled = true;
     }
     return cli.hasOption(MOUNT_ROOT_UFS_OPTION_NAME)
-        ? FuseOptions.create(libfuseVersion, FileSystemOptions.create(conf,
+        ? FuseOptions.create(FileSystemOptions.create(conf,
         Optional.of(new UfsFileSystemOptions(cli.getOptionValue(MOUNT_ROOT_UFS_OPTION_NAME)))),
-        updateCheckEnabled, conf) : FuseOptions.create(libfuseVersion, updateCheckEnabled, conf);
+        updateCheckEnabled, conf) : FuseOptions.create(updateCheckEnabled, conf);
   }
 
   private static void validateFuseConfAndOptions(AlluxioConfiguration conf, FuseOptions options) {

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -312,6 +312,10 @@ public final class AlluxioFuse {
           conf.set(PropertyKey.USER_METADATA_CACHE_EXPIRATION_TIME,
               PropertyKey.USER_METADATA_CACHE_EXPIRATION_TIME.parseValue(value), Source.RUNTIME);
           LOG.info("Set metadata cache expiration time as {} from command line input", value);
+        } else if (key.equals("fuse")) {
+          conf.set(PropertyKey.FUSE_JNIFUSE_LIBFUSE_VERSION,
+              PropertyKey.FUSE_JNIFUSE_LIBFUSE_VERSION.parseValue(value), Source.RUNTIME);
+          LOG.info("Set fuse(libfuse) version as {} from command line input", value);
         } else {
           fuseOptions.add(trimedOpt);
         }

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioJniFuseFileSystem.java
@@ -123,7 +123,8 @@ public final class AlluxioJniFuseFileSystem extends AbstractFuseFileSystem
    */
   public AlluxioJniFuseFileSystem(FileSystemContext fsContext, FileSystem fs,
       FuseOptions fuseOptions) {
-    super(Paths.get(fsContext.getClusterConf().getString(PropertyKey.FUSE_MOUNT_POINT)));
+    super(Paths.get(fsContext.getClusterConf().getString(PropertyKey.FUSE_MOUNT_POINT)),
+        fuseOptions.getLibfuseVersion());
     mFileSystemContext = fsContext;
     mFileSystem = fs;
     mConf = fsContext.getClusterConf();

--- a/integration/fuse/src/main/java/alluxio/fuse/StackFS.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/StackFS.java
@@ -18,6 +18,7 @@ import alluxio.jnifuse.FuseFillDir;
 import alluxio.jnifuse.struct.FileStat;
 import alluxio.jnifuse.struct.FuseFileInfo;
 import alluxio.jnifuse.struct.Statvfs;
+import alluxio.jnifuse.utils.LibfuseVersion;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.io.FileUtils;
 
@@ -66,9 +67,10 @@ public class StackFS extends AbstractFuseFileSystem {
   /**
    * @param root root
    * @param mountPoint mount point
+   * @param loadedLibfuseVersion the libfuse loaded version
    */
-  public StackFS(Path root, Path mountPoint) {
-    super(mountPoint);
+  public StackFS(Path root, Path mountPoint, LibfuseVersion loadedLibfuseVersion) {
+    super(mountPoint, loadedLibfuseVersion);
     mRoot = root;
   }
 

--- a/integration/fuse/src/main/java/alluxio/fuse/StackMain.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/StackMain.java
@@ -15,6 +15,7 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.jnifuse.LibFuse;
+import alluxio.jnifuse.utils.LibfuseVersion;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.CommonUtils;
 
@@ -39,8 +40,9 @@ public class StackMain {
     Path root = Paths.get(args[1]);
     Path mountPoint = Paths.get(args[0]);
     AlluxioConfiguration conf = Configuration.global();
-    LibFuse.loadLibrary(AlluxioFuseUtils.getLibfuseVersion(conf));
-    StackFS fs = new StackFS(root, mountPoint);
+    LibfuseVersion loadedLibfuseVersion = LibFuse.loadLibrary(
+        AlluxioFuseUtils.getLibfuseLoadStrategy(conf));
+    StackFS fs = new StackFS(root, mountPoint, loadedLibfuseVersion);
     Set<String> fuseOpts = new HashSet<>();
     for (int i = 2; i < args.length; i++) {
       fuseOpts.add(args[i].substring(2)); // remove -o

--- a/integration/fuse/src/main/java/alluxio/fuse/StackMain.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/StackMain.java
@@ -15,7 +15,6 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.jnifuse.LibFuse;
-import alluxio.jnifuse.utils.LibfuseVersion;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.CommonUtils;
 
@@ -40,9 +39,8 @@ public class StackMain {
     Path root = Paths.get(args[1]);
     Path mountPoint = Paths.get(args[0]);
     AlluxioConfiguration conf = Configuration.global();
-    LibfuseVersion loadedLibfuseVersion = LibFuse.loadLibrary(
-        AlluxioFuseUtils.getLibfuseLoadStrategy(conf));
-    StackFS fs = new StackFS(root, mountPoint, loadedLibfuseVersion);
+    StackFS fs = new StackFS(root, mountPoint, LibFuse.loadLibrary(
+        AlluxioFuseUtils.getLibfuseLoadStrategy(conf)));
     Set<String> fuseOpts = new HashSet<>();
     for (int i = 2; i < args.length; i++) {
       fuseOpts.add(args[i].substring(2)); // remove -o

--- a/integration/fuse/src/main/java/alluxio/fuse/StackMain.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/StackMain.java
@@ -14,7 +14,8 @@ package alluxio.fuse;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.jnifuse.LibFuse;
+import alluxio.jnifuse.utils.LibfuseVersion;
+import alluxio.jnifuse.utils.NativeLibraryLoader;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.CommonUtils;
 
@@ -39,8 +40,9 @@ public class StackMain {
     Path root = Paths.get(args[1]);
     Path mountPoint = Paths.get(args[0]);
     AlluxioConfiguration conf = Configuration.global();
-    StackFS fs = new StackFS(root, mountPoint, LibFuse.loadLibrary(
-        AlluxioFuseUtils.getLibfuseLoadStrategy(conf)));
+    LibfuseVersion libfuseVersion = AlluxioFuseUtils.getAndCheckLibfuseVersion(conf);
+    NativeLibraryLoader.getInstance().loadLibfuse(libfuseVersion);
+    StackFS fs = new StackFS(root, mountPoint, libfuseVersion);
     Set<String> fuseOpts = new HashSet<>();
     for (int i = 2; i < args.length; i++) {
       fuseOpts.add(args[i].substring(2)); // remove -o

--- a/integration/fuse/src/main/java/alluxio/fuse/options/FuseOptions.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/options/FuseOptions.java
@@ -15,6 +15,7 @@ import alluxio.client.file.options.FileSystemOptions;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.runtime.InvalidArgumentRuntimeException;
+import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.jnifuse.utils.LibfuseVersion;
 
 import com.google.common.base.Preconditions;
@@ -37,40 +38,38 @@ public class FuseOptions {
   /**
    * Creates the FUSE options.
    *
-   * @param libfuseVersion the loaded libfuse version
    * @param conf alluxio configuration
    * @return the file system options
    */
-  public static FuseOptions create(LibfuseVersion libfuseVersion, AlluxioConfiguration conf) {
-    return create(libfuseVersion, FileSystemOptions.create(conf), false, conf);
+  public static FuseOptions create(AlluxioConfiguration conf) {
+    return create(FileSystemOptions.create(conf), false, conf);
   }
 
   /**
    * Creates the FUSE options.
    *
-   * @param libfuseVersion the loaded libfuse version
    * @param updateCheckEnabled whether to enable update check
    * @param conf alluxio configuration
    * @return the file system options
    */
-  public static FuseOptions create(LibfuseVersion libfuseVersion,
+  public static FuseOptions create(
       boolean updateCheckEnabled, AlluxioConfiguration conf) {
-    return create(libfuseVersion, FileSystemOptions.create(conf), updateCheckEnabled, conf);
+    return create(FileSystemOptions.create(conf), updateCheckEnabled, conf);
   }
 
   /**
    * Creates the FUSE options.
    *
-   * @param libfuseVersion the loaded libfuse version
    * @param fileSystemOptions the file system options
    * @param updateCheckEnabled whether to enable update check
    * @param conf alluxio configuration
    * @return the file system options
    */
-  public static FuseOptions create(LibfuseVersion libfuseVersion,
+  public static FuseOptions create(
       FileSystemOptions fileSystemOptions, boolean updateCheckEnabled, AlluxioConfiguration conf) {
     Set<String> mountOptions = conf.getList(PropertyKey.FUSE_MOUNT_OPTIONS)
         .stream().filter(a -> !a.isEmpty()).collect(Collectors.toSet());
+    LibfuseVersion libfuseVersion = AlluxioFuseUtils.getAndCheckLibfuseVersion(conf);
     if (!conf.getBoolean(PropertyKey.FUSE_JNIFUSE_ENABLED)
         && libfuseVersion == LibfuseVersion.VERSION_3) {
       throw new InvalidArgumentRuntimeException("Cannot use JNR-FUSE with libfuse 3");

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
@@ -52,6 +52,7 @@ import alluxio.jnifuse.LibFuse;
 import alluxio.jnifuse.struct.FileStat;
 import alluxio.jnifuse.struct.FuseFileInfo;
 import alluxio.jnifuse.struct.Statvfs;
+import alluxio.jnifuse.utils.LibfuseVersion;
 import alluxio.resource.CloseableResource;
 import alluxio.security.authorization.Mode;
 import alluxio.wire.BlockMasterInfo;
@@ -102,10 +103,11 @@ public class AlluxioJniFuseFileSystemTest {
     mFileSystemContext = mock(FileSystemContext.class);
     mFileSystem = mock(FileSystem.class);
     when(mFileSystemContext.getClusterConf()).thenReturn(mConf);
-    LibFuse.loadLibrary(AlluxioFuseUtils.getLibfuseVersion(Configuration.global()));
+    LibfuseVersion loadedLibfuseVersion = LibFuse.loadLibrary(
+        AlluxioFuseUtils.getLibfuseLoadStrategy(mConf));
     try {
       mFuseFs = new AlluxioJniFuseFileSystem(
-          mFileSystemContext, mFileSystem, FuseOptions.create(mConf));
+          mFileSystemContext, mFileSystem, FuseOptions.create(loadedLibfuseVersion, mConf));
     } catch (UnsatisfiedLinkError e) {
       // stop test and ignore if FuseFileSystem fails to create due to missing libfuse library
       Assume.assumeNoException(e);
@@ -556,7 +558,7 @@ public class AlluxioJniFuseFileSystemTest {
   private FuseFileInfo allocateNativeFileInfo() {
     ByteBuffer buffer = ByteBuffer.allocateDirect(36);
     buffer.clear();
-    return FuseFileInfo.of(buffer);
+    return mFuseFs.createFuseFileInfo(buffer);
   }
 
   /**

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioJnrFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioJnrFuseFileSystemTest.java
@@ -46,6 +46,8 @@ import alluxio.fuse.options.FuseOptions;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.SetAttributePOptions;
+import alluxio.jnifuse.LibFuse;
+import alluxio.jnifuse.utils.LibfuseVersion;
 import alluxio.security.authorization.Mode;
 import alluxio.wire.BlockMasterInfo;
 import alluxio.wire.FileInfo;
@@ -100,7 +102,10 @@ public class AlluxioJnrFuseFileSystemTest {
   public void before() throws Exception {
     mFileSystem = mock(FileSystem.class);
     try {
-      mFuseFs = new AlluxioJnrFuseFileSystem(mFileSystem, mConf, FuseOptions.create(mConf));
+      LibFuse.loadLibrary(
+          LibFuse.LibfuseLoadStrategy.LOAD_FUSE2_ONLY);
+      mFuseFs = new AlluxioJnrFuseFileSystem(mFileSystem, mConf,
+          FuseOptions.create(LibfuseVersion.VERSION_2, mConf));
     } catch (UnsatisfiedLinkError e) {
       // stop test and ignore if FuseFileSystem fails to create due to missing libfuse library
       Assume.assumeNoException(e);

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioJnrFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioJnrFuseFileSystemTest.java
@@ -46,8 +46,7 @@ import alluxio.fuse.options.FuseOptions;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.SetAttributePOptions;
-import alluxio.jnifuse.LibFuse;
-import alluxio.jnifuse.utils.LibfuseVersion;
+import alluxio.jnifuse.utils.NativeLibraryLoader;
 import alluxio.security.authorization.Mode;
 import alluxio.wire.BlockMasterInfo;
 import alluxio.wire.FileInfo;
@@ -86,6 +85,11 @@ public class AlluxioJnrFuseFileSystemTest {
   private static final AlluxioURI BASE_EXPECTED_URI = new AlluxioURI(TEST_ROOT_PATH);
   private static final String MOUNT_POINT = "/t/mountPoint";
 
+  static {
+    NativeLibraryLoader.getInstance().loadLibfuse(
+        AlluxioFuseUtils.getAndCheckLibfuseVersion(Configuration.global()));
+  }
+
   private AlluxioJnrFuseFileSystem mFuseFs;
   private FileSystem mFileSystem;
   private FuseFileInfo mFileInfo;
@@ -102,10 +106,7 @@ public class AlluxioJnrFuseFileSystemTest {
   public void before() throws Exception {
     mFileSystem = mock(FileSystem.class);
     try {
-      LibFuse.loadLibrary(
-          LibFuse.LibfuseLoadStrategy.LOAD_FUSE2_ONLY);
-      mFuseFs = new AlluxioJnrFuseFileSystem(mFileSystem, mConf,
-          FuseOptions.create(LibfuseVersion.VERSION_2, mConf));
+      mFuseFs = new AlluxioJnrFuseFileSystem(mFileSystem, mConf, FuseOptions.create(mConf));
     } catch (UnsatisfiedLinkError e) {
       // stop test and ignore if FuseFileSystem fails to create due to missing libfuse library
       Assume.assumeNoException(e);

--- a/integration/fuse/src/test/java/alluxio/fuse/meta/UpdateCheckerTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/meta/UpdateCheckerTest.java
@@ -18,7 +18,6 @@ import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.fuse.FuseConstants;
 import alluxio.fuse.options.FuseOptions;
-import alluxio.jnifuse.utils.LibfuseVersion;
 import alluxio.metrics.MetricsSystem;
 
 import org.junit.Assert;
@@ -35,7 +34,7 @@ public class UpdateCheckerTest {
   @Test
   public void UnderFileSystemAlluxio() {
     try (UpdateChecker checker = UpdateChecker
-        .create(FuseOptions.create(LibfuseVersion.VERSION_2, Configuration.global()))) {
+        .create(FuseOptions.create(Configuration.global()))) {
       Assert.assertTrue(containsTargetInfo(checker.getUnchangeableFuseInfo(),
           UpdateChecker.ALLUXIO_FS));
     }
@@ -93,7 +92,7 @@ public class UpdateCheckerTest {
   @Test
   public void FuseOpsCalled() {
     try (UpdateChecker checker = UpdateChecker.create(FuseOptions.create(
-        LibfuseVersion.VERSION_2, Configuration.global()))) {
+        Configuration.global()))) {
       MetricsSystem.timer(FuseConstants.FUSE_READ).update(5, TimeUnit.MILLISECONDS);
       Assert.assertTrue(containsTargetInfo(checker.getFuseCheckInfo(), FuseConstants.FUSE_READ));
       MetricsSystem.timer(FuseConstants.FUSE_WRITE).update(5, TimeUnit.MILLISECONDS);
@@ -104,16 +103,15 @@ public class UpdateCheckerTest {
   }
 
   private UpdateChecker getUpdateCheckerWithUfs(String ufsAddress) {
-    return UpdateChecker.create(FuseOptions.create(LibfuseVersion.VERSION_2,
-        FileSystemOptions.create(Configuration.global(),
-            Optional.of(new UfsFileSystemOptions(ufsAddress))), false, Configuration.global()));
+    return UpdateChecker.create(FuseOptions.create(FileSystemOptions.create(Configuration.global(),
+        Optional.of(new UfsFileSystemOptions(ufsAddress))), false, Configuration.global()));
   }
 
   private UpdateChecker getUpdateCheckerWithMountOptions(String mountOptions) {
     InstancedConfiguration conf = Configuration.copyGlobal();
     conf.set(PropertyKey.FUSE_MOUNT_OPTIONS,
         PropertyKey.FUSE_MOUNT_OPTIONS.formatValue(mountOptions));
-    return UpdateChecker.create(FuseOptions.create(LibfuseVersion.VERSION_2, conf));
+    return UpdateChecker.create(FuseOptions.create(conf));
   }
 
   private boolean containsTargetInfo(List<String> list, String targetInfo) {

--- a/integration/fuse/src/test/java/alluxio/fuse/meta/UpdateCheckerTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/meta/UpdateCheckerTest.java
@@ -18,6 +18,7 @@ import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.fuse.FuseConstants;
 import alluxio.fuse.options.FuseOptions;
+import alluxio.jnifuse.utils.LibfuseVersion;
 import alluxio.metrics.MetricsSystem;
 
 import org.junit.Assert;
@@ -34,7 +35,7 @@ public class UpdateCheckerTest {
   @Test
   public void UnderFileSystemAlluxio() {
     try (UpdateChecker checker = UpdateChecker
-        .create(FuseOptions.create(Configuration.global()))) {
+        .create(FuseOptions.create(LibfuseVersion.VERSION_2, Configuration.global()))) {
       Assert.assertTrue(containsTargetInfo(checker.getUnchangeableFuseInfo(),
           UpdateChecker.ALLUXIO_FS));
     }
@@ -91,7 +92,8 @@ public class UpdateCheckerTest {
 
   @Test
   public void FuseOpsCalled() {
-    try (UpdateChecker checker = UpdateChecker.create(FuseOptions.create(Configuration.global()))) {
+    try (UpdateChecker checker = UpdateChecker.create(FuseOptions.create(
+        LibfuseVersion.VERSION_2, Configuration.global()))) {
       MetricsSystem.timer(FuseConstants.FUSE_READ).update(5, TimeUnit.MILLISECONDS);
       Assert.assertTrue(containsTargetInfo(checker.getFuseCheckInfo(), FuseConstants.FUSE_READ));
       MetricsSystem.timer(FuseConstants.FUSE_WRITE).update(5, TimeUnit.MILLISECONDS);
@@ -102,16 +104,16 @@ public class UpdateCheckerTest {
   }
 
   private UpdateChecker getUpdateCheckerWithUfs(String ufsAddress) {
-    return UpdateChecker.create(FuseOptions.create(Configuration.global(),
+    return UpdateChecker.create(FuseOptions.create(LibfuseVersion.VERSION_2,
         FileSystemOptions.create(Configuration.global(),
-            Optional.of(new UfsFileSystemOptions(ufsAddress))), false));
+            Optional.of(new UfsFileSystemOptions(ufsAddress))), false, Configuration.global()));
   }
 
   private UpdateChecker getUpdateCheckerWithMountOptions(String mountOptions) {
     InstancedConfiguration conf = Configuration.copyGlobal();
     conf.set(PropertyKey.FUSE_MOUNT_OPTIONS,
         PropertyKey.FUSE_MOUNT_OPTIONS.formatValue(mountOptions));
-    return UpdateChecker.create(FuseOptions.create(conf));
+    return UpdateChecker.create(FuseOptions.create(LibfuseVersion.VERSION_2, conf));
   }
 
   private boolean containsTargetInfo(List<String> list, String targetInfo) {

--- a/integration/fuse/src/test/java/alluxio/fuse/ufs/AbstractFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/ufs/AbstractFuseFileSystemTest.java
@@ -37,7 +37,7 @@ public abstract class AbstractFuseFileSystemTest extends AbstractTest {
   @Override
   public void beforeActions() {
     mFuseFs = new AlluxioJniFuseFileSystem(mContext, mFileSystem,
-        FuseOptions.create(LIBFUSE_VERSION, FileSystemOptions.create(
+        FuseOptions.create(FileSystemOptions.create(
             mContext.getClusterConf(), Optional.of(mUfsOptions)), false, Configuration.global()));
     mFileStat = FileStat.of(ByteBuffer.allocateDirect(256));
     mFileInfo = AlluxioFuseUtils.createTestFuseFileInfo(mFuseFs);

--- a/integration/fuse/src/test/java/alluxio/fuse/ufs/AbstractFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/ufs/AbstractFuseFileSystemTest.java
@@ -19,6 +19,8 @@ import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.fuse.AlluxioJniFuseFileSystem;
 import alluxio.fuse.options.FuseOptions;
 import alluxio.jnifuse.struct.FileStat;
+import alluxio.jnifuse.struct.FuseFileInfo;
+import alluxio.resource.CloseableResource;
 import alluxio.util.io.BufferUtils;
 
 import org.junit.Assert;
@@ -29,16 +31,16 @@ import java.util.Optional;
 
 public abstract class AbstractFuseFileSystemTest extends AbstractTest {
   protected AlluxioJniFuseFileSystem mFuseFs;
-  protected AlluxioFuseUtils.CloseableFuseFileInfo mFileInfo;
+  protected CloseableResource<FuseFileInfo> mFileInfo;
   protected FileStat mFileStat;
 
   @Override
   public void beforeActions() {
     mFuseFs = new AlluxioJniFuseFileSystem(mContext, mFileSystem,
-        FuseOptions.create(Configuration.global(), FileSystemOptions.create(
-            mContext.getClusterConf(), Optional.of(mUfsOptions)), false));
+        FuseOptions.create(mLibfuseVersion, FileSystemOptions.create(
+            mContext.getClusterConf(), Optional.of(mUfsOptions)), false, Configuration.global()));
     mFileStat = FileStat.of(ByteBuffer.allocateDirect(256));
-    mFileInfo = new AlluxioFuseUtils.CloseableFuseFileInfo();
+    mFileInfo = AlluxioFuseUtils.createTestFuseFileInfo(mFuseFs);
   }
 
   @Override

--- a/integration/fuse/src/test/java/alluxio/fuse/ufs/AbstractFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/ufs/AbstractFuseFileSystemTest.java
@@ -37,7 +37,7 @@ public abstract class AbstractFuseFileSystemTest extends AbstractTest {
   @Override
   public void beforeActions() {
     mFuseFs = new AlluxioJniFuseFileSystem(mContext, mFileSystem,
-        FuseOptions.create(mLibfuseVersion, FileSystemOptions.create(
+        FuseOptions.create(LIBFUSE_VERSION, FileSystemOptions.create(
             mContext.getClusterConf(), Optional.of(mUfsOptions)), false, Configuration.global()));
     mFileStat = FileStat.of(ByteBuffer.allocateDirect(256));
     mFileInfo = AlluxioFuseUtils.createTestFuseFileInfo(mFuseFs);

--- a/integration/fuse/src/test/java/alluxio/fuse/ufs/AbstractTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/ufs/AbstractTest.java
@@ -48,10 +48,11 @@ public abstract class AbstractTest {
   protected static final int DEFAULT_FILE_LEN = 64;
   protected static final Mode DEFAULT_MODE = new Mode(
       Mode.Bits.ALL, Mode.Bits.READ, Mode.Bits.READ);
+  protected static final LibfuseVersion LIBFUSE_VERSION = LibFuse.loadLibrary(
+      AlluxioFuseUtils.getLibfuseLoadStrategy(Configuration.global()));
 
   protected AlluxioURI mRootUfs;
   protected FileSystem mFileSystem;
-  protected LibfuseVersion mLibfuseVersion;
   protected FileSystemContext mContext;
   protected UfsFileSystemOptions mUfsOptions;
 
@@ -64,8 +65,6 @@ public abstract class AbstractTest {
     LocalUnderFileSystemFactory localUnderFileSystemFactory = new LocalUnderFileSystemFactory();
     UnderFileSystemFactoryRegistry.register(localUnderFileSystemFactory);
     mContext = FileSystemContext.create(ClientContext.create(conf));
-    mLibfuseVersion = LibFuse.loadLibrary(
-        AlluxioFuseUtils.getLibfuseLoadStrategy(conf));
     mUfsOptions = new UfsFileSystemOptions(ufs);
     mFileSystem = new UfsBaseFileSystem(mContext, mUfsOptions);
     beforeActions();

--- a/integration/fuse/src/test/java/alluxio/fuse/ufs/AbstractTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/ufs/AbstractTest.java
@@ -23,8 +23,7 @@ import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
 import alluxio.fuse.AlluxioFuseUtils;
-import alluxio.jnifuse.LibFuse;
-import alluxio.jnifuse.utils.LibfuseVersion;
+import alluxio.jnifuse.utils.NativeLibraryLoader;
 import alluxio.security.authorization.Mode;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 import alluxio.underfs.local.LocalUnderFileSystemFactory;
@@ -48,13 +47,16 @@ public abstract class AbstractTest {
   protected static final int DEFAULT_FILE_LEN = 64;
   protected static final Mode DEFAULT_MODE = new Mode(
       Mode.Bits.ALL, Mode.Bits.READ, Mode.Bits.READ);
-  protected static final LibfuseVersion LIBFUSE_VERSION = LibFuse.loadLibrary(
-      AlluxioFuseUtils.getLibfuseLoadStrategy(Configuration.global()));
 
   protected AlluxioURI mRootUfs;
   protected FileSystem mFileSystem;
   protected FileSystemContext mContext;
   protected UfsFileSystemOptions mUfsOptions;
+
+  static {
+    NativeLibraryLoader.getInstance().loadLibfuse(
+        AlluxioFuseUtils.getAndCheckLibfuseVersion(Configuration.global()));
+  }
 
   @Before
   public void before() throws Exception {

--- a/integration/fuse/src/test/java/alluxio/fuse/ufs/AbstractTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/ufs/AbstractTest.java
@@ -24,6 +24,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.conf.Source;
 import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.jnifuse.LibFuse;
+import alluxio.jnifuse.utils.LibfuseVersion;
 import alluxio.security.authorization.Mode;
 import alluxio.underfs.UnderFileSystemFactoryRegistry;
 import alluxio.underfs.local.LocalUnderFileSystemFactory;
@@ -50,6 +51,7 @@ public abstract class AbstractTest {
 
   protected AlluxioURI mRootUfs;
   protected FileSystem mFileSystem;
+  protected LibfuseVersion mLibfuseVersion;
   protected FileSystemContext mContext;
   protected UfsFileSystemOptions mUfsOptions;
 
@@ -62,7 +64,8 @@ public abstract class AbstractTest {
     LocalUnderFileSystemFactory localUnderFileSystemFactory = new LocalUnderFileSystemFactory();
     UnderFileSystemFactoryRegistry.register(localUnderFileSystemFactory);
     mContext = FileSystemContext.create(ClientContext.create(conf));
-    LibFuse.loadLibrary(AlluxioFuseUtils.getLibfuseVersion(Configuration.global()));
+    mLibfuseVersion = LibFuse.loadLibrary(
+        AlluxioFuseUtils.getLibfuseLoadStrategy(conf));
     mUfsOptions = new UfsFileSystemOptions(ufs);
     mFileSystem = new UfsBaseFileSystem(mContext, mUfsOptions);
     beforeActions();

--- a/integration/fuse/src/test/java/alluxio/jnifuse/struct/FuseFileInfoTest.java
+++ b/integration/fuse/src/test/java/alluxio/jnifuse/struct/FuseFileInfoTest.java
@@ -17,6 +17,7 @@ import alluxio.conf.Configuration;
 import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.jnifuse.LibFuse;
 
+import alluxio.jnifuse.utils.LibfuseVersion;
 import jnr.ffi.Pointer;
 import jnr.ffi.Runtime;
 import org.junit.Test;
@@ -26,8 +27,11 @@ import java.nio.ByteBuffer;
 public class FuseFileInfoTest {
   @Test
   public void offset() {
-    LibFuse.loadLibrary(AlluxioFuseUtils.getLibfuseVersion(Configuration.global()));
-    FuseFileInfo jnifi = FuseFileInfo.of(ByteBuffer.allocate(256));
+    LibfuseVersion loadedLibfuseVersion = LibFuse.loadLibrary(
+        AlluxioFuseUtils.getLibfuseLoadStrategy(Configuration.global()));
+    FuseFileInfo.Factory factory = loadedLibfuseVersion == LibfuseVersion.VERSION_2
+        ? new Fuse2FuseFileInfo.Factory() : new Fuse3FuseFileInfo.Factory();
+    FuseFileInfo jnifi = factory.create(ByteBuffer.allocate(256));
     ru.serce.jnrfuse.struct.FuseFileInfo jnrfi =
         ru.serce.jnrfuse.struct.FuseFileInfo.of(Pointer.wrap(Runtime.getSystemRuntime(), 0x0));
     assertEquals(jnrfi.flags.offset(), jnifi.flags.offset());

--- a/integration/fuse/src/test/java/alluxio/jnifuse/struct/FuseFileInfoTest.java
+++ b/integration/fuse/src/test/java/alluxio/jnifuse/struct/FuseFileInfoTest.java
@@ -27,11 +27,8 @@ import java.nio.ByteBuffer;
 public class FuseFileInfoTest {
   @Test
   public void offset() {
-    LibfuseVersion loadedLibfuseVersion = LibFuse.loadLibrary(
-        AlluxioFuseUtils.getLibfuseLoadStrategy(Configuration.global()));
-    FuseFileInfo.Factory factory = loadedLibfuseVersion == LibfuseVersion.VERSION_2
-        ? new Fuse2FuseFileInfo.Factory() : new Fuse3FuseFileInfo.Factory();
-    FuseFileInfo jnifi = factory.create(ByteBuffer.allocate(256));
+    FuseFileInfo jnifi = new Fuse2FuseFileInfo.Factory()
+        .create(ByteBuffer.allocate(256));
     ru.serce.jnrfuse.struct.FuseFileInfo jnrfi =
         ru.serce.jnrfuse.struct.FuseFileInfo.of(Pointer.wrap(Runtime.getSystemRuntime(), 0x0));
     assertEquals(jnrfi.flags.offset(), jnifi.flags.offset());

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/LibFuse.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/LibFuse.java
@@ -11,58 +11,14 @@
 
 package alluxio.jnifuse;
 
-import alluxio.jnifuse.utils.LibfuseVersion;
-import alluxio.jnifuse.utils.NativeLibraryLoader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.nio.ByteBuffer;
 
 /**
  * Load the libfuse library.
  */
 public class LibFuse {
-  private static final Logger LOG = LoggerFactory.getLogger(LibFuse.class);
-
-  /**
-   * The libfuse load strategy.
-   */
-  public enum LibfuseLoadStrategy {
-    LOAD_FUSE2_ONLY,
-    LOAD_FUSE3_ONLY,
-    FUSE3_THEN_FUSE2,
-  }
 
   public native int fuse_main_real(AbstractFuseFileSystem fs, int argc, String[] argv);
 
   public native ByteBuffer fuse_get_context();
-
-  /**
-   * Load the Libfuse library with the target load strategy.
-   *
-   * @param strategy the load strategy
-   * @return the loaded libfuse version
-   */
-  public static LibfuseVersion loadLibrary(LibfuseLoadStrategy strategy) {
-    String tmpDir = System.getenv("JNIFUSE_SHAREDLIB_DIR");
-    LibfuseVersion versionToLoad = strategy == LibfuseLoadStrategy.LOAD_FUSE2_ONLY
-        ? LibfuseVersion.VERSION_2 : LibfuseVersion.VERSION_3;
-    RuntimeException runtimeException;
-    try {
-      NativeLibraryLoader.getInstance().loadLibrary(versionToLoad, tmpDir);
-      return versionToLoad;
-    } catch (RuntimeException re) {
-      runtimeException = re;
-    }
-    if (strategy == LibfuseLoadStrategy.FUSE3_THEN_FUSE2) {
-      LOG.error("Failed to load jnifuse with libfuse 3, try loading libfuse 2", runtimeException);
-      try {
-        NativeLibraryLoader.getInstance().loadLibrary(LibfuseVersion.VERSION_2, tmpDir);
-        return LibfuseVersion.VERSION_2;
-      } catch (RuntimeException re) {
-        runtimeException = re;
-      }
-    }
-    throw runtimeException;
-  }
 }

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/LibFuse.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/LibFuse.java
@@ -55,7 +55,7 @@ public class LibFuse {
       runtimeException = re;
     }
     if (strategy == LibfuseLoadStrategy.FUSE3_THEN_FUSE2) {
-      LOG.error("Failed to load jnifuse with libfuse 3");
+      LOG.error("Failed to load jnifuse with libfuse 3, try loading libfuse 2", runtimeException);
       try {
         NativeLibraryLoader.getInstance().loadLibrary(versionToLoad, tmpDir);
         return LibfuseVersion.VERSION_2;

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/LibFuse.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/LibFuse.java
@@ -57,7 +57,7 @@ public class LibFuse {
     if (strategy == LibfuseLoadStrategy.FUSE3_THEN_FUSE2) {
       LOG.error("Failed to load jnifuse with libfuse 3, try loading libfuse 2", runtimeException);
       try {
-        NativeLibraryLoader.getInstance().loadLibrary(versionToLoad, tmpDir);
+        NativeLibraryLoader.getInstance().loadLibrary(LibfuseVersion.VERSION_2, tmpDir);
         return LibfuseVersion.VERSION_2;
       } catch (RuntimeException re) {
         runtimeException = re;

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/struct/Fuse2FuseFileInfo.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/struct/Fuse2FuseFileInfo.java
@@ -14,6 +14,7 @@ package alluxio.jnifuse.struct;
 import jnr.ffi.NativeType;
 import jnr.ffi.Runtime;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
@@ -41,5 +42,18 @@ public class Fuse2FuseFileInfo extends FuseFileInfo {
     new Padding(NativeType.UCHAR, 4); // unused flags and paddings
     this.fh = new u_int64_t();
     new u_int64_t(); // lock_owner
+  }
+
+  /**
+   * Factory class to create {@link Fuse2FuseFileInfo}s.
+   */
+  public static class Factory implements FuseFileInfo.Factory {
+    @Override
+    public FuseFileInfo create(ByteBuffer buffer) {
+      Runtime runtime = Runtime.getSystemRuntime();
+      FuseFileInfo info = new Fuse2FuseFileInfo(runtime, buffer);
+      info.useMemory(jnr.ffi.Pointer.wrap(runtime, buffer));
+      return info;
+    }
   }
 }

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/struct/Fuse3FuseFileInfo.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/struct/Fuse3FuseFileInfo.java
@@ -12,7 +12,9 @@
 package alluxio.jnifuse.struct;
 
 import jnr.ffi.NativeType;
+import jnr.ffi.Runtime;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -41,5 +43,18 @@ public class Fuse3FuseFileInfo extends FuseFileInfo {
     this.fh = new u_int64_t();
     new u_int64_t(); // lock_owner
     new u_int32_t(); // poll_events
+  }
+
+  /**
+   * Factory class to create {@link Fuse3FuseFileInfo}s.
+   */
+  public static class Factory implements FuseFileInfo.Factory {
+    @Override
+    public FuseFileInfo create(ByteBuffer buffer) {
+      Runtime runtime = Runtime.getSystemRuntime();
+      FuseFileInfo info = new Fuse3FuseFileInfo(runtime, buffer);
+      info.useMemory(jnr.ffi.Pointer.wrap(runtime, buffer));
+      return info;
+    }
   }
 }

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/struct/FuseFileInfo.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/struct/FuseFileInfo.java
@@ -11,11 +11,10 @@
 
 package alluxio.jnifuse.struct;
 
-import alluxio.jnifuse.utils.NativeLibraryLoader;
-
 import jnr.ffi.Runtime;
 import jnr.ffi.Struct;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -31,20 +30,16 @@ public class FuseFileInfo extends Struct {
     this.buffer.order(ByteOrder.LITTLE_ENDIAN);
   }
 
-  public static FuseFileInfo of(ByteBuffer buffer) {
-    Runtime runtime = Runtime.getSystemRuntime();
-    // select the actual FuseFileInfo by loaded version
-    NativeLibraryLoader.LoadState state = NativeLibraryLoader.getLoadState();
-
-    // Ensure the lib has been loaded in testing
-    // This is not possible when running a real cluster
-    if (state == NativeLibraryLoader.LoadState.NOT_LOADED) {
-      throw new RuntimeException("NativeLibraryLoader is not loaded");
-    }
-    FuseFileInfo fi = state == NativeLibraryLoader.LoadState.LOADED_2
-        ? new Fuse2FuseFileInfo(runtime, buffer)
-        : new Fuse3FuseFileInfo(runtime, buffer);
-    fi.useMemory(jnr.ffi.Pointer.wrap(runtime, buffer));
-    return fi;
+  /**
+   * The factory interface to create {@link FuseFileInfo}s.
+   */
+  public interface Factory {
+    /**
+     * Creates an instance of {@link FuseFileInfo}.
+     *
+     * @param buffer the byte buffer to wrap around
+     * @return the created object
+     */
+    FuseFileInfo create(ByteBuffer buffer);
   }
 }

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/utils/NativeLibraryLoader.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/utils/NativeLibraryLoader.java
@@ -249,10 +249,14 @@ public class NativeLibraryLoader {
   }
 
   private boolean loadToCheckLibraryExistence(String libraryName) {
-    return !tryLoad(() -> {
+    Optional<UnsatisfiedLinkError> error = tryLoad(() -> {
       System.loadLibrary(libraryName);
       LOG.info("Loaded {} by System.loadLibrary.", libraryName);
-    }).isPresent();
+    });
+    if (error.isPresent()) {
+      throw error.get();
+    }
+    return true;
   }
 
   /**

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/utils/NativeLibraryLoader.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/utils/NativeLibraryLoader.java
@@ -165,9 +165,6 @@ public class NativeLibraryLoader {
     Optional<UnsatisfiedLinkError> err;
     switch (version) {
       case VERSION_2:
-        if (!loadToCheckLibraryExistence("libfuse")) {
-          throw new RuntimeException("Failed to find libfuse 2. Please install fuse");
-        }
         err = load2(tmpDir);
         break;
       case VERSION_3:

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/utils/NativeLibraryLoader.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/utils/NativeLibraryLoader.java
@@ -165,9 +165,15 @@ public class NativeLibraryLoader {
     Optional<UnsatisfiedLinkError> err;
     switch (version) {
       case VERSION_2:
+        if (!loadToCheckLibraryExistence("libfuse")) {
+          throw new RuntimeException("Failed to find libfuse 2. Please install fuse");
+        }
         err = load2(tmpDir);
         break;
       case VERSION_3:
+        if (!loadToCheckLibraryExistence("libfuse3")) {
+          throw new RuntimeException("Failed to find libfuse 3. Please install fuse3");
+        }
         err = load3(tmpDir);
         break;
       default:
@@ -243,6 +249,13 @@ public class NativeLibraryLoader {
     }
 
     return temp;
+  }
+
+  private boolean loadToCheckLibraryExistence(String libraryName) {
+    return !tryLoad(() -> {
+      System.loadLibrary(libraryName);
+      LOG.info("Loaded {} by System.loadLibrary.", libraryName);
+    }).isPresent();
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/fuse/JNIFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNIFuseIntegrationTest.java
@@ -19,9 +19,8 @@ import alluxio.conf.PropertyKey;
 import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.fuse.AlluxioJniFuseFileSystem;
 import alluxio.fuse.options.FuseOptions;
-import alluxio.jnifuse.LibFuse;
 import alluxio.jnifuse.struct.FuseFileInfo;
-import alluxio.jnifuse.utils.LibfuseVersion;
+import alluxio.jnifuse.utils.NativeLibraryLoader;
 import alluxio.resource.CloseableResource;
 import alluxio.util.io.BufferUtils;
 
@@ -38,6 +37,12 @@ import java.util.HashSet;
  */
 public class JNIFuseIntegrationTest extends AbstractFuseIntegrationTest {
   private static final int FILE_LEN = 128;
+
+  static {
+    NativeLibraryLoader.getInstance().loadLibfuse(
+        AlluxioFuseUtils.getAndCheckLibfuseVersion(Configuration.global()));
+  }
+
   private AlluxioJniFuseFileSystem mFuseFileSystem;
 
   @Override
@@ -51,10 +56,8 @@ public class JNIFuseIntegrationTest extends AbstractFuseIntegrationTest {
     Configuration.set(PropertyKey.FUSE_MOUNT_ALLUXIO_PATH, alluxioRoot);
     Configuration.set(PropertyKey.FUSE_MOUNT_POINT, mountPoint);
     AlluxioConfiguration conf = Configuration.global();
-    LibfuseVersion loadedLibfuseVersion = LibFuse.loadLibrary(
-        AlluxioFuseUtils.getLibfuseLoadStrategy(conf));
     mFuseFileSystem = new AlluxioJniFuseFileSystem(context, fileSystem,
-        FuseOptions.create(loadedLibfuseVersion, conf));
+        FuseOptions.create(conf));
     mFuseFileSystem.mount(false, false, new HashSet<>());
   }
 

--- a/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
@@ -15,8 +15,11 @@ import alluxio.client.file.FileSystem;
 import alluxio.client.file.FileSystemContext;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
+import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.fuse.AlluxioJnrFuseFileSystem;
 import alluxio.fuse.options.FuseOptions;
+import alluxio.jnifuse.LibFuse;
+import alluxio.jnifuse.utils.LibfuseVersion;
 
 import org.junit.Assume;
 
@@ -40,8 +43,10 @@ public class JNRFuseIntegrationTest extends AbstractFuseIntegrationTest {
     Configuration.set(PropertyKey.FUSE_MOUNT_ALLUXIO_PATH, alluxioRoot);
     Configuration.set(PropertyKey.FUSE_MOUNT_POINT, mountPoint);
     Configuration.set(PropertyKey.FUSE_USER_GROUP_TRANSLATION_ENABLED, true);
+    LibfuseVersion loadedLibfuseVersion = LibFuse.loadLibrary(
+        AlluxioFuseUtils.getLibfuseLoadStrategy(Configuration.global()));
     mFuseFileSystem = new AlluxioJnrFuseFileSystem(fileSystem, Configuration.global(),
-        FuseOptions.create(Configuration.global()));
+        FuseOptions.create(loadedLibfuseVersion, Configuration.global()));
     mFuseFileSystem.mount(Paths.get(mountPoint), false, false, new String[] {"-odirect_io"});
   }
 

--- a/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/JNRFuseIntegrationTest.java
@@ -18,8 +18,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.fuse.AlluxioJnrFuseFileSystem;
 import alluxio.fuse.options.FuseOptions;
-import alluxio.jnifuse.LibFuse;
-import alluxio.jnifuse.utils.LibfuseVersion;
+import alluxio.jnifuse.utils.NativeLibraryLoader;
 
 import org.junit.Assume;
 
@@ -30,6 +29,11 @@ import java.nio.file.Paths;
  */
 public class JNRFuseIntegrationTest extends AbstractFuseIntegrationTest {
   private AlluxioJnrFuseFileSystem mFuseFileSystem;
+
+  static {
+    NativeLibraryLoader.getInstance().loadLibfuse(
+        AlluxioFuseUtils.getAndCheckLibfuseVersion(Configuration.global()));
+  }
 
   @Override
   public void configure() {
@@ -43,10 +47,8 @@ public class JNRFuseIntegrationTest extends AbstractFuseIntegrationTest {
     Configuration.set(PropertyKey.FUSE_MOUNT_ALLUXIO_PATH, alluxioRoot);
     Configuration.set(PropertyKey.FUSE_MOUNT_POINT, mountPoint);
     Configuration.set(PropertyKey.FUSE_USER_GROUP_TRANSLATION_ENABLED, true);
-    LibfuseVersion loadedLibfuseVersion = LibFuse.loadLibrary(
-        AlluxioFuseUtils.getLibfuseLoadStrategy(Configuration.global()));
     mFuseFileSystem = new AlluxioJnrFuseFileSystem(fileSystem, Configuration.global(),
-        FuseOptions.create(loadedLibfuseVersion, Configuration.global()));
+        FuseOptions.create(Configuration.global()));
     mFuseFileSystem.mount(Paths.get(mountPoint), false, false, new String[] {"-odirect_io"});
   }
 


### PR DESCRIPTION
Refactor load libfuse library related logics.
In a process, fuse library should be loaded only once.
In the test, can not avoid that it be loaded multiple times.