### PR TITLE
Update dockerfile

### DIFF
--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -86,6 +86,8 @@ RUN if [ ${ALLUXIO_USERNAME} != "root" ] \
       chmod -R g=u /mnt/alluxio && \
       mkdir /mnt/alluxio/journal && \
       chown -R ${ALLUXIO_UID}:${ALLUXIO_GID} /mnt/alluxio/journal && \
+      mkdir /mnt/alluxio/metastore && \
+      chown -R ${ALLUXIO_UID}:${ALLUXIO_GID} /mnt/alluxio/metastore && \
       mkdir /mnt/alluxio/fuse && \
       chown -R ${ALLUXIO_UID}:${ALLUXIO_GID} /mnt/alluxio/fuse; \
     fi

--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -31,13 +31,28 @@ FROM centos:7 as final
 RUN \
     yum update -y && yum upgrade -y && \
     yum install -y java-11-openjdk-devel java-11-openjdk && \
-    yum install -y ca-certificates pkgconfig udev bind-utils && \
-    yum install -y fuse3 fuse3-devel fuse3-lib && \
     yum clean all;
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
 # Disable JVM DNS cache in java11 (https://github.com/Alluxio/alluxio/pull/9452)
 RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-11-openjdk/conf/security/java.security
+
+# Install libfuse2 and libfuse3. Libfuse2 setup is modified from cheyang/fuse2:ubuntu1604-customize to be applied on centOS
+RUN \
+    yum install -y ca-certificates pkgconfig wget udev git bind-utils && \
+    yum install -y gcc gcc-c++ make cmake gettext-devel libtool autoconf && \
+    git clone https://github.com/Alluxio/libfuse.git && \
+    cd libfuse && \
+    git checkout fuse_2_9_5_customize_multi_threads && \
+    bash makeconf.sh && \
+    ./configure && \
+    make -j8 && \
+    make install && \
+    cd .. && \
+    rm -rf libfuse && \
+    yum remove -y gcc gcc-c++ make cmake gettext-devel libtool autoconf wget git && \
+    yum install -y fuse3 fuse3-devel fuse3-lib && \
+    yum clean all
 
 WORKDIR /
 

--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -31,7 +31,7 @@ FROM centos:7 as final
 RUN \
     yum update -y && yum upgrade -y && \
     yum install -y java-11-openjdk-devel java-11-openjdk && \
-    yum clean all;
+    yum clean all
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
 # Disable JVM DNS cache in java11 (https://github.com/Alluxio/alluxio/pull/9452)

--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -9,18 +9,6 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
-# ARG defined before the first FROM can be used in FROM lines
-# Only 8 and 11 are supported.
-ARG JAVA_VERSION=8
-
-# Setup CSI
-FROM golang:1.15.13-alpine AS csi-dev
-ENV GO111MODULE=on
-RUN mkdir -p /alluxio-csi
-COPY ./csi /alluxio-csi
-RUN cd /alluxio-csi && \
-    CGO_ENABLED=0 go build -o /usr/local/bin/alluxio-csi
-
 # We have to do an ADD to put the tarball into extractor, then do a COPY with chown into final
 # ADD then chown in two steps will double the image size
 #   See - https://stackoverflow.com/questions/30085621/why-does-chown-increase-size-of-docker-image
@@ -30,9 +18,7 @@ RUN cd /alluxio-csi && \
 #   See - https://github.com/moby/moby/issues/35525
 FROM alpine:3.10.2 AS alluxio-extractor
 # Note that downloads for *-SNAPSHOT tarballs are not available.
-ARG ALLUXIO_TARBALL=http://downloads.alluxio.io/downloads/files/2.10.0-SNAPSHOT/alluxio-2.10.0-SNAPSHOT-bin.tar.gz
-# (Alert):It's not recommended to set this Argument to true, unless you know exactly what you are doing
-ARG ENABLE_DYNAMIC_USER=false
+ARG ALLUXIO_TARBALL=https://downloads.alluxio.io/downloads/files/291-gamma/alluxio-291-gamma-bin.tar.gz
 
 ADD ${ALLUXIO_TARBALL} /opt/
 # Remote tarball needs to be untarred. Local tarball is untarred automatically.
@@ -41,55 +27,22 @@ RUN cd /opt && \
     (if ls | grep -q ".tar.gz"; then tar -xzf *.tar.gz && rm *.tar.gz; fi) && \
     ln -s alluxio-* alluxio
 
