### PR TITLE
Add encoding-type support for S3 ListObjects and more logging

### DIFF
--- a/core/common/src/main/java/alluxio/util/ThreadUtils.java
+++ b/core/common/src/main/java/alluxio/util/ThreadUtils.java
@@ -43,6 +43,15 @@ public final class ThreadUtils {
     Throwable t = new Throwable(String.format("Stack trace for thread %s (State: %s):",
         thread.getName(), thread.getState()));
     t.setStackTrace(thread.getStackTrace());
+    return formatStackTrace(t);
+  }
+
+  /**
+   * Return formatted stacktrace of Throwable instance.
+   * @param t - a Throwable instance
+   * @return a human-readable representation of the Throwable's stack trace
+   */
+  public static String formatStackTrace(Throwable t) {
     StringWriter sw = new StringWriter();
     t.printStackTrace(new PrintWriter(sw));
     return sw.toString();

--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -75,7 +75,14 @@ public abstract class WebServer {
     mServiceName = serviceName;
 
     QueuedThreadPool threadPool = new QueuedThreadPool();
+<<<<<<< HEAD
     int webThreadCount = Configuration.getInt(PropertyKey.WEB_THREADS);
+||||||| parent of df82a6b8c8 (Add encoding-type support for S3 ListObjects and more logging)
+    int webThreadCount = ServerConfiguration.getInt(PropertyKey.WEB_THREADS);
+=======
+    int webThreadCount = ServerConfiguration.getInt(PropertyKey.WEB_THREADS);
+    threadPool.setName(mServiceName.replace(" ", "-").toUpperCase());
+>>>>>>> df82a6b8c8 (Add encoding-type support for S3 ListObjects and more logging)
 
     // Jetty needs at least (1 + selectors + acceptors) threads.
     threadPool.setMinThreads(webThreadCount * 2 + 1);

--- a/core/server/common/src/main/java/alluxio/web/WebServer.java
+++ b/core/server/common/src/main/java/alluxio/web/WebServer.java
@@ -75,14 +75,8 @@ public abstract class WebServer {
     mServiceName = serviceName;
 
     QueuedThreadPool threadPool = new QueuedThreadPool();
-<<<<<<< HEAD
     int webThreadCount = Configuration.getInt(PropertyKey.WEB_THREADS);
-||||||| parent of df82a6b8c8 (Add encoding-type support for S3 ListObjects and more logging)
-    int webThreadCount = ServerConfiguration.getInt(PropertyKey.WEB_THREADS);
-=======
-    int webThreadCount = ServerConfiguration.getInt(PropertyKey.WEB_THREADS);
     threadPool.setName(mServiceName.replace(" ", "-").toUpperCase());
->>>>>>> df82a6b8c8 (Add encoding-type support for S3 ListObjects and more logging)
 
     // Jetty needs at least (1 + selectors + acceptors) threads.
     threadPool.setMinThreads(webThreadCount * 2 + 1);

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -22,13 +22,9 @@ import alluxio.exception.AlluxioException;
 import alluxio.grpc.Bits;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
-<<<<<<< HEAD
 import alluxio.grpc.PMode;
-||||||| parent of df82a6b8c8 (Add encoding-type support for S3 ListObjects and more logging)
-=======
 import alluxio.util.ThreadUtils;
 import alluxio.web.ProxyWebServer;
->>>>>>> df82a6b8c8 (Add encoding-type support for S3 ListObjects and more logging)
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.base.Stopwatch;
@@ -77,21 +73,11 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
    */
   public CompleteMultipartUploadHandler(final FileSystem fs, final String baseUri) {
     mMetaFs = fs;
-<<<<<<< HEAD
-    mExecutor = Executors.newFixedThreadPool(Configuration.getInt(
-        PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_POOL_SIZE));
-    mKeepAliveEnabled = Configuration.getBoolean(
-||||||| parent of df82a6b8c8 (Add encoding-type support for S3 ListObjects and more logging)
-    mExecutor = Executors.newFixedThreadPool(ServerConfiguration.getInt(
-        PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_POOL_SIZE));
-    mKeepAliveEnabled = ServerConfiguration.getBoolean(
-=======
     ThreadFactory namedThreadFactory = new ThreadFactoryBuilder()
             .setNameFormat("MULTIPART-UPLOAD-%d").build();
-    mExecutor = Executors.newFixedThreadPool(ServerConfiguration.getInt(
+    mExecutor = Executors.newFixedThreadPool(Configuration.getInt(
         PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_POOL_SIZE), namedThreadFactory);
-    mKeepAliveEnabled = ServerConfiguration.getBoolean(
->>>>>>> df82a6b8c8 (Add encoding-type support for S3 ListObjects and more logging)
+    mKeepAliveEnabled = Configuration.getBoolean(
         PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_KEEPALIVE_ENABLED);
     mKeepAliveTime = Configuration.getMs(
         PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_KEEPALIVE_TIME_INTERVAL);
@@ -109,32 +95,10 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
       if (!s.startsWith(mS3Prefix)) {
         return;
       }
-<<<<<<< HEAD
       if (!request.getMethod().equals("POST") || request.getParameter("uploadId") == null) {
         return;
       } // Otherwise, handle CompleteMultipartUpload
-||||||| parent of df82a6b8c8 (Add encoding-type support for S3 ListObjects and more logging)
-      // Build log message capturing the request details
-      // TODO(czhu): Move this to a separate logging handler
-      StringBuilder sb = new StringBuilder();
-      sb.append("Alluxio S3 API received ");
-      sb.append(request.getMethod());
-      sb.append(" request: URI=");
-      sb.append(s);
-      if (request.getQueryString() != null) { sb.append("?").append(request.getQueryString()); }
-      sb.append(" User=");
-=======
       stopwatch = Stopwatch.createStarted();
-      // Build log message capturing the request details
-      // TODO(czhu): Move this to a separate logging handler
-      StringBuilder sb = new StringBuilder();
-      sb.append("Alluxio S3 API received ");
-      sb.append(request.getMethod());
-      sb.append(" request: URI=");
-      sb.append(s);
-      if (request.getQueryString() != null) { sb.append("?").append(request.getQueryString()); }
-      sb.append(" User=");
->>>>>>> df82a6b8c8 (Add encoding-type support for S3 ListObjects and more logging)
       final String user;
       try {
         // TODO(czhu): support S3RestServiceHandler.getUserFromSignature()

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
@@ -50,7 +50,7 @@ public final class ListBucketOptions {
     mPrefix = "";
     mMaxKeys = DEFAULT_MAX_KEYS;
     mDelimiter = null;
-    mEncodingType = DEFAULT_ENCODING_TYPE;
+    mEncodingType = null;
     // listObject parameter
     mMarker = null;
     // listObjectV2 parameter

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -285,8 +285,7 @@ public class ListBucketResult {
     on these fields for now:
     Prefix, Key, and StartAfter
      */
-    if (getEncodingType() != null
-            && getEncodingType().equals(ListBucketOptions.DEFAULT_ENCODING_TYPE)) {
+    if (StringUtils.equals(getEncodingType(), ListBucketOptions.DEFAULT_ENCODING_TYPE)) {
       mContents.stream().forEach(content -> {
         try {
           content.mKey = URLEncoder.encode(content.mKey, "UTF-8");

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketResult.java
@@ -25,6 +25,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -147,8 +149,7 @@ public class ListBucketResult {
     if (StringUtils.isNotEmpty(mDelimiter)) {
       mCommonPrefixes = new ArrayList<>();
     } // otherwise, mCommonPrefixes is null
-    mEncodingType = options.getEncodingType() == null ? ListBucketOptions.DEFAULT_ENCODING_TYPE
-        : options.getEncodingType();
+    mEncodingType = options.getEncodingType();
 
     mListType = options.getListType();
     if (mListType == null) { // ListObjects v1
@@ -272,6 +273,46 @@ public class ListBucketResult {
         .limit(mMaxKeys + 1) // limit to +1 in order to check if we have exactly MaxKeys or not
         .filter(content -> !content.mIsCommonPrefix)
         .collect(Collectors.toList());
+
+    /*
+    As explained in:
+    https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#API_ListObjectsV2_ResponseElements
+    The encoding type, if specified, we will return encoded key name values in the
+    following response elements:
+      Delimiter, Prefix, Key, and StartAfter.
+    AWS S3 for some reason is not encoding every char,  / and * for example.
+    Since we are not supporting delimiter other than /, we will apply url encoding
+    on these fields for now:
+    Prefix, Key, and StartAfter
+     */
+    if (getEncodingType() != null
+            && getEncodingType().equals(ListBucketOptions.DEFAULT_ENCODING_TYPE)) {
+      mContents.stream().forEach(content -> {
+        try {
+          content.mKey = URLEncoder.encode(content.mKey, "UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+          // IGNORE, return as is
+        }
+      });
+
+      if (mCommonPrefixes != null) {
+        mCommonPrefixes.stream().forEach(commonPrefix -> {
+          try {
+            commonPrefix.mPrefix = URLEncoder.encode(commonPrefix.mPrefix, "UTF-8");
+          } catch (UnsupportedEncodingException ex) {
+            // IGNORE, return as is
+          }
+        });
+      }
+
+      if (mStartAfter != null) {
+        try {
+          mStartAfter = URLEncoder.encode(mStartAfter, "UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+          // IGNORE, return as is
+        }
+      }
+    }
 
     // Sanity-check the number of keys being returned
     if (mContents.size() + (mCommonPrefixes == null ? 0 : mCommonPrefixes.size()) != keyCount[0]) {
@@ -480,7 +521,7 @@ public class ListBucketResult {
    * Common Prefixes list placeholder object.
    */
   public static class CommonPrefix {
-    private final String mPrefix;
+    private String mPrefix;
 
     private CommonPrefix(String prefix) {
       mPrefix = prefix;
@@ -517,7 +558,7 @@ public class ListBucketResult {
    */
   public static class Content {
     /* The object's key. */
-    private final String mKey;
+    private String mKey;
     /* Date and time the object was last modified. */
     private final String mLastModified;
     /* Size in bytes of the object. */

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -318,9 +318,15 @@ public final class S3RestServiceHandler {
             throw S3RestUtils.toBucketS3Exception(e, bucket, auditContext);
           }
         }
-<<<<<<< HEAD
         // Otherwise, this is ListObjects(v2)
         int maxKeys = maxKeysParam == null ? ListBucketOptions.DEFAULT_MAX_KEYS : maxKeysParam;
+        if (encodingTypeParam != null
+            && !StringUtils.equals(encodingTypeParam, ListBucketOptions.DEFAULT_ENCODING_TYPE)) {
+          throw new S3Exception(bucket, new S3ErrorCode(
+                  S3ErrorCode.INVALID_ARGUMENT.getCode(),
+                  "Invalid Encoding Method specified in Request.",
+                  S3ErrorCode.INVALID_ARGUMENT.getStatus()));
+        }
         ListBucketOptions listBucketOptions = ListBucketOptions.defaults()
             .setMarker(markerParam)
             .setPrefix(prefixParam)
@@ -330,40 +336,6 @@ public final class S3RestServiceHandler {
             .setListType(listTypeParam)
             .setContinuationToken(continuationTokenParam)
             .setStartAfter(startAfterParam);
-||||||| parent of df82a6b8c8 (Add encoding-type support for S3 ListObjects and more logging)
-      }
-      // Otherwise, this is ListObjects(v2)
-      int maxKeys = maxKeysParam == null ? ListBucketOptions.DEFAULT_MAX_KEYS : maxKeysParam;
-      ListBucketOptions listBucketOptions = ListBucketOptions.defaults()
-          .setMarker(markerParam)
-          .setPrefix(prefixParam)
-          .setMaxKeys(maxKeys)
-          .setDelimiter(delimiterParam)
-          .setEncodingType(encodingTypeParam)
-          .setListType(listTypeParam)
-          .setContinuationToken(continuationTokenParam)
-          .setStartAfter(startAfterParam);
-=======
-      }
-      // Otherwise, this is ListObjects(v2)
-      int maxKeys = maxKeysParam == null ? ListBucketOptions.DEFAULT_MAX_KEYS : maxKeysParam;
-      if (encodingTypeParam != null
-              && !StringUtils.equals(encodingTypeParam, ListBucketOptions.DEFAULT_ENCODING_TYPE)) {
-        throw new S3Exception(bucket, new S3ErrorCode(
-                S3ErrorCode.INVALID_ARGUMENT.getCode(),
-                "Invalid Encoding Method specified in Request.",
-                S3ErrorCode.INVALID_ARGUMENT.getStatus()));
-      }
-      ListBucketOptions listBucketOptions = ListBucketOptions.defaults()
-          .setMarker(markerParam)
-          .setPrefix(prefixParam)
-          .setMaxKeys(maxKeys)
-          .setDelimiter(delimiterParam)
-          .setEncodingType(encodingTypeParam)
-          .setListType(listTypeParam)
-          .setContinuationToken(continuationTokenParam)
-          .setStartAfter(startAfterParam);
->>>>>>> df82a6b8c8 (Add encoding-type support for S3 ListObjects and more logging)
 
         List<URIStatus> children;
         try {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -318,6 +318,7 @@ public final class S3RestServiceHandler {
             throw S3RestUtils.toBucketS3Exception(e, bucket, auditContext);
           }
         }
+<<<<<<< HEAD
         // Otherwise, this is ListObjects(v2)
         int maxKeys = maxKeysParam == null ? ListBucketOptions.DEFAULT_MAX_KEYS : maxKeysParam;
         ListBucketOptions listBucketOptions = ListBucketOptions.defaults()
@@ -329,6 +330,40 @@ public final class S3RestServiceHandler {
             .setListType(listTypeParam)
             .setContinuationToken(continuationTokenParam)
             .setStartAfter(startAfterParam);
+||||||| parent of df82a6b8c8 (Add encoding-type support for S3 ListObjects and more logging)
+      }
+      // Otherwise, this is ListObjects(v2)
+      int maxKeys = maxKeysParam == null ? ListBucketOptions.DEFAULT_MAX_KEYS : maxKeysParam;
+      ListBucketOptions listBucketOptions = ListBucketOptions.defaults()
+          .setMarker(markerParam)
+          .setPrefix(prefixParam)
+          .setMaxKeys(maxKeys)
+          .setDelimiter(delimiterParam)
+          .setEncodingType(encodingTypeParam)
+          .setListType(listTypeParam)
+          .setContinuationToken(continuationTokenParam)
+          .setStartAfter(startAfterParam);
+=======
+      }
+      // Otherwise, this is ListObjects(v2)
+      int maxKeys = maxKeysParam == null ? ListBucketOptions.DEFAULT_MAX_KEYS : maxKeysParam;
+      if (encodingTypeParam != null
+              && !StringUtils.equals(encodingTypeParam, ListBucketOptions.DEFAULT_ENCODING_TYPE)) {
+        throw new S3Exception(bucket, new S3ErrorCode(
+                S3ErrorCode.INVALID_ARGUMENT.getCode(),
+                "Invalid Encoding Method specified in Request.",
+                S3ErrorCode.INVALID_ARGUMENT.getStatus()));
+      }
+      ListBucketOptions listBucketOptions = ListBucketOptions.defaults()
+          .setMarker(markerParam)
+          .setPrefix(prefixParam)
+          .setMaxKeys(maxKeys)
+          .setDelimiter(delimiterParam)
+          .setEncodingType(encodingTypeParam)
+          .setListType(listTypeParam)
+          .setContinuationToken(continuationTokenParam)
+          .setStartAfter(startAfterParam);
+>>>>>>> df82a6b8c8 (Add encoding-type support for S3 ListObjects and more logging)
 
         List<URIStatus> children;
         try {


### PR DESCRIPTION
Cherry pick of https://github.com/Alluxio/alluxio/pull/16530

### What changes are proposed in this pull request?

1. respect encoding-type flag in list-objects ( list-objects-v2 equivalent) and url-encoding the following return fields:
       Prefix, Key, and StartAfter
2. add util to print stacktrace of throwable in existing print thread stack trace util func
3. add service name in the webservice serving threads when starting for better tracing purpose
4. add access log in CompleteMultipartUploadHandler as well
5. add logging in CompleteMultipartUploadTask for better exception tracking.

### Why are the changes needed?

1. to fix the bug where  + in object names is shown as space when using aws s3 clit -> respect encoding-type flag fixed this
2. track completemultipartupload exception for better debugging purpose.

### Does this PR introduce any user facing changes?

N/A
