### PR TITLE
Add check code for alluxio.user.conf.sync.interval

### DIFF
--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -409,6 +409,7 @@ public class InstancedConfiguration implements AlluxioConfiguration {
     checkZkConfiguration();
     checkTieredLocality();
     checkTieredStorage();
+    checkUserSyncInterval();
   }
 
   @Override
@@ -517,6 +518,18 @@ public class InstancedConfiguration implements AlluxioConfiguration {
     Preconditions.checkState(interval < timeout,
         "heartbeat interval (%s=%s) must be less than heartbeat timeout (%s=%s)", intervalKey,
         interval, timeoutKey, timeout);
+  }
+  
+   /**
+   * Checks the user sync interval
+   *
+   * @throws IllegalStateException if invalid value is set
+   */
+  private void checkUserSyncInterval() {
+    long interval = getMs(PropertyKey.USER_CONF_SYNC_INTERVAL);
+    Preconditions.checkArgument(interval > 0 ,
+        String.format("The alluxio.user.conf.sync.interval can't set to %s;"
+             + "it must be longer than 0", interval));
   }
 
   /**

--- a/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
@@ -565,6 +565,7 @@ public class InstancedConfigurationTest {
   public void shortMasterHeartBeatTimeout() {
     mConfiguration.set(PropertyKey.MASTER_STANDBY_HEARTBEAT_INTERVAL, "5min");
     mConfiguration.set(PropertyKey.MASTER_HEARTBEAT_TIMEOUT, "4min");
+    mConfiguration.set(PropertyKey.USER_CONF_SYNC_INTERVAL, "0");
     mThrown.expect(IllegalStateException.class);
     mConfiguration.validate();
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

improve [#17062 ](https://github.com/Alluxio/alluxio/issues/17062)
Add pre-check code for alluxio.user.conf.sync.interval to avoid persistent logging while staring the Alluxio

### Why are the changes needed?
It will costs system resource usage continuously.

### Does this PR introduce any user facing changes?

nothing
