### PR TITLE
Add incrementCounter method to make it compatible with presto

### DIFF
--- a/core/common/src/main/java/alluxio/client/file/CacheContext.java
+++ b/core/common/src/main/java/alluxio/client/file/CacheContext.java
@@ -152,6 +152,19 @@ public class CacheContext {
     return this;
   }
 
+
+  /**
+   * Increments the counter {@code name} by {@code value}.
+   * <p>
+   * Default implementation does nothing. Subclass can implement its own tracking mechanism.
+   *
+   * @param name name of the counter
+   * @param value value of the counter
+   */
+  public void incrementCounter(String name, long value) {
+    // Default implementation does nothing
+  }
+
   /**
    * Increments the counter {@code name} by {@code value}.
    * <p>


### PR DESCRIPTION
PrestoDB and TrinoDB depends on the old incrementCounter method which has two parameters. Therefore, although we have replaced this the method with another one that has three parameters, we still need to reserve the old method to make it compatible with PrestoDB/TrinoDB .  