### PR TITLE
Update registry for CSI images

### DIFF
--- a/integration/kubernetes/helm-chart/alluxio/values.yaml
+++ b/integration/kubernetes/helm-chart/alluxio/values.yaml
@@ -691,7 +691,7 @@ csi:
     dnsPolicy: ClusterFirstWithHostNet
     provisioner:
       # for kubernetes 1.17 or above
-      image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.5
+      image: registry.k8s.io/sig-storage/csi-provisioner:v2.0.5
       resources:
         limits:
           cpu: 100m
@@ -723,7 +723,7 @@ csi:
           cpu: "1"
           memory: "1Gi"
     driverRegistrar:
-      image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.0
+      image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.0.0
       resources:
         limits:
           cpu: 100m


### PR DESCRIPTION
The old registry k8s.gcr.io will be frozen early April 2023. The new registry registry.k8s.io will replace the old one. Thus updating the registry for csi images.

Source: https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/