### PR TITLE
Set default fuse version to 3 and support setting via command line

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6491,9 +6491,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey FUSE_JNIFUSE_LIBFUSE_VERSION =
       intBuilder(Name.FUSE_JNIFUSE_LIBFUSE_VERSION)
-          .setDefaultValue(2)
+          .setDefaultValue(3)
           .setDescription("The version of libfuse used by libjnifuse. "
-              + "Libfuse2 and Libfuse3 are supported.")
+              + "Libfuse2 (value=\"2\") and Libfuse3 (value=\"3\", default value) are supported.")
           .setScope(Scope.ALL)
           .build();
   public static final PropertyKey FUSE_SHARED_CACHING_READER_ENABLED =

--- a/integration/fuse/bin/alluxio-fuse-sdk
+++ b/integration/fuse/bin/alluxio-fuse-sdk
@@ -23,6 +23,7 @@ General options
 
 Alluxio mount options
 \t-o <ALLUXIO_PROPERTY_KEY>=<ALLUXIO_PROPERTY_VALUE> \tThe credentials of the target ufs address should be provided here so that alluxio fuse can access the target data set. Other alluxio common/user configuration can also be provided here
+\t-o fuse=<version> (Default=\"3\") \tUnderlying libfuse version to use. Set to 2 if you are using fuse 2.
 \t-o data_cache=<local_cache_directory> (Default=\"\" which means disabled) \tLocal folder to use for local data cache.
 \t-o data_cache_size=<size> (Default=\"512MB\") \tMaximum cache size for local data cache directory.  
 \t-o metadata_cache_size=<size> (Default=\"0\" which means disabled) \tMaximum number of entries in the metadata cache. Each 1000 entries cause about 2MB memory.

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuse.java
@@ -292,6 +292,10 @@ public final class AlluxioFuse {
           PropertyKey propertyKey = PropertyKey.fromString(key);
           conf.set(propertyKey, propertyKey.parseValue(value), Source.RUNTIME);
           LOG.info("Set Alluxio property key({}={}) from command line input", key, value);
+        } else if (key.equals("fuse")) {
+          conf.set(PropertyKey.FUSE_JNIFUSE_LIBFUSE_VERSION,
+              PropertyKey.FUSE_JNIFUSE_LIBFUSE_VERSION.parseValue(value), Source.RUNTIME);
+          LOG.info("Set libfuse version to {} from command line input", value);
         } else if (key.equals("data_cache")) {
           conf.set(PropertyKey.USER_CLIENT_CACHE_ENABLED, true, Source.RUNTIME);
           conf.set(PropertyKey.USER_CLIENT_CACHE_DIRS,

--- a/integration/fuse/src/test/java/alluxio/fuse/meta/UpdateCheckerTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/meta/UpdateCheckerTest.java
@@ -21,6 +21,7 @@ import alluxio.fuse.options.FuseOptions;
 import alluxio.metrics.MetricsSystem;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.util.List;
@@ -71,6 +72,7 @@ public class UpdateCheckerTest {
 
   @Test
   public void localKernelDataCacheDisabled() {
+    Assume.assumeTrue(Configuration.getInt(PropertyKey.FUSE_JNIFUSE_LIBFUSE_VERSION) == 2);
     try (UpdateChecker checker = getUpdateCheckerWithMountOptions("direct_io")) {
       Assert.assertFalse(containsTargetInfo(checker.getUnchangeableFuseInfo(),
           UpdateChecker.LOCAL_KERNEL_DATA_CACHE));

--- a/integration/fuse/src/test/java/alluxio/jnifuse/struct/FuseFileInfoTest.java
+++ b/integration/fuse/src/test/java/alluxio/jnifuse/struct/FuseFileInfoTest.java
@@ -14,6 +14,7 @@ package alluxio.jnifuse.struct;
 import static org.junit.Assert.assertEquals;
 
 import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 import alluxio.fuse.AlluxioFuseUtils;
 import alluxio.jnifuse.LibFuse;
 
@@ -26,8 +27,9 @@ import java.nio.ByteBuffer;
 public class FuseFileInfoTest {
   @Test
   public void offset() {
+    Configuration.set(PropertyKey.FUSE_JNIFUSE_LIBFUSE_VERSION, 2);
     LibFuse.loadLibrary(AlluxioFuseUtils.getLibfuseVersion(Configuration.global()));
-    FuseFileInfo jnifi = FuseFileInfo.of(ByteBuffer.allocate(256));
+    FuseFileInfo jnifi = FuseFileInfo.of(ByteBuffer.allocate(40));
     ru.serce.jnrfuse.struct.FuseFileInfo jnrfi =
         ru.serce.jnrfuse.struct.FuseFileInfo.of(Pointer.wrap(Runtime.getSystemRuntime(), 0x0));
     assertEquals(jnrfi.flags.offset(), jnifi.flags.offset());


### PR DESCRIPTION
Set default fuse version to 3 because of easy to use and better performance.
One can sudo yum install fuse3 and then alluxio-fuse to be able to enjoy the 
 better performance brought by MAX_IDLE_THREADS=64 (64 threads instead 10 idle threads to execute fuse operations for better performance).
