### PR TITLE
Pass full UFS path from client to worker

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -119,6 +119,7 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
   public List<URIStatus> listStatus(AlluxioURI path, ListStatusPOptions options)
       throws FileDoesNotExistException, IOException, AlluxioException {
     AlluxioURI ufsFullPath = convertAlluxioPathToUFSPath(path);
+    ufsFullPath = new AlluxioURI(PathUtils.normalizePath(ufsFullPath.toString(), "/"));
     return mDelegatedFileSystem.listStatus(ufsFullPath, options);
   }
 
@@ -186,7 +187,7 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
       }
 
       // Treat this path as Alluxio relative, and add the UFS root before it.
-      String ufsFullPath = PathUtils.concatPath(rootUFS, alluxioPath.getPath());
+      String ufsFullPath = PathUtils.concatPath(rootUFS, alluxioPath.toString());
       return new AlluxioURI(ufsFullPath);
     } else {
       return alluxioPath;

--- a/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -31,7 +31,6 @@ import alluxio.grpc.ListStatusPOptions;
 import alluxio.grpc.OpenFilePOptions;
 import alluxio.grpc.RenamePOptions;
 import alluxio.proto.dataserver.Protocol;
-import alluxio.util.CommonUtils;
 import alluxio.util.FileSystemOptionsUtils;
 import alluxio.util.io.PathUtils;
 
@@ -160,9 +159,14 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
   }
 
   /**
-   * Converts the Alluxio based path to UfsBaseFileSystem based path.
+   * Converts the Alluxio based path to UfsBaseFileSystem based path if needed.
    *
-   * UfsBaseFileSystem expects absolute/full file path.
+   * UfsBaseFileSystem expects absolute/full file path. The Dora Worker
+   * expects absolute/full file path, too. So we need to convert the input path from Alluxio
+   * relative path to full UFS path if it is an Alluxio relative path.
+   * We do this by checking if the path is leading with the UFS root. If the input path
+   * is already considered to be UFS path, it should be leading a UFS path with appropriate scheme.
+   * If local file system is used, please add "file://" scheme before the path.
    *
    * @param alluxioPath Alluxio based path
    * @return UfsBaseFileSystem based full path
@@ -171,17 +175,18 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
     if (mDelegatedFileSystem instanceof UfsBaseFileSystem) {
       UfsBaseFileSystem under = (UfsBaseFileSystem) mDelegatedFileSystem;
       AlluxioURI rootUFS = under.getRootUFS();
-      String relativePath = alluxioPath.getPath();
       try {
-        if (alluxioPath.hasScheme() && rootUFS.isAncestorOf(alluxioPath)) {
-          relativePath = CommonUtils.stripPrefixIfPresent(alluxioPath.toString(),
-              rootUFS.toString());
+        if (rootUFS.isAncestorOf(alluxioPath)) {
+          // Treat this path as a full UFS path.
+          return alluxioPath;
         }
       } catch (InvalidPathException e) {
-        // Do thing. The actual operation on this Uri will report error.
+        LOG.error("Invalid path {}", alluxioPath);
+        throw new RuntimeException(e);
       }
 
-      String ufsFullPath = PathUtils.concatPath(rootUFS, relativePath);
+      // Treat this path as Alluxio relative, and add the UFS root before it.
+      String ufsFullPath = PathUtils.concatPath(rootUFS, alluxioPath.getPath());
       return new AlluxioURI(ufsFullPath);
     } else {
       return alluxioPath;

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -27,7 +27,6 @@ import alluxio.underfs.UfsFileStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.util.UnderFileSystemUtils;
-import alluxio.util.io.PathUtils;
 import alluxio.worker.WorkerProcess;
 import alluxio.worker.dora.DoraMetaStore;
 import alluxio.worker.dora.DoraWorker;
@@ -122,7 +121,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
     try {
       String alluxioFilePath = request.getPath();
 
-      String ufsFullPath = PathUtils.concatPath(mRootUFS, alluxioFilePath);
+      String ufsFullPath = alluxioFilePath; // Now the full UFS path is passed from client.
       String fn = new AlluxioURI(alluxioFilePath).getName();
 
       UfsFileStatus status = mUfsFileStatusCache.getIfPresent(ufsFullPath);

--- a/tests/src/test/java/alluxio/client/fuse/dora/readonly/stream/InStreamTest.java
+++ b/tests/src/test/java/alluxio/client/fuse/dora/readonly/stream/InStreamTest.java
@@ -32,8 +32,8 @@ public class InStreamTest extends AbstractStreamTest {
     AlluxioURI alluxioURI = getTestFileUri();
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
     AlluxioURI filePathInAlluxio = new AlluxioURI(alluxioURI.getName());
-    URIStatus uriStatus = mFileSystem.getStatus(filePathInAlluxio);
-    try (FuseFileStream inStream = createStream(filePathInAlluxio)) {
+    URIStatus uriStatus = mFileSystem.getStatus(alluxioURI);
+    try (FuseFileStream inStream = createStream(alluxioURI)) {
       Assert.assertEquals(uriStatus.getLength(), inStream.getFileStatus().getFileLength());
       ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN);
       Assert.assertEquals(DEFAULT_FILE_LEN, inStream.read(buffer, DEFAULT_FILE_LEN, 0));
@@ -55,8 +55,7 @@ public class InStreamTest extends AbstractStreamTest {
   public void randomRead() throws Exception {
     AlluxioURI alluxioURI = getTestFileUri();
     writeIncreasingByteArrayToFile(alluxioURI, DEFAULT_FILE_LEN);
-    AlluxioURI fileNameInAlluxio = new AlluxioURI(alluxioURI.getName());
-    try (FuseFileStream inStream = createStream(fileNameInAlluxio)) {
+    try (FuseFileStream inStream = createStream(alluxioURI)) {
       ByteBuffer buffer = ByteBuffer.allocate(DEFAULT_FILE_LEN / 2);
       Assert.assertEquals(DEFAULT_FILE_LEN / 2,
           inStream.read(buffer, DEFAULT_FILE_LEN / 2, DEFAULT_FILE_LEN / 2));


### PR DESCRIPTION
So Dora client can access Alluxio relative path and full ufs path.

### What changes are proposed in this pull request?

Prepare a full UFS path for client APIs and then pass it to worker.

### Why are the changes needed?

We want Dora client to accept Alluxio path, and as well as full UFS path.

### Does this PR introduce any user facing changes?

Now the client APIs accept Alluxio path relative to UFS root, and also the full
UFS path. 