### PR TITLE
Improve backup error propagation and messaging

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/ufs/UfsJournalCheckpointThread.java
@@ -226,9 +226,9 @@ public final class UfsJournalCheckpointThread extends AutopsyThread {
       try {
         switch (mJournalReader.advance()) {
           case CHECKPOINT:
-            LOG.debug("{}: Restoring from checkpoint", mMaster.getName());
+            LOG.info("{}: Restoring from checkpoint", mMaster.getName());
             mMaster.restoreFromCheckpoint(mJournalReader.getCheckpoint());
-            LOG.debug("{}: Finished restoring from checkpoint", mMaster.getName());
+            LOG.info("{}: Finished restoring from checkpoint", mMaster.getName());
             break;
           case LOG:
             entry = mJournalReader.getEntry();

--- a/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
+++ b/core/server/master/src/main/java/alluxio/master/backup/BackupWorkerRole.java
@@ -168,10 +168,10 @@ public class BackupWorkerRole extends AbstractBackupRole {
     try {
       mJournalSystem.suspend(this::interruptBackup);
       LOG.info("Suspended journals for backup.");
-    } catch (IOException e) {
-      String failMessage = "Failed to suspended journals for backup.";
-      LOG.error(failMessage, e);
-      throw new RuntimeException(failMessage, e);
+    } catch (Exception e) {
+      CompletableFuture<Void> future = new CompletableFuture<>();
+      future.completeExceptionally(e);
+      return future;
     }
     // Schedule a timeout task to resume journals if protocol is not followed by the leader.
     mBackupTimeoutTask = mTaskScheduler.schedule(() -> {


### PR DESCRIPTION
### Why are the changes needed?
The backup command needs to be more responsive. These changes make a follower tasked with taking a backup that cannot currently do so (because it is restoring from a checkpoint) return an error to the leader immediately, rather than waiting for a timeout.
This makes the `bin/alluxio fsadmin backup` command much more responsive and interactive.

### Does this PR introduce any user facing changes?
No.