### PR TITLE
Check multipart uploads metadata dir only once

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3BucketTask.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3BucketTask.java
@@ -198,6 +198,8 @@ public class S3BucketTask extends S3BaseTask {
                 mOPType.name(), user, mHandler.getBucket(), null)) {
           S3RestUtils.checkPathIsAlluxioDirectory(userFs, path, auditContext);
           try {
+            S3RestUtils.initMultipartUploadsMetadataDir(mHandler.getMetaFS(),
+                mHandler.getMultipartUploadsMetadataDirCreateFlag());
             List<URIStatus> children = mHandler.getMetaFS().listStatus(new AlluxioURI(
                     S3RestUtils.MULTIPART_UPLOADS_METADATA_DIR));
             final List<URIStatus> uploadIds = children.stream()

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Handler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3Handler.java
@@ -36,6 +36,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -90,6 +91,7 @@ public class S3Handler {
   private String mUser;
   private S3BaseTask mS3Task;
   private FileSystem mMetaFS;
+  private AtomicBoolean mMultipartUploadsMetadataDirCreateFlag;
 
   /**
    * S3Handler Constructor.
@@ -233,7 +235,8 @@ public class S3Handler {
     mMetaFS = (FileSystem) context.getAttribute(ProxyWebServer.FILE_SYSTEM_SERVLET_RESOURCE_KEY);
     mAsyncAuditLogWriter = (AsyncUserAccessAuditLogWriter) context.getAttribute(
         ProxyWebServer.ALLUXIO_PROXY_AUDIT_LOG_WRITER_KEY);
-    S3RestUtils.tryInitMultipartUploadsMetadataDir(context, mMetaFS);
+    mMultipartUploadsMetadataDirCreateFlag = (AtomicBoolean) context.getAttribute(
+        ProxyWebServer.MULTIPART_UPLOADS_METADATA_DIR_CREATE_FLAG);
   }
 
   /**
@@ -496,5 +499,13 @@ public class S3Handler {
    */
   public void setStopwatch(Stopwatch stopwatch) {
     mStopwatch = stopwatch;
+  }
+
+  /**
+   * Get multipart uploads metadata dir create flag.
+   * @return multipart uploads metadata dir create flag
+   */
+  public AtomicBoolean getMultipartUploadsMetadataDirCreateFlag() {
+    return mMultipartUploadsMetadataDirCreateFlag;
   }
 }

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ObjectTask.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ObjectTask.java
@@ -871,6 +871,8 @@ public class S3ObjectTask extends S3BaseTask {
           }
 
           try {
+            S3RestUtils.initMultipartUploadsMetadataDir(mHandler.getMetaFS(),
+                mHandler.getMultipartUploadsMetadataDirCreateFlag());
             // Find an unused UUID
             String uploadId;
             do {

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3RestServiceHandler.java
@@ -70,6 +70,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -137,6 +138,7 @@ public final class S3RestServiceHandler {
   private final Pattern mBucketValidNamePattern;
 
   private final RateLimiter mGlobalRateLimiter;
+  private final AtomicBoolean mMultipartUploadsMetadataDirCreateFlag;
 
   /**
    * Constructs a new {@link S3RestServiceHandler}.
@@ -166,7 +168,8 @@ public final class S3RestServiceHandler {
     mBucketValidNamePattern = Pattern.compile("[a-z0-9][a-z0-9\\.-]{1,61}[a-z0-9]");
     mGlobalRateLimiter = (RateLimiter) context.getAttribute(
         ProxyWebServer.GLOBAL_RATE_LIMITER_SERVLET_RESOURCE_KEY);
-    S3RestUtils.tryInitMultipartUploadsMetadataDir(context, mMetaFS);
+    mMultipartUploadsMetadataDirCreateFlag = (AtomicBoolean) context.getAttribute(
+        ProxyWebServer.MULTIPART_UPLOADS_METADATA_DIR_CREATE_FLAG);
   }
 
   /**
@@ -310,6 +313,8 @@ public final class S3RestServiceHandler {
         }
         if (uploads != null) { // ListMultipartUploads
           try {
+            S3RestUtils.initMultipartUploadsMetadataDir(mMetaFS,
+                mMultipartUploadsMetadataDirCreateFlag);
             List<URIStatus> children = mMetaFS.listStatus(new AlluxioURI(
                 S3RestUtils.MULTIPART_UPLOADS_METADATA_DIR));
             final List<URIStatus> uploadIds = children.stream()
@@ -1031,6 +1036,8 @@ public final class S3RestServiceHandler {
         }
 
         try {
+          S3RestUtils.initMultipartUploadsMetadataDir(mMetaFS,
+              mMultipartUploadsMetadataDirCreateFlag);
           // Find an unused UUID
           String uploadId;
           do {

--- a/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
+++ b/core/server/proxy/src/main/java/alluxio/web/ProxyWebServer.java
@@ -47,7 +47,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.servlet.ServletException;
@@ -74,7 +74,7 @@ public final class ProxyWebServer extends WebServer {
 
   private final RateLimiter mGlobalRateLimiter;
   private final FileSystem mFileSystem;
-  private final AtomicReference<Boolean> mIsMultipartUploadsMetadataDirCreated;
+  private final AtomicBoolean mMultipartUploadsMetadataDirCreateFlag;
   private AsyncUserAccessAuditLogWriter mAsyncAuditLogWriter;
   public static final String PROXY_S3_HANDLER_MAP = "Proxy S3 Handler Map";
   public ConcurrentHashMap<Request, S3Handler> mS3HandlerMap = new ConcurrentHashMap<>();
@@ -114,7 +114,7 @@ public final class ProxyWebServer extends WebServer {
     mFileSystem = FileSystem.Factory.create(Configuration.global());
     // Use this flag to delay creating metadata directory. Do not create directory directly,
     // this will change the behavior of constructor and cause some tests to fail.
-    mIsMultipartUploadsMetadataDirCreated = new AtomicReference<>(null);
+    mMultipartUploadsMetadataDirCreateFlag = new AtomicBoolean(false);
 
     long rate =
         (long) Configuration.getInt(PropertyKey.PROXY_S3_GLOBAL_READ_RATE_LIMIT_MB) * Constants.MB;
@@ -146,7 +146,7 @@ public final class ProxyWebServer extends WebServer {
               mGlobalRateLimiter);
         }
         getServletContext().setAttribute(MULTIPART_UPLOADS_METADATA_DIR_CREATE_FLAG,
-            mIsMultipartUploadsMetadataDirCreated);
+            mMultipartUploadsMetadataDirCreateFlag);
       }
 
       @Override
@@ -180,7 +180,7 @@ public final class ProxyWebServer extends WebServer {
               getServletContext().setAttribute(PROXY_S3_V2_HEAVY_POOL, createHeavyThreadPool());
               getServletContext().setAttribute(PROXY_S3_HANDLER_MAP, mS3HandlerMap);
               getServletContext().setAttribute(MULTIPART_UPLOADS_METADATA_DIR_CREATE_FLAG,
-                  mIsMultipartUploadsMetadataDirCreated);
+                  mMultipartUploadsMetadataDirCreateFlag);
             }
           });
       mServletContextHandler


### PR DESCRIPTION
### What changes are proposed in this pull request?

Check multipart uploads metadata dir only once.

### Why are the changes needed?

If we set `alluxio.user.file.metadata.sync.interval=0`to disable metadata cache, highly concurrent requests will result in a long time to check the directory, like this:
![image](https://user-images.githubusercontent.com/45056332/228258522-f904b57c-5ad3-41c2-8e27-21f0dc9468d7.png)

but the normal processing time should like this:
![image](https://user-images.githubusercontent.com/45056332/228260744-8b3f9a5c-7e8d-4b58-a5d4-e78b50f7fbd1.png)


