### PR TITLE
Fix block writer serialized runner rejected execution

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/GrpcExecutors.java
@@ -55,14 +55,14 @@ public final class GrpcExecutors {
   public static final ExecutorService BLOCK_READER_EXECUTOR =
       new ImpersonateThreadPoolExecutor(BLOCK_READER_THREAD_POOL_EXECUTOR);
 
-  private static final ThreadPoolExecutor BLOCK_SERIALIZED_THREAD_POOL_EXECUTOR =
+  private static final ThreadPoolExecutor BLOCK_READER_SERIALIZED_THREAD_POOL_EXECUTOR =
       new ThreadPoolExecutor(THREADS_MIN,
           Configuration.getInt(PropertyKey.WORKER_NETWORK_BLOCK_READER_THREADS_MAX),
           THREAD_STOP_MS, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(32),
           ThreadFactoryUtils.build("BlockDataReaderSerializedExecutor-%d", true),
           new ThreadPoolExecutor.CallerRunsPolicy());
   public static final ExecutorService BLOCK_READER_SERIALIZED_RUNNER_EXECUTOR =
-      new ImpersonateThreadPoolExecutor(BLOCK_SERIALIZED_THREAD_POOL_EXECUTOR);
+      new ImpersonateThreadPoolExecutor(BLOCK_READER_SERIALIZED_THREAD_POOL_EXECUTOR);
 
   private static final ThreadPoolExecutor BLOCK_WRITE_THREAD_POOL_EXECUTOR =
       new ThreadPoolExecutor(THREADS_MIN, Configuration.getInt(
@@ -71,6 +71,15 @@ public final class GrpcExecutors {
           ThreadFactoryUtils.build("BlockDataWriterExecutor-%d", true));
   public static final ExecutorService BLOCK_WRITER_EXECUTOR =
           new ImpersonateThreadPoolExecutor(BLOCK_WRITE_THREAD_POOL_EXECUTOR);
+
+  private static final ThreadPoolExecutor BLOCK_WRITER_SERIALIZED_THREAD_POOL_EXECUTOR =
+      new ThreadPoolExecutor(THREADS_MIN,
+          Configuration.getInt(PropertyKey.WORKER_NETWORK_BLOCK_WRITER_THREADS_MAX),
+          THREAD_STOP_MS, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(32),
+          ThreadFactoryUtils.build("BlockDataWriterSerializedExecutor-%d", true),
+          new ThreadPoolExecutor.CallerRunsPolicy());
+  public static final ExecutorService BLOCK_WRITER_SERIALIZED_RUNNER_EXECUTOR =
+      new ImpersonateThreadPoolExecutor(BLOCK_WRITER_SERIALIZED_THREAD_POOL_EXECUTOR);
 
   static {
     MetricsSystem.registerCachedGaugeIfAbsent(MetricsSystem.getMetricName(
@@ -106,16 +115,16 @@ public final class GrpcExecutors {
 
     MetricsSystem.registerGaugeIfAbsent(MetricsSystem.getMetricName(
         MetricKey.WORKER_BLOCK_SERIALIZED_THREAD_ACTIVE_COUNT.getName()),
-        BLOCK_SERIALIZED_THREAD_POOL_EXECUTOR::getActiveCount);
+        BLOCK_READER_SERIALIZED_THREAD_POOL_EXECUTOR::getActiveCount);
     MetricsSystem.registerGaugeIfAbsent(MetricsSystem.getMetricName(
         MetricKey.WORKER_BLOCK_SERIALIZED_THREAD_CURRENT_COUNT.getName()),
-        BLOCK_SERIALIZED_THREAD_POOL_EXECUTOR::getPoolSize);
+        BLOCK_READER_SERIALIZED_THREAD_POOL_EXECUTOR::getPoolSize);
     MetricsSystem.registerGaugeIfAbsent(MetricsSystem.getMetricName(
         MetricKey.WORKER_BLOCK_SERIALIZED_THREAD_MAX_COUNT.getName()),
-        BLOCK_SERIALIZED_THREAD_POOL_EXECUTOR::getMaximumPoolSize);
+        BLOCK_READER_SERIALIZED_THREAD_POOL_EXECUTOR::getMaximumPoolSize);
     MetricsSystem.registerGaugeIfAbsent(MetricsSystem.getMetricName(
         MetricKey.WORKER_BLOCK_SERIALIZED_COMPLETED_TASK_COUNT.getName()),
-        BLOCK_SERIALIZED_THREAD_POOL_EXECUTOR::getCompletedTaskCount);
+        BLOCK_READER_SERIALIZED_THREAD_POOL_EXECUTOR::getCompletedTaskCount);
 
     MetricsSystem.registerGaugeIfAbsent(MetricsSystem.getMetricName(
         MetricKey.WORKER_BLOCK_WRITER_THREAD_ACTIVE_COUNT.getName()),


### PR DESCRIPTION
### What changes are proposed in this pull request?

Mirroring #11310 for write handlers.

This PR uses a dedicated thread pool for block writer's serialized executor, mirroring what we do with block readers.
The important change is using `CallerRunsPolicy` instead of the default `AbortPolicy`, which will prevent `RejectedExecutionException` in case of an excessive surge of RPCs.

### Why are the changes needed?

Fix #16528.

### Does this PR introduce any user facing changes?

No.
