### PR TITLE
Fix double counting job success when restore job from journal

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/job/AbstractJob.java
+++ b/core/server/master/src/main/java/alluxio/master/job/AbstractJob.java
@@ -95,9 +95,6 @@ public abstract class AbstractJob<T extends Task<?>> implements Job<T> {
     if (!isRunning()) {
       mEndTime = OptionalLong.of(System.currentTimeMillis());
     }
-    if (state == JobState.SUCCEEDED) {
-      LoadJob.JOB_LOAD_SUCCESS.inc();
-    }
   }
 
   @Override

--- a/core/server/master/src/main/java/alluxio/master/job/LoadJob.java
+++ b/core/server/master/src/main/java/alluxio/master/job/LoadJob.java
@@ -208,6 +208,12 @@ public class LoadJob extends AbstractJob<LoadJob.LoadTask> {
     JOB_LOAD_FAIL.inc();
   }
 
+  @Override
+  public void setJobSuccess() {
+    setJobState(JobState.SUCCEEDED);
+    JOB_LOAD_SUCCESS.inc();
+  }
+
   /**
    * Add bytes to total loaded bytes.
    * @param bytes bytes to be added to total

--- a/core/server/master/src/main/java/alluxio/master/scheduler/Scheduler.java
+++ b/core/server/master/src/main/java/alluxio/master/scheduler/Scheduler.java
@@ -334,7 +334,7 @@ public final class Scheduler {
         }
         else {
           if (job.isHealthy()) {
-            job.setJobState(JobState.SUCCEEDED);
+            job.setJobSuccess();
           }
           else {
             job.failJob(new InternalRuntimeException("Job failed because it's not healthy."));

--- a/job/common/src/main/java/alluxio/scheduler/job/Job.java
+++ b/job/common/src/main/java/alluxio/scheduler/job/Job.java
@@ -68,6 +68,11 @@ public interface Job<T extends Task<?>> {
   void failJob(AlluxioRuntimeException reason);
 
   /**
+   * set job as success.
+   */
+  void setJobSuccess();
+
+  /**
    * Get job progress.
    * @param format progress report format
    * @param verbose whether to include detailed information


### PR DESCRIPTION
### What changes are proposed in this pull request?

When we restore a job from the journal we would call setJobStatus and would double count job that already finished successfully

### Why are the changes needed?

fix bug

### Does this PR introduce any user facing changes?

na
