### PR TITLE
Support netty data transmission in dora

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/FileSystemContext.java
@@ -638,7 +638,7 @@ public class FileSystemContext implements Closeable {
       final WorkerNetAddress workerNetAddress, final ClientContext context, UserState userState)
       throws IOException {
     SocketAddress address = NetworkAddressUtils
-        .getDataPortSocketAddress(workerNetAddress, context.getClusterConf());
+        .getRpcPortSocketAddress(workerNetAddress, context.getClusterConf());
     GrpcServerAddress serverAddress = GrpcServerAddress.create(workerNetAddress.getHost(), address);
     final ClientPoolKey key = new ClientPoolKey(address, AuthenticationUtils
             .getImpersonationUser(userState.getSubject(), context.getClusterConf()));

--- a/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
@@ -13,7 +13,6 @@ package alluxio.client.file.dora;
 
 import static com.google.common.base.Preconditions.checkState;
 
-import alluxio.client.ReadType;
 import alluxio.client.block.BlockWorkerInfo;
 import alluxio.client.block.stream.BlockWorkerClient;
 import alluxio.client.block.stream.DataReader;
@@ -21,7 +20,6 @@ import alluxio.client.block.stream.GrpcDataReader;
 import alluxio.client.block.stream.NettyDataReader;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.URIStatus;
-import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.grpc.FileInfo;
 import alluxio.grpc.GetStatusPOptions;
@@ -101,7 +99,6 @@ public class DoraCacheClient {
         .setChunkSize(mChunkSize);
     return new NettyDataReader.Factory(mContext, workerNetAddress, builder);
   }
-
 
   /**
    * Get status.

--- a/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheFileInStream.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  */
 public class DoraCacheFileInStream extends FileInStream {
 
-  private final GrpcDataReader.Factory mGrpcReaderFactory;
+  private final DataReader.Factory mReaderFactory;
   private final long mLength;
 
   private long mPos = 0;
@@ -39,12 +39,12 @@ public class DoraCacheFileInStream extends FileInStream {
 
   /**
    * Constructor.
-   * @param grpcReaderFactory
+   * @param readerFactory
    * @param length
    */
-  public DoraCacheFileInStream(GrpcDataReader.Factory grpcReaderFactory,
+  public DoraCacheFileInStream(DataReader.Factory readerFactory,
       long length) {
-    mGrpcReaderFactory = grpcReaderFactory;
+    mReaderFactory = readerFactory;
     mLength = length;
   }
 
@@ -104,7 +104,7 @@ public class DoraCacheFileInStream extends FileInStream {
     }
 
     int totalBytesRead = 0;
-    try (DataReader reader = mGrpcReaderFactory.create(position, length)) {
+    try (DataReader reader = mReaderFactory.create(position, length)) {
       while (totalBytesRead < length) {
         DataBuffer dataBuffer = null;
         try {
@@ -169,7 +169,7 @@ public class DoraCacheFileInStream extends FileInStream {
     try {
       closeDataReader();
     } finally {
-      mGrpcReaderFactory.close();
+      mReaderFactory.close();
     }
     mClosed = true;
   }
@@ -179,7 +179,7 @@ public class DoraCacheFileInStream extends FileInStream {
    */
   private void readChunk() throws IOException {
     if (mDataReader == null) {
-      mDataReader = mGrpcReaderFactory.create(mPos, mLength - mPos);
+      mDataReader = mReaderFactory.create(mPos, mLength - mPos);
     }
 
     if (mCurrentChunk != null && mCurrentChunk.readableBytes() == 0) {

--- a/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheFileInStream.java
@@ -12,7 +12,6 @@
 package alluxio.client.file.dora;
 
 import alluxio.client.block.stream.DataReader;
-import alluxio.client.block.stream.GrpcDataReader;
 import alluxio.client.file.FileInStream;
 import alluxio.exception.PreconditionMessage;
 import alluxio.exception.status.OutOfRangeException;

--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
@@ -387,10 +387,9 @@ public class UfsBaseFileSystem implements FileSystem {
   public void needsSync(AlluxioURI path) throws IOException, AlluxioException {
     throw new UnsupportedOperationException();
   }
-
   @Override
   public boolean submitLoad(AlluxioURI path, java.util.OptionalLong bandwidth,
-      boolean usePartialListing, boolean verify) {
+                            boolean usePartialListing, boolean verify) {
     throw new UnsupportedOperationException();
   }
 
@@ -401,7 +400,7 @@ public class UfsBaseFileSystem implements FileSystem {
 
   @Override
   public String getLoadProgress(AlluxioURI path,
-      java.util.Optional<alluxio.grpc.LoadProgressReportFormat> format, boolean verbose) {
+                                java.util.Optional<alluxio.grpc.LoadProgressReportFormat> format, boolean verbose) {
     throw new UnsupportedOperationException();
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
@@ -232,7 +232,7 @@ public class UfsBaseFileSystem implements FileSystem {
 
   @Override
   public void iterateStatus(AlluxioURI path, final ListStatusPOptions options,
-                            Consumer<? super URIStatus> action) {
+      Consumer<? super URIStatus> action) {
     call(() -> {
       ListOptions ufsOptions = ListOptions.defaults();
       if (options.hasRecursive()) {
@@ -331,7 +331,7 @@ public class UfsBaseFileSystem implements FileSystem {
 
   @Override
   public void setAcl(AlluxioURI path, SetAclAction action, List<AclEntry> entries,
-                     SetAclPOptions options) {
+      SetAclPOptions options) {
     call(() -> mUfs.get().setAclEntries(path.getPath(), entries));
   }
 
@@ -390,7 +390,7 @@ public class UfsBaseFileSystem implements FileSystem {
 
   @Override
   public boolean submitLoad(AlluxioURI path, java.util.OptionalLong bandwidth,
-                            boolean usePartialListing, boolean verify) {
+      boolean usePartialListing, boolean verify) {
     throw new UnsupportedOperationException();
   }
 
@@ -401,8 +401,7 @@ public class UfsBaseFileSystem implements FileSystem {
 
   @Override
   public String getLoadProgress(AlluxioURI path,
-                                java.util.Optional<alluxio.grpc.LoadProgressReportFormat> format,
-                                boolean verbose) {
+      java.util.Optional<alluxio.grpc.LoadProgressReportFormat> format, boolean verbose) {
     throw new UnsupportedOperationException();
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
@@ -232,7 +232,7 @@ public class UfsBaseFileSystem implements FileSystem {
 
   @Override
   public void iterateStatus(AlluxioURI path, final ListStatusPOptions options,
-      Consumer<? super URIStatus> action) {
+                            Consumer<? super URIStatus> action) {
     call(() -> {
       ListOptions ufsOptions = ListOptions.defaults();
       if (options.hasRecursive()) {
@@ -331,7 +331,7 @@ public class UfsBaseFileSystem implements FileSystem {
 
   @Override
   public void setAcl(AlluxioURI path, SetAclAction action, List<AclEntry> entries,
-      SetAclPOptions options) {
+                     SetAclPOptions options) {
     call(() -> mUfs.get().setAclEntries(path.getPath(), entries));
   }
 
@@ -387,6 +387,7 @@ public class UfsBaseFileSystem implements FileSystem {
   public void needsSync(AlluxioURI path) throws IOException, AlluxioException {
     throw new UnsupportedOperationException();
   }
+
   @Override
   public boolean submitLoad(AlluxioURI path, java.util.OptionalLong bandwidth,
                             boolean usePartialListing, boolean verify) {
@@ -400,7 +401,8 @@ public class UfsBaseFileSystem implements FileSystem {
 
   @Override
   public String getLoadProgress(AlluxioURI path,
-                                java.util.Optional<alluxio.grpc.LoadProgressReportFormat> format, boolean verbose) {
+                                java.util.Optional<alluxio.grpc.LoadProgressReportFormat> format,
+                                boolean verbose) {
     throw new UnsupportedOperationException();
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/FileReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/FileReadHandler.java
@@ -58,7 +58,7 @@ import javax.annotation.concurrent.GuardedBy;
  * Handles file read request.
  */
 public class FileReadHandler implements StreamObserver<ReadRequest> {
-  private static final Logger LOG = LoggerFactory.getLogger(BlockReadHandler.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FileReadHandler.class);
 
   private static final long MAX_CHUNK_SIZE =
       Configuration.getBytes(PropertyKey.WORKER_NETWORK_READER_MAX_CHUNK_SIZE_BYTES);

--- a/core/server/worker/src/main/java/alluxio/worker/netty/AbstractReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/AbstractReadHandler.java
@@ -119,7 +119,8 @@ abstract class AbstractReadHandler<T extends ReadRequestContext<?>>
       mContext = createRequestContext(msg);
     }
 
-    validateReadRequest(msg);
+    //TODO(JiamingMai): dora client will send -1 as the block id
+    //validateReadRequest(msg);
 
     try (LockResource lr = new LockResource(mLock)) {
       mContext.setPosToQueue(mContext.getRequest().getStart());

--- a/core/server/worker/src/main/java/alluxio/worker/netty/FileReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/FileReadHandler.java
@@ -1,0 +1,178 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.worker.netty;
+
+import alluxio.Constants;
+import alluxio.DefaultStorageTierAssoc;
+import alluxio.StorageTierAssoc;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.metrics.MetricsSystem;
+import alluxio.network.netty.FileTransferType;
+import alluxio.network.protocol.databuffer.DataBuffer;
+import alluxio.network.protocol.databuffer.DataFileChannel;
+import alluxio.network.protocol.databuffer.NettyDataBuffer;
+import alluxio.proto.dataserver.Protocol;
+import alluxio.retry.RetryPolicy;
+import alluxio.retry.TimeoutRetry;
+import alluxio.worker.block.io.BlockReader;
+import alluxio.worker.block.io.LocalFileBlockReader;
+import alluxio.worker.dora.DoraWorker;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.File;
+import java.nio.channels.FileChannel;
+import java.util.concurrent.ExecutorService;
+import com.google.common.base.Preconditions;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles file read request.
+ */
+public class FileReadHandler extends AbstractReadHandler<BlockReadRequestContext> {
+  private static final Logger LOG = LoggerFactory.getLogger(FileReadHandler.class);
+
+  private static final long UFS_BLOCK_OPEN_TIMEOUT_MS =
+      Configuration.getMs(PropertyKey.WORKER_UFS_BLOCK_OPEN_TIMEOUT_MS);
+
+  private final DoraWorker mWorker;
+
+  /**
+   * The transfer type used by the data server.
+   */
+  private final FileTransferType mTransferType;
+
+  /**
+   * Creates an instance of {@link FileReadHandler}.
+   *
+   * @param executorService the executor service to run data readers
+   * @param worker block worker
+   */
+  public FileReadHandler(ExecutorService executorService, DoraWorker worker, FileTransferType fileTransferType) {
+    super(executorService);
+    mWorker = worker;
+    mTransferType = fileTransferType;
+  }
+
+  @Override
+  protected BlockReadRequestContext createRequestContext(Protocol.ReadRequest request) {
+    return new BlockReadRequestContext(request);
+  }
+
+  @Override
+  protected AbstractReadHandler<BlockReadRequestContext>.PacketReader createPacketReader(
+      BlockReadRequestContext context, Channel channel) {
+    return new BlockPacketReader(context, channel, mWorker);
+  }
+
+  /**
+   * The packet reader to read from a local block worker.
+   */
+  @NotThreadSafe
+  public final class BlockPacketReader extends PacketReader {
+    /**
+     * The Block Worker.
+     */
+    private final DoraWorker mWorker;
+    /**
+     * An object storing the mapping of tier aliases to ordinals.
+     */
+    private final StorageTierAssoc mStorageTierAssoc = new DefaultStorageTierAssoc(
+        PropertyKey.WORKER_TIERED_STORE_LEVELS,
+        PropertyKey.Template.WORKER_TIERED_STORE_LEVEL_ALIAS);
+
+    BlockPacketReader(BlockReadRequestContext context, Channel channel, DoraWorker worker) {
+      super(context, channel);
+      mWorker = worker;
+    }
+
+    @Override
+    protected void completeRequest(BlockReadRequestContext context) throws Exception {
+      BlockReader reader = context.getBlockReader();
+      if (reader != null) {
+        try {
+          reader.close();
+        } catch (Exception e) {
+          LOG.warn("Failed to close block reader for block {} with error {}.",
+              context.getRequest().getId(), e.getMessage());
+        }
+      }
+    }
+
+    @Override
+    protected DataBuffer getDataBuffer(BlockReadRequestContext context, Channel channel,
+                                       long offset, int len) throws Exception {
+      openBlock(context, channel);
+      BlockReader blockReader = context.getBlockReader();
+      Preconditions.checkState(blockReader != null);
+      if (mTransferType == FileTransferType.TRANSFER
+          && (blockReader instanceof LocalFileBlockReader)) {
+        return new DataFileChannel(new File(((LocalFileBlockReader) blockReader).getFilePath()),
+            offset, len);
+      } else {
+        ByteBuf buf = channel.alloc().buffer(len, len);
+        try {
+          while (buf.writableBytes() > 0 && blockReader.transferTo(buf) != -1) {
+          }
+          return new NettyDataBuffer(buf);
+        } catch (Throwable e) {
+          buf.release();
+          throw e;
+        }
+      }
+    }
+
+    /**
+     * Opens the block if it is not open.
+     *
+     * @param channel the netty channel
+     * @throws Exception if it fails to open the block
+     */
+    private void openBlock(BlockReadRequestContext context, Channel channel) throws Exception {
+      if (context.getBlockReader() != null) {
+        return;
+      }
+      alluxio.worker.netty.BlockReadRequest request = context.getRequest();
+      int retryInterval = Constants.SECOND_MS;
+      RetryPolicy retryPolicy = new TimeoutRetry(UFS_BLOCK_OPEN_TIMEOUT_MS, retryInterval);
+      do {
+        try {
+          BlockReader reader = mWorker.createFileReader(request.getOpenUfsBlockOptions().getUfsPath(),
+              request.getStart(), false, request.getOpenUfsBlockOptions());
+          String metricName = "BytesReadAlluxio";
+          context.setBlockReader(reader);
+          context.setCounter(MetricsSystem.counter(metricName));
+          //TODO(JiamingMai): Do we still need to access block?
+          // It seems that it is not necessary any more.
+          //mWorker.accessBlock(request.getSessionId(), request.getId());
+          if (reader.getChannel() instanceof FileChannel) {
+            ((FileChannel) reader.getChannel()).position(request.getStart());
+          }
+          return;
+        } catch (Exception e) {
+          throw e;
+        }
+
+        //TODO(JiamingMai): Not sure if this is necessary.
+        /*
+        ProtoMessage heartbeat = new ProtoMessage(Protocol.ReadResponse.newBuilder()
+            .setType(Protocol.ReadResponse.Type.UFS_READ_HEARTBEAT).build());
+        // Sends an empty buffer to the client to make sure that the client does not timeout when
+        // the server is waiting for the UFS block access.
+        channel.writeAndFlush(new RPCProtoMessage(heartbeat));
+        */
+      } while (retryPolicy.attempt());
+    }
+  }
+}

--- a/core/server/worker/src/main/java/alluxio/worker/netty/FileReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/FileReadHandler.java
@@ -156,9 +156,6 @@ public class FileReadHandler extends AbstractReadHandler<BlockReadRequestContext
           String metricName = "BytesReadAlluxio";
           context.setBlockReader(reader);
           context.setCounter(MetricsSystem.counter(metricName));
-          //TODO(JiamingMai): Do we still need to access block?
-          // It seems that it is not necessary any more.
-          //mWorker.accessBlock(blockReadRequest.getSessionId(), blockReadRequest.getId());
           if (reader.getChannel() instanceof FileChannel) {
             ((FileChannel) reader.getChannel()).position(blockReadRequest.getStart());
           }

--- a/core/server/worker/src/main/java/alluxio/worker/netty/PipelineHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/PipelineHandler.java
@@ -84,7 +84,7 @@ final class PipelineHandler extends ChannelInitializer<Channel> {
     // UFS Handlers
     pipeline.addLast("ufsFileWriteHandler", new UfsFileWriteHandler(
         NettyExecutors.FILE_WRITER_EXECUTOR, mWorkerProcess.getUfsManager()));
-    // Unsupported Mess nage Handler
+    // Unsupported Message Handler
     pipeline.addLast("unsupportedMessageHandler", new UnsupportedMessageHandler());
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/netty/PipelineHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/PipelineHandler.java
@@ -115,5 +115,4 @@ final class PipelineHandler extends ChannelInitializer<Channel> {
     // Unsupported Message Handler
     pipeline.addLast("unsupportedMessageHandler", new UnsupportedMessageHandler());
   }
-
 }

--- a/core/server/worker/src/main/java/alluxio/worker/netty/PipelineHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/PipelineHandler.java
@@ -20,6 +20,7 @@ import alluxio.network.protocol.RPCMessageEncoder;
 import alluxio.worker.WorkerProcess;
 import alluxio.worker.block.AsyncCacheRequestManager;
 import alluxio.worker.block.BlockWorker;
+import alluxio.worker.dora.DoraWorker;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
@@ -37,6 +38,8 @@ final class PipelineHandler extends ChannelInitializer<Channel> {
   private final WorkerProcess mWorkerProcess;
   private final FileTransferType mFileTransferType;
   private final AsyncCacheRequestManager mRequestManager;
+  private static final boolean DORA_WORKER_ENABLED =
+      Configuration.getBoolean(PropertyKey.DORA_CLIENT_READ_LOCATION_POLICY_ENABLED);
 
   /**
    * @param workerProcess the Alluxio worker process
@@ -45,8 +48,13 @@ final class PipelineHandler extends ChannelInitializer<Channel> {
     mWorkerProcess = workerProcess;
     mFileTransferType = Configuration
         .getEnum(PropertyKey.WORKER_NETWORK_NETTY_FILE_TRANSFER_TYPE, FileTransferType.class);
-    mRequestManager = new AsyncCacheRequestManager(
-        NettyExecutors.ASYNC_CACHE_MANAGER_EXECUTOR, mWorkerProcess.getWorker(BlockWorker.class));
+    if (DORA_WORKER_ENABLED) {
+      // TODO(JiamingMai): AsyncCacheRequestManager need to use DoraWorker if we want to enable Dora
+      mRequestManager = null;
+    } else {
+      mRequestManager = new AsyncCacheRequestManager(
+          NettyExecutors.ASYNC_CACHE_MANAGER_EXECUTOR, mWorkerProcess.getWorker(BlockWorker.class));
+    }
   }
 
   @Override
@@ -67,6 +75,27 @@ final class PipelineHandler extends ChannelInitializer<Channel> {
     pipeline.addLast("heartbeatHandler", new HeartbeatHandler());
 
     // Block Handlers
+    if (DORA_WORKER_ENABLED) {
+      addBlockHandlerForDora(pipeline);
+    } else {
+      addBlockHandlerByDefault(pipeline);
+    }
+
+    // UFS Handlers
+    pipeline.addLast("ufsFileWriteHandler", new UfsFileWriteHandler(
+        NettyExecutors.FILE_WRITER_EXECUTOR, mWorkerProcess.getUfsManager()));
+    // Unsupported Mess nage Handler
+    pipeline.addLast("unsupportedMessageHandler", new UnsupportedMessageHandler());
+  }
+
+  private void addBlockHandlerForDora(ChannelPipeline pipeline) {
+    pipeline.addLast("blockReadHandler",
+        new FileReadHandler(NettyExecutors.BLOCK_READER_EXECUTOR,
+            mWorkerProcess.getWorker(DoraWorker.class), mFileTransferType));
+    //TODO(JiamingMai): WriteHandle also needs to be replaced, but it has not been implemented yet
+  }
+
+  private void addBlockHandlerByDefault(ChannelPipeline pipeline) {
     pipeline.addLast("blockReadHandler",
         new BlockReadHandler(NettyExecutors.BLOCK_READER_EXECUTOR,
             mWorkerProcess.getWorker(BlockWorker.class), mFileTransferType));
@@ -80,12 +109,11 @@ final class PipelineHandler extends ChannelInitializer<Channel> {
         new ShortCircuitBlockWriteHandler(NettyExecutors.RPC_EXECUTOR,
             mWorkerProcess.getWorker(BlockWorker.class)));
     pipeline.addLast("asyncCacheHandler", new AsyncCacheHandler(mRequestManager));
-
     // UFS Handlers
     pipeline.addLast("ufsFileWriteHandler", new UfsFileWriteHandler(
         NettyExecutors.FILE_WRITER_EXECUTOR, mWorkerProcess.getUfsManager()));
-
     // Unsupported Message Handler
     pipeline.addLast("unsupportedMessageHandler", new UnsupportedMessageHandler());
   }
+
 }

--- a/core/server/worker/src/main/java/alluxio/worker/netty/PipelineHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/PipelineHandler.java
@@ -109,10 +109,5 @@ final class PipelineHandler extends ChannelInitializer<Channel> {
         new ShortCircuitBlockWriteHandler(NettyExecutors.RPC_EXECUTOR,
             mWorkerProcess.getWorker(BlockWorker.class)));
     pipeline.addLast("asyncCacheHandler", new AsyncCacheHandler(mRequestManager));
-    // UFS Handlers
-    pipeline.addLast("ufsFileWriteHandler", new UfsFileWriteHandler(
-        NettyExecutors.FILE_WRITER_EXECUTOR, mWorkerProcess.getUfsManager()));
-    // Unsupported Message Handler
-    pipeline.addLast("unsupportedMessageHandler", new UnsupportedMessageHandler());
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support netty data transmission in dora to further improve reading performance. 

### Why are the changes needed?

Experimental result shows that replacing gRPC with netty to transfer data can improve the reading performant by 30%-50%. Based on this context, dora can also benefit from netty data transmission. Therefore, it is meaningful to support netty data transmission in dora.

### Does this PR introduce any user facing changes?

To enable netty, just add the following configurations to `alluxio-site.properties`. Notice that we can enable `epoll` if we are using Linux. As Windows and MacOS don't support `epoll`, we use `nio` instead.

```
###### NETTY CONFIG ######
alluxio.user.netty.data.transmission.enabled=true
#alluxio.worker.network.netty.channel=epoll
alluxio.worker.network.netty.channel=nio
#alluxio.worker.network.netty.file.transfer=MAPPED
alluxio.worker.network.netty.file.transfer=TRANSFER
alluxio.worker.network.netty.backlog=40
```
