### PR TITLE
Clear metrics when closing JournalStateMachine

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -367,6 +367,11 @@ public class JournalStateMachine extends BaseStateMachine {
   @Override
   public void close() {
     mClosed = true;
+    MetricsSystem.removeMetrics(MetricKey.MASTER_EMBEDDED_JOURNAL_SNAPSHOT_LAST_INDEX.getName());
+    MetricsSystem.removeMetrics(MetricKey.MASTER_JOURNAL_ENTRIES_SINCE_CHECKPOINT.getName());
+    MetricsSystem.removeMetrics(MetricKey.MASTER_JOURNAL_LAST_CHECKPOINT_TIME.getName());
+    MetricsSystem.removeMetrics(MetricKey.MASTER_JOURNAL_LAST_APPLIED_COMMIT_INDEX.getName());
+    MetricsSystem.removeMetrics(MetricKey.MASTER_JOURNAL_CHECKPOINT_WARN.getName());
     synchronized (mSnapshotManager) {
       mSnapshotManager.notifyAll();
     }

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -1192,6 +1192,11 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     return mServer;
   }
 
+  @VisibleForTesting
+  ConcurrentHashMap<String, RaftJournal> getJournals() {
+    return mJournals;
+  }
+
   /**
    * Updates raft group with the current values from raft server.
    */

--- a/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalSystemMetricsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalSystemMetricsTest.java
@@ -48,9 +48,9 @@ public final class RaftJournalSystemMetricsTest {
   @Test
   public void journalStateMachineMetrics() throws Exception {
     Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES,
-        "localhost:19200,localhost:19201,localhost:19202");
+        "localhost:29200,localhost:29201,localhost:29202");
     Configuration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
-    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_PORT, 19200);
+    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_PORT, 29200);
     RaftJournalSystem system =
         new RaftJournalSystem(mFolder.newFolder().toURI(), ServiceType.MASTER_RAFT);
     String[] metricsNames = new String[] {

--- a/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalSystemMetricsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalSystemMetricsTest.java
@@ -73,6 +73,9 @@ public final class RaftJournalSystemMetricsTest {
       assertNotNull(MetricsSystem.METRIC_REGISTRY.getGauges().get(name));
     }
     newStateMachine.close();
+    for (String name : metricsNames) {
+      assertNull(MetricsSystem.METRIC_REGISTRY.getGauges().get(name));
+    }
   }
 
   @Test


### PR DESCRIPTION
### What changes are proposed in this pull request?

Clear metrics when closing JournalStateMachine,
so when a new instance of JournalStateMachine is created, those metrics can be refreshed.

https://github.com/Alluxio/alluxio/blob/bd30e25d7b0103e30dd8de611da250ced85cdf27/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java#L293-L297

Fix #16704.

### Why are the changes needed?

Fix a bug that after a primacy change, metrics of JournalStateMachine will get stuck.

### Does this PR introduce any user facing changes?

No.