### PR TITLE
Support Maven reproducible builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
     <parquet.version>1.11.0</parquet.version>
     <protobuf.version>3.19.6</protobuf.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputTimestamp>${git.commit.time}</project.build.outputTimestamp>
     <slf4j.version>1.7.30</slf4j.version>
     <jackson.version>2.13.3</jackson.version>
     <hadoop-cos.version>3.1.0-5.8.5</hadoop-cos.version>
@@ -313,6 +314,11 @@
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
         <version>1.2</version>
+      </dependency>
+      <dependency>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>4.0.5</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
@@ -952,7 +958,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.4</version>
+          <version>3.2.0</version>
           <configuration>
             <excludes>
               <exclude>**/log4j.properties</exclude>
@@ -978,12 +984,12 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <!-- Needs to be 2.4.2 or later to prevent MSHADE-148 -->
-          <version>3.2.1</version>
+          <version>3.2.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>2.3</version>
+          <version>3.2.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1038,7 +1044,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>properties-maven-plugin</artifactId>
-          <version>1.0.0</version>
+          <version>1.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -1141,6 +1147,32 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+
+      <!-- Use commit time for reproducible builds - https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+          <dateFormat>yyyy-MM-dd'T'HH:mm:ss'Z'</dateFormat>
+          <includeOnlyProperties>
+            <includeOnlyProperty>git.commit.time</includeOnlyProperty>
+            <includeOnlyProperty>git.build.version</includeOnlyProperty>
+            <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+          </includeOnlyProperties>
+          <commitIdGenerationMode>full</commitIdGenerationMode>
+        </configuration>
       </plugin>
 
       <!-- SpotBugs -->


### PR DESCRIPTION
### What changes are proposed in this pull request?

See title.

Adds https://github.com/git-commit-id/git-commit-id-maven-plugin v.4.0.5 as a dependency. Latest version (5.0.0) requires Java 11.

### Why are the changes needed?

Updating `pom.xml` to support reproducible Maven builds. See https://maven.apache.org/guides/mini/guide-reproducible-builds.html.

### Does this PR introduce any user facing changes?

Adds a `git.properties` file to output directories containing commit into (can be configurable).

ex:
```
#Generated by Git-Commit-Id-Plugin
git.build.version=2.10.0-SNAPSHOT
git.commit.id.abbrev=622dfb4
git.commit.id.full=622dfb4ca246020efaeb169b18012bd394170e9a
git.commit.time=2023-02-13T21\:47\:53Z

```
