### PR TITLE
Use URI hash as PageId for netty FileReader

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/netty/FileReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/netty/FileReadHandler.java
@@ -11,6 +11,7 @@
 
 package alluxio.worker.netty;
 
+import alluxio.AlluxioURI;
 import alluxio.Constants;
 import alluxio.conf.Configuration;
 import alluxio.conf.PropertyKey;
@@ -150,8 +151,9 @@ public class FileReadHandler extends AbstractReadHandler<BlockReadRequestContext
       do {
         try {
           BlockReader reader =
-              mWorker.createFileReader(blockReadRequest.getOpenUfsBlockOptions().getUfsPath(),
-              blockReadRequest.getStart(),
+              mWorker.createFileReader(
+                  new AlluxioURI(blockReadRequest.getOpenUfsBlockOptions().getUfsPath()).hash(),
+                  blockReadRequest.getStart(),
                   false, blockReadRequest.getOpenUfsBlockOptions());
           String metricName = "BytesReadAlluxio";
           context.setBlockReader(reader);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Use URI hash as PageId for netty FileReader

### Why are the changes needed?

We use  URI hash as PageId everywhere else.

### Does this PR introduce any user facing changes?
N/A
