### PR TITLE
[SMALLFIX] Remove unrelated property key

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -576,17 +576,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.SERVER)
           .build();
-  public static final PropertyKey GRPC_REFLECTION_ENABLED =
-      booleanBuilder(Name.GRPC_REFLECTION_ENABLED)
-          .setDefaultValue(false)
-          .setDescription("If true, grpc reflection will be enabled on alluxio grpc servers, "
-              + "including masters, workers, job masters and job workers. "
-              + " This makes grpc tools such as grpcurl or grpcui can send grpc requests to "
-              + "the master server easier without knowing the protobufs. "
-              + "This is a debug option.")
-          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
-          .setScope(Scope.ALL)
-          .build();
   public static final PropertyKey HOME =
       stringBuilder(Name.HOME)
           .setDefaultValue("/opt/alluxio")
@@ -6497,8 +6486,6 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String DEBUG = "alluxio.debug";
     public static final String EXTENSIONS_DIR = "alluxio.extensions.dir";
     public static final String EXIT_COLLECT_INFO = "alluxio.exit.collect.info";
-    public static final String GRPC_REFLECTION_ENABLED =
-        "alluxio.grpc.reflection.enabled";
     public static final String HOME = "alluxio.home";
     public static final String INTEGRATION_MASTER_RESOURCE_CPU =
         "alluxio.integration.master.resource.cpu";


### PR DESCRIPTION
### What changes are proposed in this pull request?

There is a property key brought into 2.8 during cherry pick by accident. This change removes it.
