### PR TITLE
Fix metadata sync behavior when descendant type is NONE

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -3410,6 +3410,18 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setIsHidden(true)
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .build();
+  public static final PropertyKey
+      MASTER_METADATA_SYNC_GET_DIRECTORY_STATUS_SKIP_LOADING_CHILDREN =
+      booleanBuilder(Name.MASTER_METADATA_SYNC_GET_DIRECTORY_STATUS_SKIP_LOADING_CHILDREN)
+          .setDescription(
+              "If set to true, skip loading children during metadata sync when "
+                  + "descendant type is set to NONE, for example, a metadata sync triggered "
+                  + "by a getStatus on a directory.")
+          .setScope(Scope.MASTER)
+          .setDefaultValue(true)
+          .setIsHidden(true)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .build();
   // In Java8 in container environment Runtime.availableProcessors() always returns 1,
   // which is not the actual number of cpus, so we set a safe default value 32.
   public static final PropertyKey MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE =
@@ -7544,6 +7556,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.master.metadata.sync.instrument.executor";
     public static final String MASTER_METADATA_SYNC_REPORT_FAILURE =
         "alluxio.master.metadata.sync.report.failure";
+    public static final String MASTER_METADATA_SYNC_GET_DIRECTORY_STATUS_SKIP_LOADING_CHILDREN =
+        "alluxio.master.metadata.sync.get.directory.status.skip.loading.children";
     public static final String MASTER_METADATA_SYNC_UFS_PREFETCH_POOL_SIZE =
         "alluxio.master.metadata.sync.ufs.prefetch.pool.size";
     public static final String MASTER_METADATA_SYNC_TRAVERSAL_ORDER =

