### PR TITLE
Remove duplicate word in comments

### DIFF
--- a/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
+++ b/job/server/src/main/java/alluxio/master/job/plan/PlanCoordinator.java
@@ -58,7 +58,7 @@ public final class PlanCoordinator {
   private final PlanInfo mPlanInfo;
   private final CommandManager mCommandManager;
 
-  /** The context containing containing the necessary references to schedule jobs. */
+  /** The context containing the necessary references to schedule jobs. */
   private final JobServerContext mJobServerContext;
 
   /**


### PR DESCRIPTION
Fixing a typo by removing duplicate word in comments.