### PR TITLE
Add local read benchmarks for PagedBlockStore

### DIFF
--- a/microbench/src/main/java/alluxio/worker/BlockStoreBase.java
+++ b/microbench/src/main/java/alluxio/worker/BlockStoreBase.java
@@ -124,7 +124,12 @@ public class BlockStoreBase implements AutoCloseable {
     }
     mMonoBlockStore.commitBlock(1, blockId, false);
 
-    // todo(yangchen): create local block for PagedBlockStore
+    mPagedBlockStore.createBlock(1, blockId, 0,
+            new CreateBlockOptions(null, null, blockSize));
+    try (BlockWriter writer = mPagedBlockStore.createBlockWriter(1, blockId)) {
+      writer.append(ByteBuffer.wrap(data));
+    }
+    mPagedBlockStore.commitBlock(1, blockId, false);
   }
 
   /**

--- a/microbench/src/main/java/alluxio/worker/BlockStoreRandomReadBench.java
+++ b/microbench/src/main/java/alluxio/worker/BlockStoreRandomReadBench.java
@@ -146,6 +146,18 @@ public class BlockStoreRandomReadBench {
   }
 
   @Benchmark
+  public void pagedBlockStoreRandReadLocal(RandomReadParams params) throws Exception {
+    randReadLocal(params.mBlockStoreBase.mPagedBlockStore,
+        params.mLocalBlockId, params.mBlockSize, params.mOffsets, params.mReadSize);
+  }
+
+  @Benchmark
+  public void pagedBlockStoreRandTransferLocal(RandomReadParams params) throws Exception {
+    randTransferLocal(params.mBlockStoreBase.mPagedBlockStore,
+        params.mLocalBlockId, params.mBlockSize, params.mOffsets, params.mReadSize);
+  }
+
+  @Benchmark
   public void pagedBlockStoreRandReadUfs(RandomReadParams params) throws Exception {
     randReadUfs(params.mBlockStoreBase.mPagedBlockStore, params.mUfsBlockId,
         params.mUfsMountId, params.mUfsPath, params.mBlockSize, params.mOffsets, params.mReadSize);

--- a/microbench/src/main/java/alluxio/worker/BlockStoreSequentialReadBench.java
+++ b/microbench/src/main/java/alluxio/worker/BlockStoreSequentialReadBench.java
@@ -133,6 +133,18 @@ public class BlockStoreSequentialReadBench {
         params.mLocalBlockId, params.mBlockSizeByte);
   }
 
+  @Benchmark
+  public void pagedBlockStoreReadLocal(BlockStoreParams params) throws Exception {
+    readFullyLocal(params.mBlockStoreBase.mPagedBlockStore,
+        params.mLocalBlockId, params.mBlockSizeByte);
+  }
+
+  @Benchmark
+  public void pagedBlockStoreTransferLocal(BlockStoreParams params) throws Exception {
+    transferFullyLocal(params.mBlockStoreBase.mPagedBlockStore,
+            params.mLocalBlockId, params.mBlockSizeByte);
+  }
+
   /**
    * Use {@link BlockReader#read} to read all block cached locally to memory.
    * This method simulates {@link alluxio.worker.grpc.BlockReadHandler}'s use of BlockStore


### PR DESCRIPTION
### What changes are proposed in this pull request?
Added benchmarks for `PagedBlockStore` that read from local storage rather than UFS. 

### Why are the changes needed?
This piece is missing as `PagedBlockStore` didn't support creating local blocks then.

### Does this PR introduce any user facing changes?
No.
