### PR TITLE
Remove some overhead in big file read

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -94,6 +94,9 @@ public class LocalPageStore implements PageStore {
     try (RandomAccessFile localFile = new RandomAccessFile(pagePath.toString(), "r")) {
       int bytesSkipped = localFile.skipBytes(pageOffset);
       if (pageOffset != bytesSkipped) {
+        long pageLength = pagePath.toFile().length();
+        Preconditions.checkArgument(pageOffset <= pageLength,
+            "page offset %s exceeded page size %s", pageOffset, pageLength);
         throw new IOException(
             String.format("Failed to read page %s (%s) from offset %s: %s bytes skipped",
                 pageId, pagePath, pageOffset, bytesSkipped));

--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsFileInStream.java
@@ -67,6 +67,9 @@ public class UfsFileInStream extends FileInStream {
 
   @Override
   public int read(ByteBuffer byteBuffer, int off, int len) throws IOException {
+    if (byteBuffer.hasArray()) {
+      return read(byteBuffer.array(), off, len);
+    }
     byte[] byteArray = new byte[len];
     int totalBytesRead = read(byteArray, 0, len);
     if (totalBytesRead <= 0) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove some overhead in big file read (cache hit/ cache miss) in fuse sdk.

### Why are the changes needed?

Improve overall read performance

### Does this PR introduce any user facing changes?

NA
