### PR TITLE
Disable short circuit IO for Dora by default

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6530,7 +6530,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey USER_SHORT_CIRCUIT_ENABLED =
       booleanBuilder(Name.USER_SHORT_CIRCUIT_ENABLED)
-          .setDefaultValue(true)
+          .setDefaultValue(false)
           .setDescription("The short circuit read/write which allows the clients to "
               + "read/write data without going through Alluxio workers if the data is local "
               + "is enabled if set to true.")


### PR DESCRIPTION
### What changes are proposed in this pull request?

Disable short-circuit IO for Dora by default.

### Why are the changes needed?

Dora does not support short circuit IO any more.

### Does this PR introduce any user facing changes?

Yes, the default value is changed.