### PR TITLE
Remove a useless lock on MountTable

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
+++ b/core/server/master/src/main/java/alluxio/master/file/meta/MountTable.java
@@ -772,9 +772,11 @@ public final class MountTable implements DelegatingJournaled {
 
     @Override
     public CloseableIterator<JournalEntry> getJournalEntryIterator() {
-      try (LockResource r = new LockResource(mReadLock)) {
-        return getJournalEntryIteratorInternal();
-      }
+      // This is not locked because we can not lock when this iterator is used
+      // The correctness is guaranteed by the fact that when backup/checkpoint iterates
+      // journal entries, the state is locked on the master and MountTable is effectively
+      // exclusively locked
+      return getJournalEntryIteratorInternal();
     }
 
     private CloseableIterator<JournalEntry> getJournalEntryIteratorInternal() {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove a lock on MountTable which does not take effect.

### Why are the changes needed?

The thread safety of journal entry conversion is effectively achieved by the state lock and master pausing journal application during backup/checkpoint. So there's effectively no need for a defensive copy.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
