### PR TITLE
support dynamic refresh impersonation user

### DIFF
--- a/core/common/src/main/java/alluxio/conf/Configuration.java
+++ b/core/common/src/main/java/alluxio/conf/Configuration.java
@@ -13,6 +13,7 @@ package alluxio.conf;
 
 import alluxio.Constants;
 import alluxio.RuntimeConstants;
+import alluxio.collections.Pair;
 import alluxio.conf.path.PathConfiguration;
 import alluxio.exception.status.AlluxioStatusException;
 import alluxio.exception.status.UnauthenticatedException;
@@ -49,6 +50,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
+import javax.annotation.Nullable;
 
 /**
  * <p>
@@ -78,6 +80,7 @@ public final class Configuration
 {
   private static final Logger LOG = LoggerFactory.getLogger(Configuration.class);
 
+  private static final AtomicReference<String> SERVER_CONFIG_PATH = new AtomicReference<>();
   private static final AtomicReference<InstancedConfiguration> SERVER_CONFIG_REFERENCE =
       new AtomicReference<>();
 
@@ -92,6 +95,14 @@ public final class Configuration
    */
   public static AlluxioProperties copyProperties() {
     return SERVER_CONFIG_REFERENCE.get().copyProperties();
+  }
+
+  /**
+   * Get server config path.
+   * @return server config path
+   */
+  public static String serverConfigPath() {
+    return SERVER_CONFIG_PATH.get();
   }
 
   /**
@@ -572,6 +583,16 @@ public final class Configuration
    * Reloads site properties from disk.
    */
   public static void reloadProperties() {
+    Pair<String, InstancedConfiguration> conf = loadProperties();
+    SERVER_CONFIG_PATH.set(conf.getFirst());
+    SERVER_CONFIG_REFERENCE.set(conf.getSecond());
+  }
+
+  /**
+   * Reloads site properties from disk.
+   * @return properties location and config instance
+   */
+  public static Pair<String, InstancedConfiguration> loadProperties() {
     // Bootstrap the configuration. This is necessary because we need to resolve alluxio.home
     // (likely to be in system properties) to locate the conf dir to search for the site
     // property file.
@@ -595,9 +616,8 @@ public final class Configuration
             alluxioProperties.merge(properties.get(), Source.siteProperty(file));
             conf = new InstancedConfiguration(alluxioProperties);
             conf.validate();
-            SERVER_CONFIG_REFERENCE.set(conf);
             // If a site conf is successfully loaded, stop trying different paths.
-            return;
+            return new Pair<>(file, conf);
           }
         } catch (FileNotFoundException e) {
           // skip
@@ -616,7 +636,7 @@ public final class Configuration
             alluxioProperties.merge(properties.get(), Source.siteProperty(resource.getPath()));
             conf = new InstancedConfiguration(alluxioProperties);
             conf.validate();
-            SERVER_CONFIG_REFERENCE.set(conf);
+            return new Pair<>(resource.getPath(), conf);
           }
         } catch (IOException e) {
           LOG.warn("Failed to read properties from {}: {}", resource, e.toString());
@@ -624,7 +644,7 @@ public final class Configuration
       }
     }
     conf.validate();
