### PR TITLE
Remove k8s from build tarball script in Dora

### DIFF
--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/common.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/common.go
@@ -43,9 +43,8 @@ var hadoopDistributions = map[string]version{
 }
 
 type GenerateTarballOpts struct {
-	SkipUI   bool
-	SkipHelm bool
-	Fuse     bool
+	SkipUI bool
+	Fuse   bool
 }
 
 type module struct {

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-fuse-tarball.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-fuse-tarball.go
@@ -31,9 +31,8 @@ func Fuse(args []string) error {
 		return err
 	}
 	if err := generateTarball(&GenerateTarballOpts{
-		SkipUI:   false,
-		SkipHelm: false,
-		Fuse:     true,
+		SkipUI: false,
+		Fuse:   true,
 	}); err != nil {
 		return err
 	}

--- a/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-release-tarballs.go
+++ b/dev/scripts/src/alluxio.org/build-distribution/cmd/generate-release-tarballs.go
@@ -40,9 +40,8 @@ func generateTarballs() error {
 	fmt.Printf("Generating tarball %v\n", fmt.Sprintf("alluxio-%v-bin.tar.gz", versionMarker))
 	// Do not skip UI and Helm
 	if err := generateTarball(&GenerateTarballOpts{
-		SkipUI:   false,
-		SkipHelm: false,
-		Fuse:     false,
+		SkipUI: false,
+		Fuse:   false,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Remove k8s-related code from build tarball script. It breaks the build process.