### PR TITLE
Use thread context class loader instead to avoid presto exception

### DIFF
--- a/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
+++ b/core/common/src/main/java/alluxio/extensions/ExtensionFactoryRegistry.java
@@ -242,7 +242,7 @@ public class ExtensionFactoryRegistry<T extends ExtensionFactory<?, S>,
         String jarPath = extensionURL.toString();
 
         ClassLoader extensionsClassLoader = new ExtensionsClassLoader(new URL[] {extensionURL},
-            ClassLoader.getSystemClassLoader());
+            Thread.currentThread().getContextClassLoader());
         ServiceLoader<T> extensionServiceLoader =
             ServiceLoader.load(mFactoryClass, extensionsClassLoader);
         for (T factory : extensionServiceLoader) {


### PR DESCRIPTION
**Background:**
For each connector (e.g. hive-hadoop2), Presto uses an independent `PluginClassLoader` to load its classes. However, in our dora's client, it also use an `ExtensionsClassloader` to load the classes for each UFS implementation. Moreover, it breaks the parent delegation and uses `ClassLoader.getSystemClassLoader()`
as its parent's class loader. So only when the new class loader cannot load the classes, it calls its parent's class loader (`ClassLoader.getSystemClassLoader()`) to load the classes. However, the classes in `${PRESTO_HOME}/plugin/hive-hadoop2/alluxio-shaded-client-2.10.0-SNAPSHOT.jar` is loaded by the PluginClassLoader, but not the `ClassLoaders$AppClassLoader.` Therefore, Presto throws No under file system factory found exception during the time we are querying with presto-cli.

**Solution:**
Use `Thread.currentThread().getContextClassLoader()` instead to set the `PluginClassLoader` as the parent class loader.