### PR TITLE
Add configurable TTL for Dora Worker RocksDBMetaStore

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -7412,7 +7412,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
   public static final PropertyKey DORA_WORKER_METASTORE_ROCKSDB_DIR =
       stringBuilder(Name.DORA_WORKER_METASTORE_ROCKSDB_DIR)
           .setDefaultValue(format("${%s}/metastore", Name.WORK_DIR))
-          .setDescription("The base dir of RocksDB to store Dora meta data")
+          .setDescription("The base dir of RocksDB to store Dora metadata")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.WORKER)
+          .build();
+
+  public static final PropertyKey DORA_WORKER_METASTORE_ROCKSDB_TTL =
+      intBuilder(Name.DORA_WORKER_METASTORE_ROCKSDB_TTL)
+          .setDefaultValue(60 * 60 * 24) // 24 hours
+          .setDescription("The TTL (Time To Live) of RocksDB of Dora metadata")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.WORKER)
           .build();
@@ -8942,6 +8950,9 @@ public final class PropertyKey implements Comparable<PropertyKey> {
 
     public static final String DORA_WORKER_METASTORE_ROCKSDB_DIR =
         "alluxio.dora.worker.metastore.rocksdb.dir";
+
+    public static final String DORA_WORKER_METASTORE_ROCKSDB_TTL =
+        "alluxio.dora.worker.metastore.rocksdb.ttl";
 
     private Name() {} // prevent instantiation
   }

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -7418,9 +7418,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
 
   public static final PropertyKey DORA_WORKER_METASTORE_ROCKSDB_TTL =
-      intBuilder(Name.DORA_WORKER_METASTORE_ROCKSDB_TTL)
-          .setDefaultValue(60 * 60 * 24) // 24 hours
-          .setDescription("The TTL (Time To Live) of RocksDB of Dora metadata")
+      durationBuilder(Name.DORA_WORKER_METASTORE_ROCKSDB_TTL)
+          .setDefaultValue("-1s") // -1s means no expiry
+          .setDescription("The TTL (Time To Live) in duration of RocksDB of Dora metadata. "
+              + "0s or negative value means no expiry")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.WORKER)
           .build();

--- a/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -71,6 +71,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -185,7 +186,10 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
             Configuration.getConfiguration(Scope.WORKER));
         LOG.info("Worker registered with worker ID: {}", mWorkerId.get());
         String dbDir = Configuration.getString(PropertyKey.DORA_WORKER_METASTORE_ROCKSDB_DIR);
-        int ttl = Configuration.getInt(PropertyKey.DORA_WORKER_METASTORE_ROCKSDB_TTL);
+        Duration duration =
+            Configuration.getDuration(PropertyKey.DORA_WORKER_METASTORE_ROCKSDB_TTL);
+        long ttl = duration.isZero() || duration.isNegative() ? -1 : duration.getSeconds();
+
         mMetaStore = new RocksDBDoraMetaStore(dbDir, ttl);
         break;
       } catch (IOException ioe) {

--- a/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -185,7 +185,8 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
             Configuration.getConfiguration(Scope.WORKER));
         LOG.info("Worker registered with worker ID: {}", mWorkerId.get());
         String dbDir = Configuration.getString(PropertyKey.DORA_WORKER_METASTORE_ROCKSDB_DIR);
-        mMetaStore = new RocksDBDoraMetaStore(dbDir);
+        int ttl = Configuration.getInt(PropertyKey.DORA_WORKER_METASTORE_ROCKSDB_TTL);
+        mMetaStore = new RocksDBDoraMetaStore(dbDir, ttl);
         break;
       } catch (IOException ioe) {
         if (!retry.attempt()) {

--- a/core/server/worker/src/main/java/alluxio/worker/dora/RocksDBDoraMetaStore.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/RocksDBDoraMetaStore.java
@@ -54,7 +54,7 @@ public class RocksDBDoraMetaStore implements DoraMetaStore {
 
   // The TTL (in seconds) for metadata. It must be greater than 0, or -1.
   // -1 means never expiring.
-  private final int mMetaTTL;
+  private final long mMetaTTL;
 
   private final List<RocksObject> mToClose = new ArrayList<>();
 
@@ -66,7 +66,7 @@ public class RocksDBDoraMetaStore implements DoraMetaStore {
    * @param baseDir the base directory in which to store inode metadata
    * @param metaTTL The TTL for this metastore
    */
-  public RocksDBDoraMetaStore(String baseDir, int metaTTL) {
+  public RocksDBDoraMetaStore(String baseDir, long metaTTL) {
     RocksDB.loadLibrary();
 
     Preconditions.checkState(metaTTL > 0 || metaTTL == -1);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add a configurable TTL to Dora RocksDBMetaStore, and check if the retrieved metadata has expired or not.

### Why are the changes needed?

We need a way to invalidate the cached Metadata in RocksDBMetaStore.
A configurable TTL is the easiest way to do so.

### Does this PR introduce any user facing changes?
A new property key "alluxio.dora.worker.metastore.rocksdb.ttl" is added for this TTL.