### PR TITLE
Make version service return unavailable on standby masters

### DIFF
--- a/core/common/src/main/java/alluxio/grpc/GrpcServerBuilder.java
+++ b/core/common/src/main/java/alluxio/grpc/GrpcServerBuilder.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
@@ -262,7 +263,18 @@ public final class GrpcServerBuilder {
    * @return the built {@link GrpcServer}
    */
   public GrpcServer build() {
-    addService(new GrpcService(new ServiceVersionClientServiceHandler(mServices))
+    return build(null);
+  }
+
+  /**
+   * Build the server.
+   * It attaches required services and interceptors for authentication.
+   *
+   * @param nodeStateSupplier a supplier to provide the node state (PRIMARY/STANDBY)
+   * @return the built {@link GrpcServer}
+   */
+  public GrpcServer build(@Nullable Supplier<NodeState> nodeStateSupplier) {
+    addService(new GrpcService(new ServiceVersionClientServiceHandler(mServices, nodeStateSupplier))
         .disableAuthentication());
     if (mGrpcReflectionEnabled) {
       // authentication needs to be disabled so that the grpc command line tools can call

--- a/core/server/master/src/main/java/alluxio/master/MasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/MasterProcess.java
@@ -276,4 +276,11 @@ public abstract class MasterProcess implements Process {
   public boolean waitForReady(int timeoutMs) {
     return waitForGrpcServerReady(timeoutMs);
   }
+
+  /**
+   * @return the primary selector
+   */
+  public PrimarySelector getPrimarySelector() {
+    return mLeaderSelector;
+  }
 }

--- a/core/server/master/src/main/java/alluxio/master/service/rpc/RpcServerService.java
+++ b/core/server/master/src/main/java/alluxio/master/service/rpc/RpcServerService.java
@@ -111,7 +111,7 @@ public class RpcServerService implements SimpleService {
         LOG.info("registered service {}", type.name());
       });
     });
-    mGrpcServer = builder.build();
+    mGrpcServer = builder.build(() -> mMasterProcess.getPrimarySelector().getStateUnsafe());
     try {
       mGrpcServer.start();
       mMasterProcess.getSafeModeManager().ifPresent(SafeModeManager::notifyRpcServerStarted);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Make version service return unavailable on standby masters

### Why are the changes needed?

In this https://github.com/Alluxio/alluxio/pull/16839 PR, we adds the capability to run grpc services on standby masters. However, if one uses an old alluxio client and connects to the new master with standby master enabled, it will get some errors. This PR is used to address the issue to make the change backward compatible.  

### Does this PR introduce any user facing changes?

N/A