### PR TITLE
Use java11 for builds

### DIFF
--- a/.github/workflows/fuse_integration_tests.yml
+++ b/.github/workflows/fuse_integration_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ["8", "11"]
+        java: ["11"]
         version: ["2", "3"]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/java11_integration_tests.yml
+++ b/.github/workflows/java11_integration_tests.yml
@@ -1,4 +1,4 @@
-name: Java 8 Integration Tests
+name: Java 11 Integration Tests
 
 on: [pull_request]
 
@@ -42,7 +42,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-java8-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-java11-${{ hashFiles('**/pom.xml') }}
 
       - name: Cache local Go modules
         uses: actions/cache@v2

--- a/.github/workflows/java11_integration_tests_ft.yml
+++ b/.github/workflows/java11_integration_tests_ft.yml
@@ -1,4 +1,4 @@
-name: Java 8 Fault Tolerant Integration Tests
+name: Java 11 Fault Tolerant Integration Tests
 
 on: [pull_request]
 
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-java8-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-java11-${{ hashFiles('**/pom.xml') }}
 
       - name: Cache local Go modules
         uses: actions/cache@v2

--- a/.github/workflows/java11_integration_tests_webui.yml
+++ b/.github/workflows/java11_integration_tests_webui.yml
@@ -1,4 +1,4 @@
-name: Java 8 Unit Tests
+name: Java 11 Integration Tests (w/ webui)
 
 on: [pull_request]
 
@@ -11,9 +11,7 @@ jobs:
       matrix:
         modules:
           - >-
-            !alluxio.client.**,!alluxio.master.**
-          - >-
-            alluxio.client.**,alluxio.master.**
+            alluxio.web.**
 
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.title, 'DOCFIX') &&
@@ -32,7 +30,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-java8-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-java11-${{ hashFiles('**/pom.xml') }}
 
       - name: Cache local Go modules
         uses: actions/cache@v2
@@ -47,8 +45,8 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!assembly/client,!assembly/server \
-          dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl '!tests,!webui'
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!shaded/client,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server \
+          dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
         timeout-minutes: 60
 
       - name: Archive artifacts

--- a/.github/workflows/java11_unit_tests.yml
+++ b/.github/workflows/java11_unit_tests.yml
@@ -1,4 +1,4 @@
-name: Java 8 Integration Tests (w/ webui)
+name: Java 11 Unit Tests
 
 on: [pull_request]
 
@@ -11,7 +11,9 @@ jobs:
       matrix:
         modules:
           - >-
-            alluxio.web.**
+            !alluxio.client.**,!alluxio.master.**
+          - >-
+            alluxio.client.**,alluxio.master.**
 
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.title, 'DOCFIX') &&
@@ -30,7 +32,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-java8-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-java11-${{ hashFiles('**/pom.xml') }}
 
       - name: Cache local Go modules
         uses: actions/cache@v2
@@ -45,10 +47,10 @@ jobs:
           ALLUXIO_DOCKER_NO_TTY=true \
           ALLUXIO_DOCKER_GIT_CLEAN=true \
           ALLUXIO_DOCKER_MVN_RUNTOEND=true \
-          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!shaded/client,!integration/tools/hms,!integration/yarn,!assembly/client,!assembly/server \
-          dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl tests
+          ALLUXIO_DOCKER_MVN_PROJECT_LIST=!webui,!shaded/client,!assembly/client,!assembly/server \
+          dev/github/run_docker.sh "\"-Dtest=${{ matrix.modules }}\"" -pl '!tests,!webui'
         timeout-minutes: 60
-      
+
       - name: Archive artifacts
         continue-on-error: true
         uses: actions/upload-artifact@v2

--- a/dev/github/run_checks.sh
+++ b/dev/github/run_checks.sh
@@ -17,6 +17,8 @@ set -ex
 
 if [ -n "${ALLUXIO_GIT_CLEAN}" ]
 then
+  # https://stackoverflow.com/questions/72978485/git-submodule-update-failed-with-fatal-detected-dubious-ownership-in-repositor
+  git config --global --add safe.directory '*'
   git clean -fdx
 fi
 
@@ -28,10 +30,10 @@ fi
 
 export MAVEN_OPTS="-Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS"
 
-# Always use java 8 to compile the source code
+# Always use java 11 to compile the source code
 JAVA_HOME_BACKUP=${JAVA_HOME}
 PATH_BACKUP=${PATH}
-JAVA_HOME=/usr/local/openjdk-8
+JAVA_HOME=/usr/local/openjdk-11
 PATH=$JAVA_HOME/bin:$PATH
 mvn -Duser.home=/home/jenkins -T 4C clean install -Pdeveloper -DskipTests -Dmaven.javadoc.skip \
 -Dsurefire.forkCount=2 ${mvn_args}

--- a/dev/github/run_docker.sh
+++ b/dev/github/run_docker.sh
@@ -23,7 +23,7 @@ function main {
   fi
   if [ -z "${ALLUXIO_DOCKER_IMAGE}" ]
   then
-    ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.0.8-jdk8"
+    ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.1.0-jdk11"
   fi
 
   local run_args="--rm"

--- a/dev/github/run_docker.sh
+++ b/dev/github/run_docker.sh
@@ -23,7 +23,7 @@ function main {
   fi
   if [ -z "${ALLUXIO_DOCKER_IMAGE}" ]
   then
-    ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.1.0-jdk11"
+    ALLUXIO_DOCKER_IMAGE="alluxio/alluxio-maven:0.1.1-jdk11"
   fi
 
   local run_args="--rm"

--- a/dev/github/run_tests.sh
+++ b/dev/github/run_tests.sh
@@ -22,6 +22,8 @@ fi
 
 if [ -n "${ALLUXIO_GIT_CLEAN}" ]
 then
+  # https://stackoverflow.com/questions/72978485/git-submodule-update-failed-with-fatal-detected-dubious-ownership-in-repositor
+  git config --global --add safe.directory '*'
   git clean -fdx
 fi
 
@@ -39,10 +41,10 @@ fi
 
 export MAVEN_OPTS="-Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS"
 
-# Always use java 8 to compile the source code
+# Always use java 11 to compile the source code
 JAVA_HOME_BACKUP=${JAVA_HOME}
 PATH_BACKUP=${PATH}
-JAVA_HOME=/usr/local/openjdk-8
+JAVA_HOME=/usr/local/openjdk-11
 PATH=$JAVA_HOME/bin:$PATH
 mvn -Duser.home=/home/jenkins -T 4C clean install -Pdeveloper -Dfindbugs.skip -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip \
 -Dlicense.skip -Dsurefire.forkCount=2 ${mvn_args}


### PR DESCRIPTION
update default alluxio-maven docker image used to the `0.1.0-jdk11` tag. this changes the default jdk from 8 to 11 and upgrades maven from 3.6.3 to 3.8.5

rename github action workflows from jdk8 -> jdk11