### PR TITLE
Add UFS root before the Alluxio file path

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -67,9 +67,7 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
   @Override
   public URIStatus getStatus(AlluxioURI path, GetStatusPOptions options)
       throws IOException, AlluxioException {
-    UfsBaseFileSystem under = (UfsBaseFileSystem) mDelegatedFileSystem;
-    AlluxioURI ufsFullPath = new AlluxioURI(
-        PathUtils.concatPath(under.getRootUFS(), path.getPath()));
+    AlluxioURI ufsFullPath = convertAlluxioPathToUFSPath(path);
 
     if (!mMetadataCacheEnabled) {
       return mDelegatedFileSystem.getStatus(ufsFullPath, options);
@@ -119,40 +117,48 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
   @Override
   public List<URIStatus> listStatus(AlluxioURI path, ListStatusPOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException {
-    UfsBaseFileSystem under = (UfsBaseFileSystem) mDelegatedFileSystem;
-
-    String ufsFullPath = PathUtils.concatPath(under.getRootUFS(), path.getPath());
-    return mDelegatedFileSystem.listStatus(new AlluxioURI(ufsFullPath), options);
+    AlluxioURI ufsFullPath = convertAlluxioPathToUFSPath(path);
+    return mDelegatedFileSystem.listStatus(ufsFullPath, options);
   }
 
   @Override
   public FileOutStream createFile(AlluxioURI path, CreateFilePOptions options)
       throws FileAlreadyExistsException, InvalidPathException, IOException, AlluxioException {
-    UfsBaseFileSystem under = (UfsBaseFileSystem) mDelegatedFileSystem;
-    String ufsFullPath = PathUtils.concatPath(under.getRootUFS(), path.getPath());
+    AlluxioURI ufsFullPath = convertAlluxioPathToUFSPath(path);
     LOG.warn("Dora Client does not support create/write. This is only for test.");
-    return mDelegatedFileSystem.createFile(new AlluxioURI(ufsFullPath), options);
+    return mDelegatedFileSystem.createFile(ufsFullPath, options);
   }
 
   @Override
   public void createDirectory(AlluxioURI path, CreateDirectoryPOptions options)
       throws FileAlreadyExistsException, InvalidPathException, IOException, AlluxioException {
-    UfsBaseFileSystem under = (UfsBaseFileSystem) mDelegatedFileSystem;
-    String ufsFullPath = PathUtils.concatPath(under.getRootUFS(), path.getPath());
+    AlluxioURI ufsFullPath = convertAlluxioPathToUFSPath(path);
     LOG.warn("Dora Client does not support create/write. This is only for test.");
 
-    mDelegatedFileSystem.createDirectory(new AlluxioURI(ufsFullPath), options);
+    mDelegatedFileSystem.createDirectory(ufsFullPath, options);
   }
 
   @Override
   public void rename(AlluxioURI src, AlluxioURI dst, RenamePOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException {
-    UfsBaseFileSystem under = (UfsBaseFileSystem) mDelegatedFileSystem;
-    String srcUfsFullPath = PathUtils.concatPath(under.getRootUFS(), src.getPath());
-    String dstUfsFullPath = PathUtils.concatPath(under.getRootUFS(), dst.getPath());
+    AlluxioURI srcUfsFullPath = convertAlluxioPathToUFSPath(src);
+    AlluxioURI dstUfsFullPath = convertAlluxioPathToUFSPath(dst);
     LOG.warn("Dora Client does not support create/write. This is only for test.");
 
-    mDelegatedFileSystem.rename(new AlluxioURI(srcUfsFullPath),
-        new AlluxioURI(dstUfsFullPath), options);
+    mDelegatedFileSystem.rename(srcUfsFullPath, dstUfsFullPath, options);
+  }
+
+  /**
+   * Converts the Alluxio based path to UfsBaseFileSystem based path.
+   *
+   * UfsBaseFileSystem expects absolute/full file path.
+   *
+   * @param alluxioPath Alluxio based path
+   * @return UfsBaseFileSystem based full path
+   */
+  private AlluxioURI convertAlluxioPathToUFSPath(AlluxioURI alluxioPath) {
+    UfsBaseFileSystem under = (UfsBaseFileSystem) mDelegatedFileSystem;
+    String ufsFullPath = PathUtils.concatPath(under.getRootUFS(), alluxioPath.getPath());
+    return new AlluxioURI(ufsFullPath);
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Dora Cache file system implementation.
@@ -146,6 +147,15 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
     LOG.warn("Dora Client does not support create/write. This is only for test.");
 
     mDelegatedFileSystem.rename(srcUfsFullPath, dstUfsFullPath, options);
+  }
+
+  @Override
+  public void iterateStatus(AlluxioURI path, ListStatusPOptions options,
+                            Consumer<? super URIStatus> action)
+      throws FileDoesNotExistException, IOException, AlluxioException {
+    AlluxioURI ufsFullPath = convertAlluxioPathToUFSPath(path);
+
+    mDelegatedFileSystem.iterateStatus(ufsFullPath, options, action);
   }
 
   /**

--- a/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -69,7 +69,9 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
       return mDoraClient.getStatus(path.getPath(), options);
     } catch (RuntimeException ex) {
       LOG.debug("Dora client get status error. Fall back to UFS.", ex);
-      return mDelegatedFileSystem.getStatus(path, options);
+      UfsBaseFileSystem under = (UfsBaseFileSystem) mDelegatedFileSystem;
+      String ufsFullPath = PathUtils.concatPath(under.getRootUFS(), path.getPath());
+      return mDelegatedFileSystem.getStatus(new AlluxioURI(ufsFullPath), options);
     }
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
@@ -395,11 +395,11 @@ public class UfsBaseFileSystem implements FileSystem {
    * @return the client-side status
    */
   private URIStatus transformStatus(UfsStatus ufsStatus) {
-    AlluxioURI ufsUri = new AlluxioURI(PathUtils.concatPath(mRootUFS,
-        CommonUtils.stripPrefixIfPresent(ufsStatus.getName(), mRootUFS.getPath())));
+    String path = CommonUtils.stripPrefixIfPresent(ufsStatus.getName(), mRootUFS.toString());
+    AlluxioURI ufsUri = new AlluxioURI(PathUtils.concatPath(mRootUFS, path));
     FileInfo info = new FileInfo().setName(ufsUri.getName())
-        .setPath(ufsUri.toString())
-        .setFileId(ufsUri.hashCode())
+        .setPath(path)
+        .setFileId(ufsUri.toString().hashCode())
         .setUfsPath(ufsUri.toString())
         .setFolder(ufsStatus.isDirectory())
         .setOwner(ufsStatus.getOwner())
@@ -407,7 +407,7 @@ public class UfsBaseFileSystem implements FileSystem {
         .setMode(ufsStatus.getMode())
         .setCompleted(true);
     if (ufsStatus.getLastModifiedTime() != null) {
-      info.setLastModificationTimeMs(info.getLastModificationTimeMs());
+      info.setLastModificationTimeMs(ufsStatus.getLastModifiedTime());
     }
     if (ufsStatus.getXAttr() != null) {
       info.setXAttr(ufsStatus.getXAttr());

--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
@@ -293,7 +293,7 @@ public class UfsBaseFileSystem implements FileSystem {
       // TODO(lu) deal with other options e.g. maxUfsReadConcurrency
       return new UfsFileInStream(offset -> {
         try {
-          return mUfs.get().open(status.getPath(), OpenOptions.defaults().setOffset(offset));
+          return mUfs.get().open(status.getUfsPath(), OpenOptions.defaults().setOffset(offset));
         } catch (IOException e) {
           throw AlluxioRuntimeException.from(e);
         }

--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
@@ -87,7 +87,7 @@ public class UfsBaseFileSystem implements FileSystem {
   private final Closer mCloser = Closer.create();
   protected final FileSystemContext mFsContext;
   protected final CloseableResource<UnderFileSystem> mUfs;
-  protected final AlluxioURI mRootUFS;
+  private final AlluxioURI mRootUFS;
   protected volatile boolean mClosed = false;
 
   /**
@@ -420,6 +420,15 @@ public class UfsBaseFileSystem implements FileSystem {
       info.setLength(0);
     }
     return new URIStatus(info);
+  }
+
+  /**
+   * Gets the UFS Root.
+   *
+   * @return AlluxioURI of UFS Root
+   */
+  public AlluxioURI getRootUFS() {
+    return mRootUFS;
   }
 
   private static void call(UfsCallable callable) {

--- a/core/client/fs/src/test/java/alluxio/client/file/ufs/UfsBaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/ufs/UfsBaseFileSystemTest.java
@@ -214,13 +214,14 @@ public class UfsBaseFileSystemTest {
 
   @Test
   public void getFileStatus() throws IOException, AlluxioException {
-    AlluxioURI uri = mRootUfs.join("/getFileStatusFolder/getFileStatus");
+    String fileName = "/getFileStatusFolder/getFileStatus";
+    AlluxioURI uri = mRootUfs.join(fileName);
     mRootUfs.getPath();
     mFileSystem.createFile(uri,
         CreateFilePOptions.newBuilder().setRecursive(true).build()).close();
     URIStatus status = mFileSystem.getStatus(uri);
     Assert.assertEquals(uri.getName(), status.getName());
-    Assert.assertEquals(uri.getPath(), status.getPath());
+    Assert.assertEquals(fileName, status.getPath());
     Assert.assertEquals(uri.toString(), status.getUfsPath());
     Assert.assertTrue(status.isCompleted());
     Assert.assertFalse(status.isFolder());
@@ -231,11 +232,12 @@ public class UfsBaseFileSystemTest {
 
   @Test
   public void getDirectoryStatus() throws IOException, AlluxioException {
-    AlluxioURI uri = mRootUfs.join("/getDirectoryStatus");
+    String fileName = "/getDirectoryStatus";
+    AlluxioURI uri = mRootUfs.join(fileName);
     mFileSystem.createDirectory(uri);
     URIStatus status = mFileSystem.getStatus(uri);
     Assert.assertEquals(uri.getName(), status.getName());
-    Assert.assertEquals(uri.getPath(), status.getPath());
+    Assert.assertEquals(fileName, status.getPath());
     Assert.assertEquals(uri.toString(), status.getUfsPath());
     Assert.assertTrue(status.isCompleted());
     Assert.assertTrue(status.isFolder());

--- a/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
+++ b/integration/fuse/src/test/java/alluxio/fuse/AlluxioJniFuseFileSystemTest.java
@@ -382,9 +382,11 @@ public class AlluxioJniFuseFileSystemTest {
   public void mkDir() throws Exception {
     long mode = 0755L;
     mFuseFs.mkdir("/foo/bar", mode);
+
     verify(mFileSystem).createDirectory(BASE_EXPECTED_URI.join("/foo/bar"),
         CreateDirectoryPOptions.newBuilder()
             .setMode(new alluxio.security.authorization.Mode((short) mode).toProto())
+            .setRecursive(true)
             .build());
   }
 

--- a/tests/src/test/java/alluxio/client/fuse/dora/readonly/stream/InStreamTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/dora/readonly/stream/InStreamTest.java
@@ -54,7 +54,8 @@ public class InStreamTest extends AbstractStreamTest {
   public void randomRead() throws Exception {
     AlluxioURI alluxioURI = getTestFileUri();
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
-    try (FuseFileStream inStream = createStream(alluxioURI)) {
+    AlluxioURI fileNameInAlluxio = new AlluxioURI(alluxioURI.getName());
+    try (FuseFileStream inStream = createStream(fileNameInAlluxio)) {
       ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN / 2);
       Assert.assertEquals(DEFAULT_FILE_LEN / 2,
           inStream.read(buffer, DEFAULT_FILE_LEN / 2, DEFAULT_FILE_LEN / 2));

--- a/tests/src/test/java/alluxio/client/fuse/dora/readonly/stream/InStreamTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/dora/readonly/stream/InStreamTest.java
@@ -31,8 +31,9 @@ public class InStreamTest extends AbstractStreamTest {
   public void createRead() throws Exception {
     AlluxioURI alluxioURI = getTestFileUri();
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
-    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
-    try (FuseFileStream inStream = createStream(alluxioURI)) {
+    AlluxioURI filePathInAlluxio = new AlluxioURI(alluxioURI.getName());
+    URIStatus uriStatus = mFileSystem.getStatus(filePathInAlluxio);
+    try (FuseFileStream inStream = createStream(filePathInAlluxio)) {
       Assert.assertEquals(uriStatus.getLength(), inStream.getFileStatus().getFileLength());
       ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN);
       Assert.assertEquals(DEFAULT_FILE_LEN, inStream.read(buffer, DEFAULT_FILE_LEN, 0));

--- a/tests/src/test/java/alluxio/client/fuse/dora/stream/InOrOutStreamOutTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/dora/stream/InOrOutStreamOutTest.java
@@ -41,6 +41,8 @@ public class InOrOutStreamOutTest extends OutStreamTest {
   @Test(expected = UnimplementedRuntimeException.class)
   public void read() throws Exception {
     AlluxioURI alluxioURI = getTestFileUri();
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     try (FuseFileStream outStream = createStream(alluxioURI, false)) {
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
       outStream.write(buffer, DEFAULT_FILE_LEN, 0);

--- a/tests/src/test/java/alluxio/client/fuse/dora/stream/OutStreamTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/dora/stream/OutStreamTest.java
@@ -83,6 +83,8 @@ public class OutStreamTest extends AbstractStreamTest {
   @Test (expected = FailedPreconditionRuntimeException.class)
   public void read() throws Exception {
     AlluxioURI alluxioURI = getTestFileUri();
+    mFileSystem.createDirectory(alluxioURI.getParent(),
+        CreateDirectoryPOptions.newBuilder().setRecursive(true).build());
     try (FuseFileStream outStream = createStream(alluxioURI, false)) {
       ByteBuffer buffer = BufferUtils.getIncreasingByteBuffer(DEFAULT_FILE_LEN);
       outStream.write(buffer, DEFAULT_FILE_LEN, 0);


### PR DESCRIPTION
Signed-off-by: Huang Hua <huanghua78@msn.com>

### What changes are proposed in this pull request?

In Dora client, we need to join the UFS root with the Alluxio file path before calling UfsBaseFileSystem operations.

### Why are the changes needed?

All input FilePath strings from client are Alluxio based file path. So, the root path of the UFS should be added before the Alluxio file path and be passed to UfsBaseFileSystem on client side. The file path returned from UfsBaseFileSystem.getStatus() and UfsBaseFileSystem.listStatus() also need to be stripped with its UFS root.

When the FileStatus is sent back from DoraWorker, the file path in FileInfo needs similar transformation.

### Does this PR introduce any user facing changes?

No
