### PR TITLE
Allow standby master manual checkpoint

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/meta/RetryHandlingMetaMasterClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/meta/RetryHandlingMetaMasterClient.java
@@ -23,6 +23,7 @@ import alluxio.grpc.MasterInfoField;
 import alluxio.grpc.MetaMasterClientServiceGrpc;
 import alluxio.grpc.ServiceType;
 import alluxio.master.MasterClientContext;
+import alluxio.master.selectionpolicy.MasterSelectionPolicy;
 import alluxio.wire.BackupStatus;
 import alluxio.wire.ConfigCheckReport;
 
@@ -49,7 +50,16 @@ public class RetryHandlingMetaMasterClient extends AbstractMasterClient
    * @param conf master client configuration
    */
   public RetryHandlingMetaMasterClient(MasterClientContext conf) {
-    super(conf);
+    this(conf, MasterSelectionPolicy.Factory.primaryMaster());
+  }
+
+  /**
+   * Creates a new meta master client using a custom master selection policy.
+   * @param conf master client configuration
+   * @param policy the policy that determines which Alluxio master to target
+   */
+  public RetryHandlingMetaMasterClient(MasterClientContext conf, MasterSelectionPolicy policy) {
+    super(conf, policy);
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -278,6 +278,17 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
   }
 
   @Override
+  public Map<ServiceType, GrpcService> getStandbyServices() {
+    // for manual snapshot taking on any master
+    Map<ServiceType, GrpcService> services = new HashMap<>();
+    services.put(ServiceType.META_MASTER_CLIENT_SERVICE,
+        new GrpcService(ServerInterceptors.intercept(
+            new MetaMasterClientServiceHandler(this),
+            new ClientContextServerInjector())));
+    return services;
+  }
+
+  @Override
   public String getName() {
     return Constants.META_MASTER_NAME;
   }

--- a/docs/en/operation/Admin-CLI.md
+++ b/docs/en/operation/Admin-CLI.md
@@ -97,8 +97,11 @@ This command is mainly used for debugging and to avoid master journal logs from 
 Checkpointing requires a pause in master metadata changes, so use this command sparingly to avoid 
 interfering with other users of the system.
 
+The `-address` option allows you to take a checkpoint on a specific master. When omitted, it targets the leading master.
+Make sure to have `alluxio.standby.master.grpc.enabled=true` in your configuration for this to work.
+
 ```shell
-$ ./bin/alluxio fsadmin journal checkpoint
+$ ./bin/alluxio fsadmin journal checkpoint [-address <HOSTNAME:PORT>]
 ```
 
 ### doctor

--- a/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
+++ b/minicluster/src/main/java/alluxio/multi/process/PortCoordination.java
@@ -106,6 +106,8 @@ public class PortCoordination {
   public static final List<ReservedPort> QUORUM_SHELL_INFO = allocate(3, 0);
   public static final List<ReservedPort> QUORUM_SHELL_REMOVE = allocate(5, 0);
 
+  public static final List<ReservedPort> CHECKPOINT_SHELL = allocate(3, 1);
+
   public static final List<ReservedPort> WORKER_ALL_MASTER_REGISTRATION = allocate(3, 1);
 
   private static synchronized List<ReservedPort> allocate(int numMasters, int numWorkers) {

--- a/shell/src/main/java/alluxio/cli/fsadmin/journal/CheckpointCommand.java
+++ b/shell/src/main/java/alluxio/cli/fsadmin/journal/CheckpointCommand.java
@@ -87,7 +87,7 @@ public class CheckpointCommand extends AbstractFsAdminCommand {
         + "is mainly used for debugging and to avoid master journal logs "
         + "from growing unbounded. Checkpointing requires a pause in master metadata changes, "
         + "so use this command sparingly to avoid interfering with other users of the system. "
-        + "The '-address' option can direct the snapshot taking to a specific master.";
+        + "The '-address' option can direct the checkpoint taking to a specific master.";
   }
 
   @Override
@@ -98,6 +98,6 @@ public class CheckpointCommand extends AbstractFsAdminCommand {
   @Override
   public Options getOptions() {
     return new Options().addOption(ADDRESS_OPTION_NAME, true,
-        "Server address of the master taking the snapshot");
+        "Server address of the master taking the checkpoint");
   }
 }

--- a/tests/src/test/java/alluxio/client/cli/fsadmin/command/CheckpointCommandIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/cli/fsadmin/command/CheckpointCommandIntegrationTest.java
@@ -53,8 +53,6 @@ public final class CheckpointCommandIntegrationTest extends AbstractFsAdminShell
         Assert.assertTrue(mOutput.toString()
             .contains(String.format("Successfully took a checkpoint on master %s%n", strAddr)));
       }
-    } catch (Exception e) {
-      System.out.println(e);
     } finally {
       cluster.stop();
     }

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-//    o.sync();
+    o.sync();
     //#else
     o.hflush();
     //#endif

--- a/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/hadoop/FileSystemRenameIntegrationTest.java
@@ -236,7 +236,7 @@ public final class FileSystemRenameIntegrationTest extends BaseIntegrationTest {
     // Due to Hadoop 1 support we stick with the deprecated version. If we drop support for it
     // FSDataOutputStream.hflush will be the new one.
     //#ifdef HADOOP1
-    o.sync();
+//    o.sync();
     //#else
     o.hflush();
     //#endif


### PR DESCRIPTION
### What changes are proposed in this pull request?
Add a new `-address` option to the `bin/alluxio fsadmin journal checkpoint` command so that manual checkpoints can be triggered on any master.

### Why are the changes needed?
To gain better insight into the performance and behavior of snapshot taking and sending on standby masters.

### Does this PR introduce any user facing changes?
Yes, there is now a new CLI option that users can use to trigger a checkpoint on any master. 
