### PR TITLE
Add rate limit for s3 proxy

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5303,7 +5303,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB =
-      longBuilder(Name.PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB)
+      intBuilder(Name.PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setDescription("Limit the maximum read speed for each connection. "
               + "Set value less than or equal to 0 to disable rate limits.")
@@ -5311,7 +5311,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_S3_GLOBAL_READ_RATE_LIMIT_MB =
-      longBuilder(Name.PROXY_S3_GLOBAL_READ_RATE_LIMIT_MB)
+      intBuilder(Name.PROXY_S3_GLOBAL_READ_RATE_LIMIT_MB)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setDescription("Limit the maximum read speed for all connections. "
               + "Set value less than or equal to 0 to disable rate limits.")

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5305,7 +5305,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey PROXY_S3_READ_RATE_LIMIT_MB =
       longBuilder(Name.PROXY_S3_READ_RATE_LIMIT_MB)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
-          .setDescription("Limit the maximum read speed for each getObject request")
+          .setDescription("Limit the maximum read speed for each getObject request.")
           .setDefaultValue(0)
           .setScope(Scope.SERVER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5302,10 +5302,19 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
-  public static final PropertyKey PROXY_S3_READ_RATE_LIMIT_MB =
-      longBuilder(Name.PROXY_S3_READ_RATE_LIMIT_MB)
+  public static final PropertyKey PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB =
+      longBuilder(Name.PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
-          .setDescription("Limit the maximum read speed for each getObject request.")
+          .setDescription("Limit the maximum read speed for each connection. "
+              + "Set value less than or equal to 0 to disable rate limits.")
+          .setDefaultValue(0)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey PROXY_S3_GLOBAL_READ_RATE_LIMIT_MB =
+      longBuilder(Name.PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setDescription("Limit the maximum read speed for all connections. "
+              + "Set value less than or equal to 0 to disable rate limits.")
           .setDefaultValue(0)
           .setScope(Scope.SERVER)
           .build();
@@ -8424,7 +8433,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String PROXY_S3_V2_ASYNC_PROCESSING_ENABLED =
             "alluxio.proxy.s3.v2.async.processing.enabled";
     public static final String S3_UPLOADS_ID_XATTR_KEY = "s3_uploads_mulitpartupload_id";
-    public static final String PROXY_S3_READ_RATE_LIMIT_MB = "alluxio.proxy.s3.read.rate.limit.mb";
+    public static final String PROXY_S3_GLOBAL_READ_RATE_LIMIT_MB =
+        "alluxio.proxy.s3.global.read.rate.limit.mb";
+    public static final String PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB =
+        "alluxio.proxy.s3.single.connection.read.rate.limit.mb";
 
     //
     // Locality related properties

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5311,7 +5311,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey PROXY_S3_GLOBAL_READ_RATE_LIMIT_MB =
-      longBuilder(Name.PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB)
+      longBuilder(Name.PROXY_S3_GLOBAL_READ_RATE_LIMIT_MB)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setDescription("Limit the maximum read speed for all connections. "
               + "Set value less than or equal to 0 to disable rate limits.")

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5302,6 +5302,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey PROXY_S3_READ_RATE_LIMIT_MB =
+      longBuilder(Name.PROXY_S3_READ_RATE_LIMIT_MB)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setDescription("Limit the maximum read speed for each getObject request")
+          .setDefaultValue(0)
+          .setScope(Scope.SERVER)
+          .build();
 
   //
   // Locality related properties
@@ -8417,6 +8424,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String PROXY_S3_V2_ASYNC_PROCESSING_ENABLED =
             "alluxio.proxy.s3.v2.async.processing.enabled";
     public static final String S3_UPLOADS_ID_XATTR_KEY = "s3_uploads_mulitpartupload_id";
+    public static final String PROXY_S3_READ_RATE_LIMIT_MB = "alluxio.proxy.s3.read.rate.limit.mb";
 
     //
     // Locality related properties

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/RateLimitInputStream.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/RateLimitInputStream.java
@@ -12,6 +12,7 @@
 package alluxio.proxy.s3;
 
 import com.google.common.util.concurrent.RateLimiter;
+
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -20,18 +21,23 @@ import java.io.InputStream;
  */
 public class RateLimitInputStream extends InputStream {
 
-  private final InputStream inputStream;
-  private final RateLimiter rateLimiter;
+  private final InputStream mInputStream;
+  private final RateLimiter mRateLimiter;
 
+  /**
+   * Constructs a new {@link RateLimitInputStream}.
+   * @param inputStream Original stream to be limited
+   * @param rate Maximal reading bytes per second
+   */
   public RateLimitInputStream(InputStream inputStream, long rate) {
-    this.inputStream = inputStream;
-    this.rateLimiter = RateLimiter.create(rate);
+    mInputStream = inputStream;
+    mRateLimiter = RateLimiter.create(rate);
   }
 
   @Override
   public int read() throws IOException {
-    rateLimiter.acquire(1);
-    return inputStream.read();
+    mRateLimiter.acquire(1);
+    return mInputStream.read();
   }
 
   @Override
@@ -41,12 +47,12 @@ public class RateLimitInputStream extends InputStream {
 
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
-    rateLimiter.acquire(Math.min(b.length - off, len));
-    return inputStream.read(b, off, len);
+    mRateLimiter.acquire(Math.min(b.length - off, len));
+    return mInputStream.read(b, off, len);
   }
 
   @Override
   public void close() throws IOException {
-    inputStream.close();
+    mInputStream.close();
   }
 }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/RateLimitInputStream.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/RateLimitInputStream.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * This class is a wrap for InputStream which limit rate when reading bytes.
+ * This class is a wrapper for InputStream which limit rate when reading bytes.
  */
 public class RateLimitInputStream extends InputStream {
 

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/RateLimitInputStream.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/RateLimitInputStream.java
@@ -1,0 +1,49 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import com.google.common.util.concurrent.RateLimiter;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class RateLimitInputStream extends InputStream {
+
+  private final InputStream inputStream;
+  private final RateLimiter rateLimiter;
+
+  public RateLimitInputStream(InputStream inputStream, long rate) {
+    this.inputStream = inputStream;
+    this.rateLimiter = RateLimiter.create(rate);
+  }
+
+  @Override
+  public int read() throws IOException {
+    rateLimiter.acquire(1);
+    return inputStream.read();
+  }
+
+  @Override
+  public int read(byte[] b) throws IOException {
+    return read(b, 0, b.length);
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    rateLimiter.acquire(Math.min(b.length - off, len));
+    return inputStream.read(b, off, len);
+  }
+
+  @Override
+  public void close() throws IOException {
+    inputStream.close();
+  }
+}

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/RateLimitInputStream.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/RateLimitInputStream.java
@@ -15,6 +15,9 @@ import com.google.common.util.concurrent.RateLimiter;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * This class is a wrap for InputStream which limit rate when reading bytes.
+ */
 public class RateLimitInputStream extends InputStream {
 
   private final InputStream inputStream;

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -108,8 +108,6 @@ public final class S3RestServiceHandler {
   /* Object is after bucket in the URL path */
   public static final String OBJECT_PARAM = "{bucket}/{object:.+}";
 
-  public static final long MB = 1024 * 1024L;
-
   private final FileSystem mMetaFS;
   private final InstancedConfiguration mSConf;
 
@@ -174,11 +172,8 @@ public final class S3RestServiceHandler {
       );
     }
 
-    long globalRate = mSConf.getLong(PropertyKey.PROXY_S3_GLOBAL_READ_RATE_LIMIT_MB) * MB;
-    if (globalRate <= 0) {
-      globalRate = Long.MAX_VALUE;
-    }
-    mGlobalRateLimiter = RateLimiter.create(globalRate);
+    mGlobalRateLimiter = (RateLimiter) context.getAttribute(
+        ProxyWebServer.GLOBAL_RATE_LIMITER_SERVLET_RESOURCE_KEY);
   }
 
   /**
@@ -1257,7 +1252,8 @@ public final class S3RestServiceHandler {
 
           InputStream rateLimitInputStream;
           long rate =
-              mSConf.getLong(PropertyKey.PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB) * MB;
+              mSConf.getLong(PropertyKey.PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB)
+                  * Constants.MB;
           if (rate <= 0) {
             rateLimitInputStream = new RateLimitInputStream(ris, mGlobalRateLimiter);
           } else {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -1252,7 +1252,7 @@ public final class S3RestServiceHandler {
 
           InputStream inputStream;
           long rate =
-              mSConf.getLong(PropertyKey.PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB)
+              (long) mSConf.getInt(PropertyKey.PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB)
                   * Constants.MB;
           RateLimiter currentRateLimiter = S3RestUtils.createRateLimiter(rate).orElse(null);
           if (currentRateLimiter == null && mGlobalRateLimiter == null) {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -40,6 +40,7 @@ import alluxio.util.SecurityUtils;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Longs;
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.protobuf.ByteString;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -56,6 +57,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -687,6 +689,18 @@ public final class S3RestUtils {
         throw S3RestUtils.toObjectS3Exception(e, objectPath, auditContext);
       }
     }
+  }
+
+  /**
+   * Create a rate limiter for given rate.
+   * @param rate bytes per second
+   * @return empty if rate <= 0
+   */
+  public static Optional<RateLimiter> createRateLimiter(long rate) {
+    if (rate <= 0) {
+      return Optional.empty();
+    }
+    return Optional.of(RateLimiter.create(rate));
   }
 
     /**

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -108,7 +108,7 @@ public final class ProxyWebServer extends WebServer {
 
     mFileSystem = FileSystem.Factory.create(Configuration.global());
     long rate =
-        Configuration.getLong(PropertyKey.PROXY_S3_GLOBAL_READ_RATE_LIMIT_MB) * Constants.MB;
+        (long) Configuration.getInt(PropertyKey.PROXY_S3_GLOBAL_READ_RATE_LIMIT_MB) * Constants.MB;
     mGlobalRateLimiter = S3RestUtils.createRateLimiter(rate).orElse(null);
 
     if (Configuration.getBoolean(PropertyKey.PROXY_AUDIT_LOGGING_ENABLED)) {

--- a/core/server/proxy/src/test/java/alluxio/proxy/s3/RateLimitInputStreamTest.java
+++ b/core/server/proxy/src/test/java/alluxio/proxy/s3/RateLimitInputStreamTest.java
@@ -11,22 +11,23 @@
 
 package alluxio.proxy.s3;
 
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.UUID;
-import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 public class RateLimitInputStreamTest {
 
   public static final int MB = 1024 * 1024;
   public static final int KB = 1024;
 
-  private byte[] data;
+  private byte[] mData;
 
   @Before
   public void init() throws IOException {
@@ -37,13 +38,13 @@ public class RateLimitInputStreamTest {
       byteArrayOutputStream.write(bytes);
       count += bytes.length;
     }
-    data = Arrays.copyOf(byteArrayOutputStream.toByteArray(), MB);
+    mData = Arrays.copyOf(byteArrayOutputStream.toByteArray(), MB);
   }
 
   @Test
   public void testRead() throws IOException {
     long rate = 100 * KB;
-    ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(mData);
     RateLimitInputStream rateLimitInputStream = new RateLimitInputStream(inputStream, rate);
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(MB);
     long start = System.currentTimeMillis();
@@ -52,7 +53,6 @@ public class RateLimitInputStreamTest {
     long duration = end - start;
     long expectedDuration = MB / rate * 1000;
     Assert.assertTrue(duration >= expectedDuration && duration <= expectedDuration + 1000);
-    Assert.assertArrayEquals(data, byteArrayOutputStream.toByteArray());
+    Assert.assertArrayEquals(mData, byteArrayOutputStream.toByteArray());
   }
-
 }

--- a/core/server/proxy/src/test/java/alluxio/proxy/s3/RateLimitInputStreamTest.java
+++ b/core/server/proxy/src/test/java/alluxio/proxy/s3/RateLimitInputStreamTest.java
@@ -1,0 +1,58 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.UUID;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RateLimitInputStreamTest {
+
+  public static final int MB = 1024 * 1024;
+  public static final int KB = 1024;
+
+  private byte[] data;
+
+  @Before
+  public void init() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(MB);
+    int count = 0;
+    while (count < MB) {
+      byte[] bytes = UUID.randomUUID().toString().getBytes();
+      byteArrayOutputStream.write(bytes);
+      count += bytes.length;
+    }
+    data = Arrays.copyOf(byteArrayOutputStream.toByteArray(), MB);
+  }
+
+  @Test
+  public void testRead() throws IOException {
+    long rate = 100 * KB;
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
+    RateLimitInputStream rateLimitInputStream = new RateLimitInputStream(inputStream, rate);
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(MB);
+    long start = System.currentTimeMillis();
+    IOUtils.copy(rateLimitInputStream, byteArrayOutputStream, KB);
+    long end = System.currentTimeMillis();
+    long duration = end - start;
+    long expectedDuration = MB / rate * 1000;
+    Assert.assertTrue(duration >= expectedDuration && duration <= expectedDuration + 1000);
+    Assert.assertArrayEquals(data, byteArrayOutputStream.toByteArray());
+  }
+
+}

--- a/core/server/proxy/src/test/java/alluxio/proxy/s3/RateLimitInputStreamTest.java
+++ b/core/server/proxy/src/test/java/alluxio/proxy/s3/RateLimitInputStreamTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -50,19 +51,22 @@ public class RateLimitInputStreamTest {
 
   @Test
   public void testSingleThreadRead() throws IOException {
-    long rate1 = 100 * KB;
-    long rate2 = 200 * KB;
-    ByteArrayInputStream inputStream = new ByteArrayInputStream(mData);
-    RateLimitInputStream rateLimitInputStream = new RateLimitInputStream(inputStream,
-        RateLimiter.create(rate1), RateLimiter.create(rate2));
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(MB);
-    long start = System.currentTimeMillis();
-    IOUtils.copy(rateLimitInputStream, byteArrayOutputStream, KB);
-    long end = System.currentTimeMillis();
-    long duration = end - start;
-    long expectedDuration = MB / Math.min(rate1, rate2) * 1000;
-    Assert.assertTrue(duration >= expectedDuration && duration <= expectedDuration + 1000);
-    Assert.assertArrayEquals(mData, byteArrayOutputStream.toByteArray());
+    Random random = new Random();
+    for (int i = 1; i <= 5; i++) {
+      long rate1 = (random.nextInt(4) + 1) * 100 * KB;
+      long rate2 = (random.nextInt(4) + 1) * 100 * KB;
+      ByteArrayInputStream inputStream = new ByteArrayInputStream(mData);
+      RateLimitInputStream rateLimitInputStream = new RateLimitInputStream(inputStream,
+          RateLimiter.create(rate1), RateLimiter.create(rate2));
+      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(MB);
+      long start = System.currentTimeMillis();
+      IOUtils.copy(rateLimitInputStream, byteArrayOutputStream, KB);
+      long end = System.currentTimeMillis();
+      long duration = end - start;
+      long expectedDuration = MB / Math.min(rate1, rate2) * 1000;
+      Assert.assertTrue(duration >= expectedDuration && duration <= expectedDuration + 1000);
+      Assert.assertArrayEquals(mData, byteArrayOutputStream.toByteArray());
+    }
   }
 
   private void testMultiThreadRead(long globalRate, long rate, int threadNum) {

--- a/core/server/proxy/src/test/java/alluxio/proxy/s3/RateLimitInputStreamTest.java
+++ b/core/server/proxy/src/test/java/alluxio/proxy/s3/RateLimitInputStreamTest.java
@@ -11,6 +11,9 @@
 
 package alluxio.proxy.s3;
 
+import static alluxio.Constants.KB;
+import static alluxio.Constants.MB;
+
 import com.google.common.util.concurrent.RateLimiter;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
@@ -30,9 +33,6 @@ import java.util.concurrent.FutureTask;
 import java.util.stream.Collectors;
 
 public class RateLimitInputStreamTest {
-
-  public static final int MB = 1024 * 1024;
-  public static final int KB = 1024;
 
   private byte[] mData;
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add read limit for s3 proxy when getObject return files.

### Why are the changes needed?

We use NVME to speed up reading algorithm model, but we find that the reading speed of alluxio is too fast and k8s container will consume a lot of network card resources, and then affect other containers of the same host, so we need to limit the reading speed.

### Does this PR introduce any user facing changes?

Add two properties:
1. `alluxio.proxy.s3.global.read.rate.limit.mb` to limit all connections rate;
2. `alluxio.proxy.s3.single.connection.read.rate.limit.mb` to limit single connection rate.
