### PR TITLE
Fix NPE for s3 proxy v2

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/signature/AwsSignatureProcessor.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/signature/AwsSignatureProcessor.java
@@ -114,8 +114,13 @@ public class AwsSignatureProcessor {
       SignatureInfo signatureInfo = parseSignature();
       String stringToSign = "";
       if (signatureInfo.getVersion() == SignatureInfo.Version.V4) {
-        stringToSign =
-                StringToSignProducer.createSignatureBase(signatureInfo, mContext);
+        if (mContext != null) {
+          stringToSign =
+              StringToSignProducer.createSignatureBase(signatureInfo, mContext);
+        } else {
+          stringToSign =
+              StringToSignProducer.createSignatureBase(signatureInfo, mServletRequest);
+        }
       }
       String awsAccessId = signatureInfo.getAwsAccessId();
       // ONLY validate aws access id when needed.

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/signature/StringToSignProducer.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/signature/StringToSignProducer.java
@@ -104,7 +104,7 @@ public final class StringToSignProducer {
     return createSignatureBase(signatureInfo,
         request.getScheme()
         request.getMethod(),
-        uri.getPath(),
+        request.getRequestURI()
         getHeaders(request),
         getParameterMap(request));
   }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/signature/StringToSignProducer.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/signature/StringToSignProducer.java
@@ -164,6 +164,11 @@ public final class StringToSignProducer {
     return strToSign.toString();
   }
 
+  /**
+   * Get all headers by given http request, and the result map will ignore case.
+   * @param request
+   * @return
+   */
   private static Map<String, String> getHeaders(HttpServletRequest request) {
     Map<String, String> result = new TreeMap<>(String::compareToIgnoreCase);
     Enumeration<String> headerNames = request.getHeaderNames();
@@ -177,6 +182,12 @@ public final class StringToSignProducer {
     return result;
   }
 
+  /**
+   * Get all parameters by given http request,
+   * if there are multiple values for the same key, the first one will be taken.
+   * @param request
+   * @return
+   */
   private static Map<String, String> getParameterMap(HttpServletRequest request) {
     return request.getParameterMap().entrySet()
         .stream()

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/signature/StringToSignProducer.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/signature/StringToSignProducer.java
@@ -102,7 +102,7 @@ public final class StringToSignProducer {
   ) throws Exception {
     URI uri = new URI(request.getRequestURL().toString());
     return createSignatureBase(signatureInfo,
-        uri.getScheme(),
+        request.getScheme()
         request.getMethod(),
         uri.getPath(),
         getHeaders(request),

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/signature/StringToSignProducer.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/signature/StringToSignProducer.java
@@ -37,13 +37,14 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.StringJoiner;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.container.ContainerRequestContext;
 
@@ -178,12 +179,9 @@ public final class StringToSignProducer {
   }
 
   private static Map<String, String> getParameterMap(HttpServletRequest request) {
-    Map<String, String[]> parameterMap = request.getParameterMap();
-    Map<String, String> result = new HashMap<>();
-    for (String key : parameterMap.keySet()) {
-      result.put(key, parameterMap.get(key)[0]);
-    }
-    return result;
+    return request.getParameterMap().entrySet()
+        .stream()
+        .collect(Collectors.toMap(Entry::getKey, e -> e.getValue()[0]));
   }
 
   /**

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/signature/StringToSignProducer.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/signature/StringToSignProducer.java
@@ -100,11 +100,10 @@ public final class StringToSignProducer {
       SignatureInfo signatureInfo,
       HttpServletRequest request
   ) throws Exception {
-    URI uri = new URI(request.getRequestURL().toString());
     return createSignatureBase(signatureInfo,
-        request.getScheme()
+        request.getScheme(),
         request.getMethod(),
-        request.getRequestURI()
+        request.getRequestURI(),
         getHeaders(request),
         getParameterMap(request));
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix NPE for S3 Porxy.

### Why are the changes needed?

When we enable s3 v2 and authentication, the NullPointException will occur:
```
alluxio.s3.rest.authentication.enabled=true
alluxio.proxy.s3.v2.version.enabled=true
```
like: 
```
2023-03-14 22:54:51,738 ERROR S3Handler - Exception during create s3handler:alluxio.proxy.s3.S3Exception
	at alluxio.proxy.s3.signature.AwsSignatureProcessor.getAuthInfo(AwsSignatureProcessor.java:138)
	at alluxio.proxy.s3.S3RestUtils.getUserFromSignature(S3RestUtils.java:576)
	at alluxio.proxy.s3.S3RestUtils.getUser(S3RestUtils.java:562)
	at alluxio.proxy.s3.S3Handler.doAuthentication(S3Handler.java:458)
	at alluxio.proxy.s3.S3Handler.init(S3Handler.java:230)
	at alluxio.proxy.s3.S3Handler.createHandler(S3Handler.java:147)
	at alluxio.proxy.s3.S3RequestServlet.service(S3RequestServlet.java:73)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799)
	at org.eclipse.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1631)
	at alluxio.web.CORSFilter.doFilter(CORSFilter.java:54)
	at alluxio.web.HttpFilter.doFilter(HttpFilter.java:48)
	at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
	at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:548)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:600)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:235)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1440)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:501)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1355)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:59)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:516)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NullPointerException
	at alluxio.proxy.s3.signature.StringToSignProducer.createSignatureBase(StringToSignProducer.java:78)
	at alluxio.proxy.s3.signature.AwsSignatureProcessor.getAuthInfo(AwsSignatureProcessor.java:118)
	... 42 more
```

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
