### PR TITLE
Update retry policy for object stores

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1292,7 +1292,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "when under storage metadata doesn't match Alluxio's expectations. "
               + "These retries use exponential backoff. "
               + "This property determines the maximum number of retries. "
-              + "This property defaults to 0 as modern object store UFSs provide strong consistency.")
+              + "This property defaults to 0 as modern object store UFSs provide strong "
+              + "consistency.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -1286,12 +1286,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey UNDERFS_EVENTUAL_CONSISTENCY_RETRY_MAX_NUM =
       intBuilder(Name.UNDERFS_EVENTUAL_CONSISTENCY_RETRY_MAX_NUM)
-          .setDefaultValue(20)
+          .setDefaultValue(0)
           .setDescription("To handle eventually consistent storage semantics "
               + "for certain under storages, Alluxio will perform retries "
               + "when under storage metadata doesn't match Alluxio's expectations. "
               + "These retries use exponential backoff. "
-              + "This property determines the maximum number of retries.")
+              + "This property determines the maximum number of retries. "
+              + "This property defaults to 0 as modern object store UFSs provide strong consistency.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();

--- a/core/common/src/main/java/alluxio/retry/SleepingRetry.java
+++ b/core/common/src/main/java/alluxio/retry/SleepingRetry.java
@@ -25,7 +25,7 @@ public abstract class SleepingRetry implements RetryPolicy {
   private int mAttemptCount = 0;
 
   protected SleepingRetry(int maxRetries) {
-    Preconditions.checkArgument(maxRetries > 0, "Max retries must be a positive number");
+    Preconditions.checkArgument(maxRetries >= 0, "Max retries must be a non-negative number");
     mMaxRetries = maxRetries;
   }
 

--- a/core/common/src/test/java/alluxio/underfs/ObjectUnderFileSystemTest.java
+++ b/core/common/src/test/java/alluxio/underfs/ObjectUnderFileSystemTest.java
@@ -15,9 +15,13 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import alluxio.AlluxioURI;
+import alluxio.ConfigurationRule;
 import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 
+import com.google.common.collect.ImmutableMap;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -27,6 +31,11 @@ import java.net.SocketException;
 
 public class ObjectUnderFileSystemTest {
   private static final AlluxioConfiguration CONF = Configuration.global();
+
+  @Rule
+  public ConfigurationRule mConfigurationRule = new ConfigurationRule(ImmutableMap.of(
+      PropertyKey.UNDERFS_EVENTUAL_CONSISTENCY_RETRY_MAX_NUM, 20),
+      Configuration.modifiableGlobal());
 
   private ObjectUnderFileSystem mObjectUFS = new MockObjectUnderFileSystem(new AlluxioURI("/"),
       UnderFileSystemConfiguration.defaults(CONF));


### PR DESCRIPTION
Modern object stores ensure strong consistency as follows:

Alibaba oss: https://www.alibabacloud.com/help/en/object-storage-service/latest/what-is-oss
Amazon S3: https://aws.amazon.com/s3/consistency/
GCP Cloud Storage: https://cloud.google.com/storage/docs/consistency
Huawei OBS: https://support.huaweicloud.com/intl/en-us/api-obs/obs_04_0118.html

When this is non-zero and the UFS is strongly consistent, and Alluxio is out of sync, some operations may retry over and over even though nothing will change, slowing down the system for long periods of time. This value should be 0 by default with strong consistency as Alluxio will see the most up to date version the first time it accesses the object.
