### PR TITLE
Fix incorrect flag passing into delete op

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -3119,7 +3119,7 @@ public class DefaultFileSystemMaster extends CoreMaster
         try {
           deleteInternal(rpcContext, dstInodePath, DeleteContext
                   .mergeFrom(DeletePOptions.newBuilder()
-                          .setRecursive(true).setAlluxioOnly(context.getPersist())), true);
+                          .setRecursive(true).setAlluxioOnly(!context.getPersist())), true);
           dstInodePath.removeLastInode();
         } catch (DirectoryNotEmptyException ex) {
           // IGNORE, this will never happen


### PR DESCRIPTION
### What changes are proposed in this pull request?

Incorrect usage of flag in atomic rename for the final step of completing the target multipart-upload file.

### Why are the changes needed?

if write type is cache_thru or thru, the atomic rename ( delete target and rename src to target ) will incorrectly delete
alluxio-only instead of deleting UFS, hence making the renaming op in UFS fail.

### Does this PR introduce any user facing changes?
N/A
