### PR TITLE
Implement ListStatus RPC from client to Worker in Dora

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
@@ -42,6 +42,7 @@ import io.grpc.stub.StreamObserver;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Iterator;
 
 /**
  * gRPC client for worker communication.
@@ -180,5 +181,5 @@ public interface BlockWorkerClient extends Closeable {
    * @param request
    * @return List of Status
    */
-  java.util.Iterator<ListStatusPResponse> listStatus(ListStatusPRequest request);
+  Iterator<ListStatusPResponse> listStatus(ListStatusPRequest request);
 }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockWorkerClient.java
@@ -20,6 +20,8 @@ import alluxio.grpc.CreateLocalBlockResponse;
 import alluxio.grpc.GetStatusPRequest;
 import alluxio.grpc.GetStatusPResponse;
 import alluxio.grpc.GrpcServerAddress;
+import alluxio.grpc.ListStatusPRequest;
+import alluxio.grpc.ListStatusPResponse;
 import alluxio.grpc.LoadRequest;
 import alluxio.grpc.LoadResponse;
 import alluxio.grpc.MoveBlockRequest;
@@ -172,4 +174,11 @@ public interface BlockWorkerClient extends Closeable {
    * @return status
    */
   GetStatusPResponse getStatus(GetStatusPRequest request);
+
+  /**
+   * List status from Worker.
+   * @param request
+   * @return List of Status
+   */
+  java.util.Iterator<ListStatusPResponse> listStatus(ListStatusPRequest request);
 }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
@@ -60,6 +60,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -260,7 +261,7 @@ public class DefaultBlockWorkerClient implements BlockWorkerClient {
   }
 
   @Override
