### PR TITLE
Throw correct exception when creating a file but it exists

### DIFF
--- a/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
+++ b/underfs/local/src/main/java/alluxio/underfs/local/LocalUnderFileSystem.java
@@ -48,6 +48,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -114,7 +115,15 @@ public class LocalUnderFileSystem extends ConsistentUnderFileSystem
         throw new IOException(ExceptionMessage.PARENT_CREATION_FAILED.getMessage(path));
       }
     }
-    OutputStream stream = new BufferedOutputStream(new FileOutputStream(path));
+    OutputStream stream;
+    try {
+      stream = new BufferedOutputStream(new FileOutputStream(path));
+    } catch (FileNotFoundException e) {
+      if (exists(path)) {
+        throw new FileAlreadyExistsException(path, path, e.getMessage());
+      }
+      throw e;
+    }
     try {
       setMode(path, options.getMode().toShort());
     } catch (IOException e) {


### PR DESCRIPTION
### What changes are proposed in this pull request?

Throw FileAlreadyExistsException exception if dir already exists when creating a file

### Why are the changes needed?

Upper layer file system expects a FileAlreadyExistsException exception when creating a new file but if a dir with the same file already exists.
HDFS contract test expects FileAlreadyExistsException in this case.

### Does this PR introduce any user facing changes?

N/A
