### PR TITLE
Add rate limiter for ufs reader

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5165,21 +5165,21 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey WORKER_UFS_READ_TOTAL_THROUGHPUT =
-      stringBuilder(Name.WORKER_UFS_READ_TOTAL_THROUGHPUT)
+      dataSizeBuilder(Name.WORKER_UFS_READ_TOTAL_THROUGHPUT)
           .setDefaultValue("5GB")
           .setDescription("The total throughput limit for cluster to read from ufs.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey WORKER_UFS_READ_DEFAULT_THROUGHPUT =
-      stringBuilder(Name.WORKER_UFS_READ_DEFAULT_THROUGHPUT)
+      dataSizeBuilder(Name.WORKER_UFS_READ_DEFAULT_THROUGHPUT)
           .setDefaultValue("500MB")
           .setDescription("The default throughput limit for worker to read from ufs.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
   public static final PropertyKey WORKER_UFS_READ_MIN_THROUGHPUT =
-      stringBuilder(Name.WORKER_UFS_READ_MIN_THROUGHPUT)
+      dataSizeBuilder(Name.WORKER_UFS_READ_MIN_THROUGHPUT)
           .setDefaultValue("100MB")
           .setDescription("The min throughput limit for worker to read from ufs.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5150,6 +5150,48 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
           .build();
+  public static final PropertyKey WORKER_UFS_READ_THROUGHPUT_LIMIT_ENABLED =
+      booleanBuilder(Name.WORKER_UFS_READ_THROUGHPUT_LIMIT_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("Whether or not to enable limit throughput for reading from ufs.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey WORKER_UFS_READ_THROUGHPUT_POLICY =
+      classBuilder(Name.WORKER_UFS_READ_THROUGHPUT_POLICY)
+          .setDefaultValue("The default throughput calculation policy for limit reading from ufs.")
+          .setDescription("alluxio.master.block.throughput.ConstantThroughputPolicy")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey WORKER_UFS_READ_TOTAL_THROUGHPUT =
+      stringBuilder(Name.WORKER_UFS_READ_TOTAL_THROUGHPUT)
+          .setDefaultValue("5GB")
+          .setDescription("The total throughput limit for cluster to read from ufs.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey WORKER_UFS_READ_DEFAULT_THROUGHPUT =
+      stringBuilder(Name.WORKER_UFS_READ_DEFAULT_THROUGHPUT)
+          .setDefaultValue("500MB")
+          .setDescription("The default throughput limit for worker to read from ufs.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey WORKER_UFS_READ_MIN_THROUGHPUT =
+      stringBuilder(Name.WORKER_UFS_READ_MIN_THROUGHPUT)
+          .setDefaultValue("100MB")
+          .setDescription("The min throughput limit for worker to read from ufs.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey WORKER_UFS_READ_THROUGHPUT_MAX_MULTIPLE =
+      intBuilder(Name.WORKER_UFS_READ_THROUGHPUT_MAX_MULTIPLE)
+          .setDefaultValue(3)
+          .setDescription("The worker throughput can reach the maximum multiple of the average.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
 
   //
   // Proxy related properties
@@ -8405,6 +8447,18 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String WORKER_UFS_INSTREAM_CACHE_MAX_SIZE =
         "alluxio.worker.ufs.instream.cache.max.size";
     public static final String WORKER_WHITELIST = "alluxio.worker.whitelist";
+    public static final String WORKER_UFS_READ_THROUGHPUT_LIMIT_ENABLED =
+        "alluxio.worker.ufs.read.throughput.limit.enabled";
+    public static final String WORKER_UFS_READ_THROUGHPUT_POLICY =
+        "alluxio.worker.ufs.read.throughput.policy.class";
+    public static final String WORKER_UFS_READ_TOTAL_THROUGHPUT =
+        "alluxio.worker.ufs.read.total.throughput";
+    public static final String WORKER_UFS_READ_DEFAULT_THROUGHPUT =
+        "alluxio.worker.ufs.read.default.throughput";
+    public static final String WORKER_UFS_READ_MIN_THROUGHPUT =
+        "alluxio.worker.ufs.read.min.throughput";
+    public static final String WORKER_UFS_READ_THROUGHPUT_MAX_MULTIPLE =
+        "alluxio.worker.ufs.read.throughput.max.multiple";
 
     //
     // Proxy related properties

--- a/core/common/src/main/java/alluxio/worker/block/BlockStore.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockStore.java
@@ -18,6 +18,7 @@ import alluxio.proto.dataserver.Protocol;
 import alluxio.worker.SessionCleanable;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
+import alluxio.worker.block.io.UnderFileSystemReadRateLimiter;
 import alluxio.worker.block.meta.BlockMeta;
 import alluxio.worker.block.meta.TempBlockMeta;
 
@@ -88,11 +89,13 @@ public interface BlockStore extends Closeable, SessionCleanable {
    * @param offset the offset within the block
    * @param positionShort whether the operation is using positioned read to a small buffer size
    * @param options the options
+   * @param rateLimiter the rate limiter for reading from ufs
    * @return a block reader to read data from
    * @throws IOException if it fails to get block reader
    */
   BlockReader createBlockReader(long sessionId, long blockId, long offset,
-      boolean positionShort, Protocol.OpenUfsBlockOptions options)
+      boolean positionShort, Protocol.OpenUfsBlockOptions options,
+      UnderFileSystemReadRateLimiter rateLimiter)
       throws IOException;
 
   /**
@@ -104,11 +107,12 @@ public interface BlockStore extends Closeable, SessionCleanable {
    * @param offset the offset within the block
    * @param positionShort whether the operation is using positioned read to a small buffer size
    * @param options the options
+   * @param rateLimiter the rate limiter for reading from ufs
    * @return the block reader instance
    * @throws IOException if it fails to get block reader
    */
   BlockReader createUfsBlockReader(long sessionId, long blockId, long offset, boolean positionShort,
-      Protocol.OpenUfsBlockOptions options)
+      Protocol.OpenUfsBlockOptions options, UnderFileSystemReadRateLimiter rateLimiter)
       throws IOException;
 
   /**

--- a/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
+++ b/core/common/src/main/java/alluxio/worker/block/BlockWorker.java
@@ -26,6 +26,7 @@ import alluxio.worker.SessionCleanable;
 import alluxio.worker.Worker;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
+import alluxio.worker.block.io.UnderFileSystemReadRateLimiter;
 
 import java.io.IOException;
 import java.util.List;
@@ -243,4 +244,9 @@ public interface BlockWorker extends Worker, SessionCleanable {
    * @return the worker address
    */
   WorkerNetAddress getWorkerAddress();
+
+  /**
+   * @return ufs read RateLimiter
+   */
+  UnderFileSystemReadRateLimiter getUfsReadRateLimiter();
 }

--- a/core/common/src/main/java/alluxio/worker/block/io/UnderFileSystemReadRateLimiter.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/UnderFileSystemReadRateLimiter.java
@@ -1,0 +1,92 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.block.io;
+
+import com.google.common.util.concurrent.RateLimiter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * RateLimiter for reading ufs.
+ */
+public class UnderFileSystemReadRateLimiter {
+  private static final Logger LOG = LoggerFactory.getLogger(UnderFileSystemReadRateLimiter.class);
+
+  private RateLimiter mReadLimiter;
+  private long mReadBytes;
+  private boolean mLimiterEnabled;
+
+  /**
+   * Constructs a new instance for {@link UnderFileSystemReadRateLimiter}.
+   * @param permitsPerSecond  the rate of the RateLimiter
+   */
+  public UnderFileSystemReadRateLimiter(long permitsPerSecond) {
+    mReadLimiter = RateLimiter.create(permitsPerSecond);
+    mReadBytes = 0;
+    mLimiterEnabled = false;
+  }
+
+  /**
+   * Set the rate.
+   *
+   * @param permitsPerSecond new rate of the RateLimiter
+   */
+  public synchronized void setRate(long permitsPerSecond) {
+    if (permitsPerSecond > 0) {
+      if (!isLimiterEnabled()) {
+        LOG.info("The throughput limit is enabled.");
+      }
+      mLimiterEnabled = true;
+      mReadLimiter.setRate(permitsPerSecond);
+    } else {
+      if (isLimiterEnabled()) {
+        LOG.warn("The throughput limit is disabled.");
+      }
+      mLimiterEnabled = false;
+    }
+    mReadBytes = 0;
+  }
+
+  /**
+   * A blocked method to acquire resources.
+   * @param permits num of requested resource
+   * @return time spent sleeping to enforce rate
+   */
+  public synchronized double acquire(int permits) {
+    if (isLimiterEnabled()) {
+      mReadBytes += permits;
+      return mReadLimiter.acquire(permits);
+    }
+    return 0;
+  }
+
+  /**
+   * @return the stable rate
+   */
+  public synchronized long getRate() {
+    return (long) mReadLimiter.getRate();
+  }
+
+  /**
+   * @return ture if has read file
+   */
+  public synchronized boolean hasRead() {
+    return mReadBytes != 0;
+  }
+
+  /**
+   * @return true if limiter enabled
+   */
+  public synchronized boolean isLimiterEnabled() {
+    return mLimiterEnabled;
+  }
+}

--- a/core/common/src/main/java/alluxio/worker/block/io/UnderFileSystemReadRateLimiter.java
+++ b/core/common/src/main/java/alluxio/worker/block/io/UnderFileSystemReadRateLimiter.java
@@ -42,15 +42,9 @@ public class UnderFileSystemReadRateLimiter {
    */
   public synchronized void setRate(long permitsPerSecond) {
     if (permitsPerSecond > 0) {
-      if (!isLimiterEnabled()) {
-        LOG.info("The throughput limit is enabled.");
-      }
       mLimiterEnabled = true;
       mReadLimiter.setRate(permitsPerSecond);
     } else {
-      if (isLimiterEnabled()) {
-        LOG.warn("The throughput limit is disabled.");
-      }
       mLimiterEnabled = false;
     }
     mReadBytes = 0;

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMaster.java
@@ -399,4 +399,13 @@ public interface BlockMaster extends Master, ContainerIdGenerable {
    * @param workerNetAddress the worker address
    */
   void notifyWorkerId(long workerId, WorkerNetAddress workerNetAddress);
+
+  /**
+   * Recalculate the worker's maximum throughput.
+   *
+   * @param workerId the worker id
+   * @param throughput latest worker throughput
+   * @return new maximum throughput for the worker
+   */
+  long refreshWorkerThroughput(long workerId, long throughput);
 }

--- a/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/block/BlockMasterWorkerServiceHandler.java
@@ -87,11 +87,13 @@ public final class BlockMasterWorkerServiceHandler extends
 
     final List<Metric> metrics = request.getOptions().getMetricsList()
         .stream().map(Metric::fromProto).collect(Collectors.toList());
+    final long throughput = request.getThroughput();
 
     RpcUtils.call(LOG, () ->
         BlockHeartbeatPResponse.newBuilder().setCommand(mBlockMaster.workerHeartbeat(workerId,
           capacityBytesOnTiers, usedBytesOnTiers, removedBlockIds, addedBlocksMap,
-            lostStorageMap, metrics)).build(),
+            lostStorageMap, metrics))
+                .setThroughput(mBlockMaster.refreshWorkerThroughput(workerId, throughput)).build(),
         "blockHeartbeat", "request=%s", responseObserver, request);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -48,6 +48,7 @@ import alluxio.master.CoreMaster;
 import alluxio.master.CoreMasterContext;
 import alluxio.master.block.meta.MasterWorkerInfo;
 import alluxio.master.block.meta.WorkerMetaLockSection;
+import alluxio.master.block.throughput.ThroughputPolicy;
 import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.checkpoint.CheckpointName;
 import alluxio.master.metastore.BlockMetaStore;
@@ -67,6 +68,7 @@ import alluxio.resource.CloseableIterator;
 import alluxio.resource.LockResource;
 import alluxio.security.authentication.ClientContextServerInjector;
 import alluxio.util.CommonUtils;
+import alluxio.util.FormatUtils;
 import alluxio.util.IdUtils;
 import alluxio.util.ThreadFactoryUtils;
 import alluxio.util.WaitForOptions;
@@ -288,6 +290,8 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
   private final boolean mStandbyMasterRpcEnabled = Configuration.getBoolean(
       PropertyKey.STANDBY_MASTER_GRPC_ENABLED);
 
+  private ThroughputPolicy mThroughputPolicy;
+
   /**
    * Creates a new instance of {@link DefaultBlockMaster}.
    *
@@ -322,6 +326,10 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
         this::getLostBlocksCount);
     MetricsSystem.registerCachedGaugeIfAbsent(MetricKey.MASTER_TO_REMOVE_BLOCK_COUNT.getName(),
         this::getToRemoveBlockCount, 30, TimeUnit.SECONDS);
+
+    if (Configuration.getBoolean(PropertyKey.WORKER_UFS_READ_THROUGHPUT_LIMIT_ENABLED)) {
+      mThroughputPolicy = ThroughputPolicy.Factory.create(Configuration.global());
+    }
   }
 
   /**
@@ -1475,6 +1483,23 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
       LOG.warn("Adding block ids {} for worker {} but these blocks don't exist. "
           + "These blocks will be ignored", sb, workerId);
     }
+  }
+
+  @Override
+  public long refreshWorkerThroughput(long workerId, long throughput) {
+    MasterWorkerInfo worker = mWorkers.getFirstByField(ID_INDEX, workerId);
+    long newThroughput = 0;
+    if (worker == null) {
+      LOG.warn("Could not find worker id: {} for heartbeat.", workerId);
+      return newThroughput;
+    }
+    if (mThroughputPolicy != null) {
+      worker.setReadUfsThroughput(throughput);
+      newThroughput = mThroughputPolicy.updateWorkerThroughput(mWorkers, worker);
+      LOG.debug("New throughput for worker {} is {}/s", workerId,
+          FormatUtils.getSizeFromBytes((long) newThroughput));
+    }
+    return newThroughput;
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/block/DefaultBlockMaster.java
@@ -1497,7 +1497,7 @@ public class DefaultBlockMaster extends CoreMaster implements BlockMaster {
       worker.setReadUfsThroughput(throughput);
       newThroughput = mThroughputPolicy.updateWorkerThroughput(mWorkers, worker);
       LOG.debug("New throughput for worker {} is {}/s", workerId,
-          FormatUtils.getSizeFromBytes((long) newThroughput));
+          FormatUtils.getSizeFromBytes(newThroughput));
     }
     return newThroughput;
   }

--- a/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
+++ b/core/server/master/src/main/java/alluxio/master/block/meta/MasterWorkerInfo.java
@@ -156,6 +156,9 @@ public final class MasterWorkerInfo {
   /** Stores the mapping from WorkerMetaLockSection to the lock. */
   private final Map<WorkerMetaLockSection, ReadWriteLock> mLockTypeToLock;
 
+  /** Worker's throughput for reading from ufs. */
+  private long mReadUfsThroughput;
+
   /**
    * Creates a new instance of {@link MasterWorkerInfo}.
    *
@@ -729,5 +732,19 @@ public final class MasterWorkerInfo {
    */
   public BuildVersion getBuildVersion() {
     return mBuildVersion.get();
+  }
+
+  /**
+   * @param readUfsThroughput the read ufs throughput
+   */
+  public void setReadUfsThroughput(long readUfsThroughput) {
+    mReadUfsThroughput = readUfsThroughput;
+  }
+
+  /**
+   * @return the read ufs throughput
+   */
+  public long getReadUfsThroughput() {
+    return mReadUfsThroughput;
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/block/throughput/AverageThroughputPolicy.java
+++ b/core/server/master/src/main/java/alluxio/master/block/throughput/AverageThroughputPolicy.java
@@ -1,0 +1,59 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.block.throughput;
+
+import static alluxio.conf.PropertyKey.WORKER_UFS_READ_THROUGHPUT_MAX_MULTIPLE;
+
+import alluxio.collections.IndexedSet;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.master.block.meta.MasterWorkerInfo;
+
+/**
+ * A throughput calculation policy that uses the average value.
+ */
+public class AverageThroughputPolicy implements ThroughputPolicy {
+
+  private final AlluxioConfiguration mConf;
+  private final long mDefaultThroughput;
+  private final long mMinThroughput;
+  private final long mTotalThroughput;
+  private final int mMaxMultiple;
+
+  /**
+   * Constructs a new {@link ConstantThroughputPolicy}.
+   *
+   * @param conf Alluxio configuration
+   */
+  public AverageThroughputPolicy(AlluxioConfiguration conf) {
+    mConf = conf;
+    mDefaultThroughput = mConf.getBytes(PropertyKey.WORKER_UFS_READ_DEFAULT_THROUGHPUT);
+    mMinThroughput = mConf.getBytes(PropertyKey.WORKER_UFS_READ_MIN_THROUGHPUT);
+    mTotalThroughput = mConf.getBytes(PropertyKey.WORKER_UFS_READ_TOTAL_THROUGHPUT);
+    mMaxMultiple = mConf.getInt(WORKER_UFS_READ_THROUGHPUT_MAX_MULTIPLE);
+  }
+
+  @Override
+  public long updateWorkerThroughput(IndexedSet<MasterWorkerInfo> workers,
+      MasterWorkerInfo curWorker) {
+    long workingCount = workers.stream().filter(workerInfo ->
+        workerInfo.getReadUfsThroughput() != 0 || workerInfo == curWorker).count();
+    // curWorker has been lost
+    if (workingCount == 0) {
+      return mDefaultThroughput;
+    }
+    long averageThroughput = mTotalThroughput / workingCount;
+    long maxThroughput = mTotalThroughput / workers.size()
+        * Math.min(workers.size(), mMaxMultiple);
+    return Math.max(mMinThroughput, Math.min(averageThroughput, maxThroughput));
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/block/throughput/ConstantThroughputPolicy.java
+++ b/core/server/master/src/main/java/alluxio/master/block/throughput/ConstantThroughputPolicy.java
@@ -1,0 +1,42 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.block.throughput;
+
+import alluxio.collections.IndexedSet;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.master.block.meta.MasterWorkerInfo;
+
+/**
+ * A throughput calculation policy that uses the constant value.
+ */
+public class ConstantThroughputPolicy implements ThroughputPolicy {
+
+  private final AlluxioConfiguration mConf;
+  private final long mThroughput;
+
+  /**
+   * Constructs a new {@link ConstantThroughputPolicy}.
+   *
+   * @param conf Alluxio configuration
+   */
+  public ConstantThroughputPolicy(AlluxioConfiguration conf) {
+    mConf = conf;
+    mThroughput = mConf.getBytes(PropertyKey.WORKER_UFS_READ_DEFAULT_THROUGHPUT);
+  }
+
+  @Override
+  public long updateWorkerThroughput(IndexedSet<MasterWorkerInfo> mWorkers,
+      MasterWorkerInfo curWorker) {
+    return mThroughput;
+  }
+}

--- a/core/server/master/src/main/java/alluxio/master/block/throughput/ThroughputPolicy.java
+++ b/core/server/master/src/main/java/alluxio/master/block/throughput/ThroughputPolicy.java
@@ -1,0 +1,58 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.block.throughput;
+
+import alluxio.collections.IndexedSet;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import alluxio.master.block.meta.MasterWorkerInfo;
+import alluxio.util.CommonUtils;
+
+/**
+ * Ufs Read Throughput Policy Interface.
+ */
+public interface ThroughputPolicy {
+
+  /**
+   * The factory for the {@link ThroughputPolicy}.
+   */
+  class Factory {
+    private Factory() {}
+
+    /**
+     * Factory for creating {@link ThroughputPolicy}.
+     *
+     * @param conf Alluxio configuration
+     * @return a new instance of {@link ThroughputPolicy}
+     */
+    public static ThroughputPolicy create(AlluxioConfiguration conf) {
+      try {
+        Class<ThroughputPolicy> clazz = (Class<ThroughputPolicy>) Class
+            .forName(conf.getString(PropertyKey.WORKER_UFS_READ_THROUGHPUT_POLICY));
+        return CommonUtils.createNewClassInstance(clazz, new Class[] {AlluxioConfiguration.class},
+            new Object[] {conf});
+      } catch (ClassNotFoundException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  /**
+   * Calculate worker throughput.
+   *
+   * @param mWorkers worker info set
+   * @param curWorker current worker info
+   * @return throughput for current worker
+   */
+  public long updateWorkerThroughput(IndexedSet<MasterWorkerInfo> mWorkers,
+                                     MasterWorkerInfo curWorker);
+}

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSync.java
@@ -120,7 +120,8 @@ public final class BlockMasterSync implements HeartbeatExecutor {
   public void heartbeat() {
     boolean success = mBlockMasterSyncHelper.heartbeat(
         mWorkerId.get(), mBlockWorker.getReport(),
-        mBlockWorker.getStoreMeta(), this::handleMasterCommand);
+        mBlockWorker.getStoreMeta(), this::handleMasterCommand,
+        mBlockWorker.getUfsReadRateLimiter());
     if (success) {
       mLastSuccessfulHeartbeatMs = System.currentTimeMillis();
     } else {

--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSyncHelper.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockMasterSyncHelper.java
@@ -145,7 +145,6 @@ public class BlockMasterSyncHelper {
           blockReport.getLostStorage(), throughput, metrics);
       cmdFromMaster = response.getCommand();
       handler.handle(cmdFromMaster);
-      cmdFromMaster = response.getCommand();
       rateLimiter.setRate(response.getThroughput());
       return true;
     } catch (Exception e) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/MonoBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/MonoBlockStore.java
@@ -37,6 +37,7 @@ import alluxio.worker.block.DefaultBlockWorker.Metrics;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
 import alluxio.worker.block.io.DelegatingBlockReader;
+import alluxio.worker.block.io.UnderFileSystemReadRateLimiter;
 import alluxio.worker.block.meta.BlockMeta;
 import alluxio.worker.block.meta.TempBlockMeta;
 import alluxio.worker.grpc.GrpcExecutors;
@@ -156,7 +157,8 @@ public class MonoBlockStore implements BlockStore {
 
   @Override
   public BlockReader createBlockReader(long sessionId, long blockId, long offset,
-      boolean positionShort, Protocol.OpenUfsBlockOptions options)
+      boolean positionShort, Protocol.OpenUfsBlockOptions options,
+      UnderFileSystemReadRateLimiter rateLimiter)
       throws IOException {
     BlockReader reader;
     Optional<? extends BlockMeta> blockMeta = mLocalBlockStore.getVolatileBlockMeta(blockId);
@@ -169,7 +171,8 @@ public class MonoBlockStore implements BlockStore {
         throw new BlockDoesNotExistRuntimeException(blockId);
       }
       // When the block does not exist in Alluxio but exists in UFS, try to open the UFS block.
-      reader = createUfsBlockReader(sessionId, blockId, offset, positionShort, options);
+      reader = createUfsBlockReader(sessionId, blockId, offset,
+          positionShort, options, rateLimiter);
     }
     return reader;
   }
@@ -177,11 +180,11 @@ public class MonoBlockStore implements BlockStore {
   @Override
   public BlockReader createUfsBlockReader(long sessionId, long blockId, long offset,
       boolean positionShort,
-      Protocol.OpenUfsBlockOptions options)
+      Protocol.OpenUfsBlockOptions options, UnderFileSystemReadRateLimiter rateLimiter)
       throws IOException {
     try {
       BlockReader reader = mUnderFileSystemBlockStore.createBlockReader(sessionId, blockId, offset,
-          positionShort, options);
+          positionShort, options, rateLimiter);
       BlockReader blockReader = new DelegatingBlockReader(reader,
           () -> closeUfsBlock(sessionId, blockId));
       Metrics.WORKER_ACTIVE_CLIENTS.inc();

--- a/core/server/worker/src/main/java/alluxio/worker/block/SpecificMasterBlockSync.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/SpecificMasterBlockSync.java
@@ -206,7 +206,8 @@ public class SpecificMasterBlockSync implements HeartbeatExecutor, Closeable {
         beforeHeartbeat();
         success = mBlockMasterSyncHelper.heartbeat(
             mWorkerId.get(), report,
-            mBlockWorker.getStoreMeta(), this::handleMasterCommand);
+            mBlockWorker.getStoreMeta(), this::handleMasterCommand,
+            mBlockWorker.getUfsReadRateLimiter());
       } catch (Exception e) {
         LOG.error("Failed to receive master heartbeat command. worker id {}", mWorkerId, e);
       }

--- a/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/UnderFileSystemBlockStore.java
@@ -27,6 +27,7 @@ import alluxio.resource.LockResource;
 import alluxio.underfs.UfsManager;
 import alluxio.worker.SessionCleanable;
 import alluxio.worker.block.io.BlockReader;
+import alluxio.worker.block.io.UnderFileSystemReadRateLimiter;
 import alluxio.worker.block.meta.UnderFileSystemBlockMeta;
 
 import com.codahale.metrics.Counter;
@@ -230,11 +231,13 @@ public final class UnderFileSystemBlockStore implements SessionCleanable, Closea
    * @param offset the read offset within the block (NOT the file)
    * @param positionShort whether the client op is a positioned read to a small buffer
    * @param options the open ufs options
+   * @param rateLimiter the rate limiter for reading from ufs
    * @return the block reader instance
    * {@link UnderFileSystemBlockStore}
    */
   public BlockReader createBlockReader(final long sessionId, long blockId, long offset,
-      boolean positionShort, Protocol.OpenUfsBlockOptions options)
+      boolean positionShort, Protocol.OpenUfsBlockOptions options,
+      UnderFileSystemReadRateLimiter rateLimiter)
       throws IOException, BlockAlreadyExistsException {
     if (!options.hasUfsPath() && options.getBlockInUfsTier()) {
       // This is a fallback UFS block read. Reset the UFS block path according to the UfsBlock
@@ -274,7 +277,8 @@ public final class UnderFileSystemBlockStore implements SessionCleanable, Closea
               MetricsSystem.escape(uri)));
     BlockReader reader =
         UnderFileSystemBlockReader.create(blockInfo.getMeta(), offset, positionShort,
-            mLocalBlockStore, ufsClient, mUfsInstreamCache, ufsBytesRead, ufsBytesReadThroughput);
+            mLocalBlockStore, ufsClient, mUfsInstreamCache, rateLimiter, ufsBytesRead,
+            ufsBytesReadThroughput);
     blockInfo.setBlockReader(reader);
     return reader;
   }

--- a/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/page/PagedBlockStore.java
@@ -46,6 +46,7 @@ import alluxio.worker.block.UfsInputStreamCache;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
 import alluxio.worker.block.io.DelegatingBlockReader;
+import alluxio.worker.block.io.UnderFileSystemReadRateLimiter;
 import alluxio.worker.block.meta.BlockMeta;
 import alluxio.worker.block.meta.TempBlockMeta;
 
@@ -221,7 +222,8 @@ public class PagedBlockStore implements BlockStore {
 
   @Override
   public BlockReader createBlockReader(long sessionId, long blockId, long offset,
-                                       boolean positionShort, Protocol.OpenUfsBlockOptions options)
+      boolean positionShort, Protocol.OpenUfsBlockOptions options,
+      UnderFileSystemReadRateLimiter rateLimiter)
       throws IOException {
     BlockLock blockLock = mLockManager.acquireBlockLock(sessionId, blockId, BlockLockType.READ);
 
@@ -299,8 +301,8 @@ public class PagedBlockStore implements BlockStore {
 
   @Override
   public BlockReader createUfsBlockReader(long sessionId, long blockId, long offset,
-                                          boolean positionShort,
-                                          Protocol.OpenUfsBlockOptions options) throws IOException {
+      boolean positionShort, Protocol.OpenUfsBlockOptions options,
+      UnderFileSystemReadRateLimiter rateLimiter) throws IOException {
     PagedBlockMeta blockMeta = mPageMetaStore
         .getBlock(blockId)
         .orElseGet(() -> {

--- a/core/server/worker/src/test/java/alluxio/worker/block/BlockMasterClientTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/BlockMasterClientTest.java
@@ -316,7 +316,8 @@ public class BlockMasterClientTest {
         removedBlocks,
         addedBlocks,
         lostStorage,
-        metrics).getCommandType());
+        0,
+        metrics).getCommand().getCommandType());
   }
 
   @Test

--- a/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTestBase.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/DefaultBlockWorkerTestBase.java
@@ -247,6 +247,7 @@ public class DefaultBlockWorkerTestBase {
             anyList(),
             anyMap(),
             anyMap(),
+            anyLong(),
             anyList()
         );
     return client;

--- a/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/NoopBlockWorker.java
@@ -26,6 +26,7 @@ import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.block.io.BlockReader;
 import alluxio.worker.block.io.BlockWriter;
+import alluxio.worker.block.io.UnderFileSystemReadRateLimiter;
 
 import java.io.IOException;
 import java.util.List;
@@ -165,6 +166,10 @@ public class NoopBlockWorker implements BlockWorker {
   @Override
   public WorkerNetAddress getWorkerAddress() {
     throw new UnsupportedOperationException();
+  }
+
+  public UnderFileSystemReadRateLimiter getUfsReadRateLimiter() {
+    return null;
   }
 
   @Override

--- a/core/server/worker/src/test/java/alluxio/worker/block/SpecificMasterBlockSyncTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/SpecificMasterBlockSyncTest.java
@@ -206,8 +206,8 @@ public class SpecificMasterBlockSyncTest {
             .setThroughput(0).build();
       }
       return BlockHeartbeatPResponse.newBuilder()
-              .setCommand(Command.newBuilder().setCommandType(CommandType.Nothing).build())
-              .setThroughput(0).build();
+          .setCommand(Command.newBuilder().setCommandType(CommandType.Nothing).build())
+          .setThroughput(0).build();
     }
 
     @Override

--- a/core/server/worker/src/test/java/alluxio/worker/block/SpecificMasterBlockSyncTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/SpecificMasterBlockSyncTest.java
@@ -19,6 +19,7 @@ import alluxio.ClientContext;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.FailedToAcquireRegisterLeaseException;
+import alluxio.grpc.BlockHeartbeatPResponse;
 import alluxio.grpc.Command;
 import alluxio.grpc.CommandType;
 import alluxio.grpc.ConfigProperty;
@@ -187,21 +188,26 @@ public class SpecificMasterBlockSyncTest {
     }
 
     @Override
-    public synchronized Command heartbeat(
+    public synchronized BlockHeartbeatPResponse heartbeat(
         long workerId, Map<String, Long> capacityBytesOnTiers,
         Map<String, Long> usedBytesOnTiers,
         List<Long> removedBlocks,
         Map<BlockStoreLocation, List<Long>> addedBlocks,
         Map<String, List<String>> lostStorage,
+        long throughput,
         List<Metric> metrics) throws IOException {
       mHeartbeatCallCount++;
       if (mHeartbeatFailed) {
         throw new IOException("heartbeat failed");
       }
       if (mReturnRegisterCommand) {
-        return Command.newBuilder().setCommandType(CommandType.Register).build();
+        return BlockHeartbeatPResponse.newBuilder()
+            .setCommand(Command.newBuilder().setCommandType(CommandType.Register).build())
+            .setThroughput(0).build();
       }
-      return Command.newBuilder().setCommandType(CommandType.Nothing).build();
+      return BlockHeartbeatPResponse.newBuilder()
+              .setCommand(Command.newBuilder().setCommandType(CommandType.Nothing).build())
+              .setThroughput(0).build();
     }
 
     @Override

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
@@ -270,4 +270,15 @@ public final class UnderFileSystemBlockReaderTest {
         mUfsBytesRead, mUfsBytesReadThroughput);
     assertTrue(mReader.getLocation().startsWith(mOpenUfsBlockOptions.getUfsPath()));
   }
+
+  @Test
+  public void readWithRateLimiter() throws Exception {
+    Configuration.set(PropertyKey.WORKER_UFS_READ_THROUGHPUT_LIMIT_ENABLED, true);
+    mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mRateLimiter,
+        mUfsBytesRead, mUfsBytesReadThroughput);
+    mRateLimiter.setRate(TEST_BLOCK_SIZE);
+    mReader.read(0, TEST_BLOCK_SIZE);
+    assertTrue(mRateLimiter.hasRead());
+  }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockReaderTest.java
@@ -34,6 +34,7 @@ import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.util.io.BufferUtils;
 import alluxio.worker.block.io.BlockReader;
+import alluxio.worker.block.io.UnderFileSystemReadRateLimiter;
 import alluxio.worker.block.meta.UnderFileSystemBlockMeta;
 
 import com.codahale.metrics.Counter;
@@ -62,6 +63,7 @@ public final class UnderFileSystemBlockReaderTest {
   private UfsManager.UfsClient mUfsClient;
   private UfsInputStreamCache mUfsInstreamCache;
   private Protocol.OpenUfsBlockOptions mOpenUfsBlockOptions;
+  private UnderFileSystemReadRateLimiter mRateLimiter;
   private Counter mUfsBytesRead;
   private Meter mUfsBytesReadThroughput;
 
@@ -111,6 +113,8 @@ public final class UnderFileSystemBlockReaderTest {
         MetricKey.WORKER_BYTES_READ_UFS_THROUGHPUT.isClusterAggregated(),
         MetricInfo.TAG_UFS,
         MetricsSystem.escape(mUfsClient.getUfsMountPointUri()));
+    mRateLimiter = new UnderFileSystemReadRateLimiter(Configuration.getBytes(
+        PropertyKey.WORKER_UFS_READ_DEFAULT_THROUGHPUT));
   }
 
   private void checkTempBlock(long start, long length) throws Exception {
@@ -128,7 +132,8 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void readFullBlock() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mRateLimiter,
+        mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
     mReader.close();
@@ -138,7 +143,8 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void readPartialBlock() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mRateLimiter,
+        mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE - 1);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE - 1, buffer));
     mReader.close();
@@ -149,7 +155,8 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void offset() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mRateLimiter,
+        mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuffer buffer = mReader.read(2, TEST_BLOCK_SIZE - 2);
     assertTrue(BufferUtils
         .equalIncreasingByteBuffer(2, (int) TEST_BLOCK_SIZE - 2, buffer));
@@ -161,7 +168,8 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void readOverlap() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 2, false,
-        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mRateLimiter,
+        mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuffer buffer = mReader.read(2, TEST_BLOCK_SIZE - 2);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(2, (int) TEST_BLOCK_SIZE - 2, buffer));
     buffer = mReader.read(0, TEST_BLOCK_SIZE - 2);
@@ -178,7 +186,8 @@ public final class UnderFileSystemBlockReaderTest {
     mUnderFileSystemBlockMeta = new UnderFileSystemBlockMeta(SESSION_ID, BLOCK_ID,
         mOpenUfsBlockOptions.toBuilder().setNoCache(true).build());
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mRateLimiter,
+        mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     // read should succeed even if error is thrown when caching
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
@@ -193,7 +202,7 @@ public final class UnderFileSystemBlockReaderTest {
         .when(errorThrowingBlockStore)
         .requestSpace(anyLong(), anyLong(), anyLong());
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        errorThrowingBlockStore, mUfsClient, mUfsInstreamCache,
+        errorThrowingBlockStore, mUfsClient, mUfsInstreamCache, mRateLimiter,
         mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
@@ -207,7 +216,7 @@ public final class UnderFileSystemBlockReaderTest {
     doThrow(new ResourceExhaustedRuntimeException("Ignored", false)).when(errorThrowingBlockStore)
         .createBlock(anyLong(), anyLong(), any(AllocateOptions.class));
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        errorThrowingBlockStore, mUfsClient, mUfsInstreamCache,
+        errorThrowingBlockStore, mUfsClient, mUfsInstreamCache, mRateLimiter,
         mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuffer buffer = mReader.read(0, TEST_BLOCK_SIZE);
     assertTrue(BufferUtils.equalIncreasingByteBuffer(0, (int) TEST_BLOCK_SIZE, buffer));
@@ -218,7 +227,8 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void transferFullBlock() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mRateLimiter,
+        mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuf buf =
         PooledByteBufAllocator.DEFAULT.buffer((int) TEST_BLOCK_SIZE * 2, (int) TEST_BLOCK_SIZE * 2);
     try {
@@ -236,7 +246,8 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void transferPartialBlock() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mRateLimiter,
+        mUfsBytesRead, mUfsBytesReadThroughput);
     ByteBuf buf =
         PooledByteBufAllocator.DEFAULT.buffer((int) TEST_BLOCK_SIZE / 2, (int) TEST_BLOCK_SIZE / 2);
     try {
@@ -255,7 +266,8 @@ public final class UnderFileSystemBlockReaderTest {
   @Test
   public void getLocation() throws Exception {
     mReader = UnderFileSystemBlockReader.create(mUnderFileSystemBlockMeta, 0, false,
-        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mUfsBytesRead, mUfsBytesReadThroughput);
+        mAlluxioBlockStore, mUfsClient, mUfsInstreamCache, mRateLimiter,
+        mUfsBytesRead, mUfsBytesReadThroughput);
     assertTrue(mReader.getLocation().startsWith(mOpenUfsBlockOptions.getUfsPath()));
   }
 }

--- a/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockStoreTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/UnderFileSystemBlockStoreTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertTrue;
 
 import alluxio.AlluxioURI;
 import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.BlockAlreadyExistsException;
 import alluxio.exception.runtime.NotFoundRuntimeException;
 import alluxio.master.NoopUfsManager;
@@ -24,6 +25,7 @@ import alluxio.proto.dataserver.Protocol;
 import alluxio.underfs.UfsManager;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.worker.block.io.BlockReader;
+import alluxio.worker.block.io.UnderFileSystemReadRateLimiter;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -44,6 +46,7 @@ public final class UnderFileSystemBlockStoreTest {
   private LocalBlockStore mAlluxioBlockStore;
   private Protocol.OpenUfsBlockOptions mOpenUfsBlockOptions;
   private UfsManager mUfsManager;
+  private UnderFileSystemReadRateLimiter mRateLimiter;
 
   @Rule
   public TemporaryFolder mFolder = new TemporaryFolder();
@@ -68,6 +71,8 @@ public final class UnderFileSystemBlockStoreTest {
     mOpenUfsBlockOptions = Protocol.OpenUfsBlockOptions.newBuilder().setMaxUfsReadConcurrency(5)
         .setBlockSize(TEST_BLOCK_SIZE).setOffsetInFile(TEST_BLOCK_SIZE)
         .setUfsPath(mTempFilePath).setMountId(MOUNT_ID).build();
+    mRateLimiter = new UnderFileSystemReadRateLimiter(Configuration.getBytes(
+        PropertyKey.WORKER_UFS_READ_DEFAULT_THROUGHPUT));
   }
 
   @Test
@@ -131,7 +136,7 @@ public final class UnderFileSystemBlockStoreTest {
         .build();
 
     BlockReader reader = blockStore
-        .createBlockReader(sessionId, BLOCK_ID, 0, false, options);
+        .createBlockReader(sessionId, BLOCK_ID, 0, false, options, mRateLimiter);
 
     assertArrayEquals(data, reader.read(0, TEST_BLOCK_SIZE).array());
   }
@@ -194,7 +199,7 @@ public final class UnderFileSystemBlockStoreTest {
         .build();
 
     BlockReader reader = blockStore
-        .createBlockReader(sessionId, BLOCK_ID, 0, false, options);
+        .createBlockReader(sessionId, BLOCK_ID, 0, false, options, mRateLimiter);
 
     blockStore.closeBlock(sessionId, BLOCK_ID);
     assertTrue(reader.isClosed());

--- a/core/transport/src/main/proto/grpc/block_master.proto
+++ b/core/transport/src/main/proto/grpc/block_master.proto
@@ -206,10 +206,12 @@ message BlockHeartbeatPRequest {
   map<string, StorageList> lostStorage = 6;
   /** use repeated fields to represent mapping from BlockStoreLocationProto to TierList */
   repeated LocationBlockIdListEntry addedBlocks = 7;
+  optional int64 throughput = 8;
 }
 
 message BlockHeartbeatPResponse {
   optional grpc.Command command = 1;
+  optional int64 throughput = 2;
 }
 
 message CommitBlockPResponse {}

--- a/microbench/src/main/java/alluxio/worker/BlockStoreSequentialReadBench.java
+++ b/microbench/src/main/java/alluxio/worker/BlockStoreSequentialReadBench.java
@@ -54,8 +54,8 @@ public class BlockStoreSequentialReadBench {
   private static final int MAX_SIZE = 64 * 1024 * 1024;
 
   private static final UnderFileSystemReadRateLimiter RATE_LIMITER =
-          new UnderFileSystemReadRateLimiter(Configuration.getBytes(
-                  PropertyKey.WORKER_UFS_READ_DEFAULT_THROUGHPUT));
+      new UnderFileSystemReadRateLimiter(Configuration.getBytes(
+          PropertyKey.WORKER_UFS_READ_DEFAULT_THROUGHPUT));
 
   /**
    * A mock consumer of the data read from the store.

--- a/stress/shell/src/main/java/alluxio/stress/cli/WorkerHeartbeatBench.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/WorkerHeartbeatBench.java
@@ -115,7 +115,8 @@ public class WorkerHeartbeatBench extends RpcBench<BlockMasterBenchParameters> {
             // So an empty map will be used here
             ImmutableMap.of(),
             LOST_STORAGE,
-            EMPTY_METRICS);
+            0,
+            EMPTY_METRICS).getCommand();
         LOG.debug("Received command from heartbeat {}", cmd);
         Instant e = Instant.now();
         Duration d = Duration.between(s, e);

--- a/tests/src/test/java/alluxio/server/block/BlockWorkerRegisterStreamIntegrationTest.java
+++ b/tests/src/test/java/alluxio/server/block/BlockWorkerRegisterStreamIntegrationTest.java
@@ -44,8 +44,8 @@ import alluxio.conf.PropertyKey;
 import alluxio.exception.status.DeadlineExceededException;
 import alluxio.exception.status.InternalException;
 import alluxio.exception.status.NotFoundException;
+import alluxio.grpc.BlockHeartbeatPResponse;
 import alluxio.grpc.BlockMasterWorkerServiceGrpc;
-import alluxio.grpc.Command;
 import alluxio.grpc.ConfigProperty;
 import alluxio.grpc.GrpcExceptionUtils;
 import alluxio.grpc.LocationBlockIdListEntry;
@@ -505,14 +505,14 @@ public class BlockWorkerRegisterStreamIntegrationTest {
     }
 
     @Override
-    public synchronized Command heartbeat(
+    public synchronized BlockHeartbeatPResponse heartbeat(
         final long workerId, final Map<String, Long> capacityBytesOnTiers,
         final Map<String, Long> usedBytesOnTiers,
         final List<Long> removedBlocks, final Map<BlockStoreLocation, List<Long>> addedBlocks,
-        final Map<String, List<String>> lostStorage, final List<Metric> metrics) {
+        final Map<String, List<String>> lostStorage, long throughput, final List<Metric> metrics) {
       assertEquals(mRemovedBlocks, removedBlocks);
       assertEquals(mAddedBlocks, addedBlocks);
-      return Command.getDefaultInstance();
+      return BlockHeartbeatPResponse.getDefaultInstance();
     }
 
     @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add rate limiter for ufs reader.

### Why are the changes needed?

It can be used to limit the bandwidth occupied by alluxio when reading from ufs.

### Does this PR introduce any user facing changes?
Add six properties:
- `alluxio.worker.ufs.read.throughput.limit.enabled` to enable limit throughput for reading from ufs.
- `alluxio.worker.ufs.read.throughput.policy.class` to set throughput calculation policy for limit reading from ufs.
- `alluxio.worker.ufs.read.total.throughput` to set total throughput limit for cluster to read from ufs.
- `alluxio.worker.ufs.read.default.throughput` to set the throughput limit for worker to read from ufs.
- `alluxio.worker.ufs.read.min.throughput` to set min throughput limit for worker to read from ufs.
- `alluxio.worker.ufs.read.throughput.max.multiple` to set the worker throughput can reach the maximum multiple of the average.

