### PR TITLE
Support overwrite option in createFile

### DIFF
--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -37,6 +37,7 @@ import alluxio.client.file.FileSystemMasterClient;
 import alluxio.client.file.URIStatus;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.ExceptionMessage;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.util.ConfigurationUtils;
 import alluxio.wire.BlockInfo;
@@ -665,15 +666,15 @@ public class AbstractFileSystemTest {
     when(alluxioFs.exists(new AlluxioURI(HadoopUtils.getPathWithoutScheme(path))))
         .thenReturn(true);
     when(alluxioFs.createFile(eq(new AlluxioURI(HadoopUtils.getPathWithoutScheme(path))), any()))
-        .thenThrow(new FileAlreadyExistsException("Not allowed to create() (overwrite=false) for "
-            + "existing Alluxio path: " + path.toString()));
+        .thenThrow(new FileAlreadyExistsException(
+            ExceptionMessage.CANNOT_OVERWRITE_FILE_WITHOUT_OVERWRITE.getMessage(path.toString())));
 
     try (FileSystem alluxioHadoopFs = new FileSystem(alluxioFs)) {
       alluxioHadoopFs.create(path, false, 100, (short) 1, 1000);
       fail("create() of existing file is expected to fail");
     } catch (IOException e) {
       assertEquals("alluxio.exception.FileAlreadyExistsException: "
-              + "Not allowed to create() (overwrite=false) for existing Alluxio path: " + path,
+              + ExceptionMessage.CANNOT_OVERWRITE_FILE_WITHOUT_OVERWRITE.getMessage(path),
           e.getMessage());
     }
   }

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -665,13 +665,15 @@ public class AbstractFileSystemTest {
     when(alluxioFs.exists(new AlluxioURI(HadoopUtils.getPathWithoutScheme(path))))
         .thenReturn(true);
     when(alluxioFs.createFile(eq(new AlluxioURI(HadoopUtils.getPathWithoutScheme(path))), any()))
-        .thenThrow(new FileAlreadyExistsException(path.toString()));
+        .thenThrow(new FileAlreadyExistsException("Not allowed to create() (overwrite=false) for "
+            + "existing Alluxio path: " + path.toString()));
 
     try (FileSystem alluxioHadoopFs = new FileSystem(alluxioFs)) {
       alluxioHadoopFs.create(path, false, 100, (short) 1, 1000);
       fail("create() of existing file is expected to fail");
     } catch (IOException e) {
-      assertEquals("Not allowed to create() (overwrite=false) for existing Alluxio path: " + path,
+      assertEquals("alluxio.exception.FileAlreadyExistsException: "
+              + "Not allowed to create() (overwrite=false) for existing Alluxio path: " + path,
           e.getMessage());
     }
   }

--- a/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
+++ b/core/common/src/main/java/alluxio/exception/ExceptionMessage.java
@@ -95,6 +95,9 @@ public enum ExceptionMessage {
   ROOT_CANNOT_BE_RENAMED("The root directory cannot be renamed"),
   JOURNAL_ENTRY_MISSING(
       "Journal entries are missing between sequence number {0} (inclusive) and {1} (exclusive)."),
+  CANNOT_OVERWRITE_DIRECTORY("{0} already exists. Directories cannot be overwritten with create"),
+  CANNOT_OVERWRITE_FILE_WITHOUT_OVERWRITE("{0} already exists. If you want to overwrite the file,"
+      + " you need to specify the overwrite option."),
 
   // block master
   NO_WORKER_FOUND("No worker with workerId {0,number,#} is found"),

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1888,8 +1888,13 @@ public class DefaultFileSystemMaster extends CoreMaster
       FileAlreadyExistsException {
     if (inodePath.fullPathExists()) {
       Inode currentInode = inodePath.getInode();
+      if (!context.getOptions().getOverwrite()) {
+        throw new FileAlreadyExistsException(
+            "Not allowed to create() (overwrite=false) for existing Alluxio path: "
+                + inodePath.getUri());
+      }
       // if the fullpath is a file and the option is to overwrite, delete it
-      if (currentInode instanceof InodeFile && context.getOptions().getOverwrite()) {
+      if (currentInode instanceof InodeFile) {
         try {
           deleteInternal(rpcContext, inodePath, DeleteContext.mergeFrom(
               DeletePOptions.newBuilder().setRecursive(true)

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1904,6 +1904,7 @@ public class DefaultFileSystemMaster extends CoreMaster
                   .setAlluxioOnly(!context.isPersisted())), true);
           inodePath.removeLastInode();
         } catch (DirectoryNotEmptyException e) {
+          // Should not reach here
           throw new InvalidPathException(
               ExceptionMessage.CANNOT_OVERWRITE_DIRECTORY.getMessage(inodePath.getUri()));
         }

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterFsOptsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterFsOptsTest.java
@@ -14,6 +14,7 @@ package alluxio.master.file;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -109,31 +110,28 @@ public class FileSystemMasterFsOptsTest extends FileSystemMasterTestBase {
   public void createFileWithOverwrite() throws Exception {
     AlluxioURI path = new AlluxioURI("/test");
     mFileSystemMaster.createFile(path, CreateFileContext.defaults());
-    //create without overwrite
-    try {
+    // create without overwrite
+    Exception e = assertThrows(FileAlreadyExistsException.class, () -> {
       mFileSystemMaster.createFile(path, CreateFileContext.defaults());
-      fail();
-    } catch (FileAlreadyExistsException e) {
-      assertTrue(e.getMessage()
-          .contains(ExceptionMessage.CANNOT_OVERWRITE_FILE_WITHOUT_OVERWRITE.getMessage(path)));
-    }
+    });
+    assertTrue(e.getMessage()
+        .contains(ExceptionMessage.CANNOT_OVERWRITE_FILE_WITHOUT_OVERWRITE.getMessage(path)));
 
-    //create with overwrite
+    // create with overwrite
     CreateFileContext createFileContextWithOverwrite = CreateFileContext.defaults();
     createFileContextWithOverwrite.getOptions().setOverwrite(true);
     mFileSystemMaster.createFile(path, createFileContextWithOverwrite);
     FileInfo info = mFileSystemMaster.getFileInfo(path, GetStatusContext.defaults());
 
-    //overwrite an existed directory
+    // overwrite an existed directory
     AlluxioURI testpath = new AlluxioURI("/test2");
     mFileSystemMaster.createDirectory(testpath, CreateDirectoryContext.defaults());
-    try {
+
+    e = assertThrows(FileAlreadyExistsException.class, () -> {
       mFileSystemMaster.createFile(testpath, createFileContextWithOverwrite);
-      fail();
-    } catch (FileAlreadyExistsException e) {
-      assertTrue(e.getMessage()
+    });
+    assertTrue(e.getMessage()
           .contains(ExceptionMessage.CANNOT_OVERWRITE_DIRECTORY.getMessage(testpath)));
-    }
   }
 
   /**

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -137,6 +137,7 @@ message CreateFilePOptions {
   optional int64 persistenceWaitTime = 10;
   map<string, bytes> xattr = 11;
   optional XAttrPropagationStrategy xattrPropStrat = 12 [default = NEW_PATHS];
+  optional bool overwrite = 13;
 }
 message CreateFilePRequest {
   /** the path of the file */

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -2404,6 +2404,11 @@
                     "value": "NEW_PATHS"
                   }
                 ]
+              },
+              {
+                "id": 13,
+                "name": "overwrite",
+                "type": "bool"
               }
             ],
             "maps": [

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
@@ -237,15 +237,16 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
     File file = mTestFolder.newFile();
     try (Closeable c = new ConfigurationRule(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT,
         WriteType.MUST_CACHE.toString(), Configuration.modifiableGlobal()).toResource()) {
-      Assert.assertEquals(0, sFsShell.run("copyFromLocal", file.getAbsolutePath(), "/"));
+      Assert.assertEquals(0, sFsShell.run("copyFromLocal", file.getAbsolutePath(), "/test"));
     }
     try (Closeable c = new ConfigurationRule(PropertyKey.USER_FILE_WRITE_TYPE_DEFAULT,
         WriteType.CACHE_THROUGH.toString(), Configuration.modifiableGlobal()).toResource()) {
       mOutput.reset();
-      sFsShell.run("copyFromLocal", file.getAbsolutePath(), "/");
+      sFsShell.run("copyFromLocal", file.getAbsolutePath(), "/test");
     }
     Assert.assertThat(mOutput.toString(),
-        containsString("Not allowed to create() (overwrite=false) for existing Alluxio path"));
+        containsString(
+            ExceptionMessage.CANNOT_OVERWRITE_FILE_WITHOUT_OVERWRITE.getMessage("/test")));
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
@@ -196,7 +196,8 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
     String[] cmd2 = {"copyFromLocal", testFile2.getPath(), alluxioFilePath.getPath()};
     Assert.assertEquals(-1, sFsShell.run(cmd2));
     Assert.assertThat(mOutput.toString(), containsString(
-        "Not allowed to create() (overwrite=false) for existing Alluxio path: " + alluxioFilePath.getPath()));
+        "Not allowed to create() (overwrite=false) for existing Alluxio path: "
+            + alluxioFilePath.getPath()));
     // Make sure the original file is intact
     Assert.assertTrue(BufferUtils
         .equalIncreasingByteArray(LEN1, readContent(alluxioFilePath, LEN1)));

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
@@ -196,7 +196,7 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
     String[] cmd2 = {"copyFromLocal", testFile2.getPath(), alluxioFilePath.getPath()};
     Assert.assertEquals(-1, sFsShell.run(cmd2));
     Assert.assertThat(mOutput.toString(), containsString(
-        "Not allowed to create file because path already exists: " + alluxioFilePath.getPath()));
+        "Not allowed to create() (overwrite=false) for existing Alluxio path: " + alluxioFilePath.getPath()));
     // Make sure the original file is intact
     Assert.assertTrue(BufferUtils
         .equalIncreasingByteArray(LEN1, readContent(alluxioFilePath, LEN1)));
