### PR TITLE
Enable heartbeat for Dora workers temporarily

### DIFF
--- a/core/common/src/main/java/alluxio/resource/Pool.java
+++ b/core/common/src/main/java/alluxio/resource/Pool.java
@@ -39,6 +39,31 @@ public interface Pool<T> extends Closeable {
   T acquire(long time, TimeUnit unit) throws TimeoutException, IOException;
 
   /**
+   * Acquires a resource wrapped inside a {@link PooledResource}, which will release
+   * the resource to this pool when it's closed.
+   *
+   * @return pooled resource
+   */
+  // TODO(bowen): the raw {@link #acquire()} methods should be renamed to sth like acquireLeaked,
+  //  and this should be the default acquire methods
+  default PooledResource<T> acquireCloseable() throws IOException {
+    return new PooledResource<>(acquire(), this);
+  }
+
+  /**
+   * Acquires a resource wrapped inside a {@link PooledResource}, which will release
+   * the resource to this pool when it's closed.
+   *
+   * @param time time it takes before timeout if no resource is available
+   * @param unit the unit of the time
+   * @return pooled resource
+   */
+  default PooledResource<T> acquireCloseable(long time, TimeUnit unit)
+      throws TimeoutException, IOException {
+    return new PooledResource<>(acquire(time, unit), this);
+  }
+
+  /**
    * Releases the resource to the pool.
    *
    * @param resource the resource to release

--- a/core/common/src/main/java/alluxio/resource/PooledResource.java
+++ b/core/common/src/main/java/alluxio/resource/PooledResource.java
@@ -1,0 +1,58 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.resource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * A pooled resource that was acquired from a {@link Pool}, and will be released back
+ * to the pool when it's closed.
+ *
+ * @param <T> resource type
+ */
+public class PooledResource<T> extends CloseableResource<T> {
+  private static final Logger LOG = LoggerFactory.getLogger(PooledResource.class);
+  // weak reference is important as a leaked resource shouldn't keep the entire pool alive
+  protected final WeakReference<Pool<T>> mPool;
+  protected final String mPoolDescription;
+
+  /**
+   * Creates a new pooled resource with the pool from which it was acquired.
+   *
+   * @param resource the resource
+   * @param pool the pool where the resource was acquired
+   */
+  public PooledResource(T resource, Pool<T> pool) {
+    super(resource);
+    mPool = new WeakReference<>(pool);
+    mPoolDescription = String.format("%s @ %d",
+        pool.getClass().getName(), System.identityHashCode(pool)).intern();
+  }
+
+  @Override
+  public void closeResource() {
+    Pool<T> pool = mPool.get();
+    if (pool != null) {
+      pool.release(get());
+    } else {
+      // the pool is gone before this resource can be released, report a leak
+      T leaked = get();
+      LOG.warn(
+          "resource {} of type {} leaked from pool {} which had been GCed before the resource "
+          + "could be released",
+          leaked, leaked.getClass().getName(), mPoolDescription);
+    }
+  }
+}

--- a/core/common/src/test/java/alluxio/resource/PooledResourceTest.java
+++ b/core/common/src/test/java/alluxio/resource/PooledResourceTest.java
@@ -1,0 +1,106 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class PooledResourceTest {
+  @Test
+  public void releaseOnClose() {
+    TestPool pool = new TestPool(5);
+    try (PooledResource<Integer> i = new PooledResource<>(pool.acquire(), pool)) {
+      assertEquals(1, (int) i.get());
+      assertEquals(0, pool.getAvailableCount());
+      assertEquals(1, pool.getLeakCount());
+    }
+    assertEquals(1, pool.getAvailableCount());
+    assertEquals(0, pool.getLeakCount());
+  }
+
+  @Test
+  public void leakDoesNotPreventPoolFromBeingGCed() throws Exception {
+    long gcTimeout = 1000;
+    TestPool pool = new TestPool(5);
+    ReferenceQueue<TestPool> referenceQueue = new ReferenceQueue<>();
+    PhantomReference<TestPool> poolRef = new PhantomReference<>(pool, referenceQueue);
+    PooledResource<Integer> i = new PooledResource<>(pool.acquire(), pool);
+    PooledResource<Integer> toLeak = new PooledResource<>(pool.acquire(), pool);
+    assertEquals(1, (int) i.get());
+    assertEquals(2, (int) toLeak.get());
+    assertEquals(0, pool.getAvailableCount());
+    assertEquals(2, pool.getLeakCount());
+
+    i.close();
+    assertEquals(1, pool.getLeakCount());
+    assertEquals(1, pool.getAvailableCount());
+
+    // GC the pool before toLeak is released
+    pool = null;
+    System.gc();
+
+    // check the pool has really been GCed
+    Reference<? extends TestPool> enqueued = referenceQueue.remove(gcTimeout);
+    assertNotNull("ref is null, pool is likely not GCed before timeout", enqueued);
+    assertEquals(poolRef, enqueued);
+    enqueued.clear();
+
+    // we should still be able to close this without getting an exception
+    toLeak.close();
+  }
+
+  static class TestPool extends ResourcePool<Integer> {
+    int mCounter = 0;
+
+    TestPool(int capacity) {
+      super(capacity, new ConcurrentLinkedQueue<>());
+    }
+
+    @Override
+    public void close() throws IOException {
+      // do nothing
+    }
+
+    @Override
+    public Integer createNewResource() {
+      mCounter += 1;
+      return mCounter;
+    }
+
+    /**
+     * Gets the number of resources that are immediately available in the pool, without having to
+     * call {@link #createNewResource()}.
+     *
+     * @return number of resources
+     */
+    public int getAvailableCount() {
+      return mResources.size();
+    }
+
+    /**
+     * Gets the number of resources that has been acquired from this pooled but not released yet.
+     *
+     * @return the number of resources that is considered leaked
+     */
+    public int getLeakCount() {
+      return size() - getAvailableCount();
+    }
+  }
+}

--- a/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -170,12 +170,14 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
 
   @Override
   public void close() throws IOException {
-    super.close();
-    mResourceCloser.close();
-    try {
-      mCacheManager.close();
+    try (AutoCloseable ignoredCloser = mResourceCloser;
+         AutoCloseable ignoredCacheManager = mCacheManager
+    ) {
+      // do nothing as we are closing
     } catch (Exception e) {
       throw new IOException(e);
+    } finally {
+      super.close();
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -12,7 +12,6 @@
 package alluxio.worker.dora;
 
 import alluxio.AlluxioURI;
-import alluxio.ClientContext;
 import alluxio.Constants;
 import alluxio.DefaultStorageTierAssoc;
 import alluxio.Server;
@@ -24,27 +23,38 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.status.NotFoundException;
+import alluxio.grpc.Command;
+import alluxio.grpc.CommandType;
 import alluxio.grpc.GrpcService;
 import alluxio.grpc.Scope;
 import alluxio.grpc.ServiceType;
-import alluxio.master.MasterClientContext;
+import alluxio.heartbeat.HeartbeatContext;
+import alluxio.heartbeat.HeartbeatExecutor;
+import alluxio.heartbeat.HeartbeatThread;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.retry.RetryPolicy;
 import alluxio.retry.RetryUtils;
+import alluxio.security.user.ServerUserState;
 import alluxio.underfs.FileId;
 import alluxio.underfs.PagedUfsReader;
 import alluxio.underfs.UfsInputStreamCache;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerNetAddress;
+import alluxio.worker.AbstractWorker;
 import alluxio.worker.block.BlockMasterClient;
+import alluxio.worker.block.BlockMasterClientPool;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.page.UfsBlockReadOptions;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Closer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -55,7 +65,8 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Page store based dora worker.
  */
-public class PagedDoraWorker implements DoraWorker {
+public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
+  private static final Logger LOG = LoggerFactory.getLogger(PagedDoraWorker.class);
   // for now Dora Worker does not support Alluxio <-> UFS mapping,
   // and assumes all UFS paths belong to the same UFS.
   private static final int MOUNT_POINT = 1;
@@ -66,6 +77,8 @@ public class PagedDoraWorker implements DoraWorker {
   private final UfsInputStreamCache mUfsStreamCache;
   private final long mPageSize;
   private final AlluxioConfiguration mConf;
+  private final BlockMasterClientPool mBlockMasterClientPool;
+  private WorkerNetAddress mAddress;
 
   /**
    * Constructor.
@@ -73,11 +86,13 @@ public class PagedDoraWorker implements DoraWorker {
    * @param conf
    */
   public PagedDoraWorker(AtomicReference<Long> workerId, AlluxioConfiguration conf) {
+    super(ExecutorServiceFactories.fixedThreadPool("dora-worker-executor", 5));
     mWorkerId = workerId;
     mConf = conf;
     mUfsManager = mResourceCloser.register(new DoraUfsManager());
     mUfsStreamCache = new UfsInputStreamCache();
     mPageSize = Configuration.global().getBytes(PropertyKey.WORKER_PAGE_STORE_PAGE_SIZE);
+    mBlockMasterClientPool = new BlockMasterClientPool();
     try {
       CacheManagerOptions options = CacheManagerOptions.createForWorker(Configuration.global());
       PageMetaStore metaStore = PageMetaStore.create(options);
@@ -104,11 +119,28 @@ public class PagedDoraWorker implements DoraWorker {
 
   @Override
   public void start(WorkerNetAddress address) throws IOException {
+    super.start(address);
+    mAddress = address;
+    register();
+
+    // setup worker-master heartbeat
+    // the heartbeat is only used to notify the aliveness of this worker, so that clients
+    // can get the latest worker list from master.
+    // TODO(bowen): once we set up a worker discovery service in place of master, remove this
+    getExecutorService()
+        .submit(new HeartbeatThread(HeartbeatContext.WORKER_BLOCK_SYNC,
+            mResourceCloser.register(new BlockMasterSync()),
+            (int) Configuration.getMs(PropertyKey.WORKER_BLOCK_HEARTBEAT_INTERVAL_MS),
+            mConf, ServerUserState.global()));
+  }
+
+  private void register() throws IOException {
+    Preconditions.checkState(mAddress != null, "worker not started");
     RetryPolicy retry = RetryUtils.defaultWorkerMasterClientRetry();
-    MasterClientContext ctx = MasterClientContext.newBuilder(ClientContext.create()).build();
     while (true) {
-      try (BlockMasterClient masterClient = new BlockMasterClient(ctx)) {
-        mWorkerId.set(masterClient.getId(address));
+      BlockMasterClient masterClient = mBlockMasterClientPool.acquire();
+      try {
+        mWorkerId.set(masterClient.getId(mAddress));
         StorageTierAssoc storageTierAssoc =
             new DefaultStorageTierAssoc(ImmutableList.of(Constants.MEDIUM_MEM));
         masterClient.register(
@@ -119,21 +151,26 @@ public class PagedDoraWorker implements DoraWorker {
             ImmutableMap.of(),
             ImmutableMap.of(),
             Configuration.getConfiguration(Scope.WORKER));
+        LOG.info("Worker registered with worker ID: {}", mWorkerId.get());
         break;
       } catch (IOException ioe) {
         if (!retry.attempt()) {
           throw ioe;
         }
+      } finally {
+        mBlockMasterClientPool.release(masterClient);
       }
     }
   }
 
   @Override
   public void stop() throws IOException {
+    super.stop();
   }
 
   @Override
   public void close() throws IOException {
+    super.close();
     mResourceCloser.close();
     try {
       mCacheManager.close();
@@ -182,5 +219,42 @@ public class PagedDoraWorker implements DoraWorker {
 
   @Override
   public void cleanupSession(long sessionId) {
+  }
+
+  private class BlockMasterSync implements HeartbeatExecutor {
+    @Override
+    public void heartbeat() throws InterruptedException {
+      final Command cmdFromMaster;
+      BlockMasterClient masterClient = mBlockMasterClientPool.acquire();
+      try {
+        cmdFromMaster = masterClient.heartbeat(mWorkerId.get(),
+            ImmutableMap.of(Constants.MEDIUM_MEM, (long) Constants.GB),
+            ImmutableMap.of(Constants.MEDIUM_MEM, 0L),
+            ImmutableList.of(),
+            ImmutableMap.of(),
+            ImmutableMap.of(),
+            ImmutableList.of());
+      } catch (IOException e) {
+        LOG.warn("failed to heartbeat to master", e);
+        return;
+      } finally {
+        mBlockMasterClientPool.release(masterClient);
+      }
+
+      LOG.debug("received master command: {}", cmdFromMaster.getCommandType());
+      // only handles re-register command
+      if (cmdFromMaster.getCommandType() == CommandType.Register) {
+        try {
+          register();
+        } catch (IOException e) {
+          LOG.warn("failed to re-register to master during heartbeat", e);
+        }
+      }
+    }
+
+    @Override
+    public void close() {
+      // do nothing
+    }
   }
 }


### PR DESCRIPTION
Since we do not have a standalone worker discovery mechanism, clients still need to pull the worker list from master. If workers do not send heartbeats then master will mark a worker as lost after a timeout.

This PR temporarily enables heartbeats until we implement a worker discovery mechanism independent of the masters.