### PR TITLE
Create RocksDBDoraMetaStore in specified dir without workerID

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -185,7 +185,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
             Configuration.getConfiguration(Scope.WORKER));
         LOG.info("Worker registered with worker ID: {}", mWorkerId.get());
         String dbDir = Configuration.getString(PropertyKey.DORA_WORKER_METASTORE_ROCKSDB_DIR);
-        mMetaStore = new RocksDBDoraMetaStore(dbDir + ".worker." + mWorkerId);
+        mMetaStore = new RocksDBDoraMetaStore(dbDir);
         break;
       } catch (IOException ioe) {
         if (!retry.attempt()) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove the ".worker + workerId" from the DBdir

### Why are the changes needed?

Workers should be running from different dirs. They should have different DBdir configured.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
N/A
