### PR TITLE
Add allowOnStandbyMasters option for version grpc endpoint

### DIFF
--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -139,7 +139,10 @@ public abstract class AbstractClient implements Client {
     try {
       return mVersionService
           .getServiceVersion(
-              GetServiceVersionPRequest.newBuilder().setServiceType(getRemoteServiceType()).build())
+              GetServiceVersionPRequest.newBuilder()
+                  .setServiceType(getRemoteServiceType())
+                  .setAllowOnStandbyMasters(true)
+                  .build())
           .getVersion();
     } catch (Throwable t) {
       throw AlluxioStatusException.fromThrowable(t);

--- a/core/common/src/main/java/alluxio/AbstractClient.java
+++ b/core/common/src/main/java/alluxio/AbstractClient.java
@@ -141,7 +141,7 @@ public abstract class AbstractClient implements Client {
           .getServiceVersion(
               GetServiceVersionPRequest.newBuilder()
                   .setServiceType(getRemoteServiceType())
-                  .setAllowOnStandbyMasters(true)
+                  .setAllowedOnStandbyMasters(true)
                   .build())
           .getVersion();
     } catch (Throwable t) {

--- a/core/common/src/main/java/alluxio/grpc/ServiceVersionClientServiceHandler.java
+++ b/core/common/src/main/java/alluxio/grpc/ServiceVersionClientServiceHandler.java
@@ -51,7 +51,7 @@ public final class ServiceVersionClientServiceHandler
   @SuppressFBWarnings(value = "DB_DUPLICATE_SWITCH_CLAUSES")
   public void getServiceVersion(GetServiceVersionPRequest request,
       StreamObserver<GetServiceVersionPResponse> responseObserver) {
-    if (request.getRejectOnStandbyMasters() && mStandbyRpcEnabled
+    if (!request.getAllowOnStandbyMasters() && mStandbyRpcEnabled
         && mNodeStateSupplier != null && mNodeStateSupplier.get() == NodeState.STANDBY) {
       responseObserver.onError(Status.UNAVAILABLE
           .withDescription("GetServiceVersion is not supported on standby master")

--- a/core/common/src/main/java/alluxio/grpc/ServiceVersionClientServiceHandler.java
+++ b/core/common/src/main/java/alluxio/grpc/ServiceVersionClientServiceHandler.java
@@ -51,7 +51,8 @@ public final class ServiceVersionClientServiceHandler
   @SuppressFBWarnings(value = "DB_DUPLICATE_SWITCH_CLAUSES")
   public void getServiceVersion(GetServiceVersionPRequest request,
       StreamObserver<GetServiceVersionPResponse> responseObserver) {
-    if (!request.getAllowOnStandbyMasters() && mStandbyRpcEnabled
+    // getAllowedOnStandbyMasters() is defaulted to false
+    if (!request.getAllowedOnStandbyMasters() && mStandbyRpcEnabled
         && mNodeStateSupplier != null && mNodeStateSupplier.get() == NodeState.STANDBY) {
       responseObserver.onError(Status.UNAVAILABLE
           .withDescription("GetServiceVersion is not supported on standby master")

--- a/core/common/src/main/java/alluxio/grpc/ServiceVersionClientServiceHandler.java
+++ b/core/common/src/main/java/alluxio/grpc/ServiceVersionClientServiceHandler.java
@@ -51,7 +51,7 @@ public final class ServiceVersionClientServiceHandler
   @SuppressFBWarnings(value = "DB_DUPLICATE_SWITCH_CLAUSES")
   public void getServiceVersion(GetServiceVersionPRequest request,
       StreamObserver<GetServiceVersionPResponse> responseObserver) {
-    if (mStandbyRpcEnabled
+    if (request.getRejectOnStandbyMasters() && mStandbyRpcEnabled
         && mNodeStateSupplier != null && mNodeStateSupplier.get() == NodeState.STANDBY) {
       responseObserver.onError(Status.UNAVAILABLE
           .withDescription("GetServiceVersion is not supported on standby master")

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -166,6 +166,7 @@ public class PollingMasterInquireClient implements MasterInquireClient {
                 TimeUnit.MILLISECONDS);
     try {
       versionClient.getServiceVersion(GetServiceVersionPRequest.newBuilder()
+          .setRejectOnStandbyMasters(true)
           .setServiceType(mServiceType).build());
     } catch (StatusRuntimeException e) {
       throw AlluxioStatusException.fromThrowable(e);

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -166,7 +166,6 @@ public class PollingMasterInquireClient implements MasterInquireClient {
                 TimeUnit.MILLISECONDS);
     try {
       versionClient.getServiceVersion(GetServiceVersionPRequest.newBuilder()
-          .setRejectOnStandbyMasters(true)
           .setServiceType(mServiceType).build());
     } catch (StatusRuntimeException e) {
       throw AlluxioStatusException.fromThrowable(e);

--- a/core/transport/src/main/proto/grpc/version.proto
+++ b/core/transport/src/main/proto/grpc/version.proto
@@ -34,6 +34,15 @@ enum ServiceType {
 
 message GetServiceVersionPRequest {
   optional ServiceType serviceType = 1;
+  // This field is added for backwards compatibility.
+  // When gRPC services are enabled on standby masters, PollingMasterInquireClient will not be able to
+  // tell which master is the primary and which is the standby by calling this endpoint.
+  // By adding this field and letting standby master reject the request,
+  // we enable gRPC services on standby masters without making client side code change.
+  // We don't make the standby master always reject the request because this endpoint
+  // is also used when a client connects to a master where the service version is checked and
+  // we don't want to affect that logic.
+  optional bool rejectOnStandbyMasters = 2;
 }
 message GetServiceVersionPResponse {
   optional int64 version = 1;

--- a/core/transport/src/main/proto/grpc/version.proto
+++ b/core/transport/src/main/proto/grpc/version.proto
@@ -34,17 +34,27 @@ enum ServiceType {
 
 message GetServiceVersionPRequest {
   optional ServiceType serviceType = 1;
-  // This field is added for backwards compatibility.
-  // When gRPC services are enabled on standby masters, PollingMasterInquireClient will not be able to
-  // tell which master is the primary and which is the standby by calling this endpoint.
-  // So we rejected get service version requests on standby masters,
-  // which allows us to enable gRPC services on standby masters without making client side code change.
-  // However, this endpoint is also used outside the PollingMasterInquireClient.
-  // When a client makes a request to a master, it will also call this endpoint to verify the version.
-  // And hence the request to standby master will never succeed because it will constantly be rejected.
-  // We added this field as a backdoor to let these version verification requests pass through
-  // so that a client can make requests to standby masters successfully.
-  optional bool allowOnStandbyMasters = 2;
+  // The purpose of this field is to make grpc service on standby masters work without
+  // making client changes and keeps backwards compatibility.
+  // This requests of this endpoint will be rejected on standby masters by default,
+  // unless this field is set.
+  // Two places use this request:
+  // 1. PollingMasterInquireClient uses this endpoint to tell who is the primary master.
+  // 2. AbstractClient uses this endpoint to verify the version before it RPCs with the master.
+  //
+  // Behaviors:
+  // 1. old clients -> new cluster standby masters
+  // PollingMasterInquireClient does not set this field and is able to tell which one is primary master because
+  // the request will be rejected on the standby master.
+  // AbstractClient does not set this field.
+  // Old clients only connects to primary so this doesn't break the existing behavior.
+  //
+  // 2. new clients -> new cluster standby masters
+  // PollingMasterInquireClient does not set this field and is able to tell which one is primary master because
+  // the request will be rejected on the standby master.
+  // AbstractClient sets this field to true. Rpcs to standby masters can go through and pass the version verification.
+
+  optional bool allowedOnStandbyMasters = 2;
 }
 message GetServiceVersionPResponse {
   optional int64 version = 1;

--- a/core/transport/src/main/proto/grpc/version.proto
+++ b/core/transport/src/main/proto/grpc/version.proto
@@ -36,7 +36,7 @@ message GetServiceVersionPRequest {
   optional ServiceType serviceType = 1;
   // The purpose of this field is to make grpc service on standby masters work without
   // making client changes and keeps backwards compatibility.
-  // This requests of this endpoint will be rejected on standby masters by default,
+  // This requests to this endpoint will be rejected on standby masters by default,
   // unless this field is set.
   // Two places use this request:
   // 1. PollingMasterInquireClient uses this endpoint to tell who is the primary master.

--- a/core/transport/src/main/proto/grpc/version.proto
+++ b/core/transport/src/main/proto/grpc/version.proto
@@ -37,12 +37,14 @@ message GetServiceVersionPRequest {
   // This field is added for backwards compatibility.
   // When gRPC services are enabled on standby masters, PollingMasterInquireClient will not be able to
   // tell which master is the primary and which is the standby by calling this endpoint.
-  // By adding this field and letting standby master reject the request,
-  // we enable gRPC services on standby masters without making client side code change.
-  // We don't make the standby master always reject the request because this endpoint
-  // is also used when a client connects to a master where the service version is checked and
-  // we don't want to affect that logic.
-  optional bool rejectOnStandbyMasters = 2;
+  // So we rejected get service version requests on standby masters,
+  // which allows us to enable gRPC services on standby masters without making client side code change.
+  // However, this endpoint is also used outside the PollingMasterInquireClient.
+  // When a client makes a request to a master, it will also call this endpoint to verify the version.
+  // And hence the request to standby master will never succeed because it will constantly be rejected.
+  // We added this field as a backdoor to let these version verification requests pass through
+  // so that a client can make requests to standby masters successfully.
+  optional bool allowOnStandbyMasters = 2;
 }
 message GetServiceVersionPResponse {
   optional int64 version = 1;

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -8210,6 +8210,11 @@
                 "id": 1,
                 "name": "serviceType",
                 "type": "ServiceType"
+              },
+              {
+                "id": 2,
+                "name": "rejectOnStandbyMasters",
+                "type": "bool"
               }
             ]
           },

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -8213,7 +8213,7 @@
               },
               {
                 "id": 2,
-                "name": "rejectOnStandbyMasters",
+                "name": "allowOnStandbyMasters",
                 "type": "bool"
               }
             ]

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -8213,7 +8213,7 @@
               },
               {
                 "id": 2,
-                "name": "allowOnStandbyMasters",
+                "name": "allowedOnStandbyMasters",
                 "type": "bool"
               }
             ]


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add a rejectOnStandbyMasters on version grpc endpoint 

### Why are the changes needed?

We added a PR to make standby master return unavailable on this version service endpoint
https://github.com/Alluxio/alluxio/pull/16854

However, in addition to the polling master inquire client, the AbstractMasterClient also needs this endpoint. 
https://github.com/Alluxio/alluxio/blob/master/core/common/src/main/java/alluxio/AbstractClient.java#L172
When a client makes a request to standby master, such check will constantly fail and resulted in failures. 

So we want the logic done in #16854 only applies to PollingMasterInquireClient and hence we added this boolean field to bypass the check. 

### Does this PR introduce any user facing changes?

N/A
