### PR TITLE
Reduce redundant calls in getObject of S3 API

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -31,6 +31,7 @@ import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.ListStatusPOptions;
+import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.PMode;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.XAttrPropagationStrategy;
@@ -1239,7 +1240,7 @@ public final class S3RestServiceHandler {
           createAuditContext("getObject", user, bucket, object)) {
         try {
           URIStatus status = userFs.getStatus(objectUri);
-          FileInStream is = userFs.openFile(objectUri);
+          FileInStream is = userFs.openFile(status, OpenFilePOptions.getDefaultInstance());
           S3RangeSpec s3Range = S3RangeSpec.Factory.create(range);
           RangeFileInStream ris = RangeFileInStream.Factory.create(is, status.getLength(), s3Range);
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

I replace` FileInStream is = userFs.openFile(objectUri); ` with `FileInStream is = userFs.openFile(status, OpenFilePOptions.getDefaultInstance());`  around 1242th line in S3RestServiceHandler.java

### Why are the changes needed?

When I detected alluxio proxy, I found that `S3RestServiceHandler.GetObject` calls `FileSystem.getStatus()` twice.
I found that the 1241th line and 1242th line in S3RestServiceHandler.java caused this problem:
```
URIStatus status = userFs.getStatus(objectUri);
FileInStream is = userFs.openFile(objectUri); 
```
`userFs.openFile(objectUri) `calls `openFile(getStatus(objectUri), OpenFilePOptions.getDefaultInstance())`, which  leads to double time consuming.
To reduce redundant calls,  I replace` FileInStream is = userFs.openFile(objectUri); ` with `FileInStream is = userFs.openFile(status, OpenFilePOptions.getDefaultInstance());`

After this change, the percentage of the time spent on fetching instance `is` in getObject is as follows:
| fetch instance `is` | before  | now|
| ----------- | ----------- | ----------- |
| expression | openFile(objectUri)  | openFile(status, OpenFilePOptions.getDefaultInstance())|
| the percentage of the time consuming | 51%      | 21%       |



### Does this PR introduce any user facing changes?
There is no operation users should take.
Users only feel that Alluxio proxy runs faster while  requesting to get objects.