### PR TITLE
Build and symlink to shaded client jar within client/build/

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -202,7 +202,7 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 			"bin/alluxio-stop.sh",
 			"bin/alluxio-workers.sh",
 			"bin/launch-process",
-			fmt.Sprintf("client/alluxio-%v-client.jar", version),
+			fmt.Sprintf("client/build/alluxio-%v-client.jar", version),
 			"conf/rocks-inode-bloom.ini.template",
 			"conf/rocks-block-bloom.ini.template",
 			"conf/rocks-inode.ini.template",
@@ -238,6 +238,13 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 	for _, path := range pathsToCopy {
 		mkdir(filepath.Join(dstPath, filepath.Dir(path)))
 		run(fmt.Sprintf("adding %v", path), "cp", path, filepath.Join(dstPath, path))
+	}
+
+	if !fuse {
+		run("create symlink for client jar", "ln", "-s",
+			fmt.Sprintf("build/alluxio-%v-client.jar", version),
+			filepath.Join(dstPath, fmt.Sprintf("client/alluxio-%v-client.jar", version)),
+		)
 	}
 
 	modulesToAdd := map[string]module{}

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -202,7 +202,7 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 			"bin/alluxio-stop.sh",
 			"bin/alluxio-workers.sh",
 			"bin/launch-process",
-			fmt.Sprintf("client/build/alluxio-%v-client.jar", version),
+			fmt.Sprintf("client/build/alluxio-%v-hdfs2-client.jar", version),
 			"conf/rocks-inode-bloom.ini.template",
 			"conf/rocks-block-bloom.ini.template",
 			"conf/rocks-inode.ini.template",
@@ -242,7 +242,7 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 
 	if !fuse {
 		run("create symlink for client jar", "ln", "-s",
-			fmt.Sprintf("build/alluxio-%v-client.jar", version),
+			fmt.Sprintf("build/alluxio-%v-hdfs2-client.jar", version),
 			filepath.Join(dstPath, fmt.Sprintf("client/alluxio-%v-client.jar", version)),
 		)
 	}

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-tarball.go
@@ -202,7 +202,7 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 			"bin/alluxio-stop.sh",
 			"bin/alluxio-workers.sh",
 			"bin/launch-process",
-			fmt.Sprintf("client/build/alluxio-%v-hdfs2-client.jar", version),
+			fmt.Sprintf("client/build/alluxio-%v-hadoop2-client.jar", version),
 			"conf/rocks-inode-bloom.ini.template",
 			"conf/rocks-block-bloom.ini.template",
 			"conf/rocks-inode.ini.template",
@@ -242,7 +242,7 @@ func addAdditionalFiles(srcPath, dstPath string, hadoopVersion version, version 
 
 	if !fuse {
 		run("create symlink for client jar", "ln", "-s",
-			fmt.Sprintf("build/alluxio-%v-hdfs2-client.jar", version),
+			fmt.Sprintf("build/alluxio-%v-hadoop2-client.jar", version),
 			filepath.Join(dstPath, fmt.Sprintf("client/alluxio-%v-client.jar", version)),
 		)
 	}

--- a/shaded/client/pom.xml
+++ b/shaded/client/pom.xml
@@ -334,7 +334,7 @@
             </goals>
             <configuration>
               <sourceFile>${basedir}/target/${project.artifactId}-${project.version}.jar</sourceFile>
-              <destinationFile>${project.parent.parent.basedir}/client/build/alluxio-${project.version}-hdfs2-client.jar</destinationFile>
+              <destinationFile>${project.parent.parent.basedir}/client/build/alluxio-${project.version}-hadoop2-client.jar</destinationFile>
             </configuration>
           </execution>
         </executions>
@@ -354,7 +354,7 @@
               <executable>ln</executable>
               <arguments>
                 <argument>-fnsv</argument>
-                <argument>build/alluxio-${project.version}-hdfs2-client.jar</argument>
+                <argument>build/alluxio-${project.version}-hadoop2-client.jar</argument>
                 <argument>${project.parent.parent.basedir}/client/alluxio-${project.version}-client.jar</argument>
               </arguments>
             </configuration>

--- a/shaded/client/pom.xml
+++ b/shaded/client/pom.xml
@@ -334,7 +334,7 @@
             </goals>
             <configuration>
               <sourceFile>${basedir}/target/${project.artifactId}-${project.version}.jar</sourceFile>
-              <destinationFile>${project.parent.parent.basedir}/client/build/alluxio-${project.version}-client.jar</destinationFile>
+              <destinationFile>${project.parent.parent.basedir}/client/build/alluxio-${project.version}-hdfs2-client.jar</destinationFile>
             </configuration>
           </execution>
         </executions>
@@ -355,7 +355,7 @@
               <arguments>
                 <argument>-fnsv</argument>
                 <argument>build/alluxio-${project.version}-client.jar</argument>
-                <argument>${project.parent.parent.basedir}/client/alluxio-${project.version}-client.jar</argument>
+                <argument>${project.parent.parent.basedir}/client/alluxio-${project.version}-hdfs2-client.jar</argument>
               </arguments>
             </configuration>
           </execution>

--- a/shaded/client/pom.xml
+++ b/shaded/client/pom.xml
@@ -354,8 +354,8 @@
               <executable>ln</executable>
               <arguments>
                 <argument>-fnsv</argument>
-                <argument>build/alluxio-${project.version}-client.jar</argument>
-                <argument>${project.parent.parent.basedir}/client/alluxio-${project.version}-hdfs2-client.jar</argument>
+                <argument>build/alluxio-${project.version}-hdfs2-client.jar</argument>
+                <argument>${project.parent.parent.basedir}/client/alluxio-${project.version}-client.jar</argument>
               </arguments>
             </configuration>
           </execution>

--- a/shaded/client/pom.xml
+++ b/shaded/client/pom.xml
@@ -334,7 +334,29 @@
             </goals>
             <configuration>
               <sourceFile>${basedir}/target/${project.artifactId}-${project.version}.jar</sourceFile>
-              <destinationFile>${project.parent.parent.basedir}/client/alluxio-${project.version}-client.jar</destinationFile>
+              <destinationFile>${project.parent.parent.basedir}/client/build/alluxio-${project.version}-client.jar</destinationFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>symlink-jar</id>
+            <phase>install</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>ln</executable>
+              <arguments>
+                <argument>-fnsv</argument>
+                <argument>build/alluxio-${project.version}-client.jar</argument>
+                <argument>${project.parent.parent.basedir}/client/alluxio-${project.version}-client.jar</argument>
+              </arguments>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
- change the build destination of the shaded client jar from `client/alluxio-VERSION-client.jar` to `client/build/alluxio-VERSION-client.jar`
- add a new step to create a symlink at the previous `client/alluxio-VERSION-client.jar` pointing to the new destination. also mimic this step in the tarball generation script

with the client jar being a symlink, this will allow the addition of a hadoop3 compatible shaded client jar via
- adding new modules in core/client/ and shaded/ to define the new client jar
- building the new shaded client jar also within `client/build/`
- exposing a new flag/profile to replace the current symlink with a new symlink pointing to the hadoop3 client jar + also doing the same within the tarball generation script

this change was tested by building the release tarball, starting a local cluster from the extracted tarball, and running `bin/alluxio runTests` to validate usage of the client via symlinked jar. artifact and jar names are all kept the same to preserve backcompat for maven dependencies and existing usage respectively; changing them to denote them as `hadoop2` would break backcompat