@@ -243,7 +243,7 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
       sFsShell.run("copyFromLocal", file.getAbsolutePath(), "/");
     }
     Assert.assertThat(mOutput.toString(),
-        containsString("Not allowed to create file because path already exists"));
+        containsString("Not allowed to create() (overwrite=false) for existing Alluxio path"));
   }
 
   @Test

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CopyFromLocalCommandIntegrationTest.java
@@ -24,6 +24,7 @@ import alluxio.client.file.URIStatus;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
+import alluxio.exception.ExceptionMessage;
 import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
@@ -196,8 +197,8 @@ public final class CopyFromLocalCommandIntegrationTest extends AbstractFileSyste
     String[] cmd2 = {"copyFromLocal", testFile2.getPath(), alluxioFilePath.getPath()};
     Assert.assertEquals(-1, sFsShell.run(cmd2));
     Assert.assertThat(mOutput.toString(), containsString(
-        "Not allowed to create() (overwrite=false) for existing Alluxio path: "
-            + alluxioFilePath.getPath()));
+        ExceptionMessage.CANNOT_OVERWRITE_FILE_WITHOUT_OVERWRITE.getMessage(
+            alluxioFilePath.getPath())));
     // Make sure the original file is intact
     Assert.assertTrue(BufferUtils
         .equalIncreasingByteArray(LEN1, readContent(alluxioFilePath, LEN1)));

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
@@ -25,6 +25,7 @@ import alluxio.conf.Configuration;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
+import alluxio.exception.ExceptionMessage;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.ReadPType;
@@ -505,8 +506,8 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
     String[] cmd2 = {"cp", "file://" +  testFile2.getPath(), alluxioFilePath.getPath()};
     Assert.assertEquals(-1, sFsShell.run(cmd2));
     Assert.assertThat(mOutput.toString(), containsString(
-        "Not allowed to create() (overwrite=false) for existing Alluxio path: "
-            + alluxioFilePath.getPath()));
+        ExceptionMessage.CANNOT_OVERWRITE_FILE_WITHOUT_OVERWRITE.getMessage(
+            alluxioFilePath.getPath())));
     // Make sure the original file is intact
     Assert.assertTrue(BufferUtils
         .equalIncreasingByteArray(LEN1, readContent(alluxioFilePath, LEN1)));

--- a/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fs/command/CpCommandIntegrationTest.java
@@ -505,7 +505,8 @@ public final class CpCommandIntegrationTest extends AbstractFileSystemShellTest 
     String[] cmd2 = {"cp", "file://" +  testFile2.getPath(), alluxioFilePath.getPath()};
     Assert.assertEquals(-1, sFsShell.run(cmd2));
     Assert.assertThat(mOutput.toString(), containsString(
-        "Not allowed to create file because path already exists: " + alluxioFilePath.getPath()));
+        "Not allowed to create() (overwrite=false) for existing Alluxio path: "
+            + alluxioFilePath.getPath()));
     // Make sure the original file is intact
     Assert.assertTrue(BufferUtils
         .equalIncreasingByteArray(LEN1, readContent(alluxioFilePath, LEN1)));


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support overwrite option in createFile
### Why are the changes needed?

before this change, if we have the same name file existing in Alluxio, we will try `getStatus`, `deleteFile`, and then create the new one. now we just need to call `createFile` with overwrite option. no matter in hdfs api or s3 api. Excessive RPCs are saved.

### Does this PR introduce any user facing changes?
add a new option in CreateFileOption for overwriting.
