### PR TITLE
Support fuse test to test against S3

### DIFF
--- a/integration/fuse/pom.xml
+++ b/integration/fuse/pom.xml
@@ -78,6 +78,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-underfs-s3a</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/integration/fuse/src/test/java/alluxio/fuse/ufs/FuseFileSystemDataTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/ufs/FuseFileSystemDataTest.java
@@ -384,6 +384,7 @@ public class FuseFileSystemDataTest extends AbstractFuseFileSystemTest {
     Assert.assertEquals(DEFAULT_FILE_LEN * 2, mFileStat.st_size.intValue());
     Assert.assertEquals(0, mFuseFs.release(FILE, mFileInfo.get()));
     Assert.assertEquals(DEFAULT_FILE_LEN * 2, mFileStat.st_size.intValue());
+    Assert.assertEquals(0, mFuseFs.unlink(FILE));
   }
 
   private void createOpenTest(Consumer<Function<Integer, Integer>> testCase,

--- a/integration/fuse/src/test/java/alluxio/fuse/ufs/FuseFileSystemMetadataTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/ufs/FuseFileSystemMetadataTest.java
@@ -22,6 +22,7 @@ import alluxio.security.authorization.Mode;
 import alluxio.util.io.BufferUtils;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -162,11 +163,10 @@ public class FuseFileSystemMetadataTest extends AbstractFuseFileSystemTest {
     Assert.assertEquals(0, mFuseFs.mkdir(DIR, DEFAULT_MODE.toShort()));
   }
 
-  /**
-   * S3 does not have mode concept and mode will always be 700.
-   */
   @Test
-  public void chmodLocalUfsOnly() {
+  public void chmod() {
+    // S3 does not have mode concept and mode will always be 700.
+    Assume.assumeTrue(mIsLocalUFS);
     createEmptyFile(FILE);
     Mode mode = new Mode(Mode.Bits.EXECUTE, Mode.Bits.WRITE, Mode.Bits.READ);
     mFuseFs.chmod(FILE, mode.toShort());


### PR DESCRIPTION
Support fuse test to test against S3 by passing maven parameter `-Dalluxio.test.s3a.path=s3://alluxio-test-fuse/`.