### PR TITLE
Print exception stack in s3 proxy

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -37,6 +37,7 @@ import alluxio.security.authentication.AuthType;
 import alluxio.security.authentication.AuthenticatedClientUser;
 import alluxio.security.user.ServerUserState;
 import alluxio.util.SecurityUtils;
+import alluxio.util.ThreadUtils;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.annotations.VisibleForTesting;
@@ -129,7 +130,11 @@ public final class S3RestUtils {
       XmlMapper mapper = new XmlMapper();
       return Response.ok(mapper.writeValueAsString(result)).build();
     } catch (Exception e) {
-      LOG.warn("Error invoking REST endpoint for {}:\n{}", resource, e.getMessage(), e);
+      String errOutputMsg = e.getMessage();
+      if (StringUtils.isEmpty(errOutputMsg)) {
+        errOutputMsg = ThreadUtils.formatStackTrace(e);
+      }
+      LOG.warn("Error invoking REST endpoint for {}:\n{}", resource, errOutputMsg);
       return S3ErrorResponse.createErrorResponse(e, resource);
     }
   }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -129,7 +129,7 @@ public final class S3RestUtils {
       XmlMapper mapper = new XmlMapper();
       return Response.ok(mapper.writeValueAsString(result)).build();
     } catch (Exception e) {
-      LOG.warn("Error invoking REST endpoint for {}:\n{}", resource, e.getMessage());
+      LOG.warn("Error invoking REST endpoint for {}:\n{}", resource, e.getMessage(), e);
       return S3ErrorResponse.createErrorResponse(e, resource);
     }
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Print exception stack for s3 proxy.

### Why are the changes needed?

Sometimes, the message of exception is null, and we need print stack to find where the exception occurred.

Before add exception stack:
```
2023-03-24 14:47:50,164 INFO  ProxyWebServer - [ACCESSLOG] ListObjects Request:Request[GET //localhost:39999/api/v1/s3/s3/?prefix=user%2Fhumengyu%2Fword1&encoding-type=url]@54efde7a - Status:500 - ContentLength:None - Elapsed(ms):561
2023-03-24 14:47:50,325 WARN  S3RestUtils - Error invoking REST endpoint for s3:
null
2023-03-24 14:47:50,328 INFO  ProxyWebServer - [ACCESSLOG] ListObjects Request:Request[GET //localhost:39999/api/v1/s3/s3/?prefix=user%2Fhumengyu%2Fword1&encoding-type=url]@54efde7a - Status:500 - ContentLength:None - Elapsed(ms):18
2023-03-24 14:47:50,469 WARN  S3RestUtils - Error invoking REST endpoint for s3:
null
2023-03-24 14:47:50,472 INFO  ProxyWebServer - [ACCESSLOG] ListObjects Request:Request[GET //localhost:39999/api/v1/s3/s3/?prefix=user%2Fhumengyu%2Fword1&encoding-type=url]@54efde7a - Status:500 - ContentLength:None - Elapsed(ms):16
2023-03-24 14:47:50,828 WARN  S3RestUtils - Error invoking REST endpoint for s3:
null
2023-03-24 14:47:50,830 INFO  ProxyWebServer - [ACCESSLOG] ListObjects Request:Request[GET //localhost:39999/api/v1/s3/s3/?prefix=user%2Fhumengyu%2Fword1&encoding-type=url]@54efde7a - Status:500 - ContentLength:None - Elapsed(ms):14
```
After add exception stack:
```
2023-03-24 14:54:41,470 WARN  S3RestUtils - Error invoking REST endpoint for s3:
null
alluxio.proxy.s3.S3Exception
  at alluxio.proxy.s3.S3RestUtils.toBucketS3Exception(S3RestUtils.java:214)
  at alluxio.proxy.s3.S3BucketTask$ListObjectsTask.lambda$continueTask$1(S3BucketTask.java:335)
  at alluxio.proxy.s3.S3RestUtils.call(S3RestUtils.java:107)
  at alluxio.proxy.s3.S3BucketTask$ListObjectsTask.continueTask(S3BucketTask.java:264)
  at alluxio.proxy.s3.S3RequestServlet.serveRequest(S3RequestServlet.java:124)
  at alluxio.proxy.s3.S3RequestServlet.lambda$service$0(S3RequestServlet.java:93)
  at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
  at java.util.concurrent.FutureTask.run(FutureTask.java:266)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
  at java.lang.Thread.run(Thread.java:748)
Caused by: alluxio.exception.AlluxioException
  at alluxio.exception.status.AlluxioStatusException.toAlluxioException(AlluxioStatusException.java:110)
  at alluxio.client.file.BaseFileSystem.wrapAndThrowAlluxioStatusException(BaseFileSystem.java:648)
  at alluxio.client.file.BaseFileSystem.rpc(BaseFileSystem.java:625)
  at alluxio.client.file.BaseFileSystem.exists(BaseFileSystem.java:207)
  at alluxio.client.file.DelegatingFileSystem.exists(DelegatingFileSystem.java:99)
  at alluxio.client.file.FileSystemCache$InstanceCachingFileSystem.exists(FileSystemCache.java:251)
  at alluxio.client.file.FileSystem.exists(FileSystem.java:302)
  at alluxio.proxy.s3.S3BucketTask$ListObjectsTask.lambda$continueTask$1(S3BucketTask.java:315)
  ... 9 more
Caused by: alluxio.exception.status.UnknownException
  at alluxio.exception.status.AlluxioStatusException.from(AlluxioStatusException.java:174)
  at alluxio.exception.status.AlluxioStatusException.fromStatusRuntimeException(AlluxioStatusException.java:215)
  at alluxio.AbstractClient.retryRPCInternal(AbstractClient.java:486)
  at alluxio.AbstractClient.retryRPC(AbstractClient.java:450)
  at alluxio.AbstractClient.retryRPC(AbstractClient.java:439)
  at alluxio.client.file.RetryHandlingFileSystemMasterClient.exists(RetryHandlingFileSystemMasterClient.java:192)
  at alluxio.client.file.BaseFileSystem.lambda$exists$4(BaseFileSystem.java:210)
  at alluxio.client.file.BaseFileSystem.rpc(BaseFileSystem.java:623)
  ... 14 more
Caused by: io.grpc.StatusRuntimeException: UNKNOWN
  at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:262)
  at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:243)
  at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:156)
  at alluxio.grpc.FileSystemMasterClientServiceGrpc$FileSystemMasterClientServiceBlockingStub.exists(FileSystemMasterClientServiceGrpc.java:2018)
  at alluxio.client.file.RetryHandlingFileSystemMasterClient.lambda$exists$6(RetryHandlingFileSystemMasterClient.java:192)
  at alluxio.AbstractClient.retryRPCInternal(AbstractClient.java:484)
  ... 19 more
```
