### PR TITLE
Fix UT of alluxio.master.transport.GrpcMessagingTransportTest

### DIFF
--- a/core/server/common/src/test/java/alluxio/master/transport/GrpcMessagingTransportTest.java
+++ b/core/server/common/src/test/java/alluxio/master/transport/GrpcMessagingTransportTest.java
@@ -18,6 +18,7 @@ import io.atomix.catalyst.buffer.BufferInput;
 import io.atomix.catalyst.buffer.BufferOutput;
 import io.atomix.catalyst.serializer.CatalystSerializable;
 import io.atomix.catalyst.serializer.Serializer;
+import io.grpc.StatusRuntimeException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -150,7 +151,8 @@ public class GrpcMessagingTransportTest {
     try {
       sendRequest(clientConnection, new DummyRequest("dummy")).get();
     } catch (ExecutionException e) {
-      Assert.assertTrue(e.getCause() instanceof IllegalStateException);
+      Assert.assertTrue(e.getCause() instanceof IllegalStateException
+          || e.getCause() instanceof StatusRuntimeException);
       failed = true;
     }
     Assert.assertTrue(failed);


### PR DESCRIPTION
The alluxio.master.transport.GrpcMessagingTransportTest.testServerClosed fails randomly.

This test may fail at different reasons and the following expcetions may be thrown out: IllegalStateException or io.grpc.StatusRuntimeException.

### What changes are proposed in this pull request?

Change the expected Exceptions in assertion.

### Why are the changes needed?

This test fails like:
```
Error: 8.418 [ERROR] Tests run: 5, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 1.214 s <<< FAILURE! - in alluxio.master.transport.GrpcMessagingTransportTest
[11033](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11034)
Error: 8.425 [ERROR] alluxio.master.transport.GrpcMessagingTransportTest.testServerClosed  Time elapsed: 1.004 s  <<< FAILURE!
[11034](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11035)
java.lang.AssertionError
[11035](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11036)
	at org.junit.Assert.fail(Assert.java:87)
[11036](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11037)
	at org.junit.Assert.assertTrue(Assert.java:42)
[11037](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11038)
	at org.junit.Assert.assertTrue(Assert.java:53)
[11038](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11039)
	at alluxio.master.transport.GrpcMessagingTransportTest.testServerClosed(GrpcMessagingTransportTest.java:153)
[11039](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11040)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[11040](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11041)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[11041](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11042)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[11042](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11043)
	at java.lang.reflect.Method.invoke(Method.java:498)
[11043](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11044)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
[11044](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11045)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
[11045](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11046)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
[11046](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11047)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
[11047](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11048)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
[11048](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11049)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
[11049](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11050)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
[11050](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11051)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
[11051](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11052)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
[11052](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11053)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
[11053](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11054)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
[11054](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11055)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
[11055](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11056)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
[11056](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11057)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
[11057](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11058)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
[11058](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11059)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
[11059](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11060)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
[11060](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11061)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
[11061](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11062)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:364)
[11062](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11063)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:272)
[11063](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11064)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:237)
[11064](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11065)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:158)
[11065](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11066)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:428)
[11066](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11067)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
[11067](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11068)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:562)
[11068](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11069)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:548)
[11069](https://github.com/Alluxio/alluxio/actions/runs/4360970594/jobs/7624399342#step:6:11070)
```

It fails because the Exceptions returned are different from what's expected.



### Does this PR introduce any user facing changes?

N/A