### PR TITLE
Fix metadata sync behavior when descendant type is NONE

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3650,6 +3650,18 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setIsHidden(true)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
+  public static final PropertyKey
+      MASTER_METADATA_SYNC_SKIP_LOADING_CHILDREN_ON_DESCENDANT_TYPE_NONE =
+      booleanBuilder(Name.MASTER_METADATA_SYNC_SKIP_LOADING_CHILDREN_ON_DESCENDANT_TYPE_NONE)
+          .setDescription(
+              "If set to true, skip loading children during metadata sync when "
+                  + "descendant type is set to NONE, for example, a metadata sync triggered "
+                  + "by a getStatus on a directory.")
+          .setScope(Scope.MASTER)
+          .setDefaultValue(true)
+          .setIsHidden(true)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .build();
   // In Java8 in container environment Runtime.availableProcessors() always returns 1,
   // which is not the actual number of cpus, so we set a safe default value 32.
   public static final PropertyKey MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE =
@@ -7906,6 +7918,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metadata.sync.instrument.executor";
     public static final String MASTER_METADATA_SYNC_REPORT_FAILURE =
         "alluxio.master.metadata.sync.report.failure";
+    public static final String MASTER_METADATA_SYNC_SKIP_LOADING_CHILDREN_ON_DESCENDANT_TYPE_NONE =
+        "alluxio.master.metadata.skip.loading.children.on.descendant.type.none";
     public static final String MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE =
         "alluxio.master.metadata.sync.ufs.prefetch.pool.size";
     public static final String MASTER_METADATA_SYNC_TRAVERSAL_ORDER =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3651,8 +3651,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
   public static final PropertyKey
