### PR TITLE
Bump xstream version to 1.4.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -797,7 +797,7 @@
       <dependency>
         <artifactId>xstream</artifactId>
         <groupId>com.thoughtworks.xstream</groupId>
-        <version>1.4.19</version>
+        <version>1.4.20</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
### Why are the changes needed?

This should address [CVE-2022-40151](https://nvd.nist.gov/vuln/detail/CVE-2022-40151)

### Does this PR introduce any user facing changes?

No
