### PR TITLE
Fix Orc vulnerabilities

### DIFF
--- a/job/server/pom.xml
+++ b/job/server/pom.xml
@@ -42,6 +42,12 @@
     <dependency>
       <groupId>org.apache.orc</groupId>
       <artifactId>orc-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-storage-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>


### PR DESCRIPTION
Vulnerability found in non-os package type (java)
 /opt/alluxio-2.9.0/assembly/alluxio-client-2.9.0.jar:hadoop-annotations
(CVE-2021-33036 - https://nvd.nist.gov/vuln/detail/CVE-2021-33036) 
CVE-2021-33036+alluxio-client-2.9.0.jar:hadoop-annotations
https://nvd.nist.gov/vuln/detail/CVE-2021-33036 

alluxio-job-server -> orc-core 1.6 -> hive-storage-api 2.7
```
docs/en/api/Java-API.md:org.apache.orc.OrcFile.ReaderOptions options = new org.apache.orc.OrcFile.ReaderOptions(conf)
docs/en/api/Java-API.md:org.apache.orc.Reader orc = org.apache.orc.OrcFile.createReader(
job/server/pom.xml:      <groupId>org.apache.orc</groupId>
job/server/src/main/java/alluxio/job/plan/transform/format/orc/OrcReader.java:import org.apache.orc.OrcFile;
job/server/src/main/java/alluxio/job/plan/transform/format/orc/OrcReader.java:import org.apache.orc.Reader;
job/server/src/main/java/alluxio/job/plan/transform/format/orc/OrcReader.java:import org.apache.orc.RecordReader;
job/server/src/main/java/alluxio/job/plan/transform/format/orc/OrcSchema.java:import org.apache.orc.Reader;
job/server/src/main/java/alluxio/job/plan/transform/format/orc/OrcSchema.java:import org.apache.orc.TypeDescription;
```
Likely the hive-metstore-api is not needed