### PR TITLE
Fix the bug that cannot cache file with block store when using netty

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockReader.java
@@ -145,7 +145,8 @@ public final class UnderFileSystemBlockReader extends BlockReader {
 
   @Override
   public ReadableByteChannel getChannel() {
-    throw new UnsupportedOperationException("UFSFileBlockReader#getChannel is not supported");
+    LOG.warn("UFSFileBlockReader#getChannel is not supported");
+    return null;
   }
 
   @Override


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Fix the bug that cannot cache file with block store when using Netty data transmission.

**Why are the changes needed?**
`UnderFileSystemBlockReader#getChannel` is not supported, but it throws exception (as shown below) when we check the state using `reader.getChannel() instanceOf FileChannel` in `BlockReadHandler`. We are sure that `UnderFileSystemBlockReader#getChannel` will never be called actually, so we can just return null to avoid this exception here.

```
Caused by: alluxio.exception.status.InternalException: Channel to node3/xxx.xxx.xxx.xxx:59999: UFSFileBlockReader#getChannel not supported
at alluxio.exception.status.AlluxioStatusException.from(AlluxioStatusException.java:159)
at alluxio.util.CommonUtils.unwrapResponseFrom(CommonUtils.java:712)
at alluxio.client.block,stream.NettyDataReader$PacketReadHandler .channelRead(NettyDataReader .java:266
alluxio.shaded.client. ionetty.channel.AbstractChannelHandlerContext. invokeChannelRead(AbstractChannelHandlerContext.jav
at alluxio.shaded.client.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead
```
**Does this PR introduce any user facing changes?**
No, it doesn't.