### PR TITLE
Implement getChannel for PagedBlockReader

### DIFF
--- a/core/common/src/main/java/alluxio/worker/block/io/BlockReadableChannel.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/BlockReadableChannel.java
@@ -1,0 +1,84 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block.io;
+
+import com.google.common.base.Preconditions;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.ReadableByteChannel;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Readable channel implementation for {@link BlockReader}s.
+ * <br>
+ * The channel can be safely read from multiple threads. Its closed state is independent of
+ * that of the block reader that created it. Its internal position is shared with the block reader,
+ * that is, calling {@link #read(ByteBuffer)} will advance the internal position of the block
+ * reader, and subsequent calls to {@link BlockReader#transferTo(ByteBuf)} will start from where
+ * the channel was left off.
+ */
+@ThreadSafe
+public class BlockReadableChannel implements ReadableByteChannel {
+  private final BlockReader mReader;
+  private volatile boolean mClosed = false;
+
+  /**
+   * Creates a new channel from a block reader.
+   *
+   * @param reader reader
+   */
+  public BlockReadableChannel(BlockReader reader) {
+    mReader = Preconditions.checkNotNull(reader, "reader");
+  }
+
+  // reading from this channel will also affect the internal position used by the
+  // reader's transferTo method
+  // the interface does not clearly state whether the position should be
+  // shared between the channel and transferTo, and existing impls disagree with each other
+  // todo(bowen): make the interface clear about internal position, possibly by adding a new
+  //   getChannel(long start) method that has a separate position.
+  @Override
+  public int read(ByteBuffer dst) throws IOException {
+    if (mClosed) {
+      throw new ClosedChannelException();
+    }
+    int maxReadable = dst.remaining();
+    int position = dst.position();
+    synchronized (this) {
+      ByteBuf buf = Unpooled.wrappedBuffer(dst);
+      buf.writerIndex(0);
+      int bytesRead = mReader.transferTo(buf);
+      Preconditions.checkState(bytesRead <= maxReadable, "buffer overflow");
+      if (bytesRead > 0) {
+        dst.position(position + bytesRead);
+      }
+      return bytesRead;
+    }
+  }
+
+  @Override
+  public boolean isOpen() {
+    return !mClosed;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (mClosed) {
+      return;
+    }
+    mClosed = true;
+  }
+}

--- a/core/common/src/test/java/alluxio/worker/block/io/BlockReadableChannelTest.java
+++ b/core/common/src/test/java/alluxio/worker/block/io/BlockReadableChannelTest.java
@@ -1,0 +1,81 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block.io;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import alluxio.Constants;
+import alluxio.util.io.BufferUtils;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+
+public class BlockReadableChannelTest {
+  private static final int DATA_SIZE = Constants.KB;
+  private BlockReadableChannel mChannel;
+  private final BlockReader mReader =
+      new MockBlockReader(BufferUtils.getIncreasingByteArray(DATA_SIZE));
+
+  @Before
+  public void setup() throws Exception {
+    mChannel = new BlockReadableChannel(mReader);
+  }
+
+  @Test
+  public void closed() throws Exception {
+    assertTrue(mChannel.isOpen());
+    mChannel.close();
+    assertThrows(ClosedChannelException.class, () -> mChannel.read(ByteBuffer.allocate(1)));
+  }
+
+  @Test
+  public void read() throws Exception {
+    int headerSize = 1;
+    int trailerSize = 1;
+    ByteBuffer buffer = ByteBuffer.allocate(DATA_SIZE + headerSize + trailerSize);
+    buffer.clear();
+    buffer.put((byte) 0x42); // fill with some data so that the position starts with non-zero
+    assertEquals(DATA_SIZE, IOUtils.read(mChannel, buffer));
+    assertEquals(headerSize + DATA_SIZE, buffer.position());
+    buffer.flip();
+    assertEquals((byte) 0x42, buffer.get());
+    assertTrue(BufferUtils.equalIncreasingByteBuffer(0, DATA_SIZE, buffer.slice()));
+  }
+
+  /**
+   * Calling {@link BlockReadableChannel#read(ByteBuffer)} and
+   * {@link BlockReader#transferTo(ByteBuf)} shares the same internal position.
+   */
+  @Test
+  public void dependentInternalPosition() throws Exception {
+    int dataSize = 100;
+    ByteBuffer buffer = ByteBuffer.allocate(dataSize);
+    buffer.clear();
+    assertEquals(dataSize, IOUtils.read(mChannel, buffer));
+    buffer.flip();
+    assertTrue(BufferUtils.equalIncreasingByteBuffer(0, dataSize, buffer));
+
+    buffer.clear();
+    ByteBuf buf = Unpooled.wrappedBuffer(buffer);
+    buf.writerIndex(0);
+    assertEquals(dataSize, mReader.transferTo(buf));
+    assertTrue(BufferUtils.equalIncreasingByteBuffer(dataSize, dataSize, buffer));
+  }
+}

--- a/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/PagedFileReader.java
@@ -21,6 +21,7 @@ import alluxio.metrics.MetricsSystem;
 import alluxio.network.protocol.databuffer.NioDirectBufferPool;
 import alluxio.underfs.FileId;
 import alluxio.underfs.PagedUfsReader;
+import alluxio.worker.block.io.BlockReadableChannel;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.page.NettyBufTargetBuffer;
 
@@ -162,7 +163,7 @@ public class PagedFileReader extends BlockReader {
 
   @Override
   public ReadableByteChannel getChannel() {
-    throw new UnsupportedOperationException();
+    return new BlockReadableChannel(this);
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockReader.java
@@ -20,6 +20,7 @@ import alluxio.grpc.ErrorType;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
 import alluxio.network.protocol.databuffer.NioDirectBufferPool;
+import alluxio.worker.block.io.BlockReadableChannel;
 import alluxio.worker.block.io.BlockReader;
 
 import com.google.common.base.Preconditions;
@@ -167,7 +168,7 @@ public class PagedBlockReader extends BlockReader {
 
   @Override
   public ReadableByteChannel getChannel() {
-    throw new UnsupportedOperationException();
+    return new BlockReadableChannel(this);
   }
 
   @Override

--- a/core/server/worker/src/test/java/alluxio/worker/page/PagedBlockReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/page/PagedBlockReaderTest.java
@@ -43,6 +43,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -236,6 +237,28 @@ public class PagedBlockReaderTest {
     buffer.flip();
     assertTrue(BufferUtils.equalIncreasingByteBuffer(
         (byte) (mOffset % CARDINALITY_BYTE), buffer.remaining(), buffer));
+  }
+
+  @Test
+  public void channelRead() throws Exception {
+    ReadableByteChannel channel = mReader.getChannel();
+    int headerSize = 1;
+    int trailerSize = 4;
+    ByteBuffer buffer =
+        ByteBuffer.allocate((int) (BLOCK_SIZE - mOffset) + headerSize + trailerSize);
+    buffer.clear();
+    buffer.put((byte) 0x42); // fill with some data so that position starts with non-zero
+    if (BLOCK_SIZE == mOffset) {
+      assertEquals(-1, channel.read(buffer));
+      assertEquals(headerSize, buffer.position());
+    } else {
+      assertEquals(BLOCK_SIZE - mOffset, channel.read(buffer));
+      assertEquals(headerSize + BLOCK_SIZE - mOffset, buffer.position());
+      buffer.flip();
+      assertEquals((byte) 0x42, buffer.get());
+      assertTrue(BufferUtils.equalIncreasingByteBuffer(
+          (byte) (mOffset % CARDINALITY_BYTE), buffer.remaining(), buffer.slice()));
+    }
   }
 
   private static UfsBlockReadOptions createUfsBlockOptions(String ufsPath) {


### PR DESCRIPTION
Implement `getChannel`. The implementation does not yet enable zero-copy transfer with netty.