### PR TITLE
Enable default metadata cache for FUSE SDK

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemUtils.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemUtils.java
@@ -13,6 +13,7 @@ package alluxio.client.file;
 
 import alluxio.AlluxioURI;
 import alluxio.Constants;
+import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
 import alluxio.exception.FileDoesNotExistException;
@@ -38,6 +39,14 @@ public final class FileSystemUtils {
 
   // prevent instantiation
   private FileSystemUtils() {}
+
+  /**
+   * @param conf the configuration to get info from
+   * @return whether metadata cache is enabled in the given configuration
+   */
+  public static boolean metadataEnabled(AlluxioConfiguration conf) {
+    return !(conf.getInt(PropertyKey.USER_METADATA_CACHE_MAX_SIZE) == 0);
+  }
 
   /**
    * Shortcut for {@code waitCompleted(fs, uri, -1, TimeUnit.MILLISECONDS)}, i.e., wait for an

--- a/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/MetadataCache.java
@@ -75,6 +75,15 @@ public final class MetadataCache {
 
   /**
    * @param maxSize the max size of the cache
+   */
+  public MetadataCache(int maxSize) {
+    mCache = CacheBuilder.newBuilder()
+        .maximumSize(maxSize)
+        .build();
+  }
+
+  /**
+   * @param maxSize the max size of the cache
    * @param expirationTimeMs the expiration time (in milliseconds) of the cached item
    */
   public MetadataCache(int maxSize, long expirationTimeMs) {

--- a/core/client/fs/src/main/java/alluxio/client/file/options/FileSystemOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/options/FileSystemOptions.java
@@ -11,6 +11,7 @@
 
 package alluxio.client.file.options;
 
+import alluxio.client.file.FileSystemUtils;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.PropertyKey;
 
@@ -45,7 +46,7 @@ public class FileSystemOptions {
    */
   public static FileSystemOptions create(AlluxioConfiguration conf,
       Optional<UfsFileSystemOptions> ufsOptions) {
-    return new FileSystemOptions(conf.getBoolean(PropertyKey.USER_METADATA_CACHE_ENABLED),
+    return new FileSystemOptions(FileSystemUtils.metadataEnabled(conf),
         conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_ENABLED),
         ufsOptions);
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/MetadataCachingFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/MetadataCachingFileSystemTest.java
@@ -20,6 +20,7 @@ import alluxio.ClientContext;
 import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.conf.Source;
 import alluxio.exception.FileDoesNotExistException;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.NotFoundException;
@@ -68,6 +69,7 @@ public class MetadataCachingFileSystemTest {
 
   @Before
   public void before() throws Exception {
+    mConf.set(PropertyKey.USER_METADATA_CACHE_MAX_SIZE, 1000, Source.RUNTIME);
     // Avoid async update file access time to call getStatus to mess up the test results
     mConf.set(PropertyKey.USER_UPDATE_FILE_ACCESSTIME_DISABLED, true);
     mClientContext = ClientContext.create(mConf);

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5859,30 +5859,25 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
-  public static final PropertyKey USER_METADATA_CACHE_ENABLED =
-      booleanBuilder(Name.USER_METADATA_CACHE_ENABLED)
-          .setDefaultValue(false)
-          .setDescription("If this is enabled, metadata of paths will be cached. "
-              + "The cached metadata will be evicted when it expires after "
-              + Name.USER_METADATA_CACHE_EXPIRATION_TIME
-              + " or the cache size is over the limit of "
-              + Name.USER_METADATA_CACHE_MAX_SIZE + ".")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.CLIENT)
-          .build();
   public static final PropertyKey USER_METADATA_CACHE_MAX_SIZE =
       intBuilder(Name.USER_METADATA_CACHE_MAX_SIZE)
-          .setDefaultValue(100000)
-          .setDescription("Maximum number of paths with cached metadata. Only valid if "
-              + "alluxio.user.metadata.cache.enabled is set to true.")
+          .setDefaultValue(0)
+          .setDescription(String.format("Maximum number of paths with cached metadata."
+              + "The cached metadata will be evicted when it expires after %s "
+              + "or the cache size is over the limit of %s. "
+              + "Each 1000 entries cost around 2MB memory. "
+              + "Recommend using 20,000 entries are cached "
+              + "with around 40MB memory consumption for FUSE client.",
+              Name.USER_METADATA_CACHE_EXPIRATION_TIME,
+              Name.USER_METADATA_CACHE_MAX_SIZE))
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_METADATA_CACHE_EXPIRATION_TIME =
       durationBuilder(Name.USER_METADATA_CACHE_EXPIRATION_TIME)
-          .setDefaultValue("10min")
           .setDescription("Metadata will expire and be evicted after being cached for this time "
-              + "period. Only valid if alluxio.user.metadata.cache.enabled is set to true.")
+              + "period. If the value is not set, metadata will not be expired "
+              + "and will only be evicted after reaching the " + Name.USER_METADATA_CACHE_MAX_SIZE)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();

--- a/integration/fuse/bin/alluxio-fuse-sdk
+++ b/integration/fuse/bin/alluxio-fuse-sdk
@@ -25,8 +25,8 @@ Alluxio mount options
 \t-o <ALLUXIO_PROPERTY_KEY>=<ALLUXIO_PROPERTY_VALUE> \tThe credentials of the target ufs address should be provided here so that alluxio fuse can access the target data set. Other alluxio common/user configuration can also be provided here
 \t-o data_cache=<local_cache_directory> (Default=\"\" which means disabled) \tLocal folder to use for local data cache.
 \t-o data_cache_size=<size> (Default=\"512MB\") \tMaximum cache size for local data cache directory.  
-\t-o metadata_cache_size=<size> (Default=\"0\" which means disabled) \tMaximum number of entries in the metadata cache. Each 1000 entries cause about 2MB memory.
-\t-o metadata_cache_expire=<timeout> (Default=\"10min\") \tSpecify expire time for entries in the metadata cache
+\t-o metadata_cache_size=<size> (Default=\"20000\" (around 40MB memory)) \tMaximum number of entries in the metadata cache. Each 1000 entries cost about 2MB memory.
+\t-o metadata_cache_expire=<timeout> (Default=\"no expire\") \tSpecify expire time for entries in the metadata cache (e.g. \"10min\", \"2h\").
 
 FUSE mount options
 \tMost of the generic mount options described in 'man mount' and many FUSE specific mount options are supported.

--- a/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/AbstractMetadataCacheSubCommand.java
+++ b/integration/fuse/src/main/java/alluxio/cli/command/metadatacache/AbstractMetadataCacheSubCommand.java
@@ -14,6 +14,7 @@ package alluxio.cli.command.metadatacache;
 import alluxio.AlluxioURI;
 import alluxio.cli.command.AbstractFuseShellCommand;
 import alluxio.client.file.FileSystem;
+import alluxio.client.file.FileSystemUtils;
 import alluxio.client.file.MetadataCachingFileSystem;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.AlluxioConfiguration;
@@ -38,10 +39,10 @@ public abstract class AbstractMetadataCacheSubCommand extends AbstractFuseShellC
 
   @Override
   public URIStatus run(AlluxioURI path, String[] argv) throws InvalidArgumentException {
-    if (!mConf.getBoolean(PropertyKey.USER_METADATA_CACHE_ENABLED)) {
+    if (!FileSystemUtils.metadataEnabled(mConf)) {
       throw new InvalidArgumentRuntimeException(String.format("%s command is "
-              + "not supported when %s is false", getCommandName(),
-          PropertyKey.USER_METADATA_CACHE_ENABLED.getName()));
+              + "not supported when %s is zero", getCommandName(),
+          PropertyKey.USER_METADATA_CACHE_MAX_SIZE.getName()));
     }
     return runSubCommand(path, argv, (MetadataCachingFileSystem) mFileSystem);
   }

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -302,10 +302,6 @@ public final class AlluxioFuse {
               PropertyKey.USER_CLIENT_CACHE_SIZE.parseValue(value), Source.RUNTIME);
           LOG.info("Set data cache size as {} from command line input", value);
         } else if (key.equals("metadata_cache_size")) {
-          if (value.equals("0")) {
-            continue;
-          }
-          conf.set(PropertyKey.USER_METADATA_CACHE_ENABLED, true, Source.RUNTIME);
           conf.set(PropertyKey.USER_METADATA_CACHE_MAX_SIZE,
               PropertyKey.USER_METADATA_CACHE_MAX_SIZE.parseValue(value), Source.RUNTIME);
           LOG.info("Set metadata cache size as {} from command line input", value);
@@ -321,6 +317,13 @@ public final class AlluxioFuse {
         conf.set(PropertyKey.FUSE_MOUNT_OPTIONS, fuseOptions, Source.RUNTIME);
         LOG.info("Set fuse mount point options as {} from command line input",
             String.join(",", fuseOptions));
+      }
+      Source metadataCacheSizeSource = conf.getSource(PropertyKey.USER_METADATA_CACHE_MAX_SIZE);
+      if (metadataCacheSizeSource == Source.DEFAULT
+          || metadataCacheSizeSource == Source.CLUSTER_DEFAULT) {
+        conf.set(PropertyKey.USER_METADATA_CACHE_MAX_SIZE, 20000, Source.RUNTIME);
+        LOG.info("Set default metadata cache size to 20,000 entries "
+            + "with around 40MB memory consumption for FUSE");
       }
     }
   }

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
@@ -95,7 +95,8 @@ public class AlluxioJniFuseFileSystemTest {
   public ConfigurationRule mConfiguration =
       new ConfigurationRule(ImmutableMap.of(PropertyKey.FUSE_CACHED_PATHS_MAX, 0,
           PropertyKey.FUSE_MOUNT_ALLUXIO_PATH, TEST_ROOT_PATH,
-          PropertyKey.FUSE_MOUNT_POINT, MOUNT_POINT), mConf);
+          PropertyKey.FUSE_MOUNT_POINT, MOUNT_POINT,
+          PropertyKey.USER_METADATA_CACHE_MAX_SIZE, 0), mConf);
 
   @Before
   public void before() throws Exception {

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioJnrFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioJnrFuseFileSystemTest.java
@@ -94,7 +94,8 @@ public class AlluxioJnrFuseFileSystemTest {
       new ConfigurationRule(ImmutableMap.of(PropertyKey.FUSE_CACHED_PATHS_MAX, 0,
           PropertyKey.FUSE_USER_GROUP_TRANSLATION_ENABLED, true,
           PropertyKey.FUSE_MOUNT_ALLUXIO_PATH, TEST_ROOT_PATH,
-          PropertyKey.FUSE_MOUNT_POINT, MOUNT_POINT), mConf);
+          PropertyKey.FUSE_MOUNT_POINT, MOUNT_POINT,
+          PropertyKey.USER_METADATA_CACHE_MAX_SIZE, 0), mConf);
 
   @Before
   public void before() throws Exception {

--- a/integration/fuse/src/test/java/alluxio/fuse/cli/FuseShellTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/cli/FuseShellTest.java
@@ -29,6 +29,7 @@ import alluxio.client.file.URIStatus;
 import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.conf.Source;
 import alluxio.exception.runtime.InvalidArgumentRuntimeException;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.grpc.GetStatusPOptions;
@@ -68,6 +69,7 @@ public class FuseShellTest {
 
   @Before
   public void before() throws Exception {
+    mConf.set(PropertyKey.USER_METADATA_CACHE_MAX_SIZE, 1000, Source.RUNTIME);
     ClientContext clientContext = ClientContext.create(mConf);
     FileSystemContext fileContext = PowerMockito.mock(FileSystemContext.class);
     mFileSystemMasterClient = new GetStatusFileSystemMasterClient();

--- a/integration/fuse/src/test/java/alluxio/fuse/cli/FuseShellTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/cli/FuseShellTest.java
@@ -68,7 +68,6 @@ public class FuseShellTest {
 
   @Before
   public void before() throws Exception {
-    mConf.set(PropertyKey.USER_METADATA_CACHE_ENABLED, true);
     ClientContext clientContext = ClientContext.create(mConf);
     FileSystemContext fileContext = PowerMockito.mock(FileSystemContext.class);
     mFileSystemMasterClient = new GetStatusFileSystemMasterClient();
@@ -112,7 +111,7 @@ public class FuseShellTest {
 
   @Test(expected = InvalidArgumentRuntimeException.class)
   public  void runMetadataCacheCommandWhenSpecialCommandDisable() {
-    mConf.set(PropertyKey.USER_METADATA_CACHE_ENABLED, false);
+    mConf.set(PropertyKey.USER_METADATA_CACHE_MAX_SIZE, 0);
     AlluxioURI reservedPath = new AlluxioURI("/dir/.alluxiocli.metadatacache.drop");
     new FuseShell(mFileSystem, mConf).runCommand(reservedPath);
   }

--- a/integration/fuse/src/test/java/alluxio/fuse/ufs/AbstractTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/ufs/AbstractTest.java
@@ -72,6 +72,7 @@ public abstract class AbstractTest {
     }
     mRootUfs = new AlluxioURI(ufs);
     conf.set(PropertyKey.FUSE_MOUNT_POINT, "/t/mountPoint", Source.RUNTIME);
+    conf.set(PropertyKey.USER_METADATA_CACHE_MAX_SIZE, 0);
     mContext = FileSystemContext.create(ClientContext.create(conf));
     LibFuse.loadLibrary(AlluxioFuseUtils.getLibfuseVersion(Configuration.global()));
     mUfsOptions = new UfsFileSystemOptions(ufs);

--- a/tests/src/test/java/alluxio/client/fuse/AbstractFuseIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/AbstractFuseIntegrationTest.java
@@ -106,6 +106,7 @@ public abstract class AbstractFuseIntegrationTest {
 
   @Before
   public void before() throws Exception {
+    Configuration.set(PropertyKey.USER_METADATA_CACHE_MAX_SIZE, 0);
     String clusterName =
         IntegrationTestUtils.getTestName(getClass().getSimpleName(), mTestName.getMethodName());
     mMountPoint = AlluxioTestDirectory.createTemporaryDirectory(clusterName).getAbsolutePath();

--- a/tests/src/test/java/alluxio/client/fuse/file/AbstractFuseFileStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/file/AbstractFuseFileStreamIntegrationTest.java
@@ -46,6 +46,7 @@ public abstract class AbstractFuseFileStreamIntegrationTest extends BaseIntegrat
       new LocalAlluxioClusterResource.Builder()
           .setProperty(PropertyKey.FUSE_AUTH_POLICY_CLASS,
               "alluxio.fuse.auth.LaunchUserGroupAuthPolicy")
+          .setProperty(PropertyKey.USER_METADATA_CACHE_MAX_SIZE, 0)
           .build();
 
   protected FileSystem mFileSystem = null;


### PR DESCRIPTION
### What changes are proposed in this pull request?

Enable default client-side metadata cache (20,000 entries with 40MB memory).

### Why are the changes needed?

Each fuse.open() has two extra get file status calls which cannot be provided via kernel metadata cache but can via user space metadata cache. Enable user space metadata cache can largely improve the overall fuse FIO small file read performance. S3FS-FUSE has similar settings of enable user space metadata cache (100,000 entries with 40MB memory) by default.

FIO benchmarking FUSE SDK against s3-fuse in terms of small file read:
fio --name=sequentialread --rw=read --bs=100k --numjobs=1 --filesize=100k --direct=1 --group_reporting --nrfiles 1000

<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>

  | S3 FUSE | ALLUXIO FUSE
-- | -- | --
Original | 9000 KiB/s | 1500 KiB/s
Kernal metadata cache (attr_timeout=7200, entry_timeout=7200) | 9000 KiB/s | 2400 KiB/s
User metadata cache | 9000 KiB/s | 1150 MiB/s


### Does this PR introduce any user facing changes?

Yeah, alluxio-fuse mount <..> metadata cache option with default value changed
-o metadata_cache_size=<size> (Default=\"20000\" (around 40MB memory)) 
-o metadata_cache_expire=<timeout> (Default=\"no expire\") 
