### PR TITLE
Add TTL enforcement

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
 import javax.annotation.concurrent.GuardedBy;
 
 /**
@@ -297,4 +298,12 @@ public interface CacheManager extends AutoCloseable {
    * @return true if append was successful
    */
   boolean append(PageId pageId, int appendAt, byte[] page, CacheContext cacheContext);
+
+  /**
+   * Invalidate the pages that match the given predicate.
+   * @param predicate
+   */
+  default void invalidate(Predicate<PageInfo> predicate) {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManagerOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManagerOptions.java
@@ -30,6 +30,9 @@ public class CacheManagerOptions {
   private long mPageSize;
   private List<PageStoreOptions> mPageStoreOptions;
   private boolean mQuotaEnabled;
+  private boolean mTtlEnabled;
+  private long mTtlCheckIntervalSeconds;
+  private long mTtlThresholdSeconds;
 
   /**
    * @param conf
@@ -50,6 +53,9 @@ public class CacheManagerOptions {
         .setMaxEvictionRetries(conf.getInt(PropertyKey.USER_CLIENT_CACHE_EVICTION_RETRIES))
         .setPageSize(conf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE))
         .setQuotaEnabled(conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_QUOTA_ENABLED))
+        .setTtlEnabled(conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_TTL_ENABLED))
+        .setTtlCheckIntervalSeconds(conf.getLong(PropertyKey.USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS))
+        .setTtlThresholdSeconds(conf.getLong(PropertyKey.USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS))
         .setCacheEvictorOptions(cacheEvictorOptions)
         .setPageStoreOptions(PageStoreOptions.create(conf));
     return options;
@@ -111,6 +117,28 @@ public class CacheManagerOptions {
    */
   public boolean isQuotaEnabled() {
     return mQuotaEnabled;
+  }
+
+  /**
+   * @return if cache ttl is enabled
+   */
+  public boolean isTtlEnabled() {
+    return mTtlEnabled;
+  }
+
+  /**
+   * @return the check interval of ttl
+   */
+  public long getTtlCheckIntervalSeconds() {
+    return mTtlCheckIntervalSeconds;
+  }
+
+  /**
+   *
+   * @return the time threshold of cache ttl
+   */
+  public long getTtlThresholdSeconds() {
+    return mTtlThresholdSeconds;
   }
 
   /**
@@ -211,6 +239,33 @@ public class CacheManagerOptions {
   public CacheManagerOptions setPageStoreOptions(
       List<PageStoreOptions> pageStoreOptions) {
     mPageStoreOptions = pageStoreOptions;
+    return this;
+  }
+
+  /**
+   * @param isTtlEnabled
+   * @return the updated options
+   */
+  public CacheManagerOptions setTtlEnabled(boolean isTtlEnabled) {
+    mTtlEnabled = isTtlEnabled;
+    return this;
+  }
+
+  /**
+   * @param checkIntervalSeconds
+   * @return the updated options
+   */
+  public CacheManagerOptions setTtlCheckIntervalSeconds(long checkIntervalSeconds) {
+    mTtlCheckIntervalSeconds = checkIntervalSeconds;
+    return this;
+  }
+
+  /**
+   * @param thresholdSeconds
+   * @return the updated options
+   */
+  public CacheManagerOptions setTtlThresholdSeconds(long thresholdSeconds) {
+    mTtlThresholdSeconds = thresholdSeconds;
     return this;
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -50,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
@@ -638,6 +639,21 @@ public class LocalCacheManager implements CacheManager {
       }
     }
     return pageIds;
+  }
+
+  @Override
+  public void invalidate(Predicate<PageInfo> predicate) {
+    mPageStoreDirs.forEach(dir -> {
+      try {
+        dir.scanPages(pageInfo -> {
+          if (pageInfo.isPresent() && predicate.test(pageInfo.get())) {
+            delete(pageInfo.get().getPageId());
+          }
+        });
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
   }
 
   @Override

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageInfo.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageInfo.java
@@ -28,6 +28,7 @@ public class PageInfo {
   private final long mPageSize;
   private final CacheScope mCacheScope;
   private final PageStoreDir mLocalCacheDir;
+  private final long mCreatedTimestamp;
 
   /**
    * @param pageId page id
@@ -46,10 +47,23 @@ public class PageInfo {
    */
   public PageInfo(PageId pageId, long pageSize, CacheScope cacheScope,
                   PageStoreDir pageStoreDir) {
+    this(pageId, pageSize, cacheScope, pageStoreDir, System.currentTimeMillis());
+  }
+
+  /**
+   * @param pageId page id
+   * @param pageSize page size in bytes
+   * @param cacheScope scope of this page
+   * @param pageStoreDir directory of this page
+   * @param createdTimestamp created time
+   */
+  public PageInfo(PageId pageId, long pageSize, CacheScope cacheScope,
+      PageStoreDir pageStoreDir, long createdTimestamp) {
     mPageId = pageId;
     mPageSize = pageSize;
     mCacheScope = cacheScope;
     mLocalCacheDir = pageStoreDir;
+    mCreatedTimestamp = createdTimestamp;
   }
 
   /**
@@ -78,6 +92,13 @@ public class PageInfo {
    */
   public PageStoreDir getLocalCacheDir() {
     return mLocalCacheDir;
+  }
+
+  /**
+   * @return the created time
+   */
+  public long getCreatedTimestamp() {
+    return mCreatedTimestamp;
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5919,21 +5919,21 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_CLIENT_CACHE_TTL_ENABLED =
-     booleanBuilder(Name.USER_CLIENT_CACHE_TTL_ENABLED)
+      booleanBuilder(Name.USER_CLIENT_CACHE_TTL_ENABLED)
           .setDefaultValue(false)
           .setDescription("Whether to support cache quota.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS =
-     longBuilder(Name.USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS)
+      longBuilder(Name.USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS)
           .setDefaultValue(3600)
           .setDescription("TTL check interval time in seconds.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS =
-     longBuilder(Name.USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS)
+      longBuilder(Name.USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS)
           .setDefaultValue(3600 * 3)
           .setDescription("TTL threshold time in seconds.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5918,6 +5918,27 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_CLIENT_CACHE_TTL_ENABLED =
+     booleanBuilder(Name.USER_CLIENT_CACHE_TTL_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("Whether to support cache quota.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS =
+     longBuilder(Name.USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS)
+          .setDefaultValue(3600)
+          .setDescription("TTL check interval time in seconds.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS =
+     longBuilder(Name.USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS)
+          .setDefaultValue(3600 * 3)
+          .setDescription("TTL threshold time in seconds.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_CLIENT_CACHE_SIZE =
       listBuilder(Name.USER_CLIENT_CACHE_SIZE)
           .setDefaultValue("512MB")
@@ -8468,6 +8489,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.client.cache.page.size";
     public static final String USER_CLIENT_CACHE_QUOTA_ENABLED =
         "alluxio.user.client.cache.quota.enabled";
+    public static final String USER_CLIENT_CACHE_TTL_ENABLED =
+            "alluxio.user.client.cache.ttl.enabled";
+    public static final String USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS =
+            "alluxio.user.client.cache.ttl.check.interval.seconds";
+    public static final String USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS =
+            "alluxio.user.client.cache.ttl.threshold.seconds";
     public static final String USER_CLIENT_CACHE_SIZE =
         "alluxio.user.client.cache.size";
     public static final String USER_CLIENT_CACHE_STORE_OVERHEAD =


### PR DESCRIPTION
### What changes are proposed in this pull request?

This change adds a scheduled thread in LocalCacheManager, to periodically check the page create time, and delete pages that have passed the configurable time threshold.

This change is on top of this PR: https://github.com/Alluxio/alluxio/pull/16783/files

### Why are the changes needed?

Certain use cases require the cached data to be removed beyond certain longevity. This is mainly for compliance considerations.

### Does this PR introduce any user facing changes?

No
