### PR TITLE
Merge JournalContext for persistence

### DIFF
--- a/core/server/common/src/main/java/alluxio/master/journal/MasterJournalContext.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/MasterJournalContext.java
@@ -61,7 +61,6 @@ public final class MasterJournalContext implements JournalContext {
 
   @Override
   public synchronized void append(JournalEntry entry) {
-    // TODO(jiacheng): add flushing on batch
     mFlushCounter = mAsyncJournalWriter.appendEntry(entry);
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/MasterJournalContext.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/MasterJournalContext.java
@@ -61,6 +61,7 @@ public final class MasterJournalContext implements JournalContext {
 
   @Override
   public synchronized void append(JournalEntry entry) {
+    // TODO(jiacheng): add flushing on batch
     mFlushCounter = mAsyncJournalWriter.appendEntry(entry);
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4361,7 +4361,7 @@ public class DefaultFileSystemMaster extends CoreMaster
      * @param fileId the file ID
      */
     private void handleExpired(long fileId, JournalContext journalContext,
-       AtomicInteger journalCount) throws AlluxioException {
+        AtomicInteger journalCount) throws AlluxioException {
       try (LockedInodePath inodePath = mInodeTree
           .lockFullInodePath(fileId, LockPattern.WRITE_INODE, journalContext)) {
         InodeFile inode = inodePath.getInodeFile();

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -114,7 +114,6 @@ import alluxio.master.file.meta.UfsSyncPathCache;
 import alluxio.master.file.meta.options.MountInfo;
 import alluxio.master.journal.DelegatingJournaled;
 import alluxio.master.journal.FileSystemMergeJournalContext;
-import alluxio.master.journal.Journal;
 import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.Journaled;
 import alluxio.master.journal.JournaledGroup;
@@ -196,8 +195,6 @@ import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import io.grpc.ServerInterceptors;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.concurrent.ConcurrentException;
-import org.apache.commons.lang3.concurrent.LazyInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -4363,8 +4360,8 @@ public class DefaultFileSystemMaster extends CoreMaster
      *
      * @param fileId the file ID
      */
-    private void handleExpired(long fileId, JournalContext journalContext, AtomicInteger journalCount)
-        throws AlluxioException {
+    private void handleExpired(long fileId, JournalContext journalContext,
+       AtomicInteger journalCount) throws AlluxioException {
       try (LockedInodePath inodePath = mInodeTree
           .lockFullInodePath(fileId, LockPattern.WRITE_INODE, journalContext)) {
         InodeFile inode = inodePath.getInodeFile();
@@ -4492,6 +4489,7 @@ public class DefaultFileSystemMaster extends CoreMaster
     @Override
     public void heartbeat() throws InterruptedException {
       LOG.debug("Async Persist heartbeat start");
+      java.util.concurrent.TimeUnit.SECONDS.sleep(mQuietPeriodSeconds);
       AtomicInteger journalCounter = new AtomicInteger(0);
       try (JournalContext journalContext = createJournalContext()) {
         // Process persist requests.
@@ -4579,7 +4577,6 @@ public class DefaultFileSystemMaster extends CoreMaster
         // The next primary will process all TO_BE_PERSISTED files and create new persist jobs
         LOG.warn("Journal is not running, cannot persist files");
       }
-      java.util.concurrent.TimeUnit.SECONDS.sleep(mQuietPeriodSeconds);
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4522,7 +4522,7 @@ public class DefaultFileSystemMaster extends CoreMaster
               uri = inodePath.getUri();
             } catch (FileDoesNotExistException e) {
               LOG.debug("The file (id={}) to be persisted was not found. Likely this file has been "
-                      + "removed by users", fileId, e);
+                  + "removed by users", fileId, e);
               continue;
             }
             try {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4607,7 +4607,7 @@ public class DefaultFileSystemMaster extends CoreMaster
       List<Long> blockIds = new ArrayList<>();
       UfsManager.UfsClient ufsClient = null;
       // This journal flush is per job and cannot be batched easily,
-      // because easy execution is in a separate thread and this thread doesn't wait for those
+      // because each execution is in a separate thread and this thread doesn't wait for those
       // to complete
       try (JournalContext journalContext = createJournalContext();
           LockedInodePath inodePath = mInodeTree

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4607,7 +4607,8 @@ public class DefaultFileSystemMaster extends CoreMaster
       List<Long> blockIds = new ArrayList<>();
       UfsManager.UfsClient ufsClient = null;
       // This journal flush is per job and cannot be batched easily,
-      // because easy execution is in a separate thread
+      // because easy execution is in a separate thread and this thread doesn't wait for those
+      // to complete
       try (JournalContext journalContext = createJournalContext();
           LockedInodePath inodePath = mInodeTree
               .lockFullInodePath(fileId, LockPattern.WRITE_INODE, journalContext)) {

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -4575,7 +4575,7 @@ public class DefaultFileSystemMaster extends CoreMaster
         // the primary failed over, or journal is closed
         // In either case, it is fine to close JournalContext and throw away the journal entries
         // The next primary will process all TO_BE_PERSISTED files and create new persist jobs
-        LOG.warn("Journal is not running, cannot persist files");
+        LOG.error("Journal is not running, cannot persist files");
       }
     }
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

`PersistenceChecker` and `PersistenceScheduler` will regularly check all files that need persistence. Some fields in the inode is used to track the persistence status. So PersistenceChecker and PersistentSchedule will constantly update inodes, which creates journal entries. 

Currently one JournalContext is created on processing each file, and closed after this file is processed. This means the journal entries are flushed once per file. In this change, we merge those flushes to:
1. Reduce frequent JournalContext usage, which acquires the state lock
2. Reduce the number of synchronous journal flushes

The idea is also consistent with https://github.com/Alluxio/alluxio/pull/16529

The correctness is guaranteed by:
1. It is fine to lose those journal entries on async persist on failover. If an inode status is not PERSISTED, the new primary will attempt to persist it anyways.

### Why are the changes needed?

Mentioned above

### Does this PR introduce any user facing changes?

Users should not perceive this change.
