### PR TITLE
Add some logs when the standby master send a heartbeat request

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/DefaultMetaMaster.java
@@ -593,6 +593,7 @@ public final class DefaultMetaMaster extends CoreMaster implements MetaMaster {
 
   @Override
   public MetaCommand masterHeartbeat(long masterId, MasterHeartbeatPOptions options) {
+    LOG.debug("A heartbeat request was received from Standby master: {}.", masterId);
     MasterInfo master = mMasters.getFirstByField(ID_INDEX, masterId);
     if (master == null) {
       LOG.warn("Could not find master id: {} for heartbeat.", masterId);

--- a/core/server/master/src/main/java/alluxio/master/meta/MetaMasterSync.java
+++ b/core/server/master/src/main/java/alluxio/master/meta/MetaMasterSync.java
@@ -68,6 +68,8 @@ public final class MetaMasterSync implements HeartbeatExecutor {
       if (mMasterId.get() == UNINITIALIZED_MASTER_ID) {
         setIdAndRegister();
       }
+      LOG.debug("Standby master: {} send a heartbeat request to the leader master.",
+          mMasterId.get());
       command = mMasterClient.heartbeat(mMasterId.get());
       handleCommand(command);
     } catch (IOException e) {


### PR DESCRIPTION
### What changes are proposed in this pull request?
When the standby master send a heartbeat request to the leader master, many times there is no trace. When necessary, we should record their correspondence.

### Why are the changes needed?
Adding some logs is necessary, here are some reasons:
1. When the master node fails, logs can help troubleshoot the cause.
2. It can make the communication between the standby master and the leader master clearer.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
