### PR TITLE
Remove unneeded isFile call in UfsBaseFileSystem.getStatus

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
@@ -212,11 +212,7 @@ public class UfsBaseFileSystem implements FileSystem {
 
   @Override
   public URIStatus getStatus(AlluxioURI path, final GetStatusPOptions options) {
-    return callWithReturn(() -> {
-      String ufsPath = path.getPath();
-      return transformStatus(mUfs.get().isFile(ufsPath)
-          ? mUfs.get().getFileStatus(ufsPath) : mUfs.get().getDirectoryStatus(ufsPath));
-    });
+    return callWithReturn(() -> transformStatus(mUfs.get().getStatus(path.getPath())));
   }
 
   @Override


### PR DESCRIPTION
Use mdtest to get file status of 1000 files, by removing the isFile call, the get status performance can double.