### PR TITLE
Improve state lock tracking and report on error

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3223,7 +3223,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_STATE_LOCK_ERROR_THRESHOLD =
       intBuilder(Name.MASTER_STATE_LOCK_ERROR_THRESHOLD)
-          .setDefaultValue("20")
+          .setDefaultValue(20)
           .setDescription("Used to trace and debug state lock issues. When a thread recursively "
               + "acquires the state lock more than threshold, log an error for further debugging.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3221,6 +3221,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "if this property is true. This property is available since 1.7.1")
           .setScope(Scope.MASTER)
           .build();
+  public static final PropertyKey MASTER_STATE_LOCK_ERROR_THRESHOLD =
+      intBuilder(Name.MASTER_STATE_LOCK_ERROR_THRESHOLD)
+          .setDefaultValue("20")
+          .setDescription("Used to trace and debug state lock issues. When a thread recursively "
+              + "acquires the state lock more than threshold, log an error for further debugging.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_TIERED_STORE_GLOBAL_LEVEL0_ALIAS =
       stringBuilder(Name.MASTER_TIERED_STORE_GLOBAL_LEVEL0_ALIAS)
           .setDefaultValue(Constants.MEDIUM_MEM)
@@ -7891,6 +7899,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.skip.root.acl.check";
     public static final String MASTER_STARTUP_BLOCK_INTEGRITY_CHECK_ENABLED =
         "alluxio.master.startup.block.integrity.check.enabled";
+    public static final String MASTER_STATE_LOCK_ERROR_THRESHOLD =
+        "alluxio.master.state.lock.error.threshold";
     public static final String MASTER_TIERED_STORE_GLOBAL_LEVEL0_ALIAS =
         "alluxio.master.tieredstore.global.level0.alias";
     public static final String MASTER_TIERED_STORE_GLOBAL_LEVEL1_ALIAS =

--- a/core/server/common/src/main/java/alluxio/master/StateLockManager.java
+++ b/core/server/common/src/main/java/alluxio/master/StateLockManager.java
@@ -28,6 +28,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -186,7 +188,7 @@ public class StateLockManager {
     // Return the resource.
     // Register an action to remove the thread from holders registry before releasing the lock.
     return new LockResource(mStateLock.readLock(), false, false, () -> {
-      // this is invoked in the same thread at the end of try-with-resource so should be okay
+      // This is invoked in the same thread at the end of try-with-resource
       Thread removedFrom = Thread.currentThread();
       mSharedLockHolders.computeIfPresent(removedFrom.getName(), (k, v) -> {
         mSharedWaitersAndHolders.remove(Thread.currentThread());
@@ -294,8 +296,8 @@ public class StateLockManager {
   /**
    * @return the list of thread identifiers that are waiting and holding on the shared lock
    */
-  public List<String> getSharedWaitersAndHolders() {
-    return new ArrayList<>(mSharedLockHolders.keySet());
+  public Collection<String> getSharedWaitersAndHolders() {
+    return Collections.unmodifiableSet(mSharedLockHolders.keySet());
   }
 
   /**

--- a/core/server/common/src/main/java/alluxio/master/StateLockManager.java
+++ b/core/server/common/src/main/java/alluxio/master/StateLockManager.java
@@ -30,13 +30,16 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -59,9 +62,10 @@ public class StateLockManager {
 
   /** The state-lock. */
   private ReentrantReadWriteLock mStateLock = new ReentrantReadWriteLock(true);
-
   /** The set of threads that are waiting for or holding the state-lock in shared mode. */
   private Set<Thread> mSharedWaitersAndHolders;
+  /** Stores the name of each thread whos taking locks. */
+  private Map<String, LongAdder> mSharedLockHolders = new ConcurrentHashMap<>();
   /** Scheduler that is used for interrupt-cycle. */
   private ScheduledExecutorService mScheduler;
 
@@ -77,6 +81,11 @@ public class StateLockManager {
   private ScheduledFuture<?> mInterrupterFuture;
   /** Whether interrupt-cycle is entered. */
   private AtomicBoolean mInterruptCycleTicking = new AtomicBoolean(false);
+  /**
+   * Logs when a thread acquires the shared state lock too many times,
+   * which indicates a deep recursion.
+   */
+  private int mLogThreshold = Configuration.getInt(PropertyKey.MASTER_STATE_LOCK_ERROR_THRESHOLD);
 
   /** This is the deadline for forcing the lock. */
   private long mForcedDurationMs;
@@ -143,7 +152,7 @@ public class StateLockManager {
       final int readLockCount = mStateLock.getReadLockCount();
       if (readLockCount > READ_LOCK_COUNT_HIGH) {
         SAMPLING_LOG.info("Read Lock Count Too High: {} {}", readLockCount,
-            mSharedWaitersAndHolders);
+            mSharedLockHolders);
       }
     }
 
@@ -158,12 +167,36 @@ public class StateLockManager {
     }
     // Register thread for interrupt cycle.
     mSharedWaitersAndHolders.add(Thread.currentThread());
-    // Grab the lock interruptibly.
-    mStateLock.readLock().lockInterruptibly();
+    String threadName = Thread.currentThread().getName();
+    mSharedLockHolders.computeIfAbsent(threadName, k -> new LongAdder()).increment();
+    if (mSharedLockHolders.get(threadName).longValue() > mLogThreshold) {
+      Exception e = new Exception("Thread recursion is deeper than " + mLogThreshold);
+      LOG.warn("Current thread is {}. All state lock holders are {}",
+          threadName, mSharedLockHolders, e);
+    }
+    try {
+      // Grab the lock interruptibly.
+      mStateLock.readLock().lockInterruptibly();
+    } catch (Error e) {
+      // An Error is thrown when the lock is acquired 65536 times, log the jstack before exiting
+      LOG.error("Logging all thread stacks before exiting", e);
+      ThreadUtils.logAllThreads();
+      throw e;
+    }
     // Return the resource.
     // Register an action to remove the thread from holders registry before releasing the lock.
     return new LockResource(mStateLock.readLock(), false, false, () -> {
-      mSharedWaitersAndHolders.remove(Thread.currentThread());
+      // this is invoked in the same thread at the end of try-with-resource so should be okay
+      Thread removedFrom = Thread.currentThread();
+      mSharedLockHolders.computeIfPresent(removedFrom.getName(), (k, v) -> {
+        mSharedWaitersAndHolders.remove(Thread.currentThread());
+        if (v.longValue() <= 1L) {
+          return null;
+        } else {
+          v.decrement();
+          return v;
+        }
+      });
     });
   }
 
@@ -233,9 +266,8 @@ public class StateLockManager {
       activateInterruptCycle();
       // Force the lock.
       LOG.info("Thread-{} forcing the lock with {} waiters/holders: {}",
-          ThreadUtils.getCurrentThreadIdentifier(), mSharedWaitersAndHolders.size(),
-          mSharedWaitersAndHolders.stream().map((th) -> Long.toString(th.getId()))
-              .collect(Collectors.joining(",")));
+          ThreadUtils.getCurrentThreadIdentifier(), mSharedLockHolders.size(),
+          mSharedLockHolders);
       try {
         if (beforeAttempt != null) {
           beforeAttempt.run();
@@ -263,12 +295,7 @@ public class StateLockManager {
    * @return the list of thread identifiers that are waiting and holding on the shared lock
    */
   public List<String> getSharedWaitersAndHolders() {
-    List<String> result = new ArrayList<>();
-
-    for (Thread waiterOrHolder : mSharedWaitersAndHolders) {
-      result.add(ThreadUtils.getThreadIdentifier(waiterOrHolder));
-    }
-    return result;
+    return new ArrayList<>(mSharedLockHolders.keySet());
   }
 
   /**

--- a/core/server/common/src/test/java/alluxio/master/StateLockManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/StateLockManagerTest.java
@@ -18,7 +18,6 @@ import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.resource.LockResource;
 import alluxio.util.CommonUtils;
-import alluxio.util.ThreadUtils;
 
 import com.google.common.util.concurrent.SettableFuture;
 import org.junit.Assert;
@@ -27,7 +26,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
@@ -151,7 +149,8 @@ public class StateLockManagerTest {
       StateLockingThread sharedHolderThread = new StateLockingThread(stateLockManager, false);
       sharedHolderThread.start();
       sharedHolderThread.waitUntilStateLockAcquired();
-      final Collection<String> sharedWaitersAndHolders = stateLockManager.getSharedWaitersAndHolders();
+      final Collection<String> sharedWaitersAndHolders =
+          stateLockManager.getSharedWaitersAndHolders();
       assertEquals(i, sharedWaitersAndHolders.size());
       assertTrue(sharedWaitersAndHolders.contains(
           sharedHolderThread.getName()));

--- a/core/server/common/src/test/java/alluxio/master/StateLockManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/StateLockManagerTest.java
@@ -26,6 +26,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -140,6 +141,7 @@ public class StateLockManagerTest {
   }
 
   @Test
+  // TODO(jiacheng): run this test before committing
   public void testGetStateLockSharedWaitersAndHolders() throws Throwable {
     final StateLockManager stateLockManager = new StateLockManager();
 
@@ -149,10 +151,10 @@ public class StateLockManagerTest {
       StateLockingThread sharedHolderThread = new StateLockingThread(stateLockManager, false);
       sharedHolderThread.start();
       sharedHolderThread.waitUntilStateLockAcquired();
-      final List<String> sharedWaitersAndHolders = stateLockManager.getSharedWaitersAndHolders();
+      final Collection<String> sharedWaitersAndHolders = stateLockManager.getSharedWaitersAndHolders();
       assertEquals(i, sharedWaitersAndHolders.size());
       assertTrue(sharedWaitersAndHolders.contains(
-          ThreadUtils.getThreadIdentifier(sharedHolderThread)));
+          sharedHolderThread.getName()));
     }
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -5317,7 +5317,7 @@ public class DefaultFileSystemMaster extends CoreMaster
   }
 
   @Override
-  public List<String> getStateLockSharedWaitersAndHolders() {
+  public Collection<String> getStateLockSharedWaitersAndHolders() {
     return mMasterContext.getStateLockManager().getSharedWaitersAndHolders();
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMaster.java
@@ -627,7 +627,7 @@ public interface FileSystemMaster extends Master {
   /**
    * @return the list of thread identifiers that are waiting and holding the state lock
    */
-  List<String> getStateLockSharedWaitersAndHolders();
+  Collection<String> getStateLockSharedWaitersAndHolders();
 
   /**
    * Mark a path as needed synchronization with the UFS, when this path or any

--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemMasterClientServiceHandler.java
@@ -104,6 +104,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -471,9 +472,9 @@ public final class FileSystemMasterClientServiceHandler
 
   @Override
   public void getStateLockHolders(GetStateLockHoldersPRequest request,
-                                  StreamObserver<GetStateLockHoldersPResponse> responseObserver) {
+      StreamObserver<GetStateLockHoldersPResponse> responseObserver) {
     RpcUtils.call(LOG, () -> {
-      final List<String> holders = mFileSystemMaster.getStateLockSharedWaitersAndHolders();
+      final Collection<String> holders = mFileSystemMaster.getStateLockSharedWaitersAndHolders();
       return GetStateLockHoldersPResponse.newBuilder().addAllThreads(holders).build();
     }, "getStateLockHolders", "request=%s", responseObserver, request);
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. Change tracking threads to keeping thread read lock holder count
2. Log jstack on state lock error so we can further check who are holding the state lock

### Why are the changes needed?

Make debugging state lock issues slightly easier.

### Does this PR introduce any user facing changes?

A chunky jstack output will appear in the master.log, which may look intimidating at first glance. This is good because I want people to notice and send the output to us.
