### PR TITLE
Fix dependencies conflicts thrown by trino and prestodb

### DIFF
--- a/shaded/client/pom.xml
+++ b/shaded/client/pom.xml
@@ -293,6 +293,10 @@
                     <exclude>org/rocksdb/**/*</exclude>
                   </excludes>
                 </relocation>
+                <relocation>
+                  <pattern>software/amazon/ion/</pattern>
+                  <shadedPattern>${shading.prefix}.software.amazon.ion</shadedPattern>
+                </relocation>
               </relocations>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />


### PR DESCRIPTION
This PR is the same as [PR#17129](https://github.com/Alluxio/alluxio/pull/17129) except that it is for dora

PR Background - Bug description:
[PrestoDB](https://prestodb.io/) and [TrinoDB](https://trino.io/) use our shaded JAR in their pom.xml. When upgrading the version of alluxio-shaded-client from 2.8.1 to 2.9.1, we fail to compile the codes of presto/trino. This is because there is dependency conflict.

Solution:
Relocate the dependencies in shaded/client/pom.xml to avoid duplicate classes and files.

TIPS: You can execute `cd ${ALLUXIO_HOME}/shaded && mvn clean install -Prelease -DskipTests -T 4C` to package the shaded JAR.