### PR TITLE
Support display config hash and timestamp in web page

### DIFF
--- a/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
+++ b/core/common/src/main/java/alluxio/conf/AlluxioProperties.java
@@ -273,4 +273,11 @@ public class AlluxioProperties {
   public String hash() {
     return mHash.get();
   }
+
+  /**
+   * @return the last update time of the properties
+   */
+  public long getLastUpdateTime() {
+    return mHash.getLastUpdateTime();
+  }
 }

--- a/core/common/src/main/java/alluxio/conf/Configuration.java
+++ b/core/common/src/main/java/alluxio/conf/Configuration.java
@@ -641,4 +641,11 @@ public final class Configuration
     }
     return Optional.of(properties);
   }
+
+  /**
+   * @return the last update time
+   */
+  public static long getLastUpdateTime() {
+    return SERVER_CONFIG_REFERENCE.get().getLastUpdateTime();
+  }
 }

--- a/core/common/src/main/java/alluxio/conf/Hash.java
+++ b/core/common/src/main/java/alluxio/conf/Hash.java
@@ -51,7 +51,6 @@ public final class Hash {
    */
   public void markOutdated() {
     mShouldUpdate.set(true);
-    mLastUpdateTime = System.currentTimeMillis();
   }
 
   private String compute() {
@@ -72,6 +71,7 @@ public final class Hash {
         // If another thread has recomputed the version, no need to recompute again.
         if (mShouldUpdate.get()) {
           mVersion = compute();
+          mLastUpdateTime = System.currentTimeMillis();
           mShouldUpdate.set(false);
         }
       }
@@ -82,7 +82,7 @@ public final class Hash {
   /**
    * @return the latest update time
    */
-  public long getLastUpdateTime() {
+  public synchronized long getLastUpdateTime() {
     return mLastUpdateTime;
   }
 }

--- a/core/common/src/main/java/alluxio/conf/Hash.java
+++ b/core/common/src/main/java/alluxio/conf/Hash.java
@@ -29,6 +29,7 @@ public final class Hash {
   private final Supplier<Stream<byte[]>> mProperties;
   private final AtomicBoolean mShouldUpdate;
   private volatile String mVersion;
+  private long mLastUpdateTime;
 
   /**
    * @param properties a stream of encoded properties
@@ -50,6 +51,7 @@ public final class Hash {
    */
   public void markOutdated() {
     mShouldUpdate.set(true);
+    mLastUpdateTime = System.currentTimeMillis();
   }
 
   private String compute() {
@@ -75,5 +77,12 @@ public final class Hash {
       }
     }
     return mVersion;
+  }
+
+  /**
+   * @return the latest update time
+   */
+  public long getLastUpdateTime() {
+    return mLastUpdateTime;
   }
 }

--- a/core/common/src/main/java/alluxio/conf/Hash.java
+++ b/core/common/src/main/java/alluxio/conf/Hash.java
@@ -29,7 +29,7 @@ public final class Hash {
   private final Supplier<Stream<byte[]>> mProperties;
   private final AtomicBoolean mShouldUpdate;
   private volatile String mVersion;
-  private long mLastUpdateTime;
+  private volatile long mLastUpdateTime;
 
   /**
    * @param properties a stream of encoded properties

--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -680,6 +680,13 @@ public class InstancedConfiguration implements AlluxioConfiguration {
     }
   }
 
+  /**
+   * @return the last update time
+   */
+  public long getLastUpdateTime() {
+    return mProperties.getLastUpdateTime();
+  }
+
   private class UnresolvablePropertyException extends Exception {
 
     public UnresolvablePropertyException(String msg) {

--- a/core/common/src/main/java/alluxio/wire/ConfigHash.java
+++ b/core/common/src/main/java/alluxio/wire/ConfigHash.java
@@ -11,7 +11,9 @@
 
 package alluxio.wire;
 
+import alluxio.conf.PropertyKey;
 import alluxio.grpc.GetConfigHashPResponse;
+import alluxio.util.CommonUtils;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
@@ -25,23 +27,29 @@ import javax.annotation.concurrent.ThreadSafe;
 public class ConfigHash {
   private final String mClusterConfigHash;
   private final String mPathConfigHash;
+  private long mClusterConfigLastUpdateTime;
+  private long mPathConfigLastUpdateTime;
 
   /**
    * Constructs a new ConfigHash.
    *
    * @param clusterConfigHash cluster configuration hash, cannot be null
    * @param pathConfigHash path configuration hash, cannot be null
+   * @param clusterConfigLastUpdateTime the cluster config last update time
+   * @param pathConfigLastUpdateTime path config last update time
    */
-  public ConfigHash(String clusterConfigHash, String pathConfigHash) {
+  public ConfigHash(String clusterConfigHash, String pathConfigHash,
+      long clusterConfigLastUpdateTime, long pathConfigLastUpdateTime) {
     Preconditions.checkNotNull(clusterConfigHash, "clusterConfigHash");
     Preconditions.checkNotNull(pathConfigHash, "pathConfigHash");
     mClusterConfigHash = clusterConfigHash;
     mPathConfigHash = pathConfigHash;
+    mClusterConfigLastUpdateTime = clusterConfigLastUpdateTime;
+    mPathConfigLastUpdateTime = pathConfigLastUpdateTime;
   }
 
   private ConfigHash(GetConfigHashPResponse response) {
-    mClusterConfigHash = response.getClusterConfigHash();
-    mPathConfigHash = response.getPathConfigHash();
+    this(response.getClusterConfigHash(), response.getPathConfigHash(), 0, 0);
   }
 
   /**
@@ -78,6 +86,36 @@ public class ConfigHash {
    */
   public String getPathConfigHash() {
     return mPathConfigHash;
+  }
+
+  /**
+   * @return cluster config last update time
+   */
+  public long getClusterConfigLastUpdateTime() {
+    return mClusterConfigLastUpdateTime;
+  }
+
+  /**
+   * @return path config last update time
+   */
+  public long getPathConfigLastUpdateTime() {
+    return mPathConfigLastUpdateTime;
+  }
+
+  /**
+   * @return cluster config last update time text
+   */
+  public String getClusterConfigLastUpdateTimeText() {
+    return CommonUtils.convertMsToDate(mClusterConfigLastUpdateTime,
+        alluxio.conf.Configuration.getString(PropertyKey.USER_DATE_FORMAT_PATTERN));
+  }
+
+  /**
+   * @return path config last update time text
+   */
+  public String getPathConfigLastUpdateTimeText() {
+    return CommonUtils.convertMsToDate(mPathConfigLastUpdateTime,
+        alluxio.conf.Configuration.getString(PropertyKey.USER_DATE_FORMAT_PATTERN));
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/wire/Configuration.java
+++ b/core/common/src/main/java/alluxio/wire/Configuration.java
@@ -40,6 +40,10 @@ public final class Configuration {
   private final String mClusterConfHash;
   /** Path configuration hash. */
   private final String mPathConfHash;
+  /** Cluster configuration last update time. */
+  private final long mClusterConfLastUpdateTime;
+  /** Path configuration last update time. */
+  private final long mPathConfLastUpdateTime;
 
   /**
    * @return new configuration builder
@@ -57,6 +61,8 @@ public final class Configuration {
     private Map<String, List<Property>> mPathConf = new HashMap<>();
     private String mClusterConfHash;
     private String mPathConfHash;
+    private long mClusterConfLastUpdateTime;
+    private long mPathConfLastUpdateTime;
 
     /**
      * Adds a cluster level property.
@@ -102,19 +108,41 @@ public final class Configuration {
     }
 
     /**
+     * Sets cluster config last update time.
+     *
+     * @param lastUpdateTime the last update time
+     */
+    public void setClusterConfLastUpdateTime(long lastUpdateTime) {
+      mClusterConfLastUpdateTime = lastUpdateTime;
+    }
+
+    /**
+     * Sets path config last update time.
+     *
+     * @param lastUpdateTime the last update time
+     */
+    public void setPathConfLastUpdateTime(long lastUpdateTime) {
+      mPathConfLastUpdateTime = lastUpdateTime;
+    }
+
+    /**
      * @return a newly constructed configuration
      */
     public Configuration build() {
-      return new Configuration(mClusterConf, mPathConf, mClusterConfHash, mPathConfHash);
+      return new Configuration(mClusterConf, mPathConf, mClusterConfHash, mPathConfHash,
+          mClusterConfLastUpdateTime, mPathConfLastUpdateTime);
     }
   }
 
   private Configuration(List<Property> clusterConf, Map<String, List<Property>> pathConf,
-      String clusterConfHash, String pathConfHash) {
+      String clusterConfHash, String pathConfHash,
+      long clusterConfLastUpdateTime, long pathConfLastUpdateTime) {
     mClusterConf = clusterConf;
     mPathConf = pathConf;
     mClusterConfHash = clusterConfHash;
     mPathConfHash = pathConfHash;
+    mClusterConfLastUpdateTime = clusterConfLastUpdateTime;
+    mPathConfLastUpdateTime = pathConfLastUpdateTime;
   }
 
   private Configuration(GetConfigurationPResponse conf) {
@@ -131,6 +159,8 @@ public final class Configuration {
 
     mClusterConfHash = conf.getClusterConfigHash();
     mPathConfHash = conf.getPathConfigHash();
+    mClusterConfLastUpdateTime = conf.getClusterConfigLastUpdateTime();
+    mPathConfLastUpdateTime = conf.getPathConfigLastUpdateTime();
   }
 
   /**
@@ -164,6 +194,8 @@ public final class Configuration {
     if (mPathConfHash != null) {
       response.setPathConfigHash(mPathConfHash);
     }
+    response.setClusterConfigLastUpdateTime(mClusterConfLastUpdateTime);
+    response.setPathConfigLastUpdateTime(mPathConfLastUpdateTime);
     return response.build();
   }
 
@@ -193,5 +225,19 @@ public final class Configuration {
    */
   public String getPathConfHash() {
     return mPathConfHash;
+  }
+
+  /**
+   * @return cluster conf last update time
+   */
+  public long getClusterConfLastUpdateTime() {
+    return mClusterConfLastUpdateTime;
+  }
+
+  /**
+   * @return path conf last update time
+   */
+  public long getPathConfLastUpdateTime() {
+    return mPathConfLastUpdateTime;
   }
 }

--- a/core/common/src/main/java/alluxio/wire/MasterWebUIConfiguration.java
+++ b/core/common/src/main/java/alluxio/wire/MasterWebUIConfiguration.java
@@ -23,7 +23,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * Alluxio WebUI configuration information.
  */
 @NotThreadSafe
-public final class MasterWebUIConfiguration implements Serializable {
+public class MasterWebUIConfiguration implements Serializable {
   private static final long serialVersionUID = -2277858633604882055L;
 
   private List<String> mWhitelist;

--- a/core/common/src/main/java/alluxio/wire/MasterWebUIConfiguration.java
+++ b/core/common/src/main/java/alluxio/wire/MasterWebUIConfiguration.java
@@ -23,7 +23,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * Alluxio WebUI configuration information.
  */
 @NotThreadSafe
-public class MasterWebUIConfiguration implements Serializable {
+public final class MasterWebUIConfiguration implements Serializable {
   private static final long serialVersionUID = -2277858633604882055L;
 
   private List<String> mWhitelist;

--- a/core/common/src/main/java/alluxio/wire/MasterWebUIConfiguration.java
+++ b/core/common/src/main/java/alluxio/wire/MasterWebUIConfiguration.java
@@ -28,6 +28,10 @@ public final class MasterWebUIConfiguration implements Serializable {
 
   private List<String> mWhitelist;
   private TreeSet<Triple<String, String, String>> mConfiguration;
+  private String mClusterConfigHash;
+  private String mPathConfigHash;
+  private String mClusterConfigLastUpdateTime;
+  private String mPathConfigLastUpdateTime;
 
   /**
    * Creates a new instance of {@link MasterWebUIConfiguration}.
@@ -73,6 +77,78 @@ public final class MasterWebUIConfiguration implements Serializable {
    */
   public MasterWebUIConfiguration setWhitelist(List<String> whitelist) {
     mWhitelist = whitelist;
+    return this;
+  }
+
+  /**
+   * @return cluster config hash
+   */
+  public String getClusterConfigHash() {
+    return mClusterConfigHash;
+  }
+
+  /**
+   * Sets cluster config hash.
+   * @param clusterConfigHash the cluster config hash
+   * @return the configuration
+   */
+  public MasterWebUIConfiguration setClusterConfigHash(String clusterConfigHash) {
+    mClusterConfigHash = clusterConfigHash;
+    return this;
+  }
+
+  /**
+   * @return path config hash
+   */
+  public String getPathConfigHash() {
+    return mPathConfigHash;
+  }
+
+  /**
+   * Sets path config hash.
+   *
+   * @param pathConfigHash the path config hash
+   * @return the configuration
+   */
+  public MasterWebUIConfiguration setPathConfigHash(String pathConfigHash) {
+    mPathConfigHash = pathConfigHash;
+    return this;
+  }
+
+  /**
+   * @return cluster config last update time
+   */
+  public String getClusterConfigLastUpdateTime() {
+    return mClusterConfigLastUpdateTime;
+  }
+
+  /**
+   * Sets cluster config last update time.
+   *
+   * @param clusterConfigLastUpdateTime the cluster config last update time
+   * @return the configuration
+   */
+  public MasterWebUIConfiguration setClusterConfigLastUpdateTime(
+      String clusterConfigLastUpdateTime) {
+    mClusterConfigLastUpdateTime = clusterConfigLastUpdateTime;
+    return this;
+  }
+
+  /**
+   * @return path config last update time
+   */
+  public String getPathConfigLastUpdateTime() {
+    return mPathConfigLastUpdateTime;
+  }
+
+  /**
+   * Sets the path config last update time.
+   * @param pathConfigLastUpdateTime path config last update time
+   * @return the configuration
+   */
+  public MasterWebUIConfiguration setPathConfigLastUpdateTime(
+      String pathConfigLastUpdateTime) {
+    mPathConfigLastUpdateTime = pathConfigLastUpdateTime;
     return this;
   }
 

--- a/core/common/src/main/java/alluxio/wire/MasterWebUIConfiguration.java
+++ b/core/common/src/main/java/alluxio/wire/MasterWebUIConfiguration.java
@@ -28,10 +28,7 @@ public final class MasterWebUIConfiguration implements Serializable {
 
   private List<String> mWhitelist;
   private TreeSet<Triple<String, String, String>> mConfiguration;
-  private String mClusterConfigHash;
-  private String mPathConfigHash;
-  private String mClusterConfigLastUpdateTime;
-  private String mPathConfigLastUpdateTime;
+  private ConfigHash mConfigHash;
 
   /**
    * Creates a new instance of {@link MasterWebUIConfiguration}.
@@ -83,72 +80,17 @@ public final class MasterWebUIConfiguration implements Serializable {
   /**
    * @return cluster config hash
    */
-  public String getClusterConfigHash() {
-    return mClusterConfigHash;
+  public ConfigHash getConfigHash() {
+    return mConfigHash;
   }
 
   /**
-   * Sets cluster config hash.
-   * @param clusterConfigHash the cluster config hash
+   * Sets config hash.
+   * @param configHash the config hash
    * @return the configuration
    */
-  public MasterWebUIConfiguration setClusterConfigHash(String clusterConfigHash) {
-    mClusterConfigHash = clusterConfigHash;
-    return this;
-  }
-
-  /**
-   * @return path config hash
-   */
-  public String getPathConfigHash() {
-    return mPathConfigHash;
-  }
-
-  /**
-   * Sets path config hash.
-   *
-   * @param pathConfigHash the path config hash
-   * @return the configuration
-   */
-  public MasterWebUIConfiguration setPathConfigHash(String pathConfigHash) {
-    mPathConfigHash = pathConfigHash;
-    return this;
-  }
-
-  /**
-   * @return cluster config last update time
-   */
-  public String getClusterConfigLastUpdateTime() {
-    return mClusterConfigLastUpdateTime;
-  }
-
-  /**
-   * Sets cluster config last update time.
-   *
-   * @param clusterConfigLastUpdateTime the cluster config last update time
-   * @return the configuration
-   */
-  public MasterWebUIConfiguration setClusterConfigLastUpdateTime(
-      String clusterConfigLastUpdateTime) {
-    mClusterConfigLastUpdateTime = clusterConfigLastUpdateTime;
-    return this;
-  }
-
-  /**
-   * @return path config last update time
-   */
-  public String getPathConfigLastUpdateTime() {
-    return mPathConfigLastUpdateTime;
-  }
-
-  /**
-   * Sets the path config last update time.
-   * @param pathConfigLastUpdateTime path config last update time
-   * @return the configuration
-   */
-  public MasterWebUIConfiguration setPathConfigLastUpdateTime(
-      String pathConfigLastUpdateTime) {
-    mPathConfigLastUpdateTime = pathConfigLastUpdateTime;
+  public MasterWebUIConfiguration setConfigHash(ConfigHash configHash) {
+    mConfigHash = configHash;
     return this;
   }
 

--- a/core/common/src/main/java/alluxio/wire/WorkerWebUIConfiguration.java
+++ b/core/common/src/main/java/alluxio/wire/WorkerWebUIConfiguration.java
@@ -28,6 +28,10 @@ public final class WorkerWebUIConfiguration implements Serializable {
 
   private List<String> mWhitelist;
   private TreeSet<Triple<String, String, String>> mConfiguration;
+  private String mClusterConfigHash;
+  private String mPathConfigHash;
+  private String mClusterConfigLastUpdateTime;
+  private String mPathConfigLastUpdateTime;
 
   /**
    * Creates a new instance of {@link WorkerWebUIConfiguration}.
@@ -73,6 +77,78 @@ public final class WorkerWebUIConfiguration implements Serializable {
    */
   public WorkerWebUIConfiguration setWhitelist(List<String> whitelist) {
     mWhitelist = whitelist;
+    return this;
+  }
+
+  /**
+   * @return cluster config hash
+   */
+  public String getClusterConfigHash() {
+    return mClusterConfigHash;
+  }
+
+  /**
+   * Sets cluster config hash.
+   * @param clusterConfigHash the cluster config hash
+   * @return the configuration
+   */
+  public WorkerWebUIConfiguration setClusterConfigHash(String clusterConfigHash) {
+    mClusterConfigHash = clusterConfigHash;
+    return this;
+  }
+
+  /**
+   * @return path config hash
+   */
+  public String getPathConfigHash() {
+    return mPathConfigHash;
+  }
+
+  /**
+   * Sets path config hash.
+   *
+   * @param pathConfigHash the path config hash
+   * @return the configuration
+   */
+  public WorkerWebUIConfiguration setPathConfigHash(String pathConfigHash) {
+    mPathConfigHash = pathConfigHash;
+    return this;
+  }
+
+  /**
+   * @return cluster config last update time
+   */
+  public String getClusterConfigLastUpdateTime() {
+    return mClusterConfigLastUpdateTime;
+  }
+
+  /**
+   * Sets cluster config last update time.
+   *
+   * @param clusterConfigLastUpdateTime the cluster config last update time
+   * @return the configuration
+   */
+  public WorkerWebUIConfiguration setClusterConfigLastUpdateTime(
+      String clusterConfigLastUpdateTime) {
+    mClusterConfigLastUpdateTime = clusterConfigLastUpdateTime;
+    return this;
+  }
+
+  /**
+   * @return path config last update time
+   */
+  public String getPathConfigLastUpdateTime() {
+    return mPathConfigLastUpdateTime;
+  }
+
+  /**
+   * Sets the path config last update time.
+   * @param pathConfigLastUpdateTime path config last update time
+   * @return the configuration
+   */
+  public WorkerWebUIConfiguration setPathConfigLastUpdateTime(
+      String pathConfigLastUpdateTime) {
+    mPathConfigLastUpdateTime = pathConfigLastUpdateTime;
     return this;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -810,12 +810,11 @@ public final class AlluxioMasterRestServiceHandler {
       MasterWebUIConfiguration response = new MasterWebUIConfiguration();
 
       response.setWhitelist(mFileSystemMaster.getWhiteList());
-
+      alluxio.wire.Configuration conf = mMetaMaster.getConfiguration(
+          GetConfigurationPOptions.newBuilder().setRawValue(true).build());
       TreeSet<Triple<String, String, String>> sortedProperties = new TreeSet<>();
       Set<String> alluxioConfExcludes = Sets.newHashSet(PropertyKey.MASTER_WHITELIST.toString());
-      for (ConfigProperty configProperty : mMetaMaster
-          .getConfiguration(GetConfigurationPOptions.newBuilder().setRawValue(true).build())
-          .toProto().getClusterConfigsList()) {
+      for (ConfigProperty configProperty : conf.toProto().getClusterConfigsList()) {
         String confName = configProperty.getName();
         if (!alluxioConfExcludes.contains(confName)) {
           sortedProperties.add(new ImmutableTriple<>(confName,
@@ -825,7 +824,14 @@ public final class AlluxioMasterRestServiceHandler {
       }
 
       response.setConfiguration(sortedProperties);
-
+      response.setClusterConfigHash(conf.getClusterConfHash());
+      response.setPathConfigHash(conf.getPathConfHash());
+      response.setClusterConfigLastUpdateTime(
+          CommonUtils.convertMsToDate(conf.getClusterConfLastUpdateTime(),
+              alluxio.conf.Configuration.getString(PropertyKey.USER_DATE_FORMAT_PATTERN)));
+      response.setPathConfigLastUpdateTime(
+          CommonUtils.convertMsToDate(conf.getPathConfLastUpdateTime(),
+              alluxio.conf.Configuration.getString(PropertyKey.USER_DATE_FORMAT_PATTERN)));
       return response;
     }, Configuration.global());
   }

--- a/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/AlluxioMasterRestServiceHandler.java
@@ -62,6 +62,7 @@ import alluxio.wire.AlluxioMasterInfo;
 import alluxio.wire.BlockLocation;
 import alluxio.wire.Capacity;
 import alluxio.wire.ConfigCheckReport;
+import alluxio.wire.ConfigHash;
 import alluxio.wire.FileBlockInfo;
 import alluxio.wire.FileInfo;
 import alluxio.wire.MasterInfo;
@@ -824,14 +825,8 @@ public final class AlluxioMasterRestServiceHandler {
       }
 
       response.setConfiguration(sortedProperties);
-      response.setClusterConfigHash(conf.getClusterConfHash());
-      response.setPathConfigHash(conf.getPathConfHash());
-      response.setClusterConfigLastUpdateTime(
-          CommonUtils.convertMsToDate(conf.getClusterConfLastUpdateTime(),
-              alluxio.conf.Configuration.getString(PropertyKey.USER_DATE_FORMAT_PATTERN)));
-      response.setPathConfigLastUpdateTime(
-          CommonUtils.convertMsToDate(conf.getPathConfLastUpdateTime(),
-              alluxio.conf.Configuration.getString(PropertyKey.USER_DATE_FORMAT_PATTERN)));
+      response.setConfigHash(new ConfigHash(conf.getClusterConfHash(), conf.getPathConfHash(),
+          conf.getClusterConfLastUpdateTime(), conf.getPathConfLastUpdateTime()));
       return response;
     }, Configuration.global());
   }

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -422,6 +422,7 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
       // NOTE(cc): assumes that Configuration is read-only when master is running, otherwise,
       // the following hash might not correspond to the above cluster configuration.
       builder.setClusterConfHash(Configuration.hash());
+      builder.setClusterConfLastUpdateTime(Configuration.getLastUpdateTime());
     }
 
     if (!options.getIgnorePathConf()) {
@@ -430,6 +431,7 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
           properties.forEach((key, value) ->
               builder.addPathProperty(path, key, value)));
       builder.setPathConfHash(pathProperties.getHash());
+      builder.setPathConfLastUpdateTime(pathProperties.getLastUpdateTime());
     }
 
     return builder.build();

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -439,7 +439,8 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
 
   @Override
   public ConfigHash getConfigHash() {
-    return new ConfigHash(Configuration.hash(), mPathProperties.hash());
+    return new ConfigHash(Configuration.hash(), mPathProperties.hash(),
+        Configuration.getLastUpdateTime(), mPathProperties.getLastUpdateTime());
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/meta/PathProperties.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/PathProperties.java
@@ -66,7 +66,7 @@ public final class PathProperties implements DelegatingJournaled {
    */
   public PathPropertiesView snapshot() {
     try (LockResource r = new LockResource(mLock.readLock())) {
-      return new PathPropertiesView(get(), hash());
+      return new PathPropertiesView(get(), hash(), mHash.getLastUpdateTime());
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/meta/PathProperties.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/PathProperties.java
@@ -155,6 +155,13 @@ public final class PathProperties implements DelegatingJournaled {
   }
 
   /**
+   * @return the last update time of the properties
+   */
+  public long getLastUpdateTime() {
+    return mHash.getLastUpdateTime();
+  }
+
+  /**
    * Journaled state of path level properties.
    */
   @NotThreadSafe

--- a/core/server/master/src/main/java/alluxio/master/meta/PathPropertiesView.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/PathPropertiesView.java
@@ -19,16 +19,20 @@ import java.util.Map;
 public final class PathPropertiesView {
   private final Map<String, Map<String, String>> mProperties;
   private final String mHash;
+  private final long mLastUpdateTime;
 
   /**
    * Constructs a read-only view of path level properties.
    *
    * @param properties map from path to properties
    * @param hash hash of all path level properties
+   * @param lastUpdateTime last update time
    */
-  public PathPropertiesView(Map<String, Map<String, String>> properties, String hash) {
+  public PathPropertiesView(Map<String, Map<String, String>> properties, String hash,
+      long lastUpdateTime) {
     mProperties = properties;
     mHash = hash;
+    mLastUpdateTime = lastUpdateTime;
   }
 
   /**
@@ -43,5 +47,12 @@ public final class PathPropertiesView {
    */
   public String getHash() {
     return mHash;
+  }
+
+  /**
+   * @return last update time
+   */
+  public long getLastUpdateTime() {
+    return mLastUpdateTime;
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -43,8 +43,8 @@ import alluxio.util.webui.WebUtils;
 import alluxio.web.WorkerWebServer;
 import alluxio.wire.AlluxioWorkerInfo;
 import alluxio.wire.Capacity;
-import alluxio.wire.MasterWebUIConfiguration;
 import alluxio.wire.WorkerWebUIBlockInfo;
+import alluxio.wire.WorkerWebUIConfiguration;
 import alluxio.wire.WorkerWebUIInit;
 import alluxio.wire.WorkerWebUILogs;
 import alluxio.wire.WorkerWebUIMetrics;
@@ -534,7 +534,7 @@ public final class AlluxioWorkerRestServiceHandler {
   @Path(WEBUI_CONFIG)
   public Response getWebUIConfiguration() {
     return RestUtils.call(() -> {
-      MasterWebUIConfiguration response = new MasterWebUIConfiguration();
+      WorkerWebUIConfiguration response = new WorkerWebUIConfiguration();
 
       response.setWhitelist(mBlockWorker.getWhiteList());
       alluxio.wire.Configuration conf = mBlockWorker.getConfiguration(

--- a/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/AlluxioWorkerRestServiceHandler.java
@@ -45,7 +45,6 @@ import alluxio.wire.AlluxioWorkerInfo;
 import alluxio.wire.Capacity;
 import alluxio.wire.MasterWebUIConfiguration;
 import alluxio.wire.WorkerWebUIBlockInfo;
-import alluxio.wire.WorkerWebUIConfiguration;
 import alluxio.wire.WorkerWebUIInit;
 import alluxio.wire.WorkerWebUILogs;
 import alluxio.wire.WorkerWebUIMetrics;

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -485,8 +485,8 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
       // NOTE(cc): assumes that Configuration is read-only when master is running, otherwise,
       // the following hash might not correspond to the above cluster configuration.
       builder.setClusterConfHash(Configuration.hash());
+      builder.setClusterConfLastUpdateTime(Configuration.getLastUpdateTime());
     }
-
     return builder.build();
   }
 

--- a/core/transport/src/main/proto/grpc/meta_master.proto
+++ b/core/transport/src/main/proto/grpc/meta_master.proto
@@ -22,6 +22,8 @@ message GetConfigurationPResponse{
   map<string, ConfigProperties> pathConfigs = 2;
   optional string clusterConfigHash = 3;
   optional string pathConfigHash = 4;
+  optional int64 clusterConfigLastUpdateTime = 5;
+  optional int64 pathConfigLastUpdateTime = 6;
 }
 
 enum ConfigStatus {

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -3270,6 +3270,21 @@
             ]
           },
           {
+            "name": "S3SyntaxOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "overwrite",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "isMultipartUpload",
+                "type": "bool"
+              }
+            ]
+          },
+          {
             "name": "RenamePResponse"
           },
           {
@@ -3284,6 +3299,11 @@
                 "id": 2,
                 "name": "persist",
                 "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "s3SyntaxOptions",
+                "type": "S3SyntaxOptions"
               }
             ]
           },
@@ -5539,6 +5559,16 @@
                 "id": 4,
                 "name": "pathConfigHash",
                 "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "clusterConfigLastUpdateTime",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "pathConfigLastUpdateTime",
+                "type": "int64"
               }
             ],
             "maps": [

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -3270,21 +3270,6 @@
             ]
           },
           {
-            "name": "S3SyntaxOptions",
-            "fields": [
-              {
-                "id": 1,
-                "name": "overwrite",
-                "type": "bool"
-              },
-              {
-                "id": 2,
-                "name": "isMultipartUpload",
-                "type": "bool"
-              }
-            ]
-          },
-          {
             "name": "RenamePResponse"
           },
           {
@@ -3299,11 +3284,6 @@
                 "id": 2,
                 "name": "persist",
                 "type": "bool"
-              },
-              {
-                "id": 3,
-                "name": "s3SyntaxOptions",
-                "type": "S3SyntaxOptions"
               }
             ]
           },
@@ -5559,16 +5539,6 @@
                 "id": 4,
                 "name": "pathConfigHash",
                 "type": "string"
-              },
-              {
-                "id": 5,
-                "name": "clusterConfigLastUpdateTime",
-                "type": "int64"
-              },
-              {
-                "id": 6,
-                "name": "pathConfigLastUpdateTime",
-                "type": "int64"
               }
             ],
             "maps": [

--- a/microbench/src/main/java/alluxio/fsmaster/BenchStandaloneGrpcServer.java
+++ b/microbench/src/main/java/alluxio/fsmaster/BenchStandaloneGrpcServer.java
@@ -139,7 +139,7 @@ public class BenchStandaloneGrpcServer {
         }
 
         private final GetConfigHashPResponse mGetConfigHashResponse =
-            new ConfigHash(Configuration.hash(), new PathProperties().hash()).toProto();
+            new ConfigHash(Configuration.hash(), new PathProperties().hash(), 0, 0).toProto();
 
         @Override
         public void getConfigHash(GetConfigHashPOptions request,


### PR DESCRIPTION
### What changes are proposed in this pull request?

Display the config hash and config updated time

<img width="550" alt="image" src="https://user-images.githubusercontent.com/17329931/207004719-8c684f3d-24c7-4fce-bd95-32ff795b6172.png">

<img width="534" alt="image" src="https://user-images.githubusercontent.com/17329931/207027205-865183d3-c288-4c99-bbee-a53c6d4ba579.png">


### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
