### PR TITLE
Port changes of [#16620] to branch-2.9

### DIFF
--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -390,6 +390,7 @@ public class InstancedConfiguration implements AlluxioConfiguration {
     checkTieredLocality();
     checkTieredStorage();
     checkMasterThrottleThresholds();
+    checkCheckpointZipConfig();
   }
 
   @Override
@@ -594,6 +595,18 @@ public class InstancedConfiguration implements AlluxioConfiguration {
           "Alias \"%s\" on tier %s on worker (configured by %s) is not found in global tiered "
               + "storage setting: %s",
           alias, i, key, String.join(", ", globalTierAliasSet));
+    }
+  }
+
+  /**
+   * @throws IllegalStateException if invalid checkpoint zip configuration parameters are found
+   */
+  private void checkCheckpointZipConfig() {
+    int compression = getInt(PropertyKey.MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL);
+    if (compression < -1 || compression > 9) {
+      throw new IllegalStateException(String.format("Zip compression level for property key %s"
+          + " must be between -1 and 9 inclusive",
+          PropertyKey.MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL.getName()));
     }
   }
 

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2316,19 +2316,65 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+<<<<<<< HEAD
+||||||| parent of 61f5af80c6 (Add compression level option for RocksDB checkpoint)
+  public static final PropertyKey MASTER_METASTORE_DIR_INODE =
+      stringBuilder(Name.MASTER_METASTORE_DIR_INODE)
+          .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
+          .setDescription("If the metastore is ROCKS, this property controls where the RocksDB "
+              + "stores inode metadata. This property defaults to " + Name.MASTER_METASTORE_DIR
+              + ". And it can be used to change inode metadata storage path to a different disk "
+              + "to improve RocksDB performance.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_METASTORE_DIR_BLOCK =
+      stringBuilder(Name.MASTER_METASTORE_DIR_BLOCK)
+          .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
+          .setDescription("If the metastore is ROCKS, this property controls where the RocksDB "
+              + "stores block metadata. This property defaults to " + Name.MASTER_METASTORE_DIR
+              + ". And it can be used to change block metadata storage path to a different disk "
+              + "to improve RocksDB performance.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+=======
+  public static final PropertyKey MASTER_METASTORE_DIR_INODE =
+      stringBuilder(Name.MASTER_METASTORE_DIR_INODE)
+          .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
+          .setDescription("If the metastore is ROCKS, this property controls where the RocksDB "
+              + "stores inode metadata. This property defaults to " + Name.MASTER_METASTORE_DIR
+              + ". And it can be used to change inode metadata storage path to a different disk "
+              + "to improve RocksDB performance.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_METASTORE_DIR_BLOCK =
+      stringBuilder(Name.MASTER_METASTORE_DIR_BLOCK)
+          .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
+          .setDescription("If the metastore is ROCKS, this property controls where the RocksDB "
+              + "stores block metadata. This property defaults to " + Name.MASTER_METASTORE_DIR
+              + ". And it can be used to change block metadata storage path to a different disk "
+              + "to improve RocksDB performance.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL =
+      intBuilder(Name.MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL)
+          .setDefaultValue(-1)
+          .setDescription("The zip compression level of checkpointing rocksdb, the zip"
+                  + " format defines ten levels of compression, ranging from 0"
+                  + " (no compression, but very fast) to 9 (best compression, but slow)."
+                  + " Or -1 for the system default compression level.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+>>>>>>> 61f5af80c6 (Add compression level option for RocksDB checkpoint)
   public static final PropertyKey MASTER_METASTORE_ROCKS_PARALLEL_BACKUP =
       booleanBuilder(Name.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP)
         .setDefaultValue(false)
-        .setDescription("Whether to backup rocksdb in parallel")
-        .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-        .setScope(Scope.MASTER)
-        .build();
-  public static final PropertyKey MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_COMPRESSION_LEVEL =
-      intBuilder(Name.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_COMPRESSION_LEVEL)
-        .setDefaultValue(6)
-        .setDescription("The zip compression level of backing up rocksdb in parallel, the zip"
-            + " format defines ten levels of compression, ranging from 0"
-            + " (no compression, but very fast) to 9 (best compression, but slow)")
+        .setDescription(format("Whether to checkpoint rocksdb in parallel using the number of"
+            + " threads set by %s.", Name.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_THREADS))
         .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
         .setScope(Scope.MASTER)
         .build();
@@ -7544,10 +7590,22 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metadata.sync.ufs.prefetch.timeout";
     public static final String MASTER_METASTORE = "alluxio.master.metastore";
     public static final String MASTER_METASTORE_DIR = "alluxio.master.metastore.dir";
+<<<<<<< HEAD
+||||||| parent of 61f5af80c6 (Add compression level option for RocksDB checkpoint)
+    public static final String MASTER_METASTORE_DIR_INODE =
+        "alluxio.master.metastore.dir.inode";
+    public static final String MASTER_METASTORE_DIR_BLOCK =
+        "alluxio.master.metastore.dir.block";
+=======
+    public static final String MASTER_METASTORE_DIR_INODE =
+        "alluxio.master.metastore.dir.inode";
+    public static final String MASTER_METASTORE_DIR_BLOCK =
+        "alluxio.master.metastore.dir.block";
+    public static final String MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL =
+        "alluxio.master.metastore.rocks.checkpoint.compression.level";
+>>>>>>> 61f5af80c6 (Add compression level option for RocksDB checkpoint)
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP =
         "alluxio.master.metastore.rocks.parallel.backup";
-    public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_COMPRESSION_LEVEL =
-        "alluxio.master.metastore.rocks.parallel.backup.compression.level";
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_THREADS =
         "alluxio.master.metastore.rocks.parallel.backup.threads";
     public static final String MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2316,49 +2316,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
-<<<<<<< HEAD
-||||||| parent of 61f5af80c6 (Add compression level option for RocksDB checkpoint)
-  public static final PropertyKey MASTER_METASTORE_DIR_INODE =
-      stringBuilder(Name.MASTER_METASTORE_DIR_INODE)
-          .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
-          .setDescription("If the metastore is ROCKS, this property controls where the RocksDB "
-              + "stores inode metadata. This property defaults to " + Name.MASTER_METASTORE_DIR
-              + ". And it can be used to change inode metadata storage path to a different disk "
-              + "to improve RocksDB performance.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.MASTER)
-          .build();
-  public static final PropertyKey MASTER_METASTORE_DIR_BLOCK =
-      stringBuilder(Name.MASTER_METASTORE_DIR_BLOCK)
-          .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
-          .setDescription("If the metastore is ROCKS, this property controls where the RocksDB "
-              + "stores block metadata. This property defaults to " + Name.MASTER_METASTORE_DIR
-              + ". And it can be used to change block metadata storage path to a different disk "
-              + "to improve RocksDB performance.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.MASTER)
-          .build();
-=======
-  public static final PropertyKey MASTER_METASTORE_DIR_INODE =
-      stringBuilder(Name.MASTER_METASTORE_DIR_INODE)
-          .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
-          .setDescription("If the metastore is ROCKS, this property controls where the RocksDB "
-              + "stores inode metadata. This property defaults to " + Name.MASTER_METASTORE_DIR
-              + ". And it can be used to change inode metadata storage path to a different disk "
-              + "to improve RocksDB performance.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.MASTER)
-          .build();
-  public static final PropertyKey MASTER_METASTORE_DIR_BLOCK =
-      stringBuilder(Name.MASTER_METASTORE_DIR_BLOCK)
-          .setDefaultValue(String.format("${%s}", Name.MASTER_METASTORE_DIR))
-          .setDescription("If the metastore is ROCKS, this property controls where the RocksDB "
-              + "stores block metadata. This property defaults to " + Name.MASTER_METASTORE_DIR
-              + ". And it can be used to change block metadata storage path to a different disk "
-              + "to improve RocksDB performance.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.MASTER)
-          .build();
   public static final PropertyKey MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL =
       intBuilder(Name.MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL)
           .setDefaultValue(-1)
@@ -2369,7 +2326,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
->>>>>>> 61f5af80c6 (Add compression level option for RocksDB checkpoint)
   public static final PropertyKey MASTER_METASTORE_ROCKS_PARALLEL_BACKUP =
       booleanBuilder(Name.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP)
         .setDefaultValue(false)
@@ -7590,20 +7546,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metadata.sync.ufs.prefetch.timeout";
     public static final String MASTER_METASTORE = "alluxio.master.metastore";
     public static final String MASTER_METASTORE_DIR = "alluxio.master.metastore.dir";
-<<<<<<< HEAD
-||||||| parent of 61f5af80c6 (Add compression level option for RocksDB checkpoint)
-    public static final String MASTER_METASTORE_DIR_INODE =
-        "alluxio.master.metastore.dir.inode";
-    public static final String MASTER_METASTORE_DIR_BLOCK =
-        "alluxio.master.metastore.dir.block";
-=======
-    public static final String MASTER_METASTORE_DIR_INODE =
-        "alluxio.master.metastore.dir.inode";
-    public static final String MASTER_METASTORE_DIR_BLOCK =
-        "alluxio.master.metastore.dir.block";
     public static final String MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL =
         "alluxio.master.metastore.rocks.checkpoint.compression.level";
->>>>>>> 61f5af80c6 (Add compression level option for RocksDB checkpoint)
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP =
         "alluxio.master.metastore.rocks.parallel.backup";
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_THREADS =

--- a/core/server/common/src/main/java/alluxio/util/TarUtils.java
+++ b/core/server/common/src/main/java/alluxio/util/TarUtils.java
@@ -18,6 +18,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipParameters;
 import org.apache.commons.io.IOUtils;
 
 import java.io.File;
@@ -38,11 +39,15 @@ public final class TarUtils {
    * stream.
    *
    * @param dirPath the path to archive
+   * @param compressionLevel the compression level to use (0 for no compression, 9 for the most
+   *                         compression, or -1 for system default)
    * @param output the output stream to write the data to
    */
-  public static void writeTarGz(Path dirPath, OutputStream output)
+  public static void writeTarGz(Path dirPath, OutputStream output, int compressionLevel)
       throws IOException, InterruptedException {
-    GzipCompressorOutputStream zipStream = new GzipCompressorOutputStream(output);
+    GzipParameters params = new GzipParameters();
+    params.setCompressionLevel(compressionLevel);
+    GzipCompressorOutputStream zipStream = new GzipCompressorOutputStream(output, params);
     TarArchiveOutputStream archiveStream = new TarArchiveOutputStream(zipStream);
     archiveStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
     archiveStream.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);

--- a/tests/src/test/java/alluxio/server/ft/journal/MultiProcessCheckpointTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/MultiProcessCheckpointTest.java
@@ -31,7 +31,21 @@ import java.net.URI;
 public class MultiProcessCheckpointTest {
 
   @Test
-  public void test() throws Exception {
+  public void testDefault() throws Exception {
+    runTest(-1, false);
+  }
+
+  @Test
+  public void testNoCompression() throws Exception {
+    runTest(0, false);
+  }
+
+  @Test
+  public void testParallelCompression() throws Exception {
+    runTest(-1, true);
+  }
+
+  void runTest(int compressionLevel, boolean parallelCompression) throws Exception {
     MultiProcessCluster cluster = MultiProcessCluster.newBuilder(PortCoordination.CHECKPOINT)
         .setClusterName("CheckpointTest")
         .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS)
@@ -41,6 +55,10 @@ public class MultiProcessCheckpointTest {
         .addProperty(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 100)
         .addProperty(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, "500")
         .addProperty(PropertyKey.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS, "500")
+        .addProperty(PropertyKey.MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL,
+            compressionLevel)
+        .addProperty(PropertyKey.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP,
+            parallelCompression)
         .setNumMasters(2)
         .setNumWorkers(0)
         .build();


### PR DESCRIPTION
### Why are the changes needed?

Allows the user to specify the compression level of the RocksDB checkpoint for both single and multithreaded compression.

Fixes an issue where the compression level for the multithreaded compression was not being used.

### Does this PR introduce any user facing changes?

Adds the property key `alluxio.master.metastore.rocks.checkpoint.compression.level`.

Removes the property key `alluxio.master.metastore.rocks.parallel.backup.compression.level` as its value was not being used.

[This is manually generated PR to cherry-pick committed PR Alluxio/alluxio#16620 into target branch branch-2.9]