### PR TITLE
Fix snapshot from follower thread leak

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2588,6 +2588,21 @@ public final class PropertyKey implements Comparable<PropertyKey> {
                   .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
                   .setScope(Scope.MASTER)
                   .build();
+  public static final PropertyKey MASTER_JOURNAL_REQUEST_DATA_TIMEOUT =
+      durationBuilder(Name.MASTER_JOURNAL_REQUEST_DATA_TIMEOUT)
+          .setDefaultValue(20000)
+          .setDescription("Time to wait for follower to respond to request to send a new snapshot")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_JOURNAL_REQUEST_INFO_TIMEOUT =
+      durationBuilder(Name.MASTER_JOURNAL_REQUEST_INFO_TIMEOUT)
+          .setDefaultValue(20000)
+          .setDescription("Time to wait for follower to respond to request to get information"
+              + " about its latest snapshot")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.MASTER)
+          .build();
   public static final PropertyKey MASTER_JOURNAL_SPACE_MONITOR_INTERVAL =
       durationBuilder(Name.MASTER_JOURNAL_SPACE_MONITOR_INTERVAL)
       .setDefaultValue("10min")
@@ -6771,6 +6786,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.journal.log.size.bytes.max";
     public static final String MASTER_JOURNAL_LOG_CONCURRENCY_MAX =
         "alluxio.master.journal.log.concurrency.max";