-  public java.util.Iterator<ListStatusPResponse> listStatus(ListStatusPRequest request) {
+  public Iterator<ListStatusPResponse> listStatus(ListStatusPRequest request) {
     return mRpcBlockingStub.withDeadlineAfter(mRpcTimeoutMs, TimeUnit.MILLISECONDS)
         .listStatus(request);
   }

--- a/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/DefaultBlockWorkerClient.java
@@ -31,6 +31,8 @@ import alluxio.grpc.GrpcChannelBuilder;
 import alluxio.grpc.GrpcNetworkGroup;
 import alluxio.grpc.GrpcSerializationUtils;
 import alluxio.grpc.GrpcServerAddress;
+import alluxio.grpc.ListStatusPRequest;
+import alluxio.grpc.ListStatusPResponse;
 import alluxio.grpc.LoadRequest;
 import alluxio.grpc.LoadResponse;
 import alluxio.grpc.MoveBlockRequest;
@@ -255,5 +257,11 @@ public class DefaultBlockWorkerClient implements BlockWorkerClient {
   public GetStatusPResponse getStatus(GetStatusPRequest request) {
     return mRpcBlockingStub.withDeadlineAfter(mRpcTimeoutMs, TimeUnit.MILLISECONDS)
         .getStatus(request);
+  }
+
+  @Override
+  public java.util.Iterator<ListStatusPResponse> listStatus(ListStatusPRequest request) {
+    return mRpcBlockingStub.withDeadlineAfter(mRpcTimeoutMs, TimeUnit.MILLISECONDS)
+        .listStatus(request);
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -132,7 +132,15 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
       throws FileDoesNotExistException, IOException, AlluxioException {
     AlluxioURI ufsFullPath = convertAlluxioPathToUFSPath(path);
     ufsFullPath = new AlluxioURI(PathUtils.normalizePath(ufsFullPath.toString(), "/"));
-    return mDelegatedFileSystem.listStatus(ufsFullPath, options);
+
+    try {
+      return mDoraClient.listStatus(ufsFullPath.toString(), options);
+    } catch (RuntimeException ex) {
+      UFS_FALLBACK_COUNTER.inc();
+      LOG.debug("Dora client list status error ({} times). Fall back to UFS.",
+          UFS_FALLBACK_COUNTER.getCount(), ex);
+      return mDelegatedFileSystem.listStatus(ufsFullPath, options);
+    }
   }
 
   @Override

--- a/core/common/src/main/java/alluxio/worker/dora/DoraWorker.java
+++ b/core/common/src/main/java/alluxio/worker/dora/DoraWorker.java
@@ -13,6 +13,8 @@ package alluxio.worker.dora;
 
 import alluxio.grpc.GetStatusPOptions;
 import alluxio.proto.dataserver.Protocol;
+import alluxio.underfs.UfsStatus;
+import alluxio.underfs.options.ListOptions;
 import alluxio.wire.FileInfo;
 import alluxio.worker.DataWorker;
 import alluxio.worker.SessionCleanable;
@@ -32,6 +34,15 @@ public interface DoraWorker extends DataWorker, SessionCleanable {
    * @return the file info
    */
   FileInfo getFileInfo(String fileId, GetStatusPOptions options) throws IOException;
+
+  /**
+   * List status from Under File System.
+   * @param path
+   * @param options
+   * @return list of status
+   * @throws IOException
+   */
+  UfsStatus[] listStatus(String path, ListOptions options) throws IOException;
 
   /**
    * Creates the file reader to read from Alluxio dora.

--- a/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -103,7 +103,7 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
   private WorkerNetAddress mAddress;
 
   private RocksDBDoraMetaStore mMetaStore;
-  private UnderFileSystem mUfs;
+  private final UnderFileSystem mUfs;
 
   /**
    * Constructor.

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -115,8 +115,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
     try {
       ListOptions options = ListOptions.defaults().setRecursive(
           request.getOptions().hasRecursive() ? request.getOptions().getRecursive() : false);
-      UfsStatus[] statuses;
-      statuses = mWorker.listStatus(request.getPath(), options);
+      UfsStatus[] statuses = mWorker.listStatus(request.getPath(), options);
 
       ListStatusPResponse.Builder builder = ListStatusPResponse.newBuilder();
 

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -18,11 +18,16 @@ import alluxio.grpc.BlockWorkerGrpc;
 import alluxio.grpc.GetStatusPRequest;
 import alluxio.grpc.GetStatusPResponse;
 import alluxio.grpc.GrpcUtils;
+import alluxio.grpc.ListStatusPRequest;
+import alluxio.grpc.ListStatusPResponse;
 import alluxio.grpc.ReadRequest;
 import alluxio.grpc.ReadResponse;
 import alluxio.grpc.ReadResponseMarshaller;
+import alluxio.underfs.UfsStatus;
+import alluxio.underfs.options.ListOptions;
 import alluxio.worker.WorkerProcess;
 import alluxio.worker.dora.DoraWorker;
+import alluxio.worker.dora.PagedDoraWorker;
 
 import com.google.common.collect.ImmutableMap;
 import io.grpc.MethodDescriptor;
@@ -98,6 +103,37 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
       responseObserver.onCompleted();
     } catch (IOException e) {
       LOG.error(String.format("Failed to get status of %s: ", request.getPath()), e);
+      responseObserver.onError(e);
+    }
+  }
+
+  @Override
+  public void listStatus(ListStatusPRequest request,
+                         StreamObserver<ListStatusPResponse> responseObserver) {
+    LOG.debug("listStatus is called for {}", request.getPath());
+
+    try {
+      ListOptions options = ListOptions.defaults().setRecursive(
+          request.getOptions().hasRecursive() ? request.getOptions().getRecursive() : false);
+      UfsStatus[] statuses;
+      statuses = mWorker.listStatus(request.getPath(), options);
+
+      ListStatusPResponse.Builder builder = ListStatusPResponse.newBuilder();
+
+      for (int i = 0; i < statuses.length; i++) {
+        UfsStatus status = statuses[i];
+        String ufsFullPath = status.getName();
+        alluxio.grpc.FileInfo fi =
+            ((PagedDoraWorker) mWorker).buildFileInfoFromUfsStatus(status, ufsFullPath);
+
+        builder.addFileInfos(fi);
+      }
+      ListStatusPResponse response = builder.build();
+
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (Exception e) {
+      LOG.error(String.format("Failed to list status of %s: ", request.getPath()), e);
       responseObserver.onError(e);
     }
   }

--- a/core/transport/src/main/proto/grpc/block_worker.proto
+++ b/core/transport/src/main/proto/grpc/block_worker.proto
@@ -16,6 +16,13 @@ service BlockWorker {
    * Returns the status of the file or directory.
    */
   rpc GetStatus (grpc.file.GetStatusPRequest) returns (grpc.file.GetStatusPResponse);
+  /**
+   * If the path points to a file, the method returns a singleton with its file information.
+   * If the path points to a directory, the method returns a list with file information for the
+   * directory contents.
+   */
+  rpc ListStatus(grpc.file.ListStatusPRequest) returns (stream grpc.file.ListStatusPResponse);
+
 
   rpc ReadBlock (stream ReadRequest) returns (stream ReadResponse);
   rpc WriteBlock (stream WriteRequest) returns (stream WriteResponse);

--- a/core/transport/src/main/proto/grpc/table/layout/hive/hive.proto
+++ b/core/transport/src/main/proto/grpc/table/layout/hive/hive.proto
@@ -6,7 +6,6 @@ option java_outer_classname = "HiveLayoutProto";
 
 package alluxio.grpc.table.layout;
 
-import "grpc/common.proto";
 import "grpc/table/table_master.proto";
 
 message StorageFormat {

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -1376,6 +1376,12 @@
                 "out_type": "grpc.file.GetStatusPResponse"
               },
               {
+                "name": "ListStatus",
+                "in_type": "grpc.file.ListStatusPRequest",
+                "out_type": "grpc.file.ListStatusPResponse",
+                "out_streamed": true
+              },
+              {
                 "name": "ReadBlock",
                 "in_type": "ReadRequest",
                 "out_type": "ReadResponse",
@@ -6891,9 +6897,6 @@
           }
         ],
         "imports": [
-          {
-            "path": "grpc/common.proto"
-          },
           {
             "path": "grpc/table/table_master.proto"
           }


### PR DESCRIPTION
This first version of ListStatus from client to Dora worker.
More items are needed:
divide big directory contents into batch limited by max batch size.


### What changes are proposed in this pull request?

Dora client sends ListStatus() request to Dora Worker, and Worker sends ListStatus()
to UFS, and then the results are propagated back.

### Why are the changes needed?

This is the first step to do worker side ListStatus() cache.

### Does this PR introduce any user facing changes?

N/A