### PR TITLE
Fix domain socket default setting in helm

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
+++ b/integration/kubernetes/helm-chart/alluxio/CHANGELOG.md
@@ -320,3 +320,7 @@
 
 - Improve indentation in worker daemonset template
 - Configure ports in master service following values.yaml
+
+0.6.54
+
+- Replace PVC with hostPath for worker domain socket

--- a/integration/kubernetes/helm-chart/alluxio/Chart.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.6.53
+version: 0.6.54
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/templates/worker/daemonset.yaml
@@ -88,6 +88,18 @@ spec:
       {{- if .Values.imagePullSecrets }}
 {{ include "alluxio.imagePullSecrets" . | indent 6 }}
       {{- end}}
+      {{- if and (eq .Values.shortCircuit.enabled true) (eq .Values.shortCircuit.volumeType "hostPath") }}
+      initContainers:
+        - name: alluxio-domain-permission
+          image: {{ .Values.image }}:{{ .Values.imageTag }}
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          command: ["sh", "-c", "chmod -R 777 /opt/domain"]
+          volumeMounts:
+          - name: alluxio-domain
+            mountPath: /opt/domain
+      {{- end }}
       containers:
         {{- if .Values.worker.extraContainers }}
 {{ include "alluxio.extraContainers" (dict "extraContainers" .Values.worker.extraContainers) | indent 8 }}

--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -448,7 +448,7 @@ shortCircuit:
   policy: uuid
   # volumeType controls the type of shortCircuit volume.
   # It can be "persistentVolumeClaim" or "hostPath"
-  volumeType: persistentVolumeClaim
+  volumeType: hostPath
   size: 1Mi
   # Attributes to use if the domain socket volume is PVC
   pvcName: alluxio-worker-domain-socket


### PR DESCRIPTION
Solves https://github.com/Alluxio/alluxio/issues/16721

Using persistent volume claim for domain socket doesn't work because:
    1. The access mode has to be `ReadWriteOnce` (can only be mounted for reading/writing on one physical machine) because domain socket is a same-node inter-process communication. It doesn't make sense if the directory exists on a different machine and the communication is through network.
    2. Based on 1 and since worker is Daemonset, each node has only 1 worker, the persistent volume cannot be mounted to multiple workers, and thus all workers but one would not successfully start.
    3. Creating one persistent volume claim for every worker also doesn't work because it's not supported by Daemonset.

Thus we change the default to `hostPath`. K8s will create the dir with root as owner, so we need to do a chmod for alluxio to have proper permission.