### PR TITLE
Remove redundant arguments from ByteBuffer read API

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/block/stream/BlockInStream.java
@@ -333,24 +333,20 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
     Objects.requireNonNull(b, "Read buffer cannot be null");
-    return read(ByteBuffer.wrap(b), off, len);
+    return read(ByteBuffer.wrap(b, off, len));
   }
 
   /**
    * Reads up to len bytes of data from the input stream into the byte buffer.
    *
    * @param byteBuffer the buffer into which the data is read
-   * @param off the start offset in the buffer at which the data is written
-   * @param len the maximum number of bytes to read
    * @return the total number of bytes read into the buffer, or -1 if there is no more data because
    *         the end of the stream has been reached
    */
-  public int read(ByteBuffer byteBuffer, int off, int len) throws IOException {
-    Preconditions.checkArgument(off >= 0 && len >= 0 && len + off <= byteBuffer.capacity(),
-        PreconditionMessage.ERR_BUFFER_STATE.toString(), byteBuffer.capacity(), off, len);
+  public int read(ByteBuffer byteBuffer) throws IOException {
+    int len = byteBuffer.remaining();
     checkIfClosed();
     if (len == 0) {
-
       return 0;
     }
     if (mPos == mLength) {
@@ -372,7 +368,6 @@ public class BlockInStream extends InputStream implements BoundedStream, Seekabl
       return -1;
     }
     int toRead = Math.min(len, mCurrentChunk.readableBytes());
-    byteBuffer.position(off).limit(off + toRead);
     mCurrentChunk.readBytes(byteBuffer);
     mPos += toRead;
     if (mPos == mLength) {

--- a/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/AlluxioFileInStream.java
@@ -190,9 +190,8 @@ public class AlluxioFileInStream extends FileInStream {
   }
 
   @Override
-  public int read(ByteBuffer byteBuffer, int off, int len) throws IOException {
-    Preconditions.checkArgument(off >= 0 && len >= 0 && len + off <= byteBuffer.capacity(),
-        PreconditionMessage.ERR_BUFFER_STATE.toString(), byteBuffer.capacity(), off, len);
+  public int read(ByteBuffer byteBuffer) throws IOException {
+    int len = byteBuffer.remaining();
     if (len == 0) {
       return 0;
     }
@@ -200,17 +199,17 @@ public class AlluxioFileInStream extends FileInStream {
       return -1;
     }
 
-    int bytesLeft = len;
-    int currentOffset = off;
+    // casting from long to int is safe since len never exceeds Integer.MAX_VALUE
+    final int bytesToRead = (int) Math.min((long) len, mLength - mPosition);
+    int totalBytesRead = 0;
     RetryPolicy retry = mRetryPolicySupplier.get();
     IOException lastException = null;
-    while (bytesLeft > 0 && mPosition != mLength && retry.attempt()) {
+    while (bytesToRead - totalBytesRead > 0 && retry.attempt()) {
       try {
         updateStream();
-        int bytesRead = mBlockInStream.read(byteBuffer, currentOffset, bytesLeft);
+        int bytesRead = mBlockInStream.read(byteBuffer);
         if (bytesRead > 0) {
-          bytesLeft -= bytesRead;
-          currentOffset += bytesRead;
+          totalBytesRead += bytesRead;
           mPosition += bytesRead;
         }
         retry = mRetryPolicySupplier.get();
@@ -232,7 +231,7 @@ public class AlluxioFileInStream extends FileInStream {
     if (lastException != null) {
       throw lastException;
     }
-    return len - bytesLeft;
+    return totalBytesRead;
   }
 
   // When Alluxio detects the underlying file length has changed,

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/CacheManager.java
@@ -256,7 +256,8 @@ public interface CacheManager extends AutoCloseable, CacheStatus {
    */
   default int get(PageId pageId, int pageOffset, int bytesToRead, byte[] buffer, int offsetInBuffer,
       CacheContext cacheContext) {
-    return get(pageId, pageOffset, bytesToRead, new ByteArrayTargetBuffer(buffer, offsetInBuffer),
+    return get(pageId, pageOffset, bytesToRead,
+        new ByteArrayTargetBuffer(buffer, offsetInBuffer, buffer.length - offsetInBuffer),
         cacheContext);
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java
@@ -127,17 +127,14 @@ public class LocalCacheFileInStream extends FileInStream {
 
   @Override
   public int read(byte[] bytesBuffer, int offset, int length) throws IOException {
-    return readInternal(new ByteArrayTargetBuffer(bytesBuffer, offset), offset, length,
+    return readInternal(new ByteArrayTargetBuffer(bytesBuffer, offset, offset + length),
         ReadType.READ_INTO_BYTE_ARRAY, mPosition, false);
   }
 
   @Override
-  public int read(ByteBuffer buffer, int offset, int length) throws IOException {
-    int totalBytesRead = readInternal(new ByteBufferTargetBuffer(buffer), offset, length,
+  public int read(ByteBuffer buffer) throws IOException {
+    int totalBytesRead = readInternal(new ByteBufferTargetBuffer(buffer),
         ReadType.READ_INTO_BYTE_BUFFER, mPosition, false);
-    if (totalBytesRead == -1) {
-      return -1;
-    }
     return totalBytesRead;
   }
 
@@ -160,7 +157,7 @@ public class LocalCacheFileInStream extends FileInStream {
     }
     int bytesLoadToBuffer = (int) Math.min(mBufferSize, mStatus.getLength() - position);
     int bytesRead =
-        localCachedRead(new ByteArrayTargetBuffer(mBuffer, 0),  bytesLoadToBuffer, readType,
+        localCachedRead(new ByteArrayTargetBuffer(mBuffer), bytesLoadToBuffer, readType,
             position, stopwatch);
     mBufferStartOffset = position;
     mBufferEndOffset = position + bytesRead;
@@ -228,11 +225,10 @@ public class LocalCacheFileInStream extends FileInStream {
   }
 
   // TODO(binfan): take ByteBuffer once CacheManager takes ByteBuffer to avoid extra mem copy
-  private int readInternal(PageReadTargetBuffer targetBuffer, int offset, int length,
+  private int readInternal(PageReadTargetBuffer targetBuffer,
       ReadType readType, long position, boolean isPositionedRead) throws IOException {
-    Preconditions.checkArgument(length >= 0, "length should be non-negative");
-    Preconditions.checkArgument(offset >= 0, "offset should be non-negative");
     Preconditions.checkArgument(position >= 0, "position should be non-negative");
+    int length = targetBuffer.remaining();
     if (length == 0) {
       return 0;
     }
@@ -291,7 +287,7 @@ public class LocalCacheFileInStream extends FileInStream {
 
   @Override
   public int positionedRead(long pos, byte[] b, int off, int len) throws IOException {
-    return readInternal(new ByteArrayTargetBuffer(b, off), off, len, ReadType.READ_INTO_BYTE_ARRAY,
+    return readInternal(new ByteArrayTargetBuffer(b, off, len), ReadType.READ_INTO_BYTE_ARRAY,
         pos, true);
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheManager.java
@@ -553,7 +553,7 @@ public class LocalCacheManager implements CacheManager {
     if (appendAt > 0) {
       byte[] newPage = new byte[appendAt + page.length];
       int readBytes = get(pageId, 0, appendAt,
-          new ByteArrayTargetBuffer(newPage, 0),  cacheContext);
+          new ByteArrayTargetBuffer(newPage),  cacheContext);
       boolean success = delete(pageId, cacheContext.isTemporary());
       LOG.debug("delete pageId: " + pageId
           + ", appendAt: " + appendAt + ", readBytes: " + readBytes + ", success: " + success);

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/ByteArrayTargetBuffer.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/ByteArrayTargetBuffer.java
@@ -13,6 +13,8 @@ package alluxio.client.file.cache.store;
 
 import alluxio.annotation.SuppressFBWarnings;
 
+import com.google.common.base.Preconditions;
+
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
@@ -26,15 +28,30 @@ import java.nio.channels.WritableByteChannel;
     justification = "The target byte array is exposed as we expect.")
 public class ByteArrayTargetBuffer implements PageReadTargetBuffer {
   private final byte[] mTarget;
+  private final int mLimit;
   private int mOffset;
 
   /**
    * Constructor.
+   * This sets the offset to 0 and the length to the length of the byte array.
+   *
    * @param target
-   * @param offset
    */
-  public ByteArrayTargetBuffer(byte[] target, int offset) {
+  public ByteArrayTargetBuffer(byte[] target) {
+    this(target, 0, target.length);
+  }
+
+  /**
+   * Constructor.
+   * @param target the target buffer
+   * @param offset the starting index of the byte array where data is written to
+   * @param length the maximum length of data that will be written to the array
+   */
+  public ByteArrayTargetBuffer(byte[] target, int offset, int length) {
+    Preconditions.checkArgument(offset >= 0 && offset <= target.length, "offset");
+    Preconditions.checkArgument(length >= 0 && length <= target.length - offset, "length");
     mTarget = target;
+    mLimit = offset + length;
     mOffset = offset;
   }
 
@@ -49,17 +66,21 @@ public class ByteArrayTargetBuffer implements PageReadTargetBuffer {
   }
 
   @Override
-  public long offset() {
+  public int offset() {
     return mOffset;
   }
 
   @Override
-  public long remaining() {
-    return mTarget.length - mOffset;
+  public int remaining() {
+    return mLimit - mOffset;
   }
 
   @Override
   public void writeBytes(byte[] srcArray, int srcOffset, int length) {
+    if (length > remaining()) {
+      throw new IndexOutOfBoundsException(String.format(
+          "length: %d, remaining in buffer: %d", length, remaining()));
+    }
     System.arraycopy(srcArray, srcOffset, mTarget, mOffset, length);
     mOffset += length;
   }

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/ByteBufferTargetBuffer.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/ByteBufferTargetBuffer.java
@@ -41,7 +41,7 @@ public class ByteBufferTargetBuffer implements PageReadTargetBuffer {
   }
 
   @Override
-  public long offset() {
+  public int offset() {
     return mTarget.position();
   }
 
@@ -51,7 +51,7 @@ public class ByteBufferTargetBuffer implements PageReadTargetBuffer {
   }
 
   @Override
-  public long remaining() {
+  public int remaining() {
     return mTarget.remaining();
   }
 

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/LocalPageStore.java
@@ -104,7 +104,7 @@ public class LocalPageStore implements PageStore {
                 pageId, pagePath, pageOffset, bytesSkipped));
       }
       int bytesRead = 0;
-      int bytesLeft = Math.min((int) target.remaining(), bytesToRead);
+      int bytesLeft = Math.min(target.remaining(), bytesToRead);
       while (bytesLeft > 0) {
         int bytes = target.readFromFile(localFile, bytesLeft);
         if (bytes <= 0) {

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/PageReadTargetBuffer.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/PageReadTargetBuffer.java
@@ -35,7 +35,7 @@ public interface PageReadTargetBuffer {
   /**
    * @return offset in the buffer
    */
-  long offset();
+  int offset();
 
   /**
    * @return the writable channel
@@ -45,7 +45,7 @@ public interface PageReadTargetBuffer {
   /**
    * @return the remaining for this buffer
    */
-  long remaining();
+  int remaining();
 
   /**
    * @param srcArray

--- a/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/cache/store/RocksPageStore.java
@@ -189,8 +189,8 @@ public class RocksPageStore implements PageStore {
       Preconditions.checkArgument(pageOffset <= page.length,
           "page offset %s exceeded page size %s", pageOffset, page.length);
       int bytesLeft =
-          Math.min(page.length - pageOffset, Math.min((int) target.remaining(), bytesToRead));
-      System.arraycopy(page, pageOffset, target.byteArray(), (int) target.offset(), bytesLeft);
+          Math.min(page.length - pageOffset, Math.min(target.remaining(), bytesToRead));
+      System.arraycopy(page, pageOffset, target.byteArray(), target.offset(), bytesLeft);
       return bytesLeft;
     } catch (RocksDBException e) {
       throw new IOException("Failed to retrieve page", e);

--- a/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheFileInStream.java
@@ -55,13 +55,12 @@ public class DoraCacheFileInStream extends FileInStream {
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
     Objects.requireNonNull(b, "Read buffer cannot be null");
-    return read(ByteBuffer.wrap(b), off, len);
+    return read(ByteBuffer.wrap(b, off, len));
   }
 
   @Override
-  public int read(ByteBuffer byteBuffer, int off, int len) throws IOException {
-    Preconditions.checkArgument(off >= 0 && len >= 0 && len + off <= byteBuffer.capacity(),
-        PreconditionMessage.ERR_BUFFER_STATE.toString(), byteBuffer.capacity(), off, len);
+  public int read(ByteBuffer byteBuffer) throws IOException {
+    int len = byteBuffer.remaining();
     Preconditions.checkState(!mClosed, "Cannot do operations on a closed BlockInStream");
     if (len == 0) {
       return 0;
@@ -82,7 +81,6 @@ public class DoraCacheFileInStream extends FileInStream {
       return -1;
     }
     int toRead = Math.min(len, mCurrentChunk.readableBytes());
-    byteBuffer.position(off).limit(off + toRead);
     mCurrentChunk.readBytes(byteBuffer);
     mPos += toRead;
     if (mPos == mLength) {

--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsFileInStream.java
@@ -66,16 +66,16 @@ public class UfsFileInStream extends FileInStream {
   }
 
   @Override
-  public int read(ByteBuffer byteBuffer, int off, int len) throws IOException {
+  public int read(ByteBuffer byteBuffer) throws IOException {
+    int len = byteBuffer.remaining();
     if (byteBuffer.hasArray()) {
-      return read(byteBuffer.array(), off, len);
+      return read(byteBuffer.array(), byteBuffer.arrayOffset(), byteBuffer.remaining());
     }
     byte[] byteArray = new byte[len];
     int totalBytesRead = read(byteArray, 0, len);
     if (totalBytesRead <= 0) {
       return totalBytesRead;
     }
-    byteBuffer.position(off).limit(off + len);
     byteBuffer.put(byteArray, 0, totalBytesRead);
     return totalBytesRead;
   }

--- a/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/cache/LocalCacheFileInStreamTest.java
@@ -159,9 +159,11 @@ public class LocalCacheFileInStreamTest {
     ByteArrayCacheManager manager = new ByteArrayCacheManager();
     LocalCacheFileInStream stream = setupWithSingleFile(fileData, manager);
 
-    byte[] readData = new byte[fileSize];
+    int bufferSize = fileSize + 1;
+    byte[] readData = new byte[bufferSize];
     ByteBuffer buffer = ByteBuffer.wrap(readData);
-    int totalBytesRead = stream.read(buffer, 0, fileSize + 1);
+    buffer.position(0).limit(bufferSize);
+    int totalBytesRead = stream.read(buffer);
     Assert.assertEquals(-1, totalBytesRead);
   }
 
@@ -172,9 +174,11 @@ public class LocalCacheFileInStreamTest {
     ByteArrayCacheManager manager = new ByteArrayCacheManager();
     LocalCacheFileInStream stream = setupWithSingleFile(fileData, manager);
 
-    byte[] readData = new byte[fileSize];
+    int bufferSize = fileSize + 1;
+    byte[] readData = new byte[bufferSize];
     ByteBuffer buffer = ByteBuffer.wrap(readData);
-    int totalBytesRead = stream.read(buffer, 0, fileSize + 1);
+    buffer.position(0).limit(bufferSize);
+    int totalBytesRead = stream.read(buffer);
     Assert.assertEquals(fileSize, totalBytesRead);
   }
 
@@ -1022,9 +1026,9 @@ public class LocalCacheFileInStreamTest {
     }
 
     @Override
-    public int read(ByteBuffer byteBuffer, int off, int len) throws IOException {
+    public int read(ByteBuffer byteBuffer) throws IOException {
       mTicker.advance(StepTicker.Type.CACHE_MISS);
-      return mDelegate.read(byteBuffer, off, len);
+      return mDelegate.read(byteBuffer);
     }
 
     @Override

--- a/core/common/src/main/java/alluxio/network/protocol/databuffer/NioDataBuffer.java
+++ b/core/common/src/main/java/alluxio/network/protocol/databuffer/NioDataBuffer.java
@@ -72,10 +72,11 @@ public class NioDataBuffer implements DataBuffer {
     if (mBuffer.remaining() <= outputBuf.remaining()) {
       outputBuf.put(mBuffer);
     } else {
-      int oldLimit = mBuffer.limit();
-      mBuffer.limit(mBuffer.position() + outputBuf.remaining());
-      outputBuf.put(mBuffer);
-      mBuffer.limit(oldLimit);
+      int bytesToRead = outputBuf.remaining();
+      ByteBuffer slice = mBuffer.slice();
+      slice.limit(bytesToRead);
+      outputBuf.put(slice);
+      mBuffer.position(mBuffer.position() + bytesToRead);
     }
   }
 

--- a/core/server/worker/src/main/java/alluxio/worker/page/NettyBufTargetBuffer.java
+++ b/core/server/worker/src/main/java/alluxio/worker/page/NettyBufTargetBuffer.java
@@ -26,7 +26,6 @@ import java.nio.channels.WritableByteChannel;
  */
 public class NettyBufTargetBuffer implements PageReadTargetBuffer {
   private final ByteBuf mTarget;
-  private long mOffset = 0;
 
   /**
    * @param target target buffer
@@ -46,8 +45,8 @@ public class NettyBufTargetBuffer implements PageReadTargetBuffer {
   }
 
   @Override
-  public long offset() {
-    return mOffset;
+  public int offset() {
+    return mTarget.writerIndex();
   }
 
   @Override
@@ -72,7 +71,7 @@ public class NettyBufTargetBuffer implements PageReadTargetBuffer {
   }
 
   @Override
-  public long remaining() {
+  public int remaining() {
     return mTarget.writableBytes();
   }
 

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileInOrOutStream.java
@@ -89,7 +89,7 @@ public class FuseFileInOrOutStream implements FuseFileStream {
   }
 
   @Override
-  public synchronized int read(ByteBuffer buf, long size, long offset) {
+  public synchronized int read(long position, ByteBuffer buf) {
     if (mOutStream.isPresent()) {
       throw new UnimplementedRuntimeException(
           "Alluxio does not support reading while writing/truncating");
@@ -97,11 +97,11 @@ public class FuseFileInOrOutStream implements FuseFileStream {
     if (!mInStream.isPresent()) {
       mInStream = Optional.of(FuseFileInStream.create(mFileSystem, mLockManager, mUri));
     }
-    return mInStream.get().read(buf, size, offset);
+    return mInStream.get().read(position, buf);
   }
 
   @Override
-  public synchronized void write(ByteBuffer buf, long size, long offset) {
+  public synchronized void write(long position, ByteBuffer buf) {
     if (mInStream.isPresent()) {
       throw new UnimplementedRuntimeException(
           "Alluxio does not support reading while writing/truncating");
@@ -110,7 +110,7 @@ public class FuseFileInOrOutStream implements FuseFileStream {
       mOutStream = Optional.of(FuseFileOutStream.create(mFileSystem, mAuthPolicy,
           mLockManager, mUri, OpenFlags.O_WRONLY.intValue(), mMode));
     }
-    mOutStream.get().write(buf, size, offset);
+    mOutStream.get().write(position, buf);
   }
 
   @Override

--- a/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
+++ b/integration/fuse/src/main/java/alluxio/fuse/file/FuseFileStream.java
@@ -31,21 +31,19 @@ public interface FuseFileStream extends AutoCloseable {
   /**
    * Reads data from the stream.
    *
+   * @param position the offset of the target stream to begin reading
    * @param buf the byte buffer to read data to
-   * @param size the size to read
-   * @param offset the offset of the target stream to begin reading
    * @return the bytes read
    */
-  int read(ByteBuffer buf, long size, long offset);
+  int read(long position, ByteBuffer buf);
 
   /**
    * Writes data to the stream.
    *
+   * @param position the offset to starting writing into the stream
    * @param buf the byte buffer to read data from and write to the stream
-   * @param size the size to write
-   * @param offset the offset to write
    */
-  void write(ByteBuffer buf, long size, long offset);
+  void write(long position, ByteBuffer buf);
 
   /**
    * @return file status

--- a/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/FuseFileSystem.java
+++ b/integration/jnifuse/fs/src/main/java/alluxio/jnifuse/FuseFileSystem.java
@@ -65,11 +65,11 @@ public interface FuseFileSystem {
     throw new UnsupportedOperationException("open");
   }
 
-  default int read(String path, ByteBuffer buf, long size, long offset, FuseFileInfo fi) {
+  default int read(String path, long position, ByteBuffer buf, FuseFileInfo fi) {
     throw new UnsupportedOperationException("read");
   }
 
-  default int write(String path, ByteBuffer buf, long size, long offset, FuseFileInfo fi) {
+  default int write(String path, long position, ByteBuffer buf, FuseFileInfo fi) {
     throw new UnsupportedOperationException("write");
   }
 

--- a/integration/jnifuse/native/src/main/native/libjnifuse/operation.cc
+++ b/integration/jnifuse/native/src/main/native/libjnifuse/operation.cc
@@ -100,7 +100,7 @@ ReadOperation::ReadOperation(JniFuseFileSystem *fs) {
   this->obj = this->fs->getFSObj();
   this->clazz = env->GetObjectClass(this->fs->getFSObj());
   this->signature =
-      "(Ljava/lang/String;Ljava/nio/ByteBuffer;JJLjava/nio/ByteBuffer;)I";
+      "(Ljava/lang/String;JLjava/nio/ByteBuffer;Ljava/nio/ByteBuffer;)I";
   this->methodID = env->GetMethodID(this->clazz, "readCallback", signature);
 }
 
@@ -112,8 +112,8 @@ int ReadOperation::call(const char *path, char *buf, size_t size, off_t offset,
   jobject fibuf =
       env->NewDirectByteBuffer((void *)fi, sizeof(struct fuse_file_info));
 
-  int ret = env->CallIntMethod(this->obj, this->methodID, jspath, buffer, size,
-                               offset, fibuf);
+  int ret = env->CallIntMethod(this->obj, this->methodID, jspath, offset, buffer,
+                               fibuf);
   env->DeleteLocalRef(jspath);
   env->DeleteLocalRef(buffer);
   env->DeleteLocalRef(fibuf);
@@ -346,7 +346,7 @@ WriteOperation::WriteOperation(JniFuseFileSystem *fs) {
   this->obj = this->fs->getFSObj();
   this->clazz = env->GetObjectClass(this->fs->getFSObj());
   this->signature =
-      "(Ljava/lang/String;Ljava/nio/ByteBuffer;JJLjava/nio/ByteBuffer;)I";
+      "(Ljava/lang/String;JLjava/nio/ByteBuffer;Ljava/nio/ByteBuffer;)I";
   this->methodID = env->GetMethodID(this->clazz, "writeCallback", signature);
 }
 
@@ -358,8 +358,8 @@ int WriteOperation::call(const char *path, const char *buf, size_t size,
   jobject fibuf =
       env->NewDirectByteBuffer((void *)fi, sizeof(struct fuse_file_info));
 
-  int ret = env->CallIntMethod(this->obj, this->methodID, jspath, buffer, size,
-                               off, fibuf);
+  int ret = env->CallIntMethod(this->obj, this->methodID, jspath, off, buffer,
+                               fibuf);
 
   env->DeleteLocalRef(jspath);
   env->DeleteLocalRef(buffer);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove redundant `offset` and `length` arguments of read APIs where a `ByteBuffer` is used as the output buffer.

### Why are the changes needed?

The `offset` and `length` arguments are commonly found in byte array-based APIs. A `ByteBuffer`, however, already has an internal position and a limit that indicates the offset and length of the read call. Passing in redundant arguments poses a risk that the passed in arguments conflict with the ByteBuffer's internal properties, and leads to very subtle bugs.

### Does this PR introduce any user facing changes?

No.