### PR TITLE
Fix fuse metadata command ClassCastException

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/DelegatingFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DelegatingFileSystem.java
@@ -266,7 +266,7 @@ public class DelegatingFileSystem implements FileSystem {
   }
 
   /**
-   * @return The underlying file system
+   * @return the underlying fileSystem
    */
   public FileSystem getUnderlyingFileSystem() {
     return mDelegatedFileSystem;

--- a/core/client/fs/src/main/java/alluxio/client/file/DelegatingFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DelegatingFileSystem.java
@@ -264,4 +264,11 @@ public class DelegatingFileSystem implements FileSystem {
   public void close() throws IOException {
     mDelegatedFileSystem.close();
   }
+
+  /**
+   * @return The underlying file system
+   */
+  public FileSystem getUnderlyingFileSystem() {
+    return mDelegatedFileSystem;
+  }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. Add a method `getUnderlyingFileSystem()` in DelegatingFileSystem to get underlying FileSystem;
2. Add judgment logic to the fileSystem in AbstractMetadataCacheSubCommand.

### Why are the changes needed?

https://github.com/Alluxio/alluxio/issues/17029

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs? false
  3. addition or removal of property keys? false
  4. webui? false
