### PR TITLE
Eliminate race condition in completempupload and support overwrite

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/UnderFileSystemFileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/UnderFileSystemFileOutStream.java
@@ -14,7 +14,11 @@ package alluxio.client.block.stream;
 import alluxio.client.file.FileSystemContext;
 import alluxio.client.file.options.OutStreamOptions;
 import alluxio.grpc.RequestType;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.wire.WorkerNetAddress;
+
+import com.codahale.metrics.Timer;
 
 import java.io.IOException;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -48,5 +52,13 @@ public class UnderFileSystemFileOutStream extends BlockOutStream {
    */
   protected UnderFileSystemFileOutStream(DataWriter dataWriter, WorkerNetAddress address) {
     super(dataWriter, Long.MAX_VALUE, address);
+  }
+
+  @Override
+  public void close() throws IOException {
+    try (Timer.Context ctx = MetricsSystem
+            .uniformTimer(MetricKey.CLOSE_UFS_OUTSTREAM_LATENCY.getName()).time()) {
+      super.close();
+    }
   }
 }

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileOutStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileOutStream.java
@@ -39,6 +39,7 @@ import alluxio.wire.OperationId;
 import alluxio.wire.WorkerNetAddress;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
 import com.google.common.io.Closer;
 import org.slf4j.Logger;
