### PR TITLE
Add kerberos client support

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -82,7 +82,7 @@ RUN \
     cd .. && \
     rm -rf libfuse && \
     yum remove -y gcc gcc-c++ make cmake gettext-devel libtool autoconf wget git && \
-    yum install -y fuse3 fuse3-devel fuse3-lib && \
+    yum install -y fuse3 fuse3-devel fuse3-lib krb5-workstation krb5-libs && \
     yum clean all
 
 # Configuration for the modified libfuse2


### PR DESCRIPTION
### What changes are proposed in this pull request?

Added kerberos client support to alluxio docker image.

### Why are the changes needed?

Previous version of Alluxio used Debian based linux distro and kerberos support was present. After moving to Centos, kerberos client support is not present which may break already existing users' environment once they upgrade to the new version of the Alluxio.

### Does this PR introduce any user facing changes?

NA
