### PR TITLE
Fix getDbIterator remove typo

### DIFF
--- a/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
+++ b/table/server/master/src/main/java/alluxio/master/table/AlluxioCatalog.java
@@ -457,7 +457,7 @@ public class AlluxioCatalog implements Journaled {
       @Override
       public void remove() {
         throw new UnsupportedOperationException(
-            "GetDbIteratorr#Iterator#remove is not supported.");
+            "GetDbIterator#Iterator#remove is not supported.");
       }
     };
   }


### PR DESCRIPTION
The method "remove" in anonymous Iterator created by getDbIterator has a typo.

