### PR TITLE
Support multithread checkpointing with compression/decompression

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6861,7 +6861,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metadata.sync.ufs.prefetch.timeout";
     public static final String MASTER_METASTORE = "alluxio.master.metastore";
     public static final String MASTER_METASTORE_DIR = "alluxio.master.metastore.dir";
-
     public static final String MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL =
         "alluxio.master.metastore.rocks.checkpoint.compression.level";
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2224,6 +2224,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+<<<<<<< HEAD
   public static final PropertyKey MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL =
       intBuilder(Name.MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL)
           .setDefaultValue(-1)
@@ -2234,6 +2235,34 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
+||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
+=======
+  public static final PropertyKey MASTER_METASTORE_ROCKS_PARALLEL_BACKUP =
+      booleanBuilder(Name.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP)
+        .setDefaultValue(false)
+        .setDescription("Whether to backup rocksdb in parallel")
+        .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+        .setScope(Scope.MASTER)
+        .build();
+  public static final PropertyKey MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_COMPRESSION_LEVEL =
+      intBuilder(Name.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_COMPRESSION_LEVEL)
+        .setDefaultValue(6)
+        .setDescription("The zip compression level of backing up rocksdb in parallel, the zip"
+            + " format defines ten levels of compression, ranging from 0"
+            + " (no compression, but very fast) to 9 (best compression, but slow)")
+        .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+        .setScope(Scope.MASTER)
+        .build();
+  public static final PropertyKey MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_THREADS =
+      intBuilder(Name.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_THREADS)
+        .setDefaultSupplier(() -> Math.min(16,
+            Math.max(1, Runtime.getRuntime().availableProcessors() / 2)),
+            "The default number of threads used by backing up rocksdb in parallel.")
+        .setDescription("The number of threads used by backing up rocksdb in parallel.")
+        .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+        .setScope(Scope.MASTER)
+        .build();
+>>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
   public static final PropertyKey MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE =
       intBuilder(Name.MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE)
           // TODO(andrew): benchmark different batch sizes to improve the default and provide a
@@ -6836,8 +6865,18 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metadata.sync.ufs.prefetch.timeout";
     public static final String MASTER_METASTORE = "alluxio.master.metastore";
     public static final String MASTER_METASTORE_DIR = "alluxio.master.metastore.dir";
+<<<<<<< HEAD
     public static final String MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL =
         "alluxio.master.metastore.rocks.checkpoint.compression.level";
+||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
+=======
+    public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP =
+        "alluxio.master.metastore.rocks.parallel.backup";
+    public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_COMPRESSION_LEVEL =
+        "alluxio.master.metastore.rocks.parallel.backup.compression.level";
+    public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_THREADS =
+        "alluxio.master.metastore.rocks.parallel.backup.threads";
+>>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
     public static final String MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE =
         "alluxio.master.metastore.inode.cache.evict.batch.size";
     public static final String MASTER_METASTORE_INODE_CACHE_HIGH_WATER_MARK_RATIO =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2224,7 +2224,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
-<<<<<<< HEAD
   public static final PropertyKey MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL =
       intBuilder(Name.MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL)
           .setDefaultValue(-1)
@@ -2235,8 +2234,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.MASTER)
           .build();
-||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
-=======
   public static final PropertyKey MASTER_METASTORE_ROCKS_PARALLEL_BACKUP =
       booleanBuilder(Name.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP)
         .setDefaultValue(false)
@@ -2262,7 +2259,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
         .setScope(Scope.MASTER)
         .build();
->>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
   public static final PropertyKey MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE =
       intBuilder(Name.MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE)
           // TODO(andrew): benchmark different batch sizes to improve the default and provide a
@@ -6865,18 +6861,15 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metadata.sync.ufs.prefetch.timeout";
     public static final String MASTER_METASTORE = "alluxio.master.metastore";
     public static final String MASTER_METASTORE_DIR = "alluxio.master.metastore.dir";
-<<<<<<< HEAD
+
     public static final String MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL =
         "alluxio.master.metastore.rocks.checkpoint.compression.level";
-||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
-=======
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP =
         "alluxio.master.metastore.rocks.parallel.backup";
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_COMPRESSION_LEVEL =
         "alluxio.master.metastore.rocks.parallel.backup.compression.level";
     public static final String MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_THREADS =
         "alluxio.master.metastore.rocks.parallel.backup.threads";
