### PR TITLE
Check for master TTL checker interval

### DIFF
--- a/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
+++ b/core/common/src/main/java/alluxio/conf/InstancedConfiguration.java
@@ -391,6 +391,7 @@ public class InstancedConfiguration implements AlluxioConfiguration {
     checkTieredStorage();
     checkMasterThrottleThresholds();
     checkCheckpointZipConfig();
+    checkMasterTTLInterval();
   }
 
   @Override
@@ -502,6 +503,16 @@ public class InstancedConfiguration implements AlluxioConfiguration {
     // heartbeat interval is worker-side.
   }
 
+  /**
+   * Checks that master TTL checker interval
+   * @throws IllegalStateException if the TTL check interval <= 0
+   */
+  private void checkMasterTTLInterval() {
+    long interval = getMs(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS);
+    checkState(interval > 0,
+        "Invalid value of alluxio.master.ttl.checker.interval %s, it must be lager than 0", interval);
+  }
+  
   /**
    * Checks that the interval is shorter than the timeout.
    *

--- a/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
+++ b/core/common/src/test/java/alluxio/conf/InstancedConfigurationTest.java
@@ -675,6 +675,7 @@ public class InstancedConfigurationTest {
   public void shortMasterHeartBeatTimeout() {
     mConfiguration.set(PropertyKey.MASTER_STANDBY_HEARTBEAT_INTERVAL, "5min");
     mConfiguration.set(PropertyKey.MASTER_HEARTBEAT_TIMEOUT, "4min");
+    mConfiguration.set(PropertyKey.MASTER_TTL_CHECKER_INTERVAL_MS, "0");
     mThrown.expect(IllegalStateException.class);
     mConfiguration.validate();
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?
improve [#17057](https://github.com/Alluxio/alluxio/issues/17057)
Add pre-check code for master ttl checker interval to avoid persistent logging while staring the Alluxio

### Why are the changes needed?
It will costs system resource usage continuously and cover old log info by one minute.

### Does this PR introduce any user facing changes?
nothing
