### PR TITLE
Fix the client stressbench concurrency problem

### DIFF
--- a/stress/shell/src/main/java/alluxio/stress/cli/client/ClientIOWritePolicy.java
+++ b/stress/shell/src/main/java/alluxio/stress/cli/client/ClientIOWritePolicy.java
@@ -65,7 +65,7 @@ public final class ClientIOWritePolicy implements BlockLocationPolicy {
    * @return the address of the worker to write to
    */
   @Override
-  public Optional<WorkerNetAddress> getWorker(GetWorkerOptions options) {
+  public synchronized Optional<WorkerNetAddress> getWorker(GetWorkerOptions options) {
     Map<WorkerNetAddress, BlockWorkerInfo> eligibleWorkers = new HashMap<>();
     for (BlockWorkerInfo info : options.getBlockWorkerInfos()) {
       eligibleWorkers.put(info.getNetAddress(), info);


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix client stressbench concurrency problem.

### Why are the changes needed?
Reproduce:
Cluster:  
1 master and 2 workers

Command:
`bin/alluxio runClass alluxio.stress.cli.client.StressClientIOBench --operation Write --base alluxio:///stress-client-io-base --write-num-workers 2 --file-size 1m --threads 8`

Result: user_root.log
<img width="1152" alt="image" src="https://user-images.githubusercontent.com/42070967/220555496-c275578d-9eb7-4244-b897-9e5142d977d1.png">

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
