### PR TITLE
[SMALLFIX] Add a missing javadoc param

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystem.java
@@ -159,6 +159,7 @@ public interface FileSystem extends Closeable {
 
     /**
      * @param context the FileSystemContext to use with the FileSystem
+     * @param options the options associate with the FileSystem
      * @return a new FileSystem instance
      */
     public static FileSystem create(FileSystemContext context, FileSystemOptions options) {


### PR DESCRIPTION
add a missing javadoc `@param`