### PR TITLE
Skip ssh for localhost

### DIFF
--- a/bin/alluxio-common.sh
+++ b/bin/alluxio-common.sh
@@ -68,3 +68,12 @@ function get_ramdisk_array() {
   done
   IFS=$oldifs
 }
+
+function ssh_command() {
+  local host=$1
+  local command=""
+  if [[ $host != "localhost" && $host != "127.0.0.1" ]]; then
+    command="ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -tt ${host}"
+  fi
+  echo "${command}"
+}

--- a/bin/alluxio-common.sh
+++ b/bin/alluxio-common.sh
@@ -69,6 +69,7 @@ function get_ramdisk_array() {
   IFS=$oldifs
 }
 
+# Compose the ssh command according to the hostname
 function ssh_command() {
   local host=$1
   local command=""

--- a/bin/alluxio-workers.sh
+++ b/bin/alluxio-workers.sh
@@ -39,7 +39,12 @@ echo "Executing the following command on all worker nodes and logging to ${ALLUX
 
 for worker in ${HOSTLIST[@]}; do
   echo "[${worker}] Connecting as ${USER}..." >> ${ALLUXIO_TASK_LOG}
-  nohup ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -tt ${worker} ${LAUNCHER} \
+  if [[ $worker = "localhost" || $worker = "127.0.0.1" ]]; then
+    ssh_command=""
+  else
+    ssh_command="ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -tt ${worker}"
+  fi
+  nohup ${ssh_command} ${LAUNCHER} \
     $"${@// /\\ }" 2>&1 | while read line; do echo "[$(date '+%F %T')][${worker}] ${line}"; done >> ${ALLUXIO_TASK_LOG} &
   pids[${#pids[@]}]=$!
 done

--- a/bin/alluxio-workers.sh
+++ b/bin/alluxio-workers.sh
@@ -12,12 +12,7 @@
 
 set -o pipefail
 
-LAUNCHER=
-# If debugging is enabled propagate that through to sub-shells
-if [[ "$-" == *x* ]]; then
-  LAUNCHER="bash -x"
-fi
-BIN=$(cd "$( dirname "$( readlink "$0" || echo "$0" )" )"; pwd)
+. $(dirname "$0")/alluxio-common.sh
 
 USAGE="Usage: alluxio-workers.sh command..."
 
@@ -39,12 +34,7 @@ echo "Executing the following command on all worker nodes and logging to ${ALLUX
 
 for worker in ${HOSTLIST[@]}; do
   echo "[${worker}] Connecting as ${USER}..." >> ${ALLUXIO_TASK_LOG}
-  if [[ $worker = "localhost" || $worker = "127.0.0.1" ]]; then
-    ssh_command=""
-  else
-    ssh_command="ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -tt ${worker}"
-  fi
-  nohup ${ssh_command} ${LAUNCHER} \
+  nohup $(ssh_command ${worker}) ${LAUNCHER} \
     $"${@// /\\ }" 2>&1 | while read line; do echo "[$(date '+%F %T')][${worker}] ${line}"; done >> ${ALLUXIO_TASK_LOG} &
   pids[${#pids[@]}]=$!
 done


### PR DESCRIPTION
### What changes are proposed in this pull request?

Skip ssh connection while running locally.

### Why are the changes needed?

I was trying to setup a one-node cluster with the latest version to do some simple tests. However, I encountered the following exception while executing `/bin/alluxio format`

```
$ ./bin/alluxio format
Executing the following command on all worker nodes and logging to /home/test/deploy/alluxio/logs/task.log: /home/test/deploy/alluxio/bin/alluxio formatWorker
Waiting for tasks to finish...
test@localhost's password:
test@localhost's password:
test@localhost's password:
Task on 'localhost' fails, exit code: 255
There are task failures, look at /home/test/deploy/alluxio/logs/task.log for details.
```

In the log, it has

```
[2023-03-24 17:12:20][localhost] Failed to add the host to the list of known hosts (/home/test/.ssh/known_hosts).
[2023-03-24 17:13:28][localhost] Permission denied, please try again.
[2023-03-24 17:13:29][localhost] Permission denied, please try again.
[2023-03-24 17:13:30][localhost] Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).
```

However, in our cluster, we do not know the password of our accounts in a specific server. So I feel it's better to skip the "ssh" part for a local one-node cluster.

### Does this PR introduce any user facing changes?

NO.