### PR TITLE
Set Metadata cache TTL to 48 hours

### DIFF
--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -7330,7 +7330,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
 
   public static final PropertyKey DORA_UFS_FILE_STATUS_CACHE_TTL =
       durationBuilder(Name.DORA_UFS_FILE_STATUS_CACHE_TTL)
-          .setDefaultValue("10min")
+          .setDefaultValue("48h")
           .setDescription("The TTL of the cache of UFS file status")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.WARN)
           .setScope(Scope.WORKER)
@@ -7355,7 +7355,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
 
   public static final PropertyKey DORA_UFS_LIST_STATUS_CACHE_TTL =
       durationBuilder(Name.DORA_UFS_LIST_STATUS_CACHE_TTL)
-          .setDefaultValue("2min")
+          .setDefaultValue("48h")
           .setDescription("The TTL of the cache of UFS list status results")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.WORKER)
@@ -7363,7 +7363,7 @@ public final class PropertyKey implements Comparable<PropertyKey> {
 
   public static final PropertyKey DORA_UFS_LIST_STATUS_CACHE_NR_DIRS =
       intBuilder(Name.DORA_UFS_LIST_STATUS_CACHE_NR_DIRS)
-          .setDefaultValue(1)
+          .setDefaultValue(50)
           .setDescription("Number of the file/dir cache of UFS list status results")
           .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
           .setScope(Scope.WORKER)


### PR DESCRIPTION
This will result in longer cache life for metadata. It increases metadata operation performance. This is suitable for read-only use case.

### What changes are proposed in this pull request?

Increase TTL values for metadata cache. Increase to 48 hours. If the metadata is not used in 48 hours, they can be considered not needed in near future.

### Why are the changes needed?

For better performance.

### Does this PR introduce any user facing changes?

N/A
