### PR TITLE
Return specific exception in Worker handler if it is known

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -106,7 +106,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
       responseObserver.onCompleted();
     } catch (IOException e) {
       LOG.debug(String.format("Failed to get status of %s: ", request.getPath()), e);
-      responseObserver.onError(AlluxioRuntimeException.from(e).toGrpcStatusException());
+      responseObserver.onError(AlluxioRuntimeException.from(e).toGrpcStatusRuntimeException());
     }
   }
 
@@ -123,7 +123,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
         responseObserver.onError(
             new AlluxioRuntimeException(Status.NOT_FOUND,
                 String.format("%s Not Found", request.getPath()),
-                null, ErrorType.Internal, false).toGrpcStatusException());
+                null, ErrorType.Internal, false).toGrpcStatusRuntimeException());
         return;
       }
 
@@ -144,7 +144,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
       responseObserver.onCompleted();
     } catch (Exception e) {
       LOG.error(String.format("Failed to list status of %s: ", request.getPath()), e);
-      responseObserver.onError(AlluxioRuntimeException.from(e).toGrpcStatusException());
+      responseObserver.onError(AlluxioRuntimeException.from(e).toGrpcStatusRuntimeException());
     }
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -123,7 +123,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
         responseObserver.onError(
             new AlluxioRuntimeException(Status.NOT_FOUND,
                 String.format("%s Not Found", request.getPath()),
-                null, ErrorType.Internal, false).toGrpcStatusRuntimeException());
+                null, ErrorType.User, false).toGrpcStatusRuntimeException());
         return;
       }
 

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -16,6 +16,7 @@ import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.runtime.AlluxioRuntimeException;
 import alluxio.grpc.BlockWorkerGrpc;
+import alluxio.grpc.ErrorType;
 import alluxio.grpc.GetStatusPRequest;
 import alluxio.grpc.GetStatusPResponse;
 import alluxio.grpc.GrpcUtils;
@@ -119,7 +120,10 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
           request.getOptions().hasRecursive() ? request.getOptions().getRecursive() : false);
       UfsStatus[] statuses = mWorker.listStatus(request.getPath(), options);
       if (statuses == null) {
-        responseObserver.onError(new io.grpc.StatusException(Status.NOT_FOUND));
+        responseObserver.onError(
+            new AlluxioRuntimeException(Status.NOT_FOUND,
+                String.format("%s Not Found", request.getPath()),
+                null, ErrorType.Internal, false).toGrpcStatusException());
         return;
       }
 

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -14,6 +14,7 @@ package alluxio.worker.grpc;
 import alluxio.annotation.SuppressFBWarnings;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
+import alluxio.exception.runtime.AlluxioRuntimeException;
 import alluxio.grpc.BlockWorkerGrpc;
 import alluxio.grpc.GetStatusPRequest;
 import alluxio.grpc.GetStatusPResponse;
@@ -37,7 +38,6 @@ import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
@@ -105,12 +105,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
       responseObserver.onCompleted();
     } catch (IOException e) {
       LOG.debug(String.format("Failed to get status of %s: ", request.getPath()), e);
-      // Worker should try return specific exceptions if it knows what exception it is.
-      if (e instanceof FileNotFoundException) {
-        responseObserver.onError(new io.grpc.StatusException(Status.NOT_FOUND));
-      } else {
-        responseObserver.onError(new io.grpc.StatusException(Status.UNKNOWN));
-      }
+      responseObserver.onError(AlluxioRuntimeException.from(e).toGrpcStatusException());
     }
   }
 
@@ -145,7 +140,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
       responseObserver.onCompleted();
     } catch (Exception e) {
       LOG.error(String.format("Failed to list status of %s: ", request.getPath()), e);
-      responseObserver.onError(new io.grpc.StatusException(Status.UNKNOWN));
+      responseObserver.onError(AlluxioRuntimeException.from(e).toGrpcStatusException());
     }
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -15,8 +15,8 @@ import alluxio.annotation.SuppressFBWarnings;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
 import alluxio.exception.runtime.AlluxioRuntimeException;
+import alluxio.exception.runtime.NotFoundRuntimeException;
 import alluxio.grpc.BlockWorkerGrpc;
-import alluxio.grpc.ErrorType;
 import alluxio.grpc.GetStatusPRequest;
 import alluxio.grpc.GetStatusPResponse;
 import alluxio.grpc.GrpcUtils;
@@ -33,7 +33,6 @@ import alluxio.worker.dora.PagedDoraWorker;
 
 import com.google.common.collect.ImmutableMap;
 import io.grpc.MethodDescriptor;
-import io.grpc.Status;
 import io.grpc.stub.CallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
@@ -121,9 +120,8 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
       UfsStatus[] statuses = mWorker.listStatus(request.getPath(), options);
       if (statuses == null) {
         responseObserver.onError(
-            new AlluxioRuntimeException(Status.NOT_FOUND,
-                String.format("%s Not Found", request.getPath()),
-                null, ErrorType.User, false).toGrpcStatusRuntimeException());
+            new NotFoundRuntimeException(String.format("%s Not Found", request.getPath()))
+                .toGrpcStatusRuntimeException());
         return;
       }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Dora Worker service should try to check the types of the exceptions.
If they are known, Dora worker should convert them to known gRPC exceptions and return them back.

### Why are the changes needed?

If the exception types are known, we can handle the exceptions better, e.g. retry the operation or try alternatives.

### Does this PR introduce any user facing changes?

N/A