### PR TITLE
Support new version string as XXX-XXX

### DIFF
--- a/core/common/src/main/java/alluxio/RuntimeConstants.java
+++ b/core/common/src/main/java/alluxio/RuntimeConstants.java
@@ -24,7 +24,7 @@ public final class RuntimeConstants {
   public static final String VERSION = ProjectConstants.VERSION;
 
   static {
-    if (VERSION.endsWith("SNAPSHOT")) {
+    if (VERSION.endsWith("SNAPSHOT") || !VERSION.contains("\\.")) {
       ALLUXIO_DOCS_URL = "https://docs.alluxio.io/os/user/edge";
       ALLUXIO_JAVADOC_URL = "https://docs.alluxio.io/os/javadoc/edge";
     } else {


### PR DESCRIPTION
Support new version string e.g. 291-alpha.
Fix RUNTIME ArrayIndexOutOfBoundException issues when starting master/worker process.
Split the version string with dot and want to get second element, which throws ArrayIndexOutOfBoundException
