### PR TITLE
Fix concurrent sync dedup

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/LockingScheme.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/LockingScheme.java
@@ -32,13 +32,19 @@ public final class LockingScheme {
   private final LockPattern mDesiredLockPattern;
   private final SyncCheck mShouldSync;
 
+  // CHECKSTYLE.OFF: LineLengthExceed - cannot break the method link
   /**
    * Constructs a {@link LockingScheme}.
+   *
+   * Avoid using this constructor where shouldSync is set true, if possible.
+   * {@link #LockingScheme(AlluxioURI, LockPattern, FileSystemMasterCommonPOptions, UfsSyncPathCache, DescendantType)}
+   * is the preferred one in such case, to make the metadata sync dedup feature work.
    *
    * @param path the path to lock
    * @param desiredLockPattern the desired lock mode
    * @param shouldSync true if the path should be synced
    */
+  // CHECKSTYLE.ON: LineLengthExceed
   public LockingScheme(AlluxioURI path, LockPattern desiredLockPattern, boolean shouldSync) {
     mPath = path;
     mDesiredLockPattern = desiredLockPattern;

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataConcurrentTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataConcurrentTest.java
@@ -162,6 +162,23 @@ public class FileSystemMasterSyncMetadataConcurrentTest
     assertEquals(InodeSyncStream.SyncStatus.OK, iss3.sync());
   }
 
+  @Test
+  public void syncWhenShouldSyncIsSetTrue() throws Exception {
+    Supplier<InodeSyncStream> inodeSyncStreamSupplier =  () -> new InodeSyncStream(
+        new LockingScheme(
+            new AlluxioURI("/"), InodeTree.LockPattern.READ, true),
+        mFileSystemMaster, mFileSystemMaster.getSyncPathCache(),
+        RpcContext.NOOP, DescendantType.ALL, FileSystemMasterCommonPOptions.getDefaultInstance(),
+        false,
+        false,
+        false);
+
+    InodeSyncStream iss1 = inodeSyncStreamSupplier.get();
+    InodeSyncStream iss2 = inodeSyncStreamSupplier.get();
+    assertSyncHappenTwice(syncConcurrent(iss1, iss2));
+    assertSyncHappenTwice(syncSequential(inodeSyncStreamSupplier, inodeSyncStreamSupplier));
+  }
+
   private void assertTheSecondSyncSkipped(
       Pair<InodeSyncStream.SyncStatus, InodeSyncStream.SyncStatus> results) {
     assertEquals(InodeSyncStream.SyncStatus.OK, results.getFirst());


### PR DESCRIPTION
### What changes are proposed in this pull request?

The concurrent sync feature will throw exception if the locking scheme uses the constructor that takes a shouldSync boolean. This PR fixes it.

### Does this PR introduce any user facing changes?

N/A