### PR TITLE
Use dynamic buffering for sequential read in PositionReadFileInStream

### DIFF
--- a/core/client/fs/src/main/java/alluxio/client/file/PositionReadFileInStream.java
+++ b/core/client/fs/src/main/java/alluxio/client/file/PositionReadFileInStream.java
@@ -12,11 +12,15 @@
 package alluxio.client.file;
 
 import alluxio.PositionReader;
-import alluxio.client.file.FileInStream;
 import alluxio.exception.PreconditionMessage;
+import alluxio.network.protocol.databuffer.PooledDirectNioByteBuf;
 
 import com.amazonaws.annotation.NotThreadSafe;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.EvictingQueue;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -31,6 +35,120 @@ public class PositionReadFileInStream extends FileInStream {
   private long mPos = 0;
   private boolean mClosed;
   private final PositionReader mPositionReader;
+  private final PrefetchCache mCache;
+
+  private static class PrefetchCache implements AutoCloseable {
+    private static final int MAX_PREFETCH_MULTIPLIER = 16;
+    private final long mFileLength;
+    private final EvictingQueue<CallTrace> mCallHistory =
+        EvictingQueue.create(MAX_PREFETCH_MULTIPLIER);
+    private int mPrefetchSize = 0;
+
+    private ByteBuf mCache = Unpooled.wrappedBuffer(new byte[0]);
+    private long mCacheStartPos = 0;
+
+    PrefetchCache(long fileLength) {
+      mFileLength = fileLength;
+    }
+
+    private void update() {
+      int consecutiveReadLength = 0;
+      long lastReadEnd = -1;
+      for (CallTrace trace : mCallHistory) {
+        if (trace.mPosition == lastReadEnd) {
+          lastReadEnd += trace.mLength;
+          consecutiveReadLength += trace.mLength;
+        } else {
+          lastReadEnd = trace.mPosition + trace.mLength;
+          consecutiveReadLength = trace.mLength;
+        }
+      }
+      mPrefetchSize = consecutiveReadLength;
+    }
+
+    private void addTrace(long pos, int size) {
+      mCallHistory.add(new CallTrace(pos, size));
+      update();
+    }
+
+    /**
+     * Fills the output with bytes from the prefetch cache.
+     *
+     * @param targetStartPos the position within the file to read from
+     * @param outBuffer output buffer
+     * @return number of bytes copied from the cache, 0 if the cache does not contain the requested
+     *         range of data
+     */
+    private int fillWithCache(long targetStartPos, ByteBuffer outBuffer) {
+      if (mCacheStartPos <= targetStartPos) {
+        if (targetStartPos - mCacheStartPos < mCache.readableBytes()) {
+          final int posInCache = (int) (targetStartPos - mCacheStartPos);
+          final int size = Math.min(outBuffer.remaining(), mCache.readableBytes() - posInCache);
+          ByteBuffer slice = outBuffer.slice();
+          slice.limit(size);
+          mCache.getBytes(posInCache, slice);
+          outBuffer.position(outBuffer.position() + size);
+          return size;
+        } else {
+          // the position is beyond the cache end position
+          return 0;
+        }
+      } else {
+        // the position is behind the cache start position
+        return 0;
+      }
+    }
+
+    /**
+     * Prefetches and caches data from the reader.
+     *
+     * @param reader reader
+     * @param pos position within the file
+     * @param minBytesToRead minimum number of bytes to read from the reader
+     * @return number of bytes that's been prefetched, 0 if exception occurs
+     */
+    private int prefetch(PositionReader reader, long pos, int minBytesToRead) {
+      int prefetchSize = Math.max(mPrefetchSize, minBytesToRead);
+      // cap to remaining file length
+      prefetchSize = (int) Math.min(mFileLength - pos, prefetchSize);
+
+      if (mCache.capacity() < prefetchSize) {
+        mCache.release();
+        mCache = PooledDirectNioByteBuf.allocate(prefetchSize);
+        mCacheStartPos = 0;
+      }
+      mCache.clear();
+      try {
+        int bytesPrefetched = reader.read(pos, mCache, prefetchSize);
+        if (bytesPrefetched > 0) {
+          mCache.readerIndex(0).writerIndex(bytesPrefetched);
+          mCacheStartPos = pos;
+        }
+        return bytesPrefetched;
+      } catch (IOException ignored) {
+        // silence exceptions as we don't care if prefetch fails
+        mCache.clear();
+        return 0;
+      }
+    }
+
+    @Override
+    public void close() {
+      mCache.release();
+      mCache = Unpooled.wrappedBuffer(new byte[0]);
+      mCacheStartPos = 0;
+    }
+  }
+
+  private static class CallTrace {
+    final long mPosition;
+    final int mLength;
+
+    private CallTrace(long pos, int length) {
+      mPosition = pos;
+      mLength = length;
+    }
+  }
 
   /**
    * Constructor.
@@ -41,11 +159,27 @@ public class PositionReadFileInStream extends FileInStream {
       long length) {
     mPositionReader = reader;
     mLength = length;
+    mCache = new PrefetchCache(mLength);
   }
 
   @Override
   public long remaining() {
     return mLength - mPos;
+  }
+
+  @VisibleForTesting
+  int getBufferedLength() {
+    return mCache.mCache.readableBytes();
+  }
+
+  @VisibleForTesting
+  long getBufferedPosition() {
+    return mCache.mCacheStartPos;
+  }
+
+  @VisibleForTesting
+  int getPrefetchSize() {
+    return mCache.mPrefetchSize;
   }
 
   @Override
@@ -56,18 +190,76 @@ public class PositionReadFileInStream extends FileInStream {
 
   @Override
   public int read(ByteBuffer byteBuffer, int off, int len) throws IOException {
-    int bytesRead = mPositionReader.read(mPos, byteBuffer, len);
-    if (bytesRead <= 0) {
-      return bytesRead;
+    byteBuffer.position(off).limit(off + len);
+    mCache.addTrace(mPos, len);
+    int totalBytesRead = 0;
+    int bytesReadFromCache = mCache.fillWithCache(mPos, byteBuffer);
+    totalBytesRead += bytesReadFromCache;
+    mPos += bytesReadFromCache;
+    if (!byteBuffer.hasRemaining()) {
+      return totalBytesRead;
     }
+    int bytesPrefetched = mCache.prefetch(mPositionReader, mPos, byteBuffer.remaining());
+    if (bytesPrefetched < 0) {
+      if (totalBytesRead == 0) {
+        return -1;
+      }
+      return totalBytesRead;
+    }
+    bytesReadFromCache = mCache.fillWithCache(mPos, byteBuffer);
+    totalBytesRead += bytesReadFromCache;
+    mPos += bytesReadFromCache;
+    if (!byteBuffer.hasRemaining()) {
+      return totalBytesRead;
+    }
+    int bytesRead = mPositionReader.read(mPos, byteBuffer, byteBuffer.remaining());
+    if (bytesRead < 0) {
+      if (totalBytesRead == 0) {
+        return -1;
+      }
+      return totalBytesRead;
+    }
+    totalBytesRead += bytesRead;
     mPos += bytesRead;
-    return bytesRead;
+    return totalBytesRead;
   }
 
   @Override
-  public int positionedRead(long position, byte[] buffer, int offset, int length)
+  public int positionedRead(long position, byte[] buffer, int offset, int len)
       throws IOException {
-    return mPositionReader.read(position, buffer, offset, length);
+    long pos = position;
+    ByteBuffer byteBuffer = ByteBuffer.wrap(buffer, offset, len);
+    mCache.addTrace(position, len);
+    int totalBytesRead = 0;
+    int bytesReadFromCache = mCache.fillWithCache(pos, byteBuffer);
+    totalBytesRead += bytesReadFromCache;
+    pos += bytesReadFromCache;
+    if (!byteBuffer.hasRemaining()) {
+      return totalBytesRead;
+    }
+    int bytesPrefetched = mCache.prefetch(mPositionReader, pos, byteBuffer.remaining());
+    if (bytesPrefetched < 0) {
+      if (totalBytesRead == 0) {
+        return -1;
+      }
+      return totalBytesRead;
+    }
+    bytesReadFromCache = mCache.fillWithCache(pos, byteBuffer);
+    totalBytesRead += bytesReadFromCache;
+    pos += bytesReadFromCache;
+    if (!byteBuffer.hasRemaining()) {
+      return totalBytesRead;
+    }
+    int bytesRead = mPositionReader.read(pos, byteBuffer, byteBuffer.remaining());
+    if (bytesRead < 0) {
+      if (totalBytesRead == 0) {
+        return -1;
+      }
+      return totalBytesRead;
+    }
+    totalBytesRead += bytesRead;
+    pos += bytesRead;
+    return totalBytesRead;
   }
 
   @Override
@@ -105,5 +297,6 @@ public class PositionReadFileInStream extends FileInStream {
     }
     mClosed = true;
     mPositionReader.close();
+    mCache.close();
   }
 }

--- a/core/client/fs/src/test/java/alluxio/client/file/PositionReadFileInStreamTest.java
+++ b/core/client/fs/src/test/java/alluxio/client/file/PositionReadFileInStreamTest.java
@@ -1,0 +1,166 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio.client.file;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import alluxio.ByteArrayPositionReader;
+import alluxio.Constants;
+import alluxio.PositionReader;
+import alluxio.collections.Pair;
+import alluxio.file.ReadTargetBuffer;
+import alluxio.util.io.BufferUtils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+@RunWith(Parameterized.class)
+public class PositionReadFileInStreamTest {
+  private final PositionReader mPositionReader;
+  private final byte[] mBuffer;
+  private final int mDataLength;
+  private final int mBufferSize;
+
+  @Parameterized.Parameters(name = "{index}_DL_{0}_BS_{1}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        /* data length,       buffer size */
+        { Constants.KB,       63 },
+        { Constants.KB,       64 },
+        { Constants.KB,       65 },
+        { Constants.KB,       Constants.KB - 1 },
+        { Constants.KB,       Constants.KB },
+        { Constants.MB * 10,  Constants.KB * 10 },
+        { Constants.MB * 10,  Constants.KB * 10 - 1},
+        { Constants.MB * 10,  Constants.KB * 10 + 1},
+    });
+  }
+
+  public PositionReadFileInStreamTest(int dataLength, int bufferSize) {
+    mDataLength = dataLength;
+    mBufferSize = bufferSize;
+    mPositionReader = new ByteArrayPositionReader(BufferUtils.getIncreasingByteArray(dataLength));
+    mBuffer = new byte[bufferSize];
+  }
+
+  @Test
+  public void sequentialReadWithIdenticalBufferSize() throws Exception {
+    testSequentialRead(1.0);
+  }
+
+  @Test
+  public void sequentialReadWithRandomBufferSizes() throws Exception {
+    testSequentialRead(0.5);
+  }
+
+  private void testSequentialRead(double smallBufProb) throws Exception {
+    PositionReader spy = Mockito.spy(mPositionReader);
+    PositionReadFileInStream stream = new PositionReadFileInStream(spy, mDataLength);
+    int readLength;
+    int totalBytesRead = 0;
+    int bytesRead;
+    int numUnbufferedCalls = 0;
+    for (Pair<Integer, Integer> pair :
+        generateReadSequence(1.0, smallBufProb, mDataLength, mBufferSize)) {
+      readLength = pair.getSecond();
+      if (stream.getBufferedPosition() + stream.getBufferedLength()
+          < stream.getPos() + readLength) {
+        numUnbufferedCalls += 1;
+      }
+      bytesRead = stream.read(mBuffer, 0, readLength);
+      assertEquals(bytesRead, readLength);
+      totalBytesRead += bytesRead;
+      assertTrue(BufferUtils.equalIncreasingByteBuffer(
+          totalBytesRead - bytesRead, bytesRead, ByteBuffer.wrap(mBuffer, 0, bytesRead)));
+      verify(spy, times(numUnbufferedCalls)
+          .description("position: " + stream.getPos() + ", length: " + readLength))
+          .readInternal(anyLong(), any(ReadTargetBuffer.class), anyInt());
+    }
+  }
+
+  @Test
+  public void positionedReadWithRandomBufferSize() throws Exception {
+    PositionReader spy = Mockito.spy(mPositionReader);
+    PositionReadFileInStream stream = new PositionReadFileInStream(spy, mDataLength);
+    int readLength;
+    int bytesRead;
+    int numUnbufferedCalls = 0;
+    int position;
+    for (Pair<Integer, Integer> pair :
+        generateReadSequence(0.7, 0.0, mDataLength, mBufferSize)) {
+      position = pair.getFirst();
+      readLength = pair.getSecond();
+      if (stream.getBufferedPosition() + stream.getBufferedLength() < position + readLength) {
+        numUnbufferedCalls += 1;
+      }
+      bytesRead = stream.positionedRead(position, mBuffer, 0, readLength);
+      assertEquals(bytesRead, readLength);
+      assertTrue(BufferUtils.equalIncreasingByteBuffer(
+          position, bytesRead, ByteBuffer.wrap(mBuffer, 0, bytesRead)));
+      verify(spy, times(numUnbufferedCalls)
+          .description("position: " + position + ", length: " + readLength))
+          .readInternal(anyLong(), any(ReadTargetBuffer.class), anyInt());
+    }
+  }
+
+  /**
+   * Generates a sequence of read positions and length.
+   *
+   * @param continuousProb probability of each read operation starts from the end position of
+   *                       the last operation. If 1.0, then the whole read will be sequential
+   * @param fixedBufferProb probability that the read size is equal to the buffer size. If 1.0,
+   *                        then every read is made with the same buffer size
+   * @param fileLength the total length of the file being read
+   * @param bufferSize the size of the buffer for one read
+   * @return a sequence of pairs of (position, length)
+   */
+  private List<Pair<Integer, Integer>> generateReadSequence(
+      double continuousProb, double fixedBufferProb, int fileLength, int bufferSize) {
+    final int randSeed = 0xdeadd00d;
+    Random rng = new Random(randSeed);
+    List<Pair<Integer, Integer>> sequence = new ArrayList<>();
+    int lastPosition = 0;
+    int position;
+    int size;
+    while (lastPosition < fileLength) {
+      if (rng.nextDouble() <= continuousProb) {
+        position = lastPosition;
+      } else {
+        position = lastPosition + rng.nextInt(fileLength - lastPosition + 1);
+      }
+      if (rng.nextDouble() <= fixedBufferProb) {
+        size = bufferSize;
+      } else {
+        size = rng.nextInt(bufferSize + 1);
+      }
+      size = Math.min(size, fileLength - position);
+      lastPosition = position + size;
+      Pair<Integer, Integer> pair = new Pair<>(position, size);
+      sequence.add(pair);
+    }
+    return sequence;
+  }
+}

