### PR TITLE
Optimize s3 proxy list objects

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5328,6 +5328,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey PROXY_S3_OPTIMIZED_LIST_OBJECTS_ENABLE =
+      booleanBuilder(Name.PROXY_S3_OPTIMIZED_LIST_OBJECTS_ENABLE)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setDescription("Whether to use an optimized way to list files. "
+              + "This results in more RPC calls, but is more memory friendly for s3 proxy.")
+          .setDefaultValue(false)
+          .setScope(Scope.SERVER)
+          .build();
 
   //
   // Locality related properties
@@ -8447,6 +8455,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String PROXY_S3_V2_ASYNC_PROCESSING_ENABLED =
             "alluxio.proxy.s3.v2.async.processing.enabled";
     public static final String S3_UPLOADS_ID_XATTR_KEY = "s3_uploads_mulitpartupload_id";
+    public static final String PROXY_S3_OPTIMIZED_LIST_OBJECTS_ENABLE =
+        "alluxio.proxy.s3.optimized.list.objects.enable";
 
     //
     // Locality related properties

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -351,11 +351,24 @@ public final class S3RestServiceHandler {
             }
             children = userFs.listStatus(new AlluxioURI(path));
           } else {
+            boolean optimizedListObjects = mSConf.getBoolean(
+                PropertyKey.PROXY_S3_OPTIMIZED_LIST_OBJECTS_ENABLE);
             if (prefixParam != null) {
               path = parsePathWithDelimiter(path, prefixParam, AlluxioURI.SEPARATOR);
             }
-            ListStatusPOptions options = ListStatusPOptions.newBuilder().setRecursive(true).build();
-            children = userFs.listStatus(new AlluxioURI(path), options);
+            if (optimizedListObjects) {
+              children = S3RestUtils.listStatusByPrefix(uri -> {
+                try {
+                  return userFs.listStatus(uri);
+                } catch (Exception e) {
+                  throw new RuntimeException(e);
+                }
+              }, path, maxKeys);
+            } else {
+              ListStatusPOptions options = ListStatusPOptions.newBuilder().setRecursive(true)
+                  .build();
+              children = userFs.listStatus(new AlluxioURI(path), options);
+            }
           }
         } catch (FileDoesNotExistException e) {
           // Since we've called S3RestUtils.checkPathIsAlluxioDirectory() on the bucket path
@@ -1416,6 +1429,11 @@ public final class S3RestServiceHandler {
 
   private String parsePathWithDelimiter(String bucketPath, String prefix, String delimiter)
       throws S3Exception {
+    return parsePathWithDelimiter(bucketPath, prefix, delimiter, true);
+  }
+
+  private String parsePathWithDelimiter(String bucketPath, String prefix, String delimiter,
+      boolean returnParent) throws S3Exception {
     // TODO(czhu): allow non-"/" delimiters
     // Alluxio only support use / as delimiter
     if (!delimiter.equals(AlluxioURI.SEPARATOR)) {
@@ -1427,7 +1445,7 @@ public final class S3RestServiceHandler {
     char delim = AlluxioURI.SEPARATOR.charAt(0);
     String normalizedBucket =
         bucketPath.replace(S3Constants.BUCKET_SEPARATOR, AlluxioURI.SEPARATOR);
-    String normalizedPrefix = normalizeS3Prefix(prefix, delim);
+    String normalizedPrefix = normalizeS3Prefix(prefix, delim, returnParent);
 
     if (!normalizedPrefix.isEmpty() && !normalizedPrefix.startsWith(AlluxioURI.SEPARATOR)) {
       normalizedPrefix = AlluxioURI.SEPARATOR + normalizedPrefix;
@@ -1438,11 +1456,15 @@ public final class S3RestServiceHandler {
   /**
    * Normalize the prefix from S3 request.
    **/
-  private String normalizeS3Prefix(String prefix, char delimiter) {
+  private String normalizeS3Prefix(String prefix, char delimiter, boolean returnParent) {
     if (prefix != null) {
-      int pos = prefix.lastIndexOf(delimiter);
-      if (pos >= 0) {
-        return prefix.substring(0, pos + 1);
+      if (returnParent) {
+        int pos = prefix.lastIndexOf(delimiter);
+        if (pos >= 0) {
+          return prefix.substring(0, pos + 1);
+        }
+      } else {
+        return prefix;
       }
     }
     return "";

--- a/core/server/proxy/src/test/java/alluxio/proxy/s3/S3RestUtilsTest.java
+++ b/core/server/proxy/src/test/java/alluxio/proxy/s3/S3RestUtilsTest.java
@@ -1,0 +1,89 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.proxy.s3;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.URIStatus;
+import alluxio.wire.FileInfo;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class S3RestUtilsTest {
+
+  private final List<String> mFakeFiles = ImmutableList.of(
+      "/",
+      "/a",
+      "/a/b",
+      "/a/b/c",
+      "/a/b/c/d",
+      "/a/b/cc",
+      "/a/b/cc/a",
+      "/a/b/cc/b",
+      "/a/b/cc/c",
+      "/a/b/cc/d",
+      "/a/e",
+      "/b"
+  );
+
+  private URIStatus createUriStatus(String path) {
+    FileInfo fileInfo = new FileInfo();
+    fileInfo.setPath(path);
+    fileInfo.setFolder(true);
+    return new URIStatus(fileInfo);
+  }
+
+  /**
+   * Mock filesystem listStatus.
+   */
+  private List<String> listStatus(String path) {
+    return mFakeFiles.stream()
+        .filter(
+            file -> file.startsWith(path) && file.length() > path.length() && !file.replaceFirst(
+                path.equals("/") ? path : (path + "/"), "").contains("/"))
+        .collect(Collectors.toList());
+  }
+
+  private List<String> listStatusByPrefix(String prefix, int maxKeys) {
+    Function<AlluxioURI, List<URIStatus>> uriStatusProvider = uri -> listStatus(uri.getPath())
+        .stream()
+        .map(this::createUriStatus)
+        .collect(Collectors.toList());
+    return S3RestUtils.listStatusByPrefix(uriStatusProvider, prefix, maxKeys).stream()
+        .map(URIStatus::getPath).sorted().collect(Collectors.toList());
+  }
+
+  @Test
+  public void testListStatusByPrefix() {
+    Assert.assertEquals(ImmutableList.of("/a"), listStatusByPrefix("/a", 1));
+    Assert.assertEquals(ImmutableList.of("/a", "/a/b"), listStatusByPrefix("/a", 2));
+    Assert.assertEquals(ImmutableList.of("/a", "/a/b", "/a/e"), listStatusByPrefix("/a", 3));
+    Assert.assertEquals(ImmutableList.of("/a", "/a/b", "/a/b/c", "/a/e"),
+        listStatusByPrefix("/a", 4));
+
+    Assert.assertEquals(ImmutableList.of("/a/b"), listStatusByPrefix("/a/b", 1));
+    Assert.assertEquals(ImmutableList.of("/a/b", "/a/b/c"), listStatusByPrefix("/a/b", 2));
+    Assert.assertEquals(ImmutableList.of("/a/b", "/a/b/c", "/a/b/cc"),
+        listStatusByPrefix("/a/b", 3));
+
+    Assert.assertEquals(ImmutableList.of("/a/b/c"), listStatusByPrefix("/a/b/c", 1));
+    Assert.assertEquals(ImmutableList.of("/a/b/c", "/a/b/cc"), listStatusByPrefix("/a/b/c", 2));
+    Assert.assertEquals(
+        ImmutableList.of("/a/b/c", "/a/b/c/d", "/a/b/cc", "/a/b/cc/a", "/a/b/cc/b", "/a/b/cc/c",
+            "/a/b/cc/d"), listStatusByPrefix("/a/b/c", 10));
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Optimize s3 proxy list objects.

### Why are the changes needed?
In the current version, listobjects is implemented by recursively traversing the parent directory, which has some problems:
1. The `maxkeys` doesn't work, we always traverse the full amount of directories and can't stop midway;
2. Large amount of children may cause s3 proxy OOM.

### Does this PR introduce any user facing changes?
Add a new property to enable a new way to list objects named `alluxio.proxy.s3.optimized.list.objects.enable`.
