### PR TITLE
Make client retry a failed worker after a timeout

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -81,6 +81,7 @@ public class AlluxioFileInStream extends FileInStream {
   private final BlockStoreClient mBlockStore;
   private final FileSystemContext mContext;
   private final boolean mPassiveCachingEnabled;
+  private final long mForgiveWorkerErrorTimeoutMs;
 
   /* Convenience values derived from mStatus, use these instead of querying mStatus. */
   /** Length of the file in bytes. */
@@ -137,6 +138,8 @@ public class AlluxioFileInStream extends FileInStream {
       mBlockInStream = null;
       mCachedPositionedReadStream = null;
       mLastBlockIdCached = 0;
+      mForgiveWorkerErrorTimeoutMs = conf.getMs(PropertyKey.USER_FORGIVE_WORKER_ERROR_TIMEOUT);
+      LOG.info("Stream created with worker error timeout {}", mForgiveWorkerErrorTimeoutMs);
     } catch (Throwable t) {
       // If there is any exception, including RuntimeException such as thrown by conf.getBoolean,
       // release the acquired resource, otherwise, FileSystemContext reinitialization will be
@@ -302,8 +305,10 @@ public class AlluxioFileInStream extends FileInStream {
         // Positioned read may be called multiple times for the same block. Caching the in-stream
         // allows us to avoid the block store rpc to open a new stream for each call.
         if (mCachedPositionedReadStream == null) {
+          maybeForgiveFailedWorkers();
           mCachedPositionedReadStream = mBlockStore.getInStream(blockId, mOptions, mFailedWorkers);
         } else if (mCachedPositionedReadStream.getId() != blockId) {
+          maybeForgiveFailedWorkers();
           closeBlockInStream(mCachedPositionedReadStream);
           mCachedPositionedReadStream = mBlockStore.getInStream(blockId, mOptions, mFailedWorkers);
         }
@@ -391,6 +396,7 @@ public class AlluxioFileInStream extends FileInStream {
     }
     // Create stream
     boolean isBlockInfoOutdated = true;
+    maybeForgiveFailedWorkers();
     // blockInfo is "outdated" when all the locations in that blockInfo are failed workers,
     // if there is at least one location that is not a failed worker, then it's not outdated.
     if (mFailedWorkers.isEmpty() || mFailedWorkers.size() < blockInfo.getLocations().size()) {
@@ -404,6 +410,8 @@ public class AlluxioFileInStream extends FileInStream {
       }
     }
     if (isBlockInfoOutdated) {
+      LOG.warn("All known locations for block {} are failed workers. Re-create the BlockStream "
+          + "from the start. Failed workers are {}", blockId, mFailedWorkers.keySet());
       mBlockInStream = mBlockStore.getInStream(blockId, mOptions, mFailedWorkers);
     } else {
       mBlockInStream = mBlockStore.getInStream(blockInfo, mOptions, mFailedWorkers);
@@ -411,6 +419,22 @@ public class AlluxioFileInStream extends FileInStream {
     // Set the stream to the correct position.
     long offset = mPosition % mBlockSize;
     mBlockInStream.seek(offset);
+  }
+
+  /**
+   * An I/O like read() or positionedRead() will retry for USER_BLOCK_READ_RETRY_MAX_DURATION.
+   * So USER_FORGIVE_WORKER_ERROR_TIMEOUT should be shorter than it to take effect.
+   */
+  private void maybeForgiveFailedWorkers() {
+    long now = CommonUtils.getCurrentMs();
+    mFailedWorkers.entrySet().removeIf(entry -> {
+      if (now - entry.getValue() >= mForgiveWorkerErrorTimeoutMs) {
+        LOG.info("I/O to worker {} failed more than {}ms ago, try this worker again", entry.getKey(),
+            mForgiveWorkerErrorTimeoutMs);
+        return true;
+      }
+      return false;
+    });
   }
 
   private void closeBlockInStream(BlockInStream stream) throws IOException {

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5669,6 +5669,14 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setDefaultValue("5min")
           .setScope(Scope.CLIENT)
           .build();
+  public static final PropertyKey USER_FORGIVE_WORKER_ERROR_TIMEOUT =
+      durationBuilder(Name.USER_FORGIVE_WORKER_ERROR_TIMEOUT)
+          .setDescription("When a worker fails a request, a stream will not to reuse that worker "
+              + "within this timeout. After this timeout, the stream will give that worker another "
+              + "chance and try to read/write it again.")
+          .setDefaultValue("1min")
+          .setScope(Scope.CLIENT)
+          .build();
   public static final PropertyKey USER_CONF_CLUSTER_DEFAULT_ENABLED =
       booleanBuilder(Name.USER_CONF_CLUSTER_DEFAULT_ENABLED)
           .setDefaultValue(true)
@@ -8641,6 +8649,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.user.block.read.retry.sleep.max";
     public static final String USER_BLOCK_READ_RETRY_MAX_DURATION =
         "alluxio.user.block.read.retry.max.duration";
+    public static final String USER_FORGIVE_WORKER_ERROR_TIMEOUT =
+            "alluxio.user.forgive.worker.error.timeout";
     public static final String USER_BLOCK_WORKER_CLIENT_POOL_GC_THRESHOLD_MS =
         "alluxio.user.block.worker.client.pool.gc.threshold";
     public static final String USER_BLOCK_WORKER_CLIENT_POOL_MIN =


### PR DESCRIPTION
### What changes are proposed in this pull request?

In a stream the retry timeout is typically 5min (sometimes more, sometimes less, depending on the user config). When a worker is restarted, we want the stream to retry that worker after a while and after all other options have been exhausted, so the stream still succeeds and no error is returned to the application.

### Why are the changes needed?

Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.

### Does this PR introduce any user facing changes?

Please list the user-facing changes introduced by your change, including
  1. change in user-facing APIs
  2. addition or removal of property keys
  3. webui
