### PR TITLE
Change matcher in CapacityCommandIntegrationTest

### DIFF
--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/CapacityCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/CapacityCommandIntegrationTest.java
@@ -15,9 +15,10 @@ import alluxio.cli.fsadmin.report.CapacityCommand;
 import alluxio.client.cli.fsadmin.AbstractFsAdminShellTest;
 import alluxio.util.FormatUtils;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.regex.Pattern;
 
 /**
  * Tests for report capacity command.
@@ -29,18 +30,20 @@ public final class CapacityCommandIntegrationTest extends AbstractFsAdminShellTe
     Assert.assertEquals(0, ret);
     String output = mOutput.toString();
     String size = FormatUtils.getSizeFromBytes(SIZE_BYTES);
-    Assert.assertThat(output, CoreMatchers.containsString("Capacity information for all workers: \n"
-        + "    Total Capacity: " + size + "\n"
-        + "        Tier: MEM  Size: " + size + "\n"
-        + "    Used Capacity: 0B\n"
-        + "        Tier: MEM  Size: 0B\n"
-        + "    Used Percentage: 0%\n"
-        + "    Free Percentage: 100%\n"));
-    // CHECKSTYLE.OFF: LineLengthExceed - Much more readable
-    Assert.assertThat(output, CoreMatchers.containsString(
-        "Worker Name      Last Heartbeat   Storage       MEM              Version          Revision"));
-    Assert.assertThat(output, CoreMatchers.containsString(
-        "                                  used          0B (0%)"));
+    String[] lines = output.split("\n");
+    Assert.assertEquals(11, lines.length);
+    Assert.assertEquals("Capacity information for all workers: ", lines[0]);
+    Assert.assertEquals("    Total Capacity: " + size, lines[1]);
+    Assert.assertEquals("        Tier: MEM  Size: " + size, lines[2]);
+    Assert.assertEquals("    Used Capacity: 0B", lines[3]);
+    Assert.assertEquals("        Tier: MEM  Size: 0B", lines[4]);
+    Assert.assertEquals("    Used Percentage: 0%", lines[5]);
+    Assert.assertEquals("    Free Percentage: 100%", lines[6]);
+    Assert.assertEquals("", lines[7]);
+    Assert.assertTrue(Pattern.matches(
+        "Worker Name {6,}Last Heartbeat {3}Storage {7}MEM {14}Version {10}Revision *", lines[8]));
+    Assert.assertTrue(lines[9].contains("capacity      " + size));
+    Assert.assertTrue(lines[10].contains("used          0B (0%)"));
   }
 
   @Test
@@ -56,19 +59,20 @@ public final class CapacityCommandIntegrationTest extends AbstractFsAdminShellTe
     Assert.assertEquals(0, ret);
     String output = mOutput.toString();
     String size = FormatUtils.getSizeFromBytes(SIZE_BYTES);
-    Assert.assertThat(output, CoreMatchers.containsString(
-        "Capacity information for live workers: \n"
-        + "    Total Capacity: " + size + "\n"
-        + "        Tier: MEM  Size: " + size + "\n"
-        + "    Used Capacity: 0B\n"
-        + "        Tier: MEM  Size: 0B\n"
-        + "    Used Percentage: 0%\n"
-        + "    Free Percentage: 100%\n"));
-    // CHECKSTYLE.OFF: LineLengthExceed - Much more readable
-    Assert.assertThat(output, CoreMatchers.containsString(
-        "Worker Name      Last Heartbeat   Storage       MEM              Version          Revision"));
-    Assert.assertThat(output, CoreMatchers.containsString(
-        "                                  used          0B (0%)"));
+    String[] lines = output.split("\n");
+    Assert.assertEquals(11, lines.length);
+    Assert.assertEquals("Capacity information for live workers: ", lines[0]);
+    Assert.assertEquals("    Total Capacity: " + size, lines[1]);
+    Assert.assertEquals("        Tier: MEM  Size: " + size, lines[2]);
+    Assert.assertEquals("    Used Capacity: 0B", lines[3]);
+    Assert.assertEquals("        Tier: MEM  Size: 0B", lines[4]);
+    Assert.assertEquals("    Used Percentage: 0%", lines[5]);
+    Assert.assertEquals("    Free Percentage: 100%", lines[6]);
+    Assert.assertEquals("", lines[7]);
+    Assert.assertTrue(Pattern.matches(
+        "Worker Name {6,}Last Heartbeat {3}Storage {7}MEM {14}Version {10}Revision *", lines[8]));
+    Assert.assertTrue(lines[9].contains("capacity      " + size));
+    Assert.assertTrue(lines[10].contains("used          0B (0%)"));
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/CapacityCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/CapacityCommandIntegrationTest.java
@@ -18,8 +18,6 @@ import alluxio.util.FormatUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.regex.Pattern;
-
 /**
  * Tests for report capacity command.
  */
