### PR TITLE
Fix ufs root issue when HDFS is used as UFS

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -242,6 +242,10 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
 
       // Treat this path as Alluxio relative, and add the UFS root before it.
       String ufsFullPath = PathUtils.concatPath(rootUFS, alluxioPath.toString());
+      if (alluxioPath.isRoot()) {
+        ufsFullPath = ufsFullPath + AlluxioURI.SEPARATOR;
+      }
+
       return new AlluxioURI(ufsFullPath);
     } else {
       return alluxioPath;


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add a path SEPARATOR to the end of the path for root

### Why are the changes needed?

Because when concat the ufs root with "/", the ending "/" will be trimmed.
We need it for HDFS UFS.

This bug only exists for HDFS UFS.

### Does this PR introduce any user facing changes?

N/A