### PR TITLE
Add relocation for guice avoiding dependency conflict with Presto

### DIFF
--- a/shaded/client/pom.xml
+++ b/shaded/client/pom.xml
@@ -251,6 +251,10 @@
                   </excludes>
                 </relocation>
                 <relocation>
+                  <pattern>com/google/inject/</pattern>
+                  <shadedPattern>${shading.prefix}.com.google.inject.</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>io/</pattern>
                   <shadedPattern>${shading.prefix}.io.</shadedPattern>
                   <excludes>
@@ -267,6 +271,10 @@
                   <excludes>
                     <exclude>**/pom.xml</exclude>
                   </excludes>
+                </relocation>
+                <relocation>
+                  <pattern>javax/inject/</pattern>
+                  <shadedPattern>${shading.prefix}.javax.inject.</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org/</pattern>


### PR DESCRIPTION
Both Presto and Alluxio use guice for dependency injection, and the versions of guice may be different in Presto and Alluxio. Therefore, we add relocation for guice avoiding dependency conflict with Presto. 