### PR TITLE
Bump alluxio-maven maven version to 3.8.6

### DIFF
--- a/dev/github/Dockerfile-jdk11
+++ b/dev/github/Dockerfile-jdk11
@@ -11,7 +11,7 @@
 
 # See https://hub.docker.com/r/alluxio/alluxio-maven for instructions on running the image.
 
-FROM maven:3.8.5-jdk-11
+FROM maven:3.8.6-jdk-11
 
 # need to create /.config to avoid npm errors
 RUN mkdir -p /home/jenkins && \


### PR DESCRIPTION
fixes a deadlock issue in parallel builds that we are encountering when building the repo

https://maven.apache.org/docs/3.8.6/release-notes.html
