### PR TITLE
Add more details in Log4j default settings

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -31,7 +31,7 @@ log4j.appender.=org.apache.log4j.varia.NullAppender
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.Target=System.out
 log4j.appender.Console.layout=org.apache.log4j.PatternLayout
-log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
 
 # The ParquetWriter logs for every row group which is not noisy for large row group size,
 # but very noisy for small row group size.
@@ -44,7 +44,7 @@ log4j.appender.JOB_MASTER_LOGGER.File=${alluxio.logs.dir}/job_master.log
 log4j.appender.JOB_MASTER_LOGGER.MaxFileSize=10MB
 log4j.appender.JOB_MASTER_LOGGER.MaxBackupIndex=100
 log4j.appender.JOB_MASTER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.JOB_MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.JOB_MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
 
 # Appender for Job Workers
 log4j.appender.JOB_WORKER_LOGGER=org.apache.log4j.RollingFileAppender
@@ -52,7 +52,7 @@ log4j.appender.JOB_WORKER_LOGGER.File=${alluxio.logs.dir}/job_worker.log
 log4j.appender.JOB_WORKER_LOGGER.MaxFileSize=10MB
 log4j.appender.JOB_WORKER_LOGGER.MaxBackupIndex=100
 log4j.appender.JOB_WORKER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.JOB_WORKER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.JOB_WORKER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
 
 # Appender for Master
 log4j.appender.MASTER_LOGGER=org.apache.log4j.RollingFileAppender
@@ -60,7 +60,7 @@ log4j.appender.MASTER_LOGGER.File=${alluxio.logs.dir}/master.log
 log4j.appender.MASTER_LOGGER.MaxFileSize=10MB
 log4j.appender.MASTER_LOGGER.MaxBackupIndex=100
 log4j.appender.MASTER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
 
 # Appender for Master
 log4j.appender.SECONDARY_MASTER_LOGGER=org.apache.log4j.RollingFileAppender
@@ -68,7 +68,7 @@ log4j.appender.SECONDARY_MASTER_LOGGER.File=${alluxio.logs.dir}/secondary_master
 log4j.appender.SECONDARY_MASTER_LOGGER.MaxFileSize=10MB
 log4j.appender.SECONDARY_MASTER_LOGGER.MaxBackupIndex=100
 log4j.appender.SECONDARY_MASTER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.SECONDARY_MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.SECONDARY_MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
 
 # Appender for Master audit
 log4j.appender.MASTER_AUDIT_LOGGER=org.apache.log4j.RollingFileAppender
@@ -76,7 +76,7 @@ log4j.appender.MASTER_AUDIT_LOGGER.File=${alluxio.logs.dir}/master_audit.log
 log4j.appender.MASTER_AUDIT_LOGGER.MaxFileSize=10MB
 log4j.appender.MASTER_AUDIT_LOGGER.MaxBackupIndex=100
 log4j.appender.MASTER_AUDIT_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.MASTER_AUDIT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.MASTER_AUDIT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
 
 # Appender for Job Master audit
 log4j.appender.JOB_MASTER_AUDIT_LOGGER=org.apache.log4j.RollingFileAppender
@@ -84,7 +84,7 @@ log4j.appender.JOB_MASTER_AUDIT_LOGGER.File=${alluxio.logs.dir}/job_master_audit
 log4j.appender.JOB_MASTER_AUDIT_LOGGER.MaxFileSize=10MB
 log4j.appender.JOB_MASTER_AUDIT_LOGGER.MaxBackupIndex=100
 log4j.appender.JOB_MASTER_AUDIT_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.JOB_MASTER_AUDIT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.JOB_MASTER_AUDIT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
 
 # Appender for Proxy
 log4j.appender.PROXY_LOGGER=org.apache.log4j.RollingFileAppender
@@ -92,7 +92,7 @@ log4j.appender.PROXY_LOGGER.File=${alluxio.logs.dir}/proxy.log
 log4j.appender.PROXY_LOGGER.MaxFileSize=10MB
 log4j.appender.PROXY_LOGGER.MaxBackupIndex=100
 log4j.appender.PROXY_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.PROXY_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.PROXY_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
 
 # Appender for Proxy audit
 log4j.appender.PROXY_AUDIT_LOGGER=org.apache.log4j.RollingFileAppender
@@ -100,7 +100,7 @@ log4j.appender.PROXY_AUDIT_LOGGER.File=${alluxio.logs.dir}/proxy_audit.log
 log4j.appender.PROXY_AUDIT_LOGGER.MaxFileSize=10MB
 log4j.appender.PROXY_AUDIT_LOGGER.MaxBackupIndex=100
 log4j.appender.PROXY_AUDIT_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.PROXY_AUDIT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+log4j.appender.PROXY_AUDIT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2}[%t](%F:%M:%L) - %m%n
 
 # Appender for Workers
 log4j.appender.WORKER_LOGGER=org.apache.log4j.RollingFileAppender
