### PR TITLE
Respect MaxRamPercentage in container

### DIFF
--- a/bin/launch-process
+++ b/bin/launch-process
@@ -122,7 +122,7 @@ launch_master() {
   fi
 
   # use a default Xmx value for the master
-  local res="$(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "Xmx")"
+  local res="$(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "Xmx") + $(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "MaxRAMPercentage")"
   if [[ "${res}" -eq "0" ]]; then
     ALLUXIO_MASTER_JAVA_OPTS+=" -Xmx8g "
   fi

--- a/bin/launch-process
+++ b/bin/launch-process
@@ -122,8 +122,8 @@ launch_master() {
   fi
 
   # use a default Xmx value for the master
-  local res="$(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "Xmx") + $(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "MaxRAMPercentage")"
-  if [[ "${res}" -eq "0" ]]; then
+  local res="$(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "Xmx") $(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "MaxRAMPercentage")"
+  if [[ "${res}" -eq "0 0" ]]; then
     ALLUXIO_MASTER_JAVA_OPTS+=" -Xmx8g "
   fi
   # use a default MetaspaceSize value for the master
@@ -140,8 +140,8 @@ launch_master() {
 # Launch a secondary master process
 launch_secondary_master() {
   # use a default Xmx value for the master
-  local res="$(contains "${ALLUXIO_SECONDARY_MASTER_JAVA_OPTS}" "Xmx")"
-  if [[ "${res}" -eq "0" ]]; then
+  local res="$(contains "${ALLUXIO_SECONDARY_MASTER_JAVA_OPTS}" "Xmx") $(contains "${ALLUXIO_SECONDARY_MASTER_JAVA_OPTS}" "MaxRAMPercentage")"
+  if [[ "${res}" -eq "0 0" ]]; then
     ALLUXIO_SECONDARY_MASTER_JAVA_OPTS+=" -Xmx8g "
   fi
   launch_process "${ALLUXIO_SECONDARY_MASTER_ATTACH_OPTS}" \
@@ -159,8 +159,8 @@ launch_job_master() {
 # Launch a worker process
 launch_worker() {
   # use a default Xmx value for the worker
-  local res="$(contains "${ALLUXIO_WORKER_JAVA_OPTS}" "Xmx")"
-  if [[ "${res}" -eq "0" ]]; then
+  local res="$(contains "${ALLUXIO_WORKER_JAVA_OPTS}" "Xmx") $(contains "${ALLUXIO_WORKER_JAVA_OPTS}" "MaxRAMPercentage")"
+  if [[ "${res}" -eq "0 0" ]]; then
     ALLUXIO_WORKER_JAVA_OPTS+=" -Xmx4g "
   fi
 

--- a/bin/launch-process
+++ b/bin/launch-process
@@ -47,8 +47,9 @@ unless you know what you are doing.
 contains() {
   if [[ "$1" = *"$2"* ]]; then
     printf "1"
+  else
+    printf "0"
   fi
-  printf "0"
 }
 
 # Sets environment variables by sourcing ${ALLUXIO_HOME}/libexec/alluxio-config.sh
@@ -122,8 +123,9 @@ launch_master() {
   fi
 
   # use a default Xmx value for the master
-  local res="$(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "Xmx") $(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "MaxRAMPercentage")"
-  if [[ "${res}" -eq "0 0" ]]; then
+  local contain_xmx="$(contains "${ALLUXIO_MASTER_JAVA_OPTS}")"
+  local contain_max_percentage="$(contains "${ALLUXIO_MASTER_JAVA_OPTS}" "MaxRAMPercentage")"
+  if [[ "${contain_xmx}" -eq "0" ]] && [[ "${contain_max_percentage}" -eq "0" ]]; then
     ALLUXIO_MASTER_JAVA_OPTS+=" -Xmx8g "
   fi
   # use a default MetaspaceSize value for the master
@@ -140,8 +142,9 @@ launch_master() {
 # Launch a secondary master process
 launch_secondary_master() {
   # use a default Xmx value for the master
-  local res="$(contains "${ALLUXIO_SECONDARY_MASTER_JAVA_OPTS}" "Xmx") $(contains "${ALLUXIO_SECONDARY_MASTER_JAVA_OPTS}" "MaxRAMPercentage")"
-  if [[ "${res}" -eq "0 0" ]]; then
+  local contain_xmx="$(contains "${ALLUXIO_SECONDARY_MASTER_JAVA_OPTS}")"
+  local contain_max_percentage="$(contains "${ALLUXIO_SECONDARY_MASTER_JAVA_OPTS}" "MaxRAMPercentage")"
+  if [[ "${contain_xmx}" -eq "0" ]] && [[ "${contain_max_percentage}" -eq "0" ]]; then
     ALLUXIO_SECONDARY_MASTER_JAVA_OPTS+=" -Xmx8g "
   fi
   launch_process "${ALLUXIO_SECONDARY_MASTER_ATTACH_OPTS}" \
@@ -159,8 +162,9 @@ launch_job_master() {
 # Launch a worker process
 launch_worker() {
   # use a default Xmx value for the worker
-  local res="$(contains "${ALLUXIO_WORKER_JAVA_OPTS}" "Xmx") $(contains "${ALLUXIO_WORKER_JAVA_OPTS}" "MaxRAMPercentage")"
-  if [[ "${res}" -eq "0 0" ]]; then
+  local contain_xmx="$(contains "${ALLUXIO_WORKER_JAVA_OPTS}")"
+  local contain_max_percentage="$(contains "${ALLUXIO_WORKER_JAVA_OPTS}" "MaxRAMPercentage")"
+  if [[ "${contain_xmx}" -eq "0" ]] && [[ "${contain_max_percentage}" -eq "0" ]]; then
     ALLUXIO_WORKER_JAVA_OPTS+=" -Xmx4g "
   fi
 


### PR DESCRIPTION
Currently if user specifies `MaxRamPercentage` without specifying `Xmx`, Alluxio still gives a defualt `Xmx` which will override the `MaxRamPercentage` because of priority. Fix this by if user specifies `MaxRamPercentage` we don't give a default `Xmx`. 

First step of solving https://github.com/Alluxio/alluxio/issues/10083
Replace https://github.com/Alluxio/alluxio/pull/15819