### PR TITLE
Add global rate limiter to s3 proxy v2 attribute

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -169,6 +169,8 @@ public final class ProxyWebServer extends WebServer {
               getServletContext().setAttribute(PROXY_S3_V2_LIGHT_POOL, createLightThreadPool());
               getServletContext().setAttribute(PROXY_S3_V2_HEAVY_POOL, createHeavyThreadPool());
               getServletContext().setAttribute(PROXY_S3_HANDLER_MAP, mS3HandlerMap);
+              getServletContext().setAttribute(GLOBAL_RATE_LIMITER_SERVLET_RESOURCE_KEY,
+                  mGlobalRateLimiter);
             }
           });
       mServletContextHandler


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add global rate limiter to s3 proxy v2 attribute.

### Why are the changes needed?

The global rate limiter does not work in s3 proxy v2, because we didn't add it to the attribute of servletContext.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
