### PR TITLE
Add metrics sink to job master

### DIFF
--- a/job/server/src/main/java/alluxio/master/job/JobMaster.java
+++ b/job/server/src/main/java/alluxio/master/job/JobMaster.java
@@ -184,6 +184,10 @@ public class JobMaster extends AbstractMaster implements NoopJournaled {
   @Override
   public void start(Boolean isLeader) throws IOException {
     super.start(isLeader);
+
+    // Start serving metrics system, this will not block
+    MetricsSystem.startSinks(Configuration.getString(PropertyKey.METRICS_CONF_FILE));
+
     // Fail any jobs that were still running when the last job master stopped.
     for (PlanCoordinator planCoordinator : mPlanTracker.coordinators()) {
       if (!planCoordinator.isJobFinished()) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Adding metrics sink to job master.

### Why are the changes needed?

Fix the issue that the job master is unable to sink metrics. 

### Does this PR introduce any user facing changes?

Yes, this change will enable users to sink metrics from the job master.
