### PR TITLE
Fix cli distributed command hang issue

### DIFF
--- a/job/server/src/main/java/alluxio/master/job/tracker/CmdRunAttempt.java
+++ b/job/server/src/main/java/alluxio/master/job/tracker/CmdRunAttempt.java
@@ -173,12 +173,14 @@ public class CmdRunAttempt {
       return Status.FAILED;
     }
 
-    // This make an assumption that this job tree only goes 1 level deep
     boolean finished = true;
-    for (JobInfo child : jobInfo.getChildren()) {
-      if (!child.getStatus().isFinished()) {
-        finished = false;
-        break;
+    if (!jobInfo.getStatus().isFinished()) {
+      // This make an assumption that this job tree only goes 1 level deep
+      for (JobInfo child : jobInfo.getChildren()) {
+        if (!child.getStatus().isFinished()) {
+          finished = false;
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
Cherry pick of https://github.com/Alluxio/alluxio/pull/16786

### What changes are proposed in this pull request?
Whenever the job command status is being asked for the job command id, it is mostly being asked by alluxio cli client in synchronous mode, it should return the status immediately in case of plan info has one of the finished status like failed, completed or cancelled instead of checking its children tasks' status and deriving the final status.

### Why are the changes needed?
As per #16708, the distributed cli commands like distcp and distload hang; same behaviour observed consistently whenever any job worker is declared disconnected by job master.

Currently, the job master derives the status for job command id by calling its children job control id which internally, derives its status from its children's status. In normal circumstances, all the children of job control id have expected status but in circumstance like any job worker disconnected from job master, children have different odd status combination like one has RUNNING while other has FAILED or COMPLETED even though its job control id has FAILED final status (plan info). This situation makes the job command id always in RUNNING state and apparently, alluxio cli client waits forever.

The job control id (plan info) should return the status whenever it has one of the finished status like failed, completed or cancelled instead of deriving from its children.

### Does this PR introduce any user facing changes? NA

pr-link: Alluxio/alluxio#16786
change-id: cid-e99b94fb06552c9b1e57278788c679cee1158bac