### PR TITLE
Revert registerMetrics call in gainPrimacy

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -545,7 +545,6 @@ public class RaftJournalSystem extends AbstractJournalSystem {
     mAsyncJournalWriter
         .set(new AsyncJournalWriter(mRaftJournalWriter, () -> getJournalSinks(null)));
     mTransferLeaderAllowed.set(true);
-    super.registerMetrics();
     LOG.info("Gained primacy.");
   }
 

--- a/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalSystemMetricsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalSystemMetricsTest.java
@@ -65,7 +65,7 @@ public final class RaftJournalSystemMetricsTest {
 
     Map<String, Long> sn1 = ImmutableMap.of("DefaultBlockMaster", 1L, "DefaultMetaMaster", 2L);
     Mockito.doReturn(sn1).when(system).getCurrentSequenceNumbers();
-    system.startInternal();
+    system.start();
     Mockito.doReturn(null).when(system).getRaftRoleInfo();
     assertEquals(-1, getClusterLeaderIndex());
     assertEquals(-1, getMasterRoleId());

--- a/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalSystemMetricsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalSystemMetricsTest.java
@@ -99,6 +99,8 @@ public final class RaftJournalSystemMetricsTest {
     assertEquals(RaftProtos.RaftPeerRole.LEADER_VALUE, getMasterRoleId());
     assertEquals(system.getLocalPeerId().toString(), getClusterLeaderId());
     assertEquals(sn2, getMasterJournalSequenceNumbers(system));
+
+    system.stop();
   }
 
   private static int getClusterLeaderIndex() {

--- a/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalSystemMetricsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/raft/RaftJournalSystemMetricsTest.java
@@ -47,9 +47,9 @@ public final class RaftJournalSystemMetricsTest {
   @Test
   public void metrics() throws Exception {
     Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_ADDRESSES,
-        "localhost:19200,localhost:19201,localhost:19202");
+        "localhost:22200,localhost:22201,localhost:22202");
     Configuration.set(PropertyKey.MASTER_HOSTNAME, "localhost");
-    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_PORT, 19200);
+    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_PORT, 22200);
     RaftJournalSystem raftJournalSystem =
         new RaftJournalSystem(mFolder.newFolder().toURI(), ServiceType.MASTER_RAFT);
     RaftJournalSystem system = Mockito.spy(raftJournalSystem);
@@ -60,7 +60,7 @@ public final class RaftJournalSystemMetricsTest {
         .setFollowerInfo(RaftProtos.FollowerInfoProto.newBuilder()
             .setLeaderInfo(RaftProtos.ServerRpcProto.newBuilder()
                 .setId(RaftProtos.RaftPeerProto.newBuilder()
-                    .setId(ByteString.copyFromUtf8("localhost_19201")))))
+                    .setId(ByteString.copyFromUtf8("localhost_22201")))))
         .build();
 
     Map<String, Long> sn1 = ImmutableMap.of("DefaultBlockMaster", 1L, "DefaultMetaMaster", 2L);
@@ -90,7 +90,7 @@ public final class RaftJournalSystemMetricsTest {
     Mockito.doReturn(followerInfo).when(system).getRaftRoleInfo();
     assertEquals(1, getClusterLeaderIndex());
     assertEquals(RaftProtos.RaftPeerRole.FOLLOWER_VALUE, getMasterRoleId());
-    assertEquals("localhost_19201", getClusterLeaderId());
+    assertEquals("localhost_22201", getClusterLeaderId());
     assertEquals(sn2, getMasterJournalSequenceNumbers(system));
 
     system.gainPrimacy();


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR reverts the `super.registerMetrics();` call in gainPrimacy, which was introduced in #16656.

### Why are the changes needed?

It turns out that `RaftJournalSystem.getCurrentSequenceNumbers()` shouldn't change very often,
because `RaftJournalSystem.mJournals` are only modified when constructor of `AbstractMaster` calls `RaftJournalSystem.createJournal()`.

### Does this PR introduce any user facing changes?
No.