### PR TITLE
Introduce S3 mock server to enhance unit testing

### DIFF
--- a/core/server/master/pom.xml
+++ b/core/server/master/pom.xml
@@ -141,12 +141,6 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.alluxio</groupId>
-      <artifactId>alluxio-underfs-s3a</artifactId>
-      <version>2.10.0-SNAPSHOT</version>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/core/server/master/pom.xml
+++ b/core/server/master/pom.xml
@@ -117,6 +117,11 @@
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.findify</groupId>
+      <artifactId>s3mock_2.13</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Internal test dependencies -->
     <dependency>
@@ -136,6 +141,12 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
+      <dependency>
+          <groupId>org.alluxio</groupId>
+          <artifactId>alluxio-underfs-s3a</artifactId>
+          <version>2.10.0-SNAPSHOT</version>
+          <scope>compile</scope>
+      </dependency>
   </dependencies>
 
   <build>

--- a/core/server/master/pom.xml
+++ b/core/server/master/pom.xml
@@ -141,12 +141,12 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
-      <dependency>
-          <groupId>org.alluxio</groupId>
-          <artifactId>alluxio-underfs-s3a</artifactId>
-          <version>2.10.0-SNAPSHOT</version>
-          <scope>compile</scope>
-      </dependency>
+    <dependency>
+      <groupId>org.alluxio</groupId>
+      <artifactId>alluxio-underfs-s3a</artifactId>
+      <version>2.10.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/server/master/pom.xml
+++ b/core/server/master/pom.xml
@@ -141,6 +141,12 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
+      <dependency>
+          <groupId>org.alluxio</groupId>
+          <artifactId>alluxio-underfs-s3a</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <build>

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterS3UfsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterS3UfsTest.java
@@ -61,6 +61,8 @@ public final class FileSystemMasterS3UfsTest extends FileSystemMasterTestBase {
     Configuration.set(PropertyKey.UNDERFS_S3_ENDPOINT, "localhost:8001");
     Configuration.set(PropertyKey.UNDERFS_S3_ENDPOINT_REGION, "us-west-2");
     Configuration.set(PropertyKey.UNDERFS_S3_DISABLE_DNS_BUCKETS, true);
+    Configuration.set(PropertyKey.S3A_ACCESS_KEY, "_");
+    Configuration.set(PropertyKey.S3A_SECRET_KEY, "_");
 
     AwsClientBuilder.EndpointConfiguration
         endpoint = new AwsClientBuilder.EndpointConfiguration(

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterS3UfsTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterS3UfsTest.java
@@ -1,0 +1,113 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.master.file;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import alluxio.AlluxioURI;
+import alluxio.client.WriteType;
+import alluxio.conf.Configuration;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.AccessControlException;
+import alluxio.exception.FileAlreadyExistsException;
+import alluxio.exception.FileDoesNotExistException;
+import alluxio.exception.InvalidPathException;
+import alluxio.master.file.contexts.CreateDirectoryContext;
+import alluxio.master.file.contexts.ExistsContext;
+import alluxio.master.file.contexts.MountContext;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import io.findify.s3mock.S3Mock;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Unit tests for {@link FileSystemMaster}.
+ */
+public final class FileSystemMasterS3UfsTest extends FileSystemMasterTestBase {
+  private static final Logger LOG = LoggerFactory.getLogger(FileSystemMasterS3UfsTest.class);
+  private static final String TEST_BUCKET = "test-bucket";
+  private static final String TEST_FILE = "test_file";
+  private static final String TEST_DIRECTORY = "test_directory";
+  private static final String TEST_CONTENT = "test_content";
+  private static final AlluxioURI UFS_ROOT = new AlluxioURI("s3://test-bucket/");
+  private static final AlluxioURI MOUNT_POINT = new AlluxioURI("/s3_mount");
+  private AmazonS3 mS3Client;
+  private S3Mock mS3MockServer;
+
+  @Override
+  public void before() throws Exception {
+    mS3MockServer = new S3Mock.Builder().withPort(8001).withInMemoryBackend().build();
+    mS3MockServer.start();
+
+    Configuration.set(PropertyKey.UNDERFS_S3_ENDPOINT, "localhost:8001");
+    Configuration.set(PropertyKey.UNDERFS_S3_ENDPOINT_REGION, "us-west-2");
+    Configuration.set(PropertyKey.UNDERFS_S3_DISABLE_DNS_BUCKETS, true);
+
+    AwsClientBuilder.EndpointConfiguration
+        endpoint = new AwsClientBuilder.EndpointConfiguration(
+        "http://localhost:8001", "us-west-2");
+    mS3Client = AmazonS3ClientBuilder
+        .standard()
+        .withPathStyleAccessEnabled(true)
+        .withEndpointConfiguration(endpoint)
+        .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+        .build();
+    mS3Client.createBucket(TEST_BUCKET);
+
+    super.before();
+  }
+
+  @Test
+  public void basicWrite()
+      throws FileDoesNotExistException, FileAlreadyExistsException, AccessControlException,
+      IOException, InvalidPathException {
+    mFileSystemMaster.mount(MOUNT_POINT, UFS_ROOT, MountContext.defaults());
+    mFileSystemMaster.createDirectory(
+        MOUNT_POINT.join(TEST_DIRECTORY),
+        CreateDirectoryContext.defaults().setWriteType(WriteType.THROUGH)
+    );
+    assertEquals(1, mS3Client.listObjects(TEST_BUCKET).getObjectSummaries().size());
+    assertNotNull(mS3Client.getObject(TEST_BUCKET, TEST_DIRECTORY + "/"));
+  }
+
+  @Test
+  public void basicSync()
+      throws FileDoesNotExistException, FileAlreadyExistsException, AccessControlException,
+      IOException, InvalidPathException {
+    mFileSystemMaster.mount(MOUNT_POINT, UFS_ROOT, MountContext.defaults());
+    mS3Client.putObject(TEST_BUCKET, TEST_FILE, TEST_CONTENT);
+    assertTrue(mFileSystemMaster.exists(MOUNT_POINT.join(TEST_FILE), ExistsContext.defaults()));
+  }
+
+  @Override
+  public void after() throws Exception {
+    mS3Client = null;
+    try {
+      if (mS3MockServer != null) {
+        mS3MockServer.shutdown();
+      }
+    } finally {
+      mS3MockServer = null;
+    }
+    super.after();
+  }
+}

--- a/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
+++ b/minicluster/src/main/java/alluxio/master/AbstractLocalAlluxioCluster.java
@@ -224,7 +224,11 @@ public abstract class AbstractLocalAlluxioCluster {
     String underfsAddress = Configuration.getString(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS);
 
     // Deletes the ufs dir for this test from to avoid permission problems
-    UnderFileSystemUtils.deleteDirIfExists(ufs, underfsAddress);
+    // Do not delete the ufs root if the ufs is an object storage.
+    // In test environment, this means s3 mock is used.
+    if (!ufs.isObjectStorage()) {
+      UnderFileSystemUtils.deleteDirIfExists(ufs, underfsAddress);
+    }
 
     // Creates ufs dir. This must be called before starting UFS with UnderFileSystemCluster.create()
     UnderFileSystemUtils.mkdirIfNotExists(ufs, underfsAddress);

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
     <jnr-fuse.version>0.5.5</jnr-fuse.version>
     <kerby.version>1.0.1</kerby.version>
     <fastutil.version>8.5.9</fastutil.version>
+    <s3mock.version>0.2.6</s3mock.version>
   </properties>
 
   <modules>
@@ -715,6 +716,12 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava-testlib</artifactId>
         <version>${guava.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.findify</groupId>
+        <artifactId>s3mock_2.13</artifactId>
+        <version>${s3mock.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -222,6 +222,12 @@
       <artifactId>alluxio-integration-fuse</artifactId>
       <version>${project.version}</version>
     </dependency>
+      <dependency>
+          <groupId>org.alluxio</groupId>
+          <artifactId>alluxio-underfs-s3a</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <profiles>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -56,6 +56,11 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.findify</groupId>
+      <artifactId>s3mock_2.13</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <scope>compile</scope>

--- a/tests/src/test/java/alluxio/client/fs/FileSystemS3UfsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemS3UfsIntegrationTest.java
@@ -1,0 +1,116 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.fs;
+
+import static org.junit.Assert.assertEquals;
+
+import alluxio.AlluxioURI;
+import alluxio.client.file.FileInStream;
+import alluxio.client.file.FileOutStream;
+import alluxio.client.file.FileSystem;
+import alluxio.conf.PropertyKey;
+import alluxio.exception.AlluxioException;
+import alluxio.grpc.CreateFilePOptions;
+import alluxio.grpc.WritePType;
+import alluxio.testutils.BaseIntegrationTest;
+import alluxio.testutils.LocalAlluxioClusterResource;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.S3Object;
+import io.findify.s3mock.S3Mock;
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class FileSystemS3UfsIntegrationTest extends BaseIntegrationTest {
+  private static final String TEST_CONTENT = "TestContents";
+  private static final String TEST_FILE = "test_file";
+  private static final int USER_QUOTA_UNIT_BYTES = 1000;
+  @Rule
+  public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
+      new LocalAlluxioClusterResource.Builder()
+          .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, USER_QUOTA_UNIT_BYTES)
+          .setStartCluster(false)
+          .build();
+  private FileSystem mFileSystem = null;
+  private AmazonS3 mS3Client = null;
+  @Rule
+  public ExpectedException mThrown = ExpectedException.none();
+  private S3Mock mS3MockServer;
+  private static final String TEST_BUCKET = "test-bucket";
+
+  @Before
+  public void before() throws Exception {
+    mS3MockServer = new S3Mock.Builder().withPort(8001).withInMemoryBackend().build();
+    mS3MockServer.start();
+    AwsClientBuilder.EndpointConfiguration
+        endpoint = new AwsClientBuilder.EndpointConfiguration(
+        "http://localhost:8001", "us-west-2");
+    mS3Client = AmazonS3ClientBuilder
+        .standard()
+        .withPathStyleAccessEnabled(true)
+        .withEndpointConfiguration(endpoint)
+        .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+        .build();
+    mS3Client.createBucket(TEST_BUCKET);
+
+    mLocalAlluxioClusterResource.setProperty(PropertyKey.UNDERFS_S3_ENDPOINT, "localhost:8001");
+    mLocalAlluxioClusterResource.setProperty(PropertyKey.UNDERFS_S3_ENDPOINT_REGION, "us-west-2");
+    mLocalAlluxioClusterResource.setProperty(PropertyKey.UNDERFS_S3_DISABLE_DNS_BUCKETS, true);
+    mLocalAlluxioClusterResource.setProperty(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS,
+        "s3://" + TEST_BUCKET);
+    mLocalAlluxioClusterResource.start();
+    mFileSystem = mLocalAlluxioClusterResource.get().getClient();
+  }
+
+  @After
+  public void after() {
+    mS3Client = null;
+    try {
+      if (mS3MockServer != null) {
+        mS3MockServer.shutdown();
+      }
+    } finally {
+      mS3MockServer = null;
+    }
+  }
+
+  @Test
+  public void basicMetadataSync() throws IOException, AlluxioException {
+    mS3Client.putObject(TEST_BUCKET, TEST_FILE, TEST_CONTENT);
+    FileInStream fis = mFileSystem.openFile(new AlluxioURI("/" + TEST_FILE));
+    assertEquals(TEST_CONTENT, IOUtils.toString(fis, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void basicWriteThrough() throws IOException, AlluxioException {
+    FileOutStream fos = mFileSystem.createFile(
+        new AlluxioURI("/" + TEST_FILE),
+        CreateFilePOptions.newBuilder().setWriteType(WritePType.CACHE_THROUGH).build());
+    fos.write(TEST_CONTENT.getBytes());
+    fos.close();
+    try (S3Object s3Object = mS3Client.getObject(TEST_BUCKET, TEST_FILE)) {
+      assertEquals(
+          TEST_CONTENT, IOUtils.toString(s3Object.getObjectContent(), StandardCharsets.UTF_8));
+    }
+  }
+}

--- a/tests/src/test/java/alluxio/client/fs/FileSystemS3UfsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemS3UfsIntegrationTest.java
@@ -83,7 +83,6 @@ public class FileSystemS3UfsIntegrationTest extends BaseIntegrationTest {
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
   }
 
-
   @After
   public void after() {
     mS3Client = null;

--- a/tests/src/test/java/alluxio/client/fs/FileSystemS3UfsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemS3UfsIntegrationTest.java
@@ -83,6 +83,7 @@ public class FileSystemS3UfsIntegrationTest extends BaseIntegrationTest {
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
   }
 
+
   @After
   public void after() {
     mS3Client = null;

--- a/tests/src/test/java/alluxio/client/fs/FileSystemS3UfsIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/FileSystemS3UfsIntegrationTest.java
@@ -49,6 +49,12 @@ public class FileSystemS3UfsIntegrationTest extends BaseIntegrationTest {
   public LocalAlluxioClusterResource mLocalAlluxioClusterResource =
       new LocalAlluxioClusterResource.Builder()
           .setProperty(PropertyKey.USER_FILE_BUFFER_BYTES, USER_QUOTA_UNIT_BYTES)
+          .setProperty(PropertyKey.UNDERFS_S3_ENDPOINT, "localhost:8001")
+          .setProperty(PropertyKey.UNDERFS_S3_ENDPOINT_REGION, "us-west-2")
+          .setProperty(PropertyKey.UNDERFS_S3_DISABLE_DNS_BUCKETS, true)
+          .setProperty(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS, "s3://" + TEST_BUCKET)
+          .setProperty(PropertyKey.S3A_ACCESS_KEY, "_")
+          .setProperty(PropertyKey.S3A_SECRET_KEY, "_")
           .setStartCluster(false)
           .build();
   private FileSystem mFileSystem = null;
@@ -73,11 +79,6 @@ public class FileSystemS3UfsIntegrationTest extends BaseIntegrationTest {
         .build();
     mS3Client.createBucket(TEST_BUCKET);
 
-    mLocalAlluxioClusterResource.setProperty(PropertyKey.UNDERFS_S3_ENDPOINT, "localhost:8001");
-    mLocalAlluxioClusterResource.setProperty(PropertyKey.UNDERFS_S3_ENDPOINT_REGION, "us-west-2");
-    mLocalAlluxioClusterResource.setProperty(PropertyKey.UNDERFS_S3_DISABLE_DNS_BUCKETS, true);
-    mLocalAlluxioClusterResource.setProperty(PropertyKey.MASTER_MOUNT_TABLE_ROOT_UFS,
-        "s3://" + TEST_BUCKET);
     mLocalAlluxioClusterResource.start();
     mFileSystem = mLocalAlluxioClusterResource.get().getClient();
   }

--- a/underfs/pom.xml
+++ b/underfs/pom.xml
@@ -76,6 +76,13 @@
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <!-- External test dependencies -->
+    <dependency>
+      <groupId>io.findify</groupId>
+      <artifactId>s3mock_2.13</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemMockServerTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemMockServerTest.java
@@ -22,7 +22,8 @@ import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.ListOptions;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -71,7 +72,7 @@ public class S3AUnderFileSystemMockServerTest {
         .standard()
         .withPathStyleAccessEnabled(true)
         .withEndpointConfiguration(endpoint)
-        .withCredentials(new DefaultAWSCredentialsProviderChain())
+        .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
         .build();
     mClient.createBucket(TEST_BUCKET);
     mS3UnderFileSystem =

--- a/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemMockServerTest.java
+++ b/underfs/s3a/src/test/java/alluxio/underfs/s3a/S3AUnderFileSystemMockServerTest.java
@@ -1,0 +1,135 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.underfs.s3a;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import alluxio.AlluxioURI;
+import alluxio.conf.Configuration;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.underfs.UfsStatus;
+import alluxio.underfs.UnderFileSystemConfiguration;
+import alluxio.underfs.options.ListOptions;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import io.findify.s3mock.S3Mock;
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Executors;
+
+/**
+ * Unit tests for the {@link S3AUnderFileSystem} using an s3 mock server.
+ */
+public class S3AUnderFileSystemMockServerTest {
+  private static final InstancedConfiguration CONF = Configuration.copyGlobal();
+
+  private static final String TEST_BUCKET = "test-bucket";
+  private static final String TEST_FILE = "test_file";
+  private static final AlluxioURI TEST_FILE_URI = new AlluxioURI("s3://test-bucket/test_file");
+  private static final String TEST_CONTENT = "test_content";
+
+  private S3AUnderFileSystem mS3UnderFileSystem;
+  private AmazonS3 mClient;
+
+  private S3Mock mS3MockServer;
+
+  @Rule
+  public final ExpectedException mThrown = ExpectedException.none();
+
+  @Before
+  public void before() throws AmazonClientException {
+    mS3MockServer = new S3Mock.Builder().withPort(8001).withInMemoryBackend().build();
+    mS3MockServer.start();
+
+    AwsClientBuilder.EndpointConfiguration
+        endpoint = new AwsClientBuilder.EndpointConfiguration(
+        "http://localhost:8001", "us-west-2");
+    mClient = AmazonS3ClientBuilder
+        .standard()
+        .withPathStyleAccessEnabled(true)
+        .withEndpointConfiguration(endpoint)
+        .withCredentials(new DefaultAWSCredentialsProviderChain())
+        .build();
+    mClient.createBucket(TEST_BUCKET);
+    mS3UnderFileSystem =
+        new S3AUnderFileSystem(new AlluxioURI("s3://" + TEST_BUCKET), mClient, TEST_BUCKET,
+            Executors.newSingleThreadExecutor(), new TransferManager(),
+            UnderFileSystemConfiguration.defaults(CONF), false);
+  }
+
+  @After
+  public void after() {
+    mClient = null;
+    try {
+      if (mS3MockServer != null) {
+        mS3MockServer.shutdown();
+      }
+    } finally {
+      mS3MockServer = null;
+    }
+  }
+
+  @Test
+  public void read() throws IOException {
+    mClient.putObject(TEST_BUCKET, TEST_FILE, TEST_CONTENT);
+
+    InputStream is =
+        mS3UnderFileSystem.open(TEST_FILE_URI.getPath());
+    assertEquals(TEST_CONTENT, IOUtils.toString(is, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void listRecursive() throws IOException {
+    mClient.putObject(TEST_BUCKET, "d1/d1/f1", TEST_CONTENT);
+    mClient.putObject(TEST_BUCKET, "d1/d1/f2", TEST_CONTENT);
+    mClient.putObject(TEST_BUCKET, "d1/d2/f1", TEST_CONTENT);
+    mClient.putObject(TEST_BUCKET, "d2/d1/f1", TEST_CONTENT);
+    mClient.putObject(TEST_BUCKET, "d3/", "");
+    mClient.putObject(TEST_BUCKET, "f1", TEST_CONTENT);
+    mClient.putObject(TEST_BUCKET, "f2", TEST_CONTENT);
+
+    UfsStatus[] ufsStatuses = mS3UnderFileSystem.listStatus(
+        "/", ListOptions.defaults().setRecursive(true));
+
+    /*
+      Objects:
+       d1/
+       d1/d1/
+       d1/d1/f1
+       d1/d1/f2
+       d1/d2/
+       d1/d2/f1
+       d2/
+       d2/d1/
+       d2/d1/f1
+       d3/
+       f1
+       f2
+     */
+    assertNotNull(ufsStatuses);
+    assertEquals(12, ufsStatuses.length);
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Introduce a s3 mock server and used it in unit testing

### Why are the changes needed?

When we doing the new metadata sync redesign project, we need a reliable way to test the interactions with s3 UFS and help us deal with corner cases. 

### Does this PR introduce any user facing changes?

N/A