--- a/core/common/src/main/java/alluxio/conf/PropertyKey.java
+++ b/core/common/src/main/java/alluxio/conf/PropertyKey.java
@@ -5983,6 +5983,17 @@ public final class PropertyKey implements Comparable<PropertyKey> {
               + "aggregated, so different applications must set their own ids or leave this value "
               + "unset to use a randomly generated id.")
           .build();
+  public static final PropertyKey USER_POSITION_READER_STREAMING_MULTIPLIER =
+      intBuilder(Name.USER_POSITION_READER_STREAMING_MULTIPLIER)
+          .setScope(Scope.CLIENT)
+          .setDefaultValue(16)
+          .setDescription("The size of the sliding window of historic read calls that will be "
+              + "used to determine the size of dynamic buffering. Larger window allows more "
+              + "aggressive prefetching, but uses more memory and suffers a greater loss if the "
+              + "buffered data ends up being unused.")
+          .setIsHidden(true)
+          .setConsistencyCheckLevel(ConsistencyCheckLevel.IGNORE)
+          .build();
   public static final PropertyKey USER_SKIP_AUTHORITY_CHECK =
       booleanBuilder(Name.USER_SKIP_AUTHORITY_CHECK)
           .setScope(Scope.CLIENT)
@@ -8564,6 +8575,8 @@ public final class PropertyKey implements Comparable<PropertyKey> {
     public static final String USER_METRICS_HEARTBEAT_INTERVAL_MS =
         "alluxio.user.metrics.heartbeat.interval";
     public static final String USER_APP_ID = "alluxio.user.app.id";
+    public static final String USER_POSITION_READER_STREAMING_MULTIPLIER =
+        "alluxio.user.position.reader.streaming.multiplier";
     public static final String USER_NETWORK_DATA_TIMEOUT =
         "alluxio.user.network.data.timeout";
     public static final String USER_NETWORK_READER_BUFFER_SIZE_MESSAGES =

--- a/core/common/src/test/java/alluxio/ByteArrayPositionReader.java
+++ b/core/common/src/test/java/alluxio/ByteArrayPositionReader.java
@@ -1,0 +1,55 @@
+/*
+ * The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+ * (the "License"). You may not use this work except in compliance with the License, which is
+ * available at www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied, as more fully set forth in the License.
+ *
+ * See the NOTICE file distributed with this work for information regarding copyright ownership.
+ */
+
+package alluxio;
+
+import alluxio.file.ReadTargetBuffer;
+
+import com.google.common.base.Preconditions;
+
+import java.io.IOException;
+
+/**
+ * Test position reader that reads data from a byte array.
+ */
+public class ByteArrayPositionReader implements PositionReader {
+  private final byte[] mData;
+
+  /**
+   * Creates a new reader from the byte array.
+   *
+   * @param data data
+   */
+  public ByteArrayPositionReader(byte[] data) {
+    mData = data;
+  }
+
+  @Override
+  public int readInternal(long position, ReadTargetBuffer buffer, int length) throws IOException {
+    Preconditions.checkArgument(length >= 0, "negative length: %s", length);
+    if (position > mData.length) {
+      throw new ArrayIndexOutOfBoundsException("Index: " + position + ", length: " + mData.length);
+    }
+    if (length == 0) {
+      return 0;
+    }
+    if (position == mData.length) {
+      return -1;
+    }
+    buffer.writeBytes(mData, (int) position, length);
+    return length;
+  }
+
+  @Override
+  public void close() throws IOException {
+    // do nothing
+  }
+}


### PR DESCRIPTION
### What changes are proposed in this pull request?

Use dynamic buffering for sequential read.

### Why are the changes needed?

It's hard to assume the consumer of a seekable, positioned readable input stream will be doing sequential reads. If the consumer randomly reads from different positions, then it would be pointless to do aggressive buffering since it would only cause read amplification and wastes time and bandwith.

Otherwise, if the read sequence is consecutive, then it can benefit from prefetching and buffering.

The idea of this PR is to first observe the read sequence, calculate the length of consecutive reads, and based on that, tries to prefetch data from the underlying reader. It keeps a sliding window of recent read calls, and use the sum of the consecutive read lengths in the window as the size of the prefetch.

With dynamic buffering, the prefetch size will gradually grow bigger if the sequence stays consecutive. It will be reset to 0 if any non-sequential read occurs.

### Does this PR introduce any user facing changes?

No.
