### PR TITLE
Remove incorrect copy in StackFS

### DIFF
--- a/integration/fuse/src/main/java/alluxio/fuse/StackMain.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/StackMain.java
@@ -45,7 +45,6 @@ public class StackMain {
     for (int i = 2; i < args.length; i++) {
       fuseOpts.add(args[i].substring(2)); // remove -o
     }
-    System.arraycopy(args, 2, fuseOpts, 0, args.length - 2);
     try {
       CommonUtils.PROCESS_TYPE.set(CommonUtils.ProcessType.CLIENT);
       MetricsSystem.startSinks(conf.getString(PropertyKey.METRICS_CONF_FILE));


### PR DESCRIPTION
All properties have already copied from `args` to set `fuseOpts` in line 45-47. Arraycopy would error out.