### PR TITLE
[SMALLFIX]Update job service batch size default value

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6814,7 +6814,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
       intBuilder(Name.JOB_REQUEST_BATCH_SIZE)
           .setDescription("The batch size client uses to make requests to the "
               + "job master.")
-          .setDefaultValue(20)
+          .setDefaultValue(1)
           .setScope(Scope.CLIENT)
           .build();
   public static final PropertyKey JOB_WORKER_BIND_HOST =


### PR DESCRIPTION
Cherry pick of https://github.com/Alluxio/alluxio/pull/16802

### What changes are proposed in this pull request?

Set job service batch size default to 1 to avoid using batched jobs. Batched job is no longer helpful for job service since we move the scheduling logic from client to job master. Eventually, we would deprecate batched job.

### Why are the changes needed?
Reduce code complexity

### Does this PR introduce any user facing changes? na

pr-link: Alluxio/alluxio#16802
change-id: cid-32e57177652918bd7ec6d962e70439f6f2312fc5