### PR TITLE
Revert "Remove master/worker java opts from monitor java opts"

### DIFF
--- a/bin/alluxio-monitor.sh
+++ b/bin/alluxio-monitor.sh
@@ -53,19 +53,13 @@ get_env() {
   CLASSPATH=${ALLUXIO_CLIENT_CLASSPATH}
   ALLUXIO_TASK_LOG="${ALLUXIO_LOGS_DIR}/task.log"
 
-  ALLUXIO_MONITOR_JAVA_OPTS_DEFAULT="-Xms256M -Xmx256M"
-  if [ -z ${ALLUXIO_MASTER_MONITOR_JAVA_OPTS} ]; then
-    ALLUXIO_MASTER_MONITOR_JAVA_OPTS=${ALLUXIO_MONITOR_JAVA_OPTS_DEFAULT}
-  fi
-  if [ -z ${ALLUXIO_WORKER_MONITOR_JAVA_OPTS} ]; then
-    ALLUXIO_WORKER_MONITOR_JAVA_OPTS=${ALLUXIO_MONITOR_JAVA_OPTS_DEFAULT}
-  fi
-  if [ -z ${ALLUXIO_JOB_MASTER_MONITOR_JAVA_OPTS} ]; then
-    ALLUXIO_JOB_MASTER_MONITOR_JAVA_OPTS=${ALLUXIO_MONITOR_JAVA_OPTS_DEFAULT}
-  fi
-  if [ -z ${ALLUXIO_JOB_WORKER_MONITOR_JAVA_OPTS} ]; then
-    ALLUXIO_JOB_WORKER_MONITOR_JAVA_OPTS=${ALLUXIO_MONITOR_JAVA_OPTS_DEFAULT}
-  fi
+  # Remove the remote debug configuration to avoid the error: "transport error 20: bind failed: Address already in use."
+  # See https://github.com/Alluxio/alluxio/issues/10958
+  # See https://github.com/Alluxio/alluxio/issues/15168
+  ALLUXIO_MASTER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_MASTER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//' | sed 's/-Dcom.sun.management.jmxremote.port=[0-9]*//')
+  ALLUXIO_WORKER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_WORKER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//' | sed 's/-Dcom.sun.management.jmxremote.port=[0-9]*//')
+  ALLUXIO_JOB_MASTER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_JOB_MASTER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//' | sed 's/-Dcom.sun.management.jmxremote.port=[0-9]*//')
+  ALLUXIO_JOB_WORKER_MONITOR_JAVA_OPTS=$(echo ${ALLUXIO_JOB_WORKER_JAVA_OPTS} | sed 's/^-agentlib:jdwp=transport=dt_socket.*address=[0-9]*//'| sed 's/-Dcom.sun.management.jmxremote.port=[0-9]*//')
 }
 
 prepare_monitor() {

--- a/conf/alluxio-env.sh.template
+++ b/conf/alluxio-env.sh.template
@@ -72,22 +72,6 @@
 # E.g. "-Dalluxio.user.file.writetype.default=CACHE_THROUGH"
 # ALLUXIO_USER_JAVA_OPTS
 
-# Config properties for the monitoring service used by Alluxio shell to monitor the healthiness of Alluxio master process. (Default: "-Xms256M -Xmx256M")
-# E.g. "-Xms256M -Xmx256M"
-# ALLUXIO_MASTER_MONITOR_JAVA_OPTS
-
-# Config properties for the monitoring service used by Alluxio shell to monitor the healthiness of Alluxio worker process. (Default: "-Xms256M -Xmx256M")
-# E.g. "-Xms256M -Xmx256M"
-# ALLUXIO_WORKER_MONITOR_JAVA_OPTS
-
-# Config properties for the monitoring service used by Alluxio shell to monitor the healthiness of Alluxio job master process. (Default: "-Xms256M -Xmx256M")
-# E.g. "-Xms256M -Xmx256M"
-# ALLUXIO_JOB_MASTER_MONITOR_JAVA_OPTS
-
-# Config properties for the monitoring service used by Alluxio shell to monitor the healthiness of Alluxio job worker process. (Default: "-Xms256M -Xmx256M")
-# E.g. "-Xms256M -Xmx256M"
-# ALLUXIO_JOB_WORKER_MONITOR_JAVA_OPTS
-
 # Additional classpath entries for Alluxio processes. (Default: "")
 # E.g. "/path/to/library1/:/path/to/library2/"
 # ALLUXIO_CLASSPATH


### PR DESCRIPTION
This reverts commit bd3ab80ba462a6863787d325c93c796dce3e18de.
This commit solve the related issues but require us to set the same configuration twice especially in Kubernetes environment which all configuration including address information are set through java opts