-      MASTER_METADATA_SYNC_SKIP_LOADING_CHILDREN_ON_DESCENDANT_TYPE_NONE =
-      booleanBuilder(Name.MASTER_METADATA_SYNC_SKIP_LOADING_CHILDREN_ON_DESCENDANT_TYPE_NONE)
+      MASTER_METADATA_SYNC_GET_DIRECTORY_STATUS_SKIP_LOADING_CHILDREN =
+      booleanBuilder(Name.MASTER_METADATA_SYNC_GET_DIRECTORY_STATUS_SKIP_LOADING_CHILDREN)
           .setDescription(
               "If set to true, skip loading children during metadata sync when "
                   + "descendant type is set to NONE, for example, a metadata sync triggered "
@@ -7918,8 +7918,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metadata.sync.instrument.executor";
     public static final String MASTER_METADATA_SYNC_REPORT_FAILURE =
         "alluxio.master.metadata.sync.report.failure";
-    public static final String MASTER_METADATA_SYNC_SKIP_LOADING_CHILDREN_ON_DESCENDANT_TYPE_NONE =
-        "alluxio.master.metadata.skip.loading.children.on.descendant.type.none";
+    public static final String MASTER_METADATA_SYNC_GET_DIRECTORY_STATUS_SKIP_LOADING_CHILDREN =
+        "alluxio.master.metadata.sync.get.directory.status.skip.loading.children";
     public static final String MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE =
         "alluxio.master.metadata.sync.ufs.prefetch.pool.size";
     public static final String MASTER_METADATA_SYNC_TRAVERSAL_ORDER =

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -296,9 +296,9 @@ public class InodeSyncStream {
   private final int mConcurrencyLevel =
       Configuration.getInt(PropertyKey.MASTER_METADATA_SYNC_CONCURRENCY_LEVEL);
 
-  private final boolean mSkipLoadChildrenOnDescendantTypeNone =
+  private final boolean mGetDirectoryStatusSkipLoadingChildren =
       Configuration.getBoolean(
-          PropertyKey.MASTER_METADATA_SYNC_SKIP_LOADING_CHILDREN_ON_DESCENDANT_TYPE_NONE);
+          PropertyKey.MASTER_METADATA_SYNC_GET_DIRECTORY_STATUS_SKIP_LOADING_CHILDREN);
 
   private final FileSystemMasterAuditContext mAuditContext;
   private final Function<LockedInodePath, Inode> mAuditContextSrcInodeFunc;
@@ -483,7 +483,7 @@ public class InodeSyncStream {
         // If descendantType is ONE, then we shouldn't process any more paths except for those
         // currently in the queue
         stopNum = mPendingPaths.size();
-      } else if (mSkipLoadChildrenOnDescendantTypeNone && mDescendantType == DescendantType.NONE) {
+      } else if (mGetDirectoryStatusSkipLoadingChildren && mDescendantType == DescendantType.NONE) {
         // If descendantType is NONE, do not process any path in the queue after
         // the inode itself is loaded.
         stopNum = 0;
@@ -907,7 +907,7 @@ public class InodeSyncStream {
     if (mDescendantType == DescendantType.ONE) {
       syncChildren =
           syncChildren && mRootScheme.getPath().equals(inodePath.getUri());
-    } else if (mDescendantType == DescendantType.NONE && mSkipLoadChildrenOnDescendantTypeNone) {
+    } else if (mDescendantType == DescendantType.NONE && mGetDirectoryStatusSkipLoadingChildren) {
       syncChildren = false;
     }
 

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -296,6 +296,10 @@ public class InodeSyncStream {
   private final int mConcurrencyLevel =
       Configuration.getInt(PropertyKey.MASTER_METADATA_SYNC_CONCURRENCY_LEVEL);
 
+  private final boolean mSkipLoadChildrenOnDescendantTypeNone =
+      Configuration.getBoolean(
+          PropertyKey.MASTER_METADATA_SYNC_SKIP_LOADING_CHILDREN_ON_DESCENDANT_TYPE_NONE);
+
   private final FileSystemMasterAuditContext mAuditContext;
   private final Function<LockedInodePath, Inode> mAuditContextSrcInodeFunc;
 
@@ -479,7 +483,7 @@ public class InodeSyncStream {
         // If descendantType is ONE, then we shouldn't process any more paths except for those
         // currently in the queue
         stopNum = mPendingPaths.size();
-      } else if (mDescendantType == DescendantType.NONE) {
+      } else if (mSkipLoadChildrenOnDescendantTypeNone && mDescendantType == DescendantType.NONE) {
         // If descendantType is NONE, do not process any path in the queue after
         // the inode itself is loaded.
         stopNum = 0;
@@ -903,7 +907,7 @@ public class InodeSyncStream {
     if (mDescendantType == DescendantType.ONE) {
       syncChildren =
           syncChildren && mRootScheme.getPath().equals(inodePath.getUri());
-    } else if (mDescendantType == DescendantType.NONE) {
+    } else if (mDescendantType == DescendantType.NONE && mSkipLoadChildrenOnDescendantTypeNone) {
       syncChildren = false;
     }
 

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -479,6 +479,10 @@ public class InodeSyncStream {
         // If descendantType is ONE, then we shouldn't process any more paths except for those
         // currently in the queue
         stopNum = mPendingPaths.size();
+      } else if (mDescendantType == DescendantType.NONE) {
+        // If descendantType is NONE, do not process any path in the queue after
+        // the inode itself is loaded.
+        stopNum = 0;
       }
 
       // process the sync result for the original path
@@ -899,6 +903,8 @@ public class InodeSyncStream {
     if (mDescendantType == DescendantType.ONE) {
       syncChildren =
           syncChildren && mRootScheme.getPath().equals(inodePath.getUri());
+    } else if (mDescendantType == DescendantType.NONE) {
+      syncChildren = false;
     }
 
     int childCount = inode.isDirectory() ? (int) inode.asDirectory().getChildCount() : 0;

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -863,14 +863,20 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
 
     // delete the file and wait a bit
     new File(ufsPath("/delete/file")).delete();
-    CommonUtils.sleepMs(2000);
+    CommonUtils.sleepMs(3000);
 
     // getStatus (not listStatus) on the root, with a shorter interval than the sleep.
     // This will sync that directory. The sync interval has to be long enough for the internal
     // syncing process to finish within that time.
     mFileSystem.getStatus(new AlluxioURI(alluxioPath("/delete")), GetStatusPOptions.newBuilder()
         .setCommonOptions(
-            FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(1000).build()).build());
+            FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(2000).build()).build());
+
+    // a following list status should trigger a metadata sync even though the path was just synced,
+    // because the descendant type is ONE this time, and it was NONE previously.
+    mFileSystem.listStatus(new AlluxioURI(alluxioPath("/delete")),
+        ListStatusPOptions.newBuilder().setRecursive(false).setCommonOptions(
+            FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(2000).build()).build());
 
     // verify that the file is deleted, without syncing
     try {


### PR DESCRIPTION
### What changes are proposed in this pull request?

When the metadata sync descendant type is NONE, stop loading the children of the sync root.  

If a metadata sync is trigged by a GetStatus() call on a directory 
Previous behavior: The directory itself, as well as all its sub directories in the inode store will be synced.
New behavior: ONLY the directory itself will be loaded. 

### Why are the changes needed?

This PR addresses https://github.com/Alluxio/alluxio/issues/16922.
The incorrect metadata sync behavior on GetStatus for a directory loads more children of the directory than expected and put a lot of pressure on UFS side. 

### Does this PR introduce any user facing changes?

Yes. The metadata sync behavior has been changed. See the comment above. The previous behavior was actually wrong and we added a hidden feature flag to allow customers to fallback. 