### PR TITLE
Remove redundant get file status call in fuse.open()

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInStream.java
@@ -24,6 +24,7 @@ import alluxio.exception.runtime.NotFoundRuntimeException;
 import alluxio.exception.runtime.UnimplementedRuntimeException;
 import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.fuse.lock.FuseReadWriteLockManager;
+import alluxio.grpc.OpenFilePOptions;
 import alluxio.resource.CloseableResource;
 
 import com.google.common.base.Preconditions;
@@ -78,7 +79,8 @@ public class FuseFileInStream implements FuseFileStream {
       }
 
       try {
-        FileInStream is = fileSystem.openFile(uri);
+        FileInStream is = fileSystem.openFile(status.get(),
+            OpenFilePOptions.getDefaultInstance());
         return new FuseFileInStream(is, lockResource,
             new FileStatus(status.get().getLength()), uri);
       } catch (IOException | AlluxioException e) {

--- a/integration/fuse/src/main/java/alluxio/fuse/options/FuseOptions.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/options/FuseOptions.java
@@ -33,6 +33,7 @@ public class FuseOptions {
   private final FileSystemOptions mFileSystemOptions;
   private final Set<String> mFuseMountOptions;
   private final boolean mUpdateCheckEnabled;
+  private final boolean mSpecialCommandEnabled;
 
   /**
    * Creates the FUSE options.
@@ -100,7 +101,8 @@ public class FuseOptions {
         LOG.info("Added fuse mount option {} for FUSE 3", idleThreadsOption);
       }
     }
-    return new FuseOptions(fileSystemOptions, mountOptions, updateCheckEnabled);
+    return new FuseOptions(fileSystemOptions, mountOptions, updateCheckEnabled,
+        conf.getBoolean(PropertyKey.FUSE_SPECIAL_COMMAND_ENABLED));
   }
 
   /**
@@ -109,12 +111,14 @@ public class FuseOptions {
    * @param fileSystemOptions the file system options
    * @param fuseMountOptions the FUSE mount options
    * @param updateCheckEnabled whether to enable update check
+   * @param specialCommandEnabled whether fuse special commands are enabled
    */
   private FuseOptions(FileSystemOptions fileSystemOptions,
-      Set<String> fuseMountOptions, boolean updateCheckEnabled) {
+      Set<String> fuseMountOptions, boolean updateCheckEnabled, boolean specialCommandEnabled) {
     mFileSystemOptions = Preconditions.checkNotNull(fileSystemOptions);
     mFuseMountOptions = Preconditions.checkNotNull(fuseMountOptions);
     mUpdateCheckEnabled = updateCheckEnabled;
+    mSpecialCommandEnabled = specialCommandEnabled;
   }
 
   /**
@@ -136,5 +140,12 @@ public class FuseOptions {
    */
   public boolean updateCheckEnabled() {
     return mUpdateCheckEnabled;
+  }
+
+  /**
+   * @return true if fuse special command is enabled
+   */
+  public boolean specialCommandEnabled() {
+    return mSpecialCommandEnabled;
   }
 }

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
@@ -401,9 +401,11 @@ public class AlluxioJniFuseFileSystemTest {
     setUpOpenMock(expectedPath);
 
     FileInStream is = mock(FileInStream.class);
-    when(mFileSystem.openFile(expectedPath)).thenReturn(is);
+    URIStatus status = mFileSystem.getStatus(expectedPath);
+    OpenFilePOptions options = OpenFilePOptions.getDefaultInstance();
+    when(mFileSystem.openFile(status, options)).thenReturn(is);
     mFuseFs.open("/foo/bar", mFileInfo);
-    verify(mFileSystem).openFile(expectedPath);
+    verify(mFileSystem).openFile(status, options);
   }
 
   @Test

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
@@ -46,6 +46,7 @@ import alluxio.exception.FileIncompleteException;
 import alluxio.fuse.options.FuseOptions;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.jnifuse.ErrorCodes;
 import alluxio.jnifuse.LibFuse;
@@ -432,7 +433,8 @@ public class AlluxioJniFuseFileSystemTest {
           return 4;
         });
 
-    when(mFileSystem.openFile(expectedPath)).thenReturn(fakeInStream);
+    when(mFileSystem.openFile(mFileSystem.getStatus(expectedPath),
+        OpenFilePOptions.getDefaultInstance())).thenReturn(fakeInStream);
     mFileInfo.flags.set(O_RDONLY.intValue());
 
     // prepare something to read to it


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove extra get status call in fuse.open()

### Why are the changes needed?

Reduce one unneeded get metadata call

### Does this PR introduce any user facing changes?

NA
