### PR TITLE
Fix hanging page store test

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -150,7 +150,8 @@ public class LocalCacheManager implements CacheManager {
    * @param pageId page identifier
    * @return the page lock id
    */
-  private int getPageLockId(PageId pageId) {
+  @VisibleForTesting
+  public int getPageLockId(PageId pageId) {
     return Math.floorMod((int) (pageId.getFileId().hashCode() + pageId.getPageIndex()), LOCK_SIZE);
   }
 

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -46,13 +46,7 @@ import alluxio.util.io.PathUtils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-<<<<<<< HEAD
-||||||| parent of 7a4e0a53a3 (Fix hanging page store test)
-import org.junit.Assume;
-=======
 import org.junit.After;
-import org.junit.Assume;
->>>>>>> 7a4e0a53a3 (Fix hanging page store test)
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheManagerTest.java
@@ -46,6 +46,13 @@ import alluxio.util.io.PathUtils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+<<<<<<< HEAD
+||||||| parent of 7a4e0a53a3 (Fix hanging page store test)
+import org.junit.Assume;
+=======
+import org.junit.After;
+import org.junit.Assume;
+>>>>>>> 7a4e0a53a3 (Fix hanging page store test)
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,8 +62,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Paths;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -108,6 +117,11 @@ public final class LocalCacheManagerTest {
     mPageStoreDir = new LocalPageStoreDir(mPageStoreOptions, mPageStore, mEvictor);
     mPageMetaStore = new DefaultPageMetaStore(ImmutableList.of(mPageStoreDir));
     mCacheManager = createLocalCacheManager();
+  }
+
+  @After
+  public void after() throws Exception {
+    mCacheManager.close();
   }
 
   private byte[] page(int i, int pageLen) {
@@ -799,6 +813,7 @@ public final class LocalCacheManagerTest {
 
   @Test
   public void asyncCache() throws Exception {
+    // this must be smaller than the number of locks in the page store for the test to succeed
     final int threads = 16;
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_ENABLED, true);
     mConf.set(PropertyKey.USER_CLIENT_CACHE_ASYNC_WRITE_THREADS, threads);
@@ -812,14 +827,30 @@ public final class LocalCacheManagerTest {
     pageStore.setPutHanging(true);
     mPageMetaStore = new DefaultPageMetaStore(ImmutableList.of(dir));
     mCacheManager = createLocalCacheManager(mConf, mPageMetaStore);
+    Set<Integer> lockedPages = new HashSet<>();
     for (int i = 0; i < threads; i++) {
       PageId pageId = new PageId("5", i);
       assertTrue(mCacheManager.put(pageId, page(i, PAGE_SIZE_BYTES)));
+      lockedPages.add(mCacheManager.getPageLockId(pageId));
     }
-    pageStore.setPutHanging(false);
-    //fallback to caller's thread when queue is full
-    assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
-    while (pageStore.getPuts() < threads) {
+    // by setting the following line the hanging will only be stopped when the current
+    // thread adds a page
+    pageStore.setStopHangingThread(Thread.currentThread().getId());
+    // fallback to caller's thread (the current here) when queue is full
+    // find a page id that is not already locked
+    int pageLockId;
+    long nxtIdx = 0;
+    PageId callerPageId;
+    do {
+      callerPageId = new PageId("0L", nxtIdx);
+      pageLockId = mCacheManager.getPageLockId(callerPageId);
+      nxtIdx++;
+    } while (lockedPages.contains(pageLockId));
+    // this page will be inserted by the current thread and not a worker thread
+    assertTrue(mCacheManager.put(callerPageId, PAGE1));
+    // Wait for all tasks to complete
+    // one for each thread worker thread, and one on the main thread
+    while (pageStore.getPuts() < threads + 1) {
       Thread.sleep(1000);
     }
     pageStore.setPutHanging(true);
@@ -827,6 +858,7 @@ public final class LocalCacheManagerTest {
       PageId pageId = new PageId("6", i);
       assertTrue(mCacheManager.put(pageId, page(i, PAGE_SIZE_BYTES)));
     }
+    pageStore.setPutHanging(false);
   }
 
   @Test
@@ -850,6 +882,7 @@ public final class LocalCacheManagerTest {
     }
     pageStore.setPutHanging(true);
     assertTrue(mCacheManager.put(PAGE_ID1, PAGE1));
+    pageStore.setPutHanging(false);
   }
 
   @Test


### PR DESCRIPTION
In the async page store, when worker threads run out, the caller thread
should perform the action.

The test had a race condition where all the threads could block,
including the calling thread.

pr-link: https://github.com/Alluxio/alluxio/pull/16731
change-id: cid-81d809c343968d68b57988978575d8b9e4ace63a

Original commit https://github.com/Alluxio/alluxio/commit/7a4e0a53a3ea89630c0cd9bca77bb7fdea254873