### PR TITLE
Fix double arg parsing in runTests

### DIFF
--- a/shell/src/main/java/alluxio/cli/TestRunner.java
+++ b/shell/src/main/java/alluxio/cli/TestRunner.java
@@ -105,7 +105,6 @@ public final class TestRunner {
   public static void main(String[] args) throws Exception {
     TestRunner runner = new TestRunner();
     JCommander jCommander = new JCommander(runner);
-    jCommander.parse(args);
     jCommander.setProgramName("TestRunner");
     jCommander.parse(args);
     if (runner.mHelp) {


### PR DESCRIPTION
both https://github.com/Alluxio/alluxio/pull/17170/files#diff-c80fd5152cf94b0cc483c26efb94f3946af189626fc4f10c0232bf968432078e and https://github.com/Alluxio/alluxio/pull/17068/files introduced the same change but in different lines so the merge was clean, but resulted in parsing args twice

caught by running `bin/alluxio runTests --directory /path/to/dir` with error msg:
```
error: Exception in thread "main" com.beust.jcommander.ParameterException: Can only specify option --directory once.
	at com.beust.jcommander.ParameterDescription.addValue(ParameterDescription.java:240)
	at com.beust.jcommander.JCommander.processFixedArity(JCommander.java:913)
	at com.beust.jcommander.JCommander.processFixedArity(JCommander.java:894)
	at com.beust.jcommander.JCommander.parseValues(JCommander.java:724)
	at com.beust.jcommander.JCommander.parse(JCommander.java:356)
	at com.beust.jcommander.JCommander.parse(JCommander.java:335)
	at alluxio.cli.TestRunner.main(TestRunner.java:110)
```