### PR TITLE
Fix the active rpc metrics

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/BlockReadHandler.java
@@ -478,7 +478,7 @@ public class BlockReadHandler implements StreamObserver<alluxio.grpc.ReadRequest
         replyError(error);
       } else if (eof) {
         replyEof();
-      } else {
+      } else if (cancel) {
         replyCancel();
       }
     }


### PR DESCRIPTION
### What changes are proposed in this pull request?

mentioned in #16629 

### Why are the changes needed?

The `Cluster.ActiveRpcReadCount` metric could get an impossible value like a negative number. The main reason is that the request handling doesn't cover all situations.

### Does this PR introduce any user facing changes?

Nope
