### PR TITLE
Pull request: Enable use of AnonymousAWSCredentials() in S3AUnderFileSystem

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1755,6 +1755,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       .setScope(Scope.SERVER)
       .setDisplayType(DisplayType.CREDENTIALS)
       .build();
+  public static final PropertyKey S3A_ANONYMOUS = booleanBuilder(Name.S3A_ANONYMOUS)
+      .setAlias(Name.AWS_ANONYMOUS)
+      .setDefaultValue(false)
+      .setDescription("The anonymous credentials for S3 bucket.")
+      .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+      .setScope(Scope.SERVER)
+      .setDisplayType(DisplayType.CREDENTIALS)
+      .build();
   public static final PropertyKey S3A_ACCESS_KEY = stringBuilder(Name.S3A_ACCESS_KEY)
       .setAlias(Name.AWS_ACCESS_KEY)
       .setDescription("The access key of S3 bucket.")
@@ -7542,8 +7550,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String OSS_ACCESS_KEY = "fs.oss.accessKeyId";
     public static final String OSS_ENDPOINT_KEY = "fs.oss.endpoint";
     public static final String OSS_SECRET_KEY = "fs.oss.accessKeySecret";
+    public static final String S3A_ANONYMOUS = "s3a.anonymous";
     public static final String S3A_ACCESS_KEY = "s3a.accessKeyId";
     public static final String S3A_SECRET_KEY = "s3a.secretKey";
+    public static final String AWS_ANONYMOUS = "aws.anonymous";
     public static final String AWS_ACCESS_KEY = "aws.accessKeyId";
     public static final String AWS_SECRET_KEY = "aws.secretKey";
     public static final String SWIFT_AUTH_METHOD_KEY = "fs.swift.auth.method";

--- a/docs/en/ufs/S3.md
+++ b/docs/en/ufs/S3.md
@@ -56,6 +56,13 @@ s3a.accessKeyId=<S3 ACCESS KEY>
 s3a.secretKey=<S3 SECRET KEY>
 ```
 
+For anonymous s3 specify access by setting s3a.anonymous in
+`alluxio-site.properties`.
+
+```
+s3a.anonymous=True
+```
+
 For other methods of setting AWS credentials, see the credentials section in [Advanced Setup](#advanced-credentials-setup).
 
 After these changes, Alluxio should be configured to work with S3 as its under storage system, and

--- a/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
+++ b/underfs/s3a/src/main/java/alluxio/underfs/s3a/S3AUnderFileSystem.java
@@ -34,6 +34,7 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
@@ -129,10 +130,15 @@ public class S3AUnderFileSystem extends ObjectUnderFileSystem {
       UnderFileSystemConfiguration conf) {
     // Set the aws credential system properties based on Alluxio properties, if they are set;
     // otherwise, use the default credential provider.
-    if (conf.isSet(PropertyKey.S3A_ACCESS_KEY)
-        && conf.isSet(PropertyKey.S3A_SECRET_KEY)) {
-      return new AWSStaticCredentialsProvider(new BasicAWSCredentials(
-          conf.getString(PropertyKey.S3A_ACCESS_KEY), conf.getString(PropertyKey.S3A_SECRET_KEY)));
+    if (conf.isSet(PropertyKey.S3A_ANONYMOUS)){
+        return new AWSStaticCredentialsProvider(new AnonymousAWSCredentials());
+    }
+    else
+    {
+        if (conf.isSet(PropertyKey.S3A_ACCESS_KEY) && conf.isSet(PropertyKey.S3A_SECRET_KEY)) {
+            return new AWSStaticCredentialsProvider(new BasicAWSCredentials(
+                conf.getString(PropertyKey.S3A_ACCESS_KEY), conf.getString(PropertyKey.S3A_SECRET_KEY)));
+	    }
     }
     // Checks, in order, env variables, system properties, profile file, and instance profile.
     return new DefaultAWSCredentialsProviderChain();


### PR DESCRIPTION
### What changes are proposed in this pull request?

[Enable use of AnonymousAWSCredentials() in S3AUnderFileSystem](https://github.com/Alluxio/alluxio/commit/607ec1de101d77b107a858da32ea9d8d96b2197b) https://github.com/Alluxio/alluxio/issues/16772
 
This change adds a boolean flag s3a.anonymous to S3AUnderFileSystem

### Why are the changes needed?

Allows Alluxio to access public datasets, e.g.: 
`alluxio fs mount --readonly --option s3a.anonymous=True /dask-data/ s3://dask-data/`

Without these changes I saw the following errors in logs/proxy.log:
```
2023-01-15 14:54:32,217 WARN  AlluxioFileInStream - Failed to read block 50633637888 of file /dask-data/airline-data/1987.csv from worker WorkerNetAddress{host=192.168.1.235, containerHost=, rpcPort=29999, dataPort=29999, webPort=30000, domainSocketPath=, tieredIdentity=TieredIdentity(node=192.168.1.235, rack=null)}. This worker will be skipped for future read operations, will retry: alluxio.exception.status.PermissionDeniedException: Failed to open key: airline-data/1987.csv bucket: dask-data attempts: 1 error: The AWS Access Key Id you provided does not exist in our records. (Service: Amazon S3; Status Code: 403; Error Code: InvalidAccessKeyId; Request ID: ZZZZ0000000W40Z; S3 Extended Request ID: Vp/73grjNLfw5NLc8+Hd4kyhTE8gvjR+Nhv63J7KzW36JrdcY7GjUw/in+kKMOG9YDzr/Cq0Fu4=; Proxy: null) (Zero Copy GrpcDataReader).
```

### Does this PR introduce any user facing changes?

Adds one new key and one new alias: s3a.anonymous and aws.anonymous
