### PR TITLE
Make the client poll the master concurrently

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -6226,6 +6226,13 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_MASTER_POLLING_CONCURRENT =
+      booleanBuilder(Name.USER_MASTER_POLLING_CONCURRENT)
+          .setDefaultValue(false)
+          .setDescription("Whether to concurrently polling the master.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_METADATA_CACHE_ENABLED =
       booleanBuilder(Name.USER_METADATA_CACHE_ENABLED)
           .setDefaultValue(false)
@@ -8781,6 +8788,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.local.writer.chunk.size.bytes";
     public static final String USER_LOGGING_THRESHOLD = "alluxio.user.logging.threshold";
     public static final String USER_MASTER_POLLING_TIMEOUT = "alluxio.user.master.polling.timeout";
+    public static final String USER_MASTER_POLLING_CONCURRENT =
+        "alluxio.user.master.polling.concurrent";
     public static final String USER_METADATA_CACHE_ENABLED =
         "alluxio.user.metadata.cache.enabled";
     public static final String USER_METADATA_CACHE_MAX_SIZE =

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -32,7 +32,6 @@ import alluxio.security.user.UserState;
 import alluxio.uri.Authority;
 import alluxio.uri.MultiMasterAuthority;
 
-import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.grpc.StatusRuntimeException;

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -157,9 +157,7 @@ public class PollingMasterInquireClient implements MasterInquireClient {
           if (address != null) {
             return address;
           }
-        } catch (InterruptedException e) {
-          throw new RuntimeException(e);
-        } catch (ExecutionException e) {
+        } catch (InterruptedException | ExecutionException e) {
           break;
         }
       }

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -60,13 +60,13 @@ import javax.annotation.Nullable;
  */
 public class PollingMasterInquireClient implements MasterInquireClient {
   private static final Logger LOG = LoggerFactory.getLogger(PollingMasterInquireClient.class);
-  private static final Supplier<ExecutorService> EXECUTOR_SERVICE = Suppliers.memoize(() ->
+  private static final ExecutorService EXECUTOR_SERVICE =
       Executors.newCachedThreadPool(
           new ThreadFactoryBuilder()
               .setDaemon(true)
               .setNameFormat("pollingMasterThread-%d")
               .build()
-      ));
+      );
 
   private final MultiMasterConnectDetails mConnectDetails;
   private final Supplier<RetryPolicy> mRetryPolicySupplier;