-RUN if [ ${ENABLE_DYNAMIC_USER} = "true" ] ; then \
-       chmod -R 777 /opt/* ; \
-    fi
-
-# Configure Java
-FROM centos:7 as build_java8
-RUN \
-    yum update -y && yum upgrade -y && \
-    yum install -y java-1.8.0-openjdk-devel java-1.8.0-openjdk && \
-    yum clean all
-ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk
-# Disable JVM DNS cache in java8 (https://github.com/Alluxio/alluxio/pull/9452)
-RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-1.8.0-openjdk/jre/lib/security/java.security
-
-FROM centos:7 as build_java11
+FROM centos:7 as final
 RUN \
     yum update -y && yum upgrade -y && \
     yum install -y java-11-openjdk-devel java-11-openjdk && \
-    yum clean all
+    yum install -y ca-certificates pkgconfig udev bind-utils && \
+    yum install -y fuse3 fuse3-devel fuse3-lib && \
+    yum clean all;
+
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
 # Disable JVM DNS cache in java11 (https://github.com/Alluxio/alluxio/pull/9452)
 RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-11-openjdk/conf/security/java.security
 
-FROM build_java${JAVA_VERSION} AS final
-
 WORKDIR /
 
-# Install libfuse2 and libfuse3. Libfuse2 setup is modified from cheyang/fuse2:ubuntu1604-customize to be applied on centOS
-RUN \
-    yum install -y ca-certificates pkgconfig wget udev git && \
-    yum install -y gcc gcc-c++ make cmake gettext-devel libtool autoconf && \
-    git clone https://github.com/Alluxio/libfuse.git && \
-    cd libfuse && \
-    git checkout fuse_2_9_5_customize_multi_threads && \
-    bash makeconf.sh && \
-    ./configure && \
-    make -j8 && \
-    make install && \
-    cd .. && \
-    rm -rf libfuse && \
-    yum remove -y gcc gcc-c++ make cmake gettext-devel libtool autoconf wget git && \
-    yum install -y fuse3 fuse3-devel fuse3-lib && \
-    yum clean all
-
-# Configuration for the modified libfuse2
-ENV MAX_IDLE_THREADS "64"
-
-# /lib64 is for rocksdb native libraries, /usr/local/lib is for libfuse2 native libraries
-ENV LD_LIBRARY_PATH "/lib64:/usr/local/lib:${LD_LIBRARY_PATH}"
+# /lib64 is for rocksdb native libraries
+ENV LD_LIBRARY_PATH "/lib64:${LD_LIBRARY_PATH}"
 
 ARG ALLUXIO_USERNAME=alluxio
 ARG ALLUXIO_GROUP=alluxio
@@ -98,8 +51,6 @@ ARG ALLUXIO_GID=1000
 
 # For dev image to know the user
 ENV ALLUXIO_DEV_UID=${ALLUXIO_UID}
-
-ARG ENABLE_DYNAMIC_USER=true
 
 # Add Tini for Alluxio helm charts (https://github.com/Alluxio/alluxio/pull/12233)
 # - https://github.com/krallin/tini
@@ -115,11 +66,13 @@ RUN if [ ${ALLUXIO_USERNAME} != "root" ] \
       groupadd --gid ${ALLUXIO_GID} ${ALLUXIO_GROUP} && \
       useradd --system -m --uid ${ALLUXIO_UID} --gid ${ALLUXIO_GROUP} ${ALLUXIO_USERNAME} && \
       usermod -a -G root ${ALLUXIO_USERNAME} && \
-      mkdir -p /journal && \
-      chown -R ${ALLUXIO_UID}:${ALLUXIO_GID} /journal && \
-      chmod -R g=u /journal && \
-      mkdir /mnt/alluxio-fuse && \
-      chown -R ${ALLUXIO_UID}:${ALLUXIO_GID} /mnt/alluxio-fuse; \
+      mkdir -p /mnt/alluxio && \
+      chown -R ${ALLUXIO_UID}:${ALLUXIO_GID} /mnt/alluxio && \
+      chmod -R g=u /mnt/alluxio && \
+      mkdir /mnt/alluxio/journal && \
+      chown -R ${ALLUXIO_UID}:${ALLUXIO_GID} /mnt/alluxio/journal && \
+      mkdir /mnt/alluxio/fuse && \
+      chown -R ${ALLUXIO_UID}:${ALLUXIO_GID} /mnt/alluxio/fuse; \
     fi
 
 # Docker 19.03+ required to expand variables in --chown argument
@@ -127,14 +80,9 @@ RUN if [ ${ALLUXIO_USERNAME} != "root" ] \
 COPY --from=alluxio-extractor --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} /opt /opt/
 COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} conf /opt/alluxio/conf/
 COPY --chown=${ALLUXIO_USERNAME}:${ALLUXIO_GROUP} entrypoint.sh /
-COPY --from=csi-dev /usr/local/bin/alluxio-csi /usr/local/bin/
 
-RUN if [ ${ENABLE_DYNAMIC_USER} = "true" ] ; then \
-       chmod -R 777 /journal; \
-       chmod -R 777 /mnt; \
-       # Enable user_allow_other option for fuse in non-root mode
-       echo "user_allow_other" >> /etc/fuse.conf; \
-    fi
+# Enable user_allow_other option for fuse in non-root mode
+RUN echo "user_allow_other" >> /etc/fuse.conf
 
 USER ${ALLUXIO_UID}
 

--- a/integration/docker/Dockerfile
+++ b/integration/docker/Dockerfile
@@ -56,8 +56,8 @@ RUN \
 
 WORKDIR /
 
-# /lib64 is for rocksdb native libraries
-ENV LD_LIBRARY_PATH "/lib64:${LD_LIBRARY_PATH}"
+# /lib64 is for rocksdb native libraries, /usr/local/lib is for libfuse2 native libraries
+ENV LD_LIBRARY_PATH "/lib64:/usr/local/lib:${LD_LIBRARY_PATH}"
 
 ARG ALLUXIO_USERNAME=alluxio
 ARG ALLUXIO_GROUP=alluxio

--- a/integration/docker/Dockerfile-dev
+++ b/integration/docker/Dockerfile-dev
@@ -9,23 +9,14 @@
 # See the NOTICE file distributed with this work for information regarding copyright ownership.
 #
 
-FROM alluxio/alluxio:2.10.0-SNAPSHOT
+FROM alluxio/alluxio:291-gamma
 
 USER root
 
 RUN \
     yum update -y && yum upgrade -y && \
-    yum install -y java-11-openjdk-devel java-11-openjdk && \
     yum install -y ca-certificates pkgconfig wget udev git gcc gcc-c++ make cmake gettext-devel libtool autoconf unzip vim && \
     yum clean all
-
-# Create a symlink for setting JAVA_HOME depending on java version. ENV cannot be set conditionally.
-RUN ln -s /usr/lib/jvm/java-1.8.0-openjdk /usr/lib/jvm/java-8-openjdk
-ARG JAVA_VERSION=8
-ENV JAVA_HOME /usr/lib/jvm/java-${JAVA_VERSION}-openjdk
-
-# Disable JVM DNS cache in java11 (https://github.com/Alluxio/alluxio/pull/9452)
-RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/java-11-openjdk/conf/security/java.security
 
 # Install arthas(https://github.com/alibaba/arthas) for analyzing performance bottleneck
 RUN wget -qO /tmp/arthas.zip "https://github.com/alibaba/arthas/releases/download/arthas-all-3.4.6/arthas-bin.zip" && \

--- a/integration/docker/entrypoint.sh
+++ b/integration/docker/entrypoint.sh
@@ -104,17 +104,7 @@ function formatWorkerIfSpecified {
 }
 
 function mountAlluxioFSWithFuseOption {
-  if [[ -n ${FUSE_ALLUXIO_PATH} || -n ${MOUNT_POINT} ]]; then
-    echo "Use of environment variables FUSE_ALLUXIO_PATH and MOUNT_POINT for Alluxio Fuse are deprecated."
-    printUsage
-    exit 1
-  fi
-  local mountOptions="$1"
-  if [[ "${mountOptions}" =~ ${FUSE_OPTS}=* ]]; then
-    exec integration/fuse/bin/alluxio-fuse mount -n -o "${mountOptions#*=}" "${@:2}"
-  else
-    exec integration/fuse/bin/alluxio-fuse mount -n "${@:1}"
-  fi
+  exec integration/fuse/bin/alluxio-fuse mount "${@}" -f
 }
 
 function mountFuseWithUFS {


### PR DESCRIPTION
Update the Dockerfile for Dora. Changes include:

1. Stop supporting Java8. Only Java11 is supported.
2. Remove CSI module. CSI is not supported by Dora right now.
3. Modify `entrypoint.sh` script for fuse.
4. Remove the functionality of dynamic user. It is hacky and broken right now. 
5. Add `bind-utils` package, so that worker and fuse won't be launched until master is ready by running `nslookup` to find master pod. Same idea as https://github.com/Alluxio/alluxio/pull/16868#discussion_r1123069583 but no need of external dependency.