### PR TITLE
Use RPC hostname as fallback master hostname

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -232,7 +232,7 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
     mCoreMasterContext = masterContext;
     mMasterAddress =
         new Address().setHost(Configuration.getOrDefault(PropertyKey.MASTER_HOSTNAME,
-            "localhost"))
+            mRpcConnectAddress.getHostName()))
             .setRpcPort(mPort);
     /* Handle to the block master. */
     blockMaster.registerLostWorkerFoundListener(mWorkerConfigStore::lostNodeFound);


### PR DESCRIPTION
### What changes are proposed in this pull request?

> Please modify alluxio-site.properties to either set alluxio.master.hostname, configure zookeeper with alluxio.zookeeper.enabled=true and alluxio.zookeeper.address=[comma-separated zookeeper master addresses], or utilize internal HA by setting alluxio.master.embedded.journal.addresses=[comma-separated alluxio master addresses]

First, according to the quote above, it is allowed to not set `alluxio.master.hostname` in HA mode.
When `alluxio.master.hostname` is not set, master address fallsback to `localhost`,
which causes `IndexedSet<MasterInfo> mMasters` lose information if masters are using the same port.

### Why are the changes needed?

Fix problems if `alluxio.master.hostname` is not set in HA mode.

1. Standby and lost masters are not displayed in WebUI if masters are using the same port.
2. Display more informative hostname of masters.

### Does this PR introduce any user facing changes?

Before:
<img width="1218" alt="WebUI Masters showing localhost" src="https://user-images.githubusercontent.com/5821159/206352710-b3d809cf-3fb5-4bce-865a-26d8182b893b.png">

After:
<img width="1196" alt="WebUI Masters showing RPC address" src="https://user-images.githubusercontent.com/5821159/206352724-6279ac56-8e47-4dd3-833d-c69dd360c740.png">
