### PR TITLE
Fix FileSystemMergeJournalContext related

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/FileSystemJournalEntryMerger.java
+++ b/core/server/master/src/main/java/alluxio/master/file/FileSystemJournalEntryMerger.java
@@ -70,6 +70,14 @@ public class FileSystemJournalEntryMerger implements JournalEntryMerger {
             MutableInodeDirectory.fromJournalEntry(existingEntry.getInodeDirectory());
         if (entry.hasUpdateInode()) {
           inodeDirectory.updateFromEntry(entry.getUpdateInode());
+          // Update Inode directory does not contain directory fingerprint,
+          // so we still need to add the new inode journal entry to the list to keep the
+          // fingerprint update,
+          // while we still merge it with the existing inode directory on as best efforts.
+          if (entry.getUpdateInode().hasUfsFingerprint()
+              && !entry.getUpdateInode().getUfsFingerprint().equals("")) {
+            mJournalEntries.add(entry);
+          }
         } else if (entry.hasUpdateInodeDirectory()) {
           inodeDirectory.updateFromEntry(entry.getUpdateInodeDirectory());
         }

--- a/core/server/master/src/test/java/alluxio/master/file/meta/LockedInodePathTest.java
+++ b/core/server/master/src/test/java/alluxio/master/file/meta/LockedInodePathTest.java
@@ -24,6 +24,7 @@ import alluxio.conf.PropertyKey;
 import alluxio.exception.InvalidPathException;
 import alluxio.exception.status.UnavailableException;
 import alluxio.master.file.meta.InodeTree.LockPattern;
+import alluxio.master.journal.FileSystemMergeJournalContext;
 import alluxio.master.journal.JournalContext;
 import alluxio.master.journal.NoopJournalContext;
 
@@ -598,7 +599,7 @@ public class LockedInodePathTest extends BaseInodeLockingTest {
   @Test
   public void testFlushJournal() throws InvalidPathException, UnavailableException {
     AtomicInteger journalFlushCount = new AtomicInteger();
-    JournalContext journalContext = mock(JournalContext.class);
+    JournalContext journalContext = mock(FileSystemMergeJournalContext.class);
     Mockito.doAnswer(
         (mock) -> {
           journalFlushCount.getAndIncrement();


### PR DESCRIPTION
### What changes are proposed in this pull request?

1. Only force flushing journals when a locked inode path is closed for FileSystemMergeJournalContext
2. Fix the journal merger broken logic where updating the fingerprint for a directry will be ignored.

### Why are the changes needed?

We used to fix the merge journal context in https://github.com/Alluxio/alluxio/pull/17071, where a regular non-merging journal context is used when listStatus() is called. 

However, if a listStatus triggers a metadata sync and MASTER_FILE_SYSTEM_MERGE_INODE_JOURNALS is set to true, journals will be flushed on every lockedInodePath close during the metadata sync. This behavior leads to journals being flushed too many times and impairs the metadata sync performance. 

Also we found a minor issue that when inode directory journals are merged, the fingerprint will be ignored. This is becuase inode directory journal does not have a fingerprint field.

### Does this PR introduce any user facing changes?

N/A