@@ -108,7 +108,7 @@ log4j.appender.WORKER_LOGGER.File=${alluxio.logs.dir}/worker.log
 log4j.appender.WORKER_LOGGER.MaxFileSize=10MB
 log4j.appender.WORKER_LOGGER.MaxBackupIndex=100
 log4j.appender.WORKER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.WORKER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.WORKER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
 
 # Remote appender for Job Master
 log4j.appender.REMOTE_JOB_MASTER_LOGGER=org.apache.log4j.net.SocketAppender
@@ -170,7 +170,7 @@ log4j.appender.LOGSERVER_LOGGER.File=${alluxio.logs.dir}/logserver.log
 log4j.appender.LOGSERVER_LOGGER.MaxFileSize=10MB
 log4j.appender.LOGSERVER_LOGGER.MaxBackupIndex=100
 log4j.appender.LOGSERVER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.LOGSERVER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.LOGSERVER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
 
 # (Local) appender for log server to log on behalf of log clients
 # No need to configure file path because log server will dynamically
@@ -179,7 +179,7 @@ log4j.appender.LOGSERVER_CLIENT_LOGGER=org.apache.log4j.RollingFileAppender
 log4j.appender.LOGSERVER_CLIENT_LOGGER.MaxFileSize=10MB
 log4j.appender.LOGSERVER_CLIENT_LOGGER.MaxBackupIndex=100
 log4j.appender.LOGSERVER_CLIENT_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.LOGSERVER_CLIENT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.LOGSERVER_CLIENT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
 
 # Appender for User
 log4j.appender.USER_LOGGER=org.apache.log4j.RollingFileAppender
@@ -187,7 +187,7 @@ log4j.appender.USER_LOGGER.File=${alluxio.user.logs.dir}/user_${user.name}.log
 log4j.appender.USER_LOGGER.MaxFileSize=10MB
 log4j.appender.USER_LOGGER.MaxBackupIndex=10
 log4j.appender.USER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.USER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.USER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
 
 # Appender for Fuse
 log4j.appender.FUSE_LOGGER=org.apache.log4j.RollingFileAppender
@@ -195,7 +195,7 @@ log4j.appender.FUSE_LOGGER.File=${alluxio.logs.dir}/fuse.log
 log4j.appender.FUSE_LOGGER.MaxFileSize=100MB
 log4j.appender.FUSE_LOGGER.MaxBackupIndex=10
 log4j.appender.FUSE_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.FUSE_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.FUSE_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
 
 # Disable noisy DEBUG logs
 log4j.logger.com.amazonaws.util.EC2MetadataUtils=OFF

--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -31,7 +31,7 @@ log4j.appender.=org.apache.log4j.varia.NullAppender
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.Target=System.out
 log4j.appender.Console.layout=org.apache.log4j.PatternLayout
-log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
+log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %-5p [%t](%F:%L) - %m%n
 
 # The ParquetWriter logs for every row group which is not noisy for large row group size,
 # but very noisy for small row group size.
@@ -44,7 +44,7 @@ log4j.appender.JOB_MASTER_LOGGER.File=${alluxio.logs.dir}/job_master.log
 log4j.appender.JOB_MASTER_LOGGER.MaxFileSize=10MB
 log4j.appender.JOB_MASTER_LOGGER.MaxBackupIndex=100
 log4j.appender.JOB_MASTER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.JOB_MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
+log4j.appender.JOB_MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p [%t](%F:%L) - %m%n
 
 # Appender for Job Workers
 log4j.appender.JOB_WORKER_LOGGER=org.apache.log4j.RollingFileAppender
@@ -52,7 +52,7 @@ log4j.appender.JOB_WORKER_LOGGER.File=${alluxio.logs.dir}/job_worker.log
 log4j.appender.JOB_WORKER_LOGGER.MaxFileSize=10MB
 log4j.appender.JOB_WORKER_LOGGER.MaxBackupIndex=100
 log4j.appender.JOB_WORKER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.JOB_WORKER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
+log4j.appender.JOB_WORKER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p [%t](%F:%L) - %m%n
 
 # Appender for Master
 log4j.appender.MASTER_LOGGER=org.apache.log4j.RollingFileAppender
@@ -60,7 +60,7 @@ log4j.appender.MASTER_LOGGER.File=${alluxio.logs.dir}/master.log
 log4j.appender.MASTER_LOGGER.MaxFileSize=10MB
 log4j.appender.MASTER_LOGGER.MaxBackupIndex=100
 log4j.appender.MASTER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
+log4j.appender.MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p [%t](%F:%L) - %m%n
 
 # Appender for Master
 log4j.appender.SECONDARY_MASTER_LOGGER=org.apache.log4j.RollingFileAppender
@@ -68,7 +68,7 @@ log4j.appender.SECONDARY_MASTER_LOGGER.File=${alluxio.logs.dir}/secondary_master
 log4j.appender.SECONDARY_MASTER_LOGGER.MaxFileSize=10MB
 log4j.appender.SECONDARY_MASTER_LOGGER.MaxBackupIndex=100
 log4j.appender.SECONDARY_MASTER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.SECONDARY_MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
+log4j.appender.SECONDARY_MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p [%t](%F:%L) - %m%n
 
 # Appender for Master audit
 log4j.appender.MASTER_AUDIT_LOGGER=org.apache.log4j.RollingFileAppender
