### PR TITLE
Fix infinite recursion with RefCountedNioByteBuf.setBytes

### DIFF
--- a/core/common/src/main/java/alluxio/network/protocol/databuffer/RefCountedNioByteBuf.java
+++ b/core/common/src/main/java/alluxio/network/protocol/databuffer/RefCountedNioByteBuf.java
@@ -281,7 +281,9 @@ abstract class RefCountedNioByteBuf extends AbstractReferenceCountedByteBuf {
   @Override
   public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
     ensureIndexInBounds(srcIndex, src.capacity(), index, capacity(), length);
-    src.getBytes(srcIndex, this, index, length);
+    ByteBuffer dup = mDelegate.duplicate();
+    dup.position(index).limit(index + length);
+    src.getBytes(srcIndex, dup);
     return this;
   }
 

--- a/core/common/src/test/java/alluxio/network/protocol/databuffer/RefCountedNioByteBufTest.java
+++ b/core/common/src/test/java/alluxio/network/protocol/databuffer/RefCountedNioByteBufTest.java
@@ -12,10 +12,13 @@
 package alluxio.network.protocol.databuffer;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import alluxio.Constants;
+import alluxio.util.io.BufferUtils;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -54,6 +57,18 @@ public class RefCountedNioByteBufTest {
       ByteBuf buf = new LeakyByteBuf(ByteBuffer.allocate(8), 8, 8);
       assertThrows(IllegalArgumentException.class,
           () -> buf.capacity(10));
+    }
+
+    @Test
+    public void setBytesWithAnotherByteBuf() {
+      ByteBuf srcBuf = Unpooled.directBuffer(100);
+      srcBuf.setBytes(0, BufferUtils.getIncreasingByteArray(100));
+      ByteBuf dstBuf = new LeakyByteBuf(ByteBuffer.allocateDirect(100), 100, 100);
+      final int offset = 42;
+      final int length = 17;
+      dstBuf.setBytes(0, srcBuf, offset, length);
+      assertTrue(BufferUtils.equalIncreasingByteBuffer(
+          offset, length, dstBuf.slice(0, length).nioBuffer()));
     }
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Fix an infinite recursion with `RefCountedNioByteBuf.setBytes` which causes stack overflow error.

### Why are the changes needed?

The current implementation of `RefCountedNioByteBuf.setBytes(int index, ByteBuf src, int srcIndex, int length)` delegates the copying of bytes to the `getBytes(int index, ByteBuf dst, int dstIndex, int length)` method of the source buffer.

In some implementations of a direct `ByteBuf`, e.g. [`io.netty.buffer.UnpooledUnsafeDirectByteBuf`](https://github.com/netty/netty/blob/d773f37e3422b8bc38429bbde94583173c3b7e4a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java), the `getBytes(int index, ByteBuf src, int srcIndex, int length)` method in turn delegates the call back to the `setBytes` method of the destination buffer ([here](https://github.com/netty/netty/blob/d773f37e3422b8bc38429bbde94583173c3b7e4a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java#L159) and [here](https://github.com/netty/netty/blob/d773f37e3422b8bc38429bbde94583173c3b7e4a/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java#L464)). This causes an infinite recursion.

Error stack when stack overflow:

```
Exception in thread "main" java.lang.StackOverflowError
        at io.netty.buffer.AbstractByteBuf.ensureAccessible(AbstractByteBuf.java:1488)
        at alluxio.network.protocol.databuffer.RefCountedNioByteBuf.ensureIndexInBounds(RefCountedNioByteBuf.java:418)
        at alluxio.network.protocol.databuffer.RefCountedNioByteBuf.setBytes(RefCountedNioByteBuf.java:283)
        at alluxio.network.protocol.databuffer.PooledDirectNioByteBuf.setBytes(PooledDirectNioByteBuf.java:22)
        at io.netty.buffer.UnsafeByteBufUtil.getBytes(UnsafeByteBufUtil.java:476)
        at io.netty.buffer.PooledUnsafeDirectByteBuf.getBytes(PooledUnsafeDirectByteBuf.java:124)
        at alluxio.network.protocol.databuffer.RefCountedNioByteBuf.setBytes(RefCountedNioByteBuf.java:284)
        at alluxio.network.protocol.databuffer.PooledDirectNioByteBuf.setBytes(PooledDirectNioByteBuf.java:22)
        at io.netty.buffer.UnsafeByteBufUtil.getBytes(UnsafeByteBufUtil.java:476)
        at io.netty.buffer.PooledUnsafeDirectByteBuf.getBytes(PooledUnsafeDirectByteBuf.java:124)
        at alluxio.network.protocol.databuffer.RefCountedNioByteBuf.setBytes(RefCountedNioByteBuf.java:284)
        at alluxio.network.protocol.databuffer.PooledDirectNioByteBuf.setBytes(PooledDirectNioByteBuf.java:22)
...
```

An unit test is added to cover this case.

### Does this PR introduce any user facing changes?

No.
