### PR TITLE
Implement the getBlockLocations  to mock the block info for Presto

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/dora/DoraCacheClient.java
@@ -152,7 +152,7 @@ public class DoraCacheClient {
     }
   }
 
-  private WorkerNetAddress getWorkerNetAddress(String path) {
+  public WorkerNetAddress getWorkerNetAddress(String path) {
     List<BlockWorkerInfo> workers = null;
     try {
       workers = mContext.getCachedWorkers();


### PR DESCRIPTION
As Presto requires the Block Information based on a specific file path by default, we need to implement the getBlockLocations  to mock the block info for Presto. Otherwise, Presto will throw exception when querying.