+    public static final String MASTER_JOURNAL_REQUEST_DATA_TIMEOUT =
+        "alluxio.master.journal.request.data.timeout";
+    public static final String MASTER_JOURNAL_REQUEST_INFO_TIMEOUT =
+        "alluxio.master.journal.request.info.timeout";
     public static final String MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS =
         "alluxio.master.journal.tailer.shutdown.quiet.wait.time";
     public static final String MASTER_JOURNAL_TAILER_SLEEP_TIME_MS =

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -459,19 +459,11 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   }
 
   private RaftClient createClient() {
-<<<<<<< HEAD
-    long timeoutMs =
-        ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT);
-||||||| parent of 94316d7ab9 (Fix snapshot from follower thread leak)
-    long timeoutMs =
-        Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT);
-=======
-    return createClient(Configuration.getMs(
+    return createClient(ServerConfiguration.getMs(
         PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT));
   }
 
   private RaftClient createClient(long timeoutMs) {
->>>>>>> 94316d7ab9 (Fix snapshot from follower thread leak)
     long retryBaseMs =
         ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_INTERVAL);
     RaftProperties properties = new RaftProperties();
@@ -899,7 +891,7 @@ public class RaftJournalSystem extends AbstractJournalSystem {
    */
   public synchronized CompletableFuture<RaftClientReply> sendMessageAsync(
       RaftPeerId server, Message message) {
-    return sendMessageAsync(server, message, Configuration.getMs(
+    return sendMessageAsync(server, message, ServerConfiguration.getMs(
         PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT));
   }
 

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalSystem.java
@@ -459,8 +459,19 @@ public class RaftJournalSystem extends AbstractJournalSystem {
   }
 
   private RaftClient createClient() {
+<<<<<<< HEAD
     long timeoutMs =
         ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT);
+||||||| parent of 94316d7ab9 (Fix snapshot from follower thread leak)
+    long timeoutMs =
+        Configuration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT);
+=======
+    return createClient(Configuration.getMs(
+        PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT));
+  }
+
+  private RaftClient createClient(long timeoutMs) {
+>>>>>>> 94316d7ab9 (Fix snapshot from follower thread leak)
     long retryBaseMs =
         ServerConfiguration.getMs(PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_INTERVAL);
     RaftProperties properties = new RaftProperties();
@@ -888,7 +899,21 @@ public class RaftJournalSystem extends AbstractJournalSystem {
    */
   public synchronized CompletableFuture<RaftClientReply> sendMessageAsync(
       RaftPeerId server, Message message) {
-    RaftClient client = createClient();
+    return sendMessageAsync(server, message, Configuration.getMs(
+        PropertyKey.MASTER_EMBEDDED_JOURNAL_RAFT_CLIENT_REQUEST_TIMEOUT));
+  }
+
+  /**
+   * Sends a message to a raft server asynchronously.
+   *
+   * @param server the raft peer id of the target server
+   * @param message the message to send
+   * @param timeoutMs the message timeout in milliseconds
+   * @return a future to be completed with the client reply
+   */
+  public synchronized CompletableFuture<RaftClientReply> sendMessageAsync(
+      RaftPeerId server, Message message, long timeoutMs) {
+    RaftClient client = createClient(timeoutMs);
     RaftClientRequest request = RaftClientRequest.newBuilder()
             .setClientId(mRawClientId)
             .setServerId(server)

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
@@ -12,8 +12,16 @@
 package alluxio.master.journal.raft;
 
 import alluxio.ClientContext;
+import alluxio.Constants;
 import alluxio.collections.Pair;
+<<<<<<< HEAD
 import alluxio.conf.ServerConfiguration;
+||||||| parent of 94316d7ab9 (Fix snapshot from follower thread leak)
+import alluxio.conf.Configuration;
+=======
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+>>>>>>> 94316d7ab9 (Fix snapshot from follower thread leak)
 import alluxio.exception.status.AbortedException;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.NotFoundException;
@@ -32,8 +40,10 @@ import alluxio.grpc.UploadSnapshotPResponse;
 import alluxio.master.MasterClientContext;
 import alluxio.metrics.MetricKey;
 import alluxio.metrics.MetricsSystem;
+import alluxio.resource.LockResource;
 import alluxio.security.authentication.ClientIpAddressInjector;
 import alluxio.util.LogUtils;
+import alluxio.util.logging.SamplingLogger;
 
 import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
@@ -58,11 +68,22 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
+import java.util.Objects;
 import java.util.PriorityQueue;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -101,11 +122,21 @@ import java.util.stream.Collectors;
  */
 public class SnapshotReplicationManager {
   private static final Logger LOG = LoggerFactory.getLogger(SnapshotReplicationManager.class);
+  private static final Logger SAMPLING_LOG = new SamplingLogger(LOG, 5L * Constants.SECOND_MS);
 
   private final SimpleStateMachineStorage mStorage;
   private final RaftJournalSystem mJournalSystem;
   private volatile SnapshotInfo mDownloadedSnapshot;
   private final PriorityQueue<Pair<SnapshotMetadata, RaftPeerId>> mSnapshotCandidates;
+  private Future<Void> mRequestDataFuture;
+  private final Lock mRequestDataLock = new ReentrantLock();
+  private final Condition mRequestDataCondition = mRequestDataLock.newCondition();
+  private final ExecutorService mRequestDataExecutor = Executors.newSingleThreadExecutor();
+
+  private static final long SNAPSHOT_INFO_TIMEOUT_MS =
+      Configuration.getMs(PropertyKey.MASTER_JOURNAL_REQUEST_INFO_TIMEOUT);
+  private static final long SNAPSHOT_DATA_TIMEOUT_MS =
+      Configuration.getMs(PropertyKey.MASTER_JOURNAL_REQUEST_DATA_TIMEOUT);
 
   private enum DownloadState {
     /** No snapshot download is in progress. */
@@ -219,7 +250,7 @@ public class SnapshotReplicationManager {
     SnapshotUploader<UploadSnapshotPRequest, UploadSnapshotPResponse> snapshotUploader =
         SnapshotUploader.forFollower(mStorage, snapshot);
     RaftJournalServiceClient client = createJournalServiceClient();
-    LOG.info("Sending stream request to {} for snapshot {}", client.getAddress(),
+    LOG.info("Sending stream request to leader {} for snapshot {}", client.getAddress(),
         snapshot.getTermIndex());
     StreamObserver<UploadSnapshotPRequest> requestObserver =
         client.uploadSnapshot(snapshotUploader);
@@ -254,6 +285,7 @@ public class SnapshotReplicationManager {
     if (mDownloadState.get() == DownloadState.DOWNLOADED) {
       return installDownloadedSnapshot();
     }
+    SAMPLING_LOG.info("Call copy snapshot from follower in state {}", mDownloadState.get());
     if (mDownloadState.get() == DownloadState.IDLE) {
       CompletableFuture.runAsync(this::requestSnapshotFromFollowers);
     }
@@ -270,6 +302,7 @@ public class SnapshotReplicationManager {
       StreamObserver<UploadSnapshotPResponse> responseStreamObserver) {
     String followerIp = ClientIpAddressInjector.getIpAddress();
     LOG.info("Received upload snapshot request from follower {}", followerIp);
+
     SnapshotDownloader<UploadSnapshotPResponse, UploadSnapshotPRequest> observer =
         SnapshotDownloader.forLeader(mStorage, responseStreamObserver,
             followerIp);
@@ -279,17 +312,26 @@ public class SnapshotReplicationManager {
     }
     observer.getFuture()
         .thenApply(termIndex -> {
-          mDownloadedSnapshot = observer.getSnapshotToInstall();
-          transitionState(DownloadState.STREAM_DATA, DownloadState.DOWNLOADED);
-          return termIndex;
+          try (LockResource ignored = new LockResource(mRequestDataLock)) {
+            mDownloadedSnapshot = observer.getSnapshotToInstall();
+            transitionState(DownloadState.STREAM_DATA, DownloadState.DOWNLOADED);
+            // Cancel any pending data requests since the download was successful
+            mRequestDataFuture.cancel(true);
+            mRequestDataCondition.signalAll();
+            return termIndex;
+          }
         }).exceptionally(e -> {
-          LOG.error("Unexpected exception downloading snapshot from follower {}.", followerIp, e);
-          // this allows the leading master to request other followers for their snapshots. It
-          // previously collected information about other snapshots in requestInfo(). If no other
-          // snapshots are available requestData() will return false and mDownloadState will be IDLE
-          transitionState(DownloadState.STREAM_DATA, DownloadState.REQUEST_DATA);
-          CompletableFuture.runAsync(this::requestSnapshotFromFollowers);
-          return null;
+          try (LockResource ignored = new LockResource(mRequestDataLock)) {
+            LOG.error("Unexpected exception downloading snapshot from follower {}.", followerIp, e);
+            // this allows the leading master to request other followers for their snapshots. It
+            // previously collected information about other snapshots in requestInfo(). If no other
+            // snapshots are available requestData() will return false and mDownloadState will be
+            // IDLE
+            transitionState(DownloadState.STREAM_DATA, DownloadState.REQUEST_DATA);
+            // Notify the request data tasks to start a request with a new candidate
+            mRequestDataCondition.signalAll();
+            return null;
+          }
         });
     return observer;
   }
@@ -303,7 +345,29 @@ public class SnapshotReplicationManager {
    */
   public Message handleRequest(JournalQueryRequest queryRequest) throws IOException {
     if (queryRequest.hasSnapshotInfoRequest()) {
+      SnapshotMetadata requestSnapshot = queryRequest.getSnapshotInfoRequest().getSnapshotInfo();
+      Instant start = Instant.now();
       SnapshotInfo latestSnapshot = mStorage.getLatestSnapshot();
+      synchronized (this) {
+        // We may need to wait for a valid snapshot to be ready
+        while ((latestSnapshot == null
+            || (queryRequest.getSnapshotInfoRequest().hasSnapshotInfo()
+            && (requestSnapshot.getSnapshotTerm() > latestSnapshot.getTerm()
+            || (requestSnapshot.getSnapshotTerm() == latestSnapshot.getTerm()
+            && requestSnapshot.getSnapshotIndex() >= latestSnapshot.getIndex()))))
+            && Duration.between(start, Instant.now()).toMillis() < SNAPSHOT_INFO_TIMEOUT_MS) {
+          LOG.info("Received snapshot info request from leader - {}, but do not have a "
+              + "snapshot ready - {}", requestSnapshot, latestSnapshot);
+          try {
+            wait(SNAPSHOT_DATA_TIMEOUT_MS - Long.min(SNAPSHOT_DATA_TIMEOUT_MS,
+                Math.abs(Duration.between(start, Instant.now()).toMillis())));
+          } catch (InterruptedException e) {
+            LOG.debug("Interrupted while waiting for snapshot", e);
+            break;
+          }
+          latestSnapshot = mStorage.getLatestSnapshot();
+        }
+      }
       if (latestSnapshot == null) {
         LOG.debug("No snapshot to send");
         return toMessage(GetSnapshotInfoResponse.getDefaultInstance());
@@ -312,11 +376,11 @@ public class SnapshotReplicationManager {
           .setSnapshotInfoResponse(GetSnapshotInfoResponse.newBuilder().setLatest(
               toSnapshotMetadata(latestSnapshot.getTermIndex())))
           .build();
-      LOG.debug("Sent snapshot info response {}", response);
+      LOG.info("Sent snapshot info response to leader {}", response);
       return toMessage(response);
     }
     if (queryRequest.hasSnapshotRequest()) {
-      LOG.debug("Start sending snapshot to leader");
+      LOG.info("Start sending snapshot to leader");
       sendSnapshotToLeader();
       return Message.EMPTY;
     }
@@ -379,6 +443,7 @@ public class SnapshotReplicationManager {
    * @return the index of the installed snapshot
    */
   private long installDownloadedSnapshot() {
+    LOG.info("Call install downloaded snapshot");
     if (!transitionState(DownloadState.DOWNLOADED, DownloadState.INSTALLING)) {
       return RaftLog.INVALID_LOG_INDEX;
     }
@@ -409,8 +474,21 @@ public class SnapshotReplicationManager {
       if (!tempFile.renameTo(snapshotFile)) {
         throw new IOException(String.format("Failed to rename %s to %s", tempFile, snapshotFile));
       }
+<<<<<<< HEAD
       mStorage.loadLatestSnapshot();
       LOG.info("Completed storing snapshot at {} to file {}", downloaded, snapshotFile);
+||||||| parent of 94316d7ab9 (Fix snapshot from follower thread leak)
+      mStorage.loadLatestSnapshot();
+      LOG.info("Completed storing snapshot at {} to file {} with size {}", downloaded,
+          snapshotFile, FormatUtils.getSizeFromBytes(snapshotFile.length()));
+=======
+      synchronized (this) {
+        mStorage.loadLatestSnapshot();
+        notifyAll();
+      }
+      LOG.info("Completed storing snapshot at {} to file {} with size {}", downloaded,
+          snapshotFile, FormatUtils.getSizeFromBytes(snapshotFile.length()));
+>>>>>>> 94316d7ab9 (Fix snapshot from follower thread leak)
       return downloaded.getIndex();
     } catch (Exception e) {
       LOG.error("Failed to install snapshot", e);
@@ -437,17 +515,14 @@ public class SnapshotReplicationManager {
       mSnapshotCandidates.clear();
       requestInfo();
       transitionState(DownloadState.REQUEST_INFO, DownloadState.REQUEST_DATA);
-    }
-    if (mDownloadState.get() == DownloadState.REQUEST_DATA) {
-      if (!requestData()) {
-        transitionState(DownloadState.REQUEST_DATA, DownloadState.IDLE);
-      }
+      mRequestDataFuture = mRequestDataExecutor.submit(this::requestData, null);
     }
   }
 
   private void requestInfo() {
     Preconditions.checkState(mDownloadState.get() == DownloadState.REQUEST_INFO);
     try {
+      LOG.info("Call request snapshot info from followers");
       SingleFileSnapshotInfo latestSnapshot = mStorage.getLatestSnapshot();
       SnapshotMetadata snapshotMetadata = latestSnapshot == null ? null :
           SnapshotMetadata.newBuilder()
@@ -455,6 +530,13 @@ public class SnapshotReplicationManager {
               .setSnapshotIndex(latestSnapshot.getIndex())
               .build();
       // build SnapshotInfoRequests
+      GetSnapshotInfoRequest infoRequest;
+      if (snapshotMetadata == null) {
+        infoRequest = GetSnapshotInfoRequest.getDefaultInstance();
+      } else {
+        infoRequest = GetSnapshotInfoRequest.newBuilder()
+            .setSnapshotInfo(snapshotMetadata).build();
+      }
       Map<RaftPeerId, CompletableFuture<RaftClientReply>> jobs = mJournalSystem
           .getQuorumServerInfoList()
           .stream()
@@ -466,8 +548,8 @@ public class SnapshotReplicationManager {
           .collect(Collectors.toMap(Function.identity(),
               peerId -> mJournalSystem.sendMessageAsync(peerId, toMessage(JournalQueryRequest
                   .newBuilder()
-                  .setSnapshotInfoRequest(GetSnapshotInfoRequest.getDefaultInstance())
-                  .build()))));
+                  .setSnapshotInfoRequest(infoRequest)
+                  .build()), SNAPSHOT_INFO_TIMEOUT_MS)));
       // query all secondary masters for information about their latest snapshot
       for (Map.Entry<RaftPeerId, CompletableFuture<RaftClientReply>> job : jobs.entrySet()) {
         RaftPeerId peerId = job.getKey();
@@ -481,8 +563,9 @@ public class SnapshotReplicationManager {
           if (!response.hasSnapshotInfoResponse()) {
             throw new IOException("Invalid response for GetSnapshotInfoRequest " + response);
           }
-          LOG.debug("Received snapshot info from follower {} - {}", peerId, response);
           SnapshotMetadata latest = response.getSnapshotInfoResponse().getLatest();
+          LOG.info("Received snapshot info from follower {} - {}, my current snapshot is {}",
+              peerId, latest, snapshotMetadata);
           if (snapshotMetadata == null
               || (latest.getSnapshotTerm() >= snapshotMetadata.getSnapshotTerm())
               && latest.getSnapshotIndex() > snapshotMetadata.getSnapshotIndex()) {
@@ -497,8 +580,9 @@ public class SnapshotReplicationManager {
     }
   }
 
-  private boolean requestData() {
+  private void requestData() {
     Preconditions.checkState(mDownloadState.get() == DownloadState.REQUEST_DATA);
+<<<<<<< HEAD
     // request snapshots from the most recent to least recent
     while (!mSnapshotCandidates.isEmpty()) {
       Pair<SnapshotMetadata, RaftPeerId> candidate = mSnapshotCandidates.poll();
@@ -513,14 +597,63 @@ public class SnapshotReplicationManager {
             .get();
         if (reply.getException() != null) {
           throw reply.getException();
+||||||| parent of 94316d7ab9 (Fix snapshot from follower thread leak)
+    // request snapshots from the most recent to the least recent
+    while (!mSnapshotCandidates.isEmpty()) {
+      Pair<SnapshotMetadata, RaftPeerId> candidate = mSnapshotCandidates.poll();
+      SnapshotMetadata metadata = candidate.getFirst();
+      RaftPeerId peerId = candidate.getSecond();
+      LOG.info("Request data from follower {} for snapshot (t: {}, i: {})",
+          peerId, metadata.getSnapshotTerm(), metadata.getSnapshotIndex());
+      try {
+        RaftClientReply reply = mJournalSystem.sendMessageAsync(peerId,
+                toMessage(JournalQueryRequest.newBuilder()
+                    .setSnapshotRequest(GetSnapshotRequest.getDefaultInstance()).build()))
+            .get();
+        if (reply.getException() != null) {
+          throw reply.getException();
+=======
+    // request snapshots from the most recent to the least recent
+    try {
+      while (!mSnapshotCandidates.isEmpty() && mDownloadState.get() == DownloadState.REQUEST_DATA) {
+        Pair<SnapshotMetadata, RaftPeerId> candidate = mSnapshotCandidates.poll();
+        SnapshotMetadata metadata = Objects.requireNonNull(candidate).getFirst();
+        RaftPeerId peerId = candidate.getSecond();
+        LOG.info("Request data from follower {} for snapshot (t: {}, i: {})",
+            peerId, metadata.getSnapshotTerm(), metadata.getSnapshotIndex());
+        try {
+          RaftClientReply reply = mJournalSystem.sendMessageAsync(peerId,
+                  toMessage(JournalQueryRequest.newBuilder()
+                      .setSnapshotRequest(GetSnapshotRequest.getDefaultInstance()).build()))
+              .get();
+          if (reply.getException() != null) {
+            throw reply.getException();
+          }
+          // Wait a timeout before trying the next follower, or until we are awoken
+          try (LockResource ignored = new LockResource(mRequestDataLock)) {
+            do {
+              mRequestDataCondition.await(SNAPSHOT_DATA_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            } while (mDownloadState.get() != DownloadState.REQUEST_DATA);
+          }
+        } catch (InterruptedException | CancellationException ignored) {
+          // We are usually interrupted when a snapshot transfer is complete,
+          // so we can just return without trying a new candidate.
+          // It is fine even if we are interrupted in other cases as
+          // a new request info will be initiated by the next takeSnapshot() call.
+          return;
+        } catch (Exception e) {
+          LOG.warn("Failed to request snapshot data from {}: {}", peerId, e);
+>>>>>>> 94316d7ab9 (Fix snapshot from follower thread leak)
         }
-        return true;
-      } catch (Exception e) {
-        LOG.warn("Failed to request snapshot data from {}: {}", peerId, e);
+      }
+    } finally {
+      // Ensure that we return to the IDLE state in case the REQUEST_DATA operations
+      // were not successful, for example if we were interrupted for some reason
+      // other than a successful download.
+      if (mDownloadState.get() == DownloadState.REQUEST_DATA) {
+        transitionState(DownloadState.REQUEST_DATA, DownloadState.IDLE);
       }
     }
-    // return failure if there are no more candidates to ask snapshot from
-    return false;
   }
 
   @VisibleForTesting

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -461,8 +461,17 @@ public class RaftJournalTest {
    */
   private List<RaftJournalSystem> createJournalSystems(int journalSystemCount) throws Exception {
     // Override defaults for faster quorum formation.
+<<<<<<< HEAD
     ServerConfiguration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, 550);
     ServerConfiguration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, 1100);
+||||||| parent of 94316d7ab9 (Fix snapshot from follower thread leak)
+    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, 550);
+    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, 1100);
+=======
+    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, 550);
+    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, 1100);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 10);
+>>>>>>> 94316d7ab9 (Fix snapshot from follower thread leak)
 
     List<InetSocketAddress> clusterAddresses = new ArrayList<>(journalSystemCount);
     List<Integer> freePorts = getFreePorts(journalSystemCount);

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/RaftJournalTest.java
@@ -461,17 +461,9 @@ public class RaftJournalTest {
    */
   private List<RaftJournalSystem> createJournalSystems(int journalSystemCount) throws Exception {
     // Override defaults for faster quorum formation.
-<<<<<<< HEAD
     ServerConfiguration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, 550);
     ServerConfiguration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, 1100);
-||||||| parent of 94316d7ab9 (Fix snapshot from follower thread leak)
-    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, 550);
-    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, 1100);
-=======
-    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MIN_ELECTION_TIMEOUT, 550);
-    Configuration.set(PropertyKey.MASTER_EMBEDDED_JOURNAL_MAX_ELECTION_TIMEOUT, 1100);
-    Configuration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 10);
->>>>>>> 94316d7ab9 (Fix snapshot from follower thread leak)
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, 10);
 
     List<InetSocketAddress> clusterAddresses = new ArrayList<>(journalSystemCount);
     List<Integer> freePorts = getFreePorts(journalSystemCount);

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -12,6 +12,8 @@
 package alluxio.master.journal.raft;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
 
 import alluxio.ConfigurationRule;
 import alluxio.conf.PropertyKey;
@@ -51,6 +53,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -58,7 +61,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class SnapshotReplicationManagerTest {
@@ -84,6 +89,8 @@ public class SnapshotReplicationManagerTest {
   private Server mServer;
 
   private void before(int numFollowers) throws Exception {
+    Configuration.set(PropertyKey.MASTER_JOURNAL_REQUEST_INFO_TIMEOUT, 550);
+    Configuration.set(PropertyKey.MASTER_JOURNAL_REQUEST_DATA_TIMEOUT, 550);
     mLeader = Mockito.mock(RaftJournalSystem.class);
     Mockito.when(mLeader.isLeader()).thenReturn(true);
     Mockito.when(mLeader.getLocalPeerId()).thenReturn(RaftPeerId.getRaftPeerId("leader"));
@@ -123,16 +130,38 @@ public class SnapshotReplicationManagerTest {
     }).collect(Collectors.toList());
 
     Mockito.when(mLeader.getQuorumServerInfoList()).thenReturn(quorumServerInfos);
-    Mockito.when(mLeader.sendMessageAsync(any(), any())).thenAnswer((args) -> {
+    Answer<?> fn = (args) -> {
       RaftPeerId peerId = args.getArgument(0, RaftPeerId.class);
       Message message = args.getArgument(1, Message.class);
       JournalQueryRequest queryRequest = JournalQueryRequest.parseFrom(
           message.getContent().asReadOnlyByteBuffer());
-      Message response = mFollowers.get(peerId).mSnapshotManager.handleRequest(queryRequest);
-      RaftClientReply reply = Mockito.mock(RaftClientReply.class);
-      Mockito.when(reply.getMessage()).thenReturn(response);
-      return CompletableFuture.completedFuture(reply);
-    });
+      return CompletableFuture.supplyAsync(() -> {
+        CompletableFuture<RaftClientReply> fut = CompletableFuture.supplyAsync(() -> {
+          Message response;
+          try {
+            response = mFollowers.get(peerId).mSnapshotManager.handleRequest(queryRequest);
+          } catch (IOException e) {
+            throw new CompletionException(e);
+          }
+          RaftClientReply reply = Mockito.mock(RaftClientReply.class);
+          Mockito.when(reply.getMessage()).thenReturn(response);
+          return reply;
+        });
+        RaftClientReply result;
+        try {
+          if (args.getArguments().length == 3) {
+            result = fut.get(args.getArgument(2), TimeUnit.MILLISECONDS);
+          } else {
+            result = fut.get();
+          }
+          return result;
+        } catch (Exception e) {
+          throw new CompletionException(e);
+        }
+      });
+    };
+    Mockito.when(mLeader.sendMessageAsync(any(), any())).thenAnswer(fn);
+    Mockito.when(mLeader.sendMessageAsync(any(), any(), anyLong())).thenAnswer(fn);
   }
 
   private SimpleStateMachineStorage getSimpleStateMachineStorage() throws IOException {
@@ -221,6 +250,81 @@ public class SnapshotReplicationManagerTest {
   }
 
   @Test
+  public void failGetInfoEqualTermHigherIndex() throws Exception {
+    before(2);
+    List<Follower> followers = new ArrayList<>(mFollowers.values());
+    Follower firstFollower = followers.get(0);
+    Follower secondFollower = followers.get(1);
+
+    createSnapshotFile(firstFollower.mStore); // create default 0, 1 snapshot
+    createSnapshotFile(secondFollower.mStore, 0, 2); // preferable to the default 0, 1 snapshot
+    // the second follower will not reply to the getInfo request, so the leader will request from
+    // the first after a timeout
+    secondFollower.disableGetInfo();
+
+    mLeaderSnapshotManager.maybeCopySnapshotFromFollower();
+
+    CommonUtils.waitFor("leader snapshot to complete",
+        () -> mLeaderSnapshotManager.maybeCopySnapshotFromFollower() != -1, mWaitOptions);
+    // verify that the leader still requests and get the snapshot from the first follower
+    validateSnapshotFile(mLeaderStore, 0, 1);
+  }
+
+  @Test
+  public void failSnapshotRequestEqualTermHigherIndex() throws Exception {
+    before(2);
+    List<Follower> followers = new ArrayList<>(mFollowers.values());
+    Follower firstFollower = followers.get(0);
+    Follower secondFollower = followers.get(1);
+
+    createSnapshotFile(firstFollower.mStore); // create default 0, 1 snapshot
+    createSnapshotFile(secondFollower.mStore, 0, 2); // preferable to the default 0, 1 snapshot
+    // the second follower will not start the snapshot upload, so the leader will request from the
+    // first after a timeout
+    secondFollower.disableFollowerUpload();
+
+    mLeaderSnapshotManager.maybeCopySnapshotFromFollower();
+
+    CommonUtils.waitFor("leader snapshot to complete",
+        () -> mLeaderSnapshotManager.maybeCopySnapshotFromFollower() != -1, mWaitOptions);
+    // verify that the leader still requests and get the snapshot from the first follower
+    validateSnapshotFile(mLeaderStore, 0, 1);
+  }
+
+  @Test
+  public void failFailThenSuccess() throws Exception {
+    before(3);
+    List<Follower> followers = new ArrayList<>(mFollowers.values());
+    Follower firstFollower = followers.get(0);
+    Follower secondFollower = followers.get(1);
+
+    createSnapshotFile(firstFollower.mStore, 0, 1);
+    createSnapshotFile(secondFollower.mStore, 0, 1);
+
+    firstFollower.disableFollowerUpload();
+    secondFollower.disableGetInfo();
+
+    mLeaderSnapshotManager.maybeCopySnapshotFromFollower();
+
+    try {
+      CommonUtils.waitForResult("upload failure",
+          () -> mLeaderSnapshotManager.maybeCopySnapshotFromFollower(),
+          (num) -> num == 1,
+          WaitForOptions.defaults().setInterval(10).setTimeoutMs(100));
+    } catch (Exception e) {
+      // expected to fail: no snapshot could be uploaded
+    }
+
+    Follower thirdFollower = followers.get(2);
+    createSnapshotFile(thirdFollower.mStore, 0, 2);
+    mLeaderSnapshotManager.maybeCopySnapshotFromFollower();
+    CommonUtils.waitForResult("upload failure",
+        () -> mLeaderSnapshotManager.maybeCopySnapshotFromFollower(),
+        (num) -> num == 2, mWaitOptions);
+    validateSnapshotFile(mLeaderStore, 0, 2);
+  }
+
+  @Test
   public void requestSnapshotHigherTermLowerIndex() throws Exception {
     before(2);
     List<Follower> followers = new ArrayList<>(mFollowers.values());
@@ -250,8 +354,10 @@ public class SnapshotReplicationManagerTest {
     for (int i = 2; i < 12; i++) {
       if (i % 2 == 0) {
         createSnapshotFile(secondFollower.mStore, 0, i);
+        secondFollower.notifySnapshotInstalled();
       } else {
         createSnapshotFile(firstFollower.mStore, 0, i);
+        firstFollower.notifySnapshotInstalled();
       }
       CommonUtils.waitFor("leader snapshot to complete",
           () -> mLeaderSnapshotManager.maybeCopySnapshotFromFollower() != -1, mWaitOptions);
@@ -332,7 +438,7 @@ public class SnapshotReplicationManagerTest {
   private class Follower {
     final String mHost;
     final int mRpcPort;
-    SnapshotReplicationManager mSnapshotManager;
+    final SnapshotReplicationManager mSnapshotManager;
     RaftJournalSystem mJournalSystem;
     SimpleStateMachineStorage mStore;
 
@@ -343,6 +449,27 @@ public class SnapshotReplicationManagerTest {
       mJournalSystem = Mockito.mock(RaftJournalSystem.class);
       mSnapshotManager = Mockito.spy(new SnapshotReplicationManager(mJournalSystem, mStore));
       Mockito.doReturn(client).when(mSnapshotManager).createJournalServiceClient();
+    }
+
+    void notifySnapshotInstalled() {
+      synchronized (mSnapshotManager) {
+        mSnapshotManager.notifyAll();
+      }
+    }
+
+    void disableFollowerUpload() throws IOException {
+      Mockito.doNothing().when(mSnapshotManager).sendSnapshotToLeader();
+    }
+
+    void disableGetInfo() throws IOException {
+      Mockito.doAnswer((args) -> {
+        synchronized (mSnapshotManager) {
+          // we sleep so nothing is returned
+          mSnapshotManager.wait();
+        }
+        return null;
+      }).when(mSnapshotManager)
+          .handleRequest(argThat(JournalQueryRequest::hasSnapshotInfoRequest));
     }
 
     RaftPeerId getRaftPeerId() {

--- a/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/common/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -89,8 +89,8 @@ public class SnapshotReplicationManagerTest {
   private Server mServer;
 
   private void before(int numFollowers) throws Exception {
-    Configuration.set(PropertyKey.MASTER_JOURNAL_REQUEST_INFO_TIMEOUT, 550);
-    Configuration.set(PropertyKey.MASTER_JOURNAL_REQUEST_DATA_TIMEOUT, 550);
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_REQUEST_INFO_TIMEOUT, 550);
+    ServerConfiguration.set(PropertyKey.MASTER_JOURNAL_REQUEST_DATA_TIMEOUT, 550);
     mLeader = Mockito.mock(RaftJournalSystem.class);
     Mockito.when(mLeader.isLeader()).thenReturn(true);
     Mockito.when(mLeader.getLocalPeerId()).thenReturn(RaftPeerId.getRaftPeerId("leader"));

--- a/core/transport/src/main/proto/grpc/raft_journal.proto
+++ b/core/transport/src/main/proto/grpc/raft_journal.proto
@@ -23,6 +23,7 @@ message AddQuorumServerRequest {
 }
 
 message GetSnapshotInfoRequest {
+  optional SnapshotMetadata snapshotInfo = 1;
 }
 
 message GetSnapshotInfoResponse {

--- a/core/transport/src/main/proto/proto.lock
+++ b/core/transport/src/main/proto/proto.lock
@@ -5935,7 +5935,14 @@
             ]
           },
           {
-            "name": "GetSnapshotInfoRequest"
+            "name": "GetSnapshotInfoRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "snapshotInfo",
+                "type": "SnapshotMetadata"
+              }
+            ]
           },
           {
             "name": "GetSnapshotInfoResponse",


### PR DESCRIPTION
Cherry pick of https://github.com/Alluxio/alluxio/pull/15873

When using Ratis, the primary master does not take a snapshot itself, instead it requests a snapshot from a follower. This pull request fixes two issues with the current implementation of this.

1. Currently when a snapshot needs to be taken as given by alluxio.master.journal.checkpoint.period.entries, Ratis will call takeSnapshot() in the JournalStateMachine each time a journal entry is committed until a new snapshot is installed. On the primary master takeSnapshot() runs asynchronously by first requesting snapshot information from each follower, then downloading a snapshot form one of them if a valid snapshot is available. If no valid snapshot is available (which is likely since all nodes take snapshots at the same log index and it takes time to generate a snapshot) the request happens repeatedly until one is available, but each request allocates a new GRPC connection, eventually this may cause the master to crash or fail over from allocating too many threads. This is fixed by having the follower block until a valid snapshot is available before sending the reply (with a configurable timeout).

2. Currently when a primary master sends a request to a follower to start sending the snapshot it always expects the follower to start a new RPC to do this, but if the follower does not do this (for example due to any sort of failure or network issue) then the primary master will always be waiting for this RPC and never install a new snapshot. This is fixed by adding a timeout for the follower to start the RPC, and if the timeout runs out, a new follower is tried, or the snapshot request protocol starts again if none are available presently.