### PR TITLE
Aggregate BlockReaderThreadActiveCount and BlockWriterThreadActiveCount at master

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -1367,6 +1367,18 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("The number of active write-RPCs managed by workers")
           .setMetricType(MetricType.COUNTER)
           .build();
+  public static final MetricKey CLUSTER_BLOCK_READER_THREAD_ACTIVE_COUNT =
+      new Builder("Cluster.BlockReaderThreadActiveCount")
+          .setDescription("The total number of block read threads "
+              + "that are actively executing tasks in reader thread pool by workers")
+          .setMetricType(MetricType.COUNTER)
+          .build();
+  public static final MetricKey CLUSTER_BLOCK_WRITER_THREAD_ACTIVE_COUNT =
+      new Builder("Cluster.BlockWriterThreadActiveCount")
+          .setDescription("The total number of block write threads "
+              + "that are actively executing tasks in writer thread pool by workers")
+          .setMetricType(MetricType.COUNTER)
+          .build();
   public static final MetricKey CLUSTER_BYTES_READ_DIRECT =
       new Builder("Cluster.BytesReadDirect")
           .setDescription("Total number of bytes read from all workers "
@@ -1913,7 +1925,7 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("The approximate number of block read "
               + "threads that are actively executing tasks in reader thread pool")
           .setMetricType(MetricType.GAUGE)
-          .setIsClusterAggregated(false)
+          .setIsClusterAggregated(true)
           .build();
   public static final MetricKey WORKER_BLOCK_READER_THREAD_CURRENT_COUNT =
       new Builder("Worker.BlockReaderThreadCurrentCount")
@@ -1967,7 +1979,7 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("The approximate number of block write "
               + "threads that are actively executing tasks in writer thread pool")
           .setMetricType(MetricType.GAUGE)
-          .setIsClusterAggregated(false)
+          .setIsClusterAggregated(true)
           .build();
   public static final MetricKey WORKER_BLOCK_WRITER_THREAD_CURRENT_COUNT =
       new Builder("Worker.BlockWriterThreadCurrentCount")

--- a/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metrics/MetricsStore.java
@@ -197,6 +197,12 @@ public class MetricsStore {
       mClusterCounters.putIfAbsent(new ClusterCounterKey(InstanceType.WORKER,
           MetricKey.WORKER_ACTIVE_RPC_WRITE_COUNT.getMetricName()),
           MetricsSystem.counter(MetricKey.CLUSTER_ACTIVE_RPC_WRITE_COUNT.getName()));
+      mClusterCounters.putIfAbsent(new ClusterCounterKey(InstanceType.WORKER,
+              MetricKey.WORKER_BLOCK_READER_THREAD_ACTIVE_COUNT.getMetricName()),
+          MetricsSystem.counter(MetricKey.CLUSTER_BLOCK_READER_THREAD_ACTIVE_COUNT.getName()));
+      mClusterCounters.putIfAbsent(new ClusterCounterKey(InstanceType.WORKER,
+              MetricKey.WORKER_BLOCK_WRITER_THREAD_ACTIVE_COUNT.getMetricName()),
+          MetricsSystem.counter(MetricKey.CLUSTER_BLOCK_WRITER_THREAD_ACTIVE_COUNT.getName()));
 
       // client metrics
       mClusterCounters.putIfAbsent(new ClusterCounterKey(InstanceType.CLIENT,


### PR DESCRIPTION
### What changes are proposed in this pull request?

Aggregate BlockReaderThreadActiveCount and BlockWriterThreadActiveCount at master

### Why are the changes needed?

As `Worker.ActiveClients`, `Cluster.ActiveRpcReadCount` and `Cluster.ActiveRpcWriteCount` are not correct currently (please refer #16229), and it is not easy to fix/maintain ActiveRpcReadCount/ActiveRpcWriteCount because of their calculation mechanism, in order to have a learning about the global workload, we can aggregate BlockReaderThreadActiveCount/BlockWriterThreadActiveCount at master to achieve this target.

For `BlockReaderThreadActiveCount/BlockWriterThreadActiveCount`, they just need to call the method `getActiveCount` with the executor, which is simple and accurate.
For `ActiveRpcReadCount/ActiveRpcWriteCount`, they need to track each entry/exit point, which is more complex.


### Does this PR introduce any user facing changes?

No