### PR TITLE
[DOCFIX] Fix monitor helm chart Grafana dashboard link

### DIFF
--- a/integration/kubernetes/helm-chart/monitor/README.md
+++ b/integration/kubernetes/helm-chart/monitor/README.md
@@ -70,7 +70,7 @@ metrics:
      prometheus.io/path: "/metrics/prometheus/"
 ```
 ### 4. Download the alluxio dashboard
-Download the alluxio dashboard from [Alluxio grafana dashboard V1](https://grafana.com/grafana/dashboards/17763-alluxio-prometheus-grafana-monitor-v1/), then
+Download the alluxio dashboard from [Alluxio grafana dashboard V1](https://grafana.com/grafana/dashboards/17785-alluxio-prometheus-grafana-monitor-v1/), then
 move the dashboard file to `monitor/source/grafana/dashboard` directory.
 
 ## Helm Chart Values


### PR DESCRIPTION
The old Grafana dashboard link in the Readme returns 404. Replace it with the correct link.

Solves https://github.com/Alluxio/alluxio/issues/16796