### PR TITLE
Add metrics for in memory data structures

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -322,12 +322,14 @@ public final class MetricKey implements Comparable<MetricKey> {
   // Master file statistics
   public static final MetricKey MASTER_FILES_PINNED =
       new Builder("Master.FilesPinned")
-          .setDescription("Total number of currently pinned files")
+          .setDescription("Total number of currently pinned files. "
+              + "Note that IDs for these files are stored in memory.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_FILES_TO_PERSIST =
       new Builder("Master.FilesToBePersisted")
-          .setDescription("Total number of currently to be persisted files")
+          .setDescription("Total number of currently to be persisted files."
+              + " Note that the IDs for these files are stored in memory.")
           .setMetricType(MetricType.GAUGE)
           .build();
   public static final MetricKey MASTER_FILE_SIZE =
@@ -419,6 +421,20 @@ public final class MetricKey implements Comparable<MetricKey> {
       new Builder("Master.BlockReplicaCount")
           .setDescription("Total number of block replicas in Alluxio")
           .setMetricType(MetricType.GAUGE)
+          .build();
+  public static final MetricKey MASTER_TTL_BUCKETS =
+      new Builder("Master.TTLBuckets")
+          .setDescription("The number of TTL buckets at the master. Note that these buckets"
+              + " are stored in memory.")
+          .setMetricType(MetricType.GAUGE)
+          .setIsClusterAggregated(false)
+          .build();
+  public static final MetricKey MASTER_TTL_INODES =
+      new Builder("Master.TTLInodes")
+          .setDescription("The total number of inodes contained in TTL buckets at the mater."
+              + " Note that these inodes are stored in memory.")
+          .setMetricType(MetricType.GAUGE)
+          .setIsClusterAggregated(false)
           .build();
   public static final MetricKey MASTER_INODE_HEAP_SIZE =
       new Builder("Master.InodeHeapSize")
@@ -615,6 +631,13 @@ public final class MetricKey implements Comparable<MetricKey> {
   public static final MetricKey MASTER_MOUNT_OPS =
       new Builder("Master.MountOps")
           .setDescription("Total number of Mount operations")
+          .setMetricType(MetricType.COUNTER)
+          .build();
+  public static final MetricKey MASTER_REPLICATION_LIMITED_FILES =
+      new Builder("Master.ReplicationLimitedFiles")
+          .setDescription("Number of files that have a replication count set to a "
+              + "non-default value. Note that these files have IDs that are stored "
+              + "in memory.")
           .setMetricType(MetricType.COUNTER)
           .build();
   public static final MetricKey MASTER_RENAME_PATH_OPS =

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -5145,6 +5145,12 @@ public class DefaultFileSystemMaster extends CoreMaster
           inodeTree::getPinnedSize);
       MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_FILES_TO_PERSIST.getName(),
           () -> inodeTree.getToBePersistedIds().size());
+      MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_REPLICATION_LIMITED_FILES.getName(),
+          () -> inodeTree.getReplicationLimitedFileIds().size());
+      MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_TTL_BUCKETS.getName(),
+          () -> inodeTree.getTtlBuckets().getNumBuckets());
+      MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_TTL_INODES.getName(),
+          () -> inodeTree.getTtlBuckets().getNumInodes());
       MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_TOTAL_PATHS.getName(),
           inodeTree::getInodeCount);
       MetricsSystem.registerGaugeIfAbsent(MetricKey.MASTER_FILE_SIZE.getName(),

--- a/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
@@ -89,18 +89,27 @@ public final class TtlBucket implements Comparable<TtlBucket> {
    * Adds a inode to the bucket.
    *
    * @param inode the inode to be added
+   * @return true if a new inode was added to the bucket
    */
-  public void addInode(Inode inode) {
-    mInodes.put(inode.getId(), inode);
+  public boolean addInode(Inode inode) {
+    return mInodes.put(inode.getId(), inode) == null;
   }
 
   /**
    * Removes a inode from the bucket.
    *
    * @param inode the inode to be removed
+   * @return true if a inode was removed
    */
-  public void removeInode(InodeView inode) {
-    mInodes.remove(inode.getId());
+  public boolean removeInode(InodeView inode) {
+    return mInodes.remove(inode.getId()) != null;
+  }
+
+  /**
+   * @return the number of inodes in the bucket
+   */
+  public int size() {
+    return mInodes.size();
   }
 
   /**


### PR DESCRIPTION
As mentioned in https://github.com/Alluxio/alluxio/issues/8991, some data structures about state of index in the master are stored in memory, which could cause memory issues.

To know if this is happening, some metrics are added to compute the size of these structures.

These already existed:
Master.FilesPinned
Master.FilesToBePersisted

And these are added:
Master.TTLBuckets
Master.TTLInodes
Master.ReplicationLimitedFiles

For an example of how these new metrics work, can try something like:
In Alluxio-site.properties set ```alluxio.master.ttl.checker.interval.ms=60000```

Then run
``` ./bin/alluxio runTests -Dalluxio.user.file.create.ttl=1m  -Dalluxio.user.file.create.ttl.action=DELETE -Dalluxio.user.file.replication.max=1```

And watch
```watch -n 1 "curl 127.0.0.1:19999/metrics/json/ | grep -i -A 4 -e Master.TTL -e Master.ReplicationLimitedFiles"```


