### PR TITLE
Merge journal context in LostFileDetector

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
+++ b/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
@@ -98,7 +98,8 @@ final class LostFileDetector implements HeartbeatExecutor {
       try (JournalContext journalContext = mFileSystemMaster.createJournalContext()) {
         // update the state on the 2nd pass
         for (long fileId : toMarkFiles) {
-          try (LockedInodePath inodePath = mInodeTree.lockFullInodePath(fileId, LockPattern.WRITE_INODE, journalContext)) {
+          try (LockedInodePath inodePath = mInodeTree.lockFullInodePath(
+              fileId, LockPattern.WRITE_INODE, journalContext)) {
             Inode inode = inodePath.getInode();
             if (inode.getPersistenceState() != PersistenceState.PERSISTED) {
               mInodeTree.updateInode(journalContext,

--- a/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
+++ b/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
@@ -81,7 +81,6 @@ final class LostFileDetector implements HeartbeatExecutor {
         if (inode.getPersistenceState() != PersistenceState.PERSISTED) {
           toMarkFiles.add(fileId);
         }
-        // The
         iter.remove();
       } catch (FileDoesNotExistException e) {
         LOG.debug("Exception trying to get inode from inode tree", e);

--- a/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
+++ b/core/server/master/src/main/java/alluxio/master/file/LostFileDetector.java
@@ -92,14 +92,9 @@ final class LostFileDetector implements HeartbeatExecutor {
     if (toMarkFiles.size() > 0) {
       // Here the candidate block has been removed from the checklist
       // But the journal entries have not yet been flushed
-      // It is fine if these entries are not flushed, because if there is a new primary,
-      // the checklist will be re-generated when workers register
-      // The only exception scenario is when workers register to standby masters
-      // so there is not another register to the new primary and the checklist is not recreated
-      // We tolerate that scenario and expect when that worker registers again,
-      // the lost blocks will be identified
-      // Also, the impact is trivial because the issue is more about losing that file,
-      // than not marking the file as LOST
+      // If the journal entries are lost, we will never be able to mark them again,
+      // because the worker will never report those removedBlocks to the master again
+      // This is fine because the LOST status is purely for display now
       try (JournalContext journalContext = mFileSystemMaster.createJournalContext()) {
         // update the state on the 2nd pass
         for (long fileId : toMarkFiles) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

`LostFileDetector` checks all files that are possibly LOST in Alluxio, meaning the data only resides in Alluxio (not PERSISTED) and now cannot be found(no block found).

We used to create one JournalContext when updating each file's status. In this PR we change that to batching, to avoid too many synchronous flushing. This is consistent with https://github.com/Alluxio/alluxio/pull/16529

It is fine to batch because:
1. It's relatively low impact if we lose entries marking inodes as LOST. Losing a file is HIGH impact, while not identifying a lost file is LOW impact. That identification is asynchronous and can be turned off anyways.
2. Even if an inode is marked LOST, we don't have any special handling... The client will just try to read it the same way and results in IOException. That means the LOST status is not important (unless later we really give it some attention).

### Why are the changes needed?

Performance improvements

### Does this PR introduce any user facing changes?

Users shouldn't perceive this.
