### PR TITLE
Make ReconfigurableRegistry thread-safe

### DIFF
--- a/core/common/src/main/java/alluxio/conf/ReconfigurableRegistry.java
+++ b/core/common/src/main/java/alluxio/conf/ReconfigurableRegistry.java
@@ -45,7 +45,7 @@ public class ReconfigurableRegistry {
    * @return false if no listener related to the given property, otherwise, return false
    */
   public static synchronized boolean update() {
-    for (Reconfigurable listener : LISTENER_LIST) {
+    for (Reconfigurable listener : new LinkedList<>(LISTENER_LIST)) {
       listener.update();
     }
     return true;


### PR DESCRIPTION
### What changes are proposed in this pull request?

The update method is called safely

### Why are the changes needed?

When the update call unregister, will throw ConcurrentModificationException
  

### Does this PR introduce any user facing changes?


NA.