@@ -156,7 +156,7 @@ public class PollingMasterInquireClient implements MasterInquireClient {
     List<Future<InetSocketAddress>> futures = new ArrayList<>(addresses.size());
     try {
       ExecutorCompletionService<InetSocketAddress> completionService =
-          new ExecutorCompletionService<>(EXECUTOR_SERVICE.get());
+          new ExecutorCompletionService<>(EXECUTOR_SERVICE);
       for (InetSocketAddress address : addresses) {
         futures.add(completionService.submit(() -> checkActiveAddress(address)));
       }

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -41,6 +41,11 @@ import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -129,29 +134,81 @@ public class PollingMasterInquireClient implements MasterInquireClient {
       addresses = mConnectDetails.getAddresses();
     }
 
+    if (mConfiguration.getBoolean(PropertyKey.USER_MASTER_POLLING_CONCURRENT)) {
+      return getAddressConcurrent(addresses);
+    } else {
+      return getAddress(addresses);
+    }
+  }
+
+  @Nullable
+  private InetSocketAddress getAddressConcurrent(List<InetSocketAddress> addresses) {
+    ExecutorService executorService = Executors.newFixedThreadPool(addresses.size());
+    try {
+      ExecutorCompletionService<InetSocketAddress> completionService =
+          new ExecutorCompletionService<>(executorService);
+      for (InetSocketAddress address : addresses) {
+        completionService.submit(() -> checkActiveAddress(address));
+      }
+      for (int i = 0; i < addresses.size(); i++) {
+        try {
+          Future<InetSocketAddress> future = completionService.take();
+          InetSocketAddress address = future.get();
+          if (address != null) {
+            return address;
+          }
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+          break;
+        }
+      }
+      return null;
+    } finally {
+      executorService.shutdownNow();
+    }
+  }
+
+  @Nullable
+  private InetSocketAddress getAddress(List<InetSocketAddress> addresses) {
     for (InetSocketAddress address : addresses) {
       try {
-        LOG.debug("Checking whether {} is listening for RPCs", address);
-        pingMetaService(address);
-        LOG.debug("Successfully connected to {}", address);
-        return address;
-      } catch (UnavailableException e) {
-        LOG.debug("Failed to connect to {}", address);
-      } catch (DeadlineExceededException e) {
-        LOG.debug("Timeout while connecting to {}", address);
-      } catch (CancelledException e) {
-        LOG.debug("Cancelled while connecting to {}", address);
-      } catch (NotFoundException e) {
-        // If the gRPC server is enabled but the metadata service isn't enabled,
-        // try the next master address.
-        LOG.debug("Meta service rpc endpoint not found on {}. {}", address, e);
-      }  catch (AlluxioStatusException e) {
-        LOG.error("Error while connecting to {}. {}", address, e);
-        // Breaking the loop on non filtered error.
+        if (checkActiveAddress(address) != null) {
+          return address;
+        }
+      } catch (AlluxioStatusException e) {
         break;
       }
     }
     return null;
+  }
+
+  private InetSocketAddress checkActiveAddress(InetSocketAddress address)
+      throws AlluxioStatusException {
+    try {
+      LOG.debug("Checking whether {} is listening for RPCs", address);
+      pingMetaService(address);
+      LOG.debug("Successfully connected to {}", address);
+      return address;
+    } catch (UnavailableException e) {
+      LOG.debug("Failed to connect to {}", address);
+      return null;
+    } catch (DeadlineExceededException e) {
+      LOG.debug("Timeout while connecting to {}", address);
+      return null;
+    } catch (CancelledException e) {
+      LOG.debug("Cancelled while connecting to {}", address);
+      return null;
+    } catch (NotFoundException e) {
+      // If the gRPC server is enabled but the metadata service isn't enabled,
+      // try the next master address.
+      LOG.debug("Meta service rpc endpoint not found on {}. {}", address, e);
+      return null;
+    } catch (AlluxioStatusException e) {
+      LOG.error("Error while connecting to {}. {}", address, e);
+      // Breaking the loop on non filtered error.
+      throw e;
+    }
   }
 
   private void pingMetaService(InetSocketAddress address) throws AlluxioStatusException {

--- a/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
+++ b/core/common/src/main/java/alluxio/master/PollingMasterInquireClient.java
@@ -135,14 +135,14 @@ public class PollingMasterInquireClient implements MasterInquireClient {
     }
 
     if (mConfiguration.getBoolean(PropertyKey.USER_MASTER_POLLING_CONCURRENT)) {
-      return getAddressConcurrent(addresses);
+      return findActiveAddressConcurrent(addresses);
     } else {
-      return getAddress(addresses);
+      return findActiveAddress(addresses);
     }
   }
 
   @Nullable
-  private InetSocketAddress getAddressConcurrent(List<InetSocketAddress> addresses) {
+  private InetSocketAddress findActiveAddressConcurrent(List<InetSocketAddress> addresses) {
     ExecutorService executorService = Executors.newFixedThreadPool(addresses.size());
     try {
       ExecutorCompletionService<InetSocketAddress> completionService =
@@ -170,7 +170,7 @@ public class PollingMasterInquireClient implements MasterInquireClient {
   }
 
   @Nullable
-  private InetSocketAddress getAddress(List<InetSocketAddress> addresses) {
+  private InetSocketAddress findActiveAddress(List<InetSocketAddress> addresses) {
     for (InetSocketAddress address : addresses) {
       try {
         if (checkActiveAddress(address) != null) {

--- a/core/common/src/main/java/alluxio/network/RejectingServer.java
+++ b/core/common/src/main/java/alluxio/network/RejectingServer.java
@@ -12,6 +12,7 @@
 package alluxio.network;
 
 import alluxio.Constants;
+import alluxio.util.CommonUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,13 +32,23 @@ public final class RejectingServer extends Thread {
 
   private final InetSocketAddress mAddress;
   private ServerSocket mServerSocket;
+  private final long mSleepTime;
 
   /**
    * @param address the socket address to reject requests on
    */
   public RejectingServer(InetSocketAddress address) {
+    this(address, 0);
+  }
+
+  /**
+   * @param address the socket address to reject requests on
+   * @param sleepTime sleep time before close connection
+   */
+  public RejectingServer(InetSocketAddress address, long sleepTime) {
     super("RejectingServer-" + address);
     mAddress = address;
+    mSleepTime = sleepTime;
   }
 
   @Override
@@ -52,6 +63,9 @@ public final class RejectingServer extends Thread {
     while (!Thread.interrupted()) {
       try {
         Socket s = mServerSocket.accept();
+        if (mSleepTime > 0) {
+          CommonUtils.sleepMs(mSleepTime);
+        }
         s.close();
       } catch (SocketException e) {
         return;

--- a/core/common/src/main/java/alluxio/network/RejectingServer.java
+++ b/core/common/src/main/java/alluxio/network/RejectingServer.java
@@ -14,6 +14,7 @@ package alluxio.network;
 import alluxio.Constants;
 import alluxio.util.CommonUtils;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +46,7 @@ public final class RejectingServer extends Thread {
    * @param address the socket address to reject requests on
    * @param sleepTime sleep time before close connection
    */
+  @VisibleForTesting
   public RejectingServer(InetSocketAddress address, long sleepTime) {
     super("RejectingServer-" + address);
     mAddress = address;

--- a/core/common/src/test/java/alluxio/conf/ConfigurationBuilder.java
+++ b/core/common/src/test/java/alluxio/conf/ConfigurationBuilder.java
@@ -24,7 +24,7 @@ public class ConfigurationBuilder {
    * @return the updated configuration builder
    */
   public ConfigurationBuilder setProperty(PropertyKey key, Object value) {
-    mProperties.put(key, value.toString(), Source.RUNTIME);
+    mProperties.put(key, value, Source.RUNTIME);
     return this;
   }
 

--- a/core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java
+++ b/core/common/src/test/java/alluxio/master/PollingMasterInquireClientTest.java
@@ -11,12 +11,20 @@
 
 package alluxio.master;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import alluxio.Constants;
+import alluxio.conf.AlluxioProperties;
 import alluxio.conf.ConfigurationBuilder;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
 import alluxio.exception.status.UnavailableException;
+import alluxio.grpc.GrpcServer;
+import alluxio.grpc.GrpcServerAddress;
+import alluxio.grpc.GrpcServerBuilder;
+import alluxio.grpc.GrpcService;
 import alluxio.grpc.ServiceType;
+import alluxio.grpc.ServiceVersionClientServiceGrpc;
 import alluxio.network.RejectingServer;
 import alluxio.retry.CountingRetry;
 import alluxio.util.network.NetworkAddressUtils;
@@ -46,11 +54,41 @@ public class PollingMasterInquireClientTest {
     PollingMasterInquireClient client = new PollingMasterInquireClient(addrs,
         () -> new CountingRetry(0), new ConfigurationBuilder().build(),
         ServiceType.META_MASTER_CLIENT_SERVICE);
+    assertThrows("Expected polling to fail", UnavailableException.class,
+        client::getPrimaryRpcAddress);
+  }
+
+  @Test(timeout = 10000)
+  public void concurrentPollingMaster() throws Exception {
+    int port1 = PortRegistry.reservePort();
+    int port2 = PortRegistry.reservePort();
+    InetSocketAddress serverAddress1 = new InetSocketAddress("127.0.0.1", port1);
+    InetSocketAddress serverAddress2 = new InetSocketAddress("127.0.0.1", port2);
+    RejectingServer s1 = new RejectingServer(serverAddress1, 20000);
+    GrpcServer s2 =
+        GrpcServerBuilder.forAddress(GrpcServerAddress.create(serverAddress2),
+                new InstancedConfiguration(new AlluxioProperties()))
+            .addService(ServiceType.META_MASTER_CLIENT_SERVICE, new GrpcService(
+                new ServiceVersionClientServiceGrpc.ServiceVersionClientServiceImplBase() {
+                })).build();
     try {
+      s1.start();
+      s2.start();
+      List<InetSocketAddress> addrs =
+          Arrays.asList(InetSocketAddress.createUnresolved("127.0.0.1", port1),
+              InetSocketAddress.createUnresolved("127.0.0.1", port2));
+      PollingMasterInquireClient client = new PollingMasterInquireClient(addrs,
+          () -> new CountingRetry(0),
+          new ConfigurationBuilder()
+              .setProperty(PropertyKey.USER_MASTER_POLLING_CONCURRENT, true)
+              .build(),
+          ServiceType.META_MASTER_CLIENT_SERVICE);
       client.getPrimaryRpcAddress();
-      fail("Expected polling to fail");
-    } catch (UnavailableException e) {
-      // Expected
+    } finally {
+      s1.stopAndJoin();
+      s2.shutdown();
+      PortRegistry.release(port1);
+      PortRegistry.release(port2);
     }
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Make the client poll the master concurrently.

### Why are the changes needed?
Currently, we find the active master node by polling each node in series. If a node did not respond due to network or other issues, this may take a lot of time and affect service availability. Make the client poll the master concurrently can alleviate this problem.

### Does this PR introduce any user facing changes?
