### PR TITLE
Add more observability on inode tree corruption

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournal.java
@@ -641,7 +641,7 @@ public class UfsJournal implements Journal {
   public synchronized void close() {
     if (mState.get() == State.PRIMARY && mWriter != null) {
       LOG.info("Closing journal {}, state {} last journal location {}, next sequence number {}",
-          this, this.mState, this.mWriter.currentLogName(), mWriter.getNextSequenceNumber());
+          this, mState, mWriter.currentLogName(), mWriter.getNextSequenceNumber());
     }
     if (mAsyncWriter != null) {
       mAsyncWriter.close();

--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalLogWriter.java
@@ -522,7 +522,7 @@ public final class UfsJournalLogWriter implements JournalWriter {
     }
   }
 
-  private String currentLogName() {
+  String currentLogName() {
     if (mJournalOutputStream != null) {
       return mJournalOutputStream.currentLog().toString();
     }

--- a/core/server/master/src/main/java/alluxio/master/block/BlockContainerIdGenerator.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockContainerIdGenerator.java
@@ -42,6 +42,13 @@ public final class BlockContainerIdGenerator implements ContainerIdGenerable {
   }
 
   /**
+   * @return the next container id
+   */
+  public long peekNewContainerId() {
+    return mNextContainerId.get();
+  }
+
+  /**
    * @param id the next container id to use
    */
   public void setNextContainerId(long id) {

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -494,6 +494,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
   @Override
   public void stop() throws IOException {
+    LOG.info("Next container id before close: {}", mBlockContainerIdGenerator.peekNewContainerId());
     super.stop();
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -754,6 +754,7 @@ public class DefaultFileSystemMaster extends CoreMaster
 
   @Override
   public void stop() throws IOException {
+    LOG.info("Next directory id before close: {}", mDirectoryIdGenerator.peekDirectoryId());
     if (mAsyncAuditLogWriter != null) {
       mAsyncAuditLogWriter.stop();
       mAsyncAuditLogWriter = null;

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectoryIdGenerator.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeDirectoryIdGenerator.java
@@ -69,6 +69,15 @@ public class InodeDirectoryIdGenerator implements Journaled {
     return directoryId;
   }
 
+  /**
+   * @return the next directory id
+   */
+  public synchronized long peekDirectoryId() {
+    long containerId = mNextDirectoryId.getContainerId();
+    long sequenceNumber = mNextDirectoryId.getSequenceNumber();
+    return BlockId.createBlockId(containerId, sequenceNumber);
+  }
+
   private void initialize(JournalContext context) throws UnavailableException {
     if (!mInitialized) {
       applyAndJournal(context, toEntry(mContainerIdGenerator.getNewContainerId(), 0));

--- a/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/SimpleInodeLockList.java
@@ -88,10 +88,30 @@ public class SimpleInodeLockList implements InodeLockList {
       Preconditions.checkState(!endsInInode(),
           "Cannot lock inode %s for lock list %s because the lock list already ends in an inode",
           inode.getId(), this);
-      Preconditions.checkState(inode.getName().equals(mLastEdge.getName()),
-          "Expected to lock inode %s but locked inode %s", mLastEdge.getName(), inode.getName());
+      checkInodeNameAndEdgeNameMatch(inode);
     }
     lockAndAddInode(inode, mode);
+  }
+
+  /**
+   * Checks if the inode name and the edge name match.
+   * @param inode the inode to check
+   */
+  private void checkInodeNameAndEdgeNameMatch(Inode inode) throws IllegalStateException {
+    if (!inode.getName().equals(mLastEdge.getName())) {
+      StringBuilder sb = new StringBuilder();
+      for (InodeView currentInode : mInodes) {
+        sb.append("[");
+        sb.append(currentInode.toProto());
+        sb.append("]->");
+      }
+      sb.append("[END]");
+      throw new IllegalStateException(
+          String.format(
+              "Expected to lock inode %s but locked inode name %s, id: %s, parent_id: %s. %n",
+              mLastEdge.getName(), inode.getName(), inode.getId(), inode.getParentId())
+              + "Locked inode path: " + sb);
+    }
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metastore/InodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/InodeStore.java
@@ -17,7 +17,6 @@ import alluxio.master.file.meta.InodeTree;
 import alluxio.master.file.meta.InodeView;
 import alluxio.master.file.meta.MutableInode;
 import alluxio.master.journal.checkpoint.Checkpointed;
-import alluxio.master.metastore.heap.HeapInodeStore;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +41,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public interface InodeStore extends ReadOnlyInodeStore, Checkpointed, Closeable {
-  Logger LOG = LoggerFactory.getLogger(HeapInodeStore.class);
+  Logger LOG = LoggerFactory.getLogger(InodeStore.class);
 
   /**
    * Gets a mutable representation of the specified inode.

--- a/core/server/master/src/main/java/alluxio/master/metastore/InodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/InodeStore.java
@@ -13,9 +13,14 @@ package alluxio.master.metastore;
 
 import alluxio.master.file.meta.Inode;
 import alluxio.master.file.meta.InodeLockManager;
+import alluxio.master.file.meta.InodeTree;
 import alluxio.master.file.meta.InodeView;
 import alluxio.master.file.meta.MutableInode;
 import alluxio.master.journal.checkpoint.Checkpointed;
+import alluxio.master.metastore.heap.HeapInodeStore;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.util.Optional;
@@ -37,6 +42,8 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public interface InodeStore extends ReadOnlyInodeStore, Checkpointed, Closeable {
+  Logger LOG = LoggerFactory.getLogger(HeapInodeStore.class);
+
   /**
    * Gets a mutable representation of the specified inode.
    *
@@ -177,6 +184,39 @@ public interface InodeStore extends ReadOnlyInodeStore, Checkpointed, Closeable 
 
   @Override
   default void close() {}
+
+  /**
+   * Traverses the inode path starting from the given inode up to the root. Used for debugging.
+   * @param inode the leaf inode
+   * @return the string that contains all inode proto on the path
+   */
+  default String getInodePathString(InodeView inode) {
+    int iterationCount = 100;
+    try {
+      StringBuilder sb = new StringBuilder();
+      InodeView currentInode = inode;
+      do {
+        sb.append('[');
+        sb.append(currentInode.toProto());
+        sb.append("]<-");
+        currentInode = get(currentInode.getParentId()).orElse(null);
+        if (currentInode == null) {
+          break;
+        }
+        iterationCount--;
+      } while (currentInode.getParentId() != InodeTree.NO_PARENT && iterationCount >= 0);
+      if (iterationCount == 0) {
+        sb.append("[Ignored]...");
+      } else {
+        sb.append("[ROOT]");
+      }
+      return sb.toString();
+    } catch (Exception e) {
+      LOG.error("Traverse and print inode path failed, {}{}", e.getClass().getName(),
+          e.getMessage());
+      return "ERROR";
+    }
+  }
 
   /**
    * Used to perform batched writes. Call {@link #createWriteBatch()} to use batched writes.

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
@@ -180,13 +180,13 @@ public abstract class Cache<K, V> implements Closeable {
    * @param key the key
    * @param value the value
    */
-  public void putNew(K key, V value) {
+  public void putNewEntry(K key, V value) {
     putInternal(key, value, true);
   }
 
   /**
    * Writes a key/value pair to the cache.
-   * If it is known that the entry is new, prefer {@link #putNew(Object, Object)}.
+   * If it is known that the entry is new, prefer {@link #putNewEntry(Object, Object)}.
    *
    * @param key the key
    * @param value the value

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/Cache.java
@@ -174,13 +174,31 @@ public abstract class Cache<K, V> implements Closeable {
 
   /**
    * Writes a key/value pair to the cache.
+   * This method is similar to {@link #put(Object, Object)}, but with an added information that
+   * the entry is new.
+   *
+   * @param key the key
+   * @param value the value
+   */
+  public void putNew(K key, V value) {
+    putInternal(key, value, true);
+  }
+
+  /**
+   * Writes a key/value pair to the cache.
+   * If it is known that the entry is new, prefer {@link #putNew(Object, Object)}.
    *
    * @param key the key
    * @param value the value
    */
   public void put(K key, V value) {
+    putInternal(key, value, false);
+  }
+
+  private void putInternal(K key, V value, boolean isNewEntry) {
     mMap.compute(key, (k, entry) -> {
-      onPut(key, value);
+      V existingValue = entry == null ? null : entry.mValue;
+      onPut(key, existingValue, value, isNewEntry);
       if (entry == null && cacheIsFull()) {
         writeToBackingStore(key, value);
         return null;
@@ -450,9 +468,11 @@ public abstract class Cache<K, V> implements Closeable {
    * Callback triggered whenever a new key/value pair is added by put(key, value).
    *
    * @param key the added key
+   * @param existingValue the current value if exists, otherwise null
    * @param value the added value
+   * @param isNewKey a user input boolean indicates if the key is a new key or not
    */
-  protected void onPut(K key, V value) {}
+  protected void onPut(K key, @Nullable V existingValue, V value, boolean isNewKey) {}
 
   /**
    * Callback triggered whenever a key is removed by remove(key).

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
@@ -189,7 +189,7 @@ public final class CachingInodeStore implements InodeStore, Closeable {
     if (inode.isDirectory()) {
       mListingCache.addEmptyDirectory(inode.getId());
     }
-    mInodeCache.putNew(inode.getId(), inode);
+    mInodeCache.putNewEntry(inode.getId(), inode);
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/caching/CachingInodeStore.java
@@ -302,13 +302,14 @@ public final class CachingInodeStore implements InodeStore, Closeable {
     @Override
     protected void onPut(
         Long id, @Nullable MutableInode<?> existingInode, MutableInode<?> inode, boolean newEntry) {
-      if (newEntry && existingInode != null && !existingInode.getName().equals(inode.getName())) {
+      if (newEntry && existingInode != null && inode != null
+          && !existingInode.getName().equals(inode.getName())) {
         LOG.error(
-            "[InodeTreeCorruption] writing inode {} with id {}, parent id {} "
-                + "but a different inode name {} parent id {} already exists. "
+            "[InodeTreeCorruption] trying writing the inode name {} id {}, parent id {}, "
+                + "but a different inode name {} id {} parent id {} already exists. "
                 + "Your journal files are probably corrupted!",
             inode.getName(), inode.getId(), inode.getParentId(),
-            existingInode.getName(), existingInode.getParentId());
+            existingInode.getName(), existingInode.getId(), existingInode.getParentId());
         if (LOG.isDebugEnabled()) {
           LOG.debug("[InodeTreeCorruption] Existing inode: {}, new written inode: {}",
               getInodePathString(existingInode), getInodePathString(inode));

--- a/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/heap/HeapInodeStore.java
@@ -86,11 +86,11 @@ public class HeapInodeStore implements InodeStore {
     mInodes.compute(inode.getId(), (k, existingInode) -> {
       if (existingInode != null && !existingInode.getName().equals(inode.getName())) {
         LOG.error(
-            "[InodeTreeCorruption] writing inode {} with id {}, parent id {} "
-                + "but a different inode name {} parent id {} already exists. "
+            "[InodeTreeCorruption] trying writing the inode name {} id {}, parent id {}, "
+                + "but a different inode name {} id {} parent id {} already exists. "
                 + "Your journal files are probably corrupted!",
             inode.getName(), inode.getId(), inode.getParentId(),
-            existingInode.getName(), existingInode.getParentId());
+            existingInode.getName(), existingInode.getId(), existingInode.getParentId());
         if (LOG.isDebugEnabled()) {
           LOG.debug("[InodeTreeCorruption] Existing inode: {}, new written inode: {}",
               getInodePathString(existingInode), getInodePathString(inode));


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add more logs to detect inode tree corruption

### Why are the changes needed?

Some users reported a issue that expecting to lock inode A but inode B is locked. After the investigation, we figured that this might be due to inode tree corruption caused by journal loss. So we add more logs to help users debug the issue better. 

### Does this PR introduce any user facing changes?

N/A