### PR TITLE
Fix setTtl workflow and ttlbucket bugs

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
@@ -63,7 +63,7 @@ final class InodeTtlChecker implements HeartbeatExecutor {
     Set<TtlBucket> expiredBuckets = mTtlBuckets.pollExpiredBuckets(System.currentTimeMillis());
     Set<Inode> failedInodes = new HashSet();
     for (TtlBucket bucket : expiredBuckets) {
-      for (long inodeId : bucket.getInodes()) {
+      for (long inodeId : bucket.getInodeIds()) {
         // Throw if interrupted.
         if (Thread.interrupted()) {
           throw new InterruptedException("InodeTtlChecker interrupted.");

--- a/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeTtlChecker.java
@@ -63,7 +63,7 @@ final class InodeTtlChecker implements HeartbeatExecutor {
     Set<TtlBucket> expiredBuckets = mTtlBuckets.pollExpiredBuckets(System.currentTimeMillis());
     Set<Inode> failedInodes = new HashSet();
     for (TtlBucket bucket : expiredBuckets) {
-        for (long inodeId : bucket.getInodes()) {
+      for (long inodeId : bucket.getInodes()) {
         // Throw if interrupted.
         if (Thread.interrupted()) {
           throw new InterruptedException("InodeTtlChecker interrupted.");
@@ -87,8 +87,9 @@ final class InodeTtlChecker implements HeartbeatExecutor {
             inode = mTtlBuckets.loadInode(inodeId);
             // Check again if this inode is indeed expired.
             if (inode == null || inode.getTtl() == Constants.NO_TTL
-                || inode.getCreationTimeMs() + inode.getTtl() > System.currentTimeMillis())
+                || inode.getCreationTimeMs() + inode.getTtl() > System.currentTimeMillis()) {
               continue;
+            }
             TtlAction ttlAction = inode.getTtlAction();
             LOG.info("Path {} TTL has expired, performing action {}", path.getPath(), ttlAction);
             switch (ttlAction) {
@@ -148,7 +149,7 @@ final class InodeTtlChecker implements HeartbeatExecutor {
     }
     // Put back those failed-to-expire inodes for next round retry.
     if (!failedInodes.isEmpty()) {
-      for(Inode inode : failedInodes) {
+      for (Inode inode : failedInodes) {
         mTtlBuckets.insert(inode);
       }
     }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
@@ -17,7 +17,11 @@ import alluxio.conf.PropertyKey;
 import com.google.common.base.Objects;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentSkipListSet;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -43,7 +47,7 @@ public final class TtlBucket implements Comparable<TtlBucket> {
    * A collection of inodes whose ttl value is in the range of this bucket's interval. The mapping
    * is from inode id to inode.
    */
-  private final ConcurrentHashMap<Long, Inode> mInodes;
+  private final ConcurrentSkipListSet<Long> mInodeList;
 
   /**
    * Creates a new instance of {@link TtlBucket}.
@@ -52,7 +56,7 @@ public final class TtlBucket implements Comparable<TtlBucket> {
    */
   public TtlBucket(long startTimeMs) {
     mTtlIntervalStartTimeMs = startTimeMs;
-    mInodes = new ConcurrentHashMap<>();
+    mInodeList = new ConcurrentSkipListSet<>();
   }
 
   /**
@@ -81,9 +85,10 @@ public final class TtlBucket implements Comparable<TtlBucket> {
    * @return the set of all inodes in the bucket backed by the internal set, changes made to the
    *         returned set will be shown in the internal set, and vice versa
    */
-  public Collection<Inode> getInodes() {
-    return mInodes.values();
+  public Collection<Long> getInodes() {
+    return mInodeList;
   }
+
 
   /**
    * Adds a inode to the bucket.
@@ -92,24 +97,24 @@ public final class TtlBucket implements Comparable<TtlBucket> {
    * @return true if a new inode was added to the bucket
    */
   public boolean addInode(Inode inode) {
-    return mInodes.put(inode.getId(), inode) == null;
+    return mInodeList.add(inode.getId());
   }
 
   /**
-   * Removes a inode from the bucket.
+   * Removes an inode from the bucket.
    *
    * @param inode the inode to be removed
-   * @return true if a inode was removed
+   * @return true if an inode was removed
    */
   public boolean removeInode(InodeView inode) {
-    return mInodes.remove(inode.getId()) != null;
+    return mInodeList.remove(inode.getId());
   }
 
   /**
    * @return the number of inodes in the bucket
    */
   public int size() {
-    return mInodes.size();
+    return mInodeList.size();
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
@@ -11,12 +11,14 @@
 
 package alluxio.master.file.meta;
 
+import alluxio.collections.ConcurrentHashSet;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 
 import com.google.common.base.Objects;
 
 import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -43,7 +45,7 @@ public final class TtlBucket implements Comparable<TtlBucket> {
    * A collection of inodes whose ttl value is in the range of this bucket's interval. The mapping
    * is from inode id to inode.
    */
-  private final ConcurrentSkipListSet<Long> mInodeList;
+  private final ConcurrentHashSet<Long> mInodeList;
 
   /**
    * Creates a new instance of {@link TtlBucket}.
@@ -52,7 +54,7 @@ public final class TtlBucket implements Comparable<TtlBucket> {
    */
   public TtlBucket(long startTimeMs) {
     mTtlIntervalStartTimeMs = startTimeMs;
-    mInodeList = new ConcurrentSkipListSet<>();
+    mInodeList = new ConcurrentHashSet<>();
   }
 
   /**
@@ -78,10 +80,10 @@ public final class TtlBucket implements Comparable<TtlBucket> {
   }
 
   /**
-   * @return the set of all inodes in the bucket backed by the internal set, changes made to the
-   *         returned set will be shown in the internal set, and vice versa
+   * @return the set of all inodes ids in the bucket backed by the internal set,
+   * changes made to the returned set will be shown in the internal set, and vice versa.
    */
-  public Collection<Long> getInodes() {
+  public Collection<Long> getInodeIds() {
     return mInodeList;
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
@@ -93,7 +93,7 @@ public final class TtlBucket implements Comparable<TtlBucket> {
    * @return collection of inode to its left ttl process retry attempts
    */
   public Collection<Map.Entry<Long, Integer>> getInodeExpiries() {
-    return mInodeToRetryMap.entrySet();
+    return Collections.unmodifiableSet(mInodeToRetryMap.entrySet());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
@@ -108,7 +108,7 @@ public final class TtlBucket implements Comparable<TtlBucket> {
    * Adds an inode to the bucket with a specific left retry number.
    *
    * @param inode the inode to be added
-   * @param numOfRetry  num of retry left when added to the ttlbucket
+   * @param numOfRetry num of retries left when added to the ttlbucket
    */
   public void addInode(Inode inode, int numOfRetry) {
     mInodeToRetryMap.compute(inode.getId(), (k, v) -> {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
@@ -17,10 +17,6 @@ import alluxio.conf.PropertyKey;
 import com.google.common.base.Objects;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListSet;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -88,7 +84,6 @@ public final class TtlBucket implements Comparable<TtlBucket> {
   public Collection<Long> getInodes() {
     return mInodeList;
   }
-
 
   /**
    * Adds a inode to the bucket.

--- a/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
@@ -17,6 +17,7 @@ import alluxio.conf.PropertyKey;
 import com.google.common.base.Objects;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.ThreadSafe;
@@ -81,11 +82,10 @@ public final class TtlBucket implements Comparable<TtlBucket> {
   }
 
   /**
-   * @return the set of all inodes ids in the bucket backed by the internal set,
-   * changes made to the returned set will be shown in the internal set, and vice versa.
+   * @return an unmodifiable view of all inodes ids in the bucket
    */
   public Collection<Long> getInodeIds() {
-    return mInodeToRetryMap.keySet();
+    return Collections.unmodifiableSet(mInodeToRetryMap.keySet());
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucket.java
@@ -18,8 +18,6 @@ import alluxio.conf.PropertyKey;
 import com.google.common.base.Objects;
 
 import java.util.Collection;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentSkipListSet;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**

--- a/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucketList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucketList.java
@@ -113,14 +113,23 @@ public final class TtlBucketList implements Checkpointed {
   }
 
   /**
+   * Insert inode to the ttlbucket with default number of retry attempts.
+   * @param inode
+   */
+  public void insert(Inode inode) {
+    insert(inode, TtlBucket.DEFAULT_RETRY_ATTEMPTS);
+  }
+
+  /**
    * Inserts an inode to the appropriate bucket where its ttl end time lies in the
    * bucket's interval, if no appropriate bucket exists, a new bucket will be created to contain
    * this inode, if ttl value is {@link Constants#NO_TTL}, the inode won't be inserted to any
    * buckets and nothing will happen.
    *
    * @param inode the inode to be inserted
+   * @param numOfRetry number of retries left to process this inode
    */
-  public void insert(Inode inode) {
+  public void insert(Inode inode, int numOfRetry) {
     if (inode.getTtl() == Constants.NO_TTL) {
       return;
     }
@@ -143,7 +152,7 @@ public final class TtlBucketList implements Checkpointed {
           continue;
         }
       }
-      bucket.addInode(inode);
+      bucket.addInode(inode, numOfRetry);
       /* if we added to the bucket but it got concurrently polled by InodeTtlChecker,
       we're not sure this newly-added inode will be processed by the checker,
       so we need to try insert again. Resolve for (c.f. ALLUXIO-2821) */

--- a/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucketList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucketList.java
@@ -204,7 +204,7 @@ public final class TtlBucketList implements Checkpointed {
   public void writeToCheckpoint(OutputStream output) throws IOException, InterruptedException {
     CheckpointOutputStream cos = new CheckpointOutputStream(output, CheckpointType.LONGS);
     for (TtlBucket bucket : mBucketList) {
-      for (long inodeId : bucket.getInodes()) {
+      for (long inodeId : bucket.getInodeIds()) {
         cos.writeLong(inodeId);
       }
     }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucketList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucketList.java
@@ -206,8 +206,9 @@ public final class TtlBucketList implements Checkpointed {
   }
 
   /*
-  [Notice] This checkpointing will iterate through inodes with concurrent modification to those
-  TtlBuckets at the same time.
+  Checkpointing a snapshot of the current inodes in ttlbucketlist. It's ok we checkpointed
+  some inodes that have already been processed during the process as the expiry of inode
+  will be double-checked at time of processing in InodeTtlChecker.
    */
   @Override
   public void writeToCheckpoint(OutputStream output) throws IOException, InterruptedException {

--- a/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucketList.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/TtlBucketList.java
@@ -155,7 +155,7 @@ public final class TtlBucketList implements Checkpointed {
       bucket.addInode(inode, numOfRetry);
       /* if we added to the bucket but it got concurrently polled by InodeTtlChecker,
       we're not sure this newly-added inode will be processed by the checker,
-      so we need to try insert again. Resolve for (c.f. ALLUXIO-2821) */
+      so we need to try insert again. */
       if (mBucketList.contains(bucket)) {
         break;
       }

--- a/core/server/master/src/test/java/alluxio/master/file/meta/TtlBucketListTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/TtlBucketListTest.java
@@ -63,7 +63,7 @@ public final class TtlBucketListTest {
   private void assertExpired(List<TtlBucket> expiredBuckets, int bucketIndex,
       Inode... inodes) {
     TtlBucket bucket = expiredBuckets.get(bucketIndex);
-    Assert.assertEquals(inodes.length, bucket.getInodeIds().size());
+    Assert.assertEquals(inodes.length, bucket.size());
     List<Long> inodeIds = Lists.newArrayList(inodes).stream().map(Inode::getId)
         .collect(Collectors.toList());
     Assert.assertTrue(bucket.getInodeIds().containsAll(inodeIds));

--- a/core/server/master/src/test/java/alluxio/master/file/meta/TtlBucketListTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/TtlBucketListTest.java
@@ -63,10 +63,10 @@ public final class TtlBucketListTest {
   private void assertExpired(List<TtlBucket> expiredBuckets, int bucketIndex,
       Inode... inodes) {
     TtlBucket bucket = expiredBuckets.get(bucketIndex);
-    Assert.assertEquals(inodes.length, bucket.getInodes().size());
+    Assert.assertEquals(inodes.length, bucket.getInodeIds().size());
     List<Long> inodeIds = Lists.newArrayList(inodes).stream().map(Inode::getId)
         .collect(Collectors.toList());
-    Assert.assertTrue(bucket.getInodes().containsAll(inodeIds));
+    Assert.assertTrue(bucket.getInodeIds().containsAll(inodeIds));
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/file/meta/TtlBucketTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/TtlBucketTest.java
@@ -74,25 +74,25 @@ public class TtlBucketTest {
   public void addAndRemoveInodeFile() {
     Inode fileTtl1 = TtlTestUtils.createFileWithIdAndTtl(0, 1);
     Inode fileTtl2 = TtlTestUtils.createFileWithIdAndTtl(1, 2);
-    Assert.assertTrue(mBucket.getInodes().isEmpty());
+    Assert.assertTrue(mBucket.getInodeIds().isEmpty());
 
     mBucket.addInode(fileTtl1);
-    Assert.assertEquals(1, mBucket.getInodes().size());
+    Assert.assertEquals(1, mBucket.getInodeIds().size());
 
     // The same file, won't be added.
     mBucket.addInode(fileTtl1);
-    Assert.assertEquals(1, mBucket.getInodes().size());
+    Assert.assertEquals(1, mBucket.getInodeIds().size());
 
     // Different file, will be added.
     mBucket.addInode(fileTtl2);
-    Assert.assertEquals(2, mBucket.getInodes().size());
+    Assert.assertEquals(2, mBucket.getInodeIds().size());
 
     // Remove files;
     mBucket.removeInode(fileTtl1);
-    Assert.assertEquals(1, mBucket.getInodes().size());
-    Assert.assertTrue(mBucket.getInodes().contains(fileTtl2.getId()));
+    Assert.assertEquals(1, mBucket.getInodeIds().size());
+    Assert.assertTrue(mBucket.getInodeIds().contains(fileTtl2.getId()));
     mBucket.removeInode(fileTtl2);
-    Assert.assertEquals(0, mBucket.getInodes().size());
+    Assert.assertEquals(0, mBucket.getInodeIds().size());
   }
 
   /**
@@ -103,25 +103,25 @@ public class TtlBucketTest {
   public void addAndRemoveInodeDirectory() {
     Inode directoryTtl1 = TtlTestUtils.createDirectoryWithIdAndTtl(0, 1);
     Inode directoryTtl2 = TtlTestUtils.createDirectoryWithIdAndTtl(1, 2);
-    Assert.assertTrue(mBucket.getInodes().isEmpty());
+    Assert.assertTrue(mBucket.getInodeIds().isEmpty());
 
     mBucket.addInode(directoryTtl1);
-    Assert.assertEquals(1, mBucket.getInodes().size());
+    Assert.assertEquals(1, mBucket.getInodeIds().size());
 
     // The same directory, won't be added.
     mBucket.addInode(directoryTtl1);
-    Assert.assertEquals(1, mBucket.getInodes().size());
+    Assert.assertEquals(1, mBucket.getInodeIds().size());
 
     // Different directory, will be added.
     mBucket.addInode(directoryTtl2);
-    Assert.assertEquals(2, mBucket.getInodes().size());
+    Assert.assertEquals(2, mBucket.getInodeIds().size());
 
     // Remove directorys;
     mBucket.removeInode(directoryTtl1);
-    Assert.assertEquals(1, mBucket.getInodes().size());
-    Assert.assertTrue(mBucket.getInodes().contains(directoryTtl2.getId()));
+    Assert.assertEquals(1, mBucket.getInodeIds().size());
+    Assert.assertTrue(mBucket.getInodeIds().contains(directoryTtl2.getId()));
     mBucket.removeInode(directoryTtl2);
-    Assert.assertEquals(0, mBucket.getInodes().size());
+    Assert.assertEquals(0, mBucket.getInodeIds().size());
   }
 
   /**

--- a/core/server/master/src/test/java/alluxio/master/file/meta/TtlBucketTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/TtlBucketTest.java
@@ -90,7 +90,7 @@ public class TtlBucketTest {
     // Remove files;
     mBucket.removeInode(fileTtl1);
     Assert.assertEquals(1, mBucket.getInodes().size());
-    Assert.assertTrue(mBucket.getInodes().contains(fileTtl2));
+    Assert.assertTrue(mBucket.getInodes().contains(fileTtl2.getId()));
     mBucket.removeInode(fileTtl2);
     Assert.assertEquals(0, mBucket.getInodes().size());
   }
@@ -119,7 +119,7 @@ public class TtlBucketTest {
     // Remove directorys;
     mBucket.removeInode(directoryTtl1);
     Assert.assertEquals(1, mBucket.getInodes().size());
-    Assert.assertTrue(mBucket.getInodes().contains(directoryTtl2));
+    Assert.assertTrue(mBucket.getInodes().contains(directoryTtl2.getId()));
     mBucket.removeInode(directoryTtl2);
     Assert.assertEquals(0, mBucket.getInodes().size());
   }

--- a/core/server/master/src/test/java/alluxio/master/file/meta/TtlBucketTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/TtlBucketTest.java
@@ -77,22 +77,32 @@ public class TtlBucketTest {
     Assert.assertTrue(mBucket.getInodeIds().isEmpty());
 
     mBucket.addInode(fileTtl1);
-    Assert.assertEquals(1, mBucket.getInodeIds().size());
+    Assert.assertEquals(1, mBucket.size());
 
     // The same file, won't be added.
     mBucket.addInode(fileTtl1);
-    Assert.assertEquals(1, mBucket.getInodeIds().size());
+    Assert.assertEquals(1, mBucket.size());
 
     // Different file, will be added.
     mBucket.addInode(fileTtl2);
-    Assert.assertEquals(2, mBucket.getInodeIds().size());
+    Assert.assertEquals(2, mBucket.size());
 
     // Remove files;
     mBucket.removeInode(fileTtl1);
-    Assert.assertEquals(1, mBucket.getInodeIds().size());
+    Assert.assertEquals(1, mBucket.size());
     Assert.assertTrue(mBucket.getInodeIds().contains(fileTtl2.getId()));
     mBucket.removeInode(fileTtl2);
-    Assert.assertEquals(0, mBucket.getInodeIds().size());
+    Assert.assertEquals(0, mBucket.size());
+
+    // Retry attempts;
+    mBucket.addInode(fileTtl1);
+    Assert.assertTrue(mBucket.getInodeIds().contains(fileTtl1.getId()));
+    int retryAttempt = mBucket.getInodeExpiries().iterator().next().getValue();
+    Assert.assertEquals(retryAttempt, TtlBucket.DEFAULT_RETRY_ATTEMPTS);
+    mBucket.addInode(fileTtl1, 2);
+    Assert.assertTrue(mBucket.getInodeIds().contains(fileTtl1.getId()));
+    int newRetryAttempt = mBucket.getInodeExpiries().iterator().next().getValue();
+    Assert.assertEquals(newRetryAttempt, 2);
   }
 
   /**
@@ -106,19 +116,19 @@ public class TtlBucketTest {
     Assert.assertTrue(mBucket.getInodeIds().isEmpty());
 
     mBucket.addInode(directoryTtl1);
-    Assert.assertEquals(1, mBucket.getInodeIds().size());
+    Assert.assertEquals(1, mBucket.size());
 
     // The same directory, won't be added.
     mBucket.addInode(directoryTtl1);
-    Assert.assertEquals(1, mBucket.getInodeIds().size());
+    Assert.assertEquals(1, mBucket.size());
 
     // Different directory, will be added.
     mBucket.addInode(directoryTtl2);
-    Assert.assertEquals(2, mBucket.getInodeIds().size());
+    Assert.assertEquals(2, mBucket.size());
 
     // Remove directorys;
     mBucket.removeInode(directoryTtl1);
-    Assert.assertEquals(1, mBucket.getInodeIds().size());
+    Assert.assertEquals(1, mBucket.size());
     Assert.assertTrue(mBucket.getInodeIds().contains(directoryTtl2.getId()));
     mBucket.removeInode(directoryTtl2);
     Assert.assertEquals(0, mBucket.getInodeIds().size());

--- a/shell/src/main/java/alluxio/cli/fs/command/FileSystemCommandUtils.java
+++ b/shell/src/main/java/alluxio/cli/fs/command/FileSystemCommandUtils.java
@@ -45,7 +45,7 @@ public final class FileSystemCommandUtils {
    */
   public static void setTtl(FileSystem fs, AlluxioURI path, long ttlMs,
       TtlAction ttlAction) throws AlluxioException, IOException {
-    SetAttributePOptions options = SetAttributePOptions.newBuilder().setRecursive(true)
+    SetAttributePOptions options = SetAttributePOptions.newBuilder().setRecursive(false)
         .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
             .setTtl(ttlMs).setTtlAction(ttlAction).build())
         .build();

--- a/tests/src/test/java/alluxio/client/fs/TtlIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/TtlIntegrationTest.java
@@ -235,10 +235,10 @@ public class TtlIntegrationTest extends BaseIntegrationTest {
     // Individual children file's ttl should not be changed.
     Random random = new Random();
     int fileNum = random.nextInt(numFiles);
-    URIStatus anyFileStatus = mFileSystem.getStatus(new AlluxioURI("/" + directoryName +
-        "/" + fileNamePrefix + fileNum));
-    assert(anyFileStatus.getFileInfo().getTtl() ==
-        (fileNum % 2 == 0 ? TTL_INTERVAL_MS * 2000 : TTL_INTERVAL_MS * 1000));
+    URIStatus anyFileStatus = mFileSystem.getStatus(new AlluxioURI("/" + directoryName
+        + "/" + fileNamePrefix + fileNum));
+    assert (anyFileStatus.getFileInfo().getTtl()
+        == (fileNum % 2 == 0 ? TTL_INTERVAL_MS * 2000 : TTL_INTERVAL_MS * 1000));
 
     CommonUtils.sleepMs(4 * TTL_INTERVAL_MS);
     HeartbeatScheduler.execute(HeartbeatContext.MASTER_TTL_CHECK);

--- a/tests/src/test/java/alluxio/client/fs/TtlIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/TtlIntegrationTest.java
@@ -20,10 +20,13 @@ import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
+import alluxio.client.file.URIStatus;
 import alluxio.conf.PropertyKey;
+import alluxio.grpc.CreateDirectoryPOptions;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.LoadMetadataPType;
+import alluxio.grpc.SetAttributePOptions;
 import alluxio.grpc.TtlAction;
 import alluxio.grpc.WritePType;
 import alluxio.heartbeat.HeartbeatContext;
@@ -41,6 +44,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Random;
 
 /**
  * Integration tests for handling file TTLs (times to live).
@@ -195,6 +199,56 @@ public class TtlIntegrationTest extends BaseIntegrationTest {
       } else {
         assertTrue(mFileSystem.exists(files[i]));
       }
+    }
+  }
+
+  /**
+   * Tests that ttl on a directory will be enforced on all its children regarless
+   * of their ttl.
+   * @throws Exception
+   */
+  @Test
+  public void expireADirectory() throws Exception {
+    int numFiles = 100;
+    AlluxioURI[] files = new AlluxioURI[numFiles];
+    String directoryName = "dir1";
+    mFileSystem.createDirectory(new AlluxioURI("/" + directoryName),
+        CreateDirectoryPOptions.newBuilder().setWriteType(WritePType.CACHE_THROUGH).build());
+    String fileNamePrefix = "fileDelete";
+    for (int i = 0; i < numFiles; i++) {
+      files[i] = new AlluxioURI("/" + directoryName + "/" + fileNamePrefix + i);
+      // Only the even-index files should expire.
+      long ttl = i % 2 == 0 ? TTL_INTERVAL_MS * 2000 : TTL_INTERVAL_MS * 1000;
+      mOutStream = mFileSystem.createFile(files[i],
+          CreateFilePOptions.newBuilder().setWriteType(WritePType.CACHE_THROUGH)
+              .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder().setTtl(ttl)
+                  .setTtlAction(TtlAction.DELETE)).build());
+      mOutStream.write(mBuffer, 0, 10);
+      mOutStream.close();
+    }
+    // Set much smaller ttl on directory.
+    SetAttributePOptions setTTlOptions = SetAttributePOptions.newBuilder().setRecursive(false)
+        .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
+            .setTtl(TTL_INTERVAL_MS).setTtlAction(TtlAction.DELETE).build())
+        .build();
+    mFileSystem.setAttribute(new AlluxioURI("/" + directoryName), setTTlOptions);
+    // Individual children file's ttl should not be changed.
+    Random random = new Random();
+    int fileNum = random.nextInt(numFiles);
+    URIStatus anyFileStatus = mFileSystem.getStatus(new AlluxioURI("/" + directoryName +
+        "/" + fileNamePrefix + fileNum));
+    assert(anyFileStatus.getFileInfo().getTtl() ==
+        (fileNum % 2 == 0 ? TTL_INTERVAL_MS * 2000 : TTL_INTERVAL_MS * 1000));
+
+    CommonUtils.sleepMs(4 * TTL_INTERVAL_MS);
+    HeartbeatScheduler.execute(HeartbeatContext.MASTER_TTL_CHECK);
+    /* Even though children have longer ttl, but parents' ttl overrides all.
+    No Children should exist now. */
+    for (int i = 0; i < numFiles; i++) {
+      assertFalse(mFileSystem.exists(files[i]));
+      String fileName = directoryName + "/" + fileNamePrefix + i;
+      // Check Ufs file existence
+      assertFalse(Arrays.stream(mUfs.list()).anyMatch(s -> s.equals(fileName)));
     }
   }
 }

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
@@ -251,9 +251,9 @@ public class ConcurrentFileSystemMasterSetTtlIntegrationTest extends BaseIntegra
     // Now file2 inode should either be in ttlbucket or it is cleaned up as part of
     // the ttlchecker processing
     List<URIStatus> fileStatus = mFileSystem.listStatus(new AlluxioURI("/"));
-    Assert.assertTrue(String.format("file1:{} still exists and didn't get expired.", fileUri1.getPath()),
-        !fileStatus.stream().anyMatch(status -> new AlluxioURI(status.getFileInfo().getPath())
-            .equals(fileUri1)));
+    Assert.assertTrue(String.format("file1:{} still exists and didn't get expired.",
+            fileUri1.getPath()), !fileStatus.stream().anyMatch(
+                status -> new AlluxioURI(status.getFileInfo().getPath()).equals(fileUri1)));
     if (fileStatus.stream().anyMatch(status -> new AlluxioURI(status.getFileInfo().getPath())
         .equals(fileUri2))) {
       // The inode is not being processed during concurrent insertion into ttlbucket

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
@@ -15,9 +15,11 @@ import alluxio.AlluxioURI;
 import alluxio.AuthenticatedUserRule;
 import alluxio.Constants;
 import alluxio.client.file.FileSystem;
+import alluxio.client.file.URIStatus;
 import alluxio.collections.ConcurrentHashSet;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.SetAttributePOptions;
@@ -39,6 +41,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -133,6 +136,7 @@ public class ConcurrentFileSystemMasterSetTtlIntegrationTest extends BaseIntegra
         errors.add(ex);
       }
     };
+
     for (int i = 0; i < numFiles; i++) {
       final int iteration = i;
       Thread t = new Thread(new Runnable() {
@@ -141,6 +145,8 @@ public class ConcurrentFileSystemMasterSetTtlIntegrationTest extends BaseIntegra
           try {
             AuthenticatedClientUser.set(TEST_USER);
             barrier.await();
+            HeartbeatScheduler.execute(HeartbeatContext.MASTER_TTL_CHECK);
+
             mFileSystem.setAttribute(paths[iteration], SetAttributePOptions.newBuilder()
                 .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
                     .setTtl(ttls[iteration]).setTtlAction(TtlAction.DELETE))
@@ -171,6 +177,95 @@ public class ConcurrentFileSystemMasterSetTtlIntegrationTest extends BaseIntegra
     if (errors.size() != expected) {
       Assert.fail(String.format("Expected %d errors, but got %d, errors:\n",
           expected, errors.size()) + Joiner.on("\n").join(errors));
+    }
+  }
+
+  @Test
+  public void testConcurrentInsertAndExpire() throws Exception {
+    /* (ALLUXIO-2821) When an inode is concurrently added to ttlbucket and inodettlchecker
+    has been processing this particular ttlbucket. The inode should not be left out forever
+    without being processed by inodettlchecker further. */
+    // Create two files
+    String fileNamePrefix = "file";
+    AlluxioURI fileUri1 = new AlluxioURI("/" + fileNamePrefix + "1");
+    AlluxioURI fileUri2 = new AlluxioURI("/" + fileNamePrefix + "2");
+    mFileSystem.createFile(fileUri1,
+            CreateFilePOptions.newBuilder().setWriteType(WritePType.MUST_CACHE).build());
+    mFileSystem.createFile(fileUri2,
+        CreateFilePOptions.newBuilder().setWriteType(WritePType.MUST_CACHE).build());
+    // Set ttl on file1.
+    SetAttributePOptions setTTlOptions = SetAttributePOptions.newBuilder().setRecursive(false)
+        .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
+            .setTtl(TTL_INTERVAL_MS).setTtlAction(TtlAction.DELETE).build())
+        .build();
+    mFileSystem.setAttribute((fileUri1), setTTlOptions);
+
+    CommonUtils.sleepMs(4 * TTL_INTERVAL_MS);
+    // One thread to run InodeTtlChecker, file1 should be expired, another thread
+    // to set the ttl of file2 which with same ttl as file1, which is supposed to
+    // land in the bucket that's being processed by ttlchecker at the same time.
+    final CyclicBarrier barrier = new CyclicBarrier(2);
+    List<Thread> threads = new ArrayList<>(2);
+    final ConcurrentHashSet<Throwable> errors = new ConcurrentHashSet<>();
+    Thread.UncaughtExceptionHandler exceptionHandler = new Thread.UncaughtExceptionHandler() {
+      public void uncaughtException(Thread th, Throwable ex) {
+        errors.add(ex);
+      }
+    };
+    Thread ttlCheckerThread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          AuthenticatedClientUser.set(TEST_USER);
+          barrier.await();
+          HeartbeatScheduler.execute(HeartbeatContext.MASTER_TTL_CHECK);
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    });
+    ttlCheckerThread.setUncaughtExceptionHandler(exceptionHandler);
+    threads.add(ttlCheckerThread);
+
+    Thread setTtlFile2Thread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          AuthenticatedClientUser.set(TEST_USER);
+          barrier.await();
+          SetAttributePOptions setTTlOptions = SetAttributePOptions.newBuilder().setRecursive(false)
+              .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
+                  .setTtl(TTL_INTERVAL_MS).setTtlAction(TtlAction.DELETE).build())
+              .build();
+          mFileSystem.setAttribute(fileUri2, setTTlOptions);
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    });
+    setTtlFile2Thread.setUncaughtExceptionHandler(exceptionHandler);
+    threads.add(setTtlFile2Thread);
+    Collections.shuffle(threads);
+    long startMs = CommonUtils.getCurrentMs();
+    for (Thread t : threads) {
+      t.start();
+    }
+    for (Thread t : threads) {
+      t.join();
+    }
+    // Now file2 inode should either be in ttlbucket or it is cleaned up as part of
+    // the ttlchecker processing
+    List<URIStatus> fileStatus = mFileSystem.listStatus(new AlluxioURI("/"));
+    assert(!fileStatus.stream().anyMatch(status -> new AlluxioURI(status.getFileInfo().getPath())
+        .equals(fileUri1)));
+    if (fileStatus.stream().anyMatch(status -> new AlluxioURI(status.getFileInfo().getPath())
+        .equals(fileUri2))) {
+      // The inode is not being processed during concurrent insertion into ttlbucket
+      assert (fileStatus.get(0).getFileInfo().getTtl() == TTL_INTERVAL_MS);
+      // Now run ttl checker again, it should be gone.
+      HeartbeatScheduler.execute(HeartbeatContext.MASTER_TTL_CHECK);
+      Assert.assertEquals("There are remaining file existing with expired TTLs",
+          0, mFileSystem.listStatus(new AlluxioURI("/")).size());
     }
   }
 }

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
@@ -188,7 +188,7 @@ public class ConcurrentFileSystemMasterSetTtlIntegrationTest extends BaseIntegra
     AlluxioURI fileUri1 = new AlluxioURI("/" + fileNamePrefix + "1");
     AlluxioURI fileUri2 = new AlluxioURI("/" + fileNamePrefix + "2");
     mFileSystem.createFile(fileUri1,
-            CreateFilePOptions.newBuilder().setWriteType(WritePType.MUST_CACHE).build());
+        CreateFilePOptions.newBuilder().setWriteType(WritePType.MUST_CACHE).build());
     mFileSystem.createFile(fileUri2,
         CreateFilePOptions.newBuilder().setWriteType(WritePType.MUST_CACHE).build());
     // Set ttl on file1.

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
@@ -19,7 +19,6 @@ import alluxio.client.file.URIStatus;
 import alluxio.collections.ConcurrentHashSet;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
-import alluxio.exception.AlluxioException;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.SetAttributePOptions;
@@ -41,7 +40,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -256,7 +254,7 @@ public class ConcurrentFileSystemMasterSetTtlIntegrationTest extends BaseIntegra
     // Now file2 inode should either be in ttlbucket or it is cleaned up as part of
     // the ttlchecker processing
     List<URIStatus> fileStatus = mFileSystem.listStatus(new AlluxioURI("/"));
-    assert(!fileStatus.stream().anyMatch(status -> new AlluxioURI(status.getFileInfo().getPath())
+    assert (!fileStatus.stream().anyMatch(status -> new AlluxioURI(status.getFileInfo().getPath())
         .equals(fileUri1)));
     if (fileStatus.stream().anyMatch(status -> new AlluxioURI(status.getFileInfo().getPath())
         .equals(fileUri2))) {

--- a/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/concurrent/ConcurrentFileSystemMasterSetTtlIntegrationTest.java
@@ -177,9 +177,9 @@ public class ConcurrentFileSystemMasterSetTtlIntegrationTest extends BaseIntegra
 
   @Test
   public void testConcurrentInsertAndExpire() throws Exception {
-    /* (ALLUXIO-2821) When an inode is concurrently added to ttlbucket and inodettlchecker
-    has been processing this particular ttlbucket. The inode should not be left out forever
-    without being processed by inodettlchecker further. */
+    /* Test race condition when an inode is concurrently added to ttlbucket and
+    inodettlchecker has been processing this particular ttlbucket, the inode should
+    not be left out forever unprocessed in the future rounds. */
     // Create two files
     String fileNamePrefix = "file";
     AlluxioURI fileUri1 = new AlluxioURI("/" + fileNamePrefix + "1");

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-//    o.sync();
+    o.sync();
     //#else
     o.hflush();
     //#endif

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-    o.sync();
+//    o.sync();
     //#else
     o.hflush();
     //#endif


### PR DESCRIPTION
### What changes are proposed in this pull request?

1)setttl cmd on a big directory unnecessary setattr recursively, while dir ttl already supercedes children ttl. there's absolutely no reason to save ttl on children node individually.
2)ttlbucket unnecessarily saves Inode obj on heap unboundedly, where it could and should only save inodeid and load inode from inodestore to double check expiry during inodettlchecker processing.
3)fix race condition on ttlbucketlists from ttlchecker and insertion from foreground.
4)fix case where any expiration of inodes failed during ttlchecker it will never be retried again.

### Why are the changes needed?

Reduce heavy GC when setttl on a huge folder / bug fixes as indicated above for ttl 

### Does this PR introduce any user facing changes?

yes. So now setTtl command on a dir will not set ttl attributes for all its children. 