->>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
     public static final String MASTER_METASTORE_INODE_CACHE_EVICT_BATCH_SIZE =
         "alluxio.master.metastore.inode.cache.evict.batch.size";
     public static final String MASTER_METASTORE_INODE_CACHE_HIGH_WATER_MARK_RATIO =

--- a/core/common/src/main/java/alluxio/util/executor/ExecutorServiceUtils.java
+++ b/core/common/src/main/java/alluxio/util/executor/ExecutorServiceUtils.java
@@ -1,0 +1,51 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util.executor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Util class for ExecutorService.
+ */
+public class ExecutorServiceUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutorServiceUtils.class);
+
+  /**
+   * ShutdownAndAwaitTermination with default timeout.
+   * @param executorService
+   */
+  public static void shutdownAndAwaitTermination(ExecutorService executorService) {
+    shutdownAndAwaitTermination(executorService, 1000);
+  }
+
+  /**
+   * Gracefully shutdown ExecutorService method.
+   * @param executorService
+   * @param timeoutMillis
+   */
+  public static void shutdownAndAwaitTermination(ExecutorService executorService,
+      long timeoutMillis) {
+    executorService.shutdown();
+    try {
+      if (!executorService.awaitTermination(timeoutMillis, TimeUnit.MILLISECONDS)) {
+        executorService.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      executorService.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/core/server/common/src/main/java/alluxio/master/journal/checkpoint/CheckpointType.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/checkpoint/CheckpointType.java
@@ -32,9 +32,9 @@ public enum CheckpointType {
    */
   LONGS(2, new LongsCheckpointFormat()),
   /**
-   * A RocksDB backup in .tar.gz format.
+   * A RocksDB backup in .tar.gz format with single thread.
    */
-  ROCKS(3, new TarballCheckpointFormat()),
+  ROCKS_SINGLE(3, new TarballCheckpointFormat()),
   /**
    * This format sequentially writes delimited InodeMeta.Inode protocol buffers one after another
    * using the protocol buffer writeDelimitedTo method.
@@ -43,7 +43,11 @@ public enum CheckpointType {
   /**
    * A checkpoint consisting of a single long value written by a data output stream.
    */
-  LONG(5, new LongCheckpointFormat());
+  LONG(5, new LongCheckpointFormat()),
+  /**
+   * A RocksDB backup in .zip format with multi threads.
+   */
+  ROCKS_PARALLEL(6, new ZipCheckpointFormat());
 
   private final long mId;
   private final CheckpointFormat mCheckpointFormat;

--- a/core/server/common/src/main/java/alluxio/master/journal/checkpoint/ZipCheckpointFormat.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/checkpoint/ZipCheckpointFormat.java
@@ -11,27 +11,21 @@
 
 package alluxio.master.journal.checkpoint;
 
-import alluxio.util.TarUtils;
-
 import com.google.common.base.Preconditions;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 /**
- * Format for checkpoints written as tarballs.
+ * Format for checkpoints written as zip files, created by parallel compression.
  */
-public class TarballCheckpointFormat implements CheckpointFormat {
+public class ZipCheckpointFormat implements CheckpointFormat {
   @Override
-  public TarballCheckpointReader createReader(CheckpointInputStream in) {
-    return new TarballCheckpointReader(in);
+  public ZipCheckpointReader createReader(CheckpointInputStream in) {
+    return new ZipCheckpointReader(in);
   }
 
   @Override
-  public void parseToHumanReadable(CheckpointInputStream in, PrintStream out) throws IOException {
+  public void parseToHumanReadable(CheckpointInputStream in, PrintStream out) {
     out.println("No human-readable string representation available. Use bin/alluxio readJournal "
         + "to inspect the checkpoint");
   }
@@ -39,27 +33,15 @@ public class TarballCheckpointFormat implements CheckpointFormat {
   /**
    * Reads a tarball-based checkpoint.
    */
-  public static class TarballCheckpointReader implements CheckpointReader {
-    private final InputStream mStream;
+  public static class ZipCheckpointReader implements CheckpointReader {
 
     /**
      * @param in the checkpoint input stream to read from
      */
-    public TarballCheckpointReader(CheckpointInputStream in) {
+    public ZipCheckpointReader(CheckpointInputStream in) {
       // We may add new tarball-based checkpoint types in the future.
-      Preconditions.checkState(in.getType() == CheckpointType.ROCKS_SINGLE,
+      Preconditions.checkState(in.getType() == CheckpointType.ROCKS_PARALLEL,
           "Unexpected checkpoint type: %s", in.getType());
-      mStream = in;
-    }
-
-    /**
-     * Unpacks the tarball data to the given path. Parent directories are created as needed.
-     *
-     * @param path the path to unpack to
-     */
-    public void unpackToDirectory(Path path) throws IOException {
-      Files.createDirectories(path);
-      TarUtils.readTarGz(path, mStream);
     }
   }
 }

--- a/core/server/common/src/main/java/alluxio/util/ParallelZipUtils.java
+++ b/core/server/common/src/main/java/alluxio/util/ParallelZipUtils.java
@@ -1,0 +1,193 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util;
+
+import static java.util.stream.Collectors.toList;
+
+import alluxio.util.executor.ExecutorServiceFactories;
+import alluxio.util.executor.ExecutorServiceUtils;
+import alluxio.util.io.FileUtils;
+
+import org.apache.commons.compress.archivers.zip.ParallelScatterZipCreator;
+import org.apache.commons.compress.archivers.zip.Zip64Mode;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.compress.parallel.InputStreamSupplier;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.NullInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Stream;
+
+/**
+ * Utility methods for working with parallel zip archives.
+ */
+public class ParallelZipUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(ParallelZipUtils.class);
+
+  /**
+   * Creates a zipped archive from the given path in parallel, streaming the data
+   * to the give output stream.
+   *
+   * @param dirPath
+   * @param outputStream
+   * @param poolSize
+   * @param compressionLevel
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  public static void compress(Path dirPath, OutputStream outputStream, int poolSize,
+        int compressionLevel)
+      throws IOException, InterruptedException {
+    LOG.info("compress in parallel for path {}", dirPath);
+    ExecutorService executor = ExecutorServiceFactories.fixedThreadPool(
+        "parallel-zip-compress-pool", poolSize).create();
+    ParallelScatterZipCreator parallelScatterZipCreator = new ParallelScatterZipCreator(executor);
+    ZipArchiveOutputStream zipArchiveOutputStream = new ZipArchiveOutputStream(outputStream);
+    zipArchiveOutputStream.setUseZip64(Zip64Mode.Always);
+    zipArchiveOutputStream.setLevel(compressionLevel);
+
+    try {
+      try (final Stream<Path> stream = Files.walk(dirPath)) {
+        for (Path subPath : stream.collect(toList())) {
+          if (Thread.interrupted()) {
+            throw new InterruptedException();
+          }
+
+          File file = subPath.toFile();
+
+          final InputStreamSupplier inputStreamSupplier = () -> {
+            try {
+              if (file.exists() && file.isFile()) {
+                return new FileInputStream(file);
+              } else {
+                return new NullInputStream(0);
+              }
+            } catch (FileNotFoundException e) {
+              LOG.warn("Can't find file when parallel zip, path = {}", subPath);
+              return new NullInputStream(0);
+            }
+          };
+
+          String entryName = dirPath.relativize(subPath).toString();
+          if (file.isDirectory()) {
+            entryName += File.separator;
+          }
+
+          ZipArchiveEntry zipArchiveEntry = new ZipArchiveEntry(entryName);
+          zipArchiveEntry.setMethod(ZipArchiveEntry.DEFLATED);
+
+          parallelScatterZipCreator.addArchiveEntry(zipArchiveEntry, inputStreamSupplier);
+        }
+      }
+
+      parallelScatterZipCreator.writeTo(zipArchiveOutputStream);
+      zipArchiveOutputStream.finish();
+      zipArchiveOutputStream.flush();
+    } catch (ExecutionException e) {
+      LOG.error("Parallel compress rocksdb failed", e);
+      throw new IOException(e);
+    } finally {
+      if (!executor.isTerminated()) {
+        LOG.info("ParallelScatterZipCreator failed to shut down the thread pool, cleaning up now.");
+        ExecutorServiceUtils.shutdownAndAwaitTermination(executor);
+      }
+    }
+
+    LOG.info("Completed parallel compression for path {}, statistics: {}",
+        dirPath, parallelScatterZipCreator.getStatisticsMessage().toString());
+  }
+
+  /**
+   * Reads a zipped archive from a path in parallel and writes it to the given path.
+   *
+   * @param dirPath
+   * @param backupPath
+   * @param poolSize
+   */
+  public static void decompress(Path dirPath, String backupPath, int poolSize) throws IOException {
+    LOG.info("decompress in parallel from path {} to {}", backupPath, dirPath);
+    ExecutorService executor = ExecutorServiceFactories.fixedThreadPool(
+        "parallel-zip-decompress-pool", poolSize).create();
+    CompletionService<Boolean> completionService = new ExecutorCompletionService<Boolean>(executor);
+
+    try (ZipFile zipFile = new ZipFile(backupPath)) {
+      Enumeration<ZipArchiveEntry> entries = zipFile.getEntries();
+      int taskCount = 0;
+
+      while (entries.hasMoreElements()) {
+        taskCount += 1;
+        ZipArchiveEntry entry = entries.nextElement();
+        completionService.submit(() -> {
+          unzipEntry(zipFile, entry, dirPath);
+          return true;
+        });
+      }
+
+      for (int i = 0; i < taskCount; i++) {
+        completionService.take().get();
+      }
+    } catch (ExecutionException e) {
+      LOG.error("Parallel decompress rocksdb fail", e);
+      FileUtils.deletePathRecursively(dirPath.toString());
+      throw new IOException(e);
+    } catch (InterruptedException e) {
+      LOG.info("Parallel decompress rocksdb interrupted");
+      FileUtils.deletePathRecursively(dirPath.toString());
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    } finally {
+      ExecutorServiceUtils.shutdownAndAwaitTermination(executor);
+    }
+  }
+
+  /**
+   * Unzip entry in ZipFile.
+   *
+   * @param zipFile
+   * @param entry
+   * @param dirPath
+   * @throws Exception
+   */
+  private static void unzipEntry(ZipFile zipFile, ZipArchiveEntry entry, Path dirPath)
+      throws Exception {
+    File outputFile = new File(dirPath.toFile(), entry.getName());
+    outputFile.getParentFile().mkdirs();
+
+    if (entry.isDirectory()) {
+      outputFile.mkdir();
+    } else {
+      try (InputStream inputStream = zipFile.getInputStream(entry);
+           FileOutputStream fileOutputStream = new FileOutputStream(outputFile)) {
+        IOUtils.copy(inputStream, fileOutputStream);
+      }
+    }
+  }
+
+  private ParallelZipUtils() {} // Utils class
+}

--- a/core/server/common/src/test/java/alluxio/util/ParallelZipUtilsTest.java
+++ b/core/server/common/src/test/java/alluxio/util/ParallelZipUtilsTest.java
@@ -1,0 +1,91 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Units tests for {@link ParallelZipUtils}.
+ */
+public final class ParallelZipUtilsTest {
+  @Rule
+  public TemporaryFolder mFolder = new TemporaryFolder();
+
+  @Test
+  public void emptyDir() throws Exception {
+    Path empty = mFolder.newFolder("emptyDir").toPath();
+
+    zipUnzipTest(empty);
+  }
+
+  @Test
+  public void oneFileDir() throws Exception {
+    Path dir = mFolder.newFolder("oneFileDir").toPath();
+    Path file = dir.resolve("file");
+    Files.write(file, "test content".getBytes());
+
+    zipUnzipTest(dir);
+  }
+
+  @Test
+  public void tenFileDir() throws Exception {
+    Path dir = mFolder.newFolder("tenFileDir").toPath();
+    for (int i = 0; i < 10; i++) {
+      Path file = dir.resolve("file" + i);
+      Files.write(file, ("test content and a lot of test content" + i).getBytes());
+    }
+
+    zipUnzipTest(dir);
+  }
+
+  @Test
+  public void emptySubDir() throws Exception {
+    Path dir = mFolder.newFolder("emptySubDir").toPath();
+    Path subDir = dir.resolve("subDir");
+    Files.createDirectory(subDir);
+
+    zipUnzipTest(dir);
+  }
+
+  @Test
+  public void nested() throws Exception {
+    Path dir = mFolder.newFolder("emptySubDir").toPath();
+    Path current = dir;
+    for (int i = 0; i < 10; i++) {
+      Path newDir = current.resolve("dir" + i);
+      Files.createDirectory(newDir);
+      current = newDir;
+    }
+    Path file = current.resolve("file");
+    Files.write(file, "hello world".getBytes());
+
+    zipUnzipTest(dir);
+  }
+
+  private void zipUnzipTest(Path path) throws Exception {
+    String zippedPath = mFolder.newFile("zipped").getPath();
+    try (FileOutputStream fos = new FileOutputStream(zippedPath)) {
+      ParallelZipUtils.compress(path, fos, 5, 5);
+    }
+
+    Path reconstructed = mFolder.newFolder("unzipped").toPath();
+    reconstructed.toFile().delete();
+    ParallelZipUtils.decompress(reconstructed, zippedPath, 5);
+    FileUtil.assertDirectoriesEqual(path, reconstructed);
+  }
+}

--- a/core/server/common/src/test/java/alluxio/util/TarUtilsTest.java
+++ b/core/server/common/src/test/java/alluxio/util/TarUtilsTest.java
@@ -11,6 +11,7 @@
 
 package alluxio.util;
 
+<<<<<<< HEAD
 import static org.mockito.ArgumentMatchers.any;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -20,6 +21,13 @@ import alluxio.util.io.FileUtils;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.junit.Assert;
+||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+=======
+>>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -30,8 +38,13 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+<<<<<<< HEAD
 import java.io.IOException;
 import java.io.File;
+||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
+import java.io.IOException;
+=======
+>>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -123,24 +136,7 @@ public final class TarUtilsTest {
     Path reconstructed = mFolder.newFolder("untarred").toPath();
     reconstructed.toFile().delete();
     TarUtils.readTarGz(reconstructed, new ByteArrayInputStream(baos.toByteArray()));
-    assertDirectoriesEqual(path, reconstructed);
-  }
-
-  private void assertDirectoriesEqual(Path path, Path reconstructed) throws Exception {
-    Files.walk(path).forEach(subPath -> {
-      Path relative = path.relativize(subPath);
-      Path resolved = reconstructed.resolve(relative);
-      assertTrue(resolved + " should exist since " + subPath + " exists", Files.exists(resolved));
-      assertEquals(subPath.toFile().isFile(), resolved.toFile().isFile());
-      if (path.toFile().isFile()) {
-        try {
-          assertArrayEquals(resolved + " should have the same content as " + subPath,
-              Files.readAllBytes(path), Files.readAllBytes(resolved));
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
-      }
-    });
+    FileUtil.assertDirectoriesEqual(path, reconstructed);
   }
 
   @Test

--- a/core/server/common/src/test/java/alluxio/util/TarUtilsTest.java
+++ b/core/server/common/src/test/java/alluxio/util/TarUtilsTest.java
@@ -11,23 +11,12 @@
 
 package alluxio.util;
 
-<<<<<<< HEAD
 import static org.mockito.ArgumentMatchers.any;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import alluxio.util.io.FileUtils;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.junit.Assert;
-||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-=======
->>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -38,13 +27,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-<<<<<<< HEAD
-import java.io.IOException;
 import java.io.File;
-||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
-import java.io.IOException;
-=======
->>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
 import java.nio.file.Files;
 import java.nio.file.Path;
 

--- a/core/server/master/src/main/java/alluxio/master/journal/tool/AbstractJournalDumper.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/AbstractJournalDumper.java
@@ -85,7 +85,7 @@ public abstract class AbstractJournalDumper {
       case COMPOUND:
         readCompoundCheckpoint(checkpoint, path);
         break;
-      case ROCKS:
+      case ROCKS_SINGLE:
         readRocksCheckpoint(checkpoint, path);
         break;
       default:

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
@@ -23,17 +23,10 @@ import alluxio.util.TarUtils;
 import alluxio.util.io.FileUtils;
 
 import com.google.common.base.Preconditions;
-<<<<<<< HEAD
-||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
-import org.rocksdb.BlockBasedTableConfig;
-import org.rocksdb.BloomFilter;
-import org.rocksdb.Cache;
-=======
 import org.apache.commons.io.IOUtils;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.BloomFilter;
 import org.rocksdb.Cache;
->>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
 import org.rocksdb.Checkpoint;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
@@ -52,13 +45,8 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-<<<<<<< HEAD
-||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
-import java.util.Optional;
-=======
 import java.util.Optional;
 import java.util.UUID;
->>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -94,21 +82,14 @@ public final class RocksStore implements Closeable {
    * @param columnFamilyDescriptors columns to create within the rocks database
    * @param columnHandles column handle references to populate
    */
-<<<<<<< HEAD
   public RocksStore(String name, String dbPath, String checkpointPath,
-||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
-  public RocksStore(String name, String dbPath, String checkpointPath,
-      DBOptions dbOpts,
-=======
-  public RocksStore(String name, String dbPath, String checkpointPath, DBOptions dbOpts,
->>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
       Collection<ColumnFamilyDescriptor> columnFamilyDescriptors,
       List<AtomicReference<ColumnFamilyHandle>> columnHandles) {
     Preconditions.checkState(columnFamilyDescriptors.size() == columnHandles.size());
     mName = name;
     mDbPath = dbPath;
     mDbCheckpointPath = checkpointPath;
-    mParallelBackupPoolSize = Configuration.getInt(
+    mParallelBackupPoolSize = ServerConfiguration.getInt(
         PropertyKey.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_THREADS);
     mColumnFamilyDescriptors = columnFamilyDescriptors;
     mDbOpts = new DBOptions()
@@ -228,29 +209,23 @@ public final class RocksStore implements Closeable {
     } catch (RocksDBException e) {
       throw new IOException(e);
     }
-<<<<<<< HEAD
     LOG.info("Checkpoint complete, creating tarball");
-    TarUtils.writeTarGz(Paths.get(mDbCheckpointPath), out, mCompressLevel);
-||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
-    LOG.info("Checkpoint complete, creating tarball");
-    TarUtils.writeTarGz(Paths.get(mDbCheckpointPath), out);
-=======
+    TarUtils.writeTarGz(Paths.get(mDbCheckpointPath), output, mCompressLevel);
 
-    if (Configuration.getBoolean(PropertyKey.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP)) {
+    if (ServerConfiguration.getBoolean(PropertyKey.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP)) {
       CheckpointOutputStream out = new CheckpointOutputStream(output,
           CheckpointType.ROCKS_PARALLEL);
       LOG.info("Checkpoint complete, compressing with {} threads", mParallelBackupPoolSize);
-      int compressLevel = Configuration.getInt(
+      int compressLevel = ServerConfiguration.getInt(
           PropertyKey.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_COMPRESSION_LEVEL);
       ParallelZipUtils.compress(Paths.get(mDbCheckpointPath), out,
           mParallelBackupPoolSize, compressLevel);
     } else {
       CheckpointOutputStream out = new CheckpointOutputStream(output, CheckpointType.ROCKS_SINGLE);
       LOG.info("Checkpoint complete, compressing with one thread");
-      TarUtils.writeTarGz(Paths.get(mDbCheckpointPath), out);
+      TarUtils.writeTarGz(Paths.get(mDbCheckpointPath), output, mCompressLevel);
     }
 
->>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
     LOG.info("Completed rocksdb checkpoint in {}ms", (System.nanoTime() - startNano) / 1_000_000);
     // Checkpoint is no longer needed, delete to save space.
     FileUtils.deletePathRecursively(mDbCheckpointPath);
@@ -271,7 +246,7 @@ public final class RocksStore implements Closeable {
     FileUtils.deletePathRecursively(mDbPath);
 
     if (input.getType() == CheckpointType.ROCKS_PARALLEL) {
-      List<String> tmpDirs = Configuration.getList(PropertyKey.TMP_DIRS);
+      List<String> tmpDirs = ServerConfiguration.getList(PropertyKey.TMP_DIRS);
       String tmpZipFilePath = new File(tmpDirs.get(0), "alluxioRockStore-" + UUID.randomUUID())
           .getPath();
 

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
@@ -18,10 +18,22 @@ import alluxio.master.journal.checkpoint.CheckpointInputStream;
 import alluxio.master.journal.checkpoint.CheckpointOutputStream;
 import alluxio.master.journal.checkpoint.CheckpointType;
 import alluxio.retry.TimeoutRetry;
+import alluxio.util.ParallelZipUtils;
 import alluxio.util.TarUtils;
 import alluxio.util.io.FileUtils;
 
 import com.google.common.base.Preconditions;
+<<<<<<< HEAD
+||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.BloomFilter;
+import org.rocksdb.Cache;
+=======
+import org.apache.commons.io.IOUtils;
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.BloomFilter;
+import org.rocksdb.Cache;
+>>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
 import org.rocksdb.Checkpoint;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
@@ -33,12 +45,20 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+<<<<<<< HEAD
+||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
+import java.util.Optional;
+=======
+import java.util.Optional;
+import java.util.UUID;
+>>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -55,6 +75,7 @@ public final class RocksStore implements Closeable {
   private final String mName;
   private final String mDbPath;
   private final String mDbCheckpointPath;
+  private final Integer mParallelBackupPoolSize;
   private final Collection<ColumnFamilyDescriptor> mColumnFamilyDescriptors;
   private final DBOptions mDbOpts;
 
@@ -73,13 +94,22 @@ public final class RocksStore implements Closeable {
    * @param columnFamilyDescriptors columns to create within the rocks database
    * @param columnHandles column handle references to populate
    */
+<<<<<<< HEAD
   public RocksStore(String name, String dbPath, String checkpointPath,
+||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
+  public RocksStore(String name, String dbPath, String checkpointPath,
+      DBOptions dbOpts,
+=======
+  public RocksStore(String name, String dbPath, String checkpointPath, DBOptions dbOpts,
+>>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
       Collection<ColumnFamilyDescriptor> columnFamilyDescriptors,
       List<AtomicReference<ColumnFamilyHandle>> columnHandles) {
     Preconditions.checkState(columnFamilyDescriptors.size() == columnHandles.size());
     mName = name;
     mDbPath = dbPath;
     mDbCheckpointPath = checkpointPath;
+    mParallelBackupPoolSize = Configuration.getInt(
+        PropertyKey.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_THREADS);
     mColumnFamilyDescriptors = columnFamilyDescriptors;
     mDbOpts = new DBOptions()
             // Concurrent memtable write is not supported for hash linked list memtable
@@ -191,7 +221,6 @@ public final class RocksStore implements Closeable {
     LOG.info("Creating rocksdb checkpoint at {}", mDbCheckpointPath);
     long startNano = System.nanoTime();
 
-    CheckpointOutputStream out = new CheckpointOutputStream(output, CheckpointType.ROCKS);
     try {
       // createCheckpoint requires that the directory not already exist.
       FileUtils.deletePathRecursively(mDbCheckpointPath);
@@ -199,8 +228,29 @@ public final class RocksStore implements Closeable {
     } catch (RocksDBException e) {
       throw new IOException(e);
     }
+<<<<<<< HEAD
     LOG.info("Checkpoint complete, creating tarball");
     TarUtils.writeTarGz(Paths.get(mDbCheckpointPath), out, mCompressLevel);
+||||||| parent of ae065e34b9 (Support multithread checkpointing with compression/decompression)
+    LOG.info("Checkpoint complete, creating tarball");
+    TarUtils.writeTarGz(Paths.get(mDbCheckpointPath), out);
+=======
+
+    if (Configuration.getBoolean(PropertyKey.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP)) {
+      CheckpointOutputStream out = new CheckpointOutputStream(output,
+          CheckpointType.ROCKS_PARALLEL);
+      LOG.info("Checkpoint complete, compressing with {} threads", mParallelBackupPoolSize);
+      int compressLevel = Configuration.getInt(
+          PropertyKey.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_COMPRESSION_LEVEL);
+      ParallelZipUtils.compress(Paths.get(mDbCheckpointPath), out,
+          mParallelBackupPoolSize, compressLevel);
+    } else {
+      CheckpointOutputStream out = new CheckpointOutputStream(output, CheckpointType.ROCKS_SINGLE);
+      LOG.info("Checkpoint complete, compressing with one thread");
+      TarUtils.writeTarGz(Paths.get(mDbCheckpointPath), out);
+    }
+
+>>>>>>> ae065e34b9 (Support multithread checkpointing with compression/decompression)
     LOG.info("Completed rocksdb checkpoint in {}ms", (System.nanoTime() - startNano) / 1_000_000);
     // Checkpoint is no longer needed, delete to save space.
     FileUtils.deletePathRecursively(mDbCheckpointPath);
@@ -214,11 +264,34 @@ public final class RocksStore implements Closeable {
   public synchronized void restoreFromCheckpoint(CheckpointInputStream input) throws IOException {
     LOG.info("Restoring rocksdb from checkpoint");
     long startNano = System.nanoTime();
-    Preconditions.checkState(input.getType() == CheckpointType.ROCKS,
+    Preconditions.checkState(input.getType() == CheckpointType.ROCKS_SINGLE
+        || input.getType() == CheckpointType.ROCKS_PARALLEL,
         "Unexpected checkpoint type in RocksStore: " + input.getType());
     stopDb();
     FileUtils.deletePathRecursively(mDbPath);
-    TarUtils.readTarGz(Paths.get(mDbPath), input);
+
+    if (input.getType() == CheckpointType.ROCKS_PARALLEL) {
+      List<String> tmpDirs = Configuration.getList(PropertyKey.TMP_DIRS);
+      String tmpZipFilePath = new File(tmpDirs.get(0), "alluxioRockStore-" + UUID.randomUUID())
+          .getPath();
+
+      try {
+        try (FileOutputStream fos = new FileOutputStream(tmpZipFilePath)) {
+          IOUtils.copy(input, fos);
+        }
+
+        ParallelZipUtils.decompress(Paths.get(mDbPath), tmpZipFilePath,
+            mParallelBackupPoolSize);
+
+        FileUtils.deletePathRecursively(tmpZipFilePath);
+      } catch (Exception e) {
+        LOG.warn("Failed to decompress checkpoint from {} to {}", tmpZipFilePath, mDbPath);
+        throw e;
+      }
+    } else {
+      TarUtils.readTarGz(Paths.get(mDbPath), input);
+    }
+
     try {
       createDb();
     } catch (RocksDBException e) {

--- a/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
+++ b/core/server/master/src/main/java/alluxio/master/metastore/rocks/RocksStore.java
@@ -24,9 +24,6 @@ import alluxio.util.io.FileUtils;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.io.IOUtils;
-import org.rocksdb.BlockBasedTableConfig;
-import org.rocksdb.BloomFilter;
-import org.rocksdb.Cache;
 import org.rocksdb.Checkpoint;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
@@ -45,7 +42,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.ThreadSafe;

--- a/tests/src/test/java/alluxio/server/ft/journal/TriggeredCheckpointTest.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/TriggeredCheckpointTest.java
@@ -68,6 +68,42 @@ public class TriggeredCheckpointTest {
   }
 
   @Test
+  public void ufsJournalWithParallelBackupRocksDb() throws Exception {
+    int numFiles = 100;
+    MultiProcessCluster cluster = MultiProcessCluster
+        .newBuilder(PortCoordination.TRIGGERED_UFS_CHECKPOINT)
+        .setClusterName("TriggeredUfsCheckpointTest")
+        .addProperty(PropertyKey.MASTER_JOURNAL_TYPE, JournalType.UFS)
+        .addProperty(PropertyKey.MASTER_JOURNAL_CHECKPOINT_PERIOD_ENTRIES, numFiles)
+        .addProperty(PropertyKey.MASTER_METASTORE, "ROCKS")
+        .addProperty(PropertyKey.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP, true)
+        .addProperty(PropertyKey.MASTER_METASTORE_ROCKS_PARALLEL_BACKUP_THREADS, 5)
+        .setNumMasters(1)
+        .setNumWorkers(1)
+        .build();
+    try {
+      cluster.start();
+      cluster.waitForAllNodesRegistered(20 * Constants.SECOND_MS);
+
+      // Get enough journal entries
+      createFiles(cluster, numFiles);
+
+      // Trigger checkpoint
+      Assert.assertEquals(cluster.getMasterAddresses().get(0).getHostname(),
+          cluster.getMetaMasterClient().checkpoint());
+      String journalLocation = cluster.getJournalDir();
+      UfsJournal ufsJournal = new UfsJournal(URIUtils.appendPathOrDie(new URI(journalLocation),
+          Constants.FILE_SYSTEM_MASTER_NAME), new NoopMaster(""), 0, Collections::emptySet);
+      Assert.assertEquals(1, UfsJournalSnapshot.getSnapshot(ufsJournal).getCheckpoints().size());
+
+      validateCheckpointInClusterRestart(cluster);
+      cluster.notifySuccess();
+    } finally {
+      cluster.destroy();
+    }
+  }
+
+  @Test
   public void embeddedJournal() throws Exception {
     MultiProcessCluster cluster = MultiProcessCluster
         .newBuilder(PortCoordination.TRIGGERED_EMBEDDED_CHECKPOINT)


### PR DESCRIPTION
Cherry pick of https://github.com/Alluxio/alluxio/pull/16151

### What changes are proposed in this pull request?
Parallel zip compression and decompression can be used for RocksInodeStore.

### Why are the changes needed?
Checkpoint is too slow for RocksIndoeStore with more than 1 billion data

### Does this PR introduce any user facing changes?
It can be enabled by alluxio.master.parallel.backup.rocksdb, and the degree of parallelism can be determined by alluxio.master.parallel.backup.rocksdb.thread.pool.size