@@ -76,7 +76,7 @@ log4j.appender.MASTER_AUDIT_LOGGER.File=${alluxio.logs.dir}/master_audit.log
 log4j.appender.MASTER_AUDIT_LOGGER.MaxFileSize=10MB
 log4j.appender.MASTER_AUDIT_LOGGER.MaxBackupIndex=100
 log4j.appender.MASTER_AUDIT_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.MASTER_AUDIT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
+log4j.appender.MASTER_AUDIT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p [%t](%F:%L) - %m%n
 
 # Appender for Job Master audit
 log4j.appender.JOB_MASTER_AUDIT_LOGGER=org.apache.log4j.RollingFileAppender
@@ -84,7 +84,7 @@ log4j.appender.JOB_MASTER_AUDIT_LOGGER.File=${alluxio.logs.dir}/job_master_audit
 log4j.appender.JOB_MASTER_AUDIT_LOGGER.MaxFileSize=10MB
 log4j.appender.JOB_MASTER_AUDIT_LOGGER.MaxBackupIndex=100
 log4j.appender.JOB_MASTER_AUDIT_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.JOB_MASTER_AUDIT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
+log4j.appender.JOB_MASTER_AUDIT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p [%t](%F:%L) - %m%n
 
 # Appender for Proxy
 log4j.appender.PROXY_LOGGER=org.apache.log4j.RollingFileAppender
@@ -92,7 +92,7 @@ log4j.appender.PROXY_LOGGER.File=${alluxio.logs.dir}/proxy.log
 log4j.appender.PROXY_LOGGER.MaxFileSize=10MB
 log4j.appender.PROXY_LOGGER.MaxBackupIndex=100
 log4j.appender.PROXY_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.PROXY_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
+log4j.appender.PROXY_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p [%t](%F:%L) - %m%n
 
 # Appender for Proxy audit
 log4j.appender.PROXY_AUDIT_LOGGER=org.apache.log4j.RollingFileAppender
@@ -108,7 +108,7 @@ log4j.appender.WORKER_LOGGER.File=${alluxio.logs.dir}/worker.log
 log4j.appender.WORKER_LOGGER.MaxFileSize=10MB
 log4j.appender.WORKER_LOGGER.MaxBackupIndex=100
 log4j.appender.WORKER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.WORKER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
+log4j.appender.WORKER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p [%t](%F:%L) - %m%n
 
 # Remote appender for Job Master
 log4j.appender.REMOTE_JOB_MASTER_LOGGER=org.apache.log4j.net.SocketAppender
@@ -170,7 +170,7 @@ log4j.appender.LOGSERVER_LOGGER.File=${alluxio.logs.dir}/logserver.log
 log4j.appender.LOGSERVER_LOGGER.MaxFileSize=10MB
 log4j.appender.LOGSERVER_LOGGER.MaxBackupIndex=100
 log4j.appender.LOGSERVER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.LOGSERVER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
+log4j.appender.LOGSERVER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p [%t](%F:%L) - %m%n
 
 # (Local) appender for log server to log on behalf of log clients
 # No need to configure file path because log server will dynamically
@@ -179,7 +179,7 @@ log4j.appender.LOGSERVER_CLIENT_LOGGER=org.apache.log4j.RollingFileAppender
 log4j.appender.LOGSERVER_CLIENT_LOGGER.MaxFileSize=10MB
 log4j.appender.LOGSERVER_CLIENT_LOGGER.MaxBackupIndex=100
 log4j.appender.LOGSERVER_CLIENT_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.LOGSERVER_CLIENT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
+log4j.appender.LOGSERVER_CLIENT_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p [%t](%F:%L) - %m%n
 
 # Appender for User
 log4j.appender.USER_LOGGER=org.apache.log4j.RollingFileAppender
@@ -187,7 +187,7 @@ log4j.appender.USER_LOGGER.File=${alluxio.user.logs.dir}/user_${user.name}.log
 log4j.appender.USER_LOGGER.MaxFileSize=10MB
 log4j.appender.USER_LOGGER.MaxBackupIndex=10
 log4j.appender.USER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.USER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
+log4j.appender.USER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p [%t](%F:%L) - %m%n
 
 # Appender for Fuse
 log4j.appender.FUSE_LOGGER=org.apache.log4j.RollingFileAppender
@@ -195,7 +195,7 @@ log4j.appender.FUSE_LOGGER.File=${alluxio.logs.dir}/fuse.log
 log4j.appender.FUSE_LOGGER.MaxFileSize=100MB
 log4j.appender.FUSE_LOGGER.MaxBackupIndex=10
 log4j.appender.FUSE_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.FUSE_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}[%t](%F:%L) - %m%n
+log4j.appender.FUSE_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p [%t](%F:%L) - %m%n
 
 # Disable noisy DEBUG logs
 log4j.logger.com.amazonaws.util.EC2MetadataUtils=OFF


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add filename:linenumber:threadid details into default log4j settings so logs could be more informative when doing debugging.

### Why are the changes needed?

During debugging, it is hard to trace events for one particular file/event/thread with current default log4j settings

### Does this PR introduce any user facing changes?

N/A
