### PR TITLE
Make WORKER_MASTER_CONNECT_RETRY_TIMEOUT get a proper value

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/BlockSyncMasterGroup.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/BlockSyncMasterGroup.java
@@ -50,8 +50,8 @@ public class BlockSyncMasterGroup implements Closeable {
   private static BlockMasterClientFactory sBlockMasterClientFactory
       = new BlockMasterClientFactory();
 
-  private static final long WORKER_MASTER_CONNECT_RETRY_TIMEOUT =
-      Configuration.getMs(PropertyKey.WORKER_MASTER_CONNECT_RETRY_TIMEOUT);
+  private static final long WORKER_MASTER_CONNECT_RETRY_TIMEOUT = Math.min(
+      Configuration.getMs(PropertyKey.WORKER_MASTER_CONNECT_RETRY_TIMEOUT), Integer.MAX_VALUE);
 
   /**
    * Creates a block sync master group.


### PR DESCRIPTION
### What changes are proposed in this pull request?

Make WORKER_MASTER_CONNECT_RETRY_TIMEOUT use Integer.Max when the actual value exceeds Integer.Max.

### Why are the changes needed?

In our alluxio cluster, `alluxio.worker.master.connect.retry.timeout` is set to 30day, which exceeds the upper limit of Integer, causing the worker fail to start:

```
2023-02-27 17:17:24,353 ERROR SpecificMasterBlockSync - Fatal error: Failed to register with primary master
java.util.concurrent.TimeoutException: Timed out waiting for alluxio.worker.block.BlockSyncMasterGroup@d8948cd to start options: WaitForOptions{interval=20, timeout=-1702967296} last value: false
        at alluxio.util.CommonUtils.waitForResult(CommonUtils.java:383)
        at alluxio.util.CommonUtils.waitFor(CommonUtils.java:341)
        at alluxio.worker.block.BlockSyncMasterGroup.waitForPrimaryMasterRegistrationComplete(BlockSyncMasterGroup.java:122)
        at alluxio.worker.block.AllMasterRegistrationBlockWorker.start(AllMasterRegistrationBlockWorker.java:69)
        at alluxio.worker.block.AllMasterRegistrationBlockWorker.start(AllMasterRegistrationBlockWorker.java:31)
        at alluxio.Registry.start(Registry.java:129)
        at alluxio.worker.AlluxioWorkerProcess.startWorkers(AlluxioWorkerProcess.java:274)
        at alluxio.worker.AlluxioWorkerProcess.start(AlluxioWorkerProcess.java:221)
        at alluxio.ProcessUtils.run(ProcessUtils.java:37)
        at alluxio.worker.AlluxioWorker.main(AlluxioWorker.java:78)
```
### Does this PR introduce any user facing changes?
No
