### PR TITLE
Change default value for checkpoint compression level

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -2318,7 +2318,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .build();
   public static final PropertyKey MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL =
       intBuilder(Name.MASTER_METASTORE_ROCKS_CHECKPOINT_COMPRESSION_LEVEL)
-          .setDefaultValue(-1)
+          .setDefaultValue(1)
           .setDescription("The zip compression level of checkpointing rocksdb, the zip"
                   + " format defines ten levels of compression, ranging from 0"
                   + " (no compression, but very fast) to 9 (best compression, but slow)."


### PR DESCRIPTION
Cherry pick of https://github.com/Alluxio/alluxio/pull/16801

### What changes are proposed in this pull request? Change the default value for a property key.

### Why are the changes needed?
After some internal testing, we saw that a compression level of 1 compressed 98% as much as a compression level of -1 (system default) but reduced compression time by 23%. In light of this, we believe that 1 is the better default value.
<img width="488" alt="Screenshot 2023-01-19 at 12 37 55 PM" src="https://user-images.githubusercontent.com/23088925/213555012-db10d943-b80a-449b-bb87-eb285920a472.png"> <img width="438" alt="Screenshot 2023-01-19 at 12 40 25 PM" src="https://user-images.githubusercontent.com/23088925/213555046-f564f93a-d6a7-4cd6-a098-0bcb5676afa7.png">


### Does this PR introduce any user facing changes? No

pr-link: Alluxio/alluxio#16801
change-id: cid-0fb5fd90bcec7d2d9390056702bd58c0752237c1