### PR TITLE
Replace ManagementFactoryHelper with ManagementFactory for java11

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -163,7 +164,7 @@ public final class MetricsSystem {
 
   private static BufferPoolMXBean getDirectBufferPool() {
     for (BufferPoolMXBean bufferPoolMXBean
-        : sun.management.ManagementFactoryHelper.getBufferPoolMXBeans()) {
+        :  ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)) {
       if (bufferPoolMXBean.getName().equals("direct")) {
         return bufferPoolMXBean;
       }

--- a/dev/jenkins/run_docker.sh
+++ b/dev/jenkins/run_docker.sh
@@ -23,7 +23,7 @@ function main {
   fi
   if [ -z "${ALLUXIO_DOCKER_IMAGE}" ]
   then
-    ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.0.8-jdk8"
+    ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.0.8-jdk11"
   fi
 
   local run_args="--rm"

--- a/dev/jenkins/run_docker.sh
+++ b/dev/jenkins/run_docker.sh
@@ -23,7 +23,7 @@ function main {
   fi
   if [ -z "${ALLUXIO_DOCKER_IMAGE}" ]
   then
-    ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.0.8-jdk11"
+    ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.0.8-jdk8"
   fi
 
   local run_args="--rm"


### PR DESCRIPTION
### What changes are proposed in this pull request?

Replace ManagementFactoryHelper with ManagementFactory for java11

### Why are the changes needed?
Java 11 doesn't support to directly call ManagementFactoryHelper, so it is necessary to find an alternative one in java11.

### Does this PR introduce any user facing changes?

NA
