### PR TITLE
Dump metrics + stacks on failover/crash

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -586,17 +586,11 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.SERVER)
           .setIsHidden(true)
           .build();
-  public static final PropertyKey EXIT_COLLECT_METRICS =
-      booleanBuilder(Name.EXIT_COLLECT_METRICS)
+  public static final PropertyKey EXIT_COLLECT_INFO =
+      booleanBuilder(Name.EXIT_COLLECT_INFO)
           .setDefaultValue(true)
-          .setDescription("If true, the process will dump metrics into the log.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.SERVER)
-          .build();
-  public static final PropertyKey EXIT_COLLECT_STACKS =
-      booleanBuilder(Name.EXIT_COLLECT_STACKS)
-          .setDefaultValue(true)
-          .setDescription("If true, the process will dump thread stack traces into the log.")
+          .setDescription("If true, the process will dump metrics and jstack into the log folder. "
+              + "This only applies to Alluxio master and worker processes.")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
@@ -2461,18 +2455,11 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "the master addresses.")
           .setScope(Scope.ALL)
           .build();
-  public static final PropertyKey MASTER_FAILOVER_COLLECT_METRICS =
-      booleanBuilder(Name.MASTER_FAILOVER_COLLECT_METRICS)
+  public static final PropertyKey MASTER_FAILOVER_COLLECT_INFO =
+      booleanBuilder(Name.MASTER_FAILOVER_COLLECT_INFO)
           .setDefaultValue(true)
-          .setDescription("If true, the primary master will dump metrics before it "
-              + "transitions to standby.")
-          .setScope(Scope.MASTER)
-          .build();
-  public static final PropertyKey MASTER_FAILOVER_COLLECT_STACKS =
-      booleanBuilder(Name.MASTER_FAILOVER_COLLECT_STACKS)
-          .setDefaultValue(true)
-          .setDescription("If true, the primary master will dump all thread stacktraces before it "
-              + "transitions to standby.")
+          .setDescription("If true, the primary master will persist metrics and jstack into "
+              + "the log folder when it transitions to standby. ")
           .setScope(Scope.MASTER)
           .build();
 
@@ -7548,8 +7535,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String CONF_VALIDATION_ENABLED = "alluxio.conf.validation.enabled";
     public static final String DEBUG = "alluxio.debug";
     public static final String EXTENSIONS_DIR = "alluxio.extensions.dir";
-    public static final String EXIT_COLLECT_METRICS = "alluxio.exit.collect.metrics";
-    public static final String EXIT_COLLECT_STACKS = "alluxio.exit.collect.stacks";
+    public static final String EXIT_COLLECT_INFO = "alluxio.exit.collect.info";
     public static final String GRPC_REFLECTION_ENABLED =
         "alluxio.grpc.reflection.enabled";
     public static final String HOME = "alluxio.home";
@@ -7887,10 +7873,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.cluster.metrics.update.interval";
     public static final String MASTER_CONTAINER_ID_RESERVATION_SIZE =
         "alluxio.master.container.id.reservation.size";
-    public static final String MASTER_FAILOVER_COLLECT_METRICS =
-        "alluxio.master.failover.collect.metrics";
-    public static final String MASTER_FAILOVER_COLLECT_STACKS =
-        "alluxio.master.failover.collect.stacks";
+    public static final String MASTER_FAILOVER_COLLECT_INFO =
+        "alluxio.master.failover.collect.info";
     public static final String MASTER_FILE_ACCESS_TIME_UPDATER_ENABLED =
         "alluxio.master.file.access.time.updater.enabled";
     public static final String MASTER_FILE_ACCESS_TIME_JOURNAL_FLUSH_INTERVAL =

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -586,6 +586,20 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setScope(Scope.SERVER)
           .setIsHidden(true)
           .build();