@@ -40,8 +38,8 @@ public final class CapacityCommandIntegrationTest extends AbstractFsAdminShellTe
     Assert.assertEquals("    Used Percentage: 0%", lines[5]);
     Assert.assertEquals("    Free Percentage: 100%", lines[6]);
     Assert.assertEquals("", lines[7]);
-    Assert.assertTrue(Pattern.matches(
-        "Worker Name {6,}Last Heartbeat {3}Storage {7}MEM {14}Version {10}Revision *", lines[8]));
+    Assert.assertTrue(lines[8].matches(
+        "Worker Name {6,}Last Heartbeat {3}Storage {7}MEM {14}Version {10}Revision *"));
     Assert.assertTrue(lines[9].contains("capacity      " + size));
     Assert.assertTrue(lines[10].contains("used          0B (0%)"));
   }
@@ -69,8 +67,8 @@ public final class CapacityCommandIntegrationTest extends AbstractFsAdminShellTe
     Assert.assertEquals("    Used Percentage: 0%", lines[5]);
     Assert.assertEquals("    Free Percentage: 100%", lines[6]);
     Assert.assertEquals("", lines[7]);
-    Assert.assertTrue(Pattern.matches(
-        "Worker Name {6,}Last Heartbeat {3}Storage {7}MEM {14}Version {10}Revision *", lines[8]));
+    Assert.assertTrue(lines[8].matches(
+        "Worker Name {6,}Last Heartbeat {3}Storage {7}MEM {14}Version {10}Revision *"));
     Assert.assertTrue(lines[9].contains("capacity      " + size));
     Assert.assertTrue(lines[10].contains("used          0B (0%)"));
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Change matcher in CapacityCommandIntegrationTest.

1. Match the output line by line, deprecate `assertThat()`.
2. Use regexp to match the table header.

### Why are the changes needed?

1. `Assert.assertThat()` is deprecated.
2. We got following errors in our internal CI, because the worker name is too long.

```
[ERROR] Failures: 
[ERROR] alluxio.client.cli.fsadmin.command.CapacityCommandIntegrationTest.allCapacity
[ERROR]   Run 1: CapacityCommandIntegrationTest.allCapacity:40 
Expected: a string containing "Worker Name      Last Heartbeat   Storage       MEM              Version          Revision"
     but: was "Capacity information for all workers: 
    Total Capacity: 16.00MB
        Tier: MEM  Size: 16.00MB
    Used Capacity: 0B
        Tier: MEM  Size: 0B
    Used Percentage: 0%
    Free Percentage: 100%

Worker Name                                                        Last Heartbeat   Storage       MEM              Version          Revision      
                          
ci1672097607865c-0.ci1672097607865c.default.svc.cluster.local      0                capacity      16.00MB          2.10.0-SNAPSHOT  c25544758d60f4
4c0eb9fa13fc20040a3ec2ae30
                                                                                    used          0B (0%)                                         
                          
"
```

### Does this PR introduce any user facing changes?

No.