### PR TITLE
Remove hardcoded version dependency in examples module

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -27,7 +27,6 @@
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.basedir}/build</build.path>
     <failIfNoTests>false</failIfNoTests>
-    <hadoop.version>3.2.1</hadoop.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Fix the security issue introduced by following link. The newest version of hadoop fix this issue. 

- http://horus.oa.com/advisory/HOSA-pzst-tfwm6u4cy 
- http://horus.oa.com/advisory/HOSA-n612-2d07um3px
- http://horus.oa.com/advisory/HOSA-yn2x-x9qulrobf
- http://horus.oa.com/advisory/HOSA-jatn-nizpv9w2u

I remove the hadoop.version property to keep consistent with parent module.