@@ -154,7 +155,8 @@ public class AlluxioFileOutStream extends FileOutStream {
     if (mClosed) {
       return;
     }
-    try {
+    try (Timer.Context ctx = MetricsSystem
+            .uniformTimer(MetricKey.CLOSE_ALLUXIO_OUTSTREAM_LATENCY.getName()).time()) {
       if (mCurrentBlockOutStream != null) {
         mPreviousBlockOutStreams.add(mCurrentBlockOutStream);
       }

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -8068,6 +8068,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String PROXY_WEB_PORT = "alluxio.proxy.web.port";
     public static final String PROXY_AUDIT_LOGGING_ENABLED =
         "alluxio.proxy.audit.logging.enabled";
+    public static final String S3_UPLOADS_ID_XATTR_KEY = "s3_uploads_mulitpartupload_id";
 
     //
     // Locality related properties

--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -661,6 +661,32 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setIsClusterAggregated(false)
           .build();
 
+  public static final MetricKey PROXY_CHECK_UPLOADID_STATUS_LATENCY =
+          new Builder("Proxy.CheckUploadIDStatusLatency")
+                  .setDescription("Latency of check uploadId status in CompleteMultipartUpload")
+                  .setMetricType(MetricType.TIMER)
+                  .build();
+  public static final MetricKey PROXY_COMPLETE_MP_UPLOAD_MERGE_LATENCY =
+          new Builder("Proxy.CompleteMPUploadMergeLatency")
+                  .setDescription("Latency of merging parts into one object"
+                          + "in CompleteMultipartUpload")
+                  .setMetricType(MetricType.TIMER)
+                  .build();
+
+  public static final MetricKey PROXY_CLEANUP_MULTIPART_UPLOAD_LATENCY =
+          new Builder("Proxy.CleanupMultipartUploadLatency")
+                  .setDescription("Latency of cleaning up temp folder and meta"
+                          + "file from CompleteMultipartUpload")
+                  .setMetricType(MetricType.TIMER)
+                  .build();
+
+  public static final MetricKey PROXY_CLEANUP_TEMP_MULTIPART_UPLOAD_OBJ_LATENCY =
+          new Builder("Proxy.CleanupTempMultipartUploadObjectLatency")
+                  .setDescription("Latency of cleaning up temp target obj during"
+                          + "CompleteMultipartUpload")
+                  .setMetricType(MetricType.TIMER)
+                  .build();
+
   // Metadata sync metrics
   public static final MetricKey MASTER_METADATA_SYNC_UFS_MOUNT =
       new Builder("Master.MetadataSyncUfsMount.")
@@ -2360,6 +2386,18 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setMetricType(MetricType.COUNTER)
           .setIsClusterAggregated(false)
           .build();
+
+  public static final MetricKey CLOSE_UFS_OUTSTREAM_LATENCY =
+          new Builder("Client.CloseUFSOutStreamLatency")
+                  .setDescription("Latency of close UFS outstream latency")
+                  .setMetricType(MetricType.TIMER)
+                  .build();
+
+  public static final MetricKey CLOSE_ALLUXIO_OUTSTREAM_LATENCY =
+          new Builder("Client.CloseAlluxioOutStreamLatency")
+                  .setDescription("Latency of close Alluxio outstream latency")
+                  .setMetricType(MetricType.TIMER)
+                  .build();
 
   // Fuse operation timer and failure counter metrics are added dynamically.
   // Other Fuse related metrics are added here

--- a/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricsSystem.java
@@ -27,6 +27,7 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.codahale.metrics.UniformReservoir;
 import com.codahale.metrics.jvm.CachedThreadStatesGaugeSet;
 import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
@@ -624,6 +625,20 @@ public final class MetricsSystem {
    */
   public static Timer timer(String name) {
     return METRIC_REGISTRY.timer(getMetricName(name));
+  }
+
+  /**
+   * Same with {@link #timer} but with UnirformReservoir for sampling.
+   *
+   * @param name the name of the metric
+   * @return a timer object with the qualified metric name
+   */
+  public static Timer uniformTimer(String name) {
+    return METRIC_REGISTRY.timer(getMetricName(name),
+            () -> {
+              Timer timer = new Timer(new UniformReservoir());
+              return timer;
+            });
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/file/DefaultFileSystemMaster.java
@@ -2794,7 +2794,8 @@ public class DefaultFileSystemMaster extends CoreMaster
    */
   private void renameInternal(RpcContext rpcContext, LockedInodePath srcInodePath,
       LockedInodePath dstInodePath, RenameContext context) throws InvalidPathException,
-      FileDoesNotExistException, FileAlreadyExistsException, IOException, AccessControlException {
+          FileDoesNotExistException, FileAlreadyExistsException,
+          IOException, AccessControlException {
     if (!srcInodePath.fullPathExists()) {
       throw new FileDoesNotExistException(
           ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(srcInodePath.getUri()));
@@ -2846,11 +2847,12 @@ public class DefaultFileSystemMaster extends CoreMaster
           ExceptionMessage.PATH_MUST_HAVE_VALID_PARENT.getMessage(dstInodePath.getUri()));
     }
 
-    // Make sure destination path does not exist
+    // Make sure destination path does not exist, or check if there's overwrite syntax involved
     if (dstInodePath.fullPathExists()) {
-      throw new FileAlreadyExistsException(String
-          .format("Cannot rename because destination already exists. src: %s dst: %s",
-              srcInodePath.getUri(), dstInodePath.getUri()));
+      boolean proceed = checkForOverwriteSyntax(rpcContext, srcInodePath, dstInodePath, context);
+      if (!proceed) {
+        return;
+      }
     }
 
     // Now we remove srcInode from its parent and insert it into dstPath's parent
@@ -3017,6 +3019,62 @@ public class DefaultFileSystemMaster extends CoreMaster
     }
 
     Metrics.PATHS_RENAMED.inc();
+  }
+
+  /**
+   * If destination path exists, check if we are using rename for overwrite syntax.
+   * Such as objectstore client.
+   * If not, a FileAlreadyExistsException should be thrown,
+   * Else, return if the caller should proceed or not.
+   * @return should the caller proceed or not
+   */
+  private boolean checkForOverwriteSyntax(RpcContext rpcContext,
+                                          LockedInodePath srcInodePath,
+                                          LockedInodePath dstInodePath,
+                                          RenameContext context)
+          throws FileDoesNotExistException, FileAlreadyExistsException,
+          IOException, InvalidPathException {
+    if (context.getOptions().hasS3SyntaxOptions()) {
+      // For possible object overwrite
+      if (context.getOptions().getS3SyntaxOptions().getIsMultipartUpload()) {
+        String mpUploadIdDst = new String(dstInodePath.getInodeFile().getXAttr() != null
+                ? dstInodePath.getInodeFile().getXAttr()
+                .getOrDefault(PropertyKey.Name.S3_UPLOADS_ID_XATTR_KEY, new byte[0])
+                : new byte[0]);
+        String mpUploadIdSrc = new String(srcInodePath.getInodeFile().getXAttr() != null
+                ? srcInodePath.getInodeFile().getXAttr()
+                .getOrDefault(PropertyKey.Name.S3_UPLOADS_ID_XATTR_KEY, new byte[0])
+                : new byte[0]);
+        if (StringUtils.isNotEmpty(mpUploadIdSrc) && StringUtils.isNotEmpty(mpUploadIdDst)
+                && StringUtils.equals(mpUploadIdSrc, mpUploadIdDst)) {
+          LOG.info("Object with same upload exists, bail and claim success.");
+        /* This is a rename operation as part of complete a CompleteMultipartUpload call
+         and there's concurrent attempt on the same multipart upload succeeded */
+          return false;
+        }
+      }
+      /*
+       TODO(lucy) same logic could apply for create normal object instead of multipart upload,
+        check other object related property for a no-op rename
+       */
+      //we need to overwrite, delete existing destination path
+      if (context.getOptions().getS3SyntaxOptions().getOverwrite()) {
+        LOG.info("Encountered S3 Overwrite syntax, "
+                + "deleting existing file and then start renaming.");
+        try {
+          deleteInternal(rpcContext, dstInodePath, DeleteContext
+                  .mergeFrom(DeletePOptions.newBuilder()
+                          .setRecursive(true).setAlluxioOnly(context.getPersist())), true);
+          dstInodePath.removeLastInode();
+        } catch (DirectoryNotEmptyException ex) {
+          // IGNORE, this will never happen
+        }
+        return true;
+      }
+    }
+    throw new FileAlreadyExistsException(String
+            .format("Cannot rename because destination already exists. src: %s dst: %s",
+                    srcInodePath.getUri(), dstInodePath.getUri()));
   }
 
   /**

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -12,6 +12,7 @@
 package alluxio.proxy.s3;
 
 import alluxio.AlluxioURI;
+import alluxio.client.WriteType;
 import alluxio.client.file.FileInStream;
 import alluxio.client.file.FileOutStream;
 import alluxio.client.file.FileSystem;
@@ -23,15 +24,23 @@ import alluxio.grpc.Bits;
 import alluxio.grpc.CreateFilePOptions;
 import alluxio.grpc.DeletePOptions;
 import alluxio.grpc.PMode;
+import alluxio.grpc.RenamePOptions;
+import alluxio.grpc.S3SyntaxOptions;
+import alluxio.grpc.XAttrPropagationStrategy;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.util.ThreadUtils;
 import alluxio.web.ProxyWebServer;
 
+import com.codahale.metrics.Timer;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.base.Stopwatch;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.ByteString;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.binary.StringUtils;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -39,10 +48,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -224,37 +235,31 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
 
     @Override
     public CompleteMultipartUploadResult call() throws S3Exception {
+      String objectPath = null;
+      String objTempPath = null;
       try {
         String bucketPath = S3RestUtils.parsePath(AlluxioURI.SEPARATOR + mBucket);
         S3RestUtils.checkPathIsAlluxioDirectory(mUserFs, bucketPath, null);
-        String objectPath = bucketPath + AlluxioURI.SEPARATOR + mObject;
+        objectPath = bucketPath + AlluxioURI.SEPARATOR + mObject;
+        // Check for existing multipart info files and dirs
         AlluxioURI multipartTemporaryDir = new AlluxioURI(
             S3RestUtils.getMultipartTemporaryDirForObject(bucketPath, mObject, mUploadId));
         URIStatus metaStatus;
-        try {
+        try (Timer.Context ctx = MetricsSystem
+                .uniformTimer(MetricKey.PROXY_CHECK_UPLOADID_STATUS_LATENCY.getName()).time()) {
           metaStatus = S3RestUtils.checkStatusesForUploadId(mMetaFs, mUserFs,
-              multipartTemporaryDir, mUploadId).get(1);
+                  multipartTemporaryDir, mUploadId).get(1);
         } catch (Exception e) {
-          LOG.error("checkStatusesForUploadId failed:{}", ThreadUtils.formatStackTrace(e));
+          LOG.warn("checkStatusesForUploadId uploadId:{} failed. {}", mUploadId,
+                  ThreadUtils.formatStackTrace(e));
           throw new S3Exception(objectPath, S3ErrorCode.NO_SUCH_UPLOAD);
         }
 
         // Parse the HTTP request body to get the intended list of parts
-        CompleteMultipartUploadRequest request;
-        try {
-          request = new XmlMapper().readerFor(CompleteMultipartUploadRequest.class)
-              .readValue(mBody);
-        } catch (IllegalArgumentException e) {
-          LOG.error("Failed parsing CompleteMultipartUploadRequest:{}",
-                  ThreadUtils.formatStackTrace(e));
-          Throwable cause = e.getCause();
-          if (cause instanceof S3Exception) {
-            throw S3RestUtils.toObjectS3Exception((S3Exception) cause, objectPath);
-          }
-          throw S3RestUtils.toObjectS3Exception(e, objectPath);
-        }
+        CompleteMultipartUploadRequest request = parseCompleteMultipartUploadRequest(objectPath);
 
         // Check if the requested parts are available
+<<<<<<< HEAD
         List<URIStatus> uploadedParts = mUserFs.listStatus(multipartTemporaryDir);
         if (uploadedParts.size() < request.getParts().size()) {
           throw new S3Exception(objectPath, S3ErrorCode.INVALID_PART);
@@ -274,62 +279,243 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
             throw new S3Exception(objectPath, S3ErrorCode.ENTITY_TOO_SMALL);
           }
         }
+||||||| parent of e041e804b8 (Eliminate race condition in completempupload and support overwrite)
+        List<URIStatus> uploadedParts = mUserFs.listStatus(multipartTemporaryDir);
+        uploadedParts.sort(new S3RestUtils.URIStatusNameComparator());
+        if (uploadedParts.size() < request.getParts().size()) {
+          throw new S3Exception(objectPath, S3ErrorCode.INVALID_PART);
+        }
+        Map<Integer, URIStatus> uploadedPartsMap = uploadedParts.stream().collect(Collectors.toMap(
+            status -> Integer.parseInt(status.getName()),
+            status -> status
+        ));
+        int lastPartNum = request.getParts().get(request.getParts().size() - 1).getPartNumber();
+        for (CompleteMultipartUploadRequest.Part part : request.getParts()) {
+          if (!uploadedPartsMap.containsKey(part.getPartNumber())) {
+            throw new S3Exception(objectPath, S3ErrorCode.INVALID_PART);
+          }
+          if (part.getPartNumber() != lastPartNum // size requirement not applicable to last part
+              && uploadedPartsMap.get(part.getPartNumber()).getLength() < Configuration.getBytes(
+                  PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_MIN_PART_SIZE)) {
+            throw new S3Exception(objectPath, S3ErrorCode.ENTITY_TOO_SMALL);
+          }
+        }
+=======
+        List<URIStatus> uploadedParts = validateParts(request, objectPath, multipartTemporaryDir);
+>>>>>>> e041e804b8 (Eliminate race condition in completempupload and support overwrite)
 
-        CreateFilePOptions.Builder optionsBuilder = CreateFilePOptions.newBuilder()
-            .setRecursive(true)
-            .setMode(PMode.newBuilder()
-                .setOwnerBits(Bits.ALL)
-                .setGroupBits(Bits.ALL)
-                .setOtherBits(Bits.NONE).build())
-            .setWriteType(S3RestUtils.getS3WriteType());
-        // Copy Tagging xAttr if it exists
-        if (metaStatus.getXAttr().containsKey(S3Constants.TAGGING_XATTR_KEY)) {
-          optionsBuilder.putXattr(S3Constants.TAGGING_XATTR_KEY,
-              ByteString.copyFrom(metaStatus.getXAttr().get(S3Constants.TAGGING_XATTR_KEY)));
-        }
-        // Copy Content-Type Header xAttr if it exists
-        if (metaStatus.getXAttr().containsKey(S3Constants.CONTENT_TYPE_XATTR_KEY)) {
-          optionsBuilder.putXattr(S3Constants.CONTENT_TYPE_XATTR_KEY,
-              ByteString.copyFrom(metaStatus.getXAttr().get(S3Constants.CONTENT_TYPE_XATTR_KEY)));
-        }
-        AlluxioURI objectUri = new AlluxioURI(objectPath);
-        try {
-          S3RestUtils.deleteExistObject(mUserFs, objectUri);
-        } catch (IOException | AlluxioException e) {
-          throw S3RestUtils.toObjectS3Exception(e, objectUri.getPath());
-        }
-        // (re)create the merged object
+        // (re)create the merged object to a temporary object path
         LOG.debug("CompleteMultipartUploadTask (bucket: {}, object: {}, uploadId: {}) "
             + "combining {} parts...", mBucket, mObject, mUploadId, uploadedParts.size());
-        FileOutStream os = mUserFs.createFile(objectUri, optionsBuilder.build());
+        CreateFilePOptions createFileOption = prepareForCreateTempFile(metaStatus);
+        objTempPath = objectPath + ".temp." + UUID.randomUUID();
+        AlluxioURI objectTempUri = new AlluxioURI(objTempPath);
+        FileOutStream os = mUserFs.createFile(objectTempUri, createFileOption);
         MessageDigest md5 = MessageDigest.getInstance("MD5");
 
-        try (DigestOutputStream digestOutputStream = new DigestOutputStream(os, md5)) {
+        try (DigestOutputStream digestOutputStream = new DigestOutputStream(os, md5);
+             Timer.Context ctx = MetricsSystem
+                     .uniformTimer(MetricKey.PROXY_COMPLETE_MP_UPLOAD_MERGE_LATENCY
+                             .getName()).time()) {
           for (URIStatus part : uploadedParts) {
             try (FileInStream is = mUserFs.openFile(new AlluxioURI(part.getPath()))) {
               ByteStreams.copy(is, digestOutputStream);
             }
           }
         }
-        String entityTag = Hex.encodeHexString(md5.digest());
         // persist the ETag via xAttr
+        String entityTag = Hex.encodeHexString(md5.digest());
         // TODO(czhu): try to compute the ETag prior to creating the file to reduce total RPC RTT
-        S3RestUtils.setEntityTag(mUserFs, objectUri, entityTag);
+        S3RestUtils.setEntityTag(mUserFs, objectTempUri, entityTag);
+        // rename the temp file to the target object file path
+        AlluxioURI objectUri = new AlluxioURI(objectPath);
+        mUserFs.rename(objectTempUri, objectUri, RenamePOptions.newBuilder()
+                .setPersist(WriteType.fromProto(createFileOption.getWriteType()).isThrough())
+                .setS3SyntaxOptions(S3SyntaxOptions.newBuilder()
+                        .setOverwrite(true)
+                        .setIsMultipartUpload(true)
+                        .build())
+                .build());
 
         // Remove the temporary directory containing the uploaded parts and the
         // corresponding Alluxio S3 API metadata file
-        mUserFs.delete(multipartTemporaryDir,
-            DeletePOptions.newBuilder().setRecursive(true).build());
-        mMetaFs.delete(new AlluxioURI(
-            S3RestUtils.getMultipartMetaFilepathForUploadId(mUploadId)),
-            DeletePOptions.newBuilder().build());
-        if (mMultipartCleanerEnabled) {
-          MultipartUploadCleaner.cancelAbort(mMetaFs, mUserFs, mBucket, mObject, mUploadId);
+        try (Timer.Context ctx = MetricsSystem
+                .uniformTimer(MetricKey.PROXY_CLEANUP_MULTIPART_UPLOAD_LATENCY.getName()).time()) {
+          removePartsDirAndMPMetaFile(multipartTemporaryDir);
         }
         return new CompleteMultipartUploadResult(objectPath, mBucket, mObject, entityTag);
       } catch (Exception e) {
+        /* On exception we always check if someone completes the multipart object before us to
+        achieve idempotency: when a race caused by retry(most cases), the commit of
+        this object happens at time of rename op, check DefaultFileSystemMaster.rename.
+         * */
+        LOG.warn("Exception during CompleteMultipartUpload:{}", ThreadUtils.formatStackTrace(e));
+        if (objectPath != null) {
+          URIStatus objStatus = checkIfComplete(objectPath);
+          if (objStatus != null) {
+            String etag = new String(objStatus.getXAttr()
+                    .getOrDefault(S3Constants.ETAG_XATTR_KEY, new byte[0]));
+            if (!etag.isEmpty()) {
+              LOG.info("Check for idempotency, uploadId:{} idempotency check passed.", mUploadId);
+              return new CompleteMultipartUploadResult(objectPath, mBucket, mObject, etag);
+            }
+            LOG.info("Check for idempotency, uploadId:{} object path exists but no etag found.",
+                    mUploadId);
+          }
+        }
         throw S3RestUtils.toObjectS3Exception(e, mObject);
+      } finally {
+        // Cleanup temp obj path no matter what, if path not exist, ignore
+        cleanupTempPath(objTempPath);
       }
+    }
+
+    /**
+     * Prepare CreateFilePOptions for create temp multipart upload file.
+     * @param metaStatus multi part upload meta file status
+     * @return CreateFilePOptions
+     */
+    public CreateFilePOptions prepareForCreateTempFile(URIStatus metaStatus) {
+      CreateFilePOptions.Builder optionsBuilder = CreateFilePOptions.newBuilder()
+              .setRecursive(true)
+              .setMode(PMode.newBuilder()
+                      .setOwnerBits(Bits.ALL)
+                      .setGroupBits(Bits.ALL)
+                      .setOtherBits(Bits.NONE).build())
+              .putXattr(PropertyKey.Name.S3_UPLOADS_ID_XATTR_KEY,
+                      ByteString.copyFrom(mUploadId, StandardCharsets.UTF_8))
+              .setXattrPropStrat(XAttrPropagationStrategy.LEAF_NODE)
+              .setWriteType(S3RestUtils.getS3WriteType());
+      // Copy Tagging xAttr if it exists
+      if (metaStatus.getXAttr().containsKey(S3Constants.TAGGING_XATTR_KEY)) {
+        optionsBuilder.putXattr(S3Constants.TAGGING_XATTR_KEY,
+                ByteString.copyFrom(metaStatus.getXAttr().get(S3Constants.TAGGING_XATTR_KEY)));
+      }
+      // Copy Content-Type Header xAttr if it exists
+      if (metaStatus.getXAttr().containsKey(S3Constants.CONTENT_TYPE_XATTR_KEY)) {
+        optionsBuilder.putXattr(S3Constants.CONTENT_TYPE_XATTR_KEY,
+                ByteString.copyFrom(metaStatus.getXAttr().get(S3Constants.CONTENT_TYPE_XATTR_KEY)));
+      }
+      return optionsBuilder.build();
+    }
+
+    /**
+     * Parse xml http body for CompleteMultipartUploadRequest.
+     * @param objectPath
+     * @return CompleteMultipartUploadRequest
+     * @throws S3Exception
+     */
+    public CompleteMultipartUploadRequest parseCompleteMultipartUploadRequest(String objectPath)
+            throws S3Exception {
+      CompleteMultipartUploadRequest request;
+      try {
+        request = new XmlMapper().readerFor(CompleteMultipartUploadRequest.class)
+                .readValue(mBody);
+      } catch (IllegalArgumentException | JsonProcessingException e) {
+        LOG.error("Failed parsing CompleteMultipartUploadRequest:{}",
+                ThreadUtils.formatStackTrace(e));
+        Throwable cause = e.getCause();
+        if (cause instanceof S3Exception) {
+          throw S3RestUtils.toObjectS3Exception((S3Exception) cause, objectPath);
+        }
+        throw S3RestUtils.toObjectS3Exception(e, objectPath);
+      }
+      return request;
+    }
+
+    /**
+     * Validate the parts as part of this multipart uplaod request.
+     * @param request
+     * @param objectPath
+     * @param multipartTemporaryDir
+     * @return List of status of the part files
+     * @throws S3Exception
+     * @throws IOException
+     * @throws AlluxioException
+     */
+    public List<URIStatus> validateParts(CompleteMultipartUploadRequest request,
+                                         String objectPath,
+                                         AlluxioURI multipartTemporaryDir)
+            throws S3Exception, IOException, AlluxioException {
+      List<URIStatus> uploadedParts = mUserFs.listStatus(multipartTemporaryDir);
+      uploadedParts.sort(new S3RestUtils.URIStatusNameComparator());
+      if (uploadedParts.size() < request.getParts().size()) {
+        throw new S3Exception(objectPath, S3ErrorCode.INVALID_PART);
+      }
+      Map<Integer, URIStatus> uploadedPartsMap = uploadedParts.stream().collect(Collectors.toMap(
+              status -> Integer.parseInt(status.getName()),
+              status -> status
+      ));
+      int lastPartNum = request.getParts().get(request.getParts().size() - 1).getPartNumber();
+      for (CompleteMultipartUploadRequest.Part part : request.getParts()) {
+        if (!uploadedPartsMap.containsKey(part.getPartNumber())) {
+          throw new S3Exception(objectPath, S3ErrorCode.INVALID_PART);
+        }
+        if (part.getPartNumber() != lastPartNum // size requirement not applicable to last part
+                && uploadedPartsMap.get(part.getPartNumber()).getLength() < Configuration.getBytes(
+                PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_MIN_PART_SIZE)) {
+          throw new S3Exception(objectPath, S3ErrorCode.ENTITY_TOO_SMALL);
+        }
+      }
+      return uploadedParts;
+    }
+
+    /**
+     * Cleanup the multipart upload temporary folder holding the parts files.
+     * and the meta file for this multipart.
+     * @param multipartTemporaryDir
+     * @throws IOException
+     * @throws AlluxioException
+     */
+    public void removePartsDirAndMPMetaFile(AlluxioURI multipartTemporaryDir)
+            throws IOException, AlluxioException {
+      mUserFs.delete(multipartTemporaryDir,
+              DeletePOptions.newBuilder().setRecursive(true).build());
+      mMetaFs.delete(new AlluxioURI(
+                      S3RestUtils.getMultipartMetaFilepathForUploadId(mUploadId)),
+              DeletePOptions.newBuilder().build());
+      if (mMultipartCleanerEnabled) {
+        MultipartUploadCleaner.cancelAbort(mMetaFs, mUserFs, mBucket, mObject, mUploadId);
+      }
+    }
+
+    /**
+     * Cleanup the temp object file for complete multipart upload.
+     * @param objTempPath
+     */
+    public void cleanupTempPath(String objTempPath) {
+      if (objTempPath != null) {
+        try (Timer.Context ctx = MetricsSystem
+                .uniformTimer(MetricKey.PROXY_CLEANUP_TEMP_MULTIPART_UPLOAD_OBJ_LATENCY
+                        .getName()).time()) {
+          mUserFs.delete(new AlluxioURI(objTempPath), DeletePOptions.newBuilder().build());
+        } catch (Exception e) {
+          LOG.warn("Failed to clean up temp path:{}, {}", objTempPath, e.getMessage());
+        }
+      }
+    }
+
+    /**
+     * On any exception, check with Master on if the there's an object file.
+     * bearing the same upload id already got completed.
+     * @param objectPath
+     * @return the status of the existing object through CompleteMultipartUpload call
+     */
+    public URIStatus checkIfComplete(String objectPath) {
+      try {
+        URIStatus objStatus = mUserFs.getStatus(new AlluxioURI(objectPath));
+        String uploadId = new String(objStatus.getXAttr()
+                .getOrDefault(PropertyKey.Name.S3_UPLOADS_ID_XATTR_KEY, new byte[0]));
+        if (objStatus.isCompleted() && StringUtils.equals(uploadId, mUploadId)) {
+          return objStatus;
+        }
+      } catch (IOException | AlluxioException ex) {
+        // can't validate if any previous attempt has succeeded
+        LOG.warn("Check for objectPath:{} failed:{}, unsure if the complete status.",
+                objectPath, ex.getMessage());
+        return null;
+      }
+      return null;
     }
   }
 }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/CompleteMultipartUploadHandler.java