+  public static final PropertyKey EXIT_COLLECT_METRICS =
+      booleanBuilder(Name.EXIT_COLLECT_METRICS)
+          .setDefaultValue(true)
+          .setDescription("If true, the process will dump metrics into the log.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey EXIT_COLLECT_STACKS =
+      booleanBuilder(Name.EXIT_COLLECT_STACKS)
+          .setDefaultValue(true)
+          .setDescription("If true, the process will dump thread stack traces into the log.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.SERVER)
+          .build();
   public static final PropertyKey GRPC_REFLECTION_ENABLED =
       booleanBuilder(Name.GRPC_REFLECTION_ENABLED)
           .setDefaultValue(false)
@@ -2446,6 +2460,20 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "property is not used when Zookeeper is enabled, since Zookeeper already stores "
               + "the master addresses.")
           .setScope(Scope.ALL)
+          .build();
+  public static final PropertyKey MASTER_FAILOVER_COLLECT_METRICS =
+      booleanBuilder(Name.MASTER_FAILOVER_COLLECT_METRICS)
+          .setDefaultValue(true)
+          .setDescription("If true, the primary master will dump metrics before it "
+              + "transitions to standby.")
+          .setScope(Scope.MASTER)
+          .build();
+  public static final PropertyKey MASTER_FAILOVER_COLLECT_STACKS =
+      booleanBuilder(Name.MASTER_FAILOVER_COLLECT_STACKS)
+          .setDefaultValue(true)
+          .setDescription("If true, the primary master will dump all thread stacktraces before it "
+              + "transitions to standby.")
+          .setScope(Scope.MASTER)
           .build();
 
   public static final PropertyKey MASTER_FILE_ACCESS_TIME_UPDATER_ENABLED =
@@ -7520,6 +7548,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String CONF_VALIDATION_ENABLED = "alluxio.conf.validation.enabled";
     public static final String DEBUG = "alluxio.debug";
     public static final String EXTENSIONS_DIR = "alluxio.extensions.dir";
+    public static final String EXIT_COLLECT_METRICS = "alluxio.exit.collect.metrics";
+    public static final String EXIT_COLLECT_STACKS = "alluxio.exit.collect.stacks";
     public static final String GRPC_REFLECTION_ENABLED =
         "alluxio.grpc.reflection.enabled";
     public static final String HOME = "alluxio.home";
@@ -7857,6 +7887,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.cluster.metrics.update.interval";
     public static final String MASTER_CONTAINER_ID_RESERVATION_SIZE =
         "alluxio.master.container.id.reservation.size";
+    public static final String MASTER_FAILOVER_COLLECT_METRICS =
+        "alluxio.master.failover.collect.metrics";
+    public static final String MASTER_FAILOVER_COLLECT_STACKS =
+        "alluxio.master.failover.collect.stacks";
     public static final String MASTER_FILE_ACCESS_TIME_UPDATER_ENABLED =
         "alluxio.master.file.access.time.updater.enabled";
     public static final String MASTER_FILE_ACCESS_TIME_JOURNAL_FLUSH_INTERVAL =

--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -128,7 +128,11 @@ public final class ThreadUtils {
     stream.println(THREAD_BEAN.getThreadCount() + " active threads");
     long[] threadIds = THREAD_BEAN.getAllThreadIds();
     for (long id : threadIds) {
-      ThreadInfo info = THREAD_BEAN.getThreadInfo(id);
+      ThreadInfo info = THREAD_BEAN.getThreadInfo(id, Integer.MAX_VALUE);
+      if (info == null) {
+        // The thread is no longer active, ignore
+        continue;
+      }
       stream.print(info.toString());
     }
     stream.flush();

--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -116,15 +116,20 @@ public final class ThreadUtils {
 
   /**
    * Prints the information and stack traces of all threads.
+   * In order not to pause the JVM when there are tons of threads, thread stacks are printed
+   * one by one. So the thread stacks are not guaranteed to be based on one consistent
+   * snapshot.
    *
    * @param stream the stream to
    * @param title  a string title for the stack trace
    */
   public static synchronized void printThreadInfo(PrintStream stream, String title) {
     stream.println("Process Thread Dump: " + title);
-    stream.println(THREAD_BEAN.getThreadCount() + " active theads");
-    for (ThreadInfo ti: THREAD_BEAN.dumpAllThreads(true, true)) {
-      stream.print(ti.toString());
+    stream.println(THREAD_BEAN.getThreadCount() + " active threads");
+    long[] threadIds = THREAD_BEAN.getAllThreadIds();
+    for (long id : threadIds) {
+      ThreadInfo info = THREAD_BEAN.getThreadInfo(id);
+      stream.print(info.toString());
     }
     stream.flush();
   }

--- a/core/server/common/src/main/java/alluxio/ProcessUtils.java
+++ b/core/server/common/src/main/java/alluxio/ProcessUtils.java
@@ -15,16 +15,27 @@ import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 
 import alluxio.metrics.MetricsSystem;
+import alluxio.util.CommonUtils;
 import alluxio.util.ThreadUtils;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Utility methods for Alluxio {@link Process}es.
  */
 public final class ProcessUtils {
   private static final Logger LOG = LoggerFactory.getLogger(ProcessUtils.class);
+
+  public static final Set<CommonUtils.ProcessType> COLLECT_ON_EXIT =
+      ImmutableSet.of(CommonUtils.ProcessType.MASTER, CommonUtils.ProcessType.WORKER, CommonUtils.ProcessType.CLIENT);
+  public static final AtomicBoolean METRIC_DUMP_CHECK = new AtomicBoolean(false);
+  public static final AtomicBoolean STACK_DUMP_CHECK = new AtomicBoolean(false);
 
   /**
    * Runs the given {@link Process}. This method should only be called from {@code main()} methods.
@@ -39,7 +50,7 @@ public final class ProcessUtils {
       process.start();
       LOG.info("Stopping {}.", process);
 
-      dumpInformation();
+      dumpInformationOnExit();
 
       System.exit(0);
     } catch (Throwable t) {
@@ -53,7 +64,7 @@ public final class ProcessUtils {
             + "Exception \"{}\", Root Cause \"{}\"", process, t2, Throwables.getRootCause(t2),
             t2);
       }
-      dumpInformation();
+      dumpInformationOnExit();
 
       System.exit(-1);
     }
@@ -88,7 +99,7 @@ public final class ProcessUtils {
     }
     logger.error(message);
 
-    dumpInformation();
+    dumpInformationOnExit();
 
     System.exit(-1);
   }
@@ -105,6 +116,7 @@ public final class ProcessUtils {
   public static void stopProcessOnShutdown(final Process process) {
     Runtime.getRuntime().addShutdownHook(new Thread(() -> {
       try {
+        dumpInformationOnExit();
         process.stop();
       } catch (Throwable t) {
         LOG.error("Failed to stop process", t);
@@ -112,18 +124,74 @@ public final class ProcessUtils {
     }, "alluxio-process-shutdown-hook"));
   }
 
-  public static void dumpInformation() {
-    LOG.info("Logging all useful information before exiting");
+  public static void dumpInformationOnExit() {
+    dumpInformation(false);
+  }
 
-    // TODO(jiacheng): consider using a separate File to record all these
+  public static void dumpInformationOnFailover() {
+    dumpInformation(true);
+  }
 
-    // Log all threads
-    ThreadUtils.logAllThreads();
+  // TODO(jiacheng): consider using a separate File to record all these
+  private static void dumpInformation(boolean isFailover) {
+    if (!COLLECT_ON_EXIT.contains(CommonUtils.PROCESS_TYPE.get())) {
+      LOG.info("Process type is {}, skip dumping metrics and thread stacks", CommonUtils.PROCESS_TYPE.get());
+      return;
+    }
 
-    // Metrics
-    LOG.info("{}", MetricsSystem.METRIC_REGISTRY);
+    LOG.info("Logging all useful information before exiting {}", CommonUtils.PROCESS_TYPE.get());
 
-    LOG.info("Metrics and jstack are persisted.");
+    if (!STACK_DUMP_CHECK.get()) {
+      synchronized (ProcessUtils.class) {
+        // Only attempt to dump the stacks once because it produces a lot of logs
+        if (STACK_DUMP_CHECK.compareAndSet(false, true)) {
+          if (isFailover) {
+            if (Configuration.getBoolean(PropertyKey.MASTER_FAILOVER_COLLECT_STACKS)) {
+              LOG.info("Logging all thread stacks when primary master switches to standby...");
+              ThreadUtils.logAllThreads();
+            } else {
+              LOG.info("Not logging thread stacks on failover, set {}=true if that is necessary",
+                  PropertyKey.MASTER_FAILOVER_COLLECT_STACKS.getName());
+            }
+          } else {
+            if (Configuration.getBoolean(PropertyKey.EXIT_COLLECT_STACKS)) {
+              LOG.info("Logging all thread stacks on exit...");
+              ThreadUtils.logAllThreads();
+            } else {
+              LOG.info("Not logging thread stacks on exit, set {}=true if that is necessary",
+                  PropertyKey.EXIT_COLLECT_STACKS.getName());
+            }
+          }
+        }
+      }
+    }
+
+    if (!METRIC_DUMP_CHECK.get()) {
+      synchronized (ProcessUtils.class) {
+        // Only attempt to dump metrics once because it produces a lot of logs
+        if (METRIC_DUMP_CHECK.compareAndSet(false, true)) {
+          if (isFailover) {
+            if (Configuration.getBoolean(PropertyKey.MASTER_FAILOVER_COLLECT_STACKS)) {
+              LOG.info("Logging all metrics when primary master switches to standby...");
+              // TODO(jiacheng): only log necessary metrics?
+              // TODO(jiacheng): this is only logging the obj hash
+              LOG.info("{}", MetricsSystem.METRIC_REGISTRY);
+            } else {
+              LOG.info("Not logging primary master metrics on failover, set {}=true if that is necessary",
+                  PropertyKey.MASTER_FAILOVER_COLLECT_METRICS.getName());
+            }
+          } else {
+            if (Configuration.getBoolean(PropertyKey.EXIT_COLLECT_METRICS)) {
+              LOG.info("Logging all component metrics...");
+              LOG.info("{}", MetricsSystem.METRIC_REGISTRY);
+            } else {
+              LOG.info("Not logging component metrics on exit, set {}=true if that is necessary",
+                  PropertyKey.EXIT_COLLECT_METRICS.getName());
+            }
+          }
+        }
+      }
+    }
   }
 
   private ProcessUtils() {} // prevent instantiation

--- a/core/server/common/src/main/java/alluxio/ProcessUtils.java
+++ b/core/server/common/src/main/java/alluxio/ProcessUtils.java
@@ -14,19 +14,15 @@ package alluxio;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 
-import alluxio.exception.status.DeadlineExceededException;
 import alluxio.metrics.MetricsSystem;
 import alluxio.util.CommonUtils;
 import alluxio.util.ThreadUtils;
-import com.codahale.metrics.MetricRegistry;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -34,10 +30,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static alluxio.metrics.sink.MetricsServlet.OBJECT_MAPPER;
@@ -50,8 +44,7 @@ public final class ProcessUtils {
 
   public static final Set<CommonUtils.ProcessType> COLLECT_ON_EXIT =
       ImmutableSet.of(CommonUtils.ProcessType.MASTER, CommonUtils.ProcessType.WORKER);
-  public static final AtomicBoolean METRIC_DUMP_CHECK = new AtomicBoolean(false);
-  public static final AtomicBoolean STACK_DUMP_CHECK = new AtomicBoolean(false);
+  public static volatile boolean INFO_DUMP_ON_EXIT_CHECK = false;
   public static final DateTimeFormatter DATETIME_FORMAT =
       DateTimeFormatter.ofPattern("yyyyMMdd-hhmmss");
 
@@ -143,78 +136,45 @@ public final class ProcessUtils {
   }
 
   public static void dumpInformationOnExit() {
-    dumpInformation(false);
+    if (!COLLECT_ON_EXIT.contains(CommonUtils.PROCESS_TYPE.get())) {
+      LOG.info("Process type is {}, skip dumping metrics and thread stacks",
+          CommonUtils.PROCESS_TYPE.get());
+      return;
+    }
+    if (Configuration.getBoolean(PropertyKey.EXIT_COLLECT_INFO)) {
+      synchronized (ProcessUtils.class) {
+        if (!INFO_DUMP_ON_EXIT_CHECK) {
+          INFO_DUMP_ON_EXIT_CHECK = true;
+          LOG.info("Logging metrics and jstack on {} exit...", CommonUtils.PROCESS_TYPE.get());
+          String logsPath = Configuration.getString(PropertyKey.LOGS_DIR);
+          dumpMetrics(logsPath);
+          dumpStacks(logsPath);
+        }
+      }
+    } else {
+      LOG.info("Not logging metrics and jstack on exit, set {}=true if that is necessary",
+          PropertyKey.EXIT_COLLECT_INFO.getName());
+    }
   }
 
   public static void dumpInformationOnFailover() {
-    dumpInformation(true);
-  }
-
-  private static void dumpInformation(boolean isFailover) {
-    if (!COLLECT_ON_EXIT.contains(CommonUtils.PROCESS_TYPE.get())) {
-      LOG.info("Process type is {}, skip dumping metrics and thread stacks", CommonUtils.PROCESS_TYPE.get());
-      return;
-    }
-
-    LOG.info("Logging all useful information before exiting {}", CommonUtils.PROCESS_TYPE.get());
-
-    if (!STACK_DUMP_CHECK.get()) {
-      synchronized (ProcessUtils.class) {
-        // Only attempt to dump the stacks once because it produces a lot of logs
-        if (STACK_DUMP_CHECK.compareAndSet(false, true)) {
-          if (isFailover) {
-            if (Configuration.getBoolean(PropertyKey.MASTER_FAILOVER_COLLECT_STACKS)) {
-              LOG.info("Logging all thread stacks when primary master switches to standby...");
-              dumpStacks();
-            } else {
-              LOG.info("Not logging thread stacks on failover, set {}=true if that is necessary",
-                  PropertyKey.MASTER_FAILOVER_COLLECT_STACKS.getName());
-            }
-          } else {
-            if (Configuration.getBoolean(PropertyKey.EXIT_COLLECT_STACKS)) {
-              LOG.info("Logging all thread stacks on exit...");
-              dumpStacks();
-            } else {
-              LOG.info("Not logging thread stacks on exit, set {}=true if that is necessary",
-                  PropertyKey.EXIT_COLLECT_STACKS.getName());
-            }
-          }
-        }
-      }
-    }
-
-    if (!METRIC_DUMP_CHECK.get()) {
-      synchronized (ProcessUtils.class) {
-        // Only attempt to dump threads once because it produces a lot of logs
-        if (METRIC_DUMP_CHECK.compareAndSet(false, true)) {
-          if (isFailover) {
-            if (Configuration.getBoolean(PropertyKey.MASTER_FAILOVER_COLLECT_STACKS)) {
-              LOG.info("Logging all metrics when primary master switches to standby...");
-              dumpMetrics();
-            } else {
-              LOG.info("Not logging primary master metrics on failover, set {}=true if that is necessary",
-                  PropertyKey.MASTER_FAILOVER_COLLECT_METRICS.getName());
-            }
-          } else {
-            if (Configuration.getBoolean(PropertyKey.EXIT_COLLECT_METRICS)) {
-              LOG.info("Logging all component metrics...");
-              dumpMetrics();
-            } else {
-              LOG.info("Not logging component metrics on exit, set {}=true if that is necessary",
-                  PropertyKey.EXIT_COLLECT_METRICS.getName());
-            }
-          }
-        }
-      }
+    if (Configuration.getBoolean(PropertyKey.MASTER_FAILOVER_COLLECT_INFO)) {
+      LOG.info("Logging metrics and jstack when primary master switches to standby...");
+      String logsPath = Configuration.getString(PropertyKey.LOGS_DIR);
+      dumpMetrics(logsPath);
+      dumpStacks(logsPath);
+    } else {
+      LOG.info("Not logging information like metrics and jstack on failover, "
+          + "set {}=true if that is necessary",
+          PropertyKey.MASTER_FAILOVER_COLLECT_INFO.getName());
     }
   }
 
-  private static void dumpMetrics() {
-    String logsPath = Configuration.getString(PropertyKey.LOGS_DIR);
+  private static void dumpMetrics(String logDir) {
     Instant start = Instant.now();
     String childFilePath = String.format("alluxio-%s-metrics-%s.json",
         CommonUtils.PROCESS_TYPE.get().toString().toLowerCase(), DATETIME_FORMAT.format(start));
-    File metricDumpFile = new File(logsPath, childFilePath);
+    File metricDumpFile = new File(logDir, childFilePath);
     try (FileOutputStream fos = new FileOutputStream(metricDumpFile, false)) {
       // The metrics json string is ~100KB in size
       String outputContents = OBJECT_MAPPER.writerWithDefaultPrettyPrinter()
@@ -222,23 +182,24 @@ public final class ProcessUtils {
       fos.getChannel().write(ByteBuffer.wrap(outputContents.getBytes(StandardCharsets.UTF_8)));
     } catch (IOException e) {
       LOG.error("Failed to persist metrics to {}", metricDumpFile.getAbsolutePath(), e);
+      return;
     }
     Instant end = Instant.now();
     LOG.info("Dumped metrics of current process in {}ms to {}",
         Duration.between(start, end).toMillis(), childFilePath);
   }
 
-  private static void dumpStacks() {
-    String logsPath = Configuration.getString(PropertyKey.LOGS_DIR);
+  private static void dumpStacks(String logDir) {
     Instant start = Instant.now();
     String childFilePath = String.format("alluxio-%s-stacks-%s.txt",
         CommonUtils.PROCESS_TYPE.get().toString().toLowerCase(), DATETIME_FORMAT.format(start));
-    File stacksDumpFile = new File(logsPath, childFilePath);
+    File stacksDumpFile = new File(logDir, childFilePath);
     try (PrintStream stream = new PrintStream(stacksDumpFile)) {
       // Dumping one thread produces <1KB
       ThreadUtils.printThreadInfo(stream, "Dumping all threads in process");
     } catch (IOException e) {
       LOG.error("Failed to persist thread stacks to {}", stacksDumpFile.getAbsolutePath(), e);
+      return;
     }
     Instant end = Instant.now();
     LOG.info("Dumped jstack of current process in {}ms to {}",

--- a/core/server/common/src/main/java/alluxio/ProcessUtils.java
+++ b/core/server/common/src/main/java/alluxio/ProcessUtils.java
@@ -32,7 +32,10 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -45,7 +48,8 @@ public final class ProcessUtils {
       ImmutableSet.of(CommonUtils.ProcessType.MASTER, CommonUtils.ProcessType.WORKER);
   public static volatile boolean sInfoDumpOnExitCheck = false;
   public static final DateTimeFormatter DATETIME_FORMAT =
-      DateTimeFormatter.ofPattern("yyyyMMdd-hhmmss");
+      DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT).ofPattern("yyyyMMdd-HHmmss")
+          .withLocale(Locale.getDefault()).withZone(ZoneId.systemDefault());
 
   /**
    * Runs the given {@link Process}. This method should only be called from {@code main()} methods.

--- a/core/server/common/src/main/java/alluxio/ProcessUtils.java
+++ b/core/server/common/src/main/java/alluxio/ProcessUtils.java
@@ -180,6 +180,9 @@ public final class ProcessUtils {
    * Outputs process critical information like metrics and jstack before the primary master
    * fails over to standby. This is asynchronous in order not to block the failover.
    * The information will be output to separate files in the log directory.
+   *
+   * @param es the thread pool to submit tasks to
+   * @return a list of futures for async info dumping jobs
    */
   public static List<Future<Void>> dumpInformationOnFailover(ExecutorService es) {
     if (Configuration.getBoolean(PropertyKey.MASTER_FAILOVER_COLLECT_INFO)) {

--- a/core/server/common/src/main/java/alluxio/ProcessUtils.java
+++ b/core/server/common/src/main/java/alluxio/ProcessUtils.java
@@ -153,11 +153,15 @@ public final class ProcessUtils {
         if (!sInfoDumpOnExitCheck) {
           sInfoDumpOnExitCheck = true;
           LOG.info("Logging metrics and jstack on {} exit...", CommonUtils.PROCESS_TYPE.get());
-          String logsDir = Configuration.getString(PropertyKey.LOGS_DIR);
-          String outputFilePrefix = "alluxio-"
-              + CommonUtils.PROCESS_TYPE.get().toString().toLowerCase() + "-exit";
-          dumpMetrics(logsDir, outputFilePrefix);
-          dumpStacks(logsDir, outputFilePrefix);
+          try {
+            String logsDir = Configuration.getString(PropertyKey.LOGS_DIR);
+            String outputFilePrefix = "alluxio-"
+                    + CommonUtils.PROCESS_TYPE.get().toString().toLowerCase() + "-exit";
+            dumpMetrics(logsDir, outputFilePrefix);
+            dumpStacks(logsDir, outputFilePrefix);
+          } catch (Throwable t) {
+            LOG.error("Failed to dump metrics and jstacks", t);
+          }
         }
       }
     } else {

--- a/core/server/common/src/main/java/alluxio/Registry.java
+++ b/core/server/common/src/main/java/alluxio/Registry.java
@@ -187,6 +187,7 @@ public class Registry<T extends Server<U>, U> {
         result.add(dep);
       }
     }
+    System.out.println("Dependency chain is: " + result);
     return result;
   }
 

--- a/core/server/common/src/main/java/alluxio/Registry.java
+++ b/core/server/common/src/main/java/alluxio/Registry.java
@@ -187,7 +187,6 @@ public class Registry<T extends Server<U>, U> {
         result.add(dep);
       }
     }
-    System.out.println("Dependency chain is: " + result);
     return result;
   }
 

--- a/core/server/common/src/main/java/alluxio/master/StateLockManager.java
+++ b/core/server/common/src/main/java/alluxio/master/StateLockManager.java
@@ -180,6 +180,7 @@ public class StateLockManager {
       // Grab the lock interruptibly.
       mStateLock.readLock().lockInterruptibly();
     } catch (Error e) {
+      // TODO(jiacheng): this can be removed as ProcessUtils is dumping
       // An Error is thrown when the lock is acquired 65536 times, log the jstack before exiting
       LOG.error("Logging all thread stacks before exiting", e);
       ThreadUtils.logAllThreads();

--- a/core/server/common/src/main/java/alluxio/master/StateLockManager.java
+++ b/core/server/common/src/main/java/alluxio/master/StateLockManager.java
@@ -176,16 +176,8 @@ public class StateLockManager {
       LOG.warn("Current thread is {}. All state lock holders are {}",
           threadName, mSharedLockHolders, e);
     }
-    try {
-      // Grab the lock interruptibly.
-      mStateLock.readLock().lockInterruptibly();
-    } catch (Error e) {
-      // TODO(jiacheng): this can be removed as ProcessUtils is dumping
-      // An Error is thrown when the lock is acquired 65536 times, log the jstack before exiting
-      LOG.error("Logging all thread stacks before exiting", e);
-      ThreadUtils.logAllThreads();
-      throw e;
-    }
+    // Grab the lock interruptibly.
+    mStateLock.readLock().lockInterruptibly();
     // Return the resource.
     // Register an action to remove the thread from holders registry before releasing the lock.
     return new LockResource(mStateLock.readLock(), false, false, () -> {

--- a/core/server/common/src/main/java/alluxio/metrics/sink/MetricsServlet.java
+++ b/core/server/common/src/main/java/alluxio/metrics/sink/MetricsServlet.java
@@ -32,9 +32,10 @@ import javax.servlet.http.HttpServletResponse;
 @NotThreadSafe
 public class MetricsServlet implements Sink {
   public static final String SERVLET_PATH = "/metrics/json";
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+      .registerModule(new MetricsModule(TimeUnit.SECONDS, TimeUnit.MILLISECONDS, false));
 
   private MetricRegistry mMetricsRegistry;
-  private ObjectMapper mObjectMapper;
 
   /**
    * Creates a new {@link MetricsServlet} with a {@link Properties} and {@link MetricRegistry}.
@@ -43,9 +44,6 @@ public class MetricsServlet implements Sink {
    */
   public MetricsServlet(MetricRegistry registry) {
     mMetricsRegistry = registry;
-    mObjectMapper =
-        new ObjectMapper().registerModule(new MetricsModule(TimeUnit.SECONDS,
-            TimeUnit.MILLISECONDS, false));
   }
 
   private HttpServlet createServlet() {
@@ -58,7 +56,7 @@ public class MetricsServlet implements Sink {
         response.setContentType("application/json");
         response.setStatus(HttpServletResponse.SC_OK);
         response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-        String result = mObjectMapper.writerWithDefaultPrettyPrinter()
+        String result = OBJECT_MAPPER.writerWithDefaultPrettyPrinter()
             .writeValueAsString(mMetricsRegistry);
         response.getWriter().println(result);
       }

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -304,8 +304,7 @@ public class AlluxioMasterProcess extends MasterProcess {
     mJournalSystem.losePrimacy();
     stopMasterComponents();
 
-    // TODO(jiacheng): is this a good place to dump information?
-    ProcessUtils.dumpInformation();
+    ProcessUtils.dumpInformationOnFailover();
 
     LOG.info("Primary stopped");
     startMasterComponents(false);

--- a/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
+++ b/core/server/master/src/main/java/alluxio/master/AlluxioMasterProcess.java
@@ -14,6 +14,7 @@ package alluxio.master;
 import static alluxio.util.network.NetworkAddressUtils.ServiceType;
 
 import alluxio.AlluxioURI;
+import alluxio.ProcessUtils;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.AlluxioException;
@@ -302,6 +303,10 @@ public class AlluxioMasterProcess extends MasterProcess {
     // sockets in stopServing so that clients don't see NPEs.
     mJournalSystem.losePrimacy();
     stopMasterComponents();
+
+    // TODO(jiacheng): is this a good place to dump information?
+    ProcessUtils.dumpInformation();
+
     LOG.info("Primary stopped");
     startMasterComponents(false);
     LOG.info("Standby started");

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -19,6 +19,7 @@ import static alluxio.metrics.MetricInfo.UFS_OP_SAVED_PREFIX;
 import alluxio.AlluxioURI;
 import alluxio.ClientContext;
 import alluxio.Constants;
+import alluxio.ProcessUtils;
 import alluxio.Server;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.job.JobMasterClient;
@@ -1248,6 +1249,11 @@ public class DefaultFileSystemMaster extends CoreMaster
     if (context.donePartialListing()) {
       return;
     }
+
+    if (context.getOptions().getRecursive()) {
+      ProcessUtils.fatalError(LOG, "I die here");
+    }
+
     // The item should be listed if:
     // 1. We are not doing a partial listing, or have reached the start of the partial listing
     //    (partialPath is empty)

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -19,7 +19,6 @@ import static alluxio.metrics.MetricInfo.UFS_OP_SAVED_PREFIX;
 import alluxio.AlluxioURI;
 import alluxio.ClientContext;
 import alluxio.Constants;
-import alluxio.ProcessUtils;
 import alluxio.Server;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.job.JobMasterClient;
@@ -1248,10 +1247,6 @@ public class DefaultFileSystemMaster extends CoreMaster
     Inode inode = currInodePath.getInode();
     if (context.donePartialListing()) {
       return;
-    }
-
-    if (context.getOptions().getRecursive()) {
-      ProcessUtils.fatalError(LOG, "I die here");
     }
 
     // The item should be listed if:

--- a/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
+++ b/shell/src/main/java/alluxio/cli/bundler/command/CollectLogCommand.java
@@ -64,7 +64,9 @@ public class CollectLogCommand  extends AbstractCollectInfoCommand {
       "proxy.out",
       "task.log",
       "task.out",
-      "user"
+      "user",
+      "alluxio-master",
+      "alluxio-worker"
   ).collect(Collectors.toSet());
   // We tolerate the beginning of a log file to contain some rows that are not timestamped.
   // A YARN application log can have >20 rows in the beginning for


### PR DESCRIPTION
### What changes are proposed in this pull request?

The master/worker processes will dump jstack/metrics when:
1. Process exits normally, from an error, or SIGTERM from `alluxio-stop.sh`. (Note that segfault is abrupt and the process doesn't have a chance to output these information.)
2. Primary master fails over to standby.

The major changes in the code are:
1. Dumping those information into files
2. CollectInfo and CollectLog commands will capture those output files
3. Change the jstack dumping to async (https://github.com/Alluxio/alluxio/commit/9ae71902499b005852563055ae5135e97833e274 changed that to sync), so we don't block the process. The trade off is the output is not totally consistent. That should be acceptable in troubleshooting.

This change depends on https://github.com/Alluxio/alluxio/commit/9ae71902499b005852563055ae5135e97833e274

### Why are the changes needed?
Sample output files:
[alluxio-master-exit-stacks-20230315-063353.txt](https://github.com/Alluxio/alluxio/files/10980702/alluxio-master-exit-stacks-20230315-063353.txt)
[alluxio-master-exit-metrics-20230315-063353.txt](https://github.com/Alluxio/alluxio/files/10980711/alluxio-master-exit-metrics-20230315-063353.txt)

This helps persisting critical troubleshooting information because when the system unexpectedly exits or failover, the admin doesn't have a chance to manually poll these information before it's too late (process already died or primacy is lost).

### Does this PR introduce any user facing changes?
 See above
