### PR TITLE
Add the two-choice random cache eviction policy

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/evictor/TwoChoiceRandomEvictor.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/evictor/TwoChoiceRandomEvictor.java
@@ -1,0 +1,94 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file.cache.evictor;
+
+import alluxio.client.file.cache.PageId;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.function.Predicate;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Two Choice Random client-side cache eviction policy.
+ * It selects two random page IDs and evicts the one least-recently used.
+ */
+@ThreadSafe
+public class TwoChoiceRandomEvictor implements CacheEvictor {
+  private final Map<PageId, Long> mCache = Collections.synchronizedMap(new HashMap<>());
+
+  /**
+   * Constructor.
+   * @param options
+   */
+  public TwoChoiceRandomEvictor(CacheEvictorOptions options) {
+  }
+
+  @Override
+  public void updateOnGet(PageId pageId) {
+    mCache.put(pageId, Instant.now().toEpochMilli());
+  }
+
+  @Override
+  public void updateOnPut(PageId pageId) {
+    mCache.put(pageId, Instant.now().toEpochMilli());
+  }
+
+  @Override
+  public void updateOnDelete(PageId pageId) {
+    mCache.remove(pageId);
+  }
+
+  @Nullable
+  @Override
+  public PageId evict() {
+    synchronized (mCache) {
+      if (mCache.isEmpty()) {
+        return null;
+      }
+
+      // TODO(chunxu): improve the performance here
+      List<PageId> keys = new ArrayList<>(mCache.keySet());
+      Random rand = new Random();
+      PageId key1 = keys.get(rand.nextInt(keys.size()));
+      PageId key2 = keys.get(rand.nextInt(keys.size()));
+      if (mCache.get(key1) < mCache.get(key2)) {
+        return key1;
+      }
+      return key2;
+    }
+  }
+
+  @Nullable
+  @Override
+  public PageId evictMatching(Predicate<PageId> criterion) {
+    synchronized (mCache) {
+      for (PageId candidate : mCache.keySet()) {
+        if (criterion.test(candidate)) {
+          return candidate;
+        }
+      }
+      return null;
+    }
+  }
+
+  @Override
+  public void reset() {
+    mCache.clear();
+  }
+}

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/TwoChoiceRandomEvictorTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/TwoChoiceRandomEvictorTest.java
@@ -1,0 +1,81 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file.cache;
+
+import alluxio.client.file.cache.evictor.CacheEvictorOptions;
+import alluxio.client.file.cache.evictor.TwoChoiceRandomEvictor;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link TwoChoiceRandomEvictor} class.
+ */
+public class TwoChoiceRandomEvictorTest {
+  private TwoChoiceRandomEvictor mEvictor;
+  private final PageId mFirst = new PageId("1L", 2L);
+  private final PageId mSecond = new PageId("3L", 4L);
+  private final PageId mThird = new PageId("5L", 6L);
+
+  /**
+   * Sets up the instances.
+   */
+  @Before
+  public void before() {
+    mEvictor = new TwoChoiceRandomEvictor(new CacheEvictorOptions());
+  }
+
+  @Test
+  public void evictGetOrder() {
+    mEvictor.updateOnGet(mFirst);
+    Assert.assertEquals(mFirst, mEvictor.evict());
+    mEvictor.updateOnGet(mSecond);
+    Assert.assertEquals(mSecond, mEvictor.evict());
+  }
+
+  @Test
+  public void evictPutOrder() {
+    mEvictor.updateOnPut(mFirst);
+    Assert.assertEquals(mFirst, mEvictor.evict());
+    mEvictor.updateOnPut(mSecond);
+    mEvictor.updateOnPut(mFirst);
+    PageId evictedPage = mEvictor.evict();
+    Assert.assertTrue(evictedPage.equals(mFirst) || evictedPage.equals(mSecond));
+  }
+
+  @Test
+  public void evictAfterDelete() {
+    mEvictor.updateOnPut(mFirst);
+    mEvictor.updateOnPut(mSecond);
+    mEvictor.updateOnPut(mThird);
+    mEvictor.updateOnDelete(mSecond);
+    mEvictor.updateOnDelete(mThird);
+    Assert.assertEquals(mFirst, mEvictor.evict());
+  }
+
+  @Test
+  public void evictEmpty() {
+    Assert.assertNull(mEvictor.evict());
+  }
+
+  @Test
+  public void evictAllGone() {
+    mEvictor.updateOnPut(mFirst);
+    mEvictor.updateOnPut(mSecond);
+    mEvictor.updateOnPut(mThird);
+    mEvictor.updateOnDelete(mFirst);
+    mEvictor.updateOnDelete(mSecond);
+    mEvictor.updateOnDelete(mThird);
+    Assert.assertNull(mEvictor.evict());
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

The PR adds the two-choice random cache eviction policy. The algorithm selects two random page IDs and evicts the one least recently used.

### Why are the changes needed?

From some evaluation (https://danluu.com/2choices-eviction/), the two-choice random policy has competitive performance compared with LRU.

### Does this PR introduce any user facing changes?

Users can configure the new cache eviction policy.
