### PR TITLE
Fix dependencies conflicts thrown by trino

### DIFF
--- a/shaded/client/pom.xml
+++ b/shaded/client/pom.xml
@@ -262,10 +262,6 @@
                   <shadedPattern>${shading.prefix}.javassist</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>software/amazon/ion/</pattern>
-                  <shadedPattern>${shading.prefix}.software.amazon.ion</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>javax/annotation/</pattern>
                   <shadedPattern>${shading.prefix}.javax.annotation.</shadedPattern>
                   <excludes>
@@ -296,6 +292,10 @@
                     <!-- Exclude the rocksdb-jni package-->
                     <exclude>org/rocksdb/**/*</exclude>
                   </excludes>
+                </relocation>
+                <relocation>
+                  <pattern>software/amazon/ion/</pattern>
+                  <shadedPattern>${shading.prefix}.software.amazon.ion</shadedPattern>
                 </relocation>
               </relocations>
               <transformers>

--- a/shaded/client/pom.xml
+++ b/shaded/client/pom.xml
@@ -262,6 +262,10 @@
                   <shadedPattern>${shading.prefix}.javassist</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>software/amazon/ion/</pattern>
+                  <shadedPattern>${shading.prefix}.software.amazon.ion</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>javax/annotation/</pattern>
                   <shadedPattern>${shading.prefix}.javax.annotation.</shadedPattern>
                   <excludes>


### PR DESCRIPTION
**PR Background - Bug description:**
[PrestoDB](https://prestodb.io/) and [TrinoDB](https://trino.io/) use our shaded JAR in their `pom.xml`. When upgrading the version of `alluxio-shaded-client` from `2.8.1` to `2.9.1`, we fail to compile the codes of presto/trino. This is because there is dependency conflict.

**Solution:**
Relocate the dependencies in `shaded/client/pom.xml` to avoid deplicate classes and files.

**TIPS:** You can execute `cd ${ALLUXIO_HOME}/shaded && mvn clean install -Prelease -DskipTests -T 4C` to package the shaded JAR.