### PR TITLE
Fix path for URIStatus from UFSStatus

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
@@ -55,7 +55,6 @@ import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
-import alluxio.util.CommonUtils;
 import alluxio.util.ModeUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.wire.BlockLocationInfo;
@@ -70,13 +69,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -216,7 +214,11 @@ public class UfsBaseFileSystem implements FileSystem {
 
   @Override
   public URIStatus getStatus(AlluxioURI path, final GetStatusPOptions options) {
-    return callWithReturn(() -> transformStatus(mUfs.get().getStatus(path.toString())));
+    return callWithReturn(() -> {
+      UfsStatus ufsStatus = mUfs.get().getStatus(path.toString());
+
+      return transformStatus(ufsStatus, path.toString());
+    });
   }
 
   @Override
@@ -230,7 +232,13 @@ public class UfsBaseFileSystem implements FileSystem {
       if (ufsStatuses == null || ufsStatuses.length == 0) {
         return Collections.emptyList();
       }
-      return Arrays.stream(ufsStatuses).map(this::transformStatus).collect(Collectors.toList());
+      List<URIStatus> uriStatusList = new ArrayList<>();
+      for (UfsStatus ufsStatus: ufsStatuses) {
+        URIStatus uriStatus = transformStatus(ufsStatus,
+            PathUtils.concatPath(path.toString(), ufsStatus.getName()));
+        uriStatusList.add(uriStatus);
+      }
+      return uriStatusList;
     });
   }
 
@@ -246,7 +254,11 @@ public class UfsBaseFileSystem implements FileSystem {
       if (ufsStatuses == null || ufsStatuses.length == 0) {
         return;
       }
-      Arrays.stream(ufsStatuses).map(this::transformStatus).forEach(action);
+      for (UfsStatus ufsStatus: ufsStatuses) {
+        URIStatus uriStatus = transformStatus(ufsStatus,
+            PathUtils.concatPath(path.toString(), ufsStatus.getName()));
+        action.accept(uriStatus);
+      }
     });
   }
 
