### PR TITLE
Bump ratis version to 2.5.0

### DIFF
--- a/core/server/common/pom.xml
+++ b/core/server/common/pom.xml
@@ -26,7 +26,7 @@
     <!-- The following paths need to be defined here as well as in the parent pom so that mvn can -->
     <!-- run properly from sub-project directories -->
     <build.path>${project.parent.parent.parent.basedir}/build</build.path>
-    <alluxio.ratis.version>2.4.1</alluxio.ratis.version>
+    <alluxio.ratis.version>2.5.0</alluxio.ratis.version>
   </properties>
 
   <dependencies>

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/JournalStateMachine.java
@@ -207,7 +207,7 @@ public class JournalStateMachine extends BaseStateMachine {
   @Override
   public void reinitialize() throws IOException {
     LOG.info("Reinitializing state machine.");
-    mStorage.loadLatestSnapshot();
+    mStorage.getLatestSnapshot();
     loadSnapshot(mStorage.getLatestSnapshot());
     unpause();
     synchronized (mSnapshotManager) {
@@ -634,7 +634,7 @@ public class JournalStateMachine extends BaseStateMachine {
         return RaftLog.INVALID_LOG_INDEX;
       }
       try {
-        mStorage.loadLatestSnapshot();
+        mStorage.getLatestSnapshot();
       } catch (Exception e) {
         snapshotFile.delete();
         LogUtils.warnWithException(LOG, "Failed to refresh latest snapshot: {}", snapshotId, e);

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalUtils.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/RaftJournalUtils.java
@@ -68,7 +68,8 @@ public class RaftJournalUtils {
    * @throws IOException if error occurred while creating the snapshot file
    */
   public static File createTempSnapshotFile(SimpleStateMachineStorage storage) throws IOException {
-    File tempDir = new File(storage.getSmDir().getParentFile(), "tmp");
+    File smDir = storage.getSnapshotFile(0, 0).getParentFile();
+    File tempDir = new File(smDir.getParentFile(), "tmp");
     if (!tempDir.isDirectory() && !tempDir.mkdir()) {
       throw new IOException(
           "Cannot create temporary snapshot directory at " + tempDir.getAbsolutePath());

--- a/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
+++ b/core/server/common/src/main/java/alluxio/master/journal/raft/SnapshotReplicationManager.java
@@ -469,7 +469,7 @@ public class SnapshotReplicationManager {
         throw new IOException(String.format("Failed to rename %s to %s", tempFile, snapshotFile));
       }
       synchronized (this) {
-        mStorage.loadLatestSnapshot();
+        mStorage.getLatestSnapshot();
         notifyAll();
       }
       LOG.info("Completed storing snapshot at {} to file {} with size {}", downloaded,

--- a/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
+++ b/core/server/master/src/main/java/alluxio/master/journal/tool/RaftJournalDumper.java
@@ -26,6 +26,7 @@ import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.server.storage.StorageImplUtils;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
+import org.apache.ratis.util.SizeInBytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,8 +92,8 @@ public class RaftJournalDumper extends AbstractJournalDumper {
       List<LogSegmentPath> paths = LogSegmentPath.getLogSegmentPaths(storage);
       for (LogSegmentPath path : paths) {
         final int entryCount = LogSegment.readSegmentFile(path.getPath().toFile(),
-                path.getStartEnd(), RaftServerConfigKeys.Log.CorruptionPolicy.EXCEPTION,
-                null, (proto) -> {
+            path.getStartEnd(), SizeInBytes.valueOf(Integer.MAX_VALUE),
+            RaftServerConfigKeys.Log.CorruptionPolicy.EXCEPTION, null, (proto) -> {
               if (proto.hasStateMachineLogEntry()) {
                 try {
                   Journal.JournalEntry entry = Journal.JournalEntry.parseFrom(

--- a/core/server/master/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
+++ b/core/server/master/src/test/java/alluxio/master/journal/raft/SnapshotReplicationManagerTest.java
@@ -184,7 +184,7 @@ public class SnapshotReplicationManagerTest {
       throws IOException {
     java.io.File file = storage.getSnapshotFile(term, index);
     FileUtils.writeByteArrayToFile(file, BufferUtils.getIncreasingByteArray(SNAPSHOT_SIZE));
-    storage.loadLatestSnapshot();
+    storage.getLatestSnapshot();
   }
 
   private void validateSnapshotFile(SimpleStateMachineStorage storage) throws IOException {

--- a/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
+++ b/tests/src/test/java/alluxio/server/ft/journal/raft/EmbeddedJournalIntegrationTestFaultTolerance.java
@@ -175,7 +175,7 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
     rs.initialize();
     SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
     storage.init(rs);
-    SingleFileSnapshotInfo snapshot = storage.findLatestSnapshot();
+    SingleFileSnapshotInfo snapshot = storage.getLatestSnapshot();
     assertNotNull(snapshot);
     mCluster.notifySuccess();
   }
@@ -222,7 +222,7 @@ public class EmbeddedJournalIntegrationTestFaultTolerance
     rs.initialize();
     SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
     storage.init(rs);
-    SingleFileSnapshotInfo snapshot = storage.findLatestSnapshot();
+    SingleFileSnapshotInfo snapshot = storage.getLatestSnapshot();
     assertNotNull(snapshot);
     mCluster.notifySuccess();
   }


### PR DESCRIPTION
### What changes are proposed in this pull request?

Bump ratis version to 2.5.0 and fix API changes.

Currently Alluxio is using some internal API of Ratis, causing compatibility
issues between minor releases, which is being discussed in #17224.

### Why are the changes needed?

Ratis 2.5.0 is released with several new features and bug fixes.

### Does this PR introduce any user facing changes?

No.