### PR TITLE
Support setting write type to MUST_CACHE for upload parts

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5460,7 +5460,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "Set value less than or equal to 0 to disable rate limits.")
           .setDefaultValue(0)
           .setScope(Scope.SERVER)
-
+          .build();
+  public static final PropertyKey PROXY_S3_UPLOAD_PART_ONLY_CACHE_ENABLED =
+      booleanBuilder(Name.PROXY_S3_UPLOAD_PART_ONLY_CACHE_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("When this property is true, set the write type to MUST_CACHE "
+              + "for UploadPart.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
           .build();
 
   //
@@ -8625,6 +8632,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.proxy.s3.global.read.rate.limit.mb";
     public static final String PROXY_S3_SINGLE_CONNECTION_READ_RATE_LIMIT_MB =
         "alluxio.proxy.s3.single.connection.read.rate.limit.mb";
+    public static final String PROXY_S3_UPLOAD_PART_ONLY_CACHE_ENABLED =
+        "alluxio.proxy.s3.upload.part.only.cache.enabled";
 
     //
     // Locality related properties

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5469,6 +5469,22 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.SERVER)
           .build();
+  public static final PropertyKey PROXY_S3_UPLOAD_PART_REPLICATION_MIN =
+      intBuilder(Name.PROXY_S3_UPLOAD_PART_REPLICATION_MIN)
+          .setDefaultValue(1)
+          .setDescription("The target min replication level of a file in Alluxio space "
+              + "when set the write type to MUST_CACHE for UploadPart.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
+  public static final PropertyKey PROXY_S3_UPLOAD_PART_REPLICATION_MAX =
+      intBuilder(Name.PROXY_S3_UPLOAD_PART_REPLICATION_MAX)
+          .setDefaultValue(1)
+          .setDescription("The target max replication level of a file in Alluxio space "
+              + "when set the write type to MUST_CACHE for UploadPart.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
+          .setScope(Scope.SERVER)
+          .build();
 
   //
   // Locality related properties
@@ -8634,6 +8650,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.proxy.s3.single.connection.read.rate.limit.mb";
     public static final String PROXY_S3_UPLOAD_PART_ONLY_CACHE_ENABLED =
         "alluxio.proxy.s3.upload.part.only.cache.enabled";
+    public static final String PROXY_S3_UPLOAD_PART_REPLICATION_MIN =
+        "alluxio.proxy.s3.upload.part.file.replication.min";
+    public static final String PROXY_S3_UPLOAD_PART_REPLICATION_MAX =
+        "alluxio.proxy.s3.upload.part.file.replication.max";
 
     //
     // Locality related properties

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestUtils.java
@@ -735,6 +735,39 @@ public final class S3RestUtils {
     return Optional.of(RateLimiter.create(rate));
   }
 
+  /**
+   * @return s3 WritePType for UploadPart
+   */
+  public static WritePType getWriteTypeForUploadPart() {
+    if (isUploadPartOnlyCacheEnabled()) {
+      return WritePType.MUST_CACHE;
+    }
+    return getS3WriteType();
+  }
+
+  /**
+   * @return ture if UploadPart only cache is enabled
+   */
+  public static boolean isUploadPartOnlyCacheEnabled() {
+    return Configuration.getBoolean(PropertyKey.PROXY_S3_UPLOAD_PART_ONLY_CACHE_ENABLED);
+  }
+
+  /**
+   * Sets pinned to true for the input path.
+   *
+   * @param fs The {@link FileSystem} client
+   * @param path The {@link AlluxioURI} path as the input of the command
+   */
+  public static void pinnedUploadPart(FileSystem fs, AlluxioURI path)
+      throws AlluxioException, IOException {
+    List<String> availableMediumList = Configuration.getList(
+        PropertyKey.MASTER_TIERED_STORE_GLOBAL_MEDIUMTYPE);
+    SetAttributePOptions options = SetAttributePOptions.newBuilder().setPinned(true)
+        .addAllPinnedMedia(availableMediumList)
+        .build();
+    fs.setAttribute(path, options);
+  }
+
     /**
      * Comparator based on uri name， treat uri name as a Long number.
      */


### PR DESCRIPTION
### What changes are proposed in this pull request?
Set write type to MUST_CACHE for UploadPart and pinned the parts.

### Why are the changes needed?
Improve performance of upload parts.

### Does this PR introduce any user facing changes?
Add a property:

- `alluxio.proxy.s3.upload.part.only.cache.enabled`

