### PR TITLE
Fix the aggregate result problem in UfsIOBench

### DIFF
--- a/stress/common/src/main/java/alluxio/stress/worker/IOTaskSummary.java
+++ b/stress/common/src/main/java/alluxio/stress/worker/IOTaskSummary.java
@@ -177,27 +177,28 @@ public class IOTaskSummary implements Summary {
       return result;
     }
 
-    double totalDuration = 0.0;
     long totalSize = 0L;
+    double sumSpeeds = 0L;
     double[] speeds = new double[points.size()];
     double maxSpeed = 0.0;
     double minSpeed = Double.MAX_VALUE;
     int i = 0;
     for (IOTaskResult.Point p : points) {
-      totalDuration += p.mDurationSeconds;
+      result.mTotalDurationSeconds = Math.max(p.mDurationSeconds, result.mTotalDurationSeconds);
       totalSize += p.mDataSizeBytes;
       double speed = p.mDataSizeBytes / (p.mDurationSeconds * 1024 * 1024); // convert B/s to MB/s
+      sumSpeeds += speed;
       maxSpeed = Math.max(maxSpeed, speed);
       minSpeed = Math.min(minSpeed, speed);
       speeds[i++] = speed;
     }
-    double avgSpeed = totalSize / (totalDuration * 1024 * 1024); // convert B/s to MB/s
+    // calculate the average speed
+    double avgSpeed = sumSpeeds / points.size();
     double var = 0;
     for (double s : speeds) {
       var += (s - avgSpeed) * (s - avgSpeed);
     }
 
-    result.mTotalDurationSeconds = totalDuration;
     result.mTotalSizeBytes = totalSize;
     result.mMaxSpeedMbps = maxSpeed;
     result.mMinSpeedMbps = Double.compare(minSpeed, Double.MAX_VALUE) == 0 ? 0.0 : minSpeed;

