### PR TITLE
Fix ufs contract test not outputting error code on failure

### DIFF
--- a/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
@@ -107,7 +107,8 @@ public final class UnderFileSystemContractTest {
     }
     System.out.printf("Tests completed with %d failed.%n", failedCnt);
     if (failedCnt > 0) {
-      throw new RuntimeException(String.format("UFS contract test failed with %d failures", failedCnt));
+      throw new RuntimeException(String.format("UFS contract test failed with %d failures",
+          failedCnt));
     }
   }
 

--- a/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
+++ b/integration/tools/validation/src/main/java/alluxio/cli/UnderFileSystemContractTest.java
@@ -106,6 +106,9 @@ public final class UnderFileSystemContractTest {
       failedCnt += runS3Operations();
     }
     System.out.printf("Tests completed with %d failed.%n", failedCnt);
+    if (failedCnt > 0) {
+      throw new RuntimeException(String.format("UFS contract test failed with %d failures", failedCnt));
+    }
   }
 
   /**


### PR DESCRIPTION
The UnderFileSystemContractTest was outputting a successful output code even though some of the tests were failing.