### PR TITLE
Fix NPE in PermissionCheckTest

### DIFF
--- a/core/server/common/src/main/java/alluxio/Registry.java
+++ b/core/server/common/src/main/java/alluxio/Registry.java
@@ -149,6 +149,8 @@ public class Registry<T extends Server<U>, U> {
    * @see #addAlias(Class, Server)
    */
   public <W extends T> void add(Class<W> clazz, T server) {
+    Preconditions.checkNotNull(clazz, "clazz");
+    Preconditions.checkNotNull(server, "server");
     Preconditions.checkArgument(clazz.isInstance(server),
         "Server %s is not an instance of %s", server.getClass(), clazz.getName());
     try (LockResource r = new LockResource(mLock)) {
@@ -173,6 +175,8 @@ public class Registry<T extends Server<U>, U> {
    * @see #add(Class, Server)
    */
   public <W extends T> void addAlias(Class<W> clazz, T server) {
+    Preconditions.checkNotNull(clazz, "clazz");
+    Preconditions.checkNotNull(server, "server");
     Preconditions.checkArgument(clazz.isInstance(server),
         "Server %s is not an instance of %s", server.getClass(), clazz.getName());
     try (LockResource r = new LockResource(mLock)) {

--- a/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/PermissionCheckTest.java
@@ -112,8 +112,7 @@ public final class PermissionCheckTest {
   private static final Mode TEST_DIR_MODE = new Mode((short) 0755);
   private static final Mode TEST_FILE_MODE = new Mode((short) 0755);
 
-  private MasterRegistry mRegistry;
-  private MetricsMaster mMetricsMaster;
+  private final MasterRegistry mRegistry = new MasterRegistry();
   private FileSystemMaster mFileSystemMaster;
 
   @Rule
@@ -183,11 +182,11 @@ public final class PermissionCheckTest {
   public void before() throws Exception {
     Configuration.set(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, mTestFolder.newFolder());
     GroupMappingServiceTestUtils.resetCache();
-    mRegistry = new MasterRegistry();
-    mRegistry.add(MetricsMaster.class, mMetricsMaster);
     CoreMasterContext masterContext = MasterTestUtils.testMasterContext(new NoopJournalSystem(),
         new TestUserState(TEST_USER_ADMIN.getUser(), Configuration.global()));
-    mMetricsMaster = new MetricsMasterFactory().create(mRegistry, masterContext);
+    MetricsMaster metricsMaster =
+        new MetricsMasterFactory().create(mRegistry, masterContext);
+    mRegistry.add(MetricsMaster.class, metricsMaster);
     new BlockMasterFactory().create(mRegistry, masterContext);
     mFileSystemMaster = new FileSystemMasterFactory().create(mRegistry, masterContext);
     mRegistry.start(true);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix an NPE in PermissionCheckTest.

### Why are the changes needed?

The `mMetricsMaster` was initialized to `null` and the setup was adding a null pointer to the registry. A null pointer should have been rejected by the registry but it was not the case until refactoring was done in #16644.

### Does this PR introduce any user facing changes?
No.