### PR TITLE
Add cache TTL enforcement

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManagerOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManagerOptions.java
@@ -30,6 +30,9 @@ public class CacheManagerOptions {
   private long mPageSize;
   private List<PageStoreOptions> mPageStoreOptions;
   private boolean mQuotaEnabled;
+  private boolean mTtlEnabled;
+  private long mTtlCheckIntervalSeconds;
+  private long mTtlThresholdSeconds;
 
   /**
    * @param conf
@@ -50,6 +53,9 @@ public class CacheManagerOptions {
         .setMaxEvictionRetries(conf.getInt(PropertyKey.USER_CLIENT_CACHE_EVICTION_RETRIES))
         .setPageSize(conf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE))
         .setQuotaEnabled(conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_QUOTA_ENABLED))
+        .setTtlEnabled(conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_TTL_ENABLED))
+        .setTtlCheckIntervalSeconds(conf.getLong(PropertyKey.USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS))
+        .setTtlThresholdSeconds(conf.getLong(PropertyKey.USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS))
         .setCacheEvictorOptions(cacheEvictorOptions)
         .setPageStoreOptions(PageStoreOptions.create(conf));
     return options;
@@ -111,6 +117,28 @@ public class CacheManagerOptions {
    */
   public boolean isQuotaEnabled() {
     return mQuotaEnabled;
+  }
+
+  /**
+   * @return if cache ttl is enabled
+   */
+  public boolean isTtlEnabled() {
+    return mTtlEnabled;
+  }
+
+  /**
+   * @return the check interval of ttl
+   */
+  public long getTtlCheckIntervalSeconds() {
+    return mTtlCheckIntervalSeconds;
+  }
+
+  /**
+   *
+   * @return the time threshold of cache ttl
+   */
+  public long getTtlThresholdSeconds() {
+    return mTtlThresholdSeconds;
   }
 
   /**
@@ -211,6 +239,33 @@ public class CacheManagerOptions {
   public CacheManagerOptions setPageStoreOptions(
       List<PageStoreOptions> pageStoreOptions) {
     mPageStoreOptions = pageStoreOptions;
+    return this;
+  }
+
+  /**
+   * @param isTtlEnabled
+   * @return the updated options
+   */
+  public CacheManagerOptions setTtlEnabled(boolean isTtlEnabled) {
+    mTtlEnabled = isTtlEnabled;
+    return this;
+  }
+
+  /**
+   * @param checkIntervalSeconds
+   * @return the updated options
+   */
+  public CacheManagerOptions setTtlCheckIntervalSeconds(long checkIntervalSeconds) {
+    mTtlCheckIntervalSeconds = checkIntervalSeconds;
+    return this;
+  }
+
+  /**
+   * @param thresholdSeconds
+   * @return the updated options
+   */
+  public CacheManagerOptions setTtlThresholdSeconds(long thresholdSeconds) {
+    mTtlThresholdSeconds = thresholdSeconds;
     return this;
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManagerOptions.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManagerOptions.java
@@ -54,7 +54,8 @@ public class CacheManagerOptions {
         .setPageSize(conf.getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE))
         .setQuotaEnabled(conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_QUOTA_ENABLED))
         .setTtlEnabled(conf.getBoolean(PropertyKey.USER_CLIENT_CACHE_TTL_ENABLED))
-        .setTtlCheckIntervalSeconds(conf.getLong(PropertyKey.USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS))
+        .setTtlCheckIntervalSeconds(
+            conf.getLong(PropertyKey.USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS))
         .setTtlThresholdSeconds(conf.getLong(PropertyKey.USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS))
         .setCacheEvictorOptions(cacheEvictorOptions)
         .setPageStoreOptions(PageStoreOptions.create(conf));

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -15,7 +15,6 @@ import static alluxio.client.file.cache.CacheManager.State.NOT_IN_USE;
 import static alluxio.client.file.cache.CacheManager.State.READ_ONLY;
 import static alluxio.client.file.cache.CacheManager.State.READ_WRITE;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
-import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import alluxio.client.file.CacheContext;
@@ -151,15 +150,15 @@ public class LocalCacheManager implements CacheManager {
     if (options.isTtlEnabled()) {
       mTtlEnforcerExecutor = Optional.of(newScheduledThreadPool(1));
       mTtlEnforcerExecutor.get().scheduleAtFixedRate(() ->
-              LocalCacheManager.this.invalidate(pageInfo -> {
-        try {
-          return System.currentTimeMillis() - pageInfo.getCreatedTimestamp() >=
-                  options.getTtlThresholdSeconds() * 1000;
-        } catch (Exception ex) {
-          // In case of any exception, do not invalidate the cache
-          return false;
-        }
-      }), 0, options.getTtlCheckIntervalSeconds(), SECONDS);
+          LocalCacheManager.this.invalidate(pageInfo -> {
+            try {
+              return System.currentTimeMillis() - pageInfo.getCreatedTimestamp()
+                  >= options.getTtlThresholdSeconds() * 1000;
+            } catch (Exception ex) {
+              // In case of any exception, do not invalidate the cache
+              return false;
+            }
+          }), 0, options.getTtlCheckIntervalSeconds(), SECONDS);
     } else {
       mTtlEnforcerExecutor = Optional.empty();
     }

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5926,21 +5926,21 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_CLIENT_CACHE_TTL_ENABLED =
-     booleanBuilder(Name.USER_CLIENT_CACHE_TTL_ENABLED)
+      booleanBuilder(Name.USER_CLIENT_CACHE_TTL_ENABLED)
           .setDefaultValue(false)
           .setDescription("Whether to support cache quota.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS =
-     longBuilder(Name.USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS)
+      longBuilder(Name.USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS)
           .setDefaultValue(3600)
           .setDescription("TTL check interval time in seconds.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS =
-     longBuilder(Name.USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS)
+      longBuilder(Name.USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS)
           .setDefaultValue(3600 * 3)
           .setDescription("TTL threshold time in seconds.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5925,6 +5925,27 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_CLIENT_CACHE_TTL_ENABLED =
+     booleanBuilder(Name.USER_CLIENT_CACHE_TTL_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("Whether to support cache quota.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS =
+     longBuilder(Name.USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS)
+          .setDefaultValue(3600)
+          .setDescription("TTL check interval time in seconds.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.CLIENT)
+          .build();
+  public static final PropertyKey USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS =
+     longBuilder(Name.USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS)
+          .setDefaultValue(3600 * 3)
+          .setDescription("TTL threshold time in seconds.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_CLIENT_CACHE_SIZE =
       listBuilder(Name.USER_CLIENT_CACHE_SIZE)
           .setDefaultValue("512MB")
@@ -8477,6 +8498,12 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.client.cache.page.size";
     public static final String USER_CLIENT_CACHE_QUOTA_ENABLED =
         "alluxio.user.client.cache.quota.enabled";
+    public static final String USER_CLIENT_CACHE_TTL_ENABLED =
+            "alluxio.user.client.cache.ttl.enabled";
+    public static final String USER_CLIENT_CACHE_TTL_CHECK_INTERVAL_SECONDS =
+            "alluxio.user.client.cache.ttl.check.interval.seconds";
+    public static final String USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS =
+            "alluxio.user.client.cache.ttl.threshold.seconds";
     public static final String USER_CLIENT_CACHE_SIZE =
         "alluxio.user.client.cache.size";
     public static final String USER_CLIENT_CACHE_STORE_OVERHEAD =


### PR DESCRIPTION
### What changes are proposed in this pull request?

Co-Author-By: Chen Liang <chliang@uber.com>

This change adds a scheduled thread in LocalCacheManager, to periodically check the page create time, and delete pages that have passed the configurable time threshold.

### Why are the changes needed?

Certain use cases require the cached data to be removed beyond certain longevity. This is mainly for compliance considerations.

### Does this PR introduce any user facing changes?

No