### PR TITLE
Do not pass sync interval by default

### DIFF
--- a/core/client/fs/src/main/java/alluxio/util/FileSystemOptionsUtils.java
+++ b/core/client/fs/src/main/java/alluxio/util/FileSystemOptionsUtils.java
@@ -185,11 +185,13 @@ public class FileSystemOptionsUtils {
   public static FileSystemMasterCommonPOptions commonDefaults(AlluxioConfiguration conf,
       boolean withOpId) {
     FileSystemMasterCommonPOptions.Builder builder = FileSystemMasterCommonPOptions.newBuilder()
-        .setSyncIntervalMs(conf.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL))
         .setTtl(conf.getMs(PropertyKey.USER_FILE_CREATE_TTL))
         .setTtlAction(conf.getEnum(PropertyKey.USER_FILE_CREATE_TTL_ACTION, TtlAction.class));
     if (withOpId && conf.getBoolean(PropertyKey.USER_FILE_INCLUDE_OPERATION_ID)) {
       builder.setOperationId(new OperationId(UUID.randomUUID()).toFsProto());
+    }
+    if (conf.isSetByUser(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL)) {
+      builder.setSyncIntervalMs(conf.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL));
     }
     return builder.build();
   }
@@ -342,10 +344,12 @@ public class FileSystemOptionsUtils {
     // Specifically set and override *only* the metadata sync interval
     // Setting other attributes by default will make the server think the user is intentionally
     // setting the values. Most fields withinSetAttributePOptions are set by inclusion
+    FileSystemMasterCommonPOptions.Builder builder = FileSystemMasterCommonPOptions.newBuilder();
+    if (conf.isSetByUser(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL)) {
+      builder.setSyncIntervalMs(conf.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL));
+    }
     return SetAttributePOptions.newBuilder()
-        .setCommonOptions(FileSystemMasterCommonPOptions.newBuilder()
-            .setSyncIntervalMs(conf.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL))
-            .build())
+        .setCommonOptions(builder.build())
         .build();
   }
 

--- a/core/client/fs/src/main/java/alluxio/util/FileSystemOptionsUtils.java
+++ b/core/client/fs/src/main/java/alluxio/util/FileSystemOptionsUtils.java
@@ -344,8 +344,9 @@ public class FileSystemOptionsUtils {
     // Specifically set and override *only* the metadata sync interval
     // Setting other attributes by default will make the server think the user is intentionally
     // setting the values. Most fields withinSetAttributePOptions are set by inclusion
-    FileSystemMasterCommonPOptions.Builder builder = FileSystemMasterCommonPOptions.newBuilder();
+    FileSystemMasterCommonPOptions.Builder builder;
     if (conf.isSetByUser(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL)) {
+      builder = FileSystemMasterCommonPOptions.newBuilder();
       builder.setSyncIntervalMs(conf.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL));
     }
     return SetAttributePOptions.newBuilder()

--- a/core/client/fs/src/main/java/alluxio/util/FileSystemOptionsUtils.java
+++ b/core/client/fs/src/main/java/alluxio/util/FileSystemOptionsUtils.java
@@ -344,9 +344,8 @@ public class FileSystemOptionsUtils {
     // Specifically set and override *only* the metadata sync interval
     // Setting other attributes by default will make the server think the user is intentionally
     // setting the values. Most fields withinSetAttributePOptions are set by inclusion
-    FileSystemMasterCommonPOptions.Builder builder;
+    FileSystemMasterCommonPOptions.Builder builder = FileSystemMasterCommonPOptions.newBuilder();
     if (conf.isSetByUser(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL)) {
-      builder = FileSystemMasterCommonPOptions.newBuilder();
       builder.setSyncIntervalMs(conf.getMs(PropertyKey.USER_FILE_METADATA_SYNC_INTERVAL));
     }
     return SetAttributePOptions.newBuilder()


### PR DESCRIPTION
### What changes are proposed in this pull request?

Before this PR, if we did not config `alluxio.user.file.metadata.sync.interval` in client side, and config it in master side while we disable the `alluxio.user.conf.cluster.default.enabled` meanwhile, the metadata sync interval will always set to `-1`. 

After this PR, when `alluxio.user.conf.cluster.default.enabled=false`, master side `alluxio.user.file.metadata.sync.interval` will be accepted if user didn't set it.

<img width="995" alt="image" src="https://user-images.githubusercontent.com/17329931/229409070-3dd3d77f-344f-4c82-adf4-d1d16dd06cdf.png">

### Does this PR introduce any user facing changes?

No
