### PR TITLE
[SMALLFIX] Add a GuardedBy tag for worker register

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/RegisterStreamObserver.java
+++ b/core/server/master/src/main/java/alluxio/master/block/RegisterStreamObserver.java
@@ -23,9 +23,9 @@ import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.concurrent.GuardedBy;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * This class handles the master side logic of the register stream.

--- a/core/server/master/src/main/java/alluxio/master/block/RegisterStreamObserver.java
+++ b/core/server/master/src/main/java/alluxio/master/block/RegisterStreamObserver.java
@@ -23,6 +23,7 @@ import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.GuardedBy;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -35,7 +36,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class RegisterStreamObserver implements StreamObserver<RegisterWorkerPRequest> {
   private static final Logger LOG = LoggerFactory.getLogger(RegisterStreamObserver.class);
-
+  @GuardedBy("this")
   private WorkerRegisterContext mContext;
   private final BlockMaster mBlockMaster;
   // Used to send responses to the worker

--- a/core/server/master/src/test/java/alluxio/master/block/RegisterStreamTestUtils.java
+++ b/core/server/master/src/test/java/alluxio/master/block/RegisterStreamTestUtils.java
@@ -1,0 +1,176 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.block;
+
+import static alluxio.stress.cli.RpcBenchPreparationUtils.CAPACITY;
+import static alluxio.stress.rpc.TierAlias.MEM;
+import static org.junit.Assert.assertEquals;
+
+import alluxio.grpc.ConfigProperty;
+import alluxio.grpc.LocationBlockIdListEntry;
+import alluxio.grpc.RegisterWorkerPRequest;
+import alluxio.grpc.RegisterWorkerPResponse;
+import alluxio.stress.cli.RpcBenchPreparationUtils;
+import alluxio.stress.rpc.TierAlias;
+import alluxio.wire.WorkerNetAddress;
+import alluxio.worker.block.BlockStoreLocation;
+import alluxio.worker.block.RegisterStreamer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.grpc.stub.StreamObserver;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.stream.Collectors;
+
+public class RegisterStreamTestUtils {
+  private static final long MEM_USAGE = 20_000L;
+  private static final long SSD_USAGE = 500_000L;
+  private static final long HDD_USAGE = 1_000_000L;
+
+  public static final long MEM_CAPACITY_BYTES = 20_000_000L;
+  public static final Map<String, List<String>> LOST_STORAGE =
+      ImmutableMap.of(MEM.toString(), ImmutableList.of());
+  public static final List<ConfigProperty> EMPTY_CONFIG = ImmutableList.of();
+  public static final WorkerNetAddress NET_ADDRESS_1 = new WorkerNetAddress()
+      .setHost("localhost").setRpcPort(80).setDataPort(81).setWebPort(82);
+  public static final String TIER_CONFIG = "100,200,300;1000,1500;2000";
+  public static final int TIER_BLOCK_TOTAL = 100 + 200 + 300 + 1000 + 1500 + 2000;
+  public static final int BATCH_SIZE = 1000;
+  public static final Map<String, Long> USAGE_MAP = ImmutableMap.of("MEM", MEM_USAGE,
+      "SSD", SSD_USAGE, "HDD", HDD_USAGE);
+  public static final Map<String, Long> CAPACITY_MAP = ImmutableMap.of("MEM", CAPACITY,
+      "SSD", CAPACITY, "HDD", CAPACITY);
+
+  public static final Map<String, Long> MEM_CAPACITY = ImmutableMap.of("MEM", MEM_CAPACITY_BYTES);
+  public static final Map<String, Long> MEM_USAGE_EMPTY = ImmutableMap.of("MEM", 0L);
+
+  public static List<RegisterWorkerPRequest> generateRegisterStreamForEmptyWorker(long workerId) {
+    return generateRegisterStreamForEmptyWorker(workerId, MEM_CAPACITY_BYTES);
+  }
+
+  public static List<RegisterWorkerPRequest> generateRegisterStreamForEmptyWorker(
+      long workerId, long capacity) {
+    String tierConfig = "";
+    // Generate block IDs heuristically
+    Map<BlockStoreLocation, List<Long>> blockMap =
+        RpcBenchPreparationUtils.generateBlockIdOnTiers(parseTierConfig(tierConfig));
+
+    RegisterStreamer registerStreamer = new RegisterStreamer(null,
+        workerId, ImmutableList.of("MEM"), ImmutableMap.of("MEM", capacity), MEM_USAGE_EMPTY,
+        blockMap, LOST_STORAGE, EMPTY_CONFIG);
+
+    // For an empty worker there is only 1 request
+    List<RegisterWorkerPRequest> requestChunks = ImmutableList.copyOf(registerStreamer);
+    assertEquals(1, requestChunks.size());
+
+    return requestChunks;
+  }
+
+  public static List<String> getTierAliases(Map<TierAlias, List<Integer>> tierConfig) {
+    return tierConfig.keySet().stream().map(TierAlias::toString).collect(Collectors.toList());
+  }
+
+  public static List<RegisterWorkerPRequest> generateRegisterStreamForWorkerWithTiers(long workerId) {
+    List<String> tierAliases = getTierAliases(parseTierConfig(TIER_CONFIG));
+    // Generate block IDs heuristically
+    Map<TierAlias, List<Integer>> tierConfigMap = parseTierConfig(TIER_CONFIG);
+    Map<BlockStoreLocation, List<Long>> blockMap =
+        RpcBenchPreparationUtils.generateBlockIdOnTiers(tierConfigMap);
+
+    // We just use the RegisterStreamer to generate the batch of requests
+    RegisterStreamer registerStreamer = new RegisterStreamer(null,
+        workerId, tierAliases, CAPACITY_MAP, USAGE_MAP, blockMap, LOST_STORAGE, EMPTY_CONFIG);
+
+    // Get chunks from the RegisterStreamer
+    List<RegisterWorkerPRequest> requestChunks = ImmutableList.copyOf(registerStreamer);
+    int expectedBatchCount = (int) Math.ceil((TIER_BLOCK_TOTAL) / (double) BATCH_SIZE);
+    assertEquals(expectedBatchCount, requestChunks.size());
+
+    return requestChunks;
+  }
+
+  public static List<RegisterWorkerPRequest> generateRegisterStreamForWorkerWithBlocks(
+      long workerId, long blockSize, List<Long> blockList) {
+    Map<BlockStoreLocation, List<Long>> blockMap = new HashMap<>();
+    BlockStoreLocation mem = new BlockStoreLocation("MEM", 0);
+    blockMap.put(mem, blockList);
+
+    // We just use the RegisterStreamer to generate the batch of requests
+    RegisterStreamer registerStreamer = new RegisterStreamer(null,
+        workerId, ImmutableList.of("MEM"),
+        ImmutableMap.of("MEM", CAPACITY), // capacity
+        ImmutableMap.of("MEM", blockSize * blockList.size()), // usage
+        blockMap, LOST_STORAGE, EMPTY_CONFIG);
+
+    // Get chunks from the RegisterStreamer
+    List<RegisterWorkerPRequest> requestChunks = ImmutableList.copyOf(registerStreamer);
+    int expectedBatchCount = (int) Math.ceil((blockList.size()) / (double) BATCH_SIZE);
+    assertEquals(expectedBatchCount, requestChunks.size());
+
+    return requestChunks;
+  }
+
+  public static Map<TierAlias, List<Integer>> parseTierConfig(String tiersConfig) {
+    String[] tiers = tiersConfig.split(";");
+    if (tiers.length == 1 && "".equals(tiers[0])) {
+      return ImmutableMap.of();
+    }
+    int length = Math.min(tiers.length, TierAlias.values().length);
+    ImmutableMap.Builder<TierAlias, List<Integer>> builder = new ImmutableMap.Builder<>();
+    for (int i = 0; i < length; i++) {
+      builder.put(
+              TierAlias.SORTED.get(i),
+              Arrays.stream(tiers[i].split(","))
+                      .map(Integer::parseInt)
+                      .collect(Collectors.toList()));
+    }
+    return builder.build();
+  }
+
+  public static StreamObserver<RegisterWorkerPResponse> getErrorCapturingResponseObserver(
+          Queue<Throwable> errorQueue) {
+    return new StreamObserver<RegisterWorkerPResponse>() {
+      @Override
+      public void onNext(RegisterWorkerPResponse response) {}
+
+      @Override
+      public void onError(Throwable t) {
+        errorQueue.offer(t);
+      }
+
+      @Override
+      public void onCompleted() {}
+    };
+  }
+
+  public static long findFirstBlock(List<RegisterWorkerPRequest> chunks) {
+    RegisterWorkerPRequest firstBatch = chunks.get(0);
+    LocationBlockIdListEntry entry = firstBatch.getCurrentBlocks(0);
+    return entry.getValue().getBlockId(0);
+  }
+
+  public static void sendStreamToMaster(BlockMasterWorkerServiceHandler handler,
+                                        List<RegisterWorkerPRequest> requestChunks,
+                                        StreamObserver<RegisterWorkerPResponse> responseObserver) {
+    StreamObserver<RegisterWorkerPRequest> requestObserver =
+            handler.registerWorkerStream(responseObserver);
+    for (RegisterWorkerPRequest chunk : requestChunks) {
+      requestObserver.onNext(chunk);
+    }
+    requestObserver.onCompleted();
+  }
+}

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -35,6 +35,7 @@ import alluxio.util.UnderFileSystemUtils;
 import alluxio.util.WaitForOptions;
 import alluxio.util.io.FileUtils;
 import alluxio.util.network.NetworkAddressUtils;
+import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.WorkerProcess;
 
 import org.slf4j.Logger;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -58,6 +60,10 @@ public abstract class AbstractLocalAlluxioCluster {
   private static final Random RANDOM_GENERATOR = new Random();
   private static final int WAIT_MASTER_START_TIMEOUT_MS = 200_000;
 
+  // ALLUXIO CS ADD
+  final LocalAlluxioCrossClusterMaster mCrossClusterMaster;
+
+  // ALLUXIO CS END
   protected ProxyProcess mProxyProcess;
   protected Thread mProxyThread;
 
@@ -73,6 +79,21 @@ public abstract class AbstractLocalAlluxioCluster {
    * @param numWorkers the number of workers to run
    */
   AbstractLocalAlluxioCluster(int numWorkers) {
+    // ALLUXIO CS ADD
+    this(numWorkers, false);
+  }
+
+  /**
+   * @param numWorkers the number of workers to run
+   * @param includeCrossCluster whether to start a cross cluster master
+   */
+  AbstractLocalAlluxioCluster(int numWorkers, boolean includeCrossCluster) {
+    if (includeCrossCluster) {
+      mCrossClusterMaster = LocalAlluxioCrossClusterMaster.create();
+    } else {
+      mCrossClusterMaster = null;
+    }
+    // ALLUXIO CS END
     mProxyProcess = ProxyProcess.Factory.create();
     mNumWorkers = numWorkers;
     mWorkerThreads = new ArrayList<>();
@@ -87,6 +108,12 @@ public abstract class AbstractLocalAlluxioCluster {
 
     resetClientPools();
 
+    // ALLUXIO CS ADD
+    if (mCrossClusterMaster != null) {
+      mCrossClusterMaster.start();
+      TestUtils.waitForReady(mCrossClusterMaster);
+    }
+    // ALLUXIO CS END
     setupTest();
     startMasters();
     startWorkers();
@@ -123,6 +150,52 @@ public abstract class AbstractLocalAlluxioCluster {
     startMasters();
   }
 
+  // ALLUXIO CS ADD
+  /**
+   * Stop the cross cluster master if enabled.
+   */
+  public void stopCrossClusterMaster() throws Exception {
+    if (mCrossClusterMaster != null) {
+      mCrossClusterMaster.stop();
+    }
+  }
+
+  /**
+   * Start the cross cluster master if enabled.
+   */
+  public void startCrossClusterMaster() {
+    if (mCrossClusterMaster != null) {
+      mCrossClusterMaster.start();
+      TestUtils.waitForReady(mCrossClusterMaster);
+    }
+  }
+
+  /**
+   * Restart the cross cluster master if enabled.
+   */
+  public void restartCrossClusterMaster() throws Exception {
+    if (mCrossClusterMaster != null) {
+      mCrossClusterMaster.stop();
+      mCrossClusterMaster.start();
+      TestUtils.waitForReady(mCrossClusterMaster);
+    }
+  }
+
+  /**
+   * @return a new {@link alluxio.client.crosscluster.CrossClusterNameServiceClient} client
+   */
+  public alluxio.client.crosscluster.CrossClusterNameServiceClient getCrossClusterStandaloneClient() {
+    if (mCrossClusterMaster != null) {
+      alluxio.conf.InstancedConfiguration conf = new alluxio.conf.InstancedConfiguration(
+          Configuration.copyProperties());
+      conf.set(PropertyKey.USER_CONF_CLUSTER_DEFAULT_ENABLED, false);
+      return new alluxio.client.crosscluster.RetryHandlingCrossClusterNameServiceMasterClient(
+          alluxio.client.crosscluster.CrossClusterNameServiceClientContextBuilder.create(conf).build());
+    }
+    return null;
+  }
+
+  // ALLUXIO CS END
   /**
    * Configures and starts the proxy.
    */
@@ -180,6 +253,41 @@ public abstract class AbstractLocalAlluxioCluster {
   }
 
   /**
+   * Restarts workers with the addresses provided, so that the workers can restart with
+   * static addresses to simulate a worker restart in the cluster.
+   *
+   * @param addresses worker addresses to use
+   */
+  public void restartWorkers(Collection<WorkerNetAddress> addresses) throws Exception {
+    // Start the worker one by one, so we avoid updating config while this worker is starting
+    for (WorkerNetAddress addr : addresses) {
+      Configuration.set(PropertyKey.WORKER_RPC_PORT, addr.getRpcPort());
+      Configuration.set(PropertyKey.WORKER_WEB_PORT, addr.getWebPort());
+      WorkerProcess worker = WorkerProcess.Factory.create();
+      mWorkers.add(worker);
+
+      Runnable runWorker = () -> {
+        try {
+          worker.start();
+        } catch (InterruptedException e) {
+          // this is expected
+        } catch (Exception e) {
+          // Log the exception as the RuntimeException will be caught and handled silently by
+          // JUnit
+          LOG.error("Start worker error", e);
+          throw new RuntimeException(e + " \n Start Worker Error \n" + e.getMessage(), e);
+        }
+      };
+      Thread thread = new Thread(runWorker);
+      thread.setName("WorkerThread-" + System.identityHashCode(thread));
+      mWorkerThreads.add(thread);
+      thread.start();
+
+      TestUtils.waitForReady(worker);
+    }
+  }
+
+  /**
    * Sets up corresponding directories for tests.
    */
   protected void setupTest() throws IOException {
@@ -224,6 +332,11 @@ public abstract class AbstractLocalAlluxioCluster {
     stopProxy();
     stopWorkers();
     stopMasters();
+    // ALLUXIO CS ADD
+    if (mCrossClusterMaster != null) {
+      mCrossClusterMaster.stop();
+    }
+    // ALLUXIO CS END
   }
 
   /**
@@ -260,6 +373,22 @@ public abstract class AbstractLocalAlluxioCluster {
    * Stops the workers.
    */
   public void stopWorkers() throws Exception {
+    killWorkerProcesses();
+
+    // forget all the workers in the master
+    LocalAlluxioMaster master = getLocalAlluxioMaster();
+    if (master != null) {
+      DefaultBlockMaster bm =
+          (DefaultBlockMaster) master.getMasterProcess().getMaster(BlockMaster.class);
+      bm.forgetAllWorkers();
+    }
+  }
+
+  /**
+   * Kills all worker processes without forgetting them in the master,
+   * so we can validate the master mechanism handling dead workers.
+   */
+  public void killWorkerProcesses() throws Exception {
     if (mWorkers == null) {
       return;
     }
@@ -274,14 +403,6 @@ public abstract class AbstractLocalAlluxioCluster {
       }
     }
     mWorkerThreads.clear();
-
-    // forget all the workers in the master
-    LocalAlluxioMaster master = getLocalAlluxioMaster();
-    if (master != null) {
-      DefaultBlockMaster bm =
-          (DefaultBlockMaster) master.getMasterProcess().getMaster(BlockMaster.class);
-      bm.forgetAllWorkers();
-    }
   }
 
   /**

--- a/tests/src/test/java/alluxio/client/fs/BlockWorkerRegisterStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/BlockWorkerRegisterStreamIntegrationTest.java
@@ -11,20 +11,20 @@
 
 package alluxio.client.fs;
 
-import static alluxio.client.fs.RegisterStreamTestUtils.BATCH_SIZE;
-import static alluxio.client.fs.RegisterStreamTestUtils.CAPACITY_MAP;
-import static alluxio.client.fs.RegisterStreamTestUtils.EMPTY_CONFIG;
-import static alluxio.client.fs.RegisterStreamTestUtils.LOST_STORAGE;
-import static alluxio.client.fs.RegisterStreamTestUtils.MEM_CAPACITY;
-import static alluxio.client.fs.RegisterStreamTestUtils.MEM_USAGE_EMPTY;
-import static alluxio.client.fs.RegisterStreamTestUtils.NET_ADDRESS_1;
-import static alluxio.client.fs.RegisterStreamTestUtils.TIER_BLOCK_TOTAL;
-import static alluxio.client.fs.RegisterStreamTestUtils.TIER_CONFIG;
-import static alluxio.client.fs.RegisterStreamTestUtils.USAGE_MAP;
-import static alluxio.client.fs.RegisterStreamTestUtils.findFirstBlock;
-import static alluxio.client.fs.RegisterStreamTestUtils.getTierAliases;
-import static alluxio.client.fs.RegisterStreamTestUtils.parseTierConfig;
 import static alluxio.grpc.BlockMasterWorkerServiceGrpc.BlockMasterWorkerServiceStub;
+import static alluxio.master.block.RegisterStreamTestUtils.BATCH_SIZE;
+import static alluxio.master.block.RegisterStreamTestUtils.CAPACITY_MAP;
+import static alluxio.master.block.RegisterStreamTestUtils.EMPTY_CONFIG;
+import static alluxio.master.block.RegisterStreamTestUtils.LOST_STORAGE;
+import static alluxio.master.block.RegisterStreamTestUtils.MEM_CAPACITY;
+import static alluxio.master.block.RegisterStreamTestUtils.MEM_USAGE_EMPTY;
+import static alluxio.master.block.RegisterStreamTestUtils.NET_ADDRESS_1;
+import static alluxio.master.block.RegisterStreamTestUtils.TIER_BLOCK_TOTAL;
+import static alluxio.master.block.RegisterStreamTestUtils.TIER_CONFIG;
+import static alluxio.master.block.RegisterStreamTestUtils.USAGE_MAP;
+import static alluxio.master.block.RegisterStreamTestUtils.findFirstBlock;
+import static alluxio.master.block.RegisterStreamTestUtils.getTierAliases;
+import static alluxio.master.block.RegisterStreamTestUtils.parseTierConfig;
 import static alluxio.stress.cli.RpcBenchPreparationUtils.CAPACITY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -55,6 +55,7 @@ import alluxio.grpc.RegisterWorkerPRequest;
 import alluxio.grpc.RegisterWorkerPResponse;
 import alluxio.grpc.StorageList;
 import alluxio.master.MasterClientContext;
+import alluxio.master.block.RegisterStreamTestUtils;
 import alluxio.stress.cli.RpcBenchPreparationUtils;
 import alluxio.stress.rpc.TierAlias;
 import alluxio.underfs.UfsManager;
@@ -214,7 +215,7 @@ public class BlockWorkerRegisterStreamIntegrationTest {
   @Test
   public void requestsForWorker() throws Exception {
     List<RegisterWorkerPRequest> requestChunks =
-            RegisterStreamTestUtils.generateRegisterStreamForWorker(WORKER_ID);
+            RegisterStreamTestUtils.generateRegisterStreamForWorkerWithTiers(WORKER_ID);
 
     // Verify the size and content of the requests
     int expectedBatchCount = (int) Math.ceil((TIER_BLOCK_TOTAL) / (double) BATCH_SIZE);
@@ -412,7 +413,7 @@ public class BlockWorkerRegisterStreamIntegrationTest {
   public void deleteDuringRegisterStream() throws Exception {
     // Generate a request stream of blocks
     List<RegisterWorkerPRequest> requestChunks =
-          RegisterStreamTestUtils.generateRegisterStreamForWorker(WORKER_ID);
+          RegisterStreamTestUtils.generateRegisterStreamForWorkerWithTiers(WORKER_ID);
     // Select a block to remove concurrent with the stream
     long blockToRemove = findFirstBlock(requestChunks);
 


### PR DESCRIPTION
The locked section is here
https://github.com/Alluxio/alluxio/blob/c3dcda455e081ef99345f2d906e7899652b3a2e6/core/server/master/src/main/java/alluxio/master/block/RegisterStreamObserver.java#L78

The object is locked to init the context. This change only adds the missing tag. The locking logic has been in for a long time.