### PR TITLE
Implement the metadata invalidation based on user configured interval

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -74,7 +74,10 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
       return mDelegatedFileSystem.getStatus(ufsFullPath, options);
     }
     try {
-      return mDoraClient.getStatus(ufsFullPath.toString(), options);
+      GetStatusPOptions mergedOptions = FileSystemOptionsUtils.getStatusDefaults(
+          mFsContext.getPathConf(path)).toBuilder().mergeFrom(options).build();
+
+      return mDoraClient.getStatus(ufsFullPath.toString(), mergedOptions);
     } catch (RuntimeException ex) {
       LOG.debug("Dora client get status error. Fall back to UFS.", ex);
       return mDelegatedFileSystem.getStatus(ufsFullPath, options);

--- a/core/common/src/main/java/alluxio/worker/dora/DoraWorker.java
+++ b/core/common/src/main/java/alluxio/worker/dora/DoraWorker.java
@@ -11,6 +11,7 @@
 
 package alluxio.worker.dora;
 
+import alluxio.grpc.GetStatusPOptions;
 import alluxio.proto.dataserver.Protocol;
 import alluxio.wire.FileInfo;
 import alluxio.worker.DataWorker;
@@ -27,9 +28,10 @@ public interface DoraWorker extends DataWorker, SessionCleanable {
    * Gets the file information.
    *
    * @param fileId the file id
+   * @param options the options for the GetStatusPRequest
    * @return the file info
    */
-  FileInfo getFileInfo(String fileId) throws IOException;
+  FileInfo getFileInfo(String fileId, GetStatusPOptions options) throws IOException;
 
   /**
    * Creates the file reader to read from Alluxio dora.

--- a/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -230,7 +230,8 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
   public FileInfo getFileInfo(String ufsFullPath, GetStatusPOptions options) throws IOException {
     alluxio.grpc.FileInfo fi;
     long syncIntervalMs = options.hasCommonOptions()
-        ? options.getCommonOptions().getSyncIntervalMs() :
+        ? (options.getCommonOptions().hasSyncIntervalMs()
+          ? options.getCommonOptions().getSyncIntervalMs() : -1) :
         -1;
 
     DoraMeta.FileStatus status = mUfsStatusCache.getIfPresent(ufsFullPath);

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -89,7 +89,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
   public void getStatus(GetStatusPRequest request,
       StreamObserver<GetStatusPResponse> responseObserver) {
     try {
-      alluxio.wire.FileInfo fileInfo = mWorker.getFileInfo(request.getPath());
+      alluxio.wire.FileInfo fileInfo = mWorker.getFileInfo(request.getPath(), request.getOptions());
       GetStatusPResponse response =
           GetStatusPResponse.newBuilder()
               .setFileInfo(GrpcUtils.toProto(fileInfo))


### PR DESCRIPTION
### What changes are proposed in this pull request?

Pass GetStatusPOption from client to dora Worker.
Invalidate in-memory and persistent metadata based on the GetStatusPOption.CommonOptions.SyncIntervalMs

### Why are the changes needed?

If the "alluxio.user.file.metadata.sync.interval" is set to a valid number, Alluxio should do metadata invalidation
based this configuration.

### Does this PR introduce any user facing changes?
N/A

