### PR TITLE
Fix worker report all block locations to master for async restore

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -614,6 +614,9 @@ public class LocalCacheManager implements CacheManager {
       LOG.error("Failed to restore PageStore", e);
       return false;
     }
+    if (mInitService.isPresent()) {
+      mPageMetaStore.reportBlocks(pageStoreDir);
+    }
     LOG.info("PageStore ({}) restored with {} pages ({} bytes), "
             + "discarded {} pages ({} bytes)",
         pageStoreDir.getRootPath(), mPageMetaStore.numPages(), mPageMetaStore.bytes(),

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/PageMetaStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/PageMetaStore.java
@@ -55,6 +55,8 @@ public interface PageMetaStore {
    */
   void addPage(PageId pageId, PageInfo pageInfo);
 
+  default void reportBlocks(PageStoreDir pageStoreDir) {}
+
   /**
    * Adds a new temp page to the cache.
    *


### PR DESCRIPTION
### What changes are proposed in this pull request?

Using BlockHeartbeat to report all block locations to master when worker scans pages asynchronously.

### Why are the changes needed?

If not，worker may have some blocks unrecognized.

### Does this PR introduce any user facing changes?

N/A
