### PR TITLE
Fix relative path if mounted like s3://<BUCKET>/<DIR>

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/ufs/UfsBaseFileSystem.java
@@ -56,6 +56,7 @@ import alluxio.underfs.options.DeleteOptions;
 import alluxio.underfs.options.ListOptions;
 import alluxio.underfs.options.MkdirsOptions;
 import alluxio.underfs.options.OpenOptions;
+import alluxio.util.CommonUtils;
 import alluxio.util.ModeUtils;
 import alluxio.util.io.PathUtils;
 import alluxio.wire.BlockLocationInfo;
@@ -440,9 +441,14 @@ public class UfsBaseFileSystem implements FileSystem {
    */
   private URIStatus transformStatus(UfsStatus ufsStatus, String ufsFullPath) {
     AlluxioURI ufsUri = new AlluxioURI(ufsFullPath);
+    String relativePath = CommonUtils.stripPrefixIfPresent(ufsFullPath, mRootUFS.toString());
+    if (!relativePath.startsWith(AlluxioURI.SEPARATOR)) {
+      relativePath = AlluxioURI.SEPARATOR + relativePath;
+    }
+
     FileInfo info = new FileInfo().setName(ufsUri.getName())
-        .setPath(ufsUri.getPath())
-        .setUfsPath(ufsUri.toString())
+        .setPath(relativePath)
+        .setUfsPath(ufsFullPath)
         .setFileId(ufsUri.toString().hashCode())
         .setFolder(ufsStatus.isDirectory())
         .setOwner(ufsStatus.getOwner())

--- a/core/client/fs/src/test/java/alluxio/client/file/ufs/UfsBaseFileSystemTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/ufs/UfsBaseFileSystemTest.java
@@ -222,7 +222,7 @@ public class UfsBaseFileSystemTest {
     URIStatus status = mFileSystem.getStatus(uri);
     Assert.assertEquals(uri.getName(), status.getName());
     Assert.assertEquals(new AlluxioURI(fileName).getName(), status.getName());
-    Assert.assertEquals(uri.getPath(), status.getPath());
+    Assert.assertEquals(fileName, status.getPath());
     Assert.assertEquals(uri.toString(), status.getUfsPath());
     Assert.assertTrue(status.isCompleted());
     Assert.assertFalse(status.isFolder());
@@ -239,7 +239,7 @@ public class UfsBaseFileSystemTest {
     URIStatus status = mFileSystem.getStatus(uri);
     Assert.assertEquals(uri.getName(), status.getName());
     Assert.assertEquals(new AlluxioURI(fileName).getName(), status.getName());
-    Assert.assertEquals(uri.getPath(), status.getPath());
+    Assert.assertEquals(fileName, status.getPath());
     Assert.assertEquals(uri.toString(), status.getUfsPath());
     Assert.assertTrue(status.isCompleted());
     Assert.assertTrue(status.isFolder());

--- a/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
+++ b/core/server/worker/src/main/java/alluxio/worker/dora/PagedDoraWorker.java
@@ -50,6 +50,7 @@ import alluxio.underfs.UfsStatus;
 import alluxio.underfs.UnderFileSystem;
 import alluxio.underfs.UnderFileSystemConfiguration;
 import alluxio.underfs.options.ListOptions;
+import alluxio.util.CommonUtils;
 import alluxio.util.executor.ExecutorServiceFactories;
 import alluxio.wire.FileInfo;
 import alluxio.wire.WorkerNetAddress;
@@ -376,14 +377,17 @@ public class PagedDoraWorker extends AbstractWorker implements DoraWorker {
    * @return a FileInfo
    */
   public alluxio.grpc.FileInfo buildFileInfoFromUfsStatus(UfsStatus status, String ufsFullPath) {
-    AlluxioURI ufsUri = new AlluxioURI(ufsFullPath);
-    String filename = ufsUri.getName();
+    String filename = new AlluxioURI(ufsFullPath).getName();
+    String relativePath = CommonUtils.stripPrefixIfPresent(ufsFullPath, mRootUFS);
+    if (!relativePath.startsWith(AlluxioURI.SEPARATOR)) {
+      relativePath = AlluxioURI.SEPARATOR + relativePath;
+    }
 
     alluxio.grpc.FileInfo.Builder infoBuilder = alluxio.grpc.FileInfo.newBuilder()
         .setFileId(ufsFullPath.hashCode())
         .setName(filename)
-        .setPath(ufsUri.getPath())
-        .setUfsPath(ufsUri.toString())
+        .setPath(relativePath)
+        .setUfsPath(ufsFullPath)
         .setMode(status.getMode())
         .setFolder(status.isDirectory())
         .setOwner(status.getOwner())


### PR DESCRIPTION
### What changes are proposed in this pull request?

Set the URIStatus.path to a relative path against  `alluxio.master.mount.table.root.ufs`

### Why are the changes needed?

The returned URIStatus from listStatus() and getStatus() needs to be relative to `alluxio.master.mount.table.root.ufs`.
In the original code, we set the relative path to the top level root. That is not the right one if mounted like   `s3://<BUCKET>/<DIR>`

### Does this PR introduce any user facing changes?
N/A