-    SERVER_CONFIG_REFERENCE.set(conf);
+    return new Pair<>(null, conf);
   }
 
   /**

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -7055,6 +7055,22 @@ public final class PropertyKey implements Comparable<PropertyKey> {
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.ALL)
           .build();
+  public static final PropertyKey SECURITY_DYNAMIC_IMPERSONATION_ENABLED =
+      booleanBuilder(Name.SECURITY_DYNAMIC_IMPERSONATION_ENABLED)
+          .setDefaultValue(false)
+          .setDescription("Whether to dynamically update the proxy user. "
+              + "If true, the proxy user will be automatically updated when the "
+              + "configuration file changes.")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.ALL)
+          .build();
+  public static final PropertyKey SECURITY_DYNAMIC_IMPERSONATION_REFRESH_INTERVAL =
+      durationBuilder(Name.SECURITY_DYNAMIC_IMPERSONATION_REFRESH_INTERVAL)
+          .setDefaultValue("1min")
+          .setDescription("interval for refreshing impersonation users")
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
+          .setScope(Scope.ALL)
+          .build();
   public static final PropertyKey SECURITY_LOGIN_IMPERSONATION_USERNAME =
       stringBuilder(Name.SECURITY_LOGIN_IMPERSONATION_USERNAME)
           .setDescription(format("When %s is set to SIMPLE or CUSTOM, user application uses this "
@@ -8957,6 +8973,10 @@ public final class PropertyKey implements Comparable<PropertyKey> {
         "alluxio.security.group.mapping.cache.timeout";
     public static final String SECURITY_GROUP_MAPPING_CLASS =
         "alluxio.security.group.mapping.class";
+    public static final String SECURITY_DYNAMIC_IMPERSONATION_ENABLED =
+        "alluxio.security.dynamic.impersonation.enabled";
+    public static final String SECURITY_DYNAMIC_IMPERSONATION_REFRESH_INTERVAL =
+        "alluxio.security.dynamic.impersonation.refresh.interval";
     public static final String SECURITY_LOGIN_IMPERSONATION_USERNAME =
         "alluxio.security.login.impersonation.username";
     public static final String SECURITY_LOGIN_USERNAME = "alluxio.security.login.username";

--- a/core/common/src/main/java/alluxio/security/authentication/ImpersonationAuthenticator.java
+++ b/core/common/src/main/java/alluxio/security/authentication/ImpersonationAuthenticator.java
@@ -11,18 +11,28 @@
 
 package alluxio.security.authentication;
 
+import alluxio.Constants;
 import alluxio.RuntimeConstants;
 import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.AlluxioProperties;
+import alluxio.conf.Configuration;
+import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.conf.Source;
+import alluxio.resource.LockResource;
 import alluxio.util.CommonUtils;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Matcher;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.security.sasl.AuthenticationException;
@@ -37,14 +47,16 @@ import javax.security.sasl.AuthenticationException;
  */
 @ThreadSafe
 public final class ImpersonationAuthenticator {
+  private static final Logger LOG = LoggerFactory.getLogger(ImpersonationAuthenticator.class);
   public static final String WILDCARD = "*";
   private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
   // Maps users configured for impersonation to the set of groups which they can impersonate.
-  private final Map<String, Set<String>> mImpersonationGroups;
+  private Map<String, Set<String>> mImpersonationGroups;
   // Maps users configured for impersonation to the set of users which they can impersonate.
-  private final Map<String, Set<String>> mImpersonationUsers;
+  private Map<String, Set<String>> mImpersonationUsers;
 
   private AlluxioConfiguration mConfiguration;
+  private final ReentrantReadWriteLock mLock = new ReentrantReadWriteLock();
 
   /**
    * Constructs a new {@link ImpersonationAuthenticator}.
@@ -55,10 +67,74 @@ public final class ImpersonationAuthenticator {
    * @param conf conf Alluxio configuration
    */
   public ImpersonationAuthenticator(AlluxioConfiguration conf) {
-    mImpersonationGroups = new HashMap<>();
-    mImpersonationUsers = new HashMap<>();
     mConfiguration = conf;
+    loadImpersonationConfig(conf);
+    if (conf.getBoolean(PropertyKey.SECURITY_DYNAMIC_IMPERSONATION_ENABLED)) {
+      if (!(conf instanceof InstancedConfiguration)) {
+        LOG.warn("configuration is not instanced configuration. "
+            + "dynamic impersonation is not supported");
+        return;
+      }
+      startDynamicUpdateThread((InstancedConfiguration) conf);
+    }
+  }
 
+  private void startDynamicUpdateThread(InstancedConfiguration conf) {
+    Thread thread = new Thread(() -> {
+      String filePath = Configuration.serverConfigPath();
+      if (filePath == null) {
+        LOG.info("site property not set, exit the dynamic impersonation updater");
+        return;
+      }
+      File file = new File(filePath);
+      if (!file.exists()) {
+        LOG.info("{} not exists, exit the dynamic impersonation updater", filePath);
+        return;
+      }
+      long lastModified = file.lastModified();
+      while (true) {
+        try {
+          if (file.lastModified() > lastModified) {
+            lastModified = file.lastModified();
+            AlluxioProperties properties =
+                Configuration.loadProperties().getSecond().getProperties();
+            if (properties != null) {
+              for (PropertyKey key : mConfiguration.keySet()) {
+                if (PropertyKey.Template.MASTER_IMPERSONATION_GROUPS_OPTION.matches(key.getName())
+                    || PropertyKey.Template.MASTER_IMPERSONATION_USERS_OPTION
+                    .matches(key.getName())) {
+                  conf.unset(key);
+                }
+              }
+              for (Map.Entry<PropertyKey, Object> entry : properties.entrySet()) {
+                String key = entry.getKey().toString().trim();
+                String value = entry.getValue() == null ? null : entry.getValue().toString().trim();
+                if (value == null) {
+                  continue;
+                }
+                if (PropertyKey.Template.MASTER_IMPERSONATION_GROUPS_OPTION.matches(key)
+                    || PropertyKey.Template.MASTER_IMPERSONATION_USERS_OPTION.matches(key)) {
+                  conf.set(PropertyKey.fromString(key), value, Source.siteProperty(filePath));
+                }
+              }
+              loadImpersonationConfig(mConfiguration);
+              LOG.info("dynamic update impersonation config");
+            }
+          }
+          CommonUtils.sleepMs(
+              conf.getMs(PropertyKey.SECURITY_DYNAMIC_IMPERSONATION_REFRESH_INTERVAL));
+        } catch (Throwable e) {
+          LOG.error("failed to run dynamic impersonation updater", e);
+        }
+      }
+    }, "dynamic-impersonation-updater");
+    thread.setDaemon(true);
+    thread.start();
+  }
+
+  private void loadImpersonationConfig(AlluxioConfiguration conf) {
+    Map<String, Set<String>> impersonationUsers = new HashMap<>();
+    Map<String, Set<String>> impersonationGroups = new HashMap<>();
     for (PropertyKey key : conf.keySet()) {
       // Process impersonation groups
       Matcher matcher =
@@ -67,7 +143,7 @@ public final class ImpersonationAuthenticator {
         String connectionUser = matcher.group(1);
         String value = conf.getOrDefault(key, null);
         if (connectionUser != null) {
-          mImpersonationGroups.put(connectionUser, Sets.newHashSet(SPLITTER.split(value)));
+          impersonationGroups.put(connectionUser, Sets.newHashSet(SPLITTER.split(value)));
         }
       }
 
@@ -77,9 +153,13 @@ public final class ImpersonationAuthenticator {
         String connectionUser = matcher.group(1);
         String value = conf.getOrDefault(key, null);
         if (connectionUser != null) {
-          mImpersonationUsers.put(connectionUser, Sets.newHashSet(SPLITTER.split(value)));
+          impersonationUsers.put(connectionUser, Sets.newHashSet(SPLITTER.split(value)));
         }
       }
+    }
+    try (LockResource ignored = new LockResource(mLock.writeLock())) {
+      mImpersonationUsers = impersonationUsers;
+      mImpersonationGroups = impersonationGroups;
     }
   }
 
@@ -96,8 +176,12 @@ public final class ImpersonationAuthenticator {
       return;
     }
 
-    Set<String> allowedUsers = mImpersonationUsers.get(connectionUser);
-    Set<String> allowedGroups = mImpersonationGroups.get(connectionUser);
+    Set<String> allowedUsers;
+    Set<String> allowedGroups;
+    try (LockResource ignored = new LockResource(mLock.readLock())) {
+      allowedUsers = mImpersonationUsers.get(connectionUser);
+      allowedGroups = mImpersonationGroups.get(connectionUser);
+    }
 
     if (allowedUsers == null && allowedGroups == null) {
       throw new AuthenticationException(String.format(


### PR DESCRIPTION
### What changes are proposed in this pull request?
fix #17295
Automatically refresh the impersonation user configuration when the configuration file `alluxio-site.properties` is modified.

### Why are the changes needed?
support dynamic refresh impersonation user.

### Does this PR introduce any user facing changes?
When alluxio.security.dynamic.impersonation.enabled is set to true, the impersonation user can be dynamically updated if the configuration file changes.
