### PR TITLE
[SMALLFIX] Correct version name in comment

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RequestServlet.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RequestServlet.java
@@ -42,7 +42,7 @@ public class S3RequestServlet extends HttpServlet {
   public static final String S3_V2_SERVICE_PATH_PREFIX = Constants.REST_API_PREFIX
       + AlluxioURI.SEPARATOR + SERVICE_PREFIX;
   private static final Logger LOG = LoggerFactory.getLogger(S3RequestServlet.class);
-  /* (Experimental for new architecture enabled by PROXY_S3_OPTIMIZED_VERSION_ENABLED)
+  /* (Experimental for new architecture enabled by PROXY_S3_V2_VERSION_ENABLED)
    * Processing threadpools for group of requests (for now, distinguish between
    * light-weighted metadata-centric requests and heavy io requests */
   public static final String PROXY_S3_V2_LIGHT_POOL = "Proxy S3 V2 Light Pool";


### PR DESCRIPTION
### What changes are proposed in this pull request?

Rename PROXY_S3_OPTIMIZED_VERSION_ENABLED to PROXY_S3_V2_VERSION_ENABLED in comment.

### Why are the changes needed?
Using a error property about how to enable the s3 v2 api in `alluxio.proxy.s3.S3RequestServlet`.