--- a/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
+++ b/core/server/master/src/main/java/alluxio/master/file/InodeSyncStream.java
@@ -295,6 +295,10 @@ public class InodeSyncStream {
   private final int mConcurrencyLevel =
       Configuration.getInt(PropertyKey.MASTER_METADATA_SYNC_CONCURRENCY_LEVEL);
 
+  private final boolean mGetDirectoryStatusSkipLoadingChildren =
+      Configuration.getBoolean(
+          PropertyKey.MASTER_METADATA_SYNC_GET_DIRECTORY_STATUS_SKIP_LOADING_CHILDREN);
+
   private final FileSystemMasterAuditContext mAuditContext;
   private final Function<LockedInodePath, Inode> mAuditContextSrcInodeFunc;
 
@@ -477,6 +481,10 @@ public class InodeSyncStream {
         // If descendantType is ONE, then we shouldn't process any more paths except for those
         // currently in the queue
         stopNum = mPendingPaths.size();
+      } else if (mGetDirectoryStatusSkipLoadingChildren && mDescendantType == DescendantType.NONE) {
+        // If descendantType is NONE, do not process any path in the queue after
+        // the inode itself is loaded.
+        stopNum = 0;
       }
 
       // process the sync result for the original path
@@ -897,6 +905,8 @@ public class InodeSyncStream {
     if (mDescendantType == DescendantType.ONE) {
       syncChildren =
           syncChildren && mRootScheme.getPath().equals(inodePath.getUri());
+    } else if (mDescendantType == DescendantType.NONE && mGetDirectoryStatusSkipLoadingChildren) {
+      syncChildren = false;
     }
 
     int childCount = inode.isDirectory() ? (int) inode.asDirectory().getChildCount() : 0;

--- a/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/FileSystemMasterSyncMetadataTest.java
@@ -267,6 +267,73 @@ public final class FileSystemMasterSyncMetadataTest {
     assertFalse(delegateMaster.mSynced.get());
   }
 
+  /**
+   * Tests the getStatus operation does not trigger a metadata sync that loads its children.
+   */
+  @Test
+  public void getStatusOnDirectory() throws Exception {
+    AlluxioURI ufsMount = setupMockUfsS3Mount();
+    short mode = ModeUtils.getUMask("0700").toShort();
+
+    // Mock dir1 ufs path
+    AlluxioURI dir1Path = ufsMount.join("dir1");
+    UfsDirectoryStatus dir1Status = new UfsDirectoryStatus(dir1Path.getPath(), "", "", mode);
+    Mockito.when(mUfs.getParsedFingerprint(dir1Path.toString()))
+        .thenReturn(Fingerprint.create("s3", dir1Status));
+    Mockito.when(mUfs.exists(dir1Path.toString())).thenReturn(true);
+    Mockito.when(mUfs.isDirectory(dir1Path.toString())).thenReturn(true);
+    Mockito.when(mUfs.isFile(dir1Path.toString())).thenReturn(false);
+    Mockito.when(mUfs.getStatus(dir1Path.toString())).thenReturn(dir1Status);
+    Mockito.when(mUfs.getDirectoryStatus(dir1Path.toString())).thenReturn(dir1Status);
+
+    // Mock nested ufs path /dir1/dir2
+    AlluxioURI nestedDirectoryPath = ufsMount.join("dir1").join("dir2");
+    UfsDirectoryStatus nestedDirStatus =
+        new UfsDirectoryStatus(dir1Path.getPath(), "", "", mode);
+
+    Mockito.when(mUfs.getParsedFingerprint(nestedDirectoryPath.toString()))
+        .thenReturn(Fingerprint.create("s3", nestedDirStatus));
+    Mockito.when(mUfs.exists(nestedDirectoryPath.toString())).thenReturn(true);
+    Mockito.when(mUfs.isDirectory(nestedDirectoryPath.toString())).thenReturn(true);
+    Mockito.when(mUfs.isFile(nestedDirectoryPath.toString())).thenReturn(false);
+    Mockito.when(mUfs.getStatus(nestedDirectoryPath.toString())).thenReturn(nestedDirStatus);
+    Mockito.when(mUfs.getDirectoryStatus(nestedDirectoryPath.toString()))
+        .thenReturn(nestedDirStatus);
+
+    // Mock creating the same directory and nested file in UFS out of band
+    AlluxioURI dir1 = new AlluxioURI("/mnt/local/dir1");
+    AlluxioURI dir2 = new AlluxioURI("/mnt/local/dir1/dir2");
+    Mockito.when(mUfs.listStatus(eq(dir1Path.toString())))
+        .thenReturn(new UfsStatus[]{new UfsDirectoryStatus("dir2", "", "", mode)});
+    Mockito.when(mUfs.listStatus(eq(nestedDirectoryPath.toString())))
+        .thenReturn(new UfsStatus[]{});
+
+    // List the nested directory
+    // listStatus is called on UFS /dir1/dir2
+    mFileSystemMaster.listStatus(dir2, ListStatusContext.mergeFrom(
+            ListStatusPOptions.newBuilder().setCommonOptions(
+                FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(0).build())));
+    Mockito.verify(mUfs, Mockito.times(0))
+        .listStatus(eq(dir1Path.toString()));
+    Mockito.verify(mUfs, Mockito.times(1))
+        .listStatus(eq(nestedDirectoryPath.toString()));
+    Mockito.verify(mUfs, Mockito.times(1))
+        .getStatus(eq(nestedDirectoryPath.toString()));
+
+    // Get the file info of the directory /dir1
+    // listStatus is called on UFS /dir1/dir2
+    // Make sure there is neither list nor get on UFS /dir1/dir2
+    mFileSystemMaster.getFileInfo(dir1, GetStatusContext.mergeFrom(
+        GetStatusPOptions.newBuilder().setCommonOptions(
+            FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(0).build())));
+    Mockito.verify(mUfs, Mockito.times(0))
+        .listStatus(eq(dir1Path.toString()));
+    Mockito.verify(mUfs, Mockito.times(1))
+        .listStatus(eq(nestedDirectoryPath.toString()));
+    Mockito.verify(mUfs, Mockito.times(1))
+        .getStatus(eq(nestedDirectoryPath.toString()));
+  }
+
   private static class SyncAwareFileSystemMaster extends DefaultFileSystemMaster {
     AtomicBoolean mSynced = new AtomicBoolean(false);
 

--- a/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
+++ b/tests/src/test/java/alluxio/client/fs/UfsSyncIntegrationTest.java
@@ -863,14 +863,20 @@ public class UfsSyncIntegrationTest extends BaseIntegrationTest {
 
     // delete the file and wait a bit
     new File(ufsPath("/delete/file")).delete();
-    CommonUtils.sleepMs(2000);
+    CommonUtils.sleepMs(3000);
 
     // getStatus (not listStatus) on the root, with a shorter interval than the sleep.
     // This will sync that directory. The sync interval has to be long enough for the internal
     // syncing process to finish within that time.
     mFileSystem.getStatus(new AlluxioURI(alluxioPath("/delete")), GetStatusPOptions.newBuilder()
         .setCommonOptions(
-            FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(1000).build()).build());
+            FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(2000).build()).build());
+
+    // a following list status should trigger a metadata sync even though the path was just synced,
+    // because the descendant type is ONE this time, and it was NONE previously.
+    mFileSystem.listStatus(new AlluxioURI(alluxioPath("/delete")),
+        ListStatusPOptions.newBuilder().setRecursive(false).setCommonOptions(
+            FileSystemMasterCommonPOptions.newBuilder().setSyncIntervalMs(2000).build()).build());
 
     // verify that the file is deleted, without syncing
     try {


### PR DESCRIPTION
### What changes are proposed in this pull request?

When the metadata sync descendant type is NONE, stop loading the children of the sync root.

If a metadata sync is trigged by a GetStatus() call on a directory Previous behavior: The directory itself, as well as all its sub directories in the inode store will be synced.
New behavior: ONLY the directory itself will be loaded.

### Why are the changes needed?

This PR addresses https://github.com/Alluxio/alluxio/issues/16922. The incorrect metadata sync behavior on GetStatus for a directory loads more children of the directory than expected and put a lot of pressure on UFS side.

### Does this PR introduce any user facing changes?

Yes. The metadata sync behavior has been changed. See the comment above. The previous behavior was actually wrong and we added a hidden feature flag to allow customers to fallback.

pr-link: Alluxio/alluxio#16935
change-id: cid-2a5a2b4959422ecff74149881e400659d07c2163