### PR TITLE
Fix metadata sync journalling when using UFS journal

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -117,6 +117,7 @@ import alluxio.master.journal.Journaled;
 import alluxio.master.journal.JournaledGroup;
 import alluxio.master.journal.NoopJournalContext;
 import alluxio.master.journal.checkpoint.CheckpointName;
+import alluxio.master.journal.ufs.UfsJournalSystem;
 import alluxio.master.metastore.DelegatingReadOnlyInodeStore;
 import alluxio.master.metastore.InodeStore;
 import alluxio.master.metastore.ReadOnlyInodeStore;
@@ -1827,7 +1828,10 @@ public class DefaultFileSystemMaster extends CoreMaster
     long currLength = fileLength;
     for (long blockId : blockIds) {
       long currentBlockSize = Math.min(currLength, blockSize);
-      if (context != null) {
+      // if we are not using the UFS journal system, we can use the same journal context
+      // for the block info so that we do not have to create a new journal
+      // context and flush again
+      if (context != null && !(mJournalSystem instanceof UfsJournalSystem)) {
         mBlockMaster.commitBlockInUFS(blockId, currentBlockSize, context);
       } else {
         mBlockMaster.commitBlockInUFS(blockId, currentBlockSize);

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -39,6 +39,7 @@ public class PortCoordination {
   ));
   // for EmbeddedJournalIntegrationTestFaultTolerance
   public static final List<ReservedPort> EMBEDDED_JOURNAL_FAILOVER = allocate(3, 0);
+  public static final List<ReservedPort> EMBEDDED_JOURNAL_FAILOVER_METADATA_SYNC = allocate(3, 1);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_SNAPSHOT_MASTER = allocate(3, 0);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_SNAPSHOT_FOLLOWER = allocate(3, 0);
   public static final List<ReservedPort> EMBEDDED_JOURNAL_SNAPSHOT_TRANSFER_LOAD = allocate(3, 0);

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-    o.sync();
+    //o.sync();
     //#else
     o.hflush();
     //#endif

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-    //o.sync();
+    o.sync();
     //#else
     o.hflush();
     //#endif

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
@@ -21,6 +21,7 @@ import alluxio.client.file.FileSystem;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.FileAlreadyExistsException;
 import alluxio.exception.FileDoesNotExistException;
+import alluxio.grpc.MountPOptions;
 import alluxio.master.journal.JournalType;
 import alluxio.master.journal.raft.RaftJournalSystem;
 import alluxio.master.journal.raft.RaftJournalUtils;
@@ -28,17 +29,23 @@ import alluxio.multi.process.MultiProcessCluster;
 import alluxio.multi.process.PortCoordination;
 import alluxio.util.CommonUtils;
 import alluxio.util.WaitForOptions;
+import alluxio.util.io.PathUtils;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.server.storage.StorageImplUtils;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -55,6 +62,9 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
   private static final int RESTART_TIMEOUT_MS = 6 * Constants.MINUTE_MS;
   private static final int NUM_MASTERS = 3;
   private static final int NUM_WORKERS = 0;
+
+  @Rule
+  public TemporaryFolder mFolder = new TemporaryFolder();
 
   @Test
   public void failover() throws Exception {
@@ -75,6 +85,52 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
     mCluster.waitForAndKillPrimaryMaster(MASTER_INDEX_WAIT_TIME);
     assertTrue(fs.exists(testDir));
     mCluster.notifySuccess();
+  }
+
+  @Test
+  public void syncMetadataFailOver() throws Exception {
+    mCluster = MultiProcessCluster.newBuilder(
+        PortCoordination.EMBEDDED_JOURNAL_FAILOVER_METADATA_SYNC)
+        .setClusterName("EmbeddedJournalFaultTolerance_syncMetadataFailOver")
+        .setNumMasters(NUM_MASTERS)
+        .setNumWorkers(1)
+        .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.EMBEDDED)
+        .addProperty(PropertyKey.MASTER_JOURNAL_FLUSH_TIMEOUT_MS, "5min")
+        .addProperty(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 1000)
+        .addProperty(PropertyKey.MASTER_JOURNAL_LOG_SIZE_BYTES_MAX, "50KB")
+        .addProperty(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, "3s")
+        .addProperty(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, "6s")
+        .addProperty(PropertyKey.MASTER_STANDBY_HEARTBEAT_INTERVAL, "5s")
+        .build();
+    mCluster.start();
+    mCluster.waitForAllNodesRegistered(30_000);
+    String ufsPath = mFolder.newFolder().getAbsoluteFile().toString();
+    String ufsUri = "file://" + ufsPath;
+    MountPOptions options = MountPOptions.newBuilder().build();
+    FileSystem client = mCluster.getFileSystemClient();
+    AlluxioURI mountPath = new AlluxioURI("/mnt1");
+    client.mount(mountPath, new AlluxioURI(ufsUri), options);
+
+    // create a file outside alluxio
+    String fileName = "someFile";
+    String contents = "contents";
+    try (FileWriter fw = new FileWriter(Paths.get(
+        PathUtils.concatPath(ufsPath, fileName)).toString())) {
+      fw.write(contents);
+    }
+    // sync it with metadata sync
+    assertEquals(contents, IOUtils.toString(client.openFile(
+        mountPath.join(fileName)), Charset.defaultCharset()));
+
+    // restart the cluster
+    mCluster.stopMasters();
+    mCluster.startMasters();
+    mCluster.waitForAllNodesRegistered(30_000);
+
+    // read the file again
+    client = mCluster.getFileSystemClient();
+    assertEquals(contents, IOUtils.toString(client.openFile(
+        mountPath.join(fileName)), Charset.defaultCharset()));
   }
 
   @Test


### PR DESCRIPTION
This fixes an issue caused by https://github.com/Alluxio/alluxio/pull/16529

That PR reduced the number of journal flushes during metadata sync using embedded journal, but was not compatible with ufs journal as in ufs journal each master has a different journal file.

This PR disables that change when using ufs journal.