--- a/stress/common/src/main/java/alluxio/stress/worker/IOTaskSummary.java
+++ b/stress/common/src/main/java/alluxio/stress/worker/IOTaskSummary.java
@@ -150,12 +150,15 @@ public class IOTaskSummary implements Summary {
   public static class SpeedStat implements JsonSerializable {
     public double mTotalDurationSeconds;
     public long mTotalSizeBytes;
+    // Max speed among all nodes
     public double mMaxSpeedMbps;
+    // Min speed among all nodes
     public double mMinSpeedMbps;
-    // Average speed of all points
+    // Average speed of all nodes
     public double mAvgSpeedMbps;
-    // The average speed to write/read UFS on the cluster view
+    // Cluster-wide throughput
     public double mClusterAvgSpeedMbps;
+    // Standard deviation of speed reported by each node
     public double mStdDev;
 
     /**

--- a/stress/common/src/main/java/alluxio/stress/worker/IOTaskSummary.java
+++ b/stress/common/src/main/java/alluxio/stress/worker/IOTaskSummary.java
@@ -153,6 +153,8 @@ public class IOTaskSummary implements Summary {
     public double mMaxSpeedMbps;
     public double mMinSpeedMbps;
     public double mAvgSpeedMbps;
+
+    public double mClusterAvgSpeedMbps;
     public double mStdDev;
 
     /**
@@ -163,9 +165,10 @@ public class IOTaskSummary implements Summary {
     @Override
     public String toString() {
       return String.format("{totalDuration=%ss, totalSize=%s, maxSpeed=%sMB/s, "
-                      + "minSpeed=%sMB/s, " + "avgSpeed=%sMB/s, stdDev=%s}",
+                      + "minSpeed=%sMB/s, " + "avgSpeed=%sMB/s, clusterAvgSpeed=%sMB/s, "
+                      + "stdDev=%s}",
               mTotalDurationSeconds, FormatUtils.getSizeFromBytes(mTotalSizeBytes),
-              mMaxSpeedMbps, mMinSpeedMbps, mAvgSpeedMbps, mStdDev);
+              mMaxSpeedMbps, mMinSpeedMbps, mAvgSpeedMbps, mClusterAvgSpeedMbps, mStdDev);
     }
   }
 
@@ -202,6 +205,7 @@ public class IOTaskSummary implements Summary {
     result.mMaxSpeedMbps = maxSpeed;
     result.mMinSpeedMbps = Double.compare(minSpeed, Double.MAX_VALUE) == 0 ? 0.0 : minSpeed;
     result.mAvgSpeedMbps = avgSpeed;
+    result.mClusterAvgSpeedMbps = avgSpeed * points.size();
     result.mStdDev = Math.sqrt(var);
 
     return result;

--- a/stress/common/src/main/java/alluxio/stress/worker/IOTaskSummary.java
+++ b/stress/common/src/main/java/alluxio/stress/worker/IOTaskSummary.java
@@ -197,7 +197,8 @@ public class IOTaskSummary implements Summary {
     }
     // calculate the average speed for each point
     double avgPointSpeed = Arrays.stream(speeds).sum() / points.size();
-    double avgClusterSpeed = totalSize / (result.mTotalDurationSeconds * 1024 * 1024); // convert B/s to MB/s
+    double avgClusterSpeed = totalSize
+        / (result.mTotalDurationSeconds * 1024 * 1024); // convert B/s to MB/s
     double var = 0;
     for (double s : speeds) {
       var += (s - avgPointSpeed) * (s - avgPointSpeed);

--- a/stress/common/src/main/java/alluxio/stress/worker/IOTaskSummary.java
+++ b/stress/common/src/main/java/alluxio/stress/worker/IOTaskSummary.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -178,7 +179,6 @@ public class IOTaskSummary implements Summary {
     }
 
     long totalSize = 0L;
-    double sumSpeeds = 0L;
     double[] speeds = new double[points.size()];
     double maxSpeed = 0.0;
     double minSpeed = Double.MAX_VALUE;
@@ -187,13 +187,12 @@ public class IOTaskSummary implements Summary {
       result.mTotalDurationSeconds = Math.max(p.mDurationSeconds, result.mTotalDurationSeconds);
       totalSize += p.mDataSizeBytes;
       double speed = p.mDataSizeBytes / (p.mDurationSeconds * 1024 * 1024); // convert B/s to MB/s
-      sumSpeeds += speed;
       maxSpeed = Math.max(maxSpeed, speed);
       minSpeed = Math.min(minSpeed, speed);
       speeds[i++] = speed;
     }
     // calculate the average speed
-    double avgSpeed = sumSpeeds / points.size();
+    double avgSpeed = Arrays.stream(speeds).sum() / points.size();
     double var = 0;
     for (double s : speeds) {
       var += (s - avgSpeed) * (s - avgSpeed);

--- a/stress/common/src/main/java/alluxio/stress/worker/IOTaskSummary.java
+++ b/stress/common/src/main/java/alluxio/stress/worker/IOTaskSummary.java
@@ -152,8 +152,9 @@ public class IOTaskSummary implements Summary {
     public long mTotalSizeBytes;
     public double mMaxSpeedMbps;
     public double mMinSpeedMbps;
+    // Average speed of all points
     public double mAvgSpeedMbps;
-
+    // The average speed to write/read UFS on the cluster view
     public double mClusterAvgSpeedMbps;
     public double mStdDev;
 
@@ -194,18 +195,19 @@ public class IOTaskSummary implements Summary {
       minSpeed = Math.min(minSpeed, speed);
       speeds[i++] = speed;
     }
-    // calculate the average speed
-    double avgSpeed = Arrays.stream(speeds).sum() / points.size();
+    // calculate the average speed for each point
+    double avgPointSpeed = Arrays.stream(speeds).sum() / points.size();
+    double avgClusterSpeed = totalSize / (result.mTotalDurationSeconds * 1024 * 1024); // convert B/s to MB/s
     double var = 0;
     for (double s : speeds) {
-      var += (s - avgSpeed) * (s - avgSpeed);
+      var += (s - avgPointSpeed) * (s - avgPointSpeed);
     }
 
     result.mTotalSizeBytes = totalSize;
     result.mMaxSpeedMbps = maxSpeed;
     result.mMinSpeedMbps = Double.compare(minSpeed, Double.MAX_VALUE) == 0 ? 0.0 : minSpeed;
-    result.mAvgSpeedMbps = avgSpeed;
-    result.mClusterAvgSpeedMbps = avgSpeed * points.size();
+    result.mAvgSpeedMbps = avgPointSpeed;
+    result.mClusterAvgSpeedMbps = avgClusterSpeed;
     result.mStdDev = Math.sqrt(var);
 
     return result;

--- a/stress/common/src/test/java/alluxio/stress/worker/IOTaskSummaryTest.java
+++ b/stress/common/src/test/java/alluxio/stress/worker/IOTaskSummaryTest.java
@@ -73,16 +73,18 @@ public class IOTaskSummaryTest {
     IOTaskResult result = new IOTaskResult();
     double[] durations = new double[]{1.0, 1.5, 2.0, 1.11};
     long[] sizes = new long[]{200_000_000, 300_000_000, 500_000_000, 800_000_000};
+    double[] speeds = new double[sizes.length];
     for (int i = 0; i < sizes.length; i++) {
       result.addPoint(new IOTaskResult.Point(IOTaskResult.IOMode.READ, durations[i], sizes[i]));
       result.addPoint(new IOTaskResult.Point(IOTaskResult.IOMode.WRITE, durations[i], sizes[i]));
+      speeds[i] = sizes[i] / (durations[i] * 1024 * 1024);
     }
 
     IOTaskSummary summary = new IOTaskSummary(result);
     IOTaskSummary.SpeedStat readStat = summary.getReadSpeedStat();
-    double totalDuration = Arrays.stream(durations).sum();
+    double totalDuration = Arrays.stream(durations).max().orElse(0L);
     long totalSize = Arrays.stream(sizes).sum();
-    double avgSpeed = totalSize / (totalDuration * 1024 * 1024);
+    double avgSpeed = Arrays.stream(speeds).sum() / speeds.length;
     double maxSpeed = 800_000_000 / (1.11 * 1024 * 1024);
     double minSpeed = 200_000_000 / (1.0 * 1024 * 1024);
     assertEquals(totalDuration, readStat.mTotalDurationSeconds, 1e-5);

--- a/stress/common/src/test/java/alluxio/stress/worker/IOTaskSummaryTest.java
+++ b/stress/common/src/test/java/alluxio/stress/worker/IOTaskSummaryTest.java
@@ -85,6 +85,7 @@ public class IOTaskSummaryTest {
     double totalDuration = Arrays.stream(durations).max().orElse(0L);
     long totalSize = Arrays.stream(sizes).sum();
     double avgSpeed = Arrays.stream(speeds).sum() / speeds.length;
+    double clusterAvgSpeed = totalSize / (2.0 * 1024 * 1024);
     double maxSpeed = 800_000_000 / (1.11 * 1024 * 1024);
     double minSpeed = 200_000_000 / (1.0 * 1024 * 1024);
     assertEquals(totalDuration, readStat.mTotalDurationSeconds, 1e-5);
@@ -92,6 +93,7 @@ public class IOTaskSummaryTest {
     assertEquals(avgSpeed, readStat.mAvgSpeedMbps, 1e-5);
     assertEquals(maxSpeed, readStat.mMaxSpeedMbps, 1e-5);
     assertEquals(minSpeed, readStat.mMinSpeedMbps, 1e-5);
+    assertEquals(clusterAvgSpeed, readStat.mClusterAvgSpeedMbps, 1e-5);
 
     IOTaskSummary.SpeedStat writeStat = summary.getWriteSpeedStat();
     assertEquals(totalDuration, writeStat.mTotalDurationSeconds, 1e-5);
@@ -99,6 +101,7 @@ public class IOTaskSummaryTest {
     assertEquals(avgSpeed, writeStat.mAvgSpeedMbps, 1e-5);
     assertEquals(maxSpeed, writeStat.mMaxSpeedMbps, 1e-5);
     assertEquals(minSpeed, writeStat.mMinSpeedMbps, 1e-5);
+    assertEquals(clusterAvgSpeed, writeStat.mClusterAvgSpeedMbps, 1e-5);
   }
 
   private void checkEquality(IOTaskSummary.SpeedStat a, IOTaskSummary.SpeedStat b) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix the aggregate result problem in UfsIOBench.

### Why are the changes needed?
The  UfsIOBench result summary calculates the total duration by summing each  points' result, and   compute the average speed based on total duration, actually the average can't  represent the system performance. 
For examples: 
An alluxio cluster with 1 job master and 3 job worker,  Run the UfsIOBench with 16 threads:
```
./bin/alluxio runUfsIOTest --path hdfs://hdfsCluster/tmp/ufsIoBanch --io-size 2G--threads 16 --cluster
```
<img width="701" alt="WeChatWorkScreenshot_14f71ae8-abe3-410f-bc45-5d31e45e1691" src="https://user-images.githubusercontent.com/42070967/224611735-d14d73bc-fcae-44ad-9c8e-ba9f233fb526.png">

the mTotalDurationSeconds is 16 * 3 *(points duration), but actually the 16 points read and write concurrently  and finished almostly at same time.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
No
