### PR TITLE
Handle FileNotFound exception and retry getStatus() instead

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/DoraCacheFileSystem.java
@@ -94,7 +94,7 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
       return mDoraClient.getStatus(ufsFullPath.toString(), mergedOptions);
     } catch (RuntimeException ex) {
       if (ex instanceof StatusRuntimeException) {
-        if (((StatusRuntimeException) ex).getStatus().equals(Status.NOT_FOUND)) {
+        if (((StatusRuntimeException) ex).getStatus().getCode() == Status.NOT_FOUND.getCode()) {
           throw new FileNotFoundException();
         }
       }
@@ -184,7 +184,7 @@ public class DoraCacheFileSystem extends DelegatingFileSystem {
       return mDoraClient.listStatus(ufsFullPath.toString(), options);
     } catch (RuntimeException ex) {
       if (ex instanceof StatusRuntimeException) {
-        if (((StatusRuntimeException) ex).getStatus().equals(Status.NOT_FOUND)) {
+        if (((StatusRuntimeException) ex).getStatus().getCode() == Status.NOT_FOUND.getCode()) {
           return Collections.emptyList();
         }
       }

--- a/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -68,6 +68,7 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
@@ -248,6 +249,20 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
     if (statuses == null) {
       // Not found in cache. Query the Under File System.
       statuses = mUfs.listStatus(path, options);
+
+      if (statuses == null) {
+        // If empty, the request path might be a regular file/object. Let's retry getStatus().
+        try {
+          UfsStatus status = mUfs.getStatus(path);
+          // listStatus() expects relative name to the @path.
+          status.setName("");
+          statuses = new UfsStatus[1];
+          statuses[0] = status;
+        } catch (FileNotFoundException e) {
+          statuses = null;
+        }
+      }
+
       // Add this into cache. Return value might be null if not found.
       if (statuses != null) {
         mListStatusCache.put(path, statuses);


### PR DESCRIPTION
### What changes are proposed in this pull request?

If listStatus() return empty result, maybe the request path is a file, not a dir.
So try getStatus() for this file.

### Why are the changes needed?

listStatus() should work for both directory and file. This is the default behavior for most of the UFS, such as HDFS and S3.

### Does this PR introduce any user facing changes?
N/A
