### PR TITLE
Make stale labeling faster

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true # old issues/PRs first
-          operations-per-run: 100 # default is 30, enlarge for dealing with more issues/PRs
+          operations-per-run: 1000 # default is 30, enlarge for dealing with more issues/PRs
           days-before-stale: 30
           days-before-close: -1
           stale-issue-message: >


### PR DESCRIPTION
About 1 page of issues were labeled stale per week. At this rate we need 30 weeks to label all of old issues, which is too slow.