### PR TITLE
Fix file system merge journal context

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -603,6 +603,13 @@ public class DefaultFileSystemMaster extends CoreMaster
     return createJournalContext(true);
   }
 
+  /**
+   * Creates a journal context.
+   * @param useMergeJournalContext if set to true, if possible, a journal context that merges
+   *  journal entries and holds them until the context is closed. If set to false,
+   *  a normal journal context will be returned.
+   * @return the journal context
+   */
   private JournalContext createJournalContext(boolean useMergeJournalContext)
       throws UnavailableException {
     JournalContext context = super.createJournalContext();

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -600,7 +600,7 @@ public class DefaultFileSystemMaster extends CoreMaster
 
   @Override
   public JournalContext createJournalContext() throws UnavailableException {
-    return createJournalContext(true);
+    return createJournalContext(false);
   }
 
   /**
@@ -5374,7 +5374,7 @@ public class DefaultFileSystemMaster extends CoreMaster
   @VisibleForTesting
   public RpcContext createRpcContext(OperationContext operationContext)
       throws UnavailableException {
-    return new RpcContext(createBlockDeletionContext(), createJournalContext(),
+    return new RpcContext(createBlockDeletionContext(), createJournalContext(true),
         operationContext.withTracker(mStateLockCallTracker));
   }
 

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -610,7 +610,8 @@ public class DefaultFileSystemMaster extends CoreMaster
    *  a normal journal context will be returned.
    * @return the journal context
    */
-  private JournalContext createJournalContext(boolean useMergeJournalContext)
+  @VisibleForTesting
+  JournalContext createJournalContext(boolean useMergeJournalContext)
       throws UnavailableException {
     JournalContext context = super.createJournalContext();
     if (!(mMergeInodeJournals && useMergeJournalContext)) {

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -1386,16 +1386,16 @@ public class InodeSyncStream {
 
   protected RpcContext getMetadataSyncRpcContext() {
     JournalContext journalContext = mRpcContext.getJournalContext();
-    if (!mUseFileSystemMergeJournalContext
-        || !(journalContext instanceof FileSystemMergeJournalContext)) {
-      return mRpcContext;
+    if (mUseFileSystemMergeJournalContext
+        && journalContext instanceof FileSystemMergeJournalContext) {
+      return new RpcContext(
+          mRpcContext.getBlockDeletionContext(),
+          new MetadataSyncMergeJournalContext(
+              ((FileSystemMergeJournalContext) journalContext).getUnderlyingJournalContext(),
+              new FileSystemJournalEntryMerger()),
+          mRpcContext.getOperationContext());
     }
-    return new RpcContext(
-        mRpcContext.getBlockDeletionContext(),
-        new MetadataSyncMergeJournalContext(
-            ((FileSystemMergeJournalContext) journalContext).getUnderlyingJournalContext(),
-            new FileSystemJournalEntryMerger()),
-        mRpcContext.getOperationContext());
+    return mRpcContext;
   }
 
   @Override

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterTest.java
@@ -1779,10 +1779,10 @@ public final class FileSystemMasterTest extends FileSystemMasterTestBase {
 
   @Test
   public void RecursiveDeleteForceFlushJournals() throws Exception {
-    FileSystemMaster fileSystemMasterWithSpy = spy(mFileSystemMaster);
+    DefaultFileSystemMaster fileSystemMasterWithSpy = spy(mFileSystemMaster);
     AtomicInteger flushCount = new AtomicInteger();
     AtomicInteger closeCount = new AtomicInteger();
-    when(fileSystemMasterWithSpy.createJournalContext()).thenReturn(
+    when(fileSystemMasterWithSpy.createJournalContext(true)).thenReturn(
         new JournalContext() {
           private int mNumLogs = 0;
 


### PR DESCRIPTION
### What changes are proposed in this pull request?
1. do not use the FileSystemMergeJournalContext in list status operation as well as other operations that calls the FileSystemMaster public createJournalContext() method, because some of these callers does not expect journals to be held in the context until it gets closed.
2. force flushing journals if too many journals in the FileSystemMergeJournalContext
3. better observerability 

### Why are the changes needed?

A PR that addressed inode operation consistency issue 
https://github.com/Alluxio/alluxio/pull/17071/files caused issues on master side and made fuse unable to connect to it. https://github.com/Alluxio/alluxio/issues/17041

That PR introduced a FileSystemMergeJouralContext that keeps inode operation journals in memory and merges these journal entries on the fly. When the journal context closes, all of the jourals will be appended to the journal writer. This journal context is supposed to use in metadata write operations but it is also used unexpectedly in some other places:
1. ListStatus might also generate joruanl entries (e.g. update access time)
2. The journal context might also be used in other places outside the file system master (e.g.  update access time/backup/checkpoint etc.)
These places might generate excessive # of journal entries and all kept in memory and might cause OOM issue. 
So in the fix, we will just return a normal non-merging journal context instead. 

### Does this PR introduce any user facing changes?

N/A