### PR TITLE
Fix head and tail commands read less than expected

### DIFF
--- a/shell/src/main/java/alluxio/cli/fs/command/HeadCommand.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/HeadCommand.java
@@ -24,6 +24,7 @@ import alluxio.exception.status.InvalidArgumentException;
 import alluxio.util.FormatUtils;
 
 import com.google.common.base.Preconditions;
+import com.google.common.io.ByteStreams;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
@@ -71,18 +72,8 @@ public final class HeadCommand extends AbstractFileSystemCommand {
       throw new IOException(ExceptionMessage.PATH_MUST_BE_FILE.getMessage(plainPath));
     }
     try (FileInStream is = mFileSystem.openFile(plainPath)) {
-      long bytesToRead;
-      if (status.getLength() > mNumOfBytes) {
-        bytesToRead = mNumOfBytes;
-      } else {
-        bytesToRead = status.getLength();
-      }
-
-      byte[] buf = new byte[(int) bytesToRead];
-      int read = is.read(buf);
-      if (read != -1) {
-        System.out.write(buf, 0, read);
-      }
+      final long bytesToRead = Math.min(status.getLength(), mNumOfBytes);
+      ByteStreams.copy(ByteStreams.limit(is, bytesToRead), System.out);
     }
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix a bug where `fs head` and `fs tail` output less data than it is expected to.

### Why are the changes needed?

The code is buggy: it only calls `read` once, and does not check if the returned number of bytes read is equal to the total number of bytes to read as specified by the cli option.

Compare with the `cat` command: 
https://github.com/Alluxio/alluxio/blob/73f3ce83c8a3ef77ac3eebb4579bb7d412784ec9/shell/src/main/java/alluxio/cli/fs/command/CatCommand.java#L57-L63

### Does this PR introduce any user facing changes?

No.
