### PR TITLE
Add missing GuardedBy and volatile for worker stream register

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/block/RegisterStreamObserver.java
+++ b/core/server/master/src/main/java/alluxio/master/block/RegisterStreamObserver.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * This class handles the master side logic of the register stream.
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class RegisterStreamObserver implements StreamObserver<RegisterWorkerPRequest> {
   private static final Logger LOG = LoggerFactory.getLogger(RegisterStreamObserver.class);
 
+  @GuardedBy("this")
   private WorkerRegisterContext mContext;
   private final BlockMaster mBlockMaster;
   // Used to send responses to the worker

--- a/core/server/master/src/main/java/alluxio/master/block/RegisterStreamObserver.java
+++ b/core/server/master/src/main/java/alluxio/master/block/RegisterStreamObserver.java
@@ -12,6 +12,7 @@
 package alluxio.master.block;
 
 import alluxio.RpcUtils;
+import alluxio.annotation.SuppressFBWarnings;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.DeadlineExceededException;
 import alluxio.grpc.GrpcExceptionUtils;
@@ -38,7 +39,10 @@ public class RegisterStreamObserver implements StreamObserver<RegisterWorkerPReq
   private static final Logger LOG = LoggerFactory.getLogger(RegisterStreamObserver.class);
 
   @GuardedBy("this")
-  private WorkerRegisterContext mContext;
+  @SuppressFBWarnings(value = "IS_FIELD_NOT_GUARDED")
+  // Context is initialized on the 1st request so later requests are guaranteed to see the context
+  // Locking is applied on init and cleanup
+  private volatile WorkerRegisterContext mContext;
   private final BlockMaster mBlockMaster;
   // Used to send responses to the worker
   private final StreamObserver<RegisterWorkerPResponse> mMasterResponseObserver;


### PR DESCRIPTION
The locked section is here
https://github.com/Alluxio/alluxio/blob/c3dcda455e081ef99345f2d906e7899652b3a2e6/core/server/master/src/main/java/alluxio/master/block/RegisterStreamObserver.java#L78

The object is locked to init the context. This change only adds the missing tag. The locking logic has been in for a long time.
