### PR TITLE
Fix data not being cached by dora worker

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -18,6 +18,8 @@ import alluxio.DefaultStorageTierAssoc;
 import alluxio.Server;
 import alluxio.StorageTierAssoc;
 import alluxio.client.file.cache.CacheManager;
+import alluxio.client.file.cache.CacheManagerOptions;
+import alluxio.client.file.cache.PageMetaStore;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
@@ -77,7 +79,9 @@ public class PagedDoraWorker implements DoraWorker {
     mUfsStreamCache = new UfsInputStreamCache();
     mPageSize = Configuration.global().getBytes(PropertyKey.WORKER_PAGE_STORE_PAGE_SIZE);
     try {
-      mCacheManager = CacheManager.Factory.create(Configuration.global());
+      CacheManagerOptions options = CacheManagerOptions.createForWorker(Configuration.global());
+      PageMetaStore metaStore = PageMetaStore.create(options);
+      mCacheManager = CacheManager.Factory.create(Configuration.global(), options, metaStore);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix caching not working in dora worker.

### Why are the changes needed?

Two bugs are fixed:
1. Page store in Dora worker was not created with the worker specific property keys. Keys for client local cache was used, so the settings like cache dir location and sizes did not have effect.
2. `DoraCacheFileSystem.open` did not honor client side read default options, and was using hard-coded defaults from gRPC definition, which is `NO_CACHE`.

### Does this PR introduce any user facing changes?
No.
