### PR TITLE
Add disable are descendants loaded property

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1124,7 +1124,7 @@ public class DefaultFileSystemMaster extends CoreMaster
             boolean isLoaded = true;
             if (inodePath.fullPathExists()) {
               inode = inodePath.getInode();
-              if (inode.isDirectory()
+              if (inode.isDirectory() && !context.getOptions().getDisableAreDescendantsLoadedCheck()
                   && context.getOptions().getLoadMetadataType() != LoadMetadataPType.ALWAYS) {
                 InodeDirectory inodeDirectory = inode.asDirectory();
                 isLoaded = inodeDirectory.isDirectChildrenLoaded();

--- a/core/server/master/src/main/java/alluxio/master/file/loadmanager/LoadJob.java
+++ b/core/server/master/src/main/java/alluxio/master/file/loadmanager/LoadJob.java
@@ -564,6 +564,9 @@ public class LoadJob {
     }
 
     private void partialListFileInfos() {
+      if (!mStartAfter.isEmpty()) {
+        mListOptions.setDisableAreDescendantsLoadedCheck(true);
+      }
       ListStatusContext context = ListStatusContext.create(ListStatusPartialPOptions.newBuilder()
           .setOptions(mListOptions)
           .setBatchSize(PARTIAL_LISTING_BATCH_SIZE)

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -229,6 +229,12 @@ message ListStatusPOptions {
   optional bool recursive = 4;
   // No data will be transferred.
   optional bool loadMetadataOnly = 5;
+  // Setting this to true will disable checking during metadata sync to see if the children
+  // of a directory has been loaded. This will avoid a costly full traversal of the file
+  // system during recursive listings, but may result in the children of directories not
+  // being loaded. It is recommended to set this to true after the first call of a
+  // recursive partial listing.
+  optional bool disableAreDescendantsLoadedCheck = 6;
 }
 message ListStatusPRequest {
   /** the path of the file or directory */

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -2691,6 +2691,11 @@
                 "id": 5,
                 "name": "loadMetadataOnly",
                 "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "disableAreDescendantsLoadedCheck",
+                "type": "bool"
               }
             ]
           },


### PR DESCRIPTION
### What changes are proposed in this pull request?

This adds a property to the list status call to disable the are descendants loaded check.

### Why are the changes needed?

Currently before a recursive listing happens, the entire enclosed set of files are traversed to see if they all have the descendants loaded flag set in order to check if a metadata sync is needed. This can be costly especially if doing batch or partial listings. By setting this property the check can be avoided. This is, for example, recommended to set to true on the calls following the first call of a batch listing.

Note that this is recommended as more of a temporary fix for internal libraries, until a new logic design for the metadata sync is completed.

### Does this PR introduce any user facing changes?

New property in the list status options proto.
