### PR TITLE
support fuse df display the mount point's ufs size

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6520,6 +6520,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey FUSE_DF_MOUNT_POINT_ENABLED =
+      new Builder(Name.FUSE_DF_MOUNT_POINT_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("Run FUSE df in mount point mode, and will display the UFS size")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey FUSE_FS_NAME =
       stringBuilder(Name.FUSE_FS_NAME)
           .setDefaultValue("alluxio-fuse")
@@ -8509,6 +8516,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.fuse.auth.policy.custom.group";
     public static final String FUSE_CACHED_PATHS_MAX = "alluxio.fuse.cached.paths.max";
     public static final String FUSE_DEBUG_ENABLED = "alluxio.fuse.debug.enabled";
+    public static final String FUSE_DF_MOUNT_POINT_ENABLED = "alluxio.fuse.df.mount.point.enabled";
     public static final String FUSE_FS_NAME = "alluxio.fuse.fs.name";
     public static final String FUSE_JNIFUSE_ENABLED = "alluxio.fuse.jnifuse.enabled";
     public static final String FUSE_SHARED_CACHING_READER_ENABLED

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -444,34 +444,38 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
     // as Alluxio can load/store data out of entire HDFS cluster
     FileSystem hdfs = getFs();
     long space = -1;
-    if (hdfs instanceof DistributedFileSystem) {
-      // Note that, getDiskStatus() is an API from Hadoop 1, deprecated by getStatus() from
-      // Hadoop 2 and removed in Hadoop 3
-      switch (type) {
-        case SPACE_TOTAL:
-          //#ifdef HADOOP1
+    // Note that, getDiskStatus() is an API from Hadoop 1, deprecated by getStatus() from
+    // Hadoop 2 and removed in Hadoop 3
+    switch (type) {
+      case SPACE_TOTAL:
+        //#ifdef HADOOP1
+        if (hdfs instanceof DistributedFileSystem) {
           space = ((DistributedFileSystem) hdfs).getDiskStatus().getCapacity();
-          //#else
-          space = hdfs.getStatus().getCapacity();
-          //#endif
-          break;
-        case SPACE_USED:
-          //#ifdef HADOOP1
+        }
+        //#else
+        space = hdfs.getStatus().getCapacity();
+        //#endif
+        break;
+      case SPACE_USED:
+        //#ifdef HADOOP1
+        if (hdfs instanceof DistributedFileSystem) {
           space = ((DistributedFileSystem) hdfs).getDiskStatus().getDfsUsed();
-          //#else
-          space = hdfs.getStatus().getUsed();
-          //#endif
-          break;
-        case SPACE_FREE:
-          //#ifdef HADOOP1
+        }
+        //#else
+        space = hdfs.getStatus().getUsed();
+        //#endif
+        break;
+      case SPACE_FREE:
+        //#ifdef HADOOP1
+        if (hdfs instanceof DistributedFileSystem) {
           space = ((DistributedFileSystem) hdfs).getDiskStatus().getRemaining();
-          //#else
-          space = hdfs.getStatus().getRemaining();
-          //#endif
-          break;
-        default:
-          throw new IOException("Unknown space type: " + type);
-      }
+        }
+        //#else
+        space = hdfs.getStatus().getRemaining();
+        //#endif
+        break;
+      default:
+        throw new IOException("Unknown space type: " + type);
     }
     return space;
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?
I want to support fuse df show ufs‘s size.  
For example, the Ozone is mounted  on Alluxio, I want to df the ozone's quota
