### PR TITLE
[WIP] Implement createCompleteFileInternalForMetadataSync

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -26,14 +26,12 @@ import alluxio.exception.InvalidFileSizeException;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.file.options.DescendantType;
-import alluxio.grpc.CompleteFilePOptions;
 import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.FileSystemMasterCommonPOptions;
 import alluxio.grpc.GrpcUtils;
 import alluxio.grpc.LoadDescendantPType;
 import alluxio.grpc.LoadMetadataPOptions;
 import alluxio.grpc.SetAttributePOptions;
-import alluxio.master.file.contexts.CompleteFileContext;
 import alluxio.master.file.contexts.CreateDirectoryContext;
 import alluxio.master.file.contexts.CreateFileContext;
 import alluxio.master.file.contexts.DeleteContext;
@@ -1242,14 +1240,8 @@ public class InodeSyncStream {
           ? rpcContext
           : new RpcContext(
               rpcContext.getBlockDeletionContext(), merger, rpcContext.getOperationContext());
-      fsMaster.createFileInternal(wrapRpcContext, writeLockedPath, createFileContext);
-      CompleteFileContext completeContext =
-          CompleteFileContext.mergeFrom(CompleteFilePOptions.newBuilder().setUfsLength(ufsLength))
-              .setUfsStatus(context.getUfsStatus()).setMetadataLoad(true);
-      if (ufsLastModified != null) {
-        completeContext.setOperationTimeMs(ufsLastModified);
-      }
-      fsMaster.completeFileInternal(wrapRpcContext, writeLockedPath, completeContext);
+      fsMaster.createCompleteFileInternalForMetadataSync(
+          wrapRpcContext, writeLockedPath, createFileContext, ufsLength, context.getUfsStatus());
     } catch (FileAlreadyExistsException e) {
       // This may occur if a thread created or loaded the file before we got the write lock.
       // The file already exists, so nothing needs to be loaded.

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CreateFileContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CreateFileContext.java
@@ -18,6 +18,9 @@ import alluxio.wire.OperationId;
 
 import com.google.common.base.MoreObjects;
 
+import java.util.List;
+import javax.annotation.Nullable;
+
 /**
  * Implementation of {@link OperationContext} used to merge and wrap {@link CreateFilePOptions}.
  */
@@ -25,6 +28,15 @@ public class CreateFileContext
     extends CreatePathContext<CreateFilePOptions.Builder, CreateFileContext> {
 
   private boolean mCacheable;
+
+  private boolean mIsCompleted;
+  private long mLength;
+  @Nullable private List<Long> mBlockIds;
+
+  /**
+   * If set, the new file will use this id instead of a generated one when the file is created.
+   */
+  @Nullable private Long mBlockContainerId;
 
   /**
    * Creates context with given option data.
@@ -34,6 +46,10 @@ public class CreateFileContext
   private CreateFileContext(CreateFilePOptions.Builder optionsBuilder) {
     super(optionsBuilder);
     mCacheable = false;
+    mIsCompleted = false;
+    mLength = 0;
+    mBlockIds = null;
+    mBlockContainerId = null;
   }
 
   /**
@@ -90,11 +106,80 @@ public class CreateFileContext
     return super.getOperationId();
   }
 
+  /**
+   * @param isCompleted true if the file is completed, otherwise false
+   * @return the updated context object
+   */
+  public CreateFileContext setIsCompleted(boolean isCompleted) {
+    mIsCompleted = isCompleted;
+    return getThis();
+  }
+
+  /**
+   * @return true if the file is completed, otherwise false
+   */
+  public boolean isCompleted() {
+    return mIsCompleted;
+  }
+
+  /**
+   * @param length the file length
+   * @return the updated context object
+   */
+  public CreateFileContext setLength(long length) {
+    mLength = length;
+    return getThis();
+  }
+
+  /**
+   * @return the file length
+   */
+  public long getLength() {
+    return mLength;
+  }
+
+  /**
+   * @param blockIds the block ids of the file. Null if the file is incomplete
+   * @return the updated context object
+   */
+  public CreateFileContext setBlockIds(List<Long> blockIds) {
+    mBlockIds = blockIds;
+    return this;
+  }
+
+  /**
+   * @return the block ids of the file. Null if the file is incomplete
+   */
+  @Nullable
+  public List<Long> getBlockIds() {
+    return mBlockIds;
+  }
+
+  /**
+   * @param blockContainerId the block container id
+   * @return the updated context object
+   */
+  public CreateFileContext setBlockContainerId(long blockContainerId) {
+    mBlockContainerId = blockContainerId;
+    return this;
+  }
+
+  /**
+   * @return the block container id, null if auto generated one is used
+   */
+  @Nullable
+  public Long getBlockContainerId() {
+    return mBlockContainerId;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("PathContext", super.toString())
         .add("Cacheable", mCacheable)
+        .add("Length", mLength)
+        .add("IsCompleted", mIsCompleted)
+        .add("BlockContainerId", mBlockContainerId)
         .toString();
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/contexts/CreatePathContext.java
+++ b/core/server/master/src/main/java/alluxio/master/file/contexts/CreatePathContext.java
@@ -64,6 +64,7 @@ public abstract class CreatePathContext<T extends GeneratedMessageV3.Builder<?>,
   protected boolean mRecursive;
   protected long mTtl;
   protected TtlAction mTtlAction;
+  @Nullable protected String mFingerprint;
 
   /**
    * Creates context with given option data.
@@ -78,6 +79,7 @@ public abstract class CreatePathContext<T extends GeneratedMessageV3.Builder<?>,
     mMetadataLoad = false;
     mGroup = "";
     mOwner = "";
+    mFingerprint = "";
     if (SecurityUtils.isAuthenticationEnabled(Configuration.global())) {
       mOwner = SecurityUtils.getOwnerFromGrpcClient(Configuration.global());
       mGroup = SecurityUtils.getGroupFromGrpcClient(Configuration.global());
@@ -296,6 +298,23 @@ public abstract class CreatePathContext<T extends GeneratedMessageV3.Builder<?>,
   }
 
   /**
+   * @return the fingerprint
+   */
+  @Nullable
+  public String getFingerprint() {
+    return mFingerprint;
+  }
+
+  /**
+   * @param fingerprint the fingerprint
+   * @return the updated context
+   */
+  public K setFingerprint(String fingerprint) {
+    mFingerprint = fingerprint;
+    return getThis();
+  }
+
+  /**
    * @return extended attributes propagation strategy of this context
    */
   public XAttrPropagationStrategy getXAttrPropStrat() {
@@ -320,6 +339,7 @@ public abstract class CreatePathContext<T extends GeneratedMessageV3.Builder<?>,
         .add("MetadataLoad", mMetadataLoad)
         .add("writeType", mWriteType)
         .add("xattr", mXAttr)
+        .add("Fingerprint", mFingerprint)
         .toString();
   }
 }

--- a/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/InodeTree.java
@@ -1019,7 +1019,14 @@ public class InodeTree implements DelegatingJournaled {
       newInode = newDir;
     } else if (context instanceof CreateFileContext) {
       CreateFileContext fileContext = (CreateFileContext) context;
-      MutableInodeFile newFile = MutableInodeFile.create(mContainerIdGenerator.getNewContainerId(),
+      final long blockContainerId;
+      if (fileContext.getBlockContainerId() != null) {
+        blockContainerId = fileContext.getBlockContainerId();
+      } else {
+        blockContainerId = mContainerIdGenerator.getNewContainerId();
+      }
+
+      MutableInodeFile newFile = MutableInodeFile.create(blockContainerId,
           currentInodeDirectory.getId(), name, System.currentTimeMillis(), fileContext);
 
       // if the parent has a default ACL, copy that default ACL ANDed with the umask as the new

--- a/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeFile.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MutableInodeFile.java
@@ -439,8 +439,8 @@ public final class MutableInodeFile extends MutableInode<MutableInodeFile>
     CreateFilePOptionsOrBuilder options = context.getOptions();
     Preconditions.checkArgument(
         options.getReplicationMax() == Constants.REPLICATION_MAX_INFINITY
-        || options.getReplicationMax() >= options.getReplicationMin());
-    return new MutableInodeFile(blockContainerId)
+            || options.getReplicationMax() >= options.getReplicationMin());
+    MutableInodeFile inodeFile = new MutableInodeFile(blockContainerId)
         .setBlockSizeBytes(options.getBlockSizeBytes())
         .setCreationTimeMs(creationTimeMs)
         .setName(name)
@@ -461,7 +461,14 @@ public final class MutableInodeFile extends MutableInode<MutableInodeFile>
         .setShouldPersistTime(options.getPersistenceWaitTime() == Constants.NO_AUTO_PERSIST
             ? Constants.NO_AUTO_PERSIST :
             System.currentTimeMillis() + options.getPersistenceWaitTime())
-        .setXAttr(context.getXAttr());
+        .setXAttr(context.getXAttr())
+        .setUfsFingerprint(context.getFingerprint())
+        .setCompleted(context.isCompleted())
+        .setLength(context.getLength());
+    if (context.getBlockIds() != null) {
+      inodeFile.setBlockIds(context.getBlockIds());
+    }
+    return inodeFile;
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request?

Added a new endpoint for metadata sync that creates the metadata of a file as well as complete it with updating inode tree only once.

### Why are the changes needed?

Currently, during the metadata sync, when the metadata of a file is loaded from UFS, internally a createFile() and a completeFile() call are called. There are a couple of issues:
1. These two operations are not atomic and might leave the file in a limbo state. 
2. The inode tree is updated too often and cause some performance issue
3. Too many journals sent to standby masters

Hence, we created a new method dedicated to metadata sync, where a file can be completed as soon as it is created. 

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  5. addition or removal of property keys
  6. webui
