### PR TITLE
Support changing log level at runtime for alluxio-fuse

### DIFF
--- a/integration/fuse/pom.xml
+++ b/integration/fuse/pom.xml
@@ -63,6 +63,22 @@
       <artifactId>alluxio-integration-jnifuse-fs</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+    </dependency>
 
     <!-- Internal test dependencies -->
     <dependency>

--- a/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseRestServiceHandler.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/AlluxioFuseRestServiceHandler.java
@@ -1,0 +1,59 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.fuse;
+
+import alluxio.RestUtils;
+import alluxio.conf.Configuration;
+import alluxio.util.LogUtils;
+
+import io.swagger.annotations.Api;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * This class is a REST handler for requesting general FUSE information.
+ */
+@NotThreadSafe
+@Api(value = "/fuse", description = "Alluxio FUSE Rest Service")
+@Path(AlluxioFuseRestServiceHandler.SERVICE_PREFIX)
+@Produces(MediaType.APPLICATION_JSON)
+public class AlluxioFuseRestServiceHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(AlluxioFuseRestServiceHandler.class);
+
+  public static final String SERVICE_PREFIX = "fuse";
+
+  // log
+  public static final String LOG_LEVEL = "logLevel";
+  public static final String LOG_ARGUMENT_NAME = "logName";
+  public static final String LOG_ARGUMENT_LEVEL = "level";
+
+  /**
+   * @summary set the Alluxio log information
+   * @param logName the log's name
+   * @param level the log level
+   * @return the response object
+   */
+  @POST
+  @Path(LOG_LEVEL)
+  public Response logLevel(@QueryParam(LOG_ARGUMENT_NAME) final String logName,
+      @QueryParam(LOG_ARGUMENT_LEVEL) final String level) {
+    return RestUtils.call(() -> LogUtils.setLogLevel(logName, level), Configuration.global());
+  }
+}

--- a/integration/fuse/src/main/java/alluxio/fuse/FuseWebServer.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/FuseWebServer.java
@@ -15,6 +15,7 @@ import alluxio.Constants;
 import alluxio.util.io.PathUtils;
 import alluxio.web.JacksonProtobufObjectMapperProvider;
 import alluxio.web.WebServer;
+
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;

--- a/integration/fuse/src/main/java/alluxio/fuse/FuseWebServer.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/FuseWebServer.java
@@ -11,7 +11,13 @@
 
 package alluxio.fuse;
 
+import alluxio.Constants;
+import alluxio.util.io.PathUtils;
+import alluxio.web.JacksonProtobufObjectMapperProvider;
 import alluxio.web.WebServer;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletContainer;
 
 import java.net.InetSocketAddress;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -29,5 +35,13 @@ public final class FuseWebServer extends WebServer {
    */
   public FuseWebServer(String serviceName, InetSocketAddress address) {
     super(serviceName, address);
+    // REST configuration
+    ResourceConfig config = new ResourceConfig()
+        .packages("alluxio.fuse")
+        .register(JacksonProtobufObjectMapperProvider.class);
+    ServletContainer servlet = new ServletContainer(config);
+    ServletHolder servletHolder = new ServletHolder("Alluxio FUSE Web Service", servlet);
+    mServletContextHandler
+        .addServlet(servletHolder, PathUtils.concatPath(Constants.REST_API_PREFIX, "*"));
   }
 }

--- a/shell/src/main/java/alluxio/cli/LogLevel.java
+++ b/shell/src/main/java/alluxio/cli/LogLevel.java
@@ -67,6 +67,7 @@ public final class LogLevel {
   public static final String ROLE_JOB_MASTERS = "job_masters";
   public static final String ROLE_JOB_WORKER = "job_worker";
   public static final String ROLE_JOB_WORKERS = "job_workers";
+  public static final String ROLE_FUSE = "fuse";
   public static final String TARGET_SEPARATOR = ",";
   public static final String TARGET_OPTION_NAME = "target";
   private static final Option TARGET_OPTION =
@@ -305,6 +306,8 @@ public final class LogLevel {
       return ROLE_JOB_MASTER;
     } else if (port == NetworkAddressUtils.getPort(ServiceType.JOB_WORKER_WEB, conf)) {
       return ROLE_JOB_WORKER;
+    } else if (port == NetworkAddressUtils.getPort(ServiceType.FUSE_WEB, conf)) {
+      return ROLE_FUSE;
     } else {
       throw new IllegalArgumentException(String.format(
               "Unrecognized port in %s. Please make sure the port is in %s",


### PR DESCRIPTION
### What changes are proposed in this pull request?

Support changing log level at runtime for alluxio-fuse.

Now with the configuration "alluxio.fuse.web.enabled=true", the user can change the logLevel  for alluxio-fuse with the following ways

1. With `logLevel` command

```
$ ./bin/alluxio logLevel --logName=alluxio.fuse.AlluxioJniFuseFileSystem --target=localhost:49999 --level=INFO
Role inferred from port: localhost:49999[fuse]
localhost:49999[fuse]LogInfo{INFO, alluxio.fuse.AlluxioJniFuseFileSystem, Setting Level to INFO}
```

2. With `curl`

```
$ curl -X POST "http://localhost:49999/api/v1/fuse/logLevel?logName=alluxio.fuse.AlluxioJniFuseFileSystem&level=DEBUG"
{"logName":"alluxio.fuse.AlluxioJniFuseFileSystem","message":"Setting Level to DEBUG","level":"DEBUG"}
```

### Why are the changes needed?

Please refer #17174 

### Does this PR introduce any user facing changes?

NO