### PR TITLE
Support fuse sdk seek

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
@@ -51,6 +51,7 @@ import alluxio.underfs.options.CreateOptions;
 import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
+import alluxio.underfs.options.OpenOptions;
 import alluxio.util.CommonUtils;
 import alluxio.util.ModeUtils;
 import alluxio.util.io.PathUtils;
@@ -294,8 +295,13 @@ public class UfsBaseFileSystem implements FileSystem {
   public FileInStream openFile(URIStatus status, OpenFilePOptions options) {
     return callWithReturn(() -> {
       // TODO(lu) deal with other options e.g. maxUfsReadConcurrency
-      return new UfsFileInStream(mUfs.get().open(status.getPath()),
-          status.getLength());
+      return new UfsFileInStream(offset -> {
+        try {
+          return mUfs.get().open(status.getPath(), OpenOptions.defaults().setOffset(offset));
+        } catch (IOException e) {
+          throw AlluxioRuntimeException.from(e);
+        }
+      }, status.getLength());
     });
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsFileInStream.java
@@ -11,6 +11,7 @@
 
 package alluxio.client.file.ufs;
 
+import alluxio.Seekable;
 import alluxio.client.file.FileInStream;
 import alluxio.exception.PreconditionMessage;
 import alluxio.underfs.SeekableUnderFileInputStream;
@@ -138,8 +139,8 @@ public class UfsFileInStream extends FileInStream {
       mPosition = pos;
       return;
     }
-    if (mUfsInStream.get() instanceof SeekableUnderFileInputStream) {
-      ((SeekableUnderFileInputStream) mUfsInStream.get()).seek(pos);
+    if (mUfsInStream.get() instanceof Seekable) {
+      ((Seekable) mUfsInStream.get()).seek(pos);
     } else if (mPosition < pos) {
       while (mPosition < pos) {
         mPosition += mUfsInStream.get().skip(pos - mPosition);

--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsFileInStream.java
@@ -13,13 +13,15 @@ package alluxio.client.file.ufs;
 
 import alluxio.client.file.FileInStream;
 import alluxio.exception.PreconditionMessage;
+import alluxio.underfs.SeekableUnderFileInputStream;
 
 import com.google.common.base.Preconditions;
-import com.google.common.io.Closer;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.function.Function;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -27,28 +29,29 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public class UfsFileInStream extends FileInStream {
-  /** Used to manage closeable resources. */
-  private final Closer mCloser = Closer.create();
-  private final InputStream mUfsInStream;
   private final long mLength;
-  private long mPosition;
+  private final Function<Long, InputStream> mFileOpener;
+  private Optional<InputStream> mUfsInStream = Optional.empty();
+  private long mPosition = 0L;
 
   /**
    * Creates a new {@link UfsFileInStream}.
    *
-   * @param stream the embedded input stream
+   * @param fileOpener the file opener to open an ufs in stream with offset
    * @param fileLength the file length
    */
-  public UfsFileInStream(InputStream stream, long fileLength) {
-    mUfsInStream = Preconditions.checkNotNull(stream);
+  public UfsFileInStream(Function<Long, InputStream> fileOpener, long fileLength) {
+    mFileOpener = Preconditions.checkNotNull(fileOpener);
     mLength = fileLength;
-    mCloser.register(mUfsInStream);
-    mUfsInStream.mark(0);
   }
 
   @Override
   public int read() throws IOException {
-    int res = mUfsInStream.read();
+    if (mPosition == mLength) { // at end of file
+      return -1;
+    }
+    updateStreamIfNeeded();
+    int res = mUfsInStream.get().read();
     if (res == -1) {
       return -1;
     }
@@ -72,10 +75,14 @@ public class UfsFileInStream extends FileInStream {
   public int read(byte[] b, int off, int len) throws IOException {
     Preconditions.checkArgument(off >= 0 && len >= 0 && len + off <= b.length,
         PreconditionMessage.ERR_BUFFER_STATE.toString(), b.length, off, len);
+    if (mPosition == mLength) { // at end of file
+      return -1;
+    }
+    updateStreamIfNeeded();
     int currentRead = 0;
     int totalRead = 0;
     while (totalRead < len) {
-      currentRead = mUfsInStream.read(b, off + totalRead, len - totalRead);
+      currentRead = mUfsInStream.get().read(b, off + totalRead, len - totalRead);
       if (currentRead <= 0) {
         break;
       }
@@ -90,16 +97,16 @@ public class UfsFileInStream extends FileInStream {
     if (n <= 0) {
       return 0;
     }
-    long res = mUfsInStream.skip(n);
+    long toBeSkipped = Math.min(n, mLength - mPosition);
+    if (!mUfsInStream.isPresent()) {
+      mPosition += toBeSkipped;
+      return toBeSkipped;
+    }
+    long res = mUfsInStream.get().skip(toBeSkipped);
     if (res > 0) {
       mPosition += res;
     }
     return res;
-  }
-
-  @Override
-  public void close() throws IOException {
-    mCloser.close();
   }
 
   @Override
@@ -127,15 +134,34 @@ public class UfsFileInStream extends FileInStream {
     if (mPosition == pos) {
       return;
     }
-    if (mPosition < pos) {
-      mPosition += mUfsInStream.skip(pos - mPosition);
+    if (!mUfsInStream.isPresent()) {
+      mPosition = pos;
+      return;
+    }
+    if (mUfsInStream.get() instanceof SeekableUnderFileInputStream) {
+      ((SeekableUnderFileInputStream) mUfsInStream.get()).seek(pos);
+    } else if (mPosition < pos) {
+      while (mPosition < pos) {
+        mPosition += mUfsInStream.get().skip(pos - mPosition);
+      }
     } else {
-      mUfsInStream.reset();
-      mPosition = mUfsInStream.skip(pos);
+      close();
     }
-    if (mPosition != pos) {
-      throw new IOException(String.format("Failed to seek to position %s but at %s",
-          pos, mPosition));
+    mPosition = pos;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (mUfsInStream.isPresent()) {
+      mUfsInStream.get().close();
+      mUfsInStream = Optional.empty();
     }
+  }
+
+  private void updateStreamIfNeeded() {
+    if (mUfsInStream.isPresent()) {
+      return;
+    }
+    mUfsInStream = Optional.of(mFileOpener.apply(mPosition));
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsFileInStream.java
@@ -14,7 +14,6 @@ package alluxio.client.file.ufs;
 import alluxio.Seekable;
 import alluxio.client.file.FileInStream;
 import alluxio.exception.PreconditionMessage;
-import alluxio.underfs.SeekableUnderFileInputStream;
 
 import com.google.common.base.Preconditions;
 

--- a/core/common/src/main/java/alluxio/exception/runtime/UnknownRuntimeException.java
+++ b/core/common/src/main/java/alluxio/exception/runtime/UnknownRuntimeException.java
@@ -33,4 +33,13 @@ public class UnknownRuntimeException extends AlluxioRuntimeException {
   public UnknownRuntimeException(Throwable t) {
     super(STATUS, t.getMessage(), t, ERROR_TYPE, RETRYABLE);
   }
+
+  /**
+   * Constructor.
+   *
+   * @param message error message
+   */
+  public UnknownRuntimeException(String message) {
+    super(STATUS, message, null, ERROR_TYPE, RETRYABLE);
+  }
 }

--- a/integration/fuse/src/test/java/alluxio/fuse/ufs/stream/InStreamTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/ufs/stream/InStreamTest.java
@@ -64,6 +64,11 @@ public class InStreamTest extends AbstractStreamTest {
     try (FuseFileStream inStream = createStream(alluxioURI)) {
       ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN / 2);
       Assert.assertEquals(DEFAULT_FILE_LEN / 2,
+          inStream.read(buffer, DEFAULT_FILE_LEN / 2, DEFAULT_FILE_LEN / 2));
+      Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(
+          DEFAULT_FILE_LEN / 2, DEFAULT_FILE_LEN / 2, buffer));
+      buffer.clear();
+      Assert.assertEquals(DEFAULT_FILE_LEN / 2,
           inStream.read(buffer, DEFAULT_FILE_LEN / 2, DEFAULT_FILE_LEN / 3));
       Assert.assertTrue(BufferUtils.equalIncreasingByteBuffer(
           DEFAULT_FILE_LEN / 3, DEFAULT_FILE_LEN / 2, buffer));


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support seek in UfsFileInStream

### Why are the changes needed?

Fuse is seek() heavy. Every read will first seek() and then read().
Fuse.seek() can seek to any position and is a real random read.

### Does this PR introduce any user facing changes?

Supports FUSE UFS random read operations. e.g. FIO random read
