### PR TITLE
Remove the redundant DefaultBlockMaster#SuppressFBWarnings

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -15,7 +15,6 @@ import alluxio.Constants;
 import alluxio.DefaultStorageTierAssoc;
 import alluxio.Server;
 import alluxio.StorageTierAssoc;
-import alluxio.annotation.SuppressFBWarnings;
 import alluxio.client.block.options.GetWorkerReportOptions;
 import alluxio.client.block.options.GetWorkerReportOptions.WorkerRange;
 import alluxio.clock.SystemClock;
@@ -265,12 +264,6 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
   /** Handle to the metrics master. */
   private final MetricsMaster mMetricsMaster;
-
-  /**
-   * The service that detects lost worker nodes, and tries to restart the failed workers.
-   * We store it here so that it can be accessed from tests.
-   */
-  @SuppressFBWarnings("URF_UNREAD_FIELD")
 
   /* The value of the 'next container id' last journaled. */
   @GuardedBy("mBlockContainerIdGenerator")


### PR DESCRIPTION
### What changes are proposed in this pull request?
In DefaultBlockMaster, there are some redundant SuppressFBWarnings. The purpose of this pr is to remove them.
Details: https://github.com/Alluxio/alluxio/issues/16660

### Does this PR introduce any user facing changes?
For user, there is no impact.