@@ -259,50 +259,7 @@ public class CompleteMultipartUploadHandler extends AbstractHandler {
         CompleteMultipartUploadRequest request = parseCompleteMultipartUploadRequest(objectPath);
 
         // Check if the requested parts are available
-<<<<<<< HEAD
-        List<URIStatus> uploadedParts = mUserFs.listStatus(multipartTemporaryDir);
-        if (uploadedParts.size() < request.getParts().size()) {
-          throw new S3Exception(objectPath, S3ErrorCode.INVALID_PART);
-        }
-        Map<Integer, URIStatus> uploadedPartsMap = uploadedParts.stream().collect(Collectors.toMap(
-            status -> Integer.parseInt(status.getName()),
-            status -> status
-        ));
-        int lastPartNum = request.getParts().get(request.getParts().size() - 1).getPartNumber();
-        for (CompleteMultipartUploadRequest.Part part : request.getParts()) {
-          if (!uploadedPartsMap.containsKey(part.getPartNumber())) {
-            throw new S3Exception(objectPath, S3ErrorCode.INVALID_PART);
-          }
-          if (part.getPartNumber() != lastPartNum // size requirement not applicable to last part
-              && uploadedPartsMap.get(part.getPartNumber()).getLength() < Configuration.getBytes(
-                  PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_MIN_PART_SIZE)) {
-            throw new S3Exception(objectPath, S3ErrorCode.ENTITY_TOO_SMALL);
-          }
-        }
-||||||| parent of e041e804b8 (Eliminate race condition in completempupload and support overwrite)
-        List<URIStatus> uploadedParts = mUserFs.listStatus(multipartTemporaryDir);
-        uploadedParts.sort(new S3RestUtils.URIStatusNameComparator());
-        if (uploadedParts.size() < request.getParts().size()) {
-          throw new S3Exception(objectPath, S3ErrorCode.INVALID_PART);
-        }
-        Map<Integer, URIStatus> uploadedPartsMap = uploadedParts.stream().collect(Collectors.toMap(
-            status -> Integer.parseInt(status.getName()),
-            status -> status
-        ));
-        int lastPartNum = request.getParts().get(request.getParts().size() - 1).getPartNumber();
-        for (CompleteMultipartUploadRequest.Part part : request.getParts()) {
-          if (!uploadedPartsMap.containsKey(part.getPartNumber())) {
-            throw new S3Exception(objectPath, S3ErrorCode.INVALID_PART);
-          }
-          if (part.getPartNumber() != lastPartNum // size requirement not applicable to last part
-              && uploadedPartsMap.get(part.getPartNumber()).getLength() < Configuration.getBytes(
-                  PropertyKey.PROXY_S3_COMPLETE_MULTIPART_UPLOAD_MIN_PART_SIZE)) {
-            throw new S3Exception(objectPath, S3ErrorCode.ENTITY_TOO_SMALL);
-          }
-        }
-=======
         List<URIStatus> uploadedParts = validateParts(request, objectPath, multipartTemporaryDir);
->>>>>>> e041e804b8 (Eliminate race condition in completempupload and support overwrite)
 
         // (re)create the merged object to a temporary object path
         LOG.debug("CompleteMultipartUploadTask (bucket: {}, object: {}, uploadId: {}) "

--- a/core/transport/src/main/proto/grpc/file_system_master.proto
+++ b/core/transport/src/main/proto/grpc/file_system_master.proto
@@ -432,10 +432,16 @@ message FileSystemCommand {
   optional FileSystemCommandOptions commandOptions = 2;
 }
 
+message S3SyntaxOptions {
+  optional bool overwrite = 1;
+  optional bool isMultipartUpload = 2;
+}
+
 message RenamePResponse {}
 message RenamePOptions {
   optional FileSystemMasterCommonPOptions commonOptions = 1;
   optional bool persist = 2;
+  optional S3SyntaxOptions s3SyntaxOptions = 3;
 }
 message RenamePRequest {
   /** the source path of the file or directory */

--- a/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
+++ b/tests/src/test/java/alluxio/client/rest/S3ClientRestApiTest.java
@@ -1482,6 +1482,12 @@ public final class S3ClientRestApiTest extends RestApiTest {
 
   @Test
   public void duplicateMultipartUpload() throws Exception {
+    /*
+    1) Test for two mp uploads with diff upload id for creating same object,
+    one should overwrite the other
+    2) Test for CompleteMultipartUpload call should be idempotent, AKA
+    CompleteMultipartUpload made for the same uploadId should return the same result.
+     */
     final String bucketName = "bucket";
     createBucketRestCall(bucketName);
 
@@ -1524,6 +1530,8 @@ public final class S3ClientRestApiTest extends RestApiTest {
     partList1.add(new CompleteMultipartUploadRequest.Part("", 2));
     result1 = completeMultipartUploadRestCall(objectKey, uploadId1,
         new CompleteMultipartUploadRequest(partList1));
+    String result1Retry = completeMultipartUploadRestCall(objectKey, uploadId1,
+            new CompleteMultipartUploadRequest(partList1));
 
     // Verify that the response is expected.
     String expectedCombinedObject = object1 + object2;
@@ -1537,6 +1545,9 @@ public final class S3ClientRestApiTest extends RestApiTest {
         result1.trim());
     Assert.assertEquals(XML_MAPPER.readValue(result1, CompleteMultipartUploadResult.class),
         completeMultipartUploadResult1);
+
+    // Verify the response is idempotent for upload1
+    Assert.assertEquals(result1, result1Retry);
 
     // Verify that only the corresponding temporary directory is deleted.
     Assert.assertFalse(mFileSystem.exists(tmpDir1));
@@ -1553,6 +1564,11 @@ public final class S3ClientRestApiTest extends RestApiTest {
     partList2.add(new CompleteMultipartUploadRequest.Part("", 1));
     result2 = completeMultipartUploadRestCall(objectKey, uploadId2,
         new CompleteMultipartUploadRequest(partList2));
+    String result2Retry = completeMultipartUploadRestCall(objectKey, uploadId2,
+            new CompleteMultipartUploadRequest(partList2));
+
+    // Verify the response is idempotent for upload2
+    Assert.assertEquals(result2, result2Retry);
 
     // Verify that the response is expected.
     digest = md5.digest(object3.getBytes());
@@ -1572,6 +1588,15 @@ public final class S3ClientRestApiTest extends RestApiTest {
       String newObject = IOUtils.toString(is);
       Assert.assertEquals(object3, newObject);
     }
+
+    // Now if CompleteMultipartUpload is called for upload1
+    // It should say NoSuchUpload
+    HttpURLConnection connection = completeMultipartUploadRestCallWithResponse(objectKey, uploadId1,
+            new CompleteMultipartUploadRequest(partList1));
+    Assert.assertEquals(404, connection.getResponseCode());
+    S3Error response =
+            new XmlMapper().readerFor(S3Error.class).readValue(connection.getErrorStream());
+    Assert.assertEquals(S3ErrorCode.Name.NO_SUCH_UPLOAD, response.getCode());
   }
 
   @Test
@@ -2072,16 +2097,28 @@ public final class S3ClientRestApiTest extends RestApiTest {
         options).runAndGetResponse();
   }
 
-  private String completeMultipartUploadRestCall(
-      String objectUri, String uploadId, CompleteMultipartUploadRequest request)
-      throws Exception {
+  private TestCase getCompleteMultipartUploadReadCallTestCase(
+          String objectUri, String uploadId, CompleteMultipartUploadRequest request) {
     Map<String, String> params = ImmutableMap.of("uploadId", uploadId);
     return new TestCase(mHostname, mPort, mBaseUri,
-        objectUri, params, HttpMethod.POST,
-        getDefaultOptionsWithAuth()
-            .setBody(request)
-            .setContentType(TestCaseOptions.XML_CONTENT_TYPE))
-        .runAndGetResponse();
+            objectUri, params, HttpMethod.POST,
+            getDefaultOptionsWithAuth()
+                    .setBody(request)
+                    .setContentType(TestCaseOptions.XML_CONTENT_TYPE));
+  }
+
+  private String completeMultipartUploadRestCall(
+          String objectUri, String uploadId, CompleteMultipartUploadRequest request)
+          throws Exception {
+    TestCase testCase = getCompleteMultipartUploadReadCallTestCase(objectUri, uploadId, request);
+    return testCase.runAndGetResponse();
+  }
+
+  private HttpURLConnection completeMultipartUploadRestCallWithResponse(
+          String objectUri, String uploadId, CompleteMultipartUploadRequest request)
+          throws Exception {
+    TestCase testCase = getCompleteMultipartUploadReadCallTestCase(objectUri, uploadId, request);
+    return testCase.execute();
   }
 
   private HttpURLConnection abortMultipartUploadRestCall(String objectUri, String uploadId)


### PR DESCRIPTION
Cherry pick of https://github.com/Alluxio/alluxio/pull/16578

### What changes are proposed in this pull request?

Make CompleteMultipartUpload call idempotent
Support Overwrite now only for createobject from s3client thru multipart upload 

### Why are the changes needed?

When use  Spark + hadoop s3a to write to Alluxio, spark will retry if CompleteMultipartUpload took too long, since alluxio doesnt allow overwrite, s3 proxy does a delete and create in an non-atomic way which causes race condition, rendering the retry fail, and as a result failing the entire spark write.

### Does this PR introduce any user facing changes?
1) New timer (with uniformTimer call)using UniformReservoir is introduced in the MetricsSystem
2) the uniformTimer is added to measure different parts of CompleteMultipartUpload call, as well as common places such as UFS and AlluxioOutstream close call.
