### PR TITLE
Improve thread dump format to match jstack

### DIFF
--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -122,6 +122,7 @@ public final class ThreadUtils {
    */
   public static synchronized void printThreadInfo(PrintStream stream, String title) {
     stream.println("Process Thread Dump: " + title);
+    stream.println(THREAD_BEAN.getThreadCount() + " active theads");
     for (ThreadInfo ti: THREAD_BEAN.dumpAllThreads(true, true)) {
       stream.print(ti.toString());
     }

--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -120,42 +120,48 @@ public final class ThreadUtils {
    * @param stream the stream to
    * @param title  a string title for the stack trace
    */
-  public static synchronized void printThreadInfo(PrintStream stream,
-      String title) {
-    final int STACK_DEPTH = 20;
-    boolean contention = THREAD_BEAN.isThreadContentionMonitoringEnabled();
-    long[] threadIds = THREAD_BEAN.getAllThreadIds();
-    stream.println("Process Thread Dump: " + title);
-    stream.println(threadIds.length + " active threads");
-    for (long tid : threadIds) {
-      ThreadInfo info = THREAD_BEAN.getThreadInfo(tid, STACK_DEPTH);
-      if (info == null) {
-        stream.println("  Inactive");
-        continue;
-      }
-      stream.println("Thread "
-          + getTaskName(info.getThreadId(), info.getThreadName()) + ":");
-      Thread.State state = info.getThreadState();
-      stream.println("  State: " + state);
-      stream.println("  Blocked count: " + info.getBlockedCount());
-      stream.println("  Waited count: " + info.getWaitedCount());
-      if (contention) {
-        stream.println("  Blocked time: " + info.getBlockedTime());
-        stream.println("  Waited time: " + info.getWaitedTime());
-      }
-      if (state == Thread.State.WAITING) {
-        stream.println("  Waiting on " + info.getLockName());
-      } else if (state == Thread.State.BLOCKED) {
-        stream.println("  Blocked on " + info.getLockName());
-        stream.println("  Blocked by "
-            + getTaskName(info.getLockOwnerId(), info.getLockOwnerName()));
-      }
-      stream.println("  Stack:");
-      for (StackTraceElement frame : info.getStackTrace()) {
-        stream.println("    " + frame.toString());
-      }
+  // public static synchronized void printThreadInfo(PrintStream stream,
+  //     String title) {
+  //   final int STACK_DEPTH = 20;
+  //   boolean contention = THREAD_BEAN.isThreadContentionMonitoringEnabled();
+  //   long[] threadIds = THREAD_BEAN.getAllThreadIds();
+  //   stream.println("Process Thread Dump: " + title);
+  //   stream.println(threadIds.length + " active threads");
+  //   for (long tid : threadIds) {
+  //     ThreadInfo info = THREAD_BEAN.getThreadInfo(tid, STACK_DEPTH);
+  //     if (info == null) {
+  //       stream.println("  Inactive");
+  //       continue;
+  //     }
+  //     stream.println("Thread "
+  //         + getTaskName(info.getThreadId(), info.getThreadName()) + ":");
+  //     Thread.State state = info.getThreadState();
+  //     stream.println("  State: " + state);
+  //     stream.println("  Blocked count: " + info.getBlockedCount());
+  //     stream.println("  Waited count: " + info.getWaitedCount());
+  //     if (contention) {
+  //       stream.println("  Blocked time: " + info.getBlockedTime());
+  //       stream.println("  Waited time: " + info.getWaitedTime());
+  //     }
+  //     if (state == Thread.State.WAITING) {
+  //       stream.println("  Waiting on " + info.getLockName());
+  //     } else if (state == Thread.State.BLOCKED) {
+  //       stream.println("  Blocked on " + info.getLockName());
+  //       stream.println("  Blocked by "
+  //           + getTaskName(info.getLockOwnerId(), info.getLockOwnerName()));
+  //     }
+  //     stream.println("  Stack:");
+  //     for (StackTraceElement frame : info.getStackTrace()) {
+  //       stream.println("    " + frame.toString());
+  //     }
+  //   }
+  //   stream.flush();
+  // }
+
+  public static synchronized void printThreadInfo(PrintStream stream, String title) {
+    for (ThreadInfo ti: THREAD_BEAN.dumpAllThreads(true, true)) {
+      stream.print(ti.toString());
     }
-    stream.flush();
   }
 
   /**

--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -120,44 +120,6 @@ public final class ThreadUtils {
    * @param stream the stream to
    * @param title  a string title for the stack trace
    */
-  // public static synchronized void printThreadInfo(PrintStream stream,
-  //     String title) {
-  //   final int STACK_DEPTH = 20;
-  //   boolean contention = THREAD_BEAN.isThreadContentionMonitoringEnabled();
-  //   long[] threadIds = THREAD_BEAN.getAllThreadIds();
-  //   stream.println("Process Thread Dump: " + title);
-  //   stream.println(threadIds.length + " active threads");
-  //   for (long tid : threadIds) {
-  //     ThreadInfo info = THREAD_BEAN.getThreadInfo(tid, STACK_DEPTH);
-  //     if (info == null) {
-  //       stream.println("  Inactive");
-  //       continue;
-  //     }
-  //     stream.println("Thread "
-  //         + getTaskName(info.getThreadId(), info.getThreadName()) + ":");
-  //     Thread.State state = info.getThreadState();
-  //     stream.println("  State: " + state);
-  //     stream.println("  Blocked count: " + info.getBlockedCount());
-  //     stream.println("  Waited count: " + info.getWaitedCount());
-  //     if (contention) {
-  //       stream.println("  Blocked time: " + info.getBlockedTime());
-  //       stream.println("  Waited time: " + info.getWaitedTime());
-  //     }
-  //     if (state == Thread.State.WAITING) {
-  //       stream.println("  Waiting on " + info.getLockName());
-  //     } else if (state == Thread.State.BLOCKED) {
-  //       stream.println("  Blocked on " + info.getLockName());
-  //       stream.println("  Blocked by "
-  //           + getTaskName(info.getLockOwnerId(), info.getLockOwnerName()));
-  //     }
-  //     stream.println("  Stack:");
-  //     for (StackTraceElement frame : info.getStackTrace()) {
-  //       stream.println("    " + frame.toString());
-  //     }
-  //   }
-  //   stream.flush();
-  // }
-
   public static synchronized void printThreadInfo(PrintStream stream, String title) {
     for (ThreadInfo ti: THREAD_BEAN.dumpAllThreads(true, true)) {
       stream.print(ti.toString());

--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -121,6 +121,7 @@ public final class ThreadUtils {
    * @param title  a string title for the stack trace
    */
   public static synchronized void printThreadInfo(PrintStream stream, String title) {
+    stream.println("Process Thread Dump: " + title);
     for (ThreadInfo ti: THREAD_BEAN.dumpAllThreads(true, true)) {
       stream.print(ti.toString());
     }

--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -125,6 +125,7 @@ public final class ThreadUtils {
     for (ThreadInfo ti: THREAD_BEAN.dumpAllThreads(true, true)) {
       stream.print(ti.toString());
     }
+    stream.flush();
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

In Alluxio, each component's WebUI `host:port/stacks` shows all thread stacks in the current component. This change makes the output format align with `jstack` command, so analyzer tools like https://fastthread.io/ can parse it.

### Why are the changes needed?

See above

### Does this PR introduce any user facing changes?

Now can use [FastThread ](https://fastthread.io/) to analyze the `stacks` output result  of threaddump
