### PR TITLE
Improve LS by allowing to omit UFS and mount info

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -89,6 +89,7 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
   private Path mWorkingDir = new Path(AlluxioURI.SEPARATOR);
   private Statistics mStatistics = null;
   private String mAlluxioHeader = null;
+  private boolean mExcludeMountInfoOnListStatus;
 
   /**
    * Constructs a new {@link AbstractFileSystem} instance with specified a {@link FileSystem}
@@ -522,6 +523,8 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
     // Creating a new instanced configuration from an AlluxioProperties object isn't expensive.
     mAlluxioConf = new InstancedConfiguration(alluxioProps);
     mAlluxioConf.validate();
+    mExcludeMountInfoOnListStatus = mAlluxioConf.getBoolean(
+        PropertyKey.USER_HDFS_CLIENT_EXCLUDE_MOUNT_INFO_ON_LIST_STATUS);
 
     if (mFileSystem != null) {
       return;
@@ -598,9 +601,7 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
     List<URIStatus> statuses;
     try {
       ListStatusPOptions listStatusPOptions = ListStatusPOptions.getDefaultInstance().toBuilder()
-          .setExcludeMountInfo(
-              mAlluxioConf.getBoolean(
-                  PropertyKey.USER_HDFS_CLIENT_EXCLUDE_MOUNT_INFO_ON_LIST_STATUS)).build();
+          .setExcludeMountInfo(mExcludeMountInfoOnListStatus).build();
       statuses = mFileSystem.listStatus(uri, listStatusPOptions);
     } catch (FileDoesNotExistException e) {
       throw new FileNotFoundException(getAlluxioPath(path).toString());

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -598,7 +598,8 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
     List<URIStatus> statuses;
     try {
       ListStatusPOptions listStatusPOptions = ListStatusPOptions.getDefaultInstance().toBuilder()
-          .setNoNeedUseMountInfo(true).build();
+          .setNoNeedUseMountInfo(
+              mAlluxioConf.getBoolean(PropertyKey.USER_HDFS_LISTSTATUS_MOUNTINFO_DISABLE)).build();
       statuses = mFileSystem.listStatus(uri, listStatusPOptions);
     } catch (FileDoesNotExistException e) {
       throw new FileNotFoundException(getAlluxioPath(path).toString());

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -598,8 +598,9 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
     List<URIStatus> statuses;
     try {
       ListStatusPOptions listStatusPOptions = ListStatusPOptions.getDefaultInstance().toBuilder()
-          .setNoNeedUseMountInfo(
-              mAlluxioConf.getBoolean(PropertyKey.USER_HDFS_LISTSTATUS_MOUNTINFO_DISABLE)).build();
+          .setExcludeMountInfo(
+              mAlluxioConf.getBoolean(
+                  PropertyKey.USER_HDFS_CLIENT_EXCLUDE_MOUNT_INFO_ON_LIST_STATUS)).build();
       statuses = mFileSystem.listStatus(uri, listStatusPOptions);
     } catch (FileDoesNotExistException e) {
       throw new FileNotFoundException(getAlluxioPath(path).toString());

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -31,6 +31,7 @@ import alluxio.grpc.CheckAccessPOptions;
 import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
+import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.SetAttributePOptions;
 import alluxio.master.MasterInquireClient.Factory;
 import alluxio.security.CurrentUser;
@@ -596,7 +597,9 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
     AlluxioURI uri = getAlluxioPath(path);
     List<URIStatus> statuses;
     try {
-      statuses = mFileSystem.listStatus(uri);
+      ListStatusPOptions listStatusPOptions = ListStatusPOptions.getDefaultInstance().toBuilder()
+          .setNoNeedUseMountInfo(true).build();
+      statuses = mFileSystem.listStatus(uri, listStatusPOptions);
     } catch (FileDoesNotExistException e) {
       throw new FileNotFoundException(getAlluxioPath(path).toString());
     } catch (AlluxioException e) {

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -406,12 +406,15 @@ public class AbstractFileSystemTest {
     Path path = new Path("/dir");
     alluxio.client.file.FileSystem alluxioFs =
         mock(alluxio.client.file.FileSystem.class);
+    FileSystem alluxioHadoopFs = new FileSystem(alluxioFs);
+    URI uri = URI.create(Constants.HEADER + "host:1");
+    alluxioHadoopFs.initialize(uri, getConf());
     ListStatusPOptions listStatusPOptions = ListStatusPOptions.getDefaultInstance().toBuilder()
-        .setNoNeedUseMountInfo(true).build();
+        .setNoNeedUseMountInfo(alluxioHadoopFs.mAlluxioConf.getBoolean(
+            PropertyKey.USER_HDFS_LISTSTATUS_MOUNTINFO_DISABLE)).build();
     when(alluxioFs.listStatus(new AlluxioURI(HadoopUtils.getPathWithoutScheme(path)),
         listStatusPOptions))
         .thenReturn(Lists.newArrayList(new URIStatus(fileInfo1), new URIStatus(fileInfo2)));
-    FileSystem alluxioHadoopFs = new FileSystem(alluxioFs);
 
     FileStatus[] fileStatuses = alluxioHadoopFs.listStatus(path);
     assertFileInfoEqualsFileStatus(fileInfo1, fileStatuses[0]);
@@ -429,12 +432,15 @@ public class AbstractFileSystemTest {
     try {
       Path path = new Path("/ALLUXIO-2036");
       alluxio.client.file.FileSystem alluxioFs = mock(alluxio.client.file.FileSystem.class);
+      alluxioHadoopFs = new FileSystem(alluxioFs);
+      URI uri = URI.create(Constants.HEADER + "host:1");
+      alluxioHadoopFs.initialize(uri, getConf());
       ListStatusPOptions listStatusPOptions = ListStatusPOptions.getDefaultInstance().toBuilder()
-          .setNoNeedUseMountInfo(true).build();
+          .setNoNeedUseMountInfo(alluxioHadoopFs.mAlluxioConf.getBoolean(
+              PropertyKey.USER_HDFS_LISTSTATUS_MOUNTINFO_DISABLE)).build();
       when(alluxioFs.listStatus(new AlluxioURI(HadoopUtils.getPathWithoutScheme(path)),
           listStatusPOptions))
           .thenThrow(new FileNotFoundException("ALLUXIO-2036 not Found"));
-      alluxioHadoopFs = new FileSystem(alluxioFs);
       FileStatus[] fileStatuses = alluxioHadoopFs.listStatus(path);
       // if we reach here, FileNotFoundException is not thrown hence Fail the test case
       assertTrue(false);

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -38,6 +38,7 @@ import alluxio.client.file.URIStatus;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.FileAlreadyExistsException;
+import alluxio.grpc.ListStatusPOptions;
 import alluxio.util.ConfigurationUtils;
 import alluxio.wire.BlockInfo;
 import alluxio.wire.FileBlockInfo;
@@ -405,7 +406,10 @@ public class AbstractFileSystemTest {
     Path path = new Path("/dir");
     alluxio.client.file.FileSystem alluxioFs =
         mock(alluxio.client.file.FileSystem.class);
-    when(alluxioFs.listStatus(new AlluxioURI(HadoopUtils.getPathWithoutScheme(path))))
+    ListStatusPOptions listStatusPOptions = ListStatusPOptions.getDefaultInstance().toBuilder()
+        .setNoNeedUseMountInfo(true).build();
+    when(alluxioFs.listStatus(new AlluxioURI(HadoopUtils.getPathWithoutScheme(path)),
+        listStatusPOptions))
         .thenReturn(Lists.newArrayList(new URIStatus(fileInfo1), new URIStatus(fileInfo2)));
     FileSystem alluxioHadoopFs = new FileSystem(alluxioFs);
 
@@ -425,7 +429,10 @@ public class AbstractFileSystemTest {
     try {
       Path path = new Path("/ALLUXIO-2036");
       alluxio.client.file.FileSystem alluxioFs = mock(alluxio.client.file.FileSystem.class);
-      when(alluxioFs.listStatus(new AlluxioURI(HadoopUtils.getPathWithoutScheme(path))))
+      ListStatusPOptions listStatusPOptions = ListStatusPOptions.getDefaultInstance().toBuilder()
+          .setNoNeedUseMountInfo(true).build();
+      when(alluxioFs.listStatus(new AlluxioURI(HadoopUtils.getPathWithoutScheme(path)),
+          listStatusPOptions))
           .thenThrow(new FileNotFoundException("ALLUXIO-2036 not Found"));
       alluxioHadoopFs = new FileSystem(alluxioFs);
       FileStatus[] fileStatuses = alluxioHadoopFs.listStatus(path);

--- a/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
+++ b/core/client/hdfs/src/test/java/alluxio/hadoop/AbstractFileSystemTest.java
@@ -410,8 +410,8 @@ public class AbstractFileSystemTest {
     URI uri = URI.create(Constants.HEADER + "host:1");
     alluxioHadoopFs.initialize(uri, getConf());
     ListStatusPOptions listStatusPOptions = ListStatusPOptions.getDefaultInstance().toBuilder()
-        .setNoNeedUseMountInfo(alluxioHadoopFs.mAlluxioConf.getBoolean(
-            PropertyKey.USER_HDFS_LISTSTATUS_MOUNTINFO_DISABLE)).build();
+        .setExcludeMountInfo(alluxioHadoopFs.mAlluxioConf.getBoolean(
+            PropertyKey.USER_HDFS_CLIENT_EXCLUDE_MOUNT_INFO_ON_LIST_STATUS)).build();
     when(alluxioFs.listStatus(new AlluxioURI(HadoopUtils.getPathWithoutScheme(path)),
         listStatusPOptions))
         .thenReturn(Lists.newArrayList(new URIStatus(fileInfo1), new URIStatus(fileInfo2)));
@@ -436,8 +436,8 @@ public class AbstractFileSystemTest {
       URI uri = URI.create(Constants.HEADER + "host:1");
       alluxioHadoopFs.initialize(uri, getConf());
       ListStatusPOptions listStatusPOptions = ListStatusPOptions.getDefaultInstance().toBuilder()
-          .setNoNeedUseMountInfo(alluxioHadoopFs.mAlluxioConf.getBoolean(
-              PropertyKey.USER_HDFS_LISTSTATUS_MOUNTINFO_DISABLE)).build();
+          .setExcludeMountInfo(alluxioHadoopFs.mAlluxioConf.getBoolean(
+              PropertyKey.USER_HDFS_CLIENT_EXCLUDE_MOUNT_INFO_ON_LIST_STATUS)).build();
       when(alluxioFs.listStatus(new AlluxioURI(HadoopUtils.getPathWithoutScheme(path)),
           listStatusPOptions))
           .thenThrow(new FileNotFoundException("ALLUXIO-2036 not Found"));

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6053,7 +6053,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey USER_HDFS_CLIENT_EXCLUDE_MOUNT_INFO_ON_LIST_STATUS =
       booleanBuilder(Name.USER_HDFS_CLIENT_EXCLUDE_MOUNT_INFO_ON_LIST_STATUS)
           .setDefaultValue(false)
-          .setDescription("When a hdfs client listStatus a file, Whether not to use mount info")
+          .setDescription("If enabled, the mount info will be excluded from the response "
+              + "when a HDFS client calls alluxio to list status on a directory.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)
           .build();

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -8599,7 +8599,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.file.write.init.max.duration";
     public static final String USER_HOSTNAME = "alluxio.user.hostname";
     public static final String USER_HDFS_CLIENT_EXCLUDE_MOUNT_INFO_ON_LIST_STATUS =
-        "user.hdfs.liststatus.mountinfo.disable";
+        "alluxio.user.hdfs.client.exclude.mount.info.on.list.status";
     public static final String USER_LOCAL_READER_CHUNK_SIZE_BYTES =
         "alluxio.user.local.reader.chunk.size.bytes";
     public static final String USER_LOCAL_WRITER_CHUNK_SIZE_BYTES =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6050,6 +6050,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "when Alluxio workers are required but not ready.")
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_HDFS_LISTSTATUS_MOUNTINFO_DISABLE =
+      booleanBuilder(Name.USER_HDFS_LISTSTATUS_MOUNTINFO_DISABLE)
+          .setDefaultValue(true)
+          .setIsHidden(true)
+          .setDescription("When a hdfs client listStatus a file, Whether not to use mount info")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_LOCAL_READER_CHUNK_SIZE_BYTES =
       dataSizeBuilder(Name.USER_LOCAL_READER_CHUNK_SIZE_BYTES)
           .setDefaultValue("8MB")
@@ -8591,6 +8599,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_FILE_WRITE_INIT_MAX_DURATION =
         "alluxio.user.file.write.init.max.duration";
     public static final String USER_HOSTNAME = "alluxio.user.hostname";
+    public static final String USER_HDFS_LISTSTATUS_MOUNTINFO_DISABLE =
+        "user.hdfs.liststatus.mountinfo.disable";
     public static final String USER_LOCAL_READER_CHUNK_SIZE_BYTES =
         "alluxio.user.local.reader.chunk.size.bytes";
     public static final String USER_LOCAL_WRITER_CHUNK_SIZE_BYTES =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6050,10 +6050,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "when Alluxio workers are required but not ready.")
           .setScope(Scope.CLIENT)
           .build();
-  public static final PropertyKey USER_HDFS_LISTSTATUS_MOUNTINFO_DISABLE =
-      booleanBuilder(Name.USER_HDFS_LISTSTATUS_MOUNTINFO_DISABLE)
-          .setDefaultValue(true)
-          .setIsHidden(true)
+  public static final PropertyKey USER_HDFS_CLIENT_EXCLUDE_MOUNT_INFO_ON_LIST_STATUS =
+      booleanBuilder(Name.USER_HDFS_CLIENT_EXCLUDE_MOUNT_INFO_ON_LIST_STATUS)
+          .setDefaultValue(false)
           .setDescription("When a hdfs client listStatus a file, Whether not to use mount info")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
           .setScope(Scope.CLIENT)
@@ -8599,7 +8598,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_FILE_WRITE_INIT_MAX_DURATION =
         "alluxio.user.file.write.init.max.duration";
     public static final String USER_HOSTNAME = "alluxio.user.hostname";
-    public static final String USER_HDFS_LISTSTATUS_MOUNTINFO_DISABLE =
+    public static final String USER_HDFS_CLIENT_EXCLUDE_MOUNT_INFO_ON_LIST_STATUS =
         "user.hdfs.liststatus.mountinfo.disable";
     public static final String USER_LOCAL_READER_CHUNK_SIZE_BYTES =
         "alluxio.user.local.reader.chunk.size.bytes";

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -1224,7 +1224,7 @@ public class DefaultFileSystemMaster extends CoreMaster
   private void listStatusInternal(
       ListStatusContext context, RpcContext rpcContext, LockedInodePath currInodePath,
       AuditContext auditContext, DescendantType descendantType, ResultStream<FileInfo> resultStream,
-      int depth, Counter counter, List<String> partialPath,
+      int depth, @Nullable Counter counter, List<String> partialPath,
       List<String> prefixComponents)
       throws FileDoesNotExistException, UnavailableException,
       AccessControlException, InvalidPathException {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -973,14 +973,15 @@ public class DefaultFileSystemMaster extends CoreMaster
 
   private FileInfo getFileInfoInternal(LockedInodePath inodePath)
       throws UnavailableException, FileDoesNotExistException {
-    return getFileInfoInternal(inodePath, null);
+    return getFileInfoInternal(inodePath, null, false);
   }
 
   /**
    * @param inodePath the {@link LockedInodePath} to get the {@link FileInfo} for
    * @return the {@link FileInfo} for the given inode
    */
