### PR TITLE
Port changes of [#16620] to branch-2.8

### DIFF
--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -408,6 +408,7 @@ public class InstancedConfiguration implements AlluxioConfiguration {
     checkZkConfiguration();
     checkTieredLocality();
     checkTieredStorage();
+    checkCheckpointZipConfig();
   }
 
   @Override
@@ -612,6 +613,18 @@ public class InstancedConfiguration implements AlluxioConfiguration {
           "Alias \"%s\" on tier %s on worker (configured by %s) is not found in global tiered "
               + "storage setting: %s",
           alias, i, key, String.join(", ", globalTierAliasSet));
+    }
+  }
+
+  /**
+   * @throws IllegalStateException if invalid checkpoint zip configuration parameters are found
+   */
+  private void checkCheckpointZipConfig() {
+    int compression = getInt(PropertyKey.MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL);
+    if (compression < -1 || compression > 9) {
+      throw new IllegalStateException(String.format("Zip compression level for property key %s"
+          + " must be between -1 and 9 inclusive",
+          PropertyKey.MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL.getName()));
     }
   }
 

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2224,6 +2224,16 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL =
+      intBuilder(Name.MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL)
+          .setDefaultValue(-1)
+          .setDescription("The zip compression level of checkpointing rocksdb, the zip"
+              + " format defines ten levels of compression, ranging from 0"
+              + " (no compression, but very fast) to 9 (best compression, but slow)."
+              + " Or -1 for the system default compression level.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE =
       intBuilder(Name.MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE)
           // TODO(andrew): benchmark different batch sizes to improve the default and provide a
@@ -6826,6 +6836,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metadata.sync.ufs.prefetch.timeout";
     public static final String MASTER_METASTORE = "alluxio.master.metastore";
     public static final String MASTER_METASTORE_DIR = "alluxio.master.metastore.dir";
+    public static final String MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL =
+        "alluxio.master.metastore.rocks.checkpoint.compression.level";
     public static final String MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE =
         "alluxio.master.metastore.inode.cache.evict.batch.size";
     public static final String MASTER_METASTORE_INODE_CACHE_HIGH_WATER_MARK_RATIO =

--- a/core/server/common/src/main/java/alluxio/util/TarUtils.java
+++ b/core/server/common/src/main/java/alluxio/util/TarUtils.java
@@ -18,6 +18,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipParameters;
 import org.apache.commons.io.IOUtils;
 
 import java.io.File;
@@ -38,11 +39,15 @@ public final class TarUtils {
    * stream.
    *
    * @param dirPath the path to archive
+   * @param compressionLevel the compression level to use (0 for no compression, 9 for the most
+   *                         compression, or -1 for system default)
    * @param output the output stream to write the data to
    */
-  public static void writeTarGz(Path dirPath, OutputStream output)
+  public static void writeTarGz(Path dirPath, OutputStream output, int compressionLevel)
       throws IOException, InterruptedException {
-    GzipCompressorOutputStream zipStream = new GzipCompressorOutputStream(output);
+    GzipParameters params = new GzipParameters();
+    params.setCompressionLevel(compressionLevel);
+    GzipCompressorOutputStream zipStream = new GzipCompressorOutputStream(output, params);
     TarArchiveOutputStream archiveStream = new TarArchiveOutputStream(zipStream);
     archiveStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
     archiveStream.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);

--- a/core/server/common/src/test/java/alluxio/util/FileUtil.java
+++ b/core/server/common/src/test/java/alluxio/util/FileUtil.java
@@ -1,0 +1,50 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * FileUtil for TarUtilsTest and ParallelZipUtilsTest.
+ */
+public class FileUtil {
+  static void assertDirectoriesEqual(Path path, Path reconstructed) throws Exception {
+    AtomicLong pathCount = new AtomicLong(0);
+
+    Files.walk(path).forEach(subPath -> {
+      Path relative = path.relativize(subPath);
+      Path resolved = reconstructed.resolve(relative);
+      assertTrue(resolved + " should exist since " + subPath + " exists", Files.exists(resolved));
+      assertEquals(subPath.toFile().isFile(), resolved.toFile().isFile());
+      if (path.toFile().isFile()) {
+        try {
+          assertArrayEquals(resolved + " should have the same content as " + subPath,
+              Files.readAllBytes(path), Files.readAllBytes(resolved));
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      pathCount.incrementAndGet();
+    });
+
+    long reconstructedCount = Files.walk(reconstructed).count();
+    assertEquals(pathCount.get(), reconstructedCount);
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
@@ -12,6 +12,8 @@
 package alluxio.master.metastore.rocks;
 
 import alluxio.Constants;
+import alluxio.conf.PropertyKey;
+import alluxio.conf.ServerConfiguration;
 import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.CheckpointOutputStream;
 import alluxio.master.journal.checkpoint.CheckpointType;
@@ -55,6 +57,9 @@ public final class RocksStore implements Closeable {
   private final String mDbCheckpointPath;
   private final Collection<ColumnFamilyDescriptor> mColumnFamilyDescriptors;
   private final DBOptions mDbOpts;
+
+  private final int mCompressLevel = ServerConfiguration.getInt(
+      PropertyKey.MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL);
 
   private RocksDB mDb;
   private Checkpoint mCheckpoint;
@@ -195,7 +200,7 @@ public final class RocksStore implements Closeable {
       throw new IOException(e);
     }
     LOG.info("Checkpoint complete, creating tarball");
-    TarUtils.writeTarGz(Paths.get(mDbCheckpointPath), out);
+    TarUtils.writeTarGz(Paths.get(mDbCheckpointPath), out, mCompressLevel);
     LOG.info("Completed rocksdb checkpoint in {}ms", (System.nanoTime() - startNano) / 1_000_000);
     // Checkpoint is no longer needed, delete to save space.
     FileUtils.deletePathRecursively(mDbCheckpointPath);

--- a/tests/src/test/java/alluxio/server/ft/journal/MultiProcessCheckpointTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/MultiProcessCheckpointTest.java
@@ -31,7 +31,21 @@ import java.net.URI;
 public class MultiProcessCheckpointTest {
 
   @Test
-  public void test() throws Exception {
+  public void testDefault() throws Exception {
+    runTest(-1, false);
+  }
+
+  @Test
+  public void testNoCompression() throws Exception {
+    runTest(0, false);
+  }
+
+  @Test
+  public void testParallelCompression() throws Exception {
+    runTest(-1, true);
+  }
+
+  void runTest(int compressionLevel, boolean parallelCompression) throws Exception {
     MultiProcessCluster cluster = MultiProcessCluster.newBuilder(PortCoordination.CHECKPOINT)
         .setClusterName("CheckpointTest")
         .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS)
@@ -41,6 +55,10 @@ public class MultiProcessCheckpointTest {
         .addProperty(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 100)
         .addProperty(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, "500")
         .addProperty(PropertyKey.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS, "500")
+        .addProperty(PropertyKey.MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL,
+            compressionLevel)
+        .addProperty(PropertyKey.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP,
+            parallelCompression)
         .setNumMasters(2)
         .setNumWorkers(0)
         .build();

--- a/tests/src/test/java/alluxio/server/ft/journal/MultiProcessCheckpointTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/MultiProcessCheckpointTest.java
@@ -57,8 +57,6 @@ public class MultiProcessCheckpointTest {
         .addProperty(PropertyKey.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS, "500")
         .addProperty(PropertyKey.MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL,
             compressionLevel)
-        .addProperty(PropertyKey.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP,
-            parallelCompression)
         .setNumMasters(2)
         .setNumWorkers(0)
         .build();


### PR DESCRIPTION
### Why are the changes needed?

Allows the user to specify the compression level of the RocksDB checkpoint for both single and multithreaded compression.

Fixes an issue where the compression level for the multithreaded compression was not being used.

### Does this PR introduce any user facing changes?

Adds the property key `alluxio.master.metastore.rocks.checkpoint.compression.level`.

Removes the property key `alluxio.master.metastore.rocks.parallel.backup.compression.level` as its value was not being used.

[This is manually generated PR to cherry-pick committed PR Alluxio/alluxio#16620 into target branch branch-2.8]