### PR TITLE
Fix Worker.ActiveClients is negative when load from ufs

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/MonoBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/MonoBlockStore.java
@@ -152,6 +152,7 @@ public class MonoBlockStore implements BlockStore {
     Optional<? extends BlockMeta> blockMeta = mLocalBlockStore.getVolatileBlockMeta(blockId);
     if (blockMeta.isPresent()) {
       reader = mLocalBlockStore.createBlockReader(sessionId, blockId, offset);
+      DefaultBlockWorker.Metrics.WORKER_ACTIVE_CLIENTS.inc();
     } else {
       boolean checkUfs = options != null && (options.hasUfsPath() || options.getBlockInUfsTier());
       if (!checkUfs) {
@@ -160,7 +161,6 @@ public class MonoBlockStore implements BlockStore {
       // When the block does not exist in Alluxio but exists in UFS, try to open the UFS block.
       reader = createUfsBlockReader(sessionId, blockId, offset, positionShort, options);
     }
-    DefaultBlockWorker.Metrics.WORKER_ACTIVE_CLIENTS.inc();
     return reader;
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix Worker.ActiveClients is negative when load from ufs
### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  createUfsBlockReader will invoke closeUfsBlock then invoke commitBlock then this metric decrease.
But forget to increase firstly . So it need to increase firstly.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  no.
