### PR TITLE
Add a metric for the number of running scheduler job commands

### DIFF
--- a/core/common/src/main/java/alluxio/metrics/MetricKey.java
+++ b/core/common/src/main/java/alluxio/metrics/MetricKey.java
@@ -994,6 +994,11 @@ public final class MetricKey implements Comparable<MetricKey> {
           .setDescription("The number of failed Load commands")
           .setMetricType(MetricType.COUNTER)
           .build();
+  public static final MetricKey MASTER_JOB_SCHEDULER_RUNNING_COUNT =
+      new Builder("Master.JobSchedulerRunningCount")
+          .setDescription("The number of running scheduler job commands")
+          .setMetricType(MetricType.GAUGE)
+          .build();
   public static final MetricKey MASTER_JOB_LOAD_BLOCK_COUNT =
       new Builder("Master.JobLoadBlockCount")
           .setDescription("The number of blocks loaded by load commands")

--- a/core/server/master/src/main/java/alluxio/master/scheduler/Scheduler.java
+++ b/core/server/master/src/main/java/alluxio/master/scheduler/Scheduler.java
@@ -24,6 +24,8 @@ import alluxio.exception.runtime.ResourceExhaustedRuntimeException;
 import alluxio.exception.runtime.UnavailableRuntimeException;
 import alluxio.grpc.JobProgressReportFormat;
 import alluxio.job.JobDescription;
+import alluxio.metrics.MetricKey;
+import alluxio.metrics.MetricsSystem;
 import alluxio.resource.CloseableResource;
 import alluxio.scheduler.job.Job;
 import alluxio.scheduler.job.JobMetaStore;
@@ -87,6 +89,8 @@ public final class Scheduler {
   public Scheduler(WorkerProvider workerProvider, JobMetaStore jobMetaStore) {
     mWorkerProvider = workerProvider;
     mJobMetaStore = jobMetaStore;
+    MetricsSystem.registerCachedGaugeIfAbsent(
+        MetricKey.MASTER_JOB_SCHEDULER_RUNNING_COUNT.getName(), mRunningTasks::size);
   }
 
   /**


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add a metric to measure the number of running scheduler job commands.

### Why are the changes needed?

To measure the number of running scheduler commands, which can be used in the distributed copy or load.

### Does this PR introduce any user facing changes?

No.

