### PR TITLE
Fix the bug that the listStatus method returns the incorrect paths

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/FileSystem.java
@@ -22,6 +22,7 @@ import alluxio.uri.SingleMasterAuthority;
 import alluxio.uri.UnknownAuthority;
 import alluxio.uri.ZookeeperAuthority;
 import alluxio.uri.ZookeeperLogicalAuthority;
+import alluxio.util.io.PathUtils;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.conf.Configuration;
@@ -164,6 +165,7 @@ public class FileSystem extends AbstractFileSystem {
 
   @Override
   protected Path getFsPath(String fsUriHeader, URIStatus fileStatus) {
-    return new Path(fsUriHeader + fileStatus.getPath());
+    String fsPath = PathUtils.concatPath(fsUriHeader, fileStatus.getPath());
+    return new Path(fsPath);
   }
 }

--- a/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -346,14 +346,14 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
    * @return a FileInfo
    */
   public alluxio.grpc.FileInfo buildFileInfoFromUfsStatus(UfsStatus status, String ufsFullPath) {
-    String path = CommonUtils.stripPrefixIfPresent(status.getName(), mRootUFS.toString());
-    AlluxioURI ufsUri = new AlluxioURI(PathUtils.concatPath(mRootUFS, path));
+    String relativePath = CommonUtils.stripPrefixIfPresent(ufsFullPath, mRootUFS);
+    AlluxioURI ufsUri = new AlluxioURI(PathUtils.concatPath(mRootUFS, relativePath));
     String filename = ufsUri.getName();
 
     alluxio.grpc.FileInfo.Builder infoBuilder = alluxio.grpc.FileInfo.newBuilder()
         .setFileId(ufsFullPath.hashCode())
         .setName(filename)
-        .setPath(ufsUri.toString())
+        .setPath(relativePath)
         .setUfsPath(ufsUri.toString())
         .setMode(status.getMode())
         .setFolder(status.isDirectory())

--- a/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
+++ b/core/server/worker/src/main/java/alluxio/worker/grpc/DoraWorkerClientServiceHandler.java
@@ -29,6 +29,7 @@ import alluxio.grpc.ReadResponse;
 import alluxio.grpc.ReadResponseMarshaller;
 import alluxio.underfs.UfsStatus;
 import alluxio.underfs.options.ListOptions;
+import alluxio.util.io.PathUtils;
 import alluxio.worker.dora.DoraWorker;
 import alluxio.worker.dora.PagedDoraWorker;
 
@@ -134,7 +135,7 @@ public class DoraWorkerClientServiceHandler extends BlockWorkerGrpc.BlockWorkerI
 
       for (int i = 0; i < statuses.length; i++) {
         UfsStatus status = statuses[i];
-        String ufsFullPath = status.getName();
+        String ufsFullPath = PathUtils.concatPath(request.getPath(), status.getName());
         alluxio.grpc.FileInfo fi =
             ((PagedDoraWorker) mWorker).buildFileInfoFromUfsStatus(status, ufsFullPath);
 


### PR DESCRIPTION
The original implementation returns the incorrect path as it cuts the middle path.