### PR TITLE
Make workers register to all masters

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/RetryHandlingBlockMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/RetryHandlingBlockMasterClient.java
@@ -26,6 +26,8 @@ import alluxio.grpc.RemoveDecommissionedWorkerPOptions;
 import alluxio.grpc.ServiceType;
 import alluxio.grpc.WorkerLostStorageInfo;
 import alluxio.master.MasterClientContext;
+import alluxio.master.selectionpolicy.MasterSelectionPolicy;
+import alluxio.retry.RetryPolicy;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.BlockMasterInfo;
 import alluxio.wire.BlockMasterInfo.BlockMasterInfoField;
@@ -35,9 +37,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -57,6 +61,29 @@ public final class RetryHandlingBlockMasterClient extends AbstractMasterClient
    */
   public RetryHandlingBlockMasterClient(MasterClientContext conf) {
     super(conf);
+  }
+
+  /**
+   * Creates a new block master client.
+   *
+   * @param conf master client configuration
+   * @param address the master address the client connects to
+   */
+  public RetryHandlingBlockMasterClient(MasterClientContext conf, InetSocketAddress address) {
+    super(conf, MasterSelectionPolicy.Factory.specifiedMaster(address));
+  }
+
+  /**
+   * Creates a new block master client.
+   *
+   * @param conf master client configuration
+   * @param address the master address the client connects to
+   * @param retryPolicy retry policy to use
+   */
+  public RetryHandlingBlockMasterClient(
+      MasterClientContext conf, InetSocketAddress address,
+      Supplier<RetryPolicy> retryPolicy) {
+    super(conf, MasterSelectionPolicy.Factory.specifiedMaster(address), retryPolicy);
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/AbstractMasterClient.java
+++ b/core/common/src/main/java/alluxio/AbstractMasterClient.java
@@ -68,6 +68,21 @@ public abstract class AbstractMasterClient extends AbstractClient {
     mMasterSelectionPolicy = MasterSelectionPolicy.Factory.primaryMaster();
   }
 
+  /**
+   * Creates a new master client without a specific address.
+   * @param clientConf master client configuration
+   * @param selectionPolicy master selection policy: which master the client should connect to
+   * @param retryPolicySupplier retry policy to use
+   */
+  public AbstractMasterClient(
+      MasterClientContext clientConf,
+      MasterSelectionPolicy selectionPolicy,
+      Supplier<RetryPolicy> retryPolicySupplier) {
+    super(clientConf, retryPolicySupplier);
+    mMasterInquireClient = clientConf.getMasterInquireClient();
+    mMasterSelectionPolicy = selectionPolicy;
+  }
+
   @Override
   public synchronized InetSocketAddress getConfAddress() throws UnavailableException {
     return mMasterSelectionPolicy.getPrimaryMasterAddressCached(mMasterInquireClient);

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4557,7 +4557,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
-
+  public static final PropertyKey WORKER_BLOCK_HEARTBEAT_REPORT_CAPACITY_THRESHOLD =
+      intBuilder(Name.WORKER_BLOCK_HEARTBEAT_REPORT_CAPACITY_THRESHOLD)
+          .setDefaultValue(1_000_000)
+          .setDescription("To avoid OOM issue, in all master registration mode, "
+              + "after a failed worker-master block sync,"
+              + "if the block heartbeat report capacity exceeds a threshold, "
+              + "the worker will clear the reporter and set the worker state unregistered, "
+              + "so that the heartbeat thread can trigger a registration again.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.WORKER)
+          .build();
   public static final PropertyKey WORKER_PAGE_STORE_ASYNC_RESTORE_ENABLED =
       booleanBuilder(Name.WORKER_PAGE_STORE_ASYNC_RESTORE_ENABLED)
           .setDefaultValue(true)
@@ -8304,6 +8314,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.remote.io.slow.threshold";
     public static final String WORKER_BLOCK_MASTER_CLIENT_POOL_SIZE =
         "alluxio.worker.block.master.client.pool.size";
+    public static final String WORKER_BLOCK_HEARTBEAT_REPORT_CAPACITY_THRESHOLD =
+        "alluxio.worker.block.heartbeat.reporter.capacity.threshold";
     public static final String WORKER_PRINCIPAL = "alluxio.worker.principal";
     public static final String WORKER_PAGE_STORE_ASYNC_RESTORE_ENABLED =
         "alluxio.worker.page.store.async.restore.enabled";

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4532,8 +4532,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue(false)
           .setDescription("If enabled, workers will register themselves to all masters, "
               + "instead of primary master only. This can be used to save the "
-              + "master failover time because workers don't need to report the block locations "
-              + " to the new primary master. Can only be enabled when "
+              + "master failover time because the new primary immediately knows "
+              + "all existing workers and blocks. Can only be enabled when "
               + Name.STANDBY_MASTER_GRPC_ENABLED + " is turned on.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.ALL)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4527,6 +4527,27 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
+  public static final PropertyKey WORKER_REGISTER_TO_ALL_MASTERS =
+      booleanBuilder(Name.WORKER_REGISTER_TO_ALL_MASTERS)
+          .setDefaultValue(false)
+          .setDescription("If enabled, workers will register themselves to all masters, "
+              + "instead of primary master only. This can be used to save the "
+              + "master failover time because workers don't need to report the block locations "
+              + " to the new primary master. Can only be enabled when "
+              + Name.STANDBY_MASTER_GRPC_ENABLED + " is turned on.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.ALL)
+          .build();
+  public static final PropertyKey WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS =
+      durationBuilder(Name.WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS)
+          .setDefaultValue(format("${%s}", Name.WORKER_MASTER_CONNECT_RETRY_TIMEOUT))
+          .setDescription("The timeout of all master registration. If the worker can't "
+              + "connect to masters before this interval expires, the worker will exit. "
+              + "This timeout only takes effect when " + Name.WORKER_REGISTER_TO_ALL_MASTERS
+              + " is enabled.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.WORKER)
+          .build();
   public static final PropertyKey WORKER_REMOTE_IO_SLOW_THRESHOLD =
       durationBuilder(Name.WORKER_REMOTE_IO_SLOW_THRESHOLD)
           .setDefaultValue("10s")
@@ -8287,6 +8308,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.register.stream.response.timeout";
     public static final String WORKER_REGISTER_STREAM_COMPLETE_TIMEOUT =
         "alluxio.worker.register.stream.complete.timeout";
+    public static final String WORKER_REGISTER_TO_ALL_MASTERS =
+        "alluxio.worker.register.to.all.masters";
+    public static final String WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS =
+        "alluxio.worker.all.master.registration.timeout";
     public static final String WORKER_REMOTE_IO_SLOW_THRESHOLD =
         "alluxio.worker.remote.io.slow.threshold";
     public static final String WORKER_BLOCK_MASTER_CLIENT_POOL_SIZE =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4538,16 +4538,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.ALL)
           .build();
-  public static final PropertyKey WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS =
-      durationBuilder(Name.WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS)
-          .setDefaultValue(format("${%s}", Name.WORKER_MASTER_CONNECT_RETRY_TIMEOUT))
-          .setDescription("The timeout of all master registration. If the worker can't "
-              + "connect to masters before this interval expires, the worker will exit. "
-              + "This timeout only takes effect when " + Name.WORKER_REGISTER_TO_ALL_MASTERS
-              + " is enabled.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.WORKER)
-          .build();
   public static final PropertyKey WORKER_REMOTE_IO_SLOW_THRESHOLD =
       durationBuilder(Name.WORKER_REMOTE_IO_SLOW_THRESHOLD)
           .setDefaultValue("10s")
@@ -8310,8 +8300,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.register.stream.complete.timeout";
     public static final String WORKER_REGISTER_TO_ALL_MASTERS =
         "alluxio.worker.register.to.all.masters";
-    public static final String WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS =
-        "alluxio.worker.all.master.registration.timeout";
     public static final String WORKER_REMOTE_IO_SLOW_THRESHOLD =
         "alluxio.worker.remote.io.slow.threshold";
     public static final String WORKER_BLOCK_MASTER_CLIENT_POOL_SIZE =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -4557,14 +4557,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
-  public static final PropertyKey WORKER_BLOCK_HEARTBEAT_REPORT_CAPACITY_THRESHOLD =
-      intBuilder(Name.WORKER_BLOCK_HEARTBEAT_REPORT_CAPACITY_THRESHOLD)
+  public static final PropertyKey WORKER_BLOCK_HEARTBEAT_REPORT_SIZE_THRESHOLD =
+      intBuilder(Name.WORKER_BLOCK_HEARTBEAT_REPORT_SIZE_THRESHOLD)
           .setDefaultValue(1_000_000)
-          .setDescription("To avoid OOM issue, in all master registration mode, "
-              + "after a failed worker-master block sync,"
-              + "if the block heartbeat report capacity exceeds a threshold, "
-              + "the worker will clear the reporter and set the worker state unregistered, "
-              + "so that the heartbeat thread can trigger a registration again.")
+          .setDescription(
+              "When " + Name.WORKER_REGISTER_TO_ALL_MASTERS + "=true, "
+              + "because a worker will send block reports to all masters, "
+              + "we use a threshold to limit the unsent block report size in worker's memory. "
+              + "If the worker block heartbeat is larger than the threshold, "
+              + "we discard the heartbeat message and force "
+              + "the worker to register with that master with a full report."
+          )
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
@@ -8314,8 +8317,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.worker.remote.io.slow.threshold";
     public static final String WORKER_BLOCK_MASTER_CLIENT_POOL_SIZE =
         "alluxio.worker.block.master.client.pool.size";
-    public static final String WORKER_BLOCK_HEARTBEAT_REPORT_CAPACITY_THRESHOLD =
-        "alluxio.worker.block.heartbeat.reporter.capacity.threshold";
+    public static final String WORKER_BLOCK_HEARTBEAT_REPORT_SIZE_THRESHOLD =
+        "alluxio.worker.block.heartbeat.report.size.threshold";
     public static final String WORKER_PRINCIPAL = "alluxio.worker.principal";
     public static final String WORKER_PAGE_STORE_ASYNC_RESTORE_ENABLED =
         "alluxio.worker.page.store.async.restore.enabled";

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -2062,6 +2062,11 @@ public final class MetricKey implements Comparable<MetricKey> {
               + "Use this metric to monitor the RPC pressure on worker.")
           .setMetricType(MetricType.GAUGE)
           .build();
+  public static final MetricKey WORKER_MASTER_REGISTRATION_SUCCESS_COUNT =
+      new Builder("Worker.MasterRegistrationSuccessCount")
+          .setDescription("Total number of the succeed master registration.")
+          .setMetricType(MetricType.COUNTER)
+          .build();
 
   // Client metrics
   public static final MetricKey CLIENT_BLOCK_READ_CHUNK_REMOTE =

--- a/core/common/src/main/java/alluxio/worker/block/BlockHeartbeatReport.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockHeartbeatReport.java
@@ -78,7 +78,7 @@ public final class BlockHeartbeatReport {
   /**
    * @return the number of blocks in the report
    */
-  public int getBlockCount() {
+  public int getBlockChangeCount() {
     int count = mRemovedBlocks.size();
     for (List<Long> blocks: mAddedBlocks.values()) {
       count += blocks.size();

--- a/core/common/src/main/java/alluxio/worker/block/BlockHeartbeatReport.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockHeartbeatReport.java
@@ -74,4 +74,15 @@ public final class BlockHeartbeatReport {
   public Map<String, List<String>> getLostStorage() {
     return Collections.unmodifiableMap(mLostStorage);
   }
+
+  /**
+   * @return the number of blocks in the report
+   */
+  public int getBlockCount() {
+    int count = mRemovedBlocks.size();
+    for (List<Long> blocks: mAddedBlocks.values()) {
+      count += blocks.size();
+    }
+    return count;
+  }
 }

--- a/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -21,6 +21,7 @@ import alluxio.grpc.UfsReadOptions;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.wire.Configuration;
 import alluxio.wire.FileInfo;
+import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.SessionCleanable;
 import alluxio.worker.Worker;
 import alluxio.worker.block.io.BlockReader;
@@ -237,4 +238,9 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @return the block store
    */
   BlockStore getBlockStore();
+
+  /**
+   * @return the worker address
+   */
+  WorkerNetAddress getWorkerAddress();
 }

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -35,7 +35,6 @@ import alluxio.master.service.SimpleService;
 import alluxio.master.service.jvmmonitor.JvmMonitorService;
 import alluxio.master.service.metrics.MetricsService;
 import alluxio.master.service.rpc.RpcServerService;
-import alluxio.master.service.rpc.RpcServerStandbyGrpcService;
 import alluxio.master.service.web.WebServerService;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
@@ -450,14 +449,8 @@ public class AlluxioMasterProcess extends MasterProcess {
         primarySelector = new UfsJournalSingleMasterPrimarySelector();
       }
       AlluxioMasterProcess amp = new AlluxioMasterProcess(journalSystem, primarySelector);
-      if (Configuration.getBoolean(PropertyKey.STANDBY_MASTER_GRPC_ENABLED)) {
-        amp.registerService(
-            RpcServerStandbyGrpcService.Factory.create(
-                amp.getRpcBindAddress(), amp, amp.getRegistry()));
-      } else {
-        amp.registerService(
-            RpcServerService.Factory.create(amp.getRpcBindAddress(), amp, amp.getRegistry()));
-      }
+      amp.registerService(
+          RpcServerService.Factory.create(amp.getRpcBindAddress(), amp, amp.getRegistry()));
       amp.registerService(WebServerService.Factory.create(amp.getWebBindAddress(), amp));
       amp.registerService(MetricsService.Factory.create());
       amp.registerService(JvmMonitorService.Factory.create());

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -35,6 +35,7 @@ import alluxio.master.service.SimpleService;
 import alluxio.master.service.jvmmonitor.JvmMonitorService;
 import alluxio.master.service.metrics.MetricsService;
 import alluxio.master.service.rpc.RpcServerService;
+import alluxio.master.service.rpc.RpcServerStandbyGrpcService;
 import alluxio.master.service.web.WebServerService;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
@@ -449,8 +450,14 @@ public class AlluxioMasterProcess extends MasterProcess {
         primarySelector = new UfsJournalSingleMasterPrimarySelector();
       }
       AlluxioMasterProcess amp = new AlluxioMasterProcess(journalSystem, primarySelector);
-      amp.registerService(
-          RpcServerService.Factory.create(amp.getRpcBindAddress(), amp, amp.getRegistry()));
+      if (Configuration.getBoolean(PropertyKey.STANDBY_MASTER_GRPC_ENABLED)) {
+        amp.registerService(
+            RpcServerStandbyGrpcService.Factory.create(
+                amp.getRpcBindAddress(), amp, amp.getRegistry()));
+      } else {
+        amp.registerService(
+            RpcServerService.Factory.create(amp.getRpcBindAddress(), amp, amp.getRegistry()));
+      }
       amp.registerService(WebServerService.Factory.create(amp.getWebBindAddress(), amp));
       amp.registerService(MetricsService.Factory.create());
       amp.registerService(JvmMonitorService.Factory.create());

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -394,9 +394,9 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
   void removeDecommissionedWorker(long workerId) throws NotFoundException;
 
   /**
-   * Adds the worker id to a master. Both primary and standby master implement this endpoint.
+   * Notify the worker id to a master.
    * @param workerId the worker id
    * @param workerNetAddress the worker address
    */
-  void addWorkerId(long workerId, WorkerNetAddress workerNetAddress);
+  void notifyWorkerId(long workerId, WorkerNetAddress workerNetAddress);
 }

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -392,4 +392,11 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
    * @param workerId the workerId of target worker
    */
   void removeDecommissionedWorker(long workerId) throws NotFoundException;
+
+  /**
+   * Adds the worker id to a master. Both primary and standby master implement this endpoint.
+   * @param workerId the worker id
+   * @param workerNetAddress the worker address
+   */
+  void addWorkerId(long workerId, WorkerNetAddress workerNetAddress);
 }

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -15,6 +15,8 @@ import alluxio.RpcUtils;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.RegisterLeaseNotFoundException;
+import alluxio.grpc.AddWorkerIdPRequest;
+import alluxio.grpc.AddWorkerIdPResponse;
 import alluxio.grpc.BlockHeartbeatPRequest;
 import alluxio.grpc.BlockHeartbeatPResponse;
 import alluxio.grpc.BlockMasterWorkerServiceGrpc;
@@ -220,8 +222,9 @@ public final class BlockMasterWorkerServiceHandler extends
   }
 
   @Override
-  public void addWorkerId(alluxio.grpc.AddWorkerIdPRequest request,
-                          StreamObserver<alluxio.grpc.AddWorkerIdPResponse> responseObserver) {
+  public void addWorkerId(
+      AddWorkerIdPRequest request,
+      StreamObserver<AddWorkerIdPResponse> responseObserver) {
     RpcUtils.call(LOG, () -> {
       mBlockMaster.addWorkerId(request.getWorkerId(),
           GrpcUtils.fromProto(request.getWorkerNetAddress()));

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -222,9 +222,6 @@ public final class BlockMasterWorkerServiceHandler extends
   @Override
   public void addWorkerId(alluxio.grpc.AddWorkerIdPRequest request,
                           StreamObserver<alluxio.grpc.AddWorkerIdPResponse> responseObserver) {
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Received AddWorkerId {}", request);
-    }
     RpcUtils.call(LOG, () -> {
       mBlockMaster.addWorkerId(request.getWorkerId(),
           GrpcUtils.fromProto(request.getWorkerNetAddress()));

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -218,4 +218,17 @@ public final class BlockMasterWorkerServiceHandler extends
                     + "with LocationBlockIdListEntry objects %s", workerId, entryReport));
             }));
   }
+
+  @Override
+  public void addWorkerId(alluxio.grpc.AddWorkerIdPRequest request,
+                          StreamObserver<alluxio.grpc.AddWorkerIdPResponse> responseObserver) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Received AddWorkerId {}", request);
+    }
+    RpcUtils.call(LOG, () -> {
+      mBlockMaster.addWorkerId(request.getWorkerId(),
+          GrpcUtils.fromProto(request.getWorkerNetAddress()));
+      return alluxio.grpc.AddWorkerIdPResponse.getDefaultInstance();
+    }, "addWorkerId", "request=%s", responseObserver, request);
+  }
 }

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -15,8 +15,6 @@ import alluxio.RpcUtils;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.RegisterLeaseNotFoundException;
-import alluxio.grpc.AddWorkerIdPRequest;
-import alluxio.grpc.AddWorkerIdPResponse;
 import alluxio.grpc.BlockHeartbeatPRequest;
 import alluxio.grpc.BlockHeartbeatPResponse;
 import alluxio.grpc.BlockMasterWorkerServiceGrpc;
@@ -30,6 +28,8 @@ import alluxio.grpc.GetWorkerIdPRequest;
 import alluxio.grpc.GetWorkerIdPResponse;
 import alluxio.grpc.GrpcUtils;
 import alluxio.grpc.LocationBlockIdListEntry;
+import alluxio.grpc.NotifyWorkerIdPRequest;
+import alluxio.grpc.NotifyWorkerIdPResponse;
 import alluxio.grpc.RegisterWorkerPOptions;
 import alluxio.grpc.RegisterWorkerPRequest;
 import alluxio.grpc.RegisterWorkerPResponse;
@@ -222,13 +222,13 @@ public final class BlockMasterWorkerServiceHandler extends
   }
 
   @Override
-  public void addWorkerId(
-      AddWorkerIdPRequest request,
-      StreamObserver<AddWorkerIdPResponse> responseObserver) {
+  public void notifyWorkerId(
+      NotifyWorkerIdPRequest request,
+      StreamObserver<NotifyWorkerIdPResponse> responseObserver) {
     RpcUtils.call(LOG, () -> {
-      mBlockMaster.addWorkerId(request.getWorkerId(),
+      mBlockMaster.notifyWorkerId(request.getWorkerId(),
           GrpcUtils.fromProto(request.getWorkerNetAddress()));
-      return alluxio.grpc.AddWorkerIdPResponse.getDefaultInstance();
-    }, "addWorkerId", "request=%s", responseObserver, request);
+      return alluxio.grpc.NotifyWorkerIdPResponse.getDefaultInstance();
+    }, "notifyWorkerId", "request=%s", responseObserver, request);
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -34,6 +34,7 @@ import alluxio.grpc.ConfigProperty;
 import alluxio.grpc.GetRegisterLeasePRequest;
 import alluxio.grpc.GrpcService;
 import alluxio.grpc.GrpcUtils;
+import alluxio.grpc.NodeState;
 import alluxio.grpc.RegisterWorkerPOptions;
 import alluxio.grpc.RegisterWorkerPRequest;
 import alluxio.grpc.ServiceType;
@@ -67,6 +68,7 @@ import alluxio.security.authentication.ClientContextServerInjector;
 import alluxio.util.CommonUtils;
 import alluxio.util.IdUtils;
 import alluxio.util.ThreadFactoryUtils;
+import alluxio.util.WaitForOptions;
 import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.util.executor.ExecutorServiceFactory;
 import alluxio.util.network.NetworkAddressUtils;
@@ -277,6 +279,11 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
   private final RegisterLeaseManager mRegisterLeaseManager = new RegisterLeaseManager();
 
+  private final HashMap<Long, WorkerNetAddress> mWorkerIdMap = new HashMap<>();
+
+  private final boolean mWorkerRegisterToAllMasters = Configuration.getBoolean(
+      PropertyKey.WORKER_REGISTER_TO_ALL_MASTERS);
+
   /**
    * Creates a new instance of {@link DefaultBlockMaster}.
    *
@@ -374,6 +381,29 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
       }
       mBlockMetaStore.putBlock(blockInfoEntry.getBlockId(),
           BlockMeta.newBuilder().setLength(blockInfoEntry.getLength()).build());
+
+      // This can be called when
+      // 1. The master is replaying the journal.
+      // 2. A standby master is applying a journal entry from the primary master.
+      if (blockInfoEntry.hasBlockLocation()) {
+        alluxio.grpc.BlockLocation blockLocation = blockInfoEntry.getBlockLocation();
+        long workerId = blockLocation.getWorkerId();
+        MasterWorkerInfo worker = mWorkers.getFirstByField(ID_INDEX, workerId);
+        if (worker == null) {
+          // The master is replaying journal or somehow the worker is not there anymore
+          // We do not add the BlockLocation because the workerId is not reliable anymore
+          // If the worker comes back, it will register and BlockLocation will be added then
+          return true;
+        }
+        // The master is running and the journal is from an existing worker
+        mBlockMetaStore.addLocation(blockInfoEntry.getBlockId(), BlockLocation.newBuilder()
+            .setWorkerId(workerId)
+            .setTier(blockLocation.getTierAlias())
+            .setMediumType(blockLocation.getMediumType())
+            .build());
+        worker.addBlock(blockInfoEntry.getBlockId());
+        LOG.debug("Added BlockLocation for {} to worker {}", blockInfoEntry.getBlockId(), workerId);
+      }
     } else {
       return false;
     }
@@ -480,7 +510,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
   @Override
   public void start(Boolean isLeader) throws IOException {
     super.start(isLeader);
-    if (isLeader) {
+    if (isLeader || mWorkerRegisterToAllMasters) {
       getExecutorService().submit(new HeartbeatThread(
           HeartbeatContext.MASTER_LOST_WORKER_DETECTION, new LostWorkerDetectionHeartbeatExecutor(),
           () -> Configuration.getMs(PropertyKey.MASTER_LOST_WORKER_DETECTION_INTERVAL),
@@ -920,9 +950,23 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
                   block.get().getLength(), length);
             } else {
               mBlockMetaStore.putBlock(blockId, BlockMeta.newBuilder().setLength(length).build());
-              BlockInfoEntry blockInfo =
-                  BlockInfoEntry.newBuilder().setBlockId(blockId).setLength(length).build();
-              journalContext.append(JournalEntry.newBuilder().setBlockInfo(blockInfo).build());
+              BlockInfoEntry.Builder blockInfoBuilder =
+                  BlockInfoEntry.newBuilder().setBlockId(blockId).setLength(length);
+              if (mWorkerRegisterToAllMasters) {
+                blockInfoBuilder
+                    .setBlockId(blockId)
+                    .setLength(length)
+                    .setBlockLocation(
+                        alluxio.grpc.BlockLocation.newBuilder()
+                            .setWorkerId(workerId)
+                            .setMediumType(mediumType)
+                            .setTierAlias(tierAlias)
+                            .setWorkerAddress(GrpcUtils.toProto(worker.getWorkerAddress()))
+                            .build()
+                    );
+              }
+              journalContext.append(
+                  JournalEntry.newBuilder().setBlockInfo(blockInfoBuilder.build()).build());
             }
           }
           // Update the block metadata with the new worker location.
@@ -1091,13 +1135,62 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     }
 
     // Generate a new worker id.
-    long workerId = IdUtils.getRandomNonNegativeLong();
-    while (!mTempWorkers.add(new MasterWorkerInfo(workerId, workerNetAddress))) {
-      workerId = IdUtils.getRandomNonNegativeLong();
+    long workerId = generateWorkerId(workerNetAddress, mWorkerRegisterToAllMasters);
+    if (!mTempWorkers.add(new MasterWorkerInfo(workerId, workerNetAddress))) {
+      throw new RuntimeException("Duplicated worker ID for " + workerId + ": " + workerNetAddress);
     }
-
     LOG.info("getWorkerId(): WorkerNetAddress: {} id: {}", workerNetAddress, workerId);
     return workerId;
+  }
+
+  @Override
+  public Map<ServiceType, GrpcService> getStandbyServices() {
+    return getServices();
+  }
+
+  @Override
+  public void addWorkerId(long workerId, WorkerNetAddress workerNetAddress) {
+    MasterWorkerInfo existingWorker = mWorkers.getFirstByField(ID_INDEX, workerId);
+    if (existingWorker != null) {
+      LOG.warn("A registered worker {} comes again from {}",
+          workerId, existingWorker.getWorkerAddress());
+      return;
+    }
+
+    existingWorker = findUnregisteredWorker(workerId);
+    if (existingWorker != null) {
+      LOG.warn("An unregistered worker {} comes again from {}",
+          workerId, existingWorker.getWorkerAddress());
+      return;
+    }
+
+    if (!mTempWorkers.add(new MasterWorkerInfo(workerId, workerNetAddress))) {
+      throw new RuntimeException("Duplicated worker ID for " + workerId + ": " + workerNetAddress);
+    }
+  }
+
+  // TODO(elega) we change the way worker id generates and makes worker ids
+  // change when we toggle the workers registering to all masters feature flag,
+  // and might cause backward compatibility issues. Need to fix this later.
+  @VisibleForTesting
+  synchronized long generateWorkerId(WorkerNetAddress addr, boolean workerRegisterToAllMasters) {
+    if (workerRegisterToAllMasters) {
+      long workerId = IdUtils.getRandomNonNegativeLong();
+      while (mWorkerIdMap.containsKey(workerId)) {
+        workerId = IdUtils.getRandomNonNegativeLong();
+      }
+      mWorkerIdMap.put(workerId, addr);
+      return workerId;
+    }
+
+    // When standby master read feature is enabled,
+    // we use a deterministic algo to generate the same worker ID for the same address.
+    long hash = addr.hashCode() & Integer.MAX_VALUE;
+    while (mWorkerIdMap.containsKey(hash) && !addr.equals(mWorkerIdMap.get(hash))) {
+      hash = (hash + 1) & Integer.MAX_VALUE;
+    }
+    mWorkerIdMap.put(hash, addr);
+    return hash;
   }
 
   @Override
@@ -1309,6 +1402,35 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     // is time-consuming or triggers GC, the worker does not get marked as lost
     // by the LostWorkerDetectionHeartbeatExecutor
     worker.updateLastUpdatedTimeMs();
+
+    if (mWorkerRegisterToAllMasters && mPrimarySelector.getState() == NodeState.STANDBY) {
+      final List<Long> blockIdsToWait = new ArrayList<>();
+      for (long addedBlockId : addedBlocks.values().stream().flatMap(Collection::stream).collect(
+          Collectors.toList())) {
+        if (!mBlockMetaStore.getBlock(addedBlockId).isPresent()) {
+          blockIdsToWait.add(addedBlockId);
+        }
+      }
+      try {
+        CommonUtils.waitFor(
+            "Wait for blocks being committed on master before adding block locations",
+            () -> blockIdsToWait.stream().allMatch(it -> mBlockMetaStore.getBlock(it).isPresent()),
+                WaitForOptions.defaults().setInterval(200).setTimeoutMs(1000)
+        );
+      } catch (InterruptedException | TimeoutException e) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");
+        for (long blockIdToWait: blockIdsToWait) {
+          if (!mBlockMetaStore.getBlock(blockIdToWait).isPresent()) {
+            sb.append(blockIdToWait);
+            sb.append(" ,");
+          }
+        }
+        sb.append("]");
+        LOG.warn("Adding block ids {} for worker {} but these blocks don't exist. "
+            + "These blocks will be ignored", sb, workerId);
+      }
+    }
 
     // The address is final, no need for locking
     processWorkerMetrics(worker.getWorkerAddress().getHost(), metrics);
@@ -1748,5 +1870,13 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
     }
 
     private Metrics() {} // prevent instantiation
+  }
+
+  /**
+   * @return the block meta store
+   */
+  @VisibleForTesting
+  public BlockMetaStore getBlockMetaStore() {
+    return mBlockMetaStore;
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1419,7 +1419,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
       processWorkerRemovedBlocks(worker, removedBlockIds, false);
       processWorkerAddedBlocks(worker, addedBlocks);
       Set<Long> toRemoveBlocks = worker.getToRemoveBlocks();
-      if (toRemoveBlocks.isEmpty()) {
+      if (toRemoveBlocks.isEmpty() || mPrimarySelector.getState() == NodeState.STANDBY) {
         workerCommand = Command.newBuilder().setCommandType(CommandType.Nothing).build();
       } else {
         workerCommand = Command.newBuilder().setCommandType(CommandType.Free)

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -285,6 +285,9 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
   private final boolean mWorkerRegisterToAllMasters = Configuration.getBoolean(
       PropertyKey.WORKER_REGISTER_TO_ALL_MASTERS);
 
+  private final boolean mStandbyMasterRpcEnabled = Configuration.getBoolean(
+      PropertyKey.STANDBY_MASTER_GRPC_ENABLED);
+
   /**
    * Creates a new instance of {@link DefaultBlockMaster}.
    *
@@ -1131,7 +1134,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
 
   @Override
   public long getWorkerId(WorkerNetAddress workerNetAddress) {
-    if (mPrimarySelector.getState() == NodeState.STANDBY) {
+    if (mStandbyMasterRpcEnabled && mPrimarySelector.getState() == NodeState.STANDBY) {
       throw new UnavailableRuntimeException(
           "GetWorkerId operation is not supported on standby masters");
     }

--- a/core/server/master/src/test/java/alluxio/master/AlwaysPrimaryPrimarySelector.java
+++ b/core/server/master/src/test/java/alluxio/master/AlwaysPrimaryPrimarySelector.java
@@ -1,0 +1,63 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master;
+
+import alluxio.grpc.NodeState;
+import alluxio.util.interfaces.Scoped;
+
+import java.net.InetSocketAddress;
+import java.util.function.Consumer;
+
+/**
+ * A test primary selector which is always primary.
+ */
+public final class AlwaysPrimaryPrimarySelector implements PrimarySelector {
+  @Override
+  public void start(InetSocketAddress localAddress) {
+    // Nothing to do.
+  }
+
+  @Override
+  public void stop() {
+    // Nothing to do.
+  }
+
+  @Override
+  public NodeState getState() {
+    return NodeState.PRIMARY;
+  }
+
+  @Override
+  public NodeState getStateUnsafe() {
+    return NodeState.PRIMARY;
+  }
+
+  @Override
+  public Scoped onStateChange(Consumer<NodeState> listener) {
+    // State never changes.
+    return () -> { };
+  }
+
+  @Override
+  public void waitForState(NodeState state) throws InterruptedException {
+    switch (state) {
+      case PRIMARY:
+        return;
+      case STANDBY:
+        // Never happening
+        Thread.sleep(Long.MAX_VALUE);
+        break;
+      default:
+        throw new IllegalStateException("Unknown primary selector state: " + state);
+    }
+  }
+}

--- a/core/server/master/src/test/java/alluxio/master/MasterTestUtils.java
+++ b/core/server/master/src/test/java/alluxio/master/MasterTestUtils.java
@@ -50,7 +50,19 @@ public final class MasterTestUtils {
   public static CoreMasterContext testMasterContext(JournalSystem journalSystem,
       UserState userState) {
     return testMasterContext(journalSystem, userState,
-        HeapBlockMetaStore::new, x -> new HeapInodeStore());
+        HeapBlockMetaStore::new, x -> new HeapInodeStore(), new AlwaysStandbyPrimarySelector());
+  }
+
+  /**
+   * @return a basic master context for the purpose of testing
+   * @param journalSystem a journal system to use in the context
+   * @param userState the user state to use in the context
+   * @param primarySelector the primary selector
+   */
+  public static CoreMasterContext testMasterContext(JournalSystem journalSystem,
+      UserState userState, PrimarySelector primarySelector) {
+    return testMasterContext(journalSystem, userState,
+        HeapBlockMetaStore::new, x -> new HeapInodeStore(), primarySelector);
   }
 
   /**
@@ -63,10 +75,30 @@ public final class MasterTestUtils {
   public static CoreMasterContext testMasterContext(
       JournalSystem journalSystem, UserState userState,
       BlockMetaStore.Factory blockStoreFactory,
-      InodeStore.Factory inodeStoreFactory) {
+      InodeStore.Factory inodeStoreFactory
+  ) {
+    return testMasterContext(
+        journalSystem, userState, blockStoreFactory,
+        inodeStoreFactory, new AlwaysPrimaryPrimarySelector());
+  }
+
+  /**
+   * @return a basic master context for the purpose of testing
+   * @param journalSystem a journal system to use in the context
+   * @param userState the user state to use in the context
+   * @param blockStoreFactory a factory to create {@link BlockMetaStore}
+   * @param inodeStoreFactory a factory to create {@link InodeStore}
+   * @param primarySelector the primary selector
+   */
+  public static CoreMasterContext testMasterContext(
+      JournalSystem journalSystem, UserState userState,
+      BlockMetaStore.Factory blockStoreFactory,
+      InodeStore.Factory inodeStoreFactory,
+      PrimarySelector primarySelector
+  ) {
     return CoreMasterContext.newBuilder()
         .setJournalSystem(journalSystem)
-        .setPrimarySelector(new AlwaysStandbyPrimarySelector())
+        .setPrimarySelector(primarySelector)
         .setUserState(userState)
         .setSafeModeManager(new TestSafeModeManager())
         .setBackupManager(mock(BackupManager.class))

--- a/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -29,6 +29,7 @@ import alluxio.grpc.WorkerLostStorageInfo;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.HeartbeatScheduler;
 import alluxio.heartbeat.ManuallyScheduleHeartbeat;
+import alluxio.master.AlwaysPrimaryPrimarySelector;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.MasterRegistry;
 import alluxio.master.MasterTestUtils;
@@ -113,7 +114,9 @@ public class BlockMasterTest {
     mRegistry = new MasterRegistry();
     mMetrics = Lists.newArrayList();
     JournalSystem journalSystem = new NoopJournalSystem();
-    CoreMasterContext masterContext = MasterTestUtils.testMasterContext();
+    CoreMasterContext masterContext = MasterTestUtils.testMasterContext(
+        new NoopJournalSystem(), null, new AlwaysPrimaryPrimarySelector()
+    );
     mMetricsMaster = new MetricsMasterFactory().create(mRegistry, masterContext);
     mClock = new ManualClock();
     mExecutorService =

--- a/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -12,6 +12,7 @@
 package alluxio.master.block;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -514,5 +515,30 @@ public class BlockMasterTest {
     mRegistry.stop();
     assertTrue(mExecutorService.isShutdown());
     assertTrue(mExecutorService.isTerminated());
+  }
+
+  @Test
+  public void generateWorkerId() {
+    WorkerNetAddress address1 = new WorkerNetAddress().setHost("FB");
+    WorkerNetAddress address2 = new WorkerNetAddress().setHost("Ea");
+    WorkerNetAddress address3 = new WorkerNetAddress().setHost("localhost");
+
+    // FB and Ea have the same hash code in java
+    assertEquals(address1.hashCode(), address2.hashCode());
+
+    long id1 = ((DefaultBlockMaster) mBlockMaster).generateWorkerId(address1, false);
+    long id2 = ((DefaultBlockMaster) mBlockMaster).generateWorkerId(address2, false);
+    long id3 = ((DefaultBlockMaster) mBlockMaster).generateWorkerId(address3, false);
+
+    assertNotEquals(id1, id2);
+    assertNotEquals(id2, id3);
+    assertNotEquals(id1, id3);
+
+    long id4 = ((DefaultBlockMaster) mBlockMaster).generateWorkerId(address1, true);
+    long id5 = ((DefaultBlockMaster) mBlockMaster).generateWorkerId(address2, true);
+    long id6 = ((DefaultBlockMaster) mBlockMaster).generateWorkerId(address3, true);
+    assertNotEquals(id4, id5);
+    assertNotEquals(id4, id6);
+    assertNotEquals(id5, id6);
   }
 }

--- a/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/BlockMasterTest.java
@@ -12,7 +12,6 @@
 package alluxio.master.block;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -515,30 +514,5 @@ public class BlockMasterTest {
     mRegistry.stop();
     assertTrue(mExecutorService.isShutdown());
     assertTrue(mExecutorService.isTerminated());
-  }
-
-  @Test
-  public void generateWorkerId() {
-    WorkerNetAddress address1 = new WorkerNetAddress().setHost("FB");
-    WorkerNetAddress address2 = new WorkerNetAddress().setHost("Ea");
-    WorkerNetAddress address3 = new WorkerNetAddress().setHost("localhost");
-
-    // FB and Ea have the same hash code in java
-    assertEquals(address1.hashCode(), address2.hashCode());
-
-    long id1 = ((DefaultBlockMaster) mBlockMaster).generateWorkerId(address1, false);
-    long id2 = ((DefaultBlockMaster) mBlockMaster).generateWorkerId(address2, false);
-    long id3 = ((DefaultBlockMaster) mBlockMaster).generateWorkerId(address3, false);
-
-    assertNotEquals(id1, id2);
-    assertNotEquals(id2, id3);
-    assertNotEquals(id1, id3);
-
-    long id4 = ((DefaultBlockMaster) mBlockMaster).generateWorkerId(address1, true);
-    long id5 = ((DefaultBlockMaster) mBlockMaster).generateWorkerId(address2, true);
-    long id6 = ((DefaultBlockMaster) mBlockMaster).generateWorkerId(address3, true);
-    assertNotEquals(id4, id5);
-    assertNotEquals(id4, id6);
-    assertNotEquals(id5, id6);
   }
 }

--- a/core/server/master/src/test/java/alluxio/master/block/ConcurrentBlockMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/block/ConcurrentBlockMasterTest.java
@@ -27,9 +27,11 @@ import alluxio.grpc.RegisterWorkerPOptions;
 import alluxio.grpc.StorageList;
 import alluxio.heartbeat.HeartbeatContext;
 import alluxio.heartbeat.ManuallyScheduleHeartbeat;
+import alluxio.master.AlwaysPrimaryPrimarySelector;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.MasterRegistry;
 import alluxio.master.MasterTestUtils;
+import alluxio.master.journal.noop.NoopJournalSystem;
 import alluxio.master.metrics.MetricsMaster;
 import alluxio.master.metrics.MetricsMasterFactory;
 import alluxio.proto.meta.Block;
@@ -109,7 +111,9 @@ public class ConcurrentBlockMasterTest {
   @Before
   public void before() throws Exception {
     mRegistry = new MasterRegistry();
-    mMasterContext = MasterTestUtils.testMasterContext();
+    mMasterContext = MasterTestUtils.testMasterContext(
+        new NoopJournalSystem(), null, new AlwaysPrimaryPrimarySelector()
+    );
     mMetricsMaster = new MetricsMasterFactory().create(mRegistry, mMasterContext);
     mClock = new ManualClock();
     mExecutorService =

--- a/core/server/worker/src/main/java/alluxio/worker/block/AllMasterRegistrationBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AllMasterRegistrationBlockWorker.java
@@ -11,31 +11,15 @@
 
 package alluxio.worker.block;
 
-import alluxio.ProcessUtils;
 import alluxio.Sessions;
-import alluxio.conf.Configuration;
-import alluxio.conf.PropertyKey;
-import alluxio.exception.status.UnavailableException;
-import alluxio.heartbeat.HeartbeatContext;
-import alluxio.heartbeat.HeartbeatThread;
-import alluxio.security.user.ServerUserState;
-import alluxio.util.CommonUtils;
-import alluxio.util.ConfigurationUtils;
-import alluxio.util.WaitForOptions;
 import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.file.FileSystemMasterClient;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -47,12 +31,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 public class AllMasterRegistrationBlockWorker extends DefaultBlockWorker {
   private static final Logger LOG = LoggerFactory.getLogger(AllMasterRegistrationBlockWorker.class);
-  private static final long WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS =
-      Configuration.getMs(PropertyKey.WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS);
-  private final Map<InetSocketAddress, SpecificMasterBlockSync>
-      mMasterSyncOperators = new HashMap<>();
-
-  private BlockMasterClientPool.Factory mBlockMasterClientPoolFactory;
+  private BlockSyncMasterGroup mBlockSyncMasterGroup;
 
   /**
    * Constructs a block worker when workers register to all masters.
@@ -68,80 +47,29 @@ public class AllMasterRegistrationBlockWorker extends DefaultBlockWorker {
       FileSystemMasterClient fileSystemMasterClient, Sessions sessions,
       BlockStore blockStore, AtomicReference<Long> workerId) {
     super(blockMasterClientPool, fileSystemMasterClient, sessions, blockStore, workerId);
-    mBlockMasterClientPoolFactory = new BlockMasterClientPool.Factory();
-  }
-
-  @VisibleForTesting
-  void setBlockMasterClientPoolFactory(BlockMasterClientPool.Factory factory) {
-    mBlockMasterClientPoolFactory = factory;
   }
 
   @Override
-  protected void setupBlockMasterSync() throws IOException {
-    // Prepare one pool for each master because there are concurrent requests
-    List<InetSocketAddress> masterAddresses =
-        ConfigurationUtils.getMasterRpcAddresses(Configuration.global());
-
-    // Create a client pool to each master
-    // TODO(jiacheng/elega): handle master quorum changes
-    Map<InetSocketAddress, BlockMasterClientPool> masterClientPools = new HashMap<>();
-    for (InetSocketAddress masterAddr : masterAddresses) {
-      BlockMasterClientPool masterClientPool = mBlockMasterClientPoolFactory.create(masterAddr);
-      masterClientPools.put(masterAddr, masterClientPool);
-      mResourceCloser.register(masterClientPool);
-      BlockHeartbeatReporter heartbeatReporter = new BlockHeartbeatReporter();
-      mBlockStore.registerBlockStoreEventListener(heartbeatReporter);
-      // Setup BlockMasterSync
-      SpecificMasterBlockSync blockMasterSync = mResourceCloser
-          .register(new SpecificMasterBlockSync(
-              this, mWorkerId, mAddress, masterClientPool, heartbeatReporter));
-      // Register each BlockMasterSync to the block events on this worker
-      getExecutorService()
-          .submit(new HeartbeatThread(HeartbeatContext.WORKER_BLOCK_SYNC, blockMasterSync,
-              () -> Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS),
-              Configuration.global(), ServerUserState.global()));
-      mMasterSyncOperators.put(masterAddr, blockMasterSync);
-      LOG.info("Kick off BlockMasterSync with master {}", masterAddr);
-    }
-  }
-
-  private void waitForPrimaryMasterRegistrationComplete()
-      throws UnavailableException {
-    InetSocketAddress primaryMasterAddress =
-        (InetSocketAddress) mFileSystemMasterClient.getRemoteSockAddress();
-
-    SpecificMasterBlockSync primaryMasterSync =
-        mMasterSyncOperators.get(primaryMasterAddress);
-    Preconditions.checkNotNull(
-        primaryMasterSync, "Primary master block sync should not be null");
-    try {
-      CommonUtils.waitFor(this + " to start",
-          primaryMasterSync::isRegistered,
-          WaitForOptions.defaults().setTimeoutMs((int) WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS));
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      LOG.warn("Exit the worker on interruption", e);
-      throw new RuntimeException(e);
-    } catch (TimeoutException e) {
-      ProcessUtils.fatalError(LOG, e, "Failed to register with primary master");
-    }
-    LOG.info("The worker has registered with primary master, address {}",
-        mFileSystemMasterClient.getRemoteSockAddress());
+  protected void setupBlockMasterSync() {
+    mBlockSyncMasterGroup =
+        BlockSyncMasterGroup.Factory.createAllMasterSync(this);
+    mResourceCloser.register(mBlockSyncMasterGroup);
+    mBlockSyncMasterGroup.start(getExecutorService());
   }
 
   @Override
   public void start(WorkerNetAddress address) throws IOException {
     super.start(address);
-    // Because standby masters do not take read requests,
-    // workers can start as long as it has registered to the primary master.
-    // The block changes will be report to standby masters later once the registration is done.
-    waitForPrimaryMasterRegistrationComplete();
+
+    InetSocketAddress primaryMasterAddress =
+        (InetSocketAddress) mFileSystemMasterClient.getRemoteSockAddress();
+    mBlockSyncMasterGroup.waitForPrimaryMasterRegistrationComplete(primaryMasterAddress);
   }
 
   /**
-   * @return the master sync operators
+   * @return the block sync master group
    */
-  public Map<InetSocketAddress, SpecificMasterBlockSync> getMasterSyncOperators() {
-    return mMasterSyncOperators;
+  public BlockSyncMasterGroup getBlockSyncMasterGroup() {
+    return mBlockSyncMasterGroup;
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/AllMasterRegistrationBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AllMasterRegistrationBlockWorker.java
@@ -63,6 +63,9 @@ public class AllMasterRegistrationBlockWorker extends DefaultBlockWorker {
 
     InetSocketAddress primaryMasterAddress =
         (InetSocketAddress) mFileSystemMasterClient.getRemoteSockAddress();
+    // Registrations on standby masters are not required to complete for starting a worker
+    // because standby masters do not serve read requests.
+    // Standby masters will catch up following block location changes via worker heartbeats.
     mBlockSyncMasterGroup.waitForPrimaryMasterRegistrationComplete(primaryMasterAddress);
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/AllMasterRegistrationBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AllMasterRegistrationBlockWorker.java
@@ -1,0 +1,147 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block;
+
+import alluxio.ProcessUtils;
+import alluxio.Sessions;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.status.UnavailableException;
+import alluxio.heartbeat.HeartbeatContext;
+import alluxio.heartbeat.HeartbeatThread;
+import alluxio.security.user.ServerUserState;
+import alluxio.util.CommonUtils;
+import alluxio.util.ConfigurationUtils;
+import alluxio.util.WaitForOptions;
+import alluxio.wire.WorkerNetAddress;
+import alluxio.worker.file.FileSystemMasterClient;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * The class is responsible for managing all top level components of the Block Worker.
+ *
+ * This block worker implementation register workers to all masters.
+ */
+@NotThreadSafe
+public class AllMasterRegistrationBlockWorker extends DefaultBlockWorker {
+  private static final Logger LOG = LoggerFactory.getLogger(AllMasterRegistrationBlockWorker.class);
+  private static final long WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS =
+      Configuration.getMs(PropertyKey.WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS);
+  private final Map<InetSocketAddress, SpecificMasterBlockSync>
+      mMasterSyncOperators = new HashMap<>();
+
+  private BlockMasterClientPool.Factory mBlockMasterClientPoolFactory;
+
+  /**
+   * Constructs a block worker when workers register to all masters.
+   *
+   * @param blockMasterClientPool a client pool for talking to the block master
+   * @param fileSystemMasterClient a client for talking to the file system master
+   * @param sessions an object for tracking and cleaning up client sessions
+   * @param blockStore an Alluxio block store
+   * @param workerId worker id
+   */
+  public AllMasterRegistrationBlockWorker(
+      BlockMasterClientPool blockMasterClientPool,
+      FileSystemMasterClient fileSystemMasterClient, Sessions sessions,
+      BlockStore blockStore, AtomicReference<Long> workerId) {
+    super(blockMasterClientPool, fileSystemMasterClient, sessions, blockStore, workerId);
+    mBlockMasterClientPoolFactory = new BlockMasterClientPool.Factory();
+  }
+
+  @VisibleForTesting
+  void setBlockMasterClientPoolFactory(BlockMasterClientPool.Factory factory) {
+    mBlockMasterClientPoolFactory = factory;
+  }
+
+  @Override
+  protected void setupBlockMasterSync() throws IOException {
+    // Prepare one pool for each master because there are concurrent requests
+    List<InetSocketAddress> masterAddresses =
+        ConfigurationUtils.getMasterRpcAddresses(Configuration.global());
+
+    // Create a client pool to each master
+    // TODO(jiacheng/elega): handle master quorum changes
+    Map<InetSocketAddress, BlockMasterClientPool> masterClientPools = new HashMap<>();
+    for (InetSocketAddress masterAddr : masterAddresses) {
+      BlockMasterClientPool masterClientPool = mBlockMasterClientPoolFactory.create(masterAddr);
+      masterClientPools.put(masterAddr, masterClientPool);
+      mResourceCloser.register(masterClientPool);
+      BlockHeartbeatReporter heartbeatReporter = new BlockHeartbeatReporter();
+      mBlockStore.registerBlockStoreEventListener(heartbeatReporter);
+      // Setup BlockMasterSync
+      SpecificMasterBlockSync blockMasterSync = mResourceCloser
+          .register(new SpecificMasterBlockSync(
+              this, mWorkerId, mAddress, masterClientPool, heartbeatReporter));
+      // Register each BlockMasterSync to the block events on this worker
+      getExecutorService()
+          .submit(new HeartbeatThread(HeartbeatContext.WORKER_BLOCK_SYNC, blockMasterSync,
+              (int) Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS),
+              Configuration.global(), ServerUserState.global()));
+      mMasterSyncOperators.put(masterAddr, blockMasterSync);
+      LOG.info("Kick off BlockMasterSync with master {}", masterAddr);
+    }
+  }
+
+  private void waitForPrimaryMasterRegistrationComplete()
+      throws UnavailableException {
+    InetSocketAddress primaryMasterAddress =
+        (InetSocketAddress) mFileSystemMasterClient.getRemoteSockAddress();
+
+    SpecificMasterBlockSync primaryMasterSync =
+        mMasterSyncOperators.get(primaryMasterAddress);
+    Preconditions.checkNotNull(
+        primaryMasterSync, "Primary master block sync should not be null");
+    try {
+      CommonUtils.waitFor(this + " to start",
+          primaryMasterSync::isRegistered,
+          WaitForOptions.defaults().setTimeoutMs((int) WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warn("Exit the worker on interruption", e);
+      throw new RuntimeException(e);
+    } catch (TimeoutException e) {
+      ProcessUtils.fatalError(LOG, e, "Failed to register with primary master");
+    }
+    LOG.info("The worker has registered with primary master, address {}",
+        mFileSystemMasterClient.getRemoteSockAddress());
+  }
+
+  @Override
+  public void start(WorkerNetAddress address) throws IOException {
+    super.start(address);
+    // Because standby masters do not take read requests,
+    // workers can start as long as it has registered to the primary master.
+    // The block changes will be report to standby masters later once the registration is done.
+    waitForPrimaryMasterRegistrationComplete();
+  }
+
+  /**
+   * @return the master sync operators
+   */
+  public Map<InetSocketAddress, SpecificMasterBlockSync> getMasterSyncOperators() {
+    return mMasterSyncOperators;
+  }
+}

--- a/core/server/worker/src/main/java/alluxio/worker/block/AllMasterRegistrationBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AllMasterRegistrationBlockWorker.java
@@ -98,7 +98,7 @@ public class AllMasterRegistrationBlockWorker extends DefaultBlockWorker {
       // Register each BlockMasterSync to the block events on this worker
       getExecutorService()
           .submit(new HeartbeatThread(HeartbeatContext.WORKER_BLOCK_SYNC, blockMasterSync,
-              (int) Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS),
+              () -> Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS),
               Configuration.global(), ServerUserState.global()));
       mMasterSyncOperators.put(masterAddr, blockMasterSync);
       LOG.info("Kick off BlockMasterSync with master {}", masterAddr);

--- a/core/server/worker/src/main/java/alluxio/worker/block/AllMasterRegistrationBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/AllMasterRegistrationBlockWorker.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * The class is responsible for managing all top level components of the Block Worker.
+ * The class is responsible for managing all top level components of BlockWorker.
  *
  * This block worker implementation register workers to all masters.
  */

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockHeartbeatReporter.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockHeartbeatReporter.java
@@ -34,7 +34,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * through {@link alluxio.worker.block.BlockWorker#commitBlock(long, long, boolean)}.
  */
 @ThreadSafe
-public final class BlockHeartbeatReporter extends AbstractBlockStoreEventListener {
+public class BlockHeartbeatReporter extends AbstractBlockStoreEventListener {
   private static final Logger LOG = LoggerFactory.getLogger(BlockHeartbeatReporter.class);
 
   /** Lock for operations on the removed and added block collections. */
@@ -83,6 +83,17 @@ public final class BlockHeartbeatReporter extends AbstractBlockStoreEventListene
       mRemovedBlocks.clear();
       mLostStorage.clear();
       return report;
+    }
+  }
+
+  /**
+   * Clears the internal states of the reporter.
+   */
+  public void clear() {
+    synchronized (mLock) {
+      mAddedBlocks.clear();
+      mRemovedBlocks.clear();
+      mLostStorage.clear();
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockHeartbeatReporter.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockHeartbeatReporter.java
@@ -143,15 +143,6 @@ public final class BlockHeartbeatReporter extends AbstractBlockStoreEventListene
   }
 
   @Override
-  public void onCommitBlockToMaster(long blockId, BlockStoreLocation location) {
-    if (mWorkerRegisterToAllMasters) {
-      synchronized (mLock) {
-        addBlockToAddedBlocks(blockId, location);
-      }
-    }
-  }
-
-  @Override
   public void onMoveBlockByClient(long blockId, BlockStoreLocation oldLocation,
       BlockStoreLocation newLocation) {
     synchronized (mLock) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockHeartbeatReporter.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockHeartbeatReporter.java
@@ -11,16 +11,21 @@
 
 package alluxio.worker.block;
 
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -50,6 +55,9 @@ public final class BlockHeartbeatReporter extends AbstractBlockStoreEventListene
    */
   private final Map<String, List<String>> mLostStorage;
 
+  private final boolean mWorkerRegisterToAllMasters =
+      Configuration.getBoolean(PropertyKey.WORKER_REGISTER_TO_ALL_MASTERS);
+
   /**
    * Creates a new instance of {@link BlockHeartbeatReporter}.
    */
@@ -62,12 +70,11 @@ public final class BlockHeartbeatReporter extends AbstractBlockStoreEventListene
   }
 
   /**
-   * Generates the report of the block store delta in the last heartbeat period. Calling this method
-   * marks the end of a period and the start of a new heartbeat period.
+   * Generates the report of the report and clear the states.
    *
    * @return the block store delta report for the last heartbeat period
    */
-  public BlockHeartbeatReport generateReport() {
+  public BlockHeartbeatReport generateReportAndClear() {
     synchronized (mLock) {
       BlockHeartbeatReport report
           = new BlockHeartbeatReport(mAddedBlocks, mRemovedBlocks, mLostStorage);
@@ -76,6 +83,55 @@ public final class BlockHeartbeatReporter extends AbstractBlockStoreEventListene
       mRemovedBlocks.clear();
       mLostStorage.clear();
       return report;
+    }
+  }
+
+  /**
+   * Reverts the cleared block lists/maps given a generated report.
+   * used when the worker heartbeat rpc fails.
+   *
+   * @param previousReport the previous generated report
+   */
+  public void revert(BlockHeartbeatReport previousReport) {
+    synchronized (mLock) {
+      Set<Long> removedBlocksSet = new HashSet<>(mRemovedBlocks);
+      for (Entry<BlockStoreLocation, List<Long>> addedBlockEntry:
+          previousReport.getAddedBlocks().entrySet()) {
+        List<Long> blockIds = addedBlockEntry.getValue();
+        // Two pass scans to avoid creating too many ephemeral objects
+        // given that adding a block then removing it is unlikely.
+        boolean needToRemoveBlock = false;
+        for (long blockId: blockIds) {
+          if (removedBlocksSet.contains(blockId)) {
+            needToRemoveBlock = true;
+            break;
+          }
+        }
+        if (!needToRemoveBlock) {
+          mAddedBlocks.put(addedBlockEntry.getKey(), blockIds);
+          continue;
+        }
+        List<Long> blockIdsToAdd = new ArrayList<>();
+        for (long blockId: blockIds) {
+          if (!removedBlocksSet.contains(blockId)) {
+            blockIdsToAdd.add(blockId);
+          }
+        }
+        if (blockIdsToAdd.size() > 0) {
+          mAddedBlocks.put(addedBlockEntry.getKey(), blockIdsToAdd);
+        }
+      }
+      mLostStorage.putAll(previousReport.getLostStorage());
+      mRemovedBlocks.addAll(previousReport.getRemovedBlocks());
+    }
+  }
+
+  @Override
+  public void onCommitBlockToMaster(long blockId, BlockStoreLocation location) {
+    if (mWorkerRegisterToAllMasters) {
+      synchronized (mLock) {
+        addBlockToAddedBlocks(blockId, location);
+      }
     }
   }
 
@@ -134,6 +190,7 @@ public final class BlockHeartbeatReporter extends AbstractBlockStoreEventListene
   }
 
   private void removeBlockInternal(long blockId) {
+//    System.out.println("removeBlockInternal " + blockId + " " + this);
     // Remove the block from list of added blocks, in case it was added in this heartbeat period.
     removeBlockFromAddedBlocks(blockId);
     // Add to the list of removed blocks in this heartbeat period.

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
@@ -33,6 +33,7 @@ import alluxio.grpc.GetWorkerIdPRequest;
 import alluxio.grpc.GrpcUtils;
 import alluxio.grpc.LocationBlockIdListEntry;
 import alluxio.grpc.Metric;
+import alluxio.grpc.NotifyWorkerIdPRequest;
 import alluxio.grpc.RegisterWorkerPOptions;
 import alluxio.grpc.RegisterWorkerPRequest;
 import alluxio.grpc.ServiceType;
@@ -378,14 +379,14 @@ public class BlockMasterClient extends AbstractMasterClient {
    * @param workerId the worker id
    * @param address the worker address
    */
-  public void addWorkerId(long workerId, WorkerNetAddress address) throws IOException {
+  public void notifyWorkerId(long workerId, WorkerNetAddress address) throws IOException {
     retryRPC(() -> {
       LOG.info("Adding workerID to master {} with workerId {}, workerAddress {}",
           mServerAddress,
           workerId,
           address);
-      return mClient.addWorkerId(alluxio.grpc.AddWorkerIdPRequest.newBuilder()
+      return mClient.notifyWorkerId(NotifyWorkerIdPRequest.newBuilder()
           .setWorkerId(workerId).setWorkerNetAddress(GrpcUtils.toProto(address)).build());
-    }, LOG, "AddWorkerId", "workerId=%d, workerAddress=%s", workerId, address);
+    }, LOG, "NotifyWorkerId", "workerId=%d, workerAddress=%s", workerId, address);
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterClient.java
@@ -381,7 +381,7 @@ public class BlockMasterClient extends AbstractMasterClient {
    */
   public void notifyWorkerId(long workerId, WorkerNetAddress address) throws IOException {
     retryRPC(() -> {
-      LOG.info("Adding workerID to master {} with workerId {}, workerAddress {}",
+      LOG.info("Notifying workerID to master {} with workerId {}, workerAddress {}",
           mServerAddress,
           workerId,
           address);

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockSyncMasterGroup.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockSyncMasterGroup.java
@@ -49,8 +49,8 @@ public class BlockSyncMasterGroup implements Closeable {
   private static BlockMasterClientFactory sBlockMasterClientFactory
       = new BlockMasterClientFactory();
 
-  private static final long WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS =
-      Configuration.getMs(PropertyKey.WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS);
+  private static final long WORKER_MASTER_CONNECT_RETRY_TIMEOUT =
+      Configuration.getMs(PropertyKey.WORKER_MASTER_CONNECT_RETRY_TIMEOUT);
 
   /**
    * Creates a block sync master group.
@@ -119,7 +119,7 @@ public class BlockSyncMasterGroup implements Closeable {
     try {
       CommonUtils.waitFor(this + " to start",
           primaryMasterSync::isRegistered,
-          WaitForOptions.defaults().setTimeoutMs((int) WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS));
+          WaitForOptions.defaults().setTimeoutMs((int) WORKER_MASTER_CONNECT_RETRY_TIMEOUT));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       LOG.warn("Exit the worker on interruption", e);

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockSyncMasterGroup.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockSyncMasterGroup.java
@@ -39,10 +39,11 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * An abstraction layer that manages the worker heartbeats with multiple block masters.
+ * This is only active when worker.register.to.all.masters=true.
  */
 public class BlockSyncMasterGroup implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(SpecificMasterBlockSync.class);
-  private boolean mStarted = false;
+  private volatile boolean mStarted = false;
 
   private final boolean mTestMode = Configuration.getBoolean(PropertyKey.TEST_MODE);
 
@@ -61,7 +62,8 @@ public class BlockSyncMasterGroup implements Closeable {
       List<InetSocketAddress> masterAddresses,
       BlockWorker blockWorker
   ) throws IOException {
-    // TODO(jiacheng/elega): handle master quorum changes
+    // TODO(elega): handle master membership changes
+    // https://github.com/Alluxio/alluxio/issues/16898
     for (InetSocketAddress masterAddr : masterAddresses) {
       BlockMasterClient masterClient = sBlockMasterClientFactory.create(masterAddr);
       BlockHeartbeatReporter heartbeatReporter = new BlockHeartbeatReporter();

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockSyncMasterGroup.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockSyncMasterGroup.java
@@ -1,0 +1,179 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block;
+
+import alluxio.ClientContext;
+import alluxio.ProcessUtils;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.heartbeat.HeartbeatContext;
+import alluxio.heartbeat.HeartbeatThread;
+import alluxio.master.MasterClientContext;
+import alluxio.security.user.ServerUserState;
+import alluxio.util.CommonUtils;
+import alluxio.util.ConfigurationUtils;
+import alluxio.util.WaitForOptions;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * An abstraction layer that manages the worker heartbeats with multiple block masters.
+ */
+public class BlockSyncMasterGroup implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(SpecificMasterBlockSync.class);
+  private boolean mStarted = false;
+
+  private final boolean mTestMode = Configuration.getBoolean(PropertyKey.TEST_MODE);
+
+  private static BlockMasterClientFactory sBlockMasterClientFactory
+      = new BlockMasterClientFactory();
+
+  private static final long WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS =
+      Configuration.getMs(PropertyKey.WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS);
+
+  /**
+   * Creates a block sync master group.
+   * @param masterAddresses the master addresses to sync
+   * @param blockWorker the block worker instance
+   */
+  public BlockSyncMasterGroup(
+      List<InetSocketAddress> masterAddresses,
+      BlockWorker blockWorker
+  ) throws IOException {
+    // TODO(jiacheng/elega): handle master quorum changes
+    for (InetSocketAddress masterAddr : masterAddresses) {
+      BlockMasterClient masterClient = sBlockMasterClientFactory.create(masterAddr);
+      BlockHeartbeatReporter heartbeatReporter = new BlockHeartbeatReporter();
+
+      blockWorker.getBlockStore().registerBlockStoreEventListener(heartbeatReporter);
+      // Setup BlockMasterSync
+      SpecificMasterBlockSync blockMasterSync = mTestMode
+          ? new TestSpecificMasterBlockSync(
+          blockWorker, masterClient, heartbeatReporter)
+          : new SpecificMasterBlockSync(
+              blockWorker, masterClient, heartbeatReporter);
+      // Register each BlockMasterSync to the block events on this worker
+      mMasterSyncOperators.put(masterAddr, blockMasterSync);
+      LOG.info("Kick off BlockMasterSync with master {}", masterAddr);
+    }
+  }
+
+  /**
+   * Starts the heartbeats.
+   * @param executorService the executor service to run the heartbeats
+   */
+  public synchronized void start(ExecutorService executorService) {
+    if (!mStarted) {
+      mStarted = true;
+    }
+    mMasterSyncOperators.values().forEach(blockMasterSync -> executorService
+        .submit(new HeartbeatThread(HeartbeatContext.WORKER_BLOCK_SYNC, blockMasterSync,
+            () -> Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS),
+            Configuration.global(), ServerUserState.global())));
+  }
+
+  private final Map<InetSocketAddress, SpecificMasterBlockSync> mMasterSyncOperators =
+      new HashMap<>();
+
+  @Override
+  public void close() throws IOException {
+    mMasterSyncOperators.values().forEach(
+        SpecificMasterBlockSync::close
+    );
+  }
+
+  static void setBlockMasterClientFactory(BlockMasterClientFactory factory) {
+    sBlockMasterClientFactory = factory;
+  }
+
+  /**
+   * Waits until the primary master registration completes.
+   * @param primaryMasterAddress the primary master address
+   */
+  public void waitForPrimaryMasterRegistrationComplete(InetSocketAddress primaryMasterAddress) {
+    SpecificMasterBlockSync primaryMasterSync =
+        mMasterSyncOperators.get(primaryMasterAddress);
+    Preconditions.checkNotNull(
+        primaryMasterSync, "Primary master block sync should not be null");
+    try {
+      CommonUtils.waitFor(this + " to start",
+          primaryMasterSync::isRegistered,
+          WaitForOptions.defaults().setTimeoutMs((int) WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warn("Exit the worker on interruption", e);
+      throw new RuntimeException(e);
+    } catch (TimeoutException e) {
+      ProcessUtils.fatalError(LOG, e, "Failed to register with primary master");
+    }
+    LOG.info("The worker has registered with primary master, address {}", primaryMasterAddress);
+  }
+
+  /**
+   * @return if the worker is registered to all masters
+   */
+  public boolean isRegisteredToAllMasters() {
+    return mMasterSyncOperators.values().stream().allMatch(SpecificMasterBlockSync::isRegistered);
+  }
+
+  /**
+   * @return the master sync operators
+   */
+  public Map<InetSocketAddress, SpecificMasterBlockSync> getMasterSyncOperators() {
+    return mMasterSyncOperators;
+  }
+
+  /**
+   * The factory class.
+   */
+  public static class Factory {
+    /**
+     * Creates a block sync master group that heartbeats to all masters.
+     * @param blockWorker the block worker instance
+     * @return the block sync master group instance
+     */
+    public static BlockSyncMasterGroup createAllMasterSync(BlockWorker blockWorker) {
+      List<InetSocketAddress> masterAddresses =
+          ConfigurationUtils.getMasterRpcAddresses(Configuration.global());
+      try {
+        return new BlockSyncMasterGroup(masterAddresses, blockWorker);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  /**
+   * A factory class for testing purpose.
+   */
+  @VisibleForTesting
+  static class BlockMasterClientFactory {
+    BlockMasterClient create(InetSocketAddress address) {
+      MasterClientContext context = MasterClientContext
+          .newBuilder(ClientContext.create(Configuration.global())).build();
+
+      return new BlockMasterClient(context, address);
+    }
+  }
+}

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -138,8 +138,11 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   public DefaultBlockWorker(BlockMasterClientPool blockMasterClientPool,
       FileSystemMasterClient fileSystemMasterClient, Sessions sessions, BlockStore blockStore,
       AtomicReference<Long> workerId) {
-    super(ExecutorServiceFactories.fixedThreadPool("block-worker-executor",
-        Configuration.getBoolean(PropertyKey.WORKER_REGISTER_TO_ALL_MASTERS) ? 10 : 5));
+    super(
+        Configuration.getBoolean(PropertyKey.WORKER_REGISTER_TO_ALL_MASTERS)
+            ? ExecutorServiceFactories.cachedThreadPool("block-worker-executor")
+            : ExecutorServiceFactories.fixedThreadPool("block-worker-executor", 5)
+    );
     mBlockMasterClientPool = mResourceCloser.register(blockMasterClientPool);
     mFileSystemMasterClient = mResourceCloser.register(fileSystemMasterClient);
     mHeartbeatReporter = new BlockHeartbeatReporter();

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -171,6 +171,11 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   }
 
   @Override
+  public WorkerNetAddress getWorkerAddress() {
+    return mAddress;
+  }
+
+  @Override
   public Set<Class<? extends Server>> getDependencies() {
     return new HashSet<>();
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/DefaultBlockWorker.java
@@ -138,7 +138,8 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
   public DefaultBlockWorker(BlockMasterClientPool blockMasterClientPool,
       FileSystemMasterClient fileSystemMasterClient, Sessions sessions, BlockStore blockStore,
       AtomicReference<Long> workerId) {
-    super(ExecutorServiceFactories.fixedThreadPool("block-worker-executor", 5));
+    super(ExecutorServiceFactories.fixedThreadPool("block-worker-executor",
+        Configuration.getBoolean(PropertyKey.WORKER_REGISTER_TO_ALL_MASTERS) ? 10 : 5));
     mBlockMasterClientPool = mResourceCloser.register(blockMasterClientPool);
     mFileSystemMasterClient = mResourceCloser.register(fileSystemMasterClient);
     mHeartbeatReporter = new BlockHeartbeatReporter();
@@ -330,7 +331,7 @@ public class DefaultBlockWorker extends AbstractWorker implements BlockWorker {
 
   @Override
   public BlockHeartbeatReport getReport() {
-    return mHeartbeatReporter.generateReport();
+    return mHeartbeatReporter.generateReportAndClear();
   }
 
   @Override

--- a/core/server/worker/src/main/java/alluxio/worker/block/SpecificMasterBlockSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/SpecificMasterBlockSync.java
@@ -1,0 +1,248 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block;
+
+import alluxio.ProcessUtils;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.ConnectionFailedException;
+import alluxio.exception.FailedToAcquireRegisterLeaseException;
+import alluxio.grpc.Command;
+import alluxio.heartbeat.HeartbeatExecutor;
+import alluxio.retry.ExponentialBackoffRetry;
+import alluxio.retry.RetryPolicy;
+import alluxio.util.CommonUtils;
+import alluxio.wire.WorkerNetAddress;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * The block master sync thread when workers are registered to all masters.
+ * With respect to behaviors, this implementation differs from {@link BlockMasterSync} in:
+ * 1. The registration takes place asynchronously and the caller can poll the registration state.
+ *  We need to make the process async because when standby master read is enabled, workers have to
+ *  register to all masters and these registrations can happen concurrently to speed up the process.
+ * 2. A registration fail doesn't throw a fatal exception. Instead, it retries endlessly.
+ *  This is because a standby master registration failure
+ *  should not a soft failure and can be retried later.
+ */
+@NotThreadSafe
+public final class SpecificMasterBlockSync implements HeartbeatExecutor {
+  private static final Logger LOG = LoggerFactory.getLogger(SpecificMasterBlockSync.class);
+  private static final long ACQUIRE_LEASE_WAIT_MAX_DURATION =
+      Configuration.getMs(PropertyKey.WORKER_REGISTER_LEASE_RETRY_MAX_DURATION);
+
+  private final SocketAddress mMasterAddress;
+
+  /**
+   * The worker registration state.
+   * If the state is NOT_REGISTERED, heartbeat will trigger a registration.
+   * During the registration process, the state will be set to REGISTERING.
+   * When the registration is done, the state will be set to REGISTERED.
+   * When the sync receives a registration command from the master during the heartbeat,
+   * the state will be reset to NOT_REGISTERED and the sync will attempt to register it again
+   * in the next heartbeat.
+   */
+  private volatile WorkerMasterState mWorkerState = WorkerMasterState.NOT_REGISTERED;
+
+  /** An async service to remove block. */
+  private final AsyncBlockRemover mAsyncBlockRemover;
+
+  /** The worker ID for the worker. This may change if the master asks the worker to re-register. */
+  private final AtomicReference<Long> mWorkerId;
+
+  /** Client for all master communication. */
+  private final BlockMasterClient mMasterClient;
+
+  /** The net address of the worker. */
+  private final WorkerNetAddress mWorkerAddress;
+
+  /** Client-pool for all master communication. */
+  private final BlockMasterClientPool mMasterClientPool;
+
+  /** The helper instance for sync related methods. */
+  private final BlockMasterSyncHelper mBlockMasterSyncHelper;
+
+  /** The block worker responsible for interacting with Alluxio and UFS storage. */
+  private final BlockWorker mBlockWorker;
+  /** Last System.currentTimeMillis() timestamp when a heartbeat successfully completed. */
+  private long mLastSuccessfulHeartbeatMs = 0;
+
+  private final BlockHeartbeatReporter mBlockHeartbeatReporter;
+
+  /**
+   * Creates a new instance of {@link SpecificMasterBlockSync}.
+   *
+   * @param blockWorker the {@link BlockWorker} this syncer is updating to
+   * @param workerId the worker id of the worker, assigned by the block master
+   * @param workerAddress the net address of the worker
+   * @param masterClientPool the Alluxio master client pool
+   * @param heartbeatReporter the heartbeat reporter
+   */
+  public SpecificMasterBlockSync(
+      BlockWorker blockWorker, AtomicReference<Long> workerId,
+      WorkerNetAddress workerAddress, BlockMasterClientPool masterClientPool,
+      BlockHeartbeatReporter heartbeatReporter)
+      throws IOException {
+    mBlockWorker = blockWorker;
+    mWorkerId = workerId;
+    mWorkerAddress = workerAddress;
+    mMasterClientPool = masterClientPool;
+    mMasterClient = mMasterClientPool.acquire();
+    mAsyncBlockRemover = new AsyncBlockRemover(mBlockWorker);
+    mBlockMasterSyncHelper = new BlockMasterSyncHelper(mMasterClient);
+    mMasterAddress = masterClientPool.acquire().getRemoteSockAddress();
+    mBlockHeartbeatReporter = heartbeatReporter;
+  }
+
+  private void registerWithMaster() {
+    RetryPolicy retry = createEndlessRetry();
+    while (retry.attempt()) {
+      try {
+        LOG.info("Registering with master {}", mMasterAddress);
+        registerWithMasterInternal();
+        LOG.info("Finished registration with {}", mMasterAddress);
+        return;
+      } catch (Exception e) {
+        LOG.error("Failed to register with master {}, error {}, retry count {} Will retry...",
+            mMasterAddress, e, retry.getAttemptCount());
+        mWorkerState = WorkerMasterState.NOT_REGISTERED;
+      }
+    }
+    // Should not reach here because the retry is indefinite
+    ProcessUtils.fatalError(LOG, new RuntimeException(),
+        "Failed to register with master %s", mMasterAddress);
+  }
+
+  private void registerWithMasterInternal()
+      throws IOException, FailedToAcquireRegisterLeaseException {
+    // The target master is not necessarily the one that allocated the workerID
+    LOG.info("Notify the master {} about the workerID {}", mMasterAddress, mWorkerId);
+    mMasterClientPool.acquire().addWorkerId(mWorkerId.get(), mWorkerAddress);
+    BlockStoreMeta storeMeta = mBlockWorker.getStoreMetaFull();
+
+    try {
+      mBlockMasterSyncHelper.tryAcquireLease(mWorkerId.get(), storeMeta);
+    } catch (FailedToAcquireRegisterLeaseException e) {
+      if (Configuration.getBoolean(PropertyKey.TEST_MODE)) {
+        throw new RuntimeException(String.format("Master register lease timeout exceeded: %dms",
+            ACQUIRE_LEASE_WAIT_MAX_DURATION));
+      }
+      throw e;
+    }
+    mWorkerState = WorkerMasterState.REGISTERING;
+    mBlockMasterSyncHelper.registerToMaster(mWorkerId.get(), storeMeta);
+    mWorkerState = WorkerMasterState.REGISTERED;
+    mLastSuccessfulHeartbeatMs = CommonUtils.getCurrentMs();
+  }
+
+  private RetryPolicy createEndlessRetry() {
+    return new ExponentialBackoffRetry(
+        1000, 60 * 1000, Integer.MAX_VALUE);
+  }
+
+  @Override
+  public synchronized void heartbeat() throws InterruptedException {
+    if (mWorkerState == WorkerMasterState.NOT_REGISTERED) {
+      // Not registered because:
+      // 1. The worker just started, we kick off the 1st registration here.
+      // 2. Master sends a registration command during
+      // the heartbeat and resets the registration state.
+      LOG.info("The worker needs to register with master {}", mMasterAddress);
+      // This will retry indefinitely and essentially block here if the master is not ready
+      registerWithMaster();
+      LOG.info("BlockMasterSync to master {} has started", mMasterAddress);
+    }
+    if (mWorkerState == WorkerMasterState.REGISTERING) {
+      return;
+    }
+
+    RetryPolicy endlessRetry = createEndlessRetry();
+    while (endlessRetry.attempt()) {
+      BlockHeartbeatReport report = mBlockHeartbeatReporter.generateReportAndClear();
+      boolean success = mBlockMasterSyncHelper.heartbeat(
+          mWorkerId.get(), report,
+          mBlockWorker.getStoreMeta(), this::handleMasterCommand);
+      if (success) {
+        mLastSuccessfulHeartbeatMs = CommonUtils.getCurrentMs();
+        break;
+      } else {
+        mBlockHeartbeatReporter.revert(report);
+        LOG.warn(
+            "Heartbeat failed, worker id {}, worker host {} # of attempts {}, last success ts {}",
+            mWorkerId.get(), mWorkerAddress.getHost(), endlessRetry.getAttemptCount(),
+            mLastSuccessfulHeartbeatMs);
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    mAsyncBlockRemover.shutDown();
+    mMasterClientPool.release(mMasterClient);
+  }
+
+  /**
+   * @return if the worker has registered with the master successfully
+   */
+  public boolean isRegistered() {
+    return mWorkerState == WorkerMasterState.REGISTERED;
+  }
+
+  /**
+   * Handles a master command. The command is one of Unknown, Nothing, Register, Free, or Delete.
+   * This call will block until the command is complete.
+   *
+   * @param cmd the command to execute
+   * @throws IOException if I/O errors occur
+   * @throws ConnectionFailedException if connection fails
+   */
+  private void handleMasterCommand(Command cmd) throws IOException, ConnectionFailedException {
+    if (cmd == null) {
+      return;
+    }
+    switch (cmd.getCommandType()) {
+      // Currently unused
+      case Delete:
+        break;
+      // Master requests blocks to be removed from Alluxio managed space.
+      case Free:
+        mAsyncBlockRemover.addBlocksToDelete(cmd.getDataList());
+        break;
+      // No action required
+      case Nothing:
+        break;
+      // Master requests re-registration
+      case Register:
+        mWorkerState = WorkerMasterState.NOT_REGISTERED;
+        break;
+      // Unknown request
+      case Unknown:
+        LOG.error("Master heartbeat sends unknown command {}", cmd);
+        break;
+      default:
+        throw new RuntimeException("Un-recognized command from master " + cmd);
+    }
+  }
+
+  enum WorkerMasterState {
+    REGISTERED,
+    NOT_REGISTERED,
+    REGISTERING
+  }
+}

--- a/core/server/worker/src/main/java/alluxio/worker/block/TestSpecificMasterBlockSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TestSpecificMasterBlockSync.java
@@ -1,0 +1,82 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block;
+
+import alluxio.exception.FailedToAcquireRegisterLeaseException;
+import alluxio.exception.runtime.UnavailableRuntimeException;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A test {@link SpecificMasterBlockSync} that adds some interfaces for testing.
+ */
+@NotThreadSafe
+@VisibleForTesting
+public final class TestSpecificMasterBlockSync extends SpecificMasterBlockSync {
+  private static final Logger LOG = LoggerFactory.getLogger(TestSpecificMasterBlockSync.class);
+  private volatile boolean mPauseHeartbeat = false;
+  private final AtomicInteger mRegistrationSuccessCount = new AtomicInteger(0);
+
+  /**
+   * Creates a new instance of {@link SpecificMasterBlockSync}.
+   *
+   * @param blockWorker the {@link BlockWorker} this syncer is updating to
+   * @param masterClient the block master client
+   * @param heartbeatReporter the heartbeat reporter
+   */
+  public TestSpecificMasterBlockSync(
+      BlockWorker blockWorker, BlockMasterClient masterClient,
+      BlockHeartbeatReporter heartbeatReporter) throws IOException {
+    super(blockWorker, masterClient, heartbeatReporter);
+  }
+
+  /**
+   * Resumes the heartbeat.
+   */
+  public void resumeHeartbeat() {
+    mPauseHeartbeat = false;
+  }
+
+  /**
+   * Pauses the heartbeat.
+   */
+  public void pauseHeartbeat() {
+    mPauseHeartbeat = true;
+  }
+
+  /**
+   * @return registration success count
+   */
+  public int getRegistrationSuccessCount() {
+    return mRegistrationSuccessCount.get();
+  }
+
+  @Override
+  protected void registerWithMasterInternal()
+      throws IOException, FailedToAcquireRegisterLeaseException {
+    super.registerWithMasterInternal();
+    mRegistrationSuccessCount.incrementAndGet();
+  }
+
+  @Override
+  protected void beforeHeartbeat() {
+    if (mPauseHeartbeat) {
+      throw new UnavailableRuntimeException("Heartbeat paused");
+    }
+  }
+}

--- a/core/server/worker/src/main/java/alluxio/worker/block/TestSpecificMasterBlockSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/TestSpecificMasterBlockSync.java
@@ -29,7 +29,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @VisibleForTesting
 public final class TestSpecificMasterBlockSync extends SpecificMasterBlockSync {
   private static final Logger LOG = LoggerFactory.getLogger(TestSpecificMasterBlockSync.class);
-  private volatile boolean mPauseHeartbeat = false;
+  private volatile boolean mFailHeartbeat = false;
   private final AtomicInteger mRegistrationSuccessCount = new AtomicInteger(0);
 
   /**
@@ -46,17 +46,17 @@ public final class TestSpecificMasterBlockSync extends SpecificMasterBlockSync {
   }
 
   /**
-   * Resumes the heartbeat.
+   * Restores the heartbeat.
    */
-  public void resumeHeartbeat() {
-    mPauseHeartbeat = false;
+  public void restoreHeartbeat() {
+    mFailHeartbeat = false;
   }
 
   /**
-   * Pauses the heartbeat.
+   * Fails the heartbeat and lets it throws an exception.
    */
-  public void pauseHeartbeat() {
-    mPauseHeartbeat = true;
+  public void failHeartbeat() {
+    mFailHeartbeat = true;
   }
 
   /**
@@ -75,7 +75,7 @@ public final class TestSpecificMasterBlockSync extends SpecificMasterBlockSync {
 
   @Override
   protected void beforeHeartbeat() {
-    if (mPauseHeartbeat) {
+    if (mFailHeartbeat) {
       throw new UnavailableRuntimeException("Heartbeat paused");
     }
   }

--- a/core/server/worker/src/main/java/alluxio/worker/block/WorkerMasterRegistrationState.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/WorkerMasterRegistrationState.java
@@ -1,0 +1,10 @@
+package alluxio.worker.block;
+
+/**
+ * The enum class for worker master registration state.
+ */
+public enum WorkerMasterRegistrationState {
+  REGISTERED,
+  NOT_REGISTERED,
+  REGISTERING,
+}

--- a/core/server/worker/src/main/java/alluxio/worker/block/WorkerMasterRegistrationState.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/WorkerMasterRegistrationState.java
@@ -1,3 +1,14 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
 package alluxio.worker.block;
 
 /**

--- a/core/server/worker/src/test/java/alluxio/worker/block/AllMasterRegistrationBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/AllMasterRegistrationBlockWorkerTest.java
@@ -1,0 +1,77 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import alluxio.Sessions;
+import alluxio.conf.PropertyKey;
+import alluxio.master.journal.JournalType;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+/**
+ * Unit tests for {@link DefaultBlockWorker}.
+ */
+public class AllMasterRegistrationBlockWorkerTest extends DefaultBlockWorkerTestBase {
+  @Override
+  public void before() throws Exception {
+    mConfigurationRule.set(PropertyKey.WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS, "5s");
+    mConfigurationRule.set(PropertyKey.TEST_MODE, true);
+    mConfigurationRule.set(PropertyKey.WORKER_REGISTER_TO_ALL_MASTERS, true);
+    mConfigurationRule.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.EMBEDDED);
+    mConfigurationRule.set(PropertyKey.MASTER_RPC_ADDRESSES,
+        "localhost:19998,localhost:19988,localhost:19978");
+    super.before();
+
+    when(mFileSystemMasterClient.getRemoteSockAddress())
+        .thenReturn(InetSocketAddress.createUnresolved("localhost", 19998));
+
+    mBlockWorker = new AllMasterRegistrationBlockWorker(
+        mBlockMasterClientPool, mFileSystemMasterClient,
+        mock(Sessions.class), mBlockStore, new AtomicReference<>(INVALID_WORKER_ID));
+    ((AllMasterRegistrationBlockWorker) mBlockWorker)
+        .setBlockMasterClientPoolFactory(new BlockMasterClientPool.Factory() {
+          @Override
+          BlockMasterClientPool create(@Nullable InetSocketAddress address) {
+            return mBlockMasterClientPool;
+          }
+        });
+  }
+
+  @Test
+  public void workerStandbyMasterRegistrationFailed() throws IOException {
+    doThrow(new RuntimeException("error")).when(mBlockMasterClient).addWorkerId(anyLong(), any());
+    Exception e = assertThrows(Exception.class, () -> mBlockWorker.start(WORKER_ADDRESS));
+    assertTrue(e.getMessage().contains("Fatal error: Failed to register with primary master"));
+  }
+
+  @Test
+  public void workerMasterRegistration() throws IOException {
+    doNothing().when(mBlockMasterClient).addWorkerId(anyLong(), any());
+    mBlockWorker.start(WORKER_ADDRESS);
+  }
+
+  // TODO(elega) add a test to confirm the worker can start when the registration to a standby fails
+}

--- a/core/server/worker/src/test/java/alluxio/worker/block/AllMasterRegistrationBlockWorkerTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/AllMasterRegistrationBlockWorkerTest.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class AllMasterRegistrationBlockWorkerTest extends DefaultBlockWorkerTestBase {
   @Override
   public void before() throws Exception {
-    mConfigurationRule.set(PropertyKey.WORKER_ALL_MASTER_REGISTRATION_TIMEOUT_MS, "5s");
+    mConfigurationRule.set(PropertyKey.WORKER_MASTER_CONNECT_RETRY_TIMEOUT, "5s");
     mConfigurationRule.set(PropertyKey.TEST_MODE, true);
     mConfigurationRule.set(PropertyKey.WORKER_REGISTER_TO_ALL_MASTERS, true);
     mConfigurationRule.set(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.EMBEDDED);

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockHeartbeatReporterTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockHeartbeatReporterTest.java
@@ -168,9 +168,9 @@ public final class BlockHeartbeatReporterTest {
 
   @Test
   public void generateAndRevert() {
-    mReporter.onCommitBlockToMaster(1, MEM_LOC);
-    mReporter.onCommitBlockToMaster(2, MEM_LOC);
-    mReporter.onCommitBlockToMaster(3, SSD_LOC);
+    mReporter.onMoveBlockByWorker(1, MEM_LOC, SSD_LOC);
+    mReporter.onMoveBlockByWorker(2, MEM_LOC, SSD_LOC);
+    mReporter.onMoveBlockByWorker(3, SSD_LOC, HDD_LOC);
     mReporter.onRemoveBlockByClient(4);
     mReporter.onStorageLost(Constants.MEDIUM_MEM, "/foo");
     mReporter.onStorageLost(Constants.MEDIUM_MEM, "/bar");
@@ -184,9 +184,9 @@ public final class BlockHeartbeatReporterTest {
 
   @Test
   public void generateUpdateThenRevert() {
-    mReporter.onCommitBlockToMaster(1, MEM_LOC);
-    mReporter.onCommitBlockToMaster(2, MEM_LOC);
-    mReporter.onCommitBlockToMaster(3, SSD_LOC);
+    mReporter.onMoveBlockByWorker(1, HDD_LOC, MEM_LOC);
+    mReporter.onMoveBlockByWorker(2, HDD_LOC, MEM_LOC);
+    mReporter.onMoveBlockByWorker(3, HDD_LOC, SSD_LOC);
     mReporter.onRemoveBlockByClient(4);
     mReporter.onStorageLost(Constants.MEDIUM_MEM, "/foo");
     mReporter.onStorageLost(Constants.MEDIUM_HDD, "/bar");
@@ -195,8 +195,8 @@ public final class BlockHeartbeatReporterTest {
     mReporter.onRemoveBlockByClient(1);
     mReporter.onRemoveBlockByClient(3);
     mReporter.onRemoveBlockByClient(5);
-    mReporter.onCommitBlockToMaster(6, HDD_LOC);
-    mReporter.onCommitBlockToMaster(7, MEM_LOC);
+    mReporter.onMoveBlockByWorker(6, SSD_LOC, HDD_LOC);
+    mReporter.onMoveBlockByWorker(7, HDD_LOC, MEM_LOC);
     mReporter.onStorageLost(Constants.MEDIUM_MEM, "/baz");
     mReporter.mergeBack(originalReport);
     BlockHeartbeatReport newReport = mReporter.generateReportAndClear();

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockHeartbeatReporterTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockHeartbeatReporterTest.java
@@ -16,10 +16,16 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import alluxio.Constants;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -40,6 +46,7 @@ public final class BlockHeartbeatReporterTest {
    */
   @Before
   public final void before() {
+    Configuration.set(PropertyKey.WORKER_REGISTER_TO_ALL_MASTERS, true);
     mReporter = new BlockHeartbeatReporter();
   }
 
@@ -54,18 +61,18 @@ public final class BlockHeartbeatReporterTest {
   }
 
   /**
-   * Tests the {@link BlockHeartbeatReporter#generateReport()} method for an empty report.
+   * Tests the {@link BlockHeartbeatReporter#generateReportAndClear()} method for an empty report.
    */
   @Test
   public void generateReportEmpty() {
-    BlockHeartbeatReport report = mReporter.generateReport();
+    BlockHeartbeatReport report = mReporter.generateReportAndClear();
     assertTrue(report.getAddedBlocks().isEmpty());
     assertTrue(report.getRemovedBlocks().isEmpty());
   }
 
   /**
-   * Tests the {@link BlockHeartbeatReporter#generateReport()} method to correctly generate a report
-   * after moving block.
+   * Tests the {@link BlockHeartbeatReporter#generateReportAndClear()}
+   * method to correctly generate a report after moving block.
    */
   @Test
   public void generateReportMove() {
@@ -75,7 +82,7 @@ public final class BlockHeartbeatReporterTest {
     moveBlock(block1, MEM_LOC);
     moveBlock(block2, SSD_LOC);
     moveBlock(block3, HDD_LOC);
-    BlockHeartbeatReport report = mReporter.generateReport();
+    BlockHeartbeatReport report = mReporter.generateReportAndClear();
     Map<BlockStoreLocation, List<Long>> addedBlocks = report.getAddedBlocks();
 
     // Block1 moved to memory
@@ -95,8 +102,8 @@ public final class BlockHeartbeatReporterTest {
   }
 
   /**
-   * Tests the {@link BlockHeartbeatReporter#generateReport()} method that generating a report
-   * clears the state of the reporter.
+   * Tests the {@link BlockHeartbeatReporter#generateReportAndClear()}
+   * method that generating a report clears the state of the reporter.
    */
   @Test
   public void generateReportStateClear() {
@@ -104,18 +111,18 @@ public final class BlockHeartbeatReporterTest {
     moveBlock(block1, MEM_LOC);
 
     // First report should have updates
-    BlockHeartbeatReport report = mReporter.generateReport();
+    BlockHeartbeatReport report = mReporter.generateReportAndClear();
     assertFalse(report.getAddedBlocks().isEmpty());
 
     // Second report should not have updates
-    BlockHeartbeatReport nextReport = mReporter.generateReport();
+    BlockHeartbeatReport nextReport = mReporter.generateReportAndClear();
     assertTrue(nextReport.getAddedBlocks().isEmpty());
     assertTrue(nextReport.getRemovedBlocks().isEmpty());
   }
 
   /**
-   * Tests the {@link BlockHeartbeatReporter#generateReport()} method to correctly generate a report
-   * after removing blocks.
+   * Tests the {@link BlockHeartbeatReporter#generateReportAndClear()}
+   * method to correctly generate a report after removing blocks.
    */
   @Test
   public void generateReportRemove() {
@@ -125,7 +132,7 @@ public final class BlockHeartbeatReporterTest {
     removeBlock(block1);
     removeBlock(block2);
     removeBlock(block3);
-    BlockHeartbeatReport report = mReporter.generateReport();
+    BlockHeartbeatReport report = mReporter.generateReportAndClear();
 
     // All blocks should be removed
     List<Long> removedBlocks = report.getRemovedBlocks();
@@ -140,8 +147,8 @@ public final class BlockHeartbeatReporterTest {
   }
 
   /**
-   * Tests the {@link BlockHeartbeatReporter#generateReport()} method to correctly generate a report
-   * after moving a block and the removing it.
+   * Tests the {@link BlockHeartbeatReporter#generateReportAndClear()}
+   * method to correctly generate a report after moving a block and the removing it.
    */
   @Test
   public void generateReportMoveThenRemove() {
@@ -150,12 +157,49 @@ public final class BlockHeartbeatReporterTest {
     removeBlock(block1);
 
     // The block should not be in the added blocks list
-    BlockHeartbeatReport report = mReporter.generateReport();
+    BlockHeartbeatReport report = mReporter.generateReportAndClear();
     assertEquals(null, report.getAddedBlocks().get(MEM_LOC));
 
     // The block should be in the removed blocks list
     List<Long> removedBlocks = report.getRemovedBlocks();
     assertEquals(1, removedBlocks.size());
     assertTrue(removedBlocks.contains(block1));
+  }
+
+  @Test
+  public void generateAndRevert() {
+    mReporter.onCommitBlockToMaster(1, MEM_LOC);
+    mReporter.onCommitBlockToMaster(2, MEM_LOC);
+    mReporter.onCommitBlockToMaster(3, SSD_LOC);
+    mReporter.onRemoveBlockByClient(4);
+    mReporter.onStorageLost(HDD_LOC);
+    BlockHeartbeatReport originalReport = mReporter.generateReportAndClear();
+    mReporter.revert(originalReport);
+    BlockHeartbeatReport newReport = mReporter.generateReportAndClear();
+    assertEquals(originalReport.getAddedBlocks(), newReport.getAddedBlocks());
+    assertEquals(originalReport.getRemovedBlocks(), newReport.getRemovedBlocks());
+    assertEquals(originalReport.getLostStorage(), newReport.getLostStorage());
+  }
+
+  @Test
+  public void generateUpdateThenRevert() {
+    mReporter.onCommitBlockToMaster(1, MEM_LOC);
+    mReporter.onCommitBlockToMaster(2, MEM_LOC);
+    mReporter.onCommitBlockToMaster(3, SSD_LOC);
+    mReporter.onRemoveBlockByClient(4);
+    BlockHeartbeatReport originalReport = mReporter.generateReportAndClear();
+    mReporter.onRemoveBlockByClient(1);
+    mReporter.onRemoveBlockByClient(3);
+    mReporter.onRemoveBlockByClient(5);
+    mReporter.onCommitBlockToMaster(6, HDD_LOC);
+    mReporter.revert(originalReport);
+
+    BlockHeartbeatReport newReport = mReporter.generateReportAndClear();
+    assertEquals(ImmutableMap.of(
+        MEM_LOC, Collections.singletonList(2L),
+        HDD_LOC, Collections.singletonList(6L)
+    ), newReport.getAddedBlocks());
+    assertEquals(new HashSet<>(Arrays.asList(1L, 3L, 4L, 5L)),
+        new HashSet<>(newReport.getRemovedBlocks()));
   }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
@@ -163,6 +163,11 @@ public class NoopBlockWorker implements BlockWorker {
   }
 
   @Override
+  public WorkerNetAddress getWorkerAddress() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public Set<Class<? extends Server>> getDependencies() {
     return null;
   }

--- a/core/server/worker/src/test/java/alluxio/worker/block/SpecificMasterBlockSyncTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/SpecificMasterBlockSyncTest.java
@@ -51,8 +51,7 @@ public class SpecificMasterBlockSyncTest {
     TestBlockMasterClient.INSTANCE.setReturnRegisterCommand(false);
 
     SpecificMasterBlockSync sync = new SpecificMasterBlockSync(
-        getMockedBlockWorker(), new AtomicReference<>(0L), WorkerNetAddress.DUMMY, mClientPool,
-        new BlockHeartbeatReporter()
+        getMockedBlockWorker(), TestBlockMasterClient.INSTANCE, new BlockHeartbeatReporter()
     );
     assertFalse(sync.isRegistered());
 
@@ -147,10 +146,6 @@ public class SpecificMasterBlockSyncTest {
     }
 
     @Override
-    public void addWorkerId(long workerId, WorkerNetAddress address) throws IOException {
-    }
-
-    @Override
     public synchronized Command heartbeat(
         long workerId, Map<String, Long> capacityBytesOnTiers,
         Map<String, Long> usedBytesOnTiers,
@@ -168,6 +163,10 @@ public class SpecificMasterBlockSyncTest {
     public void acquireRegisterLeaseWithBackoff(
         long workerId, int estimatedBlockCount, RetryPolicy retry)
         throws IOException, FailedToAcquireRegisterLeaseException {
+    }
+
+    @Override
+    public void addWorkerId(long workerId, WorkerNetAddress address) throws IOException {
     }
   }
 
@@ -195,6 +194,10 @@ public class SpecificMasterBlockSyncTest {
     Mockito.when(blockWorker.getReport())
         .thenReturn(new BlockHeartbeatReport(Collections.emptyMap(),
         Collections.emptyList(), Collections.emptyMap()));
+    Mockito.when(blockWorker.getWorkerAddress())
+        .thenReturn(null);
+    Mockito.when(blockWorker.getWorkerId())
+        .thenReturn(new AtomicReference<>(0L));
     return blockWorker;
   }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/SpecificMasterBlockSyncTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/SpecificMasterBlockSyncTest.java
@@ -166,7 +166,7 @@ public class SpecificMasterBlockSyncTest {
     }
 
     @Override
-    public void addWorkerId(long workerId, WorkerNetAddress address) throws IOException {
+    public void notifyWorkerId(long workerId, WorkerNetAddress address) throws IOException {
     }
   }
 

--- a/core/server/worker/src/test/java/alluxio/worker/block/SpecificMasterBlockSyncTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/SpecificMasterBlockSyncTest.java
@@ -1,0 +1,200 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import alluxio.ClientContext;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.FailedToAcquireRegisterLeaseException;
+import alluxio.grpc.Command;
+import alluxio.grpc.CommandType;
+import alluxio.grpc.ConfigProperty;
+import alluxio.grpc.Metric;
+import alluxio.master.MasterClientContext;
+import alluxio.master.SingleMasterInquireClient;
+import alluxio.retry.RetryPolicy;
+import alluxio.wire.WorkerNetAddress;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class SpecificMasterBlockSyncTest {
+  @Rule
+  public TemporaryFolder mTestFolder = new TemporaryFolder();
+
+  @Test
+  public void heartbeatThread() throws Exception {
+    // Flaky registration succeeds every other time.
+    TestBlockMasterClient.INSTANCE.setFlakyRegistration(true);
+    TestBlockMasterClient.INSTANCE.setReturnRegisterCommand(false);
+
+    SpecificMasterBlockSync sync = new SpecificMasterBlockSync(
+        getMockedBlockWorker(), new AtomicReference<>(0L), WorkerNetAddress.DUMMY, mClientPool,
+        new BlockHeartbeatReporter()
+    );
+    assertFalse(sync.isRegistered());
+
+    // heartbeat registers the worker if it has not been registered.
+    sync.heartbeat();
+    assertTrue(sync.isRegistered());
+
+    // heartbeat returning register command resets the worker state.
+    Configuration.set(PropertyKey.WORKER_REGISTER_STREAM_ENABLED, true);
+    TestBlockMasterClient.INSTANCE.setReturnRegisterCommand(true);
+    sync.heartbeat();
+    TestBlockMasterClient.INSTANCE.setReturnRegisterCommand(false);
+    assertFalse(sync.isRegistered());
+
+    Configuration.set(PropertyKey.WORKER_REGISTER_STREAM_ENABLED, false);
+    TestBlockMasterClient.INSTANCE.setReturnRegisterCommand(true);
+    sync.heartbeat();
+    TestBlockMasterClient.INSTANCE.setReturnRegisterCommand(false);
+    assertFalse(sync.isRegistered());
+
+    // heartbeat registers the worker if it has not been registered.
+    sync.heartbeat();
+    assertTrue(sync.isRegistered());
+
+    assertTrue(TestBlockMasterClient.INSTANCE.mRegisterCalled);
+    assertTrue(TestBlockMasterClient.INSTANCE.mRegisterWithStreamCalled);
+  }
+
+  private static class TestBlockMasterClient extends BlockMasterClient {
+    public static final TestBlockMasterClient INSTANCE = new TestBlockMasterClient();
+
+    private boolean mLastRegisterSuccess = true;
+    private boolean mFlakyRegistration = false;
+    private boolean mReturnRegisterCommand = false;
+
+    private boolean mRegisterCalled = false;
+
+    private boolean mRegisterWithStreamCalled = false;
+
+    public void setFlakyRegistration(boolean value) {
+      mFlakyRegistration = value;
+    }
+
+    public void setReturnRegisterCommand(boolean value) {
+      mReturnRegisterCommand = value;
+    }
+
+    public TestBlockMasterClient() {
+      super(MasterClientContext
+          .newBuilder(ClientContext.create(Configuration.global()))
+          .setMasterInquireClient(new SingleMasterInquireClient(
+              InetSocketAddress.createUnresolved("localhost", 0))).build());
+    }
+
+    @Override
+    public void register(
+        long workerId, List<String> storageTierAliases,
+        Map<String, Long> totalBytesOnTiers, Map<String, Long> usedBytesOnTiers,
+        Map<BlockStoreLocation, List<Long>> currentBlocksOnLocation,
+        Map<String, List<String>> lostStorage, List<ConfigProperty> configList)
+        throws IOException {
+      if (!mFlakyRegistration) {
+        return;
+      }
+      if (mLastRegisterSuccess) {
+        mLastRegisterSuccess = false;
+        throw new IOException("Registration failed");
+      } else {
+        mLastRegisterSuccess = true;
+        mRegisterCalled = true;
+      }
+    }
+
+    @Override
+    public void registerWithStream(
+        long workerId, List<String> storageTierAliases,
+        Map<String, Long> totalBytesOnTiers,
+        Map<String, Long> usedBytesOnTiers,
+        Map<BlockStoreLocation, List<Long>> currentBlocksOnLocation,
+        Map<String, List<String>> lostStorage,
+        List<ConfigProperty> configList) throws IOException {
+      if (!mFlakyRegistration) {
+        return;
+      }
+      if (mLastRegisterSuccess) {
+        mLastRegisterSuccess = false;
+        throw new IOException("Registration failed");
+      } else {
+        mLastRegisterSuccess = true;
+        mRegisterWithStreamCalled = true;
+      }
+    }
+
+    @Override
+    public void addWorkerId(long workerId, WorkerNetAddress address) throws IOException {
+    }
+
+    @Override
+    public synchronized Command heartbeat(
+        long workerId, Map<String, Long> capacityBytesOnTiers,
+        Map<String, Long> usedBytesOnTiers,
+        List<Long> removedBlocks,
+        Map<BlockStoreLocation, List<Long>> addedBlocks,
+        Map<String, List<String>> lostStorage,
+        List<Metric> metrics) throws IOException {
+      if (mReturnRegisterCommand) {
+        return Command.newBuilder().setCommandType(CommandType.Register).build();
+      }
+      return Command.newBuilder().setCommandType(CommandType.Nothing).build();
+    }
+
+    @Override
+    public void acquireRegisterLeaseWithBackoff(
+        long workerId, int estimatedBlockCount, RetryPolicy retry)
+        throws IOException, FailedToAcquireRegisterLeaseException {
+    }
+  }
+
+  public BlockMasterClientPool mClientPool = new BlockMasterClientPool() {
+    @Override
+    public BlockMasterClient acquire() {
+      return TestBlockMasterClient.INSTANCE;
+    }
+
+    @Override
+    public void release(BlockMasterClient resource) {
+    }
+  };
+
+  private BlockWorker getMockedBlockWorker() throws Exception {
+    File tempFolder = mTestFolder.newFolder();
+    BlockMetadataManager metadataManager =
+        TieredBlockStoreTestUtils.defaultMetadataManager(tempFolder.getAbsolutePath());
+
+    BlockWorker blockWorker = Mockito.mock(BlockWorker.class);
+    Mockito.when(blockWorker.getStoreMetaFull())
+        .thenReturn(metadataManager.getBlockStoreMetaFull());
+    Mockito.when(blockWorker.getStoreMeta())
+        .thenReturn(metadataManager.getBlockStoreMetaFull());
+    Mockito.when(blockWorker.getReport())
+        .thenReturn(new BlockHeartbeatReport(Collections.emptyMap(),
+        Collections.emptyList(), Collections.emptyMap()));
+    return blockWorker;
+  }
+}

--- a/core/server/worker/src/test/java/alluxio/worker/block/SpecificMasterBlockSyncTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/SpecificMasterBlockSyncTest.java
@@ -49,7 +49,7 @@ public class SpecificMasterBlockSyncTest {
   @Test
   public void heartbeatThread() throws Exception {
     int heartbeatReportCapacityThreshold = 3;
-    Configuration.set(PropertyKey.WORKER_BLOCK_HEARTBEAT_REPORT_CAPACITY_THRESHOLD,
+    Configuration.set(PropertyKey.WORKER_BLOCK_HEARTBEAT_REPORT_SIZE_THRESHOLD,
         heartbeatReportCapacityThreshold);
     BlockHeartbeatReporter blockHeartbeatReporter = new TestBlockHeartbeatReporter();
 
@@ -98,7 +98,7 @@ public class SpecificMasterBlockSyncTest {
     TestBlockMasterClient.INSTANCE.setHeartbeatError(false);
     sync.heartbeat();
     assertTrue(sync.isRegistered());
-    assertEquals(1, blockHeartbeatReporter.generateReportAndClear().getBlockCount());
+    assertEquals(1, blockHeartbeatReporter.generateReportAndClear().getBlockChangeCount());
 
     assertTrue(TestBlockMasterClient.INSTANCE.mRegisterCalled);
     assertTrue(TestBlockMasterClient.INSTANCE.mRegisterWithStreamCalled);

--- a/core/transport/src/main/proto/grpc/block_master.proto
+++ b/core/transport/src/main/proto/grpc/block_master.proto
@@ -240,6 +240,16 @@ message CommitBlockInUfsPRequest {
 message CommitBlockInUfsPOptions {}
 message CommitBlockInUfsPResponse {}
 
+message AddWorkerIdPOptions {}
+message AddWorkerIdPRequest {
+  optional int64 workerId = 1;
+  /** the worker network address */
+  optional grpc.WorkerNetAddress workerNetAddress = 2;
+  optional AddWorkerIdPOptions options = 3;
+}
+message AddWorkerIdPResponse {
+}
+
 message GetWorkerIdPOptions {}
 message GetWorkerIdPRequest {
   /** the worker network address */
@@ -317,6 +327,11 @@ service BlockMasterWorkerService {
    * Returns a worker id for the given network address.
    */
   rpc GetWorkerId(GetWorkerIdPRequest) returns (GetWorkerIdPResponse);
+
+  /**
+    * Notify all masters about the worker ID.
+    */
+  rpc AddWorkerId(AddWorkerIdPRequest) returns (AddWorkerIdPResponse);
 
   /**
    * Registers a worker.

--- a/core/transport/src/main/proto/grpc/block_master.proto
+++ b/core/transport/src/main/proto/grpc/block_master.proto
@@ -329,8 +329,8 @@ service BlockMasterWorkerService {
   rpc GetWorkerId(GetWorkerIdPRequest) returns (GetWorkerIdPResponse);
 
   /**
-    * Notify all masters about the worker ID.
-    */
+  * Notify all masters about the worker ID.
+  */
   rpc AddWorkerId(AddWorkerIdPRequest) returns (AddWorkerIdPResponse);
 
   /**

--- a/core/transport/src/main/proto/grpc/block_master.proto
+++ b/core/transport/src/main/proto/grpc/block_master.proto
@@ -240,14 +240,14 @@ message CommitBlockInUfsPRequest {
 message CommitBlockInUfsPOptions {}
 message CommitBlockInUfsPResponse {}
 
-message AddWorkerIdPOptions {}
-message AddWorkerIdPRequest {
+message NotifyWorkerIdPOptions {}
+message NotifyWorkerIdPRequest {
   optional int64 workerId = 1;
   /** the worker network address */
   optional grpc.WorkerNetAddress workerNetAddress = 2;
-  optional AddWorkerIdPOptions options = 3;
+  optional NotifyWorkerIdPOptions options = 3;
 }
-message AddWorkerIdPResponse {
+message NotifyWorkerIdPResponse {
 }
 
 message GetWorkerIdPOptions {}
@@ -331,7 +331,7 @@ service BlockMasterWorkerService {
   /**
   * Notify all masters about the worker ID.
   */
-  rpc AddWorkerId(AddWorkerIdPRequest) returns (AddWorkerIdPResponse);
+  rpc NotifyWorkerId(NotifyWorkerIdPRequest) returns (NotifyWorkerIdPResponse);
 
   /**
    * Registers a worker.

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -8582,11 +8582,6 @@
                 "id": 2,
                 "name": "length",
                 "type": "int64"
-              },
-              {
-                "id": 3,
-                "name": "block_location",
-                "type": "grpc.BlockLocation"
               }
             ]
           },
@@ -8599,11 +8594,6 @@
                 "type": "int64"
               }
             ]
-          }
-        ],
-        "imports": [
-          {
-            "path": "grpc/common.proto"
           }
         ],
         "package": {

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -596,10 +596,10 @@
             "name": "CommitBlockInUfsPResponse"
           },
           {
-            "name": "AddWorkerIdPOptions"
+            "name": "NotifyWorkerIdPOptions"
           },
           {
-            "name": "AddWorkerIdPRequest",
+            "name": "NotifyWorkerIdPRequest",
             "fields": [
               {
                 "id": 1,
@@ -614,12 +614,12 @@
               {
                 "id": 3,
                 "name": "options",
-                "type": "AddWorkerIdPOptions"
+                "type": "NotifyWorkerIdPOptions"
               }
             ]
           },
           {
-            "name": "AddWorkerIdPResponse"
+            "name": "NotifyWorkerIdPResponse"
           },
           {
             "name": "GetWorkerIdPOptions"
@@ -858,9 +858,9 @@
                 "out_type": "GetWorkerIdPResponse"
               },
               {
-                "name": "AddWorkerId",
-                "in_type": "AddWorkerIdPRequest",
-                "out_type": "AddWorkerIdPResponse"
+                "name": "NotifyWorkerId",
+                "in_type": "NotifyWorkerIdPRequest",
+                "out_type": "NotifyWorkerIdPResponse"
               },
               {
                 "name": "RegisterWorker",

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -8582,6 +8582,11 @@
                 "id": 2,
                 "name": "length",
                 "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "block_location",
+                "type": "grpc.BlockLocation"
               }
             ]
           },
@@ -8594,6 +8599,11 @@
                 "type": "int64"
               }
             ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "grpc/common.proto"
           }
         ],
         "package": {

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -596,6 +596,32 @@
             "name": "CommitBlockInUfsPResponse"
           },
           {
+            "name": "AddWorkerIdPOptions"
+          },
+          {
+            "name": "AddWorkerIdPRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "workerId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "workerNetAddress",
+                "type": "grpc.WorkerNetAddress"
+              },
+              {
+                "id": 3,
+                "name": "options",
+                "type": "AddWorkerIdPOptions"
+              }
+            ]
+          },
+          {
+            "name": "AddWorkerIdPResponse"
+          },
+          {
             "name": "GetWorkerIdPOptions"
           },
           {
@@ -830,6 +856,11 @@
                 "name": "GetWorkerId",
                 "in_type": "GetWorkerIdPRequest",
                 "out_type": "GetWorkerIdPResponse"
+              },
+              {
+                "name": "AddWorkerId",
+                "in_type": "AddWorkerIdPRequest",
+                "out_type": "AddWorkerIdPResponse"
               },
               {
                 "name": "RegisterWorker",
@@ -8551,6 +8582,11 @@
                 "id": 2,
                 "name": "length",
                 "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "block_location",
+                "type": "grpc.BlockLocation"
               }
             ]
           },
@@ -8563,6 +8599,11 @@
                 "type": "int64"
               }
             ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "grpc/common.proto"
           }
         ],
         "package": {

--- a/core/transport/src/main/proto/proto/journal/block.proto
+++ b/core/transport/src/main/proto/proto/journal/block.proto
@@ -2,6 +2,8 @@ syntax = "proto2";
 
 package alluxio.proto.journal;
 
+import "grpc/common.proto";
+
 // Journal entry messages for the block master.
 
 // next available id: 2
@@ -13,6 +15,7 @@ message BlockContainerIdGeneratorEntry {
 message BlockInfoEntry {
   optional int64 block_id = 1;
   optional int64 length = 2;
+  optional grpc.BlockLocation block_location = 3;
 }
 
 // next available id: 2

--- a/core/transport/src/main/proto/proto/journal/block.proto
+++ b/core/transport/src/main/proto/proto/journal/block.proto
@@ -2,8 +2,6 @@ syntax = "proto2";
 
 package alluxio.proto.journal;
 
-import "grpc/common.proto";
-
 // Journal entry messages for the block master.
 
 // next available id: 2
@@ -15,7 +13,6 @@ message BlockContainerIdGeneratorEntry {
 message BlockInfoEntry {
   optional int64 block_id = 1;
   optional int64 length = 2;
-  optional grpc.BlockLocation block_location = 3;
 }
 
 // next available id: 2

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -106,6 +106,8 @@ public class PortCoordination {
   public static final List<ReservedPort> QUORUM_SHELL_INFO = allocate(3, 0);
   public static final List<ReservedPort> QUORUM_SHELL_REMOVE = allocate(5, 0);
 
+  public static final List<ReservedPort> WORKER_ALL_MASTER_REGISTRATION = allocate(3, 1);
+
   private static synchronized List<ReservedPort> allocate(int numMasters, int numWorkers) {
     int needed = numMasters * MultiProcessCluster.PORTS_PER_MASTER
         + numWorkers * MultiProcessCluster.PORTS_PER_WORKER;

--- a/tests/src/test/java/alluxio/server/block/BlockMasterRegisterStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/block/BlockMasterRegisterStreamIntegrationTest.java
@@ -38,6 +38,7 @@ import alluxio.grpc.LocationBlockIdListEntry;
 import alluxio.grpc.RegisterWorkerPRequest;
 import alluxio.grpc.RegisterWorkerPResponse;
 import alluxio.grpc.StorageList;
+import alluxio.master.AlwaysPrimaryPrimarySelector;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.MasterRegistry;
 import alluxio.master.MasterTestUtils;
@@ -48,6 +49,7 @@ import alluxio.master.block.DefaultBlockMaster;
 import alluxio.master.block.RegisterStreamObserver;
 import alluxio.master.block.WorkerRegisterContext;
 import alluxio.master.block.meta.MasterWorkerInfo;
+import alluxio.master.journal.noop.NoopJournalSystem;
 import alluxio.master.metrics.MetricsMaster;
 import alluxio.master.metrics.MetricsMasterFactory;
 import alluxio.stress.cli.RpcBenchPreparationUtils;
@@ -118,7 +120,9 @@ public class BlockMasterRegisterStreamIntegrationTest {
     Configuration.set(PropertyKey.MASTER_WORKER_REGISTER_LEASE_ENABLED, false);
 
     mRegistry = new MasterRegistry();
-    mMasterContext = MasterTestUtils.testMasterContext();
+    mMasterContext = MasterTestUtils.testMasterContext(
+        new NoopJournalSystem(), null, new AlwaysPrimaryPrimarySelector()
+    );
     mMetricsMaster = new MetricsMasterFactory().create(mRegistry, mMasterContext);
     mRegistry.add(MetricsMaster.class, mMetricsMaster);
     mClock = new ManualClock();

--- a/tests/src/test/java/alluxio/server/worker/WorkerAllMasterRegistrationTest.java
+++ b/tests/src/test/java/alluxio/server/worker/WorkerAllMasterRegistrationTest.java
@@ -1,0 +1,129 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.server.worker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import alluxio.AlluxioURI;
+import alluxio.client.WriteType;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.FileOutStream;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.status.UnavailableException;
+import alluxio.master.MultiMasterEmbeddedJournalLocalAlluxioCluster;
+import alluxio.master.block.BlockMaster;
+import alluxio.master.block.DefaultBlockMaster;
+import alluxio.multi.process.PortCoordination;
+import alluxio.testutils.IntegrationTestUtils;
+import alluxio.util.CommonUtils;
+import alluxio.wire.BlockLocationInfo;
+import alluxio.worker.block.AllMasterRegistrationBlockWorker;
+import alluxio.worker.block.BlockWorker;
+import alluxio.worker.block.SpecificMasterBlockSync;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class WorkerAllMasterRegistrationTest {
+  private MultiMasterEmbeddedJournalLocalAlluxioCluster mCluster;
+
+  @Rule
+  public TestName mTestName = new TestName();
+
+  private final List<DefaultBlockMaster> mBlockMasters = new ArrayList<>();
+  private AllMasterRegistrationBlockWorker mWorker;
+  private final int mNumMasters = 3;
+  private final int mNumWorkers = 1;
+
+  @Before
+  public void before() throws Exception {
+    mCluster = new MultiMasterEmbeddedJournalLocalAlluxioCluster(
+        mNumMasters, mNumWorkers, PortCoordination.WORKER_ALL_MASTER_REGISTRATION);
+    mCluster.initConfiguration(
+        IntegrationTestUtils.getTestName(getClass().getSimpleName(), mTestName.getMethodName()));
+    Configuration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 5);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, 100);
+    Configuration.set(PropertyKey.WORKER_REGISTER_TO_ALL_MASTERS, true);
+    Configuration.set(PropertyKey.STANDBY_MASTER_GRPC_ENABLED, true);
+    Configuration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.MUST_CACHE);
+    mCluster.start();
+
+    mWorker = (AllMasterRegistrationBlockWorker)
+        mCluster.getWorkerProcess(0).getWorker(BlockWorker.class);
+    for (int i = 0; i < mNumMasters; i++) {
+      mBlockMasters.add((DefaultBlockMaster)
+          mCluster.getLocalAlluxioMasterByIndex(i).getMasterProcess().getMaster(BlockMaster.class));
+    }
+  }
+
+  @After
+  public void after() throws Exception {
+    mCluster.stop();
+    mWorker = null;
+    mBlockMasters.clear();
+  }
+
+  @Test
+  public void happyPath() throws Exception {
+    CommonUtils.waitFor("wait for worker registration complete", () ->
+        mWorker.getMasterSyncOperators().values().stream().allMatch(
+            SpecificMasterBlockSync::isRegistered));
+
+    AllMasterRegistrationBlockWorker worker =
+        (AllMasterRegistrationBlockWorker)
+            mCluster.getWorkerProcess(0).getWorker(BlockWorker.class);
+    AlluxioURI fileUri = new AlluxioURI("/foobar");
+    String fileContent = "foobar";
+
+    FileOutStream fos = mCluster.getClient().createFile(fileUri);
+    fos.write(fileContent.getBytes());
+    fos.close();
+
+    FileInStream fis = mCluster.getClient().openFile(fileUri);
+    assertEquals(fileContent, IOUtils.toString(fis, Charset.defaultCharset()));
+
+    List<BlockLocationInfo> blockLocations =
+        mCluster.getClient().getBlockLocations(fileUri);
+    assertEquals(1, blockLocations.size());
+    assertEquals(1, blockLocations.get(0).getLocations().size());
+    long blockId = blockLocations.get(0).getBlockInfo().getBlockInfo().getBlockId();
+
+    CommonUtils.waitFor("wait for blocks being committed to all masters", () ->
+        mBlockMasters.stream().allMatch(
+            it -> it.getBlockMetaStore().getLocations(blockId).size() == 1));
+
+    worker.removeBlock(new Random().nextLong(), blockId);
+    CommonUtils.waitFor("wait for blocks being removed to all masters", () ->
+        mBlockMasters.stream().allMatch(
+            it -> it.getBlockMetaStore().getLocations(blockId).size() == 0));
+
+    assertTrue(worker.getMasterSyncOperators().values().stream().allMatch(
+        SpecificMasterBlockSync::isRegistered));
+
+    fis = mCluster.getClient().openFile(fileUri);
+    FileInStream finalFis = fis;
+    assertThrows(UnavailableException.class,
+        () -> IOUtils.toString(finalFis, Charset.defaultCharset()));
+  }
+}

--- a/tests/src/test/java/alluxio/server/worker/WorkerAllMasterRegistrationTest.java
+++ b/tests/src/test/java/alluxio/server/worker/WorkerAllMasterRegistrationTest.java
@@ -75,7 +75,7 @@ public class WorkerAllMasterRegistrationTest {
     Configuration.set(PropertyKey.WORKER_REGISTER_TO_ALL_MASTERS, true);
     Configuration.set(PropertyKey.STANDBY_MASTER_GRPC_ENABLED, true);
     Configuration.set(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.MUST_CACHE);
-    Configuration.set(PropertyKey.WORKER_BLOCK_HEARTBEAT_REPORT_CAPACITY_THRESHOLD, 5);
+    Configuration.set(PropertyKey.WORKER_BLOCK_HEARTBEAT_REPORT_SIZE_THRESHOLD, 5);
     Configuration.set(PropertyKey.MASTER_JOURNAL_FLUSH_TIMEOUT_MS, "30sec");
     Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_WRITE_TIMEOUT, "10sec");
     Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, "3s");
@@ -273,11 +273,11 @@ public class WorkerAllMasterRegistrationTest {
   }
 
   /**
-   * Tests the worker can re-register with masters if its heartbeat failed too many times.
-   * The registration is used to address OOM issue.
+   * Tests the worker can re-register with masters if its heartbeat failed too many times,
+   * and the block report becomes too big and takes up too many memory.
    */
   @Test
-  public void blockHeartbeatReportOOM() throws Exception {
+  public void heartbeatFallsBackToRegister() throws Exception {
     CommonUtils.waitFor("wait for worker registration complete", () ->
         mWorker.getBlockSyncMasterGroup().isRegisteredToAllMasters(), mDefaultWaitForOptions);
 

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileOutputStream.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileOutputStream.java
@@ -59,7 +59,7 @@ public class HdfsUnderFileOutputStream extends OutputStream implements ContentHa
   public void flush() throws IOException {
     // TODO(calvin): This functionality should be restricted to select output streams.
     //#ifdef HADOOP1
-    mOut.sync();
+    // mOut.sync();
     //#else
     // Note that, hsync() flushes out the data in client's user buffer all the way to the disk
     // device which may result in much slower performance than sync().

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileOutputStream.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileOutputStream.java
@@ -59,7 +59,7 @@ public class HdfsUnderFileOutputStream extends OutputStream implements ContentHa
   public void flush() throws IOException {
     // TODO(calvin): This functionality should be restricted to select output streams.
     //#ifdef HADOOP1
-    // mOut.sync();
+    mOut.sync();
     //#else
     // Note that, hsync() flushes out the data in client's user buffer all the way to the disk
     // device which may result in much slower performance than sync().

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -450,21 +450,21 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
       switch (type) {
         case SPACE_TOTAL:
           //#ifdef HADOOP1
-          space = ((DistributedFileSystem) hdfs).getDiskStatus().getCapacity();
+          // space = ((DistributedFileSystem) hdfs).getDiskStatus().getCapacity();
           //#else
           space = hdfs.getStatus().getCapacity();
           //#endif
           break;
         case SPACE_USED:
           //#ifdef HADOOP1
-          space = ((DistributedFileSystem) hdfs).getDiskStatus().getDfsUsed();
+          // space = ((DistributedFileSystem) hdfs).getDiskStatus().getDfsUsed();
           //#else
           space = hdfs.getStatus().getUsed();
           //#endif
           break;
         case SPACE_FREE:
           //#ifdef HADOOP1
-          space = ((DistributedFileSystem) hdfs).getDiskStatus().getRemaining();
+          // space = ((DistributedFileSystem) hdfs).getDiskStatus().getRemaining();
           //#else
           space = hdfs.getStatus().getRemaining();
           //#endif

--- a/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/alluxio/underfs/hdfs/HdfsUnderFileSystem.java
@@ -450,21 +450,21 @@ public class HdfsUnderFileSystem extends ConsistentUnderFileSystem
       switch (type) {
         case SPACE_TOTAL:
           //#ifdef HADOOP1
-          // space = ((DistributedFileSystem) hdfs).getDiskStatus().getCapacity();
+          space = ((DistributedFileSystem) hdfs).getDiskStatus().getCapacity();
           //#else
           space = hdfs.getStatus().getCapacity();
           //#endif
           break;
         case SPACE_USED:
           //#ifdef HADOOP1
-          // space = ((DistributedFileSystem) hdfs).getDiskStatus().getDfsUsed();
+          space = ((DistributedFileSystem) hdfs).getDiskStatus().getDfsUsed();
           //#else
           space = hdfs.getStatus().getUsed();
           //#endif
           break;
         case SPACE_FREE:
           //#ifdef HADOOP1
-          // space = ((DistributedFileSystem) hdfs).getDiskStatus().getRemaining();
+          space = ((DistributedFileSystem) hdfs).getDiskStatus().getRemaining();
           //#else
           space = hdfs.getStatus().getRemaining();
           //#endif


### PR DESCRIPTION
### What changes are proposed in this pull request?

Make workers register to all masters
1. Enabled grpc block master service on standby masters
2. Introduce SpecificMasterBlockSync on workers to heartbeat all masters and BlockSyncMaster for its abstraction
3. Introduce add worker id rpc to reach consensus on worker ids across masters
4. Journal the block location change
5. Update the heartbeat report generation and make it more fault tolerant
6. All a basic worker registration integration test 

### Why are the changes needed?

To accelerate the master failover process

### Does this PR introduce any user facing changes?

N/A