-  private FileInfo getFileInfoInternal(LockedInodePath inodePath, Counter counter)
+  private FileInfo getFileInfoInternal(LockedInodePath inodePath, Counter counter,
+      boolean noNeedUseMountInfo)
       throws FileDoesNotExistException, UnavailableException {
     int inMemoryPercentage;
     int inAlluxioPercentage;
@@ -1027,20 +1028,22 @@ public class DefaultFileSystemMaster extends CoreMaster
       }
     }
     fileInfo.setXAttr(inode.getXAttr());
-    MountTable.Resolution resolution;
-    try {
-      resolution = mMountTable.resolve(uri);
-    } catch (InvalidPathException e) {
-      throw new FileDoesNotExistException(e.getMessage(), e);
-    }
-    AlluxioURI resolvedUri = resolution.getUri();
-    fileInfo.setUfsPath(resolvedUri.toString());
-    fileInfo.setMountId(resolution.getMountId());
-    if (counter == null) {
-      Metrics.getUfsOpsSavedCounter(resolution.getUfsMountPointUri(),
-          Metrics.UFSOps.GET_FILE_INFO).inc();
-    } else {
-      counter.inc();
+    if (!noNeedUseMountInfo) {
+      MountTable.Resolution resolution;
+      try {
+        resolution = mMountTable.resolve(uri);
+      } catch (InvalidPathException e) {
+        throw new FileDoesNotExistException(e.getMessage(), e);
+      }
+      AlluxioURI resolvedUri = resolution.getUri();
+      fileInfo.setUfsPath(resolvedUri.toString());
+      fileInfo.setMountId(resolution.getMountId());
+      if (counter == null) {
+        Metrics.getUfsOpsSavedCounter(resolution.getUfsMountPointUri(),
+            Metrics.UFSOps.GET_FILE_INFO).inc();
+      } else {
+        counter.inc();
+      }
     }
 
     Metrics.FILE_INFOS_GOT.inc();
@@ -1146,13 +1149,16 @@ public class DefaultFileSystemMaster extends CoreMaster
           ensureFullPathAndUpdateCache(inodePath);
 
           auditContext.setSrcInode(inodePath.getInode());
-          MountTable.Resolution resolution;
+          MountTable.Resolution resolution = null;
           if (!context.getOptions().hasLoadMetadataOnly()
               || !context.getOptions().getLoadMetadataOnly()) {
             DescendantType descendantTypeForListStatus =
                 (context.getOptions().getRecursive()) ? DescendantType.ALL : DescendantType.ONE;
             try {
-              resolution = mMountTable.resolve(path);
+              if (!(context.getOptions().hasNoNeedUseMountInfo() && context.getOptions()
+                  .getNoNeedUseMountInfo())) {
+                resolution = mMountTable.resolve(path);
+              }
             } catch (InvalidPathException e) {
               throw new FileDoesNotExistException(e.getMessage(), e);
             }
@@ -1172,11 +1178,11 @@ public class DefaultFileSystemMaster extends CoreMaster
             }
             // perform the listing
             listStatusInternal(context, rpcContext, inodePath, auditContext,
-                descendantTypeForListStatus, resultStream, 0,
-                Metrics.getUfsOpsSavedCounter(resolution.getUfsMountPointUri(),
-                    Metrics.UFSOps.GET_FILE_INFO),
+                descendantTypeForListStatus, resultStream, 0, resolution == null ? null :
+                    Metrics.getUfsOpsSavedCounter(resolution.getUfsMountPointUri(),
+                        Metrics.UFSOps.GET_FILE_INFO),
                 partialPathNames, prefixComponents);
-            if (!ufsAccessed) {
+            if (!ufsAccessed && resolution != null) {
               Metrics.getUfsOpsSavedCounter(resolution.getUfsMountPointUri(),
                   Metrics.UFSOps.LIST_STATUS).inc();
             }
@@ -1242,7 +1248,10 @@ public class DefaultFileSystemMaster extends CoreMaster
       // at this depth.
       if ((depth != 0 || inode.isFile()) && prefixComponents.size() <= depth) {
         if (context.listedItem()) {
-          resultStream.submit(getFileInfoInternal(currInodePath, counter));
+          boolean noNeedUseMountInfo =
+              context.getOptions().hasNoNeedUseMountInfo() && context.getOptions()
+                  .getNoNeedUseMountInfo() ? true : false;
+          resultStream.submit(getFileInfoInternal(currInodePath, counter, noNeedUseMountInfo));
         }
         if (context.isDoneListing()) {
           return;

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -981,7 +981,7 @@ public class DefaultFileSystemMaster extends CoreMaster
    * @return the {@link FileInfo} for the given inode
    */
   private FileInfo getFileInfoInternal(LockedInodePath inodePath, Counter counter,
-      boolean noNeedUseMountInfo)
+      boolean excludeMountInfo)
       throws FileDoesNotExistException, UnavailableException {
     int inMemoryPercentage;
     int inAlluxioPercentage;
@@ -1028,7 +1028,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       }
     }
     fileInfo.setXAttr(inode.getXAttr());
-    if (!noNeedUseMountInfo) {
+    if (!excludeMountInfo) {
       MountTable.Resolution resolution;
       try {
         resolution = mMountTable.resolve(uri);
@@ -1155,8 +1155,7 @@ public class DefaultFileSystemMaster extends CoreMaster
             DescendantType descendantTypeForListStatus =
                 (context.getOptions().getRecursive()) ? DescendantType.ALL : DescendantType.ONE;
             try {
-              if (!(context.getOptions().hasNoNeedUseMountInfo() && context.getOptions()
-                  .getNoNeedUseMountInfo())) {
+              if (!context.getOptions().getExcludeMountInfo()) {
                 resolution = mMountTable.resolve(path);
               }
             } catch (InvalidPathException e) {
@@ -1248,10 +1247,8 @@ public class DefaultFileSystemMaster extends CoreMaster
       // at this depth.
       if ((depth != 0 || inode.isFile()) && prefixComponents.size() <= depth) {
         if (context.listedItem()) {
-          boolean noNeedUseMountInfo =
-              context.getOptions().hasNoNeedUseMountInfo() && context.getOptions()
-                  .getNoNeedUseMountInfo() ? true : false;
-          resultStream.submit(getFileInfoInternal(currInodePath, counter, noNeedUseMountInfo));
+          resultStream.submit(getFileInfoInternal(currInodePath, counter,
+              context.getOptions().getExcludeMountInfo()));
         }
         if (context.isDoneListing()) {
           return;

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -236,10 +236,11 @@ message ListStatusPOptions {
   // being loaded. It is recommended to set this to true after the first call of a
   // recursive partial listing.
   optional bool disableAreDescendantsLoadedCheck = 6;
-  // Setting this to true will not sets mount point info. Some Hadoop-compatible systems
-  // do not require UFS information. If there are many mount points and many sub-files
-  // in the directory, the performance will be seriously affected
-  optional bool noNeedUseMountInfo = 7;
+  // Mount info will be excluded from the list status response if this field is set to true.
+  // Resolving a path and obtain the mount info is an expensive operation.
+  // For clients that do not need this information such as hadoop-compatible clients,
+  // excluding mount info improves the endpoint performance.
+  optional bool excludeMountInfo = 7;
 }
 message ListStatusPRequest {
   /** the path of the file or directory */

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -236,6 +236,10 @@ message ListStatusPOptions {
   // being loaded. It is recommended to set this to true after the first call of a
   // recursive partial listing.
   optional bool disableAreDescendantsLoadedCheck = 6;
+  // Setting this to true will not sets mount point info. Some Hadoop-compatible systems
+  // do not require UFS information. If there are many mount points and many sub-files
+  // in the directory, the performance will be seriously affected
+  optional bool noNeedUseMountInfo = 7;
 }
 message ListStatusPRequest {
   /** the path of the file or directory */

--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -317,7 +317,7 @@ public final class LsCommand extends AbstractFileSystemCommand {
         cl.hasOption("d"), cl.hasOption("h"), cl.hasOption("p"),
         cl.getOptionValue("sort", null), cl.hasOption("r"),
         cl.getOptionValue("timestamp", "lastModificationTime"),
-        cl.hasOption("exclude-mount-info"));
+        cl.hasOption("m") || cl.hasOption("omit-mount-info"));
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -89,6 +89,14 @@ public final class LsCommand extends AbstractFileSystemCommand {
     TIMESTAMP_FIELDS.put("lastModificationTime", URIStatus::getLastModificationTimeMs);
   }
 
+  private static final Option EXCLUDE_MOUNT_INFO =
+      Option.builder()
+          .required(false)
+          .longOpt("exclude-mount-info")
+          .hasArg(false)
+          .desc("")
+          .build();
+
   private static final Option FORCE_OPTION =
       Option.builder("f")
           .required(false)
@@ -231,6 +239,7 @@ public final class LsCommand extends AbstractFileSystemCommand {
   @Override
   public Options getOptions() {
     return new Options()
+        .addOption(EXCLUDE_MOUNT_INFO)
         .addOption(FORCE_OPTION)
         .addOption(LIST_DIR_AS_FILE_OPTION)
         .addOption(LIST_HUMAN_READABLE_OPTION)
@@ -249,9 +258,11 @@ public final class LsCommand extends AbstractFileSystemCommand {
    * @param dirAsFile list the directory status as a plain file
    * @param hSize print human-readable format sizes
    * @param sortField sort the result by this field
+   * @param excludeMountInfo if enabled, the mount info will be excluded from the response
    */
   private void ls(AlluxioURI path, boolean recursive, boolean forceLoadMetadata, boolean dirAsFile,
-      boolean hSize, boolean pinnedOnly, String sortField, boolean reverse, String timestampOption)
+      boolean hSize, boolean pinnedOnly, String sortField, boolean reverse, String timestampOption,
+      boolean excludeMountInfo)
       throws AlluxioException, IOException {
     Function<URIStatus, Long> timestampFunction = TIMESTAMP_FIELDS.get(timestampOption);
     if (dirAsFile) {
@@ -265,6 +276,7 @@ public final class LsCommand extends AbstractFileSystemCommand {
       optionsBuilder.setLoadMetadataType(LoadMetadataPType.ALWAYS);
     }
     optionsBuilder.setRecursive(recursive);
+    optionsBuilder.setExcludeMountInfo(excludeMountInfo);
 
     if (sortField == null) {
       mFileSystem.iterateStatus(path, optionsBuilder.build(),
@@ -303,7 +315,8 @@ public final class LsCommand extends AbstractFileSystemCommand {
     ls(path, cl.hasOption(RECURSIVE_OPTION.getOpt()), cl.hasOption("f"),
         cl.hasOption("d"), cl.hasOption("h"), cl.hasOption("p"),
         cl.getOptionValue("sort", null), cl.hasOption("r"),
-        cl.getOptionValue("timestamp", "lastModificationTime"));
+        cl.getOptionValue("timestamp", "lastModificationTime"),
+        cl.hasOption("exclude-mount-info"));
   }
 
   @Override

--- a/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/LsCommand.java
@@ -89,14 +89,6 @@ public final class LsCommand extends AbstractFileSystemCommand {
     TIMESTAMP_FIELDS.put("lastModificationTime", URIStatus::getLastModificationTimeMs);
   }
 
-  private static final Option EXCLUDE_MOUNT_INFO =
-      Option.builder()
-          .required(false)
-          .longOpt("exclude-mount-info")
-          .hasArg(false)
-          .desc("")
-          .build();
-
   private static final Option FORCE_OPTION =
       Option.builder("f")
           .required(false)
@@ -123,6 +115,15 @@ public final class LsCommand extends AbstractFileSystemCommand {
           .required(false)
           .hasArg(false)
           .desc("list all pinned files")
+          .build();
+
+  private static final Option OMIT_MOUNT_INFO =
+      Option.builder("m")
+          .required(false)
+          .longOpt("omit-mount-info")
+          .hasArg(false)
+          .desc("if specified, the status will not include mount point related information, "
+              + "like the UFS path")
           .build();
 
   private static final Option RECURSIVE_OPTION =
@@ -239,11 +240,11 @@ public final class LsCommand extends AbstractFileSystemCommand {
   @Override
   public Options getOptions() {
     return new Options()
-        .addOption(EXCLUDE_MOUNT_INFO)
         .addOption(FORCE_OPTION)
         .addOption(LIST_DIR_AS_FILE_OPTION)
         .addOption(LIST_HUMAN_READABLE_OPTION)
         .addOption(LIST_PINNED_FILES_OPTION)
+        .addOption(OMIT_MOUNT_INFO)
         .addOption(RECURSIVE_OPTION)
         .addOption(REVERSE_SORT_OPTION)
         .addOption(SORT_OPTION)


### PR DESCRIPTION
### What changes are proposed in this pull request?
 Improve listStatus 5X performance in some scenarios.

### Why are the changes needed?
For instance,
Under the scenario:
1. Use Hadoop compatible system to access Alluxio(listStatus)
2. There are many mount point such as more than 500.
3. There are more than 2000 files in a directory.

The PathUtils.hasPrefix (comes from MountTable.getMountPoint)method will be called at least 10w (500 * 2000) times.
But actually we don't need the information of mount point.
The test can be reduced from about 400ms to 70ms under the master branch.
The test can be reduced from about 700ms to about 100ms under 2.7.1 branch.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  no