@@ -414,13 +426,12 @@ public class UfsBaseFileSystem implements FileSystem {
    * @param ufsStatus the UFS status to transform
    * @return the client-side status
    */
-  private URIStatus transformStatus(UfsStatus ufsStatus) {
-    String path = CommonUtils.stripPrefixIfPresent(ufsStatus.getName(), mRootUFS.toString());
-    AlluxioURI ufsUri = new AlluxioURI(PathUtils.concatPath(mRootUFS, path));
+  private URIStatus transformStatus(UfsStatus ufsStatus, String ufsFullPath) {
+    AlluxioURI ufsUri = new AlluxioURI(ufsFullPath);
     FileInfo info = new FileInfo().setName(ufsUri.getName())
-        .setPath(path)
-        .setFileId(ufsUri.toString().hashCode())
+        .setPath(ufsUri.getPath())
         .setUfsPath(ufsUri.toString())
+        .setFileId(ufsUri.toString().hashCode())
         .setFolder(ufsStatus.isDirectory())
         .setOwner(ufsStatus.getOwner())
         .setGroup(ufsStatus.getGroup())

--- a/core/client/fs/src/test/java/alluxio/client/file/ufs/UfsBaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/ufs/UfsBaseFileSystemTest.java
@@ -221,7 +221,8 @@ public class UfsBaseFileSystemTest {
         CreateFilePOptions.newBuilder().setRecursive(true).build()).close();
     URIStatus status = mFileSystem.getStatus(uri);
     Assert.assertEquals(uri.getName(), status.getName());
-    Assert.assertEquals(fileName, status.getPath());
+    Assert.assertEquals(new AlluxioURI(fileName).getName(), status.getName());
+    Assert.assertEquals(uri.getPath(), status.getPath());
     Assert.assertEquals(uri.toString(), status.getUfsPath());
     Assert.assertTrue(status.isCompleted());
     Assert.assertFalse(status.isFolder());
@@ -237,7 +238,8 @@ public class UfsBaseFileSystemTest {
     mFileSystem.createDirectory(uri);
     URIStatus status = mFileSystem.getStatus(uri);
     Assert.assertEquals(uri.getName(), status.getName());
-    Assert.assertEquals(fileName, status.getPath());
+    Assert.assertEquals(new AlluxioURI(fileName).getName(), status.getName());
+    Assert.assertEquals(uri.getPath(), status.getPath());
     Assert.assertEquals(uri.toString(), status.getUfsPath());
     Assert.assertTrue(status.isCompleted());
     Assert.assertTrue(status.isFolder());

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
@@ -22,7 +22,6 @@ import alluxio.uri.SingleMasterAuthority;
 import alluxio.uri.UnknownAuthority;
 import alluxio.uri.ZookeeperAuthority;
 import alluxio.uri.ZookeeperLogicalAuthority;
-import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.conf.Configuration;
@@ -165,6 +164,6 @@ public class FileSystem extends AbstractFileSystem {
 
   @Override
   protected Path getFsPath(String fsUriHeader, URIStatus fileStatus) {
-    return new Path(PathUtils.concatPath(fsUriHeader, fileStatus.getPath()));
+    return new Path(fsUriHeader + fileStatus.getPath());
   }
 }

--- a/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
@@ -22,6 +22,7 @@ import alluxio.uri.SingleMasterAuthority;
 import alluxio.uri.UnknownAuthority;
 import alluxio.uri.ZookeeperAuthority;
 import alluxio.uri.ZookeeperLogicalAuthority;
+import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.conf.Configuration;
@@ -164,6 +165,6 @@ public class FileSystem extends AbstractFileSystem {
 
   @Override
   protected Path getFsPath(String fsUriHeader, URIStatus fileStatus) {
-    return new Path(fsUriHeader + fileStatus.getPath());
+    return new Path(PathUtils.concatPath(fsUriHeader, fileStatus.getPath()));
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -50,9 +50,7 @@ import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.ListOptions;
-import alluxio.util.CommonUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
-import alluxio.util.io.PathUtils;
 import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerNetAddress;
 import alluxio.worker.AbstractWorker;
@@ -346,14 +344,13 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
    * @return a FileInfo
    */
   public alluxio.grpc.FileInfo buildFileInfoFromUfsStatus(UfsStatus status, String ufsFullPath) {
-    String path = CommonUtils.stripPrefixIfPresent(status.getName(), mRootUFS.toString());
-    AlluxioURI ufsUri = new AlluxioURI(PathUtils.concatPath(mRootUFS, path));
+    AlluxioURI ufsUri = new AlluxioURI(ufsFullPath);
     String filename = ufsUri.getName();
 
     alluxio.grpc.FileInfo.Builder infoBuilder = alluxio.grpc.FileInfo.newBuilder()
         .setFileId(ufsFullPath.hashCode())
         .setName(filename)
-        .setPath(ufsUri.toString())
+        .setPath(ufsUri.getPath())
         .setUfsPath(ufsUri.toString())
         .setMode(status.getMode())
         .setFolder(status.isDirectory())

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -29,6 +29,8 @@ import alluxio.grpc.ReadResponse;
 import alluxio.grpc.ReadResponseMarshaller;
 import alluxio.underfs.UfsStatus;
 import alluxio.underfs.options.ListOptions;
+import alluxio.util.CommonUtils;
+import alluxio.util.io.PathUtils;
 import alluxio.worker.dora.DoraWorker;
 import alluxio.worker.dora.PagedDoraWorker;
 
@@ -134,7 +136,9 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
 
       for (int i = 0; i < statuses.length; i++) {
         UfsStatus status = statuses[i];
-        String ufsFullPath = status.getName();
+        String ufsFullPath = PathUtils.concatPath(request.getPath(),
+            CommonUtils.stripPrefixIfPresent(status.getName(), request.getPath()));
+
         alluxio.grpc.FileInfo fi =
             ((PagedDoraWorker) mWorker).buildFileInfoFromUfsStatus(status, ufsFullPath);
 

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -29,7 +29,6 @@ import alluxio.grpc.ReadResponse;
 import alluxio.grpc.ReadResponseMarshaller;
 import alluxio.underfs.UfsStatus;
 import alluxio.underfs.options.ListOptions;
-import alluxio.util.CommonUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.worker.dora.DoraWorker;
 import alluxio.worker.dora.PagedDoraWorker;
@@ -136,8 +135,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
 
       for (int i = 0; i < statuses.length; i++) {
         UfsStatus status = statuses[i];
-        String ufsFullPath = PathUtils.concatPath(request.getPath(),
-            CommonUtils.stripPrefixIfPresent(status.getName(), request.getPath()));
+        String ufsFullPath = PathUtils.concatPath(request.getPath(), status.getName());
 
         alluxio.grpc.FileInfo fi =
             ((PagedDoraWorker) mWorker).buildFileInfoFromUfsStatus(status, ufsFullPath);


### PR DESCRIPTION
### What changes are proposed in this pull request?

Construct correct path for URIStatus from UFSStatus.

### Why are the changes needed?

When user issues listStatus(path), the returned result from UFS is relative path from the requested path.
We need to concat the result path after the requested path.

### Does this PR introduce any user facing changes?

N/A
