### PR TITLE
Fix build error when revision is shorter than 8 chars

### DIFF
--- a/core/common/src/main/java/alluxio/RuntimeConstants.java
+++ b/core/common/src/main/java/alluxio/RuntimeConstants.java
@@ -36,8 +36,8 @@ public final class RuntimeConstants {
     }
   }
 
-  public static final String REVISION_SHORT = ProjectConstants.REVISION.length() > 8 ?
-      ProjectConstants.REVISION.substring(0, 8) : ProjectConstants.REVISION;
+  public static final String REVISION_SHORT = ProjectConstants.REVISION.length() > 8
+      ? ProjectConstants.REVISION.substring(0, 8) : ProjectConstants.REVISION;
   public static final String VERSION_AND_REVISION_SHORT =
       VERSION + "-" + REVISION_SHORT;
 

--- a/core/common/src/main/java/alluxio/RuntimeConstants.java
+++ b/core/common/src/main/java/alluxio/RuntimeConstants.java
@@ -36,7 +36,8 @@ public final class RuntimeConstants {
     }
   }
 
-  public static final String REVISION_SHORT = ProjectConstants.REVISION.substring(0, 8);
+  public static final String REVISION_SHORT = VERSION.length() > 8 ?
+      VERSION.substring(0, 8) : VERSION;
   public static final String VERSION_AND_REVISION_SHORT =
       VERSION + "-" + REVISION_SHORT;
 

--- a/core/common/src/main/java/alluxio/RuntimeConstants.java
+++ b/core/common/src/main/java/alluxio/RuntimeConstants.java
@@ -36,8 +36,8 @@ public final class RuntimeConstants {
     }
   }
 
-  public static final String REVISION_SHORT = VERSION.length() > 8 ?
-      VERSION.substring(0, 8) : VERSION;
+  public static final String REVISION_SHORT = ProjectConstants.REVISION.length() > 8 ?
+      ProjectConstants.REVISION.substring(0, 8) : ProjectConstants.REVISION;
   public static final String VERSION_AND_REVISION_SHORT =
       VERSION + "-" + REVISION_SHORT;
 


### PR DESCRIPTION
It will through ArrayOutOfBoundException if we build alluxio in a node which have no git installed, and the `VERSION` would be shorter than 8, even empty string, so substring(8) cannot work anymore.

This PR check there are more than 8 chars in the `VERSION` first, otherwise, do not cut the